### PR TITLE
feat(v0.6.0-ga): mTLS with fingerprint allowlist — Layer 2 peer-mesh crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokenizers",
  "tokio",
@@ -298,6 +299,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -633,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +726,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -800,6 +829,16 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1243,6 +1282,16 @@ dependencies = [
  "paste",
  "raw-cpuid",
  "seq-macro",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2876,6 +2925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3485,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ axum-server = { version = "0.7", features = ["tls-rustls"] }
 # `RustlsConfig::from_pem` so no separate rustls-pemfile dep (which
 # is flagged unmaintained in the 2026 advisory DB).
 rustls = { version = "0.23", features = ["ring"] }
+# mTLS cert fingerprint allowlist (Layer 2) needs SHA-256 over the
+# client cert DER. RustCrypto sha2 — same family as the HKDF we'll use
+# for Layer 3 E2E encryption (#228).
+sha2 = "0.10"
 
 # Semantic embedding support
 candle-core = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ candle-transformers = "0.10"
 hf-hub = { version = "0.5", features = ["tokio"] }
 tokenizers = { version = "0.22" }
 instant-distance = "0.6"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "native-tls"] }
 toml = "0.8"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,17 @@ struct ServeArgs {
     /// Path to PEM-encoded TLS private key (PKCS#8 or RSA).
     #[arg(long, requires = "tls_cert")]
     tls_key: Option<PathBuf>,
+    /// Path to a file containing SHA-256 fingerprints of trusted client
+    /// certificates, one per line (case-insensitive hex, optionally with
+    /// `:` separators; comments start with `#`). When set, `serve`
+    /// demands client-cert mTLS on every connection and refuses any peer
+    /// whose cert fingerprint is not on the list. Requires `--tls-cert`
+    /// and `--tls-key`. This is the peer-mesh identity gate — a peer
+    /// without an authorised cert can't even open a TCP connection, let
+    /// alone hit `/sync/push`. Layer 2 of the peer-mesh crypto stack;
+    /// attested `agent_id` extraction (Layer 2b) lands post-v0.6.0.
+    #[arg(long, requires = "tls_cert")]
+    mtls_allowlist: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -470,6 +481,15 @@ struct SyncDaemonArgs {
     /// subsequent cycles pick up the remainder. Defaults to 500.
     #[arg(long, default_value_t = 500)]
     batch_size: usize,
+    /// Layer 2 client-cert PEM used when the peer demands mTLS. Pair
+    /// with `--client-key`. If the peer has `--mtls-allowlist` set and
+    /// this cert's SHA-256 fingerprint isn't on it, the TLS handshake
+    /// is rejected before the daemon ever reaches the sync endpoints.
+    #[arg(long, requires = "client_key")]
+    client_cert: Option<PathBuf>,
+    /// Layer 2 client-key PEM. Must pair with `--client-cert`.
+    #[arg(long, requires = "client_cert")]
+    client_key: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -872,7 +892,15 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         // before any TLS setup. Idempotent — second install is a
         // harmless no-op via ignore.
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let tls_config = load_rustls_config(cert, key).await?;
+        let tls_config = if let Some(allowlist_path) = &args.mtls_allowlist {
+            tracing::info!(
+                "mTLS enabled — client certs required. Allowlist: {}",
+                allowlist_path.display()
+            );
+            load_mtls_rustls_config(cert, key, allowlist_path).await?
+        } else {
+            load_rustls_config(cert, key).await?
+        };
         let socket_addr: std::net::SocketAddr = addr.parse()?;
         // axum-server doesn't have a direct graceful-shutdown on the
         // TLS builder yet; spawn the signal listener on the Handle
@@ -918,6 +946,285 @@ async fn load_rustls_config(
                  key must be PKCS#8 or RSA)",
         )?;
     Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — mTLS with SHA-256 fingerprint allowlist.
+//
+// Builds a rustls ServerConfig that:
+//   1. Presents the local cert/key (same as Layer 1).
+//   2. Demands a client certificate on every connection.
+//   3. Accepts the client cert only if its SHA-256 fingerprint is on the
+//      operator-configured allowlist. Any other cert — including ones
+//      signed by trusted CAs — is rejected.
+//
+// This is the fastest path to "only authorised peers can even connect"
+// without depending on a PKI/CA ecosystem. Fingerprint pinning is a
+// well-understood primitive (HTTP Public Key Pinning, SSH host keys).
+// Task 2b (post-v0.6.0) adds fingerprint → agent_id mapping so the
+// handler can refuse requests whose `sender_agent_id` doesn't match
+// the cert's expected identity.
+// ---------------------------------------------------------------------------
+
+/// Load a rustls server config with client-cert-fingerprint verification.
+async fn load_mtls_rustls_config(
+    cert_path: &Path,
+    key_path: &Path,
+    allowlist_path: &Path,
+) -> Result<axum_server::tls_rustls::RustlsConfig> {
+    let allowlist = load_fingerprint_allowlist(allowlist_path).await?;
+    if allowlist.is_empty() {
+        anyhow::bail!(
+            "mTLS allowlist at {} is empty — refuse to start rather than silently accept all peers",
+            allowlist_path.display()
+        );
+    }
+
+    let cert_pem = tokio::fs::read(cert_path)
+        .await
+        .with_context(|| format!("failed to read TLS cert from {}", cert_path.display()))?;
+    let key_pem = tokio::fs::read(key_path)
+        .await
+        .with_context(|| format!("failed to read TLS key from {}", key_path.display()))?;
+
+    let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls_pki_pem_iter_certs(&cert_pem)?;
+    let key = rustls_pki_pem_parse_private_key(&key_pem)?;
+
+    let verifier = Arc::new(FingerprintAllowlistVerifier { allowlist });
+    let server_config = rustls::ServerConfig::builder()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .context("failed to build rustls ServerConfig for mTLS")?;
+
+    Ok(axum_server::tls_rustls::RustlsConfig::from_config(
+        Arc::new(server_config),
+    ))
+}
+
+/// Parse the allowlist file: one SHA-256 fingerprint per line, case-insensitive
+/// hex with optional `:` separators. Empty lines and `#` comments are skipped.
+async fn load_fingerprint_allowlist(path: &Path) -> Result<std::collections::HashSet<[u8; 32]>> {
+    let text = tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read mTLS allowlist from {}", path.display()))?;
+    let mut set = std::collections::HashSet::new();
+    for (lineno, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Accept a leading `sha256:` marker for forward-compat with richer formats.
+        let hex_part = line.strip_prefix("sha256:").unwrap_or(line);
+        let hex_clean: String = hex_part.chars().filter(|c| *c != ':').collect();
+        if hex_clean.len() != 64 {
+            anyhow::bail!(
+                "mTLS allowlist line {}: expected 64 hex chars (optionally with `:` separators), got {}",
+                lineno + 1,
+                hex_clean.len()
+            );
+        }
+        let mut bytes = [0u8; 32];
+        for i in 0..32 {
+            bytes[i] = u8::from_str_radix(&hex_clean[i * 2..i * 2 + 2], 16)
+                .with_context(|| format!("mTLS allowlist line {}: invalid hex", lineno + 1))?;
+        }
+        set.insert(bytes);
+    }
+    Ok(set)
+}
+
+fn rustls_pki_pem_iter_certs(
+    pem: &[u8],
+) -> Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
+    use rustls::pki_types::pem::PemObject as _;
+    let mut cursor = std::io::Cursor::new(pem);
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_reader_iter(&mut cursor)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to parse TLS cert PEM")?;
+    if certs.is_empty() {
+        anyhow::bail!("TLS cert PEM contained no certificates");
+    }
+    Ok(certs)
+}
+
+fn rustls_pki_pem_parse_private_key(
+    pem: &[u8],
+) -> Result<rustls::pki_types::PrivateKeyDer<'static>> {
+    use rustls::pki_types::pem::PemObject as _;
+    let mut cursor = std::io::Cursor::new(pem);
+    let key = rustls::pki_types::PrivateKeyDer::from_pem_reader(&mut cursor)
+        .context("failed to parse TLS key PEM — expected PKCS#8, RSA, or SEC1")?;
+    Ok(key)
+}
+
+/// Custom `ClientCertVerifier` that accepts only client certs whose SHA-256
+/// DER fingerprint is on the allowlist. Ignores CA chain — fingerprint
+/// pinning is the trust anchor here, same model as SSH `known_hosts`.
+#[derive(Debug)]
+struct FingerprintAllowlistVerifier {
+    allowlist: std::collections::HashSet<[u8; 32]>,
+}
+
+impl rustls::server::danger::ClientCertVerifier for FingerprintAllowlistVerifier {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        true
+    }
+
+    fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _now: rustls::pki_types::UnixTime,
+    ) -> std::result::Result<rustls::server::danger::ClientCertVerified, rustls::Error> {
+        use sha2::{Digest, Sha256};
+        let fp: [u8; 32] = Sha256::digest(end_entity.as_ref()).into();
+        if self.allowlist.contains(&fp) {
+            Ok(rustls::server::danger::ClientCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(format!(
+                "client cert fingerprint {} not in mTLS allowlist",
+                hex_short(&fp)
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn hex_short(fp: &[u8; 32]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(12);
+    for b in &fp[..6] {
+        let _ = write!(s, "{b:02x}");
+    }
+    s.push('…');
+    s
+}
+
+/// Build a rustls `ClientConfig` with client-cert auth and a
+/// "dangerously-accept-any-server-cert" verifier. Used by the
+/// sync-daemon to present its client cert on every outbound request
+/// while connecting to peers with self-signed server certs. Peer
+/// authenticity is established on the other direction (they verify
+/// us via `--mtls-allowlist`).
+async fn build_rustls_client_config(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<rustls::ClientConfig> {
+    let cert_pem = tokio::fs::read(cert_path)
+        .await
+        .with_context(|| format!("failed to read client cert from {}", cert_path.display()))?;
+    let key_pem = tokio::fs::read(key_path)
+        .await
+        .with_context(|| format!("failed to read client key from {}", key_path.display()))?;
+
+    let certs = rustls_pki_pem_iter_certs(&cert_pem)?;
+    let key = rustls_pki_pem_parse_private_key(&key_pem)?;
+
+    // SAFETY: we accept any server cert because the server authenticates
+    // US via our client cert fingerprint (Layer 2's trust anchor), not
+    // via server-cert validation. Server-cert pinning is a Layer 2b
+    // refinement tracked in #224.
+    let config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(DangerousAnyServerVerifier))
+        .with_client_auth_cert(certs, key)
+        .context("failed to build rustls ClientConfig with client cert")?;
+    Ok(config)
+}
+
+/// `ServerCertVerifier` that accepts any peer certificate. Safe ONLY when
+/// paired with a strong reverse authentication channel — in our case the
+/// peer's `--mtls-allowlist` fingerprint-pins our client cert.
+#[derive(Debug)]
+struct DangerousAnyServerVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for DangerousAnyServerVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
 }
 
 // --- CLI ---
@@ -2498,9 +2805,31 @@ async fn cmd_sync_daemon(
         )
         .try_init();
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()?;
+    // Layer 2: if client cert is configured, build a rustls ClientConfig
+    // with client auth and hand it to reqwest via `use_preconfigured_tls`.
+    // reqwest's `from_pkcs8_pem` Identity is native-tls-only; we stay on
+    // rustls to keep a single TLS stack across the binary.
+    //
+    // Self-signed peer certs are common in the local-mesh story. The
+    // ClientConfig installs a dangerous "accept any server cert"
+    // verifier when mTLS is active — the peer's authentication of US
+    // (via our client cert fingerprint in their --mtls-allowlist) is
+    // the trust anchor, so fingerprint pinning of the peer's server
+    // cert is a Layer 2b refinement tracked in #224.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = match (&args.client_cert, &args.client_key) {
+        (Some(cert_path), Some(key_path)) => {
+            let rustls_config = build_rustls_client_config(cert_path, key_path).await?;
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .use_preconfigured_tls(rustls_config)
+                .build()?
+        }
+        _ => reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .danger_accept_invalid_certs(true)
+            .build()?,
+    };
 
     tracing::info!(
         "sync-daemon: local_agent_id={local_agent_id} peers={peers:?} interval={interval}s",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8034,6 +8034,247 @@ fn test_serve_native_tls_health_probe() {
     let _ = std::fs::remove_file(&key_path);
 }
 
+/// Compute SHA-256 fingerprint of a PEM cert's DER body via `openssl`
+/// (same CLI available on all CI runners). Returns hex without `:`.
+fn cert_sha256_fingerprint(cert_path: &std::path::Path) -> Option<String> {
+    let out = std::process::Command::new("openssl")
+        .args([
+            "x509",
+            "-noout",
+            "-fingerprint",
+            "-sha256",
+            "-in",
+            cert_path.to_str().unwrap(),
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    // openssl emits `SHA256 Fingerprint=AA:BB:...` — strip label, colons.
+    let hex: String = s
+        .split('=')
+        .nth(1)?
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .collect();
+    Some(hex.to_ascii_lowercase())
+}
+
+#[test]
+fn test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer() {
+    // Layer 2 — mTLS with SHA-256 fingerprint allowlist.
+    // Peer B runs serve with an allowlist containing peer-A's cert
+    // fingerprint. The sync-daemon on peer A presents peer-A's cert and
+    // must succeed. A second daemon presenting an unknown cert must be
+    // rejected at the TLS handshake.
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let dir = std::env::temp_dir();
+    let db_a = dir.join(format!("ai-memory-mtls-a-{}.db", uuid::Uuid::new_v4()));
+    let db_b = dir.join(format!("ai-memory-mtls-b-{}.db", uuid::Uuid::new_v4()));
+
+    // Generate three self-signed keypairs: server (peer B's TLS cert),
+    // peer-A (authorised client), and peer-C (unauthorised client).
+    let Some((server_cert, server_key)) = gen_self_signed_cert(&dir) else {
+        eprintln!("skipping: openssl not available on PATH");
+        return;
+    };
+    let Some((peer_a_cert, peer_a_key)) = gen_self_signed_cert(&dir) else {
+        eprintln!("skipping: openssl not available on PATH");
+        return;
+    };
+    let Some((peer_c_cert, peer_c_key)) = gen_self_signed_cert(&dir) else {
+        eprintln!("skipping: openssl not available on PATH");
+        return;
+    };
+
+    let allowlist_path = dir.join(format!("ai-memory-mtls-allow-{}.txt", uuid::Uuid::new_v4()));
+    let peer_a_fp =
+        cert_sha256_fingerprint(&peer_a_cert).expect("failed to fingerprint peer A cert");
+    std::fs::write(
+        &allowlist_path,
+        format!("# authorised mTLS peers\n{peer_a_fp}\n"),
+    )
+    .unwrap();
+
+    // Start peer B's serve with mTLS + allowlist.
+    let port_b = free_port();
+    let mut serve_b = cmd(bin)
+        .args([
+            "--db",
+            db_b.to_str().unwrap(),
+            "serve",
+            "--port",
+            &port_b.to_string(),
+            "--tls-cert",
+            server_cert.to_str().unwrap(),
+            "--tls-key",
+            server_key.to_str().unwrap(),
+            "--mtls-allowlist",
+            allowlist_path.to_str().unwrap(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Wait for TLS bind. wait_for_health would fail here since curl
+    // without a client cert gets rejected; so we poll via curl+mTLS.
+    let mut ready = false;
+    for _ in 0..60 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let out = std::process::Command::new("curl")
+            .args([
+                "-sk",
+                "--cert",
+                peer_a_cert.to_str().unwrap(),
+                "--key",
+                peer_a_key.to_str().unwrap(),
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                &format!("https://127.0.0.1:{port_b}/api/v1/health"),
+            ])
+            .output();
+        if let Ok(o) = out
+            && String::from_utf8_lossy(&o.stdout) == "200"
+        {
+            ready = true;
+            break;
+        }
+    }
+    assert!(ready, "mTLS serve never accepted peer A's cert for health");
+
+    // Seed a memory via mTLS POST.
+    let seed = serde_json::json!({
+        "tier": "long",
+        "namespace": "mtls-demo",
+        "title": "Peer B secret",
+        "content": "Only reachable via mTLS allowlist.",
+        "tags": ["mtls"],
+        "priority": 7,
+        "confidence": 1.0,
+        "source": "api",
+        "metadata": {},
+    });
+    let seed_out = std::process::Command::new("curl")
+        .args([
+            "-sk",
+            "--cert",
+            peer_a_cert.to_str().unwrap(),
+            "--key",
+            peer_a_key.to_str().unwrap(),
+            "-X",
+            "POST",
+            "-H",
+            "content-type: application/json",
+            "-H",
+            "x-agent-id: peer-b",
+            "-d",
+            &seed.to_string(),
+            &format!("https://127.0.0.1:{port_b}/api/v1/memories"),
+        ])
+        .output()
+        .unwrap();
+    assert!(seed_out.status.success());
+
+    // Start the sync-daemon on peer A with peer-A's client cert.
+    let mut daemon_ok = cmd(bin)
+        .args([
+            "--db",
+            db_a.to_str().unwrap(),
+            "--agent-id",
+            "peer-a",
+            "sync-daemon",
+            "--peers",
+            &format!("https://127.0.0.1:{port_b}"),
+            "--interval",
+            "1",
+            "--client-cert",
+            peer_a_cert.to_str().unwrap(),
+            "--client-key",
+            peer_a_key.to_str().unwrap(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Positive case: memory should propagate to peer A.
+    let mut found = false;
+    for _ in 0..30 {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let list = cmd(bin)
+            .args([
+                "--db",
+                db_a.to_str().unwrap(),
+                "--json",
+                "list",
+                "-n",
+                "mtls-demo",
+            ])
+            .output()
+            .unwrap();
+        if list.status.success() {
+            let v: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap_or_default();
+            if let Some(arr) = v["memories"].as_array()
+                && arr.iter().any(|m| m["title"] == "Peer B secret")
+            {
+                found = true;
+                break;
+            }
+        }
+    }
+    let _ = daemon_ok.kill();
+    let _ = daemon_ok.wait();
+
+    assert!(
+        found,
+        "authorised peer-A cert failed to sync through mTLS allowlist"
+    );
+
+    // Negative case: curl with peer-C's cert must be rejected.
+    let neg = std::process::Command::new("curl")
+        .args([
+            "-sk",
+            "--cert",
+            peer_c_cert.to_str().unwrap(),
+            "--key",
+            peer_c_key.to_str().unwrap(),
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            &format!("https://127.0.0.1:{port_b}/api/v1/health"),
+        ])
+        .output()
+        .unwrap();
+    let code = String::from_utf8_lossy(&neg.stdout);
+    assert!(
+        code == "000" || code.starts_with('5') || code.is_empty(),
+        "unauthorised cert must be rejected; got HTTP {code}"
+    );
+
+    let _ = serve_b.kill();
+    let _ = serve_b.wait();
+
+    for p in [
+        &db_a,
+        &db_b,
+        &server_cert,
+        &server_key,
+        &peer_a_cert,
+        &peer_a_key,
+        &peer_c_cert,
+        &peer_c_key,
+        &allowlist_path,
+    ] {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
 #[test]
 fn test_serve_rejects_half_tls_config() {
     // Layer 1 — clap's `requires = "tls_key"` must reject `--tls-cert`

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8034,6 +8034,32 @@ fn test_serve_native_tls_health_probe() {
     let _ = std::fs::remove_file(&key_path);
 }
 
+/// Build a `reqwest::blocking::Client` presenting the given PEM cert +
+/// key as its client identity. Accepts any server cert (self-signed in
+/// these tests — the peer authenticates US via fingerprint allowlist).
+/// Uses reqwest's rustls-tls backend; `from_pem` expects both cert and
+/// key concatenated into a single PEM blob.
+fn build_mtls_probe_client(
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> reqwest::blocking::Client {
+    // Transitive deps pull reqwest's native-tls backend via hf-hub's
+    // default-tls feature, so the test uses `from_pkcs8_pem` (native-tls
+    // variant) for maximum cross-platform consistency. The daemon in
+    // production goes through `use_preconfigured_tls` with a rustls
+    // ClientConfig (see src/main.rs).
+    let cert = std::fs::read(cert_path).expect("read client cert");
+    let key = std::fs::read(key_path).expect("read client key");
+    let identity =
+        reqwest::Identity::from_pkcs8_pem(&cert, &key).expect("parse mTLS identity (PKCS#8 PEM)");
+    reqwest::blocking::Client::builder()
+        .identity(identity)
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("build reqwest mTLS client")
+}
+
 /// Compute SHA-256 fingerprint of a PEM cert's DER body via `openssl`
 /// (same CLI available on all CI runners). Returns hex without `:`.
 fn cert_sha256_fingerprint(cert_path: &std::path::Path) -> Option<String> {
@@ -8119,31 +8145,20 @@ fn test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer() {
         .spawn()
         .unwrap();
 
-    // Wait for TLS bind. wait_for_health would fail here since curl
-    // without a client cert gets rejected; so we poll via curl+mTLS.
-    // Windows CI is measurably slower at completing the first mTLS
-    // handshake (RSA key parse + custom verifier init + cert gen on
-    // the same runner); 30s is generous for Linux and correct for
-    // Windows.
+    // Build a reqwest::blocking client presenting peer-A's cert. We use
+    // reqwest (rustls-tls backend) instead of `curl --cert` because
+    // curl on Windows CI is often the schannel build and doesn't
+    // accept PEM client certs the same way curl-openssl does.
+    let client_a = build_mtls_probe_client(&peer_a_cert, &peer_a_key);
+
+    // Wait for TLS bind — 30s poll window; Windows is slower on the
+    // first handshake (RSA key parse + custom verifier init).
+    let health_url = format!("https://127.0.0.1:{port_b}/api/v1/health");
     let mut ready = false;
     for _ in 0..300 {
         std::thread::sleep(std::time::Duration::from_millis(100));
-        let out = std::process::Command::new("curl")
-            .args([
-                "-sk",
-                "--cert",
-                peer_a_cert.to_str().unwrap(),
-                "--key",
-                peer_a_key.to_str().unwrap(),
-                "-o",
-                "/dev/null",
-                "-w",
-                "%{http_code}",
-                &format!("https://127.0.0.1:{port_b}/api/v1/health"),
-            ])
-            .output();
-        if let Ok(o) = out
-            && String::from_utf8_lossy(&o.stdout) == "200"
+        if let Ok(resp) = client_a.get(&health_url).send()
+            && resp.status().is_success()
         {
             ready = true;
             break;
@@ -8163,26 +8178,18 @@ fn test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer() {
         "source": "api",
         "metadata": {},
     });
-    let seed_out = std::process::Command::new("curl")
-        .args([
-            "-sk",
-            "--cert",
-            peer_a_cert.to_str().unwrap(),
-            "--key",
-            peer_a_key.to_str().unwrap(),
-            "-X",
-            "POST",
-            "-H",
-            "content-type: application/json",
-            "-H",
-            "x-agent-id: peer-b",
-            "-d",
-            &seed.to_string(),
-            &format!("https://127.0.0.1:{port_b}/api/v1/memories"),
-        ])
-        .output()
-        .unwrap();
-    assert!(seed_out.status.success());
+    let seed_resp = client_a
+        .post(format!("https://127.0.0.1:{port_b}/api/v1/memories"))
+        .header("content-type", "application/json")
+        .header("x-agent-id", "peer-b")
+        .body(seed.to_string())
+        .send()
+        .expect("seed POST via mTLS must succeed");
+    assert!(
+        seed_resp.status().is_success(),
+        "seed status {}",
+        seed_resp.status()
+    );
 
     // Start the sync-daemon on peer A with peer-A's client cert.
     let mut daemon_ok = cmd(bin)
@@ -8239,26 +8246,15 @@ fn test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer() {
         "authorised peer-A cert failed to sync through mTLS allowlist"
     );
 
-    // Negative case: curl with peer-C's cert must be rejected.
-    let neg = std::process::Command::new("curl")
-        .args([
-            "-sk",
-            "--cert",
-            peer_c_cert.to_str().unwrap(),
-            "--key",
-            peer_c_key.to_str().unwrap(),
-            "-o",
-            "/dev/null",
-            "-w",
-            "%{http_code}",
-            &format!("https://127.0.0.1:{port_b}/api/v1/health"),
-        ])
-        .output()
-        .unwrap();
-    let code = String::from_utf8_lossy(&neg.stdout);
+    // Negative case: reqwest with peer-C's cert must be rejected at
+    // handshake. The `send()` call returns an error (not an HTTP code)
+    // because the TLS layer fails before any HTTP exchange.
+    let client_c = build_mtls_probe_client(&peer_c_cert, &peer_c_key);
+    let neg = client_c.get(&health_url).send();
     assert!(
-        code == "000" || code.starts_with('5') || code.is_empty(),
-        "unauthorised cert must be rejected; got HTTP {code}"
+        neg.is_err(),
+        "unauthorised cert must be rejected at TLS handshake; got {:?}",
+        neg
     );
 
     let _ = serve_b.kill();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8121,8 +8121,12 @@ fn test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer() {
 
     // Wait for TLS bind. wait_for_health would fail here since curl
     // without a client cert gets rejected; so we poll via curl+mTLS.
+    // Windows CI is measurably slower at completing the first mTLS
+    // handshake (RSA key parse + custom verifier init + cert gen on
+    // the same runner); 30s is generous for Linux and correct for
+    // Windows.
     let mut ready = false;
-    for _ in 0..60 {
+    for _ in 0..300 {
         std::thread::sleep(std::time::Duration::from_millis(100));
         let out = std::process::Command::new("curl")
             .args([


### PR DESCRIPTION
## Summary

Layer 2 of the peer-mesh crypto stack. Builds on Layer 1 (PR #227) with **client-certificate authentication** on the sync endpoints — a peer without an authorised cert is rejected at the TLS handshake, well before any sync endpoint is reachable. Same trust model as SSH \`known_hosts\`: fingerprint pinning is the anchor, no CA/PKI required.

Refs #224 (Phase 3 tracking), #228 (Layer 3 E2E design)

## What ships

- \`ai-memory serve --mtls-allowlist <path>\` — one SHA-256 fingerprint per line, case-insensitive hex, optional \`sha256:\` prefix or \`:\` separators, \`#\` comments.
- \`sync-daemon --client-cert <pem> --client-key <pem>\` — daemon presents its client cert on every outbound call.
- Custom \`FingerprintAllowlistVerifier\` rejects unknown certs at handshake. Server signature verification delegates to rustls's ring provider.
- Daemon uses \`rustls::ClientConfig\` via reqwest's \`use_preconfigured_tls\` (since \`Identity::from_pkcs8_pem\` is native-tls-only; we keep a single TLS stack).

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Standard (new CLI flags + custom TLS verifier + end-to-end integration test)
- **Human approver:** @binary2029 (explicit "do all 3 now - approved - YES")
- **ai-memory entries created/updated:** none
- **Co-Authored-By trailer:** yes

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` clean
- [x] \`AI_MEMORY_NO_CONFIG=1 cargo test\` — **243 unit + 158 integration = 401 tests, all pass**
- [x] \`cargo audit\` clean (one unmaintained-crate advisory on transitive \`rustls-pemfile\` — not a vulnerability)
- [x] Integration test: two-peer mTLS mesh roundtrip + unauthorised-cert rejection

## Scope / non-scope

**In:** client-cert mTLS, fingerprint pinning allowlist, both sides of the sync (serve + daemon), integration test covering both positive and negative cases.

**Out (tracked):**
- **Attested \`sender_agent_id\`** (Layer 2b) — today mTLS gates access but agent_id is still claimed in the body. Full attestation extracts CN/SAN from the validated cert and enforces match. Tracked in #224.
- **Server-cert fingerprint pinning on daemon side** (Layer 2c) — same model in reverse. Tracked in #224.
- **E2E memory encryption** (Layer 3) — issue #228, v0.8 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)