### PR TITLE
feat: context-budget-aware recall — #1 differentiator (task 1.11) — closes #157

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -824,7 +824,43 @@ pub fn search(
         .map_err(Into::into)
 }
 
+/// Task 1.11 — rough token estimate for a memory. Uses the "~4 chars per
+/// token" heuristic on `title + content`. Deliberately byte-length-based:
+/// fast, deterministic, and correct enough for budget gating.
+#[must_use]
+pub fn estimate_memory_tokens(mem: &Memory) -> usize {
+    (mem.title.len() + mem.content.len()) / 4
+}
+
+/// Task 1.11 — truncate a scored recall list to fit within an optional
+/// token budget. Iterates in rank order; stops at the first memory whose
+/// inclusion would exceed the budget. Returns `(truncated, tokens_used)`.
+/// When `budget_tokens` is `None` the list is returned untouched, still
+/// with an accurate `tokens_used` tally so callers can surface it in
+/// response metadata.
+#[must_use]
+pub fn apply_token_budget(
+    scored: Vec<(Memory, f64)>,
+    budget_tokens: Option<usize>,
+) -> (Vec<(Memory, f64)>, usize) {
+    let mut used: usize = 0;
+    let mut out = Vec::with_capacity(scored.len());
+    for (mem, score) in scored {
+        let cost = estimate_memory_tokens(&mem);
+        if let Some(budget) = budget_tokens
+            && used.saturating_add(cost) > budget
+        {
+            break;
+        }
+        used = used.saturating_add(cost);
+        out.push((mem, score));
+    }
+    (out, used)
+}
+
 /// Recall — fuzzy OR search + touch + auto-promote + TTL extension.
+/// Task 1.11: after ranking, applies optional `budget_tokens` cap.
+/// Returns `(truncated_list, tokens_used)`.
 #[allow(clippy::too_many_arguments)]
 pub fn recall(
     conn: &Connection,
@@ -837,7 +873,8 @@ pub fn recall(
     short_extend: i64,
     mid_extend: i64,
     as_agent: Option<&str>,
-) -> Result<Vec<(Memory, f64)>> {
+    budget_tokens: Option<usize>,
+) -> Result<(Vec<(Memory, f64)>, usize)> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
     let (vis_p, vis_t, vis_u, vis_o) = compute_visibility_prefixes(as_agent);
@@ -889,13 +926,17 @@ pub fn recall(
     )?;
     let results: Vec<(Memory, f64)> = rows.collect::<rusqlite::Result<Vec<_>>>()?;
 
-    // Touch all recalled memories (bumps access, extends TTL, auto-promotes)
-    for (mem, _) in &results {
+    // Task 1.11: apply optional token budget in rank order.
+    let (budgeted, tokens_used) = apply_token_budget(results, budget_tokens);
+
+    // Touch all recalled memories that SURVIVED the budget cut — no sense
+    // bumping access counts on memories the caller will never see.
+    for (mem, _) in &budgeted {
         if let Err(e) = touch(conn, &mem.id, short_extend, mid_extend) {
             tracing::warn!("touch failed for memory {}: {}", &mem.id, e);
         }
     }
-    Ok(results)
+    Ok((budgeted, tokens_used))
 }
 
 /// Task 1.7 — vertical memory promotion.
@@ -1832,7 +1873,8 @@ pub fn recall_hybrid(
     short_extend: i64,
     mid_extend: i64,
     as_agent: Option<&str>,
-) -> Result<Vec<(Memory, f64)>> {
+    budget_tokens: Option<usize>,
+) -> Result<(Vec<(Memory, f64)>, usize)> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
     let prefixes = compute_visibility_prefixes(as_agent);
@@ -2041,14 +2083,17 @@ pub fn recall_hybrid(
     results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     results.truncate(limit);
 
-    // Touch all recalled memories
-    for (mem, _) in &results {
+    // Task 1.11: apply token budget in rank order.
+    let (budgeted, tokens_used) = apply_token_budget(results, budget_tokens);
+
+    // Touch surviving memories only.
+    for (mem, _) in &budgeted {
         if let Err(e) = touch(conn, &mem.id, short_extend, mid_extend) {
             tracing::warn!("touch failed for memory {}: {}", &mem.id, e);
         }
     }
 
-    Ok(results)
+    Ok((budgeted, tokens_used))
 }
 
 /// Checkpoint WAL for clean shutdown.
@@ -2941,7 +2986,7 @@ mod tests {
         )
         .unwrap();
 
-        let results = recall(
+        let (results, _tokens) = recall(
             &conn,
             "Rust programming",
             None,
@@ -2951,6 +2996,7 @@ mod tests {
             None,
             SHORT_TTL_EXTEND_SECS,
             MID_TTL_EXTEND_SECS,
+            None,
             None,
         )
         .unwrap();
@@ -2976,6 +3022,7 @@ mod tests {
             None,
             SHORT_TTL_EXTEND_SECS,
             MID_TTL_EXTEND_SECS,
+            None,
             None,
         );
         // May return empty or error, both acceptable
@@ -3506,7 +3553,7 @@ mod tests {
         mem.metadata = serde_json::json!({"context": "test-recall"});
         insert(&conn, &mem).unwrap();
 
-        let results = recall(
+        let (results, _tokens) = recall(
             &conn,
             "Recallable",
             Some("test"),
@@ -3516,6 +3563,7 @@ mod tests {
             None,
             3600,
             86400,
+            None,
             None,
         )
         .unwrap();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -957,8 +957,9 @@ pub async fn recall_memories_get(
         lock.2.short_extend_secs,
         lock.2.mid_extend_secs,
         p.as_agent.as_deref(),
+        p.budget_tokens,
     ) {
-        Ok(r) => {
+        Ok((r, tokens_used)) => {
             let scored: Vec<serde_json::Value> = r
                 .iter()
                 .map(|(m, s)| {
@@ -969,7 +970,15 @@ pub async fn recall_memories_get(
                     v
                 })
                 .collect();
-            Json(json!({"memories": scored, "count": scored.len()})).into_response()
+            let mut resp = json!({
+                "memories": scored,
+                "count": scored.len(),
+                "tokens_used": tokens_used,
+            });
+            if let Some(b) = p.budget_tokens {
+                resp["budget_tokens"] = json!(b);
+            }
+            Json(resp).into_response()
         }
         Err(e) => {
             tracing::error!("handler error: {e}");
@@ -1015,8 +1024,9 @@ pub async fn recall_memories_post(
         lock.2.short_extend_secs,
         lock.2.mid_extend_secs,
         body.as_agent.as_deref(),
+        body.budget_tokens,
     ) {
-        Ok(r) => {
+        Ok((r, tokens_used)) => {
             let scored: Vec<serde_json::Value> = r
                 .iter()
                 .map(|(m, s)| {
@@ -1027,7 +1037,15 @@ pub async fn recall_memories_post(
                     v
                 })
                 .collect();
-            Json(json!({"memories": scored, "count": scored.len()})).into_response()
+            let mut resp = json!({
+                "memories": scored,
+                "count": scored.len(),
+                "tokens_used": tokens_used,
+            });
+            if let Some(b) = body.budget_tokens {
+                resp["budget_tokens"] = json!(b);
+            }
+            Json(resp).into_response()
         }
         Err(e) => {
             tracing::error!("handler error: {e}");
@@ -1501,7 +1519,7 @@ mod tests {
             metadata: serde_json::json!({}),
         };
         db::insert(&lock.0, &mem).unwrap();
-        let results = db::recall(
+        let (results, _tokens) = db::recall(
             &lock.0,
             "recall handler",
             Some("test"),
@@ -1511,6 +1529,7 @@ mod tests {
             None,
             crate::models::SHORT_TTL_EXTEND_SECS,
             crate::models::MID_TTL_EXTEND_SECS,
+            None,
             None,
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,11 @@ struct RecallArgs {
     /// visibility filtering (private/team/unit/org/collective).
     #[arg(long)]
     as_agent: Option<String>,
+    /// Task 1.11: context-budget-aware recall. Return the top-ranked
+    /// memories whose cumulative estimated tokens fit within N. Omit
+    /// for unlimited (limit-based only).
+    #[arg(long)]
+    budget_tokens: Option<usize>,
 }
 
 #[derive(Args)]
@@ -1049,10 +1054,10 @@ fn cmd_recall(
     let resolved_ttl = app_config.effective_ttl();
 
     // Perform recall: hybrid if embedder available, keyword otherwise
-    let (results, mode) = if let Some(ref emb) = embedder {
+    let (results, tokens_used, mode) = if let Some(ref emb) = embedder {
         match emb.embed(&args.context) {
             Ok(query_emb) => {
-                let results = db::recall_hybrid(
+                let (results, tokens_used) = db::recall_hybrid(
                     &conn,
                     &args.context,
                     &query_emb,
@@ -1065,16 +1070,21 @@ fn cmd_recall(
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
                     args.as_agent.as_deref(),
+                    args.budget_tokens,
                 )?;
                 if let Some(ref ce) = reranker {
-                    (ce.rerank(&args.context, results), "hybrid+rerank")
+                    (
+                        ce.rerank(&args.context, results),
+                        tokens_used,
+                        "hybrid+rerank",
+                    )
                 } else {
-                    (results, "hybrid")
+                    (results, tokens_used, "hybrid")
                 }
             }
             Err(e) => {
                 eprintln!("ai-memory: embedding query failed: {e}, falling back to keyword");
-                let results = db::recall(
+                let (results, tokens_used) = db::recall(
                     &conn,
                     &args.context,
                     args.namespace.as_deref(),
@@ -1085,12 +1095,13 @@ fn cmd_recall(
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
                     args.as_agent.as_deref(),
+                    args.budget_tokens,
                 )?;
-                (results, "keyword")
+                (results, tokens_used, "keyword")
             }
         }
     } else {
-        let results = db::recall(
+        let (results, tokens_used) = db::recall(
             &conn,
             &args.context,
             args.namespace.as_deref(),
@@ -1101,8 +1112,9 @@ fn cmd_recall(
             resolved_ttl.short_extend_secs,
             resolved_ttl.mid_extend_secs,
             args.as_agent.as_deref(),
+            args.budget_tokens,
         )?;
-        (results, "keyword")
+        (results, tokens_used, "keyword")
     };
 
     if json_out {
@@ -1119,12 +1131,16 @@ fn cmd_recall(
                 v
             })
             .collect();
-        println!(
-            "{}",
-            serde_json::to_string(
-                &serde_json::json!({"memories": scored, "count": results.len(), "mode": mode})
-            )?
-        );
+        let mut body = serde_json::json!({
+            "memories": scored,
+            "count": results.len(),
+            "mode": mode,
+            "tokens_used": tokens_used,
+        });
+        if let Some(b) = args.budget_tokens {
+            body["budget_tokens"] = serde_json::json!(b);
+        }
+        println!("{}", serde_json::to_string(&body)?);
         return Ok(());
     }
     if results.is_empty() {
@@ -1814,8 +1830,9 @@ fn cmd_shell(db_path: &Path) -> Result<()> {
                     models::SHORT_TTL_EXTEND_SECS,
                     models::MID_TTL_EXTEND_SECS,
                     None,
+                    None,
                 ) {
-                    Ok(results) => {
+                    Ok((results, _tokens_used)) => {
                         for (mem, score) in &results {
                             println!(
                                 "  [{}] {} {} score={:.2}",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -110,6 +110,7 @@ fn tool_definitions() -> Value {
                         "since": {"type": "string", "description": "Only memories created after this RFC3339 timestamp"},
                         "until": {"type": "string", "description": "Only memories created before this RFC3339 timestamp"},
                         "as_agent": {"type": "string", "description": "Querying agent's namespace position (Task 1.5). Enables scope-based visibility filtering — results include private memories at this namespace, team/unit/org memories at ancestor subtrees, and collective memories globally."},
+                        "budget_tokens": {"type": "integer", "minimum": 1, "description": "Task 1.11 — context-budget-aware recall. Return the top-ranked memories whose cumulative estimated tokens (title+content, ~4 chars/token) fit in N. Response includes tokens_used + budget_tokens."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens vs JSON. 'toon' includes timestamps. 'json' for structured parsing."}
                     },
                     "required": ["context"]
@@ -916,12 +917,24 @@ fn handle_recall(
     if let Some(a) = as_agent {
         validate::validate_namespace(a).map_err(|e| e.to_string())?;
     }
+    // Task 1.11: optional token budget.
+    let budget_tokens = params["budget_tokens"]
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok());
+
+    // Helper: tack tokens_used / budget_tokens onto the response metadata.
+    let decorate_budget = |resp: &mut Value, tokens_used: usize| {
+        resp["tokens_used"] = json!(tokens_used);
+        if let Some(b) = budget_tokens {
+            resp["budget_tokens"] = json!(b);
+        }
+    };
 
     // Use hybrid recall if embedder is available
     if let Some(emb) = embedder {
         match emb.embed(context) {
             Ok(query_emb) => {
-                let results = db::recall_hybrid(
+                let (results, tokens_used) = db::recall_hybrid(
                     conn,
                     context,
                     &query_emb,
@@ -934,6 +947,7 @@ fn handle_recall(
                     resolved_ttl.short_extend_secs,
                     resolved_ttl.mid_extend_secs,
                     as_agent,
+                    budget_tokens,
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -942,6 +956,7 @@ fn handle_recall(
                     let ce_reranked = ce.rerank(context, results);
                     let memories = scored_memories(ce_reranked);
                     let mut resp = json!({"memories": memories, "count": memories.len(), "mode": "hybrid+rerank"});
+                    decorate_budget(&mut resp, tokens_used);
                     inject_namespace_standard(conn, namespace, &mut resp);
                     return Ok(resp);
                 }
@@ -949,6 +964,7 @@ fn handle_recall(
                 let memories = scored_memories(results);
                 let mut resp =
                     json!({"memories": memories, "count": memories.len(), "mode": "hybrid"});
+                decorate_budget(&mut resp, tokens_used);
                 inject_namespace_standard(conn, namespace, &mut resp);
                 return Ok(resp);
             }
@@ -959,7 +975,7 @@ fn handle_recall(
     }
 
     // Fallback to keyword-only recall
-    let results = db::recall(
+    let (results, tokens_used) = db::recall(
         conn,
         context,
         namespace,
@@ -970,10 +986,12 @@ fn handle_recall(
         resolved_ttl.short_extend_secs,
         resolved_ttl.mid_extend_secs,
         as_agent,
+        budget_tokens,
     )
     .map_err(|e| e.to_string())?;
     let memories = scored_memories(results);
     let mut resp = json!({"memories": memories, "count": memories.len(), "mode": "keyword"});
+    decorate_budget(&mut resp, tokens_used);
     inject_namespace_standard(conn, namespace, &mut resp);
     Ok(resp)
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -222,6 +222,11 @@ pub struct RecallQuery {
     /// Task 1.5 visibility filtering.
     #[serde(default)]
     pub as_agent: Option<String>,
+    /// Task 1.11 — context-budget-aware recall. When set, return the
+    /// top-scored memories whose cumulative estimated tokens fit within
+    /// this budget.
+    #[serde(default)]
+    pub budget_tokens: Option<usize>,
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -245,6 +250,9 @@ pub struct RecallBody {
     /// Task 1.5 visibility filtering.
     #[serde(default)]
     pub as_agent: Option<String>,
+    /// Task 1.11 — context-budget-aware recall.
+    #[serde(default)]
+    pub budget_tokens: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/toon.rs
+++ b/src/toon.rs
@@ -72,6 +72,13 @@ pub fn memories_to_toon(response: &Value, compact: bool) -> String {
     if let Some(mode) = response.get("mode").and_then(|v| v.as_str()) {
         meta.push(format!("mode:{mode}"));
     }
+    // Task 1.11: surface token budget info in the meta line when present.
+    if let Some(used) = response.get("tokens_used") {
+        meta.push(format!("tokens_used:{used}"));
+    }
+    if let Some(budget) = response.get("budget_tokens") {
+        meta.push(format!("budget_tokens:{budget}"));
+    }
     if !meta.is_empty() {
         out.push_str(&meta.join("|"));
         out.push('\n');

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6963,3 +6963,249 @@ fn test_approver_delete_consensus_executes_delete() {
     );
     let _ = std::fs::remove_file(&db);
 }
+
+// ---------------------------------------------------------------------------
+// Task 1.11 — Context-Budget-Aware Recall
+// ---------------------------------------------------------------------------
+
+fn fresh_budget_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-budget-{}.db", uuid::Uuid::new_v4()))
+}
+
+fn store_sized(binary: &str, db_path: &std::path::Path, title: &str, content: &str, priority: i32) {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "store",
+            "-T",
+            title,
+            "-c",
+            content,
+            "-t",
+            "long",
+            "-p",
+            &priority.to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "store failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn recall_with_budget(
+    binary: &str,
+    db_path: &std::path::Path,
+    context: &str,
+    budget: Option<usize>,
+) -> serde_json::Value {
+    let budget_str = budget.map(|n| n.to_string());
+    let mut args: Vec<&str> = vec![
+        "--db",
+        db_path.to_str().unwrap(),
+        "--json",
+        "recall",
+        context,
+    ];
+    if let Some(ref b) = budget_str {
+        args.push("--budget-tokens");
+        args.push(b);
+    }
+    let out = cmd(binary).args(args).output().unwrap();
+    assert!(
+        out.status.success(),
+        "recall failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn test_budget_unlimited_returns_all() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(bin, &db, "t1", "alpha match foo", 5);
+    store_sized(bin, &db, "t2", "alpha match bar", 5);
+    store_sized(bin, &db, "t3", "alpha match baz", 5);
+
+    let v = recall_with_budget(bin, &db, "alpha", None);
+    assert_eq!(v["count"], 3);
+    assert!(v["tokens_used"].as_u64().unwrap() > 0);
+    assert!(v.get("budget_tokens").is_none_or(|v| v.is_null()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_truncates_to_fit() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let body = "alpha match ".repeat(3);
+    for i in 1..=5 {
+        store_sized(bin, &db, &format!("t{i}"), &body, 10 - i);
+    }
+
+    let v = recall_with_budget(bin, &db, "alpha", Some(25));
+    let count = v["count"].as_u64().unwrap() as usize;
+    assert!(
+        count >= 1 && count < 5,
+        "budget must truncate; got count={count}"
+    );
+    let tokens_used = v["tokens_used"].as_u64().unwrap();
+    assert!(
+        tokens_used <= 25,
+        "tokens_used ({tokens_used}) must be <= budget (25)"
+    );
+    assert_eq!(v["budget_tokens"], 25);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_zero_returns_empty() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(bin, &db, "x", "something to find", 5);
+
+    let v = recall_with_budget(bin, &db, "something", Some(1));
+    assert_eq!(v["count"], 0);
+    assert_eq!(v["tokens_used"], 0);
+    assert_eq!(v["budget_tokens"], 1);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_preserves_rank_order() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(
+        bin,
+        &db,
+        "low-pri",
+        "alpha match filler content here longer",
+        1,
+    );
+    store_sized(bin, &db, "high-pri", "alpha match short", 10);
+
+    let v = recall_with_budget(bin, &db, "alpha", Some(8));
+    let mems = v["memories"].as_array().unwrap();
+    if !mems.is_empty() {
+        assert_eq!(mems[0]["title"], "high-pri");
+    }
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_response_includes_metadata() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(bin, &db, "meta-test", "response metadata check", 5);
+
+    let v = recall_with_budget(bin, &db, "response", Some(100));
+    assert!(v["tokens_used"].as_u64().is_some());
+    assert_eq!(v["budget_tokens"], 100);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_touch_only_surviving() {
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(bin, &db, "in-budget", "alpha short", 10);
+    store_sized(
+        bin,
+        &db,
+        "out-of-budget",
+        &("alpha ".to_string() + &"x".repeat(200)),
+        1,
+    );
+
+    let v = recall_with_budget(bin, &db, "alpha", Some(5));
+    let mems = v["memories"].as_array().unwrap();
+    assert!(!mems.is_empty());
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let excluded = lv["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["title"] == "out-of-budget")
+        .unwrap();
+    assert_eq!(
+        excluded["access_count"], 0,
+        "excluded memory must not have access_count bumped"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_budget_mcp_tool_schema_and_response() {
+    use std::io::Write;
+    let db = fresh_budget_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_sized(bin, &db, "mcp-target", "mcp budget test content", 5);
+
+    let mut child = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "mcp", "--tier", "keyword"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.as_mut().unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})
+    )
+    .unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}})
+    )
+    .unwrap();
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params":{"name":"memory_recall","arguments":{
+                "context":"budget",
+                "budget_tokens": 200,
+                "format":"json"
+            }}
+        })
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    let tools_resp: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let recall_tool = tools_resp["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "memory_recall")
+        .unwrap();
+    assert!(
+        recall_tool["inputSchema"]["properties"]["budget_tokens"].is_object(),
+        "memory_recall must advertise budget_tokens"
+    );
+
+    let call_resp: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+    let text = call_resp["result"]["content"][0]["text"].as_str().unwrap();
+    let body: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert!(body["tokens_used"].as_u64().is_some());
+    assert_eq!(body["budget_tokens"], 200);
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.11 — Context-Budget-Aware Recall** per `docs/PHASE-1.md`. **The #1 differentiator feature** — no competitor memory system offers this. Given a scored recall, return the top-ranked subset whose cumulative estimated tokens fit within a caller-supplied budget. Users can now say *"give me the most relevant memories that fit in 4K tokens"* and never waste context window on low-relevance hits.

Closes #157.

## Design

- **Token estimate:** `(title.len() + content.len()) / 4` — the standard ~4-chars-per-token heuristic. Deterministic, fast, good enough for budget gating at the memory-boundary level.
- **Budget applied AFTER ranking.** Ranking logic is untouched — budget is a cap on what the ranker already ordered.
- **Rank fidelity > budget utilization.** Accumulate in rank order; stop at the first memory whose inclusion would exceed the budget. **Do not** substitute shorter later memories for longer earlier ones.
- **Touches only survivors.** Memories that don't make the budget cut do NOT get their `access_count` bumped — no sense fluffing the recall counter for memories the caller will never see.

## Surface

**CLI:**
\`\`\`bash
ai-memory recall "postgres vacuum" --budget-tokens 4000
\`\`\`

**MCP** — `memory_recall` tool gains `budget_tokens` property:
\`\`\`json
{"name": "memory_recall", "arguments": {"context": "...", "budget_tokens": 4000}}
\`\`\`

**HTTP:**
\`\`\`
GET  /api/v1/recall?context=...&budget_tokens=4000
POST /api/v1/recall  {"context": "...", "budget_tokens": 4000}
\`\`\`

**Response metadata:**
- `tokens_used` — always present
- `budget_tokens` — present only when budget was supplied (absent on unlimited)

**TOON** meta line: `count:N|mode:hybrid|tokens_used:N|budget_tokens:N`

## Signature change

- `db::recall()` and `db::recall_hybrid()` gain trailing `budget_tokens: Option<usize>` param
- Return type: `Result<(Vec<(Memory, f64)>, usize)>` — trailing `usize` is `tokens_used`
- Callers unpack the tuple (documented in the diff; only 4 non-test call sites total)

**New helpers:**
- `estimate_memory_tokens(&Memory) -> usize` — exposed for callers that want to do their own accounting
- `apply_token_budget(scored, budget) -> (trimmed, tokens_used)` — the truncation primitive; deterministic, no DB calls

## Files changed (7 files, +395 / −32)

| File | Lines | What |
|---|---|---|
| `src/db.rs` | +58 | helpers + recall/recall_hybrid signature update + budget application + survivor-only touch |
| `src/mcp.rs` | +16/−4 | tool schema + handle_recall plumbing + decorate_budget helper |
| `src/main.rs` | +12/−7 | `RecallArgs --budget-tokens`; cmd_recall unpacks tuple + adds metadata to JSON; shell REPL updated |
| `src/handlers.rs` | +16/−4 | HTTP endpoints thread `budget_tokens`; response carries metadata |
| `src/models.rs` | +10 | `budget_tokens` field on `RecallQuery` + `RecallBody` |
| `src/toon.rs` | +6 | meta line surfaces `tokens_used` + `budget_tokens` |
| `tests/integration.rs` | +220 | 7 new integration tests |

## Tests — +7 new (6-minimum exceeded)

- `test_budget_unlimited_returns_all` — tokens_used present without budget_tokens
- `test_budget_truncates_to_fit` — count reduced, `tokens_used ≤ budget`
- `test_budget_zero_returns_empty` — tiny budget returns `count: 0`
- `test_budget_preserves_rank_order` — high-priority memory wins the slot
- `test_budget_response_includes_metadata` — both fields surfaced
- `test_budget_touch_only_surviving` — **regression guard**: excluded memory's `access_count` stays at 0 (confirms budget cut happens before touch)
- `test_budget_mcp_tool_schema_and_response` — `memory_recall` advertises `budget_tokens`; budgeted response carries both fields

**Suite total: 234 unit + 142 integration = 376 passing.**

## Gates

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ — 376/376
- `cargo audit` ✓ — 0 vulns

No new `unwrap()` in production paths.

## Phase 1 status after this PR

| Track | Tasks | Status |
|---|---|---|
| A | 1.1 / 1.2 / 1.3 | ✅ shipped v0.6.0-alpha.2 |
| B | 1.4 / 1.5 / 1.6 / 1.7 | ✅ on release/v0.6.0 |
| C | 1.8 / 1.9 / 1.10 | ✅ on release/v0.6.0 |
| D | **1.11** / 1.12 | **1.11 ✅** — only 1.12 left |

Task 1.12 (hierarchy-aware recall) now has both its deps — 1.5 (visibility) and 1.11 (budget) — satisfied. One PR to go for Phase 1 complete + `v0.6.0-rc.1`.

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"