### PR TITLE
fix(s18): relax recall_hybrid semantic cosine threshold 0.3 → 0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ All three interfaces share the same database (`src/db.rs`) and validation (`src/
 Recall is multi-stage and **never read-only** — every recall mutates the database:
 
 1. **FTS5 keyword search** — fuzzy OR query, scored by `fts.rank + priority*0.5 + access_count*0.1 + confidence*2.0 + tier_bonus + recency_factor`
-2. **Semantic search** — cosine similarity via HNSW index (or linear scan fallback), threshold >0.3
+2. **Semantic search** — cosine similarity via HNSW index (or linear scan fallback), threshold >0.2 (relaxed from 0.3 in v0.6.2 Patch 2 after scenario-18 caught a miss at 0.25-0.29 cosine for legitimately-related content)
 3. **Adaptive blending** — `final = semantic_weight * cosine + (1 - semantic_weight) * norm_fts`. Semantic weight varies 0.50 (short content ≤500 chars) → 0.15 (long content ≥5000 chars) because embeddings lose information on long text
 4. **Touch operations** (atomic) — increment `access_count`, extend TTL (1h short / 1d mid), auto-promote mid→long at 5 accesses, increment priority every 10 accesses
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2366,7 +2366,17 @@ pub fn recall_hybrid(
                 continue;
             }
             let cosine = f64::from(1.0 - hit.distance);
-            if cosine > 0.3
+            // v0.6.2 (S18 iteration): cosine gate relaxed 0.3 → 0.2.
+            // Scenario-18 caught a real-world miss at the old ceiling:
+            // semantically-related pairs with varied phrasing ("morning
+            // outdoor exercise routine" vs. "brisk uphill strides along
+            // the ridge line trails") landed at 0.25-0.29 cosine and
+            // silently fell below 0.3, returning zero semantic hits.
+            // 0.2 keeps clearly-unrelated content out (random noise
+            // hovers near 0) while admitting legitimate semantic
+            // associations; the blended score + FTS component still
+            // rank relevance on the way out.
+            if cosine > 0.2
                 && let Some(mem) = get(conn, &hit.id)?
             {
                 // Apply namespace/expiry/tag filters. Task 1.12: when
@@ -2446,7 +2456,8 @@ pub fn recall_hybrid(
                     query_embedding,
                     &emb,
                 ));
-                if cosine > 0.3 {
+                // v0.6.2 (S18): see matching note above at the HNSW gate.
+                if cosine > 0.2 {
                     scored.insert(mem.id.clone(), (mem, 0.0, cosine));
                 }
             }


### PR DESCRIPTION
S18 iteration identified real product miss: embeddings are set correctly on peers, but cosine 0.25-0.29 for legitimately-related content was under the 0.3 gate. Relaxing to 0.2 admits legitimate semantic associations; blended score still ranks. 184/0 integration. Authority: memory d7864c43.