### PR TITLE
feat: contextual recall via conversation-token embedding fusion (v0.6.0.0)

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -223,6 +223,28 @@ impl Embedder {
         if denom < 1e-12 { 0.0 } else { dot / denom }
     }
 
+    /// Fuse a primary query embedding with a secondary context embedding via
+    /// weighted linear combination (v0.6.0.0 contextual recall).
+    ///
+    /// `primary_weight` clamped to `[0.0, 1.0]`. The result is returned
+    /// un-normalized — `cosine_similarity` divides out magnitudes, so the
+    /// downstream signal is direction-only. Returns `primary.to_vec()` when
+    /// dimensions differ (graceful fallback, same policy as
+    /// `cosine_similarity`).
+    #[must_use]
+    pub fn fuse(primary: &[f32], secondary: &[f32], primary_weight: f32) -> Vec<f32> {
+        if primary.len() != secondary.len() {
+            return primary.to_vec();
+        }
+        let w = primary_weight.clamp(0.0, 1.0);
+        let one_minus_w = 1.0 - w;
+        primary
+            .iter()
+            .zip(secondary.iter())
+            .map(|(p, s)| w * p + one_minus_w * s)
+            .collect()
+    }
+
     fn download_via_hf_hub() -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)>
     {
         let api = Api::new().context("failed to initialise HuggingFace Hub API")?;
@@ -303,5 +325,55 @@ mod tests {
         let b = vec![1.0, 0.0]; // Different dimension
         let sim = Embedder::cosine_similarity(&a, &b);
         assert_eq!(sim, 0.0);
+    }
+
+    // --- v0.6.0.0 contextual recall — fuse() ---
+
+    #[test]
+    fn fuse_weighted_sum() {
+        let p = vec![1.0, 0.0, 0.0];
+        let s = vec![0.0, 1.0, 0.0];
+        let f = Embedder::fuse(&p, &s, 0.7);
+        assert!((f[0] - 0.7).abs() < 1e-6);
+        assert!((f[1] - 0.3).abs() < 1e-6);
+        assert!((f[2] - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fuse_primary_weight_clamped() {
+        let p = vec![1.0, 1.0];
+        let s = vec![0.0, 0.0];
+        let f = Embedder::fuse(&p, &s, 2.0);
+        // Clamped to 1.0 — pure primary
+        assert!((f[0] - 1.0).abs() < 1e-6);
+        assert!((f[1] - 1.0).abs() < 1e-6);
+
+        let f = Embedder::fuse(&p, &s, -0.5);
+        // Clamped to 0.0 — pure secondary
+        assert!((f[0] - 0.0).abs() < 1e-6);
+        assert!((f[1] - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn fuse_dimension_mismatch_returns_primary() {
+        let p = vec![1.0, 2.0, 3.0];
+        let s = vec![4.0, 5.0]; // mismatched
+        let f = Embedder::fuse(&p, &s, 0.7);
+        assert_eq!(f, p);
+    }
+
+    #[test]
+    fn fuse_cosine_pulls_toward_context() {
+        // Query vector: [1, 0]. Context pulls toward [0, 1] at 30%.
+        // Fused direction sits between them.
+        let q = vec![1.0_f32, 0.0];
+        let ctx = vec![0.0_f32, 1.0];
+        let fused = Embedder::fuse(&q, &ctx, 0.7);
+        // cos(fused, q) should exceed cos(fused, ctx) because primary weight is 70%.
+        let sim_q = Embedder::cosine_similarity(&fused, &q);
+        let sim_ctx = Embedder::cosine_similarity(&fused, &ctx);
+        assert!(sim_q > sim_ctx);
+        assert!(sim_q > 0.9); // ~0.919 analytically
+        assert!(sim_ctx > 0.3); // ~0.394 analytically
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,13 @@ struct RecallArgs {
     /// for unlimited (limit-based only).
     #[arg(long)]
     budget_tokens: Option<usize>,
+    /// v0.6.0.0 contextual recall. Comma-separated list of recent
+    /// conversation tokens used to bias the query embedding at 70/30
+    /// (primary/context). Shifts the recall towards memories that
+    /// match both the explicit query and the conversation's nearby
+    /// topics.
+    #[arg(long, value_delimiter = ',')]
+    context_tokens: Option<Vec<String>>,
 }
 
 #[derive(Args)]
@@ -1589,7 +1596,27 @@ fn cmd_recall(
     // Perform recall: hybrid if embedder available, keyword otherwise
     let (results, tokens_used, mode) = if let Some(ref emb) = embedder {
         match emb.embed(&args.context) {
-            Ok(query_emb) => {
+            Ok(primary_emb) => {
+                // v0.6.0.0 contextual recall. Fuse the primary query
+                // embedding with an embedding over recent conversation
+                // tokens (caller-supplied) at 70/30. Fusion is done
+                // caller-side so recall_hybrid stays unaware of the bias —
+                // the vector it receives is the final query direction.
+                let query_emb = match args.context_tokens.as_deref() {
+                    Some(tokens) if !tokens.is_empty() => {
+                        let joined = tokens.join(" ");
+                        match emb.embed(&joined) {
+                            Ok(ctx_emb) => embeddings::Embedder::fuse(&primary_emb, &ctx_emb, 0.7),
+                            Err(e) => {
+                                eprintln!(
+                                    "ai-memory: context_tokens embed failed: {e}, using primary only"
+                                );
+                                primary_emb
+                            }
+                        }
+                    }
+                    _ => primary_emb,
+                };
                 let (results, tokens_used) = db::recall_hybrid(
                     &conn,
                     &args.context,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -111,6 +111,7 @@ fn tool_definitions() -> Value {
                         "until": {"type": "string", "description": "Only memories created before this RFC3339 timestamp"},
                         "as_agent": {"type": "string", "description": "Querying agent's namespace position (Task 1.5). Enables scope-based visibility filtering — results include private memories at this namespace, team/unit/org memories at ancestor subtrees, and collective memories globally."},
                         "budget_tokens": {"type": "integer", "minimum": 1, "description": "Task 1.11 — context-budget-aware recall. Return the top-ranked memories whose cumulative estimated tokens (title+content, ~4 chars/token) fit in N. Response includes tokens_used + budget_tokens."},
+                        "context_tokens": {"type": "array", "items": {"type": "string"}, "description": "v0.6.0.0 contextual recall — recent conversation tokens used to bias the query embedding at 70/30 (primary/context). Pulls results toward memories that match both the explicit query and nearby conversation topics."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens vs JSON. 'toon' includes timestamps. 'json' for structured parsing."}
                     },
                     "required": ["context"]
@@ -880,6 +881,7 @@ fn inject_namespace_standard(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 fn handle_recall(
     conn: &rusqlite::Connection,
     params: &Value,
@@ -924,6 +926,16 @@ fn handle_recall(
         .as_u64()
         .and_then(|n| usize::try_from(n).ok());
 
+    // v0.6.0.0 contextual recall — caller-supplied recent conversation tokens.
+    let context_tokens: Vec<String> = params["context_tokens"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
     // Helper: tack tokens_used / budget_tokens onto the response metadata.
     let decorate_budget = |resp: &mut Value, tokens_used: usize| {
         resp["tokens_used"] = json!(tokens_used);
@@ -935,7 +947,23 @@ fn handle_recall(
     // Use hybrid recall if embedder is available
     if let Some(emb) = embedder {
         match emb.embed(context) {
-            Ok(query_emb) => {
+            Ok(primary_emb) => {
+                // v0.6.0.0: fuse primary query with context-token embedding
+                // at 70/30 when caller supplied conversation tokens.
+                let query_emb = if context_tokens.is_empty() {
+                    primary_emb
+                } else {
+                    let joined = context_tokens.join(" ");
+                    match emb.embed(&joined) {
+                        Ok(ctx_emb) => {
+                            crate::embeddings::Embedder::fuse(&primary_emb, &ctx_emb, 0.7)
+                        }
+                        Err(e) => {
+                            tracing::warn!("context_tokens embed failed, using primary only: {e}");
+                            primary_emb
+                        }
+                    }
+                };
                 let (results, tokens_used) = db::recall_hybrid(
                     conn,
                     context,


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.
> Re-opened from auto-closed #262 after base branch was deleted by #261 squash-merge. Rebased onto release/v0.6.0.

## Summary

Adds optional `context_tokens: Vec<String>` to `memory_recall` (MCP + CLI). When supplied, the primary query embedding is fused 70/30 with an embedding of the joined context tokens, biasing recall toward memories that match both the explicit query AND nearby conversation topics.

Fusion is **caller-side** — `recall_hybrid` stays unaware of the bias. The only runtime cost is a second `embed()` call when `context_tokens` is non-empty; no per-memory logic changes.

## Usage

CLI:
```
ai-memory recall "deploy plan" --context-tokens "kubernetes,prod,hotfix,rollback"
```

MCP:
```json
{"method":"tools/call","params":{"name":"memory_recall","arguments":{"context":"deploy plan","context_tokens":["kubernetes","prod","hotfix","rollback"]}}}
```

## Gates

- cargo fmt --check — pass
- cargo clippy -D warnings -D clippy::all -D clippy::pedantic — pass
- cargo test (integration incl. test_mcp_tools_list) — pass

## AI involvement

Re-opened and rebased by Claude Opus 4.7 (1M context). Original authorship on #262.