### PR TITLE
fix: db/mcp security hardening (promote, forget, consolidation, path leakage)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -481,8 +481,8 @@ pub fn delete(conn: &Connection, id: &str) -> Result<bool> {
     Ok(changed > 0)
 }
 
-/// Forget by pattern — delete memories matching namespace + FTS pattern + tier.
-pub fn forget(
+/// Count memories that would be deleted by forget (for `dry_run`).
+pub fn forget_count(
     conn: &Connection,
     namespace: Option<&str>,
     pattern: Option<&str>,
@@ -490,6 +490,82 @@ pub fn forget(
 ) -> Result<usize> {
     if pattern.is_none() && namespace.is_none() && tier.is_none() {
         anyhow::bail!("at least one of namespace, pattern, or tier is required");
+    }
+    if let Some(pat) = pattern {
+        let fts_query = sanitize_fts_query(pat, true);
+        let tier_str = tier.map(|t| t.as_str().to_string());
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE rowid IN (
+                SELECT m.rowid FROM memories_fts fts
+                JOIN memories m ON m.rowid = fts.rowid
+                WHERE memories_fts MATCH ?1
+                  AND (?2 IS NULL OR m.namespace = ?2)
+                  AND (?3 IS NULL OR m.tier = ?3)
+            )",
+            params![fts_query, namespace, tier_str],
+            |r| r.get(0),
+        )?;
+        return Ok(usize::try_from(count).unwrap_or(0));
+    }
+    let tier_str = tier.map(|t| t.as_str().to_string());
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE (?1 IS NULL OR namespace = ?1) AND (?2 IS NULL OR tier = ?2)",
+        params![namespace, tier_str],
+        |r| r.get(0),
+    )?;
+    Ok(usize::try_from(count).unwrap_or(0))
+}
+
+/// Forget by pattern — delete memories matching namespace + FTS pattern + tier.
+/// If `archive` is true, archives memories before deletion.
+pub fn forget(
+    conn: &Connection,
+    namespace: Option<&str>,
+    pattern: Option<&str>,
+    tier: Option<&Tier>,
+    archive: bool,
+) -> Result<usize> {
+    if pattern.is_none() && namespace.is_none() && tier.is_none() {
+        anyhow::bail!("at least one of namespace, pattern, or tier is required");
+    }
+
+    if archive {
+        // Archive matching memories before deletion
+        let now = Utc::now().to_rfc3339();
+        if let Some(pat) = pattern {
+            let fts_query = sanitize_fts_query(pat, true);
+            let tier_str = tier.map(|t| t.as_str().to_string());
+            conn.execute(
+                "INSERT OR REPLACE INTO archived_memories
+                 (id, tier, namespace, title, content, tags, priority, confidence,
+                  source, access_count, created_at, updated_at, last_accessed_at,
+                  expires_at, archived_at, archive_reason)
+                 SELECT id, tier, namespace, title, content, tags, priority, confidence,
+                        source, access_count, created_at, updated_at, last_accessed_at,
+                        expires_at, ?4, 'forget'
+                 FROM memories WHERE rowid IN (
+                    SELECT m.rowid FROM memories_fts fts
+                    JOIN memories m ON m.rowid = fts.rowid
+                    WHERE memories_fts MATCH ?1
+                      AND (?2 IS NULL OR m.namespace = ?2)
+                      AND (?3 IS NULL OR m.tier = ?3)
+                 )",
+                params![fts_query, namespace, tier_str, now],
+            )?;
+        } else {
+            let tier_str = tier.map(|t| t.as_str().to_string());
+            conn.execute(
+                "INSERT OR REPLACE INTO archived_memories
+                 (id, tier, namespace, title, content, tags, priority, confidence,
+                  source, access_count, created_at, updated_at, last_accessed_at,
+                  expires_at, archived_at, archive_reason)
+                 SELECT id, tier, namespace, title, content, tags, priority, confidence,
+                        source, access_count, created_at, updated_at, last_accessed_at,
+                        expires_at, ?3, 'forget'
+                 FROM memories WHERE (?1 IS NULL OR namespace = ?1) AND (?2 IS NULL OR tier = ?2)",
+                params![namespace, tier_str, now],
+            )?;
+        }
     }
 
     // If pattern provided, use FTS to find matching IDs
@@ -811,6 +887,15 @@ pub fn consolidate(
         all_tags.sort();
         all_tags.dedup();
         let tags_json = serde_json::to_string(&all_tags)?;
+        // Record source IDs in metadata for provenance (links would be CASCADE-deleted)
+        merged_metadata.insert(
+            "derived_from".to_string(),
+            serde_json::Value::Array(
+                ids.iter()
+                    .map(|id| serde_json::Value::String(id.clone()))
+                    .collect(),
+            ),
+        );
         let merged_metadata_value = serde_json::Value::Object(merged_metadata);
         crate::validate::validate_metadata(&merged_metadata_value)
             .context("merged metadata exceeds size limit")?;
@@ -822,10 +907,10 @@ pub fn consolidate(
             params![new_id, tier.as_str(), namespace, title, summary, tags_json, max_priority, source, total_access, now, metadata_json],
         )?;
 
-        for id in ids {
-            create_link(conn, &new_id, id, "derived_from")?;
-        }
-
+        // Delete source memories first. Note: we intentionally do NOT create
+        // derived_from links before deletion because ON DELETE CASCADE would
+        // immediately remove them. Instead, source IDs are recorded in the
+        // consolidated memory's metadata for provenance.
         for id in ids {
             delete(conn, id)?;
         }
@@ -2294,7 +2379,7 @@ mod tests {
         insert(&conn, &make_memory("B", "delete-me", Tier::Long, 5)).unwrap();
         insert(&conn, &make_memory("C", "keep", Tier::Long, 5)).unwrap();
 
-        let deleted = forget(&conn, Some("delete-me"), None, None).unwrap();
+        let deleted = forget(&conn, Some("delete-me"), None, None, false).unwrap();
         assert_eq!(deleted, 2);
         let remaining = list(&conn, None, None, 100, 0, None, None, None, None).unwrap();
         assert_eq!(remaining.len(), 1);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -553,6 +553,7 @@ pub async fn forget_memories(
         body.namespace.as_deref(),
         body.pattern.as_deref(),
         body.tier.as_ref(),
+        lock.3, // archive_on_gc
     ) {
         Ok(n) => Json(json!({"deleted": n})).into_response(),
         Err(e) => (

--- a/src/main.rs
+++ b/src/main.rs
@@ -1169,6 +1169,7 @@ fn cmd_forget(db_path: &Path, args: &ForgetArgs, json_out: bool) -> Result<()> {
         args.namespace.as_deref(),
         args.pattern.as_deref(),
         tier.as_ref(),
+        true, // always archive from CLI
     ) {
         Ok(n) => {
             if json_out {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -164,13 +164,14 @@ fn tool_definitions() -> Value {
             },
             {
                 "name": "memory_forget",
-                "description": "Bulk delete memories matching a pattern, namespace, or tier.",
+                "description": "Bulk delete memories matching a pattern, namespace, or tier. Archives before deletion. Use dry_run to preview.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "namespace": {"type": "string"},
                         "pattern": {"type": "string"},
-                        "tier": {"type": "string", "enum": ["short", "mid", "long"]}
+                        "tier": {"type": "string", "enum": ["short", "mid", "long"]},
+                        "dry_run": {"type": "boolean", "default": false, "description": "If true, report what would be deleted without deleting"}
                     }
                 }
             },
@@ -953,26 +954,45 @@ fn handle_promote(conn: &rusqlite::Connection, params: &Value) -> Result<Value, 
     } else {
         return Err("memory not found".into());
     };
-    // Atomic promote: set tier=long and clear expires_at in a single UPDATE
-    let now = chrono::Utc::now().to_rfc3339();
-    let changed = conn
-        .execute(
-            "UPDATE memories SET tier = 'long', expires_at = NULL, updated_at = ?1 WHERE id = ?2",
-            rusqlite::params![now, resolved_id],
-        )
-        .map_err(|e| e.to_string())?;
-    if changed == 0 {
+    let (found, _) = db::update(
+        conn,
+        &resolved_id,
+        None,
+        None,
+        Some(&Tier::Long),
+        None,
+        None,
+        None,
+        None,
+        Some(""), // empty string clears expires_at
+        None,
+    )
+    .map_err(|e| e.to_string())?;
+    if !found {
         return Err("memory not found".into());
     }
     Ok(json!({"promoted": true, "id": resolved_id, "tier": "long"}))
 }
 
-fn handle_forget(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+fn handle_forget(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    archive: bool,
+) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     let pattern = params["pattern"].as_str();
     let tier = params["tier"].as_str().and_then(Tier::from_str);
-    let deleted = db::forget(conn, namespace, pattern, tier.as_ref()).map_err(|e| e.to_string())?;
-    Ok(json!({"deleted": deleted}))
+    let dry_run = params["dry_run"].as_bool().unwrap_or(false);
+
+    if dry_run {
+        let count =
+            db::forget_count(conn, namespace, pattern, tier.as_ref()).map_err(|e| e.to_string())?;
+        return Ok(json!({"would_delete": count, "dry_run": true}));
+    }
+
+    let deleted =
+        db::forget(conn, namespace, pattern, tier.as_ref(), archive).map_err(|e| e.to_string())?;
+    Ok(json!({"deleted": deleted, "archived": archive}))
 }
 
 fn handle_stats(conn: &rusqlite::Connection, db_path: &Path) -> Result<Value, String> {
@@ -1319,6 +1339,7 @@ fn lookup_namespace_standard(conn: &rusqlite::Connection, namespace: &str) -> Op
 /// Example: cwd = /home/user/monorepo/frontend
 ///   → checks "frontend" (cwd), "monorepo" (parent), stops at home dir
 ///   → if "monorepo" has a standard, sets `parent_namespace` of "frontend" to "monorepo"
+#[allow(dead_code)]
 fn auto_register_path_hierarchy(conn: &rusqlite::Connection, namespace: &str) {
     // Only run if this namespace doesn't already have an explicit parent
     if db::get_namespace_parent(conn, namespace).is_some() {
@@ -1466,10 +1487,9 @@ fn handle_session_start(
         }
     }
 
-    // Auto-register parent chain from filesystem path (runs once, skips if parent already set)
-    if let Some(ns) = namespace {
-        auto_register_path_hierarchy(conn, ns);
-    }
+    // Auto-register parent chain from filesystem path — disabled by default
+    // to prevent filesystem structure leakage into the memory database.
+    // Uncomment or gate behind a config flag if desired.
 
     // Auto-prepend namespace standard (after LLM summary, separate field)
     inject_namespace_standard(conn, namespace, &mut response);
@@ -1556,7 +1576,7 @@ fn handle_request(
                 "memory_list" => handle_list(conn, arguments),
                 "memory_delete" => handle_delete(conn, arguments, vector_index),
                 "memory_promote" => handle_promote(conn, arguments),
-                "memory_forget" => handle_forget(conn, arguments),
+                "memory_forget" => handle_forget(conn, arguments, archive_on_gc),
                 "memory_stats" => handle_stats(conn, db_path),
                 "memory_update" => handle_update(conn, arguments, embedder, vector_index),
                 "memory_get" => handle_get(conn, arguments),


### PR DESCRIPTION
## Findings #4, #5, #7, #8 from issue #173

- **#7 handle_promote**: replaced raw SQL with `db::update` call, respects tier downgrade protection
- **#4 memory_forget**: archives before deletion (like GC), adds `dry_run` parameter to preview deletions
- **#5 consolidation**: stores source IDs in metadata instead of `derived_from` links (which were silently CASCADE-deleted)
- **#8 auto_register_path_hierarchy**: disabled to prevent filesystem structure leakage

## Verification

167 unit + 56 integration = 223 tests pass. `cargo fmt` and `cargo check` clean.