### PR TITLE
test(clippy): replace `assert_eq!` on floats with epsilon compare (float_cmp)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -976,7 +976,7 @@ mod tests {
     fn effective_scoring_on_empty_config() {
         let cfg = AppConfig::default();
         let s = cfg.effective_scoring();
-        assert_eq!(s.half_life_days_short, 7.0);
+        assert!((s.half_life_days_short - 7.0).abs() < f64::EPSILON);
         assert!(!s.legacy_scoring);
     }
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -316,7 +316,7 @@ mod tests {
         let a = vec![0.0, 0.0, 0.0];
         let b = vec![1.0, 2.0, 3.0];
         let sim = Embedder::cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
+        assert!(sim.abs() < f32::EPSILON);
     }
 
     #[test]
@@ -324,7 +324,7 @@ mod tests {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![1.0, 0.0]; // Different dimension
         let sim = Embedder::cosine_similarity(&a, &b);
-        assert_eq!(sim, 0.0);
+        assert!(sim.abs() < f32::EPSILON);
     }
 
     // --- v0.6.0.0 contextual recall — fuse() ---

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn lexical_score_returns_zero_for_empty_query() {
-        assert_eq!(lexical_score("", "some title", "some content"), 0.0);
+        assert!(lexical_score("", "some title", "some content").abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Clears the four remaining `clippy::float_cmp` pedantic warnings in unit tests by replacing `assert_eq!(x, target)` with epsilon-based comparison.

| File | Line | Type |
|------|------|------|
| `src/config.rs` | 979 | f64 |
| `src/embeddings.rs` | 319 | f32 |
| `src/embeddings.rs` | 327 | f32 |
| `src/reranker.rs` | 411 | f32 |

Pattern: `assert_eq!(x, target)` → `assert!((x - target).abs() < T::EPSILON)` (or `x.abs() < T::EPSILON` when `target == 0.0`).

Test-only change; production code untouched. Companion to PR #419 (manual_string_new) under the v0.6.3 charter's "drive `clippy::pedantic` clean on production code" workstream.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (CI command) — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` — 408 / 408 passing
- [x] All four affected tests still pass with the new assertion form

## AI involvement

- Authored by Claude Opus 4.7 (`claude-opus-4-7[1m]`) under the `ai-memory-v063` campaign, iteration 28
- Authority class: **Trivial** (test-only edits, no production logic)
- Charter: `/Users/fate/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)