### PR TITLE
feat: in-process semantic clustering via memory_cluster (v0.6.0.0)

### DIFF
--- a/src/clustering.rs
+++ b/src/clustering.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.6.0.0 — semantic clustering over memory embeddings.
+//!
+//! Lightweight in-process k-means. No new crate dep; the embedding
+//! and vector math already in-tree (cosine similarity, HNSW) give us
+//! everything we need.
+//!
+//! Exposed via the `memory_cluster` MCP tool which takes a namespace +
+//! optional k, groups the namespace's embeddings into k clusters, and
+//! returns the cluster assignments with a centroid tag label chosen
+//! from the most common tag across cluster members.
+//!
+//! Scope: a minimal, deterministic pass-good-enough clustering that
+//! agents can drive without a Python/scikit dependency. When k is
+//! omitted, it defaults to `sqrt(n/2)` (a conventional rule of thumb
+//! for k when the true structure is unknown), clamped to `[2, 16]`.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+/// A single cluster in the result.
+#[allow(clippy::struct_field_names)]
+#[derive(Debug, Clone, Serialize)]
+pub struct Cluster {
+    pub cluster_id: usize,
+    pub memory_ids: Vec<String>,
+    pub centroid_tags: Vec<String>,
+    pub member_count: usize,
+}
+
+/// Minimum number of memories required to attempt clustering. Below
+/// this, we return every memory as its own cluster.
+pub const MIN_MEMBERS_FOR_CLUSTERING: usize = 4;
+
+/// Compute k-means clusters for a namespace's memories. Results are
+/// deterministic for a given (embeddings, k) input (seed is
+/// fixed-from-first-member).
+///
+/// Returns `Ok(Vec<Cluster>)` sorted by descending `member_count`, or
+/// `Err(anyhow)` if the DB scan fails.
+#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+pub fn cluster_namespace(
+    conn: &Connection,
+    namespace: &str,
+    k: Option<usize>,
+) -> anyhow::Result<Vec<Cluster>> {
+    let members = load_members(conn, namespace)?;
+    if members.len() < MIN_MEMBERS_FOR_CLUSTERING {
+        // Each memory becomes its own cluster.
+        return Ok(members
+            .into_iter()
+            .enumerate()
+            .map(|(i, m)| Cluster {
+                cluster_id: i,
+                memory_ids: vec![m.id],
+                centroid_tags: m.tags.into_iter().take(3).collect(),
+                member_count: 1,
+            })
+            .collect());
+    }
+    let k = k
+        .unwrap_or_else(|| (((members.len() as f64) / 2.0).sqrt().ceil() as usize).max(2))
+        .clamp(2, members.len().min(16));
+
+    let embeddings: Vec<&[f32]> = members.iter().map(|m| m.embedding.as_slice()).collect();
+    let assignments = kmeans(&embeddings, k, 25);
+
+    // Group by assigned cluster id; compute centroid-tag labels per cluster
+    // from the most frequent tags across its members.
+    let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (idx, cluster_id) in assignments.iter().enumerate() {
+        groups.entry(*cluster_id).or_default().push(idx);
+    }
+    let mut clusters: Vec<Cluster> = groups
+        .into_iter()
+        .map(|(cluster_id, member_indices)| {
+            let mut tag_counts: HashMap<String, usize> = HashMap::new();
+            for i in &member_indices {
+                for tag in &members[*i].tags {
+                    *tag_counts.entry(tag.clone()).or_default() += 1;
+                }
+            }
+            let mut sorted_tags: Vec<_> = tag_counts.into_iter().collect();
+            sorted_tags.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            let centroid_tags: Vec<String> =
+                sorted_tags.into_iter().take(3).map(|(t, _)| t).collect();
+            let memory_ids: Vec<String> = member_indices
+                .iter()
+                .map(|i| members[*i].id.clone())
+                .collect();
+            let member_count = memory_ids.len();
+            Cluster {
+                cluster_id,
+                memory_ids,
+                centroid_tags,
+                member_count,
+            }
+        })
+        .collect();
+    clusters.sort_by(|a, b| b.member_count.cmp(&a.member_count));
+    Ok(clusters)
+}
+
+struct Member {
+    id: String,
+    tags: Vec<String>,
+    embedding: Vec<f32>,
+}
+
+fn load_members(conn: &Connection, namespace: &str) -> anyhow::Result<Vec<Member>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, tags, embedding FROM memories \
+         WHERE namespace = ?1 AND embedding IS NOT NULL",
+    )?;
+    let rows = stmt.query_map(params![namespace], |row| {
+        let id: String = row.get(0)?;
+        let tags_json: String = row.get(1)?;
+        let emb_bytes: Vec<u8> = row.get(2)?;
+        let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+        let embedding: Vec<f32> = emb_bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        Ok(Member {
+            id,
+            tags,
+            embedding,
+        })
+    })?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(Into::into)
+}
+
+/// Deterministic k-means on unit-normalized vectors. The initial
+/// centroids are sampled from the first `k` distinct members (no
+/// RNG — reproducible across calls with the same data). `max_iter`
+/// caps convergence.
+///
+/// Returns a vector of cluster assignments, one per input vector.
+#[allow(clippy::cast_precision_loss)]
+fn kmeans(embeddings: &[&[f32]], k: usize, max_iter: usize) -> Vec<usize> {
+    if embeddings.is_empty() || k == 0 {
+        return Vec::new();
+    }
+    let dim = embeddings[0].len();
+    // Seed centroids by equal-index stride across the input so that
+    // clusters that arrive in order (as rows tend to) get representative
+    // seed points from each region rather than k nearly-identical
+    // neighbors in the first few positions. Deterministic and cheap;
+    // a k-means++ seeding pass is a v0.6.1 polish target.
+    let n = embeddings.len();
+    let stride = (n / k).max(1);
+    let mut centroids: Vec<Vec<f32>> = (0..k)
+        .map(|i| embeddings[(i * stride).min(n - 1)].to_vec())
+        .collect();
+    // Pad if there are fewer than k members (caller already clamps,
+    // but defensive).
+    while centroids.len() < k {
+        centroids.push(vec![0.0; dim]);
+    }
+
+    let mut assignments = vec![0usize; embeddings.len()];
+    for _ in 0..max_iter {
+        let mut changed = false;
+        // Assign each point to its nearest centroid.
+        for (i, vec) in embeddings.iter().enumerate() {
+            let (best, _) = centroids
+                .iter()
+                .enumerate()
+                .map(|(j, c)| (j, squared_distance(vec, c)))
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap_or((0, 0.0));
+            if assignments[i] != best {
+                changed = true;
+                assignments[i] = best;
+            }
+        }
+        if !changed {
+            break;
+        }
+        // Recompute centroids as the mean of each cluster's members.
+        let mut sums: Vec<Vec<f32>> = vec![vec![0.0; dim]; k];
+        let mut counts = vec![0usize; k];
+        for (i, vec) in embeddings.iter().enumerate() {
+            let c = assignments[i];
+            for (d, v) in vec.iter().enumerate() {
+                sums[c][d] += v;
+            }
+            counts[c] += 1;
+        }
+        for c in 0..k {
+            if counts[c] > 0 {
+                let inv = 1.0 / counts[c] as f32;
+                for d in 0..dim {
+                    centroids[c][d] = sums[c][d] * inv;
+                }
+            }
+        }
+    }
+    assignments
+}
+
+fn squared_distance(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(xs: &[f32]) -> Vec<f32> {
+        xs.to_vec()
+    }
+
+    #[test]
+    fn kmeans_separates_two_obvious_clusters() {
+        // Two tight clusters far apart in 2-D space.
+        let a1 = v(&[0.0, 0.0]);
+        let a2 = v(&[0.01, -0.01]);
+        let a3 = v(&[-0.02, 0.02]);
+        let b1 = v(&[10.0, 10.0]);
+        let b2 = v(&[10.01, 9.99]);
+        let b3 = v(&[9.98, 10.02]);
+        let vecs: Vec<&[f32]> = vec![&a1, &a2, &a3, &b1, &b2, &b3];
+        let assignments = kmeans(&vecs, 2, 25);
+        // All A-group samples land in the same cluster; all B-group in
+        // the other.
+        assert_eq!(assignments[0], assignments[1]);
+        assert_eq!(assignments[0], assignments[2]);
+        assert_eq!(assignments[3], assignments[4]);
+        assert_eq!(assignments[3], assignments[5]);
+        assert_ne!(assignments[0], assignments[3]);
+    }
+
+    #[test]
+    fn kmeans_single_cluster_converges() {
+        // All points identical → all in same cluster regardless of k.
+        let p = v(&[1.0, 2.0, 3.0]);
+        let vecs: Vec<&[f32]> = vec![&p, &p, &p, &p];
+        let assignments = kmeans(&vecs, 2, 25);
+        assert_eq!(
+            assignments
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn kmeans_empty_input_safe() {
+        let assignments = kmeans(&[], 3, 25);
+        assert!(assignments.is_empty());
+    }
+
+    #[test]
+    fn squared_distance_zero_for_equal() {
+        assert!(squared_distance(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn squared_distance_positive() {
+        let d = squared_distance(&[0.0, 0.0], &[3.0, 4.0]);
+        assert!((d - 25.0).abs() < 1e-6);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 #![recursion_limit = "256"]
 
+mod clustering;
 mod color;
 mod config;
 mod db;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -458,6 +458,18 @@ fn tool_definitions() -> Value {
                     "type": "object",
                     "properties": {}
                 }
+            },
+            {
+                "name": "memory_cluster",
+                "description": "v0.6.0.0 — group a namespace's memories into semantic clusters using in-process k-means over the stored embeddings. Returns clusters sorted by member count, each with a centroid-tag label (up to 3 most-common tags across members). k defaults to ceil(sqrt(n/2)) clamped to [2, 16]. Namespaces with fewer than 4 embedded memories return each memory as its own singleton cluster.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "namespace": {"type": "string"},
+                        "k": {"type": "integer", "minimum": 2, "maximum": 16, "description": "Number of clusters; defaults to ceil(sqrt(n/2)) clamped to [2, 16]."}
+                    },
+                    "required": ["namespace"]
+                }
             }
         ]
     })
@@ -1862,6 +1874,26 @@ fn handle_agent_list(conn: &rusqlite::Connection) -> Result<Value, String> {
     }))
 }
 
+// --- v0.6.0.0 semantic clustering ---
+
+fn handle_cluster(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let namespace = params["namespace"]
+        .as_str()
+        .ok_or("namespace is required")?;
+    validate::validate_namespace(namespace).map_err(|e| e.to_string())?;
+    let k = params["k"]
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok())
+        .filter(|n| (2..=16).contains(n));
+    let clusters =
+        crate::clustering::cluster_namespace(conn, namespace, k).map_err(|e| e.to_string())?;
+    Ok(json!({
+        "namespace": namespace,
+        "count": clusters.len(),
+        "clusters": clusters,
+    }))
+}
+
 fn handle_pending_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let status = params["status"].as_str();
     let limit = usize::try_from(params["limit"].as_u64().unwrap_or(100))
@@ -2149,6 +2181,7 @@ fn handle_request(
                 }
                 "memory_agent_register" => handle_agent_register(conn, arguments),
                 "memory_agent_list" => handle_agent_list(conn),
+                "memory_cluster" => handle_cluster(conn, arguments),
                 _ => Err(format!("unknown tool: {tool_name}")),
             };
 
@@ -2463,10 +2496,11 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_31_tools() {
+    fn tool_definitions_returns_32_tools() {
+        // v0.6.0.0 adds memory_cluster on top of the 31 baseline.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 31);
+        assert_eq!(tools.len(), 32);
     }
 
     #[test]


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.

## Summary

Ship the v0.6.0.0 "semantic clustering" claim via lightweight in-process k-means over stored embeddings. Agents call \`memory_cluster(namespace, [k])\` and get back grouped memory ids with centroid-tag labels.

**No new deps** — k-means is ~50 LOC of plain Rust. A Python/scikit round-trip would have blown up the dep tree for a feature that ships fine without one.

## Usage

\`\`\`json
{"name":"memory_cluster","arguments":{"namespace":"ai-memory-mcp","k":5}}
\`\`\`

Returns:
\`\`\`json
{
  "namespace": "ai-memory-mcp",
  "count": 5,
  "clusters": [
    {"cluster_id":2,"member_count":42,"memory_ids":["...","..."],"centroid_tags":["release-v0.6.0","sprint","hygiene"]},
    {"cluster_id":0,"member_count":17,"memory_ids":["..."],"centroid_tags":["governance","sop","nhi"]},
    ...
  ]
}
\`\`\`

## Scope / defaults

- **k** defaults to \`ceil(sqrt(n/2))\` clamped to \`[2, 16]\`. Caller can override.
- Namespaces with fewer than **4 embedded memories** return each memory as its own singleton cluster (trivially uninformative for tiny sets).
- **Centroid labels**: up to 3 most-common tags across cluster members, tie-broken alphabetically for determinism.
- Results sorted by descending \`member_count\`.
- **Deterministic**: identical (embeddings, k) → identical output. No RNG; seed centroids via equal-index stride across the input.

## Algorithmic choice

Standard k-means (Lloyd's algorithm), 25-iteration cap with early termination on convergence (zero reassignments in a pass). Equal-stride seeding — when the first few vectors cluster tightly (common when memories are ordered by insertion), adjacent-neighbor seeds produce bad splits. Stride of \`n/k\` gives representative starts.

**Not shipping today**: k-means++ seeding, HDBSCAN, density-aware cluster count. v0.6.1 polish targets once we have a benchmark corpus to measure against.

## Files

- \`src/clustering.rs\` — new module: \`Cluster\` struct, \`cluster_namespace\` entry, \`kmeans\`, \`squared_distance\`, \`load_members\` DB reader, 5 unit tests
- \`src/main.rs\` — \`mod clustering;\`
- \`src/mcp.rs\` — \`memory_cluster\` tool definition, \`handle_cluster\` handler, dispatch arm, tool-count test updated

## Tool count

31 → 32.

## Quality gates

- \`cargo fmt --check\` ✓
- \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` ✓
- \`AI_MEMORY_NO_CONFIG=1 cargo test\` ✓ (252 unit + 158 integration — +5 new clustering tests)
- \`cargo audit\` ✓

All commits SSH-signed + GitHub-verified.

## AI involvement

- Agent: Claude Opus 4.7 (1M context) via Claude Code
- Authority class: Sensitive — new MCP tool. Covered by sprint authorization #260.
- Human approver: @binary2029
- Sprint authorization: #260

## Review focus

1. **Algorithm choice** — vanilla k-means with stride seeding. HDBSCAN would be more appropriate (no \`k\` guess, density-aware) but requires the \`hdbscan\` crate which pulls \`ndarray\` + friends. Acceptable v0.6.0.0 baseline? v0.6.1 can upgrade behind the same tool surface.
2. **Deterministic stride seeding** — works well when the DB row order is roughly uncorrelated with semantic clusters. If real data is sorted / temporally clustered, this seeding underperforms. k-means++ is the proper fix.
3. **In-memory full scan** — \`load_members\` SELECTs all embedded memories in the namespace. At 10k+ memories with 768-dim embeddings this is ~30MB of RAM per call. Fine for v0.6.0.0 single-operator deployments; eventually move to batch-streaming + out-of-core.
4. **Persistence** — results are NOT cached. Each call recomputes. v0.6.1 candidate: store the result in \`_internal/clusters/<namespace>\` memory for caching, invalidate on store.
5. **No HTTP / CLI surface** — MCP only. TS + Python SDKs already scaffold \`cluster()\` methods targeting \`POST /api/v1/cluster\`; that handler lands in v0.6.1.

---

Per sprint authorization #260 (v0.6.0.0 reversible items).