### PR TITLE
test(clippy): integration test helpers take &Value (needless_pass_by_value)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5681,7 +5681,7 @@ fn mcp_call(
     binary: &str,
     db_path: &std::path::Path,
     name: &str,
-    args: serde_json::Value,
+    args: &serde_json::Value,
 ) -> serde_json::Value {
     use std::io::Write;
     let mut child = cmd(binary)
@@ -5739,7 +5739,7 @@ fn test_governance_set_and_get_roundtrip() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({
+        &serde_json::json!({
             "namespace": "alphaone/eng",
             "id": sid,
             "governance": gov.clone(),
@@ -5752,7 +5752,7 @@ fn test_governance_set_and_get_roundtrip() {
         bin,
         &db,
         "memory_namespace_get_standard",
-        serde_json::json!({"namespace": "alphaone/eng"}),
+        &serde_json::json!({"namespace": "alphaone/eng"}),
     );
     assert_eq!(get_resp["governance"]["write"], "registered");
     assert_eq!(get_resp["governance"]["promote"], "approve");
@@ -5771,13 +5771,13 @@ fn test_governance_default_returned_when_unset() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({"namespace": "plain", "id": sid}),
+        &serde_json::json!({"namespace": "plain", "id": sid}),
     );
     let get_resp = mcp_call(
         bin,
         &db,
         "memory_namespace_get_standard",
-        serde_json::json!({"namespace": "plain"}),
+        &serde_json::json!({"namespace": "plain"}),
     );
     let gov = &get_resp["governance"];
     assert_eq!(gov["write"], "any");
@@ -5794,7 +5794,7 @@ fn mcp_call_raw(
     binary: &str,
     db_path: &std::path::Path,
     name: &str,
-    args: serde_json::Value,
+    args: &serde_json::Value,
 ) -> serde_json::Value {
     use std::io::Write;
     let mut child = cmd(binary)
@@ -5844,7 +5844,7 @@ fn test_governance_invalid_rejected() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({
+        &serde_json::json!({
             "namespace": "alphaone/eng",
             "id": sid,
             "governance": {
@@ -5872,7 +5872,7 @@ fn test_governance_consensus_quorum_rejected() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({
+        &serde_json::json!({
             "namespace": "alphaone",
             "id": sid,
             "governance": {
@@ -5902,7 +5902,7 @@ fn test_governance_inherit_path_surfaces_per_level() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({
+        &serde_json::json!({
             "namespace": "alphaone",
             "id": org_id,
             "governance": {
@@ -5915,7 +5915,7 @@ fn test_governance_inherit_path_surfaces_per_level() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({
+        &serde_json::json!({
             "namespace": "alphaone/eng",
             "id": team_id,
             "governance": {
@@ -5929,7 +5929,7 @@ fn test_governance_inherit_path_surfaces_per_level() {
         bin,
         &db,
         "memory_namespace_get_standard",
-        serde_json::json!({"namespace": "alphaone/eng", "inherit": true}),
+        &serde_json::json!({"namespace": "alphaone/eng", "inherit": true}),
     );
     let standards = resp["standards"].as_array().unwrap();
     assert!(standards.len() >= 2);
@@ -5957,7 +5957,7 @@ fn test_governance_legacy_memory_defaults_not_mutated() {
         bin,
         &db,
         "memory_namespace_set_standard",
-        serde_json::json!({"namespace": "legacy", "id": sid}),
+        &serde_json::json!({"namespace": "legacy", "id": sid}),
     );
     let out = cmd(bin)
         .args(["--db", db.to_str().unwrap(), "--json", "get", &sid])
@@ -5986,7 +5986,7 @@ fn set_governance(
     binary: &str,
     db_path: &std::path::Path,
     namespace: &str,
-    governance: serde_json::Value,
+    governance: &serde_json::Value,
     owner_agent_id: &str,
 ) {
     let out = cmd(binary)
@@ -6060,7 +6060,7 @@ fn test_enforce_any_allows_store() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"any","promote":"any","delete":"any","approver":"human"}),
+        &serde_json::json!({"write":"any","promote":"any","delete":"any","approver":"human"}),
         "owner",
     );
     let out = cmd(bin)
@@ -6098,7 +6098,7 @@ fn test_enforce_registered_blocks_unregistered() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let out = cmd(bin)
@@ -6146,7 +6146,7 @@ fn test_enforce_registered_allows_registered() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"registered","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let out = cmd(bin)
@@ -6179,7 +6179,7 @@ fn test_enforce_owner_blocks_non_owner_delete() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let store = cmd(bin)
@@ -6230,7 +6230,7 @@ fn test_enforce_owner_allows_self_delete() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"any","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let store = cmd(bin)
@@ -6279,7 +6279,7 @@ fn test_enforce_approve_queues_pending() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let out = cmd(bin)
@@ -6316,7 +6316,7 @@ fn test_enforce_pending_list_and_approve() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let queued = cmd(bin)
@@ -6394,7 +6394,7 @@ fn test_enforce_pending_reject_status() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let queued = cmd(bin)
@@ -6492,7 +6492,7 @@ fn test_enforce_promote_with_approve_policy() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"any","promote":"approve","delete":"any","approver":"human"}),
+        &serde_json::json!({"write":"any","promote":"approve","delete":"any","approver":"human"}),
         "owner",
     );
     let store = cmd(bin)
@@ -6545,7 +6545,7 @@ fn test_enforce_mcp_pending_tools() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let queued = cmd(bin)
@@ -6715,7 +6715,7 @@ fn test_approver_human_any_approver_accepted() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
+        &serde_json::json!({"write":"approve","promote":"any","delete":"owner","approver":"human"}),
         "owner",
     );
     let pid = queue_store(bin, &db, "alphaone", "human-target", "alice");
@@ -6736,7 +6736,7 @@ fn test_approver_agent_rejects_wrong_caller() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"agent":"maintainer"}
         }),
@@ -6761,7 +6761,7 @@ fn test_approver_agent_accepts_matching_caller() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"agent":"maintainer"}
         }),
@@ -6784,7 +6784,7 @@ fn test_approver_consensus_below_threshold_pending() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":3}
         }),
@@ -6826,7 +6826,7 @@ fn test_approver_consensus_threshold_auto_executes() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":2}
         }),
@@ -6885,7 +6885,7 @@ fn test_approver_consensus_same_agent_does_not_double_count() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":2}
         }),
@@ -6917,7 +6917,7 @@ fn test_approver_agent_rejected_not_counted_for_consensus() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"agent":"only-me"}
         }),
@@ -6945,7 +6945,7 @@ fn test_approver_delete_consensus_executes_delete() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"any","promote":"any","delete":"approve",
             "approver":{"consensus":2}
         }),
@@ -7026,7 +7026,7 @@ fn test_consensus_unregistered_voter_rejected() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":2}
         }),
@@ -7070,7 +7070,7 @@ fn test_consensus_case_variant_rejected_if_only_lowercase_registered() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":2}
         }),
@@ -7108,7 +7108,7 @@ fn test_consensus_case_insensitive_dedup_when_variants_registered() {
         bin,
         &db,
         "alphaone",
-        serde_json::json!({
+        &serde_json::json!({
             "write":"approve","promote":"any","delete":"owner",
             "approver":{"consensus":2}
         }),


### PR DESCRIPTION
## Summary

Three integration test helpers (`mcp_call`, `mcp_call_raw`, `set_governance`) in `tests/integration.rs` took `serde_json::Value` by value but only forwarded the argument into a `serde_json::json!({...})` macro. Switching to `&serde_json::Value` silences three `clippy::needless_pass_by_value` errors at lines 5684, 5797, 5989.

The body needs no change: the `json!` macro accepts `&Value` via the `serde::Serialize` blanket impl. This is the same pattern as commit 2ffd64d (`make_tools_call` in src/mcp.rs from PR #430).

All 31 call sites now prefix the literal with `&`. No runtime behavior change.

## Charter

Pillar 1 / Stream A — clean clippy::pedantic in tests, paying down test-helper debt isolated from the broader 41-warning slice in tests/integration.rs (still gated on PRs #411 + #412).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` — three targeted warnings dropped (38 errors remain in tests/integration.rs vs 41 before)
- [x] `cargo test --bin ai-memory` — 408 unit tests pass
- [x] `cargo test --test integration governance` — 7 pass
- [x] `cargo test --test integration enforce` — 11 pass
- [x] `cargo test --test integration` (full, with AI_MEMORY_AGENT_ID unset) — 184 pass; only flake is http_namespace_standard_query_string_set_get_clear "serve never came up" port-race that passes solo

## AI involvement

- **Author**: Claude Opus 4.7 (1M context) — Anthropic
- **Authority class**: Trivial (mechanical clippy fix in test code; no behavior change)
- **Workflow**: Followed docs/AI_DEVELOPER_WORKFLOW.md — recall → plan → branch → implement → gates → self-review → PR