### PR TITLE
chore(clippy): backtick `temporal/observed_by` in insert_link_full doc (doc_markdown)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -6549,7 +6549,7 @@ mod tests {
 
     // -- Pillar 2 / Stream C — kg_query (depth=1) ---------------------------
 
-    /// Insert a link with explicit temporal/observed_by columns so the
+    /// Insert a link with explicit `temporal/observed_by` columns so the
     /// `kg_query` filter tests can pin behavior without relying on
     /// wall-clock spread.
     fn insert_link_full(


### PR DESCRIPTION
## Summary

One-line doc-comment fix in a `#[cfg(test)]` helper (`src/db.rs:6552`):

- `clippy::doc_markdown` flagged `temporal/observed_by` (slash-joined
  identifier pair) as a missing backticked item.
- Quote it the same way `kg_query` is already quoted on the next line.

No behavior change — comment-only edit. Charter: chips away at the
`clippy::pedantic` cluster on `release/v0.6.3` (campaign **ai-memory-v063**,
iteration 31). Aligns with [`AI_DEVELOPER_WORKFLOW`](docs/AI_DEVELOPER_WORKFLOW.md)
hygiene standard #4 — zero pedantic warnings before release.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin ai-memory -- -D clippy::doc_markdown` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory kg_query` — 14 passed (the `insert_link_full` helper's only callers)
- [ ] CI gates (fmt, clippy, build, test) on PR

## AI involvement

- **Authority class**: Trivial (doc-comment only, single-line, no behavior change)
- **Author**: Claude Opus 4.7 (1M context), autonomous campaign agent
- **Verification**: cargo fmt + targeted clippy lint + 14 kg_query tests locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)