### PR TITLE
test(v063): smoke memory_check_duplicate via shared harness (Pillar 2 / Stream D)

### DIFF
--- a/tests/v063/mod.rs
+++ b/tests/v063/mod.rs
@@ -45,8 +45,25 @@ pub fn tmp_db(scope: &str) -> PathBuf {
 /// newlines. Each request is one JSON-RPC frame; responses come back in
 /// matching order.
 pub fn mcp_exchange(db: &std::path::Path, requests: &[&str]) -> Vec<String> {
+    mcp_exchange_with_args(db, &[], requests)
+}
+
+/// Variant of [`mcp_exchange`] that lets a test inject extra arguments
+/// after `mcp`. The canonical use case is `--tier keyword`, which
+/// suppresses embedder loading so a test can deterministically exercise
+/// the "embedder required" branch of MCP tools without depending on
+/// HuggingFace model downloads working from CI.
+pub fn mcp_exchange_with_args(
+    db: &std::path::Path,
+    extra: &[&str],
+    requests: &[&str],
+) -> Vec<String> {
+    let db_path = db.to_str().unwrap();
+    let mut args: Vec<&str> = vec!["--db", db_path, "mcp"];
+    args.extend_from_slice(extra);
+
     let mut child = cmd()
-        .args(["--db", db.to_str().unwrap(), "mcp"])
+        .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/v063_check_duplicate.rs
+++ b/tests/v063_check_duplicate.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Pillar 2 / Stream D smoke for `memory_check_duplicate` exercised through
+// the v0.6.3 shared harness. The keyword-tier daemon (the default under
+// `AI_MEMORY_NO_CONFIG=1`) does not load the embedder, so the tool MUST
+// return the documented `requires the embedder; …` error wrapped in the
+// MCP `isError: true` envelope rather than panicking or surfacing a raw
+// JSON-RPC error code. Locking that contract down here keeps a regression
+// in the dispatch path from silently changing how downstream callers
+// detect "you need a richer tier to use this tool".
+
+#[path = "v063/mod.rs"]
+mod v063;
+
+use serde_json::Value;
+
+#[test]
+fn test_check_duplicate_without_embedder_returns_documented_error() {
+    let db = v063::tmp_db("check-dup-no-embedder");
+
+    // `--tier keyword` keeps the daemon FTS-only so the embedder is
+    // explicitly None — the tier-aware sibling helper exists precisely
+    // to insulate this assertion from HuggingFace model downloads being
+    // flaky in CI (see also tests/integration.rs::http_capabilities_…
+    // line 9682 where the daemon-side test takes the same precaution).
+    let lines = v063::mcp_exchange_with_args(
+        &db,
+        &["--tier", "keyword"],
+        &[concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"#,
+            r#""name":"memory_check_duplicate","arguments":{"#,
+            r#""title":"Postgres tuning notes","#,
+            r#""content":"shared_buffers and work_mem reference values"#,
+            r#""}}}"#,
+        )],
+    );
+    assert_eq!(lines.len(), 1, "expected one MCP response, got {lines:?}");
+
+    let resp: Value = serde_json::from_str(&lines[0]).expect("parse MCP response");
+    assert_eq!(resp["id"], 1);
+
+    // Tool errors come back as ok responses with `isError: true` so a
+    // client that switches on the JSON-RPC code can still parse the
+    // payload (see src/mcp.rs handle_request: Err arm wraps in
+    // `ok_response` with `isError: true`).
+    assert_eq!(
+        resp["result"]["isError"], true,
+        "expected isError: true on no-embedder branch, got {resp}"
+    );
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("error text");
+    assert!(
+        text.contains("memory_check_duplicate requires the embedder"),
+        "unexpected error text: {text}"
+    );
+
+    // The MCP error path should NOT surface a top-level JSON-RPC `error`
+    // — the dispatcher reserves that for unknown methods (-32601).
+    assert!(
+        resp.get("error").is_none(),
+        "tool error must not double up as a JSON-RPC error: {resp}"
+    );
+
+    let _ = std::fs::remove_file(&db);
+}


### PR DESCRIPTION
## Summary

- Adds `tests/v063_check_duplicate.rs` — the second binary in the v0.6.3 integration suite — covering the no-embedder branch of `memory_check_duplicate` end-to-end through the MCP surface.
- Extends the v063 harness with `mcp_exchange_with_args` so future tests can inject `--tier keyword` / `--agent-id <id>` style flags into the spawn without forking the helper.
- Locks down the documented contract: keyword-tier dispatch returns `result.isError = true` + the literal "memory_check_duplicate requires the embedder; …" text, never a top-level JSON-RPC error.

## Charter linkage

Closes the iter 19 next-plan: "concrete proof the migration pattern works at scale" (charter §"Files to create" line 344, Pillar 2 / Stream D). The harness now exercises Pillar 1 / Stream A (taxonomy) + Pillar 2 / Stream D (duplicate-check) — two pillars from one shared module, no edits to `tests/integration.rs`.

## Stacking

This PR stacks on #411 (the harness scaffold). When #411 merges, GitHub will retarget this PR to `release/v0.6.3`.

## Test plan

- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test v063_check_duplicate` — 1 passed
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test v063_taxonomy` — 1 passed (regression check on harness edit)
- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo build --tests` — full integration suite still compiles

## AI involvement

- **Class:** Standard (test addition, no production code touched)
- **Author:** Claude Opus 4.7 (1M context), iteration 20 of the ai-memory-v063 campaign
- **Memory namespace:** `campaign-v063`

🤖 Generated with [Claude Code](https://claude.com/claude-code)