### PR TITLE
chore(clippy): hoist MockState items above statements (items_after_statements)

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -5372,11 +5372,6 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use tokio::net::TcpListener;
 
-        let state = test_state();
-
-        // Mock peer that counts sync_push POSTs and always acks.
-        let count = Arc::new(AtomicUsize::new(0));
-        let count_for_peer = count.clone();
         #[derive(Clone)]
         struct MockState {
             count: Arc<AtomicUsize>,
@@ -5391,6 +5386,12 @@ mod tests {
                 Json(json!({"applied":1,"noop":0,"skipped":0})),
             )
         }
+
+        let state = test_state();
+
+        // Mock peer that counts sync_push POSTs and always acks.
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_peer = count.clone();
         let peer_app = Router::new()
             .route("/api/v1/sync/push", axum_post(mock_sync_push))
             .with_state(MockState {


### PR DESCRIPTION
## Summary
- Resolve `clippy::pedantic items_after_statements` at `src/handlers.rs:5381` by moving the local `MockState` struct + `mock_sync_push` async fn above the test's first `let` statements.
- Pure refactor — items remain test-scoped, no behavior change.

## Charter
v0.6.3 grand-slam — clippy hygiene chip-away ahead of `v0.6.3-rc1`. The deferral note in iter-33 had paired this fix with the `tests/integration.rs` cluster (waiting on PRs #411/#412), but #411/#412 only add new files under `tests/v063/` and don't touch `src/handlers.rs`, so this fix is safe to land independently.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all` clean
- [x] `cargo clippy --bin ai-memory --tests --no-deps -- -W clippy::pedantic` confirms `items_after_statements` warning at line 5381 is gone (only the unrelated `from_millis(2000)` warning remains, covered by #415)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory http_bulk_create_fans_out_with_federation` ⇒ ok
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory` ⇒ 408 passed, 0 failed

## AI involvement
Authored end-to-end by Claude Opus 4.7 (1M context) under the `ai-memory-v063` autonomous campaign (iter #36). Operator review required before merge per repo governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)