### PR TITLE
chore(clippy): drop needless raw string hashes in config test (needless_raw_string_hashes)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -982,12 +982,12 @@ mod tests {
 
     #[test]
     fn scoring_roundtrip_through_toml() {
-        let toml_src = r#"
+        let toml_src = r"
 [scoring]
 half_life_days_short = 5.0
 half_life_days_mid = 25.0
 legacy_scoring = false
-"#;
+";
         let cfg: AppConfig = toml::from_str(toml_src).expect("parses");
         let s = cfg.effective_scoring();
         assert!((s.half_life_days_short - 5.0).abs() < f64::EPSILON);


### PR DESCRIPTION
## Summary
- The TOML body in `scoring_roundtrip_through_toml` contains no `\"` characters, so the `r#\"...\"#` raw-string hashes are unnecessary; `r\"...\"` is enough.
- Resolves `clippy::needless_raw_string_hashes` at `src/config.rs:985` under `clippy::pedantic`.

## Charter
- Pillar 0 (hygiene) — keep `clippy::pedantic` clean on `release/v0.6.3`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --bin ai-memory -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory config::tests::scoring_roundtrip_through_toml`

## AI involvement
- **Author**: Claude Opus 4.7 (1M context), via campaign runner `ai-memory-v063` iter #33.
- **Authority class**: Trivial (mechanical lint fix; no behavior change).
- **Human review**: required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)