### PR TITLE
chore(metrics): use std::ptr::from_ref in singleton test (clippy::ref_as_ptr)

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -295,7 +295,7 @@ mod tests {
         let r1 = registry();
         let r2 = registry();
         // Same instance — no double-registration.
-        assert!(std::ptr::eq(r1 as *const _, r2 as *const _));
+        assert!(std::ptr::eq(std::ptr::from_ref(r1), std::ptr::from_ref(r2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mechanical clippy fix: replace two `r as *const _` casts with `std::ptr::from_ref(r)` in `metrics::tests::registry_is_singleton`. Resolves the only `clippy::ref_as_ptr` errors that surface under `cargo clippy --all-targets -- -D clippy::pedantic`.

- Test-only code (`#[cfg(test)]` module).
- Semantically identical: `from_ref` is a `const fn` introduced in Rust 1.76 that returns `*const T` from `&T`; clippy::ref_as_ptr explicitly recommends it.
- Default `cargo clippy` gate (no `--all-targets`) was already clean and remains so.

## AI involvement

- Authored by **Claude Opus 4.7 (1M context)** under the `ai-memory-v063` campaign, iteration 22.
- Charter: `ai-memory-v0.6.3-grand-slam.md`, Pillar 1 / Stream A (clippy hygiene).
- Linked memory namespace: `campaign-v063`.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean.
- [x] `cargo clippy --all-targets ...` no longer reports `ref_as_ptr` for `src/metrics.rs:298` (other pre-existing `--all-targets` errors remain in unrelated files; tracked separately).
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory metrics::` — 3/3 pass (`registry_is_singleton`, `record_store_labels_tier`, `render_includes_registered_names`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)