### PR TITLE
feat: hierarchical namespace paths (task 1.4) — closes #150

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -308,6 +308,90 @@ pub struct AgentRegistration {
 }
 
 pub const MAX_CONTENT_SIZE: usize = 65_536;
+
+/// Maximum number of path segments in a hierarchical namespace (Task 1.4).
+/// `alphaone/engineering/platform/team/squad/pod/role/agent` = 8 levels.
+pub const MAX_NAMESPACE_DEPTH: usize = 8;
+
+/// Number of `/`-delimited segments in a namespace path.
+///
+/// Flat namespaces (`"global"`, `"ai-memory"`) return `1`. An empty string
+/// returns `0`.
+///
+/// # Examples
+/// ```
+/// # use ai_memory::models::namespace_depth;
+/// assert_eq!(namespace_depth("global"), 1);
+/// assert_eq!(namespace_depth("alphaone/engineering"), 2);
+/// assert_eq!(namespace_depth("alphaone/engineering/platform"), 3);
+/// ```
+#[must_use]
+pub fn namespace_depth(ns: &str) -> usize {
+    if ns.is_empty() {
+        return 0;
+    }
+    ns.split('/').filter(|s| !s.is_empty()).count()
+}
+
+/// Parent of a hierarchical namespace, or `None` for flat / empty inputs.
+///
+/// Part of the Task 1.4 hierarchical-namespace API. Consumed by Tasks 1.5
+/// (visibility rules), 1.6 (N-level inheritance), 1.7 (vertical promotion),
+/// and 1.12 (hierarchy-aware recall).
+#[allow(dead_code)]
+///
+/// Parent of `"a/b/c"` is `"a/b"`. Parent of `"flat"` is `None` (a flat
+/// namespace has no parent). Parent of `""` is `None`.
+///
+/// # Examples
+/// ```
+/// # use ai_memory::models::namespace_parent;
+/// assert_eq!(namespace_parent("alphaone/engineering/platform"), Some("alphaone/engineering".to_string()));
+/// assert_eq!(namespace_parent("alphaone"), None);
+/// assert_eq!(namespace_parent(""), None);
+/// ```
+#[must_use]
+pub fn namespace_parent(ns: &str) -> Option<String> {
+    ns.rsplit_once('/').map(|(parent, _)| parent.to_string())
+}
+
+/// Ancestors of a namespace, ordered most-specific-first (including the
+/// namespace itself as the first element).
+///
+/// Part of the Task 1.4 hierarchical-namespace API. Consumed by Tasks 1.6
+/// (N-level rule inheritance) and 1.12 (hierarchy-aware recall scoring).
+#[allow(dead_code)]
+///
+/// For `"a/b/c"` returns `["a/b/c", "a/b", "a"]`. For a flat namespace
+/// returns a single-element vec containing the namespace. For an empty
+/// input returns an empty vec.
+///
+/// # Examples
+/// ```
+/// # use ai_memory::models::namespace_ancestors;
+/// assert_eq!(
+///     namespace_ancestors("alphaone/engineering/platform"),
+///     vec!["alphaone/engineering/platform", "alphaone/engineering", "alphaone"]
+/// );
+/// assert_eq!(namespace_ancestors("global"), vec!["global"]);
+/// assert!(namespace_ancestors("").is_empty());
+/// ```
+#[must_use]
+pub fn namespace_ancestors(ns: &str) -> Vec<String> {
+    if ns.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(namespace_depth(ns));
+    let mut current = ns.to_string();
+    loop {
+        out.push(current.clone());
+        match namespace_parent(&current) {
+            Some(p) if !p.is_empty() => current = p,
+            _ => break,
+        }
+    }
+    out
+}
 pub const PROMOTION_THRESHOLD: i64 = 5;
 /// How much to extend TTL on access (1 hour for short, 1 day for mid)
 pub const SHORT_TTL_EXTEND_SECS: i64 = 3600;
@@ -368,5 +452,91 @@ mod tests {
         assert_eq!(Tier::Short.rank(), 0);
         assert_eq!(Tier::Mid.rank(), 1);
         assert_eq!(Tier::Long.rank(), 2);
+    }
+
+    // Task 1.4 — hierarchical namespace helpers --------------------------------
+
+    #[test]
+    fn depth_flat_namespace() {
+        assert_eq!(namespace_depth("global"), 1);
+        assert_eq!(namespace_depth("ai-memory"), 1);
+        assert_eq!(namespace_depth("under_score"), 1);
+    }
+
+    #[test]
+    fn depth_hierarchical() {
+        assert_eq!(namespace_depth("a/b"), 2);
+        assert_eq!(namespace_depth("alphaone/engineering"), 2);
+        assert_eq!(namespace_depth("alphaone/engineering/platform"), 3);
+        assert_eq!(
+            namespace_depth("a/b/c/d/e/f/g/h"),
+            8,
+            "max depth of 8 counts each segment"
+        );
+    }
+
+    #[test]
+    fn depth_empty_is_zero() {
+        assert_eq!(namespace_depth(""), 0);
+    }
+
+    #[test]
+    fn parent_hierarchical() {
+        assert_eq!(
+            namespace_parent("alphaone/engineering/platform"),
+            Some("alphaone/engineering".to_string())
+        );
+        assert_eq!(
+            namespace_parent("alphaone/engineering"),
+            Some("alphaone".to_string())
+        );
+    }
+
+    #[test]
+    fn parent_flat_is_none() {
+        assert_eq!(namespace_parent("global"), None);
+        assert_eq!(namespace_parent("ai-memory"), None);
+        assert_eq!(namespace_parent(""), None);
+    }
+
+    #[test]
+    fn ancestors_three_levels() {
+        let a = namespace_ancestors("alphaone/engineering/platform");
+        assert_eq!(
+            a,
+            vec![
+                "alphaone/engineering/platform".to_string(),
+                "alphaone/engineering".to_string(),
+                "alphaone".to_string(),
+            ],
+            "ancestors ordered most-specific-first"
+        );
+    }
+
+    #[test]
+    fn ancestors_flat_namespace() {
+        assert_eq!(namespace_ancestors("global"), vec!["global".to_string()]);
+        assert_eq!(
+            namespace_ancestors("ai-memory"),
+            vec!["ai-memory".to_string()]
+        );
+    }
+
+    #[test]
+    fn ancestors_empty_input() {
+        assert!(namespace_ancestors("").is_empty());
+    }
+
+    #[test]
+    fn ancestors_single_level() {
+        assert_eq!(namespace_ancestors("a"), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn ancestors_max_depth() {
+        let a = namespace_ancestors("a/b/c/d/e/f/g/h");
+        assert_eq!(a.len(), 8);
+        assert_eq!(a[0], "a/b/c/d/e/f/g/h");
+        assert_eq!(a[7], "a");
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -3,10 +3,15 @@
 
 use anyhow::{Result, bail};
 
-use crate::models::{CreateMemory, MAX_CONTENT_SIZE, Memory, UpdateMemory, VALID_AGENT_TYPES};
+use crate::models::{
+    CreateMemory, MAX_CONTENT_SIZE, MAX_NAMESPACE_DEPTH, Memory, UpdateMemory, VALID_AGENT_TYPES,
+};
 
 const MAX_TITLE_LEN: usize = 512;
-const MAX_NAMESPACE_LEN: usize = 128;
+/// Max characters in a namespace string (post-Task 1.4).
+/// Flat namespaces still fit in the historical 128 budget; 512 is the ceiling
+/// for hierarchical paths like `a/b/c/…` up to 8 levels deep.
+const MAX_NAMESPACE_LEN: usize = 512;
 const MAX_SOURCE_LEN: usize = 64;
 const MAX_TAG_LEN: usize = 128;
 const MAX_TAGS_COUNT: usize = 50;
@@ -63,6 +68,26 @@ pub fn validate_content(content: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a namespace (flat or hierarchical, Task 1.4).
+///
+/// Flat namespaces (`"global"`, `"ai-memory"`) remain fully valid — hierarchy
+/// is opt-in. Hierarchical paths use `/` as the segment delimiter:
+///
+/// ```text
+/// alphaone/engineering/platform
+/// ```
+///
+/// Rules:
+/// - **Not empty**, no leading/trailing whitespace
+/// - Length ≤ [`MAX_NAMESPACE_LEN`] (512 chars)
+/// - Depth (segment count) ≤ [`MAX_NAMESPACE_DEPTH`] (8)
+/// - Backslashes, null bytes, control chars, and spaces are forbidden
+/// - Leading and trailing `/` are forbidden (normalize input via
+///   [`normalize_namespace`] before validating)
+/// - Empty segments (consecutive `//`) are forbidden
+/// - Each segment is non-empty; no further character restriction beyond
+///   the whole-string checks above (preserving historical flexibility
+///   for existing flat namespaces like `ai-memory-mcp-dev`)
 pub fn validate_namespace(ns: &str) -> Result<()> {
     let trimmed = ns.trim();
     if trimmed.is_empty() {
@@ -71,13 +96,56 @@ pub fn validate_namespace(ns: &str) -> Result<()> {
     if trimmed.chars().count() > MAX_NAMESPACE_LEN {
         bail!("namespace exceeds max length of {MAX_NAMESPACE_LEN} characters");
     }
-    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains('\0') {
-        bail!("namespace cannot contain slashes or null bytes");
+    if trimmed.contains('\\') || trimmed.contains('\0') {
+        bail!("namespace cannot contain backslashes or null bytes");
     }
     if trimmed.contains(' ') {
         bail!("namespace cannot contain spaces (use hyphens or underscores)");
     }
+    if !is_clean_string(trimmed) {
+        bail!("namespace contains invalid control characters");
+    }
+    // Task 1.4 — hierarchical paths. '/' is permitted as a delimiter, but
+    // leading/trailing/empty segments are rejected to force callers to
+    // normalize input first (ambiguity between "foo" and "foo/" is not
+    // something we want to paper over at match time).
+    if trimmed.starts_with('/') {
+        bail!("namespace cannot start with '/' (normalize input first)");
+    }
+    if trimmed.ends_with('/') {
+        bail!("namespace cannot end with '/' (normalize input first)");
+    }
+    if trimmed.split('/').any(str::is_empty) {
+        bail!("namespace cannot contain empty segments (e.g. '//')");
+    }
+    let depth = crate::models::namespace_depth(trimmed);
+    if depth > MAX_NAMESPACE_DEPTH {
+        bail!("namespace depth {depth} exceeds max of {MAX_NAMESPACE_DEPTH}");
+    }
     Ok(())
+}
+
+/// Normalize a namespace input to the canonical form accepted by
+/// [`validate_namespace`]. Not called by write paths (would lowercase
+/// existing flat namespaces and break their lookup keys); instead exposed
+/// as a helper that callers opt into, and used by Task 1.5+ when accepting
+/// user-typed hierarchical paths.
+///
+/// - Trim leading/trailing whitespace
+/// - Strip leading/trailing `/`
+/// - Collapse consecutive `/` into a single separator
+/// - Lowercase the result
+///
+/// This is a pure helper; the write path does **not** auto-apply it so that
+/// callers retain control over case sensitivity on existing flat namespaces.
+/// Use it when you need to accept loose user input and produce a matchable
+/// canonical key.
+#[allow(dead_code)]
+#[must_use]
+pub fn normalize_namespace(input: &str) -> String {
+    let trimmed = input.trim();
+    let collapsed: Vec<&str> = trimmed.split('/').filter(|s| !s.is_empty()).collect();
+    collapsed.join("/").to_lowercase()
 }
 
 pub fn validate_source(source: &str) -> Result<()> {
@@ -401,14 +469,99 @@ mod tests {
     }
 
     #[test]
-    fn test_valid_namespace() {
+    fn test_valid_namespace_flat_backwards_compat() {
+        // Task 1.4: flat namespaces must still validate exactly as before.
         assert!(validate_namespace("my-project").is_ok());
         assert!(validate_namespace("global").is_ok());
         assert!(validate_namespace("under_score").is_ok());
+        assert!(validate_namespace("ai-memory-mcp-dev").is_ok());
+        assert!(validate_namespace("_agents").is_ok());
+    }
+
+    #[test]
+    fn test_valid_namespace_rejections_preserved() {
         assert!(validate_namespace("").is_err());
+        assert!(validate_namespace("   ").is_err());
         assert!(validate_namespace("has space").is_err());
-        assert!(validate_namespace("has/slash").is_err());
-        assert!(validate_namespace(&"x".repeat(129)).is_err());
+        assert!(validate_namespace("has\\backslash").is_err());
+        assert!(validate_namespace("has\0null").is_err());
+        assert!(validate_namespace("has\x07bell").is_err());
+    }
+
+    #[test]
+    fn test_namespace_length_bumped_to_512() {
+        // Historical 128-char budget is a floor; 512 is the new max for paths.
+        assert!(validate_namespace(&"x".repeat(128)).is_ok());
+        assert!(validate_namespace(&"x".repeat(512)).is_ok());
+        assert!(validate_namespace(&"x".repeat(513)).is_err());
+    }
+
+    // Task 1.4 — hierarchical paths ---------------------------------------
+
+    #[test]
+    fn test_hierarchical_paths_accepted() {
+        assert!(validate_namespace("alphaone/engineering").is_ok());
+        assert!(validate_namespace("alphaone/engineering/platform").is_ok());
+        assert!(validate_namespace("a/b/c/d/e/f/g/h").is_ok(), "8 levels OK");
+    }
+
+    #[test]
+    fn test_hierarchical_depth_cap() {
+        // 9 levels exceeds MAX_NAMESPACE_DEPTH (8)
+        assert!(validate_namespace("a/b/c/d/e/f/g/h/i").is_err());
+    }
+
+    #[test]
+    fn test_hierarchical_rejects_leading_slash() {
+        assert!(validate_namespace("/alphaone/engineering").is_err());
+    }
+
+    #[test]
+    fn test_hierarchical_rejects_trailing_slash() {
+        assert!(validate_namespace("alphaone/engineering/").is_err());
+    }
+
+    #[test]
+    fn test_hierarchical_rejects_empty_segments() {
+        assert!(validate_namespace("alphaone//engineering").is_err());
+        assert!(validate_namespace("a///b").is_err());
+    }
+
+    #[test]
+    fn test_hierarchical_rejects_control_chars() {
+        assert!(validate_namespace("a/b\x07c").is_err());
+        assert!(validate_namespace("a/b\0c").is_err());
+    }
+
+    #[test]
+    fn test_normalize_namespace_strips_slashes() {
+        assert_eq!(
+            normalize_namespace("/alphaone/engineering/"),
+            "alphaone/engineering"
+        );
+        assert_eq!(normalize_namespace("///a///b///"), "a/b");
+    }
+
+    #[test]
+    fn test_normalize_namespace_lowercases() {
+        assert_eq!(
+            normalize_namespace("AlphaOne/Engineering"),
+            "alphaone/engineering"
+        );
+        assert_eq!(normalize_namespace("MYAPP"), "myapp");
+    }
+
+    #[test]
+    fn test_normalize_namespace_trims_whitespace() {
+        assert_eq!(normalize_namespace("  alphaone/eng  "), "alphaone/eng");
+    }
+
+    #[test]
+    fn test_normalize_then_validate_roundtrip() {
+        let raw = "/AlphaOne//Engineering/Platform/";
+        let norm = normalize_namespace(raw);
+        assert_eq!(norm, "alphaone/engineering/platform");
+        assert!(validate_namespace(&norm).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.4 — Hierarchical Namespace Paths** per `docs/PHASE-1.md`. Foundation for Track B: unblocks Tasks 1.5 (visibility), 1.6 (N-level inheritance), 1.7 (vertical promotion), and half of 1.12 (hierarchy-aware recall).

- `validate_namespace()` now accepts `/`-delimited paths up to 8 levels and 512 chars
- 3 new model helpers: `namespace_depth()`, `namespace_parent()`, `namespace_ancestors()`
- `normalize_namespace()` helper for opt-in path canonicalization (strip / collapse / lowercase)
- **Zero breaking changes** to existing flat namespace behavior

Closes #150.

## Design decisions

### 1. Validator rejects leading / trailing / empty segments instead of auto-fixing

`"foo/"` and `"foo"` should not silently match the same namespace; that ambiguity would break downstream visibility and inheritance logic. The validator rejects these forms and exposes `normalize_namespace()` as an explicit opt-in helper. Callers that want loose input handling wrap their input: `validate_namespace(&normalize_namespace(user_input))`.

### 2. `normalize_namespace` is NOT auto-applied on write paths

The spec calls for lowercase normalization. Applying it on every write would lowercase any existing flat namespace that happens to contain uppercase letters, breaking its lookup key. Instead the helper is exposed for callers that want canonical keys (Task 1.5+ will use it when accepting user-typed paths). Existing write paths are untouched — ZERO breaking changes.

### 3. Depth cap is 8; length cap bumped 128 → 512

Previous 128-char limit was a floor for flat namespaces; 512 is the ceiling for 8-level paths. `"x".repeat(128)` still valid, so no flat namespace gets invalidated. 8-level max matches PHASE-1.md: `alphaone/engineering/platform/team/squad/pod/role/agent`.

### 4. Helpers tagged `#[allow(dead_code)]` with Task-downstream annotations

`namespace_parent`, `namespace_ancestors`, and `normalize_namespace` are defined here but not yet consumed by production code. Each is tagged with a comment naming the Task (1.5 / 1.6 / 1.7 / 1.12) that will wire it in. `namespace_depth` is already called from `validate_namespace`, so no annotation needed.

## Files changed (2 files, +330 / −7)

| File | Lines | What |
|---|---|---|
| `src/models.rs` | +99 | `MAX_NAMESPACE_DEPTH` const; `namespace_depth`, `namespace_parent`, `namespace_ancestors` helpers + 10 tests |
| `src/validate.rs` | +231 | `validate_namespace` accepts `/`; `normalize_namespace` helper; 13 new tests; existing test renamed for clarity |

## Tests — +23 new (10-minimum spec exceeded)

**Validator (13):**
- `test_valid_namespace_flat_backwards_compat` — `global`, `ai-memory`, `_agents`, `ai-memory-mcp-dev`
- `test_valid_namespace_rejections_preserved` — empty, whitespace, backslash, null, control chars, space
- `test_namespace_length_bumped_to_512` — 128 & 512 both valid; 513 rejected
- `test_hierarchical_paths_accepted` — 2, 3, 8 levels all OK
- `test_hierarchical_depth_cap` — 9 levels rejected
- `test_hierarchical_rejects_leading_slash` / `..._trailing_slash` / `..._empty_segments`
- `test_hierarchical_rejects_control_chars`
- `test_normalize_namespace_strips_slashes` / `..._lowercases` / `..._trims_whitespace`
- `test_normalize_then_validate_roundtrip` — typical loose-input → canonical flow

**Model helpers (10):**
- `depth_flat_namespace`, `depth_hierarchical`, `depth_empty_is_zero`
- `parent_hierarchical`, `parent_flat_is_none`
- `ancestors_three_levels`, `ancestors_flat_namespace`, `ancestors_empty_input`, `ancestors_single_level`, `ancestors_max_depth`

**Suite total: 219 unit + 85 integration = 304 passing.**

## Gates (all ✓)

- `cargo fmt --check`
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- `AI_MEMORY_NO_CONFIG=1 cargo test` — 304/304
- `cargo audit` — 0 vulns

No new `unwrap()` in production paths.

## Deviation from issue body

- Issue #150 text says "PR targets develop". This PR targets **`release/v0.6.0`** per the v0.6.0 release-train strategy adopted 2026-04-16. The same deviation is already documented in `docs/PHASE-1.md` (updated in PR #202).

## Post-merge

- Track B Tasks 1.5 / 1.6 / 1.7 are now unblocked and can run in parallel (3 independent fan-outs from this merge)
- Task 1.12 is still blocked on 1.5 + 1.11
- alpha.3 gate (per release-train memory): Track B complete → 1.5, 1.6, 1.7 + this PR = ready to tag

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard (new feature on integration branch) under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"