### PR TITLE
test(clippy): Value::is_null method ref in is_none_or (redundant_closure)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7247,7 +7247,10 @@ fn test_budget_unlimited_returns_all() {
     let v = recall_with_budget(bin, &db, "alpha", None);
     assert_eq!(v["count"], 3);
     assert!(v["tokens_used"].as_u64().unwrap() > 0);
-    assert!(v.get("budget_tokens").is_none_or(|v| v.is_null()));
+    assert!(
+        v.get("budget_tokens")
+            .is_none_or(serde_json::Value::is_null)
+    );
     let _ = std::fs::remove_file(&db);
 }
 


### PR DESCRIPTION
## Summary

Replace `|v| v.is_null()` closure with `serde_json::Value::is_null` method
reference in `test_budget_unlimited_returns_all`. Satisfies
`clippy::redundant_closure_for_method_calls` under `cargo clippy -- -D clippy::pedantic`.

One of the chip-away PRs whittling the tests/integration.rs clippy::pedantic backlog
on `release/v0.6.3` (charter §Pillar 2 — code quality / pedantic-clean gate).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests --bins -- -D clippy::all -D clippy::pedantic` no longer reports `tests/integration.rs:7250 redundant_closure` (overall errors 63 → 62)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_budget_unlimited_returns_all` passes

## AI involvement

- **Author:** Claude Opus 4.7 (1M context) under campaign `ai-memory-v063` (iter #40)
- **Authority class:** Trivial (mechanical clippy lint fix, behavior unchanged)
- **Reviewer:** human operator