### PR TITLE
chore(clippy): backtick `agent_id` in consolidate test doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3725,7 +3725,7 @@ fn test_import_trust_source_preserves_agent_id() {
 }
 
 /// GAP 2: Consolidate attribution was nondeterministic (last-write-wins from
-/// merged metadata). Fix: consolidator's agent_id becomes authoritative;
+/// merged metadata). Fix: consolidator's `agent_id` becomes authoritative;
 /// original authors preserved in `metadata.consolidated_from_agents`.
 #[test]
 fn test_consolidate_attributes_to_consolidator() {


### PR DESCRIPTION
## Summary
- `cargo clippy --tests --no-deps -- -D clippy::pedantic` flagged the doc comment on `test_consolidate_attributes_to_consolidator` for an unbackticked `agent_id` identifier (`clippy::doc_markdown` at `tests/integration.rs:3728`). Wrap it in backticks.
- Doc-only edit; no runtime behavior changes.

Charter: ai-memory v0.6.3 — Pillar (clippy::pedantic cleanup of test suite). Continues the campaign series of small standalone clippy fixes.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic 2>&1 | grep tests/integration.rs:3728` — empty (was flagged before)
- [x] No semantic change (doc-comment backticks only)

## AI involvement
Authored by Claude Opus 4.7 (1M context) under campaign `ai-memory-v063` iteration #45. SSH-signed commit. See `docs/AI_DEVELOPER_WORKFLOW.md` §8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)