### PR TITLE
docs(task 1.2): agent_id coverage + recall/TOON tests + follow-up issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,60 @@ SQLite with WAL mode, FTS5 virtual table for full-text search, schema version v7
 
 - `AI_MEMORY_DB` — database path override
 - `AI_MEMORY_NO_CONFIG=1` — skip loading `~/.config/ai-memory/config.toml`
+- `AI_MEMORY_AGENT_ID` — default `agent_id` for memories this process writes (see §Agent Identity below)
 - `RUST_LOG` — tracing filter (e.g. `RUST_LOG=ai_memory=debug`)
 
 Config precedence: CLI flags > config file > compiled defaults.
+
+### Agent Identity (NHI) — `metadata.agent_id`
+
+Every stored memory carries `metadata.agent_id` — a best-effort Non-Human Identity
+marker. See design discussion on issue #148. **agent_id is a *claimed* identity,
+not an *attested* one** — do not use it for security decisions without pairing
+with agent registration (Task 1.3, upcoming).
+
+**Resolution precedence (CLI and MCP):**
+
+1. Explicit value from caller (`--agent-id` flag, MCP `agent_id` tool param, or
+   `metadata.agent_id` embedded in an MCP store request)
+2. `AI_MEMORY_AGENT_ID` environment variable
+3. (MCP only) Value captured from `initialize.clientInfo.name` →
+   `ai:<client>@<hostname>:pid-<pid>`
+4. `host:<hostname>:pid-<pid>-<uuid8>` (stable per-process)
+5. `anonymous:pid-<pid>-<uuid8>` (fallback if hostname unavailable)
+
+**HTTP daemon mode** is multi-tenant, so there is no process-level default:
+
+1. `agent_id` field in `POST /api/v1/memories` body
+2. `X-Agent-Id` request header
+3. Per-request `anonymous:req-<uuid8>` (logged at WARN)
+
+**Validation:** `^[A-Za-z0-9_\-:@./]{1,128}$` — permits prefixed forms
+(`ai:`, `host:`, `anonymous:`), `@` scope separator, `/` for future SPIFFE-style
+ids. Rejects whitespace, null bytes, control chars, shell metacharacters.
+
+**Immutability:** Once a memory is stored, `metadata.agent_id` is preserved across
+update, dedup (UPSERT), MCP `memory_update`, HTTP `PUT /memories/{id}`, import,
+sync, and consolidate. Preservation is enforced at both caller layer
+(`identity::preserve_agent_id`) and SQL layer (`json_set` CASE clauses in
+`db::insert` and `db::insert_if_newer`).
+
+**Filter by agent_id:** `list` and `search` accept `--agent-id <id>` (CLI), the
+`agent_id` property (MCP tool), or `?agent_id=<id>` (HTTP query param).
+
+**Special metadata keys produced by the system** (do not overwrite):
+
+- `imported_from_agent_id` — original claim preserved when `ai-memory import`
+  restamps agent_id with caller's id (absent when `--trust-source` is passed)
+- `consolidated_from_agents` — array of source authors, preserved on
+  `memory_consolidate` (the consolidator's id becomes `agent_id`)
+- `mined_from` — source format tag (`claude` / `chatgpt` / `slack`) stamped by
+  `ai-memory mine` alongside the caller's `agent_id`
+
+**Defaults that leak:** The fallback `host:<hostname>:pid-…` exposes hostname and
+PID. When writing memories to a shared or upstream database, set `--agent-id` or
+`AI_MEMORY_AGENT_ID` to something scrubbed (an opaque identifier, `alice`, etc.).
+Tracking issue: #198.
 
 ## Adding New Functionality
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (24 endpoints on port 90
 - **Contradiction resolution** -- mark one memory as superseding another, demote the loser
 - **Forget by pattern** -- bulk delete by namespace + FTS pattern + tier
 - **Source tracking** -- tracks origin: user, claude, hook, api, cli, import, consolidation, system
+- **Agent identity (NHI)** -- every memory carries `metadata.agent_id` (claimed identity) with defense-in-depth immutability across update/dedup/import/sync/consolidate; filter `list`/`search` by agent
 - **Tagging** -- comma-separated tags with filter support
 
 ### Interfaces

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -206,6 +206,7 @@ At the `semantic` tier and above, ai-memory downloads a sentence-transformer mod
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AI_MEMORY_DB` | `ai-memory.db` | Database path (overridden by `--db`) |
+| `AI_MEMORY_AGENT_ID` | (auto) | Default `agent_id` stamped on memories this process writes. Used when no `--agent-id` flag is passed. See §Agent Identity below. |
 | `RUST_LOG` | (none) | Logging filter (e.g., `ai_memory=info,tower_http=debug`) |
 | `AI_MEMORY_NO_CONFIG` | (none) | Set to `1` to skip config file loading (useful for testing) |
 
@@ -482,6 +483,108 @@ Rebuild the FTS index (if it becomes corrupt):
 ```bash
 sqlite3 /path/to/ai-memory.db "INSERT INTO memories_fts(memories_fts) VALUES('rebuild')"
 ```
+
+## Agent Identity (NHI)
+
+Introduced in v0.6.0 via Task 1.2. Every memory carries `metadata.agent_id`, a
+best-effort Non-Human Identity marker for the agent that stored it. Design
+context and the threat model are tracked on issue [#148](https://github.com/alphaonedev/ai-memory-mcp/issues/148).
+
+### Trust model
+
+**`metadata.agent_id` is a *claimed* identity, not an *attested* one.** Any
+caller able to invoke the CLI / MCP / HTTP API can set any well-formed
+`agent_id`. Use it for provenance, audit, and filter scoping — **never as an
+authorization gate on its own.** True attestation arrives with agent
+registration (Task 1.3).
+
+### Resolution precedence
+
+**CLI and MCP (process-scoped):**
+
+1. Explicit caller value (`--agent-id`, MCP `agent_id` tool param, or
+   `metadata.agent_id` embedded in an MCP store request)
+2. `AI_MEMORY_AGENT_ID` environment variable
+3. (MCP only) `initialize.clientInfo.name` → `ai:<client>@<hostname>:pid-<pid>`
+4. `host:<hostname>:pid-<pid>-<uuid8>` (stable for the process's lifetime)
+5. `anonymous:pid-<pid>-<uuid8>` (only when hostname is unavailable)
+
+**HTTP daemon (request-scoped, no process-level default):**
+
+1. `agent_id` field in `POST /api/v1/memories` body
+2. `X-Agent-Id` request header
+3. `anonymous:req-<uuid8>` (synthesized per-request, logged at WARN)
+
+### Validation
+
+Server-side validator:
+`^[A-Za-z0-9_\-:@./]{1,128}$`
+
+This admits prefixed forms (`ai:`, `host:`, `anonymous:`, `human:`, `system:`),
+the `@` scope separator, `/` for future SPIFFE ids, and dots. Rejects whitespace,
+null bytes, ASCII control chars, and shell metacharacters. Payloads attempting
+SQL injection, JSON-path break-outs, or path traversal are all either validator-
+rejected or neutralized by the sanitizer (Unicode homoglyphs rejected outright).
+
+### Immutability guarantees
+
+Once a memory is stored, `metadata.agent_id` is preserved across every mutation:
+
+| Path | Preservation mechanism |
+|---|---|
+| `db::insert` UPSERT (dedup) | SQL `CASE WHEN json_extract(...) IS NOT NULL THEN json_set(...) ELSE excluded.metadata END` |
+| `db::insert_if_newer` (sync merge) | Same SQL CASE WHEN clause |
+| `db::update` with caller-supplied metadata | Caller preserves via `identity::preserve_agent_id` (every caller does — MCP `handle_store` dedup, MCP `handle_update`, HTTP `update_memory`) |
+| `db::consolidate` | Takes `consolidator_agent_id` parameter; original authors preserved in `metadata.consolidated_from_agents` |
+
+Admins running audit queries can rely on `metadata.agent_id` never changing
+post-write unless the memory is deleted and recreated.
+
+### Special metadata keys produced by the system
+
+These are written by the server; treat as read-only in queries:
+
+| Key | Written when | Shape |
+|---|---|---|
+| `agent_id` | Every write | String matching validator regex |
+| `imported_from_agent_id` | `ai-memory import` without `--trust-source`, when the incoming JSON's `agent_id` differed from the caller's | String |
+| `consolidated_from_agents` | `memory_consolidate` / `auto-consolidate` merges N sources | Array of deduplicated strings |
+| `mined_from` | `ai-memory mine` (Claude / ChatGPT / Slack export import) | String: `"claude"`, `"chatgpt"`, `"slack"` |
+| `derived_from` | `memory_consolidate` — array of source memory ids | Array of UUID strings |
+
+### Filtering by `agent_id`
+
+`list` and `search` accept an `agent_id` filter (exact match via SQLite
+`json_extract`):
+
+- CLI: `ai-memory list --agent-id alice`, `ai-memory search "x" --agent-id alice`
+- MCP: `agent_id` property on the `memory_list` / `memory_search` tool inputs
+- HTTP: `GET /api/v1/memories?agent_id=alice`, `GET /api/v1/search?q=x&agent_id=alice`
+
+`recall` does **not** accept the filter (by spec).
+
+### Operational warnings
+
+- **Default identities leak infrastructure.** When no explicit `agent_id` is
+  set, memories are stamped `host:<hostname>:pid-<pid>-<uuid8>`, exposing the
+  host's name and the running PID. For multi-tenant databases or any scenario
+  where the DB is shared outside its origin host, require callers to set
+  `AI_MEMORY_AGENT_ID` or `--agent-id` explicitly. See [#198] for tracked work
+  on a config-level opt-out.
+- **HTTP per-request anonymous fallback** emits a WARN log line
+  (`HTTP memory write without agent_id body field or X-Agent-Id header;
+  assigned anonymous:req-<uuid8>`). Grep for this in production logs to spot
+  unauthenticated writes.
+- **Import provenance** is restamped to the current caller by default. If you
+  need to restore legacy `agent_id` values verbatim (e.g., migrating a backup),
+  pass `--trust-source` explicitly.
+
+### Related tracked issues
+
+- [#148](https://github.com/alphaonedev/ai-memory-mcp/issues/148) — Task 1.2 design & NHI assessment
+- [#196](https://github.com/alphaonedev/ai-memory-mcp/issues/196) — Store responses don't echo resolved agent_id
+- [#197](https://github.com/alphaonedev/ai-memory-mcp/issues/197) — Filter values should run through validator
+- [#198](https://github.com/alphaonedev/ai-memory-mcp/issues/198) — Config-level opt-out for hostname/PID leak
 
 ## Security Hardening
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -967,6 +967,86 @@ Show archive statistics: total count and breakdown by namespace.
 
 ---
 
+## Agent Identity (NHI) — `metadata.agent_id`
+
+Every stored memory carries a `metadata.agent_id` tag that records **who (or what) stored it**. You'll see it in `recall`, `list`, `search`, and `get` responses. You can filter by it too.
+
+### Quick examples
+
+```bash
+# Default: a host-qualified id is auto-generated
+ai-memory store -T "note" -c "content"
+# stored memory's metadata.agent_id = "host:your-hostname:pid-12345-abcdef01"
+
+# Use an explicit identity
+ai-memory --agent-id alice store -T "note" -c "content"
+
+# Or via environment variable
+AI_MEMORY_AGENT_ID=alice ai-memory store -T "note" -c "content"
+
+# Filter by agent
+ai-memory list --agent-id alice
+ai-memory search "some query" --agent-id alice
+```
+
+### Resolution precedence
+
+The identity that ends up in `metadata.agent_id` is resolved in order:
+
+1. The explicit value you passed (flag, env var, MCP param, or HTTP body field)
+2. `AI_MEMORY_AGENT_ID` environment variable
+3. (MCP server only) the MCP client's `initialize.clientInfo.name` →
+   `ai:<client>@<hostname>:pid-<pid>`
+4. `host:<hostname>:pid-<pid>-<uuid8>` — a collision-free host-qualified default
+5. `anonymous:pid-<pid>-<uuid8>` — last-resort fallback if hostname lookup fails
+
+For the **HTTP API**, the precedence within a single request is:
+
+1. `agent_id` field in the POST/PUT JSON body
+2. `X-Agent-Id` request header
+3. Per-request synthesized `anonymous:req-<uuid8>` (logged at WARN)
+
+### Format rules
+
+Valid `agent_id` values match `^[A-Za-z0-9_\-:@./]{1,128}$`. Prefixed forms
+(`ai:`, `host:`, `anonymous:`, and future `human:` / `system:`) are reserved for
+specific roles but not enforced. Whitespace, null bytes, control chars, and shell
+metacharacters are rejected at validation time.
+
+### Immutability
+
+Once a memory carries an `agent_id`, that value is preserved across `update`,
+`consolidate`, `import`, `sync`, and upsert dedup. You can update a memory's
+content as a different agent, but the original author's `agent_id` stays
+recorded. `import` restamps with the current caller's id by default — pass
+`--trust-source` to import the embedded ids as-is (use only for legitimate
+backup restoration).
+
+### Special metadata fields produced by the system
+
+These extra keys may appear alongside `agent_id` — they're informational:
+
+- `imported_from_agent_id` — the original claimed agent_id from JSON when
+  `import` restamped with your caller id (absent with `--trust-source`)
+- `consolidated_from_agents` — array of source authors when a memory was produced
+  by `consolidate`
+- `mined_from` — source format tag (`claude` / `chatgpt` / `slack`) when the
+  memory came from `ai-memory mine`
+
+### Trust model
+
+`agent_id` is a **claimed** identity, not an **attested** one. Anyone who can
+invoke `ai-memory` can set any `agent_id` they want (subject to the format
+regex). Use it for provenance and filtering, not for security decisions. True
+attestation via agent registration arrives with Task 1.3.
+
+### Default leaks hostname + PID
+
+The auto-generated `host:<hostname>:pid-<pid>-<uuid8>` default exposes your
+hostname and process id. When exporting / syncing / sharing a DB externally,
+pass `--agent-id` or `AI_MEMORY_AGENT_ID` to scrub that leakage. Tracking issue
+#198 covers an opt-out config flag.
+
 ## Zero Token Cost
 
 Unlike built-in memory systems (Claude Code auto-memory, ChatGPT memory) that load your entire memory into every conversation, ai-memory uses **zero context tokens until recalled**. Only relevant memories come back, ranked by a 6-factor scoring algorithm. For Claude Code users: disable auto-memory (`"autoMemoryEnabled": false` in settings.json) to stop paying for 200+ lines of idle context.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3865,3 +3865,174 @@ fn test_mine_stamps_caller_agent_id() {
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_dir_all(&mine_dir);
 }
+
+/// Task 1.2 coverage gap: verify `metadata.agent_id` is present in the
+/// `memory_recall` response shape. The spec deliberately excluded the recall
+/// path from `--agent-id` filtering, but the field still needs to be visible
+/// in the response for downstream tooling to act on provenance.
+#[test]
+fn test_agentid_visible_in_recall_response() {
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+    let db_path = fresh_db();
+
+    // Store two memories by different agents. Using non-hyphenated tokens so
+    // FTS5 tokenizer doesn't split them.
+    for (agent, title) in [("alice", "RecallAgentATitle"), ("bob", "RecallAgentBTitle")] {
+        let out = cmd(binary)
+            .args([
+                "--db",
+                db_path.to_str().unwrap(),
+                "--agent-id",
+                agent,
+                "--json",
+                "store",
+                "-T",
+                title,
+                "-c",
+                "DistinctiveRecallToken body content",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    // Recall via MCP in JSON format — agent_id must be visible on every returned memory.
+    let req1 = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let req2 = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"memory_recall","arguments":{"context":"DistinctiveRecallToken","format":"json"}}}"#;
+
+    let output = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "mcp",
+            "--tier",
+            "keyword",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                writeln!(stdin, "{req1}").ok();
+                writeln!(stdin, "{req2}").ok();
+            }
+            drop(child.stdin.take());
+            child.wait_with_output()
+        })
+        .expect("failed to run mcp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let last_line = stdout.trim().lines().last().unwrap();
+    let resp: serde_json::Value = serde_json::from_str(last_line).unwrap();
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    let data: serde_json::Value = serde_json::from_str(text).unwrap();
+    let memories = data["memories"].as_array().expect("memories array");
+    assert!(
+        memories.len() >= 2,
+        "recall should return both memories, got: {data}"
+    );
+
+    let agents: Vec<String> = memories
+        .iter()
+        .filter_map(|m| m["metadata"]["agent_id"].as_str().map(ToString::to_string))
+        .collect();
+    assert!(
+        agents.contains(&"alice".to_string()),
+        "recall memories must include alice's agent_id, got: {agents:?}"
+    );
+    assert!(
+        agents.contains(&"bob".to_string()),
+        "recall memories must include bob's agent_id, got: {agents:?}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+/// Task 1.2 coverage gap: verify `agent_id` round-trips through both TOON
+/// non-compact (`format: "toon"`) and JSON formats. TOON **compact** format
+/// deliberately omits `metadata` for token efficiency (see src/toon.rs
+/// `MEMORY_FIELDS_COMPACT`), so `agent_id` is NOT visible in that format —
+/// that's a known tradeoff tracked separately. This test pins the two formats
+/// where agent_id must show up.
+#[test]
+fn test_agentid_visible_in_toon_and_json() {
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+    let db_path = fresh_db();
+
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            "toon-alice",
+            "--json",
+            "store",
+            "-T",
+            "ToonTestMemoryTitle",
+            "-c",
+            "ToonDistinctiveContent body",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Non-compact TOON — metadata column present, agent_id must appear.
+    let req1 = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let req_toon = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"memory_list","arguments":{"format":"toon"}}}"#;
+    let req_json = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"memory_list","arguments":{"format":"json"}}}"#;
+
+    let output = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "mcp",
+            "--tier",
+            "keyword",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                writeln!(stdin, "{req1}").ok();
+                writeln!(stdin, "{req_toon}").ok();
+                writeln!(stdin, "{req_json}").ok();
+            }
+            drop(child.stdin.take());
+            child.wait_with_output()
+        })
+        .expect("failed to run mcp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert!(
+        lines.len() >= 3,
+        "expected 3 responses (init+2 tools), got:\n{stdout}"
+    );
+
+    // lines[0] = initialize response; lines[1] = TOON tool call; lines[2] = JSON tool call.
+    // TOON (non-compact)
+    let resp_toon: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let text_toon = resp_toon["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text_toon.contains("toon-alice"),
+        "TOON (non-compact) must surface agent_id within metadata; got:\n{text_toon}"
+    );
+
+    // JSON
+    let resp_json: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+    let text_json = resp_json["result"]["content"][0]["text"].as_str().unwrap();
+    let data: serde_json::Value = serde_json::from_str(text_json).unwrap();
+    let stored_agent = data["memories"][0]["metadata"]["agent_id"].as_str();
+    assert_eq!(
+        stored_agent,
+        Some("toon-alice"),
+        "JSON response must surface agent_id; got:\n{data}"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}


### PR DESCRIPTION
## Summary

Closes the user-facing documentation gap and test-coverage gap flagged during the Task 1.2 post-merge review. All items approved by maintainer in session. No production code changed.

## Changes

### Docs (4 files, +235 lines)

| File | Added |
|---|---|
| `CLAUDE.md` | Agent Identity section: env var, precedence chain, HTTP mode, validation, immutability, special metadata keys, hostname-leak warning |
| `docs/USER_GUIDE.md` | Full end-user section: CLI/env/HTTP usage examples, precedence, format rules, immutability story, trust-model disclaimer, default-leak warning |
| `docs/ADMIN_GUIDE.md` | Operational section: resolution precedence, validation regex, immutability mechanisms (SQL + caller-layer), special metadata keys table, WARN log semantics, cross-links to tracking issues |
| `README.md` | 1-line feature bullet promoting agent_id to the top-level features list |

### Tests (+171 lines, +2 tests)

- `test_agentid_visible_in_recall_response` — MCP `memory_recall` JSON response must surface `metadata.agent_id` on every returned memory (never previously tested; spec excluded recall from filter but the field must still render in responses)
- `test_agentid_visible_in_toon_and_json` — pins the contract that TOON non-compact (`format: "toon"`) and JSON both surface `agent_id`. TOON compact (default) intentionally omits `metadata` for token efficiency; that's now tracked as follow-up #199

## Follow-up issues filed

During this pass, 4 non-blocking findings from the Task 1.2 red-team were promoted from PR comments into tracked issues:

- **#196** — store responses don't echo resolved `agent_id` (finding B, COSMETIC)
- **#197** — filter values on list/search should run through validator for consistency (finding C, LOW)
- **#198** — config-level opt-out for hostname/PID leak in default agent_id (finding D, MEDIUM, by-design tradeoff)
- **#199** — TOON compact format omits agent_id (finding E, discovered during this PR's test work)

None block `v0.6.0-alpha.1`. All can be addressed in successive alphas or deferred to post-GA.

## Test counts

- Before: 192 unit + 70 integration = 262
- After: 192 unit + **72** integration = **264**

## CI gates (verified locally before push)

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ (192 + 72 = 264 pass)

## Targets

`release/v0.6.0` — this is Task 1.2 hardening for the v0.6.0 train. Not targeting `develop` or `main` directly.

## Test plan

- [ ] CI green on ubuntu + macOS + windows (all 3 now required)
- [ ] Merge via standard §5.4 sole-approver + ruleset relax/restore pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
