### PR TITLE
chore(clippy): underscore separators in 7_776_000 literal (unreadable_literal)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -858,7 +858,7 @@ mod tests {
             short_extend_secs = 7200
         "#;
         let cfg: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.ttl.as_ref().unwrap().mid_ttl_secs, Some(7776000));
+        assert_eq!(cfg.ttl.as_ref().unwrap().mid_ttl_secs, Some(7_776_000));
         assert_eq!(cfg.ttl.as_ref().unwrap().short_extend_secs, Some(7200));
         assert!(!cfg.effective_archive_on_gc());
     }


### PR DESCRIPTION
## Summary
- Replace `7776000` with `7_776_000` in the `ttl_config_parse_toml` test assertion at `src/config.rs:861`.
- Clears one `clippy::unreadable_literal` (pedantic) warning. No behavior change — pure readability fix in a test literal.

## Charter
ai-memory v0.6.3 — clippy::pedantic hygiene sweep across `release/v0.6.3` (small, mergeable, isolated fixes).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` no longer flags `src/config.rs:861`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory config::` — 24 passed (including `ttl_config_parse_toml`)

## AI involvement
- Author: Claude Opus 4.7 (1M context), via the ai-memory-v063 campaign runner (iter #32).
- Scope: a single-line literal-formatting change in a test assertion. Reviewed by the campaign runner; no human in the loop yet.
- Authority class: Trivial (cosmetic test-only change, no production code path touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)