### PR TITLE
chore(clippy): backtick `memory_namespace_get_standard` in get_standard_inherit doc (doc_markdown)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5104,7 +5104,7 @@ fn seed_standard(
     id
 }
 
-/// Invoke memory_namespace_get_standard via MCP, returning the parsed body.
+/// Invoke `memory_namespace_get_standard` via MCP, returning the parsed body.
 fn get_standard_inherit(
     binary: &str,
     db_path: &std::path::Path,


### PR DESCRIPTION
## Summary

Resolves a `clippy::doc_markdown` warning at `tests/integration.rs:5107`
by adding backticks around the bare identifier `memory_namespace_get_standard`
in the doc comment for the `get_standard_inherit` test helper.

Pure doc-comment change — no behavior, runtime, or test-execution effect.

Charter: ai-memory-v0.6.3 grand-slam, clippy-pedantic cleanup of
`tests/integration.rs` (chip-away strategy to land standalone, low-collision
PRs that re-enumerate the warning list).

## Test plan

- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` — line 5107 no longer flagged
- [x] `cargo fmt --check`
- [x] `cargo test --test integration --no-run` — integration test binary still builds
- [x] No runtime or doctest behavior touched (single doc-comment edit)

## AI involvement

Authored by **Claude Opus 4.7 (1M context)** under campaign
`ai-memory-v063`, iteration #51. Branch: `campaign/clippy-tests-doc-markdown-get-standard-5107`.
Reviewed locally; no human edits to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)