### PR TITLE
feat(http): archive endpoint + bulk_create fanout + sync/since diagnostics (S29, S40, S39)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -805,6 +805,68 @@ pub fn delete(conn: &Connection, id: &str) -> Result<bool> {
     Ok(changed > 0)
 }
 
+/// Move a memory from `memories` to `archived_memories`. Used by the
+/// HTTP `/api/v1/archive` explicit-archive endpoint (S29) and by
+/// `sync_push` when a peer pushes an `archives: [id]` record.
+///
+/// Unlike `gc(archive=true)` this does not filter on `expires_at` — the
+/// caller is explicitly asking for the row to be archived right now.
+///
+/// Returns `true` if a row was moved, `false` if no live memory existed
+/// with this id (e.g. it was already archived or never written locally).
+/// A missing-on-peer id is expected during normal fanout and callers
+/// treat it as a no-op.
+///
+/// # Errors
+///
+/// Returns an error if the INSERT-SELECT or DELETE fails.
+pub fn archive_memory(conn: &Connection, id: &str, reason: Option<&str>) -> Result<bool> {
+    let now = Utc::now().to_rfc3339();
+    let reason = reason.unwrap_or("archive");
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = (|| -> Result<bool> {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM memories WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap_or(false);
+        if !exists {
+            return Ok(false);
+        }
+        conn.execute(
+            "INSERT OR REPLACE INTO archived_memories
+             (id, tier, namespace, title, content, tags, priority, confidence,
+              source, access_count, created_at, updated_at, last_accessed_at,
+              expires_at, archived_at, archive_reason, metadata)
+             SELECT id, tier, namespace, title, content, tags, priority, confidence,
+                    source, access_count, created_at, updated_at, last_accessed_at,
+                    expires_at, ?1, ?2, metadata
+             FROM memories WHERE id = ?3",
+            params![now, reason, id],
+        )?;
+        // Clean up namespace_meta — mirrors `delete`'s cleanup so an archived
+        // row is not still referenced as the namespace standard.
+        conn.execute(
+            "DELETE FROM namespace_meta WHERE standard_id = ?1",
+            params![id],
+        )?;
+        let removed = conn.execute("DELETE FROM memories WHERE id = ?1", params![id])?;
+        Ok(removed > 0)
+    })();
+    match result {
+        Ok(moved) => {
+            conn.execute_batch("COMMIT")?;
+            Ok(moved)
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(e)
+        }
+    }
+}
+
 /// Count memories that would be deleted by forget (for `dry_run`).
 pub fn forget_count(
     conn: &Connection,
@@ -3718,6 +3780,55 @@ mod tests {
 
         let stats = archive_stats(&conn).unwrap();
         assert_eq!(stats["archived_total"], 2);
+    }
+
+    #[test]
+    fn archive_memory_moves_live_row_to_archive() {
+        // S29 — explicit archive endpoint must move the row out of
+        // `memories` and into `archived_memories` with the caller-supplied
+        // reason. Unlike gc(archive=true), this is NOT gated on
+        // `expires_at` — the caller is asking for it right now.
+        let conn = test_db();
+        let mem = make_memory("Archive me", "s29", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+
+        let moved = archive_memory(&conn, &id, Some("explicit")).unwrap();
+        assert!(moved, "live row must be archived on first call");
+        assert!(
+            get(&conn, &id).unwrap().is_none(),
+            "row must be removed from active table"
+        );
+
+        let archived = list_archived(&conn, None, 10, 0).unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0]["id"], id);
+        assert_eq!(archived[0]["archive_reason"], "explicit");
+
+        // Second call is a no-op — row is already out of `memories`.
+        let second = archive_memory(&conn, &id, Some("explicit")).unwrap();
+        assert!(
+            !second,
+            "second archive call must report no-op (no live row)"
+        );
+    }
+
+    #[test]
+    fn archive_memory_missing_id_returns_false() {
+        // Peers that never saw M1 must no-op, not error, on sync_push
+        // archives fanout.
+        let conn = test_db();
+        let moved = archive_memory(&conn, "nonexistent-id", None).unwrap();
+        assert!(!moved);
+    }
+
+    #[test]
+    fn archive_memory_default_reason_is_archive() {
+        let conn = test_db();
+        let mem = make_memory("Default reason", "s29", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+        assert!(archive_memory(&conn, &id, None).unwrap());
+        let archived = list_archived(&conn, None, 10, 0).unwrap();
+        assert_eq!(archived[0]["archive_reason"], "archive");
     }
 
     #[test]

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -469,6 +469,97 @@ pub async fn broadcast_delete_quorum(
     Ok(tracker)
 }
 
+/// v0.6.2 (S29): fan out a just-archived memory id to every peer. Payload
+/// rides on `sync_push` via `archives: [id]`, mirroring the shape used
+/// by `broadcast_delete_quorum` for deletions. On the receiving peer,
+/// `sync_push` calls `db::archive_memory` to move the row into
+/// `archived_memories` — unlike the delete path this is a soft removal
+/// (the row remains queryable via `/api/v1/archive`).
+///
+/// Same quorum contract as `broadcast_store_quorum` / `broadcast_delete_quorum`.
+///
+/// # Errors
+///
+/// Returns `QuorumError::LocalWriteFailed` if the internal tracker Arc cannot
+/// be unwrapped (only occurs under a pathological detach race).
+// Intentional: wired into the `/api/v1/archive` HTTP endpoint in the
+// follow-up commit of this PR. Tests in this module exercise it directly.
+#[allow(dead_code)]
+pub async fn broadcast_archive_quorum(
+    config: &FederationConfig,
+    id: &str,
+) -> Result<AckTracker, QuorumError> {
+    let now = Instant::now();
+    let tracker = Arc::new(Mutex::new(AckTracker::new(config.policy.clone(), now)));
+    tracker.lock().await.record_local();
+
+    let body = serde_json::json!({
+        "sender_agent_id": config.sender_agent_id,
+        "memories": [],
+        "archives": [id],
+        "dry_run": false,
+    });
+
+    let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
+    for peer in &config.peers {
+        let client = config.client.clone();
+        let url = peer.sync_push_url.clone();
+        let peer_id = peer.id.clone();
+        let payload = body.clone();
+        let target_id = id.to_string();
+        joins.spawn(async move {
+            let outcome =
+                post_and_classify(&client, &url, &payload, &target_id, Some(&target_id)).await;
+            (peer_id, outcome)
+        });
+    }
+
+    let deadline = now + config.policy.ack_timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, joins.join_next()).await {
+            Ok(Some(Ok((peer_id, AckOutcome::Ack)))) => {
+                tracker.lock().await.record_peer_ack(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::IdDrift)))) => {
+                tracker.lock().await.record_id_drift(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::Fail(reason))))) => {
+                tracing::warn!("federation: archive peer {peer_id} failed for {id}: {reason}");
+            }
+            Ok(Some(Err(e))) => {
+                tracing::warn!("federation: archive peer join error: {e}");
+            }
+            Ok(None) | Err(_) => break,
+        }
+        if tracker.lock().await.is_quorum_met(Instant::now()) {
+            break;
+        }
+    }
+
+    if !joins.is_empty() {
+        tokio::spawn(async move {
+            while let Some(res) = joins.join_next().await {
+                if let Ok((peer_id, AckOutcome::Fail(reason))) = res {
+                    tracing::debug!(
+                        "federation: post-quorum archive peer {peer_id} did not ack: {reason}"
+                    );
+                }
+            }
+        });
+    }
+
+    let tracker = Arc::try_unwrap(tracker)
+        .map_err(|_| QuorumError::LocalWriteFailed {
+            detail: "tracker arc still referenced at finalise".to_string(),
+        })?
+        .into_inner();
+    Ok(tracker)
+}
+
 /// v0.6.2 (#325): fan out a just-committed memory link to every peer.
 /// Payload rides on `sync_push` via `links: [link]`. Same quorum contract
 /// as `broadcast_store_quorum`.
@@ -1114,5 +1205,43 @@ mod tests {
         assert_eq!(payload.got, 1);
         assert_eq!(payload.needed, 3);
         assert_eq!(payload.reason, "timeout");
+    }
+
+    // --- broadcast_archive_quorum tests (S29) ---
+
+    #[tokio::test]
+    async fn archive_quorum_two_peers_ack_meets_quorum() {
+        let (url1, count1) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let (url2, count2) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let cfg = build_config(vec![url1, url2], 2, 2000);
+        let tracker = broadcast_archive_quorum(&cfg, "mem-s29").await.unwrap();
+        let result = finalise_quorum(&tracker);
+        assert!(result.is_ok(), "expected quorum met, got {result:?}");
+        // Let detached fanout complete so both peers are observed.
+        for _ in 0..20 {
+            if count1.load(Ordering::Relaxed) == 1 && count2.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(count1.load(Ordering::Relaxed), 1);
+        assert_eq!(count2.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn archive_quorum_partition_minority_fails() {
+        // N = 3, W = 3. Two peers fail → archive quorum cannot be met.
+        let (url1, _) = spawn_mock_peer(MockBehaviour::Fail).await;
+        let (url2, _) = spawn_mock_peer(MockBehaviour::Fail).await;
+        let cfg = build_config(vec![url1, url2], 3, 500);
+        let tracker = broadcast_archive_quorum(&cfg, "mem-s29").await.unwrap();
+        let err = finalise_quorum(&tracker).unwrap_err();
+        match err {
+            QuorumError::QuorumNotMet { got, needed, .. } => {
+                assert_eq!(got, 1);
+                assert_eq!(needed, 3);
+            }
+            other => panic!("expected QuorumNotMet, got {other:?}"),
+        }
     }
 }

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -482,9 +482,6 @@ pub async fn broadcast_delete_quorum(
 ///
 /// Returns `QuorumError::LocalWriteFailed` if the internal tracker Arc cannot
 /// be unwrapped (only occurs under a pathological detach race).
-// Intentional: wired into the `/api/v1/archive` HTTP endpoint in the
-// follow-up commit of this PR. Tests in this module exercise it directly.
-#[allow(dead_code)]
 pub async fn broadcast_archive_quorum(
     config: &FederationConfig,
     id: &str,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2070,6 +2070,122 @@ pub async fn archive_stats(State(state): State<Db>) -> impl IntoResponse {
     }
 }
 
+/// Request body for `POST /api/v1/archive` — S29 explicit archive.
+#[derive(Debug, Deserialize)]
+pub struct ArchiveByIdsBody {
+    pub ids: Vec<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// POST /api/v1/archive — explicit archive of the given memory ids
+/// (S29). For each id:
+///   1. Call `db::archive_memory` locally to soft-move the row.
+///   2. If federation is configured, broadcast via
+///      `broadcast_archive_quorum` so peers land in the same terminal
+///      state (row out of `memories`, row into `archived_memories`).
+///
+/// On a quorum miss for ANY id, short-circuit with 503 via the shared
+/// `fanout_or_503`-style payload. This matches the posture of the
+/// delete + consolidate fanout endpoints.
+///
+/// Response body:
+/// ```json
+/// {"archived": [id1, id2], "missing": [id3], "count": 2}
+/// ```
+/// where `missing` enumerates ids that had no live row locally (common
+/// during retries). The response never includes content/metadata — use
+/// `GET /api/v1/archive` to list archive entries.
+pub async fn archive_by_ids(
+    State(app): State<AppState>,
+    Json(body): Json<ArchiveByIdsBody>,
+) -> impl IntoResponse {
+    // Bound the batch the same way bulk_create / sync_push do.
+    if body.ids.len() > MAX_BULK_SIZE {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("archive limited to {} ids per request", MAX_BULK_SIZE)})),
+        )
+            .into_response();
+    }
+    // Validate all ids up-front so we never start mutating on a bad batch.
+    for id in &body.ids {
+        if let Err(e) = validate::validate_id(id) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid id {id}: {e}")})),
+            )
+                .into_response();
+        }
+    }
+    let reason = body.reason.as_deref().unwrap_or("archive").to_string();
+    let mut archived: Vec<String> = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
+
+    for id in &body.ids {
+        // Local archive. Hold the lock only across this one call per id so
+        // we can release it before a potentially slow network fanout.
+        let moved = {
+            let lock = app.db.lock().await;
+            match db::archive_memory(&lock.0, id, Some(&reason)) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!("archive_by_ids: archive_memory({id}) failed: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            }
+        };
+        if !moved {
+            // Row wasn't live locally — record as missing but keep going.
+            // Do NOT fan out (peers can't know to archive from a row they
+            // may have under a different state; the originator's local
+            // state is the trigger).
+            missing.push(id.clone());
+            continue;
+        }
+
+        // Fanout. Mirror the shape used by the other
+        // quorum-backed write endpoints (delete, consolidate) — on a
+        // miss, surface the `quorum_not_met` payload with 503 + Retry-After.
+        if let Some(fed) = app.federation.as_ref() {
+            match crate::federation::broadcast_archive_quorum(fed, id).await {
+                Ok(tracker) => {
+                    if let Err(err) = crate::federation::finalise_quorum(&tracker) {
+                        let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            [("Retry-After", "2")],
+                            Json(serde_json::to_value(&payload).unwrap_or_default()),
+                        )
+                            .into_response();
+                    }
+                }
+                Err(e) => {
+                    // Local commit already landed — sync-daemon catches
+                    // stragglers. Same posture as `fanout_or_503`.
+                    tracing::warn!("archive fanout error (local committed): {e:?}");
+                }
+            }
+        }
+        archived.push(id.clone());
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "archived": archived,
+            "missing": missing,
+            "count": archived.len(),
+            "reason": reason,
+        })),
+    )
+        .into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Phase 3 foundation (issue #224) — HTTP sync endpoints.
 //
@@ -3684,6 +3800,127 @@ mod tests {
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0]["id"], id);
         assert_eq!(archived[0]["archive_reason"], "sync_push");
+    }
+
+    #[tokio::test]
+    async fn http_archive_by_ids_happy_path() {
+        // S29 — POST /api/v1/archive with `{ids:[...]}` soft-moves each
+        // live row to the archive table with the supplied reason.
+        // Missing ids are reported in a `missing` array, not an error.
+        let state = test_state();
+        let live_id = {
+            let lock = state.lock().await;
+            let now = Utc::now().to_rfc3339();
+            let mem = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: Tier::Long,
+                namespace: "s29".into(),
+                title: "Live for archive".into(),
+                content: "will be archived".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now,
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({}),
+            };
+            db::insert(&lock.0, &mem).unwrap()
+        };
+
+        let app = Router::new()
+            .route("/api/v1/archive", axum_post(archive_by_ids))
+            .with_state(test_app_state(state.clone()));
+
+        let body = serde_json::json!({
+            "ids": [live_id, "does-not-exist"],
+            "reason": "scenario_s29"
+        });
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/archive")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["count"], 1);
+        assert_eq!(v["archived"].as_array().unwrap().len(), 1);
+        assert_eq!(v["missing"].as_array().unwrap().len(), 1);
+        assert_eq!(v["reason"], "scenario_s29");
+
+        // Row is gone from active, present in archive with caller's reason.
+        let lock = state.lock().await;
+        assert!(db::get(&lock.0, &live_id).unwrap().is_none());
+        let archived = db::list_archived(&lock.0, None, 10, 0).unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0]["id"], live_id);
+        assert_eq!(archived[0]["archive_reason"], "scenario_s29");
+    }
+
+    #[tokio::test]
+    async fn http_archive_by_ids_default_reason() {
+        // When `reason` is omitted the response + archive row must record
+        // the default "archive" reason (matches `db::archive_memory`).
+        let state = test_state();
+        let live_id = {
+            let lock = state.lock().await;
+            let now = Utc::now().to_rfc3339();
+            let mem = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: Tier::Long,
+                namespace: "s29-default".into(),
+                title: "Default reason".into(),
+                content: "c".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now,
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({}),
+            };
+            db::insert(&lock.0, &mem).unwrap()
+        };
+
+        let app = Router::new()
+            .route("/api/v1/archive", axum_post(archive_by_ids))
+            .with_state(test_app_state(state.clone()));
+        let body = serde_json::json!({"ids": [live_id]});
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/archive")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["reason"], "archive");
+        let lock = state.lock().await;
+        let archived = db::list_archived(&lock.0, None, 10, 0).unwrap();
+        assert_eq!(archived[0]["archive_reason"], "archive");
     }
 
     #[tokio::test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2102,6 +2102,12 @@ pub struct SyncPushBody {
     /// same delete reaches every peer well before any revival window.
     #[serde(default)]
     pub deletions: Vec<String>,
+    /// v0.6.2 (S29): memory IDs the sender has explicitly archived and
+    /// wants propagated. Applied via `db::archive_memory` — a soft move
+    /// from `memories` to `archived_memories`. Missing-on-peer IDs no-op.
+    /// Distinct from `deletions`, which is a hard DELETE.
+    #[serde(default)]
+    pub archives: Vec<String>,
     /// v0.6.2 (#325): memory links the sender wants propagated. Applied
     /// via `db::create_link` on each peer. Duplicates are a no-op thanks
     /// to the unique `(source_id, target_id, relation)` constraint on
@@ -2159,6 +2165,15 @@ pub async fn sync_push(
         )
             .into_response();
     }
+    if body.archives.len() > MAX_BULK_SIZE {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!("sync_push limited to {} archives per request", MAX_BULK_SIZE)
+            })),
+        )
+            .into_response();
+    }
     // Receiver's local identity — default to the caller-supplied header,
     // fall back to the anonymous placeholder. Recorded in sync_state rows.
     let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
@@ -2178,6 +2193,7 @@ pub async fn sync_push(
     let mut noop = 0usize;
     let mut skipped = 0usize;
     let mut deleted = 0usize;
+    let mut archived = 0usize;
     let mut latest_seen: Option<String> = None;
 
     // v0.6.0.1 (#322): peers that apply a synced memory must also refresh
@@ -2234,6 +2250,29 @@ pub async fn sync_push(
             Ok(false) => noop += 1,
             Err(e) => {
                 tracing::warn!("sync_push: delete failed for {del_id}: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    // v0.6.2 (S29): process explicit archives. Soft-move from `memories`
+    // to `archived_memories` — distinct from deletions which hard-delete.
+    // Missing rows count as no-op (peer may have already archived or
+    // never received the original write).
+    for arch_id in &body.archives {
+        if validate::validate_id(arch_id).is_err() {
+            skipped += 1;
+            continue;
+        }
+        if body.dry_run {
+            noop += 1;
+            continue;
+        }
+        match db::archive_memory(&lock.0, arch_id, Some("sync_push")) {
+            Ok(true) => archived += 1,
+            Ok(false) => noop += 1,
+            Err(e) => {
+                tracing::warn!("sync_push: archive_memory failed for {arch_id}: {e}");
                 skipped += 1;
             }
         }
@@ -2328,6 +2367,7 @@ pub async fn sync_push(
         Json(json!({
             "applied": applied,
             "deleted": deleted,
+            "archived": archived,
             "links_applied": links_applied,
             "noop": noop,
             "skipped": skipped,
@@ -3572,6 +3612,78 @@ mod tests {
             "push must record sender in sync_state; got: {:?}",
             clock.entries
         );
+    }
+
+    #[tokio::test]
+    async fn http_sync_push_applies_archives() {
+        // S29 — sync_push must accept an `archives` field and move matching
+        // rows from `memories` to `archived_memories` via
+        // `db::archive_memory`. Missing ids no-op. The response exposes a
+        // new `archived` counter.
+        let state = test_state();
+        // Seed one row that the peer will ask us to archive; one id that
+        // doesn't exist here (must no-op, not error).
+        let id = {
+            let lock = state.lock().await;
+            let now = Utc::now().to_rfc3339();
+            let mem = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: Tier::Long,
+                namespace: "s29".into(),
+                title: "Archive M1".into(),
+                content: "body".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now,
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({}),
+            };
+            db::insert(&lock.0, &mem).unwrap()
+        };
+
+        let app = Router::new()
+            .route("/api/v1/sync/push", axum_post(sync_push))
+            .with_state(test_app_state(state.clone()));
+
+        let body = serde_json::json!({
+            "sender_agent_id": "peer-a",
+            "sender_clock": {"entries": {}},
+            "memories": [],
+            "archives": [id, "missing-on-peer"],
+            "dry_run": false
+        });
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/push")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["archived"], 1, "live row must be archived");
+        assert_eq!(v["noop"], 1, "missing id must no-op");
+
+        // Row is gone from active memories, present in archive, with the
+        // correct `sync_push` reason.
+        let lock = state.lock().await;
+        assert!(db::get(&lock.0, &id).unwrap().is_none());
+        let archived = db::list_archived(&lock.0, None, 10, 0).unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0]["id"], id);
+        assert_eq!(archived[0]["archive_reason"], "sync_push");
     }
 
     #[tokio::test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2571,11 +2571,28 @@ pub async fn sync_since(
         tracing::debug!("sync_since: sync_state_observe failed: {e}");
     }
 
+    // S39 diagnostic echo (v0.6.2). The testbook scenario writes 6 rows
+    // while peer-3 is suspended then queries `/sync/since?since=<ckpt>`
+    // and expects the 6 back. When the count comes back 0, the scenario
+    // can't tell whether:
+    //   a) the server parsed `since` differently than expected,
+    //   b) `limit` silently truncated, or
+    //   c) the returned timestamps don't actually cover the expected range.
+    // Echoing `updated_since` (what the server parsed, verbatim) plus
+    // earliest / latest `updated_at` from the result set lets the
+    // scenario pin the failure mode without changing any behavior. Fields
+    // are additive — no existing caller assertion regresses.
+    let earliest_updated_at = mems.first().map(|m| m.updated_at.clone());
+    let latest_updated_at = mems.last().map(|m| m.updated_at.clone());
+
     (
         StatusCode::OK,
         Json(json!({
             "count": mems.len(),
             "limit": limit,
+            "updated_since": q.since,
+            "earliest_updated_at": earliest_updated_at,
+            "latest_updated_at": latest_updated_at,
             "memories": mems,
         })),
     )
@@ -4557,6 +4574,91 @@ mod tests {
             .filter_map(|m| m["title"].as_str().map(str::to_string))
             .collect();
         assert_eq!(titles, vec!["new-mem".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn http_sync_since_includes_s39_diagnostic_fields() {
+        // S39 — the response must echo `updated_since` (parsed `since`)
+        // and earliest/latest `updated_at` from the returned set. This
+        // lets the scenario pin whether the server saw the expected
+        // checkpoint without changing the set-returning behavior.
+        let state = test_state();
+        // Seed three rows in strictly-ordered time so earliest != latest.
+        let mid_ts = "2024-06-01T00:00:00+00:00";
+        let newer_ts = "2025-06-01T00:00:00+00:00";
+        let newest_ts = "2026-01-01T00:00:00+00:00";
+        {
+            let lock = state.lock().await;
+            for (title, ts) in [("mid", mid_ts), ("newer", newer_ts), ("newest", newest_ts)] {
+                let mem = Memory {
+                    id: Uuid::new_v4().to_string(),
+                    tier: Tier::Long,
+                    namespace: "s39-diag".into(),
+                    title: title.into(),
+                    content: "c".into(),
+                    tags: vec![],
+                    priority: 5,
+                    confidence: 1.0,
+                    source: "api".into(),
+                    access_count: 0,
+                    created_at: ts.to_string(),
+                    updated_at: ts.to_string(),
+                    last_accessed_at: None,
+                    expires_at: None,
+                    metadata: serde_json::json!({}),
+                };
+                db::insert(&lock.0, &mem).unwrap();
+            }
+        }
+
+        let app = Router::new()
+            .route("/api/v1/sync/since", axum_get(sync_since))
+            .with_state(state.clone());
+
+        // Ask for rows strictly after 2024-01 — should return all 3.
+        let since = "2024-01-01T00:00:00%2B00:00";
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/api/v1/sync/since?since={since}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["count"], 3);
+        // Echoed `since` (unparsed, verbatim — that's the point).
+        assert_eq!(v["updated_since"], "2024-01-01T00:00:00+00:00");
+        assert_eq!(v["earliest_updated_at"], mid_ts);
+        assert_eq!(v["latest_updated_at"], newest_ts);
+
+        // Empty set → both timestamp fields are null. The `updated_since`
+        // field still echoes the parsed input.
+        let empty_app = Router::new()
+            .route("/api/v1/sync/since", axum_get(sync_since))
+            .with_state(state);
+        let resp = empty_app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/sync/since?since=2099-01-01T00:00:00%2B00:00")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["count"], 0);
+        assert!(v["earliest_updated_at"].is_null());
+        assert!(v["latest_updated_at"].is_null());
+        assert_eq!(v["updated_since"], "2099-01-01T00:00:00+00:00");
     }
 
     #[tokio::test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1907,7 +1907,7 @@ pub async fn consolidate_memories(
 }
 
 pub async fn bulk_create(
-    State(state): State<Db>,
+    State(app): State<AppState>,
     Json(bodies): Json<Vec<CreateMemory>>,
 ) -> impl IntoResponse {
     if bodies.len() > MAX_BULK_SIZE {
@@ -1918,42 +1918,70 @@ pub async fn bulk_create(
             .into_response();
     }
     let now = Utc::now();
-    let lock = state.lock().await;
-    let mut created = 0usize;
-    let mut errors = Vec::new();
-    for body in bodies {
-        if let Err(e) = validate::validate_create(&body) {
-            errors.push(format!("{}: {}", body.title, e));
-            continue;
-        }
-        let expires_at = body.expires_at.or_else(|| {
-            body.ttl_secs
-                .or(lock.2.ttl_for_tier(&body.tier))
-                .map(|s| (now + Duration::seconds(s)).to_rfc3339())
-        });
-        let mem = Memory {
-            id: Uuid::new_v4().to_string(),
-            tier: body.tier,
-            namespace: body.namespace,
-            title: body.title,
-            content: body.content,
-            tags: body.tags,
-            priority: body.priority.clamp(1, 10),
-            confidence: body.confidence.clamp(0.0, 1.0),
-            source: body.source,
-            access_count: 0,
-            created_at: now.to_rfc3339(),
-            updated_at: now.to_rfc3339(),
-            last_accessed_at: None,
-            expires_at,
-            metadata: body.metadata,
-        };
-        match db::insert(&lock.0, &mem) {
-            Ok(_) => created += 1,
-            Err(e) => errors.push(e.to_string()),
+    // Stage 1 — validate + insert locally. Collect the successfully-inserted
+    // `Memory` values so we can fanout each one after we release the DB lock
+    // (peers POST to our /sync/push and we'd deadlock on the Mutex if we
+    // held it across the network call).
+    let mut created_mems: Vec<Memory> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    {
+        let lock = app.db.lock().await;
+        for body in bodies {
+            if let Err(e) = validate::validate_create(&body) {
+                errors.push(format!("{}: {}", body.title, e));
+                continue;
+            }
+            let expires_at = body.expires_at.or_else(|| {
+                body.ttl_secs
+                    .or(lock.2.ttl_for_tier(&body.tier))
+                    .map(|s| (now + Duration::seconds(s)).to_rfc3339())
+            });
+            let mem = Memory {
+                id: Uuid::new_v4().to_string(),
+                tier: body.tier,
+                namespace: body.namespace,
+                title: body.title,
+                content: body.content,
+                tags: body.tags,
+                priority: body.priority.clamp(1, 10),
+                confidence: body.confidence.clamp(0.0, 1.0),
+                source: body.source,
+                access_count: 0,
+                created_at: now.to_rfc3339(),
+                updated_at: now.to_rfc3339(),
+                last_accessed_at: None,
+                expires_at,
+                metadata: body.metadata,
+            };
+            match db::insert(&lock.0, &mem) {
+                Ok(_) => created_mems.push(mem),
+                Err(e) => errors.push(e.to_string()),
+            }
         }
     }
-    Json(json!({"created": created, "errors": errors})).into_response()
+    // Stage 2 — federation fanout, once per successfully-inserted row. On
+    // quorum miss for one row, we record the failure in `errors` and keep
+    // going: a single memory's quorum miss should NOT abort 499 other
+    // memories the caller just paid for. This is deliberately weaker than
+    // `create_memory`'s 503 — caller opted in to bulk semantics.
+    if let Some(fed) = app.federation.as_ref() {
+        for mem in &created_mems {
+            match crate::federation::broadcast_store_quorum(fed, mem).await {
+                Ok(tracker) => {
+                    if let Err(err) = crate::federation::finalise_quorum(&tracker) {
+                        errors.push(format!("{}: {err}", mem.id));
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "bulk_create: fanout for {} failed (local committed): {e:?}",
+                        mem.id
+                    );
+                }
+            }
+        }
+    }
+    Json(json!({"created": created_mems.len(), "errors": errors})).into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -3921,6 +3949,184 @@ mod tests {
         let lock = state.lock().await;
         let archived = db::list_archived(&lock.0, None, 10, 0).unwrap();
         assert_eq!(archived[0]["archive_reason"], "archive");
+    }
+
+    #[tokio::test]
+    async fn http_bulk_create_uses_appstate_and_persists() {
+        // S40 prep — bulk_create previously took `State<Db>` with no path
+        // to `app.federation`, so every bulk row stayed on the originator.
+        // Signature is now `State<AppState>` and each row is persisted.
+        let state = test_state();
+        let app = Router::new()
+            .route("/api/v1/memories/bulk", axum_post(bulk_create))
+            .with_state(test_app_state(state.clone()));
+
+        let bodies: Vec<serde_json::Value> = (0..5)
+            .map(|i| {
+                serde_json::json!({
+                    "tier": "long",
+                    "namespace": "bulk-appstate",
+                    "title": format!("bulk-{i}"),
+                    "content": format!("body-{i}"),
+                    "tags": [],
+                    "priority": 5,
+                    "confidence": 1.0,
+                    "source": "api",
+                    "metadata": {}
+                })
+            })
+            .collect();
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/memories/bulk")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&bodies).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["created"], 5);
+        assert!(v["errors"].as_array().unwrap().is_empty());
+
+        // Every row is visible in the DB (was the S40 gap — rows never
+        // made it past the local insert loop, leaving peers empty).
+        let lock = state.lock().await;
+        let rows = db::list(
+            &lock.0,
+            Some("bulk-appstate"),
+            None,
+            100,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 5, "bulk rows must persist via AppState");
+    }
+
+    #[tokio::test]
+    async fn http_bulk_create_fans_out_with_federation() {
+        // S40 — with federation configured, each successfully-inserted row
+        // in a bulk call must fan out to every peer. We spin up an axum
+        // mock peer that records sync_push POSTs and bulk-create N rows;
+        // the mock must see N POSTs (background-detached + foreground).
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::net::TcpListener;
+
+        let state = test_state();
+
+        // Mock peer that counts sync_push POSTs and always acks.
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_peer = count.clone();
+        #[derive(Clone)]
+        struct MockState {
+            count: Arc<AtomicUsize>,
+        }
+        async fn mock_sync_push(
+            axum::extract::State(s): axum::extract::State<MockState>,
+            Json(_body): Json<serde_json::Value>,
+        ) -> (StatusCode, Json<serde_json::Value>) {
+            s.count.fetch_add(1, Ordering::Relaxed);
+            (
+                StatusCode::OK,
+                Json(json!({"applied":1,"noop":0,"skipped":0})),
+            )
+        }
+        let peer_app = Router::new()
+            .route("/api/v1/sync/push", axum_post(mock_sync_push))
+            .with_state(MockState {
+                count: count_for_peer,
+            });
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, peer_app).await.ok();
+        });
+
+        // Build a FederationConfig that targets the mock.
+        let peer_url = format!("http://{addr}");
+        let fed = crate::federation::FederationConfig::build(
+            2, // W=2 — local + 1 peer
+            &[peer_url],
+            std::time::Duration::from_millis(2000),
+            None,
+            None,
+            None,
+            "ai:bulk-test".to_string(),
+        )
+        .unwrap()
+        .expect("federation must be built");
+
+        let app_state = AppState {
+            db: state.clone(),
+            embedder: Arc::new(None),
+            vector_index: Arc::new(Mutex::new(None)),
+            federation: Arc::new(Some(fed)),
+            tier_config: Arc::new(crate::config::FeatureTier::Keyword.config()),
+        };
+        let router = Router::new()
+            .route("/api/v1/memories/bulk", axum_post(bulk_create))
+            .with_state(app_state);
+
+        // 4 rows — keeps the test fast while proving fanout ran per-row.
+        let n = 4;
+        let bodies: Vec<serde_json::Value> = (0..n)
+            .map(|i| {
+                serde_json::json!({
+                    "tier": "long",
+                    "namespace": "bulk-fanout",
+                    "title": format!("bulk-fanout-{i}"),
+                    "content": "c",
+                    "tags": [],
+                    "priority": 5,
+                    "confidence": 1.0,
+                    "source": "api",
+                    "metadata": {}
+                })
+            })
+            .collect();
+        let resp = router
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/memories/bulk")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&bodies).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["created"], n);
+
+        // Foreground fanout already waits for W-1 acks per row, so the
+        // per-row POST has landed by the time the request returns. Give
+        // detached stragglers a quick window just in case.
+        for _ in 0..20 {
+            if count.load(Ordering::Relaxed) >= n {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            n,
+            "mock peer must receive one sync_push POST per bulk row"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1157,6 +1157,7 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         .route("/api/v1/export", get(handlers::export_memories))
         .route("/api/v1/import", post(handlers::import_memories))
         .route("/api/v1/archive", get(handlers::list_archive))
+        .route("/api/v1/archive", post(handlers::archive_by_ids))
         .route("/api/v1/archive", delete(handlers::purge_archive))
         .route(
             "/api/v1/archive/{id}/restore",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8746,3 +8746,68 @@ fn http_session_start_rejects_invalid_agent_id() {
     );
     assert_eq!(code, "400");
 }
+
+#[test]
+fn http_archive_by_ids_end_to_end_moves_row_from_active_to_archive() {
+    // Scenario S29 end-to-end via a real spawned daemon:
+    //   1. POST /api/v1/memories to create M1 locally.
+    //   2. POST /api/v1/archive with {"ids":[m1]}.
+    //   3. GET /api/v1/archive and confirm M1 is present with reason.
+    //   4. GET /api/v1/memories/{m1} returns 404.
+    let d = DaemonGuard::spawn();
+    let (code, created) = curl_post(
+        d.port,
+        "/api/v1/memories",
+        &serde_json::json!({
+            "tier": "long",
+            "namespace": "s29-e2e",
+            "title": "Archive e2e",
+            "content": "will be archived by POST /api/v1/archive",
+            "tags": [],
+            "priority": 5,
+            "confidence": 1.0,
+            "source": "api",
+            "metadata": {}
+        }),
+        Some("ai:s29"),
+    );
+    assert_eq!(code, "201", "create body: {created}");
+    let id = created["id"]
+        .as_str()
+        .expect("create response must include id")
+        .to_string();
+
+    let (code, resp) = curl_post(
+        d.port,
+        "/api/v1/archive",
+        &serde_json::json!({"ids": [id], "reason": "s29-e2e"}),
+        Some("ai:s29"),
+    );
+    assert_eq!(code, "200", "archive body: {resp}");
+    assert_eq!(resp["count"], 1);
+    assert_eq!(resp["archived"][0], id);
+
+    // Active memory is gone.
+    let (code, _) = curl_get(d.port, &format!("/api/v1/memories/{id}"));
+    assert_eq!(code, "404", "archived memory must no longer be active");
+
+    // Archive list contains the entry with the supplied reason.
+    let (code, listing) = curl_get(d.port, "/api/v1/archive?namespace=s29-e2e");
+    assert_eq!(code, "200");
+    let items = listing["archived"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], id);
+    assert_eq!(items[0]["archive_reason"], "s29-e2e");
+
+    // Re-archiving the same id is idempotent — it now counts as `missing`
+    // (no live row to move), with no error.
+    let (code, resp) = curl_post(
+        d.port,
+        "/api/v1/archive",
+        &serde_json::json!({"ids": [id]}),
+        Some("ai:s29"),
+    );
+    assert_eq!(code, "200", "second archive body: {resp}");
+    assert_eq!(resp["count"], 0);
+    assert_eq!(resp["missing"].as_array().unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #360 to close the remaining 3 scenario-blocking gaps for 100% testbook v3 pass on `release/v0.6.2`.

## Fixes

### S29 — archive lifecycle

New endpoint `POST /api/v1/archive` body `{\"ids\": [...], \"reason\": \"...\"}` that:
1. Soft-archives each memory locally (move row from `memories` → `archived_memories` with configurable reason).
2. Fans out each archive op to peers via new `federation::broadcast_archive_quorum`.

Supporting plumbing:
- `db::archive_memory(conn, id, reason)` — local move, returns true if the row existed.
- `sync_push` body extended with `archives: Vec<String>` (additive, serde default = empty). Peers process each via `db::archive_memory`.
- Response shape `{archived: [ids], missing: [ids], count, reason}` — `missing` keeps the endpoint idempotent across retries.

This closes the cross-cluster archive invariant: a memory archived on node-1 is visible via GET `/archive` on any peer and restorable via `POST /archive/{id}/restore` on any peer.

### S40 — bulk_create fanout

`bulk_create` now takes `State<AppState>` and broadcasts each successfully-inserted row via `broadcast_store_quorum`. A single-row quorum miss pushes a string into `errors` and continues — the batch is not 503'd on one miss (different posture from single `create_memory`).

### S39 — sync/since diagnostics

Additive-only. Response now includes `updated_since`, `earliest_updated_at`, `latest_updated_at` so scenarios can assert the handler saw the expected checkpoint and the returned window covers our writes. No existing-assertion regression.

## Gates

- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- `cargo test --bin ai-memory` — **324 passed** (+11 from PR #360 baseline 313)
- `cargo test --test integration` — **170 passed** (+1 from PR #360 baseline 169)
- `cargo audit` — only pre-existing rustls-pemfile (RUSTSEC-2025-0134)

## Commits

1. `c868d9c` — archive plumbing (db + federation + sync_push)
2. `0465c00` — HTTP archive endpoint
3. `9936e95` — bulk_create fanout
4. `2e4678b` — sync/since diagnostic fields

## Test plan

- [ ] Merge into `release/v0.6.2`
- [ ] Revert a2a-gate scenario 29 back to `POST /api/v1/archive` (my earlier DELETE fix is now wrong direction since this endpoint exists)
- [ ] Dispatch v3r20 on all 6 cells
- [ ] Confirm S29, S39, S40 green on both frameworks + S18 (peer embedder) investigation

## Release freeze

Still ACTIVE (memory 74698d94). No tag cut. v0.6.2 Patch 2 tag waits on 100% testbook + biologic approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)