### PR TITLE
feat(bench): --update-performance-md splices fresh measurements into PERFORMANCE.md

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -79,6 +79,21 @@ The status table is updated as each Stream lands within the v0.6.3
 cycle. When measurements begin, this file will gain a "Latest measured"
 column alongside each target.
 
+## Latest Measured (p95)
+
+The block between the markers below is machine-managed. Run
+`ai-memory bench --update-performance-md` from this repo to refresh it
+in place — the command splices a fresh table into the section without
+touching anything else. Until the first refresh ships, the table reads
+"not yet measured" so operators reading this file can tell apart
+"baseline pending" from "regressed."
+
+<!-- BENCH_MEASURED_BEGIN -->
+| Operation | Target (p95) | Measured (p95) | p50 | p99 | Status |
+|---|---|---|---|---|---|
+| (not yet measured — run `ai-memory bench --update-performance-md`) | — | — | — | — | — |
+<!-- BENCH_MEASURED_END -->
+
 ## Operator Self-Verification
 
 The `ai-memory bench` subcommand seeds an in-memory disposable

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -28,9 +28,10 @@
 //! and are tracked as follow-up Stream E work — they don't belong on
 //! the hot path of a `cargo test` invocation.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusqlite::Connection;
 use serde::Serialize;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use crate::db;
@@ -494,6 +495,105 @@ fn percentile(sorted: &[f64], q: f64) -> f64 {
     sorted[lo] + (sorted[hi] - sorted[lo]) * frac
 }
 
+/// Markdown begin/end markers delimiting the machine-managed
+/// "Latest Measured" section in `PERFORMANCE.md`. Kept in lockstep with
+/// the markers in that file — changing one without the other breaks
+/// `--update-performance-md`.
+pub const PERFORMANCE_MD_BEGIN: &str = "<!-- BENCH_MEASURED_BEGIN -->";
+pub const PERFORMANCE_MD_END: &str = "<!-- BENCH_MEASURED_END -->";
+
+/// Render the markdown table that the `--update-performance-md` flag
+/// splices into `PERFORMANCE.md`. Uses the same columns as
+/// [`render_table`] but in GitHub-flavored markdown so the result reads
+/// naturally next to the budget table at the top of the file.
+#[must_use]
+pub fn render_markdown_table(results: &[OperationResult]) -> String {
+    let mut out = String::new();
+    out.push_str("| Operation | Target (p95) | Measured (p95) | p50 | p99 | Status |\n");
+    out.push_str("|---|---|---|---|---|---|\n");
+    for r in results {
+        let status_str = match r.status {
+            Status::Pass => "✅ PASS",
+            Status::Fail => "❌ FAIL",
+        };
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let target_ms = r.target_p95_ms.round() as i64;
+        let line = format!(
+            "| `{}` | < {} ms | {:.1} ms | {:.1} ms | {:.1} ms | {} |\n",
+            r.label, target_ms, r.measured_p95_ms, r.measured_p50_ms, r.measured_p99_ms, status_str,
+        );
+        out.push_str(&line);
+    }
+    out
+}
+
+/// Splice a fresh measurements table into `existing`, replacing
+/// whatever sits between [`PERFORMANCE_MD_BEGIN`] and
+/// [`PERFORMANCE_MD_END`]. Returns the rewritten document.
+///
+/// # Errors
+///
+/// Returns an error if either marker is missing or if the end marker
+/// appears before the begin marker — both indicate the file has drifted
+/// from the format `--update-performance-md` knows how to manage.
+pub fn splice_performance_md(existing: &str, results: &[OperationResult]) -> Result<String> {
+    let begin = existing.find(PERFORMANCE_MD_BEGIN).with_context(|| {
+        format!(
+            "PERFORMANCE.md missing begin marker '{PERFORMANCE_MD_BEGIN}' — \
+             refusing to rewrite"
+        )
+    })?;
+    let end = existing.find(PERFORMANCE_MD_END).with_context(|| {
+        format!(
+            "PERFORMANCE.md missing end marker '{PERFORMANCE_MD_END}' — \
+             refusing to rewrite"
+        )
+    })?;
+    if end < begin {
+        anyhow::bail!(
+            "PERFORMANCE.md markers out of order: end '{PERFORMANCE_MD_END}' appears before \
+             begin '{PERFORMANCE_MD_BEGIN}'"
+        );
+    }
+    let after_begin = begin + PERFORMANCE_MD_BEGIN.len();
+    let table = render_markdown_table(results);
+    let mut out = String::with_capacity(existing.len() + table.len());
+    out.push_str(&existing[..after_begin]);
+    out.push('\n');
+    out.push_str(&table);
+    out.push_str(&existing[end..]);
+    Ok(out)
+}
+
+/// Update the "Latest Measured" section of `PERFORMANCE.md` in place.
+/// Reads `path`, splices in a fresh table, and atomically rewrites the
+/// file via `write-temp + rename` so a crash mid-write cannot leave the
+/// repo with a half-rewritten doc.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read, the markers are
+/// missing, or the temp file cannot be renamed into place.
+pub fn update_performance_md(path: &Path, results: &[OperationResult]) -> Result<()> {
+    let existing = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let updated = splice_performance_md(&existing, results)?;
+    if updated == existing {
+        return Ok(());
+    }
+    let tmp = path.with_extension("md.bench.tmp");
+    std::fs::write(&tmp, &updated)
+        .with_context(|| format!("failed to write temp file {}", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| {
+        format!(
+            "failed to atomically replace {} with {}",
+            path.display(),
+            tmp.display()
+        )
+    })?;
+    Ok(())
+}
+
 /// Render a results table to a string in the same shape used in the
 /// `PERFORMANCE.md` "Operator Self-Verification" example.
 #[must_use]
@@ -658,6 +758,157 @@ mod tests {
                 "depth=3 on a {KG_CHAIN_FIXTURE_HOPS}-hop chain must reach exactly 3 follow-on nodes"
             );
         }
+    }
+
+    fn synth_results_two_ops() -> Vec<OperationResult> {
+        vec![
+            OperationResult {
+                operation: Operation::StoreNoEmbedding,
+                label: Operation::StoreNoEmbedding.label(),
+                target_p95_ms: 20.0,
+                measured_p50_ms: 0.3,
+                measured_p95_ms: 0.4,
+                measured_p99_ms: 0.5,
+                samples: 100,
+                status: Status::Pass,
+            },
+            OperationResult {
+                operation: Operation::KgQueryDepth5,
+                label: Operation::KgQueryDepth5.label(),
+                target_p95_ms: 250.0,
+                measured_p50_ms: 0.6,
+                measured_p95_ms: 0.7,
+                measured_p99_ms: 1.0,
+                samples: 100,
+                status: Status::Pass,
+            },
+        ]
+    }
+
+    const FIXTURE_DOC: &str = "# Performance Budgets\n\
+        \n\
+        ## Latest Measured (p95)\n\
+        \n\
+        <!-- BENCH_MEASURED_BEGIN -->\n\
+        | Operation | Target (p95) | Measured (p95) | p50 | p99 | Status |\n\
+        |---|---|---|---|---|---|\n\
+        | (not yet measured) | — | — | — | — | — |\n\
+        <!-- BENCH_MEASURED_END -->\n\
+        \n\
+        ## Operator Self-Verification\n";
+
+    #[test]
+    fn render_markdown_table_emits_one_row_per_result() {
+        let table = render_markdown_table(&synth_results_two_ops());
+        // Header + alignment line + 2 data rows = 4 lines (plus trailing).
+        assert_eq!(table.lines().count(), 4);
+        assert!(table.contains("| `memory_store (no embedding)` | < 20 ms |"));
+        assert!(table.contains("| `memory_kg_query (depth=5)` | < 250 ms |"));
+        assert!(table.contains("✅ PASS"));
+        // Header reads "Status" so the column is greppable.
+        assert!(table.contains("| Status |"));
+    }
+
+    #[test]
+    fn render_markdown_table_marks_failures() {
+        let mut results = synth_results_two_ops();
+        results[0].status = Status::Fail;
+        let table = render_markdown_table(&results);
+        assert!(table.contains("❌ FAIL"));
+    }
+
+    #[test]
+    fn splice_performance_md_replaces_only_managed_block() {
+        let updated = splice_performance_md(FIXTURE_DOC, &synth_results_two_ops()).unwrap();
+        // Surrounding doc preserved verbatim.
+        assert!(updated.starts_with("# Performance Budgets\n"));
+        assert!(updated.contains("## Operator Self-Verification"));
+        // Stale placeholder is gone, fresh measurement is present.
+        assert!(!updated.contains("(not yet measured)"));
+        assert!(updated.contains("`memory_store (no embedding)`"));
+        assert!(updated.contains("`memory_kg_query (depth=5)`"));
+        // Begin/end markers still present so subsequent runs can splice.
+        assert!(updated.contains(PERFORMANCE_MD_BEGIN));
+        assert!(updated.contains(PERFORMANCE_MD_END));
+    }
+
+    #[test]
+    fn splice_performance_md_is_idempotent() {
+        let once = splice_performance_md(FIXTURE_DOC, &synth_results_two_ops()).unwrap();
+        let twice = splice_performance_md(&once, &synth_results_two_ops()).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn splice_performance_md_errors_when_begin_marker_missing() {
+        let bad = "no markers in this doc";
+        let err = splice_performance_md(bad, &synth_results_two_ops()).unwrap_err();
+        assert!(
+            err.to_string().contains("missing begin marker"),
+            "expected begin-marker error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn splice_performance_md_errors_when_end_marker_missing() {
+        let bad = "<!-- BENCH_MEASURED_BEGIN -->\nbut no end\n";
+        let err = splice_performance_md(bad, &synth_results_two_ops()).unwrap_err();
+        assert!(
+            err.to_string().contains("missing end marker"),
+            "expected end-marker error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn splice_performance_md_errors_when_markers_out_of_order() {
+        let bad = "<!-- BENCH_MEASURED_END -->\nstuff\n<!-- BENCH_MEASURED_BEGIN -->\nmore\n";
+        let err = splice_performance_md(bad, &synth_results_two_ops()).unwrap_err();
+        assert!(
+            err.to_string().contains("out of order"),
+            "expected out-of-order error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_performance_md_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("PERFORMANCE.md");
+        std::fs::write(&path, FIXTURE_DOC).unwrap();
+        update_performance_md(&path, &synth_results_two_ops()).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("`memory_store (no embedding)`"));
+        assert!(!on_disk.contains("(not yet measured)"));
+        // Temp file from atomic rename must be cleaned up.
+        let leftover = path.with_extension("md.bench.tmp");
+        assert!(!leftover.exists(), "atomic rename left a temp file behind");
+    }
+
+    #[test]
+    fn update_performance_md_propagates_marker_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("BROKEN.md");
+        std::fs::write(&path, "no markers here").unwrap();
+        let err = update_performance_md(&path, &synth_results_two_ops()).unwrap_err();
+        assert!(err.to_string().contains("missing begin marker"));
+    }
+
+    #[test]
+    fn repo_performance_md_carries_managed_markers() {
+        // Pin the section to its declared markers — if a future PR
+        // moves them, --update-performance-md silently breaks until
+        // someone re-runs the tests, so keep the pin tight.
+        let perf_md = include_str!("../PERFORMANCE.md");
+        assert!(
+            perf_md.contains(PERFORMANCE_MD_BEGIN),
+            "PERFORMANCE.md is missing the BENCH_MEASURED_BEGIN marker"
+        );
+        assert!(
+            perf_md.contains(PERFORMANCE_MD_END),
+            "PERFORMANCE.md is missing the BENCH_MEASURED_END marker"
+        );
+        let begin = perf_md.find(PERFORMANCE_MD_BEGIN).unwrap();
+        let end = perf_md.find(PERFORMANCE_MD_END).unwrap();
+        assert!(begin < end, "PERFORMANCE.md markers are out of order");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,15 @@ struct BenchArgs {
     /// Emit results as JSON instead of the human-readable table.
     #[arg(long)]
     json: bool,
+    /// Splice a fresh measurements table into `PERFORMANCE.md`. Reads
+    /// the path provided (or `PERFORMANCE.md` in the current working
+    /// directory when no value is supplied), rewrites the
+    /// `BENCH_MEASURED_BEGIN`/`BENCH_MEASURED_END` block in place, and
+    /// atomically renames the temp file over the original. The CLI
+    /// table / JSON output still prints; this flag only adds the
+    /// docs-rewrite side effect on top.
+    #[arg(long, value_name = "PATH", num_args = 0..=1, default_missing_value = "PERFORMANCE.md")]
+    update_performance_md: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -4421,6 +4430,13 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
         );
     } else {
         print!("{}", bench::render_table(&results));
+    }
+    if let Some(perf_md_path) = &args.update_performance_md {
+        bench::update_performance_md(perf_md_path, &results)?;
+        eprintln!(
+            "bench: refreshed measurements table in {}",
+            perf_md_path.display()
+        );
     }
     if results
         .iter()


### PR DESCRIPTION
## Summary

Closes the docs loop on Pillar 3 / Stream F. Operators (and CI) can run
`ai-memory bench --update-performance-md` and a fresh "Latest Measured
(p95)" table is spliced into `PERFORMANCE.md` between two HTML-comment
markers, so the published doc carries real numbers instead of the
"not yet measured" placeholder.

The charter (§Performance Budgets, §Stream F) calls for a published
budget table that operators can verify on their own hardware. The
absolute-budget guard (already shipped) and `--baseline` (#406) catch
regressions; this PR plugs the last gap by making the published doc
itself self-refresh from a real run.

## What lands

`PERFORMANCE.md`
- new `## Latest Measured (p95)` section
- `<!-- BENCH_MEASURED_BEGIN -->` / `<!-- BENCH_MEASURED_END -->` markers
- placeholder row (`(not yet measured — run …)`) so operators reading
  the file pre-first-refresh can tell baseline-pending apart from
  regressed

`src/bench.rs`
- `PERFORMANCE_MD_BEGIN` / `PERFORMANCE_MD_END` constants pinned to the
  markers in the doc
- `render_markdown_table` — GFM table mirror of `render_table`
- `splice_performance_md` — pure-string splice; refuses to rewrite
  when markers are missing or out of order
- `update_performance_md` — atomic write (temp + rename)
- 9 new tests, including a pin that asserts the markers actually
  exist in the repo's `PERFORMANCE.md`

`src/main.rs`
- `--update-performance-md [PATH]` flag on `BenchArgs`
  - default value when no `PATH` given: `PERFORMANCE.md` in CWD
  - opt-in / side-effect-only: JSON & table output unchanged, exit
    code still driven by the absolute-budget guard
- threaded through `cmd_bench` after results render, before the bail

## Why this shape

- HTML-comment markers + atomic rename keep the rewrite safe and
  idempotent
- Splicing a managed block (rather than rewriting the whole file)
  keeps the budget table, hardware notes, and rationale prose
  untouched
- A boolean-with-default-path arg (`num_args = 0..=1`) gives operators
  the single-keystroke ergonomics
  (`ai-memory bench --update-performance-md`) while still allowing
  explicit destinations for ad-hoc runs

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test bench::` — 19 pass
      (10 pre-existing + 9 new)
- [x] End-to-end smoke:
      `ai-memory bench --update-performance-md /tmp/perf.md` writes
      a fresh table; round-trip with default-path also works
- [x] `cargo test` integration suite — 12 unrelated failures
      (`test_agentid_dedup_preserves_original` et al) reproduce on
      `release/v0.6.3` without this PR; not introduced here
- [ ] CI bench.yml run continues to pass (no behavior change to the
      bench workload itself)

## AI involvement

Authored by Claude Opus 4.7 (1M context) running as the
ai-memory-v063 campaign agent (Standard authority class — single
mergeable PR, ~280 LOC, well-tested, no schema/security changes).
All commits are SSH-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)