### PR TITLE
test(clippy): usize::try_from for as_u64 cast (cast_possible_truncation)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7261,7 +7261,7 @@ fn test_budget_truncates_to_fit() {
     }
 
     let v = recall_with_budget(bin, &db, "alpha", Some(25));
-    let count = v["count"].as_u64().unwrap() as usize;
+    let count = usize::try_from(v["count"].as_u64().unwrap()).unwrap();
     assert!(
         (1..5).contains(&count),
         "budget must truncate; got count={count}"


### PR DESCRIPTION
## Summary
- Replace `v[\"count\"].as_u64().unwrap() as usize` with `usize::try_from(v[\"count\"].as_u64().unwrap()).unwrap()` in `test_budget_truncates_to_fit`.
- Clears `clippy::cast_possible_truncation` under `-D clippy::pedantic` (the only `as_u64().unwrap() as usize` occurrence in `tests/`).
- Behaviorally equivalent on 64-bit hosts; explicit `try_from` documents the conversion and panics on overflow rather than silently truncating.

## Test plan
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_budget_truncates_to_fit` passes.
- [x] `cargo clippy --tests --no-deps -- -D warnings -D clippy::all -D clippy::pedantic` no longer reports the warning at this site.
- [x] `cargo fmt --check` clean.

## AI involvement
Authored by Claude Opus 4.7 (1M context) under the `ai-memory-v063` campaign (iter #41). Charter: `/Users/fate/agentic-mem-labs/strategy/2026-04-25/ai-memory-v0.6.3-grand-slam.md`. Standalone Pillar 2 / clippy-cleanup slice; orthogonal to open PRs #411, #412, #431, #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)