### PR TITLE
fix: strip +/- prefix operators in FTS query sanitizer

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -856,6 +856,8 @@ fn sanitize_fts_query(input: &str, use_or: bool) -> String {
                         && *c != ')'
                         && *c != ':'
                         && *c != '|'
+                        && *c != '+'
+                        && *c != '-'
                 })
                 .collect();
             if clean.is_empty() {
@@ -2311,6 +2313,12 @@ mod tests {
         // Empty input returns placeholder
         let sanitized3 = sanitize_fts_query("", true);
         assert_eq!(sanitized3, "\"_empty_\"");
+        // + and - prefix operators are stripped (prevents exclusion injection)
+        let sanitized4 = sanitize_fts_query("-secret +required", true);
+        assert!(!sanitized4.contains('-'));
+        assert!(!sanitized4.contains('+'));
+        assert!(sanitized4.contains("secret"));
+        assert!(sanitized4.contains("required"));
     }
 
     #[test]


### PR DESCRIPTION
## Finding #3 from issue #173

FTS5 uses `+` and `-` as prefix operators. Without stripping these, a malicious MCP client can send `-secret` to exclude specific memories from recall results.

## Change

Two characters added to the filter in `sanitize_fts_query`. Test added.

## Verification

`cargo test sanitize_fts` passes.