### PR TITLE
chore(clippy): backtick `agent_id` in TOON/JSON test doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3974,7 +3974,7 @@ fn test_agentid_visible_in_recall_response() {
 /// deliberately omits `metadata` for token efficiency (see src/toon.rs
 /// `MEMORY_FIELDS_COMPACT`), so `agent_id` is NOT visible in that format —
 /// that's a known tradeoff tracked separately. This test pins the two formats
-/// where agent_id must show up.
+/// where `agent_id` must show up.
 #[test]
 fn test_agentid_visible_in_toon_and_json() {
     let binary = env!("CARGO_BIN_EXE_ai-memory");


### PR DESCRIPTION
## Summary
- `cargo clippy --tests --no-deps -- -D clippy::pedantic` flagged the doc comment on `test_agentid_visible_in_toon_and_json` for an unbackticked `agent_id` identifier (`clippy::doc_markdown` at `tests/integration.rs:3977`). Wrap it in backticks.
- Doc-only edit; no runtime behavior changes.

Charter: ai-memory v0.6.3 — Pillar (clippy::pedantic cleanup of test suite). Continues the campaign series of small standalone clippy fixes.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic 2>&1 | grep tests/integration.rs:3977` — empty (was flagged before)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_agentid_visible_in_toon_and_json` — passes

## AI involvement
Authored by Claude Opus 4.7 (1M context) under campaign `ai-memory-v063` iteration #46. SSH-signed commit. See `docs/AI_DEVELOPER_WORKFLOW.md` §8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)