### PR TITLE
chore(clippy): backtick `cert_path`/`key_path` in gen_self_signed_cert doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7956,7 +7956,7 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
 // ---------------------------------------------------------------------------
 
 /// Generate a self-signed PEM cert + key pair at the given paths. Returns
-/// the (cert_path, key_path) tuple. Skips the test if openssl isn't on
+/// the (`cert_path`, `key_path`) tuple. Skips the test if openssl isn't on
 /// the PATH (rare on CI runners, but this keeps local-dev friendly).
 fn gen_self_signed_cert(dir: &std::path::Path) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
     let cert = dir.join(format!("ai-memory-test-cert-{}.pem", uuid::Uuid::new_v4()));


### PR DESCRIPTION
## Summary
- Wrap `cert_path` and `key_path` in backticks in the `gen_self_signed_cert` helper doc comment (`tests/integration.rs:7959`) — clears two `clippy::doc_markdown` (pedantic) violations sitting on the same line.

## Test plan
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` no longer reports anything at `tests/integration.rs:7959`
- [x] `cargo fmt --check`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration native_tls` (covers `gen_self_signed_cert` callers) — passes

Charter ref: ai-memory v0.6.3 grand-slam — pedantic-clippy debt drawdown in `tests/integration.rs`.

## AI involvement
- **Authored by:** Claude Opus 4.7 (1M context), running as the `ai-memory-v063` campaign agent (iter 50).
- **Reviewer / merger:** human operator. Single-line doc edit; full clippy + fmt + targeted test gates passed locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)