### PR TITLE
chore(clippy): hoist `use std::io::Write` in import_roundtrip_count_match (items_after_statements)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1417,6 +1417,8 @@ fn test_export_includes_links() {
 
 #[test]
 fn test_import_roundtrip_count_match() {
+    use std::io::Write;
+
     let binary = env!("CARGO_BIN_EXE_ai-memory");
     let dir = std::env::temp_dir();
     let db1 = dir.join(format!("ai-memory-irt-src-{}.db", uuid::Uuid::new_v4()));
@@ -1466,7 +1468,6 @@ fn test_import_roundtrip_count_match() {
         .stderr(std::process::Stdio::piped())
         .spawn()
         .unwrap();
-    use std::io::Write;
     child
         .stdin
         .take()


### PR DESCRIPTION
## Summary

Move the inner `use std::io::Write;` declaration above the first `let` in
`test_import_roundtrip_count_match`, fixing the
`clippy::items_after_statements` warning at `tests/integration.rs:1469`.
Test behavior is unchanged — the import is purely lexical scope cleanup.

Charter: v0.6.3 grand-slam — sweep `clippy::pedantic` warnings under tests/.

## Test plan

- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_import_roundtrip_count_match` — passes
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — full suite passes (185/185)
- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests --no-deps -- -D clippy::pedantic` — 1469 warning eliminated

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the campaign-runner
loop (campaign `ai-memory-v063`, iter #53). Human operator merges PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)