### PR TITLE
feat: ai-memory backup / restore CLI (VACUUM INTO + manifest)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,38 @@ enum Command {
     Agents(AgentsArgs),
     /// List / approve / reject governance-pending actions (Task 1.9)
     Pending(PendingArgs),
+    /// v0.6.0.0: snapshot the `SQLite` database to a timestamped backup
+    /// file. Uses `SQLite` `VACUUM INTO` which is hot-backup safe (no daemon
+    /// stop required). Writes a `manifest.json` alongside (sha256 + version).
+    Backup(BackupArgs),
+    /// v0.6.0.0: restore the `SQLite` database from a backup file written
+    /// by `ai-memory backup`. Verifies the manifest sha256 before
+    /// replacing the current DB. The current DB is moved aside as a safety
+    /// net before the replacement.
+    Restore(RestoreArgs),
+}
+
+#[derive(Args)]
+struct BackupArgs {
+    /// Directory where the snapshot and manifest are written. Created if
+    /// missing.
+    #[arg(long, default_value = "./backups")]
+    to: PathBuf,
+    /// Retention: after writing a new snapshot, delete the oldest
+    /// snapshots so that at most this many remain. 0 disables rotation.
+    #[arg(long, default_value_t = 48)]
+    keep: usize,
+}
+
+#[derive(Args)]
+struct RestoreArgs {
+    /// Path to a snapshot file OR a backup directory. When a directory is
+    /// supplied, the most recent snapshot is used.
+    #[arg(long)]
+    from: PathBuf,
+    /// Skip sha256 verification against the manifest. Not recommended.
+    #[arg(long)]
+    skip_verify: bool,
 }
 
 #[derive(Args)]
@@ -689,6 +721,8 @@ async fn main() -> Result<()> {
         Command::Archive(a) => cmd_archive(&db_path, a, j),
         Command::Agents(a) => cmd_agents(&db_path, a, j),
         Command::Pending(a) => cmd_pending(&db_path, a, j, cli_agent_id.as_deref()),
+        Command::Backup(a) => cmd_backup(&db_path, &a, j),
+        Command::Restore(a) => cmd_restore(&db_path, &a, j),
     };
 
     // WAL checkpoint after write commands to prevent unbounded WAL growth
@@ -3586,6 +3620,235 @@ fn cmd_mine(
         println!("Namespace: {namespace}, Tier: {tier}");
     }
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// v0.6.0.0 — backup / restore
+// ---------------------------------------------------------------------------
+
+/// Timestamp format used for snapshot filenames. RFC3339-compatible but
+/// filesystem-safe: no colons, no slashes.
+const BACKUP_TS_FMT: &str = "%Y-%m-%dT%H%M%SZ";
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BackupManifest {
+    snapshot: String,
+    sha256: String,
+    bytes: u64,
+    source_db: String,
+    version: String,
+    created_at: String,
+}
+
+fn cmd_backup(db_path: &Path, args: &BackupArgs, json_out: bool) -> Result<()> {
+    use std::io::Read;
+    std::fs::create_dir_all(&args.to)
+        .with_context(|| format!("creating backup dir {}", args.to.display()))?;
+    // SQLite VACUUM INTO is hot-backup-safe and produces a defragmented
+    // file. Equivalent to `sqlite3 source '.backup dest'` in effect but
+    // runs in-process via our existing connection.
+    let conn = db::open(db_path).context("opening source DB for backup")?;
+    let ts = chrono::Utc::now().format(BACKUP_TS_FMT).to_string();
+    let snapshot_name = format!("ai-memory-{ts}.db");
+    let snapshot_path = args.to.join(&snapshot_name);
+    if snapshot_path.exists() {
+        anyhow::bail!(
+            "refusing to overwrite existing snapshot {}",
+            snapshot_path.display()
+        );
+    }
+    conn.execute(
+        "VACUUM INTO ?1",
+        rusqlite::params![snapshot_path.to_string_lossy()],
+    )
+    .context("VACUUM INTO failed")?;
+    drop(conn);
+
+    let bytes = std::fs::metadata(&snapshot_path)?.len();
+    let sha = {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        let mut f = std::fs::File::open(&snapshot_path)?;
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = f.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        format!("{:x}", hasher.finalize())
+    };
+
+    let manifest = BackupManifest {
+        snapshot: snapshot_name.clone(),
+        sha256: sha.clone(),
+        bytes,
+        source_db: db_path.to_string_lossy().into_owned(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let manifest_path = args.to.join(format!("ai-memory-{ts}.manifest.json"));
+    let manifest_text = serde_json::to_string_pretty(&manifest)?;
+    std::fs::write(&manifest_path, manifest_text.as_bytes())?;
+
+    // Rotation — newest-first listing, drop everything past `keep`.
+    if args.keep > 0 {
+        prune_old_snapshots(&args.to, args.keep)?;
+    }
+
+    if json_out {
+        println!("{}", serde_json::to_string(&manifest)?);
+    } else {
+        println!("Snapshot: {}", snapshot_path.display());
+        println!("Manifest: {}", manifest_path.display());
+        println!("SHA-256 : {sha}");
+        println!("Bytes   : {bytes}");
+    }
+    Ok(())
+}
+
+/// Enumerate existing `ai-memory-*.db` snapshot files newest-first and
+/// delete everything past `keep`. Also deletes the matching manifest
+/// for each removed snapshot.
+fn prune_old_snapshots(dir: &Path, keep: usize) -> Result<()> {
+    let mut snaps: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(dir)?
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?.to_owned();
+            let is_snapshot = name.starts_with("ai-memory-")
+                && path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("db"));
+            if is_snapshot {
+                let mtime = entry.metadata().ok()?.modified().ok()?;
+                Some((mtime, path))
+            } else {
+                None
+            }
+        })
+        .collect();
+    snaps.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, path) in snaps.into_iter().skip(keep) {
+        let _ = std::fs::remove_file(&path);
+        // Matching manifest (same stem, .manifest.json extension pattern)
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            let manifest = dir.join(format!("{stem}.manifest.json"));
+            let _ = std::fs::remove_file(manifest);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_restore(db_path: &Path, args: &RestoreArgs, json_out: bool) -> Result<()> {
+    use std::io::Read;
+    let (snapshot_path, manifest_path) = if args.from.is_dir() {
+        // Pick the newest snapshot in the directory.
+        let mut snaps: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(&args.from)?
+            .filter_map(std::result::Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                let name = path.file_name()?.to_str()?.to_owned();
+                let is_snapshot = name.starts_with("ai-memory-")
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("db"));
+                if is_snapshot {
+                    let mtime = entry.metadata().ok()?.modified().ok()?;
+                    Some((mtime, path))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        snaps.sort_by(|a, b| b.0.cmp(&a.0));
+        let snap = snaps
+            .into_iter()
+            .next()
+            .map(|(_, p)| p)
+            .ok_or_else(|| anyhow::anyhow!("no snapshots found in {}", args.from.display()))?;
+        let stem = snap.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        let manifest = args.from.join(format!("{stem}.manifest.json"));
+        (snap, manifest)
+    } else {
+        // File path supplied directly.
+        let snap = args.from.clone();
+        let stem = snap.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        let parent = snap.parent().unwrap_or_else(|| Path::new("."));
+        let manifest = parent.join(format!("{stem}.manifest.json"));
+        (snap, manifest)
+    };
+
+    if !snapshot_path.exists() {
+        anyhow::bail!("snapshot {} does not exist", snapshot_path.display());
+    }
+
+    // SHA-256 verification against manifest.
+    if !args.skip_verify {
+        if !manifest_path.exists() {
+            anyhow::bail!(
+                "manifest {} not found; pass --skip-verify to restore anyway",
+                manifest_path.display()
+            );
+        }
+        let manifest_text = std::fs::read_to_string(&manifest_path)?;
+        let manifest: BackupManifest = serde_json::from_str(&manifest_text)
+            .with_context(|| format!("parsing manifest {}", manifest_path.display()))?;
+        let observed = {
+            use sha2::Digest;
+            let mut hasher = sha2::Sha256::new();
+            let mut f = std::fs::File::open(&snapshot_path)?;
+            let mut buf = vec![0u8; 64 * 1024];
+            loop {
+                let n = f.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+            }
+            format!("{:x}", hasher.finalize())
+        };
+        if observed != manifest.sha256 {
+            anyhow::bail!(
+                "sha256 mismatch — manifest says {}, snapshot is {}",
+                manifest.sha256,
+                observed
+            );
+        }
+    }
+
+    // Move current DB aside as a safety net (only if it exists).
+    if db_path.exists() {
+        let ts = chrono::Utc::now().format(BACKUP_TS_FMT).to_string();
+        let aside = db_path.with_extension(format!("pre-restore-{ts}.db"));
+        std::fs::rename(db_path, &aside)
+            .with_context(|| format!("moving current DB aside to {}", aside.display()))?;
+        if !json_out {
+            println!("Previous DB moved to {}", aside.display());
+        }
+    }
+
+    std::fs::copy(&snapshot_path, db_path)
+        .with_context(|| format!("copying snapshot to {}", db_path.display()))?;
+
+    if json_out {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "restored",
+                "from": snapshot_path.to_string_lossy(),
+                "to": db_path.to_string_lossy(),
+            })
+        );
+    } else {
+        println!(
+            "Restored {} → {}",
+            snapshot_path.display(),
+            db_path.display()
+        );
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3730,7 +3730,7 @@ fn prune_old_snapshots(dir: &Path, keep: usize) -> Result<()> {
             }
         })
         .collect();
-    snaps.sort_by(|a, b| b.0.cmp(&a.0));
+    snaps.sort_by_key(|b| std::cmp::Reverse(b.0));
     for (_, path) in snaps.into_iter().skip(keep) {
         let _ = std::fs::remove_file(&path);
         // Matching manifest (same stem, .manifest.json extension pattern)
@@ -3763,7 +3763,7 @@ fn cmd_restore(db_path: &Path, args: &RestoreArgs, json_out: bool) -> Result<()>
                 }
             })
             .collect();
-        snaps.sort_by(|a, b| b.0.cmp(&a.0));
+        snaps.sort_by_key(|b| std::cmp::Reverse(b.0));
         let snap = snaps
             .into_iter()
             .next()


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.

## Summary

Hot-backup-safe \`ai-memory backup\` + \`ai-memory restore\` CLI subcommands. Uses SQLite's \`VACUUM INTO\` for consistent point-in-time snapshots without stopping the daemon, plus a sha256 manifest for integrity verification on restore.

Companion to the systemd packaging PR (#266) — the \`ai-memory-backup.timer\` ships hourly \`--keep 48\` and becomes functional once this merges.

## Usage

\`\`\`sh
# Snapshot to ./backups/ with 48-hour retention (default).
ai-memory backup --to ./backups

# Restore from a directory (picks newest snapshot).
ai-memory restore --from ./backups

# Restore from a specific snapshot file.
ai-memory restore --from ./backups/ai-memory-2026-04-19T140806Z.db

# Skip the sha256 check (not recommended).
ai-memory restore --from ./snapshot.db --skip-verify
\`\`\`

## Output

\`\`\`
Snapshot: ./backups/ai-memory-2026-04-19T140806Z.db
Manifest: ./backups/ai-memory-2026-04-19T140806Z.manifest.json
SHA-256 : b832c2bdc763f26ee68acef0c739b288c1c5f54db536b517163479f9dac1abb2
Bytes   : 126976
\`\`\`

Manifest shape:
\`\`\`json
{
  "snapshot": "ai-memory-2026-04-19T140806Z.db",
  "sha256": "b832c2bdc763...",
  "bytes": 126976,
  "source_db": "./test.db",
  "version": "0.6.0",
  "created_at": "2026-04-19T14:08:06.123Z"
}
\`\`\`

## Safety

- **Restore NEVER silently overwrites** — the current DB is moved to \`<db>.pre-restore-<ts>.db\` as a safety net before the snapshot is copied in. A bad restore is always recoverable by reversing the rename.
- **SHA-256 verification on by default** — manifest mismatch aborts the restore with a clear error message. Opt-out via \`--skip-verify\` (documented against in the help text).
- **Refuse to overwrite existing snapshots** — if the timestamped filename already exists, the backup errors out rather than clobbering.

## Rotation

\`--keep N\` (default 48) enumerates \`ai-memory-*.db\` in the target directory by mtime, drops everything past N newest, and deletes the matching \`.manifest.json\` sibling too. Zero disables rotation.

At the systemd timer's hourly cadence with \`--keep 48\`, disk usage caps at ~48× DB size.

## Files

- \`src/main.rs\` — \`Command::Backup\` / \`Command::Restore\` variants, \`BackupArgs\` / \`RestoreArgs\` structs, \`cmd_backup\` / \`cmd_restore\` handlers, \`prune_old_snapshots\` helper, \`BackupManifest\` struct (serde-serialized)

No new deps. No schema change. CLI-only surface — HTTP and MCP do not expose backup primitives in this PR (v0.6.1 candidate: \`POST /api/v1/backup\` + \`GET /api/v1/backup/:id\`).

## E2E verification

\`\`\`
$ ai-memory --db test.db store --title "x" --content "..." --tier long
stored: b4f024a2-...

$ ai-memory --db test.db backup --to snapshots
Snapshot: snapshots/ai-memory-2026-04-19T140806Z.db
SHA-256 : b832c2bd...

$ ai-memory --db restored.db restore --from snapshots
Restored snapshots/ai-memory-2026-04-19T140806Z.db → restored.db

$ ai-memory --db restored.db list
[long/b4f024a2] x (p=5, ns=bktest, just now)
1 memory(ies)
\`\`\`

## Quality gates

- \`cargo fmt --check\` ✓
- \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` ✓
- \`AI_MEMORY_NO_CONFIG=1 cargo test\` ✓ (247 unit + 158 integration)
- \`cargo audit\` ✓

All commits SSH-signed + GitHub-verified.

## AI involvement

- Agent: Claude Opus 4.7 (1M context) via Claude Code
- Authority class: Sensitive — adds new CLI subcommands. Covered by sprint authorization #260.
- Human approver: @binary2029
- Sprint authorization: #260

## Review focus

1. **`VACUUM INTO` vs the SQLite online-backup API** — VACUUM INTO is simpler and creates a defragmented copy. The online-backup API (\`sqlite3_backup_*\`) is slightly more correct under heavy concurrent writes (streams via small locks). For daemon workloads at operator scale this is a non-issue, but worth noting if we need >1000 write/sec throughput.
2. **Manifest location** — sibling file vs embedded in snapshot DB itself. Sibling wins for easy operator inspection but can desync. Tradeoff accepted.
3. **S3 push** — deferred. The systemd unit has a commented-out \`ExecStartPost\` placeholder. Add in v0.6.1 via \`ai-memory backup push --remote s3://...\` using the \`aws-sdk-s3\` crate (noted in sprint auth #260's dep list but not used here).
4. **\`--keep\` semantics** — counts all matching files, not manifest-verified snapshots. A manually-created file named \`ai-memory-nonsense.db\` could confuse rotation. Mitigation: rotation only runs when backup itself succeeds.
5. **Safety-net retention** — \`<db>.pre-restore-<ts>.db\` is never auto-cleaned. Operators with frequent restore ops may want a cleanup helper in v0.6.1.

---

Per sprint authorization #260 (v0.6.0.0 reversible items).