### PR TITLE
chore(handlers): Duration::from_secs(2) in fed bulk-create test

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -5407,7 +5407,7 @@ mod tests {
         let fed = crate::federation::FederationConfig::build(
             2, // W=2 — local + 1 peer
             &[peer_url],
-            std::time::Duration::from_millis(2000),
+            std::time::Duration::from_secs(2),
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

Single-line clippy::pedantic cleanup. Replaces
`std::time::Duration::from_millis(2000)` with the equivalent
`std::time::Duration::from_secs(2)` in the
`http_bulk_create_fans_out_with_federation` test in `src/handlers.rs:5410`.

Resolves the `clippy::unreadable_literal`-adjacent warning that flags
constructing a `Duration` using a smaller unit when a larger unit would
be more readable. No behavior change — `from_millis(2000) == from_secs(2)`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --bin ai-memory federation` — 16/16 pass, including
  `handlers::tests::http_bulk_create_fans_out_with_federation`
- [x] `cargo test --bin ai-memory` — 408/408 unit tests pass
- [x] Verified the specific clippy error at `src/handlers.rs:5410` no
  longer fires
- [ ] CI: `cargo audit` (not installed locally)

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the
**ai-memory-v063** campaign, iter #23. Trivial-class change per
[`docs/AI_DEVELOPER_GOVERNANCE.md`](../blob/release/v0.6.3/docs/AI_DEVELOPER_GOVERNANCE.md):
single-line semantic-equivalent test refactor with verified test
coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)