### PR TITLE
fix: restore rust-version = 1.87 minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ai-memory"
 version = "0.5.4-patch.5"
 edition = "2024"
+rust-version = "1.87"
 authors = ["AlphaOne LLC"]
 description = "AI-agnostic persistent memory system — MCP server, HTTP API, and CLI for any AI platform"
 license = "Apache-2.0"


### PR DESCRIPTION
Dropped during reconciliation merge (#180). One line addition to Cargo.toml.