### PR TITLE
test(clippy): char::is_ascii_hexdigit in mTLS hex filter (redundant_closure)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8100,7 +8100,7 @@ fn cert_sha256_fingerprint(cert_path: &std::path::Path) -> Option<String> {
         .split('=')
         .nth(1)?
         .chars()
-        .filter(|c| c.is_ascii_hexdigit())
+        .filter(char::is_ascii_hexdigit)
         .collect();
     Some(hex.to_ascii_lowercase())
 }


### PR DESCRIPTION
## Summary
- Replaces `.filter(|c| c.is_ascii_hexdigit())` with `.filter(char::is_ascii_hexdigit)` in the mTLS fingerprint hex helper at tests/integration.rs:8103
- Clears one `clippy::redundant_closure_for_method_calls` warning toward the v0.6.3 clippy::pedantic-clean gate (charter Pillar 0).

## AI involvement
Authored by Claude Opus 4.7 (1M context). Committed under `Co-Authored-By:` trailer per repository policy. SSH-signed.

## Test plan
- [x] `cargo build --tests` passes
- [x] `cargo clippy --tests --no-deps` no longer flags 8103 redundant_closure
- [x] `cargo fmt --check` clean
- [ ] CI: full test suite + clippy gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)