### PR TITLE
feat(cli,bench): ai-memory bench scaffold (Pillar 3 / Stream E)

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -65,9 +65,10 @@ reference hardware, not absolute floors for every machine.
 | Component | State | Where |
 |---|---|---|
 | Published budgets | ✅ landed | this file |
-| `ai-memory bench` subcommand | 🚧 Stream E | `src/bench.rs` (planned) |
+| `ai-memory bench` subcommand | ✅ landed (scaffold) | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1) |
+| Embedding-bound + KG operations in `bench` | 🚧 Stream E follow-up | next iterations of v0.6.3 |
 | `bench.yml` CI workflow | 🚧 Stream F | `.github/workflows/bench.yml` (planned) |
-| Measured numbers in CI history | ⏳ pending | populated once `bench` lands |
+| Measured numbers in CI history | ⏳ pending | populated once `bench.yml` lands |
 
 The status table is updated as each Stream lands within the v0.6.3
 cycle. When measurements begin, this file will gain a "Latest measured"
@@ -75,29 +76,33 @@ column alongside each target.
 
 ## Operator Self-Verification
 
-Once Stream E lands, operators can verify the budgets on their own
-hardware with:
+The `ai-memory bench` subcommand seeds an in-memory disposable
+SQLite database (the operator's main DB is untouched) and reports
+per-operation p50/p95/p99 against the budgets above. Exit code is
+non-zero when any p95 exceeds its budget by more than the published
+10% tolerance, so the same binary is suitable for use in a CI guard
+once `bench.yml` (Stream F) wires it up.
 
 ```
 $ ai-memory bench
-Operation                      Target (p95)   Measured (p95)   Status
-────────────────────────────────────────────────────────────────────────
-memory_session_start hook      < 100 ms       …                …
-memory_recall (hot, depth=1)   <  50 ms       …                …
-memory_store (no embedding)    <  20 ms       …                …
-memory_store (with embedding)  < 200 ms       …                …
-memory_search (FTS5)           < 100 ms       …                …
-memory_check_duplicate         <  50 ms       …                …
-memory_kg_query (depth ≤ 3)    < 100 ms       …                …
-memory_kg_timeline             < 100 ms       …                …
-curator cycle (1k memories)    <  60 s        …                …
-federation ack (W=2 quorum)    <   2 s p99    …                …
+Operation                       Target (p95)   Measured (p95)   p50      p99      Status
+─────────────────────────────────────────────────────────────────────────────────────────
+memory_store (no embedding)     <   20 ms           0.6 ms         0.4      0.8    PASS
+memory_search (FTS5)            <  100 ms           1.9 ms         1.5      2.0    PASS
+memory_recall (hot, depth=1)    <   50 ms          16.5 ms        14.4     21.0    PASS
 ```
 
-The canonical workload is a 1000-memory mix sampled to be
-representative of a long-running Claude Code session. Workload inputs
-land at `benchmarks/v063/canonical_workload.json` alongside the bench
-implementation.
+`--iterations` and `--warmup` (clamped to `[1, 100_000]` and
+`[0, 10_000]` respectively) tune the sample size. `--json` emits the
+same numbers as a single JSON document for downstream tooling.
+
+Operations that depend on the embedder (`memory_store` with
+embedding, `memory_recall` cold/full hybrid), the KG (`memory_kg_query`,
+`memory_kg_timeline`), the curator daemon, and the federation ack path
+are not yet wired into `bench` — they each need fixtures or external
+services that don't belong on the hot path of a `cargo test` run.
+They land in a follow-up Stream E iteration alongside the canonical
+1000-memory workload at `benchmarks/v063/canonical_workload.json`.
 
 ## Why Publish These at All
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,432 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pillar 3 / Stream E — `ai-memory bench` workload runner.
+//!
+//! Measures hot-path operations against the budgets published in
+//! `PERFORMANCE.md` and returns p50/p95/p99 latencies plus a pass/fail
+//! verdict per operation. The CI guard (Stream F) enforces the same
+//! 10% p95 tolerance documented in `PERFORMANCE.md`.
+//!
+//! This iteration covers the three embedding-free operations
+//! (`memory_store` no-embedding, `memory_search` FTS5,
+//! `memory_recall` hot depth=1). Embedding-bound and KG operations are
+//! tracked as follow-up work — they need an embedder process and a
+//! seeded KG fixture, neither of which belongs on the hot path of a
+//! `cargo test` invocation.
+
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::Serialize;
+use std::time::{Duration, Instant};
+
+use crate::db;
+use crate::models::{Memory, Tier};
+
+/// CI guard tolerance — measured p95 may exceed budget by this factor
+/// before the run is marked `Fail`. Mirrors `PERFORMANCE.md`.
+pub const P95_TOLERANCE: f64 = 1.10;
+
+/// Default seeded namespace for the bench workload.
+pub const BENCH_NAMESPACE: &str = "ai-memory-bench";
+
+/// Default workload size — keep small enough for `cargo test`, large
+/// enough that p99 has signal.
+pub const DEFAULT_ITERATIONS: usize = 200;
+
+/// Default warmup iterations discarded from the percentile sample.
+pub const DEFAULT_WARMUP: usize = 20;
+
+/// Hot-path operations covered by this iteration of the bench tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation {
+    /// `memory_store` without embedding — pure `SQLite` write path.
+    StoreNoEmbedding,
+    /// `memory_search` — FTS5 keyword baseline.
+    SearchFts,
+    /// `memory_recall` hot path, depth=1 (no hierarchy expansion).
+    RecallHot,
+}
+
+impl Operation {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StoreNoEmbedding => "memory_store (no embedding)",
+            Self::SearchFts => "memory_search (FTS5)",
+            Self::RecallHot => "memory_recall (hot, depth=1)",
+        }
+    }
+
+    /// p95 budget in milliseconds, sourced from `PERFORMANCE.md`.
+    #[must_use]
+    pub fn target_p95_ms(self) -> f64 {
+        match self {
+            Self::StoreNoEmbedding => 20.0,
+            Self::SearchFts => 100.0,
+            Self::RecallHot => 50.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Pass,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OperationResult {
+    pub operation: Operation,
+    /// Pretty label, duplicated for JSON consumers.
+    pub label: &'static str,
+    pub target_p95_ms: f64,
+    pub measured_p50_ms: f64,
+    pub measured_p95_ms: f64,
+    pub measured_p99_ms: f64,
+    pub samples: usize,
+    pub status: Status,
+}
+
+#[derive(Debug, Clone)]
+pub struct BenchConfig {
+    pub iterations: usize,
+    pub warmup: usize,
+    pub namespace: String,
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            iterations: DEFAULT_ITERATIONS,
+            warmup: DEFAULT_WARMUP,
+            namespace: BENCH_NAMESPACE.to_string(),
+        }
+    }
+}
+
+/// Run the bench workload and return per-operation results.
+///
+/// Each operation seeds its own data inside the supplied connection so
+/// callers can hand in either a fresh in-memory DB (for tests) or a
+/// disposable on-disk DB (for the CLI).
+///
+/// # Errors
+///
+/// Returns the underlying [`db`] error if any of the seeded inserts
+/// or queries fail.
+pub fn run(conn: &Connection, config: &BenchConfig) -> Result<Vec<OperationResult>> {
+    let store = run_store_no_embedding(conn, config)?;
+    let search = run_search_fts(conn, config)?;
+    let recall = run_recall_hot(conn, config)?;
+    Ok(vec![store, search, recall])
+}
+
+fn run_store_no_embedding(conn: &Connection, config: &BenchConfig) -> Result<OperationResult> {
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        let mem = synth_memory(&config.namespace, i, "store");
+        let start = Instant::now();
+        db::insert(conn, &mem)?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::StoreNoEmbedding, &samples))
+}
+
+fn run_search_fts(conn: &Connection, config: &BenchConfig) -> Result<OperationResult> {
+    seed_corpus(conn, &config.namespace, "search", 200)?;
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        let query = format!("topic-{}", i % 50);
+        let start = Instant::now();
+        let _ = db::search(
+            conn,
+            &query,
+            Some(&config.namespace),
+            None,
+            10,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::SearchFts, &samples))
+}
+
+fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationResult> {
+    seed_corpus(conn, &config.namespace, "recall", 200)?;
+    let warmup_query = "topic 0 category 0";
+    for _ in 0..config.warmup {
+        let _ = db::recall(
+            conn,
+            warmup_query,
+            Some(&config.namespace),
+            10,
+            None,
+            None,
+            None,
+            0,
+            0,
+            None,
+            None,
+        )?;
+    }
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..config.iterations {
+        let query = format!("topic {} category {}", i % 50, i % 10);
+        let start = Instant::now();
+        let _ = db::recall(
+            conn,
+            &query,
+            Some(&config.namespace),
+            10,
+            None,
+            None,
+            None,
+            0,
+            0,
+            None,
+            None,
+        )?;
+        samples.push(start.elapsed());
+    }
+    Ok(percentile_summary(Operation::RecallHot, &samples))
+}
+
+fn seed_corpus(conn: &Connection, namespace: &str, prefix: &str, count: usize) -> Result<()> {
+    for i in 0..count {
+        let mem = synth_memory(namespace, i, prefix);
+        db::insert(conn, &mem)?;
+    }
+    Ok(())
+}
+
+fn synth_memory(namespace: &str, i: usize, prefix: &str) -> Memory {
+    let now = chrono::Utc::now().to_rfc3339();
+    Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: namespace.to_string(),
+        title: format!("bench-{prefix}-{i}"),
+        content: format!(
+            "bench memory {i} content about topic {} category {} for {prefix} workload",
+            i % 50,
+            i % 10
+        ),
+        tags: vec![],
+        priority: i32::try_from((i % 9) + 1).unwrap_or(5),
+        confidence: 1.0,
+        source: "bench".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({"agent_id": "bench"}),
+    }
+}
+
+fn percentile_summary(operation: Operation, samples: &[Duration]) -> OperationResult {
+    debug_assert!(
+        !samples.is_empty(),
+        "bench operation produced no samples; iterations must be > 0"
+    );
+    let mut sorted: Vec<f64> = samples.iter().map(duration_ms).collect();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let p50 = percentile(&sorted, 0.50);
+    let p95 = percentile(&sorted, 0.95);
+    let p99 = percentile(&sorted, 0.99);
+    let target = operation.target_p95_ms();
+    let status = if p95 <= target * P95_TOLERANCE {
+        Status::Pass
+    } else {
+        Status::Fail
+    };
+    OperationResult {
+        operation,
+        label: operation.label(),
+        target_p95_ms: target,
+        measured_p50_ms: p50,
+        measured_p95_ms: p95,
+        measured_p99_ms: p99,
+        samples: sorted.len(),
+        status,
+    }
+}
+
+fn duration_ms(d: &Duration) -> f64 {
+    let secs = d.as_secs_f64();
+    secs * 1000.0
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = q * (sorted.len() as f64 - 1.0);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        return sorted[lo];
+    }
+    let frac = rank - lo as f64;
+    sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+}
+
+/// Render a results table to a string in the same shape used in the
+/// `PERFORMANCE.md` "Operator Self-Verification" example.
+#[must_use]
+pub fn render_table(results: &[OperationResult]) -> String {
+    let mut out = String::new();
+    out.push_str(
+        "Operation                       Target (p95)   Measured (p95)   p50      p99      Status\n",
+    );
+    out.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────────────\n",
+    );
+    for r in results {
+        let status_str = match r.status {
+            Status::Pass => "PASS",
+            Status::Fail => "FAIL",
+        };
+        // target budgets are documented as small integer ms; rounding
+        // to the nearest int ms is what the table in PERFORMANCE.md
+        // shows. Saturating cast guards against pathological future
+        // changes to a non-integer or huge value.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let target_ms = r.target_p95_ms.round() as i64;
+        let line = format!(
+            "{:<30}  < {:>4} ms       {:>7.1} ms       {:>5.1}    {:>5.1}    {}\n",
+            r.label,
+            target_ms,
+            r.measured_p95_ms,
+            r.measured_p50_ms,
+            r.measured_p99_ms,
+            status_str
+        );
+        out.push_str(&line);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn fresh_conn() -> Connection {
+        db::open(std::path::Path::new(":memory:")).unwrap()
+    }
+
+    fn small_config() -> BenchConfig {
+        BenchConfig {
+            iterations: 30,
+            warmup: 5,
+            namespace: "bench-test".to_string(),
+        }
+    }
+
+    #[test]
+    fn percentile_interpolates() {
+        let s = vec![1.0, 2.0, 3.0, 4.0];
+        assert!((percentile(&s, 0.50) - 2.5).abs() < 1e-9);
+        assert!((percentile(&s, 0.0) - 1.0).abs() < 1e-9);
+        assert!((percentile(&s, 1.0) - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn percentile_handles_singleton_and_empty() {
+        assert!((percentile(&[], 0.5) - 0.0).abs() < 1e-9);
+        assert!((percentile(&[42.0], 0.99) - 42.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn run_returns_three_results() {
+        let conn = fresh_conn();
+        let results = run(&conn, &small_config()).unwrap();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].operation, Operation::StoreNoEmbedding);
+        assert_eq!(results[1].operation, Operation::SearchFts);
+        assert_eq!(results[2].operation, Operation::RecallHot);
+        for r in &results {
+            assert_eq!(r.samples, 30);
+            assert!(r.measured_p50_ms <= r.measured_p95_ms);
+            assert!(r.measured_p95_ms <= r.measured_p99_ms);
+            assert!(r.target_p95_ms > 0.0);
+        }
+    }
+
+    #[test]
+    fn status_is_fail_when_p95_over_tolerance() {
+        let r = OperationResult {
+            operation: Operation::StoreNoEmbedding,
+            label: Operation::StoreNoEmbedding.label(),
+            target_p95_ms: 20.0,
+            measured_p50_ms: 5.0,
+            measured_p95_ms: 25.0,
+            measured_p99_ms: 30.0,
+            samples: 100,
+            status: Status::Fail,
+        };
+        assert_eq!(r.status, Status::Fail);
+        // 25 > 20 * 1.10 = 22 → Fail
+        let recomputed = if 25.0_f64 <= 20.0 * P95_TOLERANCE {
+            Status::Pass
+        } else {
+            Status::Fail
+        };
+        assert_eq!(recomputed, Status::Fail);
+    }
+
+    #[test]
+    fn status_is_pass_within_tolerance() {
+        // 21 ms over 20 ms budget = 5% over → still PASS (under 10%).
+        let recomputed = if 21.0_f64 <= 20.0 * P95_TOLERANCE {
+            Status::Pass
+        } else {
+            Status::Fail
+        };
+        assert_eq!(recomputed, Status::Pass);
+    }
+
+    #[test]
+    fn render_table_includes_all_operations() {
+        let conn = fresh_conn();
+        let results = run(&conn, &small_config()).unwrap();
+        let table = render_table(&results);
+        assert!(table.contains("memory_store (no embedding)"));
+        assert!(table.contains("memory_search (FTS5)"));
+        assert!(table.contains("memory_recall (hot, depth=1)"));
+        assert!(table.contains("Status"));
+    }
+
+    #[test]
+    fn operation_targets_match_performance_md() {
+        // Pinned to PERFORMANCE.md — if you change a budget, change both.
+        assert!((Operation::StoreNoEmbedding.target_p95_ms() - 20.0).abs() < 1e-9);
+        assert!((Operation::SearchFts.target_p95_ms() - 100.0).abs() < 1e-9);
+        assert!((Operation::RecallHot.target_p95_ms() - 50.0).abs() < 1e-9);
+    }
+}

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -319,12 +319,7 @@ pub fn render_table(results: &[OperationResult]) -> String {
         let target_ms = r.target_p95_ms.round() as i64;
         let line = format!(
             "{:<30}  < {:>4} ms       {:>7.1} ms       {:>5.1}    {:>5.1}    {}\n",
-            r.label,
-            target_ms,
-            r.measured_p95_ms,
-            r.measured_p50_ms,
-            r.measured_p99_ms,
-            status_str
+            r.label, target_ms, r.measured_p95_ms, r.measured_p50_ms, r.measured_p99_ms, status_str
         );
         out.push_str(&line);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![recursion_limit = "256"]
 
 mod autonomy;
+mod bench;
 mod color;
 mod config;
 mod curator;
@@ -176,12 +177,32 @@ enum Command {
     /// between cycles. Auto-tags memories without tags and flags
     /// contradictions against nearby siblings in the same namespace.
     Curator(CuratorArgs),
+    /// v0.6.3 (Pillar 3 / Stream E): run the canonical performance
+    /// workload and print measured p50/p95/p99 against the budgets in
+    /// `PERFORMANCE.md`. Each invocation seeds a disposable temp DB so
+    /// the user's main DB is untouched. Exits non-zero when any p95
+    /// exceeds its budget by more than the published 10% tolerance.
+    Bench(BenchArgs),
     /// v0.7: migrate memories between SAL backends. Gated behind
     /// `--features sal`. Reads pages via `MemoryStore::list`, writes
     /// via `MemoryStore::store`. Idempotent: source ids are preserved
     /// and both adapters upsert on id.
     #[cfg(feature = "sal")]
     Migrate(MigrateArgs),
+}
+
+#[derive(Args)]
+struct BenchArgs {
+    /// Measured iterations per operation. Clamped to `[1, 100_000]`.
+    #[arg(long, default_value_t = bench::DEFAULT_ITERATIONS)]
+    iterations: usize,
+    /// Warmup iterations discarded from the percentile sample.
+    /// Clamped to `[0, 10_000]`.
+    #[arg(long, default_value_t = bench::DEFAULT_WARMUP)]
+    warmup: usize,
+    /// Emit results as JSON instead of the human-readable table.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -881,6 +902,7 @@ async fn main() -> Result<()> {
         Command::Backup(a) => cmd_backup(&db_path, &a, j),
         Command::Restore(a) => cmd_restore(&db_path, &a, j),
         Command::Curator(a) => cmd_curator(&db_path, &a, &app_config).await,
+        Command::Bench(a) => cmd_bench(&a),
         #[cfg(feature = "sal")]
         Command::Migrate(a) => cmd_migrate(&a).await,
     };
@@ -4373,6 +4395,40 @@ fn cmd_curator_rollback(db_path: &Path, args: &CuratorArgs) -> Result<()> {
     }
 
     unreachable!("cmd_curator_rollback entered without --rollback or --rollback-last");
+}
+
+fn cmd_bench(args: &BenchArgs) -> Result<()> {
+    let iterations = args.iterations.clamp(1, 100_000);
+    let warmup = args.warmup.min(10_000);
+    // Bench always seeds a disposable in-memory DB so the operator's
+    // main DB (and disk) are untouched. SQLite's `:memory:` URL and
+    // WAL-less mode keep the workload bounded by RAM and CPU.
+    let conn = db::open(Path::new(":memory:"))?;
+    let config = bench::BenchConfig {
+        iterations,
+        warmup,
+        namespace: bench::BENCH_NAMESPACE.to_string(),
+    };
+    let results = bench::run(&conn, &config)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "iterations": iterations,
+                "warmup": warmup,
+                "results": results,
+            }))?
+        );
+    } else {
+        print!("{}", bench::render_table(&results));
+    }
+    if results
+        .iter()
+        .any(|r| matches!(r.status, bench::Status::Fail))
+    {
+        anyhow::bail!("bench: at least one operation exceeded its p95 budget by >10%");
+    }
+    Ok(())
 }
 
 fn build_curator_llm(tier: config::FeatureTier) -> Option<llm::OllamaClient> {


### PR DESCRIPTION
## Summary

- First slice of v0.6.3 Pillar 3 / Stream E (perf instrumentation). Adds the `ai-memory bench` CLI subcommand + `src/bench.rs` runner so operators (and the upcoming `bench.yml` CI guard / Stream F) can verify the published `PERFORMANCE.md` budgets.
- Covers the three embedding-free hot-path operations: `memory_store` (no embedding) / 20 ms p95, `memory_search` (FTS5) / 100 ms p95, `memory_recall` (hot, depth=1) / 50 ms p95. Each invocation seeds a disposable `:memory:` SQLite DB so the operator's main DB is untouched.
- Reports p50/p95/p99 in human-table or `--json`. Exit code is non-zero when any p95 exceeds its target by more than the documented 10% tolerance, so the same binary slots into a CI guard once Stream F lands.
- `PERFORMANCE.md` status table now distinguishes "scaffold landed" from "Stream E follow-up" so partial coverage isn't silent. Embedding-bound + KG + curator + federation operations are tracked for a follow-up iteration — each needs fixtures or external services that don't belong on the hot path of `cargo test`.

## AI involvement

- **Authority class:** Standard (charter-aligned feature scaffold; new file under `src/`, new CLI subcommand, doc update).
- **Author:** Claude Opus 4.7 (1M context), under the autonomous v0.6.3 grand-slam campaign on `release/v0.6.3` (iteration 0015).
- **Memory namespace:** `campaign-v063`. Iteration handoff stored alongside iter-0014 (`memory_kg_query` depth 1..=5).
- **Charter section:** Phase 1 / Stream E — Performance Instrumentation.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 404 unit (was 397, +7 from the new bench tests) + 184 integration, all green. Env scrubbing of `AI_MEMORY_DB` / `AI_MEMORY_AGENT_ID` per memory `11c0f9c9` is still required locally.
- [x] Manual smoke: `./target/debug/ai-memory bench --iterations 50 --warmup 5` reports PASS for all three operations on M4; `--json` produces the same numbers as a single document.
- [ ] CI: 3-platform matrix (ubuntu / macos / windows) + `cargo audit` (run by CI; not installed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)