### PR TITLE
fix(s40): bulk_create terminal catchup batch per peer

### DIFF
--- a/src/federation.rs
+++ b/src/federation.rs
@@ -444,6 +444,89 @@ async fn post_and_classify(
     }
 }
 
+/// v0.6.2 Patch 2 (S40): post-fanout catchup for `bulk_create`.
+///
+/// After the per-row `broadcast_store_quorum` fanouts complete, issue a
+/// single batched `sync_push` per peer with *every* row the leader just
+/// committed. Peer-side `insert_if_newer` is idempotent, so rows that
+/// already landed via the per-row fanout are no-ops on the peer; rows
+/// that a peer missed (post-quorum detach failure + retry both failed,
+/// or post-quorum detach timed out on that peer) are applied.
+///
+/// ## Why a catchup batch in addition to retry-once?
+///
+/// v3r26 hermes-tls S40 and v3r27 ironclaw-off S40 both showed a
+/// single row missing on one specific peer (499/500) despite the
+/// retry-once fix in [`post_and_classify`]. Retry-once is a probability
+/// improver, not a guarantee: a peer under sustained SQLite-mutex
+/// contention can drop two consecutive POSTs inside the ~250ms retry
+/// window. A terminal batched catchup closes that last gap at O(1)
+/// extra POST per peer instead of O(N) retries per row.
+///
+/// ## Safety
+///
+/// - Idempotent: peer's `insert_if_newer` matches on `id` + `updated_at`
+///   and no-ops on already-applied rows.
+/// - Quorum contract unchanged: the catchup runs AFTER quorum has been
+///   met and the HTTP response shape decided. It cannot weaken any
+///   guarantee; it only strengthens eventual consistency.
+/// - Non-blocking for caller semantics: errors are logged and returned
+///   but the leader still returns 200 to the client. The `bulk_create`
+///   HTTP contract only promises local commit + W-1 peer acks, and
+///   those have already landed by the time this is called.
+///
+/// Returns a map of `peer_id -> error string` for peers where the
+/// catchup POST itself failed (logged by the caller). A successful
+/// catchup POST appears in the map as an empty string or is omitted.
+pub async fn bulk_catchup_push(
+    config: &FederationConfig,
+    memories: &[Memory],
+) -> Vec<(String, String)> {
+    if memories.is_empty() || config.peers.is_empty() {
+        return Vec::new();
+    }
+    let body = serde_json::json!({
+        "sender_agent_id": config.sender_agent_id,
+        "memories": memories,
+        "dry_run": false,
+    });
+    let mut joins: JoinSet<(String, Result<(), String>)> = JoinSet::new();
+    for peer in &config.peers {
+        let client = config.client.clone();
+        let url = peer.sync_push_url.clone();
+        let id = peer.id.clone();
+        let payload = body.clone();
+        joins.spawn(async move {
+            let mut req = client.post(&url).json(&payload);
+            // No Idempotency-Key on the batch — the batch is itself an
+            // idempotent replay, and the peer's `insert_if_newer`
+            // dedupes per row by (id, updated_at).
+            req = req.header("X-Catchup", "bulk");
+            let outcome = match req.send().await {
+                Ok(resp) if resp.status().is_success() => Ok(()),
+                Ok(resp) => Err(format!("http {}", resp.status())),
+                Err(e) => Err(format!("network: {e}")),
+            };
+            (id, outcome)
+        });
+    }
+    let mut errors = Vec::new();
+    while let Some(res) = joins.join_next().await {
+        match res {
+            Ok((peer_id, Err(err))) => {
+                tracing::warn!("bulk_catchup_push: peer {peer_id} failed: {err}");
+                errors.push((peer_id, err));
+            }
+            Ok((_, Ok(()))) => {}
+            Err(e) => {
+                tracing::warn!("bulk_catchup_push: join error: {e:?}");
+                errors.push(("unknown".to_string(), e.to_string()));
+            }
+        }
+    }
+    errors
+}
+
 /// Classify an `AckTracker` into either a committed quorum (`Ok(n)`) or
 /// an error with a reason suitable for the `/503 quorum_not_met`
 /// payload. Consumes the tracker — call after the broadcast loop.
@@ -1687,6 +1770,65 @@ mod tests {
             count2.load(Ordering::Relaxed),
             2,
             "persistently-failing peer must be called exactly twice (1 + 1 retry)"
+        );
+    }
+
+    #[tokio::test]
+    async fn bulk_catchup_push_hits_every_peer_once() {
+        // S40 catchup: verify the terminal batch POST reaches every
+        // peer exactly once, with the full row set in a single request.
+        let (url1, count1) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let (url2, count2) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let cfg = build_config(vec![url1, url2], 2, 2000);
+        let mems = vec![sample_memory(), sample_memory(), sample_memory()];
+        let errors = bulk_catchup_push(&cfg, &mems).await;
+        assert!(
+            errors.is_empty(),
+            "catchup must succeed on healthy peers, got {errors:?}"
+        );
+        assert_eq!(
+            count1.load(Ordering::Relaxed),
+            1,
+            "peer-1 must receive exactly one catchup batch"
+        );
+        assert_eq!(
+            count2.load(Ordering::Relaxed),
+            1,
+            "peer-2 must receive exactly one catchup batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn bulk_catchup_push_reports_peer_failures() {
+        // Catchup errors must be surfaced to the caller for logging —
+        // quorum was already met upstream, so the HTTP contract holds,
+        // but the leader should record which peers fell behind.
+        let (url1, _) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let (url2, _) = spawn_mock_peer(MockBehaviour::Fail).await;
+        let cfg = build_config(vec![url1, url2], 2, 2000);
+        let mems = vec![sample_memory()];
+        let errors = bulk_catchup_push(&cfg, &mems).await;
+        assert_eq!(errors.len(), 1, "exactly one peer failed the catchup");
+        assert!(
+            errors[0].1.contains("500") || errors[0].1.contains("http"),
+            "error must name the HTTP failure, got {:?}",
+            errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn bulk_catchup_push_empty_inputs_are_noop() {
+        // No rows + no peers → no work, no panics, no POSTs.
+        let cfg = build_config(vec![], 1, 500);
+        assert!(bulk_catchup_push(&cfg, &[]).await.is_empty());
+
+        let (url1, count1) = spawn_mock_peer(MockBehaviour::Ack).await;
+        let cfg = build_config(vec![url1], 1, 500);
+        assert!(bulk_catchup_push(&cfg, &[]).await.is_empty());
+        assert_eq!(
+            count1.load(Ordering::Relaxed),
+            0,
+            "no catchup POST must fire when the row set is empty"
         );
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2284,6 +2284,27 @@ pub async fn bulk_create(
                 Err(e) => tracing::warn!("bulk_create: fanout task join error: {e:?}"),
             }
         }
+
+        // v0.6.2 Patch 2 (S40): terminal catchup batch. Per-row quorum
+        // met above, but the post-quorum detach path — even with
+        // retry-once in `post_and_classify` — can still leave a peer
+        // one row behind under sustained SQLite-mutex contention (v3r26
+        // hermes-tls 499/500 and v3r27 ironclaw-off 499/500 both tripped
+        // the scenario despite the retry). A single batched `sync_push`
+        // per peer with every committed row closes the gap: peer's
+        // `insert_if_newer` no-ops rows it already has and applies the
+        // missing one. O(1) extra POST per peer vs O(N) per-row retries.
+        //
+        // Errors are logged and folded into the response `errors` array
+        // but do NOT fail the bulk write — quorum was already met, so
+        // the HTTP contract is satisfied. The catchup only strengthens
+        // eventual consistency within the scenario settle window.
+        if !created_mems.is_empty() {
+            let catchup_errors = crate::federation::bulk_catchup_push(fed, &created_mems).await;
+            for (peer_id, err) in catchup_errors {
+                errors.push(format!("catchup to {peer_id}: {err}"));
+            }
+        }
     }
     Json(json!({"created": created_mems.len(), "errors": errors})).into_response()
 }
@@ -4807,18 +4828,21 @@ mod tests {
         assert_eq!(v["created"], n);
 
         // Foreground fanout already waits for W-1 acks per row, so the
-        // per-row POST has landed by the time the request returns. Give
-        // detached stragglers a quick window just in case.
+        // per-row POST has landed by the time the request returns. v0.6.2
+        // Patch 2 (S40) adds a terminal catchup batch — one extra POST
+        // per peer with the full row set — so the expected total is
+        // `n + 1` per peer. Give detached stragglers a quick window.
+        let expected = n + 1;
         for _ in 0..20 {
-            if count.load(Ordering::Relaxed) >= n {
+            if count.load(Ordering::Relaxed) >= expected {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert_eq!(
             count.load(Ordering::Relaxed),
-            n,
-            "mock peer must receive one sync_push POST per bulk row"
+            expected,
+            "mock peer must receive one sync_push POST per bulk row plus one terminal catchup batch"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8968,8 +8968,14 @@ fn http_bulk_create_fans_out_concurrently() {
     // n×quorum-window. Concurrent-bounded fanout completes ≪ sequential
     // for n rows (sequential would scale to n * ack_timeout on the worst
     // case — we just assert we're not catastrophically regressed).
+    //
+    // v0.6.2 Patch 2 (S40): the terminal catchup batch adds one extra
+    // per-peer POST with all n rows. Under the cargo-test default
+    // parallelism of 16 the machine is already saturated, so the cap
+    // is 45s to absorb catchup + jitter. A sequential regression would
+    // still take ≥n * ack_timeout (100s+) and blow past this bound.
     assert!(
-        elapsed.as_secs() < 30,
+        elapsed.as_secs() < 45,
         "bulk_create took {elapsed:?} — concurrent fanout regressed"
     );
 }


### PR DESCRIPTION
## Summary

v3r27 ironclaw-off scenario-40 still failed (node-4 saw 499/500) despite the retry-once fix in #368. Hermes-off passed clean 500/500/500. Same code, same commit — retry-once improves the probability but cannot cover a peer that drops two consecutive POSTs inside the ~250ms retry window (sustained SQLite-mutex contention under 500-row concurrent fanout).

After the per-row JoinSet drains in bulk_create, issue ONE batched sync_push per peer with every committed row. Peer's insert_if_newer is idempotent (dedupes on id + updated_at), so rows already applied via per-row fanout no-op; rows that the detach path dropped land now. O(1) extra POST per peer vs O(N) per-row retries.

## v3r27 evidence

| Cell | S40 result |
|---|---|
| ironclaw-off | FAIL (node-4 499/500) |
| hermes-off | PASS (500/500/500) |

PR #368 retry-once was insufficient for the sustained-contention case.

## Safety

- Idempotent: peer-side insert_if_newer no-ops on already-applied rows. A 500-row batch containing 499 dupes costs one SQLite transaction + 499 no-op id lookups.
- Quorum contract unchanged: the catchup runs AFTER quorum is met and HTTP 200 is decided. Cannot weaken any guarantee; only strengthens eventual consistency inside the scenario settle window.
- Catchup errors fold into the bulk response errors[] for observability but do NOT fail the write.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic
- [x] AI_MEMORY_NO_CONFIG=1 cargo test — all 332 tests pass (+3 federation tests)
- [x] cargo audit — clean (pre-existing allowed rustls-pemfile warning)
- [ ] v3r28 matrix dispatch on release/v0.6.2 post-merge, expect 36/36 x 6 cells

New federation tests:
- bulk_catchup_push_hits_every_peer_once
- bulk_catchup_push_reports_peer_failures
- bulk_catchup_push_empty_inputs_are_noop

Updated integration test:
- http_bulk_create_fans_out_concurrently: expects n+1 POSTs per peer (n per-row + 1 catchup). Parallel-cargo-test wall bound raised 30s -> 45s to absorb catchup under 16-way saturation. Sequential regression would still blow past this (n * ack_timeout = 100s+).

## AI involvement

- **Author**: Claude Opus 4.7 (1M context) as AI NHI with durable engineering authority on alphaonedev repos
- **Phase**: RCA (#368 insufficient) -> branch -> implement -> gates -> PR, all four gates green pre-push
- **Memory namespace**: ai-memory-mcp

Generated with Claude Code