### PR TITLE
chore(bench): inline format args in benches/recall.rs (clippy::pedantic)

### DIFF
--- a/benches/recall.rs
+++ b/benches/recall.rs
@@ -18,17 +18,16 @@ fn binary_path() -> String {
         .expect("failed to get cargo metadata");
     let meta: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let target_dir = meta["target_directory"].as_str().unwrap().to_string();
-    format!("{}/release/ai-memory", target_dir)
+    format!("{target_dir}/release/ai-memory")
 }
 
 fn seed_memories(binary: &str, db_path: &str, count: usize) {
     for i in 0..count {
-        let title = format!("bench-memory-{}", i);
+        let title = format!("bench-memory-{i}");
+        let topic = i % 50;
+        let category = i % 10;
         let content = format!(
-            "This is benchmark memory number {} with some searchable content about topic-{} and category-{}",
-            i,
-            i % 50,
-            i % 10
+            "This is benchmark memory number {i} with some searchable content about topic-{topic} and category-{category}"
         );
         let priority = ((i % 10) + 1).to_string();
         let output = Command::new(binary)
@@ -49,7 +48,7 @@ fn seed_memories(binary: &str, db_path: &str, count: usize) {
             ])
             .output()
             .expect("failed to store memory");
-        assert!(output.status.success(), "store failed for memory {}", i);
+        assert!(output.status.success(), "store failed for memory {i}");
     }
 }
 
@@ -194,7 +193,7 @@ fn bench_insert(c: &mut Criterion) {
     group.bench_function("store_memory", |b| {
         b.iter(|| {
             counter += 1;
-            let title = format!("insert-bench-{}", counter);
+            let title = format!("insert-bench-{counter}");
             let output = Command::new(&binary)
                 .args([
                     "--db",


### PR DESCRIPTION
## Summary

Clears the four `clippy::uninlined_format_args` errors flagged on
`AI_MEMORY_NO_CONFIG=1 cargo clippy --benches -- -D warnings -D clippy::all -D clippy::pedantic`
inside `benches/recall.rs`. Pure mechanical refactor — every
`format!(\"{}/x\", v)` becomes `format!(\"{v}/x\")` (and one block
introduces local `topic`/`category` bindings to keep the inline form
readable). No behavior change.

## Context

The remaining ~64 clippy::pedantic errors against
`cargo clippy --tests --benches` live in `tests/integration.rs` (43)
and inline `#[cfg(test)]` modules under `src/` (subscriptions, validate,
config, db, metrics, etc.) — those are out of scope for this PR. This
unblocks `benches/recall.rs` from the broader cleanup and slots cleanly
into the alternative work item from iter #19's handoff
("triage the pre-existing clippy::pedantic errors on release/v0.6.3 HEAD").

The formal CLAUDE.md gate (`cargo clippy -- -D warnings -D clippy::all
-D clippy::pedantic`, no `--tests --benches`) was already clean before
this change and remains clean.

## AI involvement

- Authored by **Claude Opus 4.7 (1M context)** under the
  `ai-memory-v063` autonomous campaign (iter #21).
- Charter: `/Users/fate/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`.
- Authority class: **Trivial** (mechanical lint cleanup, no semantic
  change, no public API touched). Per `AI_DEVELOPER_GOVERNANCE.md`,
  trivial commits do not require human pre-approval but do require this
  PR-level disclosure.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo build --benches` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --benches -- -D warnings -D clippy::all -D clippy::pedantic` — `benches/recall.rs` no longer surfaces any errors (remaining errors are in unrelated `src/` test modules)
- [ ] CI: Bench workflow runs the bench suite end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)