### PR TITLE
feat(validate): allow source="chaos" for chaos-harness writes

### DIFF
--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -29,7 +29,8 @@ export type Source =
   | "cli"
   | "import"
   | "consolidation"
-  | "system";
+  | "system"
+  | "chaos";
 
 /**
  * A Memory row. Corresponds to `ai_memory::models::Memory` (15 fields).

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -89,7 +89,7 @@ fn tool_definitions() -> Value {
                         "tags": {"type": "array", "items": {"type": "string"}, "default": []},
                         "priority": {"type": "integer", "minimum": 1, "maximum": 10, "default": 5},
                         "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": 1.0},
-                        "source": {"type": "string", "enum": ["user", "claude", "hook", "api", "cli", "import", "consolidation", "system"], "default": "claude"},
+                        "source": {"type": "string", "enum": ["user", "claude", "hook", "api", "cli", "import", "consolidation", "system", "chaos"], "default": "claude"},
                         "metadata": {"type": "object", "description": "Arbitrary JSON metadata", "default": {}},
                         "agent_id": {"type": "string", "description": "Agent identifier. If omitted, the server synthesizes an NHI-hardened default (ai:<client>@<host>:pid-<pid>, host:<host>:pid-<pid>-<uuid8>, or anonymous:pid-<pid>-<uuid8>)."},
                         "scope": {"type": "string", "enum": ["private", "team", "unit", "org", "collective"], "description": "Task 1.5 visibility scope. Defaults to private when unset. Stored as metadata.scope."}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -31,6 +31,7 @@ const VALID_SOURCES: &[&str] = &[
     "import",
     "consolidation",
     "system",
+    "chaos",
 ];
 const VALID_RELATIONS: &[&str] = &["related_to", "supersedes", "contradicts", "derived_from"];
 


### PR DESCRIPTION
## Summary

- Add `\"chaos\"` to `VALID_SOURCES` so `packaging/chaos/run-chaos.sh` writes aren't rejected with 400.
- Keep three sources of the allowlist in sync: `src/validate.rs`, `src/mcp.rs` tool schema, `sdk/typescript/src/types.ts`.

## Why

Ship-gate run 16 reached Phase 4 (chaos campaign) for the first time thanks to the federation fanout fix. It then failed 5000/5000 writes because `run-chaos.sh` posts memories with `source=\"chaos\"`, which was not in the allowed set. Every write returned 400, counted as fail, convergence_bound 0.

`chaos` is a legitimate caller class — distinct from `api` (real user traffic) and `system` (internal maintenance). Keeping the value allows operational audits to distinguish ship-gate-emitted test traffic from real writes in mixed-source databases.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 158 passed
- [ ] Ship-gate run 17 against this branch — expect Phase 4 convergence_bound ≥ 0.995

## AI involvement

Implemented by Claude Opus 4.7. Attribution in commit trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)