### PR TITLE
feat(db,mcp,http): memory_kg_query depth 1..=5 (Pillar 2 / Stream C)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2388,12 +2388,11 @@ pub const KG_QUERY_DEFAULT_LIMIT: usize = 200;
 /// pathological fan-out.
 pub const KG_QUERY_MAX_LIMIT: usize = 1000;
 
-/// Maximum traversal depth supported by [`kg_query`] in this build. The
-/// first slice of Pillar 2 / Stream C ships outbound depth=1
-/// ("expand neighbors"); the recursive-CTE multi-hop traversal lands in
-/// a follow-up iteration. Keeping the constant here lets the next slice
-/// raise the ceiling in one place without touching callers.
-pub const KG_QUERY_MAX_SUPPORTED_DEPTH: usize = 1;
+/// Maximum traversal depth supported by [`kg_query`]. The recursive-CTE
+/// implementation enforces an explicit ceiling so a crafted call cannot
+/// run an unbounded traversal; the charter (`v0.6.3-grand-slam.md`
+/// § Performance Budgets) sets the published budget at depth ≤ 5.
+pub const KG_QUERY_MAX_SUPPORTED_DEPTH: usize = 5;
 
 /// Outbound KG traversal from a source memory (Pillar 2 / Stream C —
 /// `memory_kg_query`). Returns one row per link reachable within
@@ -2410,16 +2409,22 @@ pub const KG_QUERY_MAX_SUPPORTED_DEPTH: usize = 1;
 ///   When omitted entirely (`None`), the agent filter is skipped.
 /// - `limit`: row cap, clamped to [1, [`KG_QUERY_MAX_LIMIT`]].
 ///
-/// `max_depth` must be in `[1, KG_QUERY_MAX_SUPPORTED_DEPTH]`. This
-/// build supports depth=1 only; passing a larger value yields an
-/// explicit error rather than a silent truncation. The recursive CTE
-/// path lands in the follow-up iteration that finishes Stream C.
+/// `max_depth` must be in `[1, KG_QUERY_MAX_SUPPORTED_DEPTH]`; passing
+/// a larger value yields an explicit error rather than a silent
+/// truncation, so callers learn they hit the ceiling instead of
+/// receiving a partial graph.
 ///
-/// Ordering is `COALESCE(valid_from, created_at) ASC, created_at ASC`,
-/// so the result is deterministic whether or not the caller scopes by
-/// time. The `depth` field is always 1 in this build; the `path` field
-/// is the simple `<source_id>-><target_id>` string and generalizes to
-/// multi-hop paths in the follow-up iteration.
+/// Multi-hop traversal uses a recursive CTE with cycle detection on
+/// the accumulated path, so cycles in the link graph cannot loop the
+/// traversal indefinitely. Each hop reapplies the same temporal /
+/// agent filters as the anchor — a chain only extends through links
+/// that pass every filter on every hop.
+///
+/// Ordering is `depth ASC, COALESCE(valid_from, created_at) ASC,
+/// created_at ASC` — shallower hops first, then time-ordered within
+/// each level. For depth=1 callers this collapses to the original
+/// time ordering. The `depth` field reflects the actual hop count and
+/// `path` is the full `src->mid->target` chain.
 pub fn kg_query(
     conn: &Connection,
     source_id: &str,
@@ -2435,8 +2440,7 @@ pub fn kg_query(
     }
     if max_depth > KG_QUERY_MAX_SUPPORTED_DEPTH {
         anyhow::bail!(
-            "max_depth={max_depth} exceeds supported depth={KG_QUERY_MAX_SUPPORTED_DEPTH}; \
-             multi-hop traversal lands in a follow-up iteration"
+            "max_depth={max_depth} exceeds supported depth={KG_QUERY_MAX_SUPPORTED_DEPTH}"
         );
     }
 
@@ -2452,50 +2456,78 @@ pub fn kg_query(
         .unwrap_or(KG_QUERY_DEFAULT_LIMIT)
         .clamp(1, KG_QUERY_MAX_LIMIT);
 
-    // Compose the predicate dynamically. Bind values are appended in the
-    // same order so positional placeholders line up.
-    let mut sql = String::from(
-        "SELECT ml.target_id, ml.relation, ml.valid_from, ml.valid_until,
-                ml.observed_by, m.title, m.namespace
-         FROM memory_links ml
-         JOIN memories m ON m.id = ml.target_id
-         WHERE ml.source_id = ?1",
-    );
-    let mut binds: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(source_id.to_string())];
-
+    // Build the per-hop predicate once; the anchor and recursive members
+    // both apply it to a row aliased `ml`. Bind values are appended in
+    // resolution order so positional placeholders line up.
+    let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut hop_filter = String::new();
     if let Some(t) = valid_at {
-        sql.push_str(" AND ml.valid_from IS NOT NULL AND ml.valid_from <= ?");
-        sql.push_str(&(binds.len() + 1).to_string());
+        hop_filter.push_str(" AND ml.valid_from IS NOT NULL AND ml.valid_from <= ?");
         binds.push(Box::new(t.to_string()));
-        sql.push_str(" AND (ml.valid_until IS NULL OR ml.valid_until > ?");
-        sql.push_str(&(binds.len() + 1).to_string());
-        sql.push(')');
+        hop_filter.push_str(&binds.len().to_string());
+        hop_filter.push_str(" AND (ml.valid_until IS NULL OR ml.valid_until > ?");
         binds.push(Box::new(t.to_string()));
+        hop_filter.push_str(&binds.len().to_string());
+        hop_filter.push(')');
     }
-
     if let Some(agents) = allowed_agents {
         // Already short-circuited the empty case above.
-        let placeholders: Vec<String> = (0..agents.len())
-            .map(|i| format!("?{}", binds.len() + 1 + i))
-            .collect();
-        sql.push_str(" AND ml.observed_by IN (");
-        sql.push_str(&placeholders.join(", "));
-        sql.push(')');
-        for a in agents {
+        hop_filter.push_str(" AND ml.observed_by IN (");
+        for (i, a) in agents.iter().enumerate() {
             binds.push(Box::new(a.clone()));
+            if i > 0 {
+                hop_filter.push_str(", ");
+            }
+            hop_filter.push('?');
+            hop_filter.push_str(&binds.len().to_string());
         }
+        hop_filter.push(')');
     }
 
-    sql.push_str(" ORDER BY COALESCE(ml.valid_from, ml.created_at) ASC, ml.created_at ASC LIMIT ?");
-    sql.push_str(&(binds.len() + 1).to_string());
+    // Anchor binds source_id, recursive member binds max_depth, final
+    // SELECT binds the row cap. Order matters — placeholders are
+    // resolved by the position they occupy in the assembled string.
+    binds.push(Box::new(source_id.to_string()));
+    let source_ph = binds.len();
+    binds.push(Box::new(i64::try_from(max_depth).unwrap_or(i64::MAX)));
+    let max_depth_ph = binds.len();
     binds.push(Box::new(i64::try_from(cap).unwrap_or(i64::MAX)));
+    let limit_ph = binds.len();
+
+    let sql = format!(
+        "WITH RECURSIVE traversal(\
+            target_id, relation, valid_from, valid_until, observed_by, \
+            link_created_at, depth, path\
+         ) AS (\
+            SELECT ml.target_id, ml.relation, ml.valid_from, ml.valid_until, \
+                   ml.observed_by, ml.created_at, 1, \
+                   ml.source_id || '->' || ml.target_id \
+            FROM memory_links ml \
+            WHERE ml.source_id = ?{source_ph}{hop_filter} \
+            UNION ALL \
+            SELECT ml.target_id, ml.relation, ml.valid_from, ml.valid_until, \
+                   ml.observed_by, ml.created_at, t.depth + 1, \
+                   t.path || '->' || ml.target_id \
+            FROM memory_links ml \
+            JOIN traversal t ON ml.source_id = t.target_id \
+            WHERE t.depth < ?{max_depth_ph} \
+              AND t.path NOT LIKE '%' || ml.target_id || '%'\
+              {hop_filter}\
+         ) \
+         SELECT t.target_id, t.relation, t.valid_from, t.valid_until, \
+                t.observed_by, m.title, m.namespace, t.depth, t.path \
+         FROM traversal t \
+         JOIN memories m ON m.id = t.target_id \
+         ORDER BY t.depth ASC, COALESCE(t.valid_from, t.link_created_at) ASC, \
+                  t.link_created_at ASC \
+         LIMIT ?{limit_ph}",
+    );
 
     let mut stmt = conn.prepare(&sql)?;
     let bind_refs: Vec<&dyn rusqlite::ToSql> = binds.iter().map(AsRef::as_ref).collect();
-    let source_owned = source_id.to_string();
     let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), |row| {
         let target_id: String = row.get(0)?;
-        let path = format!("{source_owned}->{target_id}");
+        let depth: i64 = row.get(7)?;
         Ok(KgQueryNode {
             target_id,
             relation: row.get(1)?,
@@ -2504,8 +2536,8 @@ pub fn kg_query(
             observed_by: row.get(4)?,
             title: row.get(5)?,
             target_namespace: row.get(6)?,
-            depth: 1,
-            path,
+            depth: usize::try_from(depth).unwrap_or(0),
+            path: row.get(8)?,
         })
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -6775,16 +6807,223 @@ mod tests {
 
     #[test]
     fn kg_query_rejects_unsupported_max_depth() {
-        // The first slice ships depth=1 only; depth>=2 must produce an
-        // explicit error so the recursive-CTE follow-up can lift the
-        // ceiling without surprising callers that already passed 2+.
+        // The recursive-CTE slice supports depth 1..=5; passing 6+ must
+        // produce an explicit error so callers learn they hit the
+        // ceiling rather than receiving a partial graph.
         let conn = test_db();
         let src = make_memory("s", "ns", Tier::Long, 5);
         insert(&conn, &src).unwrap();
-        let err = kg_query(&conn, &src.id, 2, None, None, None).unwrap_err();
+        let err = kg_query(
+            &conn,
+            &src.id,
+            KG_QUERY_MAX_SUPPORTED_DEPTH + 1,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("max_depth=2"));
-        assert!(msg.contains("supported depth=1"));
+        assert!(msg.contains(&format!("max_depth={}", KG_QUERY_MAX_SUPPORTED_DEPTH + 1)));
+        assert!(msg.contains(&format!("supported depth={KG_QUERY_MAX_SUPPORTED_DEPTH}")));
+    }
+
+    #[test]
+    fn kg_query_traverses_multiple_hops() {
+        // src -> mid -> leaf. depth=2 must return both hops, with
+        // depth/path reflecting the chain.
+        let conn = test_db();
+        let src = make_memory("src", "ns", Tier::Long, 5);
+        let mid = make_memory("mid", "ns", Tier::Long, 5);
+        let leaf = make_memory("leaf", "ns", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &mid).unwrap();
+        insert(&conn, &leaf).unwrap();
+        insert_link_full(
+            &conn,
+            &src.id,
+            &mid.id,
+            "related_to",
+            Some("2026-01-01T00:00:00+00:00"),
+            None,
+            Some("agent-x"),
+        );
+        insert_link_full(
+            &conn,
+            &mid.id,
+            &leaf.id,
+            "supersedes",
+            Some("2026-01-02T00:00:00+00:00"),
+            None,
+            Some("agent-x"),
+        );
+
+        // depth=1 sees only mid.
+        let d1 = kg_query(&conn, &src.id, 1, None, None, None).unwrap();
+        assert_eq!(d1.len(), 1);
+        assert_eq!(d1[0].target_id, mid.id);
+        assert_eq!(d1[0].depth, 1);
+
+        // depth=2 sees both, ordered shallow-first.
+        let d2 = kg_query(&conn, &src.id, 2, None, None, None).unwrap();
+        assert_eq!(d2.len(), 2);
+        assert_eq!(d2[0].target_id, mid.id);
+        assert_eq!(d2[0].depth, 1);
+        assert_eq!(d2[0].path, format!("{}->{}", src.id, mid.id));
+        assert_eq!(d2[1].target_id, leaf.id);
+        assert_eq!(d2[1].depth, 2);
+        assert_eq!(d2[1].relation, "supersedes");
+        assert_eq!(d2[1].path, format!("{}->{}->{}", src.id, mid.id, leaf.id));
+    }
+
+    #[test]
+    fn kg_query_multi_hop_respects_valid_at_per_hop() {
+        // src -> mid valid 2026-01..02; mid -> leaf valid 2026-04+.
+        // At valid_at=2026-01-15 the second hop is not yet valid, so
+        // only mid is returned; at valid_at=2026-04-15 the first hop is
+        // closed, so both are filtered out.
+        let conn = test_db();
+        let src = make_memory("s", "ns", Tier::Long, 5);
+        let mid = make_memory("m", "ns", Tier::Long, 5);
+        let leaf = make_memory("l", "ns", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &mid).unwrap();
+        insert(&conn, &leaf).unwrap();
+        insert_link_full(
+            &conn,
+            &src.id,
+            &mid.id,
+            "related_to",
+            Some("2026-01-01T00:00:00+00:00"),
+            Some("2026-02-01T00:00:00+00:00"),
+            None,
+        );
+        insert_link_full(
+            &conn,
+            &mid.id,
+            &leaf.id,
+            "related_to",
+            Some("2026-04-01T00:00:00+00:00"),
+            None,
+            None,
+        );
+
+        let mid_only = kg_query(
+            &conn,
+            &src.id,
+            3,
+            Some("2026-01-15T00:00:00+00:00"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(mid_only.len(), 1);
+        assert_eq!(mid_only[0].target_id, mid.id);
+
+        let neither = kg_query(
+            &conn,
+            &src.id,
+            3,
+            Some("2026-04-15T00:00:00+00:00"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(neither.is_empty());
+    }
+
+    #[test]
+    fn kg_query_detects_cycles() {
+        // a -> b -> c -> a forms a cycle. Even with max_depth=5, the
+        // traversal must stop revisiting nodes that are already on the
+        // path; the result lists each reachable node at most once.
+        let conn = test_db();
+        let a = make_memory("a", "ns", Tier::Long, 5);
+        let b = make_memory("b", "ns", Tier::Long, 5);
+        let c = make_memory("c", "ns", Tier::Long, 5);
+        insert(&conn, &a).unwrap();
+        insert(&conn, &b).unwrap();
+        insert(&conn, &c).unwrap();
+        insert_link_full(
+            &conn,
+            &a.id,
+            &b.id,
+            "related_to",
+            Some("2026-01-01T00:00:00+00:00"),
+            None,
+            None,
+        );
+        insert_link_full(
+            &conn,
+            &b.id,
+            &c.id,
+            "related_to",
+            Some("2026-01-02T00:00:00+00:00"),
+            None,
+            None,
+        );
+        insert_link_full(
+            &conn,
+            &c.id,
+            &a.id,
+            "related_to",
+            Some("2026-01-03T00:00:00+00:00"),
+            None,
+            None,
+        );
+
+        let nodes = kg_query(&conn, &a.id, 5, None, None, None).unwrap();
+        // Expect b at depth 1 and c at depth 2; the cycle back to a is
+        // pruned. (The c->a edge could in principle surface a again at
+        // depth 3, but only if a is not on its own path — and the
+        // anchor seeds path with `a->b`, so a IS on every descendant
+        // path through b/c.)
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].target_id, b.id);
+        assert_eq!(nodes[0].depth, 1);
+        assert_eq!(nodes[1].target_id, c.id);
+        assert_eq!(nodes[1].depth, 2);
+    }
+
+    #[test]
+    fn kg_query_multi_hop_filters_by_allowed_agents_per_hop() {
+        // src -> mid (agent-a), mid -> leaf (agent-b). With allow=[a]
+        // only the first hop survives; with allow=[a,b] both surface.
+        let conn = test_db();
+        let src = make_memory("s", "ns", Tier::Long, 5);
+        let mid = make_memory("m", "ns", Tier::Long, 5);
+        let leaf = make_memory("l", "ns", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &mid).unwrap();
+        insert(&conn, &leaf).unwrap();
+        insert_link_full(
+            &conn,
+            &src.id,
+            &mid.id,
+            "related_to",
+            Some("2026-01-01T00:00:00+00:00"),
+            None,
+            Some("agent-a"),
+        );
+        insert_link_full(
+            &conn,
+            &mid.id,
+            &leaf.id,
+            "related_to",
+            Some("2026-01-02T00:00:00+00:00"),
+            None,
+            Some("agent-b"),
+        );
+
+        let allow_a = vec!["agent-a".to_string()];
+        let only_first = kg_query(&conn, &src.id, 3, None, Some(&allow_a), None).unwrap();
+        assert_eq!(only_first.len(), 1);
+        assert_eq!(only_first[0].target_id, mid.id);
+
+        let allow_both = vec!["agent-a".to_string(), "agent-b".to_string()];
+        let both = kg_query(&conn, &src.id, 3, None, Some(&allow_both), None).unwrap();
+        assert_eq!(both.len(), 2);
+        assert_eq!(both[1].target_id, leaf.id);
+        assert_eq!(both[1].depth, 2);
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2368,7 +2368,7 @@ pub async fn kg_invalidate(
 /// `memory_kg_query`). POST is used because `allowed_agents` is a list;
 /// keeping it in a body avoids over-long query strings and keeps the
 /// surface symmetric with `POST /api/v1/kg/invalidate`. `max_depth`
-/// defaults to 1 in this build (multi-hop lands in a follow-up).
+/// defaults to 1 and is bounded by `KG_QUERY_MAX_SUPPORTED_DEPTH`.
 #[derive(Debug, Deserialize)]
 pub struct KgQueryBody {
     pub source_id: String,
@@ -2379,10 +2379,11 @@ pub struct KgQueryBody {
 }
 
 /// `POST /api/v1/kg/query` — REST mirror of the MCP `memory_kg_query`
-/// tool. Returns outbound depth=1 neighbors of `source_id` filtered by
-/// the temporal/agent windows. 400 for invalid IDs/timestamps; 422 when
-/// `max_depth` exceeds the supported ceiling (clearer than 500 for what
-/// is a documented limitation, not an internal error).
+/// tool. Returns outbound multi-hop traversal from `source_id` (1..=5
+/// hops) filtered by the temporal/agent windows. 400 for invalid
+/// IDs/timestamps; 422 when `max_depth` exceeds the supported ceiling
+/// (clearer than 500 for what is a documented limitation, not an
+/// internal error).
 pub async fn kg_query(State(state): State<Db>, Json(body): Json<KgQueryBody>) -> impl IntoResponse {
     if let Err(e) = validate::validate_id(&body.source_id) {
         return (

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -238,15 +238,15 @@ fn tool_definitions() -> Value {
             },
             {
                 "name": "memory_kg_query",
-                "description": "Pillar 2 / Stream C — outbound KG traversal from a source memory ('expand neighbors'). Returns one node per link reachable from `source_id`, with the link's temporal-validity columns (valid_from, valid_until, observed_by) and the target memory's title/namespace. Filters: `valid_at` keeps only links valid at that instant; `allowed_agents` keeps only links observed by an agent in the set (empty list returns zero rows by design — empty allowlist means 'no agents are trusted'). Ordered by COALESCE(valid_from, created_at) ASC for deterministic display. This build supports `max_depth=1` only; multi-hop recursive traversal lands in a follow-up iteration and a clear error is returned for `max_depth >= 2`.",
+                "description": "Pillar 2 / Stream C — outbound KG traversal from a source memory. Returns one node per link reachable from `source_id` within `max_depth` hops, with the link's temporal-validity columns (valid_from, valid_until, observed_by) and the target memory's title/namespace. Multi-hop traversal uses a recursive CTE with cycle detection — chains only extend through links that pass every filter on every hop. Filters: `valid_at` keeps only links valid at that instant; `allowed_agents` keeps only links observed by an agent in the set (empty list returns zero rows by design — empty allowlist means 'no agents are trusted'). Ordered by depth ASC, then COALESCE(valid_from, created_at) ASC, for stable shallow-first display. `max_depth` ceiling is 5 (matches the published performance budget); larger values return an explicit error.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "source_id": {"type": "string", "description": "Memory ID whose outbound links form the traversal frontier. Typically an entity_id from memory_entity_register, but any memory works."},
-                        "max_depth": {"type": "integer", "minimum": 1, "maximum": 1, "default": 1, "description": "Hops from the source. This build supports 1 only ('expand neighbors'); larger values return an explicit error until the recursive-CTE slice ships."},
+                        "max_depth": {"type": "integer", "minimum": 1, "maximum": 5, "default": 1, "description": "Hops from the source. Supported range: 1..=5 (matches the published performance budget for `memory_kg_query`). Larger values return an explicit error."},
                         "valid_at": {"type": "string", "description": "RFC3339 timestamp; only links valid at this instant (valid_from <= valid_at AND (valid_until IS NULL OR valid_until > valid_at)) are returned. Omit to skip the temporal filter (NULL valid_from rows are then included)."},
                         "allowed_agents": {"type": "array", "items": {"type": "string"}, "description": "If provided, only links whose observed_by is in this set are returned. An empty array returns zero rows. Omit to skip the agent filter."},
-                        "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 200, "description": "Max nodes returned. Clamped to [1, 1000]."}
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 200, "description": "Max nodes returned across all depths. Clamped to [1, 1000]."}
                     },
                     "required": ["source_id"]
                 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -427,8 +427,9 @@ pub struct KgTimelineEvent {
 /// `memory_kg_query`). Each node represents a memory reachable from the
 /// query's source through one outbound link, carrying the link's
 /// temporal-validity columns plus the target memory's display fields and
-/// the traversal path. `depth` is the number of hops from the source
-/// (always 1 in this build; multi-hop lands in a follow-up iteration).
+/// the traversal path. `depth` is the actual number of hops from the
+/// source (1..=`KG_QUERY_MAX_SUPPORTED_DEPTH`); `path` is the
+/// `src->mid->target` chain as discovered by the recursive CTE.
 #[derive(Debug, Clone, Serialize)]
 pub struct KgQueryNode {
     pub target_id: String,


### PR DESCRIPTION
## Summary

- Lifts `KG_QUERY_MAX_SUPPORTED_DEPTH` from 1 to 5, matching the published `memory_kg_query` budget in `PERFORMANCE.md` / charter `ai-memory-v0.6.3-grand-slam.md` § Performance Budgets.
- Replaces the depth=1 JOIN with a recursive CTE that re-applies the temporal / agent filter on every hop and prunes cycles via the accumulated path. Each row's `depth` and `path` now reflect the actual chain (e.g. depth=2: `src->mid->target`).
- API contract is unchanged for existing callers: depth=1 collapses to the original time-ordered single-hop result; the over-ceiling MCP/HTTP error path (422 with `max_depth=N exceeds supported depth=5`) is preserved.

This finishes the Stream C `memory_kg_query` slice — the ceiling now matches the budget and traversals at depth 2..=5 are correct under temporal-validity and observed-by filtering. Iteration handoff from #391 (depth=1 first slice) called this out as the single change point.

## Charter motivation

- Charter § Critical Schema Reference — recursive CTE prototype.
- Charter Stream C — "Unit + integration tests for traversal correctness at depth 1–5".
- `PERFORMANCE.md` — `memory_kg_query (depth ≤ 5)` budget at p95 < 250 ms.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean (CI gate)
- [x] `cargo test` — 397 unit + 184 integration, all green (was 393 + 184; +4 new kg_query DB tests)
- [x] CI: ubuntu/macos/windows checks
- New tests pin: multi-hop traversal, per-hop `valid_at` filter, cycle pruning on a 3-node loop, per-hop `allowed_agents` filter.

## AI involvement

Implemented by Claude Opus 4.7 (1M context) under the ai-memory-v063 autonomous campaign (iter-0014). Charter location: `/Users/fate/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`. Memory namespace: `campaign-v063`. Branch: `campaign/kg-query-multihop-stream-c`. Commits SSH-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
