### PR TITLE
test(clippy): inline format args in autonomy assert (uninlined_format_args)

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -980,8 +980,7 @@ mod tests {
         // Forgot m_old because it's superseded by m_new.
         assert!(
             report.memories_forgotten >= 1,
-            "expected ≥1 forget, got {:?}",
-            report
+            "expected ≥1 forget, got {report:?}"
         );
         // Rollback entries written for each action.
         assert!(report.rollback_entries_written >= report.clusters_formed);


### PR DESCRIPTION
## Summary
- Inline `report` into the `{report:?}` format placeholder in the `full_autonomy_cycle_end_to_end` test assertion.
- Resolves a `clippy::uninlined_format_args` warning at `src/autonomy.rs:981` flagged under `clippy::pedantic`.

## Charter
Pillar 0 / clippy hygiene — incremental progress toward a clean `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` gate on `release/v0.6.3` (see [`docs/AI_DEVELOPER_WORKFLOW.md`](../blob/release/v0.6.3/docs/AI_DEVELOPER_WORKFLOW.md) build/test gates).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings -D clippy::pedantic` — no warnings remain in `src/autonomy.rs`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory autonomy::tests::full_autonomy_cycle_end_to_end` passes

## AI involvement
- **Author**: Claude Opus 4.7 (1M context), campaign `ai-memory-v063` iter 30
- **Authority class**: Trivial (lint-only, single-line test assert, no behavior change)
- **Review**: Operator review requested before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)