### PR TITLE
feat: scope-based visibility rules (task 1.5) — closes #151

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -9,8 +9,82 @@ use std::path::Path;
 
 use crate::models::{
     AGENTS_NAMESPACE, AgentRegistration, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD,
-    Stats, Tier, TierCount,
+    Stats, Tier, TierCount, namespace_ancestors,
 };
+
+/// Computed 4-tuple of visibility prefixes for an agent position (Task 1.5).
+/// Index 0 = agent's own namespace (private), 1 = parent (team),
+/// 2 = grandparent (unit), 3 = great-grandparent (org). Missing = `None`.
+type VisibilityPrefixes = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn compute_visibility_prefixes(as_agent: Option<&str>) -> VisibilityPrefixes {
+    let Some(ns) = as_agent else {
+        return (None, None, None, None);
+    };
+    let ancestors = namespace_ancestors(ns);
+    let p = ancestors.first().cloned();
+    let t = ancestors.get(1).cloned();
+    let u = ancestors.get(2).cloned();
+    let o = ancestors.get(3).cloned();
+    (p, t, u, o)
+}
+
+/// Rust-side visibility check for paths that can't easily attach SQL
+/// visibility (the HNSW branch of `recall_hybrid` iterates memories loaded
+/// via `get()`). Returns `true` when `as_agent` is unset (no filter) or
+/// when the memory's scope + namespace grant visibility to the caller.
+fn is_visible(mem: &Memory, prefixes: &VisibilityPrefixes) -> bool {
+    let (p, t, u, o) = prefixes;
+    if p.is_none() {
+        return true;
+    }
+    let scope = mem
+        .metadata
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("private");
+    match scope {
+        "collective" => true,
+        "private" => p.as_ref().is_some_and(|ns| &mem.namespace == ns),
+        "team" => matches_subtree(&mem.namespace, t.as_deref()),
+        "unit" => matches_subtree(&mem.namespace, u.as_deref()),
+        "org" => matches_subtree(&mem.namespace, o.as_deref()),
+        _ => false,
+    }
+}
+
+fn matches_subtree(namespace: &str, prefix: Option<&str>) -> bool {
+    match prefix {
+        None => false,
+        Some(p) => namespace == p || namespace.starts_with(&format!("{p}/")),
+    }
+}
+
+/// Generate the visibility WHERE-clause fragment starting at placeholder `start`.
+/// Uses placeholders `?start .. ?start+3` for private/team/unit/org prefixes.
+/// See `compute_visibility_prefixes` for the bind order.
+fn visibility_clause(start: usize, table_alias: &str) -> String {
+    let private_ph = start;
+    let team_ph = start + 1;
+    let unit_ph = start + 2;
+    let org_ph = start + 3;
+    let ta = table_alias;
+    format!(
+        "AND (\
+            ?{private_ph} IS NULL \
+            OR COALESCE(json_extract({ta}.metadata, '$.scope'), 'private') = 'collective' \
+            OR (COALESCE(json_extract({ta}.metadata, '$.scope'), 'private') = 'private' AND {ta}.namespace = ?{private_ph}) \
+            OR (json_extract({ta}.metadata, '$.scope') = 'team' AND ?{team_ph} IS NOT NULL AND ({ta}.namespace = ?{team_ph} OR {ta}.namespace LIKE ?{team_ph} || '/%')) \
+            OR (json_extract({ta}.metadata, '$.scope') = 'unit' AND ?{unit_ph} IS NOT NULL AND ({ta}.namespace = ?{unit_ph} OR {ta}.namespace LIKE ?{unit_ph} || '/%')) \
+            OR (json_extract({ta}.metadata, '$.scope') = 'org'  AND ?{org_ph}  IS NOT NULL AND ({ta}.namespace = ?{org_ph}  OR {ta}.namespace LIKE ?{org_ph}  || '/%'))\
+        )"
+    )
+}
 
 const SCHEMA: &str = r"
 CREATE TABLE IF NOT EXISTS memories (
@@ -662,12 +736,14 @@ pub fn search(
     until: Option<&str>,
     tags_filter: Option<&str>,
     agent_id: Option<&str>,
+    as_agent: Option<&str>,
 ) -> Result<Vec<Memory>> {
     let now = Utc::now().to_rfc3339();
     let tier_str = tier.map(|t| t.as_str().to_string());
     let fts_query = sanitize_fts_query(query, false);
+    let (vis_p, vis_t, vis_u, vis_o) = compute_visibility_prefixes(as_agent);
 
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
                 m.confidence, m.source, m.access_count, m.created_at, m.updated_at,
                 m.last_accessed_at, m.expires_at, m.metadata
@@ -682,6 +758,7 @@ pub fn search(
            AND (?7 IS NULL OR m.created_at <= ?7)
            AND (?8 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?8))
            AND (?10 IS NULL OR json_extract(m.metadata, '$.agent_id') = ?10)
+           {vis}
          ORDER BY (fts.rank * -1)
            + (m.priority * 0.5)
            + (MIN(m.access_count, 50) * 0.1)
@@ -689,7 +766,9 @@ pub fn search(
            + (1.0 / (1.0 + (julianday('now') - julianday(m.updated_at)) * 0.1))
            DESC
          LIMIT ?9",
-    )?;
+        vis = visibility_clause(11, "m"),
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(
         params![
             fts_query,
@@ -702,6 +781,10 @@ pub fn search(
             tags_filter,
             limit,
             agent_id,
+            vis_p,
+            vis_t,
+            vis_u,
+            vis_o,
         ],
         row_to_memory,
     )?;
@@ -721,11 +804,13 @@ pub fn recall(
     until: Option<&str>,
     short_extend: i64,
     mid_extend: i64,
+    as_agent: Option<&str>,
 ) -> Result<Vec<(Memory, f64)>> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
+    let (vis_p, vis_t, vis_u, vis_o) = compute_visibility_prefixes(as_agent);
 
-    let mut stmt = conn.prepare(
+    let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
                 m.confidence, m.source, m.access_count, m.created_at, m.updated_at,
                 m.last_accessed_at, m.expires_at, m.metadata,
@@ -744,11 +829,26 @@ pub fn recall(
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
+           {vis}
          ORDER BY score DESC
          LIMIT ?7",
-    )?;
+        vis = visibility_clause(8, "m"),
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(
-        params![fts_query, namespace, now, tags_filter, since, until, limit],
+        params![
+            fts_query,
+            namespace,
+            now,
+            tags_filter,
+            since,
+            until,
+            limit,
+            vis_p,
+            vis_t,
+            vis_u,
+            vis_o
+        ],
         |row| {
             let mem = row_to_memory(row)?;
             let score: f64 = row.get(15)?;
@@ -1636,13 +1736,16 @@ pub fn recall_hybrid(
     vector_index: Option<&crate::hnsw::VectorIndex>,
     short_extend: i64,
     mid_extend: i64,
+    as_agent: Option<&str>,
 ) -> Result<Vec<(Memory, f64)>> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
+    let prefixes = compute_visibility_prefixes(as_agent);
+    let (vis_p, vis_t, vis_u, vis_o) = prefixes.clone();
 
     // Step 1: Get FTS candidates (up to 3x limit to have a good pool)
     let fts_limit = (limit * 3).max(30);
-    let mut fts_stmt = conn.prepare(
+    let fts_sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
                 m.confidence, m.source, m.access_count, m.created_at, m.updated_at,
                 m.last_accessed_at, m.expires_at, m.metadata, m.embedding,
@@ -1659,12 +1762,15 @@ pub fn recall_hybrid(
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
+           {vis}
          ORDER BY fts_score DESC
          LIMIT ?7",
-    )?;
+        vis = visibility_clause(8, "m"),
+    );
+    let mut fts_stmt = conn.prepare(&fts_sql)?;
 
     // Step 2: Get semantic candidates — all memories with embeddings
-    let mut sem_stmt = conn.prepare(
+    let sem_sql = format!(
         "SELECT id, tier, namespace, title, content, tags, priority,
                 confidence, source, access_count, created_at, updated_at,
                 last_accessed_at, expires_at, metadata, embedding
@@ -1674,8 +1780,11 @@ pub fn recall_hybrid(
            AND (expires_at IS NULL OR expires_at > ?2)
            AND (?3 IS NULL OR EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE json_each.value = ?3))
            AND (?4 IS NULL OR created_at >= ?4)
-           AND (?5 IS NULL OR created_at <= ?5)",
-    )?;
+           AND (?5 IS NULL OR created_at <= ?5)
+           {vis}",
+        vis = visibility_clause(6, "memories"),
+    );
+    let mut sem_stmt = conn.prepare(&sem_sql)?;
 
     // Collect FTS results with scores
     let mut scored: HashMap<String, (Memory, f64, f64)> = HashMap::new(); // id -> (memory, fts_score, cosine_score)
@@ -1689,6 +1798,10 @@ pub fn recall_hybrid(
             since,
             until,
             fts_limit,
+            vis_p,
+            vis_t,
+            vis_u,
+            vis_o,
         ],
         |row| {
             let mem = row_to_memory(row)?;
@@ -1753,17 +1866,33 @@ pub fn recall_hybrid(
                 {
                     continue;
                 }
+                // #151 visibility filter (HNSW branch)
+                if !is_visible(&mem, &prefixes) {
+                    continue;
+                }
                 scored.insert(mem.id.clone(), (mem, 0.0, cosine));
             }
         }
     } else {
         // Fallback: linear scan over all embeddings
-        let sem_rows =
-            sem_stmt.query_map(params![namespace, now, tags_filter, since, until], |row| {
+        let sem_rows = sem_stmt.query_map(
+            params![
+                namespace,
+                now,
+                tags_filter,
+                since,
+                until,
+                vis_p,
+                vis_t,
+                vis_u,
+                vis_o
+            ],
+            |row| {
                 let mem = row_to_memory(row)?;
                 let emb_bytes: Option<Vec<u8>> = row.get(15)?;
                 Ok((mem, emb_bytes))
-            })?;
+            },
+        )?;
 
         for row in sem_rows {
             let (mem, emb_bytes) = row?;
@@ -2282,6 +2411,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(results.len(), 1);
@@ -2298,6 +2428,7 @@ mod tests {
             None,
             None,
             10,
+            None,
             None,
             None,
             None,
@@ -2332,6 +2463,7 @@ mod tests {
             None,
             SHORT_TTL_EXTEND_SECS,
             MID_TTL_EXTEND_SECS,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -2356,6 +2488,7 @@ mod tests {
             None,
             SHORT_TTL_EXTEND_SECS,
             MID_TTL_EXTEND_SECS,
+            None,
         );
         // May return empty or error, both acceptable
         assert!(results.is_ok() || results.is_err());
@@ -2871,6 +3004,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(results.len(), 1);
@@ -2894,6 +3028,7 @@ mod tests {
             None,
             3600,
             86400,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -122,6 +122,20 @@ pub async fn create_memory(
     if let Some(obj) = metadata.as_object_mut() {
         obj.insert("agent_id".to_string(), serde_json::Value::String(agent_id));
     }
+    // #151 scope: validate + merge into metadata if supplied at the top level
+    // (inline metadata.scope still works; top-level is a shortcut)
+    if let Some(ref s) = body.scope {
+        if let Err(e) = validate::validate_scope(s) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
+        if let Some(obj) = metadata.as_object_mut() {
+            obj.insert("scope".to_string(), serde_json::Value::String(s.clone()));
+        }
+    }
 
     let now = Utc::now();
     let lock = state.lock().await;
@@ -553,6 +567,16 @@ pub async fn search_memories(
         )
             .into_response();
     }
+    // #151 visibility: validate --as-agent namespace if supplied
+    if let Some(ref a) = p.as_agent
+        && let Err(e) = validate::validate_namespace(a)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid as_agent: {e}")})),
+        )
+            .into_response();
+    }
     let lock = state.lock().await;
     let limit = p.limit.unwrap_or(20).min(200);
     match db::search(
@@ -566,6 +590,7 @@ pub async fn search_memories(
         p.until.as_deref(),
         p.tags.as_deref(),
         p.agent_id.as_deref(),
+        p.as_agent.as_deref(),
     ) {
         Ok(r) => Json(json!({"results": r, "count": r.len(), "query": p.q})).into_response(),
         Err(e) => {
@@ -591,6 +616,15 @@ pub async fn recall_memories_get(
         )
             .into_response();
     }
+    if let Some(ref a) = p.as_agent
+        && let Err(e) = validate::validate_namespace(a)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid as_agent: {e}")})),
+        )
+            .into_response();
+    }
     let lock = state.lock().await;
     let limit = p.limit.unwrap_or(10).min(50);
     match db::recall(
@@ -603,6 +637,7 @@ pub async fn recall_memories_get(
         p.until.as_deref(),
         lock.2.short_extend_secs,
         lock.2.mid_extend_secs,
+        p.as_agent.as_deref(),
     ) {
         Ok(r) => {
             let scored: Vec<serde_json::Value> = r
@@ -639,6 +674,15 @@ pub async fn recall_memories_post(
         )
             .into_response();
     }
+    if let Some(ref a) = body.as_agent
+        && let Err(e) = validate::validate_namespace(a)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid as_agent: {e}")})),
+        )
+            .into_response();
+    }
     let lock = state.lock().await;
     let limit = body.limit.unwrap_or(10).min(50);
     match db::recall(
@@ -651,6 +695,7 @@ pub async fn recall_memories_post(
         body.until.as_deref(),
         lock.2.short_extend_secs,
         lock.2.mid_extend_secs,
+        body.as_agent.as_deref(),
     ) {
         Ok(r) => {
             let scored: Vec<serde_json::Value> = r
@@ -1147,6 +1192,7 @@ mod tests {
             None,
             crate::models::SHORT_TTL_EXTEND_SECS,
             crate::models::MID_TTL_EXTEND_SECS,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+#![recursion_limit = "256"]
+
 mod color;
 mod config;
 mod db;
@@ -241,6 +243,11 @@ struct StoreArgs {
     /// TTL in seconds. Overrides tier default.
     #[arg(long)]
     ttl_secs: Option<i64>,
+    /// Task 1.5 visibility scope: private (default) / team / unit / org / collective.
+    /// Stored as `metadata.scope`; affects which agents can recall this memory
+    /// when queries use `--as-agent`.
+    #[arg(long)]
+    scope: Option<String>,
 }
 
 #[derive(Args)]
@@ -282,6 +289,10 @@ struct RecallArgs {
     /// Feature tier for recall: keyword, semantic, smart, autonomous
     #[arg(long, short = 'T')]
     tier: Option<String>,
+    /// Task 1.5: querying agent's namespace position. Enables scope-based
+    /// visibility filtering (private/team/unit/org/collective).
+    #[arg(long)]
+    as_agent: Option<String>,
 }
 
 #[derive(Args)]
@@ -303,6 +314,10 @@ struct SearchArgs {
     /// Filter by `metadata.agent_id` (exact match)
     #[arg(long)]
     agent_id: Option<String>,
+    /// Task 1.5: querying agent's namespace position for scope-based
+    /// visibility filtering.
+    #[arg(long)]
+    as_agent: Option<String>,
 }
 
 #[derive(Args)]
@@ -726,6 +741,13 @@ fn cmd_store(
     if let Some(obj) = metadata.as_object_mut() {
         obj.insert("agent_id".to_string(), serde_json::Value::String(agent_id));
     }
+    // #151 scope: validate + merge into metadata
+    if let Some(ref s) = args.scope {
+        validate::validate_scope(s)?;
+        if let Some(obj) = metadata.as_object_mut() {
+            obj.insert("scope".to_string(), serde_json::Value::String(s.clone()));
+        }
+    }
 
     let mem = models::Memory {
         id: uuid::Uuid::new_v4().to_string(),
@@ -858,6 +880,10 @@ fn cmd_recall(
     json_out: bool,
     app_config: &config::AppConfig,
 ) -> Result<()> {
+    // #151: validate --as-agent namespace
+    if let Some(ref a) = args.as_agent {
+        validate::validate_namespace(a)?;
+    }
     let conn = db::open(db_path)?;
     let _ = db::gc_if_needed(&conn, app_config.effective_archive_on_gc());
 
@@ -952,6 +978,7 @@ fn cmd_recall(
                     vector_index.as_ref(),
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
+                    args.as_agent.as_deref(),
                 )?;
                 if let Some(ref ce) = reranker {
                     (ce.rerank(&args.context, results), "hybrid+rerank")
@@ -971,6 +998,7 @@ fn cmd_recall(
                     args.until.as_deref(),
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
+                    args.as_agent.as_deref(),
                 )?;
                 (results, "keyword")
             }
@@ -986,6 +1014,7 @@ fn cmd_recall(
             args.until.as_deref(),
             resolved_ttl.short_extend_secs,
             resolved_ttl.mid_extend_secs,
+            args.as_agent.as_deref(),
         )?;
         (results, "keyword")
     };
@@ -1054,6 +1083,10 @@ fn cmd_search(
     if let Some(ref aid) = args.agent_id {
         validate::validate_agent_id(aid)?;
     }
+    // #151: validate --as-agent namespace
+    if let Some(ref a) = args.as_agent {
+        validate::validate_namespace(a)?;
+    }
     let conn = db::open(db_path)?;
     let _ = db::gc_if_needed(&conn, app_config.effective_archive_on_gc());
     let tier = args.tier.as_deref().and_then(Tier::from_str);
@@ -1068,6 +1101,7 @@ fn cmd_search(
         args.until.as_deref(),
         args.tags.as_deref(),
         args.agent_id.as_deref(),
+        args.as_agent.as_deref(),
     )?;
     if json_out {
         println!(
@@ -1559,6 +1593,7 @@ fn cmd_shell(db_path: &Path) -> Result<()> {
                     None,
                     models::SHORT_TTL_EXTEND_SECS,
                     models::MID_TTL_EXTEND_SECS,
+                    None,
                 ) {
                     Ok(results) => {
                         for (mem, score) in &results {
@@ -1583,7 +1618,9 @@ fn cmd_shell(db_path: &Path) -> Result<()> {
                     eprintln!("usage: search <query>");
                     continue;
                 }
-                match db::search(&conn, &q, None, None, 20, None, None, None, None, None) {
+                match db::search(
+                    &conn, &q, None, None, 20, None, None, None, None, None, None,
+                ) {
                     Ok(results) => {
                         for mem in &results {
                             println!(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -91,7 +91,8 @@ fn tool_definitions() -> Value {
                         "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": 1.0},
                         "source": {"type": "string", "enum": ["user", "claude", "hook", "api", "cli", "import", "consolidation", "system"], "default": "claude"},
                         "metadata": {"type": "object", "description": "Arbitrary JSON metadata", "default": {}},
-                        "agent_id": {"type": "string", "description": "Agent identifier. If omitted, the server synthesizes an NHI-hardened default (ai:<client>@<host>:pid-<pid>, host:<host>:pid-<pid>-<uuid8>, or anonymous:pid-<pid>-<uuid8>)."}
+                        "agent_id": {"type": "string", "description": "Agent identifier. If omitted, the server synthesizes an NHI-hardened default (ai:<client>@<host>:pid-<pid>, host:<host>:pid-<pid>-<uuid8>, or anonymous:pid-<pid>-<uuid8>)."},
+                        "scope": {"type": "string", "enum": ["private", "team", "unit", "org", "collective"], "description": "Task 1.5 visibility scope. Defaults to private when unset. Stored as metadata.scope."}
                     },
                     "required": ["title", "content"]
                 }
@@ -108,6 +109,7 @@ fn tool_definitions() -> Value {
                         "tags": {"type": "string", "description": "Filter by tag"},
                         "since": {"type": "string", "description": "Only memories created after this RFC3339 timestamp"},
                         "until": {"type": "string", "description": "Only memories created before this RFC3339 timestamp"},
+                        "as_agent": {"type": "string", "description": "Querying agent's namespace position (Task 1.5). Enables scope-based visibility filtering — results include private memories at this namespace, team/unit/org memories at ancestor subtrees, and collective memories globally."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens vs JSON. 'toon' includes timestamps. 'json' for structured parsing."}
                     },
                     "required": ["context"]
@@ -124,6 +126,7 @@ fn tool_definitions() -> Value {
                         "tier": {"type": "string", "enum": ["short", "mid", "long"]},
                         "limit": {"type": "integer", "default": 20, "maximum": 200},
                         "agent_id": {"type": "string", "description": "Filter by metadata.agent_id (exact match)."},
+                        "as_agent": {"type": "string", "description": "Querying agent's namespace position (Task 1.5) for scope-based visibility filtering."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens. 'json' for structured parsing."}
                     },
                     "required": ["query"]
@@ -551,6 +554,17 @@ fn handle_store(
             serde_json::Value::String(agent_id.clone()),
         );
     }
+    // #151 scope: top-level `scope` param OR inline metadata.scope
+    let explicit_scope = params["scope"]
+        .as_str()
+        .or_else(|| metadata.get("scope").and_then(serde_json::Value::as_str))
+        .map(str::to_string);
+    if let Some(ref s) = explicit_scope {
+        validate::validate_scope(s).map_err(|e| e.to_string())?;
+        if let Some(obj) = metadata.as_object_mut() {
+            obj.insert("scope".to_string(), serde_json::Value::String(s.clone()));
+        }
+    }
     validate::validate_metadata(&metadata).map_err(|e| e.to_string())?;
 
     let now = chrono::Utc::now();
@@ -781,6 +795,11 @@ fn handle_recall(
     let tags = params["tags"].as_str();
     let since = params["since"].as_str();
     let until = params["until"].as_str();
+    // #151 visibility
+    let as_agent = params["as_agent"].as_str();
+    if let Some(a) = as_agent {
+        validate::validate_namespace(a).map_err(|e| e.to_string())?;
+    }
 
     // Use hybrid recall if embedder is available
     if let Some(emb) = embedder {
@@ -798,6 +817,7 @@ fn handle_recall(
                     vector_index,
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
+                    as_agent,
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -833,6 +853,7 @@ fn handle_recall(
         until,
         resolved_ttl.short_extend_secs,
         resolved_ttl.mid_extend_secs,
+        as_agent,
     )
     .map_err(|e| e.to_string())?;
     let memories = scored_memories(results);
@@ -939,6 +960,10 @@ fn handle_search(conn: &rusqlite::Connection, params: &Value) -> Result<Value, S
     if let Some(aid) = agent_id {
         validate::validate_agent_id(aid).map_err(|e| e.to_string())?;
     }
+    let as_agent = params["as_agent"].as_str();
+    if let Some(a) = as_agent {
+        validate::validate_namespace(a).map_err(|e| e.to_string())?;
+    }
     let results = db::search(
         conn,
         query,
@@ -950,6 +975,7 @@ fn handle_search(conn: &rusqlite::Connection, params: &Value) -> Result<Value, S
         None,
         None,
         agent_id,
+        as_agent,
     )
     .map_err(|e| e.to_string())?;
     Ok(json!({"results": results, "count": results.len()}))

--- a/src/models.rs
+++ b/src/models.rs
@@ -114,6 +114,10 @@ pub struct CreateMemory {
     /// via `crate::identity` (NHI-hardened precedence chain).
     #[serde(default)]
     pub agent_id: Option<String>,
+    /// Optional visibility scope (Task 1.5). One of `VALID_SCOPES`. When
+    /// unset, treated as `private` by the query layer.
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 fn default_tier() -> Tier {
@@ -168,6 +172,10 @@ pub struct SearchQuery {
     /// Filter by `metadata.agent_id` (exact match).
     #[serde(default)]
     pub agent_id: Option<String>,
+    /// Task 1.5 visibility: the querying agent's namespace position.
+    /// When set, results are filtered per `metadata.scope` rules.
+    #[serde(default)]
+    pub as_agent: Option<String>,
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -211,6 +219,9 @@ pub struct RecallQuery {
     pub since: Option<String>,
     #[serde(default)]
     pub until: Option<String>,
+    /// Task 1.5 visibility filtering.
+    #[serde(default)]
+    pub as_agent: Option<String>,
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -231,6 +242,9 @@ pub struct RecallBody {
     pub since: Option<String>,
     #[serde(default)]
     pub until: Option<String>,
+    /// Task 1.5 visibility filtering.
+    #[serde(default)]
+    pub as_agent: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -279,6 +293,11 @@ pub struct NamespaceCount {
 
 /// Namespace reserved for agent registrations (Task 1.3).
 pub const AGENTS_NAMESPACE: &str = "_agents";
+
+/// Closed set of visibility scopes stamped into `metadata.scope` (Task 1.5).
+/// Controls which agents can see a memory via hierarchical namespace matching.
+/// Memories without a `scope` field are treated as `private` by the query layer.
+pub const VALID_SCOPES: &[&str] = &["private", "team", "unit", "org", "collective"];
 
 /// Closed set of agent types. Extend carefully — values are persisted.
 pub const VALID_AGENT_TYPES: &[&str] = &[

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, bail};
 
 use crate::models::{
     CreateMemory, MAX_CONTENT_SIZE, MAX_NAMESPACE_DEPTH, Memory, UpdateMemory, VALID_AGENT_TYPES,
+    VALID_SCOPES,
 };
 
 const MAX_TITLE_LEN: usize = 512;
@@ -185,6 +186,24 @@ pub fn validate_agent_id(agent_id: &str) -> Result<()> {
         if !(c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '@' | '.' | '/')) {
             bail!("agent_id contains invalid character '{c}' (allowed: alphanumeric, _-:@./)");
         }
+    }
+    Ok(())
+}
+
+/// Validate a visibility scope against the closed `VALID_SCOPES` set
+/// (Task 1.5). Enforced on write paths that accept an explicit `scope`
+/// parameter. Memories with no `scope` metadata are treated as `private`
+/// by the query layer without needing explicit validation here.
+pub fn validate_scope(scope: &str) -> Result<()> {
+    if scope.is_empty() {
+        bail!("scope cannot be empty");
+    }
+    if !VALID_SCOPES.contains(&scope) {
+        bail!(
+            "invalid scope '{}' — must be one of: {}",
+            scope,
+            VALID_SCOPES.join(", ")
+        );
     }
     Ok(())
 }
@@ -615,6 +634,21 @@ mod tests {
         assert!(validate_agent_id("alice\\bs").is_err());
         assert!(validate_agent_id("alice?q").is_err());
         assert!(validate_agent_id("alice*glob").is_err());
+    }
+
+    #[test]
+    fn test_valid_scope() {
+        for s in ["private", "team", "unit", "org", "collective"] {
+            assert!(validate_scope(s).is_ok(), "{s} must be valid");
+        }
+    }
+
+    #[test]
+    fn test_invalid_scope() {
+        assert!(validate_scope("").is_err());
+        assert!(validate_scope("public").is_err());
+        assert!(validate_scope("PRIVATE").is_err());
+        assert!(validate_scope("personal").is_err());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4652,3 +4652,356 @@ fn test_199_toon_compact_surfaces_agent_id() {
     );
     let _ = std::fs::remove_file(&db_path);
 }
+
+// ---------------------------------------------------------------------------
+// Task 1.5 — Visibility Rules (scope-based filtering)
+// ---------------------------------------------------------------------------
+
+fn fresh_scope_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-scope-{}.db", uuid::Uuid::new_v4()))
+}
+
+/// Seed a memory with an explicit scope + namespace.
+fn seed_scoped(binary: &str, db_path: &std::path::Path, namespace: &str, title: &str, scope: &str) {
+    let out = cmd(binary)
+        .env_remove("AI_MEMORY_AGENT_ID")
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            "seed",
+            "--json",
+            "store",
+            "-n",
+            namespace,
+            "-T",
+            title,
+            "-c",
+            "content",
+            "-t",
+            "long",
+            "--scope",
+            scope,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "seed failed for {title}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn recall_as_agent(
+    binary: &str,
+    db_path: &std::path::Path,
+    as_agent: &str,
+    context: &str,
+) -> Vec<String> {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "recall",
+            context,
+            "--as-agent",
+            as_agent,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "recall failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["memories"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|m| m["title"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[test]
+fn test_scope_private_visible_only_in_exact_namespace() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/platform/agent-1",
+        "priv-self",
+        "private",
+    );
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/platform/agent-2",
+        "priv-sibling",
+        "private",
+    );
+    seed_scoped(bin, &db, "alphaone/eng/platform", "priv-parent", "private");
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "priv");
+    assert!(titles.contains(&"priv-self".to_string()));
+    assert!(!titles.contains(&"priv-sibling".to_string()));
+    assert!(!titles.contains(&"priv-parent".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_team_visible_in_parent_subtree() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "alphaone/eng/platform", "team-at-parent", "team");
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/platform/agent-5",
+        "team-sibling",
+        "team",
+    );
+    seed_scoped(bin, &db, "alphaone/eng/ops", "team-other-team", "team");
+    seed_scoped(bin, &db, "other-org/eng/platform", "team-other-org", "team");
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "team");
+    assert!(titles.contains(&"team-at-parent".to_string()));
+    assert!(titles.contains(&"team-sibling".to_string()));
+    assert!(!titles.contains(&"team-other-team".to_string()));
+    assert!(!titles.contains(&"team-other-org".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_unit_visible_in_grandparent_subtree() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "alphaone/eng", "unit-at-grand", "unit");
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/ops/agent-7",
+        "unit-other-team",
+        "unit",
+    );
+    seed_scoped(bin, &db, "alphaone/sales", "unit-other-unit", "unit");
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "unit");
+    assert!(titles.contains(&"unit-at-grand".to_string()));
+    assert!(titles.contains(&"unit-other-team".to_string()));
+    assert!(!titles.contains(&"unit-other-unit".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_org_visible_across_whole_org() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "alphaone", "org-at-root", "org");
+    seed_scoped(bin, &db, "alphaone/sales/xyz", "org-other-branch", "org");
+    seed_scoped(bin, &db, "other-corp", "org-outsider", "org");
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "org");
+    assert!(titles.contains(&"org-at-root".to_string()));
+    assert!(titles.contains(&"org-other-branch".to_string()));
+    assert!(!titles.contains(&"org-outsider".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_collective_always_visible() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(
+        bin,
+        &db,
+        "completely-unrelated-ns",
+        "coll-anywhere",
+        "collective",
+    );
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "coll");
+    assert!(titles.contains(&"coll-anywhere".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_missing_treated_as_private() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    // seed WITHOUT scope (legacy-style)
+    cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "store",
+            "-n",
+            "alphaone/eng/platform/agent-1",
+            "-T",
+            "legacy-at-self",
+            "-c",
+            "legacy",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "store",
+            "-n",
+            "alphaone/eng/platform/agent-2",
+            "-T",
+            "legacy-at-sibling",
+            "-c",
+            "legacy",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+
+    let titles = recall_as_agent(bin, &db, "alphaone/eng/platform/agent-1", "legacy");
+    assert!(titles.contains(&"legacy-at-self".to_string()));
+    assert!(!titles.contains(&"legacy-at-sibling".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_no_as_agent_returns_all() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "alphaone/eng/platform", "all-1", "private");
+    seed_scoped(bin, &db, "other/ns", "all-2", "team");
+    seed_scoped(bin, &db, "yet-another", "all-3", "collective");
+
+    // No --as-agent: visibility filtering disabled, all 3 visible
+    let out = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "recall", "all"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let titles: Vec<String> = v["memories"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|m| m["title"].as_str().map(str::to_string))
+        .collect();
+    assert!(titles.contains(&"all-1".to_string()));
+    assert!(titles.contains(&"all-2".to_string()));
+    assert!(titles.contains(&"all-3".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_search_respects_as_agent() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/platform/agent-1",
+        "search-my",
+        "private",
+    );
+    seed_scoped(
+        bin,
+        &db,
+        "alphaone/eng/platform/agent-2",
+        "search-neighbor",
+        "private",
+    );
+
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "search",
+            "search",
+            "--as-agent",
+            "alphaone/eng/platform/agent-1",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let titles: Vec<String> = v["results"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|m| m["title"].as_str().map(str::to_string))
+        .collect();
+    assert!(titles.contains(&"search-my".to_string()));
+    assert!(!titles.contains(&"search-neighbor".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_flat_namespace_only_sees_exact_match_plus_collective() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "global", "flat-private", "private");
+    seed_scoped(bin, &db, "other", "flat-elsewhere", "private");
+    seed_scoped(bin, &db, "global", "flat-team-at-self", "team");
+    seed_scoped(bin, &db, "shared", "flat-collective", "collective");
+
+    let titles = recall_as_agent(bin, &db, "global", "flat");
+    assert!(titles.contains(&"flat-private".to_string()));
+    assert!(!titles.contains(&"flat-elsewhere".to_string()));
+    assert!(titles.contains(&"flat-collective".to_string()));
+    // Flat agent has no parent; team-scope with no team_prefix → invisible
+    assert!(!titles.contains(&"flat-team-at-self".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_invalid_rejected_at_store() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "store",
+            "-T",
+            "bad-scope",
+            "-c",
+            "x",
+            "--scope",
+            "public",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "invalid --scope must be rejected");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("invalid scope"),
+        "expected validator message, got: {err}"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_scope_invalid_as_agent_rejected() {
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "recall",
+            "x",
+            "--as-agent",
+            "has space",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "invalid --as-agent must be rejected");
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.5 — Visibility Rules** per `docs/PHASE-1.md`. Depends on Task 1.4 (merged). Second of the four Track-B tasks — 1.4 ✅ and 1.5 ✅ done; 1.6 and 1.7 remain before alpha.3 can be cut.

- Each memory can carry `metadata.scope ∈ {private, team, unit, org, collective}`
- `recall()`, `search()`, and `recall_hybrid()` accept optional `as_agent: Option<&str>`
- When `as_agent` is set, results are filtered by the agent's hierarchical position
- When unset, visibility filtering is a no-op (backward compatible)

Closes #151.

## Visibility semantics

For agent at `alphaone/eng/platform/agent-1`:

| Scope | Visible if memory.namespace is... |
|---|---|
| `private` | equal to agent's exact namespace |
| `team` | `alphaone/eng/platform` or any descendant |
| `unit` | `alphaone/eng` or any descendant |
| `org` | `alphaone` or any descendant |
| `collective` | any namespace |

Memories with no `scope` field are treated as `private` by the query layer (old data stays visible at its own namespace, invisible elsewhere under `--as-agent`).

Flat-namespace agents (`--as-agent global`) have no ancestors — they see only `private`-at-self and `collective` memories. `team`/`unit`/`org`-scoped memories are invisible (no applicable prefix).

## Implementation highlights

**SQL helper** — `visibility_clause(start_placeholder, table_alias)` returns a `WHERE`-fragment with 4 positional placeholders for private/team/unit/org prefixes. The first placeholder doubles as a short-circuit: when `NULL` (no `as_agent`), the entire clause passes, so visibility filtering becomes a no-op.

**Rust-side helper** — `is_visible()` mirrors the SQL logic for the HNSW branch of `recall_hybrid`, which iterates over memories loaded via `get()` rather than through SQL. Same semantics, same defaults.

**Prefix computation** — `compute_visibility_prefixes()` reads `ancestors[0..=3]` from Task 1.4's `namespace_ancestors()`. Missing depths bind `NULL` → that scope tier is simply invisible to that agent.

## Write paths (all 3 interfaces)

- **CLI:** `ai-memory store --scope team ...`
- **MCP:** `memory_store` tool now accepts `scope` property
- **HTTP:** `POST /api/v1/memories` body accepts top-level `scope` (inline `metadata.scope` still works as a shortcut)

All three validate against `VALID_SCOPES` before merging into metadata.

## Read paths

- **CLI:** `ai-memory recall foo --as-agent alphaone/eng/platform/agent-1`
- **MCP:** `memory_recall` / `memory_search` accept `as_agent` param
- **HTTP:** `GET /api/v1/recall?as_agent=...`, `POST /api/v1/recall` body field, `GET /api/v1/search?as_agent=...`

All entry points validate `as_agent` via `validate_namespace()` before passing to db.

## Files changed (7 files, +666 / −16)

| File | Lines | What |
|---|---|---|
| `src/models.rs` | +12 | `VALID_SCOPES` const; `scope`/`as_agent` fields |
| `src/validate.rs` | +24 | `validate_scope` + 2 tests |
| `src/db.rs` | +95 | visibility helpers, 3 function signatures updated |
| `src/mcp.rs` | +33 | tool_definitions, store/recall/search plumbing |
| `src/handlers.rs` | +35 | HTTP scope/as_agent wiring + validation |
| `src/main.rs` | +51 | CLI flags + cmd_* plumbing + recursion_limit bump |
| `tests/integration.rs` | +300 | 11 integration tests |

## Tests — +13 new (10-minimum exceeded)

**Unit (2):** `test_valid_scope`, `test_invalid_scope`.

**Integration (11):** private-exact-match, team-parent-subtree, unit-grandparent-subtree, org-whole-org, collective-everywhere, missing-scope-treated-as-private, no-as-agent-returns-all, search-also-respects-as-agent, flat-namespace-sees-self+collective-only, invalid-scope-rejected-at-store, invalid-as-agent-rejected-at-recall.

**Suite total: 221 unit + 96 integration = 317 passing.**

## Gates

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ — 317/317
- `cargo audit` ✓ — 0 vulns

No new `unwrap()` in production paths.

## Migration notes

- **Existing data** (no `scope` in metadata) continues to work unchanged when `as_agent` is not supplied. When `as_agent` IS supplied, legacy memories default to `private` semantics (visible at own namespace, invisible elsewhere) — the safest default.
- **Recursion limit bump** — added `#![recursion_limit = "256"]` to the crate root because the `json!` macro in `tool_definitions()` grew past the default 128-deep limit after Task 1.3 + Task 1.4 + Task 1.5 schemas. Trivial attribute, no runtime cost.

## Track B status after this PR

- [x] Task 1.4 — Hierarchical Namespace Paths (PR #207)
- [x] **Task 1.5 — Visibility Rules (this PR)**
- [ ] Task 1.6 — N-Level Rule Inheritance
- [ ] Task 1.7 — Vertical Memory Promotion

1.6 and 1.7 both depend only on 1.4 and can be done in parallel. Once both land → cut v0.6.0-alpha.3.

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard (new feature on integration branch) under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"