### PR TITLE
chore(clippy): hoist `use std::io::Write` in seed_standard (items_after_statements)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5039,6 +5039,8 @@ fn seed_standard(
     title: &str,
     content: &str,
 ) -> String {
+    use std::io::Write;
+
     let out = cmd(binary)
         .args([
             "--db",
@@ -5065,7 +5067,6 @@ fn seed_standard(
     let id = v["id"].as_str().unwrap().to_string();
 
     // Set via MCP (CLI doesn't expose set_namespace_standard)
-    use std::io::Write;
     let mut child = cmd(binary)
         .args([
             "--db",


### PR DESCRIPTION
## Summary

The `use std::io::Write` declaration in `seed_standard` (tests/integration.rs L5068) sat after the initial `cmd(binary).output()` statement, tripping `clippy::items_after_statements` under `-D clippy::pedantic`. Hoist it to the top of the function body, matching the pattern from PRs #443 (line 298) and #444 (line 1469).

This is a **trivial** authority-class change per [`docs/AI_DEVELOPER_GOVERNANCE.md`](../blob/release/v0.6.3/docs/AI_DEVELOPER_GOVERNANCE.md):
- Test-only file
- Mechanical refactor (no semantic change)
- One `use` line moved
- All 8 `test_inherit_*` tests that exercise `seed_standard` pass; full integration suite (185 tests) green.

Charter ref: ai-memory-v0.6.3 grand-slam → housekeeping (drain pedantic-clippy queue against test code so a `cargo clippy --tests -- -D clippy::pedantic` gate becomes feasible).

Five `items_after_statements` warnings remain in tests/integration.rs (lines 5272 / 5379 / 6017 / 6577 plus 298 in flight at #443) for follow-up PRs.

## Test plan

- [x] `cargo fmt --check`
- [x] `unset AI_MEMORY_AGENT_ID; AI_MEMORY_NO_CONFIG=1 cargo clippy --tests --no-deps -- -D clippy::pedantic` no longer reports `items_after_statements` at integration.rs:5068
- [x] `unset AI_MEMORY_AGENT_ID; AI_MEMORY_NO_CONFIG=1 cargo test --test integration test_inherit_ -- --test-threads=1` → 8 passed
- [x] `unset AI_MEMORY_AGENT_ID; AI_MEMORY_NO_CONFIG=1 cargo test --test integration -- --test-threads=4` → 185 passed, 0 failed

## AI involvement

- **Author**: Claude Opus 4.7 (1M context) via campaign-runner iter #54
- **Authority class**: Trivial (test-only mechanical refactor)
- **Reviewer**: Operator (please double-check the hoist preserves the import scope, since the declaration is now visible across the whole function instead of only after the seed-store assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)