### PR TITLE
docs: v0.6.0 release banner + DigitalOcean testing link on Pages landing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,6 +334,25 @@
      ================================================================ -->
 <section class="hero">
     <div class="container">
+        <!-- v0.6.0 release banner — ship-gate certified on real DigitalOcean infrastructure -->
+        <div style="max-width:760px;margin:0 auto 1.5rem;background:linear-gradient(135deg,rgba(46,160,67,.18) 0%,rgba(46,160,67,.08) 100%);border:1px solid #2ea043;border-radius:10px;padding:1rem 1.25rem;text-align:left">
+            <p style="font-size:.65rem;text-transform:uppercase;letter-spacing:.18em;color:#7ee787;margin-bottom:.4rem;font-weight:700;display:flex;align-items:center;gap:.5rem">
+                <span style="display:inline-block;width:.5rem;height:.5rem;background:#7ee787;border-radius:50%;box-shadow:0 0 8px #7ee787"></span>
+                v0.6.0 shipped &middot; 2026-04-20 &middot; ship-gate certified
+            </p>
+            <p style="font-size:1rem;line-height:1.55;margin:0 0 .6rem">
+                <strong>We are one release away from <em>fully autonomous endpoint AI powered by ai-memory</em>.</strong>
+                v0.6.0 closes a silent data-loss bug in federation, validates 3-node replication on fresh cloud infrastructure,
+                and proves the cluster survives primary-crash-mid-write at 100% convergence.
+            </p>
+            <p style="font-size:.8rem;color:var(--text-muted);margin:0;line-height:1.5">
+                <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.0" style="color:#7ee787;font-weight:600">Release notes &rarr;</a>
+                &middot;
+                <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="color:#7ee787;font-weight:600">DigitalOcean testing dashboard &rarr;</a>
+                &middot;
+                <a href="https://github.com/alphaonedev/ai-memory-ship-gate/tree/main/runs/v0.6.0.0-final-r25" style="color:#7ee787;font-weight:600">r25 evidence (JSON) &rarr;</a>
+            </p>
+        </div>
         <img src="ai-memory-logo.jpg" alt="ai-memory logo" style="width:160px;height:auto;margin-bottom:1.5rem;border-radius:16px;filter:drop-shadow(0 0 24px rgba(255,255,255,.25))">
         <h1>Persistent Memory for <span>Any AI</span></h1>
         <div style="max-width:760px;margin:0 auto 1.5rem;background:linear-gradient(135deg,rgba(255,255,255,.08) 0%,rgba(255,255,255,.08) 100%);border:1px solid var(--border-hl);border-radius:10px;padding:1.25rem 1.5rem">


### PR DESCRIPTION
Green v0.6.0 release banner at the top of alphaonedev.github.io/ai-memory-mcp/:
- direct link to https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.0
- direct link to the DigitalOcean testing dashboard https://alphaonedev.github.io/ai-memory-ship-gate/
- direct link to the r25 evidence JSON
- framing: "We are one release away from fully autonomous endpoint AI powered by ai-memory"

Only docs/index.html touched. No code or test changes.

🤖 Generated with Claude Opus 4.7