### PR TITLE
ci: add workflow_dispatch yank (for crates.io version retraction)

### DIFF
--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -1,0 +1,32 @@
+name: Yank crates.io version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to yank (e.g. 0.6.0-alpha.1). Must exactly match a published version."
+        required: true
+      reason:
+        description: "Short reason (goes into commit log / audit trail)."
+        required: true
+        default: "superseded by hotfix"
+
+permissions:
+  contents: read
+
+jobs:
+  yank:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Yank version
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          echo "Yanking ai-memory@${{ github.event.inputs.version }}"
+          echo "Reason: ${{ github.event.inputs.reason }}"
+          cargo yank --version "${{ github.event.inputs.version }}" ai-memory


### PR DESCRIPTION
## Why on main

GitHub only discovers \`workflow_dispatch\` triggers from the **default branch**. This PR targets \`main\` so the workflow becomes triggerable via \`gh workflow run yank.yml\`.

## Why now

Need to yank \`ai-memory@0.6.0-alpha.1\` from crates.io — that alpha published but had partial release artifacts (Docker + COPR failed) and has since been superseded by \`0.6.0-alpha.2\` (v0.6.0-alpha.2 published cleanly on all 13 channels earlier this session).

## Scope

One file: \`.github/workflows/yank.yml\`. Manual trigger only (\`workflow_dispatch\`). Inputs:
- \`version\` (required) — exact semver to yank
- \`reason\` (required) — short audit string

Uses the existing \`CARGO_REGISTRY_TOKEN\` CI secret.

## Safety

- Trigger is manual only; no automatic firing on push/tag
- \`cargo yank\` is reversible (\`cargo unyank\`); no destructive permanent effect
- Yanking does not delete — it marks as yanked, users with existing pins continue working, new installs get warnings

## Usage

\`\`\`bash
gh workflow run yank.yml --ref main \\
  -f version=0.6.0-alpha.1 \\
  -f reason="superseded by 0.6.0-alpha.2 (partial publish)"
\`\`\`

Cherry-picked from \`b0aefb6\` on \`release/v0.6.0\`.

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Trivial (CI-only, no source changes)
- **Authorization:** @alphaonedev approved this session's full-send