### PR TITLE
feat: cross-backend migration tool — ai-memory migrate (Track B PR 2, stacks on #279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,52 @@ It does **not** yet claim multi-agent autonomy across a federation
 (that's Track C) or cross-backend autonomy (that's Track B).
 "100% autonomous" without those caveats would still be overclaiming.
 
+### Added — cross-backend migration (Track B PR 2)
+
+- **`ai-memory migrate --from <url> --to <url>`** CLI subcommand,
+  gated behind `--features sal`. Supported URL shapes:
+  - `sqlite:///absolute/path.db` / `sqlite://./relative.db` → `SqliteStore`
+  - `postgres://user:pass@host:port/db` → `PostgresStore`
+    (only under `--features sal-postgres`)
+- Reads pages via `MemoryStore::list`, writes via `MemoryStore::store`.
+  **Idempotent on re-run** — source ids are preserved verbatim and
+  both adapters upsert on id.
+- `--batch N` (1..10 000, default 1000), `--namespace <ns>` filter,
+  `--dry-run`, `--json` for machine-readable reports.
+- **6 unit tests**: sqlite URL parsing, unknown-scheme rejection,
+  sqlite→sqlite full-roundtrip, dry-run writes nothing, idempotent
+  re-run, namespace filter.
+- Pagination strategy: slides `until` window backwards with dedup by
+  id — handles identical `created_at` timestamps that break naïve
+  `since`-cursor paging on SQLite.
+
+### What's still out of scope for v0.7-alpha
+
+Explicitly deferred to v0.7.1 (noted in `src/migrate.rs` docblock):
+
+- **Daemon-level adapter selection** (`ai-memory serve --store-url
+  postgres://…`) — requires refactoring `handlers.rs` from
+  `crate::db::` free functions to dispatch through
+  `Box<dyn MemoryStore>`. That's a big change and belongs in its
+  own PR.
+- **Live dual-write** — reverse migration (pg → sqlite) works using
+  the same command but there is no always-on replication between
+  heterogenous backends yet.
+- **Schema rewriting** — both adapters currently agree on the
+  `Memory` shape so no field mapping is needed.
+
+### Cross-backend-autonomy claim now earned
+
+v0.7-alpha earns: **"one-shot migration between SQLite and
+Postgres/pgvector, bidirectional, idempotent"**.
+
+Still honest caveats:
+- A production deployment running `ai-memory serve` against Postgres
+  as the live store needs v0.7.1's adapter-selection refactor.
+- The migration is file-level point-in-time. For zero-downtime cutover
+  you still need to stop writes on the source, migrate, and restart
+  against the destination — documented in the module docblock.
+
 ## [0.6.0] — 2026-04-19 — Phase 1 complete + v0.6.0.0 sprint
 
 Phase 1 baseline (Tasks 1.1–1.12 from alpha train) plus the v0.6.0.0 sprint

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ mod identity;
 mod llm;
 mod mcp;
 mod metrics;
+#[cfg(feature = "sal")]
+mod migrate;
 mod mine;
 mod models;
 mod replication;
@@ -173,6 +175,12 @@ enum Command {
     /// between cycles. Auto-tags memories without tags and flags
     /// contradictions against nearby siblings in the same namespace.
     Curator(CuratorArgs),
+    /// v0.7: migrate memories between SAL backends. Gated behind
+    /// `--features sal`. Reads pages via `MemoryStore::list`, writes
+    /// via `MemoryStore::store`. Idempotent: source ids are preserved
+    /// and both adapters upsert on id.
+    #[cfg(feature = "sal")]
+    Migrate(MigrateArgs),
 }
 
 #[derive(Args)]
@@ -212,6 +220,30 @@ struct CuratorArgs {
     /// instead of a single id.
     #[arg(long)]
     rollback_last: Option<usize>,
+}
+
+#[cfg(feature = "sal")]
+#[derive(Args)]
+struct MigrateArgs {
+    /// Source URL. `sqlite:///path/to/file.db` or
+    /// `postgres://user:pass@host:port/dbname`.
+    #[arg(long)]
+    from: String,
+    /// Destination URL. Same URL shape as `--from`.
+    #[arg(long)]
+    to: String,
+    /// Page size. Clamped to [1, 10000]. Default 1000.
+    #[arg(long, default_value_t = 1000)]
+    batch: usize,
+    /// Only migrate memories in this namespace.
+    #[arg(long)]
+    namespace: Option<String>,
+    /// Emit the report but do NOT write to the destination.
+    #[arg(long)]
+    dry_run: bool,
+    /// Emit the report as JSON rather than human-readable text.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -703,6 +735,7 @@ fn human_age(iso: &str) -> String {
 }
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
 async fn main() -> Result<()> {
     color::init();
     let app_config = config::AppConfig::load();
@@ -807,6 +840,8 @@ async fn main() -> Result<()> {
         Command::Backup(a) => cmd_backup(&db_path, &a, j),
         Command::Restore(a) => cmd_restore(&db_path, &a, j),
         Command::Curator(a) => cmd_curator(&db_path, &a, &app_config).await,
+        #[cfg(feature = "sal")]
+        Command::Migrate(a) => cmd_migrate(&a).await,
     };
 
     // WAL checkpoint after write commands to prevent unbounded WAL growth
@@ -4127,6 +4162,52 @@ fn print_curator_report(r: &curator::CuratorReport) {
     for e in &r.errors {
         println!("    - {e}");
     }
+}
+
+#[cfg(feature = "sal")]
+async fn cmd_migrate(args: &MigrateArgs) -> Result<()> {
+    let src = migrate::open_store(&args.from)
+        .await
+        .context("open source store")?;
+    let dst = migrate::open_store(&args.to)
+        .await
+        .context("open destination store")?;
+    let report = migrate::migrate(
+        src.as_ref(),
+        dst.as_ref(),
+        args.batch,
+        args.namespace.clone(),
+        args.dry_run,
+    )
+    .await;
+    if args.json {
+        let value = serde_json::json!({
+            "from_url": args.from,
+            "to_url": args.to,
+            "memories_read": report.memories_read,
+            "memories_written": report.memories_written,
+            "batches": report.batches,
+            "errors": report.errors,
+            "dry_run": report.dry_run,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("migration report");
+        println!("  from:              {}", args.from);
+        println!("  to:                {}", args.to);
+        println!("  memories_read:     {}", report.memories_read);
+        println!("  memories_written:  {}", report.memories_written);
+        println!("  batches:           {}", report.batches);
+        println!("  dry_run:           {}", report.dry_run);
+        println!("  errors:            {}", report.errors.len());
+        for e in &report.errors {
+            println!("    - {e}");
+        }
+    }
+    if !report.errors.is_empty() {
+        anyhow::bail!("migration completed with {} error(s)", report.errors.len());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,337 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-backend migration tool — stream memories from one SAL backend
+//! to another (v0.7 track B, PR 2 of N).
+//!
+//! Gated behind `--features sal` (trait + `SqliteStore`), extended
+//! transparently by `--features sal-postgres` (adds the Postgres
+//! adapter).
+//!
+//! ## Supported URL shapes
+//!
+//! - `sqlite:///absolute/path/to/file.db` → `SqliteStore`
+//! - `sqlite://./relative/path.db` (two slashes) → `SqliteStore`
+//! - `postgres://user:pass@host:port/dbname` → `PostgresStore`
+//!   (only when `--features sal-postgres`)
+//!
+//! Anything else is rejected with a clear error.
+//!
+//! ## CLI
+//!
+//! ```text
+//! ai-memory migrate --from sqlite:///var/lib/ai-memory/ai-memory.db \
+//!                   --to postgres://user:pass@pg:5432/ai_memory \
+//!                   [--batch 1000] [--dry-run] [--namespace foo]
+//! ```
+//!
+//! Reads batches via `MemoryStore::list`, writes via `MemoryStore::store`.
+//! Each write uses the source memory's id verbatim — the adapter's
+//! upsert-on-id semantics means repeating the migration is idempotent.
+//!
+//! ## What this module does NOT do
+//!
+//! - **Daemon adapter selection** (`ai-memory serve --store-url
+//!   postgres://…`) — that's a bigger refactor because `handlers.rs`
+//!   still calls `crate::db::` free functions. Deferred to v0.7.1.
+//! - **Live dual-write** — this is a one-way copy. Reverse migration
+//!   (pg → sqlite) works identically but carries the same semantics.
+//! - **Schema rewriting** — both backends use the same `Memory` shape.
+
+#![cfg(feature = "sal")]
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+
+use crate::store::{CallerContext, Filter, MemoryStore, sqlite::SqliteStore};
+
+/// One migration batch. Exposed for external callers that want to
+/// run a migration programmatically (e.g. a test harness or a
+/// management-plane service).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct MigrationReport {
+    pub from_url: String,
+    pub to_url: String,
+    pub memories_read: usize,
+    pub memories_written: usize,
+    pub batches: usize,
+    pub errors: Vec<String>,
+    pub dry_run: bool,
+}
+
+/// Build a `Box<dyn MemoryStore>` from a URL. Feature-gated — the
+/// Postgres branch exists only when `sal-postgres` is compiled in.
+///
+/// Async because the `sal-postgres` branch awaits a connection-pool
+/// build. The `sqlite://` branch is synchronous under the hood but
+/// returns via the same `Future` so callers have a single polymorphic
+/// code path regardless of feature combination.
+///
+/// # Errors
+///
+/// Returns an error for unrecognised URL schemes or adapter-
+/// construction failures (bad path, unreachable Postgres, etc.).
+#[allow(clippy::unused_async)]
+pub async fn open_store(url: &str) -> Result<Box<dyn MemoryStore>> {
+    if let Some(path) = url.strip_prefix("sqlite://") {
+        // Strip the optional third slash (sqlite:///foo → /foo;
+        // sqlite://./foo → ./foo).
+        let clean = path
+            .strip_prefix('/')
+            .map_or(path, |p| if p.starts_with('/') { p } else { path });
+        let store = SqliteStore::open(clean).context("open sqlite adapter")?;
+        return Ok(Box::new(store));
+    }
+
+    #[cfg(feature = "sal-postgres")]
+    if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+        let store = crate::store::postgres::PostgresStore::connect(url)
+            .await
+            .context("connect postgres adapter")?;
+        return Ok(Box::new(store));
+    }
+
+    anyhow::bail!("unrecognised store URL: {url} (expected sqlite:///path or postgres://...)")
+}
+
+/// Run the migration. Streams through the source in pages of
+/// `batch_size`, writing each page to the destination. Idempotent on
+/// re-run — both adapters' `store` implementations upsert on memory id.
+pub async fn migrate(
+    from: &dyn MemoryStore,
+    to: &dyn MemoryStore,
+    batch_size: usize,
+    namespace_filter: Option<String>,
+    dry_run: bool,
+) -> MigrationReport {
+    let ctx = CallerContext::for_agent("ai:migrate");
+    let mut report = MigrationReport {
+        memories_read: 0,
+        memories_written: 0,
+        batches: 0,
+        errors: Vec::new(),
+        dry_run,
+        ..MigrationReport::default()
+    };
+
+    // Pagination strategy: adapters' `list` returns memories ordered by
+    // priority DESC, updated_at DESC (the in-tree SqliteStore shape).
+    // We cannot rely on a stable `since` cursor without duplicates, so
+    // we fetch with progressively smaller `until` windows and
+    // deduplicate by id. For v0.7-alpha this is fine for databases up
+    // to the order of millions of rows — large adapters will ship a
+    // cursor-based `list_page` in a follow-up.
+    let mut seen: HashSet<String> = HashSet::new();
+    let batch_size = batch_size.clamp(1, 10_000);
+    // Start with a very large upper bound so the first page is the most
+    // recent `batch_size` memories; slide `until` backwards for each
+    // subsequent page.
+    let mut until: Option<chrono::DateTime<chrono::Utc>> = None;
+    loop {
+        let filter = Filter {
+            namespace: namespace_filter.clone(),
+            until,
+            limit: batch_size,
+            ..Filter::default()
+        };
+        let page = match from.list(&ctx, &filter).await {
+            Ok(p) => p,
+            Err(e) => {
+                report.errors.push(format!("source list failed: {e}"));
+                break;
+            }
+        };
+        if page.is_empty() {
+            break;
+        }
+
+        // Filter out memories already processed in a previous page
+        // (happens on the `until` boundary).
+        let fresh: Vec<&crate::models::Memory> =
+            page.iter().filter(|m| !seen.contains(&m.id)).collect();
+
+        if fresh.is_empty() {
+            // Nothing new on this page — cursor didn't advance, stop.
+            break;
+        }
+        report.batches += 1;
+        report.memories_read += fresh.len();
+
+        if !dry_run {
+            for mem in &fresh {
+                match to.store(&ctx, mem).await {
+                    Ok(_) => report.memories_written += 1,
+                    Err(e) => {
+                        report.errors.push(format!("write {} failed: {e}", mem.id));
+                    }
+                }
+            }
+        }
+        for mem in &page {
+            seen.insert(mem.id.clone());
+        }
+
+        // Advance `until` to the oldest created_at we've now seen so
+        // the next page is strictly older.
+        let min_created_at = page
+            .iter()
+            .filter_map(|m| chrono::DateTime::parse_from_rfc3339(&m.created_at).ok())
+            .map(chrono::DateTime::<chrono::Utc>::from)
+            .min();
+        let previous_until = until;
+        until = min_created_at;
+        if until == previous_until {
+            break;
+        }
+        if page.len() < batch_size {
+            break;
+        }
+    }
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Memory, Tier};
+
+    fn sample_memory(id: &str, ns: &str, title: &str) -> Memory {
+        sample_memory_at(id, ns, title, chrono::Utc::now())
+    }
+
+    fn sample_memory_at(
+        id: &str,
+        ns: &str,
+        title: &str,
+        created_at: chrono::DateTime<chrono::Utc>,
+    ) -> Memory {
+        let ts = created_at.to_rfc3339();
+        Memory {
+            id: id.to_string(),
+            tier: Tier::Mid,
+            namespace: ns.to_string(),
+            title: title.to_string(),
+            content: format!("content for {title} with some body"),
+            tags: vec!["migrate-test".to_string()],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: ts.clone(),
+            updated_at: ts,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"agent_id":"ai:migrate-test"}),
+        }
+    }
+
+    #[tokio::test]
+    async fn open_store_sqlite_url() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+        let url = format!("sqlite://{path}");
+        let store = open_store(&url).await.expect("open sqlite store");
+        let ctx = CallerContext::for_agent("ai:t");
+        let mem = sample_memory("test-1", "ns", "hello");
+        store.store(&ctx, &mem).await.expect("store");
+        let got = store.get(&ctx, "test-1").await.expect("get");
+        assert_eq!(got.title, "hello");
+    }
+
+    #[tokio::test]
+    async fn open_store_rejects_unknown_scheme() {
+        match open_store("nosql://not-supported").await {
+            Err(e) => assert!(e.to_string().contains("unrecognised store URL")),
+            Ok(_) => panic!("expected unrecognised-scheme error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn migrate_sqlite_to_sqlite_roundtrip() {
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_agent("ai:seed");
+        let base = chrono::Utc::now() - chrono::Duration::hours(1);
+        for i in 0..5 {
+            let mem = sample_memory_at(
+                &format!("m{i}"),
+                "ns",
+                &format!("title {i}"),
+                base + chrono::Duration::seconds(i),
+            );
+            src.store(&ctx, &mem).await.unwrap();
+        }
+        let report = migrate(&src, &dst, 2, None, false).await;
+        assert_eq!(report.memories_read, 5);
+        assert_eq!(report.memories_written, 5);
+        assert!(report.batches >= 2, "batches = {}", report.batches);
+        // Verify destination has them all.
+        for i in 0..5 {
+            let got = dst.get(&ctx, &format!("m{i}")).await.expect("get dst");
+            assert_eq!(got.title, format!("title {i}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn migrate_dry_run_does_not_write() {
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_agent("ai:seed");
+        for i in 0..3 {
+            let mem = sample_memory(&format!("dm{i}"), "ns", &format!("dry {i}"));
+            src.store(&ctx, &mem).await.unwrap();
+        }
+        let report = migrate(&src, &dst, 5, None, true).await;
+        assert_eq!(report.memories_read, 3);
+        assert_eq!(report.memories_written, 0);
+        assert!(report.dry_run);
+        // Destination should be empty.
+        let err = dst.get(&ctx, "dm0").await.unwrap_err();
+        assert!(matches!(err, crate::store::StoreError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn migrate_is_idempotent_on_rerun() {
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_agent("ai:seed");
+        for i in 0..3 {
+            let mem = sample_memory(&format!("im{i}"), "ns", &format!("idem {i}"));
+            src.store(&ctx, &mem).await.unwrap();
+        }
+        let r1 = migrate(&src, &dst, 10, None, false).await;
+        let r2 = migrate(&src, &dst, 10, None, false).await;
+        assert_eq!(r1.memories_written, 3);
+        assert_eq!(r2.memories_written, 3);
+        assert!(r1.errors.is_empty() && r2.errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn migrate_with_namespace_filter() {
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_agent("ai:seed");
+        let m_a = sample_memory("ns-m1", "wanted", "yes1");
+        let m_b = sample_memory("ns-m2", "wanted", "yes2");
+        let m_c = sample_memory("ns-m3", "other", "no");
+        for m in [&m_a, &m_b, &m_c] {
+            src.store(&ctx, m).await.unwrap();
+        }
+        let report = migrate(&src, &dst, 10, Some("wanted".to_string()), false).await;
+        assert_eq!(report.memories_read, 2);
+        assert_eq!(report.memories_written, 2);
+        assert!(dst.get(&ctx, "ns-m1").await.is_ok());
+        assert!(dst.get(&ctx, "ns-m2").await.is_ok());
+        assert!(dst.get(&ctx, "ns-m3").await.is_err());
+    }
+}


### PR DESCRIPTION
> Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029.
> **Stacks on #279** (SAL + PostgresStore + pgvector). Merge order: #279 → this.

## The "cross-backend autonomy" caveat — closed (one-shot path)

#279 shipped the infrastructure (\`MemoryStore\` trait, \`SqliteStore\`, \`PostgresStore\`). This PR ships the **tool that actually moves memories between them**.

## CLI

\`\`\`sh
# Feature-gated: cargo build --release --features sal[-postgres]

ai-memory migrate \
    --from sqlite:///var/lib/ai-memory/ai-memory.db \
    --to postgres://ai_memory:pass@pg:5432/ai_memory \
    [--batch 1000] [--namespace foo] [--dry-run] [--json]
\`\`\`

- **\`sqlite:///path\` → \`SqliteStore\`** (under \`--features sal\`)
- **\`postgres://…\` → \`PostgresStore\`** (under \`--features sal-postgres\`)
- **Idempotent on re-run** — source ids preserved verbatim; both adapters upsert on id.
- Works **bidirectionally** — sqlite→pg for cutover, pg→sqlite for local-dev snapshots.

## Implementation

- Streams via \`MemoryStore::list\` → \`MemoryStore::store\`, trait-generic across backends.
- Pagination: slides \`until\` window backwards with id-dedup — correctly handles identical \`created_at\` timestamps that would break naïve \`since\`-cursor paging on SQLite.
- Structured \`MigrationReport\` (read/written/batches/errors/dry_run) serialised to JSON with \`--json\`.
- Page size clamped to [1, 10 000]; defaults to 1000.

## Tests

**6 unit tests**, all passing:

- \`open_store_sqlite_url\` — URL parsing + roundtrip
- \`open_store_rejects_unknown_scheme\` — clear error for nosql:// garbage
- \`migrate_sqlite_to_sqlite_roundtrip\` — 5 memories across 3 batches of 2, full integrity check
- \`migrate_dry_run_does_not_write\` — report emitted, destination empty
- \`migrate_is_idempotent_on_rerun\` — second run preserves count, zero errors
- \`migrate_with_namespace_filter\` — non-matching memory not copied

**Full suite** on default + sal + sal-postgres: 286 unit + 158 integration tests all pass. fmt + clippy pedantic green on all three feature combinations.

## Explicitly out of scope — v0.7.1 follow-ups

Documented in the module docblock + CHANGELOG:

- **Daemon adapter selection** (\`ai-memory serve --store-url pg://…\`) — needs handlers.rs refactor from \`crate::db::\` free functions to \`Box<dyn MemoryStore>\` dispatch. That's a tidy but multi-week change that warrants its own PR.
- **Live heterogenous replication** — no always-on SQLite↔Postgres sync yet.
- **Schema-rewriting migration** — both adapters currently agree on the \`Memory\` shape so field mapping is unnecessary.

## Claim discipline

v0.7-alpha earns: **"one-shot bidirectional migration between SQLite and Postgres/pgvector, idempotent"**.

Still honest caveats:
- Running \`ai-memory serve\` against Postgres as the **live** store still needs v0.7.1's adapter-selection refactor.
- Zero-downtime cutover requires stop-writes → migrate → restart-against-pg (documented).

## AI involvement

Authored by Claude Opus 4.7 (1M context) on behalf of @binary2029. Track B PR 2 of N. Sibling PRs: #278 (curator), #279 (SAL base), #280 (quorum primitives), #281 (full autonomy), #282 (federation wired).