### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 → 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Closes #370.

Cargo.lock-only bump of \`rustls-webpki\` from 0.103.12 to 0.103.13 to clear **RUSTSEC-2026-0104** — a reachable panic in CRL parsing, advisory published 2026-04-22.

## Scope

- **1 file, 2 lines:** \`Cargo.lock\` — version string + checksum for \`rustls-webpki\`
- No source changes, no \`Cargo.toml\` changes, no MSRV bump
- Patch-level version bump per semver → no API change, no behavior change

## Impact on ai-memory

The CVE is a panic in CRL parsing. ai-memory's TLS paths (\`reqwest\` to Ollama/HuggingFace, \`axum-server\` mTLS daemon, \`ureq\` via \`hf-hub\`, \`sqlx-postgres\`) do not currently invoke CRL validation, so the CVE is theoretical for this project. The practical effect is that \`cargo audit\` in CI on ubuntu-latest fails on every PR until this lands — observed first on #365.

## Test plan

- [ ] CI passes on all three platforms (ubuntu, macOS, Windows)
- [ ] \`cargo audit\` step in ubuntu CI turns green
- [ ] No regressions in \`cargo test\`, \`cargo clippy\`, \`cargo fmt --check\`

## AI involvement

- **Agent:** Claude Opus 4.7 (1M context)
- **Authority class:** Sensitive (dependency change)
- **Human approver:** @alphaonedev
- **Co-Authored-By trailer present:** yes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>