### PR TITLE
docs: Claude Code CLI & Desktop CLAUDE.md integration guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,87 @@ Memories are ranked by: FTS relevance + priority weight + access frequency + con
 - Priority reinforcement: +1 every 10 accesses (max 10)
 - Contradiction detection on store: warns about similar titles in same namespace
 - Deduplication: upsert on title+namespace, tier never downgrades
+
+---
+
+## Using CLAUDE.md in Your Projects
+
+> **This section is for users who want Claude Code to proactively use ai-memory in their own projects.** The instructions above describe how ai-memory works internally. The template below is what you put in **your** project's `CLAUDE.md` to instruct Claude to use ai-memory as its primary memory facility.
+
+### Why CLAUDE.md?
+
+Claude Code reads `CLAUDE.md` files at the start of every conversation. By adding ai-memory directives to your project's `CLAUDE.md`, you ensure Claude **always** recalls relevant context before starting work and **always** stores important findings — without being prompted.
+
+### CLAUDE.md Template
+
+Copy the following into your project's `CLAUDE.md` (create it if it doesn't exist). Customize the namespace and any project-specific notes.
+
+````markdown
+# Project — Claude Instructions
+
+## AI Memory (MANDATORY)
+
+Use `ai-memory` for persistent memory across conversations. This is NOT optional.
+
+### On every conversation start:
+1. Run `ai-memory recall "<topic>"` to check for relevant context before starting work
+2. If the user references prior work, recall related memories first
+
+### While working:
+- Store important findings, decisions, and bug fixes as they happen — don't wait until the end
+- Use namespace `my-project` for all project memories
+- Default tier: `long`, default priority: `5` (use `9-10` for critical knowledge)
+
+### When finishing work:
+- Store a memory summarizing what was done, why, and any gotchas for next time
+- Update existing memories if your work changes previously recorded facts
+
+### Quick reference:
+```bash
+ai-memory recall "search query"                                      # fuzzy search
+ai-memory search "exact keywords"                                    # precise match
+ai-memory store -T "Title" -n my-project -t long -p 5 -c "content"  # store
+ai-memory update <id> -c "new content"                               # update
+ai-memory list -n my-project                                         # browse
+```
+````
+
+### Where to Place CLAUDE.md
+
+| Location | Scope | Use when |
+|----------|-------|----------|
+| `<project-root>/CLAUDE.md` | Project-wide | Default — applies to every Claude Code session in the project |
+| `<subfolder>/CLAUDE.md` | Subdirectory | Adds directives when Claude works in that subdirectory |
+| `~/.claude/CLAUDE.md` | User-global | Applies to all projects (put ai-memory directives here for universal recall) |
+
+Claude Code loads all applicable `CLAUDE.md` files hierarchically — project root + any parent/child directories + user-global. The ai-memory directives in any of them will take effect.
+
+### Claude Code Desktop
+
+Claude Code Desktop reads the same `CLAUDE.md` files. The same template works for both CLI and Desktop — no separate configuration needed. Place `CLAUDE.md` in your project root and it applies to both.
+
+### Combining with MCP
+
+For the best experience, use **both** MCP and CLAUDE.md together:
+
+1. **MCP** (in `~/.claude.json`) gives Claude native `memory_recall`, `memory_store`, etc. tools
+2. **CLAUDE.md** (in your project) instructs Claude **when** and **how** to use those tools proactively
+
+Without CLAUDE.md, Claude has the tools but may not use them unless asked. Without MCP, Claude falls back to the CLI commands in CLAUDE.md. Both together gives you proactive, tool-native memory.
+
+### Session Hooks (Optional)
+
+For automatic recall at session start without relying on CLAUDE.md directives, use the session-start hook in `hooks/session-start.sh`:
+
+```json
+// Add to ~/.claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "command": "~/.claude/hooks/session-start.sh" }
+    ]
+  }
+}
+```
+
+This auto-recalls memories matching the current working directory on every session start.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Create `.mcp.json` in your project root:
 
 > **Important:** MCP servers are **not** configured in `settings.json` or `settings.local.json` — those files do not support `mcpServers`.
 
+**Make Claude proactively use ai-memory:** Add a `CLAUDE.md` file to your project root with ai-memory directives. This ensures Claude recalls context at the start of every conversation and stores findings as it works. See the [CLAUDE.md integration guide](CLAUDE.md#using-claudemd-in-your-projects) for a copy-paste template and placement options.
+
 </details>
 
 <details>

--- a/docs/index.html
+++ b/docs/index.html
@@ -318,6 +318,7 @@
         <div class="links">
             <a href="#platforms">Platforms</a>
             <a href="#install">Install</a>
+            <a href="#claude-integration">Claude Code</a>
             <a href="#features">Features</a>
             <a href="#mcp">Interfaces</a>
             <a href="#architecture">Architecture</a>
@@ -865,6 +866,125 @@
 <span class="tok-cm"># CLI:  ai-memory stats</span><span class="lang-label">text</span></code></pre>
             </li>
         </ol>
+    </div>
+</section>
+
+<!-- ================================================================
+     CLAUDE CODE INTEGRATION
+     ================================================================ -->
+<section id="claude-integration">
+    <div class="container">
+        <h2>Claude Code Integration <span class="badge">CLI &amp; Desktop</span></h2>
+        <p class="section-subtitle">Make Claude Code proactively use ai-memory in every conversation. Works with both <strong>Claude Code CLI</strong> and <strong>Claude Code Desktop</strong>.</p>
+
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1.5rem;margin-top:1.5rem">
+
+            <!-- Step 1: MCP -->
+            <div class="card" style="border-left:3px solid var(--green)">
+                <h3 style="color:var(--green);margin-bottom:.75rem">Step 1: MCP Server</h3>
+                <p style="font-size:.9rem;margin-bottom:.75rem">Add to <code>~/.claude.json</code> (user scope) so ai-memory is available in every project:</p>
+                <pre style="font-size:.8rem"><code>{
+  <span class="tok-str">"mcpServers"</span>: {
+    <span class="tok-str">"memory"</span>: {
+      <span class="tok-str">"command"</span>: <span class="tok-str">"ai-memory"</span>,
+      <span class="tok-str">"args"</span>: [<span class="tok-str">"--db"</span>, <span class="tok-str">"~/.claude/ai-memory.db"</span>,
+             <span class="tok-str">"mcp"</span>, <span class="tok-str">"--tier"</span>, <span class="tok-str">"semantic"</span>]
+    }
+  }
+}<span class="lang-label">json</span></code></pre>
+                <p style="font-size:.8rem;color:var(--text-muted)">This gives Claude 17 native memory tools. No daemon, no ports.</p>
+            </div>
+
+            <!-- Step 2: Disable auto-memory -->
+            <div class="card" style="border-left:3px solid var(--orange)">
+                <h3 style="color:var(--orange);margin-bottom:.75rem">Step 2: Disable Auto-Memory</h3>
+                <p style="font-size:.9rem;margin-bottom:.75rem">Stop paying for 200+ lines of built-in memory context on every message:</p>
+                <pre style="font-size:.8rem"><code><span class="tok-cm">// ~/.claude/settings.json</span>
+{
+  <span class="tok-str">"autoMemoryEnabled"</span>: <span class="tok-kw">false</span>
+}<span class="lang-label">json</span></code></pre>
+                <p style="font-size:.8rem;color:var(--text-muted)">ai-memory uses zero tokens until explicitly recalled &mdash; far more efficient than auto-memory.</p>
+            </div>
+
+            <!-- Step 3: CLAUDE.md -->
+            <div class="card" style="border-left:3px solid var(--accent)">
+                <h3 style="color:var(--accent);margin-bottom:.75rem">Step 3: Project CLAUDE.md</h3>
+                <p style="font-size:.9rem;margin-bottom:.75rem">Add a <code>CLAUDE.md</code> to your project root so Claude <strong>proactively</strong> uses ai-memory:</p>
+                <pre style="font-size:.8rem"><code><span class="tok-cm"># Project &mdash; Claude Instructions</span>
+
+<span class="tok-cm">## AI Memory (MANDATORY)</span>
+
+Use <span class="tok-str">`ai-memory`</span> for persistent memory.
+
+<span class="tok-cm">### On every conversation start:</span>
+1. Run <span class="tok-cmd">ai-memory recall "&lt;topic&gt;"</span>
+2. Recall related memories for prior work
+
+<span class="tok-cm">### While working:</span>
+- Store findings and decisions as they happen
+- Use namespace <span class="tok-str">`my-project`</span>
+
+<span class="tok-cm">### When finishing:</span>
+- Store a summary of what was done<span class="lang-label">markdown</span></code></pre>
+            </div>
+        </div>
+
+        <!-- Why CLAUDE.md matters -->
+        <div class="card" style="margin-top:1.5rem;border-left:3px solid var(--purple)">
+            <h3 style="color:var(--purple);margin-bottom:.75rem">Why CLAUDE.md Matters</h3>
+            <p style="font-size:.9rem;line-height:1.7">Without <code>CLAUDE.md</code>, Claude has the memory tools (via MCP) but may not use them unless explicitly asked. The <code>CLAUDE.md</code> file is read at the start of <strong>every</strong> conversation &mdash; it instructs Claude to recall context before starting work and store findings as it goes. This turns ai-memory from a passive tool into an <strong>active memory system</strong> that Claude uses autonomously.</p>
+
+            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;margin-top:1rem">
+                <div style="background:var(--bg-code);padding:1rem;border-radius:8px">
+                    <h4 style="font-size:.85rem;color:var(--text-muted);margin-bottom:.5rem">CLAUDE.md Placement</h4>
+                    <table style="font-size:.8rem;width:100%;border-collapse:collapse">
+                        <tr style="border-bottom:1px solid var(--border)"><td style="padding:4px 0"><code>&lt;project&gt;/CLAUDE.md</code></td><td style="padding:4px 0;color:var(--text-muted)">Project-wide (default)</td></tr>
+                        <tr style="border-bottom:1px solid var(--border)"><td style="padding:4px 0"><code>&lt;subfolder&gt;/CLAUDE.md</code></td><td style="padding:4px 0;color:var(--text-muted)">Subdirectory scope</td></tr>
+                        <tr><td style="padding:4px 0"><code>~/.claude/CLAUDE.md</code></td><td style="padding:4px 0;color:var(--text-muted)">User-global (all projects)</td></tr>
+                    </table>
+                </div>
+                <div style="background:var(--bg-code);padding:1rem;border-radius:8px">
+                    <h4 style="font-size:.85rem;color:var(--text-muted);margin-bottom:.5rem">CLI vs Desktop</h4>
+                    <p style="font-size:.8rem;line-height:1.6">Both <strong>Claude Code CLI</strong> and <strong>Claude Code Desktop</strong> read the same <code>CLAUDE.md</code> files and use the same MCP configuration. No separate setup needed &mdash; one configuration works for both.</p>
+                </div>
+                <div style="background:var(--bg-code);padding:1rem;border-radius:8px">
+                    <h4 style="font-size:.85rem;color:var(--text-muted);margin-bottom:.5rem">Best Practice</h4>
+                    <p style="font-size:.8rem;line-height:1.6">Use <strong>MCP + CLAUDE.md together</strong>. MCP gives Claude the tools; CLAUDE.md tells Claude when and how to use them. Session hooks (<code>hooks/session-start.sh</code>) provide an optional third layer of auto-recall.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Full CLAUDE.md template -->
+        <details style="margin-top:1.5rem">
+            <summary style="cursor:pointer;font-weight:600;color:var(--accent);font-size:1rem;padding:.75rem 0">Full CLAUDE.md Template (copy-paste ready)</summary>
+            <pre style="margin-top:.75rem;font-size:.8rem"><code><span class="tok-cm"># Project &mdash; Claude Instructions</span>
+
+<span class="tok-cm">## AI Memory (MANDATORY)</span>
+
+Use `ai-memory` for persistent memory across conversations. This is NOT optional.
+
+<span class="tok-cm">### On every conversation start:</span>
+1. Run `ai-memory recall "&lt;topic&gt;"` to check for relevant context before starting work
+2. If the user references prior work, recall related memories first
+
+<span class="tok-cm">### While working:</span>
+- Store important findings, decisions, and bug fixes as they happen &mdash; don't wait until the end
+- Use namespace `my-project` for all project memories
+- Default tier: `long`, default priority: `5` (use `9-10` for critical knowledge)
+
+<span class="tok-cm">### When finishing work:</span>
+- Store a memory summarizing what was done, why, and any gotchas for next time
+- Update existing memories if your work changes previously recorded facts
+
+<span class="tok-cm">### Quick reference:</span>
+```bash
+ai-memory recall "search query"                                      <span class="tok-cm"># fuzzy search</span>
+ai-memory search "exact keywords"                                    <span class="tok-cm"># precise match</span>
+ai-memory store -T "Title" -n my-project -t long -p 5 -c "content"  <span class="tok-cm"># store</span>
+ai-memory update &lt;id&gt; -c "new content"                               <span class="tok-cm"># update</span>
+ai-memory list -n my-project                                         <span class="tok-cm"># browse</span>
+```<span class="lang-label">markdown</span></code></pre>
+        </details>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary

- Add "Using CLAUDE.md in Your Projects" section to `CLAUDE.md` with copy-paste template, placement guide (project/subfolder/global), CLI vs Desktop notes, and session hooks
- Add cross-reference in `README.md` Claude Code platform details pointing to the CLAUDE.md guide
- Add new "Claude Code Integration" section to GitHub Pages (`docs/index.html`) with 3-step visual setup cards (MCP + disable auto-memory + CLAUDE.md), placement table, and full collapsible template

## Why

Users install ai-memory and configure MCP, but Claude doesn't proactively use it without explicit `CLAUDE.md` directives. This gap means users have to manually ask Claude to recall/store — defeating the purpose of persistent memory. The CLAUDE.md template solves this by instructing Claude to always recall at conversation start and store findings during work.

## Test plan

- [ ] Verify `docs/index.html` renders correctly on GitHub Pages
- [ ] Verify nav link to "Claude Code" section works
- [ ] Verify CLAUDE.md template in collapsible details is copy-paste ready
- [ ] Verify README.md cross-reference link resolves

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)