### PR TITLE
chore(bench): inline format args in recall bench (clippy::uninlined_format_args)

### DIFF
--- a/benches/recall.rs
+++ b/benches/recall.rs
@@ -18,12 +18,12 @@ fn binary_path() -> String {
         .expect("failed to get cargo metadata");
     let meta: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let target_dir = meta["target_directory"].as_str().unwrap().to_string();
-    format!("{}/release/ai-memory", target_dir)
+    format!("{target_dir}/release/ai-memory")
 }
 
 fn seed_memories(binary: &str, db_path: &str, count: usize) {
     for i in 0..count {
-        let title = format!("bench-memory-{}", i);
+        let title = format!("bench-memory-{i}");
         let content = format!(
             "This is benchmark memory number {} with some searchable content about topic-{} and category-{}",
             i,
@@ -49,7 +49,7 @@ fn seed_memories(binary: &str, db_path: &str, count: usize) {
             ])
             .output()
             .expect("failed to store memory");
-        assert!(output.status.success(), "store failed for memory {}", i);
+        assert!(output.status.success(), "store failed for memory {i}");
     }
 }
 
@@ -194,7 +194,7 @@ fn bench_insert(c: &mut Criterion) {
     group.bench_function("store_memory", |b| {
         b.iter(|| {
             counter += 1;
-            let title = format!("insert-bench-{}", counter);
+            let title = format!("insert-bench-{counter}");
             let output = Command::new(&binary)
                 .args([
                     "--db",


### PR DESCRIPTION
## Summary

Inlines 4 positional `format!` / `assert!` calls in `benches/recall.rs`
that triggered `clippy::uninlined_format_args` under `clippy::pedantic`.
The bench target is now `clippy --bench recall -- -D warnings -D
clippy::all -D clippy::pedantic` clean.

- `format!(\"{}/release/ai-memory\", target_dir)` → `format!(\"{target_dir}/release/ai-memory\")`
- `format!(\"bench-memory-{}\", i)` → `format!(\"bench-memory-{i}\")`
- `assert!(..., \"store failed for memory {}\", i)` → `assert!(..., \"store failed for memory {i}\")`
- `format!(\"insert-bench-{}\", counter)` → `format!(\"insert-bench-{counter}\")`

The `format!(\"... {} ... {} ... {}\", i, i % 50, i % 10)` block at
benches/recall.rs:27-32 is left alone — clippy does not flag it because
two of its three args are expressions, not bare identifiers.

## Charter motivation

ai-memory-v0.6.3 grand-slam Pillar 3 / Stream E ships the criterion
benchmark suite (kg_query / kg_timeline workloads, #392-#397). Keeping
the bench target clippy-clean under `pedantic` matches the lint
discipline the lib + bins already pass.

## AI involvement

- **Class:** Trivial (whitespace-equivalent format-string syntax change)
- **Author:** Claude Opus 4.7 (1M context), via campaign-runner
  iteration #26 of campaign ai-memory-v063

## Test plan

- [x] `cargo clippy --bench recall --no-deps -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `cargo bench --no-run --bench recall` — builds in release profile
- [x] `cargo fmt --check` — clean
- [x] `env -u AI_MEMORY_AGENT_ID cargo test` — 185 passed, 0 failed
  (the AI_MEMORY_AGENT_ID env var leaking from the campaign runner
  causes 11 unrelated NHI-prefix assertion failures; unsetting it
  restores the expected suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)