### PR TITLE
test(clippy): make_tools_call takes &Value (needless_pass_by_value)

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3627,7 +3627,7 @@ mod tests {
         String::from_utf8(buf.lock().unwrap().clone()).unwrap_or_default()
     }
 
-    fn make_tools_call(tool: &str, args: Value) -> RpcRequest {
+    fn make_tools_call(tool: &str, args: &Value) -> RpcRequest {
         RpcRequest {
             jsonrpc: "2.0".into(),
             id: Some(json!(1)),
@@ -3646,7 +3646,7 @@ mod tests {
         let tier_config = FeatureTier::Keyword.config();
         let resolved_ttl = crate::config::ResolvedTtl::default();
         let resolved_scoring = crate::config::ResolvedScoring::default();
-        let req = make_tools_call("memory_list", json!({"limit": 1}));
+        let req = make_tools_call("memory_list", &json!({"limit": 1}));
 
         let captured = run_with_capture(|| {
             let resp = handle_request(
@@ -3696,7 +3696,7 @@ mod tests {
         let resolved_scoring = crate::config::ResolvedScoring::default();
         // memory_get with a missing/invalid id is a deterministic Err
         // path: validate_id rejects empty strings.
-        let req = make_tools_call("memory_get", json!({"id": ""}));
+        let req = make_tools_call("memory_get", &json!({"id": ""}));
 
         let captured = run_with_capture(|| {
             let resp = handle_request(


### PR DESCRIPTION
## Summary

Test helper `make_tools_call` in `src/mcp.rs` (tests module) took `args: Value`
but only forwarded it into a `json!({ "arguments": args })` macro expansion,
which serializes via `serde`'s blanket `Serialize for &T` impl — so the value
never needed to be owned. Switching to `args: &Value` silences
`clippy::needless_pass_by_value` without changing behavior.

Both call sites (`memory_list` smoke at line 3649 and the `memory_get`
empty-id deterministic-error path at line 3699) updated to pass
`&json!(…)`.

This drops the deferred warning at `src/mcp.rs:3630` flagged in the
campaign log. With PR #429 (db `make_memory(tier: &Tier)`) it leaves
`src/` free of `clippy::needless_pass_by_value`.

Charter motivation: §"All four gates must pass before PR submission"
in CLAUDE.md — `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
is one of the four gates.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin ai-memory --tests -- -D warnings -D clippy::all -D clippy::pedantic` no longer reports the line-3630 warning
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --bin ai-memory mcp::` — 22 passed (incl. `tools_call_emits_span_with_tool_name_and_elapsed_ms` and `tools_call_emits_warn_event_on_handler_error`, the two callers)

## AI involvement

Authored by Claude Opus 4.7 (1M context) under campaign
`ai-memory-v063` iteration 38 (autonomous). Human-reviewed before
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)