### PR TITLE
feat(db,mcp,http): memory_entity_register + memory_entity_get_by_alias (Pillar 2 / Stream B)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2028,6 +2028,223 @@ pub fn check_duplicate(
     })
 }
 
+/// Register an entity (canonical name + aliases) under a namespace
+/// (Pillar 2 / Stream B).
+///
+/// An entity is stored as a long-tier memory:
+/// - `title = canonical_name`
+/// - `namespace = namespace`
+/// - `tags` includes [`ENTITY_TAG`]
+/// - `metadata.kind = "entity"` (so the resolver can never confuse an
+///   entity with a regular memory that happens to share a title)
+///
+/// Aliases live in the `entity_aliases` side table keyed by
+/// `(entity_id, alias)`.
+///
+/// **Idempotency:** if an entity with this `(canonical_name, namespace)`
+/// already exists, its ID is reused and `aliases` are merged with
+/// `INSERT OR IGNORE`. The returned [`EntityRegistration::created`] is
+/// `false` in that case.
+///
+/// **Collision detection:** if a non-entity memory already occupies
+/// `(title=canonical_name, namespace=namespace)`, the call errors
+/// rather than silently upgrading it (the upsert path on `insert`
+/// would otherwise overwrite the existing row's content/tags). Callers
+/// must rename the entity or its colliding memory.
+///
+/// `extra_metadata` is merged into the entity memory's metadata; any
+/// caller-supplied `kind` field is overwritten with `"entity"` and
+/// `agent_id` is stamped from the caller (NHI provenance) when
+/// `extra_metadata` does not already specify one.
+pub fn entity_register(
+    conn: &Connection,
+    canonical_name: &str,
+    namespace: &str,
+    aliases: &[String],
+    extra_metadata: &serde_json::Value,
+    agent_id: Option<&str>,
+) -> Result<crate::models::EntityRegistration> {
+    use crate::models::{ENTITY_KIND, ENTITY_TAG, EntityRegistration};
+
+    // Look up an existing entity in this namespace by canonical_name +
+    // metadata.kind. If a non-entity memory occupies the same
+    // (title, namespace), surface a hard error instead of upserting.
+    let existing_id: Option<String> = match conn.query_row(
+        "SELECT id FROM memories
+         WHERE namespace = ?1 AND title = ?2
+           AND COALESCE(json_extract(metadata, '$.kind'), '') = ?3",
+        params![namespace, canonical_name, ENTITY_KIND],
+        |r| r.get::<_, String>(0),
+    ) {
+        Ok(id) => Some(id),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    let (entity_id, created) = if let Some(id) = existing_id {
+        (id, false)
+    } else {
+        let collision: Option<String> = match conn.query_row(
+            "SELECT id FROM memories
+             WHERE namespace = ?1 AND title = ?2
+               AND COALESCE(json_extract(metadata, '$.kind'), '') != ?3",
+            params![namespace, canonical_name, ENTITY_KIND],
+            |r| r.get::<_, String>(0),
+        ) {
+            Ok(id) => Some(id),
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(e) => return Err(e.into()),
+        };
+        if collision.is_some() {
+            anyhow::bail!(
+                "entity_register: title '{canonical_name}' in namespace '{namespace}' is already used by a non-entity memory"
+            );
+        }
+
+        // Build metadata: caller-supplied object merged, kind forced
+        // to "entity", agent_id preserved from caller when not set.
+        let mut meta_map = match extra_metadata {
+            serde_json::Value::Object(m) => m.clone(),
+            _ => serde_json::Map::new(),
+        };
+        meta_map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(ENTITY_KIND.to_string()),
+        );
+        if let Some(a) = agent_id {
+            meta_map
+                .entry("agent_id".to_string())
+                .or_insert(serde_json::Value::String(a.to_string()));
+        }
+        let metadata = serde_json::Value::Object(meta_map);
+
+        let now = Utc::now().to_rfc3339();
+        let mem = Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: Tier::Long,
+            namespace: namespace.to_string(),
+            title: canonical_name.to_string(),
+            content: canonical_name.to_string(),
+            tags: vec![ENTITY_TAG.to_string()],
+            priority: 7,
+            confidence: 1.0,
+            source: "api".to_string(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata,
+        };
+        let id = insert(conn, &mem).context("insert entity memory")?;
+        (id, true)
+    };
+
+    let now = Utc::now().to_rfc3339();
+    {
+        let mut stmt = conn.prepare(
+            "INSERT OR IGNORE INTO entity_aliases (entity_id, alias, created_at)
+             VALUES (?1, ?2, ?3)",
+        )?;
+        for alias in aliases {
+            let trimmed = alias.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            stmt.execute(params![entity_id, trimmed, now])?;
+        }
+    }
+
+    let aliases_out = list_entity_aliases(conn, &entity_id)?;
+
+    Ok(EntityRegistration {
+        entity_id,
+        canonical_name: canonical_name.to_string(),
+        namespace: namespace.to_string(),
+        aliases: aliases_out,
+        created,
+    })
+}
+
+/// Resolve an alias to its registered entity (Pillar 2 / Stream B).
+///
+/// When `namespace` is `Some`, only entities in that namespace are
+/// considered. When `None`, all namespaces are searched and the
+/// most-recently-created matching entity wins (deterministic
+/// disambiguation when the same alias was registered in multiple
+/// namespaces).
+///
+/// Returns `Ok(None)` if no entity claims this alias under the given
+/// filter. Returns the full alias set for the resolved entity.
+pub fn entity_get_by_alias(
+    conn: &Connection,
+    alias: &str,
+    namespace: Option<&str>,
+) -> Result<Option<crate::models::EntityRecord>> {
+    use crate::models::{ENTITY_KIND, EntityRecord};
+
+    let trimmed = alias.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let row: std::result::Result<(String, String, String), rusqlite::Error> =
+        if let Some(ns) = namespace {
+            conn.query_row(
+                "SELECT m.id, m.title, m.namespace
+                 FROM entity_aliases ea
+                 JOIN memories m ON m.id = ea.entity_id
+                 WHERE ea.alias = ?1
+                   AND m.namespace = ?2
+                   AND COALESCE(json_extract(m.metadata, '$.kind'), '') = ?3
+                 ORDER BY m.created_at DESC
+                 LIMIT 1",
+                params![trimmed, ns, ENTITY_KIND],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+        } else {
+            conn.query_row(
+                "SELECT m.id, m.title, m.namespace
+                 FROM entity_aliases ea
+                 JOIN memories m ON m.id = ea.entity_id
+                 WHERE ea.alias = ?1
+                   AND COALESCE(json_extract(m.metadata, '$.kind'), '') = ?2
+                 ORDER BY m.created_at DESC
+                 LIMIT 1",
+                params![trimmed, ENTITY_KIND],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+        };
+
+    let (entity_id, canonical_name, ns) = match row {
+        Ok(t) => t,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    let aliases = list_entity_aliases(conn, &entity_id)?;
+    Ok(Some(EntityRecord {
+        entity_id,
+        canonical_name,
+        namespace: ns,
+        aliases,
+    }))
+}
+
+/// List all aliases registered for an entity, ordered by registration
+/// time then alphabetical for stable display.
+fn list_entity_aliases(conn: &Connection, entity_id: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT alias FROM entity_aliases
+         WHERE entity_id = ?1
+         ORDER BY created_at ASC, alias ASC",
+    )?;
+    let aliases: Vec<String> = stmt
+        .query_map(params![entity_id], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(aliases)
+}
+
 /// Register or refresh an agent in the reserved `_agents` namespace.
 ///
 /// Each agent is stored as a long-tier memory with `title = "agent:<agent_id>"`.
@@ -5362,6 +5579,238 @@ mod tests {
             params!["e1", "Alpha", &now],
         );
         assert!(dup.is_err(), "expected PK uniqueness violation");
+    }
+
+    // -- Pillar 2 / Stream B — entity_register / entity_get_by_alias ------
+
+    #[test]
+    fn entity_register_creates_new_entity_with_aliases() {
+        let conn = test_db();
+        let aliases = vec!["pa".to_string(), "Project A".to_string()];
+        let reg = entity_register(
+            &conn,
+            "Project Alpha",
+            "projects/alpha",
+            &aliases,
+            &serde_json::json!({}),
+            Some("test-agent"),
+        )
+        .unwrap();
+        assert!(reg.created, "first registration must be created=true");
+        assert_eq!(reg.canonical_name, "Project Alpha");
+        assert_eq!(reg.namespace, "projects/alpha");
+        // Aliases inserted in one call share a created_at; the
+        // secondary `alias ASC` sort orders 'P' before 'p'.
+        assert_eq!(reg.aliases, vec!["Project A".to_string(), "pa".to_string()]);
+
+        let m = get(&conn, &reg.entity_id).unwrap().unwrap();
+        assert_eq!(m.title, "Project Alpha");
+        assert_eq!(m.tier.rank(), Tier::Long.rank());
+        assert!(m.tags.contains(&"entity".to_string()));
+        assert_eq!(m.metadata["kind"], "entity");
+        assert_eq!(m.metadata["agent_id"], "test-agent");
+    }
+
+    #[test]
+    fn entity_register_reuses_existing_and_merges_aliases() {
+        let conn = test_db();
+        let first = entity_register(
+            &conn,
+            "Project Alpha",
+            "projects/alpha",
+            &["pa".to_string()],
+            &serde_json::json!({}),
+            Some("a1"),
+        )
+        .unwrap();
+        let second = entity_register(
+            &conn,
+            "Project Alpha",
+            "projects/alpha",
+            &["pa".to_string(), "alpha".to_string()],
+            &serde_json::json!({}),
+            Some("a2"),
+        )
+        .unwrap();
+        assert!(first.created);
+        assert!(!second.created, "second call must reuse the entity");
+        assert_eq!(first.entity_id, second.entity_id);
+        assert_eq!(second.aliases, vec!["pa".to_string(), "alpha".to_string()]);
+    }
+
+    #[test]
+    fn entity_register_errors_on_collision_with_non_entity_memory() {
+        let conn = test_db();
+        let mem = make_memory("Conflict", "projects/alpha", Tier::Long, 5);
+        insert(&conn, &mem).unwrap();
+        let err = entity_register(
+            &conn,
+            "Conflict",
+            "projects/alpha",
+            &[],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("non-entity memory"),
+            "expected collision error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn entity_register_skips_blank_aliases() {
+        let conn = test_db();
+        let reg = entity_register(
+            &conn,
+            "Trim Test",
+            "test",
+            &["".to_string(), "   ".to_string(), "ok".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        assert_eq!(reg.aliases, vec!["ok".to_string()]);
+    }
+
+    #[test]
+    fn entity_register_preserves_caller_metadata_keys() {
+        let conn = test_db();
+        let extra = serde_json::json!({"team": "platform", "kind": "ignored"});
+        let reg = entity_register(&conn, "Service X", "svc", &[], &extra, None).unwrap();
+        let m = get(&conn, &reg.entity_id).unwrap().unwrap();
+        assert_eq!(m.metadata["team"], "platform");
+        // Caller's `kind` is overwritten — entity records must always
+        // carry kind=entity for the resolver to find them.
+        assert_eq!(m.metadata["kind"], "entity");
+    }
+
+    #[test]
+    fn entity_get_by_alias_returns_record_with_full_alias_set() {
+        let conn = test_db();
+        let reg = entity_register(
+            &conn,
+            "Project Alpha",
+            "projects/alpha",
+            &["pa".to_string(), "alpha".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        let got = entity_get_by_alias(&conn, "pa", None).unwrap().unwrap();
+        assert_eq!(got.entity_id, reg.entity_id);
+        assert_eq!(got.canonical_name, "Project Alpha");
+        assert_eq!(got.namespace, "projects/alpha");
+        // Same-batch aliases share a created_at; alphabetical
+        // tiebreak puts "alpha" before "pa".
+        assert_eq!(got.aliases, vec!["alpha".to_string(), "pa".to_string()]);
+    }
+
+    #[test]
+    fn entity_get_by_alias_returns_none_for_unknown_alias() {
+        let conn = test_db();
+        let got = entity_get_by_alias(&conn, "missing", None).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn entity_get_by_alias_filters_by_namespace() {
+        let conn = test_db();
+        entity_register(
+            &conn,
+            "Acme",
+            "ns_a",
+            &["a".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        entity_register(
+            &conn,
+            "Acme Corp",
+            "ns_b",
+            &["a".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        let in_a = entity_get_by_alias(&conn, "a", Some("ns_a"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(in_a.namespace, "ns_a");
+        assert_eq!(in_a.canonical_name, "Acme");
+        let in_b = entity_get_by_alias(&conn, "a", Some("ns_b"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(in_b.namespace, "ns_b");
+        assert_eq!(in_b.canonical_name, "Acme Corp");
+    }
+
+    #[test]
+    fn entity_get_by_alias_without_namespace_picks_most_recent() {
+        let conn = test_db();
+        // Older entity created first.
+        entity_register(
+            &conn,
+            "Older",
+            "ns_old",
+            &["dup".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        // Sleep just enough to guarantee a strictly later created_at.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        entity_register(
+            &conn,
+            "Newer",
+            "ns_new",
+            &["dup".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        let got = entity_get_by_alias(&conn, "dup", None).unwrap().unwrap();
+        assert_eq!(got.canonical_name, "Newer");
+        assert_eq!(got.namespace, "ns_new");
+    }
+
+    #[test]
+    fn entity_get_by_alias_ignores_non_entity_memory_with_matching_alias() {
+        let conn = test_db();
+        // Insert a regular (non-entity) memory and a stray
+        // entity_aliases row pointing at it. The resolver must skip
+        // it because `kind != 'entity'`.
+        let mut mem = make_memory("Decoy", "test", Tier::Long, 5);
+        mem.metadata = serde_json::json!({});
+        let mid = insert(&conn, &mem).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO entity_aliases (entity_id, alias, created_at) VALUES (?1, ?2, ?3)",
+            params![&mid, "decoy", &now],
+        )
+        .unwrap();
+        let got = entity_get_by_alias(&conn, "decoy", None).unwrap();
+        assert!(got.is_none(), "non-entity memories must not resolve");
+    }
+
+    #[test]
+    fn entity_register_idempotent_aliases_are_deduped() {
+        let conn = test_db();
+        let reg = entity_register(
+            &conn,
+            "Dedup",
+            "test",
+            &["x".to_string(), "x".to_string(), "y".to_string()],
+            &serde_json::json!({}),
+            None,
+        )
+        .unwrap();
+        // INSERT OR IGNORE collapses the duplicate "x".
+        assert_eq!(reg.aliases.len(), 2);
+        assert!(reg.aliases.contains(&"x".to_string()));
+        assert!(reg.aliases.contains(&"y".to_string()));
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2025,6 +2025,185 @@ pub async fn check_duplicate(
     .into_response()
 }
 
+/// Request body for `POST /api/v1/entities` (Pillar 2 / Stream B).
+#[derive(Debug, Deserialize)]
+pub struct EntityRegisterBody {
+    pub canonical_name: String,
+    pub namespace: String,
+    /// Aliases that should resolve to this entity. Blanks are skipped;
+    /// duplicates collapse via `entity_aliases`'s primary key.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    /// Arbitrary metadata to merge onto the entity memory. `kind` is
+    /// always overwritten with `"entity"`.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    /// Override the resolved NHI for this request's
+    /// `metadata.agent_id`. Falls back to the `X-Agent-Id` header
+    /// when omitted.
+    pub agent_id: Option<String>,
+}
+
+/// Query parameters for `GET /api/v1/entities/by_alias` (Pillar 2 /
+/// Stream B).
+#[derive(Debug, Deserialize)]
+pub struct EntityByAliasQuery {
+    pub alias: String,
+    pub namespace: Option<String>,
+}
+
+/// `POST /api/v1/entities` — REST mirror of the MCP
+/// `memory_entity_register` tool. Idempotent on
+/// `(canonical_name, namespace)`; merges aliases on re-registration.
+pub async fn entity_register(
+    State(state): State<Db>,
+    headers: HeaderMap,
+    Json(body): Json<EntityRegisterBody>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_title(&body.canonical_name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid canonical_name: {e}")})),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate::validate_namespace(&body.namespace) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid namespace: {e}")})),
+        )
+            .into_response();
+    }
+
+    let agent_id = body
+        .agent_id
+        .as_deref()
+        .or_else(|| headers.get("x-agent-id").and_then(|v| v.to_str().ok()))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    if let Some(aid) = agent_id.as_deref()
+        && let Err(e) = validate::validate_agent_id(aid)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid agent_id: {e}")})),
+        )
+            .into_response();
+    }
+
+    let extra_metadata = if body.metadata.is_object() {
+        body.metadata.clone()
+    } else {
+        json!({})
+    };
+
+    let lock = state.lock().await;
+    match db::entity_register(
+        &lock.0,
+        &body.canonical_name,
+        &body.namespace,
+        &body.aliases,
+        &extra_metadata,
+        agent_id.as_deref(),
+    ) {
+        Ok(reg) => {
+            let status = if reg.created {
+                StatusCode::CREATED
+            } else {
+                StatusCode::OK
+            };
+            (
+                status,
+                Json(json!({
+                    "entity_id": reg.entity_id,
+                    "canonical_name": reg.canonical_name,
+                    "namespace": reg.namespace,
+                    "aliases": reg.aliases,
+                    "created": reg.created,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            // Title-collision errors carry a stable, recognisable
+            // substring; surface them as 409 Conflict so callers can
+            // distinguish a genuine name clash from internal failure.
+            let msg = e.to_string();
+            if msg.contains("non-entity memory") {
+                return (StatusCode::CONFLICT, Json(json!({"error": msg}))).into_response();
+            }
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// `GET /api/v1/entities/by_alias?alias=<>&namespace=<>` — REST mirror
+/// of the MCP `memory_entity_get_by_alias` tool. Returns
+/// `{ found: false, ... }` with HTTP 200 when no entity claims the
+/// alias under the filter, so callers don't have to disambiguate
+/// "no match" from a server error.
+pub async fn entity_get_by_alias(
+    State(state): State<Db>,
+    Query(p): Query<EntityByAliasQuery>,
+) -> impl IntoResponse {
+    let alias = p.alias.trim();
+    if alias.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "alias is required"})),
+        )
+            .into_response();
+    }
+    let namespace = p
+        .namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(ns) = namespace
+        && let Err(e) = validate::validate_namespace(ns)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid namespace: {e}")})),
+        )
+            .into_response();
+    }
+
+    let lock = state.lock().await;
+    match db::entity_get_by_alias(&lock.0, alias, namespace) {
+        Ok(Some(rec)) => Json(json!({
+            "found": true,
+            "entity_id": rec.entity_id,
+            "canonical_name": rec.canonical_name,
+            "namespace": rec.namespace,
+            "aliases": rec.aliases,
+        }))
+        .into_response(),
+        Ok(None) => Json(json!({
+            "found": false,
+            "entity_id": null,
+            "canonical_name": null,
+            "namespace": null,
+            "aliases": [],
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 pub async fn create_link(
     State(app): State<AppState>,
     Json(body): Json<LinkBody>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1161,6 +1161,15 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         // mirror of the MCP `memory_check_duplicate` tool. Body:
         // `{title, content, namespace?, threshold?}`.
         .route("/api/v1/check_duplicate", post(handlers::check_duplicate))
+        // Pillar 2 / Stream B — entity registry. REST mirror of the
+        // `memory_entity_register` and `memory_entity_get_by_alias` MCP
+        // tools. POST body: `{canonical_name, namespace, aliases?, metadata?, agent_id?}`.
+        // GET query params: `alias` (required), `namespace?`.
+        .route("/api/v1/entities", post(handlers::entity_register))
+        .route(
+            "/api/v1/entities/by_alias",
+            get(handlers::entity_get_by_alias),
+        )
         .route("/api/v1/stats", get(handlers::get_stats))
         .route("/api/v1/gc", post(handlers::run_gc))
         .route("/api/v1/export", get(handlers::export_memories))

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -182,6 +182,33 @@ fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_entity_register",
+                "description": "Pillar 2 / Stream B — register an entity (canonical name + aliases) under a namespace. Entities are stored as long-tier memories tagged 'entity' with metadata.kind='entity', so the (title, namespace) coordinate is shared with regular memories without ambiguity. Idempotent: re-registering the same canonical_name+namespace reuses the existing entity_id and merges any new aliases. Errors when the namespace+canonical_name already names a non-entity memory.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "canonical_name": {"type": "string", "description": "Display name for the entity. Stored as the entity memory's title."},
+                        "namespace": {"type": "string", "description": "Namespace under which the entity lives. Hierarchy paths (e.g. 'projects/alpha') are accepted."},
+                        "aliases": {"type": "array", "items": {"type": "string"}, "description": "Aliases that should resolve to this entity. Blank entries are skipped; duplicates are de-duped via the entity_aliases primary key."},
+                        "metadata": {"type": "object", "description": "Arbitrary metadata to attach to the entity memory. Caller-supplied 'kind' is overwritten with 'entity'; agent_id is stamped from the NHI caller when not specified."},
+                        "agent_id": {"type": "string", "description": "Override the caller's resolved NHI for the entity memory's metadata.agent_id."}
+                    },
+                    "required": ["canonical_name", "namespace"]
+                }
+            },
+            {
+                "name": "memory_entity_get_by_alias",
+                "description": "Pillar 2 / Stream B — resolve an alias to its registered entity. When 'namespace' is provided, only entities in that namespace are returned. When omitted, the most recently created matching entity wins. Returns null when no entity claims the alias under the given filter.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "alias": {"type": "string", "description": "Alias string to resolve. Whitespace is trimmed."},
+                        "namespace": {"type": "string", "description": "Restrict the resolution to this namespace. Omit to search all namespaces."}
+                    },
+                    "required": ["alias"]
+                }
+            },
+            {
                 "name": "memory_delete",
                 "description": "Delete a memory by ID.",
                 "inputSchema": {
@@ -1459,6 +1486,91 @@ fn handle_check_duplicate(
     }))
 }
 
+fn handle_entity_register(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    mcp_client: Option<&str>,
+) -> Result<Value, String> {
+    let canonical_name = params["canonical_name"]
+        .as_str()
+        .ok_or("canonical_name is required")?;
+    let namespace = params["namespace"]
+        .as_str()
+        .ok_or("namespace is required")?;
+    let aliases: Vec<String> = params["aliases"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let extra_metadata = if params["metadata"].is_object() {
+        params["metadata"].clone()
+    } else {
+        json!({})
+    };
+    let explicit_agent_id = params["agent_id"].as_str();
+
+    validate::validate_title(canonical_name).map_err(|e| e.to_string())?;
+    validate::validate_namespace(namespace).map_err(|e| e.to_string())?;
+    if let Some(aid) = explicit_agent_id {
+        validate::validate_agent_id(aid).map_err(|e| e.to_string())?;
+    }
+
+    let agent_id = crate::identity::resolve_agent_id(explicit_agent_id, mcp_client)
+        .map_err(|e| e.to_string())?;
+
+    let reg = db::entity_register(
+        conn,
+        canonical_name,
+        namespace,
+        &aliases,
+        &extra_metadata,
+        Some(&agent_id),
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(json!({
+        "entity_id": reg.entity_id,
+        "canonical_name": reg.canonical_name,
+        "namespace": reg.namespace,
+        "aliases": reg.aliases,
+        "created": reg.created,
+    }))
+}
+
+fn handle_entity_get_by_alias(
+    conn: &rusqlite::Connection,
+    params: &Value,
+) -> Result<Value, String> {
+    let alias = params["alias"].as_str().ok_or("alias is required")?;
+    let namespace = params["namespace"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(ns) = namespace {
+        validate::validate_namespace(ns).map_err(|e| e.to_string())?;
+    }
+
+    match db::entity_get_by_alias(conn, alias, namespace).map_err(|e| e.to_string())? {
+        Some(rec) => Ok(json!({
+            "found": true,
+            "entity_id": rec.entity_id,
+            "canonical_name": rec.canonical_name,
+            "namespace": rec.namespace,
+            "aliases": rec.aliases,
+        })),
+        None => Ok(json!({
+            "found": false,
+            "entity_id": null,
+            "canonical_name": null,
+            "namespace": null,
+            "aliases": [],
+        })),
+    }
+}
+
 fn handle_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     let tier = params["tier"].as_str().and_then(Tier::from_str);
@@ -2679,6 +2791,8 @@ fn handle_request(
                 "memory_list" => handle_list(conn, arguments),
                 "memory_get_taxonomy" => handle_get_taxonomy(conn, arguments),
                 "memory_check_duplicate" => handle_check_duplicate(conn, arguments, embedder),
+                "memory_entity_register" => handle_entity_register(conn, arguments, mcp_client),
+                "memory_entity_get_by_alias" => handle_entity_get_by_alias(conn, arguments),
                 "memory_delete" => handle_delete(conn, arguments, vector_index, mcp_client),
                 "memory_promote" => handle_promote(conn, arguments, mcp_client),
                 "memory_pending_list" => handle_pending_list(conn, arguments),
@@ -3043,13 +3157,14 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_38_tools() {
-        // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A) and
-        // memory_check_duplicate (Pillar 2 / Stream D) on top of the
-        // 36-tool v0.6.0.0 surface.
+    fn tool_definitions_returns_40_tools() {
+        // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
+        // memory_check_duplicate (Pillar 2 / Stream D), and
+        // memory_entity_register + memory_entity_get_by_alias
+        // (Pillar 2 / Stream B) on top of the 36-tool v0.6.0.0 surface.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 38);
+        assert_eq!(tools.len(), 40);
     }
 
     #[test]
@@ -3058,6 +3173,15 @@ mod tests {
         let tools = defs["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
         assert!(names.contains(&"memory_check_duplicate"));
+    }
+
+    #[test]
+    fn tool_definitions_include_entity_registry_tools() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"memory_entity_register"));
+        assert!(names.contains(&"memory_entity_get_by_alias"));
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -367,6 +367,42 @@ pub struct DuplicateCheck {
 /// Namespace reserved for agent registrations (Task 1.3).
 pub const AGENTS_NAMESPACE: &str = "_agents";
 
+/// Tag stamped on entity-typed memories so `(title, namespace)` can be
+/// shared across regular memories and entities without ambiguity (Pillar
+/// 2 / Stream B).
+pub const ENTITY_TAG: &str = "entity";
+
+/// Marker written to `metadata.kind` on entity-typed memories. The
+/// db layer keys entity lookups off this field so the alias resolver
+/// never returns a regular memory that happens to share a title with an
+/// entity registered later.
+pub const ENTITY_KIND: &str = "entity";
+
+/// Resolved entity record returned by `db::entity_get_by_alias` and
+/// embedded in the `db::entity_register` response (Pillar 2 / Stream B).
+/// `aliases` is the full alias set for the entity, ordered by
+/// `created_at ASC, alias ASC` for stable display.
+#[derive(Debug, Clone, Serialize)]
+pub struct EntityRecord {
+    pub entity_id: String,
+    pub canonical_name: String,
+    pub namespace: String,
+    pub aliases: Vec<String>,
+}
+
+/// Outcome of `db::entity_register`. `created` is `true` when a new
+/// entity memory was inserted, `false` when an existing entity was
+/// reused (idempotent re-registration that just merged new aliases into
+/// the existing record).
+#[derive(Debug, Clone, Serialize)]
+pub struct EntityRegistration {
+    pub entity_id: String,
+    pub canonical_name: String,
+    pub namespace: String,
+    pub aliases: Vec<String>,
+    pub created: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Task 1.9 — Governance Enforcement
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1835,7 +1835,7 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 38, "expected 38 MCP tools");
+    assert_eq!(tools.len(), 40, "expected 40 MCP tools");
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));
@@ -1844,6 +1844,8 @@ fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"memory_list"));
     assert!(tool_names.contains(&"memory_get_taxonomy"));
     assert!(tool_names.contains(&"memory_check_duplicate"));
+    assert!(tool_names.contains(&"memory_entity_register"));
+    assert!(tool_names.contains(&"memory_entity_get_by_alias"));
     assert!(tool_names.contains(&"memory_delete"));
     assert!(tool_names.contains(&"memory_promote"));
     assert!(tool_names.contains(&"memory_forget"));


### PR DESCRIPTION
## Summary

Pillar 2 / Stream B — entity registry surface on top of the v15 schema (PR #384). Adds `memory_entity_register` + `memory_entity_get_by_alias` end-to-end (DB, MCP, HTTP).

- Entities are long-tier memories tagged `entity` with `metadata.kind="entity"`; aliases live in the existing `entity_aliases` side table.
- Registration is idempotent on `(canonical_name, namespace)`: re-registering reuses the entity_id and merges new aliases via `INSERT OR IGNORE`.
- A non-entity memory occupying the same `(title, namespace)` returns a hard error rather than letting the upsert path silently overwrite an unrelated memory.
- Resolver returns the most-recently-created entity when no namespace filter is supplied; ignores stray `entity_aliases` rows that point at non-entity memories.

## Surfaces

| Layer | Identifier | Notes |
|---|---|---|
| DB | `db::entity_register` / `db::entity_get_by_alias` | 11 unit tests |
| MCP | `memory_entity_register` / `memory_entity_get_by_alias` | tool count 38 → 40 |
| HTTP | `POST /api/v1/entities` / `GET /api/v1/entities/by_alias` | 201/200/409 status discipline; X-Agent-Id header honoured |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (CI-level)
- [x] `env -u AI_MEMORY_AGENT_ID -u AI_MEMORY_DB AI_MEMORY_NO_CONFIG=1 cargo test` — 365 unit + 184 integration, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
