### PR TITLE
fix(s35): clear_namespace_standard must fan out to peers (follow-up to #363)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ benchmarks/longmemeval/results/
 
 # Local scratch (never committed)
 /backup/
+.claude/

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -1082,6 +1082,99 @@ pub async fn broadcast_namespace_meta_quorum(
     Ok(tracker)
 }
 
+/// v0.6.2 (S35 follow-up): fan out a namespace-standard *clear* to peers
+/// via `sync_push.namespace_meta_clears`. PR #363 shipped set-side fanout
+/// via `broadcast_namespace_meta_quorum` but left the clear path local-only
+/// — alice clearing on node-1 didn't propagate to bob on node-2, so the
+/// scenario-35 cross-peer clear assertion failed.
+///
+/// Same quorum contract as the set broadcast: local-write pre-counted, one
+/// POST per peer, `sync_push` bodies stuffed with the list of cleared
+/// namespaces, first W-of-N acks win.
+///
+/// # Errors
+///
+/// Returns `QuorumError::LocalWriteFailed` on pathological detach race.
+pub async fn broadcast_namespace_meta_clear_quorum(
+    config: &FederationConfig,
+    namespaces: &[String],
+) -> Result<AckTracker, QuorumError> {
+    let now = Instant::now();
+    let tracker = Arc::new(Mutex::new(AckTracker::new(config.policy.clone(), now)));
+    tracker.lock().await.record_local();
+
+    let body = serde_json::json!({
+        "sender_agent_id": config.sender_agent_id,
+        "memories": [],
+        "namespace_meta_clears": namespaces,
+        "dry_run": false,
+    });
+
+    // Use the joined namespace list as the ack-classifier's `target_id` so
+    // post-quorum logs carry enough context to trace back to the operation.
+    let target_id = namespaces.join(",");
+    let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
+    for peer in &config.peers {
+        let client = config.client.clone();
+        let url = peer.sync_push_url.clone();
+        let peer_id = peer.id.clone();
+        let payload = body.clone();
+        let target = target_id.clone();
+        joins.spawn(async move {
+            let outcome = post_and_classify(&client, &url, &payload, &target, Some(&target)).await;
+            (peer_id, outcome)
+        });
+    }
+
+    let deadline = now + config.policy.ack_timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, joins.join_next()).await {
+            Ok(Some(Ok((peer_id, AckOutcome::Ack)))) => {
+                tracker.lock().await.record_peer_ack(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::IdDrift)))) => {
+                tracker.lock().await.record_id_drift(peer_id);
+            }
+            Ok(Some(Ok((peer_id, AckOutcome::Fail(reason))))) => {
+                tracing::warn!(
+                    "federation: namespace_meta_clear peer {peer_id} failed for [{}]: {reason}",
+                    target_id
+                );
+            }
+            Ok(Some(Err(e))) => {
+                tracing::warn!("federation: namespace_meta_clear peer join error: {e}");
+            }
+            Ok(None) | Err(_) => break,
+        }
+        if tracker.lock().await.is_quorum_met(Instant::now()) {
+            break;
+        }
+    }
+
+    if !joins.is_empty() {
+        tokio::spawn(async move {
+            while let Some(res) = joins.join_next().await {
+                if let Ok((peer_id, AckOutcome::Fail(reason))) = res {
+                    tracing::debug!(
+                        "federation: post-quorum namespace_meta_clear peer {peer_id} did not ack: {reason}"
+                    );
+                }
+            }
+        });
+    }
+
+    let tracker = Arc::try_unwrap(tracker)
+        .map_err(|_| QuorumError::LocalWriteFailed {
+            detail: "tracker arc still referenced at finalise".to_string(),
+        })?
+        .into_inner();
+    Ok(tracker)
+}
+
 /// Serialised 503 payload for failed quorum writes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QuorumNotMetPayload {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3930,7 +3930,7 @@ pub async fn clear_namespace_standard_qs(
 /// v0.6.2 (S35 follow-up): shared implementation for path and query-string
 /// clear handlers. Runs the local clear then, on success, fans the cleared
 /// namespace out to peers via `broadcast_namespace_meta_clear_quorum`.
-/// Returns 503 quorum_not_met when federation is configured and the quorum
+/// Returns 503 `quorum_not_met` when federation is configured and the quorum
 /// contract fails — matching the pattern established by
 /// `set_namespace_standard_inner`.
 async fn clear_namespace_standard_inner(app: &AppState, ns: &str) -> axum::response::Response {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2572,6 +2572,13 @@ pub struct SyncPushBody {
     /// auto-detected one).
     #[serde(default)]
     pub namespace_meta: Vec<crate::models::NamespaceMetaEntry>,
+    /// v0.6.2 (S35 follow-up): namespaces whose standard the sender has
+    /// *cleared* and wants propagated. Applied via `db::clear_namespace_standard`
+    /// — missing-on-peer namespaces no-op so replays are safe. Without
+    /// this, alice clearing a standard on node-1 left the row visible on
+    /// node-2's peer, breaking cross-peer rule-lifecycle assertions.
+    #[serde(default)]
+    pub namespace_meta_clears: Vec<String>,
     /// Preview mode — classify and count, do not write.
     #[serde(default)]
     pub dry_run: bool,
@@ -2668,6 +2675,18 @@ pub async fn sync_push(
             Json(json!({
                 "error": format!(
                     "sync_push limited to {} namespace_meta per request",
+                    MAX_BULK_SIZE
+                )
+            })),
+        )
+            .into_response();
+    }
+    if body.namespace_meta_clears.len() > MAX_BULK_SIZE {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "sync_push limited to {} namespace_meta_clears per request",
                     MAX_BULK_SIZE
                 )
             })),
@@ -2931,6 +2950,30 @@ pub async fn sync_push(
         }
     }
 
+    // v0.6.2 (S35 follow-up): process incoming namespace_meta_clears. Applies
+    // via `db::clear_namespace_standard` so the peer drops its meta row and
+    // subsequent `get_standard` returns empty. Missing-on-peer namespaces
+    // no-op (`changed == 0`) — replays are safe.
+    let mut namespace_meta_cleared = 0usize;
+    for ns in &body.namespace_meta_clears {
+        if validate::validate_namespace(ns).is_err() {
+            skipped += 1;
+            continue;
+        }
+        if body.dry_run {
+            noop += 1;
+            continue;
+        }
+        match db::clear_namespace_standard(&lock.0, ns) {
+            Ok(true) => namespace_meta_cleared += 1,
+            Ok(false) => noop += 1,
+            Err(e) => {
+                tracing::warn!("sync_push: clear_namespace_standard failed for {ns}: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
     // Advance the vector clock with the highest `updated_at` we observed.
     // Skipped in dry-run mode since the caller is only previewing.
     if !body.dry_run
@@ -2998,6 +3041,7 @@ pub async fn sync_push(
             "pendings_applied": pendings_applied,
             "pending_decisions_applied": pending_decisions_applied,
             "namespace_meta_applied": namespace_meta_applied,
+            "namespace_meta_cleared": namespace_meta_cleared,
             "noop": noop,
             "skipped": skipped,
             "dry_run": body.dry_run,
@@ -3821,17 +3865,10 @@ pub async fn get_namespace_standard(
 }
 
 pub async fn clear_namespace_standard(
-    State(state): State<Db>,
+    State(app): State<AppState>,
     Path(ns): Path<String>,
 ) -> impl IntoResponse {
-    let params = json!({"namespace": ns});
-    let lock = state.lock().await;
-    let result = crate::mcp::handle_namespace_clear_standard(&lock.0, &params);
-    drop(lock);
-    match result {
-        Ok(v) => (StatusCode::OK, Json(v)).into_response(),
-        Err(e) => (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response(),
-    }
+    clear_namespace_standard_inner(&app, &ns).await
 }
 
 // Query-string forms for the S34/S35 `/api/v1/namespaces?namespace=…` shape.
@@ -3877,7 +3914,7 @@ pub async fn get_namespace_standard_qs(
 }
 
 pub async fn clear_namespace_standard_qs(
-    State(state): State<Db>,
+    State(app): State<AppState>,
     Query(q): Query<NamespaceStandardQuery>,
 ) -> impl IntoResponse {
     let Some(ns) = q.namespace else {
@@ -3887,12 +3924,51 @@ pub async fn clear_namespace_standard_qs(
         )
             .into_response();
     };
+    clear_namespace_standard_inner(&app, &ns).await
+}
+
+/// v0.6.2 (S35 follow-up): shared implementation for path and query-string
+/// clear handlers. Runs the local clear then, on success, fans the cleared
+/// namespace out to peers via `broadcast_namespace_meta_clear_quorum`.
+/// Returns 503 quorum_not_met when federation is configured and the quorum
+/// contract fails — matching the pattern established by
+/// `set_namespace_standard_inner`.
+async fn clear_namespace_standard_inner(app: &AppState, ns: &str) -> axum::response::Response {
     let params = json!({"namespace": ns});
-    let lock = state.lock().await;
+    let lock = app.db.lock().await;
     let result = crate::mcp::handle_namespace_clear_standard(&lock.0, &params);
     drop(lock);
     match result {
-        Ok(v) => (StatusCode::OK, Json(v)).into_response(),
+        Ok(v) => {
+            if let Some(fed) = app.federation.as_ref() {
+                let namespaces = vec![ns.to_string()];
+                match crate::federation::broadcast_namespace_meta_clear_quorum(fed, &namespaces)
+                    .await
+                {
+                    Ok(tracker) => {
+                        if let Err(err) = crate::federation::finalise_quorum(&tracker) {
+                            let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
+                            return (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                [("Retry-After", "2")],
+                                Json(serde_json::to_value(&payload).unwrap_or_default()),
+                            )
+                                .into_response();
+                        }
+                    }
+                    Err(err) => {
+                        let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            [("Retry-After", "2")],
+                            Json(serde_json::to_value(&payload).unwrap_or_default()),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            (StatusCode::OK, Json(v)).into_response()
+        }
         Err(e) => (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response(),
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9440,6 +9440,102 @@ fn http_sync_push_applies_namespace_meta() {
 }
 
 #[test]
+fn http_sync_push_applies_namespace_meta_clears() {
+    // S35 follow-up: verify the `sync_push.namespace_meta_clears` field
+    // drops a peer-side namespace_meta row so a subsequent GET
+    // /api/v1/namespaces?namespace=… returns empty. Regression guard for
+    // the cross-peer clear path that PR #363 missed (clear handler used
+    // State<Db>, no federation broadcast).
+    let peer = DaemonGuard::spawn();
+
+    // Seed a standard memory + meta row via sync_push so the peer has
+    // something to clear.
+    let (code, created) = curl_post(
+        peer.port,
+        "/api/v1/memories",
+        &serde_json::json!({
+            "tier": "long",
+            "namespace": "s35-clear",
+            "title": "std-to-clear",
+            "content": "to be cleared",
+            "tags": [],
+            "priority": 5,
+            "confidence": 1.0,
+            "source": "api",
+            "metadata": {}
+        }),
+        Some("ai:s35c"),
+    );
+    assert_eq!(code, "201", "seed: {created}");
+    let standard_id = created["id"].as_str().unwrap().to_string();
+
+    // Install the meta row.
+    let (code, _resp) = curl_post(
+        peer.port,
+        "/api/v1/sync/push",
+        &serde_json::json!({
+            "sender_agent_id": "ai:s35-origin",
+            "memories": [],
+            "namespace_meta": [{
+                "namespace": "s35-clear",
+                "standard_id": standard_id,
+                "parent_namespace": null,
+                "updated_at": chrono::Utc::now().to_rfc3339()
+            }],
+            "dry_run": false
+        }),
+        None,
+    );
+    assert_eq!(code, "200");
+
+    // Confirm it's visible.
+    let (code, body) = curl_get(peer.port, "/api/v1/namespaces?namespace=s35-clear");
+    assert_eq!(code, "200");
+    assert!(
+        body.to_string().contains(&standard_id) || body.to_string().contains("s35-clear"),
+        "pre-clear should surface standard: {body}"
+    );
+
+    // Now fan out a clear via sync_push.namespace_meta_clears.
+    let (code, resp) = curl_post(
+        peer.port,
+        "/api/v1/sync/push",
+        &serde_json::json!({
+            "sender_agent_id": "ai:s35-origin",
+            "memories": [],
+            "namespace_meta_clears": ["s35-clear"],
+            "dry_run": false
+        }),
+        None,
+    );
+    assert_eq!(code, "200", "sync_push clear: {resp}");
+    assert_eq!(
+        resp["namespace_meta_cleared"].as_u64().unwrap_or(0),
+        1,
+        "expected namespace_meta_cleared=1: {resp}"
+    );
+
+    // Clearing again must no-op (row gone).
+    let (code, resp) = curl_post(
+        peer.port,
+        "/api/v1/sync/push",
+        &serde_json::json!({
+            "sender_agent_id": "ai:s35-origin",
+            "memories": [],
+            "namespace_meta_clears": ["s35-clear"],
+            "dry_run": false
+        }),
+        None,
+    );
+    assert_eq!(code, "200");
+    assert_eq!(
+        resp["namespace_meta_cleared"].as_u64().unwrap_or(0),
+        0,
+        "second clear must no-op: {resp}"
+    );
+}
+
+#[test]
 fn http_capabilities_reports_embedder_loaded_correctly() {
     // S18: capabilities.features.embedder_loaded must reflect runtime
     // embedder presence, not just config. Under AI_MEMORY_NO_CONFIG=1


### PR DESCRIPTION
## Summary

Closes the residual S35 failure surfaced across every cell of v3r22 (framework-agnostic: ironclaw + hermes × off + tls + mtls all reported `child rule still visible after clear`).

PR #363 shipped **set-side** fanout via `broadcast_namespace_meta_quorum` and wired it through `set_namespace_standard_inner`. The symmetric **clear** path was left local-only: both `clear_namespace_standard` (Path form) and `clear_namespace_standard_qs` (query-string form) used `State<Db>` and called `db::clear_namespace_standard` without a broadcast.

Scenario S35 final assertion is cross-peer: alice clears on node-1, then bob GETs the standard on node-2 and must see it gone. Because the clear didn't propagate, bob's peer held the stale `namespace_meta` row — `post_clear_has_child_rule: true` in every cell's `scenario-35.json`.

## Changes

### `federation.rs`
- **New**: `broadcast_namespace_meta_clear_quorum(config, namespaces: &[String])` modelled on `broadcast_namespace_meta_quorum`. Same ack classifier, same deadline loop, same post-quorum drain task. One POST per peer with `sync_push.namespace_meta_clears: [...]`.

### `handlers.rs`
- **Additive** `SyncPushBody.namespace_meta_clears: Vec<String>` + MAX_BULK_SIZE cap.
- **Peer-side apply** via `db::clear_namespace_standard` — missing-on-peer namespace returns `Ok(false)` so replays no-op.
- **Upgrade** `clear_namespace_standard` + `clear_namespace_standard_qs` to `State<AppState>` + new shared `clear_namespace_standard_inner` that runs the local clear then fans out, returning `503 quorum_not_met` on failure — mirrors `set_namespace_standard_inner`.
- **Response**: sync_push gains `namespace_meta_cleared: <count>` alongside `namespace_meta_applied` for symmetric observability.

### `tests/integration.rs`
- **New** `http_sync_push_applies_namespace_meta_clears` — pins the sync_push apply path + the replay-safe no-op behaviour. (+1 test → 184 total.)

### `.gitignore`
- Added `.claude/` to stop an initial spurious commit of agent worktree submodules (force-pushed clean).

## Gates

- `cargo fmt --check` ✅
- `cargo check --tests` ✅
- `cargo test --test integration` → **184 / 0** (baseline 183, +1 new; zero regressions)
- `cargo audit` — no new findings expected (only `federation.rs`, `handlers.rs`, `tests/` touched; no dependency changes)

## Test plan

- [x] Local integration: `http_sync_push_applies_namespace_meta` (existing, unchanged) ✅
- [x] Local integration: `http_sync_push_applies_namespace_meta_clears` (new) ✅
- [x] Full integration suite regression-free ✅
- [ ] Merge to `release/v0.6.2`
- [ ] Dispatch v3r23 matrix → expect S35 cleared across all 6 cells
- [ ] Failure set should shrink to `{S18, S39}` (off + mtls) / `{S18, S20, S39}` (tls)

## Release posture

v0.6.2 Patch 2 release-freeze (memory `74698d94`) remains active. This fix lands on `release/v0.6.2` ahead of the next matrix rebaseline — no tag cut implied.

## AI involvement

Diagnosed + authored by **Claude Opus 4.7 (1M context)** under operator directive 2026-04-23 (`binary2029@gmail.com`) granting full engineering decision authority on alphaonedev repos. Durable authorization recorded in `ai-memory` `the-standard` namespace (memory `d7864c43`).

**RCA evidence**: v3r22 `a2a-summary.json` showing `post_clear_has_child_rule: true` across all 6 cells; `handlers.rs` grep confirming `State<Db>` on clear handlers vs. `State<AppState>` on set handlers. RCA Standard v1 applied: separated fact (handler state type) from inference, generated competing hypotheses (scenario bug vs product bug), discriminating evidence (the clear HTTP returned 200 + the get still returned the rule), scope narrow to symmetric clear fanout.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code) under AlphaOne RCA Standard v1.