### PR TITLE
fix: short/prefix ID resolution — v0.5.4-patch.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 env:
   CARGO_TERM_COLOR: always
@@ -133,6 +133,127 @@ jobs:
           files: dist/ai-memory*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  crates-io:
+    name: Publish to crates.io
+    needs: check
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --allow-dirty
+
+  homebrew:
+    name: Update Homebrew formula
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets and compute SHA256
+        id: sha
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BASE="https://github.com/alphaonedev/ai-memory-mcp/releases/download/v${VERSION}"
+
+          for TARGET in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
+            curl -sL -o "ai-memory-${TARGET}.tar.gz" "${BASE}/ai-memory-${TARGET}.tar.gz"
+            SHA=$(sha256sum "ai-memory-${TARGET}.tar.gz" | cut -d' ' -f1)
+            # Convert target to env-safe name
+            SAFE=$(echo "$TARGET" | tr '-' '_')
+            echo "sha_${SAFE}=${SHA}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: alphaonedev/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          cat > homebrew-tap/Formula/ai-memory.rb << 'FORMULA_EOF'
+          class AiMemory < Formula
+            desc "AI-agnostic persistent memory system — MCP server, HTTP API, and CLI"
+            homepage "https://alphaonedev.github.io/ai-memory-mcp/"
+            version "VERSION_PLACEHOLDER"
+            license "Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/alphaonedev/ai-memory-mcp/releases/download/v#{version}/ai-memory-aarch64-apple-darwin.tar.gz"
+                sha256 "SHA_AARCH64_APPLE_DARWIN"
+              else
+                url "https://github.com/alphaonedev/ai-memory-mcp/releases/download/v#{version}/ai-memory-x86_64-apple-darwin.tar.gz"
+                sha256 "SHA_X86_64_APPLE_DARWIN"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/alphaonedev/ai-memory-mcp/releases/download/v#{version}/ai-memory-aarch64-unknown-linux-gnu.tar.gz"
+                sha256 "SHA_AARCH64_UNKNOWN_LINUX_GNU"
+              else
+                url "https://github.com/alphaonedev/ai-memory-mcp/releases/download/v#{version}/ai-memory-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "SHA_X86_64_UNKNOWN_LINUX_GNU"
+              end
+            end
+
+            def install
+              bin.install "ai-memory"
+            end
+
+            def caveats
+              <<~EOS
+                To use with an MCP-compatible AI (Claude Code, Codex CLI, Gemini CLI, OpenClaw, etc.),
+                add to your AI platform's MCP config:
+
+                  {
+                    "mcpServers": {
+                      "memory": {
+                        "command": "ai-memory",
+                        "args": ["--db", "~/.local/share/ai-memory/memories.db", "mcp"]
+                      }
+                    }
+                  }
+
+                Documentation: https://alphaonedev.github.io/ai-memory-mcp/
+              EOS
+            end
+
+            test do
+              system "#{bin}/ai-memory", "stats", "--json", "--db", testpath/"test.db"
+            end
+          end
+          FORMULA_EOF
+
+          # Replace placeholders with actual values
+          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/" homebrew-tap/Formula/ai-memory.rb
+          sed -i "s/SHA_X86_64_UNKNOWN_LINUX_GNU/${{ steps.sha.outputs.sha_x86_64_unknown_linux_gnu }}/" homebrew-tap/Formula/ai-memory.rb
+          sed -i "s/SHA_AARCH64_UNKNOWN_LINUX_GNU/${{ steps.sha.outputs.sha_aarch64_unknown_linux_gnu }}/" homebrew-tap/Formula/ai-memory.rb
+          sed -i "s/SHA_X86_64_APPLE_DARWIN/${{ steps.sha.outputs.sha_x86_64_apple_darwin }}/" homebrew-tap/Formula/ai-memory.rb
+          sed -i "s/SHA_AARCH64_APPLE_DARWIN/${{ steps.sha.outputs.sha_aarch64_apple_darwin }}/" homebrew-tap/Formula/ai-memory.rb
+
+      - name: Push updated formula
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/ai-memory.rb
+          git commit -m "Update ai-memory to ${{ steps.version.outputs.version }}"
+          git push
 
   docker:
     name: Docker (GHCR)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.5.4-patch.4"
+version = "0.5.4-patch.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.5.4-patch.4"
+version = "0.5.4-patch.5"
 edition = "2021"
 rust-version = "1.87"
 authors = ["AlphaOne LLC"]

--- a/src/db.rs
+++ b/src/db.rs
@@ -275,6 +275,30 @@ pub fn get(conn: &Connection, id: &str) -> Result<Option<Memory>> {
     }
 }
 
+/// Look up a memory by ID prefix. Returns the memory if exactly one match is found.
+/// Returns `Ok(None)` if no matches. Returns an error if the prefix is ambiguous (>1 match).
+pub fn get_by_prefix(conn: &Connection, prefix: &str) -> Result<Option<Memory>> {
+    let pattern = format!("{prefix}%");
+    let mut stmt = conn.prepare("SELECT * FROM memories WHERE id LIKE ?1")?;
+    let rows: Vec<Memory> = stmt
+        .query_map(params![pattern], row_to_memory)?
+        .filter_map(Result::ok)
+        .collect();
+    match rows.len() {
+        0 => Ok(None),
+        1 => Ok(Some(rows.into_iter().next().expect("len checked"))),
+        n => anyhow::bail!("ambiguous ID prefix '{prefix}': {n} matches"),
+    }
+}
+
+/// Resolve an ID that may be a prefix. Tries exact match first, then prefix match.
+pub fn resolve_id(conn: &Connection, id: &str) -> Result<Option<Memory>> {
+    if let Some(mem) = get(conn, id)? {
+        return Ok(Some(mem));
+    }
+    get_by_prefix(conn, id)
+}
+
 /// Bump access count, extend TTL, auto-promote — atomic via transaction.
 pub fn touch(conn: &Connection, id: &str, short_extend: i64, mid_extend: i64) -> Result<()> {
     let now = Utc::now();
@@ -2204,6 +2228,67 @@ mod tests {
         // Empty input returns placeholder
         let sanitized3 = sanitize_fts_query("", true);
         assert_eq!(sanitized3, "\"_empty_\"");
+    }
+
+    #[test]
+    fn get_by_prefix_8char() {
+        let conn = test_db();
+        let mem = make_memory("Prefix test", "test", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+        let prefix = &id[..8];
+        let got = get_by_prefix(&conn, prefix).unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.title, "Prefix test");
+    }
+
+    #[test]
+    fn get_by_prefix_full_uuid() {
+        let conn = test_db();
+        let mem = make_memory("Full UUID prefix", "test", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+        // Full UUID used as prefix still works (LIKE 'full-uuid%' matches exact)
+        let got = get_by_prefix(&conn, &id).unwrap().unwrap();
+        assert_eq!(got.id, id);
+    }
+
+    #[test]
+    fn get_by_prefix_nonexistent() {
+        let conn = test_db();
+        let got = get_by_prefix(&conn, "ffffffff").unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn get_by_prefix_ambiguous() {
+        let conn = test_db();
+        // Insert two memories with IDs sharing a common prefix
+        let mut mem1 = make_memory("Ambig A", "test", Tier::Long, 5);
+        mem1.id = "aaaa1111-0000-0000-0000-000000000001".to_string();
+        insert(&conn, &mem1).unwrap();
+        let mut mem2 = make_memory("Ambig B", "test2", Tier::Long, 5);
+        mem2.id = "aaaa2222-0000-0000-0000-000000000002".to_string();
+        insert(&conn, &mem2).unwrap();
+        let result = get_by_prefix(&conn, "aaaa");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("ambiguous"));
+        assert!(err_msg.contains("2 matches"));
+    }
+
+    #[test]
+    fn resolve_id_exact_then_prefix() {
+        let conn = test_db();
+        let mem = make_memory("Resolve test", "test", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+        // Exact match
+        let got = resolve_id(&conn, &id).unwrap().unwrap();
+        assert_eq!(got.id, id);
+        // Prefix match
+        let got2 = resolve_id(&conn, &id[..8]).unwrap().unwrap();
+        assert_eq!(got2.id, id);
+        // Nonexistent
+        let got3 = resolve_id(&conn, "zzzzzzzz").unwrap();
+        assert!(got3.is_none());
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -113,13 +113,17 @@ pub async fn get_memory(State(state): State<Db>, Path(id): Path<String>) -> impl
             .into_response();
     }
     let lock = state.lock().await;
-    match db::get(&lock.0, &id) {
+    match db::resolve_id(&lock.0, &id) {
         Ok(Some(mem)) => {
-            let links = db::get_links(&lock.0, &id).unwrap_or_default();
+            let links = db::get_links(&lock.0, &mem.id).unwrap_or_default();
             Json(json!({"memory": mem, "links": links})).into_response()
         }
         Ok(None) => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response(),
         Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("ambiguous ID prefix") {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
+            }
             tracing::error!("handler error: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -150,9 +154,28 @@ pub async fn update_memory(
             .into_response();
     }
     let lock = state.lock().await;
+    // Resolve prefix if exact ID not found
+    let resolved_id = match db::resolve_id(&lock.0, &id) {
+        Ok(Some(mem)) => mem.id,
+        Ok(None) => {
+            return (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("ambiguous ID prefix") {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
+            }
+            tracing::error!("handler error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+    };
     match db::update(
         &lock.0,
-        &id,
+        &resolved_id,
         body.title.as_deref(),
         body.content.as_deref(),
         body.tier.as_ref(),
@@ -163,7 +186,7 @@ pub async fn update_memory(
         body.expires_at.as_deref(),
     ) {
         Ok((true, _)) => {
-            let mem = db::get(&lock.0, &id).ok().flatten();
+            let mem = db::get(&lock.0, &resolved_id).ok().flatten();
             Json(json!(mem)).into_response()
         }
         Ok((false, _)) => {
@@ -193,9 +216,38 @@ pub async fn delete_memory(State(state): State<Db>, Path(id): Path<String>) -> i
             .into_response();
     }
     let lock = state.lock().await;
+    // Try exact delete first; fall back to prefix resolution
     match db::delete(&lock.0, &id) {
         Ok(true) => Json(json!({"deleted": true})).into_response(),
-        Ok(false) => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response(),
+        Ok(false) => {
+            // Prefix fallback
+            match db::get_by_prefix(&lock.0, &id) {
+                Ok(Some(mem)) => {
+                    let full_id = mem.id;
+                    match db::delete(&lock.0, &full_id) {
+                        Ok(true) => Json(json!({"deleted": true})).into_response(),
+                        _ => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"})))
+                            .into_response(),
+                    }
+                }
+                Ok(None) => {
+                    (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("ambiguous ID prefix") {
+                        (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response()
+                    } else {
+                        tracing::error!("handler error: {e}");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({"error": "internal server error"})),
+                        )
+                            .into_response()
+                    }
+                }
+            }
+        }
         Err(e) => {
             tracing::error!("handler error: {e}");
             (
@@ -216,9 +268,28 @@ pub async fn promote_memory(State(state): State<Db>, Path(id): Path<String>) -> 
             .into_response();
     }
     let lock = state.lock().await;
+    // Resolve prefix if exact ID not found
+    let resolved_id = match db::resolve_id(&lock.0, &id) {
+        Ok(Some(mem)) => mem.id,
+        Ok(None) => {
+            return (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("ambiguous ID prefix") {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
+            }
+            tracing::error!("handler error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+    };
     match db::update(
         &lock.0,
-        &id,
+        &resolved_id,
         None,
         None,
         Some(&Tier::Long),
@@ -231,7 +302,7 @@ pub async fn promote_memory(State(state): State<Db>, Path(id): Path<String>) -> 
         Ok((true, _)) => {
             if let Err(e) = lock.0.execute(
                 "UPDATE memories SET expires_at = NULL WHERE id = ?1",
-                rusqlite::params![id],
+                rusqlite::params![resolved_id],
             ) {
                 tracing::error!("promote clear expiry failed: {e}");
                 return (
@@ -240,7 +311,7 @@ pub async fn promote_memory(State(state): State<Db>, Path(id): Path<String>) -> 
                 )
                     .into_response();
             }
-            Json(json!({"promoted": true, "id": id, "tier": "long"})).into_response()
+            Json(json!({"promoted": true, "id": resolved_id, "tier": "long"})).into_response()
         }
         Ok((false, _)) => {
             (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,7 +694,15 @@ fn cmd_store(
 fn cmd_update(db_path: &Path, args: &UpdateArgs, json_out: bool) -> Result<()> {
     validate::validate_id(&args.id)?;
     let conn = db::open(db_path)?;
-    validate::validate_id(&args.id)?;
+    // Resolve prefix if exact ID not found
+    let resolved_id = if db::get(&conn, &args.id)?.is_some() {
+        args.id.clone()
+    } else if let Some(mem) = db::get_by_prefix(&conn, &args.id)? {
+        mem.id
+    } else {
+        eprintln!("not found: {}", args.id);
+        std::process::exit(1);
+    };
     let tier = args.tier.as_deref().and_then(Tier::from_str);
     let tags: Option<Vec<String>> = args.tags.as_ref().map(|t| {
         t.split(',')
@@ -728,7 +736,7 @@ fn cmd_update(db_path: &Path, args: &UpdateArgs, json_out: bool) -> Result<()> {
     }
     let (found, _content_changed) = db::update(
         &conn,
-        &args.id,
+        &resolved_id,
         args.title.as_deref(),
         args.content.as_deref(),
         tier.as_ref(),
@@ -742,7 +750,7 @@ fn cmd_update(db_path: &Path, args: &UpdateArgs, json_out: bool) -> Result<()> {
         eprintln!("not found: {}", args.id);
         std::process::exit(1);
     }
-    if let Some(mem) = db::get(&conn, &args.id)? {
+    if let Some(mem) = db::get(&conn, &resolved_id)? {
         if json_out {
             println!("{}", serde_json::to_string(&mem)?);
         } else {
@@ -997,9 +1005,8 @@ fn cmd_search(
 fn cmd_get(db_path: &Path, args: &GetArgs, json_out: bool) -> Result<()> {
     validate::validate_id(&args.id)?;
     let conn = db::open(db_path)?;
-    validate::validate_id(&args.id)?;
-    if let Some(mem) = db::get(&conn, &args.id)? {
-        let links = db::get_links(&conn, &args.id).unwrap_or_default();
+    if let Some(mem) = db::resolve_id(&conn, &args.id)? {
+        let links = db::get_links(&conn, &mem.id).unwrap_or_default();
         if json_out {
             println!(
                 "{}",
@@ -1073,12 +1080,21 @@ fn cmd_list(
 fn cmd_delete(db_path: &Path, args: &DeleteArgs, json_out: bool) -> Result<()> {
     validate::validate_id(&args.id)?;
     let conn = db::open(db_path)?;
-    validate::validate_id(&args.id)?;
+    // Try exact delete first; if not found, resolve prefix to get the full ID
     if db::delete(&conn, &args.id)? {
         if json_out {
             println!("{}", serde_json::json!({"deleted": true, "id": args.id}));
         } else {
             println!("deleted: {}", args.id);
+        }
+    } else if let Some(mem) = db::get_by_prefix(&conn, &args.id)? {
+        let full_id = mem.id.clone();
+        if db::delete(&conn, &full_id)? {
+            if json_out {
+                println!("{}", serde_json::json!({"deleted": true, "id": full_id}));
+            } else {
+                println!("deleted: {full_id}");
+            }
         }
     } else {
         eprintln!("not found: {}", args.id);
@@ -1090,10 +1106,18 @@ fn cmd_delete(db_path: &Path, args: &DeleteArgs, json_out: bool) -> Result<()> {
 fn cmd_promote(db_path: &Path, args: &PromoteArgs, json_out: bool) -> Result<()> {
     validate::validate_id(&args.id)?;
     let conn = db::open(db_path)?;
-    validate::validate_id(&args.id)?;
+    // Resolve prefix if exact ID not found
+    let resolved_id = if db::get(&conn, &args.id)?.is_some() {
+        args.id.clone()
+    } else if let Some(mem) = db::get_by_prefix(&conn, &args.id)? {
+        mem.id
+    } else {
+        eprintln!("not found: {}", args.id);
+        std::process::exit(1);
+    };
     let (found, _) = db::update(
         &conn,
-        &args.id,
+        &resolved_id,
         None,
         None,
         Some(&Tier::Long),
@@ -1110,10 +1134,10 @@ fn cmd_promote(db_path: &Path, args: &PromoteArgs, json_out: bool) -> Result<()>
     if json_out {
         println!(
             "{}",
-            serde_json::json!({"promoted": true, "id": args.id, "tier": "long"})
+            serde_json::json!({"promoted": true, "id": resolved_id, "tier": "long"})
         );
     } else {
-        println!("promoted to long-term: {}", args.id);
+        println!("promoted to long-term: {resolved_id}");
     }
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -909,12 +909,24 @@ fn handle_delete(
 ) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
+    // Try exact delete first; fall back to prefix resolution
     let deleted = db::delete(conn, id).map_err(|e| e.to_string())?;
     if deleted {
         if let Some(idx) = vector_index {
             idx.remove(id);
         }
         Ok(json!({"deleted": true}))
+    } else if let Some(mem) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
+        let full_id = mem.id.clone();
+        let deleted = db::delete(conn, &full_id).map_err(|e| e.to_string())?;
+        if deleted {
+            if let Some(idx) = vector_index {
+                idx.remove(&full_id);
+            }
+            Ok(json!({"deleted": true}))
+        } else {
+            Err("memory not found".into())
+        }
     } else {
         Err("memory not found".into())
     }
@@ -923,18 +935,26 @@ fn handle_delete(
 fn handle_promote(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
+    // Resolve prefix if exact ID not found
+    let resolved_id = if db::get(conn, id).map_err(|e| e.to_string())?.is_some() {
+        id.to_string()
+    } else if let Some(mem) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
+        mem.id
+    } else {
+        return Err("memory not found".into());
+    };
     // Atomic promote: set tier=long and clear expires_at in a single UPDATE
     let now = chrono::Utc::now().to_rfc3339();
     let changed = conn
         .execute(
             "UPDATE memories SET tier = 'long', expires_at = NULL, updated_at = ?1 WHERE id = ?2",
-            rusqlite::params![now, id],
+            rusqlite::params![now, resolved_id],
         )
         .map_err(|e| e.to_string())?;
     if changed == 0 {
         return Err("memory not found".into());
     }
-    Ok(json!({"promoted": true, "id": id, "tier": "long"}))
+    Ok(json!({"promoted": true, "id": resolved_id, "tier": "long"}))
 }
 
 fn handle_forget(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
@@ -958,6 +978,14 @@ fn handle_update(
 ) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
+    // Resolve prefix if exact ID not found
+    let resolved_id = if db::get(conn, id).map_err(|e| e.to_string())?.is_some() {
+        id.to_string()
+    } else if let Some(mem) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
+        mem.id
+    } else {
+        return Err("memory not found".into());
+    };
     let title = params["title"].as_str();
     let content = params["content"].as_str();
     let tier = params["tier"].as_str().and_then(Tier::from_str);
@@ -998,7 +1026,7 @@ fn handle_update(
 
     let (found, content_changed) = db::update(
         conn,
-        id,
+        &resolved_id,
         title,
         content,
         tier.as_ref(),
@@ -1017,30 +1045,30 @@ fn handle_update(
     // Regenerate embedding when title or content changed
     if content_changed {
         if let Some(emb) = embedder {
-            let mem = db::get(conn, id).map_err(|e| e.to_string())?;
+            let mem = db::get(conn, &resolved_id).map_err(|e| e.to_string())?;
             if let Some(ref m) = mem {
                 let text = format!("{} {}", m.title, m.content);
                 if let Ok(embedding) = emb.embed(&text) {
-                    let _ = db::set_embedding(conn, id, &embedding);
+                    let _ = db::set_embedding(conn, &resolved_id, &embedding);
                     if let Some(idx) = vector_index {
-                        idx.remove(id);
-                        idx.insert(id.to_string(), embedding);
+                        idx.remove(&resolved_id);
+                        idx.insert(resolved_id.clone(), embedding);
                     }
                 }
             }
         }
     }
 
-    let mem = db::get(conn, id).map_err(|e| e.to_string())?;
+    let mem = db::get(conn, &resolved_id).map_err(|e| e.to_string())?;
     Ok(json!({"updated": true, "memory": mem}))
 }
 
 fn handle_get(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
-    match db::get(conn, id).map_err(|e| e.to_string())? {
+    match db::resolve_id(conn, id).map_err(|e| e.to_string())? {
         Some(mem) => {
-            let links = db::get_links(conn, id).unwrap_or_default();
+            let links = db::get_links(conn, &mem.id).unwrap_or_default();
             // Flatten: merge memory fields with links at top level (#96)
             let mut val = serde_json::to_value(&mem).map_err(|e| e.to_string())?;
             if let Some(obj) = val.as_object_mut() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2400,14 +2400,14 @@ fn test_promote_clears_expires_at() {
 }
 
 #[test]
-fn test_version_flag_patch4() {
+fn test_version_flag_patch5() {
     let binary = env!("CARGO_BIN_EXE_ai-memory");
     let output = cmd(binary).args(["--version"]).output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("0.5.4-patch.4"),
-        "version should be 0.5.4-patch.4, got: {}",
+        stdout.contains("0.5.4-patch.5"),
+        "version should be 0.5.4-patch.5, got: {}",
         stdout
     );
 }
@@ -2728,6 +2728,106 @@ fn test_namespace_standard_cascade_on_delete() {
         "standard should be null after deleting the standard memory, got: {}",
         get_data
     );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_cli_prefix_id_resolution() {
+    let dir = std::env::temp_dir();
+    let db_path = dir.join(format!("ai-memory-prefix-test-{}.db", uuid::Uuid::new_v4()));
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    // Store a memory
+    let output = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "store",
+            "-t",
+            "long",
+            "-T",
+            "Prefix resolution test",
+            "--content",
+            "Testing that short IDs work with get, update, promote, and delete",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "store failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stored: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let full_id = stored["id"].as_str().unwrap().to_string();
+    let short_id = &full_id[..8];
+
+    // Get by short prefix
+    let output = cmd(binary)
+        .args(["--db", db_path.to_str().unwrap(), "--json", "get", short_id])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "get by prefix failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let got: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(got["memory"]["id"], full_id);
+    assert_eq!(got["memory"]["title"], "Prefix resolution test");
+
+    // Update by short prefix
+    let output = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "update",
+            short_id,
+            "--content",
+            "Updated via prefix",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "update by prefix failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify updated content
+    let output = cmd(binary)
+        .args(["--db", db_path.to_str().unwrap(), "--json", "get", &full_id])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let got: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(got["memory"]["content"], "Updated via prefix");
+
+    // Delete by short prefix
+    let output = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "delete",
+            short_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "delete by prefix failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify deleted
+    let output = cmd(binary)
+        .args(["--db", db_path.to_str().unwrap(), "--json", "get", &full_id])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "get after delete should fail");
 
     let _ = std::fs::remove_file(&db_path);
 }


### PR DESCRIPTION
## Summary

- Short/prefix ID resolution across all interfaces (CLI, MCP, HTTP). `get c480e930` now works.
- CI pipeline: added `develop` branch CI, crates.io publish, Homebrew formula auto-update
- Version bump: 0.5.4-patch.4 → 0.5.4-patch.5

Closes #159

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — 0 warnings
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 198 passing (145 unit + 53 integration)
- [x] `cargo audit` — passes
- [x] 6 new tests: prefix 8-char, full UUID, nonexistent, ambiguous, resolve_id, CLI integration

🤖 Generated with [Claude Code](https://claude.ai/claude-code)