### PR TITLE
chore(clippy): backtick `memory_namespace_set_standard` in set_governance doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5981,7 +5981,7 @@ fn fresh_enforce_db() -> std::path::PathBuf {
 }
 
 /// Set a governance policy on a namespace. Seeds the standard memory under
-/// `owner_agent_id`, then calls memory_namespace_set_standard with the policy.
+/// `owner_agent_id`, then calls `memory_namespace_set_standard` with the policy.
 fn set_governance(
     binary: &str,
     db_path: &std::path::Path,


### PR DESCRIPTION
## Summary

- Backticks `memory_namespace_set_standard` in `set_governance` helper doc-comment at `tests/integration.rs:5984`, clearing one `clippy::doc_markdown` pedantic lint flagged by `cargo clippy --tests --no-deps -- -D clippy::pedantic`.

## Charter

Charter: `ai-memory-v0.6.3-grand-slam.md` — pedantic-clean test surface (small standalone clippy fix, iter #49).

## Test plan

- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` no longer flags `tests/integration.rs:5984`
- [x] `cargo fmt --check` clean
- [x] `cargo check --tests` passes (doc-comment-only change; behavior unchanged)
- [x] Commit SSH-signed

## AI involvement

- Author: Claude Opus 4.7 (1M context), invoked via Claude Code
- Human review: required before merge
- Risk class: Trivial (doc-comment text only; no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)