### PR TITLE
feat(bench): kg_query + kg_timeline workload (Pillar 3 / Stream E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Performance Budgets + CI Guard"; budgets are now continuously
   enforced against trunk and PRs.
 
+- **`ai-memory bench` KG coverage (Pillar 3 / Stream E)** —
+  `memory_kg_query` (depth=1) and `memory_kg_timeline` are now driven
+  by the `bench` subcommand against the same in-memory disposable
+  SQLite database used by the embedding-free operations. The runner
+  seeds an in-process KG fixture (50 source memories × 4 outbound
+  links each, every link `valid_from`-stamped so `kg_timeline` sees
+  them) and reports p50/p95/p99 against the 100 ms p95 budgets
+  published in `PERFORMANCE.md`. Local M4 measurements: `kg_query`
+  p95 ~0.7 ms, `kg_timeline` p95 ~0.1 ms — both PASS, both well
+  inside the 10% tolerance enforced by the `bench.yml` CI guard.
+  No new dependencies. Closes the KG half of the iter-0017 follow-up
+  ask; embedding-bound paths still need a fixture decision and are
+  tracked separately.
+
 - **Per-tool MCP tracing spans (Pillar 3 / Stream E)** — every
   `tools/call` dispatch now runs inside an `info`-level
   `mcp_tool_call` span carrying the tool name and JSON-RPC id. After

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -68,9 +68,10 @@ reference hardware, not absolute floors for every machine.
 | Component | State | Where |
 |---|---|---|
 | Published budgets | ✅ landed | this file |
-| `ai-memory bench` subcommand | ✅ landed (scaffold) | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1) |
+| `ai-memory bench` subcommand | ✅ landed | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1), `memory_kg_query` (depth=1), `memory_kg_timeline` |
 | Per-tool MCP `tracing` spans | ✅ landed | `src/mcp.rs` `handle_request` — `mcp_tool_call` span carries `tool` + `rpc_id`; `elapsed_ms` emitted at exit |
-| Embedding-bound + KG operations in `bench` | 🚧 Stream E follow-up | next iterations of v0.6.3 |
+| KG operations in `bench` | ✅ landed | `src/bench.rs` — seeds 50 sources × 4 outbound links (every link `valid_from`-stamped), drives `kg_query` at depth=1 and `kg_timeline` |
+| Embedding-bound operations in `bench` | 🚧 Stream E follow-up | needs an embedder fixture decision (opt-in flag vs cfg(test) fake vs pre-cached model) — see iter-0017 handoff |
 | `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
 | Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
 
@@ -91,22 +92,27 @@ every pull request.
 $ ai-memory bench
 Operation                       Target (p95)   Measured (p95)   p50      p99      Status
 ─────────────────────────────────────────────────────────────────────────────────────────
-memory_store (no embedding)     <   20 ms           0.6 ms         0.4      0.8    PASS
-memory_search (FTS5)            <  100 ms           1.9 ms         1.5      2.0    PASS
-memory_recall (hot, depth=1)    <   50 ms          16.5 ms        14.4     21.0    PASS
+memory_store (no embedding)     <   20 ms           0.5 ms         0.3      0.5    PASS
+memory_search (FTS5)            <  100 ms           0.7 ms         0.5      0.8    PASS
+memory_recall (hot, depth=1)    <   50 ms           5.7 ms         4.5      6.5    PASS
+memory_kg_query (depth=1)       <  100 ms           0.7 ms         0.5      0.9    PASS
+memory_kg_timeline              <  100 ms           0.1 ms         0.1      0.1    PASS
 ```
 
 `--iterations` and `--warmup` (clamped to `[1, 100_000]` and
 `[0, 10_000]` respectively) tune the sample size. `--json` emits the
 same numbers as a single JSON document for downstream tooling.
 
-Operations that depend on the embedder (`memory_store` with
-embedding, `memory_recall` cold/full hybrid), the KG (`memory_kg_query`,
-`memory_kg_timeline`), the curator daemon, and the federation ack path
-are not yet wired into `bench` — they each need fixtures or external
-services that don't belong on the hot path of a `cargo test` run.
-They land in a follow-up Stream E iteration alongside the canonical
-1000-memory workload at `benchmarks/v063/canonical_workload.json`.
+The KG rows seed an in-process fixture (50 source memories × 4
+outbound links each, every link with `valid_from` stamped) so the
+`memory_kg_query` and `memory_kg_timeline` paths run end-to-end with
+no external service. Embedding-bound paths (`memory_store` with
+embedding, `memory_recall` cold/full hybrid), the curator daemon, and
+the federation ack path are not yet wired in — they each need
+fixtures or external services that don't belong on the hot path of a
+`cargo test` run. They land in a follow-up Stream E iteration
+alongside the canonical 1000-memory workload at
+`benchmarks/v063/canonical_workload.json`.
 
 ## Why Publish These at All
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -8,12 +8,18 @@
 //! verdict per operation. The CI guard (Stream F) enforces the same
 //! 10% p95 tolerance documented in `PERFORMANCE.md`.
 //!
-//! This iteration covers the three embedding-free operations
-//! (`memory_store` no-embedding, `memory_search` FTS5,
-//! `memory_recall` hot depth=1). Embedding-bound and KG operations are
-//! tracked as follow-up work — they need an embedder process and a
-//! seeded KG fixture, neither of which belongs on the hot path of a
-//! `cargo test` invocation.
+//! Coverage in this build:
+//! - Embedding-free CRUD: `memory_store` (no embedding), `memory_search`
+//!   (FTS5), `memory_recall` (hot, depth=1).
+//! - Knowledge-graph traversal: `memory_kg_query` (depth=1) and
+//!   `memory_kg_timeline`. Both seed an in-process fixture (50 sources
+//!   × 4 outbound links each, all with explicit `valid_from`) so the
+//!   bench runs without any external service.
+//!
+//! Embedding-bound paths (`memory_store` with embedding,
+//! `memory_recall` cold/full hybrid) still require an embedder process
+//! and are tracked as follow-up Stream E work — they don't belong on
+//! the hot path of a `cargo test` invocation.
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -47,6 +53,11 @@ pub enum Operation {
     SearchFts,
     /// `memory_recall` hot path, depth=1 (no hierarchy expansion).
     RecallHot,
+    /// `memory_kg_query` recursive-CTE traversal at depth=1 (the
+    /// shallowest path through the depth ≤ 3 budget bucket).
+    KgQueryDepth1,
+    /// `memory_kg_timeline` — ordered timeline for a single source.
+    KgTimeline,
 }
 
 impl Operation {
@@ -56,16 +67,25 @@ impl Operation {
             Self::StoreNoEmbedding => "memory_store (no embedding)",
             Self::SearchFts => "memory_search (FTS5)",
             Self::RecallHot => "memory_recall (hot, depth=1)",
+            Self::KgQueryDepth1 => "memory_kg_query (depth=1)",
+            Self::KgTimeline => "memory_kg_timeline",
         }
     }
 
     /// p95 budget in milliseconds, sourced from `PERFORMANCE.md`.
+    ///
+    /// `KgQueryDepth1` is bucketed under "depth ≤ 3" (100 ms) — its
+    /// budget collapses with `SearchFts` and `KgTimeline` despite
+    /// belonging to a different table row.
     #[must_use]
+    #[allow(clippy::match_same_arms)]
     pub fn target_p95_ms(self) -> f64 {
         match self {
             Self::StoreNoEmbedding => 20.0,
             Self::SearchFts => 100.0,
             Self::RecallHot => 50.0,
+            Self::KgQueryDepth1 => 100.0,
+            Self::KgTimeline => 100.0,
         }
     }
 }
@@ -121,7 +141,10 @@ pub fn run(conn: &Connection, config: &BenchConfig) -> Result<Vec<OperationResul
     let store = run_store_no_embedding(conn, config)?;
     let search = run_search_fts(conn, config)?;
     let recall = run_recall_hot(conn, config)?;
-    Ok(vec![store, search, recall])
+    let kg_sources = seed_kg_fixture(conn, &config.namespace)?;
+    let kg_query = run_kg_query_depth1(conn, config, &kg_sources)?;
+    let kg_timeline = run_kg_timeline(conn, config, &kg_sources)?;
+    Ok(vec![store, search, recall, kg_query, kg_timeline])
 }
 
 fn run_store_no_embedding(conn: &Connection, config: &BenchConfig) -> Result<OperationResult> {
@@ -205,6 +228,86 @@ fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
         samples.push(start.elapsed());
     }
     Ok(percentile_summary(Operation::RecallHot, &samples))
+}
+
+/// Source memory IDs returned from [`seed_kg_fixture`]. Each source has
+/// `KG_FIXTURE_LINKS_PER_SOURCE` outbound links — the bench drives both
+/// `kg_query` and `kg_timeline` against the same fixture.
+const KG_FIXTURE_SOURCES: usize = 50;
+const KG_FIXTURE_LINKS_PER_SOURCE: usize = 4;
+
+fn run_kg_query_depth1(
+    conn: &Connection,
+    config: &BenchConfig,
+    sources: &[String],
+) -> Result<OperationResult> {
+    debug_assert!(
+        !sources.is_empty(),
+        "kg_query bench requires a seeded fixture"
+    );
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        let src = &sources[i % sources.len()];
+        let start = Instant::now();
+        let _ = db::kg_query(conn, src, 1, None, None, None)?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::KgQueryDepth1, &samples))
+}
+
+fn run_kg_timeline(
+    conn: &Connection,
+    config: &BenchConfig,
+    sources: &[String],
+) -> Result<OperationResult> {
+    debug_assert!(
+        !sources.is_empty(),
+        "kg_timeline bench requires a seeded fixture"
+    );
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        let src = &sources[i % sources.len()];
+        let start = Instant::now();
+        let _ = db::kg_timeline(conn, src, None, None, None)?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::KgTimeline, &samples))
+}
+
+/// Seed the in-process KG fixture: `KG_FIXTURE_SOURCES` source memories,
+/// each with `KG_FIXTURE_LINKS_PER_SOURCE` outbound links to distinct
+/// targets. Every link sets `valid_from` so `kg_timeline` (which skips
+/// rows with NULL `valid_from`) sees the full corpus. Returns the source
+/// IDs so the runners can hand them to `kg_query` / `kg_timeline`.
+fn seed_kg_fixture(conn: &Connection, namespace: &str) -> Result<Vec<String>> {
+    let mut sources = Vec::with_capacity(KG_FIXTURE_SOURCES);
+    for s in 0..KG_FIXTURE_SOURCES {
+        let src = synth_memory(namespace, s, "kg-src");
+        // `db::insert` upserts on `(title, namespace)` and returns the
+        // canonical id, which differs from `src.id` if the row already
+        // exists. Use the returned id so the fixture remains correct
+        // even when `run()` is invoked twice against the same conn.
+        let src_id = db::insert(conn, &src)?;
+        for t in 0..KG_FIXTURE_LINKS_PER_SOURCE {
+            let target_idx = s * KG_FIXTURE_LINKS_PER_SOURCE + t;
+            let tgt = synth_memory(namespace, target_idx, "kg-tgt");
+            let tgt_id = db::insert(conn, &tgt)?;
+            // `db::create_link` stamps `created_at` and `valid_from` to
+            // the current wall clock — sufficient for `kg_timeline`
+            // (which skips rows with NULL `valid_from`).
+            db::create_link(conn, &src_id, &tgt_id, "related_to")?;
+        }
+        sources.push(src_id);
+    }
+    Ok(sources)
 }
 
 fn seed_corpus(conn: &Connection, namespace: &str, prefix: &str, count: usize) -> Result<()> {
@@ -358,13 +461,15 @@ mod tests {
     }
 
     #[test]
-    fn run_returns_three_results() {
+    fn run_returns_all_five_results() {
         let conn = fresh_conn();
         let results = run(&conn, &small_config()).unwrap();
-        assert_eq!(results.len(), 3);
+        assert_eq!(results.len(), 5);
         assert_eq!(results[0].operation, Operation::StoreNoEmbedding);
         assert_eq!(results[1].operation, Operation::SearchFts);
         assert_eq!(results[2].operation, Operation::RecallHot);
+        assert_eq!(results[3].operation, Operation::KgQueryDepth1);
+        assert_eq!(results[4].operation, Operation::KgTimeline);
         for r in &results {
             assert_eq!(r.samples, 30);
             assert!(r.measured_p50_ms <= r.measured_p95_ms);
@@ -414,6 +519,8 @@ mod tests {
         assert!(table.contains("memory_store (no embedding)"));
         assert!(table.contains("memory_search (FTS5)"));
         assert!(table.contains("memory_recall (hot, depth=1)"));
+        assert!(table.contains("memory_kg_query (depth=1)"));
+        assert!(table.contains("memory_kg_timeline"));
         assert!(table.contains("Status"));
     }
 
@@ -423,5 +530,30 @@ mod tests {
         assert!((Operation::StoreNoEmbedding.target_p95_ms() - 20.0).abs() < 1e-9);
         assert!((Operation::SearchFts.target_p95_ms() - 100.0).abs() < 1e-9);
         assert!((Operation::RecallHot.target_p95_ms() - 50.0).abs() < 1e-9);
+        assert!((Operation::KgQueryDepth1.target_p95_ms() - 100.0).abs() < 1e-9);
+        assert!((Operation::KgTimeline.target_p95_ms() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn seed_kg_fixture_populates_sources_and_links() {
+        let conn = fresh_conn();
+        let sources = seed_kg_fixture(&conn, "kg-fixture-test").unwrap();
+        assert_eq!(sources.len(), KG_FIXTURE_SOURCES);
+        // Every source carries the expected fan-out, every link has a
+        // non-null `valid_from` (otherwise `kg_timeline` would skip it).
+        for src in &sources {
+            let nodes = db::kg_query(&conn, src, 1, None, None, None).unwrap();
+            assert_eq!(nodes.len(), KG_FIXTURE_LINKS_PER_SOURCE);
+            let timeline = db::kg_timeline(&conn, src, None, None, None).unwrap();
+            assert_eq!(timeline.len(), KG_FIXTURE_LINKS_PER_SOURCE);
+            for ev in &timeline {
+                // `kg_timeline` filters out NULL `valid_from` rows in SQL,
+                // so any returned event must carry a non-empty stamp.
+                assert!(
+                    !ev.valid_from.is_empty(),
+                    "kg fixture must stamp valid_from on every link"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Extends `ai-memory bench` to cover `memory_kg_query` (depth=1) and `memory_kg_timeline`. Both ops now run end-to-end against the same in-memory disposable SQLite database the embedding-free operations use, with no new dependencies and no `bench.yml` workflow change needed.
- Seeds an in-process KG fixture (50 source memories × 4 outbound links each, every link `valid_from`-stamped so `kg_timeline` sees them) — the runner picks sources round-robin so warmup + measurement see consistent fan-out.
- `PERFORMANCE.md` status table: KG row flipped from 🚧 to ✅ landed. Operator example block updated with fresh M4 measurements including both new rows. The embedding-bound row stays 🚧 pending the fixture decision the iter-0017 handoff flagged.

## Charter linkage

- Pillar 3 / Stream E (Performance Instrumentation), iter-0017 handoff §"Next iteration should": "Stream E follow-up — extend `bench` to ... KG operations (`memory_kg_query`, `memory_kg_timeline`) ... KG bench first (no external deps, smaller PR), then embedding bench."
- Charter §"Stream E — Performance Instrumentation" + §"Performance Budgets (Authoritative)" — KG row at <100 ms p95.

## Local M4 measurements (default 200/20)

```
memory_kg_query (depth=1)       <  100 ms           0.7 ms         0.5      0.9    PASS
memory_kg_timeline              <  100 ms           0.1 ms         0.1      0.1    PASS
```

Both well inside the 10% p95 tolerance enforced by `.github/workflows/bench.yml`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean (debug + release)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` — 407/407 (8 bench tests, including new `seed_kg_fixture_populates_sources_and_links`)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration` — 184/184
- [x] Local `ai-memory bench` dry-run on M4 — all five operations PASS, exit 0
- [x] Local `ai-memory bench --json` — JSON document carries both new rows under the existing schema
- [ ] CI: 4 required checks (Check ubuntu/macos/windows + ai-memory bench (ubuntu-latest)) green

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) via the autonomous campaign runner under the v0.6.3 grand-slam charter, iteration 5 (memory namespace `campaign-v063`). All four required gates (fmt, clippy, test, audit-equivalent — no new deps) pass locally before push. SSH-signed commit. No edits to release-cutting workflows, no version bump, no force push. Branch policy: short-lived sub-branch `campaign/bench-kg-stream-e` off `release/v0.6.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)