### PR TITLE
feat(v0.6.0-ga): Phase 3 foundation — vector clocks + sync --dry-run + HTTP sync endpoints

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -169,7 +169,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 );
 ";
 
-const CURRENT_SCHEMA_VERSION: i64 = 10;
+const CURRENT_SCHEMA_VERSION: i64 = 11;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -369,6 +369,28 @@ fn migrate(conn: &Connection) -> Result<()> {
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_memories_scope_idx ON memories(scope_idx)",
                 [],
+            )?;
+        }
+
+        if version < 11 {
+            // Phase 3 foundation (issue #224): vector-clock sync state.
+            // Stores the latest `updated_at` timestamp this peer has seen
+            // from each known remote peer. Used by the future CRDT-lite
+            // merge to skip memories the caller has already seen and to
+            // emit incremental `GET /api/v1/sync/since?...` responses.
+            //
+            // The table is additive — it does NOT change any existing
+            // sync behaviour in v0.6.0 GA. Entries are created lazily by
+            // the HTTP sync endpoints and by `sync --dry-run` telemetry.
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS sync_state (
+                    agent_id       TEXT NOT NULL,
+                    peer_id        TEXT NOT NULL,
+                    last_seen_at   TEXT NOT NULL,
+                    last_pulled_at TEXT NOT NULL,
+                    PRIMARY KEY (agent_id, peer_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_sync_state_agent ON sync_state(agent_id);",
             )?;
         }
 
@@ -2266,6 +2288,76 @@ pub fn recall_hybrid(
 pub fn checkpoint(conn: &Connection) -> Result<()> {
     conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 foundation (issue #224) — sync_state helpers.
+//
+// These are additive: they do not change how the existing `ai-memory sync`
+// command behaves in v0.6.0 GA. They exist so HTTP sync endpoints and the
+// CRDT-lite merge follow-up can durably track "last updated_at seen from
+// peer X" per local agent.
+// ---------------------------------------------------------------------------
+
+/// Record the latest `updated_at` this local agent has observed from `peer_id`.
+/// Monotonic by timestamp — older writes do not overwrite newer ones.
+/// Lazily creates the row on first observation.
+pub fn sync_state_observe(
+    conn: &Connection,
+    agent_id: &str,
+    peer_id: &str,
+    seen_at: &str,
+) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO sync_state (agent_id, peer_id, last_seen_at, last_pulled_at) \
+         VALUES (?1, ?2, ?3, ?4) \
+         ON CONFLICT(agent_id, peer_id) DO UPDATE SET \
+            last_seen_at = CASE WHEN excluded.last_seen_at > last_seen_at \
+                                THEN excluded.last_seen_at \
+                                ELSE last_seen_at END, \
+            last_pulled_at = excluded.last_pulled_at",
+        params![agent_id, peer_id, seen_at, now],
+    )?;
+    Ok(())
+}
+
+/// Load the full vector clock for `agent_id` — the set of
+/// (`peer_id` -> `last_seen_at`) this local agent tracks.
+pub fn sync_state_load(conn: &Connection, agent_id: &str) -> Result<crate::models::VectorClock> {
+    let mut stmt =
+        conn.prepare("SELECT peer_id, last_seen_at FROM sync_state WHERE agent_id = ?1")?;
+    let rows = stmt.query_map(params![agent_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut clock = crate::models::VectorClock::default();
+    for row in rows {
+        let (peer, at) = row?;
+        clock.entries.insert(peer, at);
+    }
+    Ok(clock)
+}
+
+/// Return memories whose `updated_at > since`, ordered by `updated_at`
+/// ascending. Used by `GET /api/v1/sync/since` to stream incremental
+/// updates to a peer. Caps at `limit` rows (caller-chosen pagination).
+pub fn memories_updated_since(
+    conn: &Connection,
+    since: Option<&str>,
+    limit: usize,
+) -> Result<Vec<Memory>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, tier, namespace, title, content, tags, priority, confidence, \
+                source, access_count, created_at, updated_at, last_accessed_at, \
+                expires_at, metadata \
+         FROM memories \
+         WHERE (?1 IS NULL OR updated_at > ?1) \
+         ORDER BY updated_at ASC \
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![since, limit], row_to_memory)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(Into::into)
 }
 
 /// Deep health check — verifies DB is accessible and FTS is functional.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1537,6 +1537,175 @@ pub async fn archive_stats(State(state): State<Db>) -> impl IntoResponse {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3 foundation (issue #224) — HTTP sync endpoints.
+//
+// These ship in v0.6.0 GA as SKELETONS running today's timestamp-aware merge
+// (`db::insert_if_newer`). Field-level CRDT-lite merge rules, streaming,
+// resume-on-interrupt, and per-peer auth tokens are v0.8.0 targets.
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /api/v1/sync/push`.
+#[derive(Deserialize)]
+pub struct SyncPushBody {
+    /// Claimed `agent_id` of the peer pushing data. Recorded in
+    /// `sync_state` for vector clock advancement. Treated as identity
+    /// only (not attestation) — same NHI model as every other write.
+    pub sender_agent_id: String,
+    /// Vector clock the sender had at push time. Foundation accepts it
+    /// and stores the latest-seen timestamp; full clock reconciliation
+    /// lands with Task 3a.1.
+    #[serde(default)]
+    #[allow(dead_code)] // Consumed by Task 3a.1 CRDT-lite; shipped now for wire compat.
+    pub sender_clock: crate::models::VectorClock,
+    /// Memories the sender is offering. Applied via the existing
+    /// timestamp-aware merge (`insert_if_newer`).
+    pub memories: Vec<Memory>,
+    /// Preview mode — classify and count, do not write.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Deserialize)]
+pub struct SyncSinceQuery {
+    /// Return memories with `updated_at > since`. Absent = full snapshot.
+    pub since: Option<String>,
+    /// Pagination cap. Defaults to 500.
+    pub limit: Option<usize>,
+    /// Caller's claimed `agent_id`; optional but recorded in `sync_state`
+    /// so the caller can later push incremental updates.
+    pub peer: Option<String>,
+}
+
+pub async fn sync_push(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Json(body): Json<SyncPushBody>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_agent_id(&body.sender_agent_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid sender_agent_id: {e}")})),
+        )
+            .into_response();
+    }
+    // Receiver's local identity — default to the caller-supplied header,
+    // fall back to the anonymous placeholder. Recorded in sync_state rows.
+    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+    let local_agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+        Ok(id) => id,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid x-agent-id: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let lock = state.lock().await;
+    let mut applied = 0usize;
+    let mut noop = 0usize;
+    let mut skipped = 0usize;
+    let mut latest_seen: Option<String> = None;
+
+    for mem in &body.memories {
+        if validate::validate_memory(mem).is_err() {
+            skipped += 1;
+            continue;
+        }
+        if latest_seen
+            .as_deref()
+            .is_none_or(|current| mem.updated_at.as_str() > current)
+        {
+            latest_seen = Some(mem.updated_at.clone());
+        }
+        if body.dry_run {
+            noop += 1;
+            continue;
+        }
+        match db::insert_if_newer(&lock.0, mem) {
+            Ok(_id) => applied += 1,
+            Err(e) => {
+                tracing::warn!("sync_push: insert_if_newer failed for {}: {e}", mem.id);
+                skipped += 1;
+            }
+        }
+    }
+
+    // Advance the vector clock with the highest `updated_at` we observed.
+    // Skipped in dry-run mode since the caller is only previewing.
+    if !body.dry_run
+        && let Some(at) = latest_seen.as_deref()
+        && let Err(e) = db::sync_state_observe(&lock.0, &local_agent_id, &body.sender_agent_id, at)
+    {
+        tracing::warn!("sync_push: sync_state_observe failed: {e}");
+    }
+
+    // Receiver's current clock, returned so the sender can learn which
+    // peers the receiver has seen. Phase 3 Task 3a.1 will use this to
+    // short-circuit redundant pushes.
+    let receiver_clock = db::sync_state_load(&lock.0, &local_agent_id)
+        .unwrap_or_else(|_| crate::models::VectorClock::default());
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "applied": applied,
+            "noop": noop,
+            "skipped": skipped,
+            "dry_run": body.dry_run,
+            "receiver_agent_id": local_agent_id,
+            "receiver_clock": receiver_clock,
+        })),
+    )
+        .into_response()
+}
+
+pub async fn sync_since(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Query(q): Query<SyncSinceQuery>,
+) -> impl IntoResponse {
+    let limit = q.limit.unwrap_or(500).min(10_000);
+    let lock = state.lock().await;
+    let mems = match db::memories_updated_since(&lock.0, q.since.as_deref(), limit) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("sync_since: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response();
+        }
+    };
+
+    // Record the puller as a peer so subsequent incremental push/pull
+    // pairs have a durable clock entry. Best-effort; don't fail the
+    // response if the side-effect write fails.
+    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+    if let (Some(peer), Ok(local_agent_id)) = (
+        q.peer.as_deref(),
+        crate::identity::resolve_http_agent_id(None, header_agent_id),
+    ) && validate::validate_agent_id(peer).is_ok()
+        && let Some(last) = mems.last()
+        && let Err(e) = db::sync_state_observe(&lock.0, &local_agent_id, peer, &last.updated_at)
+    {
+        tracing::debug!("sync_since: sync_state_observe failed: {e}");
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "count": mems.len(),
+            "limit": limit,
+            "memories": mems,
+        })),
+    )
+        .into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1825,6 +1994,214 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // --- Phase 3 foundation HTTP sync tests (issue #224) ---
+
+    #[tokio::test]
+    async fn http_sync_push_applies_and_advances_clock() {
+        // Smoke test for POST /api/v1/sync/push — memories land in the
+        // receiver's DB and the vector clock records the sender's latest
+        // `updated_at`. Full CRDT semantics are the v0.8.0 follow-up.
+        let state = test_state();
+        let app = Router::new()
+            .route("/api/v1/sync/push", axum_post(sync_push))
+            .with_state(state.clone());
+
+        let now = Utc::now().to_rfc3339();
+        let body = serde_json::json!({
+            "sender_agent_id": "peer-alice",
+            "sender_clock": {"entries": {}},
+            "memories": [{
+                "id": Uuid::new_v4().to_string(),
+                "tier": "long",
+                "namespace": "sync-smoke",
+                "title": "From peer",
+                "content": "Pushed via HTTP sync endpoint.",
+                "tags": [],
+                "priority": 5,
+                "confidence": 1.0,
+                "source": "api",
+                "access_count": 0,
+                "created_at": now,
+                "updated_at": now,
+                "last_accessed_at": null,
+                "expires_at": null,
+                "metadata": {"agent_id": "peer-alice"}
+            }],
+            "dry_run": false
+        });
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/push")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header("x-agent-id", "local-receiver")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Row landed.
+        let lock = state.lock().await;
+        let rows = db::list(
+            &lock.0,
+            Some("sync-smoke"),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        // Clock advanced — peer-alice registered against local-receiver.
+        let clock = db::sync_state_load(&lock.0, "local-receiver").unwrap();
+        assert!(
+            clock.latest_from("peer-alice").is_some(),
+            "push must record sender in sync_state; got: {:?}",
+            clock.entries
+        );
+    }
+
+    #[tokio::test]
+    async fn http_sync_push_dry_run_applies_nothing() {
+        // Phase 3 — dry_run=true must not write.
+        let state = test_state();
+        let app = Router::new()
+            .route("/api/v1/sync/push", axum_post(sync_push))
+            .with_state(state.clone());
+
+        let now = Utc::now().to_rfc3339();
+        let body = serde_json::json!({
+            "sender_agent_id": "peer-bob",
+            "sender_clock": {"entries": {}},
+            "memories": [{
+                "id": Uuid::new_v4().to_string(),
+                "tier": "long",
+                "namespace": "sync-dryrun",
+                "title": "Must not land",
+                "content": "Preview only.",
+                "tags": [],
+                "priority": 5,
+                "confidence": 1.0,
+                "source": "api",
+                "access_count": 0,
+                "created_at": now,
+                "updated_at": now,
+                "last_accessed_at": null,
+                "expires_at": null,
+                "metadata": {}
+            }],
+            "dry_run": true
+        });
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/push")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let lock = state.lock().await;
+        let rows = db::list(
+            &lock.0,
+            Some("sync-dryrun"),
+            None,
+            10,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(rows.is_empty(), "dry_run must not write rows");
+    }
+
+    #[tokio::test]
+    async fn http_sync_since_streams_new_memories_only() {
+        // Phase 3 — GET /api/v1/sync/since?since=<ts> returns only memories
+        // with updated_at > ts.
+        let state = test_state();
+        // Seed one old + one new memory.
+        let old_ts = "2020-01-01T00:00:00+00:00";
+        let new_ts = Utc::now().to_rfc3339();
+        {
+            let lock = state.lock().await;
+            for (title, ts) in [("old-mem", old_ts), ("new-mem", new_ts.as_str())] {
+                let mem = Memory {
+                    id: Uuid::new_v4().to_string(),
+                    tier: Tier::Long,
+                    namespace: "since-test".into(),
+                    title: title.into(),
+                    content: "body".into(),
+                    tags: vec![],
+                    priority: 5,
+                    confidence: 1.0,
+                    source: "api".into(),
+                    access_count: 0,
+                    created_at: ts.to_string(),
+                    updated_at: ts.to_string(),
+                    last_accessed_at: None,
+                    expires_at: None,
+                    metadata: serde_json::json!({}),
+                };
+                db::insert(&lock.0, &mem).unwrap();
+            }
+        }
+
+        let app = Router::new()
+            .route("/api/v1/sync/since", axum_get(sync_since))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/since?since=2020-06-01T00:00:00%2B00:00")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let titles: Vec<String> = v["memories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|m| m["title"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(titles, vec!["new-mem".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sync_state_observe_is_monotonic() {
+        // Phase 3 — clock advancement must never go backwards.
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let older = "2020-01-01T00:00:00+00:00";
+        let newer = "2026-04-17T00:00:00+00:00";
+
+        db::sync_state_observe(&conn, "local", "peer-a", newer).unwrap();
+        // A subsequent older observation must NOT overwrite.
+        db::sync_state_observe(&conn, "local", "peer-a", older).unwrap();
+        let clock = db::sync_state_load(&conn, "local").unwrap();
+        assert_eq!(clock.latest_from("peer-a"), Some(newer));
     }
 
     // --- API key auth middleware tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,6 +442,12 @@ struct SyncArgs {
     /// Only use this when syncing between databases you fully control (e.g., your own backup).
     #[arg(long, default_value_t = false)]
     trust_source: bool,
+    /// Phase 3 foundation (issue #224): preview what would change without
+    /// writing anything. Counts new / updated / unchanged memories and
+    /// links in each direction. Uses today's timestamp-aware merge
+    /// semantics; CRDT-lite field-level diagnostics land with #224 Task 3a.1.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
 }
 
 #[derive(Args)]
@@ -796,6 +802,11 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
             "/api/v1/pending/{id}/reject",
             post(handlers::reject_pending),
         )
+        // Phase 3 foundation (issue #224) — peer-to-peer sync endpoints.
+        // Skeletons running today's timestamp-aware merge; field-level CRDT
+        // and streaming land in v0.8.0.
+        .route("/api/v1/sync/push", post(handlers::sync_push))
+        .route("/api/v1/sync/since", get(handlers::sync_since))
         .layer(axum::middleware::from_fn_with_state(
             api_key_state,
             handlers::api_key_auth,
@@ -2061,6 +2072,44 @@ fn restamp_agent_id(mem: &mut models::Memory, caller_id: &str) {
 }
 
 #[allow(clippy::too_many_lines)]
+/// Phase 3 foundation (issue #224): preview counters for `sync --dry-run`.
+/// Classified against today's timestamp-aware merge semantics. Future work
+/// (Task 3a.1 CRDT-lite) will replace this with field-level diagnostics.
+#[allow(clippy::struct_field_names)] // naming mirrors the JSON response keys
+#[derive(Default)]
+struct SyncPreview {
+    would_pull_new: usize,
+    would_pull_update: usize,
+    would_pull_noop: usize,
+    would_push_new: usize,
+    would_push_update: usize,
+    would_push_noop: usize,
+    would_pull_links: usize,
+    would_push_links: usize,
+}
+
+impl SyncPreview {
+    fn classify(local: Option<&models::Memory>, remote: &models::Memory) -> MergeOutcome {
+        match local {
+            None => MergeOutcome::New,
+            Some(existing) => {
+                if remote.updated_at > existing.updated_at {
+                    MergeOutcome::Update
+                } else {
+                    MergeOutcome::Noop
+                }
+            }
+        }
+    }
+}
+
+enum MergeOutcome {
+    New,
+    Update,
+    Noop,
+}
+
+#[allow(clippy::too_many_lines)] // pull/push/merge variants kept inline for locality
 fn cmd_sync(
     db_path: &Path,
     args: &SyncArgs,
@@ -2073,6 +2122,11 @@ fn cmd_sync(
     // memories with the caller's id so an attacker-controlled remote DB can't
     // inject arbitrary agent_ids into the local store (and vice versa on push).
     let caller_id = identity::resolve_agent_id(cli_agent_id, None)?;
+
+    if args.dry_run {
+        return cmd_sync_dry_run(&local_conn, &remote_conn, &args.direction, json_out);
+    }
+
     match args.direction.as_str() {
         "pull" => {
             let mems = db::export_all(&remote_conn)?;
@@ -2216,6 +2270,99 @@ fn cmd_sync(
             "invalid direction: {} (use pull, push, merge)",
             args.direction
         ),
+    }
+    Ok(())
+}
+
+/// Phase 3 foundation (issue #224) — `sync --dry-run` implementation.
+///
+/// Classifies what WOULD happen without writing anything. Uses today's
+/// timestamp-aware merge rules (`updated_at > existing.updated_at → update`,
+/// otherwise no-op). The richer field-level CRDT preview lands with
+/// #224 Task 3a.1.
+fn cmd_sync_dry_run(
+    local_conn: &rusqlite::Connection,
+    remote_conn: &rusqlite::Connection,
+    direction: &str,
+    json_out: bool,
+) -> Result<()> {
+    let l_mems = db::export_all(local_conn)?;
+    let r_mems = db::export_all(remote_conn)?;
+    let l_links = db::export_links(local_conn)?;
+    let r_links = db::export_links(remote_conn)?;
+
+    let local_by_id: std::collections::HashMap<&str, &models::Memory> =
+        l_mems.iter().map(|m| (m.id.as_str(), m)).collect();
+    let remote_by_id: std::collections::HashMap<&str, &models::Memory> =
+        r_mems.iter().map(|m| (m.id.as_str(), m)).collect();
+
+    let mut preview = SyncPreview::default();
+
+    let classify_pull = direction != "push";
+    let classify_push = direction != "pull";
+
+    if classify_pull {
+        for mem in &r_mems {
+            match SyncPreview::classify(local_by_id.get(mem.id.as_str()).copied(), mem) {
+                MergeOutcome::New => preview.would_pull_new += 1,
+                MergeOutcome::Update => preview.would_pull_update += 1,
+                MergeOutcome::Noop => preview.would_pull_noop += 1,
+            }
+        }
+        preview.would_pull_links = r_links.len();
+    }
+
+    if classify_push {
+        for mem in &l_mems {
+            match SyncPreview::classify(remote_by_id.get(mem.id.as_str()).copied(), mem) {
+                MergeOutcome::New => preview.would_push_new += 1,
+                MergeOutcome::Update => preview.would_push_update += 1,
+                MergeOutcome::Noop => preview.would_push_noop += 1,
+            }
+        }
+        preview.would_push_links = l_links.len();
+    }
+
+    if json_out {
+        println!(
+            "{}",
+            serde_json::json!({
+                "dry_run": true,
+                "direction": direction,
+                "pull": {
+                    "new": preview.would_pull_new,
+                    "update": preview.would_pull_update,
+                    "noop": preview.would_pull_noop,
+                    "links": preview.would_pull_links,
+                },
+                "push": {
+                    "new": preview.would_push_new,
+                    "update": preview.would_push_update,
+                    "noop": preview.would_push_noop,
+                    "links": preview.would_push_links,
+                }
+            })
+        );
+    } else {
+        println!("DRY RUN — no changes written. Direction: {direction}");
+        if classify_pull {
+            println!(
+                "  pull: {} new, {} update, {} noop, {} links",
+                preview.would_pull_new,
+                preview.would_pull_update,
+                preview.would_pull_noop,
+                preview.would_pull_links
+            );
+        }
+        if classify_push {
+            println!(
+                "  push: {} new, {} update, {} noop, {} links",
+                preview.would_push_new,
+                preview.would_push_update,
+                preview.would_push_noop,
+                preview.would_push_links
+            );
+        }
     }
     Ok(())
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -504,6 +504,59 @@ pub struct AgentRegistration {
     pub last_seen_at: String,
 }
 
+/// Phase 3 foundation (issue #224): vector clock tracking the latest
+/// `updated_at` this peer has seen from each known remote peer.
+///
+/// Entries are populated lazily — both on HTTP `/sync/push` (receiver
+/// records the sender's latest `updated_at`) and on HTTP `/sync/since`
+/// (sender advances `last_pulled_at`). Full CRDT-lite merge rules using
+/// the clock are **not** in the v0.6.0 GA foundation; they land in a
+/// follow-up PR under issue #224 Task 3a.1. The foundation ships the
+/// wire format so adding the merge semantics later does not force a
+/// schema migration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct VectorClock {
+    /// Map of peer `agent_id` -> latest RFC3339 `updated_at` seen from
+    /// that peer. A peer absent from the map is equivalent to
+    /// "never-seen-anything." Encoded as a JSON object on the wire.
+    #[serde(default)]
+    pub entries: std::collections::BTreeMap<String, String>,
+}
+
+impl VectorClock {
+    /// Advance this clock to include `peer_id`'s latest seen timestamp.
+    /// Monotonic — an older timestamp never overwrites a newer one.
+    #[allow(dead_code)] // Consumed by Task 3a.1 CRDT-lite merge (issue #224).
+    pub fn observe(&mut self, peer_id: &str, at: &str) {
+        self.entries
+            .entry(peer_id.to_string())
+            .and_modify(|existing| {
+                if at > existing.as_str() {
+                    *existing = at.to_string();
+                }
+            })
+            .or_insert_with(|| at.to_string());
+    }
+
+    /// Look up the latest timestamp this clock has from `peer_id`.
+    #[must_use]
+    #[allow(dead_code)] // Consumed by Task 3a.1 CRDT-lite merge (issue #224).
+    pub fn latest_from(&self, peer_id: &str) -> Option<&str> {
+        self.entries.get(peer_id).map(String::as_str)
+    }
+}
+
+/// Phase 3 foundation: one row of the `sync_state` table serialised for
+/// diagnostic / API responses.
+#[allow(dead_code)] // Consumed by Task 3b.2 sync diagnostics API (issue #224).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStateEntry {
+    pub agent_id: String,
+    pub peer_id: String,
+    pub last_seen_at: String,
+    pub last_pulled_at: String,
+}
+
 pub const MAX_CONTENT_SIZE: usize = 65_536;
 
 /// Maximum number of path segments in a hierarchical namespace (Task 1.4).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7653,3 +7653,118 @@ fn test_hier_recall_touches_only_ancestor_matches() {
     assert_eq!(outsider["access_count"], 0);
     let _ = std::fs::remove_file(&db);
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3 foundation (issue #224) — CLI `sync --dry-run` end-to-end
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cli_sync_dry_run_writes_nothing() {
+    // v0.6.0 GA Phase 3 foundation: --dry-run must classify new/update/noop
+    // and NOT mutate either side of the sync. Uses today's timestamp-aware
+    // merge semantics; the richer CRDT-lite preview lands with Task 3a.1.
+    let dir = std::env::temp_dir();
+    let local_db = dir.join(format!("ai-memory-sync-local-{}.db", uuid::Uuid::new_v4()));
+    let remote_db = dir.join(format!("ai-memory-sync-remote-{}.db", uuid::Uuid::new_v4()));
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+
+    // Seed local with one memory.
+    let out = cmd(bin)
+        .args([
+            "--db",
+            local_db.to_str().unwrap(),
+            "--json",
+            "store",
+            "-n",
+            "sync-dry",
+            "-T",
+            "local-only",
+            "-c",
+            "only exists locally",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Seed remote with a different memory.
+    let out = cmd(bin)
+        .args([
+            "--db",
+            remote_db.to_str().unwrap(),
+            "--json",
+            "store",
+            "-n",
+            "sync-dry",
+            "-T",
+            "remote-only",
+            "-c",
+            "only exists remotely",
+            "-t",
+            "long",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Dry-run merge should report 1 would-pull-new and 1 would-push-new.
+    let out = cmd(bin)
+        .args([
+            "--db",
+            local_db.to_str().unwrap(),
+            "--json",
+            "sync",
+            remote_db.to_str().unwrap(),
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "sync --dry-run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["dry_run"], true);
+    assert_eq!(
+        v["pull"]["new"], 1,
+        "remote-only memory should be classified as would-pull-new; got: {v}"
+    );
+    assert_eq!(
+        v["push"]["new"], 1,
+        "local-only memory should be classified as would-push-new; got: {v}"
+    );
+
+    // Critical: neither side was mutated. Each DB should still hold only
+    // its seeded memory.
+    for (db_path, expected_title) in [(&local_db, "local-only"), (&remote_db, "remote-only")] {
+        let list = cmd(bin)
+            .args([
+                "--db",
+                db_path.to_str().unwrap(),
+                "--json",
+                "list",
+                "-n",
+                "sync-dry",
+            ])
+            .output()
+            .unwrap();
+        let lv: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+        let titles: Vec<String> = lv["memories"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .filter_map(|m| m["title"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(
+            titles,
+            vec![expected_title.to_string()],
+            "dry-run must not write; {:?}",
+            db_path
+        );
+    }
+
+    let _ = std::fs::remove_file(&local_db);
+    let _ = std::fs::remove_file(&remote_db);
+}


### PR DESCRIPTION
## Summary

Phase 3 (Memory Sharing & Sync) foundation scaffolding, per the design in #224. Ships the wire format, data model, safe preview, and HTTP endpoints — NOT the irreversible CRDT merge rules or the auto sync daemon (those stay on the original v0.8.0 timeline).

- **Schema v11:** `sync_state` table (agent_id, peer_id, last_seen_at, last_pulled_at)
- **`VectorClock` type:** monotonic per-peer timestamp tracker, JSON wire format
- **`ai-memory sync --dry-run`:** classify new/update/noop without writing either side
- **`POST /api/v1/sync/push`** + **`GET /api/v1/sync/since`:** peer-to-peer HTTP sync (using today's timestamp-aware merge; CRDT-lite follows in Task 3a.1)

All behind the existing `api_key` middleware. Additive — does not change existing `ai-memory sync` behaviour in any direction.

Refs #224 (Phase 3 tracking issue with full design + 6 sub-tasks)

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Standard (scaffolding + preview + tests; no irreversible merge semantics)
- **Human approver:** @binary2029 (explicit "do all of phase 3 now - lets go begin")
- **ai-memory entries created/updated:** none
- **Co-Authored-By trailer:** yes

## Linked issues

Refs #224 — Phase 3 tracking issue. Remaining sub-tasks (Task 3a.1 CRDT-lite merge, Task 3a.2 full clock reconciliation, Task 3b.1 auto daemon, Task 3b.2 endpoint hardening, Task 3b.3 selective hierarchy sync) land separately; sessions 7-9 remaining.

Refs #221 — orthogonal (v0.7 SAL adds non-SQLite backends).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — **243 unit + 154 integration = 397 pass**
- [x] `cargo audit` clean
- [x] New tests (5):
  - `http_sync_push_applies_and_advances_clock`
  - `http_sync_push_dry_run_applies_nothing`
  - `http_sync_since_streams_new_memories_only`
  - `sync_state_observe_is_monotonic`
  - `test_cli_sync_dry_run_writes_nothing`

## Scope / non-scope

**In (v0.6.0 GA — this PR):**
- Schema v11 sync_state + VectorClock wire format
- sync --dry-run preview
- HTTP sync push/pull skeletons with existing merge semantics

**Out (Phase 3 full, v0.8.0 — under #224 as sub-issues):**
- Field-level CRDT-lite merge rules (Task 3a.1) — irreversible, needs design review before code
- Auto background sync daemon (Task 3b.1)
- Selective sync by hierarchy (Task 3b.3)
- Clock reconciliation using received sender_clock (Task 3a.2)
- Per-peer auth tokens + streaming responses (Task 3b.2)

## ROADMAP note

Phase 3 is a v0.8.0 target in the ROADMAP. Shipping foundation in v0.6.0 is a deliberate acceleration — the scaffolding is reversible-safe; the merge rules stay on the original timeline. Phase 2 (v0.7.0 Knowledge Graph) and the v0.7 SAL (#221) are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)