### PR TITLE
chore: add CODEOWNERS — require alphaonedev approval on all changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require approval from alphaonedev
+* @alphaonedev


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring `@alphaonedev` approval on all file changes
- Once merged and branch protection updated, no PR can land on `main` or `develop` without explicit `@alphaonedev` approval