### PR TITLE
chore(reranker): epsilon comparison for f32 zero assert (clippy::float_cmp)

### DIFF
--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -408,7 +408,8 @@ mod tests {
 
     #[test]
     fn lexical_score_returns_zero_for_empty_query() {
-        assert_eq!(lexical_score("", "some title", "some content"), 0.0);
+        let s = lexical_score("", "some title", "some content");
+        assert!(s.abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replace `assert_eq!(lexical_score(...), 0.0)` with `assert!(s.abs() < f32::EPSILON)` in `lexical_score_returns_zero_for_empty_query` (src/reranker.rs:411). Functionally equivalent for the exact-zero value the empty-query branch produces, and silences one of the remaining `clippy::pedantic::float_cmp` errors that were blocking a clean clippy gate on `release/v0.6.3`.

This is the same one-line pattern as PR #416 (`src/embeddings.rs` cosine-similarity zero asserts) — together those three are the float_cmp cluster in production code.

Charter: `ai-memory-v0.6.3-grand-slam.md` — Pillar 1 / Stream A clean-clippy-gate prereq.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (CI form, lib + bin only) — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 408 unit + 185 integration pass
- [x] `cargo test reranker` — 7 reranker tests pass
- [x] SSH-signed commit (verified `Good "git" signature`)

## AI involvement

- **Author:** Claude Opus 4.7 (1M context), running as the `ai-memory-v063` campaign autonomous agent (iter #25).
- **Authority class:** Trivial (single-line test-only change, equivalent semantics).
- **Memory:** Recall via campaign iteration TOON history; handoff stored in namespace `campaign-v063`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)