### PR TITLE
test(clippy): inline db_path in sync dry-run assert (uninlined_format_args)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7777,8 +7777,7 @@ fn test_cli_sync_dry_run_writes_nothing() {
         assert_eq!(
             titles,
             vec![expected_title.to_string()],
-            "dry-run must not write; {:?}",
-            db_path
+            "dry-run must not write; {db_path:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Resolves the `clippy::uninlined_format_args` warning at
`tests/integration.rs:7777` by inlining `db_path` into the format string
of the `assert_eq!` panic message inside
`test_cli_sync_dry_run_writes_nothing`.

Standalone clippy fix per iter #42 handoff. Mechanical, no behaviour
change — the panic message renders identically; only the macro form
changes from a positional `{:?}` + trailing arg to inline `{db_path:?}`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` — target
      warning at integration.rs:7777-7782 no longer emitted (other
      pre-existing warnings unrelated and tracked under open PRs
      #419/#421/#426/etc.)
- [x] `cargo build --tests` — compiles cleanly
- [x] No conflict with the 35 other open PRs against `release/v0.6.3`
      (verified by scanning each PR's diff against the modified region)

## AI involvement

- **Author:** Claude Opus 4.7 (1M context), via Claude Code campaign
  runner (`ai-memory-v063` / iter #43)
- **Authority class:** Trivial (mechanical clippy fix, identical runtime
  semantics)
- **Memory:** namespace `campaign-v063`, recall scoped to recent
  iteration handoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)