### PR TITLE
fix: update rustls-webpki 0.103.10 -> 0.103.12 (production)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Backport of the CVE fix from PR #168 (develop) to production (main).

- Fixes RUSTSEC-2026-0098: URI name constraints incorrectly accepted
- Fixes RUSTSEC-2026-0099: Wildcard name constraint bypass

## Change

`Cargo.lock` only — 3 lines changed. `rustls-webpki` 0.103.10 → 0.103.12.

Note: main has two `rustls-webpki` versions (0.101.7 and 0.103.10). Only 0.103.x is affected. The 0.101.7 version is not covered by these advisories.

## Verification

```
cargo update -p rustls-webpki@0.103.10
```