### PR TITLE
fix(#358): mTLS allowlist tolerates inline trailing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v0.6.3 (Patch 3)
+
+### Fixed
+
+- **[#358]** mTLS allowlist parser now tolerates inline trailing `#`
+  comments after a fingerprint
+  (`load_fingerprint_allowlist`, `src/main.rs`). Previously, a line like
+  `sha256:abc…def  # node-1` was parsed whole and failed the 64-hex-char
+  length check (`got 74`), aborting `ai-memory serve` on startup. Full-line
+  `#` comments and the Ultrareview #338 strict character-set check
+  (rejects embedded whitespace inside the hex run) are preserved. Doc
+  update: `docs/ADMIN_GUIDE.md` now explicitly calls out trailing-comment
+  tolerance. Encountered in the a2a-gate mTLS matrix; the gate-side
+  generator fix in `ai-memory-ai2ai-gate#35` already worked around it for
+  v0.6.2 — this is the parser-side resolution.
+
 ## [v0.6.2] — 2026-04-24 — A2A-CERTIFIED
 
 First release to carry the a2a-gate **consecutive-green streak 3/3**

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -709,11 +709,11 @@ openssl req -x509 -newkey rsa:2048 -keyout client.key -out client.pem \
 openssl x509 -in client.pem -outform DER | sha256sum
 ```
 
-3. Build the allowlist file (one fingerprint per line; `sha256:` prefix and `:` separators are optional):
+3. Build the allowlist file (one fingerprint per line; `sha256:` prefix and `:` separators are optional). Full-line `#` comments and inline trailing `# label` annotations after a fingerprint are both tolerated:
 
 ```
 # peer A's client cert
-sha256:25ab790783dbe969f994063db0412f1930e187e5e1e6c7d79bb76224a76b7bb7
+sha256:25ab790783dbe969f994063db0412f1930e187e5e1e6c7d79bb76224a76b7bb7  # node-1
 ```
 
 4. Run with all three flags:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1351,6 +1351,14 @@ async fn load_fingerprint_allowlist(path: &Path) -> Result<std::collections::Has
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
+        // Issue #358: tolerate inline trailing comments — anything after `#`
+        // on a non-comment line is dropped before the strict hex/colon
+        // validation below. Safe because `#` is not a valid hex/colon char,
+        // so it cannot appear in a legitimate SHA-256 fingerprint.
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
         // Accept a leading `sha256:` marker for forward-compat with richer formats.
         let hex_part = line.strip_prefix("sha256:").unwrap_or(line);
         // Ultrareview #338: reject any non-hex, non-colon character —
@@ -4461,5 +4469,43 @@ mod tests {
     fn auto_namespace_returns_nonempty() {
         let ns = auto_namespace();
         assert!(!ns.is_empty());
+    }
+
+    // Issue #358: parser must accept inline trailing comments after a
+    // fingerprint, in addition to the existing full-line `#` comment skip.
+    #[tokio::test]
+    async fn fingerprint_allowlist_tolerates_trailing_comments() {
+        let fp_a = "a".repeat(64);
+        let fp_b = "b".repeat(64);
+        let fp_c = format!("{}:{}", "c".repeat(32), "c".repeat(32));
+        let body = format!(
+            "# authorised mTLS peers\n\
+             {fp_a}  # node-1\n\
+             \n\
+             sha256:{fp_b}\t# node-2 with tab\n\
+             {fp_c}\n"
+        );
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), body).unwrap();
+        let set = load_fingerprint_allowlist(tmp.path()).await.unwrap();
+        assert_eq!(set.len(), 3, "expected 3 fingerprints, got {}", set.len());
+        assert!(set.contains(&[0xaa; 32]));
+        assert!(set.contains(&[0xbb; 32]));
+        assert!(set.contains(&[0xcc; 32]));
+    }
+
+    #[tokio::test]
+    async fn fingerprint_allowlist_rejects_embedded_whitespace() {
+        // Ultrareview #338 strictness preserved — whitespace before the
+        // `#` is fine (gets trimmed), but whitespace inside the hex run
+        // still errors so soft-wrap copy-paste artefacts are caught.
+        let body = format!("{} {}\n", "a".repeat(32), "a".repeat(32));
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), body).unwrap();
+        let err = load_fingerprint_allowlist(tmp.path()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("unexpected character"),
+            "expected strict char-set error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `load_fingerprint_allowlist` (`src/main.rs`) now strips inline trailing `#` comments on non-comment lines before strict hex/colon validation, fixing #358.
- Previously, `sha256:abc…def  # node-1` was parsed whole and failed the 64-hex length check (`got 74`), aborting `ai-memory serve` on startup. Surfaced in the a2a-gate mTLS matrix; gate-side fix `alphaonedev/ai-memory-ai2ai-gate#35` already worked around this for v0.6.2 — this is the parser-side resolution.
- Ultrareview #338 strict character-set check (rejects embedded whitespace inside the hex run) is preserved. Full-line `#` comment skip is preserved.

## Scope

Opens the **v0.6.3 (Patch 3)** cycle. Not release-blocking; tracked under `[Unreleased]` in `CHANGELOG.md`. Cargo.toml stays at `0.6.2` until release time.

## Changes

- `src/main.rs`: 6-line parser tweak + 2 unit tests
  - `fingerprint_allowlist_tolerates_trailing_comments` — asserts a 4-line file with full-line `#`, blank, trailing `# node-1`, trailing `\t# node-2 with tab`, and bare/`sha256:`-prefixed entries loads exactly 3 fingerprints
  - `fingerprint_allowlist_rejects_embedded_whitespace` — asserts strict char-set still rejects `aaa…aaa aaa…aaa` so soft-wrap copy-paste artefacts surface a clear error
- `docs/ADMIN_GUIDE.md`: explicit trailing-comment tolerance + example with `# node-1`
- `CHANGELOG.md`: open `[Unreleased] — v0.6.3 (Patch 3)` with `Fixed — [#358]`

## Test plan

- [x] `cargo test --bin ai-memory fingerprint_allowlist` — 2/2 pass
- [x] `cargo clippy --bin ai-memory --tests -- -D warnings` — clean
- [ ] Existing `test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer` integration test unaffected (happy path uses no trailing comment)

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)