### PR TITLE
docs: publish v0.6.3 performance budgets (Pillar 3 / Stream F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.6.3 (Patch 3)
 
+### Added
+
+- **Performance budgets published** — new `PERFORMANCE.md` at the repo
+  root carries the authoritative p95/p99 latency contract for every
+  hot-path operation (verbatim from the v0.6.3 grand-slam charter):
+  `memory_session_start` hook, `memory_recall` hot/cold,
+  `memory_store` with/without embedding, `memory_search`,
+  `memory_check_duplicate`, `memory_kg_query` (depth ≤ 3 / ≤ 5),
+  `memory_kg_timeline`, `memory_get_taxonomy`, `curator cycle`, and
+  `federation ack`. Documents the **>10% p95 breach fails CI**
+  threshold (p99 informational until the v0.6.3 soak window closes),
+  the Apple M4 / 32 GB / NVMe SSD reference hardware baseline (with a
+  note on Linux x86_64 CI parity), and a status table flagging the
+  bench tool (Stream E) and `bench.yml` workflow (Stream F) as still
+  in-flight. Closes Pillar 3 / Stream F doc deliverable from the
+  v0.6.3 charter.
+
 ### Fixed
 
 - **[#358]** mTLS allowlist parser now tolerates inline trailing `#`

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,123 @@
+# Performance Budgets
+
+ai-memory publishes an explicit latency contract for every hot-path
+operation. **For an MCP server that fires on every conversation, load
+time IS the user experience.** Operators must be able to know — without
+reading source code — what each tool is allowed to cost and whether the
+build still meets that cost.
+
+This document is the authoritative budget table. The CI guard
+(`.github/workflows/bench.yml`, Stream F) and the `ai-memory bench`
+subcommand (Stream E) will both read from these targets once they land.
+Until then, this file establishes the contract; later patches under
+v0.6.3 wire the measurement and enforcement.
+
+## Budget Table
+
+| Operation | Target (p95) | Target (p99) | Notes |
+|---|---|---|---|
+| `memory_session_start` hook | < 100 ms | < 200 ms | Claude Code hook critical path |
+| `memory_recall` (hot, depth=1) | < 50 ms | < 150 ms | Felt during agent reasoning |
+| `memory_recall` (cold, full hybrid) | < 200 ms | < 500 ms | First-query path |
+| `memory_store` (no embedding) | < 20 ms | < 50 ms | Pure write |
+| `memory_store` (with embedding) | < 200 ms | < 500 ms | Includes ONNX/Ollama call |
+| `memory_search` (FTS5) | < 100 ms | < 250 ms | Keyword baseline |
+| `memory_check_duplicate` | < 50 ms | < 150 ms | Pre-write check |
+| `memory_kg_query` (depth ≤ 3) | < 100 ms | < 250 ms | New v0.6.3 |
+| `memory_kg_query` (depth ≤ 5) | < 250 ms | < 500 ms | New v0.6.3, tail case |
+| `memory_kg_timeline` | < 100 ms | < 250 ms | New v0.6.3 |
+| `memory_get_taxonomy` (full tree) | < 100 ms | < 250 ms | New v0.6.3 |
+| `curator cycle` (1k memories) | < 60 s | < 120 s | Background |
+| `federation ack` (W=2 quorum) | < 2 s | < 5 s | Multi-machine |
+
+## CI Guard Threshold
+
+The `bench.yml` workflow (Stream F, scheduled to land later in v0.6.3)
+runs `ai-memory bench` on every PR against `release/v0.6.3` and the
+trunk branches and **fails the build when any operation's measured p95
+exceeds its target by more than 10%.**
+
+p99 targets in the table above are **informational** until the v0.6.3
+soak window closes. They are recorded here to make the long-tail goal
+explicit and to give operators a number to compare their own
+measurements against, but a p99 breach does not fail CI during the
+v0.6.3 cycle. Promotion of p99 to a hard gate is tracked as a v0.7
+follow-up.
+
+## Hardware Baseline
+
+The targets in the table above are calibrated for:
+
+- **Local dev / reference baseline:** Apple M4, 32 GB unified memory,
+  NVMe SSD, Tier-1 thermals (no sustained throttling).
+- **CI:** GitHub-hosted Linux x86_64 runners (`ubuntu-latest`),
+  comparable single-thread performance to the M4 baseline within the
+  10% guard band. macOS and Windows runners are exercised for
+  correctness but are not the latency reference.
+
+If you measure on materially slower hardware (older laptops, heavily
+contended cloud instances, ARM developer boards) and see numbers above
+the targets, that is expected — these are *target* budgets for
+reference hardware, not absolute floors for every machine.
+
+## Status
+
+| Component | State | Where |
+|---|---|---|
+| Published budgets | ✅ landed | this file |
+| `ai-memory bench` subcommand | 🚧 Stream E | `src/bench.rs` (planned) |
+| `bench.yml` CI workflow | 🚧 Stream F | `.github/workflows/bench.yml` (planned) |
+| Measured numbers in CI history | ⏳ pending | populated once `bench` lands |
+
+The status table is updated as each Stream lands within the v0.6.3
+cycle. When measurements begin, this file will gain a "Latest measured"
+column alongside each target.
+
+## Operator Self-Verification
+
+Once Stream E lands, operators can verify the budgets on their own
+hardware with:
+
+```
+$ ai-memory bench
+Operation                      Target (p95)   Measured (p95)   Status
+────────────────────────────────────────────────────────────────────────
+memory_session_start hook      < 100 ms       …                …
+memory_recall (hot, depth=1)   <  50 ms       …                …
+memory_store (no embedding)    <  20 ms       …                …
+memory_store (with embedding)  < 200 ms       …                …
+memory_search (FTS5)           < 100 ms       …                …
+memory_check_duplicate         <  50 ms       …                …
+memory_kg_query (depth ≤ 3)    < 100 ms       …                …
+memory_kg_timeline             < 100 ms       …                …
+curator cycle (1k memories)    <  60 s        …                …
+federation ack (W=2 quorum)    <   2 s p99    …                …
+```
+
+The canonical workload is a 1000-memory mix sampled to be
+representative of a long-running Claude Code session. Workload inputs
+land at `benchmarks/v063/canonical_workload.json` alongside the bench
+implementation.
+
+## Why Publish These at All
+
+Three reasons, in order of importance:
+
+1. **Trust signal.** An MCP server that fires on every conversation
+   start cannot afford silent latency. Publishing budgets — even
+   before all measurements are live — signals operational maturity
+   and gives operators a number to argue with.
+2. **Regression guard.** A Rust binary can quietly get slower over
+   many releases. Explicit per-operation budgets, gated in CI, make
+   regressions visible in the PR that introduces them.
+3. **Capacity planning.** Operators choosing where to host
+   ai-memory (laptop, VPS, beefy server) need a comparison point.
+   "p95 < 100 ms on M4" beats "should be fast enough."
+
+## Forward References
+
+- Stream E (bench tool): `src/bench.rs`, charter §"Stream E —
+  Performance Instrumentation"
+- Stream F (CI guard): `.github/workflows/bench.yml`, charter
+  §"Stream F — Performance Budgets + CI Guard"
+- Hardware notes: charter §"Performance Budgets (Authoritative)"


### PR DESCRIPTION
## Summary

Publishes `PERFORMANCE.md` at the repo root as the authoritative
latency contract for v0.6.3, closing the Pillar 3 / Stream F doc
deliverable from the grand-slam charter.

For an MCP server that fires on every conversation, load time IS the
user experience — and ai-memory has so far had no published budgets.
This PR fixes the documentation half: every hot-path operation now has
a public p95/p99 target. The bench tool (Stream E) and `bench.yml` CI
workflow (Stream F) remain follow-up work in this release cycle, and
the doc flags both as 🚧 in its status table.

### What's in the doc

- p95/p99 targets for 13 hot-path operations, **verbatim from the
  charter** — `memory_session_start` hook, `memory_recall`
  (hot / cold), `memory_store` (no / with embedding),
  `memory_search`, `memory_check_duplicate`, `memory_kg_query` at
  depth ≤ 3 and ≤ 5, `memory_kg_timeline`, `memory_get_taxonomy`,
  `curator cycle`, and `federation ack`.
- CI guard threshold: **>10% p95 breach fails the build**; p99 is
  informational until the v0.6.3 soak window closes.
- Hardware baseline: Apple M4 / 32 GB / NVMe SSD, with Linux x86_64
  CI runners expected to be within the 10% guard band.
- Status table marking the bench tool (Stream E) and `bench.yml`
  workflow (Stream F) as still in flight.
- Operator self-verification snippet for the future `ai-memory bench`
  command.
- Forward references to the charter sections that own the bench tool
  and CI workflow.

### CHANGELOG

Adds an `### Added` bullet under `[Unreleased] — v0.6.3 (Patch 3)`
naming the new file and summarizing what it documents.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `env -u AI_MEMORY_AGENT_ID -u AI_MEMORY_DB AI_MEMORY_NO_CONFIG=1 cargo test --all` — 184 / 184 passed
- [x] No code changes — pure docs + CHANGELOG entry
- [x] No new dependencies, no schema changes
- [ ] CI green on ubuntu / macos / windows

## AI involvement

Authored end-to-end by Claude Code (Opus 4.7, 1M context) running
under the `release/v0.6.3` autonomous campaign harness, iteration 2.
Charter source: `agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`,
budget table lines 658–672. Human approval for the campaign granted
on 2026-04-25; this PR is in-scope (Pillar 3 / Stream F doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)