### PR TITLE
feat(bench): opt-in --with-embedding for memory_check_duplicate (Pillar 3 / Stream E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   KG-adjacent Stream E follow-up flagged in PERFORMANCE.md; the
   curator-cycle and federation-ack rows remain tracked separately.
 
+- **`ai-memory bench` `memory_check_duplicate` coverage (Pillar 3 /
+  Stream E)** — the opt-in `--with-embedding` workload now also
+  exercises `memory_check_duplicate`, gated against the 50 ms p95 row
+  in `PERFORMANCE.md`. The runner seeds its own dedicated 200-row
+  embedded corpus (prefix `dup-check`, distinct from the existing
+  `embed` recall corpus) and probes it with overlapping titles so
+  every iteration drives `embed(probe) + db::check_duplicate` —
+  embed call + linear cosine scan + sort — to a non-trivial nearest
+  neighbor rather than degenerate cosines. The op is opt-in behind
+  the same `--with-embedding` flag and is omitted from the default
+  `cargo test` and `bench.yml` CI paths. Local M4 measurement:
+  `memory_check_duplicate` p95 ~47 ms — PASS, dominated by the
+  one-shot embed call (~42 ms) plus the linear cosine scan + sort
+  over the 200-row corpus. Every embedding-bound row in the published
+  budget table is now covered end-to-end by `ai-memory bench`; the
+  curator-cycle and federation-ack rows are the only remaining
+  external-fixture follow-ups.
+
 - **`ai-memory bench` KG depth=3 + depth=5 coverage (Pillar 3 / Stream E)**
   — `memory_kg_query` is now exercised at the deepest hop of both
   documented budget buckets: depth=3 against the "depth ≤ 3" 100 ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Performance Budgets + CI Guard"; budgets are now continuously
   enforced against trunk and PRs.
 
+- **`ai-memory bench` embedding-bound coverage (Pillar 3 / Stream E)** —
+  the canonical `bench` workload now exercises both embedding-bound
+  budget rows from `PERFORMANCE.md`: `memory_store` (with embedding)
+  and `memory_recall` (cold, full hybrid), each gated against the
+  200 ms p95 row. The new ops are opt-in behind `--with-embedding`
+  so the default `cargo test` and `bench.yml` CI paths stay
+  embedding-free; when the flag is set the runner loads the local
+  candle MiniLM model and seeds a 200-row embedded corpus on top of
+  the existing in-memory disposable SQLite. If the model cache is
+  missing the flag is treated as a no-op with a clear stderr message
+  ("--with-embedding requested but embedder unavailable: …; skipping
+  embedding-bound operations") so a forgetful operator doesn't get a
+  hard error from a benign flag toggle. Local M4 measurements:
+  `memory_store` (with embedding) p95 ~43 ms, `memory_recall`
+  (cold, full hybrid) p95 ~25 ms — both PASS, both well inside the
+  200 ms / 10% tolerance enforced by `bench.yml`. Closes the last
+  KG-adjacent Stream E follow-up flagged in PERFORMANCE.md; the
+  curator-cycle and federation-ack rows remain tracked separately.
+
 - **`ai-memory bench` KG depth=3 + depth=5 coverage (Pillar 3 / Stream E)**
   — `memory_kg_query` is now exercised at the deepest hop of both
   documented budget buckets: depth=3 against the "depth ≤ 3" 100 ms

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -68,10 +68,10 @@ reference hardware, not absolute floors for every machine.
 | Component | State | Where |
 |---|---|---|
 | Published budgets | ✅ landed | this file |
-| `ai-memory bench` subcommand | ✅ landed | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1), `memory_kg_query` (depth=1, depth=3, depth=5), `memory_kg_timeline`. Opt-in `--with-embedding` adds `memory_store` (with embedding) and `memory_recall` (cold, full hybrid). |
+| `ai-memory bench` subcommand | ✅ landed | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1), `memory_kg_query` (depth=1, depth=3, depth=5), `memory_kg_timeline`. Opt-in `--with-embedding` adds `memory_store` (with embedding), `memory_recall` (cold, full hybrid), and `memory_check_duplicate`. |
 | Per-tool MCP `tracing` spans | ✅ landed | `src/mcp.rs` `handle_request` — `mcp_tool_call` span carries `tool` + `rpc_id`; `elapsed_ms` emitted at exit |
 | KG operations in `bench` | ✅ landed | `src/bench.rs` — fan-out fixture (50 × 4 outbound, every link `valid_from`-stamped) drives `kg_query` depth=1 + `kg_timeline`; chain fixture (50 chains × 5 hops) drives `kg_query` depth=3 + depth=5 |
-| Embedding-bound operations in `bench` | ✅ landed (opt-in) | `src/bench.rs` — `--with-embedding` flag loads the local candle MiniLM model and exercises `memory_store` (embed + insert + set_embedding) and `memory_recall` (embed query + `recall_hybrid` against an embedded 200-row corpus). Default off so the `bench.yml` CI guard stays embedding-free; if the model cache is missing the flag is treated as a no-op with a clear stderr message. |
+| Embedding-bound operations in `bench` | ✅ landed (opt-in) | `src/bench.rs` — `--with-embedding` flag loads the local candle MiniLM model and exercises `memory_store` (embed + insert + set_embedding), `memory_recall` (embed query + `recall_hybrid` against an embedded 200-row corpus), and `memory_check_duplicate` (embed probe + linear-scan over a separate embedded 200-row corpus). Default off so the `bench.yml` CI guard stays embedding-free; if the model cache is missing the flag is treated as a no-op with a clear stderr message. |
 | `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
 | Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
 
@@ -105,9 +105,9 @@ memory_kg_timeline                  <  100 ms           0.1 ms         0.1      
 `[0, 10_000]` respectively) tune the sample size. `--json` emits the
 same numbers as a single JSON document for downstream tooling.
 
-Pass `--with-embedding` to opt into the two embedding-bound rows. The
-flag loads the local candle MiniLM model on first invocation; if the
-model cache is missing it logs a clear message on stderr and falls
+Pass `--with-embedding` to opt into the three embedding-bound rows.
+The flag loads the local candle MiniLM model on first invocation; if
+the model cache is missing it logs a clear message on stderr and falls
 back to the embedding-free workload so the run still completes:
 
 ```
@@ -122,8 +122,9 @@ memory_kg_query (depth=1)           <  100 ms           0.4 ms         0.2      
 memory_kg_query (depth=3)           <  100 ms           0.6 ms         0.5      0.6    PASS
 memory_kg_query (depth=5)           <  250 ms           0.6 ms         0.6      0.6    PASS
 memory_kg_timeline                  <  100 ms           0.1 ms         0.1      0.1    PASS
-memory_store (with embedding)       <  200 ms          42.7 ms        37.6     43.3    PASS
-memory_recall (cold, full hybrid)   <  200 ms          24.5 ms        15.7     27.8    PASS
+memory_store (with embedding)       <  200 ms          42.3 ms        41.6     42.7    PASS
+memory_recall (cold, full hybrid)   <  200 ms          31.4 ms        30.6     31.8    PASS
+memory_check_duplicate              <   50 ms          47.3 ms        46.5     47.6    PASS
 ```
 
 The KG rows seed two in-process fixtures so every traversal runs
@@ -150,14 +151,22 @@ local candle MiniLM model and exercise:
   with a fresh in-memory HNSW index per run, gated against the
   200 ms p95 row. No warm cache, no shared vector index — the goal
   is the first-query path the budget table calls out.
+- `memory_check_duplicate` — `embed(probe title + content) +
+  db::check_duplicate` linear scan over a 200-row embedded corpus,
+  gated against the 50 ms p95 row. Probe titles overlap the corpus
+  prefix so each scan returns a non-trivial nearest neighbor — the
+  pre-write code path operators actually exercise.
 
 The opt-in is deliberate: the default workload stays embedding-free
 so `cargo test` and the `bench.yml` CI guard run in seconds with no
-candle model load. The curator daemon and the federation ack path
-still need fixtures or external services that don't belong on the
-hot path of a `cargo test` run; they land in follow-up Stream E
-iterations alongside the canonical 1000-memory workload at
-`benchmarks/v063/canonical_workload.json`.
+candle model load. The two remaining external-fixture gaps in the
+budget table — the curator cycle and the federation ack — still
+need fixtures or external services that don't belong on the hot path
+of a `cargo test` run. The curator cycle wants a seeded 1000-memory
+workload (`benchmarks/v063/canonical_workload.json`) plus the long
+configurable curator runner; the federation ack wants a multi-node
+cluster harness (the ship-gate Phase 2 federation rig). Both land
+in follow-up Stream E iterations.
 
 ## Why Publish These at All
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -68,10 +68,10 @@ reference hardware, not absolute floors for every machine.
 | Component | State | Where |
 |---|---|---|
 | Published budgets | ✅ landed | this file |
-| `ai-memory bench` subcommand | ✅ landed | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1), `memory_kg_query` (depth=1, depth=3, depth=5), `memory_kg_timeline` |
+| `ai-memory bench` subcommand | ✅ landed | `src/bench.rs` — covers `memory_store` (no embedding), `memory_search` (FTS5), `memory_recall` (hot, depth=1), `memory_kg_query` (depth=1, depth=3, depth=5), `memory_kg_timeline`. Opt-in `--with-embedding` adds `memory_store` (with embedding) and `memory_recall` (cold, full hybrid). |
 | Per-tool MCP `tracing` spans | ✅ landed | `src/mcp.rs` `handle_request` — `mcp_tool_call` span carries `tool` + `rpc_id`; `elapsed_ms` emitted at exit |
 | KG operations in `bench` | ✅ landed | `src/bench.rs` — fan-out fixture (50 × 4 outbound, every link `valid_from`-stamped) drives `kg_query` depth=1 + `kg_timeline`; chain fixture (50 chains × 5 hops) drives `kg_query` depth=3 + depth=5 |
-| Embedding-bound operations in `bench` | 🚧 Stream E follow-up | needs an embedder fixture decision (opt-in flag vs cfg(test) fake vs pre-cached model) — see iter-0017 handoff |
+| Embedding-bound operations in `bench` | ✅ landed (opt-in) | `src/bench.rs` — `--with-embedding` flag loads the local candle MiniLM model and exercises `memory_store` (embed + insert + set_embedding) and `memory_recall` (embed query + `recall_hybrid` against an embedded 200-row corpus). Default off so the `bench.yml` CI guard stays embedding-free; if the model cache is missing the flag is treated as a no-op with a clear stderr message. |
 | `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
 | Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
 
@@ -90,20 +90,41 @@ every pull request.
 
 ```
 $ ai-memory bench
-Operation                       Target (p95)   Measured (p95)   p50      p99      Status
-─────────────────────────────────────────────────────────────────────────────────────────
-memory_store (no embedding)     <   20 ms           0.4 ms         0.3      0.5    PASS
-memory_search (FTS5)            <  100 ms           0.5 ms         0.5      0.5    PASS
-memory_recall (hot, depth=1)    <   50 ms           4.8 ms         4.2      5.3    PASS
-memory_kg_query (depth=1)       <  100 ms           0.5 ms         0.5      0.5    PASS
-memory_kg_query (depth=3)       <  100 ms           0.6 ms         0.6      0.6    PASS
-memory_kg_query (depth=5)       <  250 ms           0.7 ms         0.6      1.0    PASS
-memory_kg_timeline              <  100 ms           0.1 ms         0.1      0.1    PASS
+Operation                           Target (p95)   Measured (p95)   p50      p99      Status
+─────────────────────────────────────────────────────────────────────────────────────────────
+memory_store (no embedding)         <   20 ms           0.4 ms         0.3      0.5    PASS
+memory_search (FTS5)                <  100 ms           0.5 ms         0.5      0.5    PASS
+memory_recall (hot, depth=1)        <   50 ms           4.8 ms         4.2      5.3    PASS
+memory_kg_query (depth=1)           <  100 ms           0.5 ms         0.5      0.5    PASS
+memory_kg_query (depth=3)           <  100 ms           0.6 ms         0.6      0.6    PASS
+memory_kg_query (depth=5)           <  250 ms           0.7 ms         0.6      1.0    PASS
+memory_kg_timeline                  <  100 ms           0.1 ms         0.1      0.1    PASS
 ```
 
 `--iterations` and `--warmup` (clamped to `[1, 100_000]` and
 `[0, 10_000]` respectively) tune the sample size. `--json` emits the
 same numbers as a single JSON document for downstream tooling.
+
+Pass `--with-embedding` to opt into the two embedding-bound rows. The
+flag loads the local candle MiniLM model on first invocation; if the
+model cache is missing it logs a clear message on stderr and falls
+back to the embedding-free workload so the run still completes:
+
+```
+$ ai-memory bench --with-embedding
+ai-memory bench: embedding-bound ops enabled (all-MiniLM-L6-v2 (384-dim, local))
+Operation                           Target (p95)   Measured (p95)   p50      p99      Status
+─────────────────────────────────────────────────────────────────────────────────────────────
+memory_store (no embedding)         <   20 ms           0.5 ms         0.3      0.6    PASS
+memory_search (FTS5)                <  100 ms           0.5 ms         0.5      0.5    PASS
+memory_recall (hot, depth=1)        <   50 ms           4.3 ms         3.5      4.6    PASS
+memory_kg_query (depth=1)           <  100 ms           0.4 ms         0.2      0.4    PASS
+memory_kg_query (depth=3)           <  100 ms           0.6 ms         0.5      0.6    PASS
+memory_kg_query (depth=5)           <  250 ms           0.6 ms         0.6      0.6    PASS
+memory_kg_timeline                  <  100 ms           0.1 ms         0.1      0.1    PASS
+memory_store (with embedding)       <  200 ms          42.7 ms        37.6     43.3    PASS
+memory_recall (cold, full hybrid)   <  200 ms          24.5 ms        15.7     27.8    PASS
+```
 
 The KG rows seed two in-process fixtures so every traversal runs
 end-to-end with no external service:
@@ -119,12 +140,24 @@ end-to-end with no external service:
   exercised at the documented depth ceiling rather than collapsing to
   a single hop.
 
-Embedding-bound paths (`memory_store` with embedding, `memory_recall`
-cold/full hybrid), the curator daemon, and the federation ack path are
-not yet wired in — they each need fixtures or external services that
-don't belong on the hot path of a `cargo test` run. They land in a
-follow-up Stream E iteration alongside the canonical 1000-memory
-workload at `benchmarks/v063/canonical_workload.json`.
+The embedding-bound rows (opt-in via `--with-embedding`) load the
+local candle MiniLM model and exercise:
+
+- `memory_store` (with embedding) — `embed(title + content) +
+  insert + set_embedding`, gated against the 200 ms p95 row.
+- `memory_recall` (cold, full hybrid) — `embed(query) +
+  recall_hybrid` against a freshly seeded 200-row embedded corpus
+  with a fresh in-memory HNSW index per run, gated against the
+  200 ms p95 row. No warm cache, no shared vector index — the goal
+  is the first-query path the budget table calls out.
+
+The opt-in is deliberate: the default workload stays embedding-free
+so `cargo test` and the `bench.yml` CI guard run in seconds with no
+candle model load. The curator daemon and the federation ack path
+still need fixtures or external services that don't belong on the
+hot path of a `cargo test` run; they land in follow-up Stream E
+iterations alongside the canonical 1000-memory workload at
+`benchmarks/v063/canonical_workload.json`.
 
 ## Why Publish These at All
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -25,6 +25,9 @@
 //!     - `memory_recall` (cold, full hybrid) — `embed(query) +
 //!       recall_hybrid` against a corpus whose entries already carry
 //!       an embedding, gated against the 200 ms p95 row.
+//!     - `memory_check_duplicate` — `embed(title + content) +
+//!       check_duplicate` linear-scan against the same embedded corpus,
+//!       gated against the 50 ms p95 row.
 //!
 //! All embedding-free fixtures live in the same in-process disposable
 //! `SQLite` — no external service required. The embedding-bound ops
@@ -89,6 +92,10 @@ pub enum Operation {
     /// against an embedded corpus. Opt-in via `--with-embedding`;
     /// budget 200 ms p95.
     RecallCold,
+    /// `memory_check_duplicate` — `embed(title + content) +
+    /// check_duplicate` linear-scan over the embedded corpus. Opt-in via
+    /// `--with-embedding`; budget 50 ms p95.
+    CheckDuplicate,
 }
 
 impl Operation {
@@ -104,6 +111,7 @@ impl Operation {
             Self::KgTimeline => "memory_kg_timeline",
             Self::StoreWithEmbedding => "memory_store (with embedding)",
             Self::RecallCold => "memory_recall (cold, full hybrid)",
+            Self::CheckDuplicate => "memory_check_duplicate",
         }
     }
 
@@ -115,7 +123,8 @@ impl Operation {
     /// share the same numeric budget as the depth ≤ 3 bucket despite
     /// belonging to different table rows in `PERFORMANCE.md`.
     /// `StoreWithEmbedding` and `RecallCold` share the embedding-bound
-    /// 200 ms p95 budget rows.
+    /// 200 ms p95 budget rows. `CheckDuplicate` lives on its own 50 ms
+    /// p95 row.
     #[must_use]
     #[allow(clippy::match_same_arms)]
     pub fn target_p95_ms(self) -> f64 {
@@ -129,6 +138,7 @@ impl Operation {
             Self::KgTimeline => 100.0,
             Self::StoreWithEmbedding => 200.0,
             Self::RecallCold => 200.0,
+            Self::CheckDuplicate => 50.0,
         }
     }
 }
@@ -216,6 +226,7 @@ pub fn run(
     if let Some(emb) = embedder {
         results.push(run_store_with_embedding(conn, config, emb)?);
         results.push(run_recall_cold(conn, config, emb)?);
+        results.push(run_check_duplicate(conn, config, emb)?);
     }
     Ok(results)
 }
@@ -490,6 +501,68 @@ fn run_recall_cold(
     Ok(percentile_summary(Operation::RecallCold, &samples))
 }
 
+/// Distinct title prefix for the embedding-bound `CheckDuplicate`
+/// corpus, disjoint from the other embedded prefixes so it can coexist
+/// in the same connection without colliding on the `(title, namespace)`
+/// upsert.
+const CHECK_DUP_CORPUS_PREFIX: &str = "dup-check";
+
+fn run_check_duplicate(
+    conn: &Connection,
+    config: &BenchConfig,
+    embedder: &Embedder,
+) -> Result<OperationResult> {
+    seed_check_duplicate_corpus(conn, &config.namespace, embedder, EMBED_CORPUS_SIZE)?;
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        // Mirror what an MCP caller would feed in: a `title + content`
+        // string at the same shape as the corpus entries, so the linear
+        // scan finds a nearest neighbor with non-trivial cosine — the
+        // path operators actually exercise pre-write.
+        let title = format!("bench-{CHECK_DUP_CORPUS_PREFIX}-candidate-{i}");
+        let content = format!(
+            "candidate memory {i} content about topic {} category {} for dup-check workload",
+            i % 50,
+            i % 10
+        );
+        let probe = format!("{title} {content}");
+        let start = Instant::now();
+        let q_emb = embedder.embed(&probe)?;
+        let _ = db::check_duplicate(
+            conn,
+            &q_emb,
+            Some(&config.namespace),
+            db::DUPLICATE_THRESHOLD_DEFAULT,
+        )?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::CheckDuplicate, &samples))
+}
+
+/// Seed an embedded corpus dedicated to the `CheckDuplicate` workload.
+/// The probes fed into `db::check_duplicate` overlap heavily with these
+/// titles + contents so each scan produces a non-trivial nearest match
+/// rather than degenerate cosines, exercising the full sort path.
+fn seed_check_duplicate_corpus(
+    conn: &Connection,
+    namespace: &str,
+    embedder: &Embedder,
+    count: usize,
+) -> Result<()> {
+    for i in 0..count {
+        let mem = synth_memory(namespace, i, CHECK_DUP_CORPUS_PREFIX);
+        let text = format!("{} {}", mem.title, mem.content);
+        let id = db::insert(conn, &mem)?;
+        let vector = embedder.embed(&text)?;
+        db::set_embedding(conn, &id, &vector)?;
+    }
+    Ok(())
+}
+
 /// Seed a corpus whose entries each carry a real embedding vector.
 /// Used by [`run_recall_cold`] so the hybrid scoring path actually
 /// has semantic candidates to consider — without embeddings the
@@ -752,7 +825,9 @@ mod tests {
             assert!(
                 !matches!(
                     r.operation,
-                    Operation::StoreWithEmbedding | Operation::RecallCold
+                    Operation::StoreWithEmbedding
+                        | Operation::RecallCold
+                        | Operation::CheckDuplicate
                 ),
                 "embedding-bound op {:?} must not appear when embedder is None",
                 r.operation,
@@ -833,10 +908,21 @@ mod tests {
                 samples: 30,
                 status: Status::Pass,
             },
+            OperationResult {
+                operation: Operation::CheckDuplicate,
+                label: Operation::CheckDuplicate.label(),
+                target_p95_ms: 50.0,
+                measured_p50_ms: 18.0,
+                measured_p95_ms: 26.0,
+                measured_p99_ms: 32.0,
+                samples: 30,
+                status: Status::Pass,
+            },
         ];
         let table = render_table(&synthetic);
         assert!(table.contains("memory_store (with embedding)"));
         assert!(table.contains("memory_recall (cold, full hybrid)"));
+        assert!(table.contains("memory_check_duplicate"));
     }
 
     #[test]
@@ -851,6 +937,7 @@ mod tests {
         assert!((Operation::KgTimeline.target_p95_ms() - 100.0).abs() < 1e-9);
         assert!((Operation::StoreWithEmbedding.target_p95_ms() - 200.0).abs() < 1e-9);
         assert!((Operation::RecallCold.target_p95_ms() - 200.0).abs() < 1e-9);
+        assert!((Operation::CheckDuplicate.target_p95_ms() - 50.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -19,21 +19,29 @@
 //!       (50 chains × 5 hops each = 300 memories + 250 links). depth=3
 //!       hits the "depth ≤ 3" 100 ms budget bucket; depth=5 hits the
 //!       "depth ≤ 5" 250 ms tail-case bucket.
+//! - Embedding-bound paths (opt-in via `run_with`):
+//!     - `memory_store` (with embedding) — `embed(text) + insert +
+//!       set_embedding`, gated against the 200 ms p95 row.
+//!     - `memory_recall` (cold, full hybrid) — `embed(query) +
+//!       recall_hybrid` against a corpus whose entries already carry
+//!       an embedding, gated against the 200 ms p95 row.
 //!
-//! Both fixtures live in the same in-process disposable `SQLite` — no
-//! external service required.
-//!
-//! Embedding-bound paths (`memory_store` with embedding,
-//! `memory_recall` cold/full hybrid) still require an embedder process
-//! and are tracked as follow-up Stream E work — they don't belong on
-//! the hot path of a `cargo test` invocation.
+//! All embedding-free fixtures live in the same in-process disposable
+//! `SQLite` — no external service required. The embedding-bound ops
+//! load the local candle `MiniLM` model the first time they're invoked
+//! (CLI: `ai-memory bench --with-embedding`); they are NOT exercised
+//! from the default `cargo test` run or the `bench.yml` CI guard so
+//! the hot path stays fast and deterministic.
 
 use anyhow::Result;
 use rusqlite::Connection;
 use serde::Serialize;
 use std::time::{Duration, Instant};
 
+use crate::config::ResolvedScoring;
 use crate::db;
+use crate::embeddings::Embedder;
+use crate::hnsw::VectorIndex;
 use crate::models::{Memory, Tier};
 
 /// CI guard tolerance — measured p95 may exceed budget by this factor
@@ -74,6 +82,13 @@ pub enum Operation {
     KgQueryDepth5,
     /// `memory_kg_timeline` — ordered timeline for a single source.
     KgTimeline,
+    /// `memory_store` with embedding — `embed(text) + insert +
+    /// set_embedding`. Opt-in via `--with-embedding`; budget 200 ms p95.
+    StoreWithEmbedding,
+    /// `memory_recall` cold/full hybrid — `embed(query) + recall_hybrid`
+    /// against an embedded corpus. Opt-in via `--with-embedding`;
+    /// budget 200 ms p95.
+    RecallCold,
 }
 
 impl Operation {
@@ -87,6 +102,8 @@ impl Operation {
             Self::KgQueryDepth3 => "memory_kg_query (depth=3)",
             Self::KgQueryDepth5 => "memory_kg_query (depth=5)",
             Self::KgTimeline => "memory_kg_timeline",
+            Self::StoreWithEmbedding => "memory_store (with embedding)",
+            Self::RecallCold => "memory_recall (cold, full hybrid)",
         }
     }
 
@@ -97,6 +114,8 @@ impl Operation {
     /// at "depth ≤ 5" (250 ms). `SearchFts` and `KgTimeline` happen to
     /// share the same numeric budget as the depth ≤ 3 bucket despite
     /// belonging to different table rows in `PERFORMANCE.md`.
+    /// `StoreWithEmbedding` and `RecallCold` share the embedding-bound
+    /// 200 ms p95 budget rows.
     #[must_use]
     #[allow(clippy::match_same_arms)]
     pub fn target_p95_ms(self) -> f64 {
@@ -108,6 +127,8 @@ impl Operation {
             Self::KgQueryDepth3 => 100.0,
             Self::KgQueryDepth5 => 250.0,
             Self::KgTimeline => 100.0,
+            Self::StoreWithEmbedding => 200.0,
+            Self::RecallCold => 200.0,
         }
     }
 }
@@ -151,15 +172,27 @@ impl Default for BenchConfig {
 
 /// Run the bench workload and return per-operation results.
 ///
+/// The seven embedding-free ops always run; the two embedding-bound
+/// ops (`memory_store` with embedding, `memory_recall` cold/full hybrid)
+/// are appended only when `embedder` is `Some`. Pass `None` from tests
+/// and from the `bench.yml` CI guard so the hot path stays fast and
+/// deterministic — no candle model load, no Ollama, no network. The
+/// CLI exposes the embedder hand-off via `ai-memory bench
+/// --with-embedding`.
+///
 /// Each operation seeds its own data inside the supplied connection so
 /// callers can hand in either a fresh in-memory DB (for tests) or a
 /// disposable on-disk DB (for the CLI).
 ///
 /// # Errors
 ///
-/// Returns the underlying [`db`] error if any of the seeded inserts
-/// or queries fail.
-pub fn run(conn: &Connection, config: &BenchConfig) -> Result<Vec<OperationResult>> {
+/// Returns the underlying [`db`] or [`Embedder`] error if any seeded
+/// insert, embed, or query fails.
+pub fn run(
+    conn: &Connection,
+    config: &BenchConfig,
+    embedder: Option<&Embedder>,
+) -> Result<Vec<OperationResult>> {
     let store = run_store_no_embedding(conn, config)?;
     let search = run_search_fts(conn, config)?;
     let recall = run_recall_hot(conn, config)?;
@@ -171,7 +204,7 @@ pub fn run(conn: &Connection, config: &BenchConfig) -> Result<Vec<OperationResul
     let kg_query_d5 =
         run_kg_query_chain(conn, config, &kg_chain_sources, Operation::KgQueryDepth5, 5)?;
     let kg_timeline = run_kg_timeline(conn, config, &kg_sources)?;
-    Ok(vec![
+    let mut results = vec![
         store,
         search,
         recall,
@@ -179,7 +212,12 @@ pub fn run(conn: &Connection, config: &BenchConfig) -> Result<Vec<OperationResul
         kg_query_d3,
         kg_query_d5,
         kg_timeline,
-    ])
+    ];
+    if let Some(emb) = embedder {
+        results.push(run_store_with_embedding(conn, config, emb)?);
+        results.push(run_recall_cold(conn, config, emb)?);
+    }
+    Ok(results)
 }
 
 fn run_store_no_embedding(conn: &Connection, config: &BenchConfig) -> Result<OperationResult> {
@@ -351,6 +389,128 @@ fn run_kg_timeline(
     Ok(percentile_summary(Operation::KgTimeline, &samples))
 }
 
+/// Corpus size for the embedding-bound recall bench. Kept small enough
+/// that the per-iteration `embed(query) + linear-scan recall_hybrid`
+/// stays inside the 200 ms p95 budget on the M4 reference baseline,
+/// large enough for the cosine-similarity ranking to have signal.
+const EMBED_CORPUS_SIZE: usize = 200;
+
+/// Distinct title prefix for the embedding-bound `RecallCold` corpus,
+/// disjoint from `seed_corpus`'s "search"/"recall" prefixes so the
+/// embedded fixture coexists in the same connection without colliding
+/// on the `(title, namespace)` upsert.
+const EMBED_CORPUS_PREFIX: &str = "embed";
+
+fn run_store_with_embedding(
+    conn: &Connection,
+    config: &BenchConfig,
+    embedder: &Embedder,
+) -> Result<OperationResult> {
+    let total = config.warmup + config.iterations;
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..total {
+        // Distinct prefix keeps these rows out of the `seed_corpus`
+        // namespace partitions so we don't churn the search/recall
+        // fixtures by upsert. Each iteration writes a fresh memory.
+        let mem = synth_memory(&config.namespace, i, "embed-store");
+        let text = format!("{} {}", mem.title, mem.content);
+        let start = Instant::now();
+        let vector = embedder.embed(&text)?;
+        let id = db::insert(conn, &mem)?;
+        db::set_embedding(conn, &id, &vector)?;
+        let elapsed = start.elapsed();
+        if i >= config.warmup {
+            samples.push(elapsed);
+        }
+    }
+    Ok(percentile_summary(Operation::StoreWithEmbedding, &samples))
+}
+
+fn run_recall_cold(
+    conn: &Connection,
+    config: &BenchConfig,
+    embedder: &Embedder,
+) -> Result<OperationResult> {
+    seed_embedded_corpus(conn, &config.namespace, embedder, EMBED_CORPUS_SIZE)?;
+    // Fresh in-memory HNSW for every run — the "cold" bench measures
+    // the first-query path: embed query + recall_hybrid against the
+    // freshly built vector index. No warmup queries, no shared cache.
+    let entries = db::get_all_embeddings(conn)?;
+    let vector_index = if entries.is_empty() {
+        VectorIndex::empty()
+    } else {
+        VectorIndex::build(entries)
+    };
+    let scoring = ResolvedScoring::default();
+    // Warmup absorbs the first-call cost of the candle BERT forward
+    // pass without polluting percentile samples.
+    for i in 0..config.warmup {
+        let q = format!("topic {} category {}", i % 50, i % 10);
+        let q_emb = embedder.embed(&q)?;
+        let _ = db::recall_hybrid(
+            conn,
+            &q,
+            &q_emb,
+            Some(&config.namespace),
+            10,
+            None,
+            None,
+            None,
+            Some(&vector_index),
+            0,
+            0,
+            None,
+            None,
+            &scoring,
+        )?;
+    }
+    let mut samples = Vec::with_capacity(config.iterations);
+    for i in 0..config.iterations {
+        let q = format!("topic {} category {}", i % 50, i % 10);
+        let start = Instant::now();
+        let q_emb = embedder.embed(&q)?;
+        let _ = db::recall_hybrid(
+            conn,
+            &q,
+            &q_emb,
+            Some(&config.namespace),
+            10,
+            None,
+            None,
+            None,
+            Some(&vector_index),
+            0,
+            0,
+            None,
+            None,
+            &scoring,
+        )?;
+        samples.push(start.elapsed());
+    }
+    Ok(percentile_summary(Operation::RecallCold, &samples))
+}
+
+/// Seed a corpus whose entries each carry a real embedding vector.
+/// Used by [`run_recall_cold`] so the hybrid scoring path actually
+/// has semantic candidates to consider — without embeddings the
+/// "cold" bench would degenerate into the same FTS-only path the
+/// `RecallHot` runner already covers.
+fn seed_embedded_corpus(
+    conn: &Connection,
+    namespace: &str,
+    embedder: &Embedder,
+    count: usize,
+) -> Result<()> {
+    for i in 0..count {
+        let mem = synth_memory(namespace, i, EMBED_CORPUS_PREFIX);
+        let text = format!("{} {}", mem.title, mem.content);
+        let id = db::insert(conn, &mem)?;
+        let vector = embedder.embed(&text)?;
+        db::set_embedding(conn, &id, &vector)?;
+    }
+    Ok(())
+}
+
 /// Seed the in-process KG fixture: `KG_FIXTURE_SOURCES` source memories,
 /// each with `KG_FIXTURE_LINKS_PER_SOURCE` outbound links to distinct
 /// targets. Every link sets `valid_from` so `kg_timeline` (which skips
@@ -495,15 +655,18 @@ fn percentile(sorted: &[f64], q: f64) -> f64 {
 }
 
 /// Render a results table to a string in the same shape used in the
-/// `PERFORMANCE.md` "Operator Self-Verification" example.
+/// `PERFORMANCE.md` "Operator Self-Verification" example. The label
+/// column is 34 chars wide — enough to fit the longest current label
+/// (`memory_recall (cold, full hybrid)`, 33 chars) without spilling
+/// into the budget column.
 #[must_use]
 pub fn render_table(results: &[OperationResult]) -> String {
     let mut out = String::new();
     out.push_str(
-        "Operation                       Target (p95)   Measured (p95)   p50      p99      Status\n",
+        "Operation                           Target (p95)   Measured (p95)   p50      p99      Status\n",
     );
     out.push_str(
-        "─────────────────────────────────────────────────────────────────────────────────────────\n",
+        "─────────────────────────────────────────────────────────────────────────────────────────────\n",
     );
     for r in results {
         let status_str = match r.status {
@@ -517,7 +680,7 @@ pub fn render_table(results: &[OperationResult]) -> String {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let target_ms = r.target_p95_ms.round() as i64;
         let line = format!(
-            "{:<30}  < {:>4} ms       {:>7.1} ms       {:>5.1}    {:>5.1}    {}\n",
+            "{:<34}  < {:>4} ms       {:>7.1} ms       {:>5.1}    {:>5.1}    {}\n",
             r.label, target_ms, r.measured_p95_ms, r.measured_p50_ms, r.measured_p99_ms, status_str
         );
         out.push_str(&line);
@@ -559,7 +722,7 @@ mod tests {
     #[test]
     fn run_returns_all_seven_results() {
         let conn = fresh_conn();
-        let results = run(&conn, &small_config()).unwrap();
+        let results = run(&conn, &small_config(), None).unwrap();
         assert_eq!(results.len(), 7);
         assert_eq!(results[0].operation, Operation::StoreNoEmbedding);
         assert_eq!(results[1].operation, Operation::SearchFts);
@@ -573,6 +736,27 @@ mod tests {
             assert!(r.measured_p50_ms <= r.measured_p95_ms);
             assert!(r.measured_p95_ms <= r.measured_p99_ms);
             assert!(r.target_p95_ms > 0.0);
+        }
+    }
+
+    #[test]
+    fn run_with_none_embedder_skips_embedding_ops() {
+        // `run(.., None)` is the path the CLI takes when the user omits
+        // `--with-embedding` and the path the `bench.yml` CI guard
+        // exercises. It must never produce embedding-bound rows so the
+        // hot path stays free of candle/Ollama dependencies.
+        let conn = fresh_conn();
+        let results = run(&conn, &small_config(), None).unwrap();
+        assert_eq!(results.len(), 7);
+        for r in &results {
+            assert!(
+                !matches!(
+                    r.operation,
+                    Operation::StoreWithEmbedding | Operation::RecallCold
+                ),
+                "embedding-bound op {:?} must not appear when embedder is None",
+                r.operation,
+            );
         }
     }
 
@@ -612,7 +796,7 @@ mod tests {
     #[test]
     fn render_table_includes_all_operations() {
         let conn = fresh_conn();
-        let results = run(&conn, &small_config()).unwrap();
+        let results = run(&conn, &small_config(), None).unwrap();
         let table = render_table(&results);
         assert!(table.contains("memory_store (no embedding)"));
         assert!(table.contains("memory_search (FTS5)"));
@@ -625,6 +809,37 @@ mod tests {
     }
 
     #[test]
+    fn render_table_includes_embedding_ops_when_present() {
+        // Synthesised results — render_table must not drop or relabel
+        // the embedding-bound rows when the CLI feeds them in.
+        let synthetic = vec![
+            OperationResult {
+                operation: Operation::StoreWithEmbedding,
+                label: Operation::StoreWithEmbedding.label(),
+                target_p95_ms: 200.0,
+                measured_p50_ms: 50.0,
+                measured_p95_ms: 90.0,
+                measured_p99_ms: 110.0,
+                samples: 30,
+                status: Status::Pass,
+            },
+            OperationResult {
+                operation: Operation::RecallCold,
+                label: Operation::RecallCold.label(),
+                target_p95_ms: 200.0,
+                measured_p50_ms: 60.0,
+                measured_p95_ms: 95.0,
+                measured_p99_ms: 130.0,
+                samples: 30,
+                status: Status::Pass,
+            },
+        ];
+        let table = render_table(&synthetic);
+        assert!(table.contains("memory_store (with embedding)"));
+        assert!(table.contains("memory_recall (cold, full hybrid)"));
+    }
+
+    #[test]
     fn operation_targets_match_performance_md() {
         // Pinned to PERFORMANCE.md — if you change a budget, change both.
         assert!((Operation::StoreNoEmbedding.target_p95_ms() - 20.0).abs() < 1e-9);
@@ -634,6 +849,8 @@ mod tests {
         assert!((Operation::KgQueryDepth3.target_p95_ms() - 100.0).abs() < 1e-9);
         assert!((Operation::KgQueryDepth5.target_p95_ms() - 250.0).abs() < 1e-9);
         assert!((Operation::KgTimeline.target_p95_ms() - 100.0).abs() < 1e-9);
+        assert!((Operation::StoreWithEmbedding.target_p95_ms() - 200.0).abs() < 1e-9);
+        assert!((Operation::RecallCold.target_p95_ms() - 200.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,11 +204,12 @@ struct BenchArgs {
     #[arg(long)]
     json: bool,
     /// Opt in to the embedding-bound operations (`memory_store` with
-    /// embedding, `memory_recall` cold/full hybrid). Loads the local
-    /// candle `MiniLM` model the first time it's invoked; if the model
-    /// cache is missing or the load fails, the flag is treated as a
-    /// no-op and a clear message is emitted on stderr. Default off so
-    /// the `bench.yml` CI guard stays fast and deterministic.
+    /// embedding, `memory_recall` cold/full hybrid, `memory_check_duplicate`).
+    /// Loads the local candle `MiniLM` model the first time it's
+    /// invoked; if the model cache is missing or the load fails, the
+    /// flag is treated as a no-op and a clear message is emitted on
+    /// stderr. Default off so the `bench.yml` CI guard stays fast and
+    /// deterministic.
     #[arg(long)]
     with_embedding: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,14 @@ struct BenchArgs {
     /// Emit results as JSON instead of the human-readable table.
     #[arg(long)]
     json: bool,
+    /// Opt in to the embedding-bound operations (`memory_store` with
+    /// embedding, `memory_recall` cold/full hybrid). Loads the local
+    /// candle `MiniLM` model the first time it's invoked; if the model
+    /// cache is missing or the load fails, the flag is treated as a
+    /// no-op and a clear message is emitted on stderr. Default off so
+    /// the `bench.yml` CI guard stays fast and deterministic.
+    #[arg(long)]
+    with_embedding: bool,
 }
 
 #[derive(Args)]
@@ -4409,13 +4417,39 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
         warmup,
         namespace: bench::BENCH_NAMESPACE.to_string(),
     };
-    let results = bench::run(&conn, &config)?;
+    // Opt-in embedder load. If `--with-embedding` is set but the model
+    // cache is missing (no network, no pre-downloaded files), the run
+    // still completes — just without the two embedding-bound ops. This
+    // matches the documented "skips with a clear message if missing"
+    // behaviour so a forgetful operator doesn't get a hard error from
+    // a benign flag toggle.
+    let embedder = if args.with_embedding {
+        match embeddings::Embedder::new_local() {
+            Ok(emb) => {
+                eprintln!(
+                    "ai-memory bench: embedding-bound ops enabled ({})",
+                    emb.model_description()
+                );
+                Some(emb)
+            }
+            Err(e) => {
+                eprintln!(
+                    "ai-memory bench: --with-embedding requested but embedder unavailable: {e}; skipping embedding-bound operations"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let results = bench::run(&conn, &config, embedder.as_ref())?;
     if args.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "iterations": iterations,
                 "warmup": warmup,
+                "with_embedding": embedder.is_some(),
                 "results": results,
             }))?
         );


### PR DESCRIPTION
## Summary

Adds the third and final embedding-bound row from `PERFORMANCE.md` to the
`ai-memory bench` workload: `memory_check_duplicate`, gated against the
50 ms p95 row. The new op is opt-in behind the same `--with-embedding`
flag as `memory_store` (with embedding) and `memory_recall` (cold, full
hybrid), so the default `cargo test` and `bench.yml` CI path stay
embedding-free.

The runner seeds a dedicated 200-row embedded corpus (prefix `dup-check`,
disjoint from the existing recall-cold corpus) and drives
`embed(probe) + db::check_duplicate` end-to-end. Probe titles overlap
the corpus prefix so each linear cosine scan returns a non-trivial
nearest neighbor — the path operators actually hit pre-write — rather
than degenerate cosines.

Local M4 measurement: p95 **~47 ms** — PASS, dominated by the one-shot
MiniLM forward pass (~42 ms) plus the linear scan + sort over the
200-row corpus. With this PR, every embedding-bound row in the published
budget table is covered end-to-end by `ai-memory bench`; the
curator-cycle and federation-ack rows are the only remaining
external-fixture follow-ups.

## AI involvement

- **Author:** Claude Opus 4.7 (1M context) — campaign agent for
  `ai-memory-v063` (iteration 9)
- **Class:** Standard (charter-aligned Stream D + Stream E follow-up)
- **Branch base:** `campaign/bench-embedding-bound` (PR #398). Once
  #398 lands, this PR rebases trivially onto `release/v0.6.3`.
- **Charter:** §"Stream D — Duplicate Check" + §"Stream E —
  Performance Instrumentation"

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory bench::` —
      11/11 pass (incl. updated `render_table_includes_embedding_ops_when_present`,
      `run_with_none_embedder_skips_embedding_ops`,
      `operation_targets_match_performance_md`)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory check_duplicate` —
      8/8 pass
- [x] `./target/release/ai-memory bench --with-embedding` —
      `memory_check_duplicate` p95 47.3 ms vs 50 ms target (PASS)
- [x] `./target/release/ai-memory bench` (no flag) —
      no embedding-bound rows in output, default workload unchanged

## Depends on

- #398 (`campaign/bench-embedding-bound`) — supplies the
  `--with-embedding` scaffolding this PR extends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)