### PR TITLE
chore(ops): add 24x7 autonomous campaign harness for v0.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ benchmarks/longmemeval/results/
 # Local scratch (never committed)
 /backup/
 .claude/
+
+# Autonomous campaign runtime state (logs, kill-switch, pid)
+.agentic/

--- a/ops/RUNBOOK.md
+++ b/ops/RUNBOOK.md
@@ -1,0 +1,344 @@
+# ai-memory-mcp v0.6.3 Grand-Slam Campaign — Runbook
+
+How to run Claude Code CLI 24x7 as an "AI NHI" developer against `ai-memory-mcp`'s `release/v0.6.3` branch, scoped strictly to the charter at `agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`.
+
+> **High-blast-radius automation.** The agent runs with `--dangerously-skip-permissions` and has merge authority on `release/v0.6.3`. Read [Risks](#risks-read-this) before starting.
+
+---
+
+## Approval scope (granted by user, 2026-04-25)
+
+| Action | Allowed? |
+|---|---|
+| Read/write files inside `/var/root/dev/ai-memory-mcp/` | ✅ |
+| Read files inside `/var/root/dev/agentic-mem-labs/` (charter) | ✅ |
+| Write iteration reports under `agentic-mem-labs/campaign-log/v0.6.3/` (via worktree) | ✅ |
+| Commit + push to `campaign-log/v0.6.3` branch on agentic-mem-labs | ✅ |
+| Commit to `release/v0.6.3` of ai-memory-mcp (signed) | ✅ |
+| Open PRs targeting `release/v0.6.3` of ai-memory-mcp | ✅ |
+| Merge PRs into `release/v0.6.3` (squash, delete branch) | ✅ |
+| `git push --force` / `--force-with-lease` | ❌ |
+| Commit/push/merge into ai-memory-mcp `main`, `develop`, other `release/*` | ❌ |
+| Commit to agentic-mem-labs `main` or any other branch | ❌ |
+| Edit charter or anything under `strategy/`, `the-standard/`, `relocated-from-public*/` | ❌ |
+| Create or push `v*` tags | ❌ |
+| `gh release create/edit`, `gh workflow run` | ❌ |
+| Edit `.github/workflows/release*.yml` | ❌ |
+| `cargo publish`, `npm publish` | ❌ |
+| Touch system locations, secrets, gh auth, global git config | ❌ |
+
+**Releases are the human's job.** This campaign builds the work; cutting `v0.6.3` is not in scope.
+
+---
+
+## What this is — full-spectrum flow
+
+Per iteration the runner:
+
+1. **Refreshes** charter (`agentic-mem-labs` main, read-only) and dev (`ai-memory-mcp release/v0.6.3`).
+2. **Refreshes the campaign-log worktree** at `/var/root/dev/agentic-mem-labs-log` pinned to branch `campaign-log/v0.6.3` of agentic-mem-labs (created on first iteration if absent).
+3. **Bumps a global iteration counter** stored at `.agentic/state/iter-counter`.
+4. **Spawns** `claude -p --dangerously-skip-permissions` with three `--add-dir` paths and a prompt that mandates 8 steps (see below).
+
+The agent's 8-step iteration:
+
+| # | Step | Side effect |
+|--:|---|---|
+| 1 | **Load memories** (recall 3 specific queries + list recent in `campaign-v063` namespace) | Read-only |
+| 2 | Read charter + last iteration report | Read-only |
+| 3 | Inspect dev repo state (`git fetch`, status, log) | Read-only |
+| 4 | Pick **one** unblocked charter item | — |
+| 5 | Implement on `campaign/<slug>` branch → tests → signed commit → push → PR → squash-merge into `release/v0.6.3` (or, for sub-10-line cosmetic, direct signed commit to `release/v0.6.3`) | **Writes to ai-memory-mcp** |
+| 6 | **Record to memory throughout** (decisions, files, PRs, blockers, "future" items) — not only at end | Writes to `ai-memory.db` |
+| 7 | **Write iteration report** at `agentic-mem-labs-log/campaign-log/v0.6.3/iter-NNNN.md` from a fixed template | **Writes to log worktree** |
+| 8 | **Append to INDEX.md** + signed commit + push to `campaign-log/v0.6.3` (no PR — append-only audit trail) | **Pushes to agentic-mem-labs** |
+
+After the agent exits, the runner sleeps `INTERVAL_SECS` and loops.
+
+---
+
+## Components
+
+| File | Purpose |
+|---|---|
+| `ops/run-campaign.sh` | The loop. Refreshes both repos + worktree, increments counter, spawns claude with the full 8-step prompt. |
+| `ops/start.sh` | Pre-flights (charter exists, dev branch correct, MCP `Connected`, signing test on **both** repos succeeds, agentic-mem-labs has identity) → `nohup` launch. |
+| `ops/stop.sh` | Touches kill-switch, drains 30 s, SIGTERM, SIGKILL if needed. |
+| `ops/com.alphaone.claude-campaign.plist` | macOS launchd daemon for true 24x7 with auto-restart. |
+| `ops/RUNBOOK.md` | This document. |
+
+Runtime state, gitignored:
+
+```
+.agentic/
+├── kill-switch                    # touch to stop
+├── runner.pid                     # PID of nohup runner
+├── state/
+│   └── iter-counter               # rolling iteration number
+└── logs/
+    ├── YYYY-MM-DD.log             # daily heartbeat
+    ├── YYYY-MM-DD.iter-NNNN.log   # per-iteration full claude output
+    ├── git.err                    # stderr from git commands
+    ├── runner.out / runner.err    # nohup launcher output
+    └── launchd.out / launchd.err  # when run via launchd
+```
+
+External worktree (sibling, not inside the repo):
+
+```
+/var/root/dev/agentic-mem-labs-log/   # git worktree, branch campaign-log/v0.6.3
+└── campaign-log/v0.6.3/
+    ├── INDEX.md                       # rolling table of every iteration
+    └── iter-NNNN.md                   # one report per iteration
+```
+
+---
+
+## Prerequisites (verified 2026-04-25)
+
+- `claude` v2.1.119 at `/opt/homebrew/bin/claude`
+- `gh` authed as `alphaonedev`
+- ai-memory-mcp cloned to `/var/root/dev/ai-memory-mcp` on `release/v0.6.3` at `9b03d63`
+- agentic-mem-labs cloned to `/var/root/dev/agentic-mem-labs` (charter source)
+- Local git identity in **both** repos: `alphaonedev <alphaonedev@users.noreply.github.com>`
+- SSH ed25519 signing tested on both repos; signing key `~/.ssh/id_ed25519.pub`
+- `memory` MCP server registered at user scope, autonomous tier, `gemma4:e2b` LLM
+- Native auto-memory disabled (`autoMemoryEnabled: false`)
+
+The `campaign-log/v0.6.3` branch on agentic-mem-labs and the worktree directory are **created on first iteration** if not pre-existing.
+
+---
+
+## Quickstart
+
+### 1. Confirm pre-flight (read-only)
+
+```bash
+cd /var/root/dev/ai-memory-mcp
+git rev-parse --abbrev-ref HEAD                       # → release/v0.6.3
+ls /var/root/dev/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md
+claude mcp list | grep memory                          # → ✓ Connected
+git config user.email && git config user.name          # → alphaonedev / alphaonedev@users.noreply...
+git -C /var/root/dev/agentic-mem-labs config user.email && git -C /var/root/dev/agentic-mem-labs config user.name
+```
+
+### 2. Make scripts executable + lint
+
+```bash
+chmod +x ops/*.sh
+bash -n ops/run-campaign.sh ops/start.sh ops/stop.sh
+plutil -lint ops/com.alphaone.claude-campaign.plist
+```
+
+### 3. Start (foreground, supervised)
+
+```bash
+ops/start.sh
+tail -f .agentic/logs/runner.out .agentic/logs/$(date +%F).log
+```
+
+`start.sh` runs eight pre-flight checks. If any fails it refuses to launch.
+
+### 4. Start (true 24x7 via launchd)
+
+Recommended only after a successful supervised run.
+
+```bash
+sudo cp ops/com.alphaone.claude-campaign.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+sudo chmod 644 /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+```
+
+`KeepAlive` is wired to the kill-switch path — `touch .agentic/kill-switch` and launchd will let it exit cleanly without respawning.
+
+### 5. Stop
+
+```bash
+ops/stop.sh
+# or for launchd:
+sudo launchctl bootout system /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+```
+
+### 6. Pause without uninstalling
+
+```bash
+touch .agentic/kill-switch
+# resume with:
+rm .agentic/kill-switch && ops/start.sh
+```
+
+---
+
+## Tunables
+
+| Env var | Default | Effect |
+|---|---|---|
+| `DEV_BRANCH` | `release/v0.6.3` | Target branch on ai-memory-mcp |
+| `CHARTER_REPO` | `/var/root/dev/agentic-mem-labs` | Read-only charter source |
+| `CHARTER_PATH` | `strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md` | Charter file relative to `CHARTER_REPO` |
+| `LOG_WORKTREE` | `/var/root/dev/agentic-mem-labs-log` | Sibling worktree where iteration reports are written |
+| `LOG_BRANCH` | `campaign-log/v0.6.3` | Branch on agentic-mem-labs that the worktree pins |
+| `LOG_DIR_REL` | `campaign-log/v0.6.3` | Path inside the log branch where reports + INDEX live |
+| `INTERVAL_SECS` | `300` (5 min) | Sleep between iterations |
+| `MAX_TURNS` | `40` | Cap on agent turns per iteration |
+| `MEMORY_NAMESPACE` | `campaign-v063` | ai-memory namespace for campaign memories |
+
+Daily log volume cap: 500 MB → loop pauses 1 hour. Adjust in `run-campaign.sh` if needed.
+
+---
+
+## Iteration report template
+
+The agent uses this template verbatim (from the prompt) for each `iter-NNNN.md`:
+
+```markdown
+# Iteration NNNN — <UTC timestamp>
+
+**Charter section:** <heading or line ref>
+**Status:** ✅ shipped / 🚧 partial / ⏸ blocked / 🛑 stopped / ⚪ no-op
+
+## What I did
+<2-5 sentence summary>
+
+## Files changed
+- `path/to/file` — why
+
+## Tests
+- `cargo test ...` — passed/failed (n tests)
+
+## Git activity
+- Branch: `campaign/<slug>` (or direct on release/v0.6.3)
+- Commits: <sha range>
+- PR: #N — <state>
+- Merged: yes/no
+
+## Memory entries written this iteration
+- `<id>` — <title>
+
+## Blockers
+<list or "none">
+
+## Next iteration should
+<one or two pointers>
+
+## Approx token usage
+~Xk
+```
+
+---
+
+## Hard rules baked into every iteration's prompt
+
+These survive `--dangerously-skip-permissions` because they are prompt-level constraints, repeated each iteration. They cannot be overridden by the charter.
+
+**Branches (ai-memory-mcp):** push/merge **only** into `release/v0.6.3`; never `main`/`develop`/other `release/*`; feature branches `campaign/<slug>`; never force-push.
+
+**Branches (agentic-mem-labs):** read `main` (charter); write **only** to `campaign-log/v0.6.3` via the worktree; never commit to `main`; never edit `strategy/`, `the-standard/`, `relocated-from-public*/`; campaign-log is append-only.
+
+**Releases (forbidden):** no `v*` tags, no `gh release`, no `gh workflow run`, no edits to `.github/workflows/release*.yml`, no `cargo publish` / `npm publish`.
+
+**Filesystem:** never `rm -rf` outside dev repo or log worktree; never write to `/etc`, `/usr`, `/System`, `/Library`, `~/.aws`, `~/.ssh`, `~/.config/gh`, `.credentials.json`; never `git config --global` or modify `~/.gitconfig`; never `gh auth` reconfigure.
+
+**Code quality:** tests pass before push; `cargo fmt && cargo clippy --all-targets -- -D warnings` clean; no `unwrap()` in non-test code without an invariant comment; conventional commits; one logical change per dev-repo commit; all commits SSH-signed.
+
+**Scope:** only items in the charter; out-of-scope ideas → `tier=mid, tags="future,deferred"` memory; one task per iteration, then stop.
+
+---
+
+## Observability
+
+```bash
+# Loop heartbeat
+tail -f /var/root/dev/ai-memory-mcp/.agentic/logs/$(date +%F).log
+
+# Most recent iteration's full claude output
+ls -t /var/root/dev/ai-memory-mcp/.agentic/logs/*.iter-*.log | head -1 | xargs tail -f
+
+# Iteration counter
+cat /var/root/dev/ai-memory-mcp/.agentic/state/iter-counter
+
+# Iteration reports (the human-readable audit trail)
+ls /var/root/dev/agentic-mem-labs-log/campaign-log/v0.6.3/
+cat /var/root/dev/agentic-mem-labs-log/campaign-log/v0.6.3/INDEX.md
+
+# Git activity on dev repo
+git -C /var/root/dev/ai-memory-mcp log --oneline -50 release/v0.6.3
+git -C /var/root/dev/ai-memory-mcp branch --list 'campaign/*'
+
+# Campaign memories
+ai-memory --db /var/root/.claude/ai-memory.db list --namespace campaign-v063 --json | jq '.[] | {id, title, content}'
+
+# PRs
+gh pr list --repo alphaonedev/ai-memory-mcp --base release/v0.6.3 --state all --limit 50
+
+# Token cost (interactive)
+claude   # then /cost
+```
+
+---
+
+## Budget
+
+- Account: Claude Max PRO ($200/mo) + Extra Usage credit (~$416 on file 2026-04-25)
+- No hard dollar cap in the runner. Watch the Anthropic billing console.
+- To slow burn: raise `INTERVAL_SECS` (e.g. 900) or lower `MAX_TURNS` (e.g. 25).
+
+---
+
+## Risks (read this)
+
+- **Token spend.** `MAX_TURNS=40` and `INTERVAL_SECS=300` cap a single iteration; daily log cap pauses on 500 MB. Neither is a hard dollar cap.
+- **Bad merge on `release/v0.6.3`.** Use `git revert`. Do **not** rebase or force-push.
+- **Branch sprawl.** Default flow uses `--delete-branch`. Periodic: `git -C /var/root/dev/ai-memory-mcp branch --merged release/v0.6.3 | grep '^  campaign/' | xargs -r -n1 git -C /var/root/dev/ai-memory-mcp branch -d`.
+- **Worktree drift.** If someone manually edits files in `/var/root/dev/agentic-mem-labs-log/` outside the agent flow, the runner's `pull --ff-only` will reject. Resolve with `git -C /var/root/dev/agentic-mem-labs-log pull --rebase`.
+- **Charter drift.** Updates flow on next iteration via main refresh. Keep it crisp.
+- **Stuck on broken state.** Agent told to STOP and write a stopped-status report. Watch for repeated 🛑 / ⚪ statuses in INDEX.md.
+- **Memory contradictions.** Curator dedupes; surface flagged via `ai-memory pending`.
+- **Hard rules are prompt-level, not a sandbox.** Mitigations: no production credentials on this node; all commits signed (auditable); release CI prompt-blocked. **Do not run on a node with prod access.**
+
+**Kill switch:** `touch /var/root/dev/ai-memory-mcp/.agentic/kill-switch`. Loop checks at top of every iteration.
+
+---
+
+## Resetting the campaign
+
+```bash
+ops/stop.sh
+git checkout release/v0.6.3 && git pull --ff-only
+
+# Local feature-branch cleanup
+git branch --list 'campaign/*' | xargs -r -n1 git branch -D
+
+# Remote PR + branch cleanup
+gh pr list --base release/v0.6.3 --state open --search "head:campaign/" --json number -q '.[].number' \
+  | xargs -I{} gh pr close {} --delete-branch
+
+# Memory cleanup (clears campaign namespace)
+ai-memory --db /var/root/.claude/ai-memory.db forget --pattern '%campaign-v063%' --confirm
+
+# Iteration counter reset
+echo 0 > .agentic/state/iter-counter
+
+# Local logs
+rm -rf .agentic/logs/*
+
+# Iteration reports stay on the campaign-log/v0.6.3 branch as historical audit.
+# To wipe them too:  cd /var/root/dev/agentic-mem-labs-log
+#                    git rm -r campaign-log/v0.6.3/iter-*.md && git commit -S -m "..." && git push
+# (Keeping INDEX.md is recommended.)
+```
+
+---
+
+## Status as of 2026-04-25 (pre-launch)
+
+- ✅ Repo cloned & on `release/v0.6.3`
+- ✅ Local identity + SSH signing verified on both repos
+- ✅ Harness scripts written, runner spec'd for full-spectrum flow (memory recall → development → memory record → iteration report → push to campaign-log)
+- ✅ `.gitignore` updated to exclude `.agentic/`
+- ✅ launchd plist staged (not yet installed)
+- ✅ Charter present
+- ⏳ `chmod +x ops/*.sh` and first `ops/start.sh` — flipped by user, not the AI
+- ⏳ `campaign-log/v0.6.3` branch on agentic-mem-labs — created by runner on first iteration
+- ⏳ Cross-encoder neural model download — to be revisited (lexical fallback in use)

--- a/ops/com.alphaone.claude-campaign.plist
+++ b/ops/com.alphaone.claude-campaign.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd plist for the ai-memory-mcp v0.6.3 grand-slam campaign.
+
+  Install (24x7, auto-restart on crash, persists across reboots):
+    sudo cp ops/com.alphaone.claude-campaign.plist /Library/LaunchDaemons/
+    sudo chown root:wheel /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+    sudo chmod 644 /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+    sudo launchctl bootstrap system /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+
+  Stop:
+    sudo launchctl bootout system /Library/LaunchDaemons/com.alphaone.claude-campaign.plist
+
+  Status:
+    sudo launchctl print system/com.alphaone.claude-campaign
+
+  KeepAlive checks the kill-switch — touching .agentic/kill-switch makes launchd
+  honor the next clean exit and stop respawning.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.alphaone.claude-campaign</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/var/root/dev/ai-memory-mcp/ops/run-campaign.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/var/root/dev/ai-memory-mcp</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>PathState</key>
+        <dict>
+            <key>/var/root/dev/ai-memory-mcp/.agentic/kill-switch</key>
+            <false/>
+        </dict>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/var/root/dev/ai-memory-mcp/.agentic/logs/launchd.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>/var/root/dev/ai-memory-mcp/.agentic/logs/launchd.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/var/root</string>
+        <key>DEV_BRANCH</key>
+        <string>release/v0.6.3</string>
+        <key>CHARTER_REPO</key>
+        <string>/var/root/dev/agentic-mem-labs</string>
+        <key>CHARTER_PATH</key>
+        <string>strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md</string>
+        <key>INTERVAL_SECS</key>
+        <string>300</string>
+        <key>MAX_TURNS</key>
+        <string>40</string>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+</dict>
+</plist>

--- a/ops/run-campaign.sh
+++ b/ops/run-campaign.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+# Autonomous Claude Code campaign runner — single iteration loop.
+#
+# Per iteration the runner:
+#   1. Refreshes the charter repo (agentic-mem-labs main, read-only).
+#   2. Refreshes the dev repo (ai-memory-mcp release/v0.6.3).
+#   3. Refreshes the campaign-log worktree (agentic-mem-labs campaign-log/v0.6.3).
+#   4. Bumps the iteration counter.
+#   5. Spawns headless `claude -p --dangerously-skip-permissions` with three --add-dir
+#      and a prompt that requires:
+#        a. RECALL specific memories before work
+#        b. Read charter
+#        c. Read last iteration report (continuity)
+#        d. Pick + implement ONE charter item on a campaign/<slug> branch
+#        e. Record significant decisions to memory throughout
+#        f. Write iteration report → /var/root/dev/agentic-mem-labs-log/campaign-log/v0.6.3/iter-NNNN.md
+#        g. Update INDEX.md
+#        h. Commit (signed) + push the report on campaign-log/v0.6.3 branch
+#   6. Sleeps the configured interval.
+# Stops cleanly when .agentic/kill-switch exists.
+
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="$REPO/.agentic"
+KILL="$STATE/kill-switch"
+LOG_DIR="$STATE/logs"
+PID_FILE="$STATE/runner.pid"
+ITER_COUNTER="$STATE/state/iter-counter"
+
+DEV_BRANCH="${DEV_BRANCH:-release/v0.6.3}"
+CHARTER_REPO="${CHARTER_REPO:-/var/root/dev/agentic-mem-labs}"
+CHARTER_PATH="${CHARTER_PATH:-strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md}"
+LOG_WORKTREE="${LOG_WORKTREE:-/var/root/dev/agentic-mem-labs-log}"
+LOG_BRANCH="${LOG_BRANCH:-campaign-log/v0.6.3}"
+LOG_DIR_REL="${LOG_DIR_REL:-campaign-log/v0.6.3}"
+INTERVAL_SECS="${INTERVAL_SECS:-300}"
+MAX_TURNS="${MAX_TURNS:-40}"
+MEMORY_NAMESPACE="${MEMORY_NAMESPACE:-campaign-v063}"
+
+mkdir -p "$LOG_DIR" "$STATE/state"
+[ ! -f "$ITER_COUNTER" ] && echo 0 > "$ITER_COUNTER"
+echo $$ > "$PID_FILE"
+cleanup() { rm -f "$PID_FILE"; }
+trap cleanup EXIT
+
+cd "$REPO"
+
+log() {
+  local f="$LOG_DIR/$(date +%F).log"
+  echo "$(date -Iseconds) $*" | tee -a "$f"
+}
+
+ensure_log_worktree() {
+  if [ ! -d "$LOG_WORKTREE/.git" ] && [ ! -f "$LOG_WORKTREE/.git" ]; then
+    log "creating campaign-log worktree at $LOG_WORKTREE on $LOG_BRANCH"
+    git -C "$CHARTER_REPO" fetch --quiet origin "$LOG_BRANCH" 2>/dev/null || true
+    if git -C "$CHARTER_REPO" rev-parse --verify "origin/$LOG_BRANCH" >/dev/null 2>&1; then
+      git -C "$CHARTER_REPO" worktree add "$LOG_WORKTREE" -b "$LOG_BRANCH" "origin/$LOG_BRANCH" 2>>"$LOG_DIR/git.err" || \
+      git -C "$CHARTER_REPO" worktree add "$LOG_WORKTREE" "$LOG_BRANCH" 2>>"$LOG_DIR/git.err"
+    else
+      git -C "$CHARTER_REPO" worktree add "$LOG_WORKTREE" -b "$LOG_BRANCH" main 2>>"$LOG_DIR/git.err"
+      mkdir -p "$LOG_WORKTREE/$LOG_DIR_REL"
+      cat > "$LOG_WORKTREE/$LOG_DIR_REL/INDEX.md" <<'INDEX_EOF'
+# Campaign Log — ai-memory v0.6.3
+
+Append-only audit trail of autonomous iterations. One row per iteration.
+
+| Iter | Date (UTC) | Status | Branch | PR | Summary |
+|---:|---|:-:|---|---:|---|
+INDEX_EOF
+      git -C "$LOG_WORKTREE" add "$LOG_DIR_REL/INDEX.md"
+      git -C "$LOG_WORKTREE" commit -S -m "chore(campaign-log): bootstrap v0.6.3 audit trail" >/dev/null
+      git -C "$LOG_WORKTREE" push -u origin "$LOG_BRANCH" 2>>"$LOG_DIR/git.err" || true
+    fi
+  fi
+  git -C "$LOG_WORKTREE" fetch --quiet origin "$LOG_BRANCH" 2>>"$LOG_DIR/git.err" || true
+  git -C "$LOG_WORKTREE" pull --quiet --ff-only origin "$LOG_BRANCH" 2>>"$LOG_DIR/git.err" || true
+}
+
+PROMPT_TEMPLATE='You are running ITERATION ITER_NUM_PLACEHOLDER of an autonomous AI NHI development campaign on ai-memory-mcp at REPO_PATH_PLACEHOLDER.
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 1 (REQUIRED, FIRST) — LOAD MEMORIES
+══════════════════════════════════════════════════════════════════════════════
+
+Use the `memory` MCP server to recall context BEFORE doing anything else.
+Run, in order:
+
+  - Recall (semantic) in namespace "MEMORY_NAMESPACE_PLACEHOLDER":
+      query 1: "campaign overview approvals scope hard rules"
+      query 2: "last completed iteration task blockers next"
+      query 3: "code quality standards conventions signing"
+  - List recent memories in namespace "MEMORY_NAMESPACE_PLACEHOLDER" (limit 25),
+    sorted by recency. Read titles and contents. Identify:
+      - the last iteration number recorded
+      - what task it shipped or blocked on
+      - any "future" / "deferred" entries that may now be unblocked
+
+If memory recall returns nothing, that means this is iteration 1 — proceed
+with charter as the only context.
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 2 — READ THE CHARTER + LAST ITERATION REPORT
+══════════════════════════════════════════════════════════════════════════════
+
+  Charter: CHARTER_FULL_PATH_PLACEHOLDER (read end-to-end)
+  Last iteration report (if any): LOG_WORKTREE_PLACEHOLDER/LOG_DIR_REL_PLACEHOLDER/iter-LAST.md
+    (find the highest-numbered iter-NNNN.md file under that directory)
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 3 — INSPECT REPO STATE
+══════════════════════════════════════════════════════════════════════════════
+
+  cd REPO_PATH_PLACEHOLDER
+  git fetch origin && git checkout DEV_BRANCH_PLACEHOLDER && git pull --ff-only
+  git status; git log --oneline -20
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 4 — PICK ONE CONCRETE TASK FROM THE CHARTER
+══════════════════════════════════════════════════════════════════════════════
+
+Pick exactly one item that is unblocked and not yet shipped. If you cannot
+find one, set status="no-op" for the report and skip to STEP 8.
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 5 — IMPLEMENT ON A FEATURE BRANCH
+══════════════════════════════════════════════════════════════════════════════
+
+  Default flow:
+    git checkout -b campaign/<short-slug> DEV_BRANCH_PLACEHOLDER
+    <implement>
+    cargo fmt && cargo clippy --all-targets -- -D warnings
+    cargo test --all
+    git add -A && git commit -S -m "<conventional commit message>"
+    git push -u origin campaign/<short-slug>
+    gh pr create --base DEV_BRANCH_PLACEHOLDER --title "..." --body "..."
+    # Once CI is green and you are confident:
+    gh pr merge --squash --delete-branch <pr-number>
+
+  Trivial fix flow (sub-10-line cosmetic only):
+    git checkout DEV_BRANCH_PLACEHOLDER
+    <edit>; git commit -S -am "<message>"; git push
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 6 — RECORD TO MEMORY THROUGHOUT (NOT JUST AT THE END)
+══════════════════════════════════════════════════════════════════════════════
+
+Throughout the iteration, use the `memory` MCP `store` tool (namespace
+"MEMORY_NAMESPACE_PLACEHOLDER") for:
+
+  - Significant decisions with rationale ("chose X over Y because Z")
+  - Files modified, tests added, PRs opened/merged (one entry per PR)
+  - Blockers encountered + how you resolved them or why you stopped
+  - Out-of-charter ideas → tier=mid, tags="future,deferred"
+
+At end of iteration, store a single SUMMARY memory titled
+  "Iteration ITER_NUM_PLACEHOLDER — <one-line outcome>"
+with content covering: branch, PR(s), files, tests, status, next.
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 7 — WRITE THE ITERATION REPORT (REQUIRED)
+══════════════════════════════════════════════════════════════════════════════
+
+Write a markdown report at:
+  LOG_WORKTREE_PLACEHOLDER/LOG_DIR_REL_PLACEHOLDER/iter-ITER_NUM_PLACEHOLDER.md
+
+Use this exact template:
+
+```markdown
+# Iteration ITER_NUM_PLACEHOLDER — <UTC timestamp>
+
+**Charter section:** <heading or line ref from charter>
+**Status:** ✅ shipped / 🚧 partial / ⏸ blocked / 🛑 stopped / ⚪ no-op
+
+## What I did
+
+<2-5 sentence terse summary>
+
+## Files changed
+
+- `path/to/file` — why
+
+## Tests
+
+- `cargo test ...` — passed / failed (n tests)
+
+## Git activity
+
+- Branch: `campaign/<slug>` (or direct on DEV_BRANCH_PLACEHOLDER)
+- Commits: <sha1..sha2>
+- PR: #N — <state>
+- Merged: yes/no
+
+## Memory entries written this iteration
+
+- `<id>` — <title>
+- `<id>` — <title>
+
+## Blockers
+
+<terse list, or "none">
+
+## Next iteration should
+
+<one or two concrete pointers>
+
+## Approx token usage
+
+~Xk
+```
+
+══════════════════════════════════════════════════════════════════════════════
+STEP 8 — UPDATE INDEX + COMMIT THE REPORT TO agentic-mem-labs
+══════════════════════════════════════════════════════════════════════════════
+
+  cd LOG_WORKTREE_PLACEHOLDER
+  # Append a row to LOG_DIR_REL_PLACEHOLDER/INDEX.md:
+  #   | ITER_NUM_PLACEHOLDER | <UTC date> | <status emoji> | campaign/<slug> | #N | <one-liner> |
+  git add LOG_DIR_REL_PLACEHOLDER/iter-ITER_NUM_PLACEHOLDER.md LOG_DIR_REL_PLACEHOLDER/INDEX.md
+  git commit -S -m "campaign-log: iter ITER_NUM_PLACEHOLDER — <one-line outcome>"
+  git push origin LOG_BRANCH_PLACEHOLDER
+
+If the push is rejected (someone else pushed in the meantime):
+  git pull --rebase origin LOG_BRANCH_PLACEHOLDER && git push origin LOG_BRANCH_PLACEHOLDER
+
+Do NOT force-push. Do NOT open a PR for this branch — it is append-only audit.
+
+══════════════════════════════════════════════════════════════════════════════
+HARD RULES — non-negotiable, repeated to you every iteration
+══════════════════════════════════════════════════════════════════════════════
+
+Branches (ai-memory-mcp):
+  • Push/merge only into DEV_BRANCH_PLACEHOLDER. NEVER main, develop, release/v0.6.2, or other release/*.
+  • Feature branches: campaign/<slug>.
+  • NEVER `git push --force` or `--force-with-lease`.
+
+Branches (agentic-mem-labs):
+  • Read main (charter). Write only to LOG_BRANCH_PLACEHOLDER via the worktree at LOG_WORKTREE_PLACEHOLDER.
+  • NEVER commit to agentic-mem-labs main, NEVER edit strategy/ docs, NEVER edit the charter, NEVER touch the-standard/ or relocated-from-public*/.
+  • The campaign-log branch is append-only. NEVER rewrite or delete past iteration files.
+
+Releases (forbidden this campaign):
+  • NEVER tag v* on either repo.
+  • NEVER `gh release create/edit`.
+  • NEVER `gh workflow run`.
+  • NEVER edit .github/workflows/release*.yml.
+  • NEVER `cargo publish` / `npm publish`.
+
+Filesystem:
+  • NEVER `rm -rf` outside REPO_PATH_PLACEHOLDER or LOG_WORKTREE_PLACEHOLDER.
+  • NEVER write to /etc, /usr, /System, /Library, ~/.aws, ~/.ssh, ~/.config/gh, .credentials.json.
+  • NEVER `git config --global` or modify ~/.gitconfig.
+  • NEVER `gh auth` reconfigure or rotate the gh token.
+
+Quality:
+  • All commits SSH-signed (existing global config handles this — do not change it).
+  • Conventional commit messages.
+  • Tests must pass before pushing the dev-branch PR.
+  • cargo fmt + cargo clippy --all-targets -- -D warnings clean.
+  • No unwrap() in non-test code without an explicit invariant comment.
+  • One logical change per dev-repo commit.
+
+Scope:
+  • Only items in the charter. Out-of-scope ideas → memory as "future".
+  • One development task per iteration, then stop.
+
+══════════════════════════════════════════════════════════════════════════════
+EXIT CONDITIONS
+══════════════════════════════════════════════════════════════════════════════
+
+  • Charter says "complete"/"done" → write iteration report with status=⚪ no-op,
+    record memory, commit + push the report, exit clean.
+  • Repo in unexpected state → STOP, write iteration report with status=🛑 stopped,
+    explain in the report, record memory, commit + push the report, exit.
+  • Hard-rule violation candidate → STOP. Same as above.
+
+Begin with STEP 1 (memory recall). Do not skip ahead.'
+
+iter_num_padded() {
+  printf '%04d' "$1"
+}
+
+iter=0
+log "runner started (pid=$$ repo=$REPO branch=$DEV_BRANCH interval=${INTERVAL_SECS}s log_branch=$LOG_BRANCH)"
+
+while true; do
+  if [ -f "$KILL" ]; then
+    log "kill-switch present at $KILL — exiting"
+    break
+  fi
+
+  # Refresh charter repo (read-only main).
+  if [ -d "$CHARTER_REPO/.git" ]; then
+    git -C "$CHARTER_REPO" fetch --quiet origin 2>>"$LOG_DIR/git.err" || true
+    git -C "$CHARTER_REPO" checkout --quiet main 2>>"$LOG_DIR/git.err" || true
+    git -C "$CHARTER_REPO" reset --quiet --hard origin/main 2>>"$LOG_DIR/git.err" || true
+  fi
+
+  if [ ! -f "$CHARTER_REPO/$CHARTER_PATH" ]; then
+    log "charter not found at $CHARTER_REPO/$CHARTER_PATH — sleeping ${INTERVAL_SECS}s"
+    sleep "$INTERVAL_SECS"
+    continue
+  fi
+
+  # Ensure log worktree exists and is current.
+  ensure_log_worktree
+
+  # Refresh dev repo + ensure on DEV_BRANCH.
+  git -C "$REPO" fetch --quiet origin 2>>"$LOG_DIR/git.err" || true
+  if ! git -C "$REPO" diff-index --quiet HEAD --; then
+    log "WARN: dev repo has uncommitted local changes — agent will see them"
+  fi
+
+  # Bump iteration counter.
+  iter_global=$(cat "$ITER_COUNTER")
+  iter_global=$((iter_global + 1))
+  echo "$iter_global" > "$ITER_COUNTER"
+  iter=$((iter+1))
+
+  ITER_PADDED=$(iter_num_padded "$iter_global")
+  iter_log="$LOG_DIR/$(date +%F).iter-${ITER_PADDED}.log"
+  log "=== iteration $ITER_PADDED (session iter $iter) starting → $iter_log ==="
+
+  # Render the prompt with all placeholders substituted.
+  PROMPT="${PROMPT_TEMPLATE//REPO_PATH_PLACEHOLDER/$REPO}"
+  PROMPT="${PROMPT//CHARTER_FULL_PATH_PLACEHOLDER/$CHARTER_REPO/$CHARTER_PATH}"
+  PROMPT="${PROMPT//DEV_BRANCH_PLACEHOLDER/$DEV_BRANCH}"
+  PROMPT="${PROMPT//ITER_NUM_PLACEHOLDER/$ITER_PADDED}"
+  PROMPT="${PROMPT//LOG_WORKTREE_PLACEHOLDER/$LOG_WORKTREE}"
+  PROMPT="${PROMPT//LOG_DIR_REL_PLACEHOLDER/$LOG_DIR_REL}"
+  PROMPT="${PROMPT//LOG_BRANCH_PLACEHOLDER/$LOG_BRANCH}"
+  PROMPT="${PROMPT//MEMORY_NAMESPACE_PLACEHOLDER/$MEMORY_NAMESPACE}"
+
+  AI_MEMORY_DB=/var/root/.claude/ai-memory.db \
+  AI_MEMORY_AGENT_ID=campaign-runner \
+  ITER_NUM="$ITER_PADDED" \
+  claude -p "$PROMPT" \
+    --dangerously-skip-permissions \
+    --add-dir "$REPO" \
+    --add-dir "$CHARTER_REPO" \
+    --add-dir "$LOG_WORKTREE" \
+    --max-turns "$MAX_TURNS" \
+    >> "$iter_log" 2>&1
+  rc=$?
+
+  log "=== iteration $ITER_PADDED ended (exit=$rc) ==="
+
+  # Daily log volume guard: pause 1h if today exceeds 500MB.
+  today_kb=$(du -sk "$LOG_DIR/$(date +%F)".* 2>/dev/null | awk '{s+=$1} END {print s+0}')
+  if [ "$today_kb" -gt 512000 ]; then
+    log "log volume for today exceeds 500MB — pausing 1 hour"
+    sleep 3600
+  fi
+
+  sleep "$INTERVAL_SECS"
+done
+
+log "runner stopped"

--- a/ops/start.sh
+++ b/ops/start.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Pre-flights then launch the autonomous campaign runner detached via nohup.
+#
+# Pre-flight checks (refuses to start if any fail):
+#   - charter file exists
+#   - dev repo on release/v0.6.3
+#   - memory MCP shows Connected
+#   - signing test commit succeeds (and is reset)
+#   - campaign-log worktree exists or can be created
+#   - agentic-mem-labs has user.email/user.name set locally
+
+set -eu
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="$REPO/.agentic"
+PID_FILE="$STATE/runner.pid"
+KILL="$STATE/kill-switch"
+LOG_DIR="$STATE/logs"
+
+DEV_BRANCH="${DEV_BRANCH:-release/v0.6.3}"
+CHARTER_REPO="${CHARTER_REPO:-/var/root/dev/agentic-mem-labs}"
+CHARTER_PATH="${CHARTER_PATH:-strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md}"
+LOG_WORKTREE="${LOG_WORKTREE:-/var/root/dev/agentic-mem-labs-log}"
+LOG_BRANCH="${LOG_BRANCH:-campaign-log/v0.6.3}"
+LOG_DIR_REL="${LOG_DIR_REL:-campaign-log/v0.6.3}"
+
+mkdir -p "$LOG_DIR" "$STATE/state"
+
+err() { echo "ERROR: $*" >&2; exit 2; }
+
+# 1. charter present
+[ -f "$CHARTER_REPO/$CHARTER_PATH" ] || err "charter not found: $CHARTER_REPO/$CHARTER_PATH"
+
+# 2. dev branch correct
+current_branch="$(git -C "$REPO" rev-parse --abbrev-ref HEAD)"
+[ "$current_branch" = "$DEV_BRANCH" ] || err "current branch is '$current_branch', expected '$DEV_BRANCH'. Run: git -C $REPO checkout $DEV_BRANCH"
+
+# 3. memory MCP healthy
+claude mcp list 2>&1 | grep -q "memory:.*Connected" || err "memory MCP server is not Connected — run 'claude mcp list' to investigate"
+
+# 4. signing works on dev repo
+git -C "$REPO" commit --allow-empty -S -m "preflight signing test" >/dev/null 2>&1 || err "signing smoke test failed on dev repo — check git config and SSH key"
+git -C "$REPO" reset --hard HEAD~1 >/dev/null 2>&1
+
+# 5. agentic-mem-labs has identity for the agent's report commits
+labs_email="$(git -C "$CHARTER_REPO" config --get user.email 2>/dev/null || true)"
+labs_name="$(git -C "$CHARTER_REPO" config --get user.name 2>/dev/null || true)"
+[ -n "$labs_email" ] || err "agentic-mem-labs has no user.email — run: git -C $CHARTER_REPO config user.email alphaonedev@users.noreply.github.com"
+[ -n "$labs_name" ] || err "agentic-mem-labs has no user.name — run: git -C $CHARTER_REPO config user.name alphaonedev"
+
+# 6. signing works on agentic-mem-labs too
+git -C "$CHARTER_REPO" commit --allow-empty -S -m "preflight signing test" >/dev/null 2>&1 || err "signing smoke test failed on agentic-mem-labs — check git config and SSH key"
+git -C "$CHARTER_REPO" reset --hard HEAD~1 >/dev/null 2>&1
+
+# 7. campaign-log worktree present (or createable)
+if [ ! -d "$LOG_WORKTREE/.git" ] && [ ! -f "$LOG_WORKTREE/.git" ]; then
+  echo "campaign-log worktree at $LOG_WORKTREE will be created on first iteration."
+fi
+
+# 8. runner not already running
+if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  err "runner already running (pid=$(cat "$PID_FILE")). Use ops/stop.sh first."
+fi
+rm -f "$KILL" "$PID_FILE"
+
+nohup "$REPO/ops/run-campaign.sh" \
+  >> "$LOG_DIR/runner.out" 2>> "$LOG_DIR/runner.err" &
+echo "started runner pid=$! — tail -f $LOG_DIR/runner.out"
+echo "kill switch: touch $KILL  (or ops/stop.sh)"

--- a/ops/stop.sh
+++ b/ops/stop.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Stop the autonomous campaign cleanly.
+# 1. Touches kill-switch so the loop exits at its next check.
+# 2. Waits up to 30s for the in-flight claude iteration to finish.
+# 3. Kills the runner if it's still alive.
+
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="$REPO/.agentic"
+PID_FILE="$STATE/runner.pid"
+KILL="$STATE/kill-switch"
+
+mkdir -p "$STATE"
+touch "$KILL"
+echo "kill-switch placed at $KILL"
+
+if [ ! -f "$PID_FILE" ]; then
+  echo "no pid file — runner not tracked"
+  exit 0
+fi
+
+pid="$(cat "$PID_FILE")"
+if ! kill -0 "$pid" 2>/dev/null; then
+  echo "pid $pid not running — cleaning up"
+  rm -f "$PID_FILE"
+  exit 0
+fi
+
+echo "waiting up to 30s for pid $pid to exit gracefully…"
+for _ in $(seq 1 30); do
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "runner exited"
+    rm -f "$PID_FILE"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "runner still alive — sending SIGTERM"
+kill "$pid" 2>/dev/null || true
+sleep 2
+kill -0 "$pid" 2>/dev/null && { echo "still alive — SIGKILL"; kill -9 "$pid"; }
+rm -f "$PID_FILE"


### PR DESCRIPTION
Adds ops/ harness (run-campaign.sh, start.sh, stop.sh, launchd plist, RUNBOOK.md) for the 24x7 AI NHI autonomous development campaign on release/v0.6.3, plus .gitignore for runtime state. 8-step per-iteration flow: load memories -> read charter -> inspect -> pick task -> implement on campaign/<slug> -> record to memory -> write iteration report -> push to campaign-log/v0.6.3 branch on agentic-mem-labs (append-only). Companion runbook landed via agentic-mem-labs PR #2. See ops/RUNBOOK.md for full operator guide.