### PR TITLE
feat: agent registration (task 1.3) — closes #149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,31 @@ Successive alphas will be tagged at each track completion (A/B/C/D per
 - **Workflow §8.5.1**: multi-agent operation cross-reference + lock acquisition
   discipline.
 
+### Added — Task 1.3 (Agent Registration)
+
+- **`_agents` reserved namespace** holding one long-tier memory per registered
+  agent (`title = "agent:<agent_id>"`, `metadata.agent_type` +
+  `metadata.capabilities` + `metadata.registered_at` + `metadata.last_seen_at`).
+- **MCP tools**: `memory_agent_register`, `memory_agent_list` (brings tool count
+  to **28**).
+- **HTTP endpoints**: `POST /api/v1/agents`, `GET /api/v1/agents` (brings
+  endpoint count to **26**).
+- **CLI**: `ai-memory agents register --agent-id … --agent-type … [--capabilities …]`
+  and `ai-memory agents list` (default sub-command).
+- **`VALID_AGENT_TYPES`** closed set: `ai:claude-opus-4.6`, `ai:claude-opus-4.7`,
+  `ai:codex-5.4`, `ai:grok-4.2`, `human`, `system`. Enforced by
+  `validate_agent_type`.
+- **Re-registration semantics**: upsert refreshes `agent_type`, `capabilities`,
+  `last_seen_at`; preserves `registered_at` and `metadata.agent_id`
+  (rides existing immutability SQL clause).
+- **Trust model unchanged**: `agent_id` is still *claimed, not attested*. Future
+  work will pair registration with provable attestation.
+- **6 new integration tests**: register+list, duplicate-preserves-registered-at,
+  invalid-type-rejected, invalid-id-rejected, namespace-isolation (no leak into
+  `global`), and raw MCP JSON-RPC register/list roundtrip.
+
 ### Pending — remaining Phase 1 tasks to land in this release train
 
-- Task 1.3 — Agent Registration — depends on 1.2 ✓
 - Task 1.4 — Hierarchical Namespace Paths — depends on 1.1 ✓
 - Task 1.5 — Visibility Rules — depends on 1.4
 - Task 1.6 — N-Level Rule Inheritance — depends on 1.4
@@ -98,7 +120,7 @@ Successive alphas will be tagged at each track completion (A/B/C/D per
 
 ### Release engineering
 
-- Branched from `develop` @ `ee6cf9a` on 2026-04-16.
+- Branched from `develop` @ `ee6cf9a` on 2026-04-16; all Phase 1 work now lands on `release/v0.6.0`.
 - Successive alphas (`v0.6.0-alpha.N`) tagged at each track completion; `v0.6.0-rc.1`
   at feature-complete; `v0.6.0` GA when Phase 1 is done and external review window
   closes.

--- a/docs/PHASE-1.md
+++ b/docs/PHASE-1.md
@@ -10,7 +10,7 @@
 ## Prerequisites
 
 - Rust 1.87+ with `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` passing
-- All work branches from `develop`, PRs target `develop`
+- All Phase 1 work branches from `release/v0.6.0`, PRs target `release/v0.6.0` (the v0.6.0 integration train — `develop` only receives work between release trains)
 - AI coding agents: Claude Code Opus 4.6, OpenAI Codex 5.4, or xAI Grok 4.2 (or via IDE plugin in Cursor/Windsurf)
 - All code is Rust. No Python, no TypeScript, no shell scripts in core.
 - Follow [ENGINEERING_STANDARDS.md](ENGINEERING_STANDARDS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
@@ -466,7 +466,7 @@ Requirements:
 7. Write minimum 8 new unit tests covering metadata CRUD, migration, roundtrip, and default values
 
 Constraints:
-- Branch from `develop`: git checkout develop && git checkout -b feature/schema-metadata
+- Branch from `release/v0.6.0`: git checkout release/v0.6.0 && git checkout -b feature/schema-metadata
 - Must pass: cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic
 - Must pass: AI_MEMORY_NO_CONFIG=1 cargo test
 - All existing 192 tests must continue to pass
@@ -499,7 +499,7 @@ Requirements:
 7. Write minimum 4 new unit tests
 
 Constraints:
-- Branch: feature/agent-identity from develop
+- Branch: feature/agent-identity from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -526,7 +526,7 @@ Requirements:
 6. Write minimum 4 new unit tests
 
 Constraints:
-- Branch: feature/agent-register from develop
+- Branch: feature/agent-register from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -571,7 +571,7 @@ Requirements:
 Key design decision: The / character is currently rejected by validate_namespace(). You need to allow / as a delimiter while still rejecting \ and null bytes. Keep all other existing validation rules.
 
 Constraints:
-- Branch: feature/hierarchical-namespaces from develop
+- Branch: feature/hierarchical-namespaces from release/v0.6.0
 - Pedantic clippy clean, all tests pass
 - ZERO breaking changes to existing flat namespace behavior
 - No new unwrap() in production code
@@ -612,7 +612,7 @@ WHERE (json_extract(metadata, '$.scope') = 'collective')
    ... etc
 
 Constraints:
-- Branch: feature/visibility-rules from develop
+- Branch: feature/visibility-rules from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -640,7 +640,7 @@ Requirements:
 5. Write minimum 6 new unit tests: 4-level chain, missing intermediates skipped, existing 3-level behavior unchanged
 
 Constraints:
-- Branch: feature/n-level-rules from develop
+- Branch: feature/n-level-rules from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -669,7 +669,7 @@ Requirements:
 6. Write minimum 4 new unit tests
 
 Constraints:
-- Branch: feature/vertical-promotion from develop
+- Branch: feature/vertical-promotion from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -716,7 +716,7 @@ Requirements:
 8. Write minimum 6 new unit tests
 
 Constraints:
-- Branch: feature/governance-metadata from develop
+- Branch: feature/governance-metadata from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -750,7 +750,7 @@ Requirements:
 Key design: When governance blocks an operation, return a response like {"status": "pending", "pending_id": "...", "reason": "governance requires approval"} instead of an error. The caller knows the action was received but not yet executed.
 
 Constraints:
-- Branch: feature/governance-enforcement from develop
+- Branch: feature/governance-enforcement from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -778,7 +778,7 @@ Requirements:
 4. Write minimum 6 new unit tests
 
 Constraints:
-- Branch: feature/governance-approvers from develop
+- Branch: feature/governance-approvers from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -813,7 +813,7 @@ Requirements:
 The value: LLMs have finite context windows. Being able to say "give me the most relevant memories that fit in 4K tokens" means agents never waste context on low-relevance memories. This is a capability no other memory system offers.
 
 Constraints:
-- Branch: feature/budget-recall from develop
+- Branch: feature/budget-recall from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -841,7 +841,7 @@ Requirements:
 7. Write minimum 4 new unit tests
 
 Constraints:
-- Branch: feature/hierarchy-recall from develop
+- Branch: feature/hierarchy-recall from release/v0.6.0
 - Pedantic clippy clean, all tests pass, no new unwrap()
 ```
 
@@ -863,7 +863,7 @@ Week 2:
   Collab 3: [1.9 Governance Enforcement] → [1.10 Approvers] → [1.12 Hierarchy Recall]
 
 Week 3:
-  All:      Integration testing, merge to develop, red team review
+  All:      Integration testing, merge release/v0.6.0 → main, red team review
             Tag v0.6.0, release
 ```
 
@@ -871,7 +871,7 @@ Week 3:
 
 ## Integration Test Plan (Post-Merge)
 
-After all 12 tasks merge to `develop`, run the full integration scenario:
+After all 12 tasks merge to `release/v0.6.0`, run the full integration scenario:
 
 1. **Register 3 agents** with different types (AI Claude, AI Codex, human)
 2. **Create namespace hierarchy:** `testorg/engineering/platform/agent-1`
@@ -905,13 +905,13 @@ After all 12 tasks merge to `develop`, run the full integration scenario:
 
 ## PR Checklist (Every Task)
 
-- [ ] Branch from `develop`
+- [ ] Branch from `release/v0.6.0`
 - [ ] `cargo fmt --check` clean
 - [ ] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` zero warnings
 - [ ] `AI_MEMORY_NO_CONFIG=1 cargo test` all passing
 - [ ] `cargo audit` clean
 - [ ] New tests cover all new functionality (minimum counts listed per task)
 - [ ] SPDX header on any new files
-- [ ] PR targets `develop`
+- [ ] PR targets `release/v0.6.0`
 - [ ] PR description states what changed and why
 - [ ] CLA signed (first PR only)

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::models::{
-    Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD, Stats, Tier, TierCount,
+    AGENTS_NAMESPACE, AgentRegistration, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD,
+    Stats, Tier, TierCount,
 };
 
 const SCHEMA: &str = r"
@@ -1051,6 +1052,131 @@ pub fn list_namespaces(conn: &Connection) -> Result<Vec<NamespaceCount>> {
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(Into::into)
+}
+
+/// Register or refresh an agent in the reserved `_agents` namespace.
+///
+/// Each agent is stored as a long-tier memory with `title = "agent:<agent_id>"`.
+/// Duplicate registration for the same `agent_id` refreshes `last_seen_at` and
+/// overwrites `agent_type` + `capabilities`, while preserving the original
+/// `registered_at` timestamp (caller-observable provenance).
+///
+/// Returns the stored memory ID.
+pub fn register_agent(
+    conn: &Connection,
+    agent_id: &str,
+    agent_type: &str,
+    capabilities: &[String],
+) -> Result<String> {
+    let title = format!("agent:{agent_id}");
+    let now = Utc::now().to_rfc3339();
+
+    // Preserve original registered_at across re-registration.
+    let registered_at = conn
+        .query_row(
+            "SELECT json_extract(metadata, '$.registered_at') FROM memories
+             WHERE namespace = ?1 AND title = ?2",
+            params![AGENTS_NAMESPACE, &title],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| now.clone());
+
+    let caps_json: Vec<serde_json::Value> = capabilities
+        .iter()
+        .map(|c| serde_json::Value::String(c.clone()))
+        .collect();
+
+    let metadata = serde_json::json!({
+        "agent_id": agent_id,
+        "agent_type": agent_type,
+        "capabilities": caps_json,
+        "registered_at": registered_at,
+        "last_seen_at": now,
+    });
+
+    let content = serde_json::to_string(&metadata)
+        .context("failed to serialize agent registration content")?;
+
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: AGENTS_NAMESPACE.to_string(),
+        title,
+        content,
+        tags: vec!["agent-registration".to_string()],
+        priority: 5,
+        confidence: 1.0,
+        source: "system".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata,
+    };
+
+    insert(conn, &mem)
+}
+
+/// List every registered agent. Rows are drawn from the `_agents` namespace
+/// and parsed out of each memory's metadata.
+pub fn list_agents(conn: &Connection) -> Result<Vec<AgentRegistration>> {
+    let now = Utc::now().to_rfc3339();
+    let mut stmt = conn.prepare(
+        "SELECT metadata FROM memories
+         WHERE namespace = ?1
+           AND (expires_at IS NULL OR expires_at > ?2)
+         ORDER BY json_extract(metadata, '$.registered_at') ASC",
+    )?;
+    let rows = stmt.query_map(params![AGENTS_NAMESPACE, now], |row| {
+        row.get::<_, String>(0)
+    })?;
+
+    let mut agents = Vec::new();
+    for r in rows {
+        let raw = r?;
+        let meta: serde_json::Value =
+            serde_json::from_str(&raw).context("failed to parse agent metadata as JSON")?;
+        let agent_id = meta
+            .get("agent_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let agent_type = meta
+            .get("agent_type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let capabilities: Vec<String> = meta
+            .get("capabilities")
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let registered_at = meta
+            .get("registered_at")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let last_seen_at = meta
+            .get("last_seen_at")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        agents.push(AgentRegistration {
+            agent_id,
+            agent_type,
+            capabilities,
+            registered_at,
+            last_seen_at,
+        });
+    }
+    Ok(agents)
 }
 
 pub fn stats(conn: &Connection, db_path: &Path) -> Result<Stats> {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -19,7 +19,7 @@ use crate::config::ResolvedTtl;
 use crate::db;
 use crate::models::{
     CreateMemory, ForgetQuery, LinkBody, ListQuery, Memory, MemoryLink, RecallBody, RecallQuery,
-    SearchQuery, Tier, UpdateMemory,
+    RegisterAgentBody, SearchQuery, Tier, UpdateMemory,
 };
 use crate::validate;
 
@@ -165,6 +165,76 @@ pub async fn create_memory(
             }
             (StatusCode::CREATED, Json(response)).into_response()
         }
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn register_agent(
+    State(state): State<Db>,
+    Json(body): Json<RegisterAgentBody>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_agent_id(&body.agent_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate::validate_agent_type(&body.agent_type) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let capabilities = body.capabilities.unwrap_or_default();
+    if let Err(e) = validate::validate_capabilities(&capabilities) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+
+    let lock = state.lock().await;
+    match db::register_agent(&lock.0, &body.agent_id, &body.agent_type, &capabilities) {
+        Ok(id) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "registered": true,
+                "id": id,
+                "agent_id": body.agent_id,
+                "agent_type": body.agent_type,
+                "capabilities": capabilities,
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn list_agents(State(state): State<Db>) -> impl IntoResponse {
+    let lock = state.lock().await;
+    match db::list_agents(&lock.0) {
+        Ok(agents) => (
+            StatusCode::OK,
+            Json(json!({"count": agents.len(), "agents": agents})),
+        )
+            .into_response(),
         Err(e) => {
             tracing::error!("handler error: {e}");
             (

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,32 @@ enum Command {
     Mine(MineArgs),
     /// Manage the memory archive (list, restore, purge, stats)
     Archive(ArchiveArgs),
+    /// Register or list agents (Task 1.3)
+    Agents(AgentsArgs),
+}
+
+#[derive(Args)]
+struct AgentsArgs {
+    #[command(subcommand)]
+    action: Option<AgentsAction>,
+}
+
+#[derive(Subcommand)]
+enum AgentsAction {
+    /// List registered agents (default)
+    List,
+    /// Register or refresh an agent
+    Register {
+        /// Agent identifier
+        #[arg(long)]
+        agent_id: String,
+        /// Agent type (ai:claude-opus-4.6, ai:claude-opus-4.7, ai:codex-5.4, ai:grok-4.2, human, system)
+        #[arg(long)]
+        agent_type: String,
+        /// Comma-separated capability tags
+        #[arg(long, default_value = "")]
+        capabilities: String,
+    },
 }
 
 #[derive(Args)]
@@ -517,6 +543,7 @@ async fn main() -> Result<()> {
         }
         Command::Mine(a) => cmd_mine(&db_path, a, j, &app_config, cli_agent_id.as_deref()),
         Command::Archive(a) => cmd_archive(&db_path, a, j),
+        Command::Agents(a) => cmd_agents(&db_path, a, j),
     };
 
     // WAL checkpoint after write commands to prevent unbounded WAL growth
@@ -615,6 +642,8 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
             post(handlers::restore_archive),
         )
         .route("/api/v1/archive/stats", get(handlers::archive_stats))
+        .route("/api/v1/agents", get(handlers::list_agents))
+        .route("/api/v1/agents", post(handlers::register_agent))
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             handlers::api_key_auth,
@@ -2005,6 +2034,74 @@ fn cmd_archive(db_path: &Path, args: ArchiveArgs, json_out: bool) -> Result<()> 
                         );
                     }
                 }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_agents(db_path: &Path, args: AgentsArgs, json_out: bool) -> Result<()> {
+    let conn = db::open(db_path)?;
+    match args.action.unwrap_or(AgentsAction::List) {
+        AgentsAction::List => {
+            let agents = db::list_agents(&conn)?;
+            if json_out {
+                println!(
+                    "{}",
+                    serde_json::json!({"count": agents.len(), "agents": agents})
+                );
+            } else if agents.is_empty() {
+                println!("no registered agents");
+            } else {
+                for a in &agents {
+                    let caps = if a.capabilities.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", a.capabilities.join(","))
+                    };
+                    println!(
+                        "{}  type={}  registered={}  last_seen={}{}",
+                        a.agent_id, a.agent_type, a.registered_at, a.last_seen_at, caps
+                    );
+                }
+                println!("{} registered agents", agents.len());
+            }
+        }
+        AgentsAction::Register {
+            agent_id,
+            agent_type,
+            capabilities,
+        } => {
+            validate::validate_agent_id(&agent_id)?;
+            validate::validate_agent_type(&agent_type)?;
+            let caps: Vec<String> = capabilities
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect();
+            validate::validate_capabilities(&caps)?;
+            let id = db::register_agent(&conn, &agent_id, &agent_type, &caps)?;
+            if json_out {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "registered": true,
+                        "id": id,
+                        "agent_id": agent_id,
+                        "agent_type": agent_type,
+                        "capabilities": caps,
+                    })
+                );
+            } else {
+                println!(
+                    "registered {agent_id} (type={agent_type}, capabilities={})",
+                    if caps.is_empty() {
+                        "-".to_string()
+                    } else {
+                        caps.join(",")
+                    }
+                );
             }
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -388,6 +388,27 @@ fn tool_definitions() -> Value {
                     },
                     "required": ["namespace"]
                 }
+            },
+            {
+                "name": "memory_agent_register",
+                "description": "Register an agent in the reserved _agents namespace. Stores agent_type and capabilities, refreshes last_seen_at on re-registration while preserving registered_at. agent_id is claimed, not attested.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": {"type": "string", "description": "Agent identifier (same validation as metadata.agent_id)"},
+                        "agent_type": {"type": "string", "enum": ["ai:claude-opus-4.6", "ai:claude-opus-4.7", "ai:codex-5.4", "ai:grok-4.2", "human", "system"]},
+                        "capabilities": {"type": "array", "items": {"type": "string"}, "default": [], "description": "Optional capability tags"}
+                    },
+                    "required": ["agent_id", "agent_type"]
+                }
+            },
+            {
+                "name": "memory_agent_list",
+                "description": "List every registered agent.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
             }
         ]
     })
@@ -1425,6 +1446,44 @@ fn auto_register_path_hierarchy(conn: &rusqlite::Connection, namespace: &str) {
 // Archive tool handlers
 // ---------------------------------------------------------------------------
 
+fn handle_agent_register(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let agent_id = params["agent_id"].as_str().ok_or("agent_id is required")?;
+    let agent_type = params["agent_type"]
+        .as_str()
+        .ok_or("agent_type is required")?;
+    let capabilities: Vec<String> = params["capabilities"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    validate::validate_agent_id(agent_id).map_err(|e| e.to_string())?;
+    validate::validate_agent_type(agent_type).map_err(|e| e.to_string())?;
+    validate::validate_capabilities(&capabilities).map_err(|e| e.to_string())?;
+
+    let id =
+        db::register_agent(conn, agent_id, agent_type, &capabilities).map_err(|e| e.to_string())?;
+
+    Ok(json!({
+        "registered": true,
+        "id": id,
+        "agent_id": agent_id,
+        "agent_type": agent_type,
+        "capabilities": capabilities,
+    }))
+}
+
+fn handle_agent_list(conn: &rusqlite::Connection) -> Result<Value, String> {
+    let agents = db::list_agents(conn).map_err(|e| e.to_string())?;
+    Ok(json!({
+        "count": agents.len(),
+        "agents": agents,
+    }))
+}
+
 fn handle_archive_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     let limit = usize::try_from(params["limit"].as_u64().unwrap_or(50)).expect("u64 as usize");
@@ -1647,6 +1706,8 @@ fn handle_request(
                 "memory_namespace_clear_standard" => {
                     handle_namespace_clear_standard(conn, arguments)
                 }
+                "memory_agent_register" => handle_agent_register(conn, arguments),
+                "memory_agent_list" => handle_agent_list(conn),
                 _ => Err(format!("unknown tool: {tool_name}")),
             };
 
@@ -1961,10 +2022,23 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_26_tools() {
+    fn tool_definitions_returns_28_tools() {
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 26);
+        assert_eq!(tools.len(), 28);
+    }
+
+    #[test]
+    fn tool_definitions_include_agent_register_and_list() {
+        let defs = tool_definitions();
+        let names: Vec<&str> = defs["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        assert!(names.contains(&"memory_agent_register"));
+        assert!(names.contains(&"memory_agent_list"));
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -277,6 +277,36 @@ pub struct NamespaceCount {
     pub count: usize,
 }
 
+/// Namespace reserved for agent registrations (Task 1.3).
+pub const AGENTS_NAMESPACE: &str = "_agents";
+
+/// Closed set of agent types. Extend carefully — values are persisted.
+pub const VALID_AGENT_TYPES: &[&str] = &[
+    "ai:claude-opus-4.6",
+    "ai:claude-opus-4.7",
+    "ai:codex-5.4",
+    "ai:grok-4.2",
+    "human",
+    "system",
+];
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterAgentBody {
+    pub agent_id: String,
+    pub agent_type: String,
+    #[serde(default)]
+    pub capabilities: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentRegistration {
+    pub agent_id: String,
+    pub agent_type: String,
+    pub capabilities: Vec<String>,
+    pub registered_at: String,
+    pub last_seen_at: String,
+}
+
 pub const MAX_CONTENT_SIZE: usize = 65_536;
 pub const PROMOTION_THRESHOLD: i64 = 5;
 /// How much to extend TTL on access (1 hour for short, 1 day for mid)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Result, bail};
 
-use crate::models::{CreateMemory, MAX_CONTENT_SIZE, Memory, UpdateMemory};
+use crate::models::{CreateMemory, MAX_CONTENT_SIZE, Memory, UpdateMemory, VALID_AGENT_TYPES};
 
 const MAX_TITLE_LEN: usize = 512;
 const MAX_NAMESPACE_LEN: usize = 128;
@@ -119,6 +119,27 @@ pub fn validate_agent_id(agent_id: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Validate an agent type against the closed `VALID_AGENT_TYPES` set.
+pub fn validate_agent_type(agent_type: &str) -> Result<()> {
+    if agent_type.is_empty() {
+        bail!("agent_type cannot be empty");
+    }
+    if !VALID_AGENT_TYPES.contains(&agent_type) {
+        bail!(
+            "invalid agent_type '{}' — must be one of: {}",
+            agent_type,
+            VALID_AGENT_TYPES.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Validate a list of capability strings. Shares `validate_tags` rules
+/// (non-empty, <=128 bytes each, clean chars, <=50 entries).
+pub fn validate_capabilities(caps: &[String]) -> Result<()> {
+    validate_tags(caps)
 }
 
 pub fn validate_tags(tags: &[String]) -> Result<()> {
@@ -441,6 +462,28 @@ mod tests {
         assert!(validate_agent_id("alice\\bs").is_err());
         assert!(validate_agent_id("alice?q").is_err());
         assert!(validate_agent_id("alice*glob").is_err());
+    }
+
+    #[test]
+    fn test_valid_agent_type() {
+        assert!(validate_agent_type("ai:claude-opus-4.6").is_ok());
+        assert!(validate_agent_type("ai:codex-5.4").is_ok());
+        assert!(validate_agent_type("ai:grok-4.2").is_ok());
+        assert!(validate_agent_type("human").is_ok());
+        assert!(validate_agent_type("system").is_ok());
+    }
+
+    #[test]
+    fn test_invalid_agent_type() {
+        assert!(validate_agent_type("").is_err());
+        assert!(validate_agent_type("bogus").is_err());
+        assert!(validate_agent_type("AI:CLAUDE").is_err());
+        assert!(validate_agent_type("ai:claude").is_err());
+    }
+
+    #[test]
+    fn test_agents_namespace_accepted() {
+        assert!(validate_namespace("_agents").is_ok());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1835,7 +1835,7 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 26, "expected 26 MCP tools");
+    assert_eq!(tools.len(), 28, "expected 28 MCP tools");
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));
@@ -1851,6 +1851,8 @@ fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"memory_link"));
     assert!(tool_names.contains(&"memory_get_links"));
     assert!(tool_names.contains(&"memory_consolidate"));
+    assert!(tool_names.contains(&"memory_agent_register"));
+    assert!(tool_names.contains(&"memory_agent_list"));
 
     let _ = std::fs::remove_file(&db_path);
 }
@@ -4033,6 +4035,316 @@ fn test_agentid_visible_in_toon_and_json() {
         Some("toon-alice"),
         "JSON response must surface agent_id; got:\n{data}"
     );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.3 — Agent Registration
+// ---------------------------------------------------------------------------
+
+fn fresh_agent_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-agentreg-{}.db", uuid::Uuid::new_v4()))
+}
+
+fn register_via_cli(
+    binary: &str,
+    db_path: &std::path::Path,
+    agent_id: &str,
+    agent_type: &str,
+    capabilities: &str,
+) -> std::process::Output {
+    cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "agents",
+            "register",
+            "--agent-id",
+            agent_id,
+            "--agent-type",
+            agent_type,
+            "--capabilities",
+            capabilities,
+        ])
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn test_agent_register_and_list() {
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let out = register_via_cli(
+        binary,
+        &db_path,
+        "alice",
+        "ai:claude-opus-4.6",
+        "recall,store",
+    );
+    assert!(
+        out.status.success(),
+        "register failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let reg: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(reg["registered"], true);
+    assert_eq!(reg["agent_id"], "alice");
+    assert_eq!(reg["agent_type"], "ai:claude-opus-4.6");
+
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "agents",
+            "list",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(listed["count"], 1);
+    let first = &listed["agents"][0];
+    assert_eq!(first["agent_id"], "alice");
+    assert_eq!(first["agent_type"], "ai:claude-opus-4.6");
+    assert_eq!(first["capabilities"][0], "recall");
+    assert_eq!(first["capabilities"][1], "store");
+    assert!(first["registered_at"].as_str().unwrap().contains('T'));
+    assert!(first["last_seen_at"].as_str().unwrap().contains('T'));
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_agent_register_duplicate_preserves_registered_at() {
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let _ = register_via_cli(binary, &db_path, "bob", "ai:codex-5.4", "search");
+    // Read back the original registered_at
+    let out1 = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "agents",
+            "list",
+        ])
+        .output()
+        .unwrap();
+    let listed1: serde_json::Value = serde_json::from_slice(&out1.stdout).unwrap();
+    let reg_at_1 = listed1["agents"][0]["registered_at"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Sleep enough that now() moves forward
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Re-register with a different type + capabilities
+    let out2 = register_via_cli(binary, &db_path, "bob", "human", "review,approve");
+    assert!(out2.status.success());
+
+    let out3 = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "agents",
+            "list",
+        ])
+        .output()
+        .unwrap();
+    let listed2: serde_json::Value = serde_json::from_slice(&out3.stdout).unwrap();
+    assert_eq!(listed2["count"], 1, "duplicate must upsert, not append");
+    let row = &listed2["agents"][0];
+    assert_eq!(
+        row["agent_type"], "human",
+        "agent_type updates on re-register"
+    );
+    assert_eq!(row["capabilities"][0], "review");
+    assert_eq!(
+        row["registered_at"].as_str().unwrap(),
+        reg_at_1,
+        "registered_at preserved across re-register"
+    );
+    assert_ne!(
+        row["last_seen_at"].as_str().unwrap(),
+        reg_at_1,
+        "last_seen_at bumps on re-register"
+    );
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_agent_register_rejects_invalid_type() {
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let out = register_via_cli(binary, &db_path, "carol", "bogus-type", "");
+    assert!(
+        !out.status.success(),
+        "invalid agent_type should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid agent_type"),
+        "expected validation message, got: {stderr}"
+    );
+
+    // Confirm no row was created.
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "agents",
+            "list",
+        ])
+        .output()
+        .unwrap();
+    let listed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(listed["count"], 0);
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_agent_register_rejects_invalid_agent_id() {
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let out = register_via_cli(binary, &db_path, "evil;id", "system", "");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("agent_id"),
+        "expected agent_id validation message, got: {stderr}"
+    );
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_agents_list_uses_reserved_namespace() {
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let _ = register_via_cli(binary, &db_path, "dave", "system", "heartbeat");
+
+    // Agent row lives in the _agents namespace
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "list",
+            "-n",
+            "_agents",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let listed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let count = listed["count"].as_u64().unwrap_or(0);
+    assert_eq!(count, 1, "agent must occupy _agents namespace");
+
+    let title = listed["memories"][0]["title"].as_str().unwrap_or("");
+    assert_eq!(title, "agent:dave");
+
+    let agent_type = listed["memories"][0]["metadata"]["agent_type"]
+        .as_str()
+        .unwrap_or("");
+    assert_eq!(agent_type, "system");
+
+    // And does NOT appear under the default (global) namespace
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "list",
+            "-n",
+            "global",
+        ])
+        .output()
+        .unwrap();
+    let listed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(listed["count"].as_u64().unwrap_or(0), 0);
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn test_mcp_agent_register_and_list() {
+    use std::io::Write;
+    let db_path = fresh_agent_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    let mut child = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "mcp",
+            "--tier",
+            "keyword",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdin = child.stdin.as_mut().unwrap();
+    let init = serde_json::json!({
+        "jsonrpc":"2.0","id":1,"method":"initialize",
+        "params":{"clientInfo":{"name":"test-suite","version":"1.0"}}
+    });
+    writeln!(stdin, "{init}").unwrap();
+
+    let reg = serde_json::json!({
+        "jsonrpc":"2.0","id":2,"method":"tools/call",
+        "params":{
+            "name":"memory_agent_register",
+            "arguments":{
+                "agent_id":"mcp-eve",
+                "agent_type":"ai:grok-4.2",
+                "capabilities":["code","chat"]
+            }
+        }
+    });
+    writeln!(stdin, "{reg}").unwrap();
+
+    let list = serde_json::json!({
+        "jsonrpc":"2.0","id":3,"method":"tools/call",
+        "params":{"name":"memory_agent_list","arguments":{}}
+    });
+    writeln!(stdin, "{list}").unwrap();
+    stdin.flush().unwrap();
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.len() >= 3,
+        "expected 3 JSON-RPC responses, got {}:\n{stdout}",
+        lines.len()
+    );
+
+    let reg_resp: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let reg_text = reg_resp["result"]["content"][0]["text"].as_str().unwrap();
+    let reg_json: serde_json::Value = serde_json::from_str(reg_text).unwrap();
+    assert_eq!(reg_json["registered"], true);
+    assert_eq!(reg_json["agent_id"], "mcp-eve");
+
+    let list_resp: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+    let list_text = list_resp["result"]["content"][0]["text"].as_str().unwrap();
+    let list_json: serde_json::Value = serde_json::from_str(list_text).unwrap();
+    assert_eq!(list_json["count"], 1);
+    assert_eq!(list_json["agents"][0]["agent_id"], "mcp-eve");
+    assert_eq!(list_json["agents"][0]["agent_type"], "ai:grok-4.2");
+    let caps = list_json["agents"][0]["capabilities"].as_array().unwrap();
+    assert_eq!(caps.len(), 2);
 
     let _ = std::fs::remove_file(&db_path);
 }


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.3 — Agent Registration** per `docs/PHASE-1.md`. Gates alpha.1 of the v0.6.0 release train.

- **MCP:** `memory_agent_register` + `memory_agent_list` (tool count 26 → 28)
- **HTTP:** `POST /api/v1/agents` + `GET /api/v1/agents` (endpoint count 24 → 26)
- **CLI:** `ai-memory agents list` (default) / `ai-memory agents register --agent-id --agent-type [--capabilities csv]`

Agents are stored as long-tier memories in a reserved `_agents` namespace (`title = "agent:<agent_id>"`, `source = "system"`). Metadata carries `agent_type`, `capabilities`, `registered_at`, `last_seen_at`. **No schema migration** — rides the existing `metadata` JSON column added in Task 1.1.

## Design decisions (flag if any need to change)

1. **Open registration** — any caller can register any `agent_id`. Matches the documented "claimed, not attested" trust model. Attestation is future work.
2. **Reuse `memories` table** — spec says "special memory"; inherits FTS, archive, GC, export/import for free.
3. **`capabilities` in metadata**, not tags — tags stay semantic discriminators.
4. **`registered_at` preserved** across re-registration; `last_seen_at` refreshes. Rides Task 1.2's SQL `json_set` CASE clause for `agent_id` immutability.

## Validator additions (`src/validate.rs`)

- `VALID_AGENT_TYPES` closed set: `ai:claude-opus-4.6`, `ai:claude-opus-4.7`, `ai:codex-5.4`, `ai:grok-4.2`, `human`, `system`.
- `validate_agent_type`, `validate_capabilities` (reuses `validate_tags` rules).
- `_agents` namespace passes existing `validate_namespace` (underscore already permitted).

## Files changed (9 files, +774 / −25)

| File | Lines |
|---|---|
| `src/models.rs` | +30 |
| `src/validate.rs` | +45 |
| `src/db.rs` | +128 |
| `src/mcp.rs` | +78 |
| `src/handlers.rs` | +72 |
| `src/main.rs` | +97 |
| `tests/integration.rs` | +314 |
| `docs/PHASE-1.md` | ±34 (24 stale `develop` → `release/v0.6.0` refs fixed in-scope) |
| `CHANGELOG.md` | +26 |

## Tests — +10 new (4-minimum spec exceeded)

- `validate.rs` (3): `test_valid_agent_type`, `test_invalid_agent_type`, `test_agents_namespace_accepted`
- `mcp.rs` (2): `tool_definitions_returns_28_tools`, `tool_definitions_include_agent_register_and_list`
- `integration.rs` (6): `test_agent_register_and_list`, `test_agent_register_duplicate_preserves_registered_at`, `test_agent_register_rejects_invalid_type`, `test_agent_register_rejects_invalid_agent_id`, `test_agents_list_uses_reserved_namespace`, `test_mcp_agent_register_and_list`

**Suite total:** 196 unit + 78 integration = **274 passing**.

## Gates (all ✓)

- `cargo fmt --check`
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- `AI_MEMORY_NO_CONFIG=1 cargo test` — 274/274
- `cargo audit` — 412 deps vs 1,049 advisories, exit 0

No new `unwrap()` in production paths.

## Deviation from spec

- Issue #149 + `docs/PHASE-1.md` both originally said "PR targets `develop`". This PR targets **`release/v0.6.0`** per the v0.6.0 release-train strategy adopted 2026-04-16. The stale `develop` references in `PHASE-1.md` (24 of them) are corrected as part of this PR.

## Deferred follow-ups (separate docs PR)

- `CLAUDE.md:173` and `docs/AI_DEVELOPER_WORKFLOW.md:289` — "PRs target develop" needs a `release/*` carve-out.
- `CLAUDE.md` tool count "23 tools + 2 prompts" and endpoint count "24 endpoints" — already stale pre-1.3; now 28 / 26.

## Post-merge

Tag `v0.6.0-alpha.1` — first publishable alpha of the release train. Triggers 6 workflows: Docker/GHCR, crates.io, Fedora COPR, 5-platform binaries, Ubuntu PPA, Homebrew.

## AI involvement (per AI_DEVELOPER_WORKFLOW.md §8.2)

- **Model:** Claude Opus 4.7 (1M context), via Claude Code CLI
- **Authority class:** Standard (feature addition) under §5.4 sole-approver policy
- **Human authorization:** @alphaonedev explicitly authorized this session's work ("approved to do all — lets go — full send")
- **AI activities:** implementation (code, tests, docs), self-review, governance-doc corrections in-scope
- **Human-approved scope:** 5 open design questions answered with AI defaults (flagged in plan, user confirmed "continue")

Closes #149.