### PR TITLE
feat(v0.6.0-ga): native TLS for serve() — Layer 1 peer-mesh crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ version = "0.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-server",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -51,6 +52,7 @@ dependencies = [
  "instant-distance",
  "reqwest",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -142,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +163,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -203,6 +236,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -363,6 +418,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -476,6 +533,15 @@ checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
 dependencies = [
  "clap",
  "roff",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -778,6 +844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1021,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1680,6 +1768,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2570,6 +2668,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2577,6 +2676,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2595,6 +2703,7 @@ version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,18 @@ uuid = { version = "1", features = ["v4"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 gethostname = "0.5"
 
+# Native TLS for `serve` (Layer 1 — issue to be filed). axum-server
+# + rustls. Accepts PEM cert + key from --tls-cert / --tls-key. No
+# OpenSSL dep; rustls matches reqwest's rustls-tls choice already in
+# use for the sync-daemon's outbound HTTPS.
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+# rustls 0.23 requires an explicit CryptoProvider — `ring` matches
+# reqwest's default for the sync-daemon, keeping a single provider
+# across the process. PEM parsing is handled by
+# `RustlsConfig::from_pem` so no separate rustls-pemfile dep (which
+# is flagged unmaintained in the 2026 advisory DB).
+rustls = { version = "0.23", features = ["ring"] }
+
 # Semantic embedding support
 candle-core = "0.10"
 candle-nn = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod reranker;
 mod toon;
 mod validate;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use axum::{
     Router,
     extract::DefaultBodyLimit,
@@ -245,6 +245,15 @@ struct ServeArgs {
     host: String,
     #[arg(long, default_value_t = DEFAULT_PORT)]
     port: u16,
+    /// Path to PEM-encoded TLS certificate (may include the full chain).
+    /// Passing both `--tls-cert` and `--tls-key` switches `serve` to
+    /// HTTPS. rustls under the hood — no OpenSSL dep. Absent both
+    /// flags = plain HTTP (same as every previous release).
+    #[arg(long, requires = "tls_key")]
+    tls_cert: Option<PathBuf>,
+    /// Path to PEM-encoded TLS private key (PKCS#8 or RSA).
+    #[arg(long, requires = "tls_cert")]
+    tls_key: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -851,14 +860,64 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         .with_state(app_state);
 
     let addr = format!("{}:{}", args.host, args.port);
-    tracing::info!("ai-memory listening on {addr}");
     tracing::info!("database: {}", db_path.display());
 
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown)
-        .await?;
+    // Native TLS (Layer 1): if both --tls-cert and --tls-key are provided,
+    // bind via axum-server + rustls. Plain HTTP otherwise — backward
+    // compatible with every prior release. The `requires = …` clap
+    // attributes prevent the half-configured case.
+    if let (Some(cert), Some(key)) = (&args.tls_cert, &args.tls_key) {
+        tracing::info!("ai-memory listening on https://{addr}");
+        // rustls 0.23 needs an explicit CryptoProvider; install ring
+        // before any TLS setup. Idempotent — second install is a
+        // harmless no-op via ignore.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tls_config = load_rustls_config(cert, key).await?;
+        let socket_addr: std::net::SocketAddr = addr.parse()?;
+        // axum-server doesn't have a direct graceful-shutdown on the
+        // TLS builder yet; spawn the signal listener on the Handle
+        // instead so ctrl_c triggers a graceful shutdown.
+        let handle = axum_server::Handle::new();
+        let handle_clone = handle.clone();
+        tokio::spawn(async move {
+            shutdown.await;
+            handle_clone.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
+        });
+        axum_server::bind_rustls(socket_addr, tls_config)
+            .handle(handle)
+            .serve(app.into_make_service())
+            .await?;
+    } else {
+        tracing::info!("ai-memory listening on http://{addr}");
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .await?;
+    }
     Ok(())
+}
+
+/// Load a PEM cert + PEM key (PKCS#8 or RSA) into an `axum-server`
+/// rustls config. Returns an error with a specific message for the
+/// operator rather than letting rustls' wrapped IO error bubble up —
+/// TLS misconfigurations are the #1 new-deploy footgun.
+async fn load_rustls_config(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<axum_server::tls_rustls::RustlsConfig> {
+    let cert = tokio::fs::read(cert_path)
+        .await
+        .with_context(|| format!("failed to read TLS cert from {}", cert_path.display()))?;
+    let key = tokio::fs::read(key_path)
+        .await
+        .with_context(|| format!("failed to read TLS key from {}", key_path.display()))?;
+    let config = axum_server::tls_rustls::RustlsConfig::from_pem(cert, key)
+        .await
+        .context(
+            "failed to parse TLS cert/key — ensure PEM-encoded (cert may be fullchain; \
+                 key must be PKCS#8 or RSA)",
+        )?;
+    Ok(config)
 }
 
 // --- CLI ---

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7933,3 +7933,129 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
     let _ = std::fs::remove_file(&db_a);
     let _ = std::fs::remove_file(&db_b);
 }
+
+// ---------------------------------------------------------------------------
+// Native TLS tests (Layer 1) — `ai-memory serve --tls-cert/--tls-key`
+// ---------------------------------------------------------------------------
+
+/// Generate a self-signed PEM cert + key pair at the given paths. Returns
+/// the (cert_path, key_path) tuple. Skips the test if openssl isn't on
+/// the PATH (rare on CI runners, but this keeps local-dev friendly).
+fn gen_self_signed_cert(dir: &std::path::Path) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    let cert = dir.join(format!("ai-memory-test-cert-{}.pem", uuid::Uuid::new_v4()));
+    let key = dir.join(format!("ai-memory-test-key-{}.pem", uuid::Uuid::new_v4()));
+    let status = std::process::Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key.to_str().unwrap(),
+            "-out",
+            cert.to_str().unwrap(),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    if let Ok(s) = status
+        && s.success()
+    {
+        return Some((cert, key));
+    }
+    None
+}
+
+#[test]
+fn test_serve_native_tls_health_probe() {
+    // Layer 1 — `ai-memory serve --tls-cert ... --tls-key ...` must serve
+    // the health endpoint over HTTPS (self-signed cert, --insecure probe).
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("ai-memory-tls-{}.db", uuid::Uuid::new_v4()));
+    let Some((cert_path, key_path)) = gen_self_signed_cert(&dir) else {
+        eprintln!("skipping: openssl not available on PATH");
+        return;
+    };
+
+    let port = free_port();
+    let mut child = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "serve",
+            "--port",
+            &port.to_string(),
+            "--tls-cert",
+            cert_path.to_str().unwrap(),
+            "--tls-key",
+            key_path.to_str().unwrap(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Poll HTTPS health endpoint — curl --insecure against the self-signed cert.
+    let mut ok = false;
+    for _ in 0..50 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Ok(out) = std::process::Command::new("curl")
+            .args([
+                "-sk",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                &format!("https://127.0.0.1:{port}/api/v1/health"),
+            ])
+            .output()
+            && String::from_utf8_lossy(&out.stdout) == "200"
+        {
+            ok = true;
+            break;
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        ok,
+        "HTTPS health endpoint never returned 200; is axum-server bound?"
+    );
+
+    let _ = std::fs::remove_file(&db);
+    let _ = std::fs::remove_file(&cert_path);
+    let _ = std::fs::remove_file(&key_path);
+}
+
+#[test]
+fn test_serve_rejects_half_tls_config() {
+    // Layer 1 — clap's `requires = "tls_key"` must reject `--tls-cert`
+    // without `--tls-key` at arg-parse time.
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("ai-memory-tls-half-{}.db", uuid::Uuid::new_v4()));
+    let out = cmd(bin)
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "serve",
+            "--port",
+            &free_port().to_string(),
+            "--tls-cert",
+            "/nonexistent/cert.pem",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "half-configured TLS must be rejected"
+    );
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

- \`ai-memory serve --tls-cert <pem> --tls-key <pem>\` binds HTTPS via axum-server + rustls (ring provider, matches reqwest's sync-daemon default)
- Backward compatible: omit both flags = plain HTTP, same as every prior release
- clap \`requires\` attrs reject half-configured TLS at parse time
- Graceful shutdown via axum-server Handle with 10s drain deadline on SIGINT

## Why this matters

The sync-daemon already talks HTTPS outbound. Native TLS on \`serve\` lets the peer-mesh demo work across the open internet from a single binary per peer — no nginx, no Caddy, no cloud.

Refs #224 (Phase 3 tracking)

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Standard (new CLI flags + TLS server binding + tests)
- **Human approver:** @binary2029 (explicit \"do all 3 now - approved - YES\")
- **ai-memory entries created/updated:** none
- **Co-Authored-By trailer:** yes

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` clean
- [x] \`AI_MEMORY_NO_CONFIG=1 cargo test\` — **245 unit + 157 integration = 402 tests, all pass**
- [x] \`cargo audit\` clean — one advisory warning on \`rustls-pemfile\` (transitively pulled by axum-server, flagged unmaintained by RUSTSEC-2025-0134, not a vulnerability; upstream will drop it when migrating to rustls 0.23's built-in PEM parsing)

## Scope / non-scope

**In:** native HTTPS for \`serve\`, self-signed integration test, error UX for TLS misconfig.

**Out:**
- mTLS / client-cert auth — separate PR (Layer 2) tonight
- E2E memory encryption — design issue for v0.8 (Layer 3)
- Let's Encrypt / ACME integration — out of scope, users bring their own certs (or run Caddy in front)

🤖 Generated with [Claude Code](https://claude.com/claude-code)