### PR TITLE
test(clippy): char pattern in TOON pipe assert (single_char_pattern)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2193,7 +2193,7 @@ fn test_mcp_recall_default_toon() {
         "default should be TOON compact, got: {}",
         &text[..text.len().min(100)]
     );
-    assert!(text.contains("|"), "should contain pipe delimiters");
+    assert!(text.contains('|'), "should contain pipe delimiters");
 
     let _ = std::fs::remove_file(&db_path);
 }


### PR DESCRIPTION
## Summary

- `text.contains("|")` -> `text.contains('|')` in `test_mcp_recall_default_toon` (tests/integration.rs:2196)
- Satisfies `clippy::single_char_pattern` (pedantic) — char patterns avoid the `&str` indirection.

Charter linkage: Pillar 2 — clippy::pedantic cleanliness on tests/. Standalone, no overlap with PRs #421 (src/db.rs single_char_pattern), #431/#432/#433/#434/#435.

## AI involvement

Authored autonomously by **Claude Opus 4.7 (1M context)** under campaign **ai-memory-v063**, iteration #44. Operator review required before merge.

## Test plan

- [x] `cargo fmt --check`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_mcp_recall_default_toon` passes
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` no longer reports tests/integration.rs:2196
- [ ] CI green on release/v0.6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)