### PR TITLE
docs(pages): prominent v0.6.2 current release + gated testing links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,26 @@
 # ai-memory Documentation
 
+<div align="center">
+
+## 🎯 Current stable release · **v0.6.2** · A2A-CERTIFIED
+
+[![Release](https://img.shields.io/badge/release-v0.6.2-brightgreen?logo=github)](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.2)
+[![A2A Gate](https://img.shields.io/badge/A2A_gate-9%2F9_green-brightgreen)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)
+[![Ship Gate](https://img.shields.io/badge/ship_gate-green-brightgreen)](https://alphaonedev.github.io/ai-memory-ship-gate/)
+[![crates.io](https://img.shields.io/crates/v/ai-memory)](https://crates.io/crates/ai-memory)
+
+**v0.6.2** cleared the a2a-gate certification bar: three consecutive full-testbook green runs across three agent frameworks and three transport modes — **324 passing scenarios**, zero partial greens.
+
+**📦 [Release v0.6.2](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.2)** ·
+**📊 [A2A gate evidence](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)** ·
+**🚢 [Ship gate](https://alphaonedev.github.io/ai-memory-ship-gate/)** ·
+**📖 [AI-NHI insights](https://alphaonedev.github.io/ai-memory-ai2ai-gate/insights/)** ·
+**🐳 [Reproduce locally](https://alphaonedev.github.io/ai-memory-ai2ai-gate/local-docker-mesh/)**
+
+</div>
+
+---
+
 Navigation hub for the `docs/` directory. Every doc below is
 authoritative for its topic; this page is just the map.
 


### PR DESCRIPTION
Centered banner at the top of docs/README.md (the Pages index) linking to the v0.6.2 release, A2A gate, ship gate, AI-NHI insights, and local-docker reproducibility spec.