### PR TITLE
fix: v0.6.0 pre-tag quick-wins — closes 7 items from #299/#300/#301/#302/#304

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -399,8 +399,13 @@ fn forget_if_superseded(
         }));
     }
 
-    // db::forget takes pattern-based args (namespace/tier/etc); we use
-    // the generic by-id path instead via db::delete which archives.
+    // IMPORTANT: `db::delete` hard-deletes (no archive row). Recovery
+    // for a forgotten memory relies on the RollbackEntry::Forget
+    // snapshot we return — the caller persists it in `_curator/rollback`
+    // with the full pre-forget memory embedded. That rollback entry
+    // is long-tier so it's not auto-GC'd; `ai-memory curator --rollback
+    // <id>` reverses the forget from that snapshot. (#300 item 1:
+    // comment previously claimed db::delete archives; it does not.)
     db::delete(conn, &mem.id)?;
 
     Ok(Some(RollbackEntry::Forget {
@@ -546,12 +551,24 @@ pub fn persist_self_report(
 /// Reverse a single rollback-log entry. Returns `true` if a reverse
 /// action was applied, `false` if the entry was already superseded
 /// (idempotent rollback).
+///
+/// Collision safety (#300 item 2): before re-inserting a snapshot we
+/// check whether another memory now owns the same
+/// `(title, namespace)` key. If it does, we refuse to overwrite —
+/// `db::insert` is an UPSERT on that key and would silently replace
+/// the unrelated memory's content. We return an error so the operator
+/// can resolve the conflict manually (delete the offender or rename
+/// one of them) rather than clobbering user data.
 pub fn reverse_rollback_entry(conn: &Connection, entry: &RollbackEntry) -> Result<bool> {
     match entry {
         RollbackEntry::Consolidate {
             originals,
             result_id,
         } => {
+            // Pre-flight: no title+ns collision against a different id?
+            for m in originals {
+                check_no_collision(conn, &m.title, &m.namespace, &m.id)?;
+            }
             // Delete the consolidated memory; re-insert the originals.
             let existed = db::delete(conn, result_id)?;
             for m in originals {
@@ -560,6 +577,7 @@ pub fn reverse_rollback_entry(conn: &Connection, entry: &RollbackEntry) -> Resul
             Ok(existed)
         }
         RollbackEntry::Forget { snapshot } => {
+            check_no_collision(conn, &snapshot.title, &snapshot.namespace, &snapshot.id)?;
             db::insert(conn, snapshot)?;
             Ok(true)
         }
@@ -584,6 +602,40 @@ pub fn reverse_rollback_entry(conn: &Connection, entry: &RollbackEntry) -> Resul
             Ok(true)
         }
     }
+}
+
+/// Refuse to overwrite a memory that took the (title, namespace) slot
+/// after the rollback target was forgotten/consolidated.
+fn check_no_collision(
+    conn: &Connection,
+    title: &str,
+    namespace: &str,
+    expected_id: &str,
+) -> Result<()> {
+    let rows = db::list(
+        conn,
+        Some(namespace),
+        None,
+        50,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+    for row in rows {
+        if row.namespace == namespace && row.title == title && row.id != expected_id {
+            anyhow::bail!(
+                "rollback aborted: memory {} now occupies (title={:?}, namespace={:?}) — \
+                 reverting would overwrite it. Resolve the conflict manually.",
+                row.id,
+                title,
+                namespace
+            );
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/curator.rs
+++ b/src/curator.rs
@@ -116,8 +116,12 @@ pub fn run_once(
     let mut report = CuratorReport::new(cfg.dry_run);
     let started = Instant::now();
 
-    let candidates = collect_candidates(conn, cfg)?;
+    let CandidateBatch {
+        memories: candidates,
+        truncated,
+    } = collect_candidates(conn, cfg)?;
     report.memories_scanned = candidates.len();
+    record_truncation(&mut report, truncated, cfg);
 
     let eligible: Vec<&Memory> = candidates
         .iter()
@@ -284,16 +288,40 @@ pub fn run_daemon(
     tracing::info!("curator daemon shutdown");
 }
 
-fn collect_candidates(conn: &Connection, cfg: &CuratorConfig) -> Result<Vec<Memory>> {
+/// Result of `collect_candidates` — the memories plus a truncation
+/// flag so callers can surface "I may have missed rows" in their
+/// report rather than silently dropping (#300 item 3 fix).
+pub(crate) struct CandidateBatch {
+    pub memories: Vec<Memory>,
+    /// True iff at least one tier hit the `max_ops_per_cycle * 4` cap;
+    /// callers should add a `report.errors` note so operators notice.
+    pub truncated: bool,
+}
+
+/// Append a truncation warning to the report when `collect_candidates`
+/// hit its per-tier cap. Extracted as a helper so `run_once` stays
+/// under clippy's `too_many_lines` ceiling.
+fn record_truncation(report: &mut CuratorReport, truncated: bool, cfg: &CuratorConfig) {
+    if truncated {
+        report.errors.push(format!(
+            "collect_candidates truncated at cap={} per tier; consider raising max_ops_per_cycle or paginating across cycles",
+            cfg.max_ops_per_cycle.saturating_mul(4)
+        ));
+    }
+}
+
+fn collect_candidates(conn: &Connection, cfg: &CuratorConfig) -> Result<CandidateBatch> {
     // We sweep mid + long tier only. Short tier is too volatile — it'll
     // likely be GC'd before the next curator cycle anyway.
+    let cap = cfg.max_ops_per_cycle.saturating_mul(4);
     let mut out = Vec::new();
+    let mut truncated = false;
     for tier in [Tier::Mid, Tier::Long] {
         let batch = db::list(
             conn,
             None,
             Some(&tier),
-            cfg.max_ops_per_cycle.saturating_mul(4),
+            cap,
             0,
             None,
             None,
@@ -301,9 +329,20 @@ fn collect_candidates(conn: &Connection, cfg: &CuratorConfig) -> Result<Vec<Memo
             None,
             None,
         )?;
+        if batch.len() >= cap {
+            // We can't tell from db::list whether there were strictly
+            // more than cap rows without a second probe, so treat
+            // cap-saturation as definitely-truncated. False positives
+            // are acceptable here — a single-line error entry is
+            // cheap, silent data loss is not.
+            truncated = true;
+        }
         out.extend(batch);
     }
-    Ok(out)
+    Ok(CandidateBatch {
+        memories: out,
+        truncated,
+    })
 }
 
 fn needs_curation(mem: &Memory, cfg: &CuratorConfig) -> bool {

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -89,9 +89,19 @@ impl FederationConfig {
             .iter()
             .enumerate()
             .map(|(i, raw)| {
+                // `id` is used as a Prometheus metric label; keep it
+                // low-cardinality. The full URL is logged separately.
+                // (#304 nit — prior form `peer-{i}:{url}` blew up the
+                // label space as deployment size grew.)
                 let trimmed = raw.trim_end_matches('/');
+                tracing::debug!(
+                    target = "federation",
+                    peer_index = i,
+                    url = trimmed,
+                    "registered peer"
+                );
                 PeerEndpoint {
-                    id: format!("peer-{i}:{trimmed}"),
+                    id: format!("peer-{i}"),
                     sync_push_url: format!("{trimmed}/api/v1/sync/push"),
                 }
             })

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -62,6 +62,21 @@ pub struct ApiKeyState {
     pub key: Option<String>,
 }
 
+/// Constant-time byte-slice equality. Doesn't short-circuit on the
+/// first mismatched byte, preventing timing-oracle leaks of secret
+/// material. Used for API-key comparison (#301 hardening item 3).
+#[inline]
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// Middleware: reject requests with 401 if `api_key` is configured and request
 /// doesn't provide a matching `X-API-Key` header or `?api_key=` query param.
 /// The `/api/v1/health` endpoint is exempt.
@@ -83,7 +98,7 @@ pub async fn api_key_auth(
     // Check X-API-Key header
     if let Some(header_val) = req.headers().get("x-api-key")
         && let Ok(val) = header_val.to_str()
-        && val == expected.as_str()
+        && constant_time_eq(val.as_bytes(), expected.as_bytes())
     {
         return next.run(req).await.into_response();
     }
@@ -92,7 +107,7 @@ pub async fn api_key_auth(
     if let Some(query) = req.uri().query() {
         for pair in query.split('&') {
             if let Some(val) = pair.strip_prefix("api_key=")
-                && val == expected.as_str()
+                && constant_time_eq(val.as_bytes(), expected.as_bytes())
             {
                 return next.run(req).await.into_response();
             }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -123,6 +123,27 @@ impl PostgresStore {
                 detail: format!("init schema: {e}"),
             })?;
 
+        // Sanity-check pgvector version. We support 0.7.x–0.8.x; older
+        // versions have HNSW behaviour differences we haven't tested
+        // against. (#302 item 2 — prior code accepted any version.)
+        let extver: Option<(String,)> =
+            sqlx::query_as("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+                .fetch_optional(&pool)
+                .await
+                .map_err(|e| StoreError::BackendUnavailable {
+                    backend: "postgres".to_string(),
+                    detail: format!("read pgvector version: {e}"),
+                })?;
+        if let Some((ver,)) = extver
+            && !(ver.starts_with("0.7") || ver.starts_with("0.8"))
+        {
+            tracing::warn!(
+                target = "store::postgres",
+                version = %ver,
+                "pgvector version outside the tested range 0.7.x–0.8.x; HNSW recall may differ"
+            );
+        }
+
         Ok(Self { pool })
     }
 

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -5,6 +5,13 @@
 -- Idempotent — this script runs on every PostgresStore::connect() and
 -- must tolerate being re-executed against an already-populated DB.
 
+-- pgvector extension. Supported version range: 0.7.x–0.8.x. pgvector
+-- had breaking HNSW behaviour changes between 0.5 and 0.7 — if we
+-- widen the range we MUST re-test HNSW recall on the fixture corpus.
+-- Pin the minimum at adapter connect time rather than here; the
+-- schema is run against whatever version is available, and the
+-- adapter checks `SELECT extversion FROM pg_extension WHERE
+-- extname='vector'` afterwards (see PostgresStore::connect).
 CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE TABLE IF NOT EXISTS memories (

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -56,11 +56,14 @@ fn box_err<E: std::fmt::Display>(e: E) -> StoreError {
 #[async_trait::async_trait]
 impl MemoryStore for SqliteStore {
     fn capabilities(&self) -> Capabilities {
-        Capabilities::TRANSACTIONS
-            | Capabilities::FULLTEXT
-            | Capabilities::DURABLE
-            | Capabilities::STRONG_CONSISTENCY
-            | Capabilities::ATOMIC_MULTI_WRITE
+        // TRANSACTIONS + ATOMIC_MULTI_WRITE are NOT advertised because
+        // the adapter does not currently expose `begin_transaction()`
+        // — the trait default returns `UnsupportedCapability`. Honesty
+        // here matters: capability bits must match runtime behaviour
+        // (issue #302 item 6). Re-add these two flags once a real
+        // transaction handle is wired through the mutex-guarded
+        // `rusqlite::Connection`.
+        Capabilities::FULLTEXT | Capabilities::DURABLE | Capabilities::STRONG_CONSISTENCY
     }
 
     async fn store(&self, _ctx: &CallerContext, memory: &Memory) -> StoreResult<String> {
@@ -289,6 +292,10 @@ mod tests {
         // happens above this layer via crate::hnsw, not inside the
         // adapter.
         assert!(!caps.contains(Capabilities::NATIVE_VECTOR));
+        // TRANSACTIONS + ATOMIC_MULTI_WRITE are NOT set — the adapter
+        // doesn't expose `begin_transaction()` (#302 item 6 fix).
+        assert!(!caps.contains(Capabilities::TRANSACTIONS));
+        assert!(!caps.contains(Capabilities::ATOMIC_MULTI_WRITE));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Seven focused fixes from the v0.6.0 code-review punchlist (#293). Each
is independent and small. None require schema changes. All pass the
CI-path clippy + fmt + test gates.

## Items closed

| Source | Title |
|---|---|
| #301 item 3 | Constant-time API-key compare (timing-oracle close) |
| #300 item 1 | Autonomy forget comment accuracy (db::delete vs archive) |
| #300 item 2 | Rollback reverse collision protection (UNIQUE title+ns) |
| #300 item 3 | Curator candidate truncation surfacing |
| #302 item 2 | pgvector version sanity check at connect |
| #302 item 6 | SqliteStore capability bit lie |
| #304 | Federation metric label cardinality |

## Gates

- \`cargo fmt --check\` ✅
- \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` ✅
- \`cargo test --features sal,sal-postgres --release\` ✅ **488/488**
- \`cargo audit\` ✅

## Still open (tracked as follow-ups to this PR)

- **#299** — federation deadline races (needs async deep-dive)
- **#301** items 1,2,4 — webhook HMAC redesign, SSRF DNS resolution, MCP subscribe auth
- **#302** items 1,3,4,5 — vector score direction, filter parity, lock contention, verify()
- **#303** — test coverage expansions (CI Postgres job, sqlite→postgres roundtrip)

## AI involvement

Diagnosed and authored by Claude Opus 4.7 during the v0.6.0 pre-tag
code-review sprint. Follow-up to blocker PR #305.

## Test plan

- [x] All existing tests pass (488/488)
- [x] fmt + clippy + audit gates green
- [ ] CI green
- [ ] Reviewer confirms: constant_time_eq looks reasonable; pgvector version check is not a hard fail