### PR TITLE
feat(db,mcp,http): memory_kg_invalidate (Pillar 2 / Stream C)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2322,6 +2322,62 @@ pub fn kg_timeline(
         .map_err(Into::into)
 }
 
+/// Outcome of [`invalidate_link`] (Pillar 2 / Stream C —
+/// `memory_kg_invalidate`). `valid_until` is the timestamp now stored on
+/// the link; `previous_valid_until` is the prior value, or `None` if
+/// this was the first invalidation. Callers can use the prior value to
+/// distinguish a fresh supersession from an idempotent retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidateResult {
+    pub valid_until: String,
+    pub previous_valid_until: Option<String>,
+}
+
+/// Mark a KG link as superseded by setting its `valid_until` column
+/// (Pillar 2 / Stream C — `memory_kg_invalidate`). Returns `Ok(None)`
+/// when the `(source_id, target_id, relation)` triple does not match an
+/// existing link. The supplied `valid_until` defaults to the current
+/// wall-clock time in RFC3339 form when omitted; callers needing
+/// historical or future supersession can pass an explicit value.
+///
+/// Idempotent: calling repeatedly overwrites the prior `valid_until`
+/// (the prior value is returned in `previous_valid_until` so callers
+/// can detect the overwrite). The schema does not yet carry an audit
+/// column for the supersession reason; that arrives with v0.7
+/// attestation. Until then, callers should record the rationale in
+/// their own logs or a paired memory.
+pub fn invalidate_link(
+    conn: &Connection,
+    source_id: &str,
+    target_id: &str,
+    relation: &str,
+    valid_until: Option<&str>,
+) -> Result<Option<InvalidateResult>> {
+    let stamp = valid_until.map_or_else(|| Utc::now().to_rfc3339(), str::to_string);
+
+    let prior = match conn.query_row(
+        "SELECT valid_until FROM memory_links \
+         WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+        params![source_id, target_id, relation],
+        |r| r.get::<_, Option<String>>(0),
+    ) {
+        Ok(v) => v,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    conn.execute(
+        "UPDATE memory_links SET valid_until = ?4 \
+         WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+        params![source_id, target_id, relation, &stamp],
+    )?;
+
+    Ok(Some(InvalidateResult {
+        valid_until: stamp,
+        previous_valid_until: prior,
+    }))
+}
+
 /// List all aliases registered for an entity, ordered by registration
 /// time then alphabetical for stable display.
 fn list_entity_aliases(conn: &Connection, entity_id: &str) -> Result<Vec<String>> {
@@ -6152,6 +6208,177 @@ mod tests {
         let conn = test_db();
         let events = kg_timeline(&conn, "nonexistent-id", None, None, None).unwrap();
         assert!(events.is_empty());
+    }
+
+    // -- Pillar 2 / Stream C — kg_invalidate -------------------------------
+
+    #[test]
+    fn invalidate_link_sets_valid_until_to_provided_timestamp() {
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        create_link(&conn, &src.id, &tgt.id, "related_to").unwrap();
+        let stamp = "2026-12-31T23:59:59+00:00";
+        let res = invalidate_link(&conn, &src.id, &tgt.id, "related_to", Some(stamp))
+            .unwrap()
+            .expect("link must exist");
+        assert_eq!(res.valid_until, stamp);
+        assert!(res.previous_valid_until.is_none());
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT valid_until FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+                params![&src.id, &tgt.id, "related_to"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored.as_deref(), Some(stamp));
+    }
+
+    #[test]
+    fn invalidate_link_defaults_to_now_when_no_timestamp_provided() {
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        create_link(&conn, &src.id, &tgt.id, "related_to").unwrap();
+        let res = invalidate_link(&conn, &src.id, &tgt.id, "related_to", None)
+            .unwrap()
+            .expect("link must exist");
+        // The default is wall-clock now; assert it parses as RFC3339 and
+        // is within a small window of the test's "now" (allow 60s skew
+        // to accommodate slow runners).
+        let parsed = chrono::DateTime::parse_from_rfc3339(&res.valid_until)
+            .expect("default valid_until must be RFC3339");
+        let now = chrono::Utc::now();
+        let drift = now.signed_duration_since(parsed.with_timezone(&chrono::Utc));
+        assert!(
+            drift.num_seconds().abs() < 60,
+            "default valid_until {} should be near now {now}",
+            res.valid_until
+        );
+    }
+
+    #[test]
+    fn invalidate_link_returns_none_for_unknown_triple() {
+        let conn = test_db();
+        // No memories or links created.
+        let res = invalidate_link(&conn, "missing-src", "missing-tgt", "related_to", None).unwrap();
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn invalidate_link_returns_none_when_relation_does_not_match() {
+        // Link exists for ("related_to") but caller asks for ("supersedes").
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        create_link(&conn, &src.id, &tgt.id, "related_to").unwrap();
+        let res = invalidate_link(&conn, &src.id, &tgt.id, "supersedes", None).unwrap();
+        assert!(res.is_none(), "must not match across relation values");
+    }
+
+    #[test]
+    fn invalidate_link_overwrites_existing_valid_until_and_reports_prior() {
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        create_link(&conn, &src.id, &tgt.id, "related_to").unwrap();
+        let first = "2026-06-01T00:00:00+00:00";
+        let second = "2026-12-01T00:00:00+00:00";
+        let r1 = invalidate_link(&conn, &src.id, &tgt.id, "related_to", Some(first))
+            .unwrap()
+            .unwrap();
+        assert!(r1.previous_valid_until.is_none());
+        let r2 = invalidate_link(&conn, &src.id, &tgt.id, "related_to", Some(second))
+            .unwrap()
+            .unwrap();
+        assert_eq!(r2.previous_valid_until.as_deref(), Some(first));
+        assert_eq!(r2.valid_until, second);
+    }
+
+    #[test]
+    fn invalidate_link_distinguishes_relation_when_multiple_links_share_endpoints() {
+        // Two links between the same pair, different relations. Invalidating
+        // one must not affect the other.
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        create_link(&conn, &src.id, &tgt.id, "related_to").unwrap();
+        create_link(&conn, &src.id, &tgt.id, "supersedes").unwrap();
+        let stamp = "2026-07-15T12:00:00+00:00";
+        invalidate_link(&conn, &src.id, &tgt.id, "related_to", Some(stamp))
+            .unwrap()
+            .unwrap();
+        let related: Option<String> = conn
+            .query_row(
+                "SELECT valid_until FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2 AND relation = 'related_to'",
+                params![&src.id, &tgt.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let supers: Option<String> = conn
+            .query_row(
+                "SELECT valid_until FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2 AND relation = 'supersedes'",
+                params![&src.id, &tgt.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(related.as_deref(), Some(stamp));
+        assert!(
+            supers.is_none(),
+            "the sibling 'supersedes' link must remain valid"
+        );
+    }
+
+    #[test]
+    fn invalidate_link_preserves_other_columns() {
+        // valid_from, observed_by, created_at, signature must not be
+        // touched by the invalidate UPDATE.
+        let conn = test_db();
+        let src = make_memory("inv-s", "test", Tier::Long, 5);
+        let tgt = make_memory("inv-t", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO memory_links \
+             (source_id, target_id, relation, created_at, valid_from, observed_by) \
+             VALUES (?1, ?2, 'related_to', ?3, '2026-01-01T00:00:00+00:00', 'agent-x')",
+            params![&src.id, &tgt.id, &now],
+        )
+        .unwrap();
+        invalidate_link(
+            &conn,
+            &src.id,
+            &tgt.id,
+            "related_to",
+            Some("2026-12-31T23:59:59+00:00"),
+        )
+        .unwrap()
+        .unwrap();
+        let (vf, ob, ca): (Option<String>, Option<String>, String) = conn
+            .query_row(
+                "SELECT valid_from, observed_by, created_at FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2 AND relation = 'related_to'",
+                params![&src.id, &tgt.id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(vf.as_deref(), Some("2026-01-01T00:00:00+00:00"));
+        assert_eq!(ob.as_deref(), Some("agent-x"));
+        assert_eq!(ca, now);
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2283,6 +2283,87 @@ pub async fn kg_timeline(
     }
 }
 
+/// JSON body for `POST /api/v1/kg/invalidate` (Pillar 2 / Stream C —
+/// `memory_kg_invalidate`). The link is identified by its composite
+/// key; `valid_until` defaults to wall-clock now when omitted.
+#[derive(Debug, Deserialize)]
+pub struct KgInvalidateBody {
+    pub source_id: String,
+    pub target_id: String,
+    pub relation: String,
+    pub valid_until: Option<String>,
+}
+
+/// `POST /api/v1/kg/invalidate` — REST mirror of `memory_kg_invalidate`.
+/// 200 with `{found: true, …, previous_valid_until}` when the link
+/// existed; 404 with `{found: false}` when no link matches the triple.
+pub async fn kg_invalidate(
+    State(state): State<Db>,
+    Json(body): Json<KgInvalidateBody>,
+) -> impl IntoResponse {
+    if let Err(e) = validate::validate_link(&body.source_id, &body.target_id, &body.relation) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let valid_until = body
+        .valid_until
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(ts) = valid_until
+        && let Err(e) = validate::validate_expires_at_format(ts)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("invalid valid_until: {e}")})),
+        )
+            .into_response();
+    }
+
+    let lock = state.lock().await;
+    match db::invalidate_link(
+        &lock.0,
+        &body.source_id,
+        &body.target_id,
+        &body.relation,
+        valid_until,
+    ) {
+        Ok(Some(res)) => (
+            StatusCode::OK,
+            Json(json!({
+                "found": true,
+                "source_id": body.source_id,
+                "target_id": body.target_id,
+                "relation": body.relation,
+                "valid_until": res.valid_until,
+                "previous_valid_until": res.previous_valid_until,
+            })),
+        )
+            .into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "found": false,
+                "source_id": body.source_id,
+                "target_id": body.target_id,
+                "relation": body.relation,
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("handler error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 pub async fn create_link(
     State(app): State<AppState>,
     Json(body): Json<LinkBody>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1174,6 +1174,12 @@ async fn serve(db_path: PathBuf, args: ServeArgs, app_config: &config::AppConfig
         // `memory_kg_timeline` tool. Query params: `source_id` (required),
         // `since?`, `until?`, `limit?`.
         .route("/api/v1/kg/timeline", get(handlers::kg_timeline))
+        // Pillar 2 / Stream C — KG link supersession. REST mirror of the
+        // MCP `memory_kg_invalidate` tool. POST body:
+        // `{source_id, target_id, relation, valid_until?}`. 200 when the
+        // link existed (with `previous_valid_until`); 404 when no link
+        // matches the triple.
+        .route("/api/v1/kg/invalidate", post(handlers::kg_invalidate))
         .route("/api/v1/stats", get(handlers::get_stats))
         .route("/api/v1/gc", post(handlers::run_gc))
         .route("/api/v1/export", get(handlers::export_memories))

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -223,6 +223,20 @@ fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_kg_invalidate",
+                "description": "Pillar 2 / Stream C — mark a KG link as superseded by setting its `valid_until` column. The link is identified by the (source_id, target_id, relation) triple (memory_links has no separate id column). When `valid_until` is omitted, the current wall-clock time is used. Idempotent: repeated calls overwrite the prior value and the response reports `previous_valid_until` so callers can detect the overwrite. Returns `found: false` when no link matches the triple.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "source_id": {"type": "string", "description": "Source memory ID of the link to invalidate."},
+                        "target_id": {"type": "string", "description": "Target memory ID of the link to invalidate."},
+                        "relation": {"type": "string", "description": "Relation label of the link (e.g. 'related_to', 'supersedes', 'derived_from'). Must be a recognized relation."},
+                        "valid_until": {"type": "string", "description": "RFC3339 timestamp marking when the assertion stops being valid. Defaults to the current time when omitted."}
+                    },
+                    "required": ["source_id", "target_id", "relation"]
+                }
+            },
+            {
                 "name": "memory_delete",
                 "description": "Delete a memory by ID.",
                 "inputSchema": {
@@ -1633,6 +1647,43 @@ fn handle_kg_timeline(conn: &rusqlite::Connection, params: &Value) -> Result<Val
     }))
 }
 
+fn handle_kg_invalidate(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let source_id = params["source_id"]
+        .as_str()
+        .ok_or("source_id is required")?;
+    let target_id = params["target_id"]
+        .as_str()
+        .ok_or("target_id is required")?;
+    let relation = params["relation"].as_str().ok_or("relation is required")?;
+    validate::validate_link(source_id, target_id, relation).map_err(|e| e.to_string())?;
+    let valid_until = params["valid_until"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(ts) = valid_until {
+        validate::validate_expires_at_format(ts).map_err(|e| e.to_string())?;
+    }
+
+    match db::invalidate_link(conn, source_id, target_id, relation, valid_until)
+        .map_err(|e| e.to_string())?
+    {
+        Some(res) => Ok(json!({
+            "found": true,
+            "source_id": source_id,
+            "target_id": target_id,
+            "relation": relation,
+            "valid_until": res.valid_until,
+            "previous_valid_until": res.previous_valid_until,
+        })),
+        None => Ok(json!({
+            "found": false,
+            "source_id": source_id,
+            "target_id": target_id,
+            "relation": relation,
+        })),
+    }
+}
+
 fn handle_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     let tier = params["tier"].as_str().and_then(Tier::from_str);
@@ -2856,6 +2907,7 @@ fn handle_request(
                 "memory_entity_register" => handle_entity_register(conn, arguments, mcp_client),
                 "memory_entity_get_by_alias" => handle_entity_get_by_alias(conn, arguments),
                 "memory_kg_timeline" => handle_kg_timeline(conn, arguments),
+                "memory_kg_invalidate" => handle_kg_invalidate(conn, arguments),
                 "memory_delete" => handle_delete(conn, arguments, vector_index, mcp_client),
                 "memory_promote" => handle_promote(conn, arguments, mcp_client),
                 "memory_pending_list" => handle_pending_list(conn, arguments),
@@ -3220,15 +3272,16 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_41_tools() {
+    fn tool_definitions_returns_42_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
-        // (Pillar 2 / Stream B), and memory_kg_timeline (Pillar 2 /
-        // Stream C) on top of the 36-tool v0.6.0.0 surface.
+        // (Pillar 2 / Stream B), and memory_kg_timeline +
+        // memory_kg_invalidate (Pillar 2 / Stream C) on top of the
+        // 36-tool v0.6.0.0 surface.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 41);
+        assert_eq!(tools.len(), 42);
     }
 
     #[test]
@@ -3254,6 +3307,14 @@ mod tests {
         let tools = defs["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
         assert!(names.contains(&"memory_kg_timeline"));
+    }
+
+    #[test]
+    fn tool_definitions_include_kg_invalidate() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"memory_kg_invalidate"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1835,7 +1835,7 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 41, "expected 41 MCP tools");
+    assert_eq!(tools.len(), 42, "expected 42 MCP tools");
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));
@@ -1847,6 +1847,7 @@ fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"memory_entity_register"));
     assert!(tool_names.contains(&"memory_entity_get_by_alias"));
     assert!(tool_names.contains(&"memory_kg_timeline"));
+    assert!(tool_names.contains(&"memory_kg_invalidate"));
     assert!(tool_names.contains(&"memory_delete"));
     assert!(tool_names.contains(&"memory_promote"));
     assert!(tool_names.contains(&"memory_forget"));


### PR DESCRIPTION
## Summary

Second tool of the KG-traversal triplet (after `memory_kg_timeline` in #389). Mark a KG link as superseded by setting its `valid_until` column — anchors the curator's supersession path so a contradicting fact can invalidate the prior assertion without deleting the row, preserving the timeline.

The link is identified by its composite key `(source_id, target_id, relation)` since `memory_links` has no separate id. `valid_until` defaults to wall-clock now when omitted. The DB function returns `Option<InvalidateResult>` — `None` when the triple does not match a row, `Some` with the value now stored and `previous_valid_until` so callers can distinguish a fresh supersession from an idempotent retry.

The schema does not yet carry an audit column for the supersession `reason`; that arrives with v0.7 attestation. Callers should record rationale in their own logs or a paired memory until then.

Tool count 41 → 42.

## Files changed

- `src/db.rs` — `InvalidateResult` struct, `invalidate_link()` (composite-key lookup, defaults to `Utc::now().to_rfc3339()`, preserves all other columns); 7 unit tests.
- `src/mcp.rs` — `memory_kg_invalidate` tool definition, `handle_kg_invalidate` handler, dispatch arm, count assertion 41 → 42, inclusion test.
- `src/handlers.rs` — `KgInvalidateBody` + `kg_invalidate` handler (200 with `previous_valid_until`, 404 with `found: false` on miss).
- `src/main.rs` — route `POST /api/v1/kg/invalidate`.
- `tests/integration.rs` — `test_mcp_tools_list` 41 → 42 + `memory_kg_invalidate` inclusion assertion.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean (strict CI gate)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `env -u AI_MEMORY_AGENT_ID -u AI_MEMORY_DB AI_MEMORY_NO_CONFIG=1 cargo test` — 383 unit (was 376) + 184 integration, all green
- [x] 7 new unit tests cover: timestamp default within ~60s of now, explicit timestamp persistence, idempotent overwrite reports prior, sibling links with different relations are not affected, other columns (`valid_from`, `observed_by`, `created_at`) preserved, returns `None` for unknown triple, returns `None` when relation does not match

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) under the v0.6.3 grand-slam autonomous campaign. Iteration 0012, branch `campaign/kg-invalidate-stream-c`. Picked off iter-0011's recommendation as the smallest unblocked Stream C deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)