### PR TITLE
feat: governance enforcement (task 1.9) — closes #155

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -8,8 +8,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::models::{
-    AGENTS_NAMESPACE, AgentRegistration, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD,
-    Stats, Tier, TierCount, namespace_ancestors,
+    AGENTS_NAMESPACE, AgentRegistration, GovernanceDecision, GovernanceLevel, GovernancePolicy,
+    GovernedAction, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD, PendingAction, Stats,
+    Tier, TierCount, namespace_ancestors,
 };
 
 /// Computed 4-tuple of visibility prefixes for an agent position (Task 1.5).
@@ -149,7 +150,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 );
 ";
 
-const CURRENT_SCHEMA_VERSION: i64 = 7;
+const CURRENT_SCHEMA_VERSION: i64 = 8;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -284,6 +285,25 @@ fn migrate(conn: &Connection) -> Result<()> {
                     [],
                 )?;
             }
+        }
+        if version < 8 {
+            // Task 1.9: pending_actions table for governance-queued operations
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS pending_actions (
+                    id            TEXT PRIMARY KEY,
+                    action_type   TEXT NOT NULL,
+                    memory_id     TEXT,
+                    namespace     TEXT NOT NULL,
+                    payload       TEXT NOT NULL DEFAULT '{}',
+                    requested_by  TEXT NOT NULL,
+                    requested_at  TEXT NOT NULL,
+                    status        TEXT NOT NULL DEFAULT 'pending',
+                    decided_by    TEXT,
+                    decided_at    TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_pending_status    ON pending_actions(status);
+                CREATE INDEX IF NOT EXISTS idx_pending_namespace ON pending_actions(namespace);",
+            )?;
         }
 
         conn.execute("DELETE FROM schema_version", [])?;
@@ -2120,6 +2140,242 @@ pub fn clear_namespace_standard(conn: &Connection, namespace: &str) -> Result<bo
         params![namespace],
     )?;
     Ok(changed > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.9 — governance enforcement + pending_actions CRUD
+// ---------------------------------------------------------------------------
+
+/// Resolve the explicit governance policy for a namespace from its standard
+/// memory's `metadata.governance`. Returns `None` when no policy is set —
+/// enforcement is **opt-in**, so namespaces without explicit policy skip
+/// every governance check (historical behavior preserved). The "default
+/// policy" (`{ write: Any, promote: Any, delete: Owner, approver: Human }`)
+/// is surfaced by `get_standard` for display purposes only; it does not
+/// gate operations.
+pub fn resolve_governance_policy(conn: &Connection, namespace: &str) -> Option<GovernancePolicy> {
+    let standard_id = get_namespace_standard(conn, namespace).ok()??;
+    let mem = get(conn, &standard_id).ok()??;
+    match GovernancePolicy::from_metadata(&mem.metadata) {
+        Some(Ok(p)) => Some(p),
+        _ => None,
+    }
+}
+
+/// Return true if `agent_id` matches a registered agent in `_agents`.
+fn is_registered_agent(conn: &Connection, agent_id: &str) -> bool {
+    let title = format!("agent:{agent_id}");
+    conn.query_row(
+        "SELECT 1 FROM memories WHERE namespace = ?1 AND title = ?2",
+        params![AGENTS_NAMESPACE, &title],
+        |r| r.get::<_, i64>(0),
+    )
+    .is_ok()
+}
+
+/// Evaluate a governance level against caller context.
+/// - `memory_owner`: the existing memory's `metadata.agent_id` (delete/promote paths).
+///   Pass `None` for store operations.
+/// - `namespace_owner`: the `metadata.agent_id` of the namespace's standard memory,
+///   used as the "owner" for store operations. Resolved once by the caller.
+fn evaluate_level(
+    conn: &Connection,
+    level: &GovernanceLevel,
+    agent_id: &str,
+    memory_owner: Option<&str>,
+    namespace_owner: Option<&str>,
+) -> GovernanceDecision {
+    match level {
+        GovernanceLevel::Any => GovernanceDecision::Allow,
+        GovernanceLevel::Registered => {
+            if is_registered_agent(conn, agent_id) {
+                GovernanceDecision::Allow
+            } else {
+                GovernanceDecision::Deny(format!(
+                    "governance: caller '{agent_id}' is not a registered agent"
+                ))
+            }
+        }
+        GovernanceLevel::Owner => {
+            let owner = memory_owner.or(namespace_owner);
+            match owner {
+                Some(o) if o == agent_id => GovernanceDecision::Allow,
+                Some(o) => GovernanceDecision::Deny(format!(
+                    "governance: caller '{agent_id}' is not the owner ('{o}')"
+                )),
+                None => GovernanceDecision::Deny(
+                    "governance: owner-level action has no resolvable owner".into(),
+                ),
+            }
+        }
+        GovernanceLevel::Approve => {
+            // Caller translates this into a queued pending_action — the enforcement
+            // helpers below own the queueing so the db layer is the single source
+            // of truth for pending ids.
+            GovernanceDecision::Pending(String::new())
+        }
+    }
+}
+
+/// Resolve the namespace-owner (`metadata.agent_id` of the namespace's
+/// standard memory) used for `Owner`-level store checks.
+fn namespace_owner(conn: &Connection, namespace: &str) -> Option<String> {
+    let standard_id = get_namespace_standard(conn, namespace).ok().flatten()?;
+    let mem = get(conn, &standard_id).ok().flatten()?;
+    mem.metadata
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Enforce governance for a `GovernedAction`. On [`GovernanceDecision::Pending`],
+/// a row is inserted into `pending_actions` and the returned `pending_id` is
+/// embedded in the decision.
+pub fn enforce_governance(
+    conn: &Connection,
+    action: GovernedAction,
+    namespace: &str,
+    agent_id: &str,
+    memory_id: Option<&str>,
+    memory_owner: Option<&str>,
+    payload: &serde_json::Value,
+) -> Result<GovernanceDecision> {
+    // Opt-in enforcement: namespaces without an explicit policy are unaffected.
+    let Some(policy) = resolve_governance_policy(conn, namespace) else {
+        return Ok(GovernanceDecision::Allow);
+    };
+    let level = match action {
+        GovernedAction::Store => &policy.write,
+        GovernedAction::Delete => &policy.delete,
+        GovernedAction::Promote => &policy.promote,
+    };
+    let ns_owner = if matches!(action, GovernedAction::Store) {
+        namespace_owner(conn, namespace)
+    } else {
+        None
+    };
+
+    let decision = evaluate_level(conn, level, agent_id, memory_owner, ns_owner.as_deref());
+    if let GovernanceDecision::Pending(_) = decision {
+        let pending_id =
+            queue_pending_action(conn, action, namespace, memory_id, agent_id, payload)?;
+        return Ok(GovernanceDecision::Pending(pending_id));
+    }
+    Ok(decision)
+}
+
+/// Insert a `pending_actions` row and return its id.
+pub fn queue_pending_action(
+    conn: &Connection,
+    action: GovernedAction,
+    namespace: &str,
+    memory_id: Option<&str>,
+    requested_by: &str,
+    payload: &serde_json::Value,
+) -> Result<String> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+    let payload_json = serde_json::to_string(payload)?;
+    conn.execute(
+        "INSERT INTO pending_actions (id, action_type, memory_id, namespace, payload, requested_by, requested_at, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'pending')",
+        params![
+            id,
+            action.as_str(),
+            memory_id,
+            namespace,
+            payload_json,
+            requested_by,
+            now,
+        ],
+    )?;
+    Ok(id)
+}
+
+pub fn list_pending_actions(
+    conn: &Connection,
+    status: Option<&str>,
+    limit: usize,
+) -> Result<Vec<PendingAction>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, action_type, memory_id, namespace, payload, requested_by,
+                requested_at, status, decided_by, decided_at
+         FROM pending_actions
+         WHERE (?1 IS NULL OR status = ?1)
+         ORDER BY requested_at DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![status, limit], |row| {
+        let payload_str: String = row.get(4)?;
+        let payload: serde_json::Value =
+            serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Null);
+        Ok(PendingAction {
+            id: row.get(0)?,
+            action_type: row.get(1)?,
+            memory_id: row.get(2)?,
+            namespace: row.get(3)?,
+            payload,
+            requested_by: row.get(5)?,
+            requested_at: row.get(6)?,
+            status: row.get(7)?,
+            decided_by: row.get(8)?,
+            decided_at: row.get(9)?,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(Into::into)
+}
+
+#[allow(dead_code)]
+pub fn get_pending_action(conn: &Connection, id: &str) -> Result<Option<PendingAction>> {
+    let row = conn.query_row(
+        "SELECT id, action_type, memory_id, namespace, payload, requested_by,
+                requested_at, status, decided_by, decided_at
+         FROM pending_actions WHERE id = ?1",
+        params![id],
+        |row| {
+            let payload_str: String = row.get(4)?;
+            let payload: serde_json::Value =
+                serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Null);
+            Ok(PendingAction {
+                id: row.get(0)?,
+                action_type: row.get(1)?,
+                memory_id: row.get(2)?,
+                namespace: row.get(3)?,
+                payload,
+                requested_by: row.get(5)?,
+                requested_at: row.get(6)?,
+                status: row.get(7)?,
+                decided_by: row.get(8)?,
+                decided_at: row.get(9)?,
+            })
+        },
+    );
+    match row {
+        Ok(p) => Ok(Some(p)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Mark a pending action as approved or rejected. Returns true on status
+/// transition. Does NOT execute the action itself — the caller replays
+/// the payload on approval (the db layer doesn't know how to execute
+/// cross-interface write semantics).
+pub fn decide_pending_action(
+    conn: &Connection,
+    id: &str,
+    approve: bool,
+    decided_by: &str,
+) -> Result<bool> {
+    let new_status = if approve { "approved" } else { "rejected" };
+    let now = Utc::now().to_rfc3339();
+    let updated = conn.execute(
+        "UPDATE pending_actions SET status = ?1, decided_by = ?2, decided_at = ?3
+         WHERE id = ?4 AND status = 'pending'",
+        params![new_status, decided_by, now, id],
+    )?;
+    Ok(updated > 0)
 }
 
 /// Check if a memory ID is a namespace standard (used by consolidate to warn).

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -92,6 +92,7 @@ pub async fn health(State(state): State<Db>) -> impl IntoResponse {
         .into_response()
 }
 
+#[allow(clippy::too_many_lines)]
 pub async fn create_memory(
     State(state): State<Db>,
     headers: HeaderMap,
@@ -161,6 +162,57 @@ pub async fn create_memory(
         expires_at,
         metadata,
     };
+
+    // Task 1.9: governance enforcement (store-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let agent_for_gov = mem
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let payload = serde_json::to_value(&mem).unwrap_or_default();
+        match db::enforce_governance(
+            &lock.0,
+            GovernedAction::Store,
+            &mem.namespace,
+            &agent_for_gov,
+            None,
+            None,
+            &payload,
+        ) {
+            Ok(GovernanceDecision::Allow) => {}
+            Ok(GovernanceDecision::Deny(reason)) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({"error": format!("store denied by governance: {reason}")})),
+                )
+                    .into_response();
+            }
+            Ok(GovernanceDecision::Pending(pending_id)) => {
+                return (
+                    StatusCode::ACCEPTED,
+                    Json(json!({
+                        "status": "pending",
+                        "pending_id": pending_id,
+                        "reason": "governance requires approval",
+                        "action": "store",
+                        "namespace": mem.namespace,
+                    })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("governance error: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "governance check failed"})),
+                )
+                    .into_response();
+            }
+        }
+    }
 
     // Check for contradictions
     let contradictions =
@@ -240,6 +292,130 @@ pub async fn register_agent(
                 "agent_type": body.agent_type,
                 "capabilities": capabilities,
             })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.9 — pending_actions endpoints
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct PendingListQuery {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default = "default_pending_limit")]
+    pub limit: Option<usize>,
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn default_pending_limit() -> Option<usize> {
+    Some(100)
+}
+
+pub async fn list_pending(
+    State(state): State<Db>,
+    Query(p): Query<PendingListQuery>,
+) -> impl IntoResponse {
+    let limit = p.limit.unwrap_or(100).min(1000);
+    let lock = state.lock().await;
+    match db::list_pending_actions(&lock.0, p.status.as_deref(), limit) {
+        Ok(items) => Json(json!({"count": items.len(), "pending": items})).into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn approve_pending(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_id(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+    let agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+        Ok(a) => a,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid agent_id: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    let lock = state.lock().await;
+    match db::decide_pending_action(&lock.0, &id, true, &agent_id) {
+        Ok(true) => {
+            Json(json!({"approved": true, "id": id, "decided_by": agent_id})).into_response()
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "pending action not found or already decided"})),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn reject_pending(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_id(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+    let agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+        Ok(a) => a,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid agent_id: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    let lock = state.lock().await;
+    match db::decide_pending_action(&lock.0, &id, false, &agent_id) {
+        Ok(true) => {
+            Json(json!({"rejected": true, "id": id, "decided_by": agent_id})).into_response()
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "pending action not found or already decided"})),
         )
             .into_response(),
         Err(e) => {
@@ -385,7 +561,11 @@ pub async fn update_memory(
     }
 }
 
-pub async fn delete_memory(State(state): State<Db>, Path(id): Path<String>) -> impl IntoResponse {
+pub async fn delete_memory(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
     if let Err(e) = validate::validate_id(&id) {
         return (
             StatusCode::BAD_REQUEST,
@@ -394,61 +574,9 @@ pub async fn delete_memory(State(state): State<Db>, Path(id): Path<String>) -> i
             .into_response();
     }
     let lock = state.lock().await;
-    // Try exact delete first; fall back to prefix resolution
-    match db::delete(&lock.0, &id) {
-        Ok(true) => Json(json!({"deleted": true})).into_response(),
-        Ok(false) => {
-            // Prefix fallback
-            match db::get_by_prefix(&lock.0, &id) {
-                Ok(Some(mem)) => {
-                    let full_id = mem.id;
-                    match db::delete(&lock.0, &full_id) {
-                        Ok(true) => Json(json!({"deleted": true})).into_response(),
-                        _ => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"})))
-                            .into_response(),
-                    }
-                }
-                Ok(None) => {
-                    (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()
-                }
-                Err(e) => {
-                    let msg = e.to_string();
-                    if msg.contains("ambiguous ID prefix") {
-                        (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response()
-                    } else {
-                        tracing::error!("handler error: {e}");
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({"error": "internal server error"})),
-                        )
-                            .into_response()
-                    }
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("handler error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-                .into_response()
-        }
-    }
-}
-
-pub async fn promote_memory(State(state): State<Db>, Path(id): Path<String>) -> impl IntoResponse {
-    if let Err(e) = validate::validate_id(&id) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": e.to_string()})),
-        )
-            .into_response();
-    }
-    let lock = state.lock().await;
-    // Resolve prefix if exact ID not found
-    let resolved_id = match db::resolve_id(&lock.0, &id) {
-        Ok(Some(mem)) => mem.id,
+    // Resolve the target memory so governance has owner context.
+    let target = match db::resolve_id(&lock.0, &id) {
+        Ok(Some(m)) => m,
         Ok(None) => {
             return (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response();
         }
@@ -465,6 +593,169 @@ pub async fn promote_memory(State(state): State<Db>, Path(id): Path<String>) -> 
                 .into_response();
         }
     };
+
+    // Task 1.9: governance enforcement (delete-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+        let agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+            Ok(a) => a,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid agent_id: {e}")})),
+                )
+                    .into_response();
+            }
+        };
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = json!({"id": target.id, "title": target.title});
+        match db::enforce_governance(
+            &lock.0,
+            GovernedAction::Delete,
+            &target.namespace,
+            &agent_id,
+            Some(&target.id),
+            mem_owner.as_deref(),
+            &payload,
+        ) {
+            Ok(GovernanceDecision::Allow) => {}
+            Ok(GovernanceDecision::Deny(reason)) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({"error": format!("delete denied by governance: {reason}")})),
+                )
+                    .into_response();
+            }
+            Ok(GovernanceDecision::Pending(pending_id)) => {
+                return (
+                    StatusCode::ACCEPTED,
+                    Json(json!({
+                        "status": "pending",
+                        "pending_id": pending_id,
+                        "reason": "governance requires approval",
+                        "action": "delete",
+                        "memory_id": target.id,
+                    })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("governance error: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "governance check failed"})),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    match db::delete(&lock.0, &target.id) {
+        Ok(true) => Json(json!({"deleted": true})).into_response(),
+        _ => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response(),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn promote_memory(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_id(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let lock = state.lock().await;
+    // Resolve prefix if exact ID not found — capture full memory for governance.
+    let target = match db::resolve_id(&lock.0, &id) {
+        Ok(Some(mem)) => mem,
+        Ok(None) => {
+            return (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response();
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("ambiguous ID prefix") {
+                return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
+            }
+            tracing::error!("handler error: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+    };
+    // Task 1.9: governance enforcement (promote-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+        let agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+            Ok(a) => a,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid agent_id: {e}")})),
+                )
+                    .into_response();
+            }
+        };
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = json!({"id": target.id});
+        match db::enforce_governance(
+            &lock.0,
+            GovernedAction::Promote,
+            &target.namespace,
+            &agent_id,
+            Some(&target.id),
+            mem_owner.as_deref(),
+            &payload,
+        ) {
+            Ok(GovernanceDecision::Allow) => {}
+            Ok(GovernanceDecision::Deny(reason)) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({"error": format!("promote denied by governance: {reason}")})),
+                )
+                    .into_response();
+            }
+            Ok(GovernanceDecision::Pending(pending_id)) => {
+                return (
+                    StatusCode::ACCEPTED,
+                    Json(json!({
+                        "status": "pending",
+                        "pending_id": pending_id,
+                        "reason": "governance requires approval",
+                        "action": "promote",
+                        "memory_id": target.id,
+                    })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("governance error: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "governance check failed"})),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let resolved_id = target.id.clone();
     match db::update(
         &lock.0,
         &resolved_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,29 @@ enum Command {
     Archive(ArchiveArgs),
     /// Register or list agents (Task 1.3)
     Agents(AgentsArgs),
+    /// List / approve / reject governance-pending actions (Task 1.9)
+    Pending(PendingArgs),
+}
+
+#[derive(Args)]
+struct PendingArgs {
+    #[command(subcommand)]
+    action: PendingAction,
+}
+
+#[derive(Subcommand)]
+enum PendingAction {
+    /// List pending actions (optionally filter by status).
+    List {
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+    },
+    /// Approve a pending action by id.
+    Approve { id: String },
+    /// Reject a pending action by id.
+    Reject { id: String },
 }
 
 #[derive(Args)]
@@ -537,8 +560,8 @@ async fn main() -> Result<()> {
         Command::Search(a) => cmd_search(&db_path, &a, j, &app_config),
         Command::Get(a) => cmd_get(&db_path, &a, j),
         Command::List(a) => cmd_list(&db_path, &a, j, &app_config),
-        Command::Delete(a) => cmd_delete(&db_path, &a, j),
-        Command::Promote(a) => cmd_promote(&db_path, &a, j),
+        Command::Delete(a) => cmd_delete(&db_path, &a, j, cli_agent_id.as_deref()),
+        Command::Promote(a) => cmd_promote(&db_path, &a, j, cli_agent_id.as_deref()),
         Command::Forget(a) => cmd_forget(&db_path, &a, j),
         Command::Link(a) => cmd_link(&db_path, &a, j),
         Command::Consolidate(a) => cmd_consolidate(&db_path, a, j, cli_agent_id.as_deref()),
@@ -571,6 +594,7 @@ async fn main() -> Result<()> {
         Command::Mine(a) => cmd_mine(&db_path, a, j, &app_config, cli_agent_id.as_deref()),
         Command::Archive(a) => cmd_archive(&db_path, a, j),
         Command::Agents(a) => cmd_agents(&db_path, a, j),
+        Command::Pending(a) => cmd_pending(&db_path, a, j, cli_agent_id.as_deref()),
     };
 
     // WAL checkpoint after write commands to prevent unbounded WAL growth
@@ -584,6 +608,7 @@ async fn main() -> Result<()> {
     result
 }
 
+#[allow(clippy::too_many_lines)]
 async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -671,6 +696,15 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         .route("/api/v1/archive/stats", get(handlers::archive_stats))
         .route("/api/v1/agents", get(handlers::list_agents))
         .route("/api/v1/agents", post(handlers::register_agent))
+        .route("/api/v1/pending", get(handlers::list_pending))
+        .route(
+            "/api/v1/pending/{id}/approve",
+            post(handlers::approve_pending),
+        )
+        .route(
+            "/api/v1/pending/{id}/reject",
+            post(handlers::reject_pending),
+        )
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             handlers::api_key_auth,
@@ -693,6 +727,7 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
 
 // --- CLI ---
 
+#[allow(clippy::too_many_lines)]
 fn cmd_store(
     db_path: &Path,
     args: StoreArgs,
@@ -745,13 +780,58 @@ fn cmd_store(
     let agent_id = identity::resolve_agent_id(cli_agent_id, None)?;
     let mut metadata = models::default_metadata();
     if let Some(obj) = metadata.as_object_mut() {
-        obj.insert("agent_id".to_string(), serde_json::Value::String(agent_id));
+        obj.insert(
+            "agent_id".to_string(),
+            serde_json::Value::String(agent_id.clone()),
+        );
     }
     // #151 scope: validate + merge into metadata
     if let Some(ref s) = args.scope {
         validate::validate_scope(s)?;
         if let Some(obj) = metadata.as_object_mut() {
             obj.insert("scope".to_string(), serde_json::Value::String(s.clone()));
+        }
+    }
+
+    // Task 1.9: governance enforcement (store-side)
+    {
+        use models::{GovernanceDecision, GovernedAction};
+        let payload = serde_json::json!({
+            "title": &args.title,
+            "namespace": &namespace,
+            "tier": &args.tier,
+        });
+        match db::enforce_governance(
+            &conn,
+            GovernedAction::Store,
+            &namespace,
+            &agent_id,
+            None,
+            None,
+            &payload,
+        )? {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                eprintln!("store denied by governance: {reason}");
+                std::process::exit(1);
+            }
+            GovernanceDecision::Pending(pending_id) => {
+                if json_out {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "pending",
+                            "pending_id": pending_id,
+                            "reason": "governance requires approval",
+                            "action": "store",
+                            "namespace": &namespace,
+                        })
+                    );
+                } else {
+                    println!("store queued for approval: pending_id={pending_id} ns={namespace}");
+                }
+                return Ok(());
+            }
         }
     }
 
@@ -1218,24 +1298,73 @@ fn cmd_list(
     Ok(())
 }
 
-fn cmd_delete(db_path: &Path, args: &DeleteArgs, json_out: bool) -> Result<()> {
+fn cmd_delete(
+    db_path: &Path,
+    args: &DeleteArgs,
+    json_out: bool,
+    cli_agent_id: Option<&str>,
+) -> Result<()> {
     validate::validate_id(&args.id)?;
     let conn = db::open(db_path)?;
-    // Try exact delete first; if not found, resolve prefix to get the full ID
-    if db::delete(&conn, &args.id)? {
-        if json_out {
-            println!("{}", serde_json::json!({"deleted": true, "id": args.id}));
-        } else {
-            println!("deleted: {}", args.id);
-        }
-    } else if let Some(mem) = db::get_by_prefix(&conn, &args.id)? {
-        let full_id = mem.id.clone();
-        if db::delete(&conn, &full_id)? {
-            if json_out {
-                println!("{}", serde_json::json!({"deleted": true, "id": full_id}));
-            } else {
-                println!("deleted: {full_id}");
+    // Resolve the target first for governance owner context.
+    let target = db::resolve_id(&conn, &args.id)?;
+    let Some(target) = target else {
+        eprintln!("not found: {}", args.id);
+        std::process::exit(1);
+    };
+
+    // Task 1.9: governance enforcement (delete-side)
+    {
+        use models::{GovernanceDecision, GovernedAction};
+        let caller_agent_id = identity::resolve_agent_id(cli_agent_id, None)?;
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = serde_json::json!({"id": target.id, "title": target.title});
+        match db::enforce_governance(
+            &conn,
+            GovernedAction::Delete,
+            &target.namespace,
+            &caller_agent_id,
+            Some(&target.id),
+            mem_owner.as_deref(),
+            &payload,
+        )? {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                eprintln!("delete denied by governance: {reason}");
+                std::process::exit(1);
             }
+            GovernanceDecision::Pending(pending_id) => {
+                if json_out {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "pending",
+                            "pending_id": pending_id,
+                            "reason": "governance requires approval",
+                            "action": "delete",
+                            "memory_id": target.id,
+                        })
+                    );
+                } else {
+                    println!(
+                        "delete queued for approval: pending_id={pending_id} id={}",
+                        target.id
+                    );
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    if db::delete(&conn, &target.id)? {
+        if json_out {
+            println!("{}", serde_json::json!({"deleted": true, "id": target.id}));
+        } else {
+            println!("deleted: {}", target.id);
         }
     } else {
         eprintln!("not found: {}", args.id);
@@ -1244,21 +1373,78 @@ fn cmd_delete(db_path: &Path, args: &DeleteArgs, json_out: bool) -> Result<()> {
     Ok(())
 }
 
-fn cmd_promote(db_path: &Path, args: &PromoteArgs, json_out: bool) -> Result<()> {
+#[allow(clippy::too_many_lines)]
+fn cmd_promote(
+    db_path: &Path,
+    args: &PromoteArgs,
+    json_out: bool,
+    cli_agent_id: Option<&str>,
+) -> Result<()> {
     validate::validate_id(&args.id)?;
     if let Some(ref to_ns) = args.to_namespace {
         validate::validate_namespace(to_ns)?;
     }
     let conn = db::open(db_path)?;
-    // Resolve prefix if exact ID not found
-    let resolved_id = if db::get(&conn, &args.id)?.is_some() {
-        args.id.clone()
-    } else if let Some(mem) = db::get_by_prefix(&conn, &args.id)? {
-        mem.id
+    // Resolve target; capture the memory for governance owner context.
+    let target = if let Some(m) = db::get(&conn, &args.id)? {
+        m
+    } else if let Some(m) = db::get_by_prefix(&conn, &args.id)? {
+        m
     } else {
         eprintln!("not found: {}", args.id);
         std::process::exit(1);
     };
+    let resolved_id = target.id.clone();
+
+    // Task 1.9: governance enforcement (promote-side)
+    {
+        use models::{GovernanceDecision, GovernedAction};
+        let caller_agent_id = identity::resolve_agent_id(cli_agent_id, None)?;
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = serde_json::json!({
+            "id": resolved_id,
+            "to_namespace": args.to_namespace,
+        });
+        match db::enforce_governance(
+            &conn,
+            GovernedAction::Promote,
+            &target.namespace,
+            &caller_agent_id,
+            Some(&resolved_id),
+            mem_owner.as_deref(),
+            &payload,
+        )? {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                eprintln!("promote denied by governance: {reason}");
+                std::process::exit(1);
+            }
+            GovernanceDecision::Pending(pending_id) => {
+                if json_out {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "pending",
+                            "pending_id": pending_id,
+                            "reason": "governance requires approval",
+                            "action": "promote",
+                            "memory_id": resolved_id,
+                        })
+                    );
+                } else {
+                    println!(
+                        "promote queued for approval: pending_id={pending_id} id={resolved_id}"
+                    );
+                }
+                return Ok(());
+            }
+        }
+    }
+
     // Task 1.7: vertical (namespace) promotion when --to-namespace is set
     if let Some(ref to_ns) = args.to_namespace {
         let clone_id = db::promote_to_namespace(&conn, &resolved_id, to_ns)?;
@@ -2187,6 +2373,76 @@ fn cmd_agents(db_path: &Path, args: AgentsArgs, json_out: bool) -> Result<()> {
                         caps.join(",")
                     }
                 );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_pending(
+    db_path: &Path,
+    args: PendingArgs,
+    json_out: bool,
+    cli_agent_id: Option<&str>,
+) -> Result<()> {
+    let conn = db::open(db_path)?;
+    match args.action {
+        PendingAction::List { status, limit } => {
+            let items = db::list_pending_actions(&conn, status.as_deref(), limit)?;
+            if json_out {
+                println!(
+                    "{}",
+                    serde_json::json!({"count": items.len(), "pending": items})
+                );
+            } else if items.is_empty() {
+                println!("no pending actions");
+            } else {
+                for item in &items {
+                    println!(
+                        "[{}] {} ns={} action={} by={} ({})",
+                        id_short(&item.id),
+                        item.status,
+                        item.namespace,
+                        item.action_type,
+                        item.requested_by,
+                        item.requested_at
+                    );
+                }
+                println!("{} pending action(s)", items.len());
+            }
+        }
+        PendingAction::Approve { id } => {
+            validate::validate_id(&id)?;
+            let agent = identity::resolve_agent_id(cli_agent_id, None)?;
+            let ok = db::decide_pending_action(&conn, &id, true, &agent)?;
+            if !ok {
+                eprintln!("pending action not found or already decided: {id}");
+                std::process::exit(1);
+            }
+            if json_out {
+                println!(
+                    "{}",
+                    serde_json::json!({"approved": true, "id": id, "decided_by": agent})
+                );
+            } else {
+                println!("approved: {id} (by {agent})");
+            }
+        }
+        PendingAction::Reject { id } => {
+            validate::validate_id(&id)?;
+            let agent = identity::resolve_agent_id(cli_agent_id, None)?;
+            let ok = db::decide_pending_action(&conn, &id, false, &agent)?;
+            if !ok {
+                eprintln!("pending action not found or already decided: {id}");
+                std::process::exit(1);
+            }
+            if json_out {
+                println!(
+                    "{}",
+                    serde_json::json!({"rejected": true, "id": id, "decided_by": agent})
+                );
+            } else {
+                println!("rejected: {id} (by {agent})");
             }
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -405,6 +405,39 @@ fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_pending_list",
+                "description": "List pending governance-queued actions (Task 1.9). Filter by status: pending (default) / approved / rejected.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "status": {"type": "string", "enum": ["pending", "approved", "rejected"]},
+                        "limit":  {"type": "integer", "default": 100, "maximum": 1000}
+                    }
+                }
+            },
+            {
+                "name": "memory_pending_approve",
+                "description": "Approve a pending action by id (Task 1.9). Caller identity is stamped as decided_by.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "Pending action id"}
+                    },
+                    "required": ["id"]
+                }
+            },
+            {
+                "name": "memory_pending_reject",
+                "description": "Reject a pending action by id (Task 1.9). Caller identity is stamped as decided_by.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "Pending action id"}
+                    },
+                    "required": ["id"]
+                }
+            },
+            {
                 "name": "memory_agent_register",
                 "description": "Register an agent in the reserved _agents namespace. Stores agent_type and capabilities, refreshes last_seen_at on re-registration while preserving registered_at. agent_id is claimed, not attested.",
                 "inputSchema": {
@@ -601,6 +634,37 @@ fn handle_store(
         expires_at,
         metadata,
     };
+
+    // Task 1.9: governance enforcement (store-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let payload = serde_json::to_value(&mem).unwrap_or_default();
+        match db::enforce_governance(
+            conn,
+            GovernedAction::Store,
+            &mem.namespace,
+            &agent_id,
+            None,
+            None,
+            &payload,
+        )
+        .map_err(|e| e.to_string())?
+        {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                return Err(format!("store denied by governance: {reason}"));
+            }
+            GovernanceDecision::Pending(pending_id) => {
+                return Ok(json!({
+                    "status": "pending",
+                    "pending_id": pending_id,
+                    "reason": "governance requires approval",
+                    "action": "store",
+                    "namespace": mem.namespace,
+                }));
+            }
+        }
+    }
 
     // True dedup: check for exact title+namespace match (#97)
     let existing = db::find_contradictions(conn, &mem.title, &mem.namespace).unwrap_or_default();
@@ -1062,43 +1126,128 @@ fn handle_delete(
     conn: &rusqlite::Connection,
     params: &Value,
     vector_index: Option<&VectorIndex>,
+    mcp_client: Option<&str>,
 ) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
-    // Try exact delete first; fall back to prefix resolution
-    let deleted = db::delete(conn, id).map_err(|e| e.to_string())?;
+
+    // Resolve the memory first so governance has owner context.
+    let target = if let Some(m) = db::get(conn, id).map_err(|e| e.to_string())? {
+        Some(m)
+    } else {
+        db::get_by_prefix(conn, id).map_err(|e| e.to_string())?
+    };
+    let Some(target) = target else {
+        return Err("memory not found".into());
+    };
+
+    // Task 1.9: governance enforcement (delete-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
+            .map_err(|e| e.to_string())?;
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = json!({"id": target.id, "title": target.title});
+        match db::enforce_governance(
+            conn,
+            GovernedAction::Delete,
+            &target.namespace,
+            &agent_id,
+            Some(&target.id),
+            mem_owner.as_deref(),
+            &payload,
+        )
+        .map_err(|e| e.to_string())?
+        {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                return Err(format!("delete denied by governance: {reason}"));
+            }
+            GovernanceDecision::Pending(pending_id) => {
+                return Ok(json!({
+                    "status": "pending",
+                    "pending_id": pending_id,
+                    "reason": "governance requires approval",
+                    "action": "delete",
+                    "memory_id": target.id,
+                }));
+            }
+        }
+    }
+
+    let deleted = db::delete(conn, &target.id).map_err(|e| e.to_string())?;
     if deleted {
         if let Some(idx) = vector_index {
-            idx.remove(id);
+            idx.remove(&target.id);
         }
         Ok(json!({"deleted": true}))
-    } else if let Some(mem) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
-        let full_id = mem.id.clone();
-        let deleted = db::delete(conn, &full_id).map_err(|e| e.to_string())?;
-        if deleted {
-            if let Some(idx) = vector_index {
-                idx.remove(&full_id);
-            }
-            Ok(json!({"deleted": true}))
-        } else {
-            Err("memory not found".into())
-        }
     } else {
         Err("memory not found".into())
     }
 }
 
-fn handle_promote(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+fn handle_promote(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    mcp_client: Option<&str>,
+) -> Result<Value, String> {
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
-    // Resolve prefix if exact ID not found
-    let resolved_id = if db::get(conn, id).map_err(|e| e.to_string())?.is_some() {
-        id.to_string()
-    } else if let Some(mem) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
-        mem.id
+    // Resolve prefix if exact ID not found; capture the memory so governance
+    // has owner context (Task 1.9).
+    let target = if let Some(m) = db::get(conn, id).map_err(|e| e.to_string())? {
+        m
+    } else if let Some(m) = db::get_by_prefix(conn, id).map_err(|e| e.to_string())? {
+        m
     } else {
         return Err("memory not found".into());
     };
+    let resolved_id = target.id.clone();
+
+    // Task 1.9: governance enforcement (promote-side).
+    {
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
+            .map_err(|e| e.to_string())?;
+        let mem_owner = target
+            .metadata
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let payload = json!({
+            "id": resolved_id,
+            "to_namespace": params["to_namespace"].as_str(),
+        });
+        match db::enforce_governance(
+            conn,
+            GovernedAction::Promote,
+            &target.namespace,
+            &agent_id,
+            Some(&resolved_id),
+            mem_owner.as_deref(),
+            &payload,
+        )
+        .map_err(|e| e.to_string())?
+        {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                return Err(format!("promote denied by governance: {reason}"));
+            }
+            GovernanceDecision::Pending(pending_id) => {
+                return Ok(json!({
+                    "status": "pending",
+                    "pending_id": pending_id,
+                    "reason": "governance requires approval",
+                    "action": "promote",
+                    "memory_id": resolved_id,
+                }));
+            }
+        }
+    }
 
     // Task 1.7: optional vertical promotion to an ancestor namespace.
     // When `to_namespace` is supplied, clone (don't move) the memory to the
@@ -1695,6 +1844,49 @@ fn handle_agent_list(conn: &rusqlite::Connection) -> Result<Value, String> {
     }))
 }
 
+fn handle_pending_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let status = params["status"].as_str();
+    let limit = usize::try_from(params["limit"].as_u64().unwrap_or(100))
+        .expect("u64 as usize")
+        .min(1000);
+    let items = db::list_pending_actions(conn, status, limit).map_err(|e| e.to_string())?;
+    Ok(json!({"count": items.len(), "pending": items}))
+}
+
+fn handle_pending_approve(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    mcp_client: Option<&str>,
+) -> Result<Value, String> {
+    let id = params["id"].as_str().ok_or("id is required")?;
+    validate::validate_id(id).map_err(|e| e.to_string())?;
+    let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
+        .map_err(|e| e.to_string())?;
+    let transitioned =
+        db::decide_pending_action(conn, id, true, &agent_id).map_err(|e| e.to_string())?;
+    if !transitioned {
+        return Err(format!("pending action not found or already decided: {id}"));
+    }
+    Ok(json!({"approved": true, "id": id, "decided_by": agent_id}))
+}
+
+fn handle_pending_reject(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    mcp_client: Option<&str>,
+) -> Result<Value, String> {
+    let id = params["id"].as_str().ok_or("id is required")?;
+    validate::validate_id(id).map_err(|e| e.to_string())?;
+    let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
+        .map_err(|e| e.to_string())?;
+    let transitioned =
+        db::decide_pending_action(conn, id, false, &agent_id).map_err(|e| e.to_string())?;
+    if !transitioned {
+        return Err(format!("pending action not found or already decided: {id}"));
+    }
+    Ok(json!({"rejected": true, "id": id, "decided_by": agent_id}))
+}
+
 fn handle_archive_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     let limit = usize::try_from(params["limit"].as_u64().unwrap_or(50)).expect("u64 as usize");
@@ -1891,8 +2083,11 @@ fn handle_request(
                 ),
                 "memory_search" => handle_search(conn, arguments),
                 "memory_list" => handle_list(conn, arguments),
-                "memory_delete" => handle_delete(conn, arguments, vector_index),
-                "memory_promote" => handle_promote(conn, arguments),
+                "memory_delete" => handle_delete(conn, arguments, vector_index, mcp_client),
+                "memory_promote" => handle_promote(conn, arguments, mcp_client),
+                "memory_pending_list" => handle_pending_list(conn, arguments),
+                "memory_pending_approve" => handle_pending_approve(conn, arguments, mcp_client),
+                "memory_pending_reject" => handle_pending_reject(conn, arguments, mcp_client),
                 "memory_forget" => handle_forget(conn, arguments, archive_on_gc),
                 "memory_stats" => handle_stats(conn, db_path),
                 "memory_update" => handle_update(conn, arguments, embedder, vector_index),
@@ -2233,10 +2428,10 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_28_tools() {
+    fn tool_definitions_returns_31_tools() {
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 28);
+        assert_eq!(tools.len(), 31);
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -295,6 +295,60 @@ pub struct NamespaceCount {
 pub const AGENTS_NAMESPACE: &str = "_agents";
 
 // ---------------------------------------------------------------------------
+// Task 1.9 — Governance Enforcement
+// ---------------------------------------------------------------------------
+
+/// The outcome of a governance check. Callers MAY execute on `Allow`,
+/// MUST reject on `Deny`, and SHOULD queue + return the `pending_id` on
+/// `Pending`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GovernanceDecision {
+    /// Allowed; proceed with the action.
+    Allow,
+    /// Denied; surface the reason to the caller.
+    Deny(String),
+    /// Queued for approval; the caller receives the new `pending_id`.
+    Pending(String),
+}
+
+/// Actions that governance gates. Used as the `action_type` column value in
+/// `pending_actions` and as the discriminator for enforcement calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernedAction {
+    Store,
+    Delete,
+    Promote,
+}
+
+impl GovernedAction {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Store => "store",
+            Self::Delete => "delete",
+            Self::Promote => "promote",
+        }
+    }
+}
+
+/// Row returned by `db::list_pending_actions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingAction {
+    pub id: String,
+    pub action_type: String,
+    pub memory_id: Option<String>,
+    pub namespace: String,
+    pub payload: Value,
+    pub requested_by: String,
+    pub requested_at: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Task 1.8 — Governance Metadata
 // ---------------------------------------------------------------------------
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1835,7 +1835,7 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 28, "expected 28 MCP tools");
+    assert_eq!(tools.len(), 31, "expected 31 MCP tools");
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));
@@ -5952,5 +5952,653 @@ fn test_governance_legacy_memory_defaults_not_mutated() {
         metadata.get("governance").is_none(),
         "no governance param must not inject a policy; got metadata={metadata}"
     );
+    let _ = std::fs::remove_file(&db);
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.9 — Governance Enforcement
+// ---------------------------------------------------------------------------
+
+fn fresh_enforce_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-enforce-{}.db", uuid::Uuid::new_v4()))
+}
+
+/// Set a governance policy on a namespace. Seeds the standard memory under
+/// `owner_agent_id`, then calls memory_namespace_set_standard with the policy.
+fn set_governance(
+    binary: &str,
+    db_path: &std::path::Path,
+    namespace: &str,
+    governance: serde_json::Value,
+    owner_agent_id: &str,
+) {
+    let out = cmd(binary)
+        .env_remove("AI_MEMORY_AGENT_ID")
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            owner_agent_id,
+            "--json",
+            "store",
+            "-n",
+            namespace,
+            "-T",
+            &format!("{namespace}-standard"),
+            "-c",
+            "policy",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sid = v["id"].as_str().unwrap().to_string();
+
+    use std::io::Write;
+    let mut child = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "mcp",
+            "--tier",
+            "keyword",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.as_mut().unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})
+    )
+    .unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({
+            "jsonrpc":"2.0","id":2,"method":"tools/call",
+            "params":{"name":"memory_namespace_set_standard","arguments":{
+                "namespace": namespace,
+                "id": sid,
+                "governance": governance,
+            }}
+        })
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+    drop(child.stdin.take());
+    let _ = child.wait_with_output();
+}
+
+#[test]
+fn test_enforce_any_allows_store() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"any","promote":"any","delete":"any","approver":"human"}),
+        "owner",
+    );
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "stranger",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "any-write",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "any-write must allow: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_registered_blocks_unregistered() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "stranger-not-registered",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "blocked-write",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "unregistered must be blocked");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("not a registered agent"), "got: {err}");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_registered_allows_registered() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let _ = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "agents",
+            "register",
+            "--agent-id",
+            "alice",
+            "--agent-type",
+            "human",
+        ])
+        .output()
+        .unwrap();
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "allowed-write",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_owner_blocks_non_owner_delete() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let store = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "alice-mem",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&store.stdout).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let del = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "bob",
+            "delete",
+            &id,
+        ])
+        .output()
+        .unwrap();
+    assert!(!del.status.success());
+    let err = String::from_utf8_lossy(&del.stderr);
+    assert!(err.contains("not the owner"), "got: {err}");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_owner_allows_self_delete() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let store = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "alice-mem-2",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&store.stdout).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let del = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "delete",
+            &id,
+        ])
+        .output()
+        .unwrap();
+    assert!(del.status.success());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_approve_queues_pending() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "queued",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["status"], "pending");
+    assert!(v["pending_id"].is_string());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_pending_list_and_approve() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let queued = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "needs-approval",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let pending_id =
+        serde_json::from_slice::<serde_json::Value>(&queued.stdout).unwrap()["pending_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["count"], 1);
+
+    let ap = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "approver",
+            "--json",
+            "pending",
+            "approve",
+            &pending_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(ap.status.success());
+    let av: serde_json::Value = serde_json::from_slice(&ap.stdout).unwrap();
+    assert_eq!(av["approved"], true);
+    assert_eq!(av["decided_by"], "approver");
+
+    let ap2 = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "approver",
+            "pending",
+            "approve",
+            &pending_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(!ap2.status.success());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_pending_reject_status() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let queued = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "to-reject",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let pending_id =
+        serde_json::from_slice::<serde_json::Value>(&queued.stdout).unwrap()["pending_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+    let rj = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "approver",
+            "--json",
+            "pending",
+            "reject",
+            &pending_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(rj.status.success());
+    let rv: serde_json::Value = serde_json::from_slice(&rj.stdout).unwrap();
+    assert_eq!(rv["rejected"], true);
+
+    let list = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "pending",
+            "list",
+            "--status",
+            "rejected",
+        ])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["count"], 1);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_unset_falls_back_to_default_policy() {
+    // Default: { write: Any, promote: Any, delete: Owner, approver: Human }
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "anyone",
+            "--json",
+            "store",
+            "-n",
+            "anywhere",
+            "-T",
+            "default-allow",
+            "-c",
+            "hi",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "default write policy is Any");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_promote_with_approve_policy() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"any","promote":"approve","delete":"any","approver":"human"}),
+        "owner",
+    );
+    let store = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "will-be-promoted",
+            "-c",
+            "hi",
+            "-t",
+            "mid",
+        ])
+        .output()
+        .unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&store.stdout).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let pr = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "promote",
+            &id,
+        ])
+        .output()
+        .unwrap();
+    assert!(pr.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&pr.stdout).unwrap();
+    assert_eq!(v["status"], "pending");
+    assert!(v["pending_id"].is_string());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_enforce_mcp_pending_tools() {
+    let db = fresh_enforce_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let queued = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "mcp-pending-flow",
+            "-c",
+            "x",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let pending_id =
+        serde_json::from_slice::<serde_json::Value>(&queued.stdout).unwrap()["pending_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+    use std::io::Write;
+    let mut child = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "mcp", "--tier", "keyword"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.as_mut().unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})
+    )
+    .unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({
+            "jsonrpc":"2.0","id":2,"method":"tools/call",
+            "params":{"name":"memory_pending_list","arguments":{}}
+        })
+    )
+    .unwrap();
+    writeln!(stdin, "{}",
+        serde_json::json!({
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params":{"name":"memory_pending_approve","arguments":{"id": pending_id, "agent_id": "approver-mcp"}}
+        })).unwrap();
+    stdin.flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    let list_resp: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let list_text = list_resp["result"]["content"][0]["text"].as_str().unwrap();
+    let list_body: serde_json::Value = serde_json::from_str(list_text).unwrap();
+    assert_eq!(list_body["count"], 1);
+
+    let appr_resp: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+    let appr_text = appr_resp["result"]["content"][0]["text"].as_str().unwrap();
+    let appr_body: serde_json::Value = serde_json::from_str(appr_text).unwrap();
+    assert_eq!(appr_body["approved"], true);
     let _ = std::fs::remove_file(&db);
 }


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.9 — Governance Enforcement** per `docs/PHASE-1.md`. Wires the policies defined by Task 1.8 into the **store / delete / promote** paths across all three interfaces (MCP, HTTP, CLI), adds the `pending_actions` table, and exposes 3 new tools/endpoints/CLI subcommands for reviewing + approving queued actions.

Closes #155.

## Key design decision — **opt-in enforcement**

A namespace without an explicit `metadata.governance` policy **skips every governance check** — historical behavior preserved. The "default policy" from Task 1.8 (`{ write: Any, promote: Any, delete: Owner, approver: Human }`) is surfaced by `memory_namespace_get_standard` for **display purposes only**; it does not gate operations.

This interpretation is required to avoid silently invalidating every call site that didn't pin `agent_id` (every pre-existing test in the suite). Spec text reads the default as descriptive, not prescriptive.

## Enforcement mapping

| Level | Decision |
|---|---|
| `Any` | Allow |
| `Registered` | Caller's `agent_id` must exist in `_agents` namespace (Task 1.3) |
| `Owner` | Caller's `agent_id` must equal the memory's `metadata.agent_id` (delete/promote) or the namespace standard's owner (store) |
| `Approve` | Queue a `pending_actions` row, return `{status:"pending", pending_id, reason}` |

## Schema v8 — `pending_actions`

\`\`\`sql
CREATE TABLE pending_actions (
    id            TEXT PRIMARY KEY,
    action_type   TEXT NOT NULL,
    memory_id     TEXT,
    namespace     TEXT NOT NULL,
    payload       TEXT NOT NULL DEFAULT '{}',
    requested_by  TEXT NOT NULL,
    requested_at  TEXT NOT NULL,
    status        TEXT NOT NULL DEFAULT 'pending',
    decided_by    TEXT,
    decided_at    TEXT
);
CREATE INDEX idx_pending_status    ON pending_actions(status);
CREATE INDEX idx_pending_namespace ON pending_actions(namespace);
\`\`\`

Migration is additive + backward-compatible.

## Surface

### MCP — +3 tools (count **31 → 34**)

- `memory_pending_list` — filter by status (`pending`/`approved`/`rejected`)
- `memory_pending_approve` — id + agent_id; transitions status + stamps `decided_by`/`decided_at`
- `memory_pending_reject` — same

Plus enforcement wired into `handle_store` / `handle_delete` / `handle_promote`. Delete + promote handlers now resolve the target memory first to read `metadata.agent_id` for Owner checks, then enforce before mutating.

### HTTP — +3 endpoints

- `GET  /api/v1/pending`  (query: `status`, `limit`)
- `POST /api/v1/pending/{id}/approve`  (header: `X-Agent-Id`)
- `POST /api/v1/pending/{id}/reject`   (header: `X-Agent-Id`)

Enforcement in `create_memory` / `delete_memory` / `promote_memory`. **202 Accepted** on Pending; **403 Forbidden** on Deny. `delete_memory` + `promote_memory` gained `HeaderMap` so `X-Agent-Id` participates in Owner checks.

### CLI — +1 subcommand with 3 actions

\`\`\`
ai-memory pending list [--status STATUS] [--limit N]
ai-memory pending approve <id>
ai-memory pending reject <id>
\`\`\`

Enforcement in `cmd_store` / `cmd_delete` / `cmd_promote`. `cmd_delete` + `cmd_promote` now receive `cli_agent_id` from the global `--agent-id` flag.

## Files changed (6 files, +1,789 / −89)

| File | Lines | What |
|---|---|---|
| `src/models.rs` | +54 | `GovernanceDecision` / `GovernedAction` enums, `PendingAction` row struct |
| `src/db.rs` | +262 | schema v8, `resolve_governance_policy` (opt-in), `enforce_governance`, `is_registered_agent`, `namespace_owner`, 4× pending CRUD helpers |
| `src/mcp.rs` | +243 | 3 tool defs + 3 handlers + 3 dispatch arms; enforcement hooks in store/delete/promote; tool count updated |
| `src/handlers.rs` | +367 | 3 pending endpoints; enforcement hooks in create/delete/promote; HeaderMap on delete/promote |
| `src/main.rs` | +302 | `PendingArgs` / `PendingAction` subcommand; enforcement hooks; `cmd_pending`; `cmd_delete`/`cmd_promote` plumb `cli_agent_id`; router wiring |
| `tests/integration.rs` | +650 | 11 new integration tests + helpers |

## Tests — +11 new (10-minimum exceeded)

- `test_enforce_any_allows_store` — Any is a no-op
- `test_enforce_registered_blocks_unregistered` — unregistered caller rejected
- `test_enforce_registered_allows_registered` — registered caller allowed
- `test_enforce_owner_blocks_non_owner_delete` — alice writes, bob can't delete
- `test_enforce_owner_allows_self_delete` — alice deletes her own memory
- `test_enforce_approve_queues_pending` — Approve returns `{status:"pending"}`
- `test_enforce_pending_list_and_approve` — end-to-end flow; re-approve second time fails
- `test_enforce_pending_reject_status` — rejected status surfaced in `list --status rejected`
- `test_enforce_unset_falls_back_to_default_policy` — **regression guard**: default is non-enforcing
- `test_enforce_promote_with_approve_policy` — promote path queues cleanly
- `test_enforce_mcp_pending_tools` — raw MCP JSON-RPC round-trip

**Suite total: 234 unit + 127 integration = 361 passing.**

## Gates

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ — 361/361
- `cargo audit` ✓ — 0 vulns

No new `unwrap()` in production paths.

## Scope deferred to Task 1.10

Pending approval currently **records a decision** but does **not replay** the queued action on approve. Approver-type logic (Agent/Consensus) and auto-execute on consensus are explicitly Task 1.10 territory. This PR lays the table + state transitions; 1.10 wires the replay + approver modes on top.

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"