### PR TITLE
chore(clippy): replace `"".to_string()` with `String::new()` (manual_string_new)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -5979,7 +5979,7 @@ mod tests {
             &conn,
             "Trim Test",
             "test",
-            &["".to_string(), "   ".to_string(), "ok".to_string()],
+            &[String::new(), "   ".to_string(), "ok".to_string()],
             &serde_json::json!({}),
             None,
         )

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -829,7 +829,7 @@ mod tests {
     fn test_valid_tags() {
         assert!(validate_tags(&["dns".to_string(), "bind9".to_string()]).is_ok());
         assert!(validate_tags(&[]).is_ok());
-        assert!(validate_tags(&["".to_string()]).is_err());
+        assert!(validate_tags(&[String::new()]).is_err());
         let too_many: Vec<String> = (0..51).map(|i| format!("tag{i}")).collect();
         assert!(validate_tags(&too_many).is_err());
     }


### PR DESCRIPTION
## Summary

Two test-only call sites flagged by `clippy::pedantic::manual_string_new`
under `cargo clippy --all-targets`. Pure literal swap, no behavior change.

- `src/db.rs:5982` — `entity_register_skips_blank_aliases`
- `src/validate.rs:832` — `test_valid_tags`

Charter alignment: continued chip-away at the `--all-targets` clippy::pedantic
backlog on `release/v0.6.3` so we can re-enable the `--all-targets` gate once
the heavier clusters (`tests/integration.rs`, the v063 test-slice migration in
#411 / #412) land.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (gate command from `CLAUDE.md`)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bins` — 408 passed, 0 failed
- [x] Targeted: `entity_register_skips_blank_aliases`, `test_valid_tags` both pass

## AI involvement

- **Author model:** Claude Opus 4.7 (1M context)
- **Authority class:** Trivial (test-only literal swap, equivalent constructor, no behavior change)
- **Memory namespace:** `campaign-v063`

🤖 Generated with [Claude Code](https://claude.com/claude-code)