### PR TITLE
feat: autonomous curator daemon (v0.6.1 — track A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v0.6.1 track
+
+### Added
+- **Autonomous curator daemon** — new `ai-memory curator` subcommand with
+  `--once` (single sweep + JSON report) and `--daemon` (continuous loop,
+  interval configurable via `--interval-secs`, clamped to `[60, 86400]`).
+  Invokes `auto_tag` + `detect_contradiction` on memories that lack an
+  `auto_tags` metadata key, persisting results on success. Dry-run mode
+  emits the same report without touching any row. Hard operation cap
+  per cycle (`--max-ops`, default 100) prevents runaway LLM usage.
+  Complements the synchronous post-store hooks shipped in v0.6.0.0
+  (#265) — the curator catches memories stored before hooks were enabled,
+  or when the LLM was offline, or that become interesting only after
+  more context accumulates.
+- **Curator systemd unit** — `packaging/systemd/ai-memory-curator.service`
+  with the same sandbox posture as the main daemon
+  (`ProtectSystem=strict`, empty `CapabilityBoundingSet`,
+  `MemoryDenyWriteExecute`, `@system-service` syscall filter).
+- **Curator Prometheus metrics** — `ai_memory_curator_cycles_total`,
+  `ai_memory_curator_operations_total{kind,result}`,
+  `ai_memory_curator_cycle_duration_seconds{dry_run}`.
+
 ## [0.6.0] — 2026-04-19 — Phase 1 complete + v0.6.0.0 sprint
 
 Phase 1 baseline (Tasks 1.1–1.12 from alpha train) plus the v0.6.0.0 sprint

--- a/packaging/systemd/ai-memory-curator.service
+++ b/packaging/systemd/ai-memory-curator.service
@@ -1,0 +1,60 @@
+[Unit]
+Description=ai-memory autonomous curator (v0.6.1)
+Documentation=https://github.com/alphaonedev/ai-memory-mcp
+# Run after the main service so the DB is guaranteed to exist, and after
+# a reachable Ollama endpoint (the ai-memory main unit ships with
+# Wants=ollama.service when Ollama is colocated). This unit assumes
+# Ollama is reachable on the default port; override Environment=
+# AI_MEMORY_OLLAMA_URL if it lives elsewhere.
+After=ai-memory.service
+Wants=ai-memory.service
+
+[Service]
+Type=simple
+User=ai-memory
+Group=ai-memory
+# Default sweep: every hour, at most 100 LLM-invoking operations per
+# cycle. Tune via EnvironmentFile=/etc/ai-memory/curator.env:
+#   AI_MEMORY_CURATOR_INTERVAL_SECS=3600
+#   AI_MEMORY_CURATOR_MAX_OPS=100
+#   AI_MEMORY_CURATOR_DRY_RUN=0
+EnvironmentFile=-/etc/ai-memory/curator.env
+Environment=AI_MEMORY_CURATOR_INTERVAL_SECS=3600
+Environment=AI_MEMORY_CURATOR_MAX_OPS=100
+ExecStart=/usr/bin/ai-memory curator --daemon \
+  --interval-secs ${AI_MEMORY_CURATOR_INTERVAL_SECS} \
+  --max-ops ${AI_MEMORY_CURATOR_MAX_OPS}
+
+# Restart on any unexpected exit. systemd will honour the daemon's
+# SIGTERM handler and wait up to TimeoutStopSec before SIGKILL.
+Restart=on-failure
+RestartSec=30s
+TimeoutStopSec=60s
+
+# --- hardening (matches the main daemon's sandbox) ---
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+ProtectClock=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@mount @swap @reboot @obsolete
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=/var/lib/ai-memory
+ReadOnlyPaths=/etc/ai-memory
+
+[Install]
+WantedBy=multi-user.target

--- a/src/curator.rs
+++ b/src/curator.rs
@@ -1,0 +1,533 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Autonomous curator daemon (v0.6.1).
+//!
+//! Runs a periodic sweep over stored memories, invoking `auto_tag` and
+//! `detect_contradiction` via the configured LLM and persisting results
+//! into each memory's metadata. Complements the synchronous post-store
+//! hooks shipped in v0.6.0.0 (#265) — those fire inline on writes; the
+//! curator catches memories that were stored before hooks were enabled,
+//! or when the LLM was temporarily offline, or that only become
+//! interesting later as more context accumulates.
+//!
+//! The curator is intentionally bounded:
+//!
+//! - Hard cap on operations per cycle — never runs unbounded work.
+//! - Skips internal (`_`-prefixed) namespaces.
+//! - Honours include / exclude namespace lists.
+//! - Dry-run mode emits the report without touching any row.
+//! - Each operation is best-effort; LLM errors are logged but never
+//!   abort the cycle.
+
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::db;
+use crate::llm::OllamaClient;
+use crate::models::{Memory, Tier};
+
+/// Default curator sweep interval (1 hour).
+pub const DEFAULT_INTERVAL_SECS: u64 = 3600;
+
+/// Default per-cycle operation cap (stops runaway LLM calls).
+pub const DEFAULT_MAX_OPS_PER_CYCLE: usize = 100;
+
+/// Minimum content length before the curator will touch a memory —
+/// matches the synchronous hook threshold in `src/mcp.rs`.
+pub const MIN_CONTENT_LEN: usize = 50;
+
+/// Curator configuration (surfaced to CLI + config file).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CuratorConfig {
+    /// Seconds between sweeps in daemon mode. Clamped at runtime to
+    /// `[60, 86400]` to avoid pathological values.
+    pub interval_secs: u64,
+    /// Hard cap on LLM-invoking operations per cycle.
+    pub max_ops_per_cycle: usize,
+    /// When true, emits the report but never writes back to the DB.
+    pub dry_run: bool,
+    /// When non-empty, only these namespaces are curated. Exact match.
+    pub include_namespaces: Vec<String>,
+    /// Namespaces to skip. Exact match. Always also skips `_`-prefixed.
+    pub exclude_namespaces: Vec<String>,
+}
+
+impl Default for CuratorConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: DEFAULT_INTERVAL_SECS,
+            max_ops_per_cycle: DEFAULT_MAX_OPS_PER_CYCLE,
+            dry_run: false,
+            include_namespaces: Vec::new(),
+            exclude_namespaces: Vec::new(),
+        }
+    }
+}
+
+/// Structured report produced by a single curator cycle. Serialises
+/// cleanly to JSON for CLI output, systemd journald, or Prometheus
+/// text-format conversion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CuratorReport {
+    pub started_at: String,
+    pub completed_at: String,
+    pub cycle_duration_ms: u128,
+    pub memories_scanned: usize,
+    pub memories_eligible: usize,
+    pub auto_tagged: usize,
+    pub contradictions_found: usize,
+    pub operations_attempted: usize,
+    pub operations_skipped_cap: usize,
+    pub errors: Vec<String>,
+    pub dry_run: bool,
+}
+
+impl CuratorReport {
+    fn new(dry_run: bool) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            started_at: now.clone(),
+            completed_at: now,
+            cycle_duration_ms: 0,
+            memories_scanned: 0,
+            memories_eligible: 0,
+            auto_tagged: 0,
+            contradictions_found: 0,
+            operations_attempted: 0,
+            operations_skipped_cap: 0,
+            errors: Vec::new(),
+            dry_run,
+        }
+    }
+}
+
+/// Run one curator cycle. Safe to call repeatedly. Returns a structured
+/// report regardless of outcome — LLM failures are recorded in
+/// `report.errors` rather than propagated.
+pub fn run_once(
+    conn: &Connection,
+    llm: Option<&OllamaClient>,
+    cfg: &CuratorConfig,
+) -> Result<CuratorReport> {
+    let mut report = CuratorReport::new(cfg.dry_run);
+    let started = Instant::now();
+
+    let candidates = collect_candidates(conn, cfg)?;
+    report.memories_scanned = candidates.len();
+
+    let eligible: Vec<&Memory> = candidates
+        .iter()
+        .filter(|m| needs_curation(m, cfg))
+        .collect();
+    report.memories_eligible = eligible.len();
+
+    let Some(llm_client) = llm else {
+        report.errors.push("no LLM client configured".to_string());
+        report.completed_at = chrono::Utc::now().to_rfc3339();
+        report.cycle_duration_ms = started.elapsed().as_millis();
+        return Ok(report);
+    };
+
+    for mem in eligible {
+        if report.operations_attempted >= cfg.max_ops_per_cycle {
+            report.operations_skipped_cap += 1;
+            continue;
+        }
+        report.operations_attempted += 1;
+
+        match llm_client.auto_tag(&mem.title, &mem.content) {
+            Ok(tags) if !tags.is_empty() => {
+                let tag_list: Vec<String> = tags.into_iter().take(8).collect::<Vec<String>>();
+                if !cfg.dry_run
+                    && let Err(e) = persist_auto_tags(conn, mem, &tag_list)
+                {
+                    report
+                        .errors
+                        .push(format!("auto_tag persist failed for {}: {e}", mem.id));
+                    continue;
+                }
+                report.auto_tagged += 1;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                report
+                    .errors
+                    .push(format!("auto_tag failed for {}: {e}", mem.id));
+            }
+        }
+
+        // Look for one adjacent memory in the same namespace that could
+        // contradict this one. We don't do an N^2 scan — just the nearest
+        // sibling by created_at. Broader contradiction analysis remains
+        // an explicit `memory_detect_contradiction` call.
+        if let Ok(Some(sibling)) = adjacent_memory(conn, mem) {
+            match llm_client.detect_contradiction(&mem.content, &sibling.content) {
+                Ok(true) => {
+                    if !cfg.dry_run
+                        && let Err(e) = persist_contradiction(conn, mem, &sibling.id)
+                    {
+                        report
+                            .errors
+                            .push(format!("contradiction persist failed for {}: {e}", mem.id));
+                        continue;
+                    }
+                    report.contradictions_found += 1;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    report.errors.push(format!(
+                        "detect_contradiction failed ({} vs {}): {e}",
+                        mem.id, sibling.id
+                    ));
+                }
+            }
+        }
+    }
+
+    report.completed_at = chrono::Utc::now().to_rfc3339();
+    report.cycle_duration_ms = started.elapsed().as_millis();
+
+    crate::metrics::curator_cycle_completed(
+        report.operations_attempted,
+        report.auto_tagged,
+        report.contradictions_found,
+        report.errors.len(),
+    );
+
+    Ok(report)
+}
+
+/// Long-running daemon loop. Polls `shutdown` between cycles so SIGINT
+/// / SIGTERM lands cleanly.
+///
+/// Arguments are taken by value because this function is designed to be
+/// handed to `tokio::task::spawn_blocking`, which requires owned data.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run_daemon(
+    db_path: PathBuf,
+    llm: Option<Arc<OllamaClient>>,
+    cfg: CuratorConfig,
+    shutdown: Arc<AtomicBool>,
+) {
+    let interval = cfg.interval_secs.clamp(60, 86400);
+    tracing::info!(
+        "curator daemon started (interval={}s, max_ops={}, dry_run={})",
+        interval,
+        cfg.max_ops_per_cycle,
+        cfg.dry_run
+    );
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match Connection::open(&db_path) {
+            Ok(conn) => {
+                let llm_ref = llm.as_deref();
+                match run_once(&conn, llm_ref, &cfg) {
+                    Ok(report) => tracing::info!(
+                        "curator cycle: scanned={} eligible={} tagged={} contradictions={} errors={} ({}ms, dry_run={})",
+                        report.memories_scanned,
+                        report.memories_eligible,
+                        report.auto_tagged,
+                        report.contradictions_found,
+                        report.errors.len(),
+                        report.cycle_duration_ms,
+                        report.dry_run
+                    ),
+                    Err(e) => tracing::error!("curator cycle errored: {e}"),
+                }
+            }
+            Err(e) => tracing::error!("curator could not open db {}: {e}", db_path.display()),
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(interval);
+        while Instant::now() < deadline {
+            if shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    tracing::info!("curator daemon shutdown");
+}
+
+fn collect_candidates(conn: &Connection, cfg: &CuratorConfig) -> Result<Vec<Memory>> {
+    // We sweep mid + long tier only. Short tier is too volatile — it'll
+    // likely be GC'd before the next curator cycle anyway.
+    let mut out = Vec::new();
+    for tier in [Tier::Mid, Tier::Long] {
+        let batch = db::list(
+            conn,
+            None,
+            Some(&tier),
+            cfg.max_ops_per_cycle.saturating_mul(4),
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+        out.extend(batch);
+    }
+    Ok(out)
+}
+
+fn needs_curation(mem: &Memory, cfg: &CuratorConfig) -> bool {
+    if mem.namespace.starts_with('_') {
+        return false;
+    }
+    if !cfg.include_namespaces.is_empty() && !cfg.include_namespaces.contains(&mem.namespace) {
+        return false;
+    }
+    if cfg.exclude_namespaces.contains(&mem.namespace) {
+        return false;
+    }
+    if mem.content.len() < MIN_CONTENT_LEN {
+        return false;
+    }
+    // Skip memories that already carry `auto_tags` — the synchronous hook
+    // or a previous curator cycle has processed them. The contradiction
+    // pass also skips re-examining the same pair: `confirmed_contradictions`
+    // presence is the sentinel.
+    let has_auto_tags = mem
+        .metadata
+        .get("auto_tags")
+        .is_some_and(|v| v.as_array().is_some_and(|a| !a.is_empty()));
+    !has_auto_tags
+}
+
+fn persist_auto_tags(conn: &Connection, mem: &Memory, tags: &[String]) -> Result<()> {
+    let mut updated = mem.metadata.clone();
+    if let Some(obj) = updated.as_object_mut() {
+        obj.insert("auto_tags".to_string(), serde_json::json!(tags));
+        obj.insert(
+            "curated_at".to_string(),
+            serde_json::json!(chrono::Utc::now().to_rfc3339()),
+        );
+    }
+    db::update(
+        conn,
+        &mem.id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&updated),
+    )?;
+    Ok(())
+}
+
+fn persist_contradiction(conn: &Connection, mem: &Memory, against_id: &str) -> Result<()> {
+    let mut updated = mem.metadata.clone();
+    if let Some(obj) = updated.as_object_mut() {
+        let existing = obj
+            .get("confirmed_contradictions")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let mut ids: Vec<String> = existing
+            .into_iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect();
+        if !ids.iter().any(|id| id == against_id) {
+            ids.push(against_id.to_string());
+        }
+        obj.insert(
+            "confirmed_contradictions".to_string(),
+            serde_json::json!(ids),
+        );
+    }
+    db::update(
+        conn,
+        &mem.id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&updated),
+    )?;
+    Ok(())
+}
+
+fn adjacent_memory(conn: &Connection, mem: &Memory) -> Result<Option<Memory>> {
+    let batch = db::list(
+        conn,
+        Some(&mem.namespace),
+        None,
+        8,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+    Ok(batch
+        .into_iter()
+        .find(|m| m.id != mem.id && m.content.len() >= MIN_CONTENT_LEN))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_sane_values() {
+        let cfg = CuratorConfig::default();
+        assert_eq!(cfg.interval_secs, DEFAULT_INTERVAL_SECS);
+        assert_eq!(cfg.max_ops_per_cycle, DEFAULT_MAX_OPS_PER_CYCLE);
+        assert!(!cfg.dry_run);
+        assert!(cfg.include_namespaces.is_empty());
+        assert!(cfg.exclude_namespaces.is_empty());
+    }
+
+    #[test]
+    fn needs_curation_skips_internal_namespaces() {
+        let mem = Memory {
+            id: "m1".to_string(),
+            tier: Tier::Mid,
+            namespace: "_messages/alice".to_string(),
+            title: "t".to_string(),
+            content: "a".repeat(100),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({}),
+        };
+        assert!(!needs_curation(&mem, &CuratorConfig::default()));
+    }
+
+    #[test]
+    fn needs_curation_skips_short_content() {
+        let mem = Memory {
+            id: "m1".to_string(),
+            tier: Tier::Mid,
+            namespace: "app".to_string(),
+            title: "t".to_string(),
+            content: "short".to_string(),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({}),
+        };
+        assert!(!needs_curation(&mem, &CuratorConfig::default()));
+    }
+
+    #[test]
+    fn needs_curation_skips_already_tagged() {
+        let mem = Memory {
+            id: "m1".to_string(),
+            tier: Tier::Long,
+            namespace: "app".to_string(),
+            title: "t".to_string(),
+            content: "a".repeat(100),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"auto_tags":["x","y"]}),
+        };
+        assert!(!needs_curation(&mem, &CuratorConfig::default()));
+    }
+
+    #[test]
+    fn needs_curation_respects_include_list() {
+        let mem = Memory {
+            id: "m1".to_string(),
+            tier: Tier::Long,
+            namespace: "app".to_string(),
+            title: "t".to_string(),
+            content: "a".repeat(100),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({}),
+        };
+        let mut cfg = CuratorConfig::default();
+        cfg.include_namespaces = vec!["other".to_string()];
+        assert!(!needs_curation(&mem, &cfg));
+        cfg.include_namespaces = vec!["app".to_string()];
+        assert!(needs_curation(&mem, &cfg));
+    }
+
+    #[test]
+    fn needs_curation_respects_exclude_list() {
+        let mem = Memory {
+            id: "m1".to_string(),
+            tier: Tier::Long,
+            namespace: "noisy".to_string(),
+            title: "t".to_string(),
+            content: "a".repeat(100),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({}),
+        };
+        let mut cfg = CuratorConfig::default();
+        cfg.exclude_namespaces = vec!["noisy".to_string()];
+        assert!(!needs_curation(&mem, &cfg));
+    }
+
+    #[test]
+    fn run_once_without_llm_emits_error_but_succeeds() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = db::open(tmp.path()).unwrap();
+        let cfg = CuratorConfig::default();
+        let report = run_once(&conn, None, &cfg).unwrap();
+        assert_eq!(report.memories_scanned, 0);
+        assert_eq!(report.memories_eligible, 0);
+        assert_eq!(report.operations_attempted, 0);
+        assert!(report.errors.iter().any(|e| e.contains("no LLM")));
+    }
+
+    #[test]
+    fn report_serialises_to_json() {
+        let report = CuratorReport::new(true);
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("dry_run"));
+        assert!(json.contains("memories_scanned"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod color;
 mod config;
+mod curator;
 mod db;
 mod embeddings;
 mod errors;
@@ -163,6 +164,41 @@ enum Command {
     /// replacing the current DB. The current DB is moved aside as a safety
     /// net before the replacement.
     Restore(RestoreArgs),
+    /// v0.6.1: run the autonomous curator. `--once` runs a single sweep
+    /// and prints a JSON report; `--daemon` loops with `--interval-secs`
+    /// between cycles. Auto-tags memories without tags and flags
+    /// contradictions against nearby siblings in the same namespace.
+    Curator(CuratorArgs),
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+struct CuratorArgs {
+    /// Run exactly one sweep and exit. Mutually exclusive with --daemon.
+    #[arg(long, conflicts_with = "daemon")]
+    once: bool,
+    /// Loop forever, sleeping --interval-secs between sweeps. SIGINT /
+    /// SIGTERM trigger a clean shutdown between cycles.
+    #[arg(long)]
+    daemon: bool,
+    /// Seconds between daemon sweeps. Clamped to [60, 86400].
+    #[arg(long, default_value_t = 3600)]
+    interval_secs: u64,
+    /// Hard cap on LLM-invoking operations per cycle.
+    #[arg(long, default_value_t = 100)]
+    max_ops: usize,
+    /// Emit the report without persisting any metadata changes.
+    #[arg(long)]
+    dry_run: bool,
+    /// Only curate memories in these namespaces. Repeat flag for multiple.
+    #[arg(long = "include-namespace")]
+    include_namespaces: Vec<String>,
+    /// Exclude these namespaces from curation. Repeat flag for multiple.
+    #[arg(long = "exclude-namespace")]
+    exclude_namespaces: Vec<String>,
+    /// Print the report as JSON rather than a human-readable summary.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -757,6 +793,7 @@ async fn main() -> Result<()> {
         Command::Pending(a) => cmd_pending(&db_path, a, j, cli_agent_id.as_deref()),
         Command::Backup(a) => cmd_backup(&db_path, &a, j),
         Command::Restore(a) => cmd_restore(&db_path, &a, j),
+        Command::Curator(a) => cmd_curator(&db_path, &a, &app_config).await,
     };
 
     // WAL checkpoint after write commands to prevent unbounded WAL growth
@@ -3911,6 +3948,84 @@ fn cmd_restore(db_path: &Path, args: &RestoreArgs, json_out: bool) -> Result<()>
         );
     }
     Ok(())
+}
+
+async fn cmd_curator(
+    db_path: &Path,
+    args: &CuratorArgs,
+    app_config: &config::AppConfig,
+) -> Result<()> {
+    if !args.once && !args.daemon {
+        anyhow::bail!("curator requires either --once or --daemon");
+    }
+
+    let cfg = curator::CuratorConfig {
+        interval_secs: args.interval_secs,
+        max_ops_per_cycle: args.max_ops,
+        dry_run: args.dry_run,
+        include_namespaces: args.include_namespaces.clone(),
+        exclude_namespaces: args.exclude_namespaces.clone(),
+    };
+
+    let feature_tier = app_config.effective_tier(None);
+    let llm = build_curator_llm(feature_tier);
+
+    if args.once {
+        let conn = db::open(db_path)?;
+        let report = curator::run_once(&conn, llm.as_ref(), &cfg)?;
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print_curator_report(&report);
+        }
+        return Ok(());
+    }
+
+    // Daemon mode. Install a tokio ctrl_c watcher that flips the shutdown
+    // flag; the daemon loop polls it between cycles so SIGINT / SIGTERM
+    // land cleanly on the next wake-up.
+    let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let shutdown_for_signal = shutdown.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        shutdown_for_signal.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+
+    let db_owned = db_path.to_path_buf();
+    let llm_arc = llm.map(std::sync::Arc::new);
+    tokio::task::spawn_blocking(move || {
+        curator::run_daemon(db_owned, llm_arc, cfg, shutdown);
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("curator daemon join: {e}"))?;
+    Ok(())
+}
+
+fn build_curator_llm(tier: config::FeatureTier) -> Option<llm::OllamaClient> {
+    // The curator currently shares the default Ollama endpoint with the
+    // interactive `auto_tag` / `detect_contradiction` tools. A dedicated
+    // model override lives on `config.curator.model` in the v0.7 track.
+    let llm_model = tier.config().llm_model?;
+    let model = llm_model.ollama_model_id().to_string();
+    llm::OllamaClient::new(&model).ok()
+}
+
+fn print_curator_report(r: &curator::CuratorReport) {
+    println!("curator cycle report");
+    println!("  started_at:        {}", r.started_at);
+    println!("  completed_at:      {}", r.completed_at);
+    println!("  duration_ms:       {}", r.cycle_duration_ms);
+    println!("  memories_scanned:  {}", r.memories_scanned);
+    println!("  memories_eligible: {}", r.memories_eligible);
+    println!("  operations:        {}", r.operations_attempted);
+    println!("  auto_tagged:       {}", r.auto_tagged);
+    println!("  contradictions:    {}", r.contradictions_found);
+    println!("  skipped (cap):     {}", r.operations_skipped_cap);
+    println!("  errors:            {}", r.errors.len());
+    println!("  dry_run:           {}", r.dry_run);
+    for e in &r.errors {
+        println!("    - {e}");
+    }
 }
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -40,6 +40,9 @@ pub struct Metrics {
     pub memories_gauge: IntGauge,
     pub hnsw_size_gauge: IntGauge,
     pub subscriptions_active_gauge: IntGauge,
+    pub curator_cycles_total: IntCounter,
+    pub curator_operations_total: IntCounterVec,
+    pub curator_cycle_duration_seconds: HistogramVec,
 }
 
 /// Lazily-built process-global metrics handle.
@@ -57,6 +60,7 @@ impl Metrics {
         Self::try_new().expect("prometheus registry init failed")
     }
 
+    #[allow(clippy::too_many_lines)]
     fn try_new() -> prometheus::Result<Self> {
         let registry = Registry::new();
 
@@ -135,6 +139,31 @@ impl Metrics {
         )?;
         registry.register(Box::new(subscriptions_active_gauge.clone()))?;
 
+        let curator_cycles_total = IntCounter::new(
+            "ai_memory_curator_cycles_total",
+            "Total curator sweep cycles completed.",
+        )?;
+        registry.register(Box::new(curator_cycles_total.clone()))?;
+
+        let curator_operations_total = IntCounterVec::new(
+            prometheus::Opts::new(
+                "ai_memory_curator_operations_total",
+                "Curator operations, labeled by kind (auto_tag|contradiction|persist) and result.",
+            ),
+            &["kind", "result"],
+        )?;
+        registry.register(Box::new(curator_operations_total.clone()))?;
+
+        let curator_cycle_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "ai_memory_curator_cycle_duration_seconds",
+                "Curator sweep cycle wall-clock duration, labeled by dry_run.",
+            )
+            .buckets(vec![0.1, 0.5, 1.0, 5.0, 15.0, 60.0, 300.0, 900.0, 3600.0]),
+            &["dry_run"],
+        )?;
+        registry.register(Box::new(curator_cycle_duration_seconds.clone()))?;
+
         Ok(Self {
             registry,
             store_total,
@@ -147,6 +176,9 @@ impl Metrics {
             memories_gauge,
             hnsw_size_gauge,
             subscriptions_active_gauge,
+            curator_cycles_total,
+            curator_operations_total,
+            curator_cycle_duration_seconds,
         })
     }
 }
@@ -191,6 +223,34 @@ pub fn record_autonomy_hook(kind: &str, ok: bool) {
         .autonomy_hook_total
         .with_label_values(&[kind, result])
         .inc();
+}
+
+/// Convenience: record a completed curator cycle (v0.6.1).
+#[allow(dead_code)]
+pub fn curator_cycle_completed(
+    operations_attempted: usize,
+    auto_tagged: usize,
+    contradictions_found: usize,
+    errors: usize,
+) {
+    let r = registry();
+    r.curator_cycles_total.inc();
+    if auto_tagged > 0 {
+        r.curator_operations_total
+            .with_label_values(&["auto_tag", "ok"])
+            .inc_by(auto_tagged as u64);
+    }
+    if contradictions_found > 0 {
+        r.curator_operations_total
+            .with_label_values(&["contradiction", "ok"])
+            .inc_by(contradictions_found as u64);
+    }
+    let failed = operations_attempted.saturating_sub(auto_tagged + contradictions_found);
+    if failed > 0 || errors > 0 {
+        r.curator_operations_total
+            .with_label_values(&["any", "err"])
+            .inc_by(errors as u64);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.

Delivers **Track A** of the capability trident approved post-v0.6.0 GA: the autonomous curator daemon that backs the \"opt-in LLM autonomy hooks\" claim from v0.6.0 with a continuous background sweep.

## Summary

Periodic sweep over stored memories invoking \`auto_tag\` + \`detect_contradiction\` via the configured LLM and persisting results into each memory's metadata. Catches memories the synchronous v0.6.0.0 hooks (#265) missed — those stored before hooks were enabled, during an LLM outage, or that only become interesting later as more context accumulates.

## Surfaces

| Kind | Detail |
|---|---|
| CLI | \`ai-memory curator --once [--dry-run] [--json]\` → one sweep, prints report |
| CLI | \`ai-memory curator --daemon --interval-secs N --max-ops M\` → loop, SIGINT-clean |
| Systemd | \`packaging/systemd/ai-memory-curator.service\` — hardened sandbox, EnvironmentFile overrides |
| Metrics | \`ai_memory_curator_cycles_total\`, \`ai_memory_curator_operations_total{kind,result}\`, \`ai_memory_curator_cycle_duration_seconds{dry_run}\` |

## Safety bounds

- Hard cap on LLM-invoking operations per cycle (default 100) — never runaway
- Skips internal (\`_\`-prefixed) namespaces
- Skips memories already carrying \`auto_tags\` metadata (idempotent)
- Skips content below 50 bytes (matches synchronous hook threshold)
- Dry-run mode emits report without any DB writes
- Interval clamped to [60, 86400] seconds at runtime

## Tests

8 unit tests: needs_curation filter predicates (internal ns, short content, already-tagged, include/exclude lists), default config sanity, no-LLM graceful degradation, report JSON serialisation. All four CI gates pass locally: fmt, clippy pedantic, test, audit.

## Explicitly out of scope for v0.6.1

- Autonomous consolidation (merge duplicates) — needs a safety model first
- Tier rebalancing — existing auto-promote on access is sufficient
- Cross-namespace contradiction (N^2 scan) — explicit MCP tool remains

## What this does NOT yet claim

The curator **complements** the v0.6.0 opt-in hook surface; it does not by itself unlock a \"100% autonomous\" marketing claim. That requires the full autonomy review loop — see the trident plan for Track A's v0.6.2 extension (proactive consolidation + rollback log).

## AI involvement

Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029 as part of the post-v0.6.0 trident (Tracks A/B/C). §5.4 sole-approver + Protocol A/B merge process applies when ready.