### PR TITLE
feat: governance approver types + auto-execute (task 1.10) — closes #156

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -8,9 +8,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::models::{
-    AGENTS_NAMESPACE, AgentRegistration, GovernanceDecision, GovernanceLevel, GovernancePolicy,
-    GovernedAction, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD, PendingAction, Stats,
-    Tier, TierCount, namespace_ancestors,
+    AGENTS_NAMESPACE, AgentRegistration, Approval, ApproverType, GovernanceDecision,
+    GovernanceLevel, GovernancePolicy, GovernedAction, Memory, MemoryLink, NamespaceCount,
+    PROMOTION_THRESHOLD, PendingAction, Stats, Tier, TierCount, namespace_ancestors,
 };
 
 /// Computed 4-tuple of visibility prefixes for an agent position (Task 1.5).
@@ -150,7 +150,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 );
 ";
 
-const CURRENT_SCHEMA_VERSION: i64 = 8;
+const CURRENT_SCHEMA_VERSION: i64 = 9;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -304,6 +304,18 @@ fn migrate(conn: &Connection) -> Result<()> {
                 CREATE INDEX IF NOT EXISTS idx_pending_status    ON pending_actions(status);
                 CREATE INDEX IF NOT EXISTS idx_pending_namespace ON pending_actions(namespace);",
             )?;
+        }
+        if version < 9 {
+            // Task 1.10: approvals JSON array for consensus approver type
+            let has_approvals: bool = conn
+                .prepare("SELECT approvals FROM pending_actions LIMIT 0")
+                .is_ok();
+            if !has_approvals {
+                conn.execute(
+                    "ALTER TABLE pending_actions ADD COLUMN approvals TEXT NOT NULL DEFAULT '[]'",
+                    [],
+                )?;
+            }
         }
 
         conn.execute("DELETE FROM schema_version", [])?;
@@ -2299,7 +2311,7 @@ pub fn list_pending_actions(
 ) -> Result<Vec<PendingAction>> {
     let mut stmt = conn.prepare(
         "SELECT id, action_type, memory_id, namespace, payload, requested_by,
-                requested_at, status, decided_by, decided_at
+                requested_at, status, decided_by, decided_at, approvals
          FROM pending_actions
          WHERE (?1 IS NULL OR status = ?1)
          ORDER BY requested_at DESC
@@ -2309,6 +2321,8 @@ pub fn list_pending_actions(
         let payload_str: String = row.get(4)?;
         let payload: serde_json::Value =
             serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Null);
+        let approvals_str: String = row.get(10)?;
+        let approvals: Vec<Approval> = serde_json::from_str(&approvals_str).unwrap_or_default();
         Ok(PendingAction {
             id: row.get(0)?,
             action_type: row.get(1)?,
@@ -2320,23 +2334,25 @@ pub fn list_pending_actions(
             status: row.get(7)?,
             decided_by: row.get(8)?,
             decided_at: row.get(9)?,
+            approvals,
         })
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(Into::into)
 }
 
-#[allow(dead_code)]
 pub fn get_pending_action(conn: &Connection, id: &str) -> Result<Option<PendingAction>> {
     let row = conn.query_row(
         "SELECT id, action_type, memory_id, namespace, payload, requested_by,
-                requested_at, status, decided_by, decided_at
+                requested_at, status, decided_by, decided_at, approvals
          FROM pending_actions WHERE id = ?1",
         params![id],
         |row| {
             let payload_str: String = row.get(4)?;
             let payload: serde_json::Value =
                 serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Null);
+            let approvals_str: String = row.get(10)?;
+            let approvals: Vec<Approval> = serde_json::from_str(&approvals_str).unwrap_or_default();
             Ok(PendingAction {
                 id: row.get(0)?,
                 action_type: row.get(1)?,
@@ -2348,6 +2364,7 @@ pub fn get_pending_action(conn: &Connection, id: &str) -> Result<Option<PendingA
                 status: row.get(7)?,
                 decided_by: row.get(8)?,
                 decided_at: row.get(9)?,
+                approvals,
             })
         },
     );
@@ -2376,6 +2393,158 @@ pub fn decide_pending_action(
         params![new_status, decided_by, now, id],
     )?;
     Ok(updated > 0)
+}
+
+/// Task 1.10 — outcome of an approver-aware approve call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApproveOutcome {
+    /// Approver check failed; policy identifies the reason.
+    Rejected(String),
+    /// Consensus quorum not yet met; vote recorded.
+    Pending { votes: usize, quorum: u32 },
+    /// Fully approved (Human single-step, matching Agent, or consensus
+    /// threshold met). Caller may now replay the payload via
+    /// `execute_pending_action`.
+    Approved,
+}
+
+/// Task 1.10 — approver-type aware approve. Enforces the
+/// `metadata.governance.approver` of the pending action's namespace.
+pub fn approve_with_approver_type(
+    conn: &Connection,
+    pending_id: &str,
+    approver_agent_id: &str,
+) -> Result<ApproveOutcome> {
+    let Some(pa) = get_pending_action(conn, pending_id)? else {
+        return Ok(ApproveOutcome::Rejected(format!(
+            "pending action not found: {pending_id}"
+        )));
+    };
+    if pa.status != "pending" {
+        return Ok(ApproveOutcome::Rejected(format!(
+            "already decided: status={}",
+            pa.status
+        )));
+    }
+    // Resolve the namespace's approver type. If no policy, default to Human —
+    // which accepts any approval (back-compat with 1.9 callers).
+    let approver =
+        resolve_governance_policy(conn, &pa.namespace).map_or(ApproverType::Human, |p| p.approver);
+
+    match approver {
+        ApproverType::Human => {
+            let ok = decide_pending_action(conn, pending_id, true, approver_agent_id)?;
+            if ok {
+                Ok(ApproveOutcome::Approved)
+            } else {
+                Ok(ApproveOutcome::Rejected("decision write failed".into()))
+            }
+        }
+        ApproverType::Agent(required) => {
+            if approver_agent_id != required {
+                return Ok(ApproveOutcome::Rejected(format!(
+                    "designated approver is '{required}'; got '{approver_agent_id}'"
+                )));
+            }
+            let ok = decide_pending_action(conn, pending_id, true, approver_agent_id)?;
+            if ok {
+                Ok(ApproveOutcome::Approved)
+            } else {
+                Ok(ApproveOutcome::Rejected("decision write failed".into()))
+            }
+        }
+        ApproverType::Consensus(quorum) => {
+            let mut approvals = pa.approvals.clone();
+            if approvals.iter().any(|a| a.agent_id == approver_agent_id) {
+                return Ok(ApproveOutcome::Pending {
+                    votes: approvals.len(),
+                    quorum,
+                });
+            }
+            approvals.push(Approval {
+                agent_id: approver_agent_id.to_string(),
+                approved_at: Utc::now().to_rfc3339(),
+            });
+            let approvals_json = serde_json::to_string(&approvals)?;
+            conn.execute(
+                "UPDATE pending_actions SET approvals = ?1 WHERE id = ?2 AND status = 'pending'",
+                params![approvals_json, pending_id],
+            )?;
+            let votes = approvals.len();
+            if u32::try_from(votes).unwrap_or(u32::MAX) >= quorum {
+                // Threshold met — transition status so the caller can replay.
+                let ok = decide_pending_action(conn, pending_id, true, approver_agent_id)?;
+                if ok {
+                    return Ok(ApproveOutcome::Approved);
+                }
+                return Ok(ApproveOutcome::Rejected(
+                    "decision write failed at consensus threshold".into(),
+                ));
+            }
+            Ok(ApproveOutcome::Pending { votes, quorum })
+        }
+    }
+}
+
+/// Task 1.10 — Execute an approved pending action's payload. Callers invoke
+/// this after `approve_with_approver_type` returns `Approved`. Returns the
+/// affected memory id (new id for store, existing id for delete/promote).
+pub fn execute_pending_action(conn: &Connection, pending_id: &str) -> Result<Option<String>> {
+    let Some(pa) = get_pending_action(conn, pending_id)? else {
+        anyhow::bail!("pending action not found: {pending_id}");
+    };
+    if pa.status != "approved" {
+        anyhow::bail!("cannot execute non-approved action (status={})", pa.status);
+    }
+    match pa.action_type.as_str() {
+        "store" => {
+            let mut mem: Memory = serde_json::from_value(pa.payload.clone())
+                .map_err(|e| anyhow::anyhow!("invalid store payload: {e}"))?;
+            // Stamp fresh id + timestamps so the execution is idempotent on replay.
+            mem.id = uuid::Uuid::new_v4().to_string();
+            let now = Utc::now().to_rfc3339();
+            mem.created_at.clone_from(&now);
+            mem.updated_at = now;
+            mem.access_count = 0;
+            let actual_id = insert(conn, &mem)?;
+            Ok(Some(actual_id))
+        }
+        "delete" => {
+            if let Some(mid) = pa.memory_id.clone() {
+                delete(conn, &mid)?;
+                Ok(Some(mid))
+            } else {
+                Ok(None)
+            }
+        }
+        "promote" => {
+            if let Some(mid) = pa.memory_id.clone() {
+                if let Some(to_ns) = pa.payload.get("to_namespace").and_then(|v| v.as_str()) {
+                    // Vertical promotion to ancestor.
+                    let clone_id = promote_to_namespace(conn, &mid, to_ns)?;
+                    return Ok(Some(clone_id));
+                }
+                // Tier bump to long + clear expiry.
+                let (_found, _changed) = update(
+                    conn,
+                    &mid,
+                    None,
+                    None,
+                    Some(&Tier::Long),
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(""),
+                    None,
+                )?;
+                Ok(Some(mid))
+            } else {
+                Ok(None)
+            }
+        }
+        other => anyhow::bail!("unknown action_type: {other}"),
+    }
 }
 
 /// Check if a memory ID is a namespace standard (used by consolidate to warn).

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -346,6 +346,7 @@ pub async fn approve_pending(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    use crate::db::ApproveOutcome;
     if let Err(e) = validate::validate_id(&id) {
         return (
             StatusCode::BAD_REQUEST,
@@ -365,13 +366,40 @@ pub async fn approve_pending(
         }
     };
     let lock = state.lock().await;
-    match db::decide_pending_action(&lock.0, &id, true, &agent_id) {
-        Ok(true) => {
-            Json(json!({"approved": true, "id": id, "decided_by": agent_id})).into_response()
-        }
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "pending action not found or already decided"})),
+    match db::approve_with_approver_type(&lock.0, &id, &agent_id) {
+        Ok(ApproveOutcome::Approved) => match db::execute_pending_action(&lock.0, &id) {
+            Ok(memory_id) => Json(json!({
+                "approved": true,
+                "id": id,
+                "decided_by": agent_id,
+                "executed": true,
+                "memory_id": memory_id,
+            }))
+            .into_response(),
+            Err(e) => {
+                tracing::error!("execute pending error: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "approved but execution failed"})),
+                )
+                    .into_response()
+            }
+        },
+        Ok(ApproveOutcome::Pending { votes, quorum }) => (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "approved": false,
+                "status": "pending",
+                "id": id,
+                "votes": votes,
+                "quorum": quorum,
+                "reason": "consensus threshold not yet reached",
+            })),
+        )
+            .into_response(),
+        Ok(ApproveOutcome::Rejected(reason)) => (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": format!("approve rejected: {reason}")})),
         )
             .into_response(),
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -793,18 +793,33 @@ fn cmd_store(
         }
     }
 
-    // Task 1.9: governance enforcement (store-side)
+    let mem = models::Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier,
+        namespace,
+        title: args.title,
+        content,
+        tags,
+        priority: args.priority.clamp(1, 10),
+        confidence: args.confidence.clamp(0.0, 1.0),
+        source: args.source,
+        access_count: 0,
+        created_at: now.to_rfc3339(),
+        updated_at: now.to_rfc3339(),
+        last_accessed_at: None,
+        expires_at,
+        metadata,
+    };
+
+    // Task 1.9: governance enforcement (store-side). Payload is the full
+    // Memory so Task 1.10's execute_pending_action can replay it on approval.
     {
         use models::{GovernanceDecision, GovernedAction};
-        let payload = serde_json::json!({
-            "title": &args.title,
-            "namespace": &namespace,
-            "tier": &args.tier,
-        });
+        let payload = serde_json::to_value(&mem).unwrap_or_default();
         match db::enforce_governance(
             &conn,
             GovernedAction::Store,
-            &namespace,
+            &mem.namespace,
             &agent_id,
             None,
             None,
@@ -824,34 +839,19 @@ fn cmd_store(
                             "pending_id": pending_id,
                             "reason": "governance requires approval",
                             "action": "store",
-                            "namespace": &namespace,
+                            "namespace": &mem.namespace,
                         })
                     );
                 } else {
-                    println!("store queued for approval: pending_id={pending_id} ns={namespace}");
+                    println!(
+                        "store queued for approval: pending_id={pending_id} ns={}",
+                        &mem.namespace
+                    );
                 }
                 return Ok(());
             }
         }
     }
-
-    let mem = models::Memory {
-        id: uuid::Uuid::new_v4().to_string(),
-        tier,
-        namespace,
-        title: args.title,
-        content,
-        tags,
-        priority: args.priority.clamp(1, 10),
-        confidence: args.confidence.clamp(0.0, 1.0),
-        source: args.source,
-        access_count: 0,
-        created_at: now.to_rfc3339(),
-        updated_at: now.to_rfc3339(),
-        last_accessed_at: None,
-        expires_at,
-        metadata,
-    };
     let contradictions =
         db::find_contradictions(&conn, &mem.title, &mem.namespace).unwrap_or_default();
     let actual_id = db::insert(&conn, &mem)?;
@@ -2412,20 +2412,50 @@ fn cmd_pending(
             }
         }
         PendingAction::Approve { id } => {
+            use db::ApproveOutcome;
             validate::validate_id(&id)?;
             let agent = identity::resolve_agent_id(cli_agent_id, None)?;
-            let ok = db::decide_pending_action(&conn, &id, true, &agent)?;
-            if !ok {
-                eprintln!("pending action not found or already decided: {id}");
-                std::process::exit(1);
-            }
-            if json_out {
-                println!(
-                    "{}",
-                    serde_json::json!({"approved": true, "id": id, "decided_by": agent})
-                );
-            } else {
-                println!("approved: {id} (by {agent})");
+            match db::approve_with_approver_type(&conn, &id, &agent)? {
+                ApproveOutcome::Approved => {
+                    let executed = db::execute_pending_action(&conn, &id)?;
+                    if json_out {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "approved": true,
+                                "id": id,
+                                "decided_by": agent,
+                                "executed": true,
+                                "memory_id": executed,
+                            })
+                        );
+                    } else {
+                        println!("approved + executed: {id} (by {agent})");
+                    }
+                }
+                ApproveOutcome::Pending { votes, quorum } => {
+                    if json_out {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "approved": false,
+                                "status": "pending",
+                                "id": id,
+                                "votes": votes,
+                                "quorum": quorum,
+                                "reason": "consensus threshold not yet reached",
+                            })
+                        );
+                    } else {
+                        println!(
+                            "approval recorded: {id} ({votes}/{quorum} consensus, not yet met)"
+                        );
+                    }
+                }
+                ApproveOutcome::Rejected(reason) => {
+                    eprintln!("approve rejected: {reason}");
+                    std::process::exit(1);
+                }
             }
         }
         PendingAction::Reject { id } => {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1858,16 +1858,33 @@ fn handle_pending_approve(
     params: &Value,
     mcp_client: Option<&str>,
 ) -> Result<Value, String> {
+    use crate::db::ApproveOutcome;
     let id = params["id"].as_str().ok_or("id is required")?;
     validate::validate_id(id).map_err(|e| e.to_string())?;
     let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
         .map_err(|e| e.to_string())?;
-    let transitioned =
-        db::decide_pending_action(conn, id, true, &agent_id).map_err(|e| e.to_string())?;
-    if !transitioned {
-        return Err(format!("pending action not found or already decided: {id}"));
+    match db::approve_with_approver_type(conn, id, &agent_id).map_err(|e| e.to_string())? {
+        ApproveOutcome::Approved => {
+            // Task 1.10: auto-execute the queued action on final approval.
+            let executed = db::execute_pending_action(conn, id).map_err(|e| e.to_string())?;
+            Ok(json!({
+                "approved": true,
+                "id": id,
+                "decided_by": agent_id,
+                "executed": true,
+                "memory_id": executed,
+            }))
+        }
+        ApproveOutcome::Pending { votes, quorum } => Ok(json!({
+            "approved": false,
+            "status": "pending",
+            "id": id,
+            "votes": votes,
+            "quorum": quorum,
+            "reason": "consensus threshold not yet reached",
+        })),
+        ApproveOutcome::Rejected(reason) => Err(format!("approve rejected: {reason}")),
     }
-    Ok(json!({"approved": true, "id": id, "decided_by": agent_id}))
 }
 
 fn handle_pending_reject(

--- a/src/models.rs
+++ b/src/models.rs
@@ -331,6 +331,13 @@ impl GovernedAction {
     }
 }
 
+/// A single approval vote recorded on a consensus-gated pending action (Task 1.10).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Approval {
+    pub agent_id: String,
+    pub approved_at: String,
+}
+
 /// Row returned by `db::list_pending_actions`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingAction {
@@ -346,6 +353,9 @@ pub struct PendingAction {
     pub decided_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decided_at: Option<String>,
+    /// Task 1.10: consensus vote log. Empty for Human/Agent paths.
+    #[serde(default)]
+    pub approvals: Vec<Approval>,
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6602,3 +6602,364 @@ fn test_enforce_mcp_pending_tools() {
     assert_eq!(appr_body["approved"], true);
     let _ = std::fs::remove_file(&db);
 }
+
+// ---------------------------------------------------------------------------
+// Task 1.10 — Approver Types (Human/Agent/Consensus) + auto-execute
+// ---------------------------------------------------------------------------
+
+fn fresh_approver_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-approver-{}.db", uuid::Uuid::new_v4()))
+}
+
+fn queue_store(
+    binary: &str,
+    db_path: &std::path::Path,
+    namespace: &str,
+    title: &str,
+    requester: &str,
+) -> String {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            requester,
+            "--json",
+            "store",
+            "-n",
+            namespace,
+            "-T",
+            title,
+            "-c",
+            "body",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "queue store failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["status"], "pending", "expected pending, got: {v}");
+    v["pending_id"].as_str().unwrap().to_string()
+}
+
+fn approve(
+    binary: &str,
+    db_path: &std::path::Path,
+    pending_id: &str,
+    approver: &str,
+) -> std::process::Output {
+    cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            approver,
+            "--json",
+            "pending",
+            "approve",
+            pending_id,
+        ])
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn test_approver_human_any_approver_accepted() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "human-target", "alice");
+    let out = approve(bin, &db, &pid, "any-random-approver");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["approved"], true);
+    assert_eq!(v["executed"], true);
+    assert!(v["memory_id"].is_string());
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_agent_rejects_wrong_caller() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"agent":"maintainer"}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "agent-target", "alice");
+    let out = approve(bin, &db, &pid, "some-other-agent");
+    assert!(!out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("designated approver") || err.to_lowercase().contains("rejected"),
+        "got: {err}"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_agent_accepts_matching_caller() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"agent":"maintainer"}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "agent-ok", "alice");
+    let out = approve(bin, &db, &pid, "maintainer");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["approved"], true);
+    assert_eq!(v["executed"], true);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_consensus_below_threshold_pending() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":3}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "cons-target", "alice");
+
+    let v1 = approve(bin, &db, &pid, "approver-1");
+    assert!(v1.status.success());
+    let j1: serde_json::Value = serde_json::from_slice(&v1.stdout).unwrap();
+    assert_eq!(j1["approved"], false);
+    assert_eq!(j1["status"], "pending");
+    assert_eq!(j1["votes"], 1);
+    assert_eq!(j1["quorum"], 3);
+
+    let v2 = approve(bin, &db, &pid, "approver-2");
+    let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
+    assert_eq!(j2["votes"], 2);
+    assert_eq!(j2["approved"], false);
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["count"], 1);
+    assert_eq!(lv["pending"][0]["status"], "pending");
+    assert_eq!(lv["pending"][0]["approvals"].as_array().unwrap().len(), 2);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_consensus_threshold_auto_executes() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "cons-exec", "alice");
+
+    let v1 = approve(bin, &db, &pid, "a1");
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&v1.stdout).unwrap()["approved"],
+        false
+    );
+    let v2 = approve(bin, &db, &pid, "a2");
+    assert!(v2.status.success());
+    let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
+    assert_eq!(j2["approved"], true);
+    assert_eq!(j2["executed"], true);
+    let memory_id = j2["memory_id"].as_str().unwrap();
+
+    let list = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "list",
+            "-n",
+            "alphaone",
+        ])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let titles: Vec<String> = lv["memories"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|m| m["title"].as_str().map(str::to_string))
+        .collect();
+    assert!(titles.contains(&"cons-exec".to_string()));
+    let ids: Vec<String> = lv["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|m| m["id"].as_str().map(str::to_string))
+        .collect();
+    assert!(ids.iter().any(|i| i == memory_id));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_consensus_same_agent_does_not_double_count() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "cons-dup", "alice");
+
+    let v1a = approve(bin, &db, &pid, "a1");
+    let v1b = approve(bin, &db, &pid, "a1");
+    let j1a: serde_json::Value = serde_json::from_slice(&v1a.stdout).unwrap();
+    let j1b: serde_json::Value = serde_json::from_slice(&v1b.stdout).unwrap();
+    assert_eq!(j1a["votes"], 1);
+    assert_eq!(j1b["votes"], 1, "same agent must not double-count");
+
+    let v2 = approve(bin, &db, &pid, "a2");
+    let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
+    assert_eq!(j2["approved"], true);
+    assert_eq!(j2["executed"], true);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_agent_rejected_not_counted_for_consensus() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"agent":"only-me"}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "agent-no-count", "alice");
+    let rej = approve(bin, &db, &pid, "wrong-caller");
+    assert!(!rej.status.success());
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["count"], 1);
+    assert_eq!(lv["pending"][0]["status"], "pending");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_approver_delete_consensus_executes_delete() {
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"any","promote":"any","delete":"approve",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let st = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "store",
+            "-n",
+            "alphaone",
+            "-T",
+            "will-delete",
+            "-c",
+            "x",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    let id = serde_json::from_slice::<serde_json::Value>(&st.stdout).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let del = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "delete",
+            &id,
+        ])
+        .output()
+        .unwrap();
+    assert!(del.status.success());
+    let jd: serde_json::Value = serde_json::from_slice(&del.stdout).unwrap();
+    assert_eq!(jd["status"], "pending");
+    let pid = jd["pending_id"].as_str().unwrap().to_string();
+
+    let _ = approve(bin, &db, &pid, "v1");
+    let v2 = approve(bin, &db, &pid, "v2");
+    let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
+    assert_eq!(j2["approved"], true);
+    assert_eq!(j2["executed"], true);
+
+    let get = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "get", &id])
+        .output()
+        .unwrap();
+    assert!(
+        !get.status.success(),
+        "memory must be deleted after consensus"
+    );
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.10 — Governance Approver Types** per `docs/PHASE-1.md`. Completes Track C (1.8 ✅ 1.9 ✅ 1.10 ✅). Builds on Task 1.9's pending_actions pipeline to enforce approver identity and **auto-replay the queued action** when consensus is met.

Closes #156.

## Semantics

| Approver type | On approve |
|---|---|
| `"human"` | Any approval is valid (single-step, matches 1.9 default) |
| `{"agent": "alice"}` | Only `alice`'s approval counts; others rejected with clear error |
| `{"consensus": 3}` | Approvals tracked in JSON vote log; **3rd distinct agent** triggers status transition **and auto-execute** |

## Schema v9

Additive migration — adds `approvals TEXT NOT NULL DEFAULT '[]'` to `pending_actions`. Each entry is `{agent_id, approved_at}`. Existing rows get an empty vote log by default.

## New types (`src/models.rs`)

\`\`\`rust
struct Approval { agent_id: String, approved_at: String }
\`\`\`

## New db helpers (`src/db.rs`)

- **`approve_with_approver_type()`** — dispatches on namespace governance approver type, records votes, transitions status on threshold. Returns `ApproveOutcome::{Approved, Pending{votes,quorum}, Rejected(reason)}`.
- **`execute_pending_action()`** — replays the queued payload on approved status:
  - `store`: deserializes full `Memory` from payload → `db::insert`
  - `delete`: re-calls `db::delete(memory_id)`
  - `promote`: either `db::promote_to_namespace(memory_id, to_ns)` (vertical) or `db::update(tier=Long, expires_at=null)` (tier bump)

## Wire-up across interfaces

**MCP** — `handle_pending_approve` calls `approve_with_approver_type`, then `execute_pending_action` on `Approved`. Response shape:

- `Approved` → `{approved:true, executed:true, memory_id}`
- `Pending{votes, quorum}` → `{approved:false, status:"pending", votes, quorum}`
- `Rejected(reason)` → tool error with reason

**HTTP** — `approve_pending` mirrors MCP logic:
- `202 Accepted` on `Pending` (consensus below threshold)
- `403 Forbidden` on `Rejected` (approver mismatch)
- `200 OK` on `Approved` with executed payload

**CLI** — `ai-memory pending approve <id>` outputs votes/quorum when still pending; prints "approved + executed: <id>" on success.

## Regression fix

Moved `cmd_store`'s Task 1.9 governance enforcement **after** the `Memory` struct is built so the payload queued on `Approve` is the **full memory**. Earlier partial-shape payload (`{title, namespace, tier}`) would have tripped Task 1.10's replay path on any CLI-originated store queue. Caught by `test_approver_consensus_threshold_auto_executes`.

## Files changed (6 files, +673 / −58)

| File | Lines | What |
|---|---|---|
| `src/models.rs` | +10 | `Approval` struct, `approvals` field on `PendingAction` |
| `src/db.rs` | +183 | schema v9, `ApproveOutcome` enum, `approve_with_approver_type`, `execute_pending_action`, extended pending CRUD |
| `src/mcp.rs` | +27 | `handle_pending_approve` uses new approver-aware path + execution |
| `src/handlers.rs` | +42 | HTTP `approve_pending` mirrors MCP semantics |
| `src/main.rs` | +108 | CLI `cmd_pending::approve` + cmd_store payload fix |
| `tests/integration.rs` | +361 | 8 new tests |

## Tests — +8 new (6-minimum exceeded)

- `test_approver_human_any_approver_accepted`
- `test_approver_agent_rejects_wrong_caller`
- `test_approver_agent_accepts_matching_caller`
- `test_approver_consensus_below_threshold_pending` — vote log grows, no status transition
- `test_approver_consensus_threshold_auto_executes` — store actually lands
- `test_approver_consensus_same_agent_does_not_double_count` — idempotent re-vote
- `test_approver_agent_rejected_not_counted_for_consensus` — rejected approver mismatch does not touch approvals
- `test_approver_delete_consensus_executes_delete` — delete payload replay actually removes the memory

**Suite total: 234 unit + 135 integration = 369 passing.**

## Gates

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ — 369/369
- `cargo audit` ✓ — 0 vulns

No new `unwrap()` in production paths.

## Track status after this PR

| Track | Tasks | Status |
|---|---|---|
| A | 1.1 / 1.2 / 1.3 | ✅ shipped v0.6.0-alpha.2 |
| B | 1.4 / 1.5 / 1.6 / 1.7 | ✅ on release/v0.6.0 |
| C | 1.8 / 1.9 / **1.10** | ✅ on release/v0.6.0 |
| D | 1.11 / 1.12 | standalone-ready (1.11); 1.12 needs 1.5 + 1.11 |

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"