### PR TITLE
fix(security): harden Consensus voting + visibility LIKE (#216, #217)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -69,6 +69,17 @@ fn matches_subtree(namespace: &str, prefix: Option<&str>) -> bool {
 /// Generate the visibility WHERE-clause fragment starting at placeholder `start`.
 /// Uses placeholders `?start .. ?start+3` for private/team/unit/org prefixes.
 /// See `compute_visibility_prefixes` for the bind order.
+///
+/// Security (issue #217): the team/unit/org branches use `LIKE` to expand a
+/// prefix into its sub-tree. Without escaping, a caller who can influence the
+/// prefix could inject SQL `LIKE` meta-characters (`%`, `_`) and broaden the
+/// match across unrelated namespaces. We neutralise this at SQL evaluation
+/// time by `replace()`-escaping `%` and `_` in the bound prefix and pairing
+/// the LIKE with `ESCAPE '\'`. `validate_namespace` already rejects backslash,
+/// so `\` cannot appear in the bound prefix and the escape sentinel is safe.
+/// The `=` equality side is unaffected by LIKE wildcards and binds the raw
+/// value so that legitimate namespaces containing `_` (e.g. `under_score`)
+/// continue to match exactly.
 fn visibility_clause(start: usize, table_alias: &str) -> String {
     let private_ph = start;
     let team_ph = start + 1;
@@ -80,9 +91,9 @@ fn visibility_clause(start: usize, table_alias: &str) -> String {
             ?{private_ph} IS NULL \
             OR COALESCE(json_extract({ta}.metadata, '$.scope'), 'private') = 'collective' \
             OR (COALESCE(json_extract({ta}.metadata, '$.scope'), 'private') = 'private' AND {ta}.namespace = ?{private_ph}) \
-            OR (json_extract({ta}.metadata, '$.scope') = 'team' AND ?{team_ph} IS NOT NULL AND ({ta}.namespace = ?{team_ph} OR {ta}.namespace LIKE ?{team_ph} || '/%')) \
-            OR (json_extract({ta}.metadata, '$.scope') = 'unit' AND ?{unit_ph} IS NOT NULL AND ({ta}.namespace = ?{unit_ph} OR {ta}.namespace LIKE ?{unit_ph} || '/%')) \
-            OR (json_extract({ta}.metadata, '$.scope') = 'org'  AND ?{org_ph}  IS NOT NULL AND ({ta}.namespace = ?{org_ph}  OR {ta}.namespace LIKE ?{org_ph}  || '/%'))\
+            OR (json_extract({ta}.metadata, '$.scope') = 'team' AND ?{team_ph} IS NOT NULL AND ({ta}.namespace = ?{team_ph} OR {ta}.namespace LIKE replace(replace(?{team_ph}, '%', '\\%'), '_', '\\_') || '/%' ESCAPE '\\')) \
+            OR (json_extract({ta}.metadata, '$.scope') = 'unit' AND ?{unit_ph} IS NOT NULL AND ({ta}.namespace = ?{unit_ph} OR {ta}.namespace LIKE replace(replace(?{unit_ph}, '%', '\\%'), '_', '\\_') || '/%' ESCAPE '\\')) \
+            OR (json_extract({ta}.metadata, '$.scope') = 'org'  AND ?{org_ph}  IS NOT NULL AND ({ta}.namespace = ?{org_ph}  OR {ta}.namespace LIKE replace(replace(?{org_ph}, '%', '\\%'), '_', '\\_') || '/%' ESCAPE '\\'))\
         )"
     )
 }
@@ -2611,15 +2622,35 @@ pub fn approve_with_approver_type(
             }
         }
         ApproverType::Consensus(quorum) => {
+            // Issue #216: a single caller could previously satisfy any
+            // Consensus(n) quorum by varying the unauthenticated `agent_id`
+            // (`alice`, `bob`, `Alice`/`alice` were three distinct votes).
+            // Two changes harden the path:
+            //   1. Require each voter to be a registered agent — raises the
+            //      bar from "claim any string" to "operator pre-registered
+            //      this id". Combined with auth on the approve endpoint
+            //      (operator-deployed) this gives a real multi-party gate.
+            //   2. Canonicalize the agent_id to lowercase for both the
+            //      duplicate-vote check and storage so case-variants of the
+            //      same id collapse to a single vote.
+            if !is_registered_agent(conn, approver_agent_id) {
+                return Ok(ApproveOutcome::Rejected(format!(
+                    "consensus voter '{approver_agent_id}' is not a registered agent"
+                )));
+            }
+            let canonical_id = approver_agent_id.to_ascii_lowercase();
             let mut approvals = pa.approvals.clone();
-            if approvals.iter().any(|a| a.agent_id == approver_agent_id) {
+            if approvals
+                .iter()
+                .any(|a| a.agent_id.eq_ignore_ascii_case(&canonical_id))
+            {
                 return Ok(ApproveOutcome::Pending {
                     votes: approvals.len(),
                     quorum,
                 });
             }
             approvals.push(Approval {
-                agent_id: approver_agent_id.to_string(),
+                agent_id: canonical_id.clone(),
                 approved_at: Utc::now().to_rfc3339(),
             });
             let approvals_json = serde_json::to_string(&approvals)?;
@@ -2630,7 +2661,7 @@ pub fn approve_with_approver_type(
             let votes = approvals.len();
             if u32::try_from(votes).unwrap_or(u32::MAX) >= quorum {
                 // Threshold met — transition status so the caller can replay.
-                let ok = decide_pending_action(conn, pending_id, true, approver_agent_id)?;
+                let ok = decide_pending_action(conn, pending_id, true, &canonical_id)?;
                 if ok {
                     return Ok(ApproveOutcome::Approved);
                 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6668,6 +6668,28 @@ fn approve(
         .unwrap()
 }
 
+/// Register an agent so it can satisfy `Consensus(n)` voting (issue #216).
+fn register_voter(binary: &str, db_path: &std::path::Path, agent_id: &str) {
+    let out = cmd(binary)
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "agents",
+            "register",
+            "--agent-id",
+            agent_id,
+            "--agent-type",
+            "ai:claude-opus-4.7",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "register voter '{agent_id}' failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 #[test]
 fn test_approver_human_any_approver_accepted() {
     let db = fresh_approver_db();
@@ -6752,6 +6774,8 @@ fn test_approver_consensus_below_threshold_pending() {
         "owner",
     );
     let pid = queue_store(bin, &db, "alphaone", "cons-target", "alice");
+    register_voter(bin, &db, "approver-1");
+    register_voter(bin, &db, "approver-2");
 
     let v1 = approve(bin, &db, &pid, "approver-1");
     assert!(v1.status.success());
@@ -6792,6 +6816,8 @@ fn test_approver_consensus_threshold_auto_executes() {
         "owner",
     );
     let pid = queue_store(bin, &db, "alphaone", "cons-exec", "alice");
+    register_voter(bin, &db, "a1");
+    register_voter(bin, &db, "a2");
 
     let v1 = approve(bin, &db, &pid, "a1");
     assert_eq!(
@@ -6849,6 +6875,8 @@ fn test_approver_consensus_same_agent_does_not_double_count() {
         "owner",
     );
     let pid = queue_store(bin, &db, "alphaone", "cons-dup", "alice");
+    register_voter(bin, &db, "a1");
+    register_voter(bin, &db, "a2");
 
     let v1a = approve(bin, &db, &pid, "a1");
     let v1b = approve(bin, &db, &pid, "a1");
@@ -6947,6 +6975,8 @@ fn test_approver_delete_consensus_executes_delete() {
     assert_eq!(jd["status"], "pending");
     let pid = jd["pending_id"].as_str().unwrap().to_string();
 
+    register_voter(bin, &db, "v1");
+    register_voter(bin, &db, "v2");
     let _ = approve(bin, &db, &pid, "v1");
     let v2 = approve(bin, &db, &pid, "v2");
     let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
@@ -6960,6 +6990,171 @@ fn test_approver_delete_consensus_executes_delete() {
     assert!(
         !get.status.success(),
         "memory must be deleted after consensus"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+// ---------------------------------------------------------------------------
+// Security regression tests — issue #216 (Consensus voter hardening) and
+// issue #217 (LIKE-wildcard smuggling in visibility filter).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_consensus_unregistered_voter_rejected() {
+    // Issue #216: an unregistered agent_id can no longer satisfy a Consensus
+    // vote. Operators must pre-register voters via `agents register`.
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "needs-2", "alice");
+    register_voter(bin, &db, "approver-1");
+    // Only approver-1 is registered; approver-2 is not.
+
+    let v1 = approve(bin, &db, &pid, "approver-1");
+    assert!(v1.status.success(), "registered voter must succeed");
+    let j1: serde_json::Value = serde_json::from_slice(&v1.stdout).unwrap();
+    assert_eq!(j1["votes"], 1);
+
+    let v2 = approve(bin, &db, &pid, "approver-2");
+    assert!(
+        !v2.status.success(),
+        "unregistered voter must be rejected; stdout={}",
+        String::from_utf8_lossy(&v2.stdout)
+    );
+
+    // Quorum must not have been reached.
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["pending"][0]["status"], "pending");
+    assert_eq!(lv["pending"][0]["approvals"].as_array().unwrap().len(), 1);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_consensus_case_variant_rejected_if_only_lowercase_registered() {
+    // Issue #216: a single caller cannot satisfy Consensus(2) by submitting
+    // {"alice","Alice"} when only "alice" was registered. The case-variant
+    // is treated as a distinct (and therefore unregistered) id.
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "case-attack", "alice");
+    register_voter(bin, &db, "alice");
+
+    let v1 = approve(bin, &db, &pid, "alice");
+    assert!(v1.status.success());
+    let v2 = approve(bin, &db, &pid, "Alice");
+    assert!(
+        !v2.status.success(),
+        "case-variant of registered id must not satisfy quorum"
+    );
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["pending"][0]["status"], "pending");
+    assert_eq!(lv["pending"][0]["approvals"].as_array().unwrap().len(), 1);
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_consensus_case_insensitive_dedup_when_variants_registered() {
+    // Issue #216: even if an operator registers both "alice" and "Alice"
+    // (operational mistake — they are distinct rows), the consensus dedup
+    // must collapse them so the attacker still only gets one vote.
+    let db = fresh_approver_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    set_governance(
+        bin,
+        &db,
+        "alphaone",
+        serde_json::json!({
+            "write":"approve","promote":"any","delete":"owner",
+            "approver":{"consensus":2}
+        }),
+        "owner",
+    );
+    let pid = queue_store(bin, &db, "alphaone", "case-dedup", "alice");
+    register_voter(bin, &db, "alice");
+    register_voter(bin, &db, "Alice");
+
+    let v1 = approve(bin, &db, &pid, "alice");
+    let j1: serde_json::Value = serde_json::from_slice(&v1.stdout).unwrap();
+    assert_eq!(j1["votes"], 1);
+
+    let v2 = approve(bin, &db, &pid, "Alice");
+    let j2: serde_json::Value = serde_json::from_slice(&v2.stdout).unwrap();
+    assert_eq!(
+        j2["votes"], 1,
+        "case-variant of an existing voter must not double-count"
+    );
+
+    let list = cmd(bin)
+        .args(["--db", db.to_str().unwrap(), "--json", "pending", "list"])
+        .output()
+        .unwrap();
+    let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(lv["pending"][0]["status"], "pending");
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_visibility_wildcard_percent_smuggling_blocked() {
+    // Issue #217: as_agent="%/y" used to expand the team-scope LIKE pattern
+    // to "%/%", matching every hierarchical namespace and exposing
+    // unrelated tenants' team-scoped memories. The fix escapes the bound
+    // prefix at SQL evaluation time.
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "alphaone/eng", "team-secret-alphaone", "team");
+    seed_scoped(bin, &db, "acme/legal", "team-secret-acme", "team");
+    seed_scoped(bin, &db, "competitor/hr", "team-secret-competitor", "team");
+
+    let titles = recall_as_agent(bin, &db, "%/y", "team");
+    assert!(
+        titles.is_empty(),
+        "wildcard smuggling must not expose any team-scoped memory; got: {titles:?}"
+    );
+    let _ = std::fs::remove_file(&db);
+}
+
+#[test]
+fn test_visibility_wildcard_underscore_smuggling_blocked() {
+    // Issue #217: as_agent="_/y" used to expand the team-scope LIKE pattern
+    // to "_/%", matching every namespace whose first segment is a single
+    // character. The fix neutralises `_` in the bound prefix.
+    let db = fresh_scope_db();
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    seed_scoped(bin, &db, "a/x", "team-secret-a", "team");
+    seed_scoped(bin, &db, "b/y", "team-secret-b", "team");
+
+    let titles = recall_as_agent(bin, &db, "_/q", "team");
+    assert!(
+        titles.is_empty(),
+        "underscore-wildcard smuggling must not expose any team-scoped memory; got: {titles:?}"
     );
     let _ = std::fs::remove_file(&db);
 }


### PR DESCRIPTION
## Summary

Addresses the two findings from the Phase 1 security review of `release/v0.6.0`.

- **#216 [HIGH]** Consensus approver: require registered voter + case-normalise dedup. A single caller could previously satisfy any `Consensus(n)` quorum by submitting N approvals with N distinct (unauthenticated) claimed agent_ids.
- **#217 [MEDIUM]** Visibility filter: escape `%`/`_` in bound LIKE prefixes and add `ESCAPE '\'` to each LIKE. Crafting `as_agent="%/y"` previously expanded team-scope LIKE to `%/%` and exposed every tenant's team-scoped memories.

Closes #216
Closes #217

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Sensitive (security fix)
- **Human approver(s) for any Sensitive items:** @binary2029 (explicit "fix all security vulnerabilities identified … approved")
- **ai-memory entries created/updated:** existing security review findings; issues #216 and #217
- **Co-Authored-By trailer present on every AI-authored commit:** yes

## Linked issues

Closes #216
Closes #217

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — **153 passed; 0 failed**
- [x] `cargo audit` clean
- [x] 5 new security regression tests:
  - `test_consensus_unregistered_voter_rejected`
  - `test_consensus_case_variant_rejected_if_only_lowercase_registered`
  - `test_consensus_case_insensitive_dedup_when_variants_registered`
  - `test_visibility_wildcard_percent_smuggling_blocked`
  - `test_visibility_wildcard_underscore_smuggling_blocked`
- [x] 4 existing consensus tests updated to pre-register voters

## Scope

Minimal, surgical fix. No refactors, no API changes, no schema changes.
Backward compatible — registered-agent requirement for Consensus voting is
a new precondition that operators satisfy via `agents register` before
configuring `approver:{"consensus":n}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)