### PR TITLE
chore(embeddings): epsilon comparison for f32 zero asserts (clippy::float_cmp)

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -316,7 +316,7 @@ mod tests {
         let a = vec![0.0, 0.0, 0.0];
         let b = vec![1.0, 2.0, 3.0];
         let sim = Embedder::cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
+        assert!(sim.abs() < f32::EPSILON);
     }
 
     #[test]
@@ -324,7 +324,7 @@ mod tests {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![1.0, 0.0]; // Different dimension
         let sim = Embedder::cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
+        assert!(sim.abs() < f32::EPSILON);
     }
 
     // --- v0.6.0.0 contextual recall — fuse() ---


### PR DESCRIPTION
## Summary

- Replace `assert_eq!(sim, 0.0)` with `assert!(sim.abs() < f32::EPSILON)` in the two `cosine_similarity` zero-result tests at `src/embeddings.rs:319` and `src/embeddings.rs:327`.
- Silences `clippy::pedantic::float_cmp` blocking a clean clippy gate on `release/v0.6.3` (charter Phase 1 cleanup; previous iteration handoff #415).

## Why

The lint flags strict `==` comparison of floats. Both branches under test (zero-vector input, dimension-mismatch input) take early-return paths that produce exact `0.0_f32`, so an epsilon test is functionally equivalent for these specific call sites and matches the project's existing pattern for f32 equality checks.

## AI involvement

- **Authority:** Trivial (test-only assertion change, no behavior change in production code paths).
- **Author:** Claude Opus 4.7 (1M context), iteration 24 of the `ai-memory-v063` campaign.
- **Charter §:** Phase 1 cleanup — clean clippy gate on `release/v0.6.3` per `docs/ENGINEERING_STANDARDS.md`.

## Test plan

- [x] `cargo fmt --check`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory cosine_similarity` (5/5 passing)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` (408 passing)
- [x] Targeted clippy: `embeddings.rs:319` and `embeddings.rs:327` no longer reported under `-D clippy::pedantic`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)