### PR TITLE
fix(cli): AI_MEMORY_AGENT_ID env no longer leaks into list/search filter

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -37,8 +37,13 @@ use anyhow::Result;
 
 use crate::validate;
 
-/// Environment variable override for `agent_id` (used by CLI via clap's
-/// `env = "AI_MEMORY_AGENT_ID"`; read directly for MCP fallback).
+/// Environment variable override for `agent_id`. Read directly here as
+/// step 2 of the precedence chain for *write* paths (CLI store/delete/
+/// update/sync, MCP tool calls). Intentionally NOT bound to clap's `env`
+/// attribute on the `--agent-id` flag because `global = true` would
+/// otherwise propagate the env value into the per-subcommand `--agent-id`
+/// *filter* fields on `list` / `search`, silently hiding memories from
+/// the caller.
 const ENV_AGENT_ID: &str = "AI_MEMORY_AGENT_ID";
 
 /// Environment variable opt-out for the hostname-revealing default (#198).
@@ -114,7 +119,7 @@ fn sanitize_component(input: &str) -> String {
 /// See module docs for precedence. Returned id is always valid per
 /// [`validate::validate_agent_id`].
 pub fn resolve_agent_id(explicit: Option<&str>, mcp_client: Option<&str>) -> Result<String> {
-    // 1. Explicit caller value (already env-merged by clap for CLI)
+    // 1. Explicit caller value (CLI `--agent-id` flag, MCP tool param)
     if let Some(id) = explicit
         && !id.is_empty()
     {
@@ -122,8 +127,10 @@ pub fn resolve_agent_id(explicit: Option<&str>, mcp_client: Option<&str>) -> Res
         return Ok(id.to_string());
     }
 
-    // 2. AI_MEMORY_AGENT_ID env var (for MCP path; CLI clap merges this already,
-    //    but MCP callers that don't pass it explicitly need this fallback)
+    // 2. AI_MEMORY_AGENT_ID env var. Read here (rather than via clap's `env`
+    //    attribute on the top-level `--agent-id` flag) so the env value
+    //    only affects *write* paths that route through this resolver — it
+    //    must NOT silently scope read filters on `list` / `search`.
     if let Ok(v) = std::env::var(ENV_AGENT_ID)
         && !v.is_empty()
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,15 @@ struct Cli {
     #[arg(long, global = true, default_value_t = false)]
     json: bool,
     /// Agent identifier used for store operations. If unset, an NHI-hardened
-    /// default is synthesized (see `ai-memory store --help`). Accepts the
-    /// `AI_MEMORY_AGENT_ID` environment variable as a fallback.
-    #[arg(long, env = "AI_MEMORY_AGENT_ID", global = true)]
+    /// default is synthesized (see `ai-memory store --help`). The
+    /// `AI_MEMORY_AGENT_ID` environment variable is read by
+    /// `identity::resolve_agent_id` as a fallback for *write* paths only —
+    /// it deliberately does NOT bind to this clap flag, because `global =
+    /// true` would otherwise propagate the env value into per-subcommand
+    /// `--agent-id` *filter* fields on `list` / `search`, silently hiding
+    /// memories from the caller (regression observed when the campaign
+    /// harness exported `AI_MEMORY_AGENT_ID`).
+    #[arg(long, global = true)]
     agent_id: Option<String>,
     /// v0.6.0.0: path to a file containing the `SQLCipher` passphrase.
     /// Only meaningful when the binary was built with

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2921,7 +2921,11 @@ fn test_mcp_store_invalid_metadata_defaults_to_empty() {
     // Then store with metadata as string (invalid — should default to {})
     // Then store with metadata as null (invalid — should default to {})
     // Verify all three have empty metadata
+    // env_remove(AI_MEMORY_AGENT_ID) so the assertion that the injected
+    // agent_id starts with `host:` or `anonymous:` (the NHI defaults)
+    // holds even when the runner exports an env override.
     let output = cmd(binary)
+        .env_remove("AI_MEMORY_AGENT_ID")
         .args(["--db", db_path.to_str().unwrap(), "mcp"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -3248,6 +3252,105 @@ fn test_agentid_env_var_supplies_default() {
     assert!(output.status.success());
     let stored: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(agent_id_of(&stored), "charlie");
+    let _ = std::fs::remove_file(&db_path);
+}
+
+// Regression: AI_MEMORY_AGENT_ID must NOT leak into list/search filter via
+// clap's `global = true` propagation. Symptom (campaign harness, iter #15+):
+// every list/search returned 0 rows because the env-derived caller id was
+// silently used as a filter, hiding all memories whose `agent_id` did not
+// match the runner's exported id.
+#[test]
+fn test_agentid_env_does_not_leak_to_list_filter() {
+    let db_path = fresh_db();
+    let binary = env!("CARGO_BIN_EXE_ai-memory");
+
+    // Seed two memories under different agents (with no env so the writes
+    // get the literal --agent-id values).
+    for (agent, title) in [("alice", "nhi-leak-a"), ("bob", "nhi-leak-b")] {
+        let out = cmd(binary)
+            .env_remove("AI_MEMORY_AGENT_ID")
+            .args([
+                "--db",
+                db_path.to_str().unwrap(),
+                "--agent-id",
+                agent,
+                "--json",
+                "store",
+                "-T",
+                title,
+                "-c",
+                "body",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "store {agent} failed");
+    }
+
+    // Now `list` with the env exported but no `--agent-id` filter flag.
+    // The env value belongs to the writer-identity precedence chain — it
+    // must NOT silently scope read filters.
+    let out = cmd(binary)
+        .env("AI_MEMORY_AGENT_ID", "charlie")
+        .args(["--db", db_path.to_str().unwrap(), "--json", "list"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let resp: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let memories = resp["memories"].as_array().expect("memories array");
+    assert_eq!(
+        memories.len(),
+        2,
+        "env should not filter list results; got: {resp}"
+    );
+
+    // Same for `search` — env-derived id must not silently filter results.
+    let out = cmd(binary)
+        .env("AI_MEMORY_AGENT_ID", "charlie")
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--json",
+            "search",
+            "body",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let resp: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let memories = resp["results"]
+        .as_array()
+        .or_else(|| resp["memories"].as_array())
+        .expect("results/memories array");
+    assert_eq!(
+        memories.len(),
+        2,
+        "env should not filter search results; got: {resp}"
+    );
+
+    // Sanity: explicit --agent-id flag at top level still works as a filter.
+    let out = cmd(binary)
+        .env("AI_MEMORY_AGENT_ID", "charlie")
+        .args([
+            "--db",
+            db_path.to_str().unwrap(),
+            "--agent-id",
+            "alice",
+            "--json",
+            "list",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let resp: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let memories = resp["memories"].as_array().expect("memories array");
+    assert_eq!(
+        memories.len(),
+        1,
+        "explicit flag should filter; got: {resp}"
+    );
+    assert_eq!(agent_id_of(&memories[0]), "alice");
+
     let _ = std::fs::remove_file(&db_path);
 }
 


### PR DESCRIPTION
## Summary

The top-level `--agent-id` flag was declared with both `global = true` and `env = \"AI_MEMORY_AGENT_ID\"`. clap's `global = true` propagated the env-derived value into every subcommand's `--agent-id` field — including the per-command `agent_id` **filter** fields on `list` / `search`. As a result, exporting `AI_MEMORY_AGENT_ID` (e.g. a campaign harness, a CI runner, or a personal shell profile) silently scoped read results to the caller's identity and hid every memory whose `metadata.agent_id` did not match.

```bash
$ env AI_MEMORY_AGENT_ID=charlie ai-memory --json list
{\"count\":0,\"memories\":[]}                   # was: silently filtered
{\"count\":2,\"memories\":[{...alice...},{...bob...}]}  # now: returns all rows
```

## Charter motivation

Phase 1 in-scope bug fix per the v0.6.3 grand-slam charter §\"In scope for this campaign\" (\"Bug fixes that surface during the above\"). Surfaced repeatedly in the campaign-runner harness over iters #15 / #16, where ~10 integration tests under `test_agentid_*` returned 0 rows on plain `list` because the harness exports `AI_MEMORY_AGENT_ID=campaign-runner:ai-memory-v063` for write-path attribution.

## Fix

- **`src/main.rs`** — drop `env = \"AI_MEMORY_AGENT_ID\"` from the top-level `--agent-id` flag. `global = true` stays so `--agent-id X` can still appear anywhere in the command line.
- **`src/identity.rs`** — refresh comments around `ENV_AGENT_ID` and `resolve_agent_id` step 2. The env-var fallback for **write** paths (CLI store/delete/update/sync, MCP tool calls) is unchanged — `resolve_agent_id` already reads `AI_MEMORY_AGENT_ID` at step 2 of the documented precedence chain. Removing it from the clap flag just stops clap from auto-merging the env into the per-subcommand **filter** fields.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 186 passed (was 185 passing + 1 failing in the campaign env pre-fix)
- [x] New regression test `test_agentid_env_does_not_leak_to_list_filter` covers both `list` and `search`, plus a sanity check that an explicit `--agent-id` flag still filters when the env is set. Verified to fail on un-fixed code (`assertion left == right failed: env should not filter list results; got: {\"count\":0,\"memories\":[]}`) and pass after.
- [x] `test_mcp_store_invalid_metadata_defaults_to_empty` now `.env_remove(\"AI_MEMORY_AGENT_ID\")`s so its NHI-default assertion holds under a runner-exported env override (pre-existing test rigidity, in the same neighborhood).
- [ ] CI green

## Backwards compatibility

- **Writes**: identical behavior. `AI_MEMORY_AGENT_ID=alice ai-memory store …` still tags the memory with `agent_id=alice` because `identity::resolve_agent_id` reads the env at step 2. CLI `--help` still documents the env var.
- **Reads**: `AI_MEMORY_AGENT_ID=alice ai-memory list` no longer silently filters. To filter, pass `--agent-id alice` explicitly. This restores the documented precedence chain (\"agent_id is per-write provenance; reads see all rows by default\").

## AI involvement

- **Author**: Claude Opus 4.7 (1M context), authority class **Standard** per `docs/AI_DEVELOPER_GOVERNANCE.md`. Two-line clap edit + comment refresh + one regression test on a release-track branch under operator supervision.
- **Reviewer**: Operator merge required (release-track guard).
- Generated as iter 17 of the `ai-memory-v063` campaign run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)