### PR TITLE
ci(bench): add bench.yml CI guard (Pillar 3 / Stream F)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,80 @@
+# Pillar 3 / Stream F — performance budget CI guard.
+#
+# Runs `ai-memory bench` on every pull request and trunk push so the
+# p95 budgets published in `PERFORMANCE.md` stay enforced. The bench
+# binary exits non-zero when any operation's measured p95 exceeds its
+# target by more than the published 10% tolerance, which fails the
+# workflow.
+#
+# Reference hardware per `PERFORMANCE.md` is GitHub-hosted Linux
+# x86_64 (`ubuntu-latest`). The macOS / Windows correctness checks
+# already live in `ci.yml`; this workflow is single-runner on purpose.
+
+name: Bench
+
+on:
+  pull_request:
+    branches: [main, develop, "release/**"]
+  push:
+    branches: [main, develop, "release/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: ai-memory bench (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --bin ai-memory
+
+      - name: Run bench (gate)
+        run: |
+          set +e
+          target/release/ai-memory bench | tee bench-table.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          {
+            echo '## ai-memory bench'
+            echo ''
+            echo '`ai-memory bench` runs the canonical workload from '
+            echo '[`src/bench.rs`](../blob/${{ github.sha }}/src/bench.rs) '
+            echo 'against the budgets published in '
+            echo '[`PERFORMANCE.md`](../blob/${{ github.sha }}/PERFORMANCE.md). '
+            echo 'Fails the build when any p95 exceeds its target by >10%.'
+            echo ''
+            echo '```'
+            cat bench-table.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
+
+      - name: Run bench (JSON for artifact)
+        if: always()
+        run: target/release/ai-memory bench --json > bench-results.json || true
+
+      - name: Upload bench artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: bench-results
+          path: |
+            bench-results.json
+            bench-table.txt
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-flight. Closes Pillar 3 / Stream F doc deliverable from the
   v0.6.3 charter.
 
+- **`bench.yml` CI guard (Pillar 3 / Stream F)** — new
+  `.github/workflows/bench.yml` runs `ai-memory bench` on every pull
+  request and trunk push (`main`, `develop`, `release/**`) plus on
+  manual `workflow_dispatch`. The job builds the release binary on
+  `ubuntu-latest` (the latency reference per `PERFORMANCE.md`),
+  streams the bench table into the workflow run summary, and uploads
+  a `bench-results` artifact (`bench-results.json` +
+  `bench-table.txt`) for downstream tooling. The `ai-memory bench`
+  binary already exits non-zero when any operation's measured p95
+  exceeds its target by more than the published 10% tolerance, so
+  the workflow fails on regression without additional gating logic.
+  Closes the last Stream F deliverable from charter §"Stream F —
+  Performance Budgets + CI Guard"; budgets are now continuously
+  enforced against trunk and PRs.
+
 - **Per-tool MCP tracing spans (Pillar 3 / Stream E)** — every
   `tools/call` dispatch now runs inside an `info`-level
   `mcp_tool_call` span carrying the tool name and JSON-RPC id. After

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -8,9 +8,10 @@ build still meets that cost.
 
 This document is the authoritative budget table. The CI guard
 (`.github/workflows/bench.yml`, Stream F) and the `ai-memory bench`
-subcommand (Stream E) will both read from these targets once they land.
-Until then, this file establishes the contract; later patches under
-v0.6.3 wire the measurement and enforcement.
+subcommand (Stream E) both read from these targets — every pull
+request against `main`, `develop`, or `release/**` runs the bench
+workload on `ubuntu-latest` and fails when any p95 exceeds its
+target by more than the published 10% tolerance.
 
 ## Budget Table
 
@@ -32,10 +33,12 @@ v0.6.3 wire the measurement and enforcement.
 
 ## CI Guard Threshold
 
-The `bench.yml` workflow (Stream F, scheduled to land later in v0.6.3)
-runs `ai-memory bench` on every PR against `release/v0.6.3` and the
-trunk branches and **fails the build when any operation's measured p95
-exceeds its target by more than 10%.**
+The `bench.yml` workflow (Stream F) runs `ai-memory bench` on every
+PR against `main`, `develop`, or `release/**` and on every push to
+those branches. It **fails the build when any operation's measured
+p95 exceeds its target by more than 10%.** The full table lands in
+the workflow run summary; the JSON document is uploaded as a
+`bench-results` artifact for downstream tooling.
 
 p99 targets in the table above are **informational** until the v0.6.3
 soak window closes. They are recorded here to make the long-tail goal
@@ -68,8 +71,8 @@ reference hardware, not absolute floors for every machine.
 | `ai-memory bench` subcommand | ✅ landed (scaffold) | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1) |
 | Per-tool MCP `tracing` spans | ✅ landed | `src/mcp.rs` `handle_request` — `mcp_tool_call` span carries `tool` + `rpc_id`; `elapsed_ms` emitted at exit |
 | Embedding-bound + KG operations in `bench` | 🚧 Stream E follow-up | next iterations of v0.6.3 |
-| `bench.yml` CI workflow | 🚧 Stream F | `.github/workflows/bench.yml` (planned) |
-| Measured numbers in CI history | ⏳ pending | populated once `bench.yml` lands |
+| `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
+| Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
 
 The status table is updated as each Stream lands within the v0.6.3
 cycle. When measurements begin, this file will gain a "Latest measured"
@@ -81,8 +84,8 @@ The `ai-memory bench` subcommand seeds an in-memory disposable
 SQLite database (the operator's main DB is untouched) and reports
 per-operation p50/p95/p99 against the budgets above. Exit code is
 non-zero when any p95 exceeds its budget by more than the published
-10% tolerance, so the same binary is suitable for use in a CI guard
-once `bench.yml` (Stream F) wires it up.
+10% tolerance — the same binary the `bench.yml` CI guard runs on
+every pull request.
 
 ```
 $ ai-memory bench


### PR DESCRIPTION
## Summary

Adds `.github/workflows/bench.yml` so the p95 budgets published in
`PERFORMANCE.md` are continuously enforced. Closes the last Stream F
deliverable from charter §\"Stream F — Performance Budgets + CI Guard\";
Pillar 3 of the v0.6.3 grand-slam charter is now complete bar the
embedding-bound + KG-bound bench extension tracked in iter-0016 handoff.

## What ships

- **`.github/workflows/bench.yml`** — runs `cargo build --release --bin
  ai-memory` then `target/release/ai-memory bench` on `ubuntu-latest`
  (the `PERFORMANCE.md` latency reference) for every pull request and
  push to `main` / `develop` / `release/**`, plus on manual
  `workflow_dispatch`. The bench table streams into the workflow run
  summary; a `bench-results` artifact (`bench-results.json` +
  `bench-table.txt`) is uploaded for downstream tooling. Concurrency is
  scoped to `bench-${{ github.workflow }}-${{ github.ref }}` with
  `cancel-in-progress: true` so superseded runs cancel cleanly.
- **`PERFORMANCE.md`** — status table flips `bench.yml` to ✅ landed
  and the prose now describes the trigger surface and where measured
  numbers live (run summary + artifact). The earlier \"will both read
  from these targets once they land\" caveat is dropped — they read now.
- **`CHANGELOG.md`** — `## [Unreleased] — v0.6.3 (Patch 4)` gains an
  Added bullet describing the new workflow, alongside the existing
  Stream E (bench scaffold + tracing spans) entries.

## Why

Per `ai-memory bench`'s existing semantics: the binary exits non-zero
when any operation's measured p95 exceeds its target by more than the
published 10% tolerance. That makes it a single-step CI gate — no
additional pass/fail logic needed in YAML.

## Test plan

- [x] `python3 yaml.safe_load(bench.yml)` (via Ruby `YAML.load_file`) — yaml-ok
- [x] `cargo build --release --bin ai-memory` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --release -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `cargo test --bin ai-memory` — 406 unit pass
- [x] `cargo test` — 184 integration pass
- [x] Local bench dry-run on M4: store 0.4 ms / search 0.6 ms / recall 5.2 ms, all PASS, exit 0
- [ ] CI green — covered by the new workflow itself plus existing `ci.yml`

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the autonomous
ai-memory-v063 campaign (iter 0017). Charter:
`/var/root/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`
§\"Stream F — Performance Budgets + CI Guard\". Authority class: Standard
(scoped CI workflow addition + non-load-bearing doc updates).
Branch policy verified — `bench.yml` is not a release-cutting workflow,
so the campaign-approvals memory `7d7cb74c` permits this edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)