### PR TITLE
fix: resolve clippy::map_unwrap_or pedantic errors blocking CI

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1041,7 +1041,7 @@ pub fn stats(conn: &Connection, db_path: &Path) -> Result<Stats> {
     let links_count: usize = conn
         .query_row("SELECT COUNT(*) FROM memory_links", [], |r| r.get(0))
         .unwrap_or(0);
-    let db_size_bytes = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
+    let db_size_bytes = std::fs::metadata(db_path).map_or(0, |m| m.len());
 
     Ok(Stats {
         total,

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -74,8 +74,7 @@ impl OllamaClient {
             .get(&url)
             .timeout(Duration::from_secs(5))
             .send()
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
+            .is_ok_and(|r| r.status().is_success())
     }
 
     /// Checks if the configured model is already pulled. If not, pulls it.


### PR DESCRIPTION
## Summary

- Two mechanical refactors to clear `clippy::map_unwrap_or` pedantic errors that recently started failing CI on `develop` after a clippy/Rust toolchain update.
- `src/db.rs:1044` — `Result::map(...).unwrap_or(0)` → `Result::map_or(0, ...)`
- `src/llm.rs:73-78` — `Result::map(...).unwrap_or(false)` → `Result::is_ok_and(...)`
- No behavioral change. Both call sites preserve identical semantics on `Ok` and `Err`.

## AI involvement

- **Agent:** Claude Opus 4.6 (1M context)
- **Authority class:** Standard (mechanical lint fix; no API change, no semantic change, no dependency change)
- **Human approver(s) for any Sensitive items:** n/a
- **ai-memory entries created/updated:** none for this PR
- **Co-Authored-By trailer present on every AI-authored commit:** yes

## Linked issues

Refs #189

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 230 passed, 0 failed (173 unit + 57 integration)
- [x] `cargo audit` clean
- [x] Manual security checklist (Engineering Standards §3.2) — n/a, mechanical refactor only
- [x] Documentation sync — n/a, no test count or MCP tool count changes
- [x] CLA on file for accountable contributor (`@alphaonedev`)

## Notes for reviewers

- This unblocks CI on develop. Once merged, PR #189 (AI Developer Workflow + Governance docs) will be rebased and its CI will go green.
- The two fixes are the *only* changes; `Cargo.lock` had a stale-version drift (`patch.5` → `patch.6`) that I deliberately left out to keep this PR minimal.