### PR TITLE
feat(db): add v15 temporal-validity KG schema (Pillar 2 / Stream B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Temporal-validity KG schema (Stream B foundation)** — SQLite schema
+  bumps to v15 (`src/db.rs::migrate`). `memory_links` gains four nullable
+  temporal columns — `valid_from`, `valid_until`, `observed_by` (TEXT),
+  and `signature` (BLOB; placeholder for v0.7 attested identity). On
+  upgrade, existing links are backfilled: `valid_from` is set to the
+  source memory's `created_at` (charter pre-flight default — defensive
+  null avoidance). Three temporal indexes are created for the upcoming
+  recursive-CTE traversal in `memory_kg_query` / `memory_kg_timeline`:
+  `idx_links_temporal_src` (source_id, valid_from, valid_until),
+  `idx_links_temporal_tgt` (target_id, valid_from, valid_until), and
+  `idx_links_relation` (relation, valid_from). New `entity_aliases`
+  side table (entity_id, alias, created_at; PK on entity_id+alias)
+  with `idx_entity_aliases_alias` lookup index unblocks the upcoming
+  Stream C entity-registry tools. The Postgres declarative schema
+  (`src/store/postgres_schema.sql`) is mirrored for fresh-init parity;
+  existing PG installs do not auto-gain the new columns since the PG
+  store layer is still WIP (an explicit ALTER migration lands when
+  `link()` is wired up there). Pure additive — no existing query
+  breaks. Charter §"Critical Schema Reference", lines 686–723.
+
 - **Performance budgets published** — new `PERFORMANCE.md` at the repo
   root carries the authoritative p95/p99 latency contract for every
   hot-path operation (verbatim from the v0.6.3 grand-slam charter):

--- a/src/db.rs
+++ b/src/db.rs
@@ -169,7 +169,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 );
 ";
 
-const CURRENT_SCHEMA_VERSION: i64 = 14;
+const CURRENT_SCHEMA_VERSION: i64 = 15;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -508,6 +508,79 @@ fn migrate(conn: &Connection) -> Result<()> {
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)",
                 [],
+            )?;
+        }
+
+        if version < 15 {
+            // v0.6.3 Stream B — Temporal-Validity KG schema additions.
+            // Charter §"Critical Schema Reference" (lines 686–723):
+            // four temporal columns on `memory_links`, three temporal
+            // indexes for KG traversal queries, and an `entity_aliases`
+            // side table for the upcoming entity registry. Pure additive
+            // — no existing column or index is dropped or renamed, so
+            // existing `link()` / `links_for()` paths keep working with
+            // the new columns NULL on legacy rows. The `valid_from`
+            // backfill matches the charter pre-flight default
+            // (charter line 428): set to the source memory's
+            // `created_at` to avoid null-handling complexity in v0.6.3
+            // KG query code.
+            let has_valid_from = conn
+                .prepare("SELECT valid_from FROM memory_links LIMIT 0")
+                .is_ok();
+            if !has_valid_from {
+                conn.execute("ALTER TABLE memory_links ADD COLUMN valid_from TEXT", [])?;
+            }
+            let has_valid_until = conn
+                .prepare("SELECT valid_until FROM memory_links LIMIT 0")
+                .is_ok();
+            if !has_valid_until {
+                conn.execute("ALTER TABLE memory_links ADD COLUMN valid_until TEXT", [])?;
+            }
+            let has_observed_by = conn
+                .prepare("SELECT observed_by FROM memory_links LIMIT 0")
+                .is_ok();
+            if !has_observed_by {
+                conn.execute("ALTER TABLE memory_links ADD COLUMN observed_by TEXT", [])?;
+            }
+            let has_signature = conn
+                .prepare("SELECT signature FROM memory_links LIMIT 0")
+                .is_ok();
+            if !has_signature {
+                conn.execute("ALTER TABLE memory_links ADD COLUMN signature BLOB", [])?;
+            }
+
+            conn.execute(
+                "UPDATE memory_links \
+                 SET valid_from = (SELECT created_at FROM memories WHERE id = memory_links.source_id) \
+                 WHERE valid_from IS NULL",
+                [],
+            )?;
+
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_links_temporal_src \
+                 ON memory_links (source_id, valid_from, valid_until)",
+                [],
+            )?;
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_links_temporal_tgt \
+                 ON memory_links (target_id, valid_from, valid_until)",
+                [],
+            )?;
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_links_relation \
+                 ON memory_links (relation, valid_from)",
+                [],
+            )?;
+
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS entity_aliases (
+                    entity_id  TEXT NOT NULL,
+                    alias      TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    PRIMARY KEY (entity_id, alias)
+                );
+                CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias
+                  ON entity_aliases (alias);",
             )?;
         }
 
@@ -4639,5 +4712,118 @@ mod tests {
         let purged = auto_purge_archive(&conn, Some(7)).unwrap();
         assert_eq!(purged, 1);
         assert!(list_archived(&conn, None, 10, 0).unwrap().is_empty());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Schema v15 (v0.6.3 Stream B) — temporal-validity KG migration.
+    // ─────────────────────────────────────────────────────────────────
+
+    fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        cols.iter().any(|c| c == column)
+    }
+
+    fn index_exists(conn: &Connection, name: &str) -> bool {
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
+            params![name],
+            |r| r.get::<_, i64>(0),
+        )
+        .is_ok()
+    }
+
+    #[test]
+    fn schema_v15_memory_links_has_temporal_columns() {
+        let conn = test_db();
+        assert!(column_exists(&conn, "memory_links", "valid_from"));
+        assert!(column_exists(&conn, "memory_links", "valid_until"));
+        assert!(column_exists(&conn, "memory_links", "observed_by"));
+        assert!(column_exists(&conn, "memory_links", "signature"));
+    }
+
+    #[test]
+    fn schema_v15_memory_links_temporal_indexes_exist() {
+        let conn = test_db();
+        assert!(index_exists(&conn, "idx_links_temporal_src"));
+        assert!(index_exists(&conn, "idx_links_temporal_tgt"));
+        assert!(index_exists(&conn, "idx_links_relation"));
+    }
+
+    #[test]
+    fn schema_v15_entity_aliases_table_exists() {
+        let conn = test_db();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM entity_aliases", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+        assert!(index_exists(&conn, "idx_entity_aliases_alias"));
+    }
+
+    #[test]
+    fn schema_v15_entity_aliases_primary_key_unique() {
+        let conn = test_db();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO entity_aliases (entity_id, alias, created_at) VALUES (?1, ?2, ?3)",
+            params!["e1", "Alpha", &now],
+        )
+        .unwrap();
+        let dup = conn.execute(
+            "INSERT INTO entity_aliases (entity_id, alias, created_at) VALUES (?1, ?2, ?3)",
+            params!["e1", "Alpha", &now],
+        );
+        assert!(dup.is_err(), "expected PK uniqueness violation");
+    }
+
+    #[test]
+    fn schema_v15_existing_links_get_valid_from_backfilled() {
+        // Simulate a v14 database with one link, then re-run the
+        // v15 migration and assert valid_from was backfilled to the
+        // source memory's created_at. We do this by opening a fresh
+        // db (which is at v15), inserting a link with NULL valid_from,
+        // rolling schema_version back to 14, and re-opening to force
+        // the v15 block to re-execute the backfill UPDATE.
+        let path = std::env::temp_dir().join(format!(
+            "ai_memory_v15_backfill_{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        {
+            let conn = open(&path).unwrap();
+            let src = make_memory("src", "test", Tier::Long, 5);
+            let tgt = make_memory("tgt", "test", Tier::Long, 5);
+            insert(&conn, &src).unwrap();
+            insert(&conn, &tgt).unwrap();
+            // Insert a link directly with NULL valid_from to mimic
+            // pre-migration state.
+            conn.execute(
+                "INSERT INTO memory_links (source_id, target_id, relation, created_at, valid_from) \
+                 VALUES (?1, ?2, 'related_to', ?3, NULL)",
+                params![&src.id, &tgt.id, &chrono::Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+            // Roll schema back to v14 and re-run migrate via re-open.
+            conn.execute("DELETE FROM schema_version", []).unwrap();
+            conn.execute("INSERT INTO schema_version (version) VALUES (14)", [])
+                .unwrap();
+        }
+
+        let conn2 = open(&path).unwrap();
+        let backfilled: Option<String> = conn2
+            .query_row("SELECT valid_from FROM memory_links LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(
+            backfilled.is_some(),
+            "expected valid_from to be backfilled, got NULL"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -93,17 +93,48 @@ CREATE INDEX IF NOT EXISTS memories_embedding_hnsw ON memories
 
 -- ─────────────────────────────────────────────────────────────────────
 -- memory_links — directional typed links between memories.
+--
+-- v0.6.3 Stream B: temporal columns + entity_aliases side table
+-- mirror SQLite schema v15 (see src/db.rs::migrate). Forward-compatible
+-- with v0.7 Apache AGE acceleration: same columns get projected as
+-- AGE graph edges. Existing PG installs at v0.6.2 will not gain the
+-- new columns automatically — the Postgres path is currently a fresh-
+-- init only target (see src/store/postgres.rs notes). An explicit ALTER
+-- migration lands when the link() implementation is wired up.
 -- ─────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS memory_links (
     source_id   TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     target_id   TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     relation    TEXT NOT NULL DEFAULT 'related_to',
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_from  TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    observed_by TEXT,
+    signature   BYTEA,
     PRIMARY KEY (source_id, target_id, relation)
 );
 
 CREATE INDEX IF NOT EXISTS memory_links_source_idx ON memory_links (source_id);
 CREATE INDEX IF NOT EXISTS memory_links_target_idx ON memory_links (target_id);
+CREATE INDEX IF NOT EXISTS idx_links_temporal_src
+    ON memory_links (source_id, valid_from, valid_until);
+CREATE INDEX IF NOT EXISTS idx_links_temporal_tgt
+    ON memory_links (target_id, valid_from, valid_until);
+CREATE INDEX IF NOT EXISTS idx_links_relation
+    ON memory_links (relation, valid_from);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- entity_aliases — alias→entity_id resolution (v0.6.3 Stream B/C).
+-- ─────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    entity_id  TEXT NOT NULL,
+    alias      TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (entity_id, alias)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias
+    ON entity_aliases (alias);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- archived_memories — GC archive for restoration.


### PR DESCRIPTION
## Summary

Lands the v0.6.3 charter's **Stream B foundation** (§"Critical Schema Reference", lines 686–723): SQLite schema v15 adds four nullable temporal columns to `memory_links` (`valid_from`, `valid_until`, `observed_by`, `signature`), three indexes for recursive-CTE traversal, and a new `entity_aliases` side table.

- **Backfill defensiveness**: existing links get `valid_from = source_memory.created_at` per the charter pre-flight default (line 428) so KG query code in Streams C/D never sees NULL.
- **Pure additive**: no column or index dropped, no existing query path changes, no new deps.
- **Postgres mirror**: declarative schema in `src/store/postgres_schema.sql` updated for fresh-init parity. Existing PG installs do not auto-gain columns yet — the PG `link()` path is still WIP, and an explicit ALTER lands when it's wired up.

Unblocks Stream C (KG query layer) and Stream D (duplicate check), which depend on the temporal columns and the entity registry table.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `env -u AI_MEMORY_AGENT_ID -u AI_MEMORY_DB AI_MEMORY_NO_CONFIG=1 cargo test --all` → 523 / 523 passed
- [x] 5 new schema_v15 unit tests in `src/db.rs::tests` cover columns, indexes, table, PK uniqueness, and the v14→v15 backfill
- [ ] CI: ubuntu / macos / windows green on this PR

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) running headless under the v0.6.3 24×7 autonomous campaign harness, iteration 0003. The previous iteration's report (iter-0002.md) explicitly flagged Stream B SQLite migration as the smallest-blast-radius next pick; this PR delivers exactly that.

Charter section: ai-memory-v0.6.3-grand-slam.md §"Critical Schema Reference", lines 686–723; pre-flight default for `valid_from` backfill from line 428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)