### PR TITLE
docs: Add BLUF statement to GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,6 +334,10 @@
 <section class="hero">
     <div class="container">
         <h1>Persistent Memory for <span>Any AI</span></h1>
+        <div style="max-width:760px;margin:0 auto 1.5rem;background:linear-gradient(135deg,rgba(248,81,73,.08) 0%,rgba(88,166,255,.08) 100%);border:1px solid var(--border-hl);border-radius:10px;padding:1.25rem 1.5rem">
+            <p style="font-size:.7rem;text-transform:uppercase;letter-spacing:.15em;color:var(--orange);margin-bottom:.5rem;font-weight:700">BLUF &mdash; Bottom Line Up Front</p>
+            <p style="font-size:1rem;line-height:1.6;margin:0"><strong style="color:var(--text)">ai-memory replaces AI vendors' built-in auto-memory features.</strong> Disable AI vendor memory to stop paying for idle context tokens wasted on every message. A moderate end user wastes <strong style="color:var(--red)">~108M input tokens per year</strong> on memory context loaded into every single message whether needed or not &mdash; via Claude &ldquo;auto-memory,&rdquo; ChatGPT memory, or similar vendor facilities.</p>
+        </div>
         <p class="bluf" style="max-width:680px;margin:0 auto 1.5rem">
             <strong style="color:var(--green)">Zero token cost until recalled.</strong>
             Built-in memory systems load your entire memory into every message. ai-memory uses zero context tokens until the AI calls <code>memory_recall</code> &mdash; only relevant memories come back, ranked and compressed via TOON format (79% smaller than JSON).


### PR DESCRIPTION
## Summary

- Add a prominent BLUF (Bottom Line Up Front) callout to the hero section of the GitHub Pages site
- States the core value prop: ai-memory replaces vendor auto-memory, saving ~108M wasted input tokens/year for a moderate user
- Styled as a gradient-bordered card above the existing "Zero token cost until recalled" copy

## Test plan

- [ ] Verify BLUF renders correctly above existing hero content
- [ ] Verify styling is consistent with site theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)