### PR TITLE
feat: hierarchy-aware recall (task 1.12) — PHASE 1 COMPLETE — closes #158

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -824,6 +824,65 @@ pub fn search(
         .map_err(Into::into)
 }
 
+/// Task 1.12 — proximity boost applied to a memory's score based on its
+/// depth distance from the queried agent namespace. Uses the formula
+/// `1 / (1 + depth_distance * 0.3)` per spec. Distance 0 = full strength
+/// (1.0), each step up the hierarchy dampens linearly.
+#[must_use]
+pub fn proximity_boost(agent_ns: &str, memory_ns: &str) -> f64 {
+    let agent_depth = crate::models::namespace_depth(agent_ns);
+    let memory_depth = crate::models::namespace_depth(memory_ns);
+    let distance = agent_depth.saturating_sub(memory_depth);
+    #[allow(clippy::cast_precision_loss)]
+    let d = distance as f64;
+    1.0 / (1.0 + d * 0.3)
+}
+
+/// Task 1.12 — SQL fragment + boolean indicating whether hierarchy
+/// expansion is in play. When active the `namespace` SQL param binds
+/// NULL (so `?N IS NULL OR m.namespace = ?N` passes trivially) and a
+/// separate `AND m.namespace IN (<ancestors>)` clause narrows to the
+/// hierarchy. When inactive the returned fragment is empty.
+///
+/// Ancestor strings are interpolated because `SQLite` `IN` with a
+/// variable-length positional list is awkward, and the inputs come
+/// from `namespace_ancestors()` → `validate_namespace`-approved
+/// strings. Single-quote doubling is applied defensively.
+fn hierarchy_in_clause(namespace: Option<&str>) -> (Option<String>, bool) {
+    let Some(ns) = namespace else {
+        return (None, false);
+    };
+    if !ns.contains('/') {
+        return (None, false);
+    }
+    let ancestors = crate::models::namespace_ancestors(ns);
+    if ancestors.is_empty() {
+        return (None, false);
+    }
+    let quoted: Vec<String> = ancestors
+        .iter()
+        .map(|a| format!("'{}'", a.replace('\'', "''")))
+        .collect();
+    (
+        Some(format!("AND m.namespace IN ({})", quoted.join(","))),
+        true,
+    )
+}
+
+/// Task 1.12 — apply proximity boost to scored memories ranked against
+/// an agent's hierarchical namespace. Re-sorts by boosted score.
+fn apply_proximity_boost(scored: Vec<(Memory, f64)>, agent_ns: &str) -> Vec<(Memory, f64)> {
+    let mut boosted: Vec<(Memory, f64)> = scored
+        .into_iter()
+        .map(|(mem, score)| {
+            let boost = proximity_boost(agent_ns, &mem.namespace);
+            (mem, score * boost)
+        })
+        .collect();
+    boosted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    boosted
+}
+
 /// Task 1.11 — rough token estimate for a memory. Uses the "~4 chars per
 /// token" heuristic on `title + content`. Deliberately byte-length-based:
 /// fast, deterministic, and correct enough for budget gating.
@@ -879,6 +938,13 @@ pub fn recall(
     let fts_query = sanitize_fts_query(context, true);
     let (vis_p, vis_t, vis_u, vis_o) = compute_visibility_prefixes(as_agent);
 
+    // Task 1.12: hierarchy expansion. If `namespace` is hierarchical (contains
+    // `/`), broaden the filter to the full ancestor chain. Flat namespaces
+    // keep exact-match semantics (backward compat).
+    let (hierarchy_in, hierarchy_active) = hierarchy_in_clause(namespace);
+    let hierarchy_fragment = hierarchy_in.unwrap_or_default();
+    let effective_namespace = if hierarchy_active { None } else { namespace };
+
     let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
                 m.confidence, m.source, m.access_count, m.created_at, m.updated_at,
@@ -894,6 +960,7 @@ pub fn recall(
          JOIN memories m ON m.rowid = fts.rowid
          WHERE memories_fts MATCH ?1
            AND (?2 IS NULL OR m.namespace = ?2)
+           {hierarchy_fragment}
            AND (m.expires_at IS NULL OR m.expires_at > ?3)
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
@@ -907,7 +974,7 @@ pub fn recall(
     let rows = stmt.query_map(
         params![
             fts_query,
-            namespace,
+            effective_namespace,
             now,
             tags_filter,
             since,
@@ -926,8 +993,15 @@ pub fn recall(
     )?;
     let results: Vec<(Memory, f64)> = rows.collect::<rusqlite::Result<Vec<_>>>()?;
 
-    // Task 1.11: apply optional token budget in rank order.
-    let (budgeted, tokens_used) = apply_token_budget(results, budget_tokens);
+    // Task 1.12: proximity boost when hierarchy expansion is active.
+    let boosted = if let (true, Some(anchor)) = (hierarchy_active, namespace) {
+        apply_proximity_boost(results, anchor)
+    } else {
+        results
+    };
+
+    // Task 1.11: apply optional token budget in rank order (AFTER proximity).
+    let (budgeted, tokens_used) = apply_token_budget(boosted, budget_tokens);
 
     // Touch all recalled memories that SURVIVED the budget cut — no sense
     // bumping access counts on memories the caller will never see.
@@ -1880,6 +1954,28 @@ pub fn recall_hybrid(
     let prefixes = compute_visibility_prefixes(as_agent);
     let (vis_p, vis_t, vis_u, vis_o) = prefixes.clone();
 
+    // Task 1.12: hierarchy expansion (same logic as `recall`). Hierarchical
+    // `namespace` broadens filter to ancestor chain; flat namespaces stay
+    // exact-match.
+    let (fts_hierarchy_in, hierarchy_active) = hierarchy_in_clause(namespace);
+    let fts_hierarchy_fragment = fts_hierarchy_in.unwrap_or_default();
+    // Semantic stmt has no `m.` alias and binds at slot 1 — compute separately.
+    let sem_hierarchy_fragment = if hierarchy_active {
+        if let Some(ns) = namespace {
+            let ancestors = crate::models::namespace_ancestors(ns);
+            let quoted: Vec<String> = ancestors
+                .iter()
+                .map(|a| format!("'{}'", a.replace('\'', "''")))
+                .collect();
+            format!("AND memories.namespace IN ({})", quoted.join(","))
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+    let effective_namespace = if hierarchy_active { None } else { namespace };
+
     // Step 1: Get FTS candidates (up to 3x limit to have a good pool)
     let fts_limit = (limit * 3).max(30);
     let fts_sql = format!(
@@ -1895,6 +1991,7 @@ pub fn recall_hybrid(
          JOIN memories m ON m.rowid = fts.rowid
          WHERE memories_fts MATCH ?1
            AND (?2 IS NULL OR m.namespace = ?2)
+           {fts_hierarchy_fragment}
            AND (m.expires_at IS NULL OR m.expires_at > ?3)
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
@@ -1914,6 +2011,7 @@ pub fn recall_hybrid(
          FROM memories
          WHERE embedding IS NOT NULL
            AND (?1 IS NULL OR namespace = ?1)
+           {sem_hierarchy_fragment}
            AND (expires_at IS NULL OR expires_at > ?2)
            AND (?3 IS NULL OR EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE json_each.value = ?3))
            AND (?4 IS NULL OR created_at >= ?4)
@@ -1929,7 +2027,7 @@ pub fn recall_hybrid(
     let fts_rows = fts_stmt.query_map(
         params![
             fts_query,
-            namespace,
+            effective_namespace,
             now,
             tags_filter,
             since,
@@ -1977,11 +2075,18 @@ pub fn recall_hybrid(
             if cosine > 0.3
                 && let Some(mem) = get(conn, &hit.id)?
             {
-                // Apply namespace/expiry/tag filters
-                if let Some(ns) = namespace
-                    && mem.namespace != ns
-                {
-                    continue;
+                // Apply namespace/expiry/tag filters. Task 1.12: when
+                // hierarchy expansion is active, allow any ancestor match
+                // (namespace_ancestors gives us the set); otherwise exact.
+                if let Some(ns) = namespace {
+                    if hierarchy_active {
+                        let ancestors = crate::models::namespace_ancestors(ns);
+                        if !ancestors.iter().any(|a| a == &mem.namespace) {
+                            continue;
+                        }
+                    } else if mem.namespace != ns {
+                        continue;
+                    }
                 }
                 if let Some(exp) = &mem.expires_at
                     && exp.as_str() <= now.as_str()
@@ -2014,7 +2119,7 @@ pub fn recall_hybrid(
         // Fallback: linear scan over all embeddings
         let sem_rows = sem_stmt.query_map(
             params![
-                namespace,
+                effective_namespace,
                 now,
                 tags_filter,
                 since,
@@ -2083,8 +2188,15 @@ pub fn recall_hybrid(
     results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     results.truncate(limit);
 
-    // Task 1.11: apply token budget in rank order.
-    let (budgeted, tokens_used) = apply_token_budget(results, budget_tokens);
+    // Task 1.12: proximity boost (if hierarchy expansion is active).
+    let boosted = if let (true, Some(anchor)) = (hierarchy_active, namespace) {
+        apply_proximity_boost(results, anchor)
+    } else {
+        results
+    };
+
+    // Task 1.11: apply token budget in rank order (AFTER proximity).
+    let (budgeted, tokens_used) = apply_token_budget(boosted, budget_tokens);
 
     // Touch surviving memories only.
     for (mem, _) in &budgeted {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7209,3 +7209,252 @@ fn test_budget_mcp_tool_schema_and_response() {
     assert_eq!(body["budget_tokens"], 200);
     let _ = std::fs::remove_file(&db);
 }
+
+// ---------------------------------------------------------------------------
+// Task 1.12 — Hierarchy-Aware Recall
+// ---------------------------------------------------------------------------
+
+fn fresh_hier_recall_db() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("ai-memory-hier-{}.db", uuid::Uuid::new_v4()))
+}
+
+fn store_at(binary: &str, db_path: &std::path::Path, namespace: &str, title: &str) {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "store",
+            "-n",
+            namespace,
+            "-T",
+            title,
+            "-c",
+            "postgres content for test",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "store failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn recall_titles(
+    binary: &str,
+    db_path: &std::path::Path,
+    namespace: &str,
+    ctx: &str,
+) -> Vec<String> {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "recall",
+            ctx,
+            "-n",
+            namespace,
+            "--limit",
+            "50",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "recall failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["memories"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|m| m["title"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[test]
+fn test_hier_recall_returns_ancestor_memories() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_at(bin, &db, "alphaone", "org-note");
+    store_at(bin, &db, "alphaone/engineering", "unit-note");
+    store_at(bin, &db, "alphaone/engineering/platform", "team-note");
+    store_at(
+        bin,
+        &db,
+        "alphaone/engineering/platform/agent-1",
+        "agent-note",
+    );
+    // Sibling outside the ancestor chain
+    store_at(
+        bin,
+        &db,
+        "alphaone/engineering/platform/agent-2",
+        "sibling-note",
+    );
+    store_at(bin, &db, "other-org", "outsider-note");
+
+    let titles = recall_titles(
+        bin,
+        &db,
+        "alphaone/engineering/platform/agent-1",
+        "postgres",
+    );
+    assert!(titles.contains(&"org-note".to_string()));
+    assert!(titles.contains(&"unit-note".to_string()));
+    assert!(titles.contains(&"team-note".to_string()));
+    assert!(titles.contains(&"agent-note".to_string()));
+    assert!(
+        !titles.contains(&"sibling-note".to_string()),
+        "sibling not in ancestor chain"
+    );
+    assert!(!titles.contains(&"outsider-note".to_string()));
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_hier_recall_proximity_boost_ranks_closest_first() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_at(bin, &db, "alphaone", "org-note");
+    store_at(bin, &db, "alphaone/engineering", "unit-note");
+    store_at(bin, &db, "alphaone/engineering/platform", "team-note");
+    store_at(
+        bin,
+        &db,
+        "alphaone/engineering/platform/agent-1",
+        "agent-note",
+    );
+
+    let titles = recall_titles(
+        bin,
+        &db,
+        "alphaone/engineering/platform/agent-1",
+        "postgres",
+    );
+    assert_eq!(titles[0], "agent-note");
+    assert_eq!(titles[titles.len() - 1], "org-note");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_hier_recall_flat_namespace_unchanged() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_at(bin, &db, "global", "flat-a");
+    store_at(bin, &db, "other", "flat-b");
+
+    let titles = recall_titles(bin, &db, "global", "postgres");
+    assert!(titles.contains(&"flat-a".to_string()));
+    assert!(
+        !titles.contains(&"flat-b".to_string()),
+        "flat namespace must stay exact-match"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_hier_recall_budget_applied_after_proximity() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    // Short body so a tight budget fits the closest memory.
+    let body = "postgres tag";
+    let entries = [
+        ("alphaone", "org"),
+        ("alphaone/engineering", "unit"),
+        ("alphaone/engineering/platform", "team"),
+        ("alphaone/engineering/platform/agent-1", "self"),
+    ];
+    for (ns, title) in entries {
+        let out = cmd(bin)
+            .args([
+                "--db",
+                db.to_str().unwrap(),
+                "--json",
+                "store",
+                "-n",
+                ns,
+                "-T",
+                title,
+                "-c",
+                body,
+                "-t",
+                "long",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    // Each memory ≈ (4 title + 12 content) / 4 = 4 tokens.
+    // Budget 10 should fit 2 memories max; closest ("self") wins top slot.
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "recall",
+            "postgres",
+            "-n",
+            "alphaone/engineering/platform/agent-1",
+            "--budget-tokens",
+            "10",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let mems = v["memories"].as_array().unwrap();
+    assert!(!mems.is_empty());
+    assert_eq!(mems[0]["title"], "self");
+    assert!(v["tokens_used"].as_u64().unwrap() <= 10);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_hier_recall_2_level_ancestor_only() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_at(bin, &db, "alphaone", "org");
+    store_at(bin, &db, "alphaone/engineering", "unit");
+    store_at(bin, &db, "alphaone/engineering/platform", "descendant");
+
+    let titles = recall_titles(bin, &db, "alphaone/engineering", "postgres");
+    assert!(titles.contains(&"org".to_string()));
+    assert!(titles.contains(&"unit".to_string()));
+    assert!(
+        !titles.contains(&"descendant".to_string()),
+        "descendant of queried ns must NOT appear — only ancestors"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_hier_recall_touches_only_ancestor_matches() {
+    let db = fresh_hier_recall_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    store_at(bin, &db, "alphaone", "ancestor-note");
+    store_at(bin, &db, "alphaone/engineering/agent-1", "agent-note");
+    store_at(bin, &db, "other-root", "outsider");
+
+    let _ = recall_titles(bin, &db, "alphaone/engineering/agent-1", "postgres");
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let outsider = lv["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["title"] == "outsider")
+        .unwrap();
+    assert_eq!(outsider["access_count"], 0);
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

**Implements Phase 1 Task 1.12 — Hierarchy-Aware Recall. The final Phase 1 task.**

Recall now honors the agent's hierarchical namespace: when `namespace` contains `/`, the query broadens to every ancestor and applies a proximity boost so closer ancestors rank higher. Flat namespaces stay exact-match (backward compat).

Closes #158. **With this PR merged, Phase 1 is complete — 12 of 12 tasks shipped on `release/v0.6.0`.**

## Behavior

For agent at `alphaone/engineering/platform/agent-1` recalling `"postgres"`:

| Namespace | Boost | Why |
|---|---|---|
| `alphaone/engineering/platform/agent-1` | **1.0** | self — full strength |
| `alphaone/engineering/platform` | ~0.77 | `1 / (1 + 1*0.3)` |
| `alphaone/engineering` | ~0.63 | `1 / (1 + 2*0.3)` |
| `alphaone` | ~0.53 | `1 / (1 + 3*0.3)` |

Final score = FTS/hybrid score × proximity boost. Results re-sorted after boost is applied.

**Siblings, descendants, and cross-org namespaces are excluded** — only strict ancestors (self + each path prefix) participate.

## Implementation (`src/db.rs`)

- **`proximity_boost(agent_ns, memory_ns) -> f64`** — `1 / (1 + d * 0.3)` where `d = agent_depth - memory_depth` (saturating).
- **`hierarchy_in_clause(ns) -> (Option<String>, bool)`** — builds `AND m.namespace IN ('a','a/b',...)` when `ns` is hierarchical. Returns `(None, false)` for flat or unset.
- **`apply_proximity_boost(scored, agent_ns) -> Vec`** — post-SQL re-ranking; multiplies each memory's score by its boost and re-sorts.
- **`recall()` and `recall_hybrid()`**: when hierarchy active, bind `NULL` for the existing `?N IS NULL OR m.namespace = ?N` slot (trivially passes), then narrow via the interpolated IN-clause. Ancestor strings come from `namespace_ancestors()` (already validated); single-quote doubling applied defensively.

## Pipeline order in recall

1. SQL query with hierarchy-expanded namespace filter
2. Apply **proximity boost** (re-ranks within ancestor set)
3. Apply **Task 1.11 token budget** (cap AFTER proximity)
4. Touch surviving memories

recall_hybrid's **HNSW branch** also updated: the in-memory namespace filter now allows ancestor matches when hierarchy is active; exact match otherwise.

## Files changed (2 files, +373 / −12)

| File | Lines | What |
|---|---|---|
| `src/db.rs` | +153 | `proximity_boost`, `hierarchy_in_clause`, `apply_proximity_boost`; recall + recall_hybrid SQL expansion + re-rank; HNSW branch updated |
| `tests/integration.rs` | +220 | 6 new integration tests |

## Tests — +6 new (4-minimum exceeded)

- `test_hier_recall_returns_ancestor_memories` — ancestor set surfaces, sibling/outsider excluded
- `test_hier_recall_proximity_boost_ranks_closest_first` — agent's own namespace wins the top slot; root last
- `test_hier_recall_flat_namespace_unchanged` — **backward compat regression guard**
- `test_hier_recall_budget_applied_after_proximity` — tight budget gives slot to closest boost
- `test_hier_recall_2_level_ancestor_only` — descendants NOT included (ancestor-only semantics)
- `test_hier_recall_touches_only_ancestor_matches` — outsiders don't get `access_count` bumped

**Suite total: 234 unit + 148 integration = 382 passing.**

## Gates

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test` ✓ — 382/382
- `cargo audit` ✓ — 0 vulns

No new `unwrap()` in production paths.

## 🎉 PHASE 1 COMPLETE — 12 of 12 tasks shipped

| Track | Tasks | Status |
|---|---|---|
| A | 1.1 / 1.2 / 1.3 | ✅ shipped v0.6.0-alpha.2 |
| B | 1.4 / 1.5 / 1.6 / 1.7 | ✅ on release/v0.6.0 |
| C | 1.8 / 1.9 / 1.10 | ✅ on release/v0.6.0 |
| D | 1.11 / **1.12** | ✅ on release/v0.6.0 |

After this PR merges, `release/v0.6.0` is **15 commits ahead** of the `v0.6.0-alpha.2` tag and ready to cut **`v0.6.0-rc.1`**.

## AI involvement

- **Model:** Claude Opus 4.7 (1M context) via Claude Code CLI
- **Authority:** Standard under §5.4 sole-approver
- **Human authorization:** @alphaonedev — "approved lets go full send - build it"