### PR TITLE
release: v0.6.3-rc1 housekeeping (P0 + P1 + P2 + P3 from full-spectrum audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,114 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `link()` is wired up there). Pure additive — no existing query
   breaks. Charter §"Critical Schema Reference", lines 686–723.
 
+- **Entity registry (Pillar 2 / Stream B)** — `memory_entity_register`
+  + `memory_entity_get_by_alias` MCP tools (count 38 → 40) plus the
+  matching HTTP surface (`POST /api/v1/entities`,
+  `GET /api/v1/entities/by_alias`, with 201 / 200 / 409 status
+  discipline and `X-Agent-Id` honoured). Entities are long-tier
+  memories tagged `entity` with `metadata.kind = "entity"`; aliases
+  live in the v15 `entity_aliases` side table. Registration is
+  idempotent on `(canonical_name, namespace)` — re-registering reuses
+  the entity_id and merges new aliases via `INSERT OR IGNORE`. A
+  non-entity memory occupying the same `(title, namespace)` returns a
+  hard error rather than letting the upsert path silently overwrite
+  unrelated content. Resolver returns the most-recently-created
+  entity when no namespace filter is supplied; ignores stray
+  `entity_aliases` rows that point at non-entity memories. Builds on
+  the v15 schema (#384). Charter §"Stream B — KG Schema + Entity
+  Model", lines 369–375.
+
+- **`memory_kg_timeline` (Pillar 2 / Stream C)** — entity-anchored
+  chronological view powering the `ai-memory kg-timeline` headline
+  demo. `db::kg_timeline()` queries `memory_links` ordered by
+  `valid_from ASC` (tie-break `created_at`) with optional inclusive
+  `since` / `until` filters; limit clamps to `[1, 1000]`, default
+  200. `db::create_link()` now stamps `valid_from = created_at` on
+  every insert so newly created links are visible to the timeline
+  without a later sweep, closing the forward gap left by the v15
+  backfill of legacy rows. `memory_kg_timeline` MCP tool (count
+  40 → 41) plus `GET /api/v1/kg/timeline?source_id=…&since=…
+  &until=…&limit=…`. Returns `KgTimelineEvent` carrying `target_id`,
+  `relation`, validity window, `observed_by`, and the target's
+  `title` / `namespace`. Charter §"Stream C — KG Query Layer",
+  lines 377–383.
+
+- **`memory_kg_invalidate` (Pillar 2 / Stream C)** — second tool of
+  the KG-traversal triplet. Marks a KG link as superseded by setting
+  its `valid_until` column so a contradicting fact can invalidate
+  the prior assertion without deleting the row, preserving the
+  timeline. The link is identified by its composite key
+  `(source_id, target_id, relation)` since `memory_links` has no
+  separate id; `valid_until` defaults to wall-clock now when
+  omitted. `db::invalidate_link()` returns
+  `Option<InvalidateResult>` — `None` when the triple does not
+  match, `Some` with the value now stored and `previous_valid_until`
+  so callers can distinguish a fresh supersession from an idempotent
+  retry. `memory_kg_invalidate` MCP tool (count 41 → 42) plus HTTP.
+  Schema does not yet carry an audit column for the supersession
+  `reason`; that arrives with v0.7 attestation. Charter §"Stream C —
+  KG Query Layer", lines 377–383.
+
+- **`memory_kg_query` depth=1 (Pillar 2 / Stream C)** — outbound
+  "expand neighbors" first slice. `memory_kg_query` MCP tool (count
+  42 → 43) plus HTTP. `db::kg_query()` ships with constants
+  `KG_QUERY_DEFAULT_LIMIT = 200`, `KG_QUERY_MAX_LIMIT = 1000`, and
+  `KG_QUERY_MAX_SUPPORTED_DEPTH = 1`; callers passing `max_depth=2`
+  get a clean error rather than a silent truncation, so the API
+  contract is stable from day one — the recursive-CTE multi-hop
+  follow-up just lifts the ceiling without changing the surface.
+  Filters per the charter spec: `valid_at` (RFC3339, only links
+  valid at that instant); `allowed_agents` (only links observed by
+  an agent in the set; **empty list returns zero rows by design** —
+  callers signaling "no agents trusted" must get an empty traversal,
+  not the unfiltered fallback); `limit` clamped to `[1, 1000]`.
+  Charter §"Stream C — KG Query Layer", lines 377–383.
+
+- **`memory_kg_query` depth 2..=5 (Pillar 2 / Stream C)** — lifts
+  `KG_QUERY_MAX_SUPPORTED_DEPTH` from 1 to 5, matching the published
+  `memory_kg_query (depth ≤ 5)` 250 ms p95 / 500 ms p99 budget in
+  `PERFORMANCE.md`. Replaces the depth=1 JOIN with a recursive CTE
+  that re-applies the temporal / agent filter on every hop and
+  prunes cycles via the accumulated `path`; each row's `depth` +
+  `path` now reflect the actual chain (e.g. depth=2 →
+  `src->mid->target`). API contract is unchanged — depth=1 collapses
+  to the original time-ordered single-hop result, and the
+  over-ceiling MCP/HTTP error path (422 with `max_depth=N exceeds
+  supported depth=5`) is preserved. Closes the Stream C
+  `memory_kg_query` slice; traversals at depth 2..=5 are now correct
+  under temporal-validity and observed-by filtering. Charter
+  §"Stream C — KG Query Layer", lines 377–383.
+
+- **`memory_check_duplicate` (Pillar 2 / Stream D)** — pre-write
+  near-duplicate check across DB / MCP / HTTP. `db::check_duplicate`
+  performs a cosine scan over live embedded memories with the
+  threshold clamped at `DUPLICATE_THRESHOLD_MIN = 0.5` (so permissive
+  callers can't dress unrelated content as a merge candidate) and
+  default `DUPLICATE_THRESHOLD_DEFAULT = 0.85` (tuned for the
+  MiniLM-L6-v2 embedder — near-paraphrases land ≥ 0.88, loosely
+  related content sits well below). `memory_check_duplicate` MCP
+  tool (count 37 → 38) returns the nearest-neighbor cosine, the
+  above-threshold boolean, and an optional `suggested_merge` target.
+  HTTP `POST /api/v1/check_duplicate` mirrors the MCP surface and
+  embeds *before* taking the DB lock (issue #219 pattern). Charter
+  §"Stream D — Duplicate Check", lines 384–386.
+
+- **`ai-memory bench` scaffold (Pillar 3 / Stream E)** — first slice
+  of perf instrumentation. New CLI subcommand + `src/bench.rs`
+  runner so operators (and the `bench.yml` CI guard / Stream F) can
+  verify the published `PERFORMANCE.md` budgets. Covers the three
+  embedding-free hot-path operations: `memory_store` (no embedding)
+  / 20 ms p95, `memory_search` (FTS5) / 100 ms p95, and
+  `memory_recall` (hot, depth=1) / 50 ms p95. Each invocation seeds
+  a disposable `:memory:` SQLite DB so the operator's main DB is
+  untouched. Reports p50 / p95 / p99 in either a human table or
+  `--json`. Exit code is non-zero when any p95 exceeds its target
+  by more than the documented 10% tolerance — so the same binary
+  slots into the CI guard once Stream F lands. `PERFORMANCE.md`
+  status table now distinguishes "scaffold landed" from "Stream E
+  follow-up" so partial coverage isn't silent. Charter §"Stream E —
+  Performance Instrumentation", lines 388–393.
+
 - **Performance budgets published** — new `PERFORMANCE.md` at the repo
   root carries the authoritative p95/p99 latency contract for every
   hot-path operation (verbatim from the v0.6.3 grand-slam charter):
@@ -131,6 +239,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tolerance. Encountered in the a2a-gate mTLS matrix; the gate-side
   generator fix in `ai-memory-ai2ai-gate#35` already worked around it for
   v0.6.2 — this is the parser-side resolution.
+
+### Tests
+
+- **[#401]** RAII `ChildGuard` fixes mTLS test daemon-leak on assert
+  panic.
+  `tests/integration.rs::test_serve_mtls_fingerprint_allowlist_accepts_only_known_peer`
+  was leaking `target/debug/ai-memory … serve` child processes
+  whenever any of its 4 asserts panicked between spawn and the
+  manual `kill()` at the bottom — `std::process::Child` has no
+  kill-on-drop on Unix. Adds a generic `ChildGuard { child:
+  Option<Child>, cleanup_paths: Vec<PathBuf> }` alongside the
+  existing `DaemonGuard`, with an unwind-safe `Drop` that kills,
+  reaps, and unlinks; refactors the mTLS test to wrap both spawned
+  children. End-user impact is zero (production `serve` deployments
+  via systemd / launchd / Docker reap children correctly), but the
+  campaign runner had been accumulating ~28 GB of orphaned daemons
+  across 7 reparented PIDs during the v0.6.3 dev sprint.
 
 ## [v0.6.2] — 2026-04-24 — A2A-CERTIFIED
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.6.2"
+version = "0.6.3-rc1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.6.2"
+version = "0.6.3-rc1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["AlphaOne LLC"]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 <p align="center"><em>universal AI memory</em></p>
 
 [![CI](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/ci.yml)
-[![Rust](https://img.shields.io/badge/rust-1.87%2B-orange?logo=rust)](https://www.rust-lang.org/)
+[![Bench](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/bench.yml/badge.svg)](https://github.com/alphaonedev/ai-memory-mcp/actions/workflows/bench.yml)
+[![Rust](https://img.shields.io/badge/rust-1.88%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
-[![Tests](https://img.shields.io/badge/tests-191_(140_unit_+_51_integration)-brightgreen)]()
-[![MCP](https://img.shields.io/badge/MCP-26_tools-blueviolet)]()
+[![Tests](https://img.shields.io/badge/tests-602_(372_unit_+_159_integration_+_71_other)-brightgreen)]()
+[![MCP](https://img.shields.io/badge/MCP-43_tools-blueviolet)]()
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)]()
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
@@ -558,6 +559,33 @@ Evaluated on the [ICLR 2025 LongMemEval-S](benchmarks/longmemeval/) dataset (500
 | **keyword** | 97.0% | 232 q/s | None |
 | **semantic** | 97.4% | 45 q/s | Embedding model (~100MB) |
 | **smart** | 97.8% | 12 q/s | Ollama + Gemma 4 E2B |
+
+### Performance Budgets (v0.6.3)
+
+Every release ships with **published p95/p99 budgets** for hot-path
+operations and a CI gate that fails any PR whose measured p95 exceeds
+the budget by more than 10 %. Targets are calibrated for M4 reference
+hardware; full table and methodology in
+[`PERFORMANCE.md`](PERFORMANCE.md).
+
+| Operation | Target p95 | Target p99 |
+|---|---|---|
+| `memory_session_start` (Claude Code hook) | < 100 ms | < 200 ms |
+| `memory_store` (no embedding) | < 20 ms | < 50 ms |
+| `memory_search` (FTS5) | < 100 ms | < 250 ms |
+| `memory_recall` (hot, depth=1) | < 50 ms | < 150 ms |
+| `memory_kg_query` (depth ≤ 3) | < 100 ms | < 250 ms |
+| `memory_kg_query` (depth ≤ 5) | < 250 ms | < 500 ms |
+| `memory_kg_timeline` | < 100 ms | < 250 ms |
+
+Run the same workload locally:
+
+```sh
+ai-memory bench                      # human-readable table
+ai-memory bench --json               # machine-parseable
+```
+
+p99 targets are informational until the v0.6.3 soak window closes.
 
 ---
 

--- a/docs/ADR-0002-kg-schema-v15-backward-incompat.md
+++ b/docs/ADR-0002-kg-schema-v15-backward-incompat.md
@@ -1,0 +1,102 @@
+# ADR-0002 — KG schema v15 is backward-incompatible
+
+Status: **Accepted** — implemented in v0.6.3 (PRs #384, #388–#392).
+
+Date: 2026-04-26
+Author: Claude Opus 4.7 (1M context) on behalf of @binary2029
+Related: ADR-0001 (Quorum replication), `docs/MIGRATION-v0.6.2-to-v0.6.3.md`
+
+---
+
+## Context
+
+v0.6.3 introduced **schema migration v15** to back the temporal
+knowledge graph (Pillar 2 / Streams B–D). The changes:
+
+- Added four columns to `memory_links`: `valid_from`, `valid_until`,
+  `observed_by`, `signature` (SQLite + Postgres parity).
+- Added three indexes: `idx_links_temporal_src`, `idx_links_temporal_tgt`,
+  `idx_links_relation`.
+- Added the `entity_aliases` side table.
+- Backfilled `valid_from = (SELECT created_at FROM memories ...)` on
+  every existing link.
+
+The migration is **idempotent on a single node**: applying it to a
+v14-schema SQLite DB leaves the result equivalent to a fresh v15
+init. The audit at `01-database.md` confirmed this works for SQLite.
+
+But the federation wire format includes the new columns. A v0.6.2
+peer that receives a `memory_links` row from a v0.6.3 peer over
+`/api/v1/sync/push` cannot parse the `valid_from` / `valid_until`
+fields and rejects the row.
+
+## Decision
+
+We accept that schema v15 is **a backward-incompatible federation
+upgrade** and require operators to coordinate the upgrade across
+all peers in a quorum mesh. We do NOT:
+
+1. Ship a wire-compatibility shim that strips temporal fields when
+   pushing to v0.6.2 peers. The temporal fields are central to the
+   v0.6.3 pillar; degrading them would silently drop invalidations.
+2. Negotiate a wire version at the start of each sync cycle. This
+   was considered (a `version` field in the sync handshake) but
+   adds protocol complexity for a one-time cost — operators upgrade
+   peers in lockstep once, not per-cycle.
+3. Auto-upgrade Postgres deployments. The Postgres adapter remains
+   **fresh-init only** in v0.6.3 (audit `01-database.md`); operators
+   either stay on SQLite, run the manual `ALTER TABLE` SQL from the
+   migration guide, or use the `migrate` subcommand to dump-and-reload.
+
+## Consequences
+
+### Required operator action
+
+When upgrading a federation mesh from v0.6.2 to v0.6.3:
+
+1. **Drain writes** — pause client agents or redirect writes to one
+   designated peer for the upgrade window.
+2. **Bring all peers down** — do NOT perform a rolling upgrade where
+   some peers run v0.6.2 and others run v0.6.3.
+3. **Replace binaries** — `cargo install ai-memory --version 0.6.3`
+   on every host (or equivalent OS-package step).
+4. **Bring all peers up** — the migration runs on first open.
+5. **Verify schema_version 15 on every peer** before resuming writes.
+6. **Resume writes**.
+
+The migration guide (`docs/MIGRATION-v0.6.2-to-v0.6.3.md`) carries
+the full procedure with copy-pasteable commands.
+
+### Failure modes if the operator skips coordination
+
+- **Mixed v14 + v15 mesh:** writes from v15 peers fail INSERT on v14
+  peers (unknown columns); v14 peers stay in a rolling
+  divergence state until upgraded. Sync-daemon never heals the v14
+  peer because every push fails.
+- **One peer skipped:** quorum may still meet (W-1 from v15 peers +
+  local commit) but the unupgraded peer accumulates schema-mismatch
+  errors and falls behind silently. Detected via
+  `federation_fanout_dropped_total[id_drift]` metric.
+
+### Recovery
+
+If a v14 peer is left in a v15 mesh:
+1. Stop the v14 peer's sync-daemon.
+2. Upgrade its binary + run the migration.
+3. Restart sync-daemon. The pull cycle catches up the missed window
+   from the still-running v15 peers.
+
+No data loss expected — v15 peers retained the writes that v14
+rejected; the rejected pushes are reapplied as new pulls after
+upgrade.
+
+## Future work
+
+- **v0.7 Layer 2b (attested sender_id)** may require another wire-
+  level change. ADR for that landing will reference this one as
+  precedent for "lockstep peer upgrade" as the standard procedure
+  for backward-incompatible KG schema bumps.
+- **In-place Postgres migration** — fresh-init-only in v0.6.3 is a
+  known adoption blocker for operators running Postgres clusters.
+  v0.7 should ship a proper Postgres migration tool comparable to
+  the SQLite path. Tracked separately.

--- a/docs/ADR-0003-kg-invalidation-eventual-consistency.md
+++ b/docs/ADR-0003-kg-invalidation-eventual-consistency.md
@@ -1,0 +1,128 @@
+# ADR-0003 — `memory_kg_invalidate` is eventually consistent across the federation
+
+Status: **Accepted** — implemented in v0.6.3 (PR #390).
+
+Date: 2026-04-26
+Author: Claude Opus 4.7 (1M context) on behalf of @binary2029
+Related: ADR-0001 (Quorum replication), ADR-0002 (Schema v15)
+
+---
+
+## Context
+
+`memory_kg_invalidate` (`POST /api/v1/kg/invalidate`) marks a
+knowledge-graph link as superseded by setting its `valid_until`
+column. The link is **NOT deleted** — historical queries pinned to
+`valid_at < valid_until` still see it; only "current state" queries
+filter it out.
+
+The audit at `05-federation.md` flagged a deliberate-but-noteworthy
+design choice: **the invalidate path does NOT call
+`broadcast_store_quorum`.** It updates the local SQLite copy and
+returns success to the caller without waiting for any peer ack. Peers
+learn about the invalidation asynchronously through the sync-daemon's
+pull cycle (default 2-second interval).
+
+Memory writes (store / update / archive / promote) DO take the
+quorum-broadcast path. Memory_link mutations (link create + invalidate)
+do not.
+
+## Decision
+
+KG link invalidations remain **eventually consistent**, NOT
+strongly-consistent. We accept this asymmetry between memory mutations
+(quorum-broadcast) and link mutations (sync-daemon-driven) because:
+
+### 1. Temporal anchoring makes "late propagation" semantically benign
+
+A link's `valid_until` is timestamped. A peer that learns of the
+invalidation 5 seconds late still records `valid_until = T_inv`; a
+historical query pinned to `valid_at = T < T_inv` correctly returns
+the link as valid; a current-state query at `T >= T_inv` correctly
+excludes it. There is no observable inconsistency from the
+application's perspective — only a propagation lag.
+
+Compare with memory store: a peer that misses a memory entirely
+returns no row, which IS an observable inconsistency. Hence the
+asymmetry is principled.
+
+### 2. Quorum-broadcasting every link mutation is too expensive
+
+A typical campaign or curator cycle invalidates dozens to hundreds of
+links per minute as the temporal graph evolves. Quorum-broadcasting
+each one with the same deadline + ack-collection machinery as memory
+writes would multiply federation traffic without proportional
+correctness gain (see #1).
+
+### 3. The sync-daemon already replicates `memory_links`
+
+The pull-side handler (`/api/v1/sync/since`) emits the full link rows
+including `valid_from` / `valid_until`. The sync-daemon's pull cycle
+(default 2s) catches invalidations within one cycle in steady state.
+
+## Consequences
+
+### Operator-visible behavior
+
+A query against peer A immediately after `memory_kg_invalidate` on
+peer B may return the now-invalid link until peer A's sync-daemon
+pulls from peer B. The lag is bounded by `--interval` (default 2s).
+
+For applications that require **strongly-consistent invalidation**
+(e.g. a contradiction-detection workflow that immediately re-queries
+the graph after invalidation), the operator must:
+
+1. Run the invalidate against every peer in the mesh in turn, OR
+2. Wait at least `max(--interval)` seconds between the invalidate
+   and the dependent read, OR
+3. Read from the same peer that wrote the invalidation.
+
+This is documented in:
+
+- `docs/MIGRATION-v0.6.2-to-v0.6.3.md` (operator guide, "KG link
+  invalidation is eventually consistent" section)
+- `docs/USER_GUIDE.md` (`memory_kg_invalidate` tool reference,
+  federation note callout)
+- `docs/API_REFERENCE.md` (`POST /api/v1/kg/invalidate` endpoint)
+
+### Failure modes
+
+- **Sync-daemon partition:** a peer cut off from the writer never
+  learns of invalidations until the partition heals. This is the
+  same failure mode as memory writes under the same partition;
+  handled by the same recovery path (pull cycle resumes after
+  partition heals).
+- **Peer crashes mid-invalidate-cycle:** the writer succeeded
+  locally; the peer that crashed will pull the invalidation on next
+  sync-daemon cycle after restart.
+- **Concurrent invalidations of the same link:** last-write-wins on
+  `valid_until`. Two peers invalidating the same link with different
+  timestamps will eventually converge to whichever peer's value
+  ended up most recently in the sync stream. The
+  `previous_valid_until` field returned by `memory_kg_invalidate`
+  surfaces overwrites for monitoring.
+
+### Tested behavior
+
+- `src/db.rs::tests::invalidate_link_overwrites_existing_valid_until_and_reports_prior`
+  pins last-write-wins semantics at the local-storage layer.
+- `tests/integration.rs::test_sync_daemon_mesh_propagates_memory_between_peers`
+  validates that the sync-daemon pull cycle reaches peers within the
+  documented window for memory mutations. The test was updated in
+  PR-rc1 to use a `ChildGuard` RAII wrapper (same fix shipped in
+  #401 for the mTLS test).
+
+## Future work — v0.7 candidates
+
+If application demand surfaces for strongly-consistent invalidation,
+two paths remain available:
+
+1. **Add a `--quorum-invalidate` CLI flag** that opts in to the
+   memory-mutation broadcast path on a per-call basis. Default would
+   stay async. Operators of high-stakes workflows could request
+   strong consistency where it matters.
+2. **Promote link mutations to first-class quorum-broadcast** in
+   v0.7 alongside the attested-sender_id work. This would unify the
+   correctness model at the cost of the federation traffic increase
+   noted above. Worth revisiting after Phase 2 testing data
+   quantifies the actual lag distribution under realistic load.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -324,6 +324,183 @@ Relations: `related_to`, `supersedes`, `contradicts`, `derived_from`.
 
 Returns inbound + outbound links for a memory.
 
+## Knowledge Graph + taxonomy (v0.6.3)
+
+These endpoints operate on the temporal-validity knowledge graph
+(`memory_links` with `valid_from` / `valid_until` / `observed_by`
+columns added in schema v15) and the namespace taxonomy. See
+`docs/MIGRATION-v0.6.2-to-v0.6.3.md` for the schema changes and
+`docs/USER_GUIDE.md` for the matching MCP tools.
+
+### `GET /api/v1/taxonomy`
+
+Walk live (non-expired) memories grouped by namespace into a
+hierarchical tree.
+
+Query params: `prefix` (optional, restricts walk), `depth` (1-10, default 5),
+`limit` (1-10000, default 1000).
+
+```json
+{
+  "tree": [
+    { "namespace": "alphaone", "count": 0, "subtree_count": 47, "children": [...] }
+  ],
+  "total_count": 47,
+  "truncated": false
+}
+```
+
+### `POST /api/v1/check_duplicate`
+
+Embedding cosine-similarity duplicate detection.
+
+```json
+{
+  "title": "Project uses PostgreSQL 15",
+  "content": "The main database is PostgreSQL 15 with pgvector for embeddings.",
+  "namespace": "my-app",
+  "threshold": 0.85
+}
+```
+
+Response:
+
+```json
+{
+  "is_duplicate": true,
+  "threshold": 0.85,
+  "nearest": { "id": "...", "title": "...", "namespace": "...", "similarity": 0.92 },
+  "suggested_merge": "...",
+  "candidates_scanned": 412
+}
+```
+
+`threshold` is clamped to a 0.5 floor. Requires the `semantic` feature
+tier or higher. Returns `409` (Conflict) only on internal embedding
+errors; threshold mismatches return `200` with `is_duplicate: false`.
+
+### `POST /api/v1/entities`
+
+Register an entity-as-typed-memory. Idempotent on
+`(canonical_name, namespace)`.
+
+```json
+{
+  "canonical_name": "PostgreSQL",
+  "namespace": "my-app",
+  "aliases": ["pg", "postgres"],
+  "metadata": {}
+}
+```
+
+Response: `{"entity_id":"ent-...","canonical_name":"PostgreSQL","namespace":"my-app","aliases":["pg","postgres","PostgreSQL"],"created":true}`.
+
+Returns `409` if a non-entity memory with the same
+`(title, namespace)` exists.
+
+### `GET /api/v1/entities/by_alias`
+
+Resolve an alias to its canonical entity.
+
+Query params: `alias` (required), `namespace` (optional; without it,
+picks the most-recently-created match across namespaces).
+
+```json
+{
+  "found": true,
+  "entity_id": "ent-...",
+  "canonical_name": "PostgreSQL",
+  "namespace": "my-app",
+  "aliases": ["pg", "postgres", "PostgreSQL"]
+}
+```
+
+`found: false` (and null fields) when the alias resolves to nothing.
+
+### `GET /api/v1/kg/timeline`
+
+Ordered timeline of links anchored at a source. Skips links with NULL
+`valid_from`.
+
+Query params: `source_id` (required), `since` / `until` (RFC 3339,
+optional), `limit` (1-1000, default 200).
+
+```json
+{
+  "source_id": "...",
+  "events": [
+    { "target_id": "...", "relation": "depends_on", "valid_from": "...", "valid_until": null, "observed_by": "..." }
+  ],
+  "count": 1
+}
+```
+
+### `POST /api/v1/kg/invalidate`
+
+Mark a link superseded by setting `valid_until`. **Does NOT delete**
+the link — historical queries pinned to `valid_at < now` still see
+it. Idempotent.
+
+```json
+{
+  "source_id": "...",
+  "target_id": "...",
+  "relation": "depends_on",
+  "valid_until": "2026-04-26T03:00:00Z"
+}
+```
+
+Response: `{"found":true,"valid_until":"...","previous_valid_until":null}`.
+
+> **Federation:** invalidations apply locally and propagate
+> asynchronously via the sync-daemon — they are NOT quorum-broadcast.
+
+### `POST /api/v1/kg/query`
+
+Recursive-CTE traversal of the temporal knowledge graph rooted at a
+source memory.
+
+```json
+{
+  "source_id": "...",
+  "max_depth": 3,
+  "valid_at": "2026-04-26T00:00:00Z",
+  "allowed_agents": ["ai:claude-code@host:pid-12345"],
+  "limit": 200
+}
+```
+
+Constraints: `max_depth` clamped to 1..=5 (depth 0 errors,
+depth > 5 errors). `allowed_agents: []` (empty array) returns zero
+rows; omit the field to skip the agent filter entirely.
+
+Response:
+
+```json
+{
+  "source_id": "...",
+  "max_depth": 3,
+  "memories": [
+    {
+      "target_id": "...",
+      "title": "...",
+      "target_namespace": "my-app",
+      "relation": "depends_on",
+      "valid_from": "...",
+      "valid_until": null,
+      "observed_by": "...",
+      "depth": 1,
+      "path": "src->tgt"
+    }
+  ],
+  "paths": ["src->tgt->..."],
+  "count": 1
+}
+```
+
+Ordering: `depth ASC, COALESCE(valid_from, link_created_at) ASC,
+link_created_at ASC`.
+
 ## Namespaces
 
 ### `GET /api/v1/namespaces`

--- a/docs/ARCHITECTURAL_LIMITS.md
+++ b/docs/ARCHITECTURAL_LIMITS.md
@@ -152,6 +152,45 @@ a correctness issue, but a storage-footprint surprise.
 `db::checkpoint` on a 10-minute cadence, staggered from GC to avoid
 lock bursts. Shutdown still runs a final checkpoint.
 
+### 13. KG link invalidation is eventually consistent across peers — **Documented in v0.6.3**
+
+`memory_kg_invalidate` updates `valid_until` on the local SQLite copy
+without quorum-broadcasting the change. Peers learn about the
+invalidation asynchronously through the sync-daemon's pull cycle
+(default 2-second interval).
+
+Temporal anchoring makes this benign in steady state: a link's
+`valid_until` is timestamped, so a peer that learns of the
+invalidation 5 seconds late still records the same `valid_until =
+T_inv` and queries pinned to `valid_at < T_inv` correctly return the
+link as valid. But applications that require strongly-consistent
+invalidation (e.g. invalidate then immediately re-query the graph
+from a different peer) must wait at least `--interval` seconds, or
+read from the writing peer.
+
+Full design rationale + recovery procedures: see
+[`ADR-0003`](ADR-0003-kg-invalidation-eventual-consistency.md).
+
+### 14. KG schema v15 is backward-incompatible across the federation — **Documented in v0.6.3**
+
+The temporal-validity columns added to `memory_links` in v0.6.3
+(schema migration v15) are NOT wire-compatible with v0.6.2 peers.
+A v14-schema peer that receives a v15 push fails the INSERT (unknown
+columns) and the row is rejected.
+
+Operators upgrading a federation mesh from v0.6.2 to v0.6.3 must:
+
+1. Drain writes for the upgrade window
+2. Bring all peers down (do NOT do a rolling upgrade)
+3. Replace the binary on every peer
+4. Bring all peers up — migration runs on first open
+5. Verify schema_version 15 on every peer before resuming writes
+
+See [`MIGRATION-v0.6.2-to-v0.6.3.md`](MIGRATION-v0.6.2-to-v0.6.3.md)
+for the full procedure and
+[`ADR-0002`](ADR-0002-kg-schema-v15-backward-incompat.md) for the
+design rationale.
+
 ## Use-case guidance
 
 | Deployment | Backend | Notes |

--- a/docs/MIGRATION-v0.6.2-to-v0.6.3.md
+++ b/docs/MIGRATION-v0.6.2-to-v0.6.3.md
@@ -1,0 +1,301 @@
+# Migrating from ai-memory v0.6.2 to v0.6.3
+
+**Audience:** operators upgrading running v0.6.2 deployments to v0.6.3.
+**Risk profile:** schema changes are additive and idempotent on **SQLite**.
+On **Postgres** the v0.6.3 adapter is fresh-init only — see "Postgres
+upgrade path" below.
+
+> **TL;DR (SQLite):** stop the daemon, replace the binary, start the
+> daemon. The migration runs on first open. No downtime expected on a
+> single node; quorum-mesh deployments require coordinated upgrade
+> (see "Federation upgrade order").
+
+---
+
+## What changed in v0.6.3
+
+Three pillars (all charter-aligned, all functionally complete):
+
+1. **Hierarchical namespace taxonomy (Pillar 1 / Stream A)** — new
+   `memory_get_taxonomy` MCP tool + `GET /api/v1/taxonomy` HTTP route.
+   Existing flat namespaces continue to work unchanged; a namespace
+   that contains a `/` (e.g. `alphaone/engineering/platform`) is
+   automatically treated as a hierarchical path with parent walks.
+
+2. **Temporal-validity knowledge graph (Pillar 2 / Streams B–D)** —
+   `memory_links` table gains four columns (`valid_from`,
+   `valid_until`, `observed_by`, `signature`), an `entity_aliases`
+   side table, and seven new MCP tools: `memory_kg_query`,
+   `memory_kg_timeline`, `memory_kg_invalidate`,
+   `memory_entity_register`, `memory_entity_get_by_alias`,
+   `memory_check_duplicate`, plus the taxonomy tool above.
+
+3. **Performance budgets (Pillar 3 / Streams E–F)** — `tracing` spans
+   on every MCP tool, an `ai-memory bench` subcommand, and a
+   `bench.yml` GitHub Actions workflow that fails any PR whose p95
+   exceeds the published budget by more than 10 %.
+
+Full deliverable inventory: see `CHANGELOG.md` `[Unreleased] — v0.6.3`
+section.
+
+---
+
+## SQLite upgrade
+
+### Pre-flight (recommended)
+
+```sh
+# 1. Snapshot the live DB
+sqlite3 /path/to/ai-memory.db ".backup /path/to/ai-memory-pre-v063.db"
+
+# 2. Confirm current schema version (expect 14)
+sqlite3 /path/to/ai-memory.db "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;"
+```
+
+### Upgrade
+
+```sh
+# 1. Stop the daemon (or the MCP host that owns it)
+launchctl bootout gui/$(id -u)/com.alphaonedev.ai-memory   # macOS / launchd
+systemctl --user stop ai-memory                             # Linux / systemd
+
+# 2. Install v0.6.3
+cargo install ai-memory --version 0.6.3
+# OR
+brew upgrade ai-memory
+# OR
+apt-get install ai-memory=0.6.3
+
+# 3. Start the daemon — the schema-v15 migration runs on first open
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.alphaonedev.ai-memory.plist
+systemctl --user start ai-memory
+
+# 4. Verify
+sqlite3 /path/to/ai-memory.db "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;"
+# Expect: 15
+```
+
+### What the v15 migration does
+
+- `ALTER TABLE memory_links ADD COLUMN valid_from TEXT;`
+- `ALTER TABLE memory_links ADD COLUMN valid_until TEXT;`
+- `ALTER TABLE memory_links ADD COLUMN observed_by TEXT;`
+- `ALTER TABLE memory_links ADD COLUMN signature BLOB;`
+- `CREATE INDEX IF NOT EXISTS idx_links_temporal_src ON memory_links(source_id, valid_from, valid_until);`
+- `CREATE INDEX IF NOT EXISTS idx_links_temporal_tgt ON memory_links(target_id, valid_from, valid_until);`
+- `CREATE INDEX IF NOT EXISTS idx_links_relation ON memory_links(relation, valid_from);`
+- `UPDATE memory_links SET valid_from = (SELECT created_at FROM memories WHERE id = source_id) WHERE valid_from IS NULL;`
+- `CREATE TABLE IF NOT EXISTS entity_aliases (entity_id TEXT NOT NULL, alias TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (entity_id, alias));`
+- `CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias ON entity_aliases(alias);`
+
+The migration is **idempotent** — restarting the daemon twice in a row
+is safe.
+
+### Rollback
+
+If you need to revert to v0.6.2 after upgrading:
+
+```sh
+# 1. Stop v0.6.3
+launchctl bootout gui/$(id -u)/com.alphaonedev.ai-memory
+
+# 2. Restore the pre-upgrade snapshot
+cp /path/to/ai-memory-pre-v063.db /path/to/ai-memory.db
+
+# 3. Reinstall v0.6.2
+cargo install ai-memory --version 0.6.2 --force
+
+# 4. Start
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.alphaonedev.ai-memory.plist
+```
+
+The new columns added by the migration are nullable, so a v0.6.2
+binary CAN read a v15 database — but it will not honor `valid_until`
+filtering or use `entity_aliases`. Restoring the pre-upgrade snapshot
+is the recommended rollback path.
+
+---
+
+## Postgres upgrade path
+
+**Important:** the Postgres backend in v0.6.3 is **fresh-init only**.
+It does NOT auto-migrate an existing v0.6.2 schema. If you have a
+running Postgres deployment, you have three choices:
+
+### Option 1 — Stay on SQLite (recommended for single-node)
+
+The SQLite backend has full v0.6.3 feature support. If your deployment
+fits on one node, switching back is a `--db file:///path.db` flag
+change.
+
+### Option 2 — Manual Postgres migration
+
+Apply the equivalent SQL to your existing Postgres database:
+
+```sql
+ALTER TABLE memory_links ADD COLUMN IF NOT EXISTS valid_from TEXT;
+ALTER TABLE memory_links ADD COLUMN IF NOT EXISTS valid_until TEXT;
+ALTER TABLE memory_links ADD COLUMN IF NOT EXISTS observed_by TEXT;
+ALTER TABLE memory_links ADD COLUMN IF NOT EXISTS signature BYTEA;
+
+CREATE INDEX IF NOT EXISTS idx_links_temporal_src
+    ON memory_links(source_id, valid_from, valid_until);
+CREATE INDEX IF NOT EXISTS idx_links_temporal_tgt
+    ON memory_links(target_id, valid_from, valid_until);
+CREATE INDEX IF NOT EXISTS idx_links_relation
+    ON memory_links(relation, valid_from);
+
+UPDATE memory_links
+   SET valid_from = (
+       SELECT created_at FROM memories WHERE id = memory_links.source_id
+   )
+ WHERE valid_from IS NULL;
+
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    entity_id  TEXT NOT NULL,
+    alias      TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (entity_id, alias)
+);
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias
+    ON entity_aliases(alias);
+```
+
+Run these inside a transaction. The `signature` column uses `BYTEA`
+on Postgres (vs `BLOB` on SQLite) — both store opaque byte strings.
+
+### Option 3 — Dump and reload via the migration tool
+
+```sh
+# 1. Dump v0.6.2 Postgres data to SQLite
+ai-memory migrate \
+    --from postgres://user@host/ai_memory \
+    --to file:///tmp/ai-memory-staging.db
+
+# 2. Initialise a fresh v0.6.3 Postgres schema
+psql -h newhost -d ai_memory_v063 -f src/store/postgres_schema.sql
+
+# 3. Reverse-migrate
+ai-memory migrate \
+    --from file:///tmp/ai-memory-staging.db \
+    --to postgres://user@newhost/ai_memory_v063
+```
+
+The `migrate` subcommand performs page-streamed upsert-on-id transfer
+and is idempotent. Test on a staging copy first.
+
+---
+
+## Federation upgrade order
+
+The v15 schema is **backward-incompatible at the wire level**. A v0.6.2
+peer cannot parse `valid_from` / `valid_until` columns in the
+`memory_links` JSON pushed by a v0.6.3 peer. Mixing v14-schema and
+v15-schema peers in the same quorum mesh will break replication.
+
+### Recommended sequence
+
+1. **Drain** — stop accepting writes for the upgrade window. Either
+   pause your client agents, or redirect writes to one designated peer.
+2. **Upgrade peers in lockstep** — bring all peers down, replace
+   binaries, bring them back up. Do NOT perform a rolling upgrade
+   where some peers are v0.6.3 and others remain v0.6.2.
+3. **Verify schema_version on every peer** before resuming writes:
+   ```sh
+   for host in peer-a peer-b peer-c; do
+       ssh $host "sqlite3 /var/lib/ai-memory.db 'SELECT MAX(version) FROM schema_version;'"
+   done
+   ```
+   Expect `15` from every peer.
+4. **Resume** — clients can now write again. The sync-daemon catches
+   up on any drift accrued during the drain window.
+
+### KG link invalidation is eventually consistent
+
+`memory_kg_invalidate` updates `valid_until` on the local SQLite copy
+**without** broadcasting via the quorum-write path. Peers learn about
+the invalidation asynchronously through the sync-daemon's pull cycle.
+This is correct by design (link invalidations are time-anchored, so
+late replication is observable as "this link became invalid at time
+T") but operators should know that:
+
+- A query against peer A immediately after `memory_kg_invalidate` may
+  return the now-invalid link until peer A's sync-daemon pulls from
+  the writer.
+- For strongly-consistent invalidation semantics, run the invalidate
+  against every peer in turn (or wait `--interval` seconds between
+  the write and the read).
+
+This may be tightened in v0.7 with quorum-broadcast invalidations.
+
+---
+
+## Operator-visible API changes
+
+### New MCP tools (zero breaking changes to existing tools)
+
+| Tool | Stream | Purpose |
+|---|---|---|
+| `memory_get_taxonomy` | A | Walk live memories grouped by namespace into a hierarchical tree |
+| `memory_kg_query` | C | Recursive CTE traversal with depth 1..=5, temporal/agent filters |
+| `memory_kg_timeline` | C | Ordered fact timeline for an entity (valid_from-anchored) |
+| `memory_kg_invalidate` | C | UPDATE `valid_until` on a link to mark it superseded (does NOT delete) |
+| `memory_entity_register` | B | Register entity-as-typed-memory with aliases |
+| `memory_entity_get_by_alias` | B | Resolve an alias to its canonical entity |
+| `memory_check_duplicate` | D | Embedding cosine-similarity duplicate detection |
+
+See `docs/USER_GUIDE.md` for parameter tables and example requests.
+See `docs/API_REFERENCE.md` for the matching HTTP endpoints.
+
+### New HTTP endpoints
+
+```
+GET    /api/v1/taxonomy
+POST   /api/v1/check_duplicate
+POST   /api/v1/entities
+GET    /api/v1/entities/by_alias
+GET    /api/v1/kg/timeline
+POST   /api/v1/kg/invalidate
+POST   /api/v1/kg/query
+```
+
+### Performance budgets
+
+`PERFORMANCE.md` at the repo root documents 13 hot-path budgets with
+p95 and p99 targets. The `bench.yml` workflow fails any PR whose
+measured p95 exceeds the budget by more than 10 %. p99 targets are
+informational until the v0.6.3 soak window closes.
+
+The `ai-memory bench` subcommand runs the same workload locally:
+
+```sh
+ai-memory bench                      # human-readable table
+ai-memory bench --json               # machine-parseable JSON
+ai-memory bench --iterations 1000    # custom sample size
+```
+
+---
+
+## Validation checklist
+
+After upgrading, confirm:
+
+- [ ] `ai-memory --version` reports `0.6.3`
+- [ ] `sqlite3 ... 'SELECT MAX(version) FROM schema_version;'` returns `15`
+- [ ] `ai-memory bench` completes without exit-code-non-zero
+- [ ] MCP `tools/list` includes the seven new tool names above
+- [ ] `curl -s http://localhost:PORT/api/v1/health` returns `200 OK`
+- [ ] Existing memories are recallable (`ai-memory recall "any test phrase"`)
+- [ ] `ai-memory taxonomy` returns the namespace tree without error
+- [ ] (Federation) every peer reports schema_version 15
+
+If any of the above fail, restore the pre-upgrade snapshot and file an
+issue with the failing check + relevant logs.
+
+---
+
+## Where to ask for help
+
+- File an issue: <https://github.com/alphaonedev/ai-memory-mcp/issues>
+- Read the troubleshooting guide: `docs/TROUBLESHOOTING.md`
+- Read the architectural limits: `docs/ARCHITECTURAL_LIMITS.md`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -967,6 +967,273 @@ Show archive statistics: total count and breakdown by namespace.
 
 ---
 
+## Knowledge Graph & Hierarchy (v0.6.3)
+
+The v0.6.3 release introduces hierarchical namespace taxonomy
+(Pillar 1 / Stream A) and a temporal-validity knowledge graph
+(Pillar 2 / Streams B–D). The tools below operate on `memory_links`
+and the `entity_aliases` side table; existing memory CRUD is
+unaffected.
+
+### memory_get_taxonomy
+
+Walk live (non-expired) memories grouped by namespace and fold them
+into a `TaxonomyNode` tree. Splits on `/` so a namespace like
+`alphaone/engineering/platform` becomes a 3-level subtree. Each node
+carries `count` (memories at exactly this namespace) and
+`subtree_count` (count plus every descendant within the depth limit).
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `prefix` | string | No | -- | Restrict the walk to namespaces under this prefix (e.g. `"alphaone/engineering"`) |
+| `depth` | integer (1-10) | No | `5` | Maximum tree depth from the root or prefix |
+| `limit` | integer (1-10000) | No | `1000` | Maximum nodes to return (response includes `truncated: true` if exceeded) |
+
+**Example response envelope:**
+
+```json
+{
+  "tree": [
+    {
+      "namespace": "alphaone",
+      "count": 0,
+      "subtree_count": 47,
+      "children": [
+        { "namespace": "alphaone/engineering", "count": 3, "subtree_count": 47, "children": [ ... ] }
+      ]
+    }
+  ],
+  "total_count": 47,
+  "truncated": false
+}
+```
+
+`total_count` is computed as an independent aggregation that stays
+honest even when `limit` drops rows from the walk.
+
+---
+
+### memory_check_duplicate
+
+Embedding cosine-similarity duplicate detection. Embeds `title +
+content`, scans live memories with non-NULL embeddings, and returns
+the nearest match with an `is_duplicate` flag.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `title` | string | Yes | -- | Candidate title |
+| `content` | string | Yes | -- | Candidate content |
+| `namespace` | string | No | -- | Restrict scan to a single namespace |
+| `threshold` | number (0.5-1.0) | No | `0.85` | Cosine similarity at or above this is `is_duplicate: true` (clamped to 0.5 floor) |
+
+**Example response:**
+
+```json
+{
+  "is_duplicate": true,
+  "threshold": 0.85,
+  "nearest": {
+    "id": "a1b2c3d4-...",
+    "title": "Project uses PostgreSQL 15",
+    "namespace": "my-app",
+    "similarity": 0.92
+  },
+  "suggested_merge": "a1b2c3d4-...",
+  "candidates_scanned": 412
+}
+```
+
+`suggested_merge` is non-null when `is_duplicate == true`. Requires
+the `semantic` feature tier or higher (embeddings must be available).
+
+---
+
+### memory_entity_register
+
+Register an entity as a typed memory (no separate entities table —
+entities live in `memories` with `metadata.kind = "entity"`). Idempotent:
+calling twice with the same `canonical_name + namespace` returns the
+same entity ID and merges any new aliases via `INSERT OR IGNORE`.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `canonical_name` | string | Yes | -- | Primary name for the entity |
+| `namespace` | string | Yes | -- | Namespace to scope the entity to |
+| `aliases` | array of strings | No | `[]` | Alternate names; blanks skipped, dupes deduped |
+| `metadata` | object | No | `{}` | Additional metadata (`kind` is forced to `"entity"`) |
+| `agent_id` | string | No | (caller NHI) | Override the recorded agent_id |
+
+**Example response (newly created):**
+
+```json
+{
+  "entity_id": "ent-9876...",
+  "canonical_name": "PostgreSQL",
+  "namespace": "my-app",
+  "aliases": ["pg", "postgres", "PostgreSQL"],
+  "created": true
+}
+```
+
+If a non-entity memory already exists with the same `(title,
+namespace)`, the call returns an error rather than overwriting it.
+
+---
+
+### memory_entity_get_by_alias
+
+Resolve an alias to its canonical entity. Trims whitespace, matches
+case-sensitively, and discriminates against non-entity memories that
+happen to share the alias.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `alias` | string | Yes | -- | Alias to look up |
+| `namespace` | string | No | -- | Restrict lookup to this namespace; if omitted, picks the most-recently-created match across namespaces |
+
+**Example response:**
+
+```json
+{
+  "found": true,
+  "entity_id": "ent-9876...",
+  "canonical_name": "PostgreSQL",
+  "namespace": "my-app",
+  "aliases": ["pg", "postgres", "PostgreSQL"]
+}
+```
+
+Returns `{"found": false, ...}` (with null fields) if no entity
+matches the alias.
+
+---
+
+### memory_kg_query
+
+Recursive-CTE traversal of the temporal knowledge graph rooted at a
+source memory. Walks outbound links up to `max_depth` hops, applies
+per-hop temporal and agent filters, and prunes cycles via
+accumulated path matching.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `source_id` | string | Yes | -- | Memory ID to start the walk from |
+| `max_depth` | integer (1-5) | No | `1` | Maximum hops; ceiling enforced (depth=0 errors, depth>5 errors) |
+| `valid_at` | string (RFC 3339) | No | -- | Apply per-hop: `valid_from <= ? AND (valid_until IS NULL OR valid_until > ?)`; rows with NULL `valid_from` are excluded when set |
+| `allowed_agents` | array of strings | No | -- | Apply per-hop: `observed_by IN (...)`; an empty array (`[]`) returns zero rows (vs. omitting which skips the filter) |
+| `limit` | integer (1-1000) | No | `200` | Maximum rows returned |
+
+**Example response:**
+
+```json
+{
+  "source_id": "a1b2c3d4-...",
+  "max_depth": 3,
+  "memories": [
+    {
+      "target_id": "e5f6g7h8-...",
+      "title": "API uses Axum 0.8",
+      "target_namespace": "my-app",
+      "relation": "depends_on",
+      "valid_from": "2026-04-25T19:25:00Z",
+      "valid_until": null,
+      "observed_by": "ai:claude-code@host:pid-12345",
+      "depth": 1,
+      "path": "a1b2c3d4->e5f6g7h8"
+    }
+  ],
+  "paths": ["a1b2c3d4->e5f6g7h8->..."],
+  "count": 1
+}
+```
+
+Ordering: `depth ASC, COALESCE(valid_from, link_created_at) ASC,
+link_created_at ASC`.
+
+---
+
+### memory_kg_timeline
+
+Ordered fact timeline for an entity. Returns every link with the
+given `source_id`, ordered by `valid_from` ascending. Skips links
+with NULL `valid_from` (legacy un-anchored links from before the v15
+migration backfill).
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `source_id` | string | Yes | -- | Entity / memory ID anchoring the timeline |
+| `since` | string (RFC 3339) | No | -- | Only events with `valid_from >= since` |
+| `until` | string (RFC 3339) | No | -- | Only events with `valid_from <= until` |
+| `limit` | integer (1-1000) | No | `200` | Maximum events |
+
+**Example response:**
+
+```json
+{
+  "source_id": "a1b2c3d4-...",
+  "events": [
+    {
+      "target_id": "e5f6g7h8-...",
+      "relation": "depends_on",
+      "valid_from": "2026-04-25T19:25:00Z",
+      "valid_until": null,
+      "observed_by": "ai:claude-code@host:pid-12345"
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+### memory_kg_invalidate
+
+Mark a knowledge-graph link as superseded by setting its `valid_until`
+column. **The link is NOT deleted** — historical queries that pin
+`valid_at` to a time before the invalidation still see it. Idempotent:
+repeated calls overwrite `valid_until`; the prior value is returned
+so callers can detect overwrites.
+
+> **Federation note:** invalidations are NOT quorum-broadcast. They
+> apply locally and propagate to peers asynchronously via the
+> sync-daemon. See `docs/MIGRATION-v0.6.2-to-v0.6.3.md` for details.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `source_id` | string | Yes | -- | Source memory ID of the link |
+| `target_id` | string | Yes | -- | Target memory ID of the link |
+| `relation` | string | Yes | -- | Relation type (the third part of the link triple) |
+| `valid_until` | string (RFC 3339) | No | (now) | When to mark the link superseded |
+
+**Example response:**
+
+```json
+{
+  "found": true,
+  "valid_until": "2026-04-26T03:00:00Z",
+  "previous_valid_until": null
+}
+```
+
+Returns `{"found": false, ...}` if no link matches the
+`(source_id, target_id, relation)` triple.
+
+---
+
 ## Agent Identity (NHI) — `metadata.agent_id`
 
 Every stored memory carries a `metadata.agent_id` tag that records **who (or what) stored it**. You'll see it in `recall`, `list`, `search`, and `get` responses. You can filter by it too.

--- a/src/db.rs
+++ b/src/db.rs
@@ -2003,10 +2003,35 @@ pub fn check_duplicate(
         if bytes.is_empty() {
             continue;
         }
+        // Skip blobs whose length is not a multiple of 4 (corrupted /
+        // truncated embedding column). chunks_exact silently drops a
+        // trailing partial chunk; we explicitly bail on the row so a
+        // bad blob doesn't compute against a shorter candidate vector
+        // (which would produce a wrong cosine score).
+        if !bytes.len().is_multiple_of(4) {
+            tracing::warn!(
+                memory_id = %id,
+                blob_len = bytes.len(),
+                "skipping duplicate-check candidate with malformed embedding length"
+            );
+            continue;
+        }
         let candidate: Vec<f32> = bytes
             .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect();
+        // Vectors of mismatched dimension would compute against a
+        // truncated query (Embedder::cosine_similarity zips). Skip
+        // rather than report a misleading similarity score.
+        if candidate.len() != query_embedding.len() {
+            tracing::warn!(
+                memory_id = %id,
+                expected = query_embedding.len(),
+                got = candidate.len(),
+                "skipping duplicate-check candidate with dimension mismatch"
+            );
+            continue;
+        }
         let similarity =
             crate::embeddings::Embedder::cosine_similarity(query_embedding, &candidate);
         scanned += 1;
@@ -5146,6 +5171,53 @@ mod tests {
         let r = check_duplicate(&conn, &q, None, 0.85).unwrap();
         assert_eq!(r.candidates_scanned, 1);
         assert_eq!(r.nearest.expect("embedded match").id, id_embedded);
+    }
+
+    #[test]
+    fn check_duplicate_skips_blob_with_non_multiple_of_4_length() {
+        // Regression: pre-fix, an embedding blob whose length was not
+        // a multiple of 4 would silently drop a trailing partial chunk
+        // via chunks_exact and compute cosine against a shorter
+        // candidate vector — producing a misleading score. The bounds
+        // check now skips the row entirely.
+        let conn = test_db();
+        let mem = make_memory("malformed-blob", "ns", Tier::Long, 5);
+        let id = insert(&conn, &mem).unwrap();
+        // Write a 7-byte blob (1 short of 8 = 2 f32s) directly to
+        // sqlite, bypassing set_embedding which only takes &[f32].
+        conn.execute(
+            "UPDATE memories SET embedding = ?1 WHERE id = ?2",
+            params![&[0u8; 7][..], &id],
+        )
+        .unwrap();
+
+        let q = vec![1.0_f32, 0.0];
+        let r = check_duplicate(&conn, &q, None, 0.85).unwrap();
+        assert_eq!(
+            r.candidates_scanned, 0,
+            "malformed blob must be skipped, not silently truncated"
+        );
+        assert!(r.nearest.is_none());
+    }
+
+    #[test]
+    fn check_duplicate_skips_blob_with_dimension_mismatch() {
+        // Regression: a blob with a valid length (multiple of 4) but
+        // wrong dimension vs the query embedding must NOT be scored;
+        // cosine_similarity zips and would silently truncate to the
+        // shorter input, producing a wrong similarity.
+        let conn = test_db();
+        // Insert a memory with a 3-dim embedding via the normal path.
+        let _id = insert_with_embedding(&conn, "different-dim", "ns", &[1.0, 0.0, 0.0]);
+
+        // Query with a 4-dim embedding — different from the candidate.
+        let q = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let r = check_duplicate(&conn, &q, None, 0.85).unwrap();
+        assert_eq!(
+            r.candidates_scanned, 0,
+            "dimension-mismatched candidate must be skipped"
+        );
+        assert!(r.nearest.is_none());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7676,6 +7676,74 @@ fn test_hier_recall_touches_only_ancestor_matches() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_cli_bench_emits_json_with_seven_results_and_passes_budget() {
+    // End-to-end CLI integration test for the `ai-memory bench`
+    // subcommand (Pillar 3 / Stream E). Verifies that:
+    //   1. The binary exits 0 (no operation exceeded its p95 budget).
+    //   2. --json output is parseable and well-shaped.
+    //   3. All 7 hot-path operations are reported.
+    //   4. Each result carries the fields documented in PERFORMANCE.md.
+    //
+    // The bench subcommand seeds a disposable :memory: SQLite DB
+    // internally, so no fixture is required. Iterations are kept tiny
+    // to keep CI time bounded — the fact that the budgets are met
+    // even at 5 iterations is itself a smoke test of the budget math.
+    let bin = env!("CARGO_BIN_EXE_ai-memory");
+    let out = cmd(bin)
+        .args(["bench", "--json", "--iterations", "5", "--warmup", "0"])
+        .output()
+        .expect("failed to spawn ai-memory bench");
+
+    assert!(
+        out.status.success(),
+        "bench exited non-zero (a budget regression?): stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("bench --json must emit UTF-8");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("bench --json must be valid JSON");
+
+    // Envelope shape.
+    assert_eq!(parsed["iterations"], serde_json::json!(5));
+    assert_eq!(parsed["warmup"], serde_json::json!(0));
+    let results = parsed["results"]
+        .as_array()
+        .expect("results must be a JSON array");
+    assert_eq!(
+        results.len(),
+        7,
+        "bench should report exactly 7 operations on release/v0.6.3, got {}",
+        results.len()
+    );
+
+    // Per-result fields. Every operation must report the documented
+    // schema so dashboards / CI parsers don't break silently.
+    for r in results {
+        for field in [
+            "operation",
+            "label",
+            "measured_p50_ms",
+            "measured_p95_ms",
+            "measured_p99_ms",
+            "target_p95_ms",
+            "samples",
+            "status",
+        ] {
+            assert!(
+                r.get(field).is_some(),
+                "bench result missing field {field}: {r:?}"
+            );
+        }
+        let status = r["status"].as_str().expect("status must be a string");
+        assert!(
+            status == "pass" || status == "fail",
+            "unexpected status value {status:?}"
+        );
+    }
+}
+
+#[test]
 fn test_cli_sync_dry_run_writes_nothing() {
     // v0.6.0 GA Phase 3 foundation: --dry-run must classify new/update/noop
     // and NOT mutate either side of the sync. Uses today's timestamp-aware
@@ -7840,9 +7908,12 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
     let db_a = dir.join(format!("ai-memory-mesh-a-{}.db", uuid::Uuid::new_v4()));
     let db_b = dir.join(format!("ai-memory-mesh-b-{}.db", uuid::Uuid::new_v4()));
 
-    // 1. Serve B.
+    // 1. Serve B. Wrap in a ChildGuard so an assert panic anywhere
+    // below still kills the spawned daemon and unlinks db_a/db_b
+    // during unwind. Bare `Child` would orphan the server to PID 1
+    // (the same failure mode #401 fixed in the mTLS test).
     let port_b = free_port();
-    let mut serve_b = cmd(bin)
+    let serve_b_child = cmd(bin)
         .args([
             "--db",
             db_b.to_str().unwrap(),
@@ -7854,6 +7925,7 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
         .stderr(std::process::Stdio::null())
         .spawn()
         .unwrap();
+    let _serve_b = ChildGuard::new(serve_b_child).with_cleanup([db_a.clone(), db_b.clone()]);
     assert!(
         wait_for_health(port_b),
         "serve B health probe never returned 200"
@@ -7893,7 +7965,9 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
     );
 
     // 3. Start the sync-daemon — tight 1-second cycle, 30-second cap.
-    let mut daemon = cmd(bin)
+    // Same ChildGuard pattern: an unwrap on the cmd output below could
+    // panic, and we don't want a leaked sync-daemon if it does.
+    let daemon_child = cmd(bin)
         .args([
             "--db",
             db_a.to_str().unwrap(),
@@ -7909,6 +7983,7 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
         .stderr(std::process::Stdio::null())
         .spawn()
         .unwrap();
+    let _daemon = ChildGuard::new(daemon_child);
 
     // 4. Poll db_A via CLI until the memory appears (or timeout).
     let mut found = false;
@@ -7936,19 +8011,14 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
         }
     }
 
-    // Teardown daemons.
-    let _ = daemon.kill();
-    let _ = daemon.wait();
-    let _ = serve_b.kill();
-    let _ = serve_b.wait();
+    // _serve_b and _daemon drop at end of scope: kill + reap + unlink
+    // temp DBs. No manual teardown needed.
 
     assert!(
         found,
         "sync-daemon failed to mesh memory from peer B → peer A within 15s"
     );
-
-    let _ = std::fs::remove_file(&db_a);
-    let _ = std::fs::remove_file(&db_b);
+    // Temp DBs are unlinked by the ChildGuard's cleanup_paths.
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes every actionable finding from the full-spectrum audit at
`/Users/fate/dev/claude-campaign-runner/audits/v063/MASTER.md`. Five
commits, each addressing a specific audit-priority bucket. Brings
release/v0.6.3 to a tag-ready state.

## Commits (oldest → newest)

1. **`5d582cb` docs(changelog): backfill v0.6.3 Unreleased entries for #387–#393, #401** — cherry-picked from `campaign/changelog-fill-v063` (P0)
2. **`cce7f0f` release: bump version to 0.6.3-rc1** (P0)
3. **`b64cabb` docs(v0.6.3): migration guide + KG tool reference + bench badge** (P1)
4. **`29fd29b` fix(db,test): bound embedding blobs + RAII guard the sync mesh test + bench CLI smoke** (P2)
5. **`5c2e56c` docs(adr): formalize v0.6.3 federation caveats as ADRs** (P3)

## What this fixes by audit priority

### P0 — block rc1 tag
- Cargo.toml bumped from `0.6.2` → `0.6.3-rc1`
- CHANGELOG.md backfilled with #387–#393, #401 entries (was the missing piece per `07-docs.md`)

### P1 — block GA release
- New `docs/MIGRATION-v0.6.2-to-v0.6.3.md` (200+ LOC, covers SQLite path, three Postgres options, federation upgrade order, validation checklist, rollback)
- USER_GUIDE.md gains a "Knowledge Graph & Hierarchy (v0.6.3)" section documenting all 7 new MCP tools (`memory_get_taxonomy`, `memory_check_duplicate`, `memory_entity_register`, `memory_entity_get_by_alias`, `memory_kg_query`, `memory_kg_timeline`, `memory_kg_invalidate`) with full parameter tables and example req/resp
- API_REFERENCE.md gains the matching HTTP endpoint reference
- README.md adds Bench badge (linked to bench.yml), updated test count (191 → 602) and MCP tool count (26 → 43), and a new "Performance Budgets (v0.6.3)" subsection

### P2 — code quality
- `src/db.rs::check_duplicate` no longer silently truncates corrupted embedding blobs via `chunks_exact(4)` — both length-mismatch and dimension-mismatch are now skipped with a `tracing::warn!`. Two regression tests added.
- `tests/integration.rs::test_sync_daemon_mesh_propagates_memory_between_peers` refactored to use `ChildGuard` (the same fix #401 shipped for the mTLS test). Eliminates the second remaining sync-test daemon-leak risk.
- New `test_cli_bench_emits_json_with_seven_results_and_passes_budget` end-to-end CLI smoke test for the bench subcommand. Verifies exit code, JSON envelope, and per-result schema.

### P3 — federation caveats (formal records)
- New `docs/ADR-0002-kg-schema-v15-backward-incompat.md` — design rationale for not shipping a v14↔v15 wire-compat shim, plus operator upgrade procedure and recovery paths
- New `docs/ADR-0003-kg-invalidation-eventual-consistency.md` — design rationale for `memory_kg_invalidate` not taking the quorum-broadcast path, plus operator workarounds and v0.7 candidates if Phase-2 testing surfaces unacceptable lag
- ARCHITECTURAL_LIMITS.md gets two new entries (#13, #14) cross-referencing the ADRs and the migration guide

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo test --test integration --no-run` — clean compile
- [x] `cargo test check_duplicate_skips_blob` — 2/2 pass
- [x] `cargo test test_cli_bench_emits_json` — 1/1 pass
- [ ] CI matrix (3 platforms + bench) — runs on PR open
- [ ] Operator-side: review the migration guide before tagging rc1

## Audit reference
Full master document: `/Users/fate/dev/claude-campaign-runner/audits/v063/MASTER.md`. Seven detailed sub-reports live alongside (`01-database.md` through `07-docs.md`). The audit was conducted by 7 parallel Explore agents and synthesized into the master after all reports landed.

## After this merges
1. Re-run the full audit (operator request) — the YELLOW areas in `06-tests.md` and `07-docs.md` should drop to GREEN.
2. Tag `v0.6.3-rc1` from release/v0.6.3 (operator-only per release-policy guardrail).
3. Stand up Phase 2 testing campaign (separate effort, separate charter, with `max_iterations: 25` and `max_runtime_days: 3` caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)