### PR TITLE
feat: SAL trait + PostgresStore + pgvector (v0.7 track B)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,15 @@
 # Affects rand 0.8.5 (via instant-distance, hf-hub) and 0.9.2 (via tokenizers, candle-core).
 # Not applicable: we do not use a custom global logger that calls rand::rng().
 # No upstream fix available — blocked on rand crate patch.
-ignore = ["RUSTSEC-2026-0097"]
+#
+# RUSTSEC-2023-0071: Marvin Attack on rsa crate via timing side-channels.
+# Reached transitively only when `--features sal-postgres` is built
+# (sqlx-macros-core unconditionally pulls sqlx-mysql → rsa). Default
+# builds of ai-memory are unaffected. We never enable the MySQL
+# backend and never expose sqlx' MySQL client surface. No fixed
+# upgrade is available on the rsa crate (per the advisory body).
+# Tracked for removal when sqlx-macros stops pulling sibling drivers.
+ignore = [
+    "RUSTSEC-2026-0097",
+    "RUSTSEC-2023-0071",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.6.1 + v0.7 tracks
 
+### Added — v0.7 Storage Abstraction Layer (Track B PR 1)
+
+- **Storage Abstraction Layer (SAL) — `MemoryStore` trait + `SqliteStore`
+  + `PostgresStore`** — preview surface for v0.7. Gated behind
+  `--features sal` (trait + sqlite adapter) and `--features sal-postgres`
+  (adds the Postgres + pgvector backend). Default builds unchanged.
+  Trait design carries over from the red-team-hardened #222 proposal:
+  typed `StoreError` with `#[non_exhaustive]`, `CallerContext` on every
+  mutator, optional `Transaction` handle, `verify()` contract, advertised
+  `Capabilities` bitflags (NATIVE_VECTOR, FULLTEXT, DURABLE, etc.).
+- **Postgres adapter ships with**:
+  - `src/store/postgres_schema.sql` — idempotent bootstrap creating the
+    `memories` table with a `vector(384)` column, pgvector `hnsw` index
+    for cosine NN search, `gin` FTS + tags + metadata indexes.
+  - `packaging/docker-compose.postgres.yml` — `pgvector/pgvector:pg16`
+    fixture for integration tests. Hardened container
+    (`cap_drop: [ALL]`, `no-new-privileges`, tmpfs for `/tmp`).
+  - Live integration tests in `src/store/postgres.rs` that skip when
+    `AI_MEMORY_TEST_POSTGRES_URL` is unset — keeps default `cargo test`
+    offline while giving CI a straightforward opt-in path.
+  - Unit-level tests: capability bits, RFC3339 parse helpers, schema
+    constants.
+
 ### Added — v0.7 quorum replication primitives (Track C PR 1)
 
 - **ADR-0001 — Quorum replication + chaos-testing methodology**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,8 +36,10 @@ name = "ai-memory"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-server",
+ "bitflags",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -50,6 +52,7 @@ dependencies = [
  "gethostname",
  "hf-hub",
  "instant-distance",
+ "pgvector",
  "prometheus",
  "reqwest",
  "rusqlite",
@@ -57,7 +60,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokenizers",
  "tokio",
  "toml",
@@ -152,6 +157,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -300,6 +325,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -577,6 +605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +624,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cookie"
@@ -653,6 +696,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +770,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -784,11 +851,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -839,7 +917,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -884,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +996,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -961,6 +1050,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1018,6 +1129,17 @@ dependencies = [
  "num-traits",
  "rand 0.9.4",
  "rand_distr",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1118,6 +1240,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1394,6 +1527,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1426,6 +1561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1580,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
@@ -1458,6 +1608,33 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1541,7 +1718,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1846,6 +2023,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1871,7 +2051,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1961,6 +2144,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2070,6 +2263,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2293,26 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2215,6 +2444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,7 +2467,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2241,6 +2476,15 @@ dependencies = [
 name = "paste"
 version = "1.0.15"
 source = "git+https://github.com/alphaonedev/paste?rev=6a30252#6a302522990cbfd9de4e0c61d91854622f7b2999"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2258,16 +2502,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "sqlx",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2584,6 +2864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,7 +2957,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2692,6 +2981,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,7 +3009,7 @@ dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -2951,6 +3260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3307,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3333,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3026,6 +3359,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3387,204 @@ dependencies = [
  "nom",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3048,6 +3598,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3338,6 +3899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,10 +4091,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3532,6 +4119,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3577,7 +4170,7 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der",
+ "der 0.8.0",
  "flate2",
  "log",
  "native-tls",
@@ -3590,7 +4183,7 @@ dependencies = [
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3706,6 +4299,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3840,11 +4439,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -3950,6 +4568,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3982,6 +4609,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4019,6 +4661,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4031,6 +4679,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4040,6 +4694,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4067,6 +4727,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4076,6 +4742,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4091,6 +4763,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4100,6 +4778,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,24 @@ toml = "0.8"
 # text/plain`). Per sprint authorization #260.
 prometheus = { version = "0.13", default-features = false }
 
+# v0.7 — Storage Abstraction Layer (SAL) deps. Gated behind the `sal`
+# feature so default builds don't pull them. `async-trait` is the
+# standard bridge for async methods on traits until stable Rust native
+# AFIT is adopted across the codebase. `bitflags` is the ecosystem
+# standard for `Capabilities`-style bitmask types. `thiserror` gives
+# us the typed `StoreError` the red-team asked for on #222. All three
+# are small, pure-Rust, MIT/Apache dual-licensed.
+async-trait = { version = "0.1", optional = true }
+bitflags = { version = "2", optional = true }
+thiserror = { version = "2", optional = true }
+
+# v0.7 — PostgresStore adapter deps. Gated behind `sal-postgres` which
+# depends on the base `sal` feature. `sqlx` is the async Postgres driver
+# (native rustls, no OpenSSL). `pgvector` is the official binding for
+# the `vector` type used by the hybrid-recall path.
+sqlx = { version = "0.8", optional = true, default-features = false, features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "json", "macros"] }
+pgvector = { version = "0.4", optional = true, features = ["sqlx"] }
+
 # v0.6.0.0 — SQLite variant selection. Default builds the standard
 # bundled SQLite (matching pre-v0.6.0.0 behavior byte-for-byte). The
 # `sqlcipher` feature swaps the underlying DB to SQLCipher (SQLite +
@@ -72,6 +90,10 @@ prometheus = { version = "0.13", default-features = false }
 default = ["sqlite-bundled"]
 sqlite-bundled = ["rusqlite/bundled"]
 sqlcipher = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
+# v0.7 — Storage Abstraction Layer. `sal` brings in the trait + SqliteStore
+# adapter. `sal-postgres` layers on the Postgres/pgvector backend.
+sal = ["dep:async-trait", "dep:bitflags", "dep:thiserror"]
+sal-postgres = ["sal", "dep:sqlx", "dep:pgvector"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/packaging/docker-compose.postgres.yml
+++ b/packaging/docker-compose.postgres.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Postgres + pgvector fixture for the SAL integration test suite (v0.7).
+#
+# Usage (from the repo root):
+#
+#   docker compose -f packaging/docker-compose.postgres.yml up -d
+#   export AI_MEMORY_TEST_POSTGRES_URL=postgres://ai_memory:ai_memory_test@localhost:5433/ai_memory_test
+#   cargo test --features sal-postgres --test sal_postgres -- --nocapture
+#   docker compose -f packaging/docker-compose.postgres.yml down -v
+#
+# Port 5433 is used instead of the default 5432 to avoid colliding with
+# a host Postgres. Override via the `POSTGRES_HOST_PORT` env var.
+
+services:
+  postgres:
+    # pgvector/pgvector bundles the vector extension with a recent
+    # Postgres 16 base image. Pinned by major version — pgvector semver
+    # has been stable on the 0.7+ release line so this image is safe to
+    # re-pull.
+    image: pgvector/pgvector:pg16
+    container_name: ai_memory_sal_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ai_memory
+      POSTGRES_PASSWORD: ai_memory_test
+      POSTGRES_DB: ai_memory_test
+      # Speeds up test setup on the fixture only — NEVER flip these on
+      # for a production Postgres.
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    ports:
+      - "${POSTGRES_HOST_PORT:-5433}:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ai_memory -d ai_memory_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+    # Hardening for the fixture — even a local test DB shouldn't ship
+    # with unnecessary caps or write access to the host.
+    cap_drop: [ALL]
+    cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
+    security_opt:
+      - no-new-privileges:true
+    read_only: false
+    tmpfs:
+      - /tmp
+      - /var/run/postgresql
+
+volumes:
+  pg_data:
+    driver: local

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ mod mine;
 mod models;
 mod replication;
 mod reranker;
+#[cfg(feature = "sal")]
+mod store;
 mod subscriptions;
 mod toon;
 mod validate;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,0 +1,347 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Storage Abstraction Layer (SAL) — v0.6.0.0 preview
+//!
+//! Defines the `MemoryStore` trait that future backends (Postgres,
+//! `LanceDB`, Qdrant, S3-backed) implement to plug into `ai-memory`.
+//! The in-tree `SqliteStore` adapter wraps the existing `crate::db`
+//! free functions so the production path can opt in gradually without
+//! a big-bang rewrite.
+//!
+//! ## Design principles (from the PR #222 red-team)
+//!
+//! 1. **Typed `StoreError`, not `anyhow::Result`** — callers must be
+//!    able to match on error kinds (`NotFound` vs `Conflict` vs
+//!    `BackendUnavailable` vs `PermissionDenied`). `#[non_exhaustive]`
+//!    lets new variants land without breaking consumers.
+//! 2. **`CallerContext` on every mutator** — governance / NHI
+//!    attribution threads through the trait boundary, not from
+//!    per-method `Option<&str>` shims that the red-team found could be
+//!    bypassed.
+//! 3. **`Transaction` handle** — multi-step ops (store + link, approve
+//!    + mutate) get an explicit unit-of-work type. Backends that lack
+//!    transactions return `StoreError::UnsupportedCapability`.
+//! 4. **`verify()` provenance contract** — signed-memory and agent
+//!    attribution guarantees from Tasks 1.2 / 1.3 survive the SAL
+//!    layer. Any adapter that silently mutates content must provide a
+//!    re-sign step.
+//! 5. **Feature-gated** — the whole module tree compiles only under
+//!    `--features sal`, so standard builds are unaffected.
+//!
+//! ## Stability
+//!
+//! This is a **v0.6.0.0 preview**. The trait surface is expected to
+//! shift during v0.7 as real adapters land. Consumers outside this
+//! repo should pin against `sal = 0.1` semantics and expect
+//! breaking changes on minor bumps.
+//!
+//! No production call site dispatches through the trait yet — the
+//! existing `crate::db` free-function API remains the active path.
+//! The `dead_code` lint is silenced at module granularity for that
+//! reason; every public symbol is reachable from the trait's unit
+//! tests and from future consumer PRs.
+
+#![allow(dead_code)]
+// The SAL trait's design-principles docblock uses numbered continuation
+// lines whose visual indent clippy `doc_lazy_continuation` doesn't
+// recognize. Reformatting to satisfy the lint makes the doc noticeably
+// uglier; silencing it module-wide is the better tradeoff.
+#![allow(clippy::doc_lazy_continuation)]
+
+pub mod sqlite;
+
+#[cfg(feature = "sal-postgres")]
+pub mod postgres;
+
+use bitflags::bitflags;
+
+use crate::models::{AgentRegistration, Memory, MemoryLink, Tier};
+
+/// The single error type returned by every `MemoryStore` method.
+///
+/// Callers match on the variant they care about; the trailing
+/// `#[non_exhaustive]` attribute reserves room for new variants
+/// without breaking downstream matches.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("memory not found: {id}")]
+    NotFound { id: String },
+
+    #[error("identifier conflict on insert: {id}")]
+    Conflict { id: String },
+
+    #[error("caller lacks permission for {action} on {target}: {reason}")]
+    PermissionDenied {
+        action: String,
+        target: String,
+        reason: String,
+    },
+
+    #[error("backend unavailable: {backend}: {detail}")]
+    BackendUnavailable { backend: String, detail: String },
+
+    #[error("invalid input: {detail}")]
+    InvalidInput { detail: String },
+
+    #[error("requested capability not supported by this backend: {capability}")]
+    UnsupportedCapability { capability: String },
+
+    #[error("integrity check failed: {detail}")]
+    IntegrityFailed { detail: String },
+
+    #[error("underlying backend error: {0}")]
+    Backend(#[from] BoxBackendError),
+}
+
+/// Escape hatch for adapter-specific errors that don't map cleanly to
+/// a `StoreError` variant. Adapters wrap their native error types in
+/// this to retain the underlying cause without leaking the concrete
+/// type across the trait boundary.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct BoxBackendError(String);
+
+impl BoxBackendError {
+    #[must_use]
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
+/// Convenience alias — every trait method returns this.
+pub type StoreResult<T> = Result<T, StoreError>;
+
+/// Identity + visibility + governance context threaded through every
+/// mutating operation. Reuses the NHI-hardened `agent_id` from the
+/// existing `crate::identity` resolution chain.
+#[derive(Debug, Clone)]
+pub struct CallerContext {
+    /// The calling agent's resolved `agent_id` (same validation as
+    /// `crate::identity::resolve_agent_id`).
+    pub agent_id: String,
+    /// Optional `as_agent` — when set, visibility filtering runs as
+    /// if this agent were the caller (Task 1.5 scope semantics).
+    pub as_agent: Option<String>,
+    /// Optional request correlator for audit trails. Opaque string;
+    /// adapters may persist as metadata.
+    pub request_id: Option<String>,
+}
+
+impl CallerContext {
+    /// Construct a caller context from a resolved agent id. Most
+    /// callers use this directly; the richer builders are for tests.
+    #[must_use]
+    pub fn for_agent(agent_id: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            as_agent: None,
+            request_id: None,
+        }
+    }
+}
+
+bitflags! {
+    /// Capability flags advertised by each adapter. Enables feature
+    /// detection at runtime so the upper layers can degrade gracefully
+    /// rather than error on unsupported ops.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Capabilities: u32 {
+        /// Adapter supports `begin_transaction` for multi-op atomicity.
+        const TRANSACTIONS         = 0b0000_0001;
+        /// Native vector search (pgvector, HNSW index inside adapter,
+        /// etc.) rather than fallback via this crate's `crate::hnsw`.
+        const NATIVE_VECTOR        = 0b0000_0010;
+        /// Adapter supports full-text search without an external index.
+        const FULLTEXT             = 0b0000_0100;
+        /// Adapter persists across process restarts (excludes
+        /// `InMemoryStore` test doubles).
+        const DURABLE              = 0b0000_1000;
+        /// Adapter supports strong (linearizable) reads. Eventual-
+        /// consistency adapters clear this bit.
+        const STRONG_CONSISTENCY   = 0b0001_0000;
+        /// Adapter honors native TTL expiry without application-level
+        /// sweeps.
+        const TTL_NATIVE           = 0b0010_0000;
+        /// Adapter supports atomic multi-row writes (batch insert
+        /// under one transaction).
+        const ATOMIC_MULTI_WRITE   = 0b0100_0000;
+    }
+}
+
+/// A unit-of-work handle. Acquired via `MemoryStore::begin_transaction`.
+///
+/// Closing semantics:
+/// - Calling `commit()` finalizes the transaction and releases the
+///   handle.
+/// - Dropping without commit aborts (rollback).
+/// - `Drop::drop` is best-effort; adapters that can fail at rollback
+///   time MUST log but NOT panic.
+#[async_trait::async_trait]
+pub trait Transaction: Send {
+    /// Commit the transaction. On success the handle is consumed.
+    async fn commit(self: Box<Self>) -> StoreResult<()>;
+    /// Explicitly roll back. Same effect as drop but surfaces any
+    /// backend error to the caller.
+    async fn rollback(self: Box<Self>) -> StoreResult<()>;
+}
+
+/// Filter shape passed to `list` / `search` / `recall`. Each field
+/// narrows the result set; `None` / empty means "don't narrow on this
+/// axis".
+#[derive(Debug, Default, Clone)]
+pub struct Filter {
+    pub namespace: Option<String>,
+    pub tier: Option<Tier>,
+    pub tags_any: Vec<String>,
+    pub agent_id: Option<String>,
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
+    pub until: Option<chrono::DateTime<chrono::Utc>>,
+    pub limit: usize,
+}
+
+/// The core trait. Every backend implements this; ai-memory's HTTP /
+/// MCP / CLI handlers depend only on `dyn MemoryStore`.
+#[async_trait::async_trait]
+pub trait MemoryStore: Send + Sync {
+    /// Capability bits advertised by this adapter. Stable across the
+    /// process lifetime.
+    fn capabilities(&self) -> Capabilities;
+
+    /// Store a memory. The `ctx` supplies the calling agent; the
+    /// `Memory.metadata.agent_id` field is authoritative over any
+    /// client-supplied value.
+    async fn store(&self, ctx: &CallerContext, memory: &Memory) -> StoreResult<String>;
+
+    /// Fetch a memory by id. Returns `NotFound` when the memory does
+    /// not exist OR when the caller lacks read permission (the trait
+    /// deliberately does not leak existence; adapters must fold
+    /// permission denials into `NotFound`).
+    async fn get(&self, ctx: &CallerContext, id: &str) -> StoreResult<Memory>;
+
+    /// Update fields of an existing memory. Every adapter MUST
+    /// preserve `metadata.agent_id` across update per Task 1.2 —
+    /// see the caller-side `identity::preserve_agent_id` helper.
+    async fn update(&self, ctx: &CallerContext, id: &str, patch: UpdatePatch) -> StoreResult<()>;
+
+    /// Hard-delete a memory. Returns `NotFound` if already gone.
+    async fn delete(&self, ctx: &CallerContext, id: &str) -> StoreResult<()>;
+
+    /// List matching memories. Ordering is adapter-specific but
+    /// deterministic across calls with identical `Filter`.
+    async fn list(&self, ctx: &CallerContext, filter: &Filter) -> StoreResult<Vec<Memory>>;
+
+    /// Keyword search (FTS-equivalent). Adapters without full-text
+    /// search may return `UnsupportedCapability` and let upper
+    /// layers fall back.
+    async fn search(
+        &self,
+        ctx: &CallerContext,
+        query: &str,
+        filter: &Filter,
+    ) -> StoreResult<Vec<Memory>>;
+
+    /// Verify the stored memory's integrity — provenance chain,
+    /// signature when present, embedding dimensionality sanity. Used
+    /// during migration + sync reconciliation.
+    async fn verify(&self, ctx: &CallerContext, id: &str) -> StoreResult<VerifyReport>;
+
+    /// Begin a transaction. Adapters that lack transaction support
+    /// return `UnsupportedCapability` and callers should downgrade to
+    /// sequential ops.
+    async fn begin_transaction(&self, _ctx: &CallerContext) -> StoreResult<Box<dyn Transaction>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "TRANSACTIONS".to_string(),
+        })
+    }
+
+    /// Create a typed link between two memories.
+    async fn link(&self, ctx: &CallerContext, link: &MemoryLink) -> StoreResult<()>;
+
+    /// Register an agent in the adapter's `_agents` namespace (Task
+    /// 1.3).
+    async fn register_agent(
+        &self,
+        ctx: &CallerContext,
+        agent: &AgentRegistration,
+    ) -> StoreResult<()>;
+}
+
+/// Partial-update payload. `None` means "leave this field alone" —
+/// serde `Option<Option<T>>` gymnastics are out of scope for v0.6.0.0.
+#[derive(Debug, Default, Clone)]
+pub struct UpdatePatch {
+    pub title: Option<String>,
+    pub content: Option<String>,
+    pub tier: Option<Tier>,
+    pub namespace: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub priority: Option<i32>,
+    pub confidence: Option<f64>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Report produced by `verify`.
+#[derive(Debug, Clone)]
+pub struct VerifyReport {
+    pub memory_id: String,
+    pub integrity_ok: bool,
+    pub findings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caller_context_builder_defaults() {
+        let ctx = CallerContext::for_agent("alice");
+        assert_eq!(ctx.agent_id, "alice");
+        assert!(ctx.as_agent.is_none());
+        assert!(ctx.request_id.is_none());
+    }
+
+    #[test]
+    fn capabilities_bitflags_compose() {
+        let caps = Capabilities::TRANSACTIONS | Capabilities::DURABLE;
+        assert!(caps.contains(Capabilities::TRANSACTIONS));
+        assert!(caps.contains(Capabilities::DURABLE));
+        assert!(!caps.contains(Capabilities::NATIVE_VECTOR));
+    }
+
+    #[test]
+    fn store_error_display_is_human_readable() {
+        let err = StoreError::NotFound {
+            id: "abc".to_string(),
+        };
+        assert_eq!(err.to_string(), "memory not found: abc");
+        let err = StoreError::PermissionDenied {
+            action: "read".to_string(),
+            target: "memory/abc".to_string(),
+            reason: "row-level ACL".to_string(),
+        };
+        assert!(err.to_string().contains("read"));
+        assert!(err.to_string().contains("row-level ACL"));
+    }
+
+    #[test]
+    fn default_begin_transaction_errors() {
+        // The default trait method returns UnsupportedCapability;
+        // adapters that actually support txns override it. This is
+        // checked indirectly — adapters without an override will
+        // surface the error via this variant when called.
+        let err = StoreError::UnsupportedCapability {
+            capability: "TRANSACTIONS".to_string(),
+        };
+        assert!(err.to_string().contains("TRANSACTIONS"));
+    }
+
+    #[test]
+    fn filter_defaults_are_empty() {
+        let f = Filter::default();
+        assert!(f.namespace.is_none());
+        assert!(f.tier.is_none());
+        assert!(f.tags_any.is_empty());
+    }
+}

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1,0 +1,593 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Postgres + pgvector adapter for the Storage Abstraction Layer (v0.7).
+//!
+//! Gated behind the `sal-postgres` cargo feature, which layers on top of
+//! the base `sal` feature. Default builds do not pull sqlx or pgvector.
+//!
+//! # Schema
+//!
+//! The adapter owns its schema (CREATE TABLE IF NOT EXISTS at init) —
+//! no manual DBA step required. The embedding column is `vector(384)`
+//! to match the default `MiniLmL6V2` model; adapters configured for
+//! `NomicEmbedV15` need to drop the column and recreate with
+//! `vector(768)` (tooling for that will land with the migration helper
+//! in a follow-up).
+//!
+//! ```sql
+//! CREATE EXTENSION IF NOT EXISTS vector;
+//!
+//! CREATE TABLE IF NOT EXISTS memories (
+//!     id            TEXT PRIMARY KEY,
+//!     tier          TEXT NOT NULL,
+//!     namespace     TEXT NOT NULL,
+//!     title         TEXT NOT NULL,
+//!     content       TEXT NOT NULL,
+//!     tags          JSONB NOT NULL DEFAULT '[]'::jsonb,
+//!     priority      INTEGER NOT NULL DEFAULT 5,
+//!     confidence    DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+//!     source        TEXT NOT NULL,
+//!     access_count  BIGINT NOT NULL DEFAULT 0,
+//!     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//!     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//!     last_accessed_at TIMESTAMPTZ,
+//!     expires_at    TIMESTAMPTZ,
+//!     metadata      JSONB NOT NULL DEFAULT '{}'::jsonb,
+//!     embedding     vector(384)
+//! );
+//!
+//! CREATE INDEX IF NOT EXISTS memories_namespace_idx ON memories (namespace);
+//! CREATE INDEX IF NOT EXISTS memories_tier_idx ON memories (tier);
+//! CREATE INDEX IF NOT EXISTS memories_tags_gin ON memories USING gin (tags);
+//! CREATE INDEX IF NOT EXISTS memories_content_fts ON memories
+//!     USING gin (to_tsvector('english', title || ' ' || content));
+//! CREATE INDEX IF NOT EXISTS memories_embedding_hnsw ON memories
+//!     USING hnsw (embedding vector_cosine_ops);
+//! ```
+//!
+//! # Capabilities
+//!
+//! This adapter advertises `TRANSACTIONS | NATIVE_VECTOR | FULLTEXT |
+//! DURABLE | STRONG_CONSISTENCY | ATOMIC_MULTI_WRITE`. It does **not**
+//! currently advertise `TTL_NATIVE` — expiry sweeps still run
+//! application-side to match `SqliteStore` semantics.
+//!
+//! # Testing
+//!
+//! Integration tests in `tests/sal_postgres.rs` run iff
+//! `AI_MEMORY_TEST_POSTGRES_URL` is set (typically pointed at the
+//! `docker compose -f packaging/docker-compose.postgres.yml up`
+//! fixture). Unit tests in this module exercise only the SQL-builder
+//! helpers that don't need a running Postgres.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use sqlx::{PgPool, Row};
+
+use super::{
+    CallerContext, Capabilities, Filter, MemoryStore, StoreError, StoreResult, UpdatePatch,
+    VerifyReport,
+};
+use crate::models::{AgentRegistration, Memory, MemoryLink, Tier};
+
+/// Bootstrap schema run at adapter init — idempotent via IF NOT EXISTS.
+const INIT_SCHEMA: &str = include_str!("postgres_schema.sql");
+
+/// Default connection pool settings. Tuned for a mid-range ai-memory
+/// daemon — adjust via `PostgresStore::with_pool_options` when wiring
+/// a larger deployment.
+const DEFAULT_MAX_CONNECTIONS: u32 = 16;
+const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// `PostgresStore` — sqlx + pgvector backend. Owns a connection pool.
+#[derive(Clone)]
+pub struct PostgresStore {
+    pool: PgPool,
+}
+
+impl PostgresStore {
+    /// Connect using a Postgres URL (e.g. `postgres://user:pass@host:5432/db`).
+    /// Runs the bootstrap schema on the first connection acquired.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::BackendUnavailable` if the connection
+    /// cannot be established or the schema bootstrap fails.
+    pub async fn connect(url: &str) -> StoreResult<Self> {
+        let options: PgConnectOptions =
+            url.parse()
+                .map_err(|e: sqlx::Error| StoreError::BackendUnavailable {
+                    backend: "postgres".to_string(),
+                    detail: format!("parse url: {e}"),
+                })?;
+        let pool = PgPoolOptions::new()
+            .max_connections(DEFAULT_MAX_CONNECTIONS)
+            .acquire_timeout(DEFAULT_ACQUIRE_TIMEOUT)
+            .connect_with(options)
+            .await
+            .map_err(|e| StoreError::BackendUnavailable {
+                backend: "postgres".to_string(),
+                detail: format!("connect: {e}"),
+            })?;
+
+        // Bootstrap schema — idempotent.
+        sqlx::raw_sql(INIT_SCHEMA)
+            .execute(&pool)
+            .await
+            .map_err(|e| StoreError::BackendUnavailable {
+                backend: "postgres".to_string(),
+                detail: format!("init schema: {e}"),
+            })?;
+
+        Ok(Self { pool })
+    }
+
+    fn row_to_memory(row: &sqlx::postgres::PgRow) -> StoreResult<Memory> {
+        let created_at: DateTime<Utc> = row
+            .try_get("created_at")
+            .map_err(|e| to_store_err("read created_at", e))?;
+        let updated_at: DateTime<Utc> = row
+            .try_get("updated_at")
+            .map_err(|e| to_store_err("read updated_at", e))?;
+        let last_accessed_at: Option<DateTime<Utc>> = row
+            .try_get("last_accessed_at")
+            .map_err(|e| to_store_err("read last_accessed_at", e))?;
+        let expires_at: Option<DateTime<Utc>> = row
+            .try_get("expires_at")
+            .map_err(|e| to_store_err("read expires_at", e))?;
+
+        let tier_str: String = row
+            .try_get("tier")
+            .map_err(|e| to_store_err("read tier", e))?;
+        let tier = Tier::from_str(&tier_str).ok_or_else(|| StoreError::IntegrityFailed {
+            detail: format!("invalid tier value: {tier_str}"),
+        })?;
+
+        let tags_json: serde_json::Value = row
+            .try_get("tags")
+            .map_err(|e| to_store_err("read tags", e))?;
+        let tags: Vec<String> = serde_json::from_value(tags_json).unwrap_or_default();
+
+        let metadata: serde_json::Value = row
+            .try_get("metadata")
+            .map_err(|e| to_store_err("read metadata", e))?;
+
+        Ok(Memory {
+            id: row.try_get("id").map_err(|e| to_store_err("read id", e))?,
+            tier,
+            namespace: row
+                .try_get("namespace")
+                .map_err(|e| to_store_err("read namespace", e))?,
+            title: row
+                .try_get("title")
+                .map_err(|e| to_store_err("read title", e))?,
+            content: row
+                .try_get("content")
+                .map_err(|e| to_store_err("read content", e))?,
+            tags,
+            priority: row
+                .try_get("priority")
+                .map_err(|e| to_store_err("read priority", e))?,
+            confidence: row
+                .try_get("confidence")
+                .map_err(|e| to_store_err("read confidence", e))?,
+            source: row
+                .try_get("source")
+                .map_err(|e| to_store_err("read source", e))?,
+            access_count: row
+                .try_get("access_count")
+                .map_err(|e| to_store_err("read access_count", e))?,
+            created_at: created_at.to_rfc3339(),
+            updated_at: updated_at.to_rfc3339(),
+            last_accessed_at: last_accessed_at.map(|t| t.to_rfc3339()),
+            expires_at: expires_at.map(|t| t.to_rfc3339()),
+            metadata,
+        })
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn to_store_err(what: &str, e: sqlx::Error) -> StoreError {
+    StoreError::BackendUnavailable {
+        backend: "postgres".to_string(),
+        detail: format!("{what}: {e}"),
+    }
+}
+
+fn parse_rfc3339_opt(s: Option<&str>) -> Option<DateTime<Utc>> {
+    s.and_then(|raw| DateTime::parse_from_rfc3339(raw).ok().map(Into::into))
+}
+
+fn parse_rfc3339_required(s: &str) -> StoreResult<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(Into::into)
+        .map_err(|e| StoreError::IntegrityFailed {
+            detail: format!("invalid rfc3339 timestamp {s}: {e}"),
+        })
+}
+
+#[async_trait]
+impl MemoryStore for PostgresStore {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::TRANSACTIONS
+            | Capabilities::NATIVE_VECTOR
+            | Capabilities::FULLTEXT
+            | Capabilities::DURABLE
+            | Capabilities::STRONG_CONSISTENCY
+            | Capabilities::ATOMIC_MULTI_WRITE
+    }
+
+    async fn store(&self, _ctx: &CallerContext, memory: &Memory) -> StoreResult<String> {
+        let created_at = parse_rfc3339_required(&memory.created_at)?;
+        let updated_at = parse_rfc3339_required(&memory.updated_at)?;
+        let last_accessed_at = parse_rfc3339_opt(memory.last_accessed_at.as_deref());
+        let expires_at = parse_rfc3339_opt(memory.expires_at.as_deref());
+        let tags_json =
+            serde_json::to_value(&memory.tags).map_err(|e| StoreError::IntegrityFailed {
+                detail: format!("serialize tags: {e}"),
+            })?;
+
+        sqlx::query(
+            "INSERT INTO memories (
+                id, tier, namespace, title, content, tags, priority, confidence,
+                source, access_count, created_at, updated_at, last_accessed_at,
+                expires_at, metadata
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            ON CONFLICT (id) DO UPDATE SET
+                title = EXCLUDED.title,
+                content = EXCLUDED.content,
+                tier = EXCLUDED.tier,
+                namespace = EXCLUDED.namespace,
+                tags = EXCLUDED.tags,
+                priority = EXCLUDED.priority,
+                confidence = EXCLUDED.confidence,
+                updated_at = EXCLUDED.updated_at,
+                metadata = EXCLUDED.metadata",
+        )
+        .bind(&memory.id)
+        .bind(memory.tier.as_str())
+        .bind(&memory.namespace)
+        .bind(&memory.title)
+        .bind(&memory.content)
+        .bind(&tags_json)
+        .bind(memory.priority)
+        .bind(memory.confidence)
+        .bind(&memory.source)
+        .bind(memory.access_count)
+        .bind(created_at)
+        .bind(updated_at)
+        .bind(last_accessed_at)
+        .bind(expires_at)
+        .bind(&memory.metadata)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| to_store_err("insert memory", e))?;
+
+        Ok(memory.id.clone())
+    }
+
+    async fn get(&self, _ctx: &CallerContext, id: &str) -> StoreResult<Memory> {
+        let row = sqlx::query("SELECT * FROM memories WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| to_store_err("select by id", e))?;
+        match row {
+            Some(r) => Self::row_to_memory(&r),
+            None => Err(StoreError::NotFound { id: id.to_string() }),
+        }
+    }
+
+    async fn update(&self, _ctx: &CallerContext, id: &str, patch: UpdatePatch) -> StoreResult<()> {
+        // One-shot COALESCE update — each patch field overrides only if
+        // Some, otherwise falls through to the existing value. Avoids a
+        // read-modify-write round trip.
+        let rows_affected = sqlx::query(
+            "UPDATE memories SET
+                title = COALESCE($2, title),
+                content = COALESCE($3, content),
+                tier = COALESCE($4, tier),
+                namespace = COALESCE($5, namespace),
+                tags = COALESCE($6, tags),
+                priority = COALESCE($7, priority),
+                confidence = COALESCE($8, confidence),
+                metadata = COALESCE($9, metadata),
+                updated_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(id)
+        .bind(patch.title)
+        .bind(patch.content)
+        .bind(patch.tier.as_ref().map(Tier::as_str))
+        .bind(patch.namespace)
+        .bind(
+            patch
+                .tags
+                .map(serde_json::to_value)
+                .transpose()
+                .map_err(|e| StoreError::IntegrityFailed {
+                    detail: format!("serialize tags patch: {e}"),
+                })?,
+        )
+        .bind(patch.priority)
+        .bind(patch.confidence)
+        .bind(patch.metadata)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| to_store_err("update", e))?
+        .rows_affected();
+
+        if rows_affected == 0 {
+            Err(StoreError::NotFound { id: id.to_string() })
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn delete(&self, _ctx: &CallerContext, id: &str) -> StoreResult<()> {
+        let rows_affected = sqlx::query("DELETE FROM memories WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| to_store_err("delete", e))?
+            .rows_affected();
+        if rows_affected == 0 {
+            Err(StoreError::NotFound { id: id.to_string() })
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn list(&self, _ctx: &CallerContext, filter: &Filter) -> StoreResult<Vec<Memory>> {
+        let limit: i64 = filter.limit.clamp(1, 1000).try_into().unwrap_or(100);
+        let rows = sqlx::query(
+            "SELECT * FROM memories
+             WHERE ($1::text IS NULL OR namespace = $1)
+               AND ($2::text IS NULL OR tier = $2)
+               AND (expires_at IS NULL OR expires_at > NOW())
+               AND ($3::timestamptz IS NULL OR created_at >= $3)
+               AND ($4::timestamptz IS NULL OR created_at <= $4)
+             ORDER BY priority DESC, updated_at DESC
+             LIMIT $5",
+        )
+        .bind(filter.namespace.as_ref())
+        .bind(filter.tier.as_ref().map(Tier::as_str))
+        .bind(filter.since)
+        .bind(filter.until)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("list", e))?;
+
+        rows.iter().map(Self::row_to_memory).collect()
+    }
+
+    async fn search(
+        &self,
+        _ctx: &CallerContext,
+        query: &str,
+        filter: &Filter,
+    ) -> StoreResult<Vec<Memory>> {
+        let limit: i64 = filter.limit.clamp(1, 1000).try_into().unwrap_or(100);
+        let rows = sqlx::query(
+            "SELECT *,
+                    ts_rank(
+                        to_tsvector('english', title || ' ' || content),
+                        plainto_tsquery('english', $1)
+                    ) AS rank
+             FROM memories
+             WHERE to_tsvector('english', title || ' ' || content) @@ plainto_tsquery('english', $1)
+               AND ($2::text IS NULL OR namespace = $2)
+               AND ($3::text IS NULL OR tier = $3)
+               AND (expires_at IS NULL OR expires_at > NOW())
+             ORDER BY rank DESC, priority DESC
+             LIMIT $4",
+        )
+        .bind(query)
+        .bind(filter.namespace.as_ref())
+        .bind(filter.tier.as_ref().map(Tier::as_str))
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("search", e))?;
+
+        rows.iter().map(Self::row_to_memory).collect()
+    }
+
+    async fn verify(&self, _ctx: &CallerContext, id: &str) -> StoreResult<VerifyReport> {
+        // Minimal verify: confirm the row is readable and the tier +
+        // timestamps parse. Integrity signatures land with the
+        // provenance work on the Postgres track next sprint.
+        let mem = self.get(_ctx, id).await?;
+        let mut findings = Vec::new();
+        if mem.content.is_empty() {
+            findings.push("empty content".to_string());
+        }
+        parse_rfc3339_required(&mem.created_at).map_err(|_| StoreError::IntegrityFailed {
+            detail: format!("invalid created_at on {id}"),
+        })?;
+        Ok(VerifyReport {
+            memory_id: id.to_string(),
+            integrity_ok: findings.is_empty(),
+            findings,
+        })
+    }
+
+    async fn link(&self, _ctx: &CallerContext, link: &MemoryLink) -> StoreResult<()> {
+        // The SQL schema has no links table yet in this preview. The
+        // follow-up PR adds `memory_links` + a link() implementation.
+        // We return UnsupportedCapability rather than silently no-op.
+        let _ = link;
+        Err(StoreError::UnsupportedCapability {
+            capability: "LINKS".to_string(),
+        })
+    }
+
+    async fn register_agent(
+        &self,
+        _ctx: &CallerContext,
+        agent: &AgentRegistration,
+    ) -> StoreResult<()> {
+        // Agent registration lives in a dedicated table on the Postgres
+        // track next sprint. The Task 1.3 baseline ships on SqliteStore
+        // only for v0.7-alpha.
+        let _ = agent;
+        Err(StoreError::UnsupportedCapability {
+            capability: "AGENT_REGISTRATION".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_advertise_native_vector() {
+        // The Postgres backend must advertise NATIVE_VECTOR + FULLTEXT
+        // so callers can skip the in-process HNSW fallback.
+        // We can't construct a real PostgresStore without a connection,
+        // so we check the constant bits directly via a dummy pool-less
+        // match. This is a trait-surface test only.
+        let caps = Capabilities::TRANSACTIONS
+            | Capabilities::NATIVE_VECTOR
+            | Capabilities::FULLTEXT
+            | Capabilities::DURABLE
+            | Capabilities::STRONG_CONSISTENCY
+            | Capabilities::ATOMIC_MULTI_WRITE;
+        assert!(caps.contains(Capabilities::NATIVE_VECTOR));
+        assert!(caps.contains(Capabilities::FULLTEXT));
+        assert!(caps.contains(Capabilities::STRONG_CONSISTENCY));
+        assert!(!caps.contains(Capabilities::TTL_NATIVE));
+    }
+
+    #[test]
+    fn parse_rfc3339_opt_handles_some_and_none() {
+        assert!(parse_rfc3339_opt(None).is_none());
+        assert!(parse_rfc3339_opt(Some("not a date")).is_none());
+        let parsed = parse_rfc3339_opt(Some("2026-04-19T16:00:00Z"));
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn parse_rfc3339_required_rejects_garbage() {
+        assert!(parse_rfc3339_required("garbage").is_err());
+        assert!(parse_rfc3339_required("2026-04-19T16:00:00Z").is_ok());
+    }
+
+    #[test]
+    fn init_schema_contains_vector_extension_and_indexes() {
+        // Sanity: make sure the bootstrap SQL references the critical
+        // constructs so a typo'd rename catches here in CI.
+        assert!(INIT_SCHEMA.contains("CREATE EXTENSION IF NOT EXISTS vector"));
+        assert!(INIT_SCHEMA.contains("memories_embedding_hnsw"));
+        assert!(INIT_SCHEMA.contains("to_tsvector"));
+    }
+
+    // ------------------------------------------------------------------
+    // Live-Postgres integration tests.
+    //
+    // Run iff AI_MEMORY_TEST_POSTGRES_URL is set; otherwise they skip
+    // cleanly so the default `cargo test` flow stays offline.
+    //
+    // Quick-start:
+    //   docker compose -f packaging/docker-compose.postgres.yml up -d
+    //   export AI_MEMORY_TEST_POSTGRES_URL=postgres://ai_memory:ai_memory_test@localhost:5433/ai_memory_test
+    //   cargo test --features sal-postgres store::postgres -- --nocapture
+    // ------------------------------------------------------------------
+
+    fn postgres_url() -> Option<String> {
+        std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
+    }
+
+    fn sample_memory(id: &str, ns: &str, title: &str, content: &str) -> Memory {
+        let now = chrono::Utc::now().to_rfc3339();
+        Memory {
+            id: id.to_string(),
+            tier: Tier::Mid,
+            namespace: ns.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            tags: vec!["test".to_string()],
+            priority: 5,
+            confidence: 1.0,
+            source: "sal-integration".to_string(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"agent_id":"ai:sal-test"}),
+        }
+    }
+
+    #[tokio::test]
+    async fn live_store_get_roundtrip() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let mem = sample_memory(
+            &format!("test-{}", uuid::Uuid::new_v4()),
+            "sal-test",
+            "hello",
+            "quick brown fox jumps over the lazy dog",
+        );
+        let returned = store.store(&ctx, &mem).await.expect("store");
+        assert_eq!(returned, mem.id);
+        let fetched = store.get(&ctx, &mem.id).await.expect("get");
+        assert_eq!(fetched.title, "hello");
+        assert_eq!(fetched.namespace, "sal-test");
+    }
+
+    #[tokio::test]
+    async fn live_search_finds_fts_match() {
+        let Some(url) = postgres_url() else {
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.unwrap();
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let id = format!("search-test-{}", uuid::Uuid::new_v4());
+        let mem = sample_memory(
+            &id,
+            "sal-search",
+            "uniquephrase xyzzy42",
+            "body containing uniquephrase xyzzy42 as a distinctive token",
+        );
+        store.store(&ctx, &mem).await.unwrap();
+        let filter = Filter {
+            namespace: Some("sal-search".to_string()),
+            limit: 5,
+            ..Filter::default()
+        };
+        let hits = store
+            .search(&ctx, "xyzzy42", &filter)
+            .await
+            .expect("search");
+        assert!(hits.iter().any(|m| m.id == id));
+    }
+
+    #[tokio::test]
+    async fn live_delete_removes_row() {
+        let Some(url) = postgres_url() else {
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.unwrap();
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let id = format!("del-test-{}", uuid::Uuid::new_v4());
+        let mem = sample_memory(&id, "sal-del", "to be deleted", "soon gone");
+        store.store(&ctx, &mem).await.unwrap();
+        store.delete(&ctx, &id).await.expect("delete");
+        let err = store.get(&ctx, &id).await.unwrap_err();
+        match err {
+            StoreError::NotFound { id: missing } => assert_eq!(missing, id),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+}

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -1,0 +1,49 @@
+-- Copyright 2026 AlphaOne LLC
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Postgres + pgvector schema for the PostgresStore SAL adapter (v0.7).
+-- Idempotent — this script runs on every PostgresStore::connect() and
+-- must tolerate being re-executed against an already-populated DB.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS memories (
+    id                TEXT PRIMARY KEY,
+    tier              TEXT NOT NULL,
+    namespace         TEXT NOT NULL,
+    title             TEXT NOT NULL,
+    content           TEXT NOT NULL,
+    tags              JSONB NOT NULL DEFAULT '[]'::jsonb,
+    priority          INTEGER NOT NULL DEFAULT 5,
+    confidence        DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    source            TEXT NOT NULL,
+    access_count      BIGINT NOT NULL DEFAULT 0,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_accessed_at  TIMESTAMPTZ,
+    expires_at        TIMESTAMPTZ,
+    metadata          JSONB NOT NULL DEFAULT '{}'::jsonb,
+    embedding         vector(384)
+);
+
+CREATE INDEX IF NOT EXISTS memories_namespace_idx ON memories (namespace);
+CREATE INDEX IF NOT EXISTS memories_tier_idx ON memories (tier);
+CREATE INDEX IF NOT EXISTS memories_priority_idx ON memories (priority DESC);
+CREATE INDEX IF NOT EXISTS memories_updated_at_idx ON memories (updated_at DESC);
+CREATE INDEX IF NOT EXISTS memories_expires_at_idx ON memories (expires_at)
+    WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS memories_tags_gin ON memories USING gin (tags);
+CREATE INDEX IF NOT EXISTS memories_metadata_gin ON memories USING gin (metadata);
+
+-- Full-text search index. Uses English stemming; the ai-memory codebase
+-- is English-primary today. Add per-namespace configurable stemming in
+-- a follow-up when the i18n track opens.
+CREATE INDEX IF NOT EXISTS memories_content_fts ON memories
+    USING gin (to_tsvector('english', title || ' ' || content));
+
+-- HNSW vector index for cosine-distance nearest-neighbor queries.
+-- Default pgvector HNSW params are reasonable for up to ~1M rows;
+-- tune `m` / `ef_construction` via ALTER INDEX ... SET for larger
+-- corpora. Rebuild required on parameter change.
+CREATE INDEX IF NOT EXISTS memories_embedding_hnsw ON memories
+    USING hnsw (embedding vector_cosine_ops);

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1,0 +1,323 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-tree `SqliteStore` adapter. Wraps the existing `crate::db` free
+//! functions so the production path can migrate to the SAL trait
+//! gradually. No behavior change vs. calling `crate::db` directly —
+//! this is a thin shim whose only job is to prove the trait surface
+//! fits the shape of the shipped code.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::db;
+use crate::models::{AgentRegistration, Memory, MemoryLink};
+
+use super::{
+    BoxBackendError, CallerContext, Capabilities, Filter, MemoryStore, StoreError, StoreResult,
+    Transaction, UpdatePatch, VerifyReport,
+};
+
+/// SAL adapter over the existing bundled-SQLite storage. Holds an
+/// `Arc<Mutex<Connection>>` matching the HTTP daemon's shared state so
+/// the adapter can be used alongside the existing free-function code
+/// paths during the migration.
+pub struct SqliteStore {
+    state: Arc<Mutex<rusqlite::Connection>>,
+    path: PathBuf,
+}
+
+impl SqliteStore {
+    /// Open (or create) a `SqliteStore` at the given path. Delegates
+    /// schema init + migration to `crate::db::open`.
+    pub fn open(path: impl Into<PathBuf>) -> StoreResult<Self> {
+        let path = path.into();
+        let conn = db::open(&path).map_err(box_err)?;
+        Ok(Self {
+            state: Arc::new(Mutex::new(conn)),
+            path,
+        })
+    }
+
+    /// Path the adapter opened. Useful for diagnostics and for
+    /// callers that need to spawn subprocesses (backup, rekey).
+    #[must_use]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+fn box_err<E: std::fmt::Display>(e: E) -> StoreError {
+    StoreError::Backend(BoxBackendError::new(e.to_string()))
+}
+
+#[async_trait::async_trait]
+impl MemoryStore for SqliteStore {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::TRANSACTIONS
+            | Capabilities::FULLTEXT
+            | Capabilities::DURABLE
+            | Capabilities::STRONG_CONSISTENCY
+            | Capabilities::ATOMIC_MULTI_WRITE
+    }
+
+    async fn store(&self, _ctx: &CallerContext, memory: &Memory) -> StoreResult<String> {
+        let conn = self.state.lock().await;
+        db::insert(&conn, memory).map_err(box_err)
+    }
+
+    async fn get(&self, _ctx: &CallerContext, id: &str) -> StoreResult<Memory> {
+        let conn = self.state.lock().await;
+        match db::get(&conn, id).map_err(box_err)? {
+            Some(mem) => Ok(mem),
+            None => Err(StoreError::NotFound { id: id.to_string() }),
+        }
+    }
+
+    async fn update(&self, _ctx: &CallerContext, id: &str, patch: UpdatePatch) -> StoreResult<()> {
+        let conn = self.state.lock().await;
+        let (found, _content_changed) = db::update(
+            &conn,
+            id,
+            patch.title.as_deref(),
+            patch.content.as_deref(),
+            patch.tier.as_ref(),
+            patch.namespace.as_deref(),
+            patch.tags.as_ref(),
+            patch.priority,
+            patch.confidence,
+            None,
+            patch.metadata.as_ref(),
+        )
+        .map_err(box_err)?;
+        if found {
+            Ok(())
+        } else {
+            Err(StoreError::NotFound { id: id.to_string() })
+        }
+    }
+
+    async fn delete(&self, _ctx: &CallerContext, id: &str) -> StoreResult<()> {
+        let conn = self.state.lock().await;
+        let removed = db::delete(&conn, id).map_err(box_err)?;
+        if removed {
+            Ok(())
+        } else {
+            Err(StoreError::NotFound { id: id.to_string() })
+        }
+    }
+
+    async fn list(&self, _ctx: &CallerContext, filter: &Filter) -> StoreResult<Vec<Memory>> {
+        let conn = self.state.lock().await;
+        let tags_first = filter.tags_any.first().map(String::as_str);
+        let since = filter.since.map(|d| d.to_rfc3339());
+        let until = filter.until.map(|d| d.to_rfc3339());
+        db::list(
+            &conn,
+            filter.namespace.as_deref(),
+            filter.tier.as_ref(),
+            if filter.limit == 0 { 100 } else { filter.limit },
+            0,
+            None,
+            since.as_deref(),
+            until.as_deref(),
+            tags_first,
+            filter.agent_id.as_deref(),
+        )
+        .map_err(box_err)
+    }
+
+    async fn search(
+        &self,
+        ctx: &CallerContext,
+        query: &str,
+        filter: &Filter,
+    ) -> StoreResult<Vec<Memory>> {
+        let conn = self.state.lock().await;
+        let tags_first = filter.tags_any.first().map(String::as_str);
+        let since = filter.since.map(|d| d.to_rfc3339());
+        let until = filter.until.map(|d| d.to_rfc3339());
+        db::search(
+            &conn,
+            query,
+            filter.namespace.as_deref(),
+            filter.tier.as_ref(),
+            if filter.limit == 0 { 100 } else { filter.limit },
+            None,
+            since.as_deref(),
+            until.as_deref(),
+            tags_first,
+            filter.agent_id.as_deref(),
+            ctx.as_agent.as_deref(),
+        )
+        .map_err(box_err)
+    }
+
+    async fn verify(&self, _ctx: &CallerContext, id: &str) -> StoreResult<VerifyReport> {
+        let conn = self.state.lock().await;
+        let Some(mem) = db::get(&conn, id).map_err(box_err)? else {
+            return Err(StoreError::NotFound { id: id.to_string() });
+        };
+        // v0.6.0.0 preview: minimal integrity check. Confirms that
+        // the memory has a non-empty title + content and its
+        // `metadata.agent_id` round-trips as a string. Real
+        // signature verification lands alongside Task 1.4.
+        let mut findings: Vec<String> = Vec::new();
+        if mem.title.trim().is_empty() {
+            findings.push("title is empty".to_string());
+        }
+        if mem.content.trim().is_empty() {
+            findings.push("content is empty".to_string());
+        }
+        if mem.metadata.get("agent_id").is_none() {
+            findings.push("metadata.agent_id missing".to_string());
+        }
+        Ok(VerifyReport {
+            memory_id: id.to_string(),
+            integrity_ok: findings.is_empty(),
+            findings,
+        })
+    }
+
+    async fn link(&self, _ctx: &CallerContext, link: &MemoryLink) -> StoreResult<()> {
+        let conn = self.state.lock().await;
+        db::create_link(
+            &conn,
+            &link.source_id,
+            &link.target_id,
+            link.relation.as_str(),
+        )
+        .map_err(box_err)
+    }
+
+    async fn register_agent(
+        &self,
+        _ctx: &CallerContext,
+        agent: &AgentRegistration,
+    ) -> StoreResult<()> {
+        let conn = self.state.lock().await;
+        db::register_agent(
+            &conn,
+            &agent.agent_id,
+            &agent.agent_type,
+            &agent.capabilities,
+        )
+        .map_err(box_err)
+        .map(|_id| ())
+    }
+}
+
+/// Transaction handle that no-ops commit (`SQLite` txn support is
+/// available via `rusqlite::Connection::unchecked_transaction` but
+/// wrapping through the mutex gets awkward — for the preview, callers
+/// that need real atomicity should still reach through `crate::db`
+/// directly).
+#[allow(dead_code)]
+pub struct SqliteTransaction;
+
+#[async_trait::async_trait]
+impl Transaction for SqliteTransaction {
+    async fn commit(self: Box<Self>) -> StoreResult<()> {
+        Ok(())
+    }
+
+    async fn rollback(self: Box<Self>) -> StoreResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Tier;
+
+    fn test_memory(title: &str, content: &str) -> Memory {
+        let now = chrono::Utc::now().to_rfc3339();
+        Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: Tier::Mid,
+            namespace: "sal-test".to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            tags: vec!["test".to_string()],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"agent_id": "alice"}),
+        }
+    }
+
+    #[tokio::test]
+    async fn roundtrip_store_get() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let store = SqliteStore::open(tmp.path()).expect("open");
+        let ctx = CallerContext::for_agent("alice");
+        let mem = test_memory("hello", "world one two three four five six seven");
+        let stored_id = store.store(&ctx, &mem).await.expect("store");
+        let loaded = store.get(&ctx, &stored_id).await.expect("get");
+        assert_eq!(loaded.title, "hello");
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_not_found() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let store = SqliteStore::open(tmp.path()).expect("open");
+        let ctx = CallerContext::for_agent("alice");
+        let err = store
+            .get(&ctx, "00000000-0000-0000-0000-000000000000")
+            .await
+            .expect_err("should be NotFound");
+        assert!(matches!(err, StoreError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn capabilities_declare_sqlite_reality() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let store = SqliteStore::open(tmp.path()).expect("open");
+        let caps = store.capabilities();
+        assert!(caps.contains(Capabilities::DURABLE));
+        assert!(caps.contains(Capabilities::FULLTEXT));
+        assert!(caps.contains(Capabilities::STRONG_CONSISTENCY));
+        // NATIVE_VECTOR is intentionally NOT set — semantic search
+        // happens above this layer via crate::hnsw, not inside the
+        // adapter.
+        assert!(!caps.contains(Capabilities::NATIVE_VECTOR));
+    }
+
+    #[tokio::test]
+    async fn verify_flags_empty_content() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let store = SqliteStore::open(tmp.path()).expect("open");
+        let ctx = CallerContext::for_agent("alice");
+        let mut mem = test_memory("hello", "x content long enough to pass validate");
+        mem.content = "nonempty for store".to_string();
+        let id = store.store(&ctx, &mem).await.expect("store");
+        // Manually corrupt metadata.agent_id via update.
+        store
+            .update(
+                &ctx,
+                &id,
+                UpdatePatch {
+                    metadata: Some(serde_json::json!({})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update");
+        let report = store.verify(&ctx, &id).await.expect("verify");
+        assert!(!report.integrity_ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("metadata.agent_id"))
+        );
+    }
+}


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.

Track B of the post-v0.6.0 trident — delivers the **infrastructure** behind a future "full cloud agentic" claim. Does NOT by itself justify that claim yet (see \"claim discipline\" below).

## What's in

Base MemoryStore trait + SqliteStore carry over from the red-team-hardened #222 design (typed StoreError, threaded CallerContext, Transaction handle, verify() contract, Capabilities bitflags). Adds a new **PostgresStore** backend on sqlx + pgvector.

| Build command | Default-build impact | Backends available |
|---|---|---|
| \`cargo build\` | unchanged | SqliteStore via \`crate::db\` free fns |
| \`cargo build --features sal\` | +async-trait, +bitflags, +thiserror | + SqliteStore adapter |
| \`cargo build --features sal-postgres\` | + sqlx + pgvector | + PostgresStore |

## Postgres adapter

- \`src/store/postgres.rs\` — sqlx + pgvector backend. Owns a connection pool (16 max, 30 s acquire timeout default). Advertises NATIVE_VECTOR | FULLTEXT | DURABLE | STRONG_CONSISTENCY | ATOMIC_MULTI_WRITE | TRANSACTIONS. Implements store / get / update / delete / list / search / verify. \`link()\` + \`register_agent()\` return UnsupportedCapability until the schema follow-up lands in the next v0.7 PR.
- \`src/store/postgres_schema.sql\` — idempotent bootstrap: \`memories\` table with \`vector(384)\` embedding column, HNSW index for cosine NN, gin indexes for FTS + tags + metadata, partial index on \`expires_at\`.
- \`packaging/docker-compose.postgres.yml\` — \`pgvector/pgvector:pg16\` fixture on port 5433. Hardened container (cap_drop=ALL, no-new-privileges, tmpfs for /tmp + /var/run/postgresql).

## Testing

- 4 unit tests (capabilities bits, RFC3339 parse helpers, schema constants).
- 3 **live integration tests** gated on \`AI_MEMORY_TEST_POSTGRES_URL\` — skip cleanly when unset so default \`cargo test\` stays offline.
- Run suite: \`docker compose -f packaging/docker-compose.postgres.yml up -d && export AI_MEMORY_TEST_POSTGRES_URL=postgres://ai_memory:ai_memory_test@localhost:5433/ai_memory_test && cargo test --features sal-postgres store::postgres\`.

All four CI gates pass locally on default features: fmt, clippy pedantic, cargo test, cargo audit.

## Claim discipline

This PR is **infrastructure**. It does NOT yet justify a "full cloud agentic" marketing claim. The v0.7 release needs:

- [ ] Daemon-level adapter selection (\`--store postgres://...\`)
- [ ] Migration tooling SQLite → Postgres
- [ ] Heterogeneous sync (SQLite ↔ Postgres)
- [ ] End-to-end integration tests running against both backends in CI

Those land in follow-up PRs. The CHANGELOG [Unreleased] block in this PR says so explicitly.

## AI involvement

Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029 as part of the post-v0.6.0 trident (Tracks A/B/C). Supersedes + extends #275 which stays closed.