### PR TITLE
docs(readme): add Performance Budgets section + Bench badge (Pillar 3 / Stream F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **README "Performance Budgets" section + Bench badge (Pillar 3 / Stream F
+  perception fix)** — `README.md` gains a `Bench` badge in the badges row
+  (pinned to `release/v0.6.3` so it tracks the current dev branch instead
+  of always-red `main`) and a new `## Performance Budgets` section
+  immediately after the existing `## Benchmark` (LongMemEval) section.
+  The new section names the >10% p95 fail-build threshold, links to the
+  authoritative `PERFORMANCE.md` budget table, and shows the same
+  `ai-memory bench` operator-self-verification snippet that
+  `PERFORMANCE.md` already publishes — keeping operators on the README
+  one click away from a number rather than asking "is this thing fast?"
+  Closes the README-side of charter §"The Marketing Line" line 532
+  ("Operators evaluating ai-memory should be able to see budgets in
+  `PERFORMANCE.md`, see CI badges showing the build passes them, and
+  run `ai-memory bench` locally").
+
 - **Hierarchical namespace taxonomy (Pillar 1 / Stream A)** — new
   `memory_get_taxonomy` MCP tool plus REST mirror at
   `GET /api/v1/taxonomy`. Walks live (non-expired) memories grouped by

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <p align="center"><em>universal AI memory</em></p>
 
 [![CI](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/ci.yml)
+[![Bench](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/bench.yml/badge.svg?branch=release%2Fv0.6.3)](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/bench.yml)
 [![Rust](https://img.shields.io/badge/rust-1.87%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
@@ -558,6 +559,29 @@ Evaluated on the [ICLR 2025 LongMemEval-S](benchmarks/longmemeval/) dataset (500
 | **keyword** | 97.0% | 232 q/s | None |
 | **semantic** | 97.4% | 45 q/s | Embedding model (~100MB) |
 | **smart** | 97.8% | 12 q/s | Ollama + Gemma 4 E2B |
+
+---
+
+## Performance Budgets
+
+ai-memory publishes an explicit per-operation latency contract in [`PERFORMANCE.md`](PERFORMANCE.md). Every pull request against `main`, `develop`, or `release/**` runs `ai-memory bench` on `ubuntu-latest` and **fails the build when any operation's measured p95 exceeds its target by more than 10%** — see the [Bench badge](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/bench.yml) above.
+
+Operators can verify on their own hardware (the bench seeds an in-memory disposable SQLite — the operator's main DB is untouched):
+
+```bash
+$ ai-memory bench
+Operation                       Target (p95)   Measured (p95)   p50      p99      Status
+─────────────────────────────────────────────────────────────────────────────────────────
+memory_store (no embedding)     <   20 ms           0.4 ms         0.3      0.5    PASS
+memory_search (FTS5)            <  100 ms           0.5 ms         0.5      0.5    PASS
+memory_recall (hot, depth=1)    <   50 ms           4.8 ms         4.2      5.3    PASS
+memory_kg_query (depth=1)       <  100 ms           0.5 ms         0.5      0.5    PASS
+memory_kg_query (depth=3)       <  100 ms           0.6 ms         0.6      0.6    PASS
+memory_kg_query (depth=5)       <  250 ms           0.7 ms         0.6      1.0    PASS
+memory_kg_timeline              <  100 ms           0.1 ms         0.1      0.1    PASS
+```
+
+`--json` and `--markdown` emit the same numbers as a JSON document or GitHub-Flavored-Markdown table for downstream tooling. Embedding-bound and curator-cycle paths are opt-in via `--with-embedding` / `--with-curator` so the default invocation never requires an external service. The full budget table, hardware baseline, and CI guard rules live in [`PERFORMANCE.md`](PERFORMANCE.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a `Bench` badge to the README badges row, pinned to `release/v0.6.3` so it tracks the active dev branch (the `bench.yml` workflow already runs on every PR / push to `release/**`).
- Add a new `## Performance Budgets` section immediately after the existing `## Benchmark` (LongMemEval) section. Names the **>10% p95 fail-build** threshold, links to the authoritative [`PERFORMANCE.md`](../blob/release/v0.6.3/PERFORMANCE.md) budget table, and reuses the same `ai-memory bench` operator-self-verification snippet that already lives in `PERFORMANCE.md` so a fresh visitor can run the verification command without leaving the README first.

Lands the README-side of the v0.6.3 grand-slam charter §"The Marketing Line" (line 532): *"Operators evaluating ai-memory should be able to see budgets in `PERFORMANCE.md`, see CI badges showing the build passes them, and run `ai-memory bench` locally to verify on their own hardware."*

## AI involvement

- **Authoring model:** Claude Opus 4.7 (1M context), running under the `ai-memory-v063` autonomous campaign.
- **Authority class:** Trivial (docs-only — README + CHANGELOG).
- **Human review:** standard PR review before merge.

## Test plan

- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` — clean (matches `ci.yml` invocation).
- [x] `cargo build` — clean.
- [x] `cargo test --bins` — 408 passed, 0 failed.
- [x] Pre-existing macOS-only integration flakes verified to reproduce on clean `release/v0.6.3` HEAD without this commit (CI on Ubuntu has been passing on the same SHAs).
- [ ] CI (`ci.yml` + `bench.yml`) green on this branch.
- [ ] Reviewer skims the rendered README to confirm the new `Bench` badge points at the right workflow + branch and the `## Performance Budgets` section flows naturally after `## Benchmark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)