### PR TITLE
fix: update rustls-webpki 0.103.10 -> 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Fixes RUSTSEC-2026-0098: URI name constraints incorrectly accepted
- Fixes RUSTSEC-2026-0099: Wildcard name constraint bypass

## Change

`Cargo.lock` only — 2 lines changed. `rustls-webpki` 0.103.10 → 0.103.12.

```
cargo update -p rustls-webpki
```

## What is NOT changed

- Zero `Cargo.toml` changes
- Zero source code changes
- Zero new dependencies
- No build toolchain changes
- `ring` remains the crypto backend (no `aws-lc-sys`/cmake)

## Verification

The patch version 0.103.12 is within the existing semver range `^0.103.5` required by `rustls 0.23.37`. No dependency pin changes needed.