### PR TITLE
fix(chaos): 3s post-write settle before convergence count

### DIFF
--- a/packaging/chaos/run-chaos.sh
+++ b/packaging/chaos/run-chaos.sh
@@ -183,6 +183,16 @@ cycle() {
         }
     done
 
+    # Post-write settle window — lets detached post-quorum fanouts
+    # finish their retries before we measure. Ship-gate run 19 showed
+    # partition_minority at convergence_bound 0.2 because the 500ms
+    # iptables DROP triggered reqwest retransmits that were still in
+    # flight when the cycle tore down: SIGKILL of the leader aborted
+    # those retries, peers never got the writes. 3s covers the
+    # federation client's default 3s quorum-timeout, after which any
+    # in-flight fanout has either succeeded or given up.
+    sleep 3
+
     # Convergence check: count rows visible at each node in THIS cycle's
     # namespace. Per-cycle namespace isolation means count_nodeN reflects
     # only the writes this cycle attempted — no bleed-over from prior


### PR DESCRIPTION
## Summary

Add a 3s settle between the last write and the convergence count in `packaging/chaos/run-chaos.sh`. Fixes Phase 4 `partition_minority` at `convergence_bound 0.2`; expected ≈ 1.0 with settle window.

## Why

Ship-gate run 19, Phase 4, on release/v0.6.0 with the PR #312 harness fixes landed:

| Fault | convergence_bound |
|---|---|
| `kill_primary_mid_write` | **1.0** ✅ |
| `partition_minority` | **0.2** ❌ |

The 500ms iptables DROP injected mid-cycle causes TCP retransmits on any in-flight fanout POSTs. reqwest's federation client timeout is 3s, so these fanouts keep retrying after the partition heals. The cycle finishes its 100 writes fast, runs the convergence count immediately, tears the cluster down with SIGKILL. Any detached fanout still mid-retransmit at count time is missed; any still mid-retransmit at teardown is aborted mid-POST so the peer never sees the write.

`kill_primary_mid_write` isn't affected because the primary is already dead — no retries to wait for.

## Fix

One line: `sleep 3` between the write loop and the convergence count. 3s matches the federation client's default 3s quorum-timeout, so any fanout that's going to succeed has done so, and any that's going to fail has given up.

## Cost

+3s × 50 cycles × N fault classes = ~2.5 min added to Phase 4 at the 50-cycle default. Still well under the workflow ceiling (13-15 min clean run target).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 158 passed (no Rust change)
- [x] `bash -n packaging/chaos/run-chaos.sh` — syntax clean
- [ ] Ship-gate run 20 — expect both fault classes at bound ≈ 1.0

🤖 Authored by Claude Opus 4.7.