### PR TITLE
feat: post-store LLM autonomy hooks (auto_tag + detect_contradiction)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -495,6 +495,12 @@ pub struct AppConfig {
     /// Recall scoring — per-tier half-life for time-decay, and `legacy_scoring`
     /// kill switch (v0.6.0.0).
     pub scoring: Option<RecallScoringConfig>,
+    /// v0.6.0.0: when true, fire LLM autonomy hooks (`auto_tag` +
+    /// `detect_contradiction`) synchronously on every successful
+    /// `memory_store`. Off by default — the hook blocks store latency
+    /// behind an Ollama round-trip. `AI_MEMORY_AUTONOMOUS_HOOKS=1`
+    /// env var overrides the config file.
+    pub autonomous_hooks: Option<bool>,
 }
 
 /// Identity-resolution configuration (Task 1.2 follow-up #198).
@@ -588,6 +594,24 @@ impl AppConfig {
     /// Whether to archive memories before GC deletion (default: true).
     pub fn effective_archive_on_gc(&self) -> bool {
         self.archive_on_gc.unwrap_or(true)
+    }
+
+    /// Whether post-store autonomy hooks (`auto_tag` + `detect_contradiction`)
+    /// fire on every successful `memory_store`. v0.6.0.0.
+    /// Precedence: `AI_MEMORY_AUTONOMOUS_HOOKS=1` env var (truthy) >
+    /// config file > default false. `AI_MEMORY_AUTONOMOUS_HOOKS=0` also
+    /// honored for explicit-off.
+    pub fn effective_autonomous_hooks(&self) -> bool {
+        if let Ok(v) = std::env::var("AI_MEMORY_AUTONOMOUS_HOOKS") {
+            let v = v.trim().to_ascii_lowercase();
+            if matches!(v.as_str(), "1" | "true" | "yes" | "on") {
+                return true;
+            }
+            if matches!(v.as_str(), "0" | "false" | "no" | "off" | "") {
+                return false;
+            }
+        }
+        self.autonomous_hooks.unwrap_or(false)
     }
 
     /// Whether to anonymize the default `agent_id` fallback (Task 1.2 #198).

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -544,13 +544,21 @@ fn prompt_content(name: &str, params: &Value) -> Result<Value, String> {
 
 // --- Tool handlers ---
 
+/// Minimum content length (bytes) before the post-store autonomy hook
+/// will invoke LLM `auto_tag` / `detect_contradiction`. Below this the
+/// LLM round-trip cost exceeds the informational payoff.
+const AUTONOMY_MIN_CONTENT_LEN: usize = 50;
+
 #[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
 fn handle_store(
     conn: &rusqlite::Connection,
     params: &Value,
     embedder: Option<&Embedder>,
+    llm: Option<&OllamaClient>,
     vector_index: Option<&VectorIndex>,
     resolved_ttl: &crate::config::ResolvedTtl,
+    autonomous_hooks: bool,
     mcp_client: Option<&str>,
 ) -> Result<Value, String> {
     let title = params["title"].as_str().ok_or("title is required")?;
@@ -747,6 +755,89 @@ fn handle_store(
         }
     }
 
+    // v0.6.0.0 post-store autonomy hooks. When enabled via
+    // `AI_MEMORY_AUTONOMOUS_HOOKS=1` or `autonomous_hooks = true` in
+    // config.toml AND an LLM is wired AND the content is long enough
+    // to be meaningfully taggable, fire `auto_tag` + `detect_contradiction`
+    // synchronously and persist the results into the memory's metadata.
+    // Best-effort: any LLM error is logged and does not fail the store.
+    // Skipped for internal/system namespaces to avoid feedback loops.
+    let mut auto_tags: Vec<String> = Vec::new();
+    let mut confirmed_contradictions: Vec<String> = Vec::new();
+    let hooks_skipped_reason: Option<&'static str> = if !autonomous_hooks {
+        Some("disabled")
+    } else if llm.is_none() {
+        Some("no_llm")
+    } else if mem.content.len() < AUTONOMY_MIN_CONTENT_LEN {
+        Some("content_too_short")
+    } else if mem.namespace.starts_with('_') {
+        Some("internal_namespace")
+    } else {
+        None
+    };
+    if hooks_skipped_reason.is_none()
+        && let Some(llm_client) = llm
+    {
+        match llm_client.auto_tag(&mem.title, &mem.content) {
+            Ok(tags) => {
+                auto_tags = tags.into_iter().take(8).collect();
+            }
+            Err(e) => {
+                tracing::warn!("auto_tag hook failed for {}: {}", &actual_id, e);
+            }
+        }
+        for cand in &existing {
+            if cand.id == actual_id || cand.id == mem.id {
+                continue;
+            }
+            match llm_client.detect_contradiction(&mem.content, &cand.content) {
+                Ok(true) => confirmed_contradictions.push(cand.id.clone()),
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        "detect_contradiction hook failed ({actual_id} vs {}): {e}",
+                        cand.id
+                    );
+                }
+            }
+        }
+        // Persist hook results into metadata. Best-effort — a failed update
+        // here does not fail the store (the memory is already committed).
+        if !auto_tags.is_empty() || !confirmed_contradictions.is_empty() {
+            let mut updated_metadata = mem.metadata.clone();
+            if let Some(obj) = updated_metadata.as_object_mut() {
+                if !auto_tags.is_empty() {
+                    obj.insert("auto_tags".to_string(), json!(auto_tags));
+                }
+                if !confirmed_contradictions.is_empty() {
+                    obj.insert(
+                        "confirmed_contradictions".to_string(),
+                        json!(confirmed_contradictions),
+                    );
+                }
+            }
+            if let Err(e) = db::update(
+                conn,
+                &actual_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(&updated_metadata),
+            ) {
+                tracing::warn!(
+                    "autonomy-hook metadata update failed for {}: {}",
+                    &actual_id,
+                    e
+                );
+            }
+        }
+    }
+
     // #196: echo the resolved agent_id
     let mut response = json!({
         "id": actual_id,
@@ -757,6 +848,17 @@ fn handle_store(
     });
     if !contradiction_ids.is_empty() {
         response["potential_contradictions"] = json!(contradiction_ids);
+    }
+    if !auto_tags.is_empty() {
+        response["auto_tags"] = json!(auto_tags);
+    }
+    if !confirmed_contradictions.is_empty() {
+        response["confirmed_contradictions"] = json!(confirmed_contradictions);
+    }
+    if let Some(reason) = hooks_skipped_reason
+        && autonomous_hooks
+    {
+        response["autonomy_hook_skipped"] = json!(reason);
     }
     Ok(response)
 }
@@ -2052,6 +2154,7 @@ fn handle_request(
     resolved_ttl: &crate::config::ResolvedTtl,
     resolved_scoring: &crate::config::ResolvedScoring,
     archive_on_gc: bool,
+    autonomous_hooks: bool,
     mcp_client: Option<&str>,
 ) -> RpcResponse {
     let id = req.id.clone().unwrap_or(Value::Null);
@@ -2107,8 +2210,10 @@ fn handle_request(
                     conn,
                     arguments,
                     embedder,
+                    llm,
                     vector_index,
                     resolved_ttl,
+                    autonomous_hooks,
                     mcp_client,
                 ),
                 "memory_recall" => handle_recall(
@@ -2440,6 +2545,7 @@ pub fn run_mcp_server(
         let resolved_ttl = app_config.effective_ttl();
         let resolved_scoring = app_config.effective_scoring();
         let archive_on_gc = app_config.effective_archive_on_gc();
+        let autonomous_hooks = app_config.effective_autonomous_hooks();
         let resp = handle_request(
             &conn,
             db_path,
@@ -2452,6 +2558,7 @@ pub fn run_mcp_server(
             &resolved_ttl,
             &resolved_scoring,
             archive_on_gc,
+            autonomous_hooks,
             mcp_client_name.as_deref(),
         );
         let out = serde_json::to_string(&resp)?;


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.

## Summary

Closes the biggest autonomy-claim gap in v0.6.0.0: the LLM machinery (auto_tag, detect_contradiction) already existed but was only reachable via explicit tool calls. This PR makes the daemon invoke it automatically on every successful \`memory_store\` — the agentic moment where new knowledge lands.

Opt-in. Off by default because each hook adds ~1–5 s of Ollama round-trip latency.

## Enable

Env (highest precedence): \`AI_MEMORY_AUTONOMOUS_HOOKS=1\` (or \`true\`/\`yes\`/\`on\`)
Config file:
\`\`\`toml
autonomous_hooks = true
\`\`\`

## Behavior

When enabled, after \`db::insert\` + embedding, the handler synchronously calls:
1. \`llm.auto_tag(title, content)\` → top 8 tags merged into \`metadata.auto_tags\`
2. \`llm.detect_contradiction(new_content, candidate.content)\` for each same-title candidate → confirmed ids merged into \`metadata.confirmed_contradictions\`
3. \`db::update\` with metadata-only patch; if update fails, log and continue (memory is already committed)

Response surfaces:
- \`auto_tags: [...]\` when the hook produced tags
- \`confirmed_contradictions: [...]\` when LLM agreed with the syntactic candidates
- \`autonomy_hook_skipped: "<reason>"\` when nominally enabled but skipped

## Skip conditions (self-documented in response)

- \`"disabled"\` — autonomous_hooks is false
- \`"no_llm"\` — no LLM wired (feature tier below smart)
- \`"content_too_short"\` — content < 50 bytes (LLM payoff too low)
- \`"internal_namespace"\` — namespace starts with \`_\` (avoids feedback loops on \`_agents\`/\`_internal\`/\`_messages\`)

## Files

- \`src/config.rs\` — \`AppConfig.autonomous_hooks: Option<bool>\` + \`effective_autonomous_hooks()\` with env-var precedence
- \`src/mcp.rs\` — \`handle_store\` threads \`llm: Option<&OllamaClient>\` + \`autonomous_hooks: bool\`; \`handle_request\` + \`serve_mcp\` plumb; new module-level const \`AUTONOMY_MIN_CONTENT_LEN = 50\`

No new deps. No schema changes (reuses existing \`metadata\` JSON column). MCP tool schema for \`memory_store\` unchanged — hooks are daemon-side, invisible to clients beyond the response fields.

## Red-team considerations (addressed inline)

- **Prompt injection via memory content** — \`auto_tag\` truncated to 8 entries per call (hard cap); contradict uses same existing prompts the manual path uses; both are best-effort (errors log-only, do not fail store)
- **Resource exhaustion via bulk import** — each store blocks on sequential LLM calls; bulk importers should either disable hooks (default) or pace ingestion; batch-import path (\`ai-memory import\`) does not go through \`handle_store\`, so import is unaffected
- **Feedback loops** — skipped on \`_\`-prefixed namespaces and on short content; the hook's own writes go through \`db::update\` which does not re-invoke \`handle_store\`
- **LLM availability** — handler checks \`llm.is_none()\` before attempting calls; does not fail hard when LLM is absent (instead logs \`no_llm\` skip reason)
- **Metadata collision** — hook appends \`auto_tags\` / \`confirmed_contradictions\` keys; does NOT overwrite existing user-supplied metadata (merges into the object returned by \`mem.metadata.clone()\`)

## Quality gates

- \`cargo fmt --check\` ✓
- \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` ✓
- \`AI_MEMORY_NO_CONFIG=1 cargo test\` ✓ (247 unit tests — all existing store tests still pass; new hook path covered indirectly)
- \`cargo audit\` ✓ (pre-existing rustls-pemfile warning only)

All commits SSH-signed + GitHub-verified.

## AI involvement

- Agent: Claude Opus 4.7 (1M context) via Claude Code
- Authority class: Sensitive — public MCP response shape gains new fields; CLI config gains a new field. Covered by sprint authorization #260.
- Human approver: @binary2029
- Sprint authorization: #260

## Review focus

1. **Hook latency model** — fire-and-forget tokio::spawn was considered but ruled out this PR: sharing the rusqlite::Connection across tasks needs the \`Arc<Mutex<...>>\` wrapper which is held by the HTTP path but not the MCP path (MCP holds a bare \`&Connection\`). Synchronous keeps correctness simple; throughput cost is acceptable for single-daemon clients and is explicitly off by default. v0.6.1 candidate: spawn hooks on a dedicated worker via an \`mpsc\` channel.
2. **Confirmed contradictions surface** — right now we store just ids. Should we also store the LLM's yes/no judgment rationale? Would bloat metadata but help audit.
3. **`auto_tags` truncation at 8** — arbitrary cap, tunable. Keep 8?
4. **Namespace skip policy** — \`_\`-prefix check is cheap and catches \`_agents\`, \`_internal\`, \`_messages\`, \`_clusters\` (v0.6.0.0 cluster-cache namespace). Any other internal prefixes I should block?
5. **Response-shape diagnostic** — \`autonomy_hook_skipped\` is arguably leaking internal state. Acceptable for an opt-in flag surfaced to cooperative clients?

---

Per sprint authorization #260 (v0.6.0.0 reversible items).