### PR TITLE
feat(v0.6.2): link fanout + consolidate fanout + embedder diagnostic (#325 #326 #327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v0.6.2 + v0.7 tracks
+
+### Fixed — v0.6.2 a2a-gate r15 bug punchlist
+
+Three correctness gaps surfaced by `a2a-hermes-v0.6.1-r15` (11/14 scenarios
+passing) — see diagnostic trace at
+[ai2ai-gate#r15 evidence](https://alphaonedev.github.io/ai-memory-ai2ai-gate/runs/).
+
+- **[#325]** `create_link` fanout — `POST /api/v1/links` now broadcasts
+  the new link to every peer via quorum write. Scenario-11 of the
+  a2a-gate harness exercised this: charlie couldn't see an M1→M2 link
+  written on alice's node. `SyncPushBody` grows a `links: Vec<MemoryLink>`
+  field applied via `db::create_link` on peers; duplicates are idempotent
+  thanks to the existing unique index on `(source_id, target_id, relation)`.
+  New `federation::broadcast_link_quorum`. Delete-link fanout deferred
+  to v0.7 CRDT-lite link tombstones (local DELETE is now routable at
+  `DELETE /api/v1/links`).
+- **[#326]** `consolidate` fanout — `POST /api/v1/consolidate` now
+  broadcasts both the new consolidated memory AND the source-id
+  deletions in a single sync_push call. Scenario-5 exposed the gap:
+  peer nodes never saw the consolidated memory at all, so
+  `metadata.consolidated_from_agents` read as `"[]"`. New
+  `federation::broadcast_consolidate_quorum`.
+- **[#327]** Embedder-failure visibility on `ai-memory serve` — the
+  prior `WARN` when HuggingFace-Hub fetch failed was easy to miss in
+  DO droplet logs, which black-holed scenario-18 semantic recall
+  silently. Now logs at `ERROR` with an `⚠️ EMBEDDER LOAD FAILED`
+  marker + operator-facing remediation pointer. `/api/v1/health`
+  grows `embedder_ready: bool` + `federation_enabled: bool` fields so
+  the harness can assert semantic-tier readiness before scenarios run.
+
 ## [Unreleased] — v0.6.1 + v0.7 tracks
 
 ### Fixed — v0.6.0 pre-tag SAL blocker punchlist (#293)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["AlphaOne LLC"]

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 
-use crate::models::Memory;
+use crate::models::{Memory, MemoryLink};
 use crate::replication::{AckTracker, QuorumError, QuorumFailureReason, QuorumPolicy};
 
 /// Configured-at-serve federation state. Parsed from
@@ -396,6 +396,175 @@ pub async fn broadcast_delete_quorum(
                 if let Ok((peer_id, AckOutcome::Fail(reason))) = res {
                     tracing::debug!(
                         "federation: post-quorum delete peer {peer_id} did not ack: {reason}"
+                    );
+                }
+            }
+        });
+    }
+
+    let tracker = Arc::try_unwrap(tracker)
+        .map_err(|_| QuorumError::LocalWriteFailed {
+            detail: "tracker arc still referenced at finalise".to_string(),
+        })?
+        .into_inner();
+    Ok(tracker)
+}
+
+/// v0.6.2 (#325): fan out a just-committed memory link to every peer.
+/// Payload rides on `sync_push` via `links: [link]`. Same quorum contract
+/// as `broadcast_store_quorum`.
+///
+/// # Errors
+///
+/// Returns `QuorumError::LocalWriteFailed` if the internal tracker Arc cannot
+/// be unwrapped (only occurs under a pathological detach race).
+pub async fn broadcast_link_quorum(
+    config: &FederationConfig,
+    link: &MemoryLink,
+) -> Result<AckTracker, QuorumError> {
+    let now = Instant::now();
+    let tracker = Arc::new(Mutex::new(AckTracker::new(config.policy.clone(), now)));
+    tracker.lock().await.record_local();
+
+    let body = serde_json::json!({
+        "sender_agent_id": config.sender_agent_id,
+        "memories": [],
+        "links": [link],
+        "dry_run": false,
+    });
+    let log_id = format!("{}→{}", link.source_id, link.target_id);
+
+    let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
+    for peer in &config.peers {
+        let client = config.client.clone();
+        let url = peer.sync_push_url.clone();
+        let peer_id = peer.id.clone();
+        let payload = body.clone();
+        let log_id = log_id.clone();
+        joins.spawn(async move {
+            let outcome = post_and_classify(&client, &url, &payload, &log_id).await;
+            (peer_id, outcome)
+        });
+    }
+
+    let deadline = now + config.policy.ack_timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, joins.join_next()).await {
+            Ok(Some(Ok((peer_id, AckOutcome::Ack)))) => {
+                tracker.lock().await.record_peer_ack(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::IdDrift)))) => {
+                tracker.lock().await.record_id_drift(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::Fail(reason))))) => {
+                tracing::warn!("federation: link peer {peer_id} failed for {log_id}: {reason}");
+            }
+            Ok(Some(Err(e))) => {
+                tracing::warn!("federation: link peer join error: {e}");
+            }
+            Ok(None) | Err(_) => break,
+        }
+        if tracker.lock().await.is_quorum_met(Instant::now()) {
+            break;
+        }
+    }
+
+    if !joins.is_empty() {
+        tokio::spawn(async move {
+            while let Some(res) = joins.join_next().await {
+                if let Ok((peer_id, AckOutcome::Fail(reason))) = res {
+                    tracing::debug!(
+                        "federation: post-quorum link peer {peer_id} did not ack: {reason}"
+                    );
+                }
+            }
+        });
+    }
+
+    let tracker = Arc::try_unwrap(tracker)
+        .map_err(|_| QuorumError::LocalWriteFailed {
+            detail: "tracker arc still referenced at finalise".to_string(),
+        })?
+        .into_inner();
+    Ok(tracker)
+}
+
+/// v0.6.2 (#326): fan out a consolidation in a single `sync_push` — the new
+/// consolidated memory + the source ids being deleted. Mirrors the local
+/// semantics of `db::consolidate` (insert new + delete sources) so peers
+/// end up in the same terminal state as the originator.
+///
+/// # Errors
+///
+/// Returns `QuorumError::LocalWriteFailed` on pathological detach race.
+pub async fn broadcast_consolidate_quorum(
+    config: &FederationConfig,
+    new_mem: &Memory,
+    source_ids: &[String],
+) -> Result<AckTracker, QuorumError> {
+    let now = Instant::now();
+    let tracker = Arc::new(Mutex::new(AckTracker::new(config.policy.clone(), now)));
+    tracker.lock().await.record_local();
+
+    let body = serde_json::json!({
+        "sender_agent_id": config.sender_agent_id,
+        "memories": [new_mem],
+        "deletions": source_ids,
+        "dry_run": false,
+    });
+
+    let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
+    for peer in &config.peers {
+        let client = config.client.clone();
+        let url = peer.sync_push_url.clone();
+        let peer_id = peer.id.clone();
+        let payload = body.clone();
+        let target_id = new_mem.id.clone();
+        joins.spawn(async move {
+            let outcome = post_and_classify(&client, &url, &payload, &target_id).await;
+            (peer_id, outcome)
+        });
+    }
+
+    let deadline = now + config.policy.ack_timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, joins.join_next()).await {
+            Ok(Some(Ok((peer_id, AckOutcome::Ack)))) => {
+                tracker.lock().await.record_peer_ack(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::IdDrift)))) => {
+                tracker.lock().await.record_id_drift(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::Fail(reason))))) => {
+                tracing::warn!(
+                    "federation: consolidate peer {peer_id} failed for {}: {reason}",
+                    new_mem.id
+                );
+            }
+            Ok(Some(Err(e))) => {
+                tracing::warn!("federation: consolidate peer join error: {e}");
+            }
+            Ok(None) | Err(_) => break,
+        }
+        if tracker.lock().await.is_quorum_met(Instant::now()) {
+            break;
+        }
+    }
+
+    if !joins.is_empty() {
+        tokio::spawn(async move {
+            while let Some(res) = joins.join_next().await {
+                if let Ok((peer_id, AckOutcome::Fail(reason))) = res {
+                    tracing::debug!(
+                        "federation: post-quorum consolidate peer {peer_id} did not ack: {reason}"
                     );
                 }
             }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -121,17 +121,28 @@ pub async fn api_key_auth(
         .into_response()
 }
 
-pub async fn health(State(state): State<Db>) -> impl IntoResponse {
-    let lock = state.lock().await;
+pub async fn health(State(app): State<AppState>) -> impl IntoResponse {
+    let lock = app.db.lock().await;
     let ok = db::health_check(&lock.0).unwrap_or(false);
+    drop(lock);
+    let embedder_ready = app.embedder.as_ref().is_some();
+    let federation_enabled = app.federation.as_ref().is_some();
     let code = if ok {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
     };
+    // v0.6.2 (#327): expose embedder status so operators can tell from
+    // /health alone whether semantic recall is wired up on this node.
     (
         code,
-        Json(json!({"status": if ok { "ok" } else { "error" }, "service": "ai-memory"})),
+        Json(json!({
+            "status": if ok { "ok" } else { "error" },
+            "service": "ai-memory",
+            "version": env!("CARGO_PKG_VERSION"),
+            "embedder_ready": embedder_ready,
+            "federation_enabled": federation_enabled,
+        })),
     )
         .into_response()
 }
@@ -1504,7 +1515,10 @@ pub async fn list_namespaces(State(state): State<Db>) -> impl IntoResponse {
     }
 }
 
-pub async fn create_link(State(state): State<Db>, Json(body): Json<LinkBody>) -> impl IntoResponse {
+pub async fn create_link(
+    State(app): State<AppState>,
+    Json(body): Json<LinkBody>,
+) -> impl IntoResponse {
     if let Err(e) = validate::validate_link(&body.source_id, &body.target_id, &body.relation) {
         return (
             StatusCode::BAD_REQUEST,
@@ -1512,9 +1526,73 @@ pub async fn create_link(State(state): State<Db>, Json(body): Json<LinkBody>) ->
         )
             .into_response();
     }
-    let lock = state.lock().await;
-    match db::create_link(&lock.0, &body.source_id, &body.target_id, &body.relation) {
-        Ok(()) => (StatusCode::CREATED, Json(json!({"linked": true}))).into_response(),
+    let lock = app.db.lock().await;
+    let create_result = db::create_link(&lock.0, &body.source_id, &body.target_id, &body.relation);
+    // Drop DB lock before fanning out — peers POST back to our sync_push
+    // and we'd deadlock on the shared Mutex if we held it.
+    drop(lock);
+    match create_result {
+        Ok(()) => {
+            // v0.6.2 (#325): propagate link to peers.
+            if let Some(fed) = app.federation.as_ref() {
+                let link = crate::models::MemoryLink {
+                    source_id: body.source_id.clone(),
+                    target_id: body.target_id.clone(),
+                    relation: body.relation.clone(),
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                };
+                match crate::federation::broadcast_link_quorum(fed, &link).await {
+                    Ok(tracker) => {
+                        if let Err(err) = crate::federation::finalise_quorum(&tracker) {
+                            let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
+                            return (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                [("Retry-After", "2")],
+                                Json(serde_json::to_value(&payload).unwrap_or_default()),
+                            )
+                                .into_response();
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("link fanout error (local committed): {e:?}");
+                    }
+                }
+            }
+            (StatusCode::CREATED, Json(json!({"linked": true}))).into_response()
+        }
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// v0.6.2 (#325) — DELETE /api/v1/links. Removes the directional link
+/// `source_id → target_id` locally. Deletion is NOT fanned out in v0.6.2:
+/// the receiving-side API is `db::delete_link`, and `sync_push` does not
+/// yet carry a link-tombstone list. Full link tombstones ship with v0.7
+/// CRDT-lite. For current scenario coverage (scenario-11 tests create),
+/// create-link fanout is sufficient.
+pub async fn delete_link(
+    State(app): State<AppState>,
+    Json(body): Json<LinkBody>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_link(&body.source_id, &body.target_id, &body.relation) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let lock = app.db.lock().await;
+    let delete_result = db::delete_link(&lock.0, &body.source_id, &body.target_id);
+    drop(lock);
+    match delete_result {
+        Ok(removed) => Json(json!({"deleted": removed})).into_response(),
         Err(e) => {
             tracing::error!("handler error: {e}");
             (
@@ -1655,7 +1733,7 @@ fn default_ns() -> String {
 }
 
 pub async fn consolidate_memories(
-    State(state): State<Db>,
+    State(app): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<ConsolidateBody>,
 ) -> impl IntoResponse {
@@ -1680,9 +1758,10 @@ pub async fn consolidate_memories(
                     .into_response();
             }
         };
-    let lock = state.lock().await;
+    let lock = app.db.lock().await;
     let tier = body.tier.unwrap_or(Tier::Long);
-    match db::consolidate(
+    let source_ids = body.ids.clone();
+    let consolidate_result = db::consolidate(
         &lock.0,
         &body.ids,
         &body.title,
@@ -1691,12 +1770,47 @@ pub async fn consolidate_memories(
         &tier,
         "consolidation",
         &consolidator_agent_id,
-    ) {
-        Ok(new_id) => (
-            StatusCode::CREATED,
-            Json(json!({"id": new_id, "consolidated": body.ids.len()})),
-        )
-            .into_response(),
+    );
+    // Read the newly consolidated memory back so we can fanout — must do
+    // this inside the same lock window because db::consolidate deletes
+    // the source rows as part of its transaction.
+    let new_mem = match &consolidate_result {
+        Ok(new_id) => db::get(&lock.0, new_id).ok().flatten(),
+        Err(_) => None,
+    };
+    // Drop DB lock before fanning out — peers POST back to our sync_push
+    // and we'd deadlock on the shared Mutex if we held it.
+    drop(lock);
+    match consolidate_result {
+        Ok(new_id) => {
+            // v0.6.2 (#326): propagate consolidation to peers so
+            // `metadata.consolidated_from_agents` and the deleted sources
+            // are in sync across the mesh.
+            if let (Some(fed), Some(mem)) = (app.federation.as_ref(), new_mem) {
+                match crate::federation::broadcast_consolidate_quorum(fed, &mem, &source_ids).await
+                {
+                    Ok(tracker) => {
+                        if let Err(err) = crate::federation::finalise_quorum(&tracker) {
+                            let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
+                            return (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                [("Retry-After", "2")],
+                                Json(serde_json::to_value(&payload).unwrap_or_default()),
+                            )
+                                .into_response();
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("consolidate fanout error (local committed): {e:?}");
+                    }
+                }
+            }
+            (
+                StatusCode::CREATED,
+                Json(json!({"id": new_id, "consolidated": body.ids.len()})),
+            )
+                .into_response()
+        }
         Err(e) => {
             tracing::error!("handler error: {e}");
             (
@@ -1893,6 +2007,12 @@ pub struct SyncPushBody {
     /// same delete reaches every peer well before any revival window.
     #[serde(default)]
     pub deletions: Vec<String>,
+    /// v0.6.2 (#325): memory links the sender wants propagated. Applied
+    /// via `db::create_link` on each peer. Duplicates are a no-op thanks
+    /// to the unique `(source_id, target_id, relation)` constraint on
+    /// `memory_links`.
+    #[serde(default)]
+    pub links: Vec<MemoryLink>,
     /// Preview mode — classify and count, do not write.
     #[serde(default)]
     pub dry_run: bool,
@@ -2024,6 +2144,34 @@ pub async fn sync_push(
         }
     }
 
+    // v0.6.2 (#325): process incoming links. Duplicates are expected on
+    // retry / re-sync and collapse to a no-op via the unique index on
+    // (source_id, target_id, relation). Invalid ids are skipped silently
+    // — same posture as deletions.
+    let mut links_applied = 0usize;
+    for link in &body.links {
+        if validate::validate_link(&link.source_id, &link.target_id, &link.relation).is_err() {
+            skipped += 1;
+            continue;
+        }
+        if body.dry_run {
+            noop += 1;
+            continue;
+        }
+        match db::create_link(&lock.0, &link.source_id, &link.target_id, &link.relation) {
+            Ok(()) => links_applied += 1,
+            Err(e) => {
+                tracing::warn!(
+                    "sync_push: create_link failed ({} -> {} / {}): {e}",
+                    link.source_id,
+                    link.target_id,
+                    link.relation
+                );
+                skipped += 1;
+            }
+        }
+    }
+
     // Advance the vector clock with the highest `updated_at` we observed.
     // Skipped in dry-run mode since the caller is only previewing.
     if !body.dry_run
@@ -2085,6 +2233,7 @@ pub async fn sync_push(
         Json(json!({
             "applied": applied,
             "deleted": deleted,
+            "links_applied": links_applied,
             "noop": noop,
             "skipped": skipped,
             "dry_run": body.dry_run,
@@ -2795,6 +2944,99 @@ mod tests {
             gone.is_none(),
             "row should have been tombstoned by sync_push"
         );
+    }
+
+    #[tokio::test]
+    async fn http_sync_push_applies_incoming_links() {
+        // v0.6.2 (#325) — sync_push's `links` field applies the listed
+        // (source, target, relation) triples via db::create_link on the
+        // receiver so peer-side link fanout works for scenario-11.
+        // (a2a-hermes-v0.6.1-r15.)
+        let state = test_state();
+        let now = Utc::now().to_rfc3339();
+
+        // Seed two memories on the receiver so the link has valid endpoints.
+        let (m1, m2) = {
+            let lock = state.lock().await;
+            let m1 = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: "link-fanout".into(),
+                title: "source".into(),
+                content: "a".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({"agent_id": "ai:seeder"}),
+            };
+            let m1_id = db::insert(&lock.0, &m1).unwrap();
+            let m2 = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: "link-fanout".into(),
+                title: "target".into(),
+                content: "b".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({"agent_id": "ai:seeder"}),
+            };
+            let m2_id = db::insert(&lock.0, &m2).unwrap();
+            (m1_id, m2_id)
+        };
+
+        let app = Router::new()
+            .route("/api/v1/sync/push", axum_post(sync_push))
+            .with_state(test_app_state(state.clone()));
+
+        let body = serde_json::json!({
+            "sender_agent_id": "peer-alice",
+            "sender_clock": {"entries": {}},
+            "memories": [],
+            "links": [{
+                "source_id": m1,
+                "target_id": m2,
+                "relation": "related_to",
+                "created_at": now,
+            }],
+            "dry_run": false
+        });
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/push")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header("x-agent-id", "local-receiver")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["links_applied"], 1);
+
+        let lock = state.lock().await;
+        let links = db::get_links(&lock.0, &m1).unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_id, m2);
+        assert_eq!(links[0].relation, "related_to");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -927,15 +927,38 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
             .await?;
             match build {
                 Ok(emb) => {
-                    tracing::info!("embedder loaded ({})", emb.model_description());
+                    tracing::info!(
+                        "embedder loaded ({}) — tier={} semantic recall enabled",
+                        emb.model_description(),
+                        feature_tier.as_str()
+                    );
                     Some(emb)
                 }
                 Err(e) => {
-                    tracing::warn!("embedder failed to load: {e}; daemon runs keyword-only");
+                    // v0.6.2 (#327): make embedder load failures loud. The
+                    // prior WARN level was easy to miss in DO droplet logs,
+                    // which led to scenario-18 black-holing (semantic recall
+                    // falling back to keyword-only without the operator
+                    // noticing). An ERROR-level log with an obvious marker
+                    // surfaces this immediately in `journalctl -u ai-memory`
+                    // or tail -f /var/log/ai-memory-serve.log.
+                    tracing::error!(
+                        "⚠️  EMBEDDER LOAD FAILED — tier={} requested semantic features, \
+                         but embedder init errored: {e}. Daemon falls back to keyword-only. \
+                         Semantic recall, sync_push embedding refresh (#322), and HNSW index \
+                         will be NO-OPS. Check network egress to HuggingFace Hub + available \
+                         memory for model weights. To force keyword-only explicitly (silences \
+                         this error), set `tier = \"keyword\"` in config.toml.",
+                        feature_tier.as_str()
+                    );
                     None
                 }
             }
         } else {
+            tracing::info!(
+                "embedder disabled — tier={} keyword-only (FTS5); semantic recall not wired",
+                feature_tier.as_str()
+            );
             None
         };
     let vector_index = if embedder.is_some() {
@@ -1088,6 +1111,7 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
             get(handlers::detect_contradictions),
         )
         .route("/api/v1/links", post(handlers::create_link))
+        .route("/api/v1/links", delete(handlers::delete_link))
         .route("/api/v1/links/{id}", get(handlers::get_links))
         .route("/api/v1/namespaces", get(handlers::list_namespaces))
         .route("/api/v1/stats", get(handlers::get_stats))


### PR DESCRIPTION
## Summary

Closes the three r15 bug-punchlist items in one PR. All three were
surfaced by `a2a-hermes-v0.6.1-r15` (11/14 passing; see
[r15 summary](https://alphaonedev.github.io/ai-memory-ai2ai-gate/runs/a2a-hermes-v0.6.1-r15/)).

- **[#325]** `POST /api/v1/links` now fans out to peers via new
  `federation::broadcast_link_quorum`. `SyncPushBody.links` applied
  by receiver via `db::create_link` (duplicates idempotent on existing
  unique index). New `DELETE /api/v1/links` (local-only until v0.7
  CRDT-lite link tombstones).
- **[#326]** `POST /api/v1/consolidate` now broadcasts the new
  consolidated memory AND source-id deletions in a single sync_push
  via new `federation::broadcast_consolidate_quorum`. `db::consolidate`
  itself was correct — the bug was purely missing fanout.
- **[#327]** Embedder-load failure on `ai-memory serve` now logs at
  ERROR level with obvious marker + remediation pointer. `/api/v1/health`
  grows `embedder_ready` + `federation_enabled` + `version`. This is a
  **diagnostic surface** — we need r16 evidence to decide whether the
  semantic black-hole is an embedder-load failure on DO droplets (H1)
  or a recall-path read-side bug (H3).

## Baseline verification (RCA Standard v1, Phase 2)

- #325: r15 scenario-11 `link_http_code=201` local, `charlie_sees_link=0`
  after settle → missing fanout, matches v0.6.1 #319 pattern 1:1.
- #326: r15 scenario-5 `consolidate_http_code=200`,
  `consolidated_from_agents=\"[]\"` on peer → peer never saw the memory
  at all → missing fanout.
- #327: r15 scenario-18 `seen_by_charlie=0` for both markers. 4 competing
  hypotheses per issue; shipping diagnostic instead of speculative fix.

## Gates

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` — **313 passing**
  (+1 new: `http_sync_push_applies_incoming_links`)
- [ ] a2a-hermes r16 dispatch — scheduled post-merge

## AI involvement

Diagnosis by AI NHI (Claude Opus 4.7) under AlphaOne RCA Standard v1
(memory `88254818`). Each root cause pinned to specific r15 evidence
before code-level hypothesis.

Model: `claude-opus-4-7` (1M context)
Scope: Standard authority (federation handler changes; unit test added;
existing 503 payload contract respected).

## Closes

- Closes #325 (create-link fanout; delete-link deferred to v0.7)
- Closes #326
- Addresses #327 (diagnostic only — root-cause fix pending r16 evidence)

## Test plan

- [x] Unit tests in this PR
- [ ] Merge → dispatch a2a-hermes r16 → expect **13/14 pass**
  (scenario-18 still red until #327 root-cause fix lands; but r16
  `/health` output will decide H1 vs H3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)