### PR TITLE
fix: v0.5.4.1 Patch 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.5.4"
+version = "0.5.4-patch.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.5.4"
+version = "0.5.4-patch.1"
 edition = "2021"
 authors = ["AlphaOne LLC"]
 description = "AI-agnostic persistent memory system — MCP server, HTTP API, and CLI for any AI platform"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1003,7 +1003,7 @@ pub fn restore_archived(conn: &Connection, id: &str) -> Result<bool> {
             "INSERT INTO memories
              (id, tier, namespace, title, content, tags, priority, confidence,
               source, access_count, created_at, updated_at, last_accessed_at, expires_at)
-             SELECT id, tier, namespace, title, content, tags, priority, confidence,
+             SELECT id, 'long', namespace, title, content, tags, priority, confidence,
                     source, access_count, created_at, ?1, last_accessed_at, NULL
              FROM archived_memories WHERE id = ?2",
             params![now, id],

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ fn id_short(id: &str) -> &str {
 #[derive(Parser)]
 #[command(
     name = "ai-memory",
+    version,
     about = "AI-agnostic persistent memory — MCP server, HTTP API, and CLI for any AI platform"
 )]
 struct Cli {
@@ -710,7 +711,7 @@ fn cmd_update(db_path: PathBuf, args: UpdateArgs, json_out: bool) -> Result<()> 
     }
     if let Some(ref ts) = args.expires_at {
         if !ts.is_empty() {
-            validate::validate_expires_at(Some(ts))?;
+            validate::validate_expires_at_format(ts)?;
         }
     }
     let (found, _content_changed) = db::update(


### PR DESCRIPTION
## Summary
- Adds `--version` / `-V` flag via clap `#[command(version)]`
- Fixes `archive_restore` to promote restored memories to `tier=long` as documented
- Fixes CLI `update` to accept past `expires_at` timestamps (parity with MCP path)
- Bumps version to `0.5.4-patch.1`

## Test Results
- 139 unit tests + 43 integration tests = **182 PASS, 0 FAIL**
- Specific test `restore_archived_memory` confirms tier promotion fix

## Related
- Dev issue: alphaonedev/ai-memory-mcp-dev#49
- Closes #137

## Test plan
- [x] `ai-memory --version` outputs `ai-memory 0.5.4-patch.1`
- [x] `ai-memory -V` outputs version
- [x] CLI update accepts past `expires_at`
- [x] `archive_restore` promotes to `tier=long` with `expires_at=NULL`
- [x] All 182 tests pass
- [x] `memory_capabilities` returns version `0.5.4-patch.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)