### PR TITLE
chore(clippy): fold+write! in test hex helper (format_collect)

### DIFF
--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -564,7 +564,14 @@ mod tests {
 // format!("{:x}", _) pattern over GenericArray outputs.
 #[cfg(test)]
 mod hex {
+    use std::fmt::Write as _;
+
     pub fn encode_fallback(bytes: &[u8]) -> String {
-        bytes.iter().map(|b| format!("{b:02x}")).collect()
+        bytes
+            .iter()
+            .fold(String::with_capacity(bytes.len() * 2), |mut output, b| {
+                let _ = write!(output, "{b:02x}");
+                output
+            })
     }
 }


### PR DESCRIPTION
## Summary

Single-spot `clippy::format_collect` cleanup in the test-only `hex::encode_fallback` helper at `src/subscriptions.rs:567`.

The previous implementation used `bytes.iter().map(|b| format!(\"{b:02x}\")).collect()`, which heap-allocates a transient `String` per byte. Replaced with the clippy-recommended `fold` over a pre-sized `String::with_capacity(bytes.len() * 2)` plus `write!(output, \"{b:02x}\")` to append in place.

The helper is gated behind `#[cfg(test)]`. Production hex paths use `format!(\"{:x}\", _)` over `GenericArray` outputs and are untouched.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory subscriptions` — 6/6 pass, including `hmac_sha256_stable` (known-vector compare against `f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8`), which exercises `encode_fallback` end-to-end.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` — 408/408 unit tests pass.
- [x] Verified the specific clippy `format_collect` warning at `src/subscriptions.rs:568` no longer fires.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the **ai-memory-v063** campaign, iter #34. Trivial-class hygiene change per [`docs/AI_DEVELOPER_GOVERNANCE.md`](../blob/release/v0.6.3/docs/AI_DEVELOPER_GOVERNANCE.md): localized test-helper refactor that preserves observable behavior and is covered by the existing known-vector test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)