### PR TITLE
fix(autonomy): annotate unused StubLlm test fields under dead_code

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -646,8 +646,15 @@ mod tests {
     /// In-test LLM stub. Deterministic: returns fixed tags + treats
     /// "contradict" as a sentinel in content to flag contradictions.
     struct StubLlm {
+        // Read by the trait impls below; the test paths in this module exercise
+        // `summarize_memories` only, so rustc 1.93+ flags these reads as dead.
+        // Curator and MCP integration tests (in `mcp.rs`/`curator.rs`) cover
+        // `auto_tag` and `detect_contradiction`; this stub keeps the protocol
+        // complete so any future autonomy test can exercise either method.
+        #[allow(dead_code)]
         auto_tag_result: Vec<String>,
         summary: String,
+        #[allow(dead_code)]
         contradiction_sentinel: String,
         calls: Mutex<Vec<String>>,
     }


### PR DESCRIPTION
## Summary

- Pre-existing baseline failure on `release/v0.6.3`: `cargo clippy --all-targets -- -D warnings` errors with `dead_code` on `StubLlm.auto_tag_result` and `StubLlm.contradiction_sentinel` (`src/autonomy.rs:649,651`).
- Under rustc 1.93's tighter dead-code analysis, field reads inside trait methods that are never called from any in-module test no longer count as live. The autonomy module's own tests exercise `summarize_memories` only; `auto_tag` and `detect_contradiction` are covered by `mcp.rs`/`curator.rs` integration tests.
- Fix: `#[allow(dead_code)]` on the two fields plus an explanatory comment. The stub keeps the protocol complete on purpose so future autonomy tests can exercise either method.

## Why this lands first

This is iteration 1 of the autonomous v0.6.3 grand-slam campaign. The campaign rules require `cargo clippy --all-targets -- -D warnings` to pass before any PR merges; this baseline blocker would otherwise break every subsequent iteration's gates. Pivoted iteration 1 from authoring `PERFORMANCE.md` (Pillar 3) to unblocking the gates so structured-memory and performance work can flow from iteration 2 onwards. `PERFORMANCE.md` is queued as the next task.

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) under the autonomous v0.6.3 campaign. Charter: `agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`. Iteration log: `agentic-mem-labs-log/campaign-log/v0.6.3/iter-0001.md`. Commit signed with the established SSH key (no config touched).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (was failing on baseline)
- [x] `cargo test --all` — 184/184 pass with proper env isolation (`env -u AI_MEMORY_AGENT_ID -u AI_MEMORY_DB AI_MEMORY_NO_CONFIG=1 cargo test --all`)
- [x] Test-only change; no production behaviour affected