### PR TITLE
proposal: v0.7 SAL skeleton — MemoryStore trait + SQLite adapter stub (draft, do not merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,9 @@ name = "ai-memory"
 version = "0.6.0-alpha.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
+ "bitflags",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -140,6 +142,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ uuid = { version = "1", features = ["v4"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 gethostname = "0.5"
 
+# v0.7 SAL proposal skeleton (issue #221) — async trait object + capability flags
+async-trait = "0.1"
+bitflags = "2"
+
 # Semantic embedding support
 candle-core = "0.10"
 candle-nn = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,12 @@ mod mcp;
 mod mine;
 mod models;
 mod reranker;
+// v0.7 SAL proposal skeleton (issue #221). Not wired into any call path
+// yet — every method is dead code until the extraction phase. Silence the
+// dead-code warnings at the module boundary so we do not need to sprinkle
+// #[allow(dead_code)] on every field in the design sketch.
+#[allow(dead_code)]
+mod store;
 mod toon;
 mod validate;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,0 +1,277 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage Abstraction Layer (SAL) — v0.7 proposal skeleton.
+//!
+//! See issue #221 for the architectural rationale. The short version:
+//! v0.6.x is `SQLite`-only and that caps deployment options (`Postgres`+pgvector,
+//! `Qdrant`, `LanceDB`, `Chroma`, managed vector stores). This module introduces
+//! a [`MemoryStore`] trait that every backend implements. `SQLite` remains the
+//! default; other backends slot in behind feature flags.
+//!
+//! # Status
+//!
+//! This is a **proposal skeleton**, not a shipped feature. The file exists so
+//! the v0.7 design can be reviewed as concrete Rust rather than prose. Most
+//! methods on [`sqlite::SqliteStore`] are `todo!()` — they'll be filled in
+//! during the v0.7.0-alpha extraction phase. Do not wire this into
+//! `main.rs` / `handlers.rs` / `mcp.rs` until the extraction lands behind
+//! a feature flag.
+//!
+//! # Design principles
+//!
+//! 1. **Backend-agnostic filters** — callers pass a structured [`Filter`]
+//!    AST, never raw SQL. Each adapter translates the AST into its native
+//!    query language (SQL for SQLite/Postgres, filter JSON for Qdrant,
+//!    metadata predicates for Chroma).
+//! 2. **Graceful degradation via [`Capabilities`]** — backends advertise
+//!    what they support natively. The core layer has fallbacks for every
+//!    capability that could be absent (e.g., if `NATIVE_FTS` is false, the
+//!    core layer runs keyword match in Rust after a filter fetch).
+//! 3. **No behaviour change during extraction** — v0.7.0-alpha lands
+//!    [`sqlite::SqliteStore`] behind the trait with identical semantics to
+//!    v0.6.x. All existing tests must pass unchanged.
+//! 4. **Governance / scope / NHI stay in the core layer** — backends filter
+//!    by namespace/scope/`agent_id` via the [`Filter`] AST but never
+//!    re-implement visibility rules.
+
+use crate::models::{ApproverType, Memory, MemoryLink, Tier};
+use anyhow::Result;
+use async_trait::async_trait;
+use bitflags::bitflags;
+
+pub mod sqlite;
+
+/// Caller context for every storage operation.
+///
+/// Carries the calling agent's identity and its position in the namespace
+/// hierarchy so backends can apply visibility filtering without each
+/// implementation re-deriving it from raw inputs.
+#[derive(Debug, Clone)]
+pub struct CallerContext {
+    /// Agent that initiated the operation (NHI). None when unauthenticated
+    /// / anonymous — backends should treat this as "no visibility filter
+    /// applied" since the core layer validates before reaching the store.
+    pub agent_id: Option<String>,
+    /// Agent's hierarchical namespace position, if known. Used by visibility
+    /// filtering to select team/unit/org-scoped memories.
+    pub as_agent_namespace: Option<String>,
+}
+
+/// Backend-agnostic filter AST.
+///
+/// Core-layer code builds a [`Filter`] from the caller's request; adapters
+/// translate it to their native query model. No raw SQL, no Qdrant JSON —
+/// nothing leaks to the trait boundary.
+#[derive(Debug, Clone, Default)]
+pub struct Filter {
+    pub namespace: Option<NamespaceFilter>,
+    pub tier: Option<Tier>,
+    pub min_priority: Option<i32>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub tags_any: Vec<String>,
+    pub agent_id: Option<String>,
+    pub scope: Option<ScopeFilter>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+/// Namespace matching semantics. Exact match for flat namespaces; the
+/// hierarchy variant expands to all ancestors (Task 1.12 proximity recall).
+#[derive(Debug, Clone)]
+pub enum NamespaceFilter {
+    Exact(String),
+    Hierarchy(String),
+}
+
+/// Visibility-scope filter matching `src/db.rs::visibility_clause` semantics.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_field_names)]
+pub struct ScopeFilter {
+    pub private_prefix: Option<String>,
+    pub team_prefix: Option<String>,
+    pub unit_prefix: Option<String>,
+    pub org_prefix: Option<String>,
+}
+
+/// A memory returned from a scored retrieval operation (keyword, vector,
+/// or hybrid recall).
+#[derive(Debug, Clone)]
+pub struct Scored {
+    pub memory: Memory,
+    pub score: f64,
+}
+
+/// Query parameters for a full hybrid-recall operation. Captures everything
+/// `db::recall_hybrid` needs today; add fields here (not to every method)
+/// as new recall features land.
+#[derive(Debug, Clone)]
+pub struct RecallRequest {
+    pub query: String,
+    pub query_embedding: Option<Vec<f32>>,
+    pub filter: Filter,
+    pub caller: CallerContext,
+    pub budget_tokens: Option<usize>,
+}
+
+/// Touch payload — recall mutates `access_count` / `last_accessed_at` / TTL /
+/// promotion on matched rows. Extracted so backends can implement it as
+/// an atomic update.
+#[derive(Debug, Clone)]
+pub struct TouchPolicy {
+    pub short_ttl_extend_secs: i64,
+    pub mid_ttl_extend_secs: i64,
+    pub promotion_threshold: i32,
+}
+
+/// Update patch used by `update`. `None` fields are left untouched.
+#[derive(Debug, Clone, Default)]
+pub struct UpdatePatch {
+    pub title: Option<String>,
+    pub content: Option<String>,
+    pub tier: Option<Tier>,
+    pub namespace: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub priority: Option<i32>,
+    pub confidence: Option<f64>,
+    pub expires_at: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Outcome of a pending-action approval.
+#[derive(Debug, Clone)]
+pub enum ApproveOutcome {
+    Approved,
+    Pending { votes: usize, quorum: u32 },
+    Rejected(String),
+}
+
+/// Agent registration payload.
+#[derive(Debug, Clone)]
+pub struct AgentRegistration {
+    pub agent_id: String,
+    pub agent_type: String,
+    pub capabilities: Vec<String>,
+}
+
+/// Approver identity for a pending-action decision.
+#[derive(Debug, Clone)]
+pub struct Approver {
+    pub agent_id: String,
+    pub approver_type: ApproverType,
+}
+
+/// Pending-action request (store/delete/promote gated by governance).
+#[derive(Debug, Clone)]
+pub struct PendingActionRequest {
+    pub action_type: String, // "store" / "delete" / "promote"
+    pub namespace: String,
+    pub requested_by: String,
+    pub payload: serde_json::Value,
+}
+
+/// Garbage-collection policy.
+#[derive(Debug, Clone, Default)]
+pub struct GcPolicy {
+    pub archive_before_delete: bool,
+    pub archive_max_days: Option<i64>,
+}
+
+/// Counters returned from a GC sweep.
+#[derive(Debug, Clone, Default)]
+pub struct GcReport {
+    pub expired: usize,
+    pub archived: usize,
+    pub purged: usize,
+}
+
+bitflags! {
+    /// Capability flags advertised by each backend. The core layer uses
+    /// these to decide when to dispatch a native operation vs. fall back
+    /// to a portable implementation.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Capabilities: u32 {
+        /// Backend has native full-text search (SQLite FTS5, Postgres
+        /// tsvector, Qdrant full-text, Elasticsearch). Absent → core
+        /// layer runs keyword match in Rust after a filter fetch.
+        const NATIVE_FTS       = 0b0000_0001;
+        /// Backend has native vector ANN (Postgres+pgvector, Qdrant,
+        /// LanceDB). Absent → core layer does linear scan in Rust.
+        const NATIVE_VECTOR    = 0b0000_0010;
+        /// Backend supports multi-statement transactions.
+        const TRANSACTIONS     = 0b0000_0100;
+        /// Backend can filter on JSON metadata fields
+        /// (SQLite `json_extract`, Postgres `->>`, Qdrant payload).
+        const JSON_FILTERS     = 0b0000_1000;
+        /// Backend supports forward-evolving schema (DDL migrations).
+        /// Document-store backends generally return false.
+        const SCHEMA_EVOLUTION = 0b0001_0000;
+        /// Backend can cheaply produce a strict row count for a filter.
+        const FAST_COUNT       = 0b0010_0000;
+        /// Backend supports cursor/pagination beyond LIMIT+OFFSET.
+        const CURSOR_PAGINATION = 0b0100_0000;
+    }
+}
+
+/// Storage trait every backend implements.
+///
+/// All methods are async; adapters that wrap a blocking driver (rusqlite)
+/// run their work via `spawn_blocking` internally. Callers do NOT need to
+/// know which model the backend uses.
+#[async_trait]
+#[allow(dead_code)] // Skeleton — methods are wired to real callers in v0.7.0-alpha.
+pub trait MemoryStore: Send + Sync {
+    // ----- CRUD -----
+    async fn store(&self, mem: &Memory) -> Result<String>;
+    async fn get(&self, id: &str, ctx: &CallerContext) -> Result<Option<Memory>>;
+    async fn update(&self, id: &str, patch: UpdatePatch) -> Result<Memory>;
+    async fn delete(&self, id: &str, ctx: &CallerContext) -> Result<bool>;
+    async fn list(&self, filter: Filter, ctx: &CallerContext) -> Result<Vec<Memory>>;
+
+    // ----- Retrieval -----
+    async fn keyword_search(&self, q: &str, filter: Filter) -> Result<Vec<Scored>>;
+    async fn vector_search(&self, embedding: &[f32], filter: Filter) -> Result<Vec<Scored>>;
+    async fn hybrid_recall(&self, req: RecallRequest) -> Result<Vec<Scored>>;
+
+    // ----- Graph -----
+    async fn link(&self, src: &str, tgt: &str, relation: &str) -> Result<()>;
+    async fn neighbors(&self, id: &str, relation: Option<&str>) -> Result<Vec<MemoryLink>>;
+
+    // ----- Governance / agents / pending actions -----
+    async fn register_agent(&self, reg: AgentRegistration) -> Result<String>;
+    async fn is_registered_agent(&self, agent_id: &str) -> Result<bool>;
+    async fn queue_pending(&self, req: PendingActionRequest) -> Result<String>;
+    async fn approve_pending(&self, id: &str, approver: Approver) -> Result<ApproveOutcome>;
+
+    // ----- Lifecycle -----
+    async fn gc(&self, policy: GcPolicy) -> Result<GcReport>;
+    async fn migrate(&self) -> Result<()>;
+    async fn health_check(&self) -> Result<bool>;
+
+    /// Static capability flags (no I/O).
+    fn capabilities(&self) -> Capabilities;
+
+    /// Human-readable backend identifier for logs and diagnostics.
+    fn backend_name(&self) -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_compose() {
+        let c = Capabilities::NATIVE_FTS | Capabilities::NATIVE_VECTOR;
+        assert!(c.contains(Capabilities::NATIVE_FTS));
+        assert!(c.contains(Capabilities::NATIVE_VECTOR));
+        assert!(!c.contains(Capabilities::TRANSACTIONS));
+    }
+
+    #[test]
+    fn filter_default_is_empty() {
+        let f = Filter::default();
+        assert!(f.namespace.is_none());
+        assert!(f.tags_any.is_empty());
+    }
+}

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! `SQLite` adapter for the [`super::MemoryStore`] trait — v0.7 proposal
+//! skeleton.
+//!
+//! See issue #221 and [`super`] for the architectural rationale. During the
+//! v0.7.0-alpha extraction phase this file will absorb the call patterns
+//! currently embedded directly in `db.rs` call sites across `mcp.rs`,
+//! `handlers.rs`, and `main.rs`. For now it sketches the shape so reviewers
+//! can react to concrete Rust.
+//!
+//! # What's wired
+//!
+//! - [`SqliteStore::store`] / [`SqliteStore::health_check`] — thin
+//!   delegations to `crate::db`, demonstrating the async → `spawn_blocking` →
+//!   rusqlite pattern the rest of the adapter will follow.
+//! - [`SqliteStore::capabilities`] / [`SqliteStore::backend_name`] — static
+//!   metadata.
+//!
+//! # What's `todo!()`
+//!
+//! Every other method. They'll be filled during v0.7.0-alpha, one per PR so
+//! the call-site migration is reviewable in small pieces.
+
+use super::{
+    AgentRegistration, ApproveOutcome, Approver, CallerContext, Capabilities, Filter, GcPolicy,
+    GcReport, MemoryStore, PendingActionRequest, RecallRequest, Scored, UpdatePatch,
+};
+use crate::db;
+use crate::models::{Memory, MemoryLink};
+use anyhow::Result;
+use async_trait::async_trait;
+use rusqlite::Connection;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// SQLite-backed store. The inner `Arc<Mutex<Connection>>` mirrors the
+/// current v0.6.x shape so the extraction can be done without touching the
+/// concurrency model; the connection pool referenced in #219 is a
+/// v0.7.x follow-up that's internal to this adapter.
+pub struct SqliteStore {
+    conn: Arc<Mutex<Connection>>,
+    #[allow(dead_code)] // Consumed by migration / health-check paths not yet ported.
+    db_path: PathBuf,
+}
+
+impl SqliteStore {
+    /// Open a `SQLite` store at `path`. Delegates schema setup to the existing
+    /// [`crate::db::open`] so the v0.7 skeleton opens identically to v0.6.x.
+    pub fn open(path: PathBuf) -> Result<Self> {
+        let conn = db::open(&path)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            db_path: path,
+        })
+    }
+}
+
+#[async_trait]
+impl MemoryStore for SqliteStore {
+    // ----- CRUD — wired as a shape demonstration -----
+    async fn store(&self, mem: &Memory) -> Result<String> {
+        let conn = self.conn.clone();
+        let mem = mem.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            db::insert(&guard, &mem)
+        })
+        .await?
+    }
+
+    async fn health_check(&self) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            Ok(db::health_check(&guard).unwrap_or(false))
+        })
+        .await?
+    }
+
+    // ----- Everything below is filled in during v0.7.0-alpha -----
+    async fn get(&self, _id: &str, _ctx: &CallerContext) -> Result<Option<Memory>> {
+        todo!("v0.7.0-alpha: port db::get + visibility filter via CallerContext")
+    }
+    async fn update(&self, _id: &str, _patch: UpdatePatch) -> Result<Memory> {
+        todo!("v0.7.0-alpha: port db::update")
+    }
+    async fn delete(&self, _id: &str, _ctx: &CallerContext) -> Result<bool> {
+        todo!("v0.7.0-alpha: port db::delete")
+    }
+    async fn list(&self, _filter: Filter, _ctx: &CallerContext) -> Result<Vec<Memory>> {
+        todo!("v0.7.0-alpha: port db::list + translate Filter to SQL")
+    }
+
+    async fn keyword_search(&self, _q: &str, _filter: Filter) -> Result<Vec<Scored>> {
+        todo!("v0.7.0-alpha: port db::search (FTS5)")
+    }
+    async fn vector_search(&self, _embedding: &[f32], _filter: Filter) -> Result<Vec<Scored>> {
+        todo!("v0.7.0-alpha: port HNSW semantic path (linear scan if index absent)")
+    }
+    async fn hybrid_recall(&self, _req: RecallRequest) -> Result<Vec<Scored>> {
+        todo!("v0.7.0-alpha: port db::recall_hybrid — the big one; keep touch atomicity")
+    }
+
+    async fn link(&self, _src: &str, _tgt: &str, _relation: &str) -> Result<()> {
+        todo!("v0.7.0-alpha: port db::link")
+    }
+    async fn neighbors(&self, _id: &str, _relation: Option<&str>) -> Result<Vec<MemoryLink>> {
+        todo!("v0.7.0-alpha: port db::get_links")
+    }
+
+    async fn register_agent(&self, _reg: AgentRegistration) -> Result<String> {
+        todo!("v0.7.0-alpha: port db::register_agent")
+    }
+    async fn is_registered_agent(&self, _agent_id: &str) -> Result<bool> {
+        todo!("v0.7.0-alpha: port is_registered_agent check")
+    }
+    async fn queue_pending(&self, _req: PendingActionRequest) -> Result<String> {
+        todo!("v0.7.0-alpha: port pending_actions queue path")
+    }
+    async fn approve_pending(&self, _id: &str, _approver: Approver) -> Result<ApproveOutcome> {
+        todo!("v0.7.0-alpha: port approve_with_approver_type (post-#216 hardening)")
+    }
+
+    async fn gc(&self, _policy: GcPolicy) -> Result<GcReport> {
+        todo!("v0.7.0-alpha: port db::gc + db::auto_purge_archive")
+    }
+    async fn migrate(&self) -> Result<()> {
+        todo!("v0.7.0-alpha: expose db::open migration path explicitly")
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // SQLite advertises everything except CURSOR_PAGINATION (LIMIT/OFFSET
+        // only in v0.6.x schema; cursor support lands with v0.8 streaming).
+        Capabilities::NATIVE_FTS
+            | Capabilities::NATIVE_VECTOR  // HNSW-in-process satisfies this at the trait boundary
+            | Capabilities::TRANSACTIONS
+            | Capabilities::JSON_FILTERS
+            | Capabilities::SCHEMA_EVOLUTION
+            | Capabilities::FAST_COUNT
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "sqlite"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn open_and_health_check() {
+        // :memory: is the v0.7 equivalent of a file-less smoke test.
+        let store = SqliteStore::open(std::path::PathBuf::from(":memory:")).unwrap();
+        assert!(store.health_check().await.unwrap());
+        assert_eq!(store.backend_name(), "sqlite");
+        assert!(
+            store
+                .capabilities()
+                .contains(Capabilities::NATIVE_FTS | Capabilities::TRANSACTIONS)
+        );
+    }
+
+    #[tokio::test]
+    async fn store_round_trip_demonstrates_shape() {
+        use crate::models::Tier;
+        use chrono::Utc;
+
+        let store = SqliteStore::open(std::path::PathBuf::from(":memory:")).unwrap();
+        let now = Utc::now().to_rfc3339();
+        let mem = Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: Tier::Long,
+            namespace: "sal-proposal".into(),
+            title: "SAL skeleton round-trip".into(),
+            content: "Prove the async → spawn_blocking → rusqlite shape.".into(),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".into(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({}),
+        };
+        let id = store.store(&mem).await.unwrap();
+        assert!(!id.is_empty());
+    }
+}


### PR DESCRIPTION
## This is a design sketch, not an extraction

Concrete Rust accompanying issue #221 (v0.7 Storage Abstraction Layer). Opened as **draft** — the goal is to give you something to read and react to on the flight, not to merge. Expect to rewrite most of this during the v0.7.0-alpha extraction phase once the trait boundary is critiqued.

Refs #221

## What's here

- `src/store/mod.rs` — `MemoryStore` async trait, `Filter` AST, `Capabilities` bitflags, `CallerContext`, request/response types
- `src/store/sqlite.rs` — `SqliteStore` stub with `store`/`health_check`/`capabilities`/`backend_name` wired (demonstrates the async → `spawn_blocking` → rusqlite pattern); every other method is `todo!()` with a pointer to the v0.7.0-alpha PR that will fill it
- `Cargo.toml` — adds `async-trait` + `bitflags`
- `main.rs` — `mod store` under `#[allow(dead_code)]` (nothing wires it yet)

## What to review for

See the commit message for the specific design questions — trait boundary level, capability flag coverage, CallerContext vs Filter placement, streaming/cursor, transaction handles.

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Standard (design proposal; no runtime behavior change)
- **Human approver:** @binary2029 (explicit "confirmed and approved - yes - do 1 - 3 now")
- **ai-memory entries created/updated:** none yet (v0.7 kickoff will stamp memory notes per task)
- **Co-Authored-By trailer:** yes

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 240 unit + 153 integration = 393 pass (4 new skeleton tests)
- [x] `cargo audit` clean

## Do not merge

Every method on `SqliteStore` except 4 is `todo!()`. This is a starting point for review, not a shippable change. When the trait is approved, v0.7.0-alpha will replace this with the real extraction and this PR closes unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)