### PR TITLE
feat(bench): --markdown switch lands sortable table in bench.yml summary (Pillar 3 / Stream F)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run bench (gate)
         run: |
           set +e
-          target/release/ai-memory bench | tee bench-table.txt
+          target/release/ai-memory bench --markdown | tee bench-table.md
           rc=${PIPESTATUS[0]}
           set -e
           {
@@ -59,9 +59,7 @@ jobs:
             echo '[`PERFORMANCE.md`](../blob/${{ github.sha }}/PERFORMANCE.md). '
             echo 'Fails the build when any p95 exceeds its target by >10%.'
             echo ''
-            echo '```'
-            cat bench-table.txt
-            echo '```'
+            cat bench-table.md
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
 
@@ -76,5 +74,5 @@ jobs:
           name: bench-results
           path: |
             bench-results.json
-            bench-table.txt
+            bench-table.md
           if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Curator-cycle bench operation (Pillar 3 / Stream E)** — new
+  `Operation::CuratorCycle` variant in `src/bench.rs`, gated against the
+  `curator cycle (1k memories) < 60 s p95` row in `PERFORMANCE.md`.
+  Opt-in via `ai-memory bench --with-curator`: seeds the canonical
+  1000-memory workload (`benchmarks/v063/canonical_workload.json`) into
+  the bench's disposable in-memory `SQLite`, runs one
+  `curator::run_once` sweep against it (with the per-cycle op cap
+  raised from the production-safe default of 100 to 1000 to cover the
+  full sweep), and reports the single-sample latency in the same
+  `OperationResult` shape every other op uses. Bench requires a
+  reachable Ollama endpoint with the curator's configured model
+  (`FeatureTier::Smart` → `gemma4:e2b`); when Ollama is unreachable
+  the flag is treated as a no-op and a clear message is emitted on
+  stderr — same opt-in/no-op pattern as `--with-embedding` from
+  earlier in this Patch. The fixture is loaded at runtime via
+  `env!("CARGO_MANIFEST_DIR")` and validated against three pinned
+  invariants (`schema_version == 1`, `seed == 20_260_426`, and
+  `count == memories.len()`) before the upsert path runs, so a
+  drifted fixture surfaces as a hard error instead of silently
+  rebasing the bench numbers. Default `cargo test` and the
+  `bench.yml` CI guard never trigger the curator op (no `--with-curator`,
+  no Ollama in CI), so the hot path stays fast and deterministic.
+  Charter §"Stream E — Performance Instrumentation"; closes the
+  curator-cycle row from the published budget table. Builds on the
+  canonical workload fixture from the prior iteration in this Patch.
+
 - **Canonical workload fixture (Pillar 3 / Stream E scaffold)** — new
   `benchmarks/v063/canonical_workload.json` is the 1000-memory
   deterministic seed required by the `curator cycle (1k memories) <

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Canonical workload fixture (Pillar 3 / Stream E scaffold)** — new
+  `benchmarks/v063/canonical_workload.json` is the 1000-memory
+  deterministic seed required by the `curator cycle (1k memories) <
+  60 s p95` row in `PERFORMANCE.md`. The schema (top-level
+  `{schema_version, seed, count, memories[]}`, every entry shaped 1:1
+  with `crate::models::CreateMemory`) lands ahead of its bench wiring
+  so the curator-cycle benchmark in a follow-up Stream E iteration can
+  `serde_json::from_str` the array straight into the upsert path. Every
+  memory is curator-eligible by construction (no `_`-prefixed
+  namespace, content always >= curator `MIN_CONTENT_LEN`, mid/long
+  tier only, no `auto_tags` metadata) so a single sweep finds 1000
+  candidates and exercises `auto_tag` + `detect_contradiction` to the
+  default `max_ops_per_cycle` (100). The fixture is reproducible from
+  source: the committed `gen_canonical_workload.py` re-emits the same
+  byte-identical JSON given the pinned seed
+  (`SEED = 20260426`), and `src/canonical_workload.rs` carries
+  `cargo test`-gated invariants on schema version, count, seed, and
+  curator-eligibility so future edits to either side cannot silently
+  drift. No production binary impact — the fixture is read at test
+  runtime, not `include_str!`-embedded. Charter §"Stream E —
+  Performance Instrumentation"; closes the curator-cycle scaffold gap
+  flagged in `PERFORMANCE.md` §"Status".
+
 - **Hierarchical namespace taxonomy (Pillar 1 / Stream A)** — new
   `memory_get_taxonomy` MCP tool plus REST mirror at
   `GET /api/v1/taxonomy`. Walks live (non-expired) memories grouped by

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -72,6 +72,7 @@ reference hardware, not absolute floors for every machine.
 | Per-tool MCP `tracing` spans | ✅ landed | `src/mcp.rs` `handle_request` — `mcp_tool_call` span carries `tool` + `rpc_id`; `elapsed_ms` emitted at exit |
 | KG operations in `bench` | ✅ landed | `src/bench.rs` — fan-out fixture (50 × 4 outbound, every link `valid_from`-stamped) drives `kg_query` depth=1 + `kg_timeline`; chain fixture (50 chains × 5 hops) drives `kg_query` depth=3 + depth=5 |
 | Embedding-bound operations in `bench` | 🚧 Stream E follow-up | needs an embedder fixture decision (opt-in flag vs cfg(test) fake vs pre-cached model) — see iter-0017 handoff |
+| `curator cycle (1k memories)` in `bench` | 🚧 opt-in via `--with-curator` | `src/bench.rs` `run_curator_cycle` — seeds `benchmarks/v063/canonical_workload.json` into a disposable `SQLite` and runs one `curator::run_once` sweep (per-cycle op cap raised to 1000). Requires a reachable Ollama endpoint with the curator's model; CLI emits a no-op message and skips the row otherwise. Default `cargo test` and the `bench.yml` CI guard do not trigger this row. |
 | `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
 | Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
 
@@ -120,11 +121,15 @@ end-to-end with no external service:
   a single hop.
 
 Embedding-bound paths (`memory_store` with embedding, `memory_recall`
-cold/full hybrid), the curator daemon, and the federation ack path are
-not yet wired in — they each need fixtures or external services that
-don't belong on the hot path of a `cargo test` run. They land in a
-follow-up Stream E iteration alongside the canonical 1000-memory
-workload at `benchmarks/v063/canonical_workload.json`.
+cold/full hybrid) and the federation ack path are not yet wired in —
+they each need fixtures or external services that don't belong on the
+hot path of a `cargo test` run. The curator-cycle row is wired but
+opt-in via `ai-memory bench --with-curator`: when set, the bench loads
+`benchmarks/v063/canonical_workload.json` (1000 deterministic memories)
+into a disposable `SQLite` and runs one `curator::run_once` sweep
+against the configured Ollama endpoint, gating the result against the
+60 s p95 budget; when Ollama is unreachable the flag is a no-op and
+the row is skipped — the same opt-in/no-op shape as `--with-embedding`.
 
 ## Why Publish These at All
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -73,8 +73,8 @@ reference hardware, not absolute floors for every machine.
 | KG operations in `bench` | ✅ landed | `src/bench.rs` — fan-out fixture (50 × 4 outbound, every link `valid_from`-stamped) drives `kg_query` depth=1 + `kg_timeline`; chain fixture (50 chains × 5 hops) drives `kg_query` depth=3 + depth=5 |
 | Embedding-bound operations in `bench` | 🚧 Stream E follow-up | needs an embedder fixture decision (opt-in flag vs cfg(test) fake vs pre-cached model) — see iter-0017 handoff |
 | `curator cycle (1k memories)` in `bench` | 🚧 opt-in via `--with-curator` | `src/bench.rs` `run_curator_cycle` — seeds `benchmarks/v063/canonical_workload.json` into a disposable `SQLite` and runs one `curator::run_once` sweep (per-cycle op cap raised to 1000). Requires a reachable Ollama endpoint with the curator's model; CLI emits a no-op message and skips the row otherwise. Default `cargo test` and the `bench.yml` CI guard do not trigger this row. |
-| `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + table) |
-| Measured numbers in CI history | ✅ collecting | each workflow run's summary carries the table; the JSON artifact is retained per GitHub Actions retention policy |
+| `bench.yml` CI workflow | ✅ landed | `.github/workflows/bench.yml` — gates every PR and trunk push on `ubuntu-latest`; uploads `bench-results` artifact (JSON + Markdown table) |
+| Measured numbers in CI history | ✅ collecting | each workflow run's summary carries a sortable Markdown table emitted by `ai-memory bench --markdown`; the JSON artifact is retained per GitHub Actions retention policy |
 
 The status table is updated as each Stream lands within the v0.6.3
 cycle. When measurements begin, this file will gain a "Latest measured"
@@ -105,6 +105,11 @@ memory_kg_timeline              <  100 ms           0.1 ms         0.1      0.1 
 `--iterations` and `--warmup` (clamped to `[1, 100_000]` and
 `[0, 10_000]` respectively) tune the sample size. `--json` emits the
 same numbers as a single JSON document for downstream tooling.
+`--markdown` emits a GitHub-Flavored-Markdown table — sortable in the
+GitHub UI when the CI workflow pipes it into `$GITHUB_STEP_SUMMARY`,
+and the data source future tooling will harvest to populate the
+"Latest measured" column promised in the [Status](#status) section.
+`--json` and `--markdown` are mutually exclusive.
 
 The KG rows seed two in-process fixtures so every traversal runs
 end-to-end with no external service:

--- a/benchmarks/v063/README.md
+++ b/benchmarks/v063/README.md
@@ -1,0 +1,89 @@
+# v0.6.3 Canonical Workload
+
+This directory holds the canonical workload fixture consumed by the
+v0.6.3 curator-cycle bench described in
+[`PERFORMANCE.md`](../../PERFORMANCE.md). It is the seed required by the
+`< 60 s p95` budget row for `curator cycle (1k memories)`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `gen_canonical_workload.py` | Deterministic generator. Re-running with no arguments produces a byte-identical `canonical_workload.json`. |
+| `canonical_workload.json` | The committed 1000-memory seed. ~390 KB. Schema version 1. |
+
+The generator is committed alongside its output so the fixture is
+reproducible from source. Bumping the seed or vocabulary requires
+re-running the script and committing both files together.
+
+## Schema
+
+`canonical_workload.json` is a single JSON object:
+
+```jsonc
+{
+  "schema_version": 1,
+  "description": "...",
+  "seed": 20260426,
+  "count": 1000,
+  "memories": [
+    {
+      "tier": "mid" | "long",
+      "namespace": "projects/alpha/decisions",
+      "title": "decisions #0000",
+      "content": "...",       // always >= curator MIN_CONTENT_LEN (50 chars)
+      "tags": ["..."],
+      "priority": 3..8,
+      "confidence": 0.6..1.0,
+      "source": "import",
+      "metadata": {}           // empty so curator.needs_curation() returns true
+    },
+    ...
+  ]
+}
+```
+
+The per-memory shape lines up 1:1 with `crate::models::CreateMemory`,
+so the bench harness can `serde_json::from_str` the array directly into
+the upsert path with no field translation.
+
+## Curator-eligibility invariants
+
+The fixture is constructed so that **every** entry passes
+`crate::curator::needs_curation`:
+
+- `namespace` never starts with `_` (curator's internal-namespace skip).
+- `content.len() >= 50` (`MIN_CONTENT_LEN`). The actual minimum produced
+  by the generator is ~74 chars; a guard pads short combinations to
+  preserve the floor across vocabulary edits.
+- `metadata.auto_tags` is unset (the empty `{}` body), so the
+  already-tagged short-circuit never fires.
+- `tier` ∈ {`mid`, `long`} only — curator scans neither short tier nor
+  internal tiers.
+
+A single curator sweep against this fixture therefore finds 1000
+candidates and runs `auto_tag` + `detect_contradiction` on the first
+`max_ops_per_cycle` (default 100) until the cap is hit.
+
+## Reproducibility
+
+```bash
+cd benchmarks/v063
+python3 gen_canonical_workload.py
+# wrote benchmarks/v063/canonical_workload.json (1000 memories)
+git diff --quiet canonical_workload.json || echo "fixture drifted"
+```
+
+The generator uses `random.Random(SEED)` with `SEED = 20260426` and
+`json.dumps(..., indent=2, sort_keys=True)` so the output is stable
+across Python 3.x patch releases. CI that wants to assert reproducibility
+can re-run the generator and `diff -q` against the committed file.
+
+## Why this lives in `benchmarks/`, not `tests/fixtures/`
+
+`tests/fixtures/` carries small inputs scoped to one or two unit tests.
+This fixture is a published artifact in its own right: the curator-cycle
+benchmark documented in `PERFORMANCE.md`, plus any future external
+benchmarking tool, want a stable on-disk path. `benchmarks/v063/` is the
+natural home and matches the `benchmarks/longmemeval/` layout already in
+the repo.

--- a/benchmarks/v063/canonical_workload.json
+++ b/benchmarks/v063/canonical_workload.json
@@ -1,0 +1,13215 @@
+{
+  "count": 1000,
+  "description": "v0.6.3 canonical workload \u2014 1000-memory deterministic seed for the curator-cycle bench. Every entry is curator-eligible (public namespace, content >= 50 chars, no auto_tags) so a single sweep exercises auto_tag + detect_contradiction up to max_ops_per_cycle. Schema mirrors crate::models::CreateMemory for direct serde_json::from_str into the bench harness.",
+  "memories": [
+    {
+      "confidence": 0.67,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: merged.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "code",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "conversations #0000"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Meeting on 2026-04-22 with alice + bob. Outcome: approved with caveats. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "oncall #0001"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: deferred to next iteration. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "meetings #0002"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0003"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Decision: federation ack budget. Owner: heidi. Rationale: operator feedback unanimous. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0004"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Client globex discussed schema migration cadence. Outcome: agreed on plan. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "migration",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "meetings #0005"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Meeting on 2026-04-22 with PM + tech lead. Outcome: agreed on plan. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "datasets #0006"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Decision: embedder warmup. Owner: carol. Rationale: best p95 trade-off. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "security"
+      ],
+      "tier": "long",
+      "title": "code #0007"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Migration note \u2014 MCP server loop. Before: synchronous-only embedder. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "blocker",
+        "code"
+      ],
+      "tier": "long",
+      "title": "meetings #0008"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Migration note \u2014 MCP server loop. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "long",
+      "title": "decisions #0009"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "oncall #0010"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Meeting on 2026-04-15 with alice + bob. Outcome: blocked on dependency. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0011"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Spike on agent-id rotation. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "contracts #0012"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Design note for memory_recall. Constraint: zero clippy::pedantic warnings. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "security",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0013"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "client",
+        "incident",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "notes #0014"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Meeting on 2026-04-22 with PM + tech lead. Outcome: approved with caveats. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "conversations #0015"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: ops on-call ping. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "notes #0016"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Code review of bench harness \u2014 feedback: needs additional test. Status: blocked.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "runbooks #0017"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Client soylent discussed curator backlog growth. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0018"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Migration note \u2014 bench harness. Before: single-tier TTL. After: namespace tree with /-delimited paths. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "code #0019"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Design note for embedder module. Constraint: p95 < 100 ms on M4. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "decisions #0020"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Spike on TTL relaxation policy. Hypothesis: embed call dominates p95. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "long",
+      "title": "contracts #0021"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0022"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Design note for bench harness. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0023"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0024"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Decision: namespace hierarchy rollout. Owner: alice. Rationale: compatible with v0.7 plan. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0025"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Postmortem: federation quorum stall. Root cause: input not truncated before tokenize. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0026"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Code review of MCP server loop \u2014 feedback: rebase before merge. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0027"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Design note for curator daemon. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "code #0028"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on schema migration cadence. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "oncall #0029"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Research note on namespace hierarchy rollout. Source: academic paper. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision",
+        "meeting",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "code #0030"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Design note for curator daemon. Constraint: zero clippy::pedantic warnings. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "spike",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "conversations #0031"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Research note on federation ack budget. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "notes #0032"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Migration note \u2014 memory_kg_query. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "code #0033"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for embedder module. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision",
+        "security",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "meetings #0034"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Design note for HTTP handlers. Constraint: zero clippy::pedantic warnings. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "code #0035"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Research note on TTL relaxation policy. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "review",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0036"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Meeting on 2026-04-22 with alice + erin + frank. Outcome: needs more data. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0037"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Meeting on 2026-05-06 with alice + erin + frank. Outcome: blocked on dependency. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "contracts #0038"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Migration note \u2014 HTTP handlers. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "review",
+        "internal",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "meetings #0039"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 amortizable across cycles. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0040"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Design note for embedder module. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0041"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: missing index on temporal columns. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "research #0042"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Migration note \u2014 MCP server loop. Before: synchronous-only embedder. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "code"
+      ],
+      "tier": "long",
+      "title": "oncall #0043"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Migration note \u2014 bench harness. Before: single curator interval. After: configurable curator interval per tier. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "meetings #0044"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Migration note \u2014 bench harness. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "meetings #0045"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Spike on schema migration cadence. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "internal",
+        "client",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "research #0046"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Code review of HTTP handlers \u2014 feedback: needs additional test. Status: changes requested.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0047"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Client globex discussed TTL relaxation policy. Outcome: agreed on plan. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0048"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Design note for curator daemon. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0049"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Meeting on 2026-04-08 with engineering leads. Outcome: deferred to next iteration. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "contracts #0050"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Meeting on 2026-04-22 with alice + erin + frank. Outcome: deferred to next iteration. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "code",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "meetings #0051"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Research note on FTS5 trigram tuning. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "notes #0052"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Postmortem: federation quorum stall. Root cause: missing index on temporal columns. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0053"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Spike on schema migration cadence. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 amortizable across cycles. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0054"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: embed call dominates p95. Result: rejected \u2014 FTS5 within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "conversations #0055"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Spike on schema migration cadence. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0056"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Spike on federation ack budget. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0057"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "meetings #0058"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client initech discussed schema migration cadence. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0059"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Migration note \u2014 bench harness. Before: no temporal columns on links. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "decision",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "reading #0060"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Spike on vector index sizing. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0061"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Decision: TTL relaxation policy. Owner: grace. Rationale: smallest blast radius. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "security",
+        "code"
+      ],
+      "tier": "long",
+      "title": "papers #0062"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Design note for memory_kg_query. Constraint: zero clippy::pedantic warnings. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "client",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "conversations #0063"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Decision: schema migration cadence. Owner: grace. Rationale: lowest-risk path forward. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0064"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "meetings #0065"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Meeting on 2026-05-06 with PM + tech lead. Outcome: deferred to next iteration. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "research #0066"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Migration note \u2014 memory_recall. Before: single curator interval. After: valid_from / valid_until on every link. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "conversations #0067"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: ack window mis-configured. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0068"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: ops on-call ping. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "long",
+      "title": "datasets #0069"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "meetings #0070"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "meeting",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "runbooks #0071"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Research note on federation ack budget. Source: conference talk. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0072"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Research note on namespace hierarchy rollout. Source: academic paper. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "code",
+        "design"
+      ],
+      "tier": "long",
+      "title": "papers #0073"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: per-tier TTL with promotion. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0074"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: ops on-call ping. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0075"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Decision: FTS5 trigram tuning. Owner: frank. Rationale: best p95 trade-off. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "code",
+        "internal",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "oncall #0076"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Client acme-corp discussed federation ack budget. Outcome: agreed on plan. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "code"
+      ],
+      "tier": "long",
+      "title": "reading #0077"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Client initech discussed federation ack budget. Outcome: needs more data. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "contracts #0078"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Spike on agent-id rotation. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 embed is 80% of latency. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0079"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Meeting on 2026-04-15 with alice + carol + dave. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "design",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0080"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client umbrella discussed federation ack budget. Outcome: approved with caveats. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0081"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Spike on curator backlog growth. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "conversations #0082"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Postmortem: federation quorum stall. Root cause: input not truncated before tokenize. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0083"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Spike on federation ack budget. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0084"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Spike on schema migration cadence. Hypothesis: HNSW build cost is amortizable. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0085"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Decision: agent-id rotation. Owner: alice. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "decisions #0086"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Code review of bench harness \u2014 feedback: rebase before merge. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security",
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0087"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Spike on TTL relaxation policy. Hypothesis: rerank adds <5 ms. Result: partial \u2014 only stalls > 8k chars. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "runbooks #0088"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Code review of memory_kg_query \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "papers #0089"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Client umbrella discussed embedder warmup. Outcome: agreed on plan. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "notes #0090"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Client acme-corp discussed vector index sizing. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0091"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Spike on subscription replay. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "notes #0092"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Meeting on 2026-04-29 with alice + erin + frank. Outcome: deferred to next iteration. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "contracts #0093"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Client initech discussed subscription replay. Outcome: needs more data. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "doc",
+        "design",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "decisions #0094"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Decision: namespace hierarchy rollout. Owner: heidi. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "code",
+        "spike",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0095"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Code review of curator daemon \u2014 feedback: minor \u2014 naming nit. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "mid",
+      "title": "code #0096"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Migration note \u2014 embedder module. Before: single curator interval. After: per-tier TTL with promotion. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "oncall #0097"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: user-reported slow start. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "internal",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "meetings #0098"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Decision: FTS5 trigram tuning. Owner: dave. Rationale: compatible with v0.7 plan. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0099"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Research note on federation ack budget. Source: external blog. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "internal",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "decisions #0100"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Meeting on 2026-04-08 with alice + carol + dave. Outcome: blocked on dependency. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "code #0101"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Postmortem: embedder OOM on long input. Root cause: warm cache invalidated on hot reload. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "code #0102"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Client soylent discussed FTS5 trigram tuning. Outcome: needs more data. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "postmortem",
+        "client"
+      ],
+      "tier": "long",
+      "title": "oncall #0103"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Design note for MCP server loop. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0104"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Client soylent discussed FTS5 trigram tuning. Outcome: needs more data. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0105"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: alert: p95 over budget. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "code #0106"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: subscription replay. Owner: heidi. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0107"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Meeting on 2026-04-08 with alice + carol + dave. Outcome: blocked on dependency. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "follow-up",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0108"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Decision: schema migration cadence. Owner: erin. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "deploy",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "notes #0109"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: log spike in errors. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "notes #0110"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "contracts #0111"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "code"
+      ],
+      "tier": "long",
+      "title": "reading #0112"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Design note for memory_kg_query. Constraint: must round-trip SQLite \u2194 Postgres. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "meetings #0113"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Migration note \u2014 curator daemon. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0114"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Spike on vector index sizing. Hypothesis: HNSW build cost is amortizable. Result: partial \u2014 only stalls > 8k chars. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "decisions #0115"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "conversations #0116"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident",
+        "decision",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "reading #0117"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "review",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "decisions #0118"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Decision: schema migration cadence. Owner: erin. Rationale: compatible with v0.7 plan. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0119"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on agent-id rotation. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0120"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client soylent discussed federation ack budget. Outcome: approved with caveats. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "blocker",
+        "design"
+      ],
+      "tier": "long",
+      "title": "runbooks #0121"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Decision: vector index sizing. Owner: carol. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0122"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "mid",
+      "title": "contracts #0123"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: alert: p95 over budget. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review",
+        "security"
+      ],
+      "tier": "long",
+      "title": "papers #0124"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Client initech discussed FTS5 trigram tuning. Outcome: needs more data. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "spike",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "research #0125"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for HTTP handlers. Constraint: zero clippy::pedantic warnings. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0126"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Meeting on 2026-05-06 with PM + tech lead. Outcome: deferred to next iteration. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "meetings #0127"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "postmortems #0128"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Migration note \u2014 bench harness. Before: single curator interval. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "internal",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "code #0129"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Meeting on 2026-04-15 with alice + carol + dave. Outcome: approved with caveats. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "reading #0130"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "internal",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "code #0131"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "decisions #0132"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0133"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Design note for MCP server loop. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0134"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: draft.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0135"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: CI bench regression. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "meetings #0136"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Client soylent discussed namespace hierarchy rollout. Outcome: agreed on plan. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "security",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "contracts #0137"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Client initech discussed federation ack budget. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0138"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Code review of MCP server loop \u2014 feedback: shape looks right. Status: approved.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "conversations #0139"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on curator backlog growth. Source: academic paper. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0140"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Migration note \u2014 curator daemon. Before: single-tier TTL. After: configurable curator interval per tier. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "design"
+      ],
+      "tier": "long",
+      "title": "meetings #0141"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Migration note \u2014 memory_recall. Before: single curator interval. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "perf",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "conversations #0142"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Meeting on 2026-05-06 with PM + tech lead. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "decisions #0143"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Design note for memory_recall. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "code #0144"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Postmortem: embedder OOM on long input. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0145"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Client acme-corp discussed schema migration cadence. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "doc",
+        "decision",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "code #0146"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Meeting on 2026-05-06 with alice + erin + frank. Outcome: agreed on plan. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0147"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: ops on-call ping. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0148"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Client initech discussed curator backlog growth. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "conversations #0149"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Migration note \u2014 embedder module. Before: flat namespace, no hierarchy. After: namespace tree with /-delimited paths. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "blocker",
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0150"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Code review of MCP server loop \u2014 feedback: rebase before merge. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0151"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Meeting on 2026-04-29 with alice + bob. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0152"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "contracts #0153"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Design note for memory_kg_query. Constraint: no new dependencies. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "decision",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "decisions #0154"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Decision: TTL relaxation policy. Owner: alice. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "code #0155"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Design note for memory_kg_query. Constraint: must round-trip SQLite \u2194 Postgres. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "security",
+        "design"
+      ],
+      "tier": "long",
+      "title": "research #0156"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0157"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Code review of MCP server loop \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "conversations #0158"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Research note on TTL relaxation policy. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "internal",
+        "doc"
+      ],
+      "tier": "long",
+      "title": "code #0159"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "postmortem",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "research #0160"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 embed is 80% of latency. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "long",
+      "title": "runbooks #0161"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Migration note \u2014 bench harness. Before: single-tier TTL. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0162"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Code review of memory_kg_query \u2014 feedback: needs additional test. Status: approved.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "oncall #0163"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Meeting on 2026-05-13 with alice + carol + dave. Outcome: deferred to next iteration. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0164"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on embedder warmup. Source: conference talk. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0165"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Postmortem: federation quorum stall. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0166"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Design note for MCP server loop. Constraint: must round-trip SQLite \u2194 Postgres. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "decisions #0167"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Research note on schema migration cadence. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "mid",
+      "title": "meetings #0168"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Research note on curator backlog growth. Source: internal RFC. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0169"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Meeting on 2026-04-29 with alice + carol + dave. Outcome: blocked on dependency. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0170"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: user-reported slow start. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0171"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Research note on schema migration cadence. Source: academic paper. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "client",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "conversations #0172"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Migration note \u2014 memory_kg_query. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0173"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Design note for HTTP handlers. Constraint: must round-trip SQLite \u2194 Postgres. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "oncall #0174"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "code",
+        "follow-up",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0175"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Code review of embedder module \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "code #0176"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Client globex discussed agent-id rotation. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "design",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "conversations #0177"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0178"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: log spike in errors. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "code #0179"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Code review of memory_kg_query \u2014 feedback: shape looks right. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "meetings #0180"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Decision: vector index sizing. Owner: frank. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "oncall #0181"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Meeting on 2026-04-22 with alice + carol + dave. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "code",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "postmortems #0182"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "design",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "decisions #0183"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: per-tier TTL with promotion. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0184"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Research note on namespace hierarchy rollout. Source: vendor docs. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "contracts #0185"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Meeting on 2026-04-22 with alice + carol + dave. Outcome: approved with caveats. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0186"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Meeting on 2026-05-06 with PM + tech lead. Outcome: deferred to next iteration. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0187"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Migration note \u2014 embedder module. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "blocker",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "code #0188"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Postmortem: FTS index drift. Root cause: warm cache invalidated on hot reload. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "meetings #0189"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "internal",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "notes #0190"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Migration note \u2014 curator daemon. Before: flat namespace, no hierarchy. After: valid_from / valid_until on every link. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "conversations #0191"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Spike on federation ack budget. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0192"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Spike on TTL relaxation policy. Hypothesis: embed call dominates p95. Result: partial \u2014 only stalls > 8k chars. Next: add migration step.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "security",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0193"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: ops on-call ping. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "oncall #0194"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "incident",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "conversations #0195"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Client soylent discussed namespace hierarchy rollout. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "conversations #0196"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Decision: curator backlog growth. Owner: frank. Rationale: smallest blast radius. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0197"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Meeting on 2026-05-13 with alice + bob. Outcome: agreed on plan. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "internal",
+        "spike",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "papers #0198"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "long",
+      "title": "decisions #0199"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: CI bench regression. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "perf",
+        "security",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "conversations #0200"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Spike on vector index sizing. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "code #0201"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0202"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Research note on vector index sizing. Source: vendor docs. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "oncall #0203"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Research note on vector index sizing. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "meetings #0204"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Meeting on 2026-05-13 with alice + erin + frank. Outcome: deferred to next iteration. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "postmortem",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "meetings #0205"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: ack window mis-configured. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "meetings #0206"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Client umbrella discussed agent-id rotation. Outcome: agreed on plan. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "long",
+      "title": "contracts #0207"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Research note on agent-id rotation. Source: academic paper. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "contracts #0208"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of memory_recall \u2014 feedback: minor \u2014 naming nit. Status: changes requested.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "runbooks #0209"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Migration note \u2014 memory_recall. Before: flat namespace, no hierarchy. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "code #0210"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Research note on curator backlog growth. Source: conference talk. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "decisions #0211"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "rfc",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "oncall #0212"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Client initech discussed agent-id rotation. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0213"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Design note for HTTP handlers. Constraint: must round-trip SQLite \u2194 Postgres. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "decisions #0214"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Migration note \u2014 curator daemon. Before: flat namespace, no hierarchy. After: configurable curator interval per tier. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0215"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Spike on TTL relaxation policy. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "code #0216"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Research note on subscription replay. Source: vendor docs. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0217"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Spike on embedder warmup. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 embed is 80% of latency. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0218"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: deferred to next iteration. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0219"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Spike on schema migration cadence. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 embed is 80% of latency. Next: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0220"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: session_start latency regression. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "meetings #0221"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "mid",
+      "title": "decisions #0222"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: deferred to next iteration. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "oncall #0223"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Migration note \u2014 memory_kg_query. Before: single-tier TTL. After: configurable curator interval per tier. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "decisions #0224"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Spike on schema migration cadence. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 embed is 80% of latency. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "follow-up",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "decisions #0225"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Code review of MCP server loop \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0226"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Client globex discussed schema migration cadence. Outcome: deferred to next iteration. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0227"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Design note for MCP server loop. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "meeting",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "decisions #0228"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0229"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: user-reported slow start. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "code #0230"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: add migration step.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "oncall #0231"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Code review of memory_kg_query \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "meetings #0232"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Code review of MCP server loop \u2014 feedback: minor \u2014 naming nit. Status: blocked.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "reading #0233"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Client umbrella discussed vector index sizing. Outcome: blocked on dependency. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "oncall #0234"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Decision: federation ack budget. Owner: carol. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "datasets #0235"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: log spike in errors. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "research #0236"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Migration note \u2014 memory_recall. Before: synchronous-only embedder. After: valid_from / valid_until on every link. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0237"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Meeting on 2026-04-08 with engineering leads. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0238"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Code review of memory_kg_query \u2014 feedback: add a regression case. Status: draft.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "conversations #0239"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Postmortem: session_start latency regression. Root cause: missing index on temporal columns. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0240"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Decision: federation ack budget. Owner: frank. Rationale: best p95 trade-off. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "papers #0241"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: alert: p95 over budget. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "code"
+      ],
+      "tier": "long",
+      "title": "conversations #0242"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Client acme-corp discussed curator backlog growth. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0243"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Research note on FTS5 trigram tuning. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "security",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0244"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Migration note \u2014 curator daemon. Before: no temporal columns on links. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "postmortems #0245"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Spike on curator backlog growth. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0246"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Client acme-corp discussed agent-id rotation. Outcome: needs more data. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "datasets #0247"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Postmortem: session_start latency regression. Root cause: ack window mis-configured. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0248"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "doc",
+        "open-question",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "decisions #0249"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "internal",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "decisions #0250"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Migration note \u2014 memory_recall. Before: no temporal columns on links. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0251"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Spike on agent-id rotation. Hypothesis: curator stalls on long content. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0252"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "conversations #0253"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Research note on TTL relaxation policy. Source: vendor docs. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0254"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0255"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Spike on subscription replay. Hypothesis: curator stalls on long content. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0256"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Research note on curator backlog growth. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0257"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Decision: curator backlog growth. Owner: frank. Rationale: lowest-risk path forward. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "migration",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "meetings #0258"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Code review of bench harness \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "rfc",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "notes #0259"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Migration note \u2014 HTTP handlers. Before: single-tier TTL. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "notes #0260"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "code"
+      ],
+      "tier": "long",
+      "title": "code #0261"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on curator backlog growth. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "spike",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "oncall #0262"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Research note on schema migration cadence. Source: vendor docs. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "review",
+        "deploy",
+        "client"
+      ],
+      "tier": "long",
+      "title": "meetings #0263"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "datasets #0264"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: needs more data. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0265"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Research note on curator backlog growth. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0266"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Code review of HTTP handlers \u2014 feedback: add a regression case. Status: merged.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0267"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Design note for memory_kg_query. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "review",
+        "meeting",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "conversations #0268"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Postmortem: FTS index drift. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration",
+        "code",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "code #0269"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Migration note \u2014 curator daemon. Before: no temporal columns on links. After: namespace tree with /-delimited paths. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "meetings #0270"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: ops on-call ping. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "oncall #0271"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Decision: agent-id rotation. Owner: erin. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "postmortem",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "contracts #0272"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Decision: TTL relaxation policy. Owner: frank. Rationale: lowest-risk path forward. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "code",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "papers #0273"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Postmortem: embedder OOM on long input. Root cause: missing index on temporal columns. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "meetings #0274"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Client initech discussed TTL relaxation policy. Outcome: approved with caveats. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "design"
+      ],
+      "tier": "long",
+      "title": "conversations #0275"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Spike on agent-id rotation. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "doc",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "notes #0276"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Meeting on 2026-04-08 with alice + erin + frank. Outcome: needs more data. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "conversations #0277"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Meeting on 2026-04-29 with engineering leads. Outcome: blocked on dependency. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "long",
+      "title": "decisions #0278"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Spike on subscription replay. Hypothesis: curator stalls on long content. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0279"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for memory_kg_query. Constraint: no new dependencies. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "review",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "research #0280"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Design note for embedder module. Constraint: must round-trip SQLite \u2194 Postgres. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "client",
+        "open-question",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "meetings #0281"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "contracts #0282"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Design note for embedder module. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "code #0283"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client initech discussed FTS5 trigram tuning. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "rfc",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0284"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Research note on TTL relaxation policy. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0285"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Migration note \u2014 curator daemon. Before: flat namespace, no hierarchy. After: configurable curator interval per tier. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "internal",
+        "security",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "papers #0286"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Decision: curator backlog growth. Owner: bob. Rationale: operator feedback unanimous. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "decisions #0287"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Migration note \u2014 memory_recall. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0288"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Code review of MCP server loop \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "datasets #0289"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: alert: p95 over budget. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "code #0290"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Migration note \u2014 curator daemon. Before: synchronous-only embedder. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0291"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Client umbrella discussed TTL relaxation policy. Outcome: blocked on dependency. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0292"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Spike on schema migration cadence. Hypothesis: FTS5 dominates p99. Result: partial \u2014 only stalls > 8k chars. Next: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "conversations #0293"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Client initech discussed TTL relaxation policy. Outcome: agreed on plan. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "doc",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "datasets #0294"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: best p95 trade-off. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "spike",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "conversations #0295"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: user-reported slow start. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "papers #0296"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code"
+      ],
+      "tier": "long",
+      "title": "postmortems #0297"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "decisions #0298"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: FTS5 trigram tuning. Owner: heidi. Rationale: compatible with v0.7 plan. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0299"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Migration note \u2014 HTTP handlers. Before: single curator interval. After: valid_from / valid_until on every link. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "oncall #0300"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Research note on schema migration cadence. Source: vendor docs. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "review",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "postmortems #0301"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Client soylent discussed embedder warmup. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0302"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "datasets #0303"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Spike on curator backlog growth. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0304"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Decision: FTS5 trigram tuning. Owner: dave. Rationale: operator feedback unanimous. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "contracts #0305"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Migration note \u2014 memory_recall. Before: single curator interval. After: namespace tree with /-delimited paths. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "decision",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0306"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Spike on TTL relaxation policy. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "migration",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "notes #0307"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Research note on agent-id rotation. Source: internal RFC. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0308"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Client globex discussed federation ack budget. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0309"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0310"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: alert: p95 over budget. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0311"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Design note for HTTP handlers. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0312"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: smallest blast radius. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "meeting",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "code #0313"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Spike on embedder warmup. Hypothesis: embed call dominates p95. Result: confirmed \u2014 embed is 80% of latency. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "code #0314"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Decision: TTL relaxation policy. Owner: alice. Rationale: smallest blast radius. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "contracts #0315"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: agreed on plan. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "conversations #0316"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: alert: p95 over budget. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "contracts #0317"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: ops on-call ping. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0318"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Migration note \u2014 memory_recall. Before: no temporal columns on links. After: namespace tree with /-delimited paths. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "contracts #0319"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0320"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Design note for HTTP handlers. Constraint: no new dependencies. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "code #0321"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: compatible with v0.7 plan. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0322"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on federation ack budget. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 embed is 80% of latency. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "long",
+      "title": "papers #0323"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Design note for HTTP handlers. Constraint: must round-trip SQLite \u2194 Postgres. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "code #0324"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "contracts #0325"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Migration note \u2014 HTTP handlers. Before: synchronous-only embedder. After: valid_from / valid_until on every link. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "papers #0326"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Postmortem: session_start latency regression. Root cause: LLM client lacked timeout. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision",
+        "client"
+      ],
+      "tier": "long",
+      "title": "papers #0327"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: schema migration cadence. Owner: grace. Rationale: compatible with v0.7 plan. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0328"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: log spike in errors. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "meetings #0329"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Code review of HTTP handlers \u2014 feedback: rebase before merge. Status: merged.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "contracts #0330"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Migration note \u2014 bench harness. Before: flat namespace, no hierarchy. After: valid_from / valid_until on every link. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "notes #0331"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: draft.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "oncall #0332"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Migration note \u2014 embedder module. Before: no temporal columns on links. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "oncall #0333"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "review",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "reading #0334"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Research note on curator backlog growth. Source: academic paper. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "papers #0335"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "contracts #0336"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on namespace hierarchy rollout. Source: vendor docs. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0337"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Decision: schema migration cadence. Owner: heidi. Rationale: best p95 trade-off. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0338"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Migration note \u2014 MCP server loop. Before: flat namespace, no hierarchy. After: namespace tree with /-delimited paths. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0339"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Design note for memory_kg_query. Constraint: zero clippy::pedantic warnings. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0340"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Meeting on 2026-04-22 with PM + tech lead. Outcome: approved with caveats. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "conversations #0341"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: embed call dominates p95. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "meeting",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "contracts #0342"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Meeting on 2026-05-06 with PM + tech lead. Outcome: approved with caveats. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "oncall #0343"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0344"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: alert: p95 over budget. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "security",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0345"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on federation ack budget. Hypothesis: embed call dominates p95. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "security",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "papers #0346"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on FTS5 trigram tuning. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "long",
+      "title": "conversations #0347"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Design note for memory_recall. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike",
+        "design"
+      ],
+      "tier": "long",
+      "title": "decisions #0348"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Decision: vector index sizing. Owner: grace. Rationale: compatible with v0.7 plan. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0349"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Code review of memory_kg_query \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0350"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on curator backlog growth. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "deploy",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "code #0351"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Decision: vector index sizing. Owner: erin. Rationale: best p95 trade-off. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0352"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Decision: schema migration cadence. Owner: grace. Rationale: lowest-risk path forward. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0353"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Migration note \u2014 embedder module. Before: single curator interval. After: per-tier TTL with promotion. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "decision",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "meetings #0354"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Design note for embedder module. Constraint: zero clippy::pedantic warnings. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0355"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on TTL relaxation policy. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "conversations #0356"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Spike on subscription replay. Hypothesis: rerank adds <5 ms. Result: rejected \u2014 FTS5 within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0357"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for memory_recall. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "decisions #0358"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Client soylent discussed curator backlog growth. Outcome: deferred to next iteration. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "code #0359"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Decision: TTL relaxation policy. Owner: grace. Rationale: lowest-risk path forward. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision",
+        "open-question",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "runbooks #0360"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Research note on federation ack budget. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "doc",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "reading #0361"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on TTL relaxation policy. Source: conference talk. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0362"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "reading #0363"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Spike on subscription replay. Hypothesis: embed call dominates p95. Result: rejected \u2014 FTS5 within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "review"
+      ],
+      "tier": "long",
+      "title": "conversations #0364"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Spike on TTL relaxation policy. Hypothesis: embed call dominates p95. Result: partial \u2014 only stalls > 8k chars. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "postmortems #0365"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: alert: p95 over budget. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "client",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0366"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "conversations #0367"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: log spike in errors. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "code #0368"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Migration note \u2014 curator daemon. Before: single-tier TTL. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0369"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Design note for memory_recall. Constraint: p95 < 100 ms on M4. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "spike",
+        "doc"
+      ],
+      "tier": "long",
+      "title": "postmortems #0370"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "decisions #0371"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: vector index sizing. Owner: carol. Rationale: lowest-risk path forward. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "internal",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "contracts #0372"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Decision: schema migration cadence. Owner: heidi. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0373"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "research #0374"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "security",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0375"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Research note on embedder warmup. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "spike",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "notes #0376"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Migration note \u2014 MCP server loop. Before: no temporal columns on links. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "decisions #0377"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Decision: federation ack budget. Owner: frank. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0378"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: warm cache invalidated on hot reload. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision",
+        "design"
+      ],
+      "tier": "long",
+      "title": "decisions #0379"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Decision: embedder warmup. Owner: frank. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "code #0380"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Research note on TTL relaxation policy. Source: conference talk. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design",
+        "client",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "meetings #0381"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Research note on namespace hierarchy rollout. Source: internal RFC. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "review",
+        "vendor",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "contracts #0382"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "research #0383"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Client globex discussed embedder warmup. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "open-question",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "research #0384"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Decision: embedder warmup. Owner: dave. Rationale: operator feedback unanimous. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0385"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Spike on subscription replay. Hypothesis: embed call dominates p95. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0386"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: ops on-call ping. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0387"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Design note for bench harness. Constraint: must round-trip SQLite \u2194 Postgres. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "review",
+        "meeting",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "reading #0388"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Code review of memory_recall \u2014 feedback: rebase before merge. Status: draft.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "long",
+      "title": "postmortems #0389"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Research note on agent-id rotation. Source: external blog. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0390"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: federation quorum stall. Root cause: warm cache invalidated on hot reload. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "oncall #0391"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Client umbrella discussed subscription replay. Outcome: needs more data. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0392"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Client globex discussed curator backlog growth. Outcome: deferred to next iteration. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "internal",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "meetings #0393"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Client acme-corp discussed federation ack budget. Outcome: approved with caveats. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0394"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "papers #0395"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Decision: FTS5 trigram tuning. Owner: frank. Rationale: smallest blast radius. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0396"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Decision: namespace hierarchy rollout. Owner: dave. Rationale: compatible with v0.7 plan. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "contracts #0397"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "decisions #0398"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0399"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Migration note \u2014 bench harness. Before: single curator interval. After: valid_from / valid_until on every link. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "decisions #0400"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Code review of curator daemon \u2014 feedback: rebase before merge. Status: approved.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "spike",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "contracts #0401"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Design note for memory_recall. Constraint: p95 < 100 ms on M4. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0402"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: TTL relaxation policy. Owner: heidi. Rationale: compatible with v0.7 plan. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "notes #0403"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Research note on embedder warmup. Source: internal RFC. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf",
+        "design",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "conversations #0404"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Client soylent discussed namespace hierarchy rollout. Outcome: deferred to next iteration. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0405"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Research note on embedder warmup. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0406"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: CI bench regression. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "mid",
+      "title": "meetings #0407"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Decision: vector index sizing. Owner: frank. Rationale: operator feedback unanimous. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "oncall #0408"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Decision: embedder warmup. Owner: carol. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "conversations #0409"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: alert: p95 over budget. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0410"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0411"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Meeting on 2026-05-06 with engineering leads. Outcome: approved with caveats. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "notes #0412"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Code review of HTTP handlers \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "contracts #0413"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Meeting on 2026-04-22 with PM + tech lead. Outcome: agreed on plan. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0414"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Decision: vector index sizing. Owner: heidi. Rationale: best p95 trade-off. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "conversations #0415"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "incident",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "decisions #0416"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Client initech discussed vector index sizing. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "contracts #0417"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Migration note \u2014 MCP server loop. Before: no temporal columns on links. After: configurable curator interval per tier. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0418"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Decision: agent-id rotation. Owner: heidi. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "vendor",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "conversations #0419"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Code review of embedder module \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "doc",
+        "design",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "meetings #0420"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Meeting on 2026-04-15 with alice + bob. Outcome: deferred to next iteration. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "internal",
+        "code",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "research #0421"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: FTS index drift. Root cause: ack window mis-configured. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "mid",
+      "title": "contracts #0422"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client initech discussed namespace hierarchy rollout. Outcome: needs more data. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "oncall #0423"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: needs more data. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "notes #0424"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0425"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Code review of memory_kg_query \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "migration",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "notes #0426"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Research note on namespace hierarchy rollout. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code",
+        "spike",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "papers #0427"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Research note on curator backlog growth. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "spike",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "decisions #0428"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Migration note \u2014 embedder module. Before: single curator interval. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "client",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "oncall #0429"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Meeting on 2026-05-13 with alice + bob. Outcome: needs more data. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "decisions #0430"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Postmortem: federation quorum stall. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "long",
+      "title": "meetings #0431"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Client initech discussed embedder warmup. Outcome: blocked on dependency. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0432"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Spike on embedder warmup. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "decisions #0433"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Research note on agent-id rotation. Source: vendor docs. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision",
+        "client"
+      ],
+      "tier": "long",
+      "title": "datasets #0434"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "code #0435"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Spike on TTL relaxation policy. Hypothesis: rerank adds <5 ms. Result: partial \u2014 only stalls > 8k chars. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "meetings #0436"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Design note for memory_kg_query. Constraint: p95 < 100 ms on M4. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision",
+        "rfc",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "postmortems #0437"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Research note on namespace hierarchy rollout. Source: external blog. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "code #0438"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "conversations #0439"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Migration note \u2014 MCP server loop. Before: no temporal columns on links. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "open-question",
+        "client"
+      ],
+      "tier": "long",
+      "title": "conversations #0440"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Research note on curator backlog growth. Source: vendor docs. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "oncall #0441"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "reading #0442"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client globex discussed vector index sizing. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "open-question",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "contracts #0443"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0444"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: alert: p95 over budget. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security",
+        "blocker",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "reading #0445"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client acme-corp discussed federation ack budget. Outcome: blocked on dependency. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "oncall #0446"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Code review of memory_recall \u2014 feedback: rebase before merge. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "meetings #0447"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Postmortem: federation quorum stall. Root cause: ack window mis-configured. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0448"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "blocker",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "reading #0449"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Client soylent discussed curator backlog growth. Outcome: approved with caveats. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "reading #0450"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Decision: subscription replay. Owner: carol. Rationale: compatible with v0.7 plan. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "code #0451"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "contracts #0452"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Code review of bench harness \u2014 feedback: shape looks right. Status: approved.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "conversations #0453"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Meeting on 2026-04-08 with alice + erin + frank. Outcome: agreed on plan. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "papers #0454"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Code review of memory_kg_query \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "code #0455"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client acme-corp discussed FTS5 trigram tuning. Outcome: needs more data. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "rfc",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "code #0456"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Spike on embedder warmup. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0457"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Research note on vector index sizing. Source: academic paper. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0458"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Spike on schema migration cadence. Hypothesis: embed call dominates p95. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "design",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "decisions #0459"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client globex discussed federation ack budget. Outcome: blocked on dependency. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "code",
+        "design",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "code #0460"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Research note on curator backlog growth. Source: conference talk. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0461"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on embedder warmup. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0462"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: federation ack budget. Owner: bob. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "meetings #0463"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Spike on TTL relaxation policy. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 embed is 80% of latency. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "code #0464"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: lowest-risk path forward. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "code #0465"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Decision: embedder warmup. Owner: bob. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "long",
+      "title": "runbooks #0466"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Spike on federation ack budget. Hypothesis: curator stalls on long content. Result: rejected \u2014 FTS5 within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "decision",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "oncall #0467"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Code review of MCP server loop \u2014 feedback: shape looks right. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "design",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "code #0468"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: missing index on temporal columns. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "contracts #0469"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on TTL relaxation policy. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "research #0470"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: namespace tree with /-delimited paths. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0471"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "reading #0472"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "notes #0473"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "decisions #0474"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "notes #0475"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Meeting on 2026-04-15 with alice + bob. Outcome: blocked on dependency. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0476"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Code review of HTTP handlers \u2014 feedback: minor \u2014 naming nit. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0477"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Code review of MCP server loop \u2014 feedback: minor \u2014 naming nit. Status: merged.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "contracts #0478"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "conversations #0479"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Postmortem: session_start latency regression. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "review",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "decisions #0480"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Spike on vector index sizing. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "conversations #0481"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Code review of memory_recall \u2014 feedback: rebase before merge. Status: changes requested.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration",
+        "code",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "runbooks #0482"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Research note on schema migration cadence. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal",
+        "client"
+      ],
+      "tier": "long",
+      "title": "contracts #0483"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Client acme-corp discussed FTS5 trigram tuning. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "contracts #0484"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Design note for embedder module. Constraint: no new dependencies. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0485"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Decision: federation ack budget. Owner: heidi. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "review",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "reading #0486"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Postmortem: federation quorum stall. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "client",
+        "internal",
+        "design"
+      ],
+      "tier": "long",
+      "title": "contracts #0487"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for bench harness. Constraint: backwards compatible with v0.6.2. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "review"
+      ],
+      "tier": "long",
+      "title": "conversations #0488"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Code review of embedder module \u2014 feedback: shape looks right. Status: changes requested.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "migration",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "code #0489"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Design note for HTTP handlers. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "papers #0490"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Client globex discussed embedder warmup. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0491"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "decision",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "conversations #0492"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Design note for memory_recall. Constraint: must round-trip SQLite \u2194 Postgres. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0493"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "decisions #0494"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Decision: agent-id rotation. Owner: grace. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "meetings #0495"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Migration note \u2014 embedder module. Before: no temporal columns on links. After: valid_from / valid_until on every link. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "security"
+      ],
+      "tier": "long",
+      "title": "papers #0496"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Code review of bench harness \u2014 feedback: shape looks right. Status: draft.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "papers #0497"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Code review of HTTP handlers \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "internal",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "contracts #0498"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "research #0499"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Decision: curator backlog growth. Owner: grace. Rationale: lowest-risk path forward. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "reading #0500"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Design note for embedder module. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc",
+        "code"
+      ],
+      "tier": "long",
+      "title": "conversations #0501"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Spike on agent-id rotation. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "review",
+        "open-question",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0502"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Spike on agent-id rotation. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "vendor",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "meetings #0503"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0504"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Migration note \u2014 MCP server loop. Before: single curator interval. After: configurable curator interval per tier. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "security",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "contracts #0505"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "mid",
+      "title": "meetings #0506"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Design note for MCP server loop. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "decisions #0507"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Design note for HTTP handlers. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "postmortems #0508"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Postmortem: session_start latency regression. Root cause: LLM client lacked timeout. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0509"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Spike on embedder warmup. Hypothesis: embed call dominates p95. Result: rejected \u2014 FTS5 within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "deploy",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "meetings #0510"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: user-reported slow start. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0511"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Migration note \u2014 embedder module. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "vendor",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "conversations #0512"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Design note for HTTP handlers. Constraint: backwards compatible with v0.6.2. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "security",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "research #0513"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Spike on schema migration cadence. Hypothesis: HNSW build cost is amortizable. Result: partial \u2014 only stalls > 8k chars. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0514"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of bench harness \u2014 feedback: shape looks right. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0515"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0516"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Migration note \u2014 curator daemon. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0517"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0518"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Code review of HTTP handlers \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0519"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of HTTP handlers \u2014 feedback: needs additional test. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "decisions #0520"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Client initech discussed embedder warmup. Outcome: agreed on plan. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "code #0521"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Code review of MCP server loop \u2014 feedback: needs additional test. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "research #0522"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Code review of HTTP handlers \u2014 feedback: rebase before merge. Status: approved.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0523"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: blocked.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "oncall #0524"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Design note for embedder module. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "internal",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "datasets #0525"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Spike on subscription replay. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0526"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Client initech discussed federation ack budget. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "code"
+      ],
+      "tier": "long",
+      "title": "postmortems #0527"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Research note on curator backlog growth. Source: internal RFC. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0528"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Migration note \u2014 embedder module. Before: flat namespace, no hierarchy. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "code #0529"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 embed is 80% of latency. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration",
+        "client",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "decisions #0530"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: embed call dominates p95. Result: confirmed \u2014 amortizable across cycles. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "oncall #0531"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Meeting on 2026-05-13 with PM + tech lead. Outcome: needs more data. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "doc",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0532"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Client initech discussed schema migration cadence. Outcome: blocked on dependency. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0533"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on namespace hierarchy rollout. Source: conference talk. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security",
+        "migration",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "conversations #0534"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Meeting on 2026-05-13 with alice + carol + dave. Outcome: approved with caveats. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "client",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0535"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Decision: federation ack budget. Owner: dave. Rationale: compatible with v0.7 plan. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "postmortems #0536"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Code review of HTTP handlers \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "client",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "decisions #0537"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Migration note \u2014 memory_kg_query. Before: synchronous-only embedder. After: background embedder pool. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "conversations #0538"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Postmortem: federation quorum stall. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "contracts #0539"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "decisions #0540"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: warm cache invalidated on hot reload. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision",
+        "code",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "research #0541"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Decision: FTS5 trigram tuning. Owner: alice. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "postmortem",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "meetings #0542"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Client acme-corp discussed embedder warmup. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "vendor",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "oncall #0543"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Research note on TTL relaxation policy. Source: external blog. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "reading #0544"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: alert: p95 over budget. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "reading #0545"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: log spike in errors. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "client",
+        "deploy",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "conversations #0546"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Research note on namespace hierarchy rollout. Source: internal RFC. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "internal",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "postmortems #0547"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Client initech discussed embedder warmup. Outcome: approved with caveats. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "notes #0548"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Spike on curator backlog growth. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0549"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "long",
+      "title": "conversations #0550"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "blocker",
+        "review"
+      ],
+      "tier": "long",
+      "title": "contracts #0551"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Decision: embedder warmup. Owner: frank. Rationale: compatible with v0.7 plan. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "papers #0552"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Code review of MCP server loop \u2014 feedback: needs additional test. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "code #0553"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: user-reported slow start. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "internal",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "conversations #0554"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Design note for MCP server loop. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "notes #0555"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Decision: curator backlog growth. Owner: alice. Rationale: operator feedback unanimous. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "meetings #0556"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Meeting on 2026-04-22 with engineering leads. Outcome: blocked on dependency. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "papers #0557"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Decision: schema migration cadence. Owner: frank. Rationale: lowest-risk path forward. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike",
+        "doc",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "reading #0558"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Code review of curator daemon \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0559"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Research note on vector index sizing. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0560"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Migration note \u2014 memory_kg_query. Before: single curator interval. After: per-tier TTL with promotion. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0561"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Client globex discussed agent-id rotation. Outcome: blocked on dependency. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "spike",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "conversations #0562"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Spike on agent-id rotation. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "open-question",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "decisions #0563"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Client umbrella discussed subscription replay. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0564"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Postmortem: FTS index drift. Root cause: LLM client lacked timeout. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0565"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Decision: curator backlog growth. Owner: grace. Rationale: operator feedback unanimous. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "client",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "reading #0566"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Client acme-corp discussed vector index sizing. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "notes #0567"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Meeting on 2026-04-29 with PM + tech lead. Outcome: approved with caveats. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "code #0568"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Migration note \u2014 memory_recall. Before: flat namespace, no hierarchy. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0569"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Decision: federation ack budget. Owner: dave. Rationale: smallest blast radius. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0570"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: curator backlog growth. Owner: erin. Rationale: best p95 trade-off. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security",
+        "perf",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "postmortems #0571"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Spike on schema migration cadence. Hypothesis: embed call dominates p95. Result: rejected \u2014 FTS5 within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "conversations #0572"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "security",
+        "open-question",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "reading #0573"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on embedder warmup. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0574"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Spike on TTL relaxation policy. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "doc",
+        "security",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0575"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Client soylent discussed embedder warmup. Outcome: needs more data. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "spike",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "decisions #0576"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Postmortem: session_start latency regression. Root cause: ack window mis-configured. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0577"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: CI bench regression. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "meetings #0578"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Research note on schema migration cadence. Source: internal RFC. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "decisions #0579"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Client globex discussed schema migration cadence. Outcome: needs more data. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "oncall #0580"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Spike on subscription replay. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "internal",
+        "design",
+        "code"
+      ],
+      "tier": "long",
+      "title": "meetings #0581"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Postmortem: session_start latency regression. Root cause: ack window mis-configured. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0582"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Research note on embedder warmup. Source: internal RFC. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design",
+        "client"
+      ],
+      "tier": "long",
+      "title": "contracts #0583"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Spike on subscription replay. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0584"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0585"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on agent-id rotation. Source: internal RFC. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0586"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Postmortem: federation quorum stall. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "decisions #0587"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0588"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Meeting on 2026-04-22 with engineering leads. Outcome: blocked on dependency. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "conversations #0589"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Migration note \u2014 MCP server loop. Before: no temporal columns on links. After: per-tier TTL with promotion. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "code #0590"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Design note for memory_kg_query. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "reading #0591"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Client soylent discussed namespace hierarchy rollout. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "papers #0592"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on vector index sizing. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0593"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Research note on schema migration cadence. Source: vendor docs. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0594"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: needs more data. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0595"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Research note on embedder warmup. Source: external blog. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "perf",
+        "postmortem",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "conversations #0596"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: ops on-call ping. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0597"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "meeting",
+        "client"
+      ],
+      "tier": "long",
+      "title": "oncall #0598"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Decision: curator backlog growth. Owner: bob. Rationale: compatible with v0.7 plan. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "doc",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "postmortems #0599"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "research #0600"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for MCP server loop. Constraint: must round-trip SQLite \u2194 Postgres. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "meetings #0601"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0602"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Research note on embedder warmup. Source: vendor docs. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "follow-up",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "papers #0603"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: CI bench regression. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0604"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Spike on vector index sizing. Hypothesis: embed call dominates p95. Result: rejected \u2014 FTS5 within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "postmortems #0605"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Design note for curator daemon. Constraint: backwards compatible with v0.6.2. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "notes #0606"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Spike on curator backlog growth. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "meetings #0607"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Meeting on 2026-04-08 with alice + erin + frank. Outcome: agreed on plan. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "code #0608"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "conversations #0609"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Design note for bench harness. Constraint: zero clippy::pedantic warnings. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc",
+        "internal",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "code #0610"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: draft.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "reading #0611"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: approved with caveats. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "internal",
+        "spike",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "datasets #0612"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Design note for memory_kg_query. Constraint: must round-trip SQLite \u2194 Postgres. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "postmortem",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0613"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: partial \u2014 only stalls > 8k chars. Next: add migration step.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "incident",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0614"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Design note for memory_kg_query. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "deploy",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "meetings #0615"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Code review of bench harness \u2014 feedback: add a regression case. Status: changes requested.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0616"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "client"
+      ],
+      "tier": "long",
+      "title": "oncall #0617"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Code review of embedder module \u2014 feedback: minor \u2014 naming nit. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "research #0618"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Client globex discussed embedder warmup. Outcome: needs more data. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0619"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Migration note \u2014 memory_recall. Before: flat namespace, no hierarchy. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security",
+        "design"
+      ],
+      "tier": "long",
+      "title": "datasets #0620"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Design note for HTTP handlers. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0621"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Migration note \u2014 HTTP handlers. Before: synchronous-only embedder. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "contracts #0622"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Decision: namespace hierarchy rollout. Owner: heidi. Rationale: compatible with v0.7 plan. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "datasets #0623"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Design note for HTTP handlers. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "decisions #0624"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: log spike in errors. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "spike",
+        "code"
+      ],
+      "tier": "long",
+      "title": "decisions #0625"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Design note for bench harness. Constraint: p95 < 100 ms on M4. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "contracts #0626"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Code review of bench harness \u2014 feedback: minor \u2014 naming nit. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "rfc",
+        "review"
+      ],
+      "tier": "long",
+      "title": "meetings #0627"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Meeting on 2026-04-29 with alice + carol + dave. Outcome: blocked on dependency. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "vendor",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "reading #0628"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Spike on subscription replay. Hypothesis: rerank adds <5 ms. Result: rejected \u2014 FTS5 within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0629"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of embedder module \u2014 feedback: needs additional test. Status: changes requested.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "security",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "notes #0630"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Design note for curator daemon. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "notes #0631"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Migration note \u2014 HTTP handlers. Before: synchronous-only embedder. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "client",
+        "perf",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "reading #0632"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Design note for memory_kg_query. Constraint: backwards compatible with v0.6.2. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0633"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Client soylent discussed schema migration cadence. Outcome: deferred to next iteration. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "datasets #0634"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Decision: vector index sizing. Owner: frank. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0635"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Client umbrella discussed schema migration cadence. Outcome: needs more data. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "oncall #0636"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Postmortem: session_start latency regression. Root cause: input not truncated before tokenize. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "reading #0637"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0638"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: alert: p95 over budget. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "papers #0639"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0640"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of memory_kg_query \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "open-question",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "conversations #0641"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "deploy",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "decisions #0642"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Design note for MCP server loop. Constraint: backwards compatible with v0.6.2. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0643"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Meeting on 2026-05-13 with PM + tech lead. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0644"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Migration note \u2014 HTTP handlers. Before: single curator interval. After: configurable curator interval per tier. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "oncall #0645"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Code review of memory_kg_query \u2014 feedback: add a regression case. Status: changes requested.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "decisions #0646"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on FTS5 trigram tuning. Source: academic paper. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "meetings #0647"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Migration note \u2014 embedder module. Before: single-tier TTL. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "meetings #0648"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Postmortem: session_start latency regression. Root cause: missing index on temporal columns. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "decisions #0649"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "review",
+        "open-question",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "meetings #0650"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Migration note \u2014 embedder module. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0651"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Decision: curator backlog growth. Owner: bob. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "notes #0652"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: missing index on temporal columns. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code",
+        "deploy",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0653"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Code review of MCP server loop \u2014 feedback: needs additional test. Status: changes requested.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "incident",
+        "follow-up",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0654"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Code review of embedder module \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "perf",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "meetings #0655"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Design note for bench harness. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "oncall #0656"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "perf",
+        "spike",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "decisions #0657"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Postmortem: embedder OOM on long input. Root cause: missing index on temporal columns. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0658"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on FTS5 trigram tuning. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "blocker",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "conversations #0659"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: user-reported slow start. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "meetings #0660"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Spike on TTL relaxation policy. Hypothesis: rerank adds <5 ms. Result: partial \u2014 only stalls > 8k chars. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0661"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Decision: FTS5 trigram tuning. Owner: erin. Rationale: operator feedback unanimous. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "meetings #0662"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Research note on FTS5 trigram tuning. Source: external blog. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0663"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "oncall #0664"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Client acme-corp discussed federation ack budget. Outcome: agreed on plan. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "spike",
+        "follow-up",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "decisions #0665"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: alert: p95 over budget. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "spike",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "decisions #0666"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Code review of curator daemon \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "doc",
+        "follow-up",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0667"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client soylent discussed curator backlog growth. Outcome: blocked on dependency. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "decision",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "decisions #0668"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Code review of memory_recall \u2014 feedback: needs additional test. Status: blocked.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "papers #0669"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: alert: p95 over budget. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0670"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Research note on TTL relaxation policy. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0671"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on embedder warmup. Source: academic paper. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "doc",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "reading #0672"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "reading #0673"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Spike on subscription replay. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "decisions #0674"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client globex discussed schema migration cadence. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "migration",
+        "follow-up",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "decisions #0675"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Meeting on 2026-04-29 with engineering leads. Outcome: approved with caveats. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "spike",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "contracts #0676"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Design note for memory_recall. Constraint: p95 < 100 ms on M4. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0677"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal",
+        "perf",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "meetings #0678"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: alert: p95 over budget. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0679"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Migration note \u2014 bench harness. Before: single-tier TTL. After: namespace tree with /-delimited paths. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "meetings #0680"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Spike on embedder warmup. Hypothesis: curator stalls on long content. Result: rejected \u2014 FTS5 within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0681"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "papers #0682"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Design note for memory_kg_query. Constraint: zero clippy::pedantic warnings. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0683"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of memory_recall \u2014 feedback: rebase before merge. Status: merged.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "oncall #0684"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: changes requested.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "decisions #0685"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on embedder warmup. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "spike",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "research #0686"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Decision: federation ack budget. Owner: bob. Rationale: smallest blast radius. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "vendor",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "reading #0687"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Research note on vector index sizing. Source: academic paper. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "meetings #0688"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: input not truncated before tokenize. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "code",
+        "perf",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "decisions #0689"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client acme-corp discussed curator backlog growth. Outcome: needs more data. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "security",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "notes #0690"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Spike on TTL relaxation policy. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0691"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Spike on federation ack budget. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 embed is 80% of latency. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "doc"
+      ],
+      "tier": "long",
+      "title": "meetings #0692"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: embed call dominates p95. Result: confirmed \u2014 rerank within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0693"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Client umbrella discussed federation ack budget. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "datasets #0694"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Migration note \u2014 curator daemon. Before: flat namespace, no hierarchy. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0695"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Client umbrella discussed curator backlog growth. Outcome: needs more data. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "doc",
+        "client"
+      ],
+      "tier": "long",
+      "title": "decisions #0696"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Migration note \u2014 MCP server loop. Before: single curator interval. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "reading #0697"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "blocker",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "notes #0698"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Client acme-corp discussed embedder warmup. Outcome: approved with caveats. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "decisions #0699"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: schema migration cadence. Owner: erin. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "reading #0700"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "meeting",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "runbooks #0701"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Migration note \u2014 MCP server loop. Before: single curator interval. After: valid_from / valid_until on every link. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "decisions #0702"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Decision: namespace hierarchy rollout. Owner: erin. Rationale: operator feedback unanimous. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0703"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Client soylent discussed schema migration cadence. Outcome: deferred to next iteration. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "long",
+      "title": "meetings #0704"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Postmortem: session_start latency regression. Root cause: input not truncated before tokenize. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "review",
+        "design",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "datasets #0705"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Client initech discussed schema migration cadence. Outcome: blocked on dependency. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "contracts #0706"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Decision: vector index sizing. Owner: dave. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "conversations #0707"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Research note on TTL relaxation policy. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0708"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision",
+        "code",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "decisions #0709"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Migration note \u2014 memory_kg_query. Before: flat namespace, no hierarchy. After: background embedder pool. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "review",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "decisions #0710"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Decision: curator backlog growth. Owner: grace. Rationale: smallest blast radius. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "client"
+      ],
+      "tier": "long",
+      "title": "research #0711"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Postmortem: FTS index drift. Root cause: LLM client lacked timeout. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "blocker",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "contracts #0712"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Client initech discussed embedder warmup. Outcome: blocked on dependency. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "contracts #0713"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of memory_kg_query \u2014 feedback: rebase before merge. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "security",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "code #0714"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Decision: namespace hierarchy rollout. Owner: bob. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "conversations #0715"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Postmortem: FTS index drift. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0716"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Spike on agent-id rotation. Hypothesis: curator stalls on long content. Result: confirmed \u2014 rerank within budget. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "doc",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "decisions #0717"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client soylent discussed curator backlog growth. Outcome: approved with caveats. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0718"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Meeting on 2026-05-13 with alice + carol + dave. Outcome: blocked on dependency. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "code",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "meetings #0719"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on vector index sizing. Source: conference talk. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0720"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Design note for embedder module. Constraint: no new dependencies. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "conversations #0721"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Migration note \u2014 bench harness. Before: no temporal columns on links. After: background embedder pool. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "datasets #0722"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Postmortem: FTS index drift. Root cause: warm cache invalidated on hot reload. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "decisions #0723"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Code review of memory_kg_query \u2014 feedback: rebase before merge. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "meetings #0724"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Client initech discussed subscription replay. Outcome: blocked on dependency. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "postmortems #0725"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Client globex discussed schema migration cadence. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0726"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Meeting on 2026-04-08 with engineering leads. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "code #0727"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Design note for MCP server loop. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0728"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on TTL relaxation policy. Source: academic paper. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "conversations #0729"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Postmortem: embedder OOM on long input. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "research #0730"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: best p95 trade-off. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "vendor",
+        "design"
+      ],
+      "tier": "long",
+      "title": "meetings #0731"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: input not truncated before tokenize. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "security",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0732"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Research note on schema migration cadence. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0733"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Decision: vector index sizing. Owner: carol. Rationale: smallest blast radius. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "conversations #0734"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "client",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "code #0735"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: user-reported slow start. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "internal",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "code #0736"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Meeting on 2026-04-29 with alice + erin + frank. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision",
+        "code",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "postmortems #0737"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Research note on schema migration cadence. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "runbooks #0738"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Spike on agent-id rotation. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0739"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client globex discussed subscription replay. Outcome: agreed on plan. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0740"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Meeting on 2026-04-22 with engineering leads. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "meetings #0741"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "client",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "decisions #0742"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "review",
+        "rfc",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "reading #0743"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Research note on federation ack budget. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "contracts #0744"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Migration note \u2014 memory_kg_query. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "decisions #0745"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Decision: schema migration cadence. Owner: carol. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "client",
+        "design",
+        "security"
+      ],
+      "tier": "long",
+      "title": "conversations #0746"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Design note for memory_recall. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0747"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Spike on curator backlog growth. Hypothesis: embed call dominates p95. Result: confirmed \u2014 embed is 80% of latency. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "reading #0748"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Spike on TTL relaxation policy. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0749"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Meeting on 2026-04-15 with alice + carol + dave. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "security",
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "datasets #0750"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Research note on TTL relaxation policy. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "papers #0751"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Meeting on 2026-05-13 with alice + bob. Outcome: needs more data. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0752"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Decision: namespace hierarchy rollout. Owner: carol. Rationale: best p95 trade-off. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0753"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Client acme-corp discussed vector index sizing. Outcome: blocked on dependency. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "contracts #0754"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "conversations #0755"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on vector index sizing. Source: vendor docs. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0756"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Postmortem: session_start latency regression. Root cause: ack window mis-configured. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0757"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Research note on TTL relaxation policy. Source: external blog. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0758"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Client soylent discussed subscription replay. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0759"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "research #0760"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Design note for embedder module. Constraint: must round-trip SQLite \u2194 Postgres. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0761"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Decision: curator backlog growth. Owner: grace. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0762"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Migration note \u2014 curator daemon. Before: no temporal columns on links. After: valid_from / valid_until on every link. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident",
+        "internal",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "meetings #0763"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Design note for curator daemon. Constraint: must round-trip SQLite \u2194 Postgres. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0764"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Design note for embedder module. Constraint: must round-trip SQLite \u2194 Postgres. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0765"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Decision: FTS5 trigram tuning. Owner: erin. Rationale: smallest blast radius. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal",
+        "doc",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "papers #0766"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Client initech discussed agent-id rotation. Outcome: blocked on dependency. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "code #0767"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Postmortem: embedder OOM on long input. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0768"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Postmortem: session_start latency regression. Root cause: LLM client lacked timeout. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0769"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Client acme-corp discussed namespace hierarchy rollout. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0770"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Code review of MCP server loop \u2014 feedback: minor \u2014 naming nit. Status: blocked.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "notes #0771"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: log spike in errors. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "follow-up",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "decisions #0772"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Spike on embedder warmup. Hypothesis: rerank adds <5 ms. Result: confirmed \u2014 embed is 80% of latency. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "research #0773"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client umbrella discussed embedder warmup. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "decision",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "reading #0774"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security",
+        "meeting",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "conversations #0775"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Client acme-corp discussed subscription replay. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "code #0776"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Code review of bench harness \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "long",
+      "title": "code #0777"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Client soylent discussed federation ack budget. Outcome: deferred to next iteration. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "review",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "decisions #0778"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: alert: p95 over budget. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "design",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "research #0779"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Spike on TTL relaxation policy. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 rerank within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "perf",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0780"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Decision: subscription replay. Owner: erin. Rationale: smallest blast radius. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "code #0781"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Migration note \u2014 memory_kg_query. Before: single-tier TTL. After: background embedder pool. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "decisions #0782"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Spike on curator backlog growth. Hypothesis: curator stalls on long content. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "code #0783"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Decision: embedder warmup. Owner: frank. Rationale: smallest blast radius. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "spike",
+        "design",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "conversations #0784"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "review",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0785"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Decision: TTL relaxation policy. Owner: alice. Rationale: best p95 trade-off. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "decisions #0786"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Migration note \u2014 memory_kg_query. Before: synchronous-only embedder. After: configurable curator interval per tier. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "meetings #0787"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Research note on subscription replay. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "code #0788"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Postmortem: FTS index drift. Root cause: ack window mis-configured. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0789"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Spike on curator backlog growth. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0790"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Spike on curator backlog growth. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 embed is 80% of latency. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "rfc",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "postmortems #0791"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Postmortem: FTS index drift. Root cause: missing index on temporal columns. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review",
+        "deploy",
+        "security"
+      ],
+      "tier": "long",
+      "title": "research #0792"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Decision: namespace hierarchy rollout. Owner: bob. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "conversations #0793"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on embedder warmup. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0794"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Research note on schema migration cadence. Source: academic paper. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "code",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0795"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Code review of MCP server loop \u2014 feedback: shape looks right. Status: draft.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "open-question",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "decisions #0796"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Code review of bench harness \u2014 feedback: needs additional test. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "contracts #0797"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of memory_recall \u2014 feedback: shape looks right. Status: blocked.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "follow-up",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "papers #0798"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Code review of memory_kg_query \u2014 feedback: rebase before merge. Status: changes requested.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "client",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "reading #0799"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Meeting on 2026-04-29 with engineering leads. Outcome: approved with caveats. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "doc",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "code #0800"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Code review of MCP server loop \u2014 feedback: shape looks right. Status: draft.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "datasets #0801"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Research note on schema migration cadence. Source: conference talk. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0802"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Research note on schema migration cadence. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "client"
+      ],
+      "tier": "long",
+      "title": "reading #0803"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Design note for curator daemon. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0804"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Design note for HTTP handlers. Constraint: must round-trip SQLite \u2194 Postgres. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "contracts #0805"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Client soylent discussed agent-id rotation. Outcome: blocked on dependency. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0806"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Design note for memory_kg_query. Constraint: backwards compatible with v0.6.2. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0807"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: ops on-call ping. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design",
+        "spike",
+        "incident"
+      ],
+      "tier": "long",
+      "title": "contracts #0808"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Meeting on 2026-04-22 with alice + erin + frank. Outcome: approved with caveats. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "incident",
+        "meeting",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "decisions #0809"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Research note on agent-id rotation. Source: external blog. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "spike",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "reading #0810"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Migration note \u2014 MCP server loop. Before: single-tier TTL. After: background embedder pool. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "oncall #0811"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "postmortem",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "datasets #0812"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: log spike in errors. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "reading #0813"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0814"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Design note for memory_kg_query. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "reading #0815"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Meeting on 2026-05-13 with engineering leads. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "research #0816"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Research note on FTS5 trigram tuning. Source: academic paper. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0817"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Spike on agent-id rotation. Hypothesis: HNSW build cost is amortizable. Result: rejected \u2014 FTS5 within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "open-question",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "meetings #0818"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "decision",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "meetings #0819"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Meeting on 2026-05-13 with PM + tech lead. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0820"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Spike on embedder warmup. Hypothesis: embed call dominates p95. Result: confirmed \u2014 rerank within budget. Next: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0821"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Meeting on 2026-05-06 with alice + bob. Outcome: blocked on dependency. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "follow-up",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "notes #0822"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Decision: agent-id rotation. Owner: bob. Rationale: compatible with v0.7 plan. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "decision",
+        "design"
+      ],
+      "tier": "long",
+      "title": "contracts #0823"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Decision: federation ack budget. Owner: frank. Rationale: best p95 trade-off. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0824"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Design note for curator daemon. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "security",
+        "vendor",
+        "code"
+      ],
+      "tier": "mid",
+      "title": "research #0825"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: ops on-call ping. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "client",
+        "code",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "papers #0826"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: blocked on dependency. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "papers #0827"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Meeting on 2026-04-29 with PM + tech lead. Outcome: needs more data. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "design",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "research #0828"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Design note for bench harness. Constraint: p95 < 100 ms on M4. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "long",
+      "title": "conversations #0829"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on namespace hierarchy rollout. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration"
+      ],
+      "tier": "long",
+      "title": "meetings #0830"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Postmortem: federation quorum stall. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "decisions #0831"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: CI bench regression. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0832"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Client umbrella discussed vector index sizing. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "doc",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "datasets #0833"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Code review of MCP server loop \u2014 feedback: rebase before merge. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0834"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Decision: subscription replay. Owner: frank. Rationale: best p95 trade-off. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "meetings #0835"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Research note on federation ack budget. Source: conference talk. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0836"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Meeting on 2026-05-13 with alice + carol + dave. Outcome: agreed on plan. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "spike",
+        "perf",
+        "security"
+      ],
+      "tier": "long",
+      "title": "conversations #0837"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Migration note \u2014 MCP server loop. Before: no temporal columns on links. After: configurable curator interval per tier. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "decisions #0838"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Spike on vector index sizing. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "incident",
+        "postmortem",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "datasets #0839"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "incident",
+        "client"
+      ],
+      "tier": "long",
+      "title": "code #0840"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Migration note \u2014 memory_kg_query. Before: synchronous-only embedder. After: per-tier TTL with promotion. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "decision",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "notes #0841"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "migration",
+        "open-question",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "code #0842"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Code review of embedder module \u2014 feedback: shape looks right. Status: changes requested.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "papers #0843"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Client acme-corp discussed vector index sizing. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "code",
+        "follow-up",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "meetings #0844"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: input not truncated before tokenize. Mitigation: raise W=2 timeout to 5 s.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0845"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Research note on TTL relaxation policy. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0846"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Decision: agent-id rotation. Owner: heidi. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "migration",
+        "client",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "meetings #0847"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Decision: curator backlog growth. Owner: erin. Rationale: lowest-risk path forward. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike",
+        "migration",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "contracts #0848"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Migration note \u2014 memory_kg_query. Before: single curator interval. After: valid_from / valid_until on every link. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0849"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Spike on FTS5 trigram tuning. Hypothesis: FTS5 dominates p99. Result: rejected \u2014 FTS5 within budget. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "conversations #0850"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on FTS5 trigram tuning. Source: external blog. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "long",
+      "title": "papers #0851"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Migration note \u2014 memory_kg_query. Before: no temporal columns on links. After: configurable curator interval per tier. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "security",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "conversations #0852"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Postmortem: federation quorum stall. Root cause: warm cache invalidated on hot reload. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "migration"
+      ],
+      "tier": "long",
+      "title": "conversations #0853"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code",
+        "client",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "contracts #0854"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Decision: embedder warmup. Owner: erin. Rationale: lowest-risk path forward. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0855"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Runbook entry \u2014 embedder warmup. Trigger: log spike in errors. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "oncall #0856"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Research note on curator backlog growth. Source: external blog. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0857"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Migration note \u2014 curator daemon. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "reading #0858"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Decision: schema migration cadence. Owner: carol. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "runbooks #0859"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Code review of memory_recall \u2014 feedback: minor \u2014 naming nit. Status: approved.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design",
+        "perf"
+      ],
+      "tier": "long",
+      "title": "decisions #0860"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Postmortem: federation quorum stall. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "blocker",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "decisions #0861"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Meeting on 2026-04-15 with alice + erin + frank. Outcome: needs more data. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "review",
+        "code"
+      ],
+      "tier": "long",
+      "title": "papers #0862"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Spike on embedder warmup. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 rerank within budget. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0863"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Migration note \u2014 memory_kg_query. Before: single-tier TTL. After: configurable curator interval per tier. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "oncall #0864"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Research note on federation ack budget. Source: external blog. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "notes #0865"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "design",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "meetings #0866"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: agreed on plan. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "vendor",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "oncall #0867"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Spike on subscription replay. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "conversations #0868"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Postmortem: embedder OOM on long input. Root cause: input not truncated before tokenize. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "decision",
+        "design",
+        "review"
+      ],
+      "tier": "long",
+      "title": "decisions #0869"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Design note for MCP server loop. Constraint: zero clippy::pedantic warnings. Approach: opt-in CLI flag.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0870"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Client globex discussed subscription replay. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "code #0871"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Meeting on 2026-04-22 with alice + bob. Outcome: needs more data. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0872"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Code review of embedder module \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "spike",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "conversations #0873"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Decision: namespace hierarchy rollout. Owner: bob. Rationale: smallest blast radius. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "decisions #0874"
+    },
+    {
+      "confidence": 0.65,
+      "content": "Meeting on 2026-04-08 with alice + carol + dave. Outcome: approved with caveats. Action items: carol benchmarks fixture.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0875"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Decision: curator backlog growth. Owner: bob. Rationale: lowest-risk path forward. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "design",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "contracts #0876"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Postmortem: FTS index drift. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "migration",
+        "follow-up",
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "decisions #0877"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Spike on federation ack budget. Hypothesis: curator stalls on long content. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0878"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Research note on agent-id rotation. Source: vendor docs. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "contracts #0879"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Client globex discussed curator backlog growth. Outcome: agreed on plan. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "review"
+      ],
+      "tier": "mid",
+      "title": "papers #0880"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: agent-id rotation. Owner: alice. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "spike",
+        "migration",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "contracts #0881"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Postmortem: federation quorum stall. Root cause: input not truncated before tokenize. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "client",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "research #0882"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Decision: TTL relaxation policy. Owner: frank. Rationale: smallest blast radius. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "code #0883"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: namespace hierarchy rollout. Owner: heidi. Rationale: operator feedback unanimous. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "conversations #0884"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Postmortem: session_start latency regression. Root cause: missing index on temporal columns. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0885"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: ops on-call ping. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0886"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Decision: subscription replay. Owner: carol. Rationale: best p95 trade-off. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0887"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Migration note \u2014 curator daemon. Before: synchronous-only embedder. After: valid_from / valid_until on every link. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "internal",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "contracts #0888"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Client initech discussed curator backlog growth. Outcome: agreed on plan. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "mid",
+      "title": "datasets #0889"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Migration note \u2014 memory_recall. Before: flat namespace, no hierarchy. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0890"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Research note on agent-id rotation. Source: external blog. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "doc",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "research #0891"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Decision: vector index sizing. Owner: erin. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0892"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Research note on schema migration cadence. Source: academic paper. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "deploy"
+      ],
+      "tier": "long",
+      "title": "decisions #0893"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Runbook entry \u2014 agent-id rotation. Trigger: CI bench regression. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0894"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Client globex discussed FTS5 trigram tuning. Outcome: agreed on plan. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "decisions #0895"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Runbook entry \u2014 TTL relaxation policy. Trigger: ops on-call ping. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "spike",
+        "open-question",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "decisions #0896"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Spike on embedder warmup. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "datasets #0897"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Code review of MCP server loop \u2014 feedback: minor \u2014 naming nit. Status: changes requested.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "rfc",
+        "spike",
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "contracts #0898"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: agreed on plan. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "datasets #0899"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Meeting on 2026-04-15 with PM + tech lead. Outcome: needs more data. Action items: frank verifies CI.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "meeting",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0900"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Code review of curator daemon \u2014 feedback: minor \u2014 naming nit. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "contracts #0901"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Migration note \u2014 curator daemon. Before: single-tier TTL. After: per-tier TTL with promotion. Risk: low \u2014 pure additive.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "perf",
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "code #0902"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Migration note \u2014 MCP server loop. Before: synchronous-only embedder. After: configurable curator interval per tier. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0903"
+    },
+    {
+      "confidence": 0.84,
+      "content": "Postmortem: FTS index drift. Root cause: LLM client lacked timeout. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "deploy",
+        "security",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "decisions #0904"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Migration note \u2014 memory_recall. Before: single-tier TTL. After: valid_from / valid_until on every link. Risk: low \u2014 gated behind opt-in flag.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "research #0905"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Research note on federation ack budget. Source: external blog. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0906"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Spike on schema migration cadence. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "migration",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "datasets #0907"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Migration note \u2014 MCP server loop. Before: flat namespace, no hierarchy. After: namespace tree with /-delimited paths. Risk: medium \u2014 needs migration plan.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "design"
+      ],
+      "tier": "long",
+      "title": "decisions #0908"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Design note for memory_kg_query. Constraint: backwards compatible with v0.6.2. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "datasets #0909"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Decision: TTL relaxation policy. Owner: alice. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "client",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "meetings #0910"
+    },
+    {
+      "confidence": 0.66,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "contracts #0911"
+    },
+    {
+      "confidence": 0.75,
+      "content": "Decision: schema migration cadence. Owner: bob. Rationale: operator feedback unanimous. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "reading #0912"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Client initech discussed namespace hierarchy rollout. Outcome: approved with caveats. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "postmortem",
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "oncall #0913"
+    },
+    {
+      "confidence": 0.98,
+      "content": "Design note for bench harness. Constraint: no new dependencies. Approach: two-phase rollout.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "code #0914"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Decision: embedder warmup. Owner: dave. Rationale: compatible with v0.7 plan. Next step: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0915"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0916"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Meeting on 2026-05-13 with PM + tech lead. Outcome: blocked on dependency. Action items: erin writes RFC.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "research #0917"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Research note on agent-id rotation. Source: vendor docs. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0918"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Client soylent discussed TTL relaxation policy. Outcome: approved with caveats. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "doc"
+      ],
+      "tier": "long",
+      "title": "papers #0919"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Research note on federation ack budget. Source: academic paper. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "runbooks #0920"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Design note for memory_recall. Constraint: zero clippy::pedantic warnings. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident",
+        "spike",
+        "design"
+      ],
+      "tier": "mid",
+      "title": "datasets #0921"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Postmortem: curator runaway on stuck LLM. Root cause: LLM client lacked timeout. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "client",
+        "deploy",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "decisions #0922"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Research note on embedder warmup. Source: vendor docs. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security",
+        "decision",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "conversations #0923"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on federation ack budget. Source: internal RFC. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "security"
+      ],
+      "tier": "mid",
+      "title": "decisions #0924"
+    },
+    {
+      "confidence": 0.61,
+      "content": "Decision: namespace hierarchy rollout. Owner: alice. Rationale: compatible with v0.7 plan. Next step: wire into bench harness.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "long",
+      "title": "reading #0925"
+    },
+    {
+      "confidence": 0.76,
+      "content": "Research note on subscription replay. Source: academic paper. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "meetings #0926"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Design note for MCP server loop. Constraint: zero clippy::pedantic warnings. Approach: schema bump with backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "doc",
+        "decision"
+      ],
+      "tier": "mid",
+      "title": "decisions #0927"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: approved.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "meeting",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "contracts #0928"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Research note on schema migration cadence. Source: academic paper. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "decision",
+        "postmortem",
+        "deploy"
+      ],
+      "tier": "mid",
+      "title": "papers #0929"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Research note on FTS5 trigram tuning. Source: vendor docs. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "blocker",
+        "review"
+      ],
+      "tier": "long",
+      "title": "postmortems #0930"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Design note for embedder module. Constraint: backwards compatible with v0.6.2. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "decisions #0931"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Research note on subscription replay. Source: conference talk. Takeaway: validates the schema choice.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "meetings #0932"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Spike on curator backlog growth. Hypothesis: HNSW build cost is amortizable. Result: confirmed \u2014 amortizable across cycles. Next: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "long",
+      "title": "code #0933"
+    },
+    {
+      "confidence": 0.7,
+      "content": "Client acme-corp discussed namespace hierarchy rollout. Outcome: needs more data. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "decisions #0934"
+    },
+    {
+      "confidence": 0.79,
+      "content": "Code review of MCP server loop \u2014 feedback: needs additional test. Status: changes requested.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "doc",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "runbooks #0935"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Spike on schema migration cadence. Hypothesis: FTS5 dominates p99. Result: confirmed \u2014 embed is 80% of latency. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "incident",
+        "vendor"
+      ],
+      "tier": "mid",
+      "title": "conversations #0936"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Code review of HTTP handlers \u2014 feedback: shape looks right. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "incident"
+      ],
+      "tier": "long",
+      "title": "research #0937"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Migration note \u2014 memory_recall. Before: synchronous-only embedder. After: namespace tree with /-delimited paths. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "perf",
+        "open-question"
+      ],
+      "tier": "long",
+      "title": "research #0938"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Code review of memory_recall \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "migration",
+        "review",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "datasets #0939"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Code review of HTTP handlers \u2014 feedback: rebase before merge. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "rfc",
+        "client"
+      ],
+      "tier": "long",
+      "title": "meetings #0940"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Design note for memory_recall. Constraint: zero clippy::pedantic warnings. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "mid",
+      "title": "contracts #0941"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Runbook entry \u2014 subscription replay. Trigger: alert: p95 over budget. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "incident",
+        "deploy",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "postmortems #0942"
+    },
+    {
+      "confidence": 0.82,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "notes #0943"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Client umbrella discussed FTS5 trigram tuning. Outcome: approved with caveats. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "papers #0944"
+    },
+    {
+      "confidence": 0.9,
+      "content": "Code review of bench harness \u2014 feedback: minor \u2014 naming nit. Status: blocked.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "contracts #0945"
+    },
+    {
+      "confidence": 0.92,
+      "content": "Decision: agent-id rotation. Owner: alice. Rationale: smallest blast radius. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "meetings #0946"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Research note on agent-id rotation. Source: conference talk. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "conversations #0947"
+    },
+    {
+      "confidence": 0.72,
+      "content": "Runbook entry \u2014 vector index sizing. Trigger: user-reported slow start. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "open-question"
+      ],
+      "tier": "mid",
+      "title": "oncall #0948"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client soylent discussed namespace hierarchy rollout. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "meetings #0949"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: user-reported slow start. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "meetings #0950"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Runbook entry \u2014 namespace hierarchy rollout. Trigger: user-reported slow start. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0951"
+    },
+    {
+      "confidence": 0.74,
+      "content": "Client acme-corp discussed namespace hierarchy rollout. Outcome: needs more data. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up"
+      ],
+      "tier": "long",
+      "title": "reading #0952"
+    },
+    {
+      "confidence": 0.8,
+      "content": "Postmortem: FTS index drift. Root cause: input not truncated before tokenize. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "deploy",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "contracts #0953"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Migration note \u2014 memory_recall. Before: single curator interval. After: valid_from / valid_until on every link. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "code #0954"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Spike on schema migration cadence. Hypothesis: rerank adds <5 ms. Result: partial \u2014 only stalls > 8k chars. Next: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "spike",
+        "open-question",
+        "internal"
+      ],
+      "tier": "mid",
+      "title": "decisions #0955"
+    },
+    {
+      "confidence": 0.87,
+      "content": "Migration note \u2014 bench harness. Before: single curator interval. After: configurable curator interval per tier. Risk: low \u2014 schema is forward-compatible.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "perf",
+        "client",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "notes #0956"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Migration note \u2014 embedder module. Before: single curator interval. After: namespace tree with /-delimited paths. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "design",
+        "security"
+      ],
+      "tier": "long",
+      "title": "decisions #0957"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Code review of MCP server loop \u2014 feedback: rebase before merge. Status: merged.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0958"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Decision: FTS5 trigram tuning. Owner: heidi. Rationale: lowest-risk path forward. Next step: draft RFC for review.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "code",
+        "blocker",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "decisions #0959"
+    },
+    {
+      "confidence": 0.78,
+      "content": "Migration note \u2014 memory_recall. Before: single curator interval. After: namespace tree with /-delimited paths. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "spike",
+        "blocker",
+        "postmortem"
+      ],
+      "tier": "long",
+      "title": "conversations #0960"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: CI bench regression. Steps: drain queue, replay subscriptions, verify.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "code",
+        "meeting"
+      ],
+      "tier": "long",
+      "title": "meetings #0961"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Runbook entry \u2014 federation ack budget. Trigger: alert: p95 over budget. Steps: rotate agent-id, refresh tokens, alert ops.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "research #0962"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Decision: TTL relaxation policy. Owner: alice. Rationale: operator feedback unanimous. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "postmortem",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "contracts #0963"
+    },
+    {
+      "confidence": 0.86,
+      "content": "Postmortem: federation quorum stall. Root cause: ack window mis-configured. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "security",
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "decisions #0964"
+    },
+    {
+      "confidence": 0.89,
+      "content": "Postmortem: FTS index drift. Root cause: input not truncated before tokenize. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/alpha/code",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "internal",
+        "security"
+      ],
+      "tier": "mid",
+      "title": "code #0965"
+    },
+    {
+      "confidence": 1.0,
+      "content": "Client umbrella discussed curator backlog growth. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/conversations",
+      "priority": 8,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "doc"
+      ],
+      "tier": "long",
+      "title": "conversations #0966"
+    },
+    {
+      "confidence": 0.88,
+      "content": "Decision: curator backlog growth. Owner: carol. Rationale: compatible with v0.7 plan. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "notes #0967"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Client globex discussed vector index sizing. Outcome: agreed on plan. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "vendor",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "notes #0968"
+    },
+    {
+      "confidence": 0.99,
+      "content": "Runbook entry \u2014 schema migration cadence. Trigger: alert: p95 over budget. Steps: scale read replica, monitor for 30 min.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "runbooks #0969"
+    },
+    {
+      "confidence": 0.77,
+      "content": "Meeting on 2026-05-06 with alice + carol + dave. Outcome: deferred to next iteration. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "meetings #0970"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Client umbrella discussed vector index sizing. Outcome: deferred to next iteration. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "decision",
+        "blocker"
+      ],
+      "tier": "mid",
+      "title": "datasets #0971"
+    },
+    {
+      "confidence": 0.64,
+      "content": "Spike on TTL relaxation policy. Hypothesis: rerank adds <5 ms. Result: rejected \u2014 FTS5 within budget. Next: add migration step.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "spike",
+        "doc"
+      ],
+      "tier": "mid",
+      "title": "conversations #0972"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Spike on namespace hierarchy rollout. Hypothesis: embed call dominates p95. Result: partial \u2014 only stalls > 8k chars. Next: wire into bench harness.",
+      "metadata": {},
+      "namespace": "clients/globex/contracts",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0973"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Runbook entry \u2014 FTS5 trigram tuning. Trigger: log spike in errors. Steps: check journal, restart daemon, file ticket.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike"
+      ],
+      "tier": "mid",
+      "title": "code #0974"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Runbook entry \u2014 curator backlog growth. Trigger: log spike in errors. Steps: snapshot state, rollback, root-cause.",
+      "metadata": {},
+      "namespace": "personal/reading",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "reading #0975"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Decision: subscription replay. Owner: alice. Rationale: compatible with v0.7 plan. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/research",
+      "priority": 4,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "postmortem",
+        "perf"
+      ],
+      "tier": "mid",
+      "title": "research #0976"
+    },
+    {
+      "confidence": 0.93,
+      "content": "Decision: federation ack budget. Owner: alice. Rationale: best p95 trade-off. Next step: add migration step.",
+      "metadata": {},
+      "namespace": "ops/runbooks",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "runbooks #0977"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Postmortem: federation quorum stall. Root cause: input not truncated before tokenize. Mitigation: added index + backfill.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "vendor",
+        "follow-up"
+      ],
+      "tier": "mid",
+      "title": "decisions #0978"
+    },
+    {
+      "confidence": 0.6,
+      "content": "Postmortem: session_start latency regression. Root cause: warm cache invalidated on hot reload. Mitigation: wrap LLM call in deadline.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "migration",
+        "spike"
+      ],
+      "tier": "long",
+      "title": "meetings #0979"
+    },
+    {
+      "confidence": 0.85,
+      "content": "Code review of curator daemon \u2014 feedback: needs additional test. Status: draft.",
+      "metadata": {},
+      "namespace": "research/papers",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "migration",
+        "client"
+      ],
+      "tier": "mid",
+      "title": "papers #0980"
+    },
+    {
+      "confidence": 0.96,
+      "content": "Decision: FTS5 trigram tuning. Owner: grace. Rationale: operator feedback unanimous. Next step: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "spike",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "decisions #0981"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Client acme-corp discussed subscription replay. Outcome: deferred to next iteration. Follow-up: open PR by EOW.",
+      "metadata": {},
+      "namespace": "projects/alpha/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "review"
+      ],
+      "tier": "long",
+      "title": "meetings #0982"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on agent-id rotation. Source: academic paper. Takeaway: reinforces v0.7 sequencing.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 8,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "notes #0983"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Migration note \u2014 HTTP handlers. Before: single curator interval. After: configurable curator interval per tier. Risk: medium \u2014 Postgres mirror still WIP.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "client"
+      ],
+      "tier": "mid",
+      "title": "decisions #0984"
+    },
+    {
+      "confidence": 0.83,
+      "content": "Meeting on 2026-04-08 with alice + bob. Outcome: needs more data. Action items: dave updates runbook.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "follow-up",
+        "code",
+        "incident"
+      ],
+      "tier": "mid",
+      "title": "meetings #0985"
+    },
+    {
+      "confidence": 0.71,
+      "content": "Client globex discussed curator backlog growth. Outcome: needs more data. Follow-up: add migration step.",
+      "metadata": {},
+      "namespace": "research/datasets",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "datasets #0986"
+    },
+    {
+      "confidence": 0.91,
+      "content": "Research note on schema migration cadence. Source: internal RFC. Takeaway: raises a soak-test concern.",
+      "metadata": {},
+      "namespace": "clients/acme-corp/contracts",
+      "priority": 7,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "contracts #0987"
+    },
+    {
+      "confidence": 0.73,
+      "content": "Meeting on 2026-05-06 with engineering leads. Outcome: agreed on plan. Action items: alice files issue, bob drafts spec.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 3,
+      "source": "import",
+      "tags": [],
+      "tier": "long",
+      "title": "meetings #0988"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Client acme-corp discussed FTS5 trigram tuning. Outcome: blocked on dependency. Follow-up: draft RFC for review.",
+      "metadata": {},
+      "namespace": "ops/oncall",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "code"
+      ],
+      "tier": "long",
+      "title": "oncall #0989"
+    },
+    {
+      "confidence": 0.63,
+      "content": "Postmortem: session_start latency regression. Root cause: LLM client lacked timeout. Mitigation: truncate at 8k tokens.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "security",
+        "meeting"
+      ],
+      "tier": "mid",
+      "title": "meetings #0990"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Design note for curator daemon. Constraint: p95 < 100 ms on M4. Approach: behind a feature flag.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 4,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "conversations #0991"
+    },
+    {
+      "confidence": 0.69,
+      "content": "Code review of memory_recall \u2014 feedback: add a regression case. Status: blocked.",
+      "metadata": {},
+      "namespace": "projects/gamma/decisions",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "design",
+        "blocker",
+        "internal"
+      ],
+      "tier": "long",
+      "title": "decisions #0992"
+    },
+    {
+      "confidence": 0.67,
+      "content": "Research note on schema migration cadence. Source: conference talk. Takeaway: supports our current plan.",
+      "metadata": {},
+      "namespace": "projects/beta/meetings",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "decision",
+        "meeting",
+        "blocker"
+      ],
+      "tier": "long",
+      "title": "meetings #0993"
+    },
+    {
+      "confidence": 0.62,
+      "content": "Design note for MCP server loop. Constraint: no new dependencies. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/gamma/meetings",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "rfc"
+      ],
+      "tier": "mid",
+      "title": "meetings #0994"
+    },
+    {
+      "confidence": 0.81,
+      "content": "Client soylent discussed vector index sizing. Outcome: agreed on plan. Follow-up: wire into bench harness.",
+      "metadata": {},
+      "namespace": "projects/beta/code",
+      "priority": 3,
+      "source": "import",
+      "tags": [
+        "incident",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "code #0995"
+    },
+    {
+      "confidence": 0.68,
+      "content": "Client umbrella discussed FTS5 trigram tuning. Outcome: blocked on dependency. Follow-up: schedule follow-up sync.",
+      "metadata": {},
+      "namespace": "clients/globex/conversations",
+      "priority": 7,
+      "source": "import",
+      "tags": [
+        "spike",
+        "vendor",
+        "migration"
+      ],
+      "tier": "mid",
+      "title": "conversations #0996"
+    },
+    {
+      "confidence": 0.94,
+      "content": "Research note on agent-id rotation. Source: vendor docs. Takeaway: argues for opt-in default.",
+      "metadata": {},
+      "namespace": "personal/notes",
+      "priority": 5,
+      "source": "import",
+      "tags": [
+        "open-question",
+        "vendor",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "notes #0997"
+    },
+    {
+      "confidence": 0.95,
+      "content": "Design note for curator daemon. Constraint: backwards compatible with v0.6.2. Approach: incremental ALTER + index.",
+      "metadata": {},
+      "namespace": "projects/beta/decisions",
+      "priority": 6,
+      "source": "import",
+      "tags": [
+        "blocker",
+        "spike",
+        "decision"
+      ],
+      "tier": "long",
+      "title": "decisions #0998"
+    },
+    {
+      "confidence": 0.97,
+      "content": "Postmortem: FTS index drift. Root cause: input not truncated before tokenize. Mitigation: preload warm cache during startup.",
+      "metadata": {},
+      "namespace": "ops/postmortems",
+      "priority": 6,
+      "source": "import",
+      "tags": [],
+      "tier": "mid",
+      "title": "postmortems #0999"
+    }
+  ],
+  "schema_version": 1,
+  "seed": 20260426
+}

--- a/benchmarks/v063/gen_canonical_workload.py
+++ b/benchmarks/v063/gen_canonical_workload.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""
+Generate the v0.6.3 canonical workload fixture
+(`benchmarks/v063/canonical_workload.json`).
+
+The output is a deterministic 1000-memory seed that the curator-cycle
+bench consumes to time one full curator sweep against the 60 s p95
+budget published in `PERFORMANCE.md`. The generator is committed alongside
+its output so the fixture is reproducible: re-running this script with no
+arguments must produce a byte-identical JSON file.
+
+Schema (top-level JSON object):
+
+    {
+      "schema_version": 1,
+      "description": "...",
+      "seed": 20260426,
+      "count": 1000,
+      "memories": [
+        {
+          "tier": "mid" | "long",
+          "namespace": "projects/alpha/decisions",
+          "title": "...",
+          "content": "...",   # always >= curator MIN_CONTENT_LEN (50 chars)
+          "tags": ["..."],
+          "priority": 1..10,
+          "confidence": 0.0..1.0,
+          "source": "import",
+          "metadata": {}      # empty so curator.needs_curation() is true
+        },
+        ...
+      ]
+    }
+
+The shape lines up 1:1 with `crate::models::CreateMemory` so bench
+wiring can `serde_json::from_str` the file directly. The fixture is
+deliberately curator-eligible: every memory is in a public hierarchical
+namespace, content >= 50 chars, no auto_tags metadata, mid/long tier
+only — so a curator sweep finds 1000 candidates and exercises the
+LLM-bound auto_tag + detect_contradiction loop until `max_ops_per_cycle`
+is hit.
+
+Usage:
+
+    cd benchmarks/v063
+    python3 gen_canonical_workload.py
+    # writes canonical_workload.json next to this script
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+SEED = 20260426  # v0.6.3 ship-target month — bump if the seed changes
+COUNT = 1000
+
+NAMESPACES = [
+    "projects/alpha/decisions",
+    "projects/alpha/meetings",
+    "projects/alpha/code",
+    "projects/alpha/research",
+    "projects/beta/decisions",
+    "projects/beta/meetings",
+    "projects/beta/code",
+    "projects/gamma/decisions",
+    "projects/gamma/meetings",
+    "clients/acme-corp/contracts",
+    "clients/acme-corp/conversations",
+    "clients/globex/contracts",
+    "clients/globex/conversations",
+    "ops/runbooks",
+    "ops/postmortems",
+    "ops/oncall",
+    "personal/notes",
+    "personal/reading",
+    "research/papers",
+    "research/datasets",
+]
+
+TAG_POOL = [
+    "decision",
+    "meeting",
+    "code",
+    "design",
+    "review",
+    "blocker",
+    "follow-up",
+    "open-question",
+    "spike",
+    "rfc",
+    "incident",
+    "postmortem",
+    "deploy",
+    "migration",
+    "security",
+    "perf",
+    "doc",
+    "client",
+    "vendor",
+    "internal",
+]
+
+# Content templates that produce >= 50 chars after substitution. The curator
+# needs deterministic but varied content so detect_contradiction has at least
+# *some* signal between adjacent memories in the same namespace.
+TEMPLATES = [
+    "Decision: {topic}. Owner: {owner}. Rationale: {rationale}. Next step: {next}.",
+    "Meeting on {date} with {attendees}. Outcome: {outcome}. Action items: {actions}.",
+    "Code review of {component} — feedback: {feedback}. Status: {status}.",
+    "Design note for {component}. Constraint: {constraint}. Approach: {approach}.",
+    "Postmortem: {incident}. Root cause: {cause}. Mitigation: {mitigation}.",
+    "Runbook entry — {topic}. Trigger: {trigger}. Steps: {steps}.",
+    "Research note on {topic}. Source: {source}. Takeaway: {takeaway}.",
+    "Client {client} discussed {topic}. Outcome: {outcome}. Follow-up: {next}.",
+    "Spike on {topic}. Hypothesis: {hypothesis}. Result: {result}. Next: {next}.",
+    "Migration note — {component}. Before: {before}. After: {after}. Risk: {risk}.",
+]
+
+VOCAB = {
+    "topic": [
+        "vector index sizing",
+        "schema migration cadence",
+        "namespace hierarchy rollout",
+        "embedder warmup",
+        "FTS5 trigram tuning",
+        "curator backlog growth",
+        "federation ack budget",
+        "agent-id rotation",
+        "TTL relaxation policy",
+        "subscription replay",
+    ],
+    "owner": [
+        "alice",
+        "bob",
+        "carol",
+        "dave",
+        "erin",
+        "frank",
+        "grace",
+        "heidi",
+    ],
+    "rationale": [
+        "lowest-risk path forward",
+        "best p95 trade-off",
+        "operator feedback unanimous",
+        "compatible with v0.7 plan",
+        "smallest blast radius",
+    ],
+    "next": [
+        "open PR by EOW",
+        "draft RFC for review",
+        "schedule follow-up sync",
+        "wire into bench harness",
+        "add migration step",
+    ],
+    "date": [
+        "2026-04-08",
+        "2026-04-15",
+        "2026-04-22",
+        "2026-04-29",
+        "2026-05-06",
+        "2026-05-13",
+    ],
+    "attendees": [
+        "alice + bob",
+        "alice + carol + dave",
+        "engineering leads",
+        "PM + tech lead",
+        "alice + erin + frank",
+    ],
+    "outcome": [
+        "agreed on plan",
+        "deferred to next iteration",
+        "blocked on dependency",
+        "approved with caveats",
+        "needs more data",
+    ],
+    "actions": [
+        "alice files issue, bob drafts spec",
+        "carol benchmarks fixture",
+        "dave updates runbook",
+        "erin writes RFC",
+        "frank verifies CI",
+    ],
+    "component": [
+        "memory_recall",
+        "memory_kg_query",
+        "curator daemon",
+        "bench harness",
+        "HTTP handlers",
+        "MCP server loop",
+        "embedder module",
+    ],
+    "feedback": [
+        "minor — naming nit",
+        "needs additional test",
+        "shape looks right",
+        "rebase before merge",
+        "add a regression case",
+    ],
+    "status": [
+        "approved",
+        "changes requested",
+        "merged",
+        "blocked",
+        "draft",
+    ],
+    "constraint": [
+        "p95 < 100 ms on M4",
+        "no new dependencies",
+        "must round-trip SQLite ↔ Postgres",
+        "backwards compatible with v0.6.2",
+        "zero clippy::pedantic warnings",
+    ],
+    "approach": [
+        "incremental ALTER + index",
+        "behind a feature flag",
+        "opt-in CLI flag",
+        "schema bump with backfill",
+        "two-phase rollout",
+    ],
+    "incident": [
+        "FTS index drift",
+        "embedder OOM on long input",
+        "curator runaway on stuck LLM",
+        "federation quorum stall",
+        "session_start latency regression",
+    ],
+    "cause": [
+        "missing index on temporal columns",
+        "input not truncated before tokenize",
+        "LLM client lacked timeout",
+        "ack window mis-configured",
+        "warm cache invalidated on hot reload",
+    ],
+    "mitigation": [
+        "added index + backfill",
+        "truncate at 8k tokens",
+        "wrap LLM call in deadline",
+        "raise W=2 timeout to 5 s",
+        "preload warm cache during startup",
+    ],
+    "trigger": [
+        "alert: p95 over budget",
+        "ops on-call ping",
+        "user-reported slow start",
+        "CI bench regression",
+        "log spike in errors",
+    ],
+    "steps": [
+        "check journal, restart daemon, file ticket",
+        "drain queue, replay subscriptions, verify",
+        "rotate agent-id, refresh tokens, alert ops",
+        "snapshot state, rollback, root-cause",
+        "scale read replica, monitor for 30 min",
+    ],
+    "source": [
+        "internal RFC",
+        "external blog",
+        "conference talk",
+        "academic paper",
+        "vendor docs",
+    ],
+    "takeaway": [
+        "supports our current plan",
+        "argues for opt-in default",
+        "raises a soak-test concern",
+        "validates the schema choice",
+        "reinforces v0.7 sequencing",
+    ],
+    "client": [
+        "acme-corp",
+        "globex",
+        "initech",
+        "umbrella",
+        "soylent",
+    ],
+    "hypothesis": [
+        "embed call dominates p95",
+        "FTS5 dominates p99",
+        "curator stalls on long content",
+        "HNSW build cost is amortizable",
+        "rerank adds <5 ms",
+    ],
+    "result": [
+        "confirmed — embed is 80% of latency",
+        "rejected — FTS5 within budget",
+        "partial — only stalls > 8k chars",
+        "confirmed — amortizable across cycles",
+        "confirmed — rerank within budget",
+    ],
+    "before": [
+        "flat namespace, no hierarchy",
+        "no temporal columns on links",
+        "synchronous-only embedder",
+        "single curator interval",
+        "single-tier TTL",
+    ],
+    "after": [
+        "namespace tree with /-delimited paths",
+        "valid_from / valid_until on every link",
+        "background embedder pool",
+        "configurable curator interval per tier",
+        "per-tier TTL with promotion",
+    ],
+    "risk": [
+        "low — pure additive",
+        "medium — needs migration plan",
+        "low — gated behind opt-in flag",
+        "medium — Postgres mirror still WIP",
+        "low — schema is forward-compatible",
+    ],
+}
+
+
+def fill_template(rng: random.Random, template: str) -> str:
+    """Substitute every `{key}` in `template` with a random pick from VOCAB[key]."""
+    out = template
+    while "{" in out and "}" in out:
+        start = out.find("{")
+        end = out.find("}", start + 1)
+        if end == -1:
+            break
+        key = out[start + 1 : end]
+        choices = VOCAB.get(key)
+        if not choices:
+            # Unknown placeholder — leave as-is, will trip a unit test.
+            break
+        pick = rng.choice(choices)
+        out = out[:start] + pick + out[end + 1 :]
+    return out
+
+
+def main() -> None:
+    rng = random.Random(SEED)
+    memories = []
+    for idx in range(COUNT):
+        ns = rng.choice(NAMESPACES)
+        template = rng.choice(TEMPLATES)
+        content = fill_template(rng, template)
+        # Pad to make sure we always clear curator MIN_CONTENT_LEN (50). The
+        # template baseline is well above 50 in practice; this guards against
+        # a future tweak that shortens a vocab entry.
+        if len(content) < 60:
+            content = content + " " + "details pending follow-up sync."
+        title = f"{ns.split('/')[-1]} #{idx:04d}"
+        tag_count = rng.randint(0, 3)
+        tags = rng.sample(TAG_POOL, k=tag_count) if tag_count else []
+        tier = "long" if rng.random() < 0.4 else "mid"
+        priority = rng.randint(3, 8)
+        confidence = round(rng.uniform(0.6, 1.0), 2)
+        memories.append(
+            {
+                "tier": tier,
+                "namespace": ns,
+                "title": title,
+                "content": content,
+                "tags": tags,
+                "priority": priority,
+                "confidence": confidence,
+                "source": "import",
+                "metadata": {},
+            }
+        )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "description": (
+            "v0.6.3 canonical workload — 1000-memory deterministic seed for "
+            "the curator-cycle bench. Every entry is curator-eligible "
+            "(public namespace, content >= 50 chars, no auto_tags) so a "
+            "single sweep exercises auto_tag + detect_contradiction up to "
+            "max_ops_per_cycle. Schema mirrors crate::models::CreateMemory "
+            "for direct serde_json::from_str into the bench harness."
+        ),
+        "seed": SEED,
+        "count": COUNT,
+        "memories": memories,
+    }
+
+    out_path = Path(__file__).resolve().parent / "canonical_workload.json"
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {out_path} ({len(memories)} memories)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -27,14 +27,26 @@
 //! `memory_recall` cold/full hybrid) still require an embedder process
 //! and are tracked as follow-up Stream E work — they don't belong on
 //! the hot path of a `cargo test` invocation.
+//!
+//! The curator-cycle bench (opt-in via `ai-memory bench --with-curator`)
+//! seeds `benchmarks/v063/canonical_workload.json` (1000 deterministic
+//! memories) into a disposable `SQLite` and runs one
+//! [`crate::curator::run_once`] sweep against it, gated against the
+//! 60 s p95 row in `PERFORMANCE.md`. It requires a reachable Ollama
+//! endpoint with the configured curator model; when no LLM is
+//! available the CLI emits a clear message and skips the op rather
+//! than failing — the same opt-in/no-op pattern as `--with-embedding`.
 
 use anyhow::Result;
 use rusqlite::Connection;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+use crate::curator::{self, CuratorConfig};
 use crate::db;
-use crate::models::{Memory, Tier};
+use crate::llm::OllamaClient;
+use crate::models::{CreateMemory, Memory, Tier};
 
 /// CI guard tolerance — measured p95 may exceed budget by this factor
 /// before the run is marked `Fail`. Mirrors `PERFORMANCE.md`.
@@ -74,6 +86,11 @@ pub enum Operation {
     KgQueryDepth5,
     /// `memory_kg_timeline` — ordered timeline for a single source.
     KgTimeline,
+    /// One [`crate::curator::run_once`] sweep over the canonical
+    /// 1000-memory workload (`benchmarks/v063/canonical_workload.json`).
+    /// Opt-in via `--with-curator`; budget 60 s p95 (the
+    /// "curator cycle (1k memories)" row in `PERFORMANCE.md`).
+    CuratorCycle,
 }
 
 impl Operation {
@@ -87,6 +104,7 @@ impl Operation {
             Self::KgQueryDepth3 => "memory_kg_query (depth=3)",
             Self::KgQueryDepth5 => "memory_kg_query (depth=5)",
             Self::KgTimeline => "memory_kg_timeline",
+            Self::CuratorCycle => "curator cycle (1k memories)",
         }
     }
 
@@ -97,6 +115,8 @@ impl Operation {
     /// at "depth ≤ 5" (250 ms). `SearchFts` and `KgTimeline` happen to
     /// share the same numeric budget as the depth ≤ 3 bucket despite
     /// belonging to different table rows in `PERFORMANCE.md`.
+    /// `CuratorCycle` carries the 60 s p95 budget for the
+    /// "curator cycle (1k memories)" row.
     #[must_use]
     #[allow(clippy::match_same_arms)]
     pub fn target_p95_ms(self) -> f64 {
@@ -108,6 +128,7 @@ impl Operation {
             Self::KgQueryDepth3 => 100.0,
             Self::KgQueryDepth5 => 250.0,
             Self::KgTimeline => 100.0,
+            Self::CuratorCycle => 60_000.0,
         }
     }
 }
@@ -349,6 +370,172 @@ fn run_kg_timeline(
         }
     }
     Ok(percentile_summary(Operation::KgTimeline, &samples))
+}
+
+/// On-disk path components of the canonical 1000-memory workload
+/// fixture. Joined under `CARGO_MANIFEST_DIR` at runtime so the bench
+/// finds the file when invoked from the repo root (the only place
+/// `--with-curator` is meaningful — the file is not shipped with
+/// installed binaries).
+pub const CANONICAL_WORKLOAD_REL_PATH: &[&str] = &["benchmarks", "v063", "canonical_workload.json"];
+
+/// Per-cycle op cap for the curator-cycle bench. The default
+/// [`CuratorConfig`] caps at 100 ops/cycle to stop runaway LLM calls
+/// in production, but the published "curator cycle (1k memories)"
+/// budget assumes a full sweep — so the bench raises the cap to
+/// match the canonical workload size.
+const CURATOR_BENCH_MAX_OPS: usize = 1000;
+
+/// Wire-shape of `benchmarks/v063/canonical_workload.json`. Mirrors
+/// the schema pinned by `crate::canonical_workload` so any future
+/// rename of those fields surfaces here in compile errors instead of
+/// silently desynchronising the bench.
+#[derive(Debug, Deserialize)]
+struct CanonicalWorkload {
+    schema_version: u32,
+    seed: u64,
+    count: usize,
+    memories: Vec<CreateMemory>,
+}
+
+/// Schema version pinned by `tests/canonical_workload.rs`. Bumped here
+/// (and there) when the on-disk shape changes incompatibly.
+const CANONICAL_WORKLOAD_SCHEMA: u32 = 1;
+
+/// Deterministic RNG seed pinned by `benchmarks/v063/gen_canonical_workload.py`.
+/// Cross-checked at load time so a regenerated fixture with a drifted
+/// seed surfaces as a hard error instead of silently rebasing the bench
+/// numbers.
+const CANONICAL_WORKLOAD_SEED: u64 = 20_260_426;
+
+/// Resolved on-disk path to the canonical workload JSON. Returns the
+/// path even if the file is missing — callers handle the absent case.
+fn canonical_workload_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for seg in CANONICAL_WORKLOAD_REL_PATH {
+        p.push(seg);
+    }
+    p
+}
+
+/// Read the canonical workload JSON into a [`CanonicalWorkload`].
+///
+/// # Errors
+///
+/// Returns an error if the file is missing, unreadable, or fails the
+/// schema-version pin.
+fn load_canonical_workload() -> Result<CanonicalWorkload> {
+    let path = canonical_workload_path();
+    let raw = std::fs::read_to_string(&path).map_err(|e| {
+        anyhow::anyhow!(
+            "canonical workload fixture not found at {}: {e} \
+             (the file is generated by benchmarks/v063/gen_canonical_workload.py and shipped on `release/v0.6.3` via PR #402)",
+            path.display()
+        )
+    })?;
+    let w: CanonicalWorkload = serde_json::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("deserialize {}: {e}", path.display()))?;
+    if w.schema_version != CANONICAL_WORKLOAD_SCHEMA {
+        anyhow::bail!(
+            "canonical workload schema_version {} != expected {} ({}). \
+             update CANONICAL_WORKLOAD_SCHEMA after auditing curator-eligibility invariants",
+            w.schema_version,
+            CANONICAL_WORKLOAD_SCHEMA,
+            path.display(),
+        );
+    }
+    if w.seed != CANONICAL_WORKLOAD_SEED {
+        anyhow::bail!(
+            "canonical workload seed {} != expected {} ({}). \
+             a drifted seed silently rebases bench numbers — regenerate the fixture or update CANONICAL_WORKLOAD_SEED",
+            w.seed,
+            CANONICAL_WORKLOAD_SEED,
+            path.display(),
+        );
+    }
+    if w.memories.len() != w.count {
+        anyhow::bail!(
+            "canonical workload count {} != memories.len() {} ({})",
+            w.count,
+            w.memories.len(),
+            path.display(),
+        );
+    }
+    Ok(w)
+}
+
+/// Convert a [`CreateMemory`] (the fixture's wire shape) into the
+/// [`Memory`] expected by [`db::insert`]. Mirrors the inline
+/// `CreateMemory` → `Memory` translation used by `handlers::create_memory`
+/// minus the HTTP-only concerns (`agent_id` resolution, scope merge).
+fn create_memory_to_memory(c: CreateMemory) -> Memory {
+    let now = chrono::Utc::now().to_rfc3339();
+    Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: c.tier,
+        namespace: c.namespace,
+        title: c.title,
+        content: c.content,
+        tags: c.tags,
+        priority: c.priority.clamp(1, 10),
+        confidence: c.confidence.clamp(0.0, 1.0),
+        source: c.source,
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: c.expires_at,
+        metadata: c.metadata,
+    }
+}
+
+/// Seed the canonical 1000-memory workload from
+/// `benchmarks/v063/canonical_workload.json` into `conn`. Returns the
+/// number of memories actually inserted (== `count` on a fresh
+/// connection; lower if the namespace was already populated).
+///
+/// # Errors
+///
+/// Returns an error if the fixture is missing, malformed, or any
+/// individual insert fails.
+pub fn seed_canonical_workload(conn: &Connection) -> Result<usize> {
+    let workload = load_canonical_workload()?;
+    let mut inserted = 0usize;
+    for c in workload.memories {
+        let mem = create_memory_to_memory(c);
+        db::insert(conn, &mem)?;
+        inserted += 1;
+    }
+    Ok(inserted)
+}
+
+/// Run one [`curator::run_once`] sweep against the canonical 1000-memory
+/// workload and return the single-sample timing as a normalised
+/// [`OperationResult`]. The curator cycle is a multi-second op so we
+/// take a single sample (p50 = p95 = p99 = the measured value) rather
+/// than a percentile distribution — same shape every other op uses so
+/// downstream JSON consumers stay uniform.
+///
+/// `llm` must be reachable; the CLI handler is responsible for
+/// short-circuiting (with a clear message) when no Ollama endpoint is
+/// available — same opt-in/no-op pattern as `--with-embedding`.
+///
+/// # Errors
+///
+/// Returns the underlying [`db`] or [`curator`] error if the workload
+/// cannot be seeded or the cycle aborts before completing.
+pub fn run_curator_cycle(conn: &Connection, llm: &OllamaClient) -> Result<OperationResult> {
+    let _seeded = seed_canonical_workload(conn)?;
+    let cfg = CuratorConfig {
+        // Bench measures the full 1000-memory sweep, not the daemon's
+        // production-safe cap of 100 ops/cycle.
+        max_ops_per_cycle: CURATOR_BENCH_MAX_OPS,
+        ..CuratorConfig::default()
+    };
+    let start = Instant::now();
+    let _report = curator::run_once(conn, Some(llm), &cfg)?;
+    let elapsed = start.elapsed();
+    Ok(percentile_summary(Operation::CuratorCycle, &[elapsed]))
 }
 
 /// Seed the in-process KG fixture: `KG_FIXTURE_SOURCES` source memories,
@@ -634,6 +821,90 @@ mod tests {
         assert!((Operation::KgQueryDepth3.target_p95_ms() - 100.0).abs() < 1e-9);
         assert!((Operation::KgQueryDepth5.target_p95_ms() - 250.0).abs() < 1e-9);
         assert!((Operation::KgTimeline.target_p95_ms() - 100.0).abs() < 1e-9);
+        assert!((Operation::CuratorCycle.target_p95_ms() - 60_000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn curator_cycle_label_carries_workload_size() {
+        // The label is what shows up in the bench table + JSON. Pin it
+        // here so the "(1k memories)" hint stays — operators read this
+        // row alongside the published "curator cycle (1k memories)" row
+        // in PERFORMANCE.md.
+        assert_eq!(
+            Operation::CuratorCycle.label(),
+            "curator cycle (1k memories)"
+        );
+    }
+
+    #[test]
+    fn canonical_workload_fixture_loads_into_create_memory() {
+        // Load + deserialize is the brittle step — if the fixture
+        // disappears or its schema drifts we want a deterministic test
+        // failure rather than a runtime surprise inside `cmd_bench
+        // --with-curator`. The schema-version + count assertions here
+        // mirror `crate::canonical_workload::tests` so a refresh of the
+        // fixture has to update both places.
+        let workload = load_canonical_workload().expect("canonical workload fixture must load");
+        assert_eq!(workload.schema_version, CANONICAL_WORKLOAD_SCHEMA);
+        assert_eq!(workload.count, 1000);
+        assert_eq!(workload.memories.len(), 1000);
+        assert_eq!(workload.seed, 20_260_426);
+    }
+
+    #[test]
+    fn seed_canonical_workload_populates_disposable_db() {
+        // Confirms the bench's seed path is curator-eligible end-to-end
+        // without needing an LLM: every row from the fixture lands in
+        // SQLite, and a fresh `run_once` with `llm = None` early-returns
+        // after counting them as eligible candidates. This is the
+        // observable contract `--with-curator` relies on before
+        // handing the conn to a real Ollama client.
+        let conn = fresh_conn();
+        let inserted = seed_canonical_workload(&conn).expect("seed must succeed");
+        assert_eq!(
+            inserted, 1000,
+            "every fixture row must reach the upsert path"
+        );
+        let cfg = CuratorConfig {
+            max_ops_per_cycle: CURATOR_BENCH_MAX_OPS,
+            ..CuratorConfig::default()
+        };
+        let report = curator::run_once(&conn, None, &cfg).expect("no-llm cycle must not error");
+        // run_once early-returns when llm is None, but the eligibility
+        // scan still runs — every fixture row must qualify per the
+        // invariants pinned in `crate::canonical_workload::tests`.
+        assert_eq!(report.memories_scanned, 1000);
+        assert_eq!(report.memories_eligible, 1000);
+        // No LLM means no operations attempted; the report's `errors`
+        // field carries the documented "no LLM client configured" entry.
+        assert_eq!(report.operations_attempted, 0);
+        assert!(
+            report.errors.iter().any(|e| e.contains("no LLM")),
+            "report.errors must surface the missing-LLM reason: {:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn render_table_renders_curator_cycle_row() {
+        // Builds a minimal results vector with a synthesized curator
+        // row so the renderer is exercised end-to-end without needing
+        // a live cycle. Confirms the row's label survives table
+        // formatting (operators see the same string in the bench
+        // table they read in PERFORMANCE.md).
+        let results = vec![OperationResult {
+            operation: Operation::CuratorCycle,
+            label: Operation::CuratorCycle.label(),
+            target_p95_ms: Operation::CuratorCycle.target_p95_ms(),
+            measured_p50_ms: 12_000.0,
+            measured_p95_ms: 12_000.0,
+            measured_p99_ms: 12_000.0,
+            samples: 1,
+            status: Status::Pass,
+        }];
+        let table = render_table(&results);
+        assert!(table.contains("curator cycle (1k memories)"));
+        assert!(table.contains("PASS"));
     }
 
     #[test]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -712,6 +712,32 @@ pub fn render_table(results: &[OperationResult]) -> String {
     out
 }
 
+/// Render the same per-operation results as a GitHub-Flavored-Markdown
+/// table. Sortable in the GitHub UI when piped into `$GITHUB_STEP_SUMMARY`,
+/// and harvestable by future tooling that wants to populate the
+/// "Latest measured" column in `PERFORMANCE.md`. Same rounding +
+/// PASS/FAIL semantics as [`render_table`].
+#[must_use]
+pub fn render_markdown(results: &[OperationResult]) -> String {
+    let mut out = String::new();
+    out.push_str("| Operation | Target (p95) | Measured (p95) | p50 | p99 | Status |\n");
+    out.push_str("|---|---:|---:|---:|---:|:---:|\n");
+    for r in results {
+        let status_str = match r.status {
+            Status::Pass => "PASS",
+            Status::Fail => "FAIL",
+        };
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let target_ms = r.target_p95_ms.round() as i64;
+        let line = format!(
+            "| `{}` | < {} ms | {:.1} ms | {:.1} ms | {:.1} ms | {} |\n",
+            r.label, target_ms, r.measured_p95_ms, r.measured_p50_ms, r.measured_p99_ms, status_str,
+        );
+        out.push_str(&line);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -883,6 +909,80 @@ mod tests {
             "report.errors must surface the missing-LLM reason: {:?}",
             report.errors
         );
+    }
+
+    #[test]
+    fn render_markdown_includes_all_operations() {
+        // The Markdown table is what bench.yml pipes into
+        // `$GITHUB_STEP_SUMMARY` so GitHub renders it as a sortable
+        // table — every row in `render_table` must also appear here.
+        let conn = fresh_conn();
+        let results = run(&conn, &small_config()).unwrap();
+        let md = render_markdown(&results);
+        // Header + alignment row.
+        assert!(
+            md.starts_with("| Operation | Target (p95) | Measured (p95) | p50 | p99 | Status |\n")
+        );
+        assert!(md.contains("|---|---:|---:|---:|---:|:---:|\n"));
+        // Every operation label is present, wrapped in backticks.
+        for op in [
+            "memory_store (no embedding)",
+            "memory_search (FTS5)",
+            "memory_recall (hot, depth=1)",
+            "memory_kg_query (depth=1)",
+            "memory_kg_query (depth=3)",
+            "memory_kg_query (depth=5)",
+            "memory_kg_timeline",
+        ] {
+            let cell = format!("| `{op}` |");
+            assert!(md.contains(&cell), "missing row for {op}: {md}");
+        }
+    }
+
+    #[test]
+    fn render_markdown_carries_pass_fail_marker() {
+        // PASS/FAIL strings must survive into the Markdown output —
+        // they are how operators (and any future PERFORMANCE.md
+        // harvester) identify regressions.
+        let pass = OperationResult {
+            operation: Operation::StoreNoEmbedding,
+            label: Operation::StoreNoEmbedding.label(),
+            target_p95_ms: 20.0,
+            measured_p50_ms: 1.0,
+            measured_p95_ms: 5.0,
+            measured_p99_ms: 8.0,
+            samples: 100,
+            status: Status::Pass,
+        };
+        let fail = OperationResult {
+            status: Status::Fail,
+            measured_p95_ms: 50.0,
+            ..pass.clone()
+        };
+        let md = render_markdown(&[pass, fail]);
+        assert!(md.contains("| PASS |"));
+        assert!(md.contains("| FAIL |"));
+    }
+
+    #[test]
+    fn render_markdown_renders_curator_cycle_row() {
+        // Mirrors `render_table_renders_curator_cycle_row` for the
+        // markdown variant — operators reading the GitHub run summary
+        // see the same opt-in row they'd see in the plain-text table.
+        let results = vec![OperationResult {
+            operation: Operation::CuratorCycle,
+            label: Operation::CuratorCycle.label(),
+            target_p95_ms: Operation::CuratorCycle.target_p95_ms(),
+            measured_p50_ms: 12_000.0,
+            measured_p95_ms: 12_000.0,
+            measured_p99_ms: 12_000.0,
+            samples: 1,
+            status: Status::Pass,
+        }];
+        let md = render_markdown(&results);
+        assert!(md.contains("| `curator cycle (1k memories)` |"));
+        assert!(md.contains("| < 60000 ms |"));
+        assert!(md.contains("| PASS |"));
     }
 
     #[test]

--- a/src/canonical_workload.rs
+++ b/src/canonical_workload.rs
@@ -1,0 +1,100 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Schema regression tests for `benchmarks/v063/canonical_workload.json`.
+//!
+//! The canonical workload is a 1000-memory deterministic seed consumed by
+//! the v0.6.3 curator-cycle bench (charter §"Stream E — Performance
+//! Instrumentation"; budget published in `PERFORMANCE.md` as
+//! `curator cycle (1k memories) < 60 s p95`). The fixture lands ahead of
+//! its bench wiring; this module pins the on-disk shape so that future
+//! edits to either the JSON or its Python generator do not silently
+//! invalidate the curator-eligibility invariants the bench relies on.
+//!
+//! The fixture is loaded at test runtime (not `include_str!`-embedded)
+//! so the production binary stays unaffected.
+
+#[cfg(test)]
+mod tests {
+    use crate::curator::MIN_CONTENT_LEN;
+    use crate::models::CreateMemory;
+    use serde::Deserialize;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Deserialize)]
+    struct Workload {
+        schema_version: u32,
+        seed: u64,
+        count: usize,
+        memories: Vec<CreateMemory>,
+    }
+
+    fn load() -> Workload {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("benchmarks")
+            .join("v063")
+            .join("canonical_workload.json");
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("deserialize {}: {e}", path.display()))
+    }
+
+    #[test]
+    fn schema_version_is_one() {
+        assert_eq!(load().schema_version, 1);
+    }
+
+    #[test]
+    fn seed_and_count_match_published_values() {
+        let w = load();
+        assert_eq!(w.seed, 20_260_426);
+        assert_eq!(w.count, 1000);
+        assert_eq!(w.memories.len(), 1000);
+    }
+
+    #[test]
+    fn deserialises_into_create_memory() {
+        // Round-trip via CreateMemory ensures the on-disk shape stays
+        // compatible with the upsert path the bench wiring will call.
+        let w = load();
+        assert!(!w.memories.is_empty());
+    }
+
+    #[test]
+    fn every_memory_is_curator_eligible() {
+        // Curator's needs_curation() requires:
+        //   - namespace not starting with '_'
+        //   - content.len() >= MIN_CONTENT_LEN
+        //   - tier == mid | long
+        //   - no metadata.auto_tags
+        // If any of these drift we silently lose curator-cycle bench coverage.
+        let w = load();
+        for (idx, m) in w.memories.iter().enumerate() {
+            assert!(
+                !m.namespace.starts_with('_'),
+                "memory[{idx}] namespace `{}` starts with underscore — curator would skip",
+                m.namespace,
+            );
+            assert!(
+                m.content.len() >= MIN_CONTENT_LEN,
+                "memory[{idx}] content len {} < MIN_CONTENT_LEN {}",
+                m.content.len(),
+                MIN_CONTENT_LEN,
+            );
+            let tier_str = m.tier.as_str();
+            assert!(
+                matches!(tier_str, "mid" | "long"),
+                "memory[{idx}] tier `{tier_str}` not mid|long — curator scans neither",
+            );
+            let auto_tags = m
+                .metadata
+                .get("auto_tags")
+                .and_then(|v| v.as_array())
+                .is_some_and(|a| !a.is_empty());
+            assert!(
+                !auto_tags,
+                "memory[{idx}] already carries auto_tags — curator would short-circuit",
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 
 mod autonomy;
 mod bench;
-mod canonical_workload;
 mod color;
 mod config;
 mod curator;
@@ -204,6 +203,15 @@ struct BenchArgs {
     /// Emit results as JSON instead of the human-readable table.
     #[arg(long)]
     json: bool,
+    /// Opt in to the curator-cycle operation: seed the canonical
+    /// 1000-memory workload (`benchmarks/v063/canonical_workload.json`)
+    /// and time one [`curator::run_once`] sweep against the 60 s p95
+    /// budget. Requires a reachable Ollama endpoint with the curator's
+    /// model. If Ollama is unreachable or the fixture is missing, the
+    /// flag is treated as a no-op and a clear message is emitted on
+    /// stderr — same opt-in/no-op shape as `--with-embedding`.
+    #[arg(long)]
+    with_curator: bool,
 }
 
 #[derive(Args)]
@@ -4410,13 +4418,40 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
         warmup,
         namespace: bench::BENCH_NAMESPACE.to_string(),
     };
-    let results = bench::run(&conn, &config)?;
+    let mut results = bench::run(&conn, &config)?;
+    // Opt-in curator-cycle bench. Built off the same in-memory DB so
+    // the canonical 1000-memory workload doesn't churn the operator's
+    // disk. If `--with-curator` is set but Ollama is unreachable or
+    // the fixture is missing, we log on stderr and continue without
+    // the row — same opt-in/no-op shape as `--with-embedding`.
+    if args.with_curator {
+        match build_curator_llm(config::FeatureTier::Smart) {
+            Some(llm) => match bench::run_curator_cycle(&conn, &llm) {
+                Ok(r) => {
+                    eprintln!("ai-memory bench: curator-cycle op enabled");
+                    results.push(r);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "ai-memory bench: --with-curator requested but the cycle failed: {e}; skipping curator-cycle op"
+                    );
+                }
+            },
+            None => {
+                eprintln!(
+                    "ai-memory bench: --with-curator requested but no Ollama endpoint reachable for the configured curator model; skipping curator-cycle op"
+                );
+            }
+        }
+    }
     if args.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "iterations": iterations,
                 "warmup": warmup,
+                "with_curator": args.with_curator
+                    && results.iter().any(|r| matches!(r.operation, bench::Operation::CuratorCycle)),
                 "results": results,
             }))?
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod autonomy;
 mod bench;
+mod canonical_workload;
 mod color;
 mod config;
 mod curator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,8 +201,14 @@ struct BenchArgs {
     #[arg(long, default_value_t = bench::DEFAULT_WARMUP)]
     warmup: usize,
     /// Emit results as JSON instead of the human-readable table.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "markdown")]
     json: bool,
+    /// Emit results as a GitHub-Flavored-Markdown table — sortable in
+    /// the GitHub UI when piped into `$GITHUB_STEP_SUMMARY` and
+    /// harvestable for the "Latest measured" column in `PERFORMANCE.md`.
+    /// Mutually exclusive with `--json`.
+    #[arg(long)]
+    markdown: bool,
     /// Opt in to the curator-cycle operation: seed the canonical
     /// 1000-memory workload (`benchmarks/v063/canonical_workload.json`)
     /// and time one [`curator::run_once`] sweep against the 60 s p95
@@ -4455,6 +4461,8 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
                 "results": results,
             }))?
         );
+    } else if args.markdown {
+        print!("{}", bench::render_markdown(&results));
     } else {
         print!("{}", bench::render_table(&results));
     }


### PR DESCRIPTION
## Summary

- Adds `ai-memory bench --markdown` — same per-op rows as `--json` / plain-text, rendered as a GitHub-Flavored-Markdown table (sortable in the GitHub UI when piped into `$GITHUB_STEP_SUMMARY`).
- Updates `.github/workflows/bench.yml` to use `--markdown` for the gate output, dropping the fenced plain-text dump from the run summary and uploading `bench-table.md` alongside `bench-results.json` in the `bench-results` artifact.
- Documents the new flag in `PERFORMANCE.md` as the data source future tooling will harvest to populate the "Latest measured" column promised in the Status table.

## Charter linkage

Pillar 3 / Stream F (`docs/charter` §"Stream F — Performance Budgets + CI Guard"). Closes the iter-11 next-plan from `campaign-v063` memory: *"a `bench --markdown` switch that lands the measured numbers in the bench.yml run summary as a sortable table, finally giving PERFORMANCE.md's `Latest measured` column a data source."*

## Stacking

Stacks on #403 (curator-cycle bench) — `render_markdown_renders_curator_cycle_row` references `Operation::CuratorCycle`, which only exists once #403 merges to `release/v0.6.3`. Rebases cleanly when that lands.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean (matches `ci.yml` invocation)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test bench::` — 16/16 pass, including three new render-markdown tests
- [x] `target/release/ai-memory bench --markdown --iterations 30 --warmup 5` renders the table as expected and exits 0
- [x] `target/release/ai-memory bench --markdown --json` rejected by clap with the expected `cannot be used with` error
- [x] Full `cargo test` non-regression: 174 passed, 11 pre-existing flakes (env-specific, identical without this change; CI on #403 is green)

## AI involvement

Implemented by Claude Opus 4.7 under campaign `ai-memory-v063` iteration #12 (`/Users/fate/.local/share/claude-campaign-runner/ai-memory-v063/logs/iter-000012-*.jsonl`). Memory namespace: `campaign-v063`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)