### PR TITLE
chore(clippy): backtick `set_standard` in seed_standard doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5031,7 +5031,7 @@ fn fresh_inherit_db() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("ai-memory-inherit-{}.db", uuid::Uuid::new_v4()))
 }
 
-/// Seed a standard memory in a namespace, then set_standard it.
+/// Seed a standard memory in a namespace, then `set_standard` it.
 fn seed_standard(
     binary: &str,
     db_path: &std::path::Path,


### PR DESCRIPTION
## Summary

- Backticks `set_standard` in `seed_standard` helper doc-comment at `tests/integration.rs:5034`, clearing one `clippy::doc_markdown` pedantic lint flagged by `cargo clippy --tests --no-deps -- -D clippy::pedantic`.

## Charter

Charter: `ai-memory-v0.6.3-grand-slam.md` — pedantic-clean test surface (small standalone clippy fix, iter #47).

## Test plan

- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` no longer flags `tests/integration.rs:5034`
- [x] `cargo check --tests` passes (doc-comment-only change; behavior unchanged)
- [x] Commit SSH-signed

## AI involvement

- Author: Claude Opus 4.7 (1M context), invoked via Claude Code
- Human review: required before merge
- Risk class: Trivial (doc-comment text only; no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)