### PR TITLE
chore(clippy): hoist `use std::io::Write` in roundtrip test (items_after_statements)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -253,6 +253,7 @@ fn test_content_size_limit() {
 
 #[test]
 fn test_import_export_roundtrip() {
+    use std::io::Write;
     let binary = env!("CARGO_BIN_EXE_ai-memory");
     let dir = std::env::temp_dir();
     let db1 = dir.join(format!("ai-memory-export-{}.db", uuid::Uuid::new_v4()));
@@ -295,7 +296,6 @@ fn test_import_export_roundtrip() {
         .stderr(std::process::Stdio::piped())
         .spawn()
         .unwrap();
-    use std::io::Write;
     child
         .stdin
         .take()


### PR DESCRIPTION
## Summary
- Resolve `clippy::pedantic items_after_statements` at `tests/integration.rs:298` by moving the local `use std::io::Write;` to the top of `test_import_export_roundtrip` (just under the function brace), where it can sit before any `let` statements.
- Pure refactor — no behavior change. The trait is still scoped to the test function only.

## Charter
v0.6.3 grand-slam — clippy hygiene chip-away ahead of `v0.6.3-rc1`. Picked from the iter #51 candidate list (items_after_statements `use` hoists at 298 / 1469 / 5068 / 5271 / 5378 / 6016 / 6576 — line 298 done here, others remain available for follow-up PRs without overlap).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all` clean
- [x] `cargo clippy --tests --no-deps -- -D clippy::pedantic` confirms `items_after_statements` warning at line 298 is gone (other 6 remaining items_after_statements at 1469/5068/5271/5378/6016/6576 are out of scope for this PR)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_import_export_roundtrip` ⇒ ok

## AI involvement
Authored end-to-end by Claude Opus 4.7 (1M context) under the `ai-memory-v063` autonomous campaign (iter #52). Operator review required before merge per repo governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)