### PR TITLE
test(clippy): use char patterns in sanitize_fts test (single_char_pattern)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -5168,9 +5168,9 @@ mod tests {
     fn sanitize_fts_strips_operators_and_quotes() {
         // FTS5 special chars: " * ^ { } ( ) : - | are stripped
         let sanitized = sanitize_fts_query("test* \"injection\" (drop)", true);
-        assert!(!sanitized.contains("*"));
-        assert!(!sanitized.contains("("));
-        assert!(!sanitized.contains(")"));
+        assert!(!sanitized.contains('*'));
+        assert!(!sanitized.contains('('));
+        assert!(!sanitized.contains(')'));
         // Standalone boolean operators are removed
         let sanitized2 = sanitize_fts_query("hello AND world OR NOT NEAR test", true);
         assert!(sanitized2.contains("hello"));


### PR DESCRIPTION
## Summary

Replaces three `&str` single-character patterns with `char` literals in the
`sanitize_fts_strips_operators_and_quotes` test, clearing
`clippy::single_char_pattern` warnings on `src/db.rs:5171-5173`.

`String::contains` is faster with a `char` than a single-character `&str`,
which is why `clippy::pedantic` flags the latter.

Charter: ai-memory-v0.6.3 grand-slam — Pillar: clippy::pedantic cleanup
on `release/v0.6.3` (one small PR per warning).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` — three single_char_pattern errors at src/db.rs:5171-5173 are resolved
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory sanitize_fts` — passes
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory db::` — 124 passed

## AI involvement

- **Author model:** Claude Opus 4.7 (1M context) — `claude-opus-4-7[1m]`
- **Authority class:** Trivial (test-only, semantics-preserving lint fix)
- **Workflow phase:** implement → gates → PR per `docs/AI_DEVELOPER_WORKFLOW.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)