### PR TITLE
ci: skip publication jobs on SemVer pre-release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,9 @@ jobs:
   crates-io:
     name: Publish to crates.io
     needs: check
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Skip pre-release tags (SemVer `-` suffix, e.g. v0.6.2-rc.0) — only
+    # real releases (v0.6.2 without suffix) publish to crates.io.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -154,7 +156,8 @@ jobs:
   homebrew:
     name: Update Homebrew formula
     needs: release
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Skip pre-release tags — Homebrew users get the latest stable only.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       - name: Extract version from tag
@@ -259,7 +262,8 @@ jobs:
   docker:
     name: Docker (GHCR)
     needs: check
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Skip pre-release tags — GHCR image tags reflect stable releases only.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       contents: read
       packages: write
@@ -298,7 +302,8 @@ jobs:
   ppa:
     name: Ubuntu PPA
     needs: check
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Skip pre-release tags — Launchpad PPA users get stable releases only.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -359,7 +364,8 @@ jobs:
   copr:
     name: Fedora COPR
     needs: release
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Skip pre-release tags — Fedora COPR users get stable releases only.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Adds \`&& !contains(github.ref_name, '-')\` to the 5 publication jobs in CI so SemVer pre-release tags (e.g. \`v0.6.2-rc.0\`) **build binaries** but **skip** crates.io / Homebrew / Docker / PPA / COPR publication.

## Unlocks

- Tag \`v0.6.2-rc.0\` → CI builds binary tarballs, uploads to GitHub Pre-release.
- ai2ai-gate consumes those tarballs via \`ai_memory_git_ref=v0.6.2-rc.0\`.
- No public distribution pipeline fires.
- When biologic approves real release: tag \`v0.6.2\` (no suffix) → full cascade fires.

## Changes

| Job | Before | After |
|---|---|---|
| Check (Linux/macOS/Windows) | always | always (unchanged) |
| Release (binary tarballs + GitHub Release upload) | v* tags | v* tags (unchanged — pre-releases still get binaries) |
| crates-io | v* tags | v* tags **WITHOUT** \`-\` |
| Homebrew | v* tags | v* tags **WITHOUT** \`-\` |
| Docker GHCR | v* tags | v* tags **WITHOUT** \`-\` |
| Ubuntu PPA | v* tags | v* tags **WITHOUT** \`-\` |
| Fedora COPR | v* tags | v* tags **WITHOUT** \`-\` |

## Test plan

- [ ] Merge → tag \`v0.6.2-rc.0\` → observe only Check + Release jobs run.
- [ ] Verify Pre-release \`v0.6.2-rc.0\` appears on GitHub Releases with tarball assets.
- [ ] Verify crates.io, Homebrew, etc. show NO new activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)