### PR TITLE
fix: replace permissive CORS with deny-by-default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -594,7 +594,7 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         ))
         .layer(TraceLayer::new_for_http())
         .layer(DefaultBodyLimit::max(2 * 1024 * 1024)) // 2MB default (bulk/import bodies capped at MAX_BULK_SIZE * per-memory limit)
-        .layer(CorsLayer::permissive())
+        .layer(CorsLayer::new())
         .with_state(state);
 
     let addr = format!("{}:{}", args.host, args.port);


### PR DESCRIPTION
## Finding #1 from issue #173

`CorsLayer::permissive()` allows any website to make cross-origin requests to the API, enabling browser-based CSRF attacks.

## Change

One line: `CorsLayer::permissive()` → `CorsLayer::new()`. Denies all cross-origin requests by default. Same-origin requests (curl, CLI, MCP) are unaffected. API key auth (already on develop) provides the authentication layer.