### PR TITLE
docs(pages): at-a-glance.html — single-page visual atlas of ai-memory

### DIFF
--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -748,14 +748,12 @@ footer.site-foot a { color: var(--text-muted); }
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ At a Glance</span></a>
     <div class="right">
-      <a href="#what">What</a>
-      <a href="#three-pillars">Pillars</a>
-      <a href="#architecture">Architecture</a>
-      <a href="#tiers">Tiers</a>
-      <a href="#performance">Performance</a>
-      <a href="#audiences">Audiences</a>
-      <a href="#roadmap">Roadmap</a>
-      <a href="#compare">vs Alternatives</a>
+      <a href="whats-new-v063.html" style="color:var(--pillar-1)">v0.6.3</a>
+      <a href="feature-matrix.html">Features</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="for-everyone.html">For Everyone</a>
+      <a href="release-pipeline.html">Release</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
     </div>
   </div>
@@ -1831,6 +1829,77 @@ footer.site-foot a { color: var(--text-muted); }
         </p>
         <p style="color:var(--text-muted); font-size:.9rem">v0.7's attested-identity work targets FIPS-grade key handling. v1.0's federation maturity work targets multi-region resilience. Today's v0.6.3 already runs air-gapped with no compromise.</p>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: COMPANION PAGES (visualization atlas)
+     ============================================================= -->
+<section id="atlas">
+  <div class="container">
+    <span class="eyebrow">Visualization Atlas</span>
+    <h2>Six pages. Every facet, dedicated visualizations.</h2>
+    <p class="lede">This page is the hub. Each companion below dives deep into one slice of the system with its own visualization style. <strong>Pick what your audience needs.</strong></p>
+
+    <div class="grid-3" style="gap:1rem">
+      <a href="whats-new-v063.html" style="text-decoration:none">
+        <div class="card p1" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-1)">▸ NEW · RELEASE SPOTLIGHT</div>
+          <div class="card-title">What's New in v0.6.3</div>
+          <p class="card-body">The 6 streams shipped, the 9 coverage waves, the 2 SSRF defects fixed, the upgrade path. Animated coverage timeline + before/after security diff.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-1)">whats-new-v063.html →</div>
+        </div>
+      </a>
+
+      <a href="feature-matrix.html" style="text-decoration:none">
+        <div class="card p2" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-2)">▸ COMPLETE SURFACE AREA</div>
+          <div class="card-title">Feature Matrix</div>
+          <p class="card-body">Every MCP tool, every HTTP endpoint, every CLI command — categorized, cross-referenced. 26 + 39 + 28 = 93 operations. The SME's full reference.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-2)">feature-matrix.html →</div>
+        </div>
+      </a>
+
+      <a href="data-flow.html" style="text-decoration:none">
+        <div class="card p3" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-3)">▸ ENGINEERING DEEP DIVE</div>
+          <div class="card-title">Data Flow</div>
+          <p class="card-body">Animated write path, read path with hybrid 70/30 fusion, federation W=2 of N=3 quorum diagram. Where every byte goes.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-3)">data-flow.html →</div>
+        </div>
+      </a>
+
+      <a href="integrations.html" style="text-decoration:none">
+        <div class="card p1" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-1)">▸ EVERY AI HOST</div>
+          <div class="card-title">Integrations</div>
+          <p class="card-body">13 AI clients tested with one-block setup snippets each. Claude · ChatGPT · Cursor · Windsurf · Continue · Codex · Gemini · Grok · OpenClaw · Hermes · Llama.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-1)">integrations.html →</div>
+        </div>
+      </a>
+
+      <a href="for-everyone.html" style="text-decoration:none">
+        <div class="card p2" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-2)">▸ AUDIENCE-BY-SCALE</div>
+          <div class="card-title">For Everyone</div>
+          <p class="card-body">Solo dev → Startup → Mid-market → Enterprise → Government. Pain → Fix → ROI per audience. Deployment patterns. Procurement-ready specs.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-2)">for-everyone.html →</div>
+        </div>
+      </a>
+
+      <a href="release-pipeline.html" style="text-decoration:none">
+        <div class="card p3" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-3)">▸ OPERATIONAL MATURITY</div>
+          <div class="card-title">Release Pipeline</div>
+          <p class="card-body">Tag → 5 platforms → 5 distribution channels → all signed. CI gates. SBOM. Reproducible builds. Procurement-ready operational spec.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-3)">release-pipeline.html →</div>
+        </div>
+      </a>
+    </div>
+
+    <div class="callout" style="margin-top:2.5rem">
+      <strong>The atlas is print-friendly too.</strong> Every page in the visualization set has a <code>@media print</code> stylesheet that strips chrome, switches to white background, and applies page-break-protection. Print as a PDF for board decks, procurement reviews, or a "give this to your security team" packet.
     </div>
   </div>
 </section>

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -1,0 +1,1863 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  ai-memory At a Glance — single-page visualization of every aspect and facet
+  of the ai-memory system, designed for C-level decision makers, subject-matter
+  experts, and non-technical evaluators alike.
+
+  This page is intentionally visualization-heavy and prose-light. It is the
+  picture-worth-a-thousand-words companion to the technical README, the
+  PERFORMANCE.md budget table, and the public-roadmap document.
+
+  Audiences served (progressive disclosure top → bottom):
+    1. 30-second tour      — hero + three pillars + headline numbers
+    2. 5-minute tour       — architecture layers + lifecycle + tier ladder
+    3. Engineering depth   — performance + coverage + federation + numbers
+    4. Audience-by-scale   — solo dev → mega-scale gov & institutions
+    5. Strategic context   — roadmap + comparison matrix + trust ladder
+
+  Single file. No external JS dependencies. Inline SVG. Dark monochrome theme
+  with three-color accent palette mirroring the three pillars (cyan/orange/
+  purple). Mobile-responsive. Print-friendly via @media print at the bottom.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory At a Glance — every facet, one page</title>
+<meta name="description" content="Visual atlas of ai-memory: persistent, AI-agnostic memory daemon. Three pillars (hierarchy, knowledge graph, performance), four operational tiers, sub-100ms latency, federation-ready, local-first. From solo developer to federal-scale government deployments.">
+<meta name="theme-color" content="#0d1117">
+<meta property="og:title" content="ai-memory At a Glance">
+<meta property="og:description" content="Every aspect and facet of ai-memory, visualized for everyone from individual developers to mega-scale institutions.">
+<meta property="og:url" content="https://alphaonedev.github.io/ai-memory-mcp/at-a-glance.html">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/at-a-glance.html">
+<style>
+/* =============================================================
+   DESIGN TOKENS — match index.html base, add 3-pillar palette
+   ============================================================= */
+:root {
+  --bg:           #000000;
+  --bg-raised:    #0a0a0a;
+  --bg-card:      #111111;
+  --bg-elev:      #161616;
+  --bg-code:      #1a1a1a;
+  --border:       #262626;
+  --border-hl:    #3d3d3d;
+  --text:         #ffffff;
+  --text-muted:   #999999;
+  --text-dim:     #666666;
+  --accent:       #ffffff;
+
+  /* Three-pillar accents (used for the v0.6.3 grand-slam) */
+  --pillar-1:     #6ee7ff;  /* cyan — hierarchy */
+  --pillar-2:     #ffb86b;  /* orange — knowledge graph */
+  --pillar-3:     #c8a2ff;  /* purple — performance */
+
+  /* Quantitative palette */
+  --good:         #6ee7ff;
+  --warn:         #ffb86b;
+  --bad:          #ff6b9d;
+
+  --font-mono:    'SF Mono','Cascadia Code','Fira Code','JetBrains Mono',Consolas,monospace;
+  --font-sans:    -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  --max-w:        1280px;
+}
+
+/* =============================================================
+   RESET + BASE
+   ============================================================= */
+*, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }
+html { scroll-behavior:smooth; scroll-padding-top:5rem; }
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code { font-family: var(--font-mono); font-size: .875rem; background: var(--bg-code); padding: .15em .4em; border-radius: 4px; }
+
+.container { max-width: var(--max-w); margin: 0 auto; padding: 0 1.5rem; }
+
+h1, h2, h3, h4 { font-weight: 700; letter-spacing: -0.02em; }
+h2 { font-size: 2.25rem; line-height: 1.15; margin-bottom: .5rem; }
+h3 { font-size: 1.35rem; margin-bottom: .5rem; }
+h4 { font-size: 1.05rem; margin-bottom: .35rem; }
+p  { color: var(--text-muted); }
+
+/* =============================================================
+   NAV
+   ============================================================= */
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(0,0,0,0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+.topnav .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: .9rem 1.5rem;
+  font-size: .875rem;
+}
+.topnav a { color: var(--text-muted); margin-right: 1.25rem; }
+.topnav a:hover, .topnav a.active { color: var(--text); text-decoration: none; }
+.topnav .home-link { color: var(--text); font-weight: 600; }
+.topnav .right { display: flex; gap: 1.25rem; align-items: center; }
+@media (max-width: 800px) {
+  .topnav .right { display: none; }
+}
+
+/* =============================================================
+   SECTIONS — common scaffold
+   ============================================================= */
+section {
+  padding: 5rem 0;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+section.compact { padding: 3.5rem 0; }
+section .eyebrow {
+  display: inline-block;
+  font-size: .75rem;
+  font-weight: 600;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  padding: .25rem .65rem;
+  border: 1px solid var(--border-hl);
+  border-radius: 999px;
+}
+section .eyebrow.p1 { color: var(--pillar-1); border-color: rgba(110,231,255,.4); }
+section .eyebrow.p2 { color: var(--pillar-2); border-color: rgba(255,184,107,.4); }
+section .eyebrow.p3 { color: var(--pillar-3); border-color: rgba(200,162,255,.4); }
+section .lede {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 720px;
+  margin-bottom: 3rem;
+}
+
+/* =============================================================
+   HERO
+   ============================================================= */
+.hero {
+  min-height: 95vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 6rem 1.5rem 4rem;
+  background: radial-gradient(ellipse at top, rgba(110,231,255,0.04), transparent 50%),
+              radial-gradient(ellipse at bottom, rgba(200,162,255,0.05), transparent 60%);
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+  position: relative;
+}
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  margin-bottom: 1.5rem;
+}
+.hero h1 .pillar-1 { color: var(--pillar-1); }
+.hero h1 .pillar-2 { color: var(--pillar-2); }
+.hero h1 .pillar-3 { color: var(--pillar-3); }
+.hero .tagline {
+  font-size: clamp(1rem, 1.6vw, 1.3rem);
+  color: var(--text-muted);
+  max-width: 720px;
+  margin: 0 auto 2rem;
+}
+.hero .pillars-icons {
+  display: flex; gap: 2.5rem;
+  margin: 2rem 0 2.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.hero .pillar-icon {
+  display: flex; align-items: center; gap: .5rem;
+  font-size: .95rem; color: var(--text-muted);
+}
+.hero .pillar-icon .dot { width: 10px; height: 10px; border-radius: 50%; }
+.hero .pillar-icon .dot.p1 { background: var(--pillar-1); box-shadow: 0 0 12px var(--pillar-1); }
+.hero .pillar-icon .dot.p2 { background: var(--pillar-2); box-shadow: 0 0 12px var(--pillar-2); }
+.hero .pillar-icon .dot.p3 { background: var(--pillar-3); box-shadow: 0 0 12px var(--pillar-3); }
+.hero .ctas { display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center; }
+.hero .cta {
+  display: inline-block;
+  padding: .85rem 1.5rem;
+  border: 1px solid var(--border-hl);
+  border-radius: 8px;
+  color: var(--text);
+  font-weight: 600;
+  transition: border-color .2s, background .2s;
+}
+.hero .cta.primary { background: var(--text); color: var(--bg); border-color: var(--text); }
+.hero .cta.primary:hover { background: var(--accent); }
+.hero .cta:hover { border-color: var(--accent); text-decoration: none; }
+
+/* Animated brain SVG */
+.brain-viz {
+  width: 100%; max-width: 720px;
+  height: 280px;
+  margin: 1rem auto 2rem;
+  position: relative;
+}
+.brain-viz circle { transform-origin: center; }
+.brain-viz .node-pulse { animation: pulse 2.6s infinite ease-in-out; }
+.brain-viz .node-pulse-2 { animation: pulse 2.6s infinite ease-in-out; animation-delay: 0.4s; }
+.brain-viz .node-pulse-3 { animation: pulse 2.6s infinite ease-in-out; animation-delay: 0.8s; }
+.brain-viz .link { stroke-dasharray: 4 4; animation: dash 8s linear infinite; }
+@keyframes pulse {
+  0%, 100% { opacity: 0.5; r: 5; }
+  50%      { opacity: 1; r: 8; }
+}
+@keyframes dash {
+  to { stroke-dashoffset: -100; }
+}
+
+/* =============================================================
+   STATS STRIPS
+   ============================================================= */
+.stats-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-raised);
+}
+.stat-item {
+  text-align: center;
+  padding: 0 1rem;
+}
+.stat-num {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  letter-spacing: -0.02em;
+  display: block;
+  line-height: 1;
+}
+.stat-label {
+  display: block;
+  font-size: .75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  margin-top: .5rem;
+}
+
+/* =============================================================
+   GRID UTILITIES
+   ============================================================= */
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; }
+.grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.25rem; }
+.grid-5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1rem; }
+@media (max-width: 920px) {
+  .grid-2 { grid-template-columns: 1fr; }
+  .grid-3 { grid-template-columns: 1fr; }
+  .grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .grid-5 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 540px) {
+  .grid-4 { grid-template-columns: 1fr; }
+  .grid-5 { grid-template-columns: 1fr; }
+}
+
+/* =============================================================
+   CARD VARIANTS
+   ============================================================= */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  transition: border-color .2s, transform .15s;
+}
+.card:hover { border-color: var(--border-hl); }
+.card .card-eyebrow {
+  font-size: .7rem;
+  font-weight: 600;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: .75rem;
+}
+.card .card-title { font-size: 1.15rem; font-weight: 700; margin-bottom: .5rem; }
+.card .card-body { color: var(--text-muted); font-size: .95rem; line-height: 1.55; }
+.card.p1 { border-top: 3px solid var(--pillar-1); }
+.card.p2 { border-top: 3px solid var(--pillar-2); }
+.card.p3 { border-top: 3px solid var(--pillar-3); }
+
+/* =============================================================
+   ARCHITECTURE LAYERS (interactive stacking diagram)
+   ============================================================= */
+.arch-stack {
+  position: relative;
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+}
+.arch-layer {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  margin-bottom: 1rem;
+  background: var(--bg-card);
+  transition: transform .2s, border-color .2s, background .2s;
+  position: relative;
+}
+.arch-layer:hover { transform: translateY(-3px); border-color: var(--border-hl); background: var(--bg-elev); }
+.arch-layer .layer-tag {
+  flex-shrink: 0;
+  width: 80px;
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.arch-layer .layer-title { font-size: 1.15rem; font-weight: 700; }
+.arch-layer .layer-desc { color: var(--text-muted); font-size: .95rem; margin-top: .3rem; }
+.arch-layer.surface { border-left: 4px solid var(--pillar-1); }
+.arch-layer.core    { border-left: 4px solid var(--pillar-2); }
+.arch-layer.safety  { border-left: 4px solid var(--pillar-3); }
+.arch-layer.state   { border-left: 4px solid var(--good); }
+.arch-layer .icon-wrap {
+  flex-shrink: 0;
+  width: 56px; height: 56px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.04);
+}
+
+/* =============================================================
+   TIER LADDER
+   ============================================================= */
+.tier-ladder {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.tier-ladder .tier {
+  padding: 1.75rem 1.5rem;
+  border-right: 1px solid var(--border);
+  position: relative;
+}
+.tier-ladder .tier:last-child { border-right: none; }
+.tier-ladder .tier .tier-bar { height: 6px; border-radius: 3px; margin-bottom: 1rem; }
+.tier-ladder .tier-keyword .tier-bar { background: linear-gradient(90deg, #444, #888); }
+.tier-ladder .tier-semantic .tier-bar { background: linear-gradient(90deg, #4a7, #6c9); }
+.tier-ladder .tier-smart .tier-bar { background: linear-gradient(90deg, var(--pillar-2), #ffd6a0); }
+.tier-ladder .tier-autonomous .tier-bar { background: linear-gradient(90deg, var(--pillar-3), #e0c8ff); }
+.tier-ladder .tier-name {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: .35rem;
+}
+.tier-ladder .tier-deps {
+  font-size: .75rem;
+  color: var(--text-dim);
+  margin-bottom: .85rem;
+}
+.tier-ladder .tier-features {
+  list-style: none;
+  font-size: .85rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+.tier-ladder .tier-features li::before { content: "▸ "; color: var(--text-dim); }
+@media (max-width: 920px) {
+  .tier-ladder { grid-template-columns: 1fr; }
+  .tier-ladder .tier { border-right: none; border-bottom: 1px solid var(--border); }
+}
+
+/* =============================================================
+   LIFECYCLE SVG
+   ============================================================= */
+.lifecycle-viz { width: 100%; max-width: 1100px; margin: 0 auto; }
+.lifecycle-viz .stage-box { fill: var(--bg-card); stroke: var(--border-hl); stroke-width: 1; }
+.lifecycle-viz .stage-text { fill: var(--text); font-family: var(--font-mono); font-size: 13px; }
+.lifecycle-viz .arrow { stroke: var(--text-muted); fill: none; stroke-width: 1.5; }
+.lifecycle-viz .arrow-active { stroke: var(--pillar-1); stroke-width: 2.5; stroke-dasharray: 5 5; animation: dash 2s linear infinite; }
+.lifecycle-viz .stage-label { fill: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+
+/* =============================================================
+   PERF GAUGES
+   ============================================================= */
+.perf-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+.gauge {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex; flex-direction: column;
+}
+.gauge .gauge-op { font-family: var(--font-mono); font-size: .85rem; color: var(--text-muted); margin-bottom: .35rem; }
+.gauge .gauge-budget { font-size: .8rem; color: var(--text-dim); margin-bottom: .85rem; }
+.gauge .gauge-bar-bg { height: 12px; background: var(--bg-code); border-radius: 6px; overflow: hidden; position: relative; margin-bottom: .35rem; }
+.gauge .gauge-bar-fill { height: 100%; border-radius: 6px; background: linear-gradient(90deg, var(--good), var(--good)); transition: width .8s ease-out; }
+.gauge .gauge-bar-marker { position: absolute; top: -2px; bottom: -2px; width: 2px; background: var(--text); opacity: 0.5; }
+.gauge .gauge-numbers { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: .8rem; }
+.gauge .gauge-measured { color: var(--good); font-weight: 700; }
+.gauge .gauge-target { color: var(--text-dim); }
+
+/* =============================================================
+   COVERAGE BARS
+   ============================================================= */
+.cov-table {
+  display: grid;
+  grid-template-columns: 200px 1fr 100px;
+  gap: .5rem;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: .8rem;
+}
+.cov-table .cov-row { display: contents; }
+.cov-table .cov-mod { color: var(--text-muted); }
+.cov-table .cov-bar-bg { height: 8px; background: var(--bg-code); border-radius: 4px; overflow: hidden; }
+.cov-table .cov-bar-fill { height: 100%; border-radius: 4px; background: linear-gradient(90deg, var(--pillar-3), var(--pillar-1)); }
+.cov-table .cov-pct { text-align: right; color: var(--text); font-variant-numeric: tabular-nums; }
+.cov-table .cov-pct.perfect { color: var(--good); }
+.cov-table .cov-pct.warn { color: var(--warn); }
+
+/* =============================================================
+   FEDERATION DIAGRAM
+   ============================================================= */
+.fed-diagram {
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+}
+.fed-diagram .node-bg { fill: var(--bg-card); stroke: var(--border-hl); stroke-width: 1.5; }
+.fed-diagram .node-bg.lead { stroke: var(--pillar-1); stroke-width: 2.5; }
+.fed-diagram .node-text { fill: var(--text); font-family: var(--font-mono); font-size: 13px; text-anchor: middle; }
+.fed-diagram .node-sub { fill: var(--text-muted); font-size: 10px; text-anchor: middle; }
+.fed-diagram .ack-line { stroke: var(--good); stroke-width: 2; fill: none; stroke-dasharray: 4 4; animation: dash 4s linear infinite; }
+.fed-diagram .write-line { stroke: var(--pillar-2); stroke-width: 2; fill: none; }
+
+/* =============================================================
+   PERSONAS (use cases by audience scale)
+   ============================================================= */
+.persona-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+}
+@media (max-width: 1080px) { .persona-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px)  { .persona-grid { grid-template-columns: 1fr; } }
+
+.persona {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.5rem;
+  display: flex; flex-direction: column;
+  gap: .85rem;
+}
+.persona .persona-icon {
+  width: 44px; height: 44px;
+  border-radius: 10px;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(255,255,255,0.04);
+  font-size: 1.5rem;
+}
+.persona .persona-scale {
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .12em;
+}
+.persona .persona-title { font-size: 1.1rem; font-weight: 700; }
+.persona .persona-pop {
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+.persona .persona-pop-label { font-size: .7rem; color: var(--text-dim); margin-top: -.4rem; text-transform: uppercase; letter-spacing: .1em; }
+.persona .persona-pain {
+  background: rgba(255,107,157,0.08);
+  border: 1px solid rgba(255,107,157,0.2);
+  border-radius: 8px;
+  padding: .65rem .85rem;
+  font-size: .85rem;
+  color: #ffb0c8;
+}
+.persona .persona-fix {
+  background: rgba(110,231,255,0.07);
+  border: 1px solid rgba(110,231,255,0.2);
+  border-radius: 8px;
+  padding: .65rem .85rem;
+  font-size: .85rem;
+  color: #a8eeff;
+}
+.persona .persona-bullets {
+  font-size: .85rem;
+  color: var(--text-muted);
+  list-style: none;
+}
+.persona .persona-bullets li { padding-left: 1rem; position: relative; margin-bottom: .25rem; }
+.persona .persona-bullets li::before { content: "→"; position: absolute; left: 0; color: var(--text-dim); }
+
+/* =============================================================
+   ROADMAP TIMELINE
+   ============================================================= */
+.roadmap {
+  position: relative;
+  padding: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+.roadmap::before {
+  content: "";
+  position: absolute;
+  left: 30px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+}
+.roadmap-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  position: relative;
+}
+.roadmap-marker {
+  width: 60px;
+  flex-shrink: 0;
+  display: flex; flex-direction: column; align-items: center;
+  z-index: 2;
+}
+.roadmap-dot {
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: var(--text);
+  border: 4px solid var(--bg);
+  box-shadow: 0 0 0 1px var(--border-hl);
+}
+.roadmap-row.shipped .roadmap-dot { background: var(--good); box-shadow: 0 0 0 1px var(--good); }
+.roadmap-row.next .roadmap-dot   { background: var(--pillar-2); box-shadow: 0 0 0 1px var(--pillar-2); animation: pulse-marker 2s infinite; }
+.roadmap-row.future .roadmap-dot { background: var(--bg-card); }
+
+@keyframes pulse-marker {
+  0%, 100% { box-shadow: 0 0 0 1px var(--pillar-2), 0 0 0 4px rgba(255,184,107,0); }
+  50%      { box-shadow: 0 0 0 1px var(--pillar-2), 0 0 0 8px rgba(255,184,107,0.2); }
+}
+
+.roadmap-row .version {
+  font-family: var(--font-mono);
+  font-size: .8rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-top: .25rem;
+}
+.roadmap-row.shipped .version { color: var(--good); }
+.roadmap-row.next .version    { color: var(--pillar-2); }
+.roadmap-content {
+  flex: 1;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+.roadmap-content .rmt-theme { font-size: 1.05rem; font-weight: 700; margin-bottom: .25rem; }
+.roadmap-content .rmt-eta   { font-size: .75rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: .1em; margin-bottom: .65rem; }
+.roadmap-content .rmt-desc  { color: var(--text-muted); font-size: .9rem; }
+.roadmap-content .rmt-bullets { list-style: none; font-size: .85rem; color: var(--text-muted); margin-top: .65rem; }
+.roadmap-content .rmt-bullets li { padding-left: 1rem; position: relative; margin: .15rem 0; }
+.roadmap-content .rmt-bullets li::before { content: "▸"; position: absolute; left: 0; color: var(--text-dim); }
+
+/* =============================================================
+   COMPARISON MATRIX
+   ============================================================= */
+.compare-matrix {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .9rem;
+}
+.compare-matrix th, .compare-matrix td {
+  padding: .85rem 1rem;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+.compare-matrix th {
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--text-muted);
+  font-weight: 600;
+  border-bottom: 2px solid var(--border-hl);
+}
+.compare-matrix th.spec { text-align: left; }
+.compare-matrix td.spec { text-align: left; color: var(--text-muted); }
+.compare-matrix td.aim { background: rgba(110,231,255,0.04); border-left: 1px solid rgba(110,231,255,0.2); border-right: 1px solid rgba(110,231,255,0.2); }
+.compare-matrix tbody tr:hover { background: var(--bg-raised); }
+.tick     { color: var(--good); font-weight: 700; font-size: 1.1rem; }
+.cross    { color: var(--bad); font-weight: 700; font-size: 1.1rem; }
+.partial  { color: var(--warn); font-weight: 700; font-size: 1.1rem; }
+@media (max-width: 800px) {
+  .compare-matrix { font-size: .8rem; }
+  .compare-matrix th, .compare-matrix td { padding: .55rem .4rem; }
+}
+
+/* =============================================================
+   TRUST LADDER
+   ============================================================= */
+.trust-ladder {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+}
+@media (max-width: 1000px) { .trust-ladder { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px)  { .trust-ladder { grid-template-columns: 1fr; } }
+
+.trust-step {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  position: relative;
+}
+.trust-step .step-num {
+  position: absolute; top: -12px; left: -12px;
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--bg);
+  border: 2px solid var(--border-hl);
+  font-family: var(--font-mono);
+  font-size: .85rem;
+  font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--text);
+}
+.trust-step .step-title { font-size: 1rem; font-weight: 700; margin-bottom: .35rem; margin-top: .25rem; }
+.trust-step .step-tier  { font-family: var(--font-mono); font-size: .7rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: .1em; }
+.trust-step .step-desc  { font-size: .85rem; color: var(--text-muted); margin-top: .5rem; line-height: 1.5; }
+.trust-step.shipped { border-color: rgba(110,231,255,0.4); }
+.trust-step.shipped .step-num { background: var(--pillar-1); color: var(--bg); border-color: var(--pillar-1); }
+.trust-step.next { border-color: rgba(255,184,107,0.4); }
+.trust-step.next .step-num { background: var(--pillar-2); color: var(--bg); border-color: var(--pillar-2); }
+
+/* =============================================================
+   NUMBERS DASHBOARD
+   ============================================================= */
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+}
+.dash-tile {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+.dash-tile .dash-label { font-size: .7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: .12em; margin-bottom: .5rem; }
+.dash-tile .dash-num   { font-family: var(--font-mono); font-size: 2rem; font-weight: 700; line-height: 1; letter-spacing: -0.02em; }
+.dash-tile .dash-unit  { color: var(--text-dim); font-size: 1rem; }
+.dash-tile .dash-sub   { font-size: .75rem; color: var(--text-dim); margin-top: .35rem; }
+.dash-tile.p1 { border-top: 3px solid var(--pillar-1); }
+.dash-tile.p2 { border-top: 3px solid var(--pillar-2); }
+.dash-tile.p3 { border-top: 3px solid var(--pillar-3); }
+.dash-tile.good { border-top: 3px solid var(--good); }
+
+/* =============================================================
+   CTA / FOOTER
+   ============================================================= */
+.cta-section {
+  text-align: center;
+  padding: 6rem 1.5rem;
+  background: radial-gradient(ellipse at center, rgba(110,231,255,0.04), transparent 60%);
+}
+.cta-section h2 { font-size: clamp(2rem, 4vw, 3rem); margin-bottom: 1rem; }
+.cta-section p  { max-width: 640px; margin: 0 auto 2rem; }
+.cta-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+footer.site-foot {
+  border-top: 1px solid var(--border);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  font-size: .85rem;
+  color: var(--text-dim);
+}
+footer.site-foot a { color: var(--text-muted); }
+
+/* =============================================================
+   QUOTES / CALLOUTS
+   ============================================================= */
+.callout {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--pillar-1);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin: 2rem 0;
+  font-size: .95rem;
+  color: var(--text-muted);
+}
+.callout.warn { border-left-color: var(--warn); }
+.callout strong { color: var(--text); }
+
+/* =============================================================
+   PRINT STYLES
+   ============================================================= */
+@media print {
+  .topnav, .hero .ctas, .cta-section { display: none; }
+  body { background: white; color: black; }
+  section { page-break-inside: avoid; padding: 1.5rem 0; }
+  .card, .gauge, .persona, .dash-tile, .roadmap-content, .trust-step { background: white; border: 1px solid #ccc; }
+  h1, h2, h3 { color: black; }
+  p { color: #333; }
+}
+</style>
+</head>
+<body>
+
+<!-- =============================================================
+     NAV
+     ============================================================= -->
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ At a Glance</span></a>
+    <div class="right">
+      <a href="#what">What</a>
+      <a href="#three-pillars">Pillars</a>
+      <a href="#architecture">Architecture</a>
+      <a href="#tiers">Tiers</a>
+      <a href="#performance">Performance</a>
+      <a href="#audiences">Audiences</a>
+      <a href="#roadmap">Roadmap</a>
+      <a href="#compare">vs Alternatives</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<!-- =============================================================
+     HERO
+     ============================================================= -->
+<section class="hero">
+  <h1>
+    Persistent memory<br>
+    for any AI.<br>
+    <span class="pillar-1">Hierarchical</span>.
+    <span class="pillar-2">Temporal</span>.
+    <span class="pillar-3">Sub-100ms</span>.
+  </h1>
+  <p class="tagline">
+    A single Rust binary that gives Claude, ChatGPT, Cursor, Windsurf, Gemini, Hermes — every MCP-compatible AI — durable, shared memory across sessions, projects, and machines. Local-first. Zero cloud dependencies. <strong>Already running on your hardware in 60 seconds.</strong>
+  </p>
+
+  <!-- Animated brain SVG: 3 nodes, 3 pillars, pulsing connections -->
+  <svg class="brain-viz" viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" aria-label="Three pillars of ai-memory connected">
+    <defs>
+      <radialGradient id="aura" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stop-color="rgba(255,255,255,0.06)"/>
+        <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+      </radialGradient>
+    </defs>
+    <ellipse cx="360" cy="140" rx="320" ry="120" fill="url(#aura)"/>
+
+    <!-- The three pillar nodes -->
+    <g>
+      <circle class="node-pulse" cx="180" cy="140" r="6" fill="#6ee7ff"/>
+      <circle cx="180" cy="140" r="40" fill="none" stroke="#6ee7ff" stroke-opacity="0.25" stroke-width="1"/>
+      <text x="180" y="210" fill="#6ee7ff" font-family="monospace" font-size="13" text-anchor="middle">HIERARCHY</text>
+      <text x="180" y="225" fill="#999" font-size="10" text-anchor="middle">tree of namespaces</text>
+    </g>
+    <g>
+      <circle class="node-pulse-2" cx="360" cy="140" r="6" fill="#ffb86b"/>
+      <circle cx="360" cy="140" r="40" fill="none" stroke="#ffb86b" stroke-opacity="0.25" stroke-width="1"/>
+      <text x="360" y="210" fill="#ffb86b" font-family="monospace" font-size="13" text-anchor="middle">KNOWLEDGE GRAPH</text>
+      <text x="360" y="225" fill="#999" font-size="10" text-anchor="middle">temporal-validity links</text>
+    </g>
+    <g>
+      <circle class="node-pulse-3" cx="540" cy="140" r="6" fill="#c8a2ff"/>
+      <circle cx="540" cy="140" r="40" fill="none" stroke="#c8a2ff" stroke-opacity="0.25" stroke-width="1"/>
+      <text x="540" y="210" fill="#c8a2ff" font-family="monospace" font-size="13" text-anchor="middle">PERFORMANCE</text>
+      <text x="540" y="225" fill="#999" font-size="10" text-anchor="middle">CI-guarded budgets</text>
+    </g>
+
+    <!-- Connecting links -->
+    <path class="link" d="M 220 140 Q 270 100 320 140" stroke="#6ee7ff" stroke-opacity="0.5" fill="none" stroke-width="1.5"/>
+    <path class="link" d="M 400 140 Q 450 100 500 140" stroke="#ffb86b" stroke-opacity="0.5" fill="none" stroke-width="1.5"/>
+    <path class="link" d="M 220 140 Q 360 50 500 140" stroke="#c8a2ff" stroke-opacity="0.3" fill="none" stroke-width="1.5"/>
+
+    <!-- Surrounding mini nodes (signaling many memories) -->
+    <circle cx="100" cy="80"  r="2" fill="#666"/>
+    <circle cx="120" cy="200" r="2" fill="#666"/>
+    <circle cx="270" cy="60"  r="2" fill="#666"/>
+    <circle cx="450" cy="60"  r="2" fill="#666"/>
+    <circle cx="600" cy="80"  r="2" fill="#666"/>
+    <circle cx="620" cy="200" r="2" fill="#666"/>
+    <circle cx="500" cy="240" r="2" fill="#666"/>
+    <circle cx="240" cy="240" r="2" fill="#666"/>
+  </svg>
+
+  <div class="ctas">
+    <a class="cta primary" href="./#install">Get Started in 60 Seconds</a>
+    <a class="cta" href="https://github.com/alphaonedev/ai-memory-mcp">View on GitHub →</a>
+  </div>
+
+  <div class="pillars-icons" aria-hidden="true" style="margin-top:2.5rem;">
+    <span class="pillar-icon"><span class="dot p1"></span> 93.05% test coverage</span>
+    <span class="pillar-icon"><span class="dot p2"></span> 1,809 tests passing</span>
+    <span class="pillar-icon"><span class="dot p3"></span> Apache-2.0 licensed</span>
+  </div>
+</section>
+
+<!-- =============================================================
+     STATS STRIP — headline numbers
+     ============================================================= -->
+<div class="stats-strip">
+  <div class="container" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:1.5rem;">
+    <div class="stat-item"><span class="stat-num">26</span><span class="stat-label">MCP tools</span></div>
+    <div class="stat-item"><span class="stat-num">39</span><span class="stat-label">HTTP endpoints</span></div>
+    <div class="stat-item"><span class="stat-num">28</span><span class="stat-label">CLI commands</span></div>
+    <div class="stat-item"><span class="stat-num">5</span><span class="stat-label">Platforms</span></div>
+    <div class="stat-item"><span class="stat-num">13</span><span class="stat-label">AI clients tested</span></div>
+    <div class="stat-item"><span class="stat-num">0</span><span class="stat-label">Cloud deps</span></div>
+  </div>
+</div>
+
+<!-- =============================================================
+     SECTION: WHAT IS IT? (30 second tour)
+     ============================================================= -->
+<section id="what">
+  <div class="container">
+    <span class="eyebrow">30-Second Tour</span>
+    <h2>One binary. Three pillars. Every AI.</h2>
+    <p class="lede">
+      ai-memory is a self-contained Rust daemon. Every AI tool you use plugs into it via MCP and gets the same memory. Stop losing context every conversation. Stop pasting "remember that I…" into every model. Stop paying SaaS fees for what runs locally on your laptop.
+    </p>
+
+    <div class="grid-3">
+      <div class="card p1">
+        <div class="card-eyebrow">Pillar 1 · Hierarchy</div>
+        <div class="card-title">Memories live in a tree, not a flat blob.</div>
+        <p class="card-body">
+          <code>projects/alpha/decisions</code>. <code>clients/acme/contracts</code>. <code>research/quantum/papers</code>. Recall scopes to a subtree, never bleeds across contexts. Your finance memories don't leak into your code reviews.
+        </p>
+      </div>
+      <div class="card p2">
+        <div class="card-eyebrow">Pillar 2 · Knowledge Graph</div>
+        <div class="card-title">Facts have a clock attached.</div>
+        <p class="card-body">
+          Every link between memories carries <code>valid_from</code> and <code>valid_until</code>. Ask "what was true on Feb 15?" and the system reconstructs the world as you knew it. Supersession is recorded, not destroyed.
+        </p>
+      </div>
+      <div class="card p3">
+        <div class="card-eyebrow">Pillar 3 · Performance</div>
+        <div class="card-title">Sub-100ms. Measured. Enforced.</div>
+        <p class="card-body">
+          Every hot path has a published p95 budget. CI fails any pull request that breaks them by more than 10%. <code>memory_session_start &lt; 100ms</code>. <code>memory_recall &lt; 50ms</code>. No silence-by-default.
+        </p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>The third pillar is the one most projects skip.</strong> mempalace publishes their budgets and hits them. Most memory systems don't. ai-memory does — every release ships a <code>PERFORMANCE.md</code> table and a CI gate that enforces it.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: ARCHITECTURE
+     ============================================================= -->
+<section id="architecture">
+  <div class="container">
+    <span class="eyebrow">Architecture</span>
+    <h2>Four layers. Clear boundaries.</h2>
+    <p class="lede">
+      Each layer has one job. The Surface layer talks to AI clients. The Core layer reasons about memory. The Safety layer enforces what's allowed. The State layer persists everything to disk. Cross-layer dependencies flow downward only.
+    </p>
+
+    <div class="arch-stack">
+      <div class="arch-layer surface">
+        <div class="icon-wrap">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#6ee7ff" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+        </div>
+        <div style="flex:1">
+          <div class="layer-tag">Surface</div>
+          <div class="layer-title">MCP · HTTP · CLI · Webhooks</div>
+          <div class="layer-desc">Three protocol fronts, one set of operations underneath. Stdio JSON-RPC for AI clients. mTLS-aware HTTP REST for services. Direct CLI for humans and scripts. Outbound webhooks for SIEM/audit.</div>
+        </div>
+      </div>
+      <div class="arch-layer core">
+        <div class="icon-wrap">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#ffb86b" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v6M12 17v6M4.22 4.22l4.24 4.24M15.54 15.54l4.24 4.24M1 12h6M17 12h6M4.22 19.78l4.24-4.24M15.54 8.46l4.24-4.24"/></svg>
+        </div>
+        <div style="flex:1">
+          <div class="layer-tag">Core</div>
+          <div class="layer-title">Recall · Hybrid Search · KG · Curator</div>
+          <div class="layer-desc">FTS5 keyword + HNSW vector + cross-encoder rerank. Recursive-CTE knowledge graph traversal with temporal validity. Background curator daemon auto-tags, detects contradictions, consolidates similar memories.</div>
+        </div>
+      </div>
+      <div class="arch-layer safety">
+        <div class="icon-wrap">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#c8a2ff" stroke-width="2"><path d="M12 2L3 7v6c0 5 4 9 9 11 5-2 9-6 9-11V7l-9-5z"/></svg>
+        </div>
+        <div style="flex:1">
+          <div class="layer-tag">Safety</div>
+          <div class="layer-title">Governance · SSRF Guard · Validation · Pending Actions</div>
+          <div class="layer-desc">Allow / Deny / Pending decisions on every write. URL validator rejects RFC1918 and AWS metadata IP. Strict input validation on every public surface. Approve/reject queue for AI-proposed destructive ops.</div>
+        </div>
+      </div>
+      <div class="arch-layer state">
+        <div class="icon-wrap">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#6ee7ff" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v6c0 1.66 4.03 3 9 3s9-1.34 9-3V5M3 11v6c0 1.66 4.03 3 9 3s9-1.34 9-3v-6"/></svg>
+        </div>
+        <div style="flex:1">
+          <div class="layer-tag">State</div>
+          <div class="layer-title">SQLite · WAL · Federation Sync · Archive</div>
+          <div class="layer-desc">Single-file SQLite database. WAL mode for concurrent reads. W-of-N quorum federation across machines. Soft-delete archive tier (recoverable). No proprietary file formats. <code>cp memory.db</code> is a backup.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout warn" style="margin-top:2.5rem;">
+      <strong>What ai-memory is NOT:</strong> not an agent framework, not a multi-step planner, not a tool-using autonomous worker. It's a memory layer. The host AI does the reasoning. ai-memory just remembers — and forgets exactly when you tell it to.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: TIER LADDER
+     ============================================================= -->
+<section id="tiers">
+  <div class="container">
+    <span class="eyebrow p2">Operational Tiers</span>
+    <h2>Pick your power level.</h2>
+    <p class="lede">
+      Four tiers, each adding capability and dependency. Start at <code>keyword</code> for laptop-grade text search with zero install. Climb to <code>autonomous</code> for self-curating memory with neural reranking. Switch tiers per-deployment.
+    </p>
+
+    <div class="tier-ladder">
+      <div class="tier tier-keyword">
+        <div class="tier-bar"></div>
+        <div class="tier-name">keyword</div>
+        <div class="tier-deps">No dependencies · &lt; 5 MB RAM</div>
+        <ul class="tier-features">
+          <li>SQLite FTS5 + BM25 ranking</li>
+          <li>Hierarchical namespaces</li>
+          <li>Tag + tier filters</li>
+          <li>Knowledge graph traversal</li>
+          <li>Federation sync</li>
+        </ul>
+      </div>
+      <div class="tier tier-semantic">
+        <div class="tier-bar"></div>
+        <div class="tier-name">semantic</div>
+        <div class="tier-deps">+ Candle MiniLM (80 MB) · 200 MB RAM</div>
+        <ul class="tier-features">
+          <li>Everything in keyword, plus:</li>
+          <li>Local nomic-embed-text vectors</li>
+          <li>HNSW approximate-nearest-neighbor</li>
+          <li>Hybrid FTS5 + vector recall</li>
+          <li>memory_check_duplicate</li>
+        </ul>
+      </div>
+      <div class="tier tier-smart">
+        <div class="tier-bar"></div>
+        <div class="tier-name">smart</div>
+        <div class="tier-deps">+ Ollama (gemma3:e2b) · 4 GB RAM</div>
+        <ul class="tier-features">
+          <li>Everything in semantic, plus:</li>
+          <li>Auto-tagging on store</li>
+          <li>Query expansion on recall</li>
+          <li>Contradiction detection</li>
+          <li>Curator daemon (manual mode)</li>
+        </ul>
+      </div>
+      <div class="tier tier-autonomous">
+        <div class="tier-bar"></div>
+        <div class="tier-name">autonomous</div>
+        <div class="tier-deps">+ Cross-encoder reranker · 6 GB RAM</div>
+        <ul class="tier-features">
+          <li>Everything in smart, plus:</li>
+          <li>Neural cross-encoder reranking</li>
+          <li>Curator daemon (auto mode)</li>
+          <li>Auto-consolidation</li>
+          <li>Self-organizing namespaces</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>Tier ≠ feature gate.</strong> Every tier ships every API surface. Higher tiers just turn on internal acceleration. The same <code>memory_recall</code> tool returns better results at higher tiers, but always returns results. <strong>You can demote at any time</strong> — your data is the same on disk.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: MEMORY LIFECYCLE
+     ============================================================= -->
+<section id="lifecycle">
+  <div class="container">
+    <span class="eyebrow p1">Memory Lifecycle</span>
+    <h2>How a memory is born, grows up, and is laid to rest.</h2>
+    <p class="lede">
+      Every memory follows the same path. The system honors what humans wrote, learns what AIs are doing, and never silently forgets anything important. Compaction is opt-in, archive is reversible, hard delete is your call.
+    </p>
+
+    <svg class="lifecycle-viz" viewBox="0 0 1100 380" xmlns="http://www.w3.org/2000/svg" aria-label="Memory lifecycle from creation to archive">
+      <!-- Stage boxes -->
+      <g>
+        <rect class="stage-box" x="10"   y="80"  width="160" height="60" rx="8"/>
+        <text class="stage-text" x="90"  y="105" text-anchor="middle">memory_store</text>
+        <text class="stage-label" x="90" y="125" text-anchor="middle">CREATED</text>
+        <text x="90" y="160" fill="#999" font-size="11" text-anchor="middle">tier=short</text>
+        <text x="90" y="173" fill="#666" font-size="10" text-anchor="middle">access_count=0</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="200"  y="80"  width="160" height="60" rx="8"/>
+        <text class="stage-text" x="280" y="105" text-anchor="middle">memory_recall</text>
+        <text class="stage-label" x="280" y="125" text-anchor="middle">USED</text>
+        <text x="280" y="160" fill="#999" font-size="11" text-anchor="middle">access_count++</text>
+        <text x="280" y="173" fill="#666" font-size="10" text-anchor="middle">extends TTL</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="390" y="80"  width="160" height="60" rx="8" stroke="#ffb86b"/>
+        <text class="stage-text" x="470" y="105" text-anchor="middle" fill="#ffb86b">auto_promote</text>
+        <text class="stage-label" x="470" y="125" text-anchor="middle">PROMOTED</text>
+        <text x="470" y="160" fill="#999" font-size="11" text-anchor="middle">tier: short → mid</text>
+        <text x="470" y="173" fill="#666" font-size="10" text-anchor="middle">5 accesses + recent</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="580" y="80"  width="160" height="60" rx="8"/>
+        <text class="stage-text" x="660" y="105" text-anchor="middle">memory_promote</text>
+        <text class="stage-label" x="660" y="125" text-anchor="middle">LONG-TERM</text>
+        <text x="660" y="160" fill="#999" font-size="11" text-anchor="middle">tier=long</text>
+        <text x="660" y="173" fill="#666" font-size="10" text-anchor="middle">manual or auto</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="770" y="80"  width="160" height="60" rx="8" stroke="#c8a2ff"/>
+        <text class="stage-text" x="850" y="105" text-anchor="middle" fill="#c8a2ff">consolidate</text>
+        <text class="stage-label" x="850" y="125" text-anchor="middle">MERGED</text>
+        <text x="850" y="160" fill="#999" font-size="11" text-anchor="middle">N → 1 + links</text>
+        <text x="850" y="173" fill="#666" font-size="10" text-anchor="middle">curator or manual</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="940" y="80"  width="150" height="60" rx="8"/>
+        <text class="stage-text" x="1015" y="105" text-anchor="middle">archive</text>
+        <text class="stage-label" x="1015" y="125" text-anchor="middle">RECOVERABLE</text>
+        <text x="1015" y="160" fill="#999" font-size="11" text-anchor="middle">soft-deleted</text>
+        <text x="1015" y="173" fill="#666" font-size="10" text-anchor="middle">restorable</text>
+      </g>
+
+      <!-- Bottom path: contradictions -->
+      <g>
+        <rect class="stage-box" x="200" y="240" width="160" height="60" rx="8" stroke="#ff6b9d"/>
+        <text class="stage-text" x="280" y="265" text-anchor="middle" fill="#ff6b9d">on_contradiction</text>
+        <text class="stage-label" x="280" y="285" text-anchor="middle">FLAGGED</text>
+        <text x="280" y="320" fill="#999" font-size="11" text-anchor="middle">webhook fires</text>
+        <text x="280" y="333" fill="#666" font-size="10" text-anchor="middle">human picks winner</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="390" y="240" width="160" height="60" rx="8"/>
+        <text class="stage-text" x="470" y="265" text-anchor="middle">memory_resolve</text>
+        <text class="stage-label" x="470" y="285" text-anchor="middle">SUPERSEDED</text>
+        <text x="470" y="320" fill="#999" font-size="11" text-anchor="middle">valid_until set</text>
+        <text x="470" y="333" fill="#666" font-size="10" text-anchor="middle">history preserved</text>
+      </g>
+
+      <g>
+        <rect class="stage-box" x="580" y="240" width="160" height="60" rx="8"/>
+        <text class="stage-text" x="660" y="265" text-anchor="middle">memory_forget</text>
+        <text class="stage-label" x="660" y="285" text-anchor="middle">USER-DELETED</text>
+        <text x="660" y="320" fill="#999" font-size="11" text-anchor="middle">explicit op</text>
+        <text x="660" y="333" fill="#666" font-size="10" text-anchor="middle">requires approval</text>
+      </g>
+
+      <!-- Arrows -->
+      <path class="arrow arrow-active" d="M 170 110 L 195 110" marker-end="url(#arrow)"/>
+      <path class="arrow arrow-active" d="M 360 110 L 385 110" marker-end="url(#arrow)"/>
+      <path class="arrow arrow-active" d="M 550 110 L 575 110" marker-end="url(#arrow)"/>
+      <path class="arrow arrow-active" d="M 740 110 L 765 110" marker-end="url(#arrow)"/>
+      <path class="arrow arrow-active" d="M 930 110 L 940 110" marker-end="url(#arrow)"/>
+
+      <path class="arrow" d="M 280 145 L 280 235" stroke-dasharray="3 3" marker-end="url(#arrow)"/>
+      <path class="arrow" d="M 360 270 L 385 270" marker-end="url(#arrow)"/>
+      <path class="arrow" d="M 550 270 L 575 270" marker-end="url(#arrow)"/>
+
+      <!-- Arrow marker -->
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#6ee7ff"/>
+        </marker>
+      </defs>
+
+      <text x="20" y="35" fill="#6ee7ff" font-size="13" font-family="monospace" font-weight="700">─── HAPPY PATH ───</text>
+      <text x="20" y="225" fill="#ff6b9d" font-size="13" font-family="monospace" font-weight="700">─── CONTRADICTION / FORGET PATH ───</text>
+    </svg>
+
+    <div class="callout">
+      <strong>Reversibility is the rule, not the exception.</strong> Every destructive operation has an undo path. Archive instead of delete. Supersede instead of overwrite. The only hard delete is <code>memory_purge_archive --older-than &lt;days&gt;</code>, and that fires governance approval.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: PERFORMANCE BUDGETS
+     ============================================================= -->
+<section id="performance">
+  <div class="container">
+    <span class="eyebrow p3">Pillar 3 · Performance</span>
+    <h2>Every hot path has a published budget.</h2>
+    <p class="lede">
+      Numbers below are real measurements, not aspirational. <code>ai-memory bench</code> runs the canonical 1,000-memory workload and reports p50/p95/p99. CI fails any PR that exceeds budget by more than 10%. Hardware baseline: Apple M4 / 32 GB / NVMe SSD.
+    </p>
+
+    <div class="perf-grid">
+      <div class="gauge">
+        <div class="gauge-op">memory_session_start</div>
+        <div class="gauge-budget">target p95 &lt; 100 ms · Claude Code hook</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 42%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">42 ms</span><span class="gauge-target">/ 100 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_recall (hot)</div>
+        <div class="gauge-budget">target p95 &lt; 50 ms · agent reasoning</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 36%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">18 ms</span><span class="gauge-target">/ 50 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_store (no embedding)</div>
+        <div class="gauge-budget">target p95 &lt; 20 ms · pure write</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 45%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">9 ms</span><span class="gauge-target">/ 20 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_store (with embedding)</div>
+        <div class="gauge-budget">target p95 &lt; 200 ms · ONNX/Ollama call</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 43%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">86 ms</span><span class="gauge-target">/ 200 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_search (FTS5)</div>
+        <div class="gauge-budget">target p95 &lt; 100 ms · keyword baseline</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 31%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">31 ms</span><span class="gauge-target">/ 100 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_check_duplicate</div>
+        <div class="gauge-budget">target p95 &lt; 50 ms · pre-write check</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 44%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">22 ms</span><span class="gauge-target">/ 50 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_kg_query (depth ≤ 3)</div>
+        <div class="gauge-budget">target p95 &lt; 100 ms · graph traversal</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 54%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">54 ms</span><span class="gauge-target">/ 100 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">memory_kg_timeline</div>
+        <div class="gauge-budget">target p95 &lt; 100 ms · ordered facts</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 38%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">38 ms</span><span class="gauge-target">/ 100 ms</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">curator cycle (1k memories)</div>
+        <div class="gauge-budget">target p95 &lt; 60 s · background</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 20%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">12 s</span><span class="gauge-target">/ 60 s</span></div>
+      </div>
+      <div class="gauge">
+        <div class="gauge-op">federation ack (W=2 quorum)</div>
+        <div class="gauge-budget">target p99 &lt; 2 s · multi-machine</div>
+        <div class="gauge-bar-bg"><div class="gauge-bar-fill" style="width: 42%"></div><div class="gauge-bar-marker" style="left:100%"></div></div>
+        <div class="gauge-numbers"><span class="gauge-measured">850 ms</span><span class="gauge-target">/ 2 s</span></div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>Every PR. Every push. Every release branch.</strong> The bench-CI workflow runs <code>ai-memory bench</code> on <code>ubuntu-latest</code> and posts a workflow summary with the table above. A regression of more than 10% on any p95 fails the build. There is no "we'll fix the latency later" path.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: TEST COVERAGE
+     ============================================================= -->
+<section id="quality">
+  <div class="container">
+    <span class="eyebrow">Test Quality</span>
+    <h2>1,809 tests. Every module above 79%.</h2>
+    <p class="lede">
+      The v0.6.3 coverage campaign took ai-memory from 56.7% line coverage to 93.05% across 9 waves of parallel agent work. 26 closers shipped ~1,200 net new tests over the ~30K-line Rust codebase. Full report: <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/release/v0.6.3/audits/v063-coverage-80pct/CAMPAIGN-FINAL-METRICS.md" style="color:var(--pillar-1)">CAMPAIGN-FINAL-METRICS.md</a>
+    </p>
+
+    <div class="grid-2" style="margin-bottom:2.5rem;">
+      <div class="dash-tile good">
+        <div class="dash-label">Codebase line coverage</div>
+        <div class="dash-num">93.05<span class="dash-unit">%</span></div>
+        <div class="dash-sub">42,894 / 46,099 lines covered</div>
+      </div>
+      <div class="dash-tile p1">
+        <div class="dash-label">Total tests passing</div>
+        <div class="dash-num">1,809</div>
+        <div class="dash-sub">0 failed · 0 ignored · 4 platforms</div>
+      </div>
+    </div>
+
+    <h3 style="margin-bottom:1rem;">Per-module coverage (sorted descending)</h3>
+    <div class="cov-table">
+      <div class="cov-row">
+        <span class="cov-mod">main.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:100%"></div></div><span class="cov-pct perfect">100.00%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">errors.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:100%"></div></div><span class="cov-pct perfect">100.00%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">color.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:100%"></div></div><span class="cov-pct perfect">100.00%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">mine.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:99.29%"></div></div><span class="cov-pct">99.29%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">toon.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:99.07%"></div></div><span class="cov-pct">99.07%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">replication.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:98.80%"></div></div><span class="cov-pct">98.80%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">subscriptions.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:97.61%"></div></div><span class="cov-pct">97.61%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">curator.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:97.13%"></div></div><span class="cov-pct">97.13%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">autonomy.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:96.80%"></div></div><span class="cov-pct">96.80%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">identity.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:96.71%"></div></div><span class="cov-pct">96.71%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">config.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:96.55%"></div></div><span class="cov-pct">96.55%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">validate.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:96.52%"></div></div><span class="cov-pct">96.52%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">models.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:95.64%"></div></div><span class="cov-pct">95.64%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">hnsw.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:95.52%"></div></div><span class="cov-pct">95.52%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">tls.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:94.85%"></div></div><span class="cov-pct">94.85%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">llm.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:94.80%"></div></div><span class="cov-pct">94.80%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">db.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:93.85%"></div></div><span class="cov-pct">93.85%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">daemon_runtime.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:93.43%"></div></div><span class="cov-pct">93.43%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">handlers.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:92.85%"></div></div><span class="cov-pct">92.85%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">federation.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:92.63%"></div></div><span class="cov-pct">92.63%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">embeddings.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:91.70%"></div></div><span class="cov-pct">91.70%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">mcp.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:91.22%"></div></div><span class="cov-pct">91.22%</span>
+      </div>
+      <div class="cov-row">
+        <span class="cov-mod">reranker.rs</span><div class="cov-bar-bg"><div class="cov-bar-fill" style="width:79.25%"></div></div><span class="cov-pct warn">79.25%</span>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>Why reranker is the lowest.</strong> The neural BERT cross-encoder needs HF-Hub model weights, which CI doesn't pre-fetch by default. Heuristic rerank path is fully covered. Closing the gap to ≥92% is a v0.7 work item with a plan in the public assertions table.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: FEDERATION
+     ============================================================= -->
+<section id="federation">
+  <div class="container">
+    <span class="eyebrow">Multi-machine Federation</span>
+    <h2>Quorum-replicated. mTLS-secured. Eventually consistent.</h2>
+    <p class="lede">
+      Run ai-memory on N machines. Writes propagate as <strong>W-of-N quorum</strong> — by default 2 of 3. Reads stay local; writes acknowledge after quorum. Every peer authenticates via mTLS with fingerprint allowlist. Catchup loop closes partition windows automatically.
+    </p>
+
+    <svg class="fed-diagram" viewBox="0 0 880 380" xmlns="http://www.w3.org/2000/svg">
+      <!-- Lead node -->
+      <g>
+        <rect class="node-bg lead" x="380" y="40" width="120" height="80" rx="12"/>
+        <text class="node-text" x="440" y="70">node-1</text>
+        <text class="node-sub" x="440" y="88">leader</text>
+        <text class="node-sub" x="440" y="105">writer</text>
+      </g>
+
+      <!-- Peer nodes -->
+      <g>
+        <rect class="node-bg" x="100" y="200" width="120" height="80" rx="12"/>
+        <text class="node-text" x="160" y="230">node-2</text>
+        <text class="node-sub" x="160" y="248">replica</text>
+        <text class="node-sub" x="160" y="265">ACK ✓</text>
+      </g>
+      <g>
+        <rect class="node-bg" x="380" y="200" width="120" height="80" rx="12"/>
+        <text class="node-text" x="440" y="230">node-3</text>
+        <text class="node-sub" x="440" y="248">replica</text>
+        <text class="node-sub" x="440" y="265">ACK ✓</text>
+      </g>
+      <g>
+        <rect class="node-bg" x="660" y="200" width="120" height="80" rx="12"/>
+        <text class="node-text" x="720" y="230">node-4</text>
+        <text class="node-sub" x="720" y="248">replica</text>
+        <text class="node-sub" x="720" y="265">offline</text>
+      </g>
+
+      <!-- Write fanout -->
+      <path class="write-line" d="M 420 120 Q 280 160 200 200" marker-end="url(#warrow)"/>
+      <path class="write-line" d="M 440 120 L 440 200" marker-end="url(#warrow)"/>
+      <path class="write-line" d="M 460 120 Q 600 160 700 200" marker-end="url(#warrow)" stroke-opacity="0.3" stroke-dasharray="4 4"/>
+
+      <!-- ACKs back -->
+      <path class="ack-line" d="M 200 200 Q 280 160 420 120"/>
+      <path class="ack-line" d="M 440 200 L 440 120"/>
+
+      <!-- Quorum threshold indicator -->
+      <text x="440" y="340" fill="#999" font-family="monospace" font-size="13" text-anchor="middle">W=2 of N=3 reached → write committed</text>
+      <text x="440" y="360" fill="#666" font-size="11" text-anchor="middle">node-4 catches up via /api/v1/sync/since when reachable</text>
+
+      <defs>
+        <marker id="warrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#ffb86b"/>
+        </marker>
+      </defs>
+    </svg>
+
+    <div class="grid-3" style="margin-top:2rem;">
+      <div class="card">
+        <div class="card-eyebrow">Transport</div>
+        <div class="card-title">mTLS · client-cert pinning</div>
+        <p class="card-body">Both sides verify each other's certificate. Fingerprint allowlist prevents accidental joins. No central PKI required.</p>
+      </div>
+      <div class="card">
+        <div class="card-eyebrow">Consistency</div>
+        <div class="card-title">Eventual · Lamport-clock vector cursors</div>
+        <p class="card-body">Per-peer sync-state cursor advances with successful pulls. Re-joining peer fast-catches-up to current epoch.</p>
+      </div>
+      <div class="card">
+        <div class="card-eyebrow">Failure</div>
+        <div class="card-title">Quorum-not-met → 503 with peer status</div>
+        <p class="card-body">Caller sees structured error: which peers responded, which timed out. No silent partial writes.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: AUDIENCES — Use cases by scale
+     ============================================================= -->
+<section id="audiences">
+  <div class="container">
+    <span class="eyebrow p3">From One to a Million</span>
+    <h2>Same binary, every scale.</h2>
+    <p class="lede">
+      ai-memory runs the same way on a developer's laptop as it does on a federation of state-government data centers. The differentiator is configuration, not code path: federation peers, mTLS allowlists, governance policies, autonomous-tier resources.
+    </p>
+
+    <div class="persona-grid">
+      <!-- Solo dev -->
+      <div class="persona">
+        <div class="persona-icon">👤</div>
+        <div class="persona-scale">SCALE 1 · INDIVIDUAL</div>
+        <div class="persona-title">Solo developer</div>
+        <div class="persona-pop">1 user · 1 box</div>
+        <div class="persona-pop-label">laptop, semantic tier</div>
+        <div class="persona-pain">"I forget what I learned last week. Claude forgets between sessions."</div>
+        <div class="persona-fix">One <code>ai-memory mcp</code> in the MCP config. Memory survives restarts, updates, machine swaps.</div>
+        <ul class="persona-bullets">
+          <li>Cross-session context</li>
+          <li>Cross-AI parity (Claude, Cursor, Codex)</li>
+          <li>Local-first privacy</li>
+        </ul>
+      </div>
+
+      <!-- Small team -->
+      <div class="persona">
+        <div class="persona-icon">👥</div>
+        <div class="persona-scale">SCALE 2 · STARTUP</div>
+        <div class="persona-title">Small team (2-25 people)</div>
+        <div class="persona-pop">2-25 users · 1-3 nodes</div>
+        <div class="persona-pop-label">shared engineering memory</div>
+        <div class="persona-pain">"Tribal knowledge dies when someone leaves. New hires re-discover landmines."</div>
+        <div class="persona-fix">Federated 3-node cluster. Per-namespace shared memory. ChatGPT memory but you own the data.</div>
+        <ul class="persona-bullets">
+          <li>Onboarding accelerator</li>
+          <li>Decision audit trail</li>
+          <li>$0 per-seat cost</li>
+        </ul>
+      </div>
+
+      <!-- Mid-size org -->
+      <div class="persona">
+        <div class="persona-icon">🏢</div>
+        <div class="persona-scale">SCALE 3 · MID-MARKET</div>
+        <div class="persona-title">Mid-size org (25-500 people)</div>
+        <div class="persona-pop">25-500 users · 5-15 nodes</div>
+        <div class="persona-pop-label">multi-team, multi-namespace</div>
+        <div class="persona-pain">"AI usage is exploding. So is the SaaS bill. So is the data-leakage risk."</div>
+        <div class="persona-fix">Per-team namespace + governance. mTLS federation. SIEM webhook integration. Local data residency.</div>
+        <ul class="persona-bullets">
+          <li>Centralized memory governance</li>
+          <li>Per-team compliance scope</li>
+          <li>SOC2-friendly audit trail</li>
+        </ul>
+      </div>
+
+      <!-- Large enterprise -->
+      <div class="persona">
+        <div class="persona-icon">🏛️</div>
+        <div class="persona-scale">SCALE 4 · ENTERPRISE</div>
+        <div class="persona-title">Large corporation (500-50k)</div>
+        <div class="persona-pop">500-50,000 users · 20-100 nodes</div>
+        <div class="persona-pop-label">multi-region federation</div>
+        <div class="persona-pain">"Each business unit wants AI. Each lawyer wants air-gapped. Each auditor wants logs."</div>
+        <div class="persona-fix">Per-BU federated cluster. Cross-region quorum. PII redaction hooks. Backup + restore + retention.</div>
+        <ul class="persona-bullets">
+          <li>Air-gapped deployments</li>
+          <li>Per-BU policy enforcement</li>
+          <li>Hooks for data-loss prevention</li>
+        </ul>
+      </div>
+
+      <!-- Mega-scale / gov -->
+      <div class="persona">
+        <div class="persona-icon">🇺🇸</div>
+        <div class="persona-scale">SCALE 5 · GOVERNMENT</div>
+        <div class="persona-title">Federal · state · local · municipal</div>
+        <div class="persona-pop">Sovereign · Air-gapped</div>
+        <div class="persona-pop-label">FedRAMP / IL5 / Sovereign</div>
+        <div class="persona-pain">"AI is mandatory. The cloud is forbidden. The vendors are foreign."</div>
+        <div class="persona-fix">Apache 2.0 OSS. Single Rust binary. Zero outbound calls. Hardware-attested keys (v0.7).</div>
+        <ul class="persona-bullets">
+          <li>100% air-gap operable</li>
+          <li>Public source-code audit</li>
+          <li>No vendor lock-in</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout" style="margin-top:2.5rem;">
+      <strong>The AgenticMem commercial tiers are an addition, not a requirement.</strong> Every audience above can run the OSS ai-memory binary indefinitely with no commercial product needed. The Attest / Federate / Sovereign commercial tiers add hardware-backed identity, managed federation, and FedRAMP-certified deployments — but only when the operator chooses.
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: ROADMAP TIMELINE
+     ============================================================= -->
+<section id="roadmap">
+  <div class="container">
+    <span class="eyebrow">Roadmap</span>
+    <h2>From v0.6.3 today to v1.0 federation maturity.</h2>
+    <p class="lede">
+      Public release sequence. Each release ships one demoable headline plus operational substrate the next release builds on. No version skipping. No quiet feature drift. <a href="https://github.com/alphaonedev/ai-memory-mcp-dev/blob/develop/ROADMAP.md" style="color:var(--pillar-1)">Public ROADMAP.md →</a>
+    </p>
+
+    <div class="roadmap">
+      <div class="roadmap-row shipped">
+        <div class="roadmap-marker">
+          <div class="roadmap-dot"></div>
+          <div class="version">v0.6.3</div>
+        </div>
+        <div class="roadmap-content">
+          <div class="rmt-theme">Structured Memory + Performance · <span style="color:var(--good)">SHIPPED rc1</span></div>
+          <div class="rmt-eta">May 2026 · 4-week sprint</div>
+          <div class="rmt-desc">Hierarchy + Knowledge Graph + Performance Budgets. The grand-slam release.</div>
+          <ul class="rmt-bullets">
+            <li>Hierarchical namespace paths (<code>projects/alpha/decisions</code>)</li>
+            <li>Temporal-validity knowledge graph (recursive CTE today, AGE-ready for v0.7)</li>
+            <li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>
+            <li>93.05% test coverage (1,809 tests passing across 4 platforms)</li>
+            <li>Two SSRF defects discovered during campaign — fixed before tag</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="roadmap-row next">
+        <div class="roadmap-marker">
+          <div class="roadmap-dot"></div>
+          <div class="version">v0.7</div>
+        </div>
+        <div class="roadmap-content">
+          <div class="rmt-theme">Trust + A2A Maturity</div>
+          <div class="rmt-eta">End Q2 2026 · gates Q3 commercial Attest launch</div>
+          <div class="rmt-desc">Ed25519 attested identity, Apache AGE acceleration, A2A messaging maturity, programmable hook pipeline.</div>
+          <ul class="rmt-bullets">
+            <li>Ed25519 signatures on every memory_link write — fills v0.6.3 placeholder column</li>
+            <li>Apache AGE wrapper on Postgres KG — Cypher path joins existing CTE path</li>
+            <li>A2A correlation IDs, ACKs, TTLs · subscription DLQ + replay · per-agent quotas</li>
+            <li>Hook pipeline foundation (subprocess JSON-over-stdio + daemon-mode IPC)</li>
+            <li>Permission system (refactors v0.6.3 governance into rules+modes+hooks)</li>
+            <li>Sidechain transcripts (raw conversation audit trail)</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="roadmap-row future">
+        <div class="roadmap-marker">
+          <div class="roadmap-dot"></div>
+          <div class="version">v0.8</div>
+        </div>
+        <div class="roadmap-content">
+          <div class="rmt-theme">Coordination Primitives</div>
+          <div class="rmt-eta">Q4 2026</div>
+          <div class="rmt-desc">Distributed task queue, typed cognition, CRDTs. The multi-agent substrate.</div>
+          <ul class="rmt-bullets">
+            <li>Task queue with attested claim/complete/abandon (replay-safe)</li>
+            <li>Typed cognition: Goal / Plan / Step / Observation / Decision relations</li>
+            <li>CRDT merge for concurrent multi-agent edits (G-Counter, OR-Set, LWW-Register)</li>
+            <li>Compaction pipeline with verify+rollback (typed-cognition supersession)</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="roadmap-row future">
+        <div class="roadmap-marker">
+          <div class="roadmap-dot"></div>
+          <div class="version">v0.9</div>
+        </div>
+        <div class="roadmap-content">
+          <div class="rmt-theme">Agentic Substrate</div>
+          <div class="rmt-eta">Q1 2027</div>
+          <div class="rmt-desc">Function calling, skill memories, streaming.</div>
+        </div>
+      </div>
+
+      <div class="roadmap-row future">
+        <div class="roadmap-marker">
+          <div class="roadmap-dot"></div>
+          <div class="version">v1.0</div>
+        </div>
+        <div class="roadmap-content">
+          <div class="rmt-theme">Federation Maturity</div>
+          <div class="rmt-eta">Q2 2027</div>
+          <div class="rmt-desc">Auto-discovery (mDNS), end-to-end encryption, MVCC, OpenTelemetry standardization, strict semver discipline.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: COMPARISON MATRIX
+     ============================================================= -->
+<section id="compare">
+  <div class="container">
+    <span class="eyebrow">vs Alternatives</span>
+    <h2>How ai-memory stacks up.</h2>
+    <p class="lede">
+      Honest comparison against the practical alternatives. Each has its place; ai-memory's place is "single binary, local-first, every AI, sub-100ms".
+    </p>
+
+    <div style="overflow-x:auto;">
+      <table class="compare-matrix">
+        <thead>
+          <tr>
+            <th class="spec">Capability</th>
+            <th class="aim">ai-memory</th>
+            <th>Vector DB<br><small>(Chroma, Qdrant, etc.)</small></th>
+            <th>SaaS memory<br><small>(ChatGPT memory, etc.)</small></th>
+            <th>mempalace</th>
+            <th>Raw text<br><small>(notes, READMEs)</small></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="spec">AI-agnostic (works with any MCP client)</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td></tr>
+          <tr><td class="spec">Cross-session persistence</td><td class="aim"><span class="tick">✓</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td></tr>
+          <tr><td class="spec">Hierarchical namespaces</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="partial">~</span></td></tr>
+          <tr><td class="spec">Temporal-validity knowledge graph</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="partial">~</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Published latency budgets + CI guard</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Hybrid recall (FTS + vector + reranker)</td><td class="aim"><span class="tick">✓</span></td><td><span class="partial">~</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Federation across machines</td><td class="aim"><span class="tick">✓</span></td><td><span class="partial">~</span></td><td><span class="cross">N/A</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Local-first · zero cloud deps</td><td class="aim"><span class="tick">✓</span></td><td><span class="partial">~</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td></tr>
+          <tr><td class="spec">Single binary install</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">N/A</span></td><td><span class="cross">✗</span></td><td><span class="tick">N/A</span></td></tr>
+          <tr><td class="spec">mTLS federation</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">N/A</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Self-curating background daemon</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Apache 2.0 OSS · auditable source</td><td class="aim"><span class="tick">✓</span></td><td><span class="partial">~</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="tick">N/A</span></td></tr>
+          <tr><td class="spec">Air-gap deployable</td><td class="aim"><span class="tick">✓</span></td><td><span class="partial">~</span></td><td><span class="cross">✗</span></td><td><span class="tick">✓</span></td><td><span class="tick">✓</span></td></tr>
+          <tr><td class="spec">Per-namespace governance</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Webhook subscriptions for SIEM</td><td class="aim"><span class="tick">✓</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td><td><span class="cross">✗</span></td></tr>
+          <tr><td class="spec">Sub-100ms session-start budget</td><td class="aim"><span class="tick">✓ 42ms</span></td><td><span class="partial">~</span></td><td><span class="partial">~</span></td><td><span class="tick">✓</span></td><td><span class="cross">N/A</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout">
+      <strong>Where mempalace wins:</strong> longer track record, larger community, Python-native stack. <strong>Where ai-memory wins:</strong> single Rust binary (no Python install), AI-agnostic via MCP (works with Claude/Cursor/Windsurf/etc., not just one host), federation primitives (W-of-N quorum), Apache 2.0 commercial-friendly license. <strong>Both are correct choices for different operators.</strong>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: TRUST LADDER
+     ============================================================= -->
+<section id="trust">
+  <div class="container">
+    <span class="eyebrow p3">Trust Ladder</span>
+    <h2>Five steps from laptop to FedRAMP.</h2>
+    <p class="lede">
+      Each step strengthens the trust boundary without breaking the layer below it. The OSS binary is operable at every step. The AgenticMem commercial tiers add managed services on top of what's already shipped.
+    </p>
+
+    <div class="trust-ladder">
+      <div class="trust-step shipped">
+        <div class="step-num">1</div>
+        <div class="step-tier">v0.6.3 · OSS</div>
+        <div class="step-title">Local-first</div>
+        <div class="step-desc">SQLite WAL, bound to 127.0.0.1, no outbound traffic. Personal-machine baseline.</div>
+      </div>
+      <div class="trust-step shipped">
+        <div class="step-num">2</div>
+        <div class="step-tier">v0.6.3 · OSS</div>
+        <div class="step-title">mTLS federation</div>
+        <div class="step-desc">Client-cert pinning, fingerprint allowlist, no central PKI. Multi-machine baseline.</div>
+      </div>
+      <div class="trust-step next">
+        <div class="step-num">3</div>
+        <div class="step-tier">v0.7 · OSS</div>
+        <div class="step-title">Ed25519 attested identity</div>
+        <div class="step-desc">Every link write signed end-to-end. Verifiable provenance for the audit trail.</div>
+      </div>
+      <div class="trust-step">
+        <div class="step-num">4</div>
+        <div class="step-tier">AgenticMem · Attest</div>
+        <div class="step-title">Hardware-backed keys</div>
+        <div class="step-desc">TPM / HSM / Secure Enclave for key storage. Compliance-ready Q3 2026.</div>
+      </div>
+      <div class="trust-step">
+        <div class="step-num">5</div>
+        <div class="step-tier">AgenticMem · Sovereign</div>
+        <div class="step-title">FedRAMP / IL5</div>
+        <div class="step-desc">Government-grade deployments. Air-gapped, audited, contractually committed.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: THE NUMBERS DASHBOARD
+     ============================================================= -->
+<section id="numbers">
+  <div class="container">
+    <span class="eyebrow">By the Numbers</span>
+    <h2>Everything quantifiable, in one place.</h2>
+    <p class="lede">
+      Every quantitative claim ai-memory makes, sourced from the post-v0.6.3 codebase and the public CAMPAIGN-FINAL-METRICS document.
+    </p>
+
+    <div class="dash-grid">
+      <div class="dash-tile p1">
+        <div class="dash-label">Line coverage</div>
+        <div class="dash-num">93.05<span class="dash-unit">%</span></div>
+        <div class="dash-sub">42,894 / 46,099 lines</div>
+      </div>
+      <div class="dash-tile p1">
+        <div class="dash-label">Region coverage</div>
+        <div class="dash-num">93.11<span class="dash-unit">%</span></div>
+        <div class="dash-sub">73,150 / 78,564 regions</div>
+      </div>
+      <div class="dash-tile p1">
+        <div class="dash-label">Function coverage</div>
+        <div class="dash-num">92.55<span class="dash-unit">%</span></div>
+        <div class="dash-sub">3,527 / 3,811 functions</div>
+      </div>
+      <div class="dash-tile good">
+        <div class="dash-label">Tests passing</div>
+        <div class="dash-num">1,809</div>
+        <div class="dash-sub">0 failed · 0 ignored</div>
+      </div>
+      <div class="dash-tile p2">
+        <div class="dash-label">MCP tools</div>
+        <div class="dash-num">26</div>
+        <div class="dash-sub">Claude / Cursor / Codex / Continue</div>
+      </div>
+      <div class="dash-tile p2">
+        <div class="dash-label">HTTP endpoints</div>
+        <div class="dash-num">39</div>
+        <div class="dash-sub">REST + SSE + mTLS</div>
+      </div>
+      <div class="dash-tile p2">
+        <div class="dash-label">CLI commands</div>
+        <div class="dash-num">28</div>
+        <div class="dash-sub">store, recall, sync, ...</div>
+      </div>
+      <div class="dash-tile p3">
+        <div class="dash-label">Session-start p95</div>
+        <div class="dash-num">42<span class="dash-unit">ms</span></div>
+        <div class="dash-sub">budget &lt; 100 ms</div>
+      </div>
+      <div class="dash-tile p3">
+        <div class="dash-label">Recall p95 (hot)</div>
+        <div class="dash-num">18<span class="dash-unit">ms</span></div>
+        <div class="dash-sub">budget &lt; 50 ms</div>
+      </div>
+      <div class="dash-tile p3">
+        <div class="dash-label">Federation ack p99</div>
+        <div class="dash-num">850<span class="dash-unit">ms</span></div>
+        <div class="dash-sub">budget &lt; 2 s · W=2</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">main.rs lines</div>
+        <div class="dash-num">75</div>
+        <div class="dash-sub">down from 4,511 · 98.3% reduction</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">Modules at 100%</div>
+        <div class="dash-num">7</div>
+        <div class="dash-sub">main, errors, color, lib, ...</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">Modules ≥ 90%</div>
+        <div class="dash-num">39</div>
+        <div class="dash-sub">of 47 total</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">Distribution targets</div>
+        <div class="dash-num">5</div>
+        <div class="dash-sub">macOS arm64/x64 · Linux arm64/x64 · Win x64</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">Package channels</div>
+        <div class="dash-num">5</div>
+        <div class="dash-sub">Homebrew · APT · COPR · GHCR · crates.io</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">SSRF defects fixed</div>
+        <div class="dash-num">2</div>
+        <div class="dash-sub">found + fixed in v0.6.3 campaign</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">Cloud dependencies</div>
+        <div class="dash-num">0</div>
+        <div class="dash-sub">100% local-first</div>
+      </div>
+      <div class="dash-tile">
+        <div class="dash-label">License</div>
+        <div class="dash-num" style="font-size:1.4rem">Apache 2.0</div>
+        <div class="dash-sub">commercial-friendly OSS</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     SECTION: WHY IT MATTERS
+     ============================================================= -->
+<section id="why">
+  <div class="container">
+    <span class="eyebrow">Why This Matters</span>
+    <h2>Memory is the missing layer in the AI stack.</h2>
+
+    <div class="grid-2">
+      <div class="card">
+        <h3>For the individual</h3>
+        <p style="color:var(--text-muted); margin-bottom:.75rem">
+          You have ~30 conversations a day with one or more AIs. Each starts cold. Each ends with knowledge that vanishes. Over a year that's roughly <strong>11,000 lost contexts</strong> — a year's worth of relationship-building with the most powerful tool you've ever owned, evaporated every 4 hours.
+        </p>
+        <p style="color:var(--text-muted); font-size:.9rem">ai-memory turns those 11,000 cold-starts into one continuous conversation that learns about you over time.</p>
+      </div>
+
+      <div class="card">
+        <h3>For the team</h3>
+        <p style="color:var(--text-muted); margin-bottom:.75rem">
+          A 25-person engineering team using Claude collectively burns ~600 cold-start latencies per day. At 200ms each, that's <strong>2 minutes/day of pure latency</strong> — but the bigger cost is the re-paste: explaining the same project context, repeatedly, to AIs that can't share what they learned.
+        </p>
+        <p style="color:var(--text-muted); font-size:.9rem">A federated ai-memory cluster shares understood context across the team. New hires walk into the conversation already in progress.</p>
+      </div>
+
+      <div class="card">
+        <h3>For the enterprise</h3>
+        <p style="color:var(--text-muted); margin-bottom:.75rem">
+          Every GenAI vendor wants your data. Every compliance officer wants it on your premise. Every architect wants it durable. Every CFO wants it predictable. <strong>The only stack that satisfies all four constraints is a local-first memory layer with a published latency contract</strong> — sitting underneath whatever AI vendor you happen to use today.
+        </p>
+        <p style="color:var(--text-muted); font-size:.9rem">ai-memory is that layer. Apache 2.0. Single binary. mTLS federation. CI-guarded budgets. Auditable from <code>git clone</code> to deployed binary in 60 seconds.</p>
+      </div>
+
+      <div class="card">
+        <h3>For the public sector</h3>
+        <p style="color:var(--text-muted); margin-bottom:.75rem">
+          AI mandates are real. Cloud bans are real. Foreign-vendor concerns are real. <strong>An OSS Rust binary that runs entirely on your hardware, requires zero outbound traffic, and ships with auditable source code is the only AI-memory primitive that works for federal, state, local, and municipal deployments.</strong>
+        </p>
+        <p style="color:var(--text-muted); font-size:.9rem">v0.7's attested-identity work targets FIPS-grade key handling. v1.0's federation maturity work targets multi-region resilience. Today's v0.6.3 already runs air-gapped with no compromise.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============================================================
+     CTA + FOOTER
+     ============================================================= -->
+<section class="cta-section">
+  <div class="container">
+    <h2>Run it locally in <span style="color:var(--pillar-1)">60 seconds</span>.</h2>
+    <p>No signup. No telemetry. No SaaS. <code>brew install ai-memory</code> or <code>cargo install ai-memory</code> — your laptop, your data, your AI.</p>
+    <div class="cta-row">
+      <a class="cta primary" href="./#install" style="display:inline-block;padding:.9rem 1.6rem;background:var(--text);color:var(--bg);font-weight:700;border-radius:8px;border:1px solid var(--text);text-decoration:none">Install Guide</a>
+      <a class="cta" href="https://github.com/alphaonedev/ai-memory-mcp" style="display:inline-block;padding:.9rem 1.6rem;border:1px solid var(--border-hl);color:var(--text);font-weight:600;border-radius:8px;text-decoration:none">View Source on GitHub →</a>
+      <a class="cta" href="./#claude-integration" style="display:inline-block;padding:.9rem 1.6rem;border:1px solid var(--border-hl);color:var(--text);font-weight:600;border-radius:8px;text-decoration:none">Claude Code Setup</a>
+    </div>
+  </div>
+</section>
+
+<footer class="site-foot">
+  <div>
+    Apache 2.0 · <a href="https://github.com/alphaonedev/ai-memory-mcp">github.com/alphaonedev/ai-memory-mcp</a> · ai-memory-mcp <strong style="color:var(--text)">v0.6.3-rc1</strong> · Built with the AI NHI by <a href="https://alphaonedev.com">AlphaOne LLC</a>
+  </div>
+  <div style="margin-top:.5rem; font-size:.75rem;">
+    All measurements on Apple M4 / 32 GB / NVMe SSD · numbers from <code>cargo llvm-cov --features sal --no-fail-fast --json</code>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -754,6 +754,11 @@ footer.site-foot a { color: var(--text-muted); }
       <a href="integrations.html">Integrations</a>
       <a href="for-everyone.html">For Everyone</a>
       <a href="release-pipeline.html">Release</a>
+      <a href="schema.html">Schema</a>
+      <a href="types.html">Types</a>
+      <a href="validators.html">Validators</a>
+      <a href="governance.html">Governance</a>
+      <a href="tracing.html">Tracing</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
     </div>
   </div>
@@ -1839,8 +1844,8 @@ footer.site-foot a { color: var(--text-muted); }
 <section id="atlas">
   <div class="container">
     <span class="eyebrow">Visualization Atlas</span>
-    <h2>Six pages. Every facet, dedicated visualizations.</h2>
-    <p class="lede">This page is the hub. Each companion below dives deep into one slice of the system with its own visualization style. <strong>Pick what your audience needs.</strong></p>
+    <h2>Eleven pages. Every facet, dedicated visualizations.</h2>
+    <p class="lede">This page is the hub. Each companion below dives deep into one slice of the system with its own visualization style. Six audience-facing pages plus five SME-detail deep-dives (schema, types, validators, governance, tracing). <strong>Pick what your audience needs.</strong></p>
 
     <div class="grid-3" style="gap:1rem">
       <a href="whats-new-v063.html" style="text-decoration:none">
@@ -1894,6 +1899,59 @@ footer.site-foot a { color: var(--text-muted); }
           <div class="card-title">Release Pipeline</div>
           <p class="card-body">Tag → 5 platforms → 5 distribution channels → all signed. CI gates. SBOM. Reproducible builds. Procurement-ready operational spec.</p>
           <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-3)">release-pipeline.html →</div>
+        </div>
+      </a>
+    </div>
+
+    <div style="margin-top:3rem;padding-top:2rem;border-top:1px solid var(--border)">
+      <span class="eyebrow">SME Deep-Dive Atlas</span>
+      <h2 style="margin-top:.5rem">Five reference pages. Every column, every type, every check.</h2>
+      <p class="lede">When the audience-facing pages are not enough — when an evaluating engineer needs to see every SQL column, every Rust type, every validator, every governance verdict, every log line. These pages are the reference contract for AI clients integrating against ai-memory.</p>
+    </div>
+
+    <div class="grid-3" style="gap:1rem;margin-top:1.5rem">
+      <a href="schema.html" style="text-decoration:none">
+        <div class="card p1" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-1)">▸ SQL ATLAS</div>
+          <div class="card-title">Schema</div>
+          <p class="card-body">Every SQLite table column-by-column. 9 tables, 15+ indexes, 6 foreign keys, v15 migration timeline. Postgres mirror via SAL. The persistence contract.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-1)">schema.html →</div>
+        </div>
+      </a>
+
+      <a href="types.html" style="text-decoration:none">
+        <div class="card p2" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-2)">▸ RUST TYPE REFERENCE</div>
+          <div class="card-title">Types</div>
+          <p class="card-body">Every public struct and enum from <code>src/models.rs</code>. 5 enums, 22 structs, 5 consts. Field-level types, defaults, serde tags. The wire-format contract.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-2)">types.html →</div>
+        </div>
+      </a>
+
+      <a href="validators.html" style="text-decoration:none">
+        <div class="card p3" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-3)">▸ INPUT-CHECK ATLAS</div>
+          <div class="card-title">Validators</div>
+          <p class="card-body">23 validate_* functions, every limit explicit, every closed set enumerated. Defense in depth — same checks on HTTP, MCP, CLI, federation receive.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-3)">validators.html →</div>
+        </div>
+      </a>
+
+      <a href="governance.html" style="text-decoration:none">
+        <div class="card p1" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-1)">▸ ALLOW / DENY / PENDING</div>
+          <div class="card-title">Governance</div>
+          <p class="card-body">The decision tree. 4 levels × 3 actions matrix. Three approver flavors (Human, Agent, Consensus). Pending-action lifecycle. Federation propagation.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-1)">governance.html →</div>
+        </div>
+      </a>
+
+      <a href="tracing.html" style="text-decoration:none">
+        <div class="card p2" style="height:100%;display:flex;flex-direction:column">
+          <div class="card-eyebrow" style="color:var(--pillar-2)">▸ OBSERVABILITY ATLAS</div>
+          <div class="card-title">Tracing</div>
+          <p class="card-body">176 log call sites across 11 modules. Setup, level taxonomy, canonical phrases AI clients can grep for. Incident-review recipes.</p>
+          <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-2)">tracing.html →</div>
         </div>
       </a>
     </div>

--- a/docs/data-flow.html
+++ b/docs/data-flow.html
@@ -1,0 +1,354 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  Data Flow — animated path diagrams for write/read/federation.
+  The "money shot" engineering visualization for SMEs who want to
+  see the hybrid recall fusion model and federation sync semantics.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Data Flow — write path, read path, federation</title>
+<meta name="description" content="Animated write path, read path with hybrid recall fusion, and W-of-N quorum federation diagrams.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/data-flow.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:2rem;margin-bottom:.5rem}h3{font-size:1.2rem}
+p{color:var(--text-muted)}
+
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+
+.hero{padding:5rem 1.5rem 3rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.5rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1.5rem}
+
+section{padding:5rem 0;border-bottom:1px solid var(--border)}
+section .eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+section .lede{color:var(--text-muted);font-size:1rem;max-width:780px;margin-bottom:2.5rem}
+
+.flow-svg{width:100%;max-width:1180px;margin:0 auto;background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem}
+.flow-svg .stage-box{fill:var(--bg-raised);stroke:var(--border-hl);stroke-width:1.5}
+.flow-svg .stage-box.hot{stroke:var(--p1);stroke-width:2}
+.flow-svg .stage-box.optional{stroke-dasharray:4 4}
+.flow-svg .stage-box.write{stroke:var(--p2)}
+.flow-svg .stage-box.read{stroke:var(--p1)}
+.flow-svg text{fill:var(--text);font-family:monospace;font-size:13px}
+.flow-svg .label{fill:var(--text-muted);font-size:11px;letter-spacing:.06em;text-transform:uppercase}
+.flow-svg .data-line{stroke:var(--p1);stroke-width:2.5;fill:none;stroke-dasharray:5 5;animation:dash-anim 4s linear infinite}
+.flow-svg .data-line.write{stroke:var(--p2)}
+.flow-svg .data-line.opt{stroke-opacity:.5;stroke-dasharray:3 3}
+@keyframes dash-anim{to{stroke-dashoffset:-100}}
+.flow-svg .group-bg{fill:rgba(255,255,255,0.02);stroke:var(--border);stroke-width:1;stroke-dasharray:2 2}
+.flow-svg .group-label{fill:var(--text-muted);font-size:10px;letter-spacing:.1em;text-transform:uppercase}
+
+/* fusion explainer */
+.fusion-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:1rem;margin:2rem 0}
+@media(max-width:800px){.fusion-grid{grid-template-columns:1fr}}
+.fusion-card{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.25rem;position:relative}
+.fusion-card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.fusion-card.f1::before{background:var(--p1)}.fusion-card.f2::before{background:var(--p2)}.fusion-card.f3::before{background:var(--p3)}
+.fusion-card h3{font-size:1rem;margin-bottom:.4rem;font-family:var(--font-mono)}
+.fusion-card .pct{font-family:var(--font-mono);font-size:1.5rem;font-weight:700;margin-bottom:.4rem}
+.fusion-card .pct.p1{color:var(--p1)}.fusion-card .pct.p2{color:var(--p2)}.fusion-card .pct.p3{color:var(--p3)}
+.fusion-card p{font-size:.85rem;color:var(--text-muted)}
+
+.callout{background:var(--bg-card);border:1px solid var(--border);border-left:3px solid var(--p1);border-radius:8px;padding:1.25rem 1.5rem;margin:2rem 0;font-size:.95rem;color:var(--text-muted)}
+.callout strong{color:var(--text)}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Data Flow</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="feature-matrix.html">Feature Matrix</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="for-everyone.html">For Everyone</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Where data flows.</h1>
+  <p class="tagline">Three end-to-end animated diagrams: write path (memory_store), read path (memory_recall with hybrid fusion), and federation (W-of-N quorum sync). Every box is a real function in <code>src/db.rs</code> or <code>src/handlers.rs</code>; every arrow is a real call.</p>
+</section>
+
+<!-- =============== WRITE PATH =============== -->
+<section id="write">
+  <div class="container">
+    <span class="eyebrow p2">Write Path · memory_store</span>
+    <h2>How a memory becomes durable.</h2>
+    <p class="lede">Validation → embedding → SQLite insert → HNSW index update → federation fanout. The full path takes ~9-86ms p95 depending on whether embedding is requested.</p>
+
+    <svg class="flow-svg" viewBox="0 0 1180 360" xmlns="http://www.w3.org/2000/svg">
+      <!-- Group: input -->
+      <rect class="group-bg" x="10" y="10" width="180" height="320"/>
+      <text class="group-label" x="20" y="30">▸ INPUT</text>
+
+      <!-- Group: core write -->
+      <rect class="group-bg" x="200" y="10" width="600" height="320"/>
+      <text class="group-label" x="210" y="30">▸ src/db.rs::store</text>
+
+      <!-- Group: post-write -->
+      <rect class="group-bg" x="810" y="10" width="360" height="320"/>
+      <text class="group-label" x="820" y="30">▸ POST-WRITE</text>
+
+      <!-- Stages -->
+      <g><rect class="stage-box write" x="30" y="120" width="140" height="80" rx="10"/><text x="100" y="155" text-anchor="middle">Memory{}</text><text x="100" y="175" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:10px">title, content, ns, tier</text></g>
+
+      <g><rect class="stage-box" x="220" y="60" width="140" height="60" rx="10"/><text x="290" y="95" text-anchor="middle">validate_*</text></g>
+      <g><rect class="stage-box" x="220" y="150" width="140" height="60" rx="10"/><text x="290" y="180" text-anchor="middle">enforce_governance</text></g>
+      <g><rect class="stage-box optional" x="220" y="240" width="140" height="60" rx="10"/><text x="290" y="270" text-anchor="middle">check_duplicate?</text><text x="290" y="285" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">if threshold set</text></g>
+
+      <g><rect class="stage-box" x="380" y="60" width="140" height="60" rx="10"/><text x="450" y="95" text-anchor="middle">resolve_agent_id</text></g>
+      <g><rect class="stage-box optional" x="380" y="150" width="140" height="60" rx="10"/><text x="450" y="180" text-anchor="middle">embed (Candle)</text><text x="450" y="195" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">semantic+ tier</text></g>
+      <g><rect class="stage-box optional" x="380" y="240" width="140" height="60" rx="10"/><text x="450" y="270" text-anchor="middle">auto_tag (LLM)</text><text x="450" y="285" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">smart+ tier</text></g>
+
+      <g><rect class="stage-box hot" x="540" y="60" width="140" height="60" rx="10"/><text x="610" y="95" text-anchor="middle">SQLite INSERT</text></g>
+      <g><rect class="stage-box hot" x="540" y="150" width="140" height="60" rx="10"/><text x="610" y="180" text-anchor="middle">FTS5 trigger</text></g>
+      <g><rect class="stage-box optional" x="540" y="240" width="140" height="60" rx="10"/><text x="610" y="270" text-anchor="middle">HNSW insert</text><text x="610" y="285" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">if embed present</text></g>
+
+      <g><rect class="stage-box optional" x="700" y="100" width="100" height="60" rx="10"/><text x="750" y="135" text-anchor="middle">contradict?</text></g>
+
+      <g><rect class="stage-box optional" x="830" y="60" width="140" height="60" rx="10"/><text x="900" y="95" text-anchor="middle">fanout_or_503</text><text x="900" y="110" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">W-of-N peers</text></g>
+      <g><rect class="stage-box optional" x="830" y="150" width="140" height="60" rx="10"/><text x="900" y="180" text-anchor="middle">dispatch_event</text><text x="900" y="195" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">webhook subs</text></g>
+      <g><rect class="stage-box" x="830" y="240" width="140" height="60" rx="10"/><text x="900" y="270" text-anchor="middle">return Memory</text><text x="900" y="285" text-anchor="middle" class="label" style="fill:var(--good);font-size:9px">with id</text></g>
+
+      <g><rect class="stage-box hot" x="990" y="150" width="160" height="60" rx="10"/><text x="1070" y="180" text-anchor="middle">caller</text><text x="1070" y="195" text-anchor="middle" class="label" style="fill:var(--good);font-size:9px">9-86ms p95</text></g>
+
+      <!-- Lines -->
+      <path class="data-line write" d="M 170 160 L 215 90"/>
+      <path class="data-line write" d="M 170 160 L 215 180"/>
+      <path class="data-line write opt" d="M 170 165 L 215 270"/>
+
+      <path class="data-line write" d="M 360 90 L 380 90"/>
+      <path class="data-line write" d="M 360 180 L 380 180"/>
+      <path class="data-line write opt" d="M 360 270 L 380 270"/>
+
+      <path class="data-line write" d="M 520 90 L 540 90"/>
+      <path class="data-line write" d="M 520 90 Q 540 130 540 180"/>
+      <path class="data-line write opt" d="M 520 180 L 540 180"/>
+      <path class="data-line write opt" d="M 520 270 L 540 270"/>
+
+      <path class="data-line write" d="M 680 90 Q 700 130 750 130"/>
+      <path class="data-line write opt" d="M 800 130 Q 815 100 830 90"/>
+      <path class="data-line write opt" d="M 800 130 Q 815 160 830 180"/>
+      <path class="data-line write" d="M 680 90 Q 720 200 830 270"/>
+
+      <path class="data-line write" d="M 970 270 L 1000 200"/>
+    </svg>
+
+    <div class="callout">
+      <strong>The dashed boxes are tier-gated.</strong> The keyword tier skips embed + auto_tag + HNSW; it stores into SQLite + FTS5 only. The semantic tier turns on embed + HNSW. The smart tier adds auto_tag. The autonomous tier additionally turns on the curator daemon for background work.
+    </div>
+  </div>
+</section>
+
+<!-- =============== READ PATH (HYBRID FUSION) =============== -->
+<section id="read">
+  <div class="container">
+    <span class="eyebrow p1">Read Path · memory_recall</span>
+    <h2>Hybrid recall: FTS5 + HNSW + reranker, fused.</h2>
+    <p class="lede">memory_recall combines three retrieval modalities and reconciles them into one ranked result set. Each modality has different strengths; the fusion model produces something none of them could alone. p95 hot-path: 18ms.</p>
+
+    <svg class="flow-svg" viewBox="0 0 1180 380" xmlns="http://www.w3.org/2000/svg">
+      <rect class="group-bg" x="10" y="10" width="170" height="340"/>
+      <text class="group-label" x="20" y="30">▸ QUERY</text>
+
+      <rect class="group-bg" x="190" y="10" width="500" height="340"/>
+      <text class="group-label" x="200" y="30">▸ THREE PARALLEL RETRIEVALS</text>
+
+      <rect class="group-bg" x="700" y="10" width="280" height="340"/>
+      <text class="group-label" x="710" y="30">▸ FUSION + RERANK</text>
+
+      <rect class="group-bg" x="990" y="10" width="180" height="340"/>
+      <text class="group-label" x="1000" y="30">▸ RESULT</text>
+
+      <!-- Query -->
+      <g><rect class="stage-box read" x="30" y="120" width="140" height="80" rx="10"/><text x="100" y="155" text-anchor="middle">query</text><text x="100" y="175" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:10px">+ ns + filters</text></g>
+
+      <!-- Optional context tokens -->
+      <g><rect class="stage-box optional" x="30" y="220" width="140" height="60" rx="10"/><text x="100" y="250" text-anchor="middle" style="font-size:11px">context_tokens</text><text x="100" y="265" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">recent conv</text></g>
+
+      <!-- Three retrievals -->
+      <g><rect class="stage-box read" x="200" y="60" width="240" height="60" rx="10"/><text x="320" y="95" text-anchor="middle">FTS5 keyword (BM25)</text></g>
+      <g><rect class="stage-box read" x="200" y="150" width="240" height="60" rx="10"/><text x="320" y="180" text-anchor="middle">embed(query) → HNSW search</text></g>
+      <g><rect class="stage-box optional" x="200" y="240" width="240" height="60" rx="10"/><text x="320" y="265" text-anchor="middle" style="font-size:11px">embed(ctx_tokens) · 70/30 fuse</text><text x="320" y="280" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">contextual recall (v0.6.0)</text></g>
+
+      <!-- Score sets -->
+      <g><rect class="stage-box" x="460" y="60" width="220" height="60" rx="10"/><text x="570" y="95" text-anchor="middle">keyword candidates {id, score}</text></g>
+      <g><rect class="stage-box" x="460" y="150" width="220" height="60" rx="10"/><text x="570" y="180" text-anchor="middle">vector candidates {id, cosine}</text></g>
+      <g><rect class="stage-box optional" x="460" y="240" width="220" height="60" rx="10"/><text x="570" y="270" text-anchor="middle" style="font-size:11px">vector + ctx blend (Embedder::fuse)</text></g>
+
+      <!-- Fusion -->
+      <g><rect class="stage-box hot" x="710" y="100" width="160" height="80" rx="10"/><text x="790" y="135" text-anchor="middle">db::recall_hybrid</text><text x="790" y="155" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:10px">union + score blend</text></g>
+      <g><rect class="stage-box optional" x="710" y="200" width="160" height="80" rx="10"/><text x="790" y="235" text-anchor="middle">cross-encoder rerank</text><text x="790" y="255" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:10px">autonomous tier</text></g>
+
+      <!-- Filters -->
+      <g><rect class="stage-box" x="890" y="60" width="80" height="60" rx="10"/><text x="930" y="95" text-anchor="middle" style="font-size:11px">budget</text><text x="930" y="110" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">tokens</text></g>
+      <g><rect class="stage-box" x="890" y="150" width="80" height="60" rx="10"/><text x="930" y="185" text-anchor="middle" style="font-size:11px">scope</text><text x="930" y="200" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">visibility</text></g>
+      <g><rect class="stage-box" x="890" y="240" width="80" height="60" rx="10"/><text x="930" y="275" text-anchor="middle" style="font-size:11px">TTL ext</text><text x="930" y="290" text-anchor="middle" class="label" style="fill:var(--text-dim);font-size:9px">touch hits</text></g>
+
+      <!-- Result -->
+      <g><rect class="stage-box hot" x="1010" y="150" width="140" height="80" rx="10"/><text x="1080" y="185" text-anchor="middle">top-K ranked</text><text x="1080" y="205" text-anchor="middle" class="label" style="fill:var(--good);font-size:9px">18ms p95 hot</text></g>
+
+      <!-- Lines -->
+      <path class="data-line" d="M 170 160 L 200 90"/>
+      <path class="data-line" d="M 170 160 L 200 180"/>
+      <path class="data-line opt" d="M 170 250 L 200 270"/>
+
+      <path class="data-line" d="M 440 90 L 460 90"/>
+      <path class="data-line" d="M 440 180 L 460 180"/>
+      <path class="data-line opt" d="M 440 270 L 460 270"/>
+
+      <path class="data-line" d="M 680 90 Q 700 110 715 130"/>
+      <path class="data-line" d="M 680 180 Q 700 165 715 145"/>
+      <path class="data-line opt" d="M 680 270 Q 700 230 715 165"/>
+
+      <path class="data-line opt" d="M 870 140 L 880 240"/>
+      <path class="data-line" d="M 870 240 Q 870 240 890 90"/>
+      <path class="data-line" d="M 870 240 L 890 180"/>
+      <path class="data-line" d="M 870 240 L 890 270"/>
+
+      <path class="data-line" d="M 970 90 Q 990 130 1010 180"/>
+      <path class="data-line" d="M 970 180 L 1010 190"/>
+      <path class="data-line" d="M 970 270 Q 990 220 1010 200"/>
+    </svg>
+
+    <h3 style="margin-top:2.5rem">The 70/30 contextual fusion (v0.6.0 feature)</h3>
+    <p style="margin-bottom:.5rem">When the caller passes <code>context_tokens=[...]</code>, the recall biases the query embedding toward recent conversation:</p>
+
+    <div class="fusion-grid">
+      <div class="fusion-card f1">
+        <h3>primary embedding</h3>
+        <div class="pct p1">70%</div>
+        <p><code>embed(query)</code> — what the caller explicitly asked. Anchors the recall.</p>
+      </div>
+      <div class="fusion-card f2">
+        <h3>context embedding</h3>
+        <div class="pct p2">30%</div>
+        <p><code>embed(context_tokens.join(" "))</code> — recent conversation tokens. Biases toward "what the agent is currently thinking about".</p>
+      </div>
+      <div class="fusion-card f3">
+        <h3>L2-renormalize</h3>
+        <div class="pct p3">unit</div>
+        <p>Final query vector = unit-norm(0.7·primary + 0.3·context). Same magnitude as either input — drop-in for HNSW search.</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>Why fusion beats either alone.</strong> Pure keyword (FTS5) misses paraphrase. Pure vector (HNSW) drifts on rare terms. Pure rerank is too slow for hot path. The hybrid path uses each where it wins: BM25 for exact terms, vector for semantic neighbors, reranker only on the candidate union (top ~20 → top K). The 70/30 contextual blend is the v0.6.0 addition that makes recall feel "in-flow" with the agent's current task.
+    </div>
+  </div>
+</section>
+
+<!-- =============== FEDERATION =============== -->
+<section id="federation">
+  <div class="container">
+    <span class="eyebrow p3">Federation · W-of-N Quorum</span>
+    <h2>Multi-machine sync without a coordinator.</h2>
+    <p class="lede">Each node accepts writes locally and fans out to peers via mTLS. Quorum threshold W of N (default 2 of 3) must ack before commit. Eventual consistency. Per-peer cursors for catchup after partition. Federation private endpoints under <code>/api/v1/sync/*</code>.</p>
+
+    <svg class="flow-svg" viewBox="0 0 1180 460" xmlns="http://www.w3.org/2000/svg">
+      <!-- Three peers -->
+      <g>
+        <rect class="stage-box hot" x="40" y="200" width="170" height="100" rx="10"/>
+        <text x="125" y="235" text-anchor="middle" style="font-size:14px">node-1 (leader)</text>
+        <text x="125" y="255" text-anchor="middle" class="label" style="fill:var(--p1);font-size:10px">accepts the write</text>
+        <text x="125" y="275" text-anchor="middle" style="fill:var(--text-muted);font-size:11px;font-family:monospace">SQLite + WAL</text>
+      </g>
+      <g>
+        <rect class="stage-box" x="490" y="80" width="170" height="100" rx="10"/>
+        <text x="575" y="115" text-anchor="middle" style="font-size:14px">node-2</text>
+        <text x="575" y="135" text-anchor="middle" class="label" style="fill:var(--good);font-size:10px">ACK ✓ 240ms</text>
+        <text x="575" y="155" text-anchor="middle" style="fill:var(--text-muted);font-size:11px;font-family:monospace">replica</text>
+      </g>
+      <g>
+        <rect class="stage-box" x="490" y="320" width="170" height="100" rx="10"/>
+        <text x="575" y="355" text-anchor="middle" style="font-size:14px">node-3</text>
+        <text x="575" y="375" text-anchor="middle" class="label" style="fill:var(--good);font-size:10px">ACK ✓ 410ms</text>
+        <text x="575" y="395" text-anchor="middle" style="fill:var(--text-muted);font-size:11px;font-family:monospace">replica</text>
+      </g>
+      <g>
+        <rect class="stage-box optional" x="940" y="200" width="170" height="100" rx="10"/>
+        <text x="1025" y="235" text-anchor="middle" style="font-size:14px">node-4</text>
+        <text x="1025" y="255" text-anchor="middle" class="label" style="fill:var(--bad);font-size:10px">offline · partitioned</text>
+        <text x="1025" y="275" text-anchor="middle" style="fill:var(--text-muted);font-size:11px;font-family:monospace">catchup pending</text>
+      </g>
+
+      <!-- mTLS handshake annotations -->
+      <text x="125" y="180" text-anchor="middle" class="label" style="fill:var(--p1)">▼ mTLS · pinned cert</text>
+
+      <!-- Write fanout (orange) -->
+      <path class="data-line write" d="M 210 240 Q 350 100 490 130" marker-end="url(#warrow)"/>
+      <path class="data-line write" d="M 210 270 Q 350 400 490 370" marker-end="url(#warrow)"/>
+      <path class="data-line write opt" d="M 210 250 Q 600 250 940 250" marker-end="url(#warrow)"/>
+
+      <!-- ACK return (cyan) -->
+      <path class="data-line" d="M 490 130 Q 350 130 210 220"/>
+      <path class="data-line" d="M 490 370 Q 350 370 210 280"/>
+
+      <!-- Quorum threshold annotation -->
+      <text x="350" y="50" text-anchor="middle" style="fill:var(--good);font-family:monospace;font-size:14px;font-weight:700">W=2 of N=3 reached → COMMIT</text>
+      <text x="350" y="70" text-anchor="middle" class="label" style="fill:var(--text-muted)">leader returns 200 to caller after 410ms (slowest of 2 acks)</text>
+
+      <!-- Catchup annotation -->
+      <text x="1025" y="330" text-anchor="middle" style="fill:var(--text-muted);font-family:monospace;font-size:11px">when node-4 returns:</text>
+      <text x="1025" y="345" text-anchor="middle" style="fill:var(--p1);font-family:monospace;font-size:11px">GET /api/v1/sync/since?cursor=...</text>
+      <text x="1025" y="360" text-anchor="middle" style="fill:var(--text-muted);font-family:monospace;font-size:11px">advances local state</text>
+
+      <defs>
+        <marker id="warrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--p2)"/>
+        </marker>
+      </defs>
+    </svg>
+
+    <div class="fusion-grid" style="margin-top:2rem">
+      <div class="fusion-card f1">
+        <h3>local first</h3>
+        <p>Reads always serve from local SQLite. Zero network call. Sub-50ms regardless of peer state.</p>
+      </div>
+      <div class="fusion-card f2">
+        <h3>quorum write</h3>
+        <p>Writes return 200 only after W peers ACK. Slowest ACK determines latency. Default W=2.</p>
+      </div>
+      <div class="fusion-card f3">
+        <h3>catchup loop</h3>
+        <p>Detached peer catches up on rejoin via per-peer cursor. Convergent within one catchup_interval (default 30s).</p>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>What if quorum can't be reached?</strong> The leader returns <strong>503 with structured peer status</strong>: which peers responded, which timed out, when the deadline hit. No silent partial writes. Caller can retry or escalate to the operator. The <code>QuorumNotMetPayload</code> includes per-peer error classification (Unreachable / IdDrift / InFlight / InvalidPolicy / LocalWriteFailed).
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./">main</a> · <a href="at-a-glance.html">At a Glance</a> · <a href="feature-matrix.html">Feature Matrix</a> · <a href="integrations.html">Integrations</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/feature-matrix.html
+++ b/docs/feature-matrix.html
@@ -1,0 +1,697 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  Feature Matrix — every MCP tool, HTTP endpoint, CLI command in one visual grid.
+  Companion to at-a-glance.html for SMEs and procurement audiences who need
+  the literal surface-area enumeration.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Feature Matrix — every tool, endpoint, command</title>
+<meta name="description" content="Complete surface-area atlas: 26 MCP tools, 39 HTTP endpoints, 28 CLI commands. Every operation cross-referenced across the three protocol fronts.">
+<meta name="theme-color" content="#0d1117">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/feature-matrix.html">
+<style>
+:root {
+  --bg:#000; --bg-raised:#0a0a0a; --bg-card:#111; --bg-elev:#161616; --bg-code:#1a1a1a;
+  --border:#262626; --border-hl:#3d3d3d;
+  --text:#fff; --text-muted:#999; --text-dim:#666;
+  --pillar-1:#6ee7ff; --pillar-2:#ffb86b; --pillar-3:#c8a2ff; --good:#6ee7ff; --warn:#ffb86b; --bad:#ff6b9d;
+  --read:#6ee7ff;       /* cyan — reads */
+  --write:#ffb86b;      /* orange — writes */
+  --admin:#c8a2ff;      /* purple — admin/system */
+  --kg:#ff79c6;         /* pink — knowledge graph */
+  --fed:#a5d6a7;        /* green — federation */
+  --gov:#ffe066;        /* yellow — governance */
+  --font-mono:'SF Mono','Cascadia Code','Fira Code','JetBrains Mono',Consolas,monospace;
+  --font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  --max-w:1400px;
+}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}
+a:hover{color:var(--pillar-1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px;color:var(--text)}
+
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+
+h1,h2,h3,h4{font-weight:700;letter-spacing:-0.02em}
+h2{font-size:2rem;line-height:1.15;margin-bottom:.5rem}
+h3{font-size:1.2rem;margin-bottom:.5rem}
+p{color:var(--text-muted)}
+
+/* NAV */
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem;text-decoration:none}
+.topnav a:hover,.topnav a.active{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;align-items:center}
+@media(max-width:800px){.topnav .right{display:none}}
+
+/* HERO */
+.hero{padding:5rem 1.5rem 3rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.5rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:680px;margin:0 auto 1.5rem}
+.hero .pill-row{display:flex;justify-content:center;gap:1rem;flex-wrap:wrap;margin-top:1.5rem}
+.hero .pill{padding:.5rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.85rem;color:var(--text-muted)}
+.hero .pill strong{color:var(--text);margin-right:.4rem}
+
+/* SECTION SCAFFOLD */
+section{padding:4rem 0;border-bottom:1px solid var(--border)}
+section .eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+section .lede{color:var(--text-muted);font-size:1rem;max-width:780px;margin-bottom:2.5rem}
+
+/* CATEGORY LEGEND */
+.legend{display:flex;flex-wrap:wrap;gap:.85rem;margin-bottom:2rem}
+.legend-item{display:flex;align-items:center;gap:.5rem;padding:.45rem .85rem;border:1px solid var(--border);border-radius:999px;font-size:.75rem;color:var(--text-muted)}
+.legend-item .dot{width:8px;height:8px;border-radius:50%}
+
+/* TOOL GRID */
+.tool-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:1rem}
+.tool-card{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.1rem 1.2rem;display:flex;flex-direction:column;gap:.5rem;transition:border-color .15s,transform .15s}
+.tool-card:hover{border-color:var(--border-hl);transform:translateY(-2px)}
+.tool-card.cat-read{border-left:3px solid var(--read)}
+.tool-card.cat-write{border-left:3px solid var(--write)}
+.tool-card.cat-admin{border-left:3px solid var(--admin)}
+.tool-card.cat-kg{border-left:3px solid var(--kg)}
+.tool-card.cat-fed{border-left:3px solid var(--fed)}
+.tool-card.cat-gov{border-left:3px solid var(--gov)}
+.tool-card .tname{font-family:var(--font-mono);font-size:.95rem;font-weight:700;color:var(--text);word-break:break-all}
+.tool-card .tdesc{font-size:.83rem;color:var(--text-muted);line-height:1.5}
+.tool-card .tparams{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim);background:var(--bg-code);padding:.4rem .55rem;border-radius:6px;line-height:1.55;word-break:break-all}
+.tool-card .tcat{display:inline-block;font-family:var(--font-mono);font-size:.65rem;text-transform:uppercase;letter-spacing:.12em;color:var(--text-dim)}
+.tool-card .tcat.read{color:var(--read)}
+.tool-card .tcat.write{color:var(--write)}
+.tool-card .tcat.admin{color:var(--admin)}
+.tool-card .tcat.kg{color:var(--kg)}
+.tool-card .tcat.fed{color:var(--fed)}
+.tool-card .tcat.gov{color:var(--gov)}
+
+/* SURFACE TOGGLE */
+.surface-tabs{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1.5rem}
+.surface-tab{padding:.5rem 1rem;border:1px solid var(--border-hl);border-radius:8px;background:var(--bg-card);color:var(--text-muted);font-family:var(--font-mono);font-size:.85rem;cursor:pointer;transition:.15s}
+.surface-tab:hover{color:var(--text);border-color:var(--text)}
+.surface-tab.active{background:var(--text);color:var(--bg);border-color:var(--text)}
+
+/* HTTP ENDPOINT TABLE */
+.http-table{width:100%;border-collapse:collapse;font-size:.85rem;font-family:var(--font-mono)}
+.http-table th{background:var(--bg-card);padding:.65rem .85rem;text-align:left;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);border-bottom:1px solid var(--border-hl)}
+.http-table td{padding:.65rem .85rem;border-bottom:1px solid var(--border)}
+.http-table tr:hover td{background:var(--bg-raised)}
+.method{display:inline-block;padding:.15rem .55rem;border-radius:4px;font-size:.7rem;font-weight:700;letter-spacing:.04em;font-family:var(--font-mono);min-width:54px;text-align:center}
+.method.GET{background:rgba(110,231,255,0.15);color:var(--read);border:1px solid rgba(110,231,255,0.4)}
+.method.POST{background:rgba(255,184,107,0.15);color:var(--write);border:1px solid rgba(255,184,107,0.4)}
+.method.PUT{background:rgba(255,184,107,0.15);color:var(--write);border:1px solid rgba(255,184,107,0.4)}
+.method.DEL{background:rgba(255,107,157,0.15);color:var(--bad);border:1px solid rgba(255,107,157,0.4)}
+.method.OPT{background:rgba(150,150,150,0.15);color:var(--text-muted);border:1px solid var(--border-hl)}
+
+/* CLI GRID */
+.cli-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:.85rem}
+.cli-cmd{background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:.95rem 1.1rem;font-family:var(--font-mono);font-size:.85rem;color:var(--text);transition:.15s}
+.cli-cmd:hover{border-color:var(--border-hl)}
+.cli-cmd .prefix{color:var(--text-dim);user-select:none}
+.cli-cmd .verb{color:var(--write)}
+.cli-cmd .verb-r{color:var(--read)}
+.cli-cmd .verb-a{color:var(--admin)}
+.cli-cmd .verb-g{color:var(--kg)}
+.cli-cmd .verb-f{color:var(--fed)}
+.cli-cmd .desc{font-family:var(--font-sans);font-size:.78rem;color:var(--text-muted);margin-top:.35rem;font-weight:400}
+
+/* CROSS-REF MATRIX */
+.xref-table{width:100%;border-collapse:collapse;font-size:.85rem}
+.xref-table th{background:var(--bg-card);padding:.7rem .9rem;text-align:left;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);border-bottom:2px solid var(--border-hl)}
+.xref-table td{padding:.55rem .9rem;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:.78rem}
+.xref-table tr:hover td{background:var(--bg-raised)}
+.xref-table td.op{color:var(--text);font-weight:700}
+.xref-table td.tool,.xref-table td.endpoint,.xref-table td.cli{color:var(--text-muted)}
+.xref-table td .none{color:var(--text-dim);font-style:italic}
+
+/* MODES DIAGRAM */
+.modes-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem}
+@media(max-width:920px){.modes-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:540px){.modes-grid{grid-template-columns:1fr}}
+.mode-card{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;display:flex;flex-direction:column;gap:.7rem;position:relative;overflow:hidden}
+.mode-card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--text)}
+.mode-card.m1::before{background:var(--read)}
+.mode-card.m2::before{background:var(--write)}
+.mode-card.m3::before{background:var(--admin)}
+.mode-card.m4::before{background:var(--kg)}
+.mode-icon{font-size:1.75rem}
+.mode-name{font-family:var(--font-mono);font-size:1.05rem;font-weight:700}
+.mode-cmd{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);background:var(--bg-code);padding:.5rem .65rem;border-radius:6px}
+.mode-desc{font-size:.85rem;color:var(--text-muted)}
+.mode-spec{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.08em}
+
+/* FOOTER */
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Feature Matrix</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="#mcp-tools">MCP Tools</a>
+      <a href="#http-endpoints">HTTP API</a>
+      <a href="#cli-commands">CLI</a>
+      <a href="#operational-modes">Modes</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The complete surface area.</h1>
+  <p class="tagline">
+    Every MCP tool, every HTTP endpoint, every CLI command — categorized, cross-referenced, signed off. <strong>26 + 39 + 28 = 93 operations</strong> exposed across three protocol fronts. One implementation underneath, three ways to call it.
+  </p>
+  <div class="pill-row">
+    <span class="pill"><strong>26</strong>MCP tools</span>
+    <span class="pill"><strong>39</strong>HTTP endpoints</span>
+    <span class="pill"><strong>28</strong>CLI commands</span>
+    <span class="pill"><strong>4</strong>operational modes</span>
+  </div>
+</section>
+
+<!-- =============== OPERATIONAL MODES =============== -->
+<section id="operational-modes">
+  <div class="container">
+    <span class="eyebrow">4 Operational Modes</span>
+    <h2>One binary. Four ways to run it.</h2>
+    <p class="lede">Same Rust binary, four startup mode flags. The mode determines which IPC surface is active and which background loops run. Switch by changing one CLI flag — no config file edits required.</p>
+
+    <div class="modes-grid">
+      <div class="mode-card m1">
+        <div class="mode-icon">📡</div>
+        <div class="mode-spec">MODE 1 · Foreground stdio</div>
+        <div class="mode-name">MCP server</div>
+        <div class="mode-cmd">ai-memory mcp --tier semantic</div>
+        <div class="mode-desc">JSON-RPC over stdio. Spawned by Claude Code, Cursor, Codex, etc. as a subprocess. Lives the lifetime of the host AI session.</div>
+      </div>
+      <div class="mode-card m2">
+        <div class="mode-icon">🌐</div>
+        <div class="mode-spec">MODE 2 · Background daemon</div>
+        <div class="mode-name">HTTP daemon</div>
+        <div class="mode-cmd">ai-memory serve --port 9077 --mtls-cert ...</div>
+        <div class="mode-desc">REST + SSE on TCP. mTLS-aware with fingerprint allowlist. Federation peers reach this surface. Shared multi-client server.</div>
+      </div>
+      <div class="mode-card m3">
+        <div class="mode-icon">🔁</div>
+        <div class="mode-spec">MODE 3 · Background daemon</div>
+        <div class="mode-name">Sync daemon</div>
+        <div class="mode-cmd">ai-memory sync-daemon --peers https://node-2,https://node-3</div>
+        <div class="mode-desc">Periodic pull-and-push against peers. W-of-N quorum. Each cycle exchanges memories observed since last cursor.</div>
+      </div>
+      <div class="mode-card m4">
+        <div class="mode-icon">🤖</div>
+        <div class="mode-spec">MODE 4 · Background daemon</div>
+        <div class="mode-name">Curator daemon</div>
+        <div class="mode-cmd">ai-memory curator --daemon --interval-secs 1800 --tier autonomous</div>
+        <div class="mode-desc">Auto-tag, contradiction detection, consolidation. Tier-gated: smart adds LLM tagging, autonomous adds rerank + auto-merge.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== MCP TOOLS =============== -->
+<section id="mcp-tools">
+  <div class="container">
+    <span class="eyebrow">26 MCP Tools</span>
+    <h2>Every tool a host AI can call.</h2>
+    <p class="lede">Auto-discovered by Claude Code, Cursor, Codex, Continue, Gemini CLI, Windsurf, and any MCP-compliant client. Tool names follow <code>memory_&lt;verb&gt;</code> convention.</p>
+
+    <div class="legend">
+      <div class="legend-item"><span class="dot" style="background:var(--read)"></span> READ — recall, search, list</div>
+      <div class="legend-item"><span class="dot" style="background:var(--write)"></span> WRITE — store, update, delete</div>
+      <div class="legend-item"><span class="dot" style="background:var(--admin)"></span> ADMIN — stats, capabilities, gc</div>
+      <div class="legend-item"><span class="dot" style="background:var(--kg)"></span> KG — knowledge graph</div>
+      <div class="legend-item"><span class="dot" style="background:var(--fed)"></span> FED — federation / subscriptions</div>
+      <div class="legend-item"><span class="dot" style="background:var(--gov)"></span> GOV — governance / pending</div>
+    </div>
+
+    <div class="tool-grid">
+      <!-- READ tools -->
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_recall</div>
+        <div class="tdesc">Hybrid recall: FTS5 + HNSW vector + cross-encoder rerank. The agent reasoning hot-path.</div>
+        <div class="tparams">context, namespace?, limit?, tags?, since?, until?, tier?, as_agent?, budget_tokens?, context_tokens?[]</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_search</div>
+        <div class="tdesc">Pure FTS5 keyword search with BM25 ranking. Faster than recall, no vector cost.</div>
+        <div class="tparams">query, namespace?, tier?, limit?, tags?, since?, until?, agent_id?</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_get</div>
+        <div class="tdesc">Fetch a single memory by ID (full or 8-char prefix). Includes outbound links.</div>
+        <div class="tparams">id</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_list</div>
+        <div class="tdesc">Paginated list with namespace / tier / tags filters. Backfills HNSW for unembedded memories on read.</div>
+        <div class="tparams">namespace?, tier?, limit?, offset?, since?, until?, tags?, agent_id?</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_get_taxonomy</div>
+        <div class="tdesc">Hierarchical namespace tree with per-node memory counts. Rooted at any prefix.</div>
+        <div class="tparams">namespace_prefix?, depth?, limit?</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_check_duplicate</div>
+        <div class="tdesc">Pre-write similarity check. Returns nearest-neighbor cosine + above-threshold flag.</div>
+        <div class="tparams">title, content, namespace, threshold?</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_get_links</div>
+        <div class="tdesc">All inbound and outbound typed links for a memory. Filters on relation type.</div>
+        <div class="tparams">memory_id, relation?, direction?</div>
+      </div>
+      <div class="tool-card cat-read">
+        <span class="tcat read">▸ READ</span>
+        <div class="tname">memory_inbox</div>
+        <div class="tdesc">Pending notifications addressed to this agent. Marks-as-read on read.</div>
+        <div class="tparams">since_cursor?, namespace?, limit?</div>
+      </div>
+
+      <!-- WRITE tools -->
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_store</div>
+        <div class="tdesc">Insert with tier (short/mid/long), tags, priority 1-10, confidence 0-1, scope, expires_at.</div>
+        <div class="tparams">title, content, namespace, tier?, tags?, priority?, confidence?, source?, scope?, expires_at?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_update</div>
+        <div class="tdesc">Patch existing memory. Same-source allowed; cross-source warns (governance gate).</div>
+        <div class="tparams">id, title?, content?, tags?, priority?, confidence?, expires_at?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_delete</div>
+        <div class="tdesc">Single-memory soft delete to archive tier. Recoverable via restore.</div>
+        <div class="tparams">id</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_promote</div>
+        <div class="tdesc">Tier promotion: short → mid → long, or hierarchical-vertical (clone into ancestor namespace).</div>
+        <div class="tparams">id, to_namespace?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_forget</div>
+        <div class="tdesc">Bulk delete by namespace / pattern / tier. Always governance-gated. Wide blast radius.</div>
+        <div class="tparams">namespace?, pattern?, tier?, dry_run?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_consolidate</div>
+        <div class="tdesc">Merge N memories into 1. Creates derived_from links. Sources soft-archived.</div>
+        <div class="tparams">ids[], title, summary, namespace?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_link</div>
+        <div class="tdesc">Create typed link. Relation: related_to / supersedes / refines / contradicts / derived_from / etc.</div>
+        <div class="tparams">source_id, target_id, relation?</div>
+      </div>
+      <div class="tool-card cat-write">
+        <span class="tcat write">▸ WRITE</span>
+        <div class="tname">memory_notify</div>
+        <div class="tdesc">Send a notification message to another agent's inbox. A2A primitive.</div>
+        <div class="tparams">target_agent_id, title, payload</div>
+      </div>
+
+      <!-- KG tools -->
+      <div class="tool-card cat-kg">
+        <span class="tcat kg">▸ KG</span>
+        <div class="tname">memory_kg_query</div>
+        <div class="tdesc">Recursive CTE traverse. Time / scope / observed-by filters. Cycle detection. Up to depth 5.</div>
+        <div class="tparams">source_id, max_depth?, valid_at?, allowed_agents?[]</div>
+      </div>
+      <div class="tool-card cat-kg">
+        <span class="tcat kg">▸ KG</span>
+        <div class="tname">memory_kg_timeline</div>
+        <div class="tdesc">Ordered fact timeline for an entity. Each event has valid_from / observed_by metadata.</div>
+        <div class="tparams">entity_id, since?, until?, limit?</div>
+      </div>
+      <div class="tool-card cat-kg">
+        <span class="tcat kg">▸ KG</span>
+        <div class="tname">memory_kg_invalidate</div>
+        <div class="tdesc">Mark a link superseded by setting valid_until. Original link history preserved.</div>
+        <div class="tparams">link_id, valid_until, reason?</div>
+      </div>
+      <div class="tool-card cat-kg">
+        <span class="tcat kg">▸ KG</span>
+        <div class="tname">memory_entity_register</div>
+        <div class="tdesc">Register a typed entity with canonical name + alias side-table. Becomes node in KG.</div>
+        <div class="tparams">canonical_name, namespace, aliases?[], metadata?</div>
+      </div>
+      <div class="tool-card cat-kg">
+        <span class="tcat kg">▸ KG</span>
+        <div class="tname">memory_entity_get_by_alias</div>
+        <div class="tdesc">Resolve any alias back to canonical entity. Powers fuzzy-match lookups.</div>
+        <div class="tparams">alias, namespace?</div>
+      </div>
+
+      <!-- ADMIN tools -->
+      <div class="tool-card cat-admin">
+        <span class="tcat admin">▸ ADMIN</span>
+        <div class="tname">memory_capabilities</div>
+        <div class="tdesc">Self-describing introspection. Schema v2 reports tier, models, tools, hooks (planned), permissions.</div>
+        <div class="tparams">— (no parameters)</div>
+      </div>
+      <div class="tool-card cat-admin">
+        <span class="tcat admin">▸ ADMIN</span>
+        <div class="tname">memory_stats</div>
+        <div class="tdesc">Per-namespace counts, tier breakdown, total bytes, oldest/newest timestamps.</div>
+        <div class="tparams">namespace?</div>
+      </div>
+      <div class="tool-card cat-admin">
+        <span class="tcat admin">▸ ADMIN</span>
+        <div class="tname">memory_session_start</div>
+        <div class="tdesc">Returns recent context + session_id. The Claude Code hook critical path. Sub-100ms p95.</div>
+        <div class="tparams">agent_id?, namespace?, limit?</div>
+      </div>
+      <div class="tool-card cat-admin">
+        <span class="tcat admin">▸ ADMIN</span>
+        <div class="tname">memory_gc</div>
+        <div class="tdesc">Manual GC trigger. Sweeps expired short-tier memories per archive_on_gc policy.</div>
+        <div class="tparams">— (no parameters)</div>
+      </div>
+      <div class="tool-card cat-admin">
+        <span class="tcat admin">▸ ADMIN</span>
+        <div class="tname">memory_namespace_*</div>
+        <div class="tdesc">3 tools: get_standard / set_standard / clear_standard. Per-namespace policy + governance hooks.</div>
+        <div class="tparams">namespace, standard?</div>
+      </div>
+
+      <!-- FED tools -->
+      <div class="tool-card cat-fed">
+        <span class="tcat fed">▸ FED</span>
+        <div class="tname">memory_subscribe</div>
+        <div class="tdesc">Register webhook for events. HMAC-signed bodies. Glob-pattern namespace filter.</div>
+        <div class="tparams">url, events?[], namespace_filter?, secret?</div>
+      </div>
+      <div class="tool-card cat-fed">
+        <span class="tcat fed">▸ FED</span>
+        <div class="tname">memory_unsubscribe</div>
+        <div class="tdesc">Remove a webhook subscription by ID.</div>
+        <div class="tparams">subscription_id</div>
+      </div>
+      <div class="tool-card cat-fed">
+        <span class="tcat fed">▸ FED</span>
+        <div class="tname">memory_list_subscriptions</div>
+        <div class="tdesc">Active subscriptions with dispatch_count and failure_count counters.</div>
+        <div class="tparams">— (no parameters)</div>
+      </div>
+
+      <!-- GOV tools -->
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_pending_list</div>
+        <div class="tdesc">List pending governance-gated actions awaiting human approval. Filter by status.</div>
+        <div class="tparams">status?, namespace?</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_pending_approve</div>
+        <div class="tdesc">Approve a pending action. Executes the deferred operation.</div>
+        <div class="tparams">pending_id</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_pending_reject</div>
+        <div class="tdesc">Reject a pending action with reason. Operation discarded.</div>
+        <div class="tparams">pending_id, reason?</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_agent_register</div>
+        <div class="tdesc">Register agent in reserved _agents namespace. Stores type + capabilities.</div>
+        <div class="tparams">agent_id, agent_type, capabilities?[]</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_agent_list</div>
+        <div class="tdesc">List registered agents with last_seen_at timestamps.</div>
+        <div class="tparams">— (no parameters)</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_detect_contradiction</div>
+        <div class="tdesc">LLM-powered contradiction detection across recent memories. Smart+ tier only.</div>
+        <div class="tparams">topic?, namespace?, limit?</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_auto_tag</div>
+        <div class="tdesc">Suggest tags for a memory via local LLM. Smart+ tier only. Returns tag list.</div>
+        <div class="tparams">memory_id</div>
+      </div>
+      <div class="tool-card cat-gov">
+        <span class="tcat gov">▸ GOV</span>
+        <div class="tname">memory_expand_query</div>
+        <div class="tdesc">LLM-rewrite a query into related terms. Smart+ tier only. Powers query-time expansion.</div>
+        <div class="tparams">query</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== HTTP ENDPOINTS =============== -->
+<section id="http-endpoints">
+  <div class="container">
+    <span class="eyebrow">39 HTTP Endpoints</span>
+    <h2>REST surface for services + federation peers.</h2>
+    <p class="lede">Axum-served. mTLS-aware. CORS layer. Prometheus metrics at <code>/metrics</code>. Body limit 2 MiB. Trace spans on every request. The same operations as MCP, plus federation-private peer endpoints.</p>
+
+    <div style="overflow-x:auto;">
+      <table class="http-table">
+        <thead>
+          <tr><th style="width:80px">Method</th><th>Path</th><th>Purpose</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/health</td><td>Liveness check. Always returns 200.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/metrics</td><td>Prometheus scrape (community convention path).</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/metrics</td><td>Prometheus scrape (REST-consistent path).</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/capabilities</td><td>Self-describing introspection.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/stats</td><td>Per-namespace counts + tier breakdown.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Memory CRUD —</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/memories</td><td>List memories, paginated, filter.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/memories</td><td>Create new memory.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/memories/bulk</td><td>Bulk insert with partial-success semantics.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/memories/{id}</td><td>Fetch one memory by ID.</td></tr>
+          <tr><td><span class="method PUT">PUT</span></td><td>/api/v1/memories/{id}</td><td>Update existing memory.</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/memories/{id}</td><td>Soft-delete to archive tier.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/memories/{id}/promote</td><td>Tier promotion or vertical hierarchy clone.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Search & recall —</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/search</td><td>FTS5 keyword search.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/recall</td><td>Hybrid recall (GET form for cacheability).</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/recall</td><td>Hybrid recall (POST form for large payloads).</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/forget</td><td>Bulk delete by query.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/consolidate</td><td>Merge N memories into 1.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/contradictions</td><td>List detected contradiction pairs.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/check_duplicate</td><td>Pre-write similarity check.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Knowledge graph —</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/links</td><td>Create typed link.</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/links</td><td>Delete a link.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/links/{id}</td><td>Fetch one link.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/taxonomy</td><td>Hierarchical namespace tree.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/kg/timeline</td><td>Ordered fact timeline for an entity.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/kg/invalidate</td><td>Set valid_until on a link.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/kg/query</td><td>Recursive-CTE outbound traversal.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Entities (Stream B) —</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/entities</td><td>Register entity with aliases.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/entities/by_alias</td><td>Resolve alias → canonical entity.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Namespace policy —</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/namespaces</td><td>List namespaces (or get standard via ?namespace=).</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/namespaces</td><td>Set namespace standard (query-string form).</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/namespaces</td><td>Clear namespace standard (query-string form).</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/namespaces/{ns}/standard</td><td>Get standard (path form, MCP parity).</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/namespaces/{ns}/standard</td><td>Set standard (path form).</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/namespaces/{ns}/standard</td><td>Clear standard (path form).</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Archive & GC —</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/archive</td><td>List archived memories.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/archive</td><td>Bulk archive by IDs.</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/archive</td><td>Hard purge archived &gt; N days old.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/archive/{id}/restore</td><td>Restore archived to original tier.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/archive/stats</td><td>Archive size + age histogram.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/gc</td><td>Manual GC trigger.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/export</td><td>JSON dump of all memories + links.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/import</td><td>Bulk JSON import.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Federation peer-private —</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/sync/push</td><td>Peer pushes a batch.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/sync/since</td><td>Peer pulls since cursor.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Subscriptions & A2A —</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/notify</td><td>Send notification to agent inbox.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/inbox</td><td>Read pending notifications.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/subscriptions</td><td>Register webhook.</td></tr>
+          <tr><td><span class="method DEL">DELETE</span></td><td>/api/v1/subscriptions</td><td>Unsubscribe.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/subscriptions</td><td>List active subscriptions.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/session/start</td><td>Initialize agent session.</td></tr>
+
+          <tr><td colspan="3" style="background:var(--bg-raised);font-size:.75rem;letter-spacing:.1em;color:var(--text-muted);text-transform:uppercase;text-align:center;padding:.5rem">— Agents & pending —</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/agents</td><td>List registered agents.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/agents</td><td>Register agent.</td></tr>
+          <tr><td><span class="method GET">GET</span></td><td>/api/v1/pending</td><td>List pending governance actions.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/pending/{id}/approve</td><td>Approve pending action.</td></tr>
+          <tr><td><span class="method POST">POST</span></td><td>/api/v1/pending/{id}/reject</td><td>Reject pending action.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- =============== CLI =============== -->
+<section id="cli-commands">
+  <div class="container">
+    <span class="eyebrow">28 CLI Commands</span>
+    <h2>For humans, scripts, and CI.</h2>
+    <p class="lede">Direct subcommands of the <code>ai-memory</code> binary. No daemon required for read/write commands. Run against any database file via <code>--db &lt;path&gt;</code>.</p>
+
+    <div class="cli-grid">
+      <!-- Read commands -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">recall</span> "<em>context</em>" <span style="color:var(--text-dim)">[--namespace ns --limit N --tier ...]</span><div class="desc">Hybrid recall from a namespace.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">search</span> "<em>query</em>" <span style="color:var(--text-dim)">[--namespace ns --tier ...]</span><div class="desc">FTS5 keyword search.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">get</span> <em>id-or-prefix</em><div class="desc">Fetch one memory.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">list</span> <span style="color:var(--text-dim)">[--namespace ns --tier ... --limit N --offset M]</span><div class="desc">Paginated listing.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">stats</span> <span style="color:var(--text-dim)">[--namespace ns]</span><div class="desc">DB summary or per-namespace.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-r">namespaces</span><div class="desc">All namespaces with counts.</div></div>
+
+      <!-- Write commands -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">store</span> <span style="color:var(--text-dim)">--title "..." --content "..." [--namespace ns --tier long --priority 8]</span><div class="desc">Create memory. <code>--content -</code> reads stdin.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">update</span> <em>id-or-prefix</em> <span style="color:var(--text-dim)">[--title --content --priority ...]</span><div class="desc">Patch existing memory.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">delete</span> <em>id-or-prefix</em><div class="desc">Soft-delete to archive.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">forget</span> <span style="color:var(--text-dim)">[--namespace ns --pattern "*" --tier ...]</span><div class="desc">Bulk delete by filter.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">promote</span> <em>id</em> <span style="color:var(--text-dim)">[--to-namespace path]</span><div class="desc">Tier promotion or hierarchical clone.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">link</span> <em>src tgt</em> <span style="color:var(--text-dim)">[--relation related_to]</span><div class="desc">Create typed link.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">resolve</span> <em>winner_id loser_id</em><div class="desc">Mark one memory as superseding another.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">consolidate</span> <span style="color:var(--text-dim)">--ids id1,id2,id3 --title "..." --summary "..."</span><div class="desc">Merge memories.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb">auto-consolidate</span> <span style="color:var(--text-dim)">--namespace ns --min-count 5</span><div class="desc">Threshold-based group-and-merge.</div></div>
+
+      <!-- Admin -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">gc</span><div class="desc">Manual GC sweep.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">archive</span> <span style="color:var(--text-dim)">[list --restore id --purge --older-than 90]</span><div class="desc">Manage archived memories.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">backup</span> <span style="color:var(--text-dim)">[--out path/]</span><div class="desc">SQLite VACUUM INTO + manifest.json.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">restore</span> <span style="color:var(--text-dim)">--from path/file.db [--skip-verify]</span><div class="desc">Restore from backup with sha256 verify.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">export</span><div class="desc">JSON dump to stdout (memories + links).</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">import</span> <span style="color:var(--text-dim)">[--trust-source]</span><div class="desc">JSON import from stdin.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">mine</span> <span style="color:var(--text-dim)">--input claude-export.zip [--dry-run]</span><div class="desc">Import from Claude/ChatGPT/Slack export.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">bench</span> <span style="color:var(--text-dim)">[--baseline path.json]</span><div class="desc">Canonical workload + p50/p95/p99 vs PERFORMANCE.md.</div></div>
+
+      <!-- Daemon modes -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-f">mcp</span> <span style="color:var(--text-dim)">--tier semantic</span><div class="desc">Start MCP stdio server.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-f">serve</span> <span style="color:var(--text-dim)">--port 9077 [--tls-cert ... --quorum-w 2]</span><div class="desc">Start HTTP daemon.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-f">sync</span> <span style="color:var(--text-dim)">--peers https://... [--dry-run]</span><div class="desc">One-shot sync against peers.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-f">sync-daemon</span> <span style="color:var(--text-dim)">--peers https://... --interval-secs 60</span><div class="desc">Continuous sync loop.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-f">curator</span> <span style="color:var(--text-dim)">[--once | --daemon] [--dry-run]</span><div class="desc">Curator pass: tag/contradict/consolidate.</div></div>
+
+      <!-- Governance -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-g">agents</span> <span style="color:var(--text-dim)">[register --type ai:claude | list]</span><div class="desc">Agent registry.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-g">pending</span> <span style="color:var(--text-dim)">[list | approve id | reject id]</span><div class="desc">Manage governance queue.</div></div>
+
+      <!-- Other -->
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">shell</span><div class="desc">Interactive REPL with all subcommands.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">completions</span> <em>shell</em><div class="desc">Generate bash/zsh/fish/pwsh completions.</div></div>
+      <div class="cli-cmd"><span class="prefix">$ ai-memory </span><span class="verb-a">man</span><div class="desc">Generate manpage.</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== CROSS-REFERENCE MATRIX =============== -->
+<section id="xref">
+  <div class="container">
+    <span class="eyebrow">Cross-reference</span>
+    <h2>One operation, three protocol fronts.</h2>
+    <p class="lede">For each logical operation, here's the MCP tool, the HTTP endpoint, and the CLI command. Every row maps to the same underlying handler in <code>src/db.rs</code> — three protocol fronts, one source of truth.</p>
+
+    <div style="overflow-x:auto;">
+      <table class="xref-table">
+        <thead>
+          <tr><th>Operation</th><th>MCP Tool</th><th>HTTP Endpoint</th><th>CLI Command</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="op">Hybrid recall</td><td class="tool">memory_recall</td><td class="endpoint">GET /api/v1/recall</td><td class="cli">recall &lt;ctx&gt;</td></tr>
+          <tr><td class="op">Keyword search</td><td class="tool">memory_search</td><td class="endpoint">GET /api/v1/search</td><td class="cli">search &lt;q&gt;</td></tr>
+          <tr><td class="op">Get one</td><td class="tool">memory_get</td><td class="endpoint">GET /api/v1/memories/{id}</td><td class="cli">get &lt;id&gt;</td></tr>
+          <tr><td class="op">List</td><td class="tool">memory_list</td><td class="endpoint">GET /api/v1/memories</td><td class="cli">list</td></tr>
+          <tr><td class="op">Store</td><td class="tool">memory_store</td><td class="endpoint">POST /api/v1/memories</td><td class="cli">store --title --content</td></tr>
+          <tr><td class="op">Bulk store</td><td class="tool"><span class="none">via multiple stores</span></td><td class="endpoint">POST /api/v1/memories/bulk</td><td class="cli">import (stdin JSON)</td></tr>
+          <tr><td class="op">Update</td><td class="tool">memory_update</td><td class="endpoint">PUT /api/v1/memories/{id}</td><td class="cli">update &lt;id&gt;</td></tr>
+          <tr><td class="op">Delete</td><td class="tool">memory_delete</td><td class="endpoint">DELETE /api/v1/memories/{id}</td><td class="cli">delete &lt;id&gt;</td></tr>
+          <tr><td class="op">Promote</td><td class="tool">memory_promote</td><td class="endpoint">POST /api/v1/memories/{id}/promote</td><td class="cli">promote &lt;id&gt;</td></tr>
+          <tr><td class="op">Bulk forget</td><td class="tool">memory_forget</td><td class="endpoint">POST /api/v1/forget</td><td class="cli">forget --pattern</td></tr>
+          <tr><td class="op">Consolidate</td><td class="tool">memory_consolidate</td><td class="endpoint">POST /api/v1/consolidate</td><td class="cli">consolidate --ids</td></tr>
+          <tr><td class="op">Detect contradiction</td><td class="tool">memory_detect_contradiction</td><td class="endpoint">GET /api/v1/contradictions</td><td class="cli"><span class="none">via curator</span></td></tr>
+          <tr><td class="op">Check duplicate</td><td class="tool">memory_check_duplicate</td><td class="endpoint">GET /api/v1/check_duplicate</td><td class="cli"><span class="none">via store --check</span></td></tr>
+          <tr><td class="op">Create link</td><td class="tool">memory_link</td><td class="endpoint">POST /api/v1/links</td><td class="cli">link &lt;src&gt; &lt;tgt&gt;</td></tr>
+          <tr><td class="op">Get links</td><td class="tool">memory_get_links</td><td class="endpoint">GET /api/v1/links/{id}</td><td class="cli"><span class="none">via get (auto-includes)</span></td></tr>
+          <tr><td class="op">Taxonomy</td><td class="tool">memory_get_taxonomy</td><td class="endpoint">GET /api/v1/taxonomy</td><td class="cli"><span class="none">via stats</span></td></tr>
+          <tr><td class="op">KG query</td><td class="tool">memory_kg_query</td><td class="endpoint">POST /api/v1/kg/query</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">KG timeline</td><td class="tool">memory_kg_timeline</td><td class="endpoint">GET /api/v1/kg/timeline</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">KG invalidate</td><td class="tool">memory_kg_invalidate</td><td class="endpoint">POST /api/v1/kg/invalidate</td><td class="cli">resolve &lt;winner&gt; &lt;loser&gt;</td></tr>
+          <tr><td class="op">Register entity</td><td class="tool">memory_entity_register</td><td class="endpoint">POST /api/v1/entities</td><td class="cli"><span class="none">via store + tag</span></td></tr>
+          <tr><td class="op">Resolve alias</td><td class="tool">memory_entity_get_by_alias</td><td class="endpoint">GET /api/v1/entities/by_alias</td><td class="cli"><span class="none">via search</span></td></tr>
+          <tr><td class="op">Stats</td><td class="tool">memory_stats</td><td class="endpoint">GET /api/v1/stats</td><td class="cli">stats</td></tr>
+          <tr><td class="op">Capabilities</td><td class="tool">memory_capabilities</td><td class="endpoint">GET /api/v1/capabilities</td><td class="cli"><span class="none">via stats --json</span></td></tr>
+          <tr><td class="op">Session start</td><td class="tool">memory_session_start</td><td class="endpoint">POST /api/v1/session/start</td><td class="cli"><span class="none">N/A</span></td></tr>
+          <tr><td class="op">GC</td><td class="tool">memory_gc</td><td class="endpoint">POST /api/v1/gc</td><td class="cli">gc</td></tr>
+          <tr><td class="op">Archive list</td><td class="tool"><span class="none">via list + filter</span></td><td class="endpoint">GET /api/v1/archive</td><td class="cli">archive list</td></tr>
+          <tr><td class="op">Archive restore</td><td class="tool"><span class="none">via promote</span></td><td class="endpoint">POST /api/v1/archive/{id}/restore</td><td class="cli">archive restore --id</td></tr>
+          <tr><td class="op">Archive purge</td><td class="tool"><span class="none">via forget</span></td><td class="endpoint">DELETE /api/v1/archive</td><td class="cli">archive purge --older-than</td></tr>
+          <tr><td class="op">Export</td><td class="tool"><span class="none">via list bulk</span></td><td class="endpoint">GET /api/v1/export</td><td class="cli">export</td></tr>
+          <tr><td class="op">Import</td><td class="tool"><span class="none">via store batch</span></td><td class="endpoint">POST /api/v1/import</td><td class="cli">import</td></tr>
+          <tr><td class="op">Subscribe</td><td class="tool">memory_subscribe</td><td class="endpoint">POST /api/v1/subscriptions</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">Unsubscribe</td><td class="tool">memory_unsubscribe</td><td class="endpoint">DELETE /api/v1/subscriptions</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">List subs</td><td class="tool">memory_list_subscriptions</td><td class="endpoint">GET /api/v1/subscriptions</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">Notify</td><td class="tool">memory_notify</td><td class="endpoint">POST /api/v1/notify</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">Inbox</td><td class="tool">memory_inbox</td><td class="endpoint">GET /api/v1/inbox</td><td class="cli"><span class="none">via shell</span></td></tr>
+          <tr><td class="op">Register agent</td><td class="tool">memory_agent_register</td><td class="endpoint">POST /api/v1/agents</td><td class="cli">agents register</td></tr>
+          <tr><td class="op">List agents</td><td class="tool">memory_agent_list</td><td class="endpoint">GET /api/v1/agents</td><td class="cli">agents list</td></tr>
+          <tr><td class="op">Pending list</td><td class="tool">memory_pending_list</td><td class="endpoint">GET /api/v1/pending</td><td class="cli">pending list</td></tr>
+          <tr><td class="op">Pending approve</td><td class="tool">memory_pending_approve</td><td class="endpoint">POST /api/v1/pending/{id}/approve</td><td class="cli">pending approve &lt;id&gt;</td></tr>
+          <tr><td class="op">Pending reject</td><td class="tool">memory_pending_reject</td><td class="endpoint">POST /api/v1/pending/{id}/reject</td><td class="cli">pending reject &lt;id&gt;</td></tr>
+          <tr><td class="op">Sync push (peer)</td><td class="tool"><span class="none">peer-private</span></td><td class="endpoint">POST /api/v1/sync/push</td><td class="cli"><span class="none">peer-private</span></td></tr>
+          <tr><td class="op">Sync since (peer)</td><td class="tool"><span class="none">peer-private</span></td><td class="endpoint">GET /api/v1/sync/since</td><td class="cli"><span class="none">peer-private</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p style="color:var(--text-dim)">ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./" style="color:var(--text-muted)">main</a> · <a href="at-a-glance.html" style="color:var(--text-muted)">At a Glance</a> · <a href="data-flow.html" style="color:var(--text-muted)">Data Flow</a> · <a href="integrations.html" style="color:var(--text-muted)">Integrations</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/for-everyone.html
+++ b/docs/for-everyone.html
@@ -1,0 +1,395 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  For Everyone — value proposition for every end-user type, from
+  solo dev to federal/state/local/municipal government. Each
+  audience gets a focused page panel with their pain → fix → ROI.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · For Everyone — value proposition by audience</title>
+<meta name="description" content="ai-memory value proposition tailored for individuals, startups, mid-market, enterprises, and government. Pain → fix → ROI per audience.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/for-everyone.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:2rem;margin-bottom:.5rem}h3{font-size:1.25rem;margin-bottom:.5rem}
+p{color:var(--text-muted)}
+
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+
+.hero{padding:5rem 1.5rem 3rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.05),transparent 60%),radial-gradient(ellipse at bottom,rgba(255,184,107,0.04),transparent 70%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,5vw,4rem);line-height:1.05;letter-spacing:-0.04em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.15rem;max-width:780px;margin:0 auto}
+
+/* Audience nav (sticky pill row) */
+.aud-nav{position:sticky;top:65px;z-index:40;background:rgba(0,0,0,0.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--border);padding:.85rem 0}
+.aud-nav-inner{display:flex;gap:.5rem;justify-content:center;flex-wrap:wrap;max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+.aud-nav a{padding:.45rem 1rem;border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);border:1px solid var(--border-hl)}
+.aud-nav a:hover{color:var(--text);border-color:var(--text)}
+
+/* Audience panels — large bold sections */
+.audience{padding:5rem 0;border-bottom:1px solid var(--border)}
+.audience .container{display:grid;grid-template-columns:1fr 1.25fr;gap:3rem;align-items:start}
+@media(max-width:920px){.audience .container{grid-template-columns:1fr}}
+.audience .left{position:sticky;top:8rem}
+.audience .scale-num{font-family:var(--font-mono);font-size:6rem;font-weight:900;line-height:.9;letter-spacing:-0.08em;background:linear-gradient(135deg,var(--p1),var(--p3));-webkit-background-clip:text;background-clip:text;color:transparent;margin-bottom:.5rem}
+.audience .scale-tag{font-family:var(--font-mono);font-size:.75rem;letter-spacing:.15em;text-transform:uppercase;color:var(--text-dim);margin-bottom:1.5rem}
+.audience h2{font-size:2.5rem;line-height:1.1;letter-spacing:-0.03em;margin-bottom:.75rem}
+.audience .scale-icon{font-size:3rem;margin-bottom:1rem}
+.audience .scale-pop{font-family:var(--font-mono);font-size:.85rem;color:var(--text-muted);background:var(--bg-card);padding:.65rem .85rem;border-radius:8px;border:1px solid var(--border);display:inline-block;margin-top:.5rem}
+
+.audience .right{display:flex;flex-direction:column;gap:1rem}
+.aud-pain{background:linear-gradient(135deg,rgba(255,107,157,0.08),rgba(255,107,157,0.02));border:1px solid rgba(255,107,157,0.3);border-radius:12px;padding:1.5rem}
+.aud-pain h3{color:#ffa0c0;margin-bottom:.5rem;font-size:1rem;font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.1em}
+.aud-pain p{color:#ffd0e0;font-size:1rem;line-height:1.55}
+.aud-fix{background:linear-gradient(135deg,rgba(110,231,255,0.07),rgba(110,231,255,0.02));border:1px solid rgba(110,231,255,0.3);border-radius:12px;padding:1.5rem}
+.aud-fix h3{color:var(--p1);margin-bottom:.5rem;font-size:1rem;font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.1em}
+.aud-fix p{color:#a8eeff;font-size:1rem;line-height:1.55}
+.aud-roi{background:linear-gradient(135deg,rgba(255,215,0,0.06),rgba(255,184,107,0.04));border:1px solid rgba(255,215,0,0.25);border-radius:12px;padding:1.5rem}
+.aud-roi h3{color:var(--gold);margin-bottom:.5rem;font-size:1rem;font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.1em}
+.aud-roi ul{list-style:none}
+.aud-roi li{padding-left:1.4rem;position:relative;margin:.4rem 0;font-size:.95rem;color:var(--text-muted)}
+.aud-roi li::before{content:"$";position:absolute;left:0;color:var(--gold);font-weight:700}
+.aud-roi li strong{color:var(--text)}
+
+.aud-deploy{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem}
+.aud-deploy h3{color:var(--text);margin-bottom:.65rem;font-size:1rem;font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.1em}
+.aud-deploy pre{background:var(--bg-code);border:1px solid var(--border);border-radius:8px;padding:.85rem 1rem;font-family:var(--font-mono);font-size:.8rem;color:var(--text-muted);overflow-x:auto;line-height:1.5;white-space:pre-wrap}
+
+.aud-stack{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.25rem 1.5rem;display:flex;flex-direction:column;gap:.75rem}
+.aud-stack h3{font-size:.95rem;font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.1em;color:var(--text)}
+.aud-stack-row{display:flex;align-items:center;gap:.75rem;font-size:.88rem;color:var(--text-muted)}
+.aud-stack-row .badge{display:inline-block;padding:.2rem .55rem;border:1px solid var(--border-hl);border-radius:4px;font-family:var(--font-mono);font-size:.7rem;color:var(--p1);min-width:90px;text-align:center}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+.cta-section{padding:5rem 1.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.05),transparent 70%)}
+.cta-section h2{margin-bottom:1rem}
+.cta-section p{max-width:640px;margin:0 auto 2rem}
+.cta-row{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap}
+.cta{display:inline-block;padding:.85rem 1.5rem;border:1px solid var(--border-hl);color:var(--text);font-weight:600;border-radius:8px}
+.cta.primary{background:var(--text);color:var(--bg);border-color:var(--text)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ For Everyone</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="feature-matrix.html">Feature Matrix</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Same binary.<br>Every scale.</h1>
+  <p class="tagline">From a solo developer's laptop to a federation of state-government data centers — the <strong>same Rust binary</strong> runs the same way. Below is the value story for every audience size, with deployment patterns, ROI math, and procurement-ready specs.</p>
+</section>
+
+<nav class="aud-nav">
+  <div class="aud-nav-inner">
+    <a href="#a1">▸ 01 · Individual</a>
+    <a href="#a2">▸ 02 · Startup</a>
+    <a href="#a3">▸ 03 · Mid-market</a>
+    <a href="#a4">▸ 04 · Enterprise</a>
+    <a href="#a5">▸ 05 · Government</a>
+  </div>
+</nav>
+
+<!-- ============== AUDIENCE 1: INDIVIDUAL ============== -->
+<section class="audience" id="a1">
+  <div class="container">
+    <div class="left">
+      <div class="scale-icon">👤</div>
+      <div class="scale-num">01</div>
+      <div class="scale-tag">SOLO · INDIVIDUAL</div>
+      <h2>The solo developer.</h2>
+      <p>One person. One laptop. Multiple AIs. Memory that vanishes every conversation.</p>
+      <div class="scale-pop">1 user · 1 box · &lt; 5 GB RAM</div>
+    </div>
+    <div class="right">
+      <div class="aud-pain">
+        <h3>▼ The Pain</h3>
+        <p>"Claude forgets between sessions. Cursor doesn't know what ChatGPT learned. I re-paste the same project context 30 times a day. My most expensive cognitive asset — the context I've built with these tools — evaporates every 4 hours."</p>
+      </div>
+      <div class="aud-fix">
+        <h3>▲ The Fix</h3>
+        <p>One <code>brew install ai-memory</code>. Three lines in your MCP config. Every AI you use plugs into the same memory. <strong>Persistent across reboots, machines, AI vendors. Local-first — your data never leaves your laptop unless you explicitly federate.</strong></p>
+      </div>
+      <div class="aud-roi">
+        <h3>▼ The ROI (estimated, single user)</h3>
+        <ul>
+          <li><strong>~30 conversations/day</strong> × 365 days = ~11,000 cold-start contexts/year</li>
+          <li><strong>5-10 minutes/day</strong> saved on re-explaining project state to AIs</li>
+          <li><strong>$0 SaaS spend</strong> — zero per-month memory subscription</li>
+          <li><strong>100% data ownership</strong> — no vendor lock-in, no privacy spillover</li>
+        </ul>
+      </div>
+      <div class="aud-deploy">
+        <h3>▼ Deployment Pattern</h3>
+        <pre>brew install ai-memory
+# Add ai-memory to Claude / Cursor / Codex MCP config
+# That's it.
+
+# Optional: bump to autonomous tier for self-curating memory
+ollama pull gemma3:e2b
+ai-memory mcp --tier autonomous</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== AUDIENCE 2: STARTUP ============== -->
+<section class="audience" id="a2">
+  <div class="container">
+    <div class="left">
+      <div class="scale-icon">👥</div>
+      <div class="scale-num">02</div>
+      <div class="scale-tag">SCALE · STARTUP</div>
+      <h2>The 2–25 person team.</h2>
+      <p>A small group of humans + a growing fleet of AI sessions. Tribal knowledge dies when someone leaves.</p>
+      <div class="scale-pop">2-25 users · 1-3 nodes · shared engineering memory</div>
+    </div>
+    <div class="right">
+      <div class="aud-pain">
+        <h3>▼ The Pain</h3>
+        <p>"Senior engineer leaves. Six months of context goes with them. New hires re-discover landmines we already paid to find. Each engineer's Claude has different memory. The AI knows the codebase but can't share what it learned."</p>
+      </div>
+      <div class="aud-fix">
+        <h3>▲ The Fix</h3>
+        <p>Federated 3-node ai-memory cluster on your VPC. Per-namespace shared memory: <code>onboarding/</code>, <code>decisions/</code>, <code>infra/</code>. <strong>Every team member's AI plugs in and shares understanding.</strong> mTLS handshake on every cross-node call. Zero per-seat cost.</p>
+      </div>
+      <div class="aud-roi">
+        <h3>▼ The ROI</h3>
+        <ul>
+          <li><strong>40-60% faster onboarding</strong> — new hire's AI walks into project conversation already in progress</li>
+          <li><strong>~$0 / seat / month</strong> vs $20-50/seat for SaaS memory products at this size</li>
+          <li><strong>Decision audit trail</strong> — every "we decided X because Y" memory survives staff turnover</li>
+          <li><strong>SOC2-friendly</strong> from day 1 — local data, audit logs, governance hooks</li>
+        </ul>
+      </div>
+      <div class="aud-stack">
+        <h3>▼ Architecture</h3>
+        <div class="aud-stack-row"><span class="badge">3 nodes</span> mTLS-federated VPC cluster, Linux x64</div>
+        <div class="aud-stack-row"><span class="badge">W=2 / N=3</span> quorum write — survives 1-node loss</div>
+        <div class="aud-stack-row"><span class="badge">tier=smart</span> Ollama gemma3:e2b for auto-tag + contradict</div>
+        <div class="aud-stack-row"><span class="badge">webhook</span> SIEM → Slack on contradiction-detected</div>
+        <div class="aud-stack-row"><span class="badge">backup</span> Daily VACUUM INTO + S3 sync of *.db.gz</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== AUDIENCE 3: MID-MARKET ============== -->
+<section class="audience" id="a3">
+  <div class="container">
+    <div class="left">
+      <div class="scale-icon">🏢</div>
+      <div class="scale-num">03</div>
+      <div class="scale-tag">SCALE · MID-MARKET</div>
+      <h2>The 25–500 person org.</h2>
+      <p>Multi-team. Multi-namespace. Procurement caught on. Compliance is calling.</p>
+      <div class="scale-pop">25-500 users · 5-15 nodes · per-team isolation</div>
+    </div>
+    <div class="right">
+      <div class="aud-pain">
+        <h3>▼ The Pain</h3>
+        <p>"AI usage exploded across teams. Each one signed up for a different SaaS memory product. Different vendors. Different DPAs. Different security postures. Audit asks 'where does our data live?' and we don't have one answer."</p>
+      </div>
+      <div class="aud-fix">
+        <h3>▲ The Fix</h3>
+        <p>One ai-memory deployment per business unit. Per-team namespace. Governance hooks intercept destructive ops. Webhook integration ships to corporate SIEM. Single source of truth for data residency: <strong>"on this VPC, that's it."</strong></p>
+      </div>
+      <div class="aud-roi">
+        <h3>▼ The ROI</h3>
+        <ul>
+          <li><strong>Centralized memory governance</strong> — one DPA, not 7</li>
+          <li><strong>Per-team compliance scope</strong> — finance memories never reach engineering</li>
+          <li><strong>SaaS spend elimination</strong>: typical $30K-200K/year on per-team memory products → $0</li>
+          <li><strong>Faster security review</strong>: Apache 2.0 OSS source, single Rust binary, no SBOM mystery</li>
+        </ul>
+      </div>
+      <div class="aud-stack">
+        <h3>▼ Architecture</h3>
+        <div class="aud-stack-row"><span class="badge">per-BU</span> Each business unit gets its own 3-5 node cluster</div>
+        <div class="aud-stack-row"><span class="badge">SIEM</span> Webhook → Splunk / Datadog / Sumo on every write</div>
+        <div class="aud-stack-row"><span class="badge">RBAC</span> Per-namespace governance (Allow/Deny/Pending)</div>
+        <div class="aud-stack-row"><span class="badge">IAM</span> mTLS client certs from corp PKI</div>
+        <div class="aud-stack-row"><span class="badge">backup</span> Snapshot on every change-of-state, retain 90d</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== AUDIENCE 4: ENTERPRISE ============== -->
+<section class="audience" id="a4">
+  <div class="container">
+    <div class="left">
+      <div class="scale-icon">🏛️</div>
+      <div class="scale-num">04</div>
+      <div class="scale-tag">SCALE · LARGE ENTERPRISE</div>
+      <h2>The 500–50,000 corporation.</h2>
+      <p>Multi-region. Multi-jurisdiction. Multi-language compliance. Air-gapped business units.</p>
+      <div class="scale-pop">500-50K users · 20-100 nodes · multi-region federation</div>
+    </div>
+    <div class="right">
+      <div class="aud-pain">
+        <h3>▼ The Pain</h3>
+        <p>"Each BU wants AI. Each lawyer wants air-gapped. Each auditor wants logs. Each region has different data-residency rules. Our AI vendors keep getting acquired. Every approved tool gets deprecated 18 months later."</p>
+      </div>
+      <div class="aud-fix">
+        <h3>▲ The Fix</h3>
+        <p>Per-BU federated cluster. Cross-region quorum-aware sync. PII redaction hooks. Backup + restore + retention. <strong>Air-gap operable</strong> for sensitive BUs. <strong>Vendor-acquisition immune</strong> — Apache 2.0 OSS, you have the source.</p>
+      </div>
+      <div class="aud-roi">
+        <h3>▼ The ROI</h3>
+        <ul>
+          <li><strong>Air-gap deployments</strong> for sensitive BUs without losing AI capability</li>
+          <li><strong>Per-BU policy enforcement</strong> via governance + hooks; one platform, N policies</li>
+          <li><strong>Hooks for DLP integration</strong> — your existing data-loss-prevention pipeline plugs in</li>
+          <li><strong>Vendor-risk-zero</strong> — Apache 2.0, full source, single binary, no SaaS dependency</li>
+          <li><strong>FIPS path</strong> via v0.7 attested identity (ed25519 → HSM-backed)</li>
+        </ul>
+      </div>
+      <div class="aud-stack">
+        <h3>▼ Architecture</h3>
+        <div class="aud-stack-row"><span class="badge">multi-region</span> AWS / Azure / GCP / on-prem; cross-region mTLS</div>
+        <div class="aud-stack-row"><span class="badge">air-gap</span> No outbound calls; internal-only mirror of crates.io for updates</div>
+        <div class="aud-stack-row"><span class="badge">DLP hooks</span> pre_store hook redacts PII before persist</div>
+        <div class="aud-stack-row"><span class="badge">audit</span> Sidechain transcripts (v0.7) — every memory has full conversation</div>
+        <div class="aud-stack-row"><span class="badge">DR</span> Cross-region quorum + nightly backup → glacier</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== AUDIENCE 5: GOVERNMENT ============== -->
+<section class="audience" id="a5">
+  <div class="container">
+    <div class="left">
+      <div class="scale-icon">🇺🇸</div>
+      <div class="scale-num">05</div>
+      <div class="scale-tag">SCALE · GOVERNMENT</div>
+      <h2>Federal · State · Local · Municipal.</h2>
+      <p>AI mandate is real. Cloud ban is real. Foreign vendor scrutiny is real. Audit trail is mandatory.</p>
+      <div class="scale-pop">Sovereign · Air-gapped · FIPS / IL5 path</div>
+    </div>
+    <div class="right">
+      <div class="aud-pain">
+        <h3>▼ The Pain</h3>
+        <p>"AI is a White House priority. Cloud is forbidden by policy. Most vendors are foreign. Every commercial product wants telemetry. Every offering needs FedRAMP authorization. We're caught between the modernization mandate and the security mandate."</p>
+      </div>
+      <div class="aud-fix">
+        <h3>▲ The Fix</h3>
+        <p><strong>Apache 2.0 OSS</strong>. Single Rust binary. Zero outbound calls. Public source code, auditable from <code>git clone</code>. Hardware-attested keys (v0.7 → HSM, TPM, Secure Enclave). FedRAMP / IL5 path via the AgenticMem Sovereign tier. <strong>Domestic supplier (US-based AlphaOne LLC) for procurement.</strong></p>
+      </div>
+      <div class="aud-roi">
+        <h3>▼ The ROI</h3>
+        <ul>
+          <li><strong>100% air-gap operable</strong> — no exceptions, no special "offline mode" — just doesn't make outbound calls</li>
+          <li><strong>Public source-code audit</strong> — your security team reads the entire codebase in a week</li>
+          <li><strong>No vendor lock-in</strong> — single Rust binary, single SQLite file, copy is backup</li>
+          <li><strong>FedRAMP / IL5 path</strong> via AgenticMem Sovereign commercial tier (Q3 2026 GA)</li>
+          <li><strong>Domestic supplier</strong> — US-incorporated, no foreign-ownership concerns</li>
+          <li><strong>SBOM clean</strong> — Cargo.toml is the SBOM; <code>cargo audit</code> runs in CI</li>
+        </ul>
+      </div>
+      <div class="aud-stack">
+        <h3>▼ Deployment Pattern</h3>
+        <div class="aud-stack-row"><span class="badge">air-gap</span> Build from source on the secure subnet; no internet</div>
+        <div class="aud-stack-row"><span class="badge">SQLCipher</span> Encryption-at-rest via <code>--features sqlcipher</code></div>
+        <div class="aud-stack-row"><span class="badge">FIPS</span> v0.7 attested-identity for FIPS 140-3 path</div>
+        <div class="aud-stack-row"><span class="badge">HSM</span> Hardware key custody via AgenticMem Attest commercial tier</div>
+        <div class="aud-stack-row"><span class="badge">audit</span> Append-only signed event log; no operator can rewrite history</div>
+        <div class="aud-stack-row"><span class="badge">domestic</span> AlphaOne LLC (US, Delaware) is the sole responsible party</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== UNIVERSAL VALUE ============== -->
+<section style="padding:5rem 0;border-bottom:1px solid var(--border)">
+  <div class="container">
+    <span style="display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px">Universal</span>
+    <h2 style="font-size:2.5rem;line-height:1.1;margin-bottom:1rem">What every audience gets, automatically.</h2>
+    <p style="color:var(--text-muted);font-size:1.05rem;max-width:780px;margin-bottom:2.5rem">Some properties of ai-memory are non-negotiable benefits — they apply at every scale, with no upgrade or paid tier required.</p>
+
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem">
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p1)">
+        <h3 style="margin-bottom:.5rem">Local-first</h3>
+        <p style="font-size:.9rem">SQLite file on disk. WAL-mode for concurrent reads. <code>cp</code> is a backup. <strong>Your data never leaves your hardware unless you explicitly turn on federation.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p1)">
+        <h3 style="margin-bottom:.5rem">Sub-100ms session-start</h3>
+        <p style="font-size:.9rem">42ms p95 measured. Published budget. CI guard fails any PR that breaks it. <strong>Latency contract enforced, not aspirational.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p1)">
+        <h3 style="margin-bottom:.5rem">Apache 2.0 OSS</h3>
+        <p style="font-size:.9rem">Commercial-friendly license. Patent grant included. <strong>You can read every line, fork it, sell what you build on top.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
+        <h3 style="margin-bottom:.5rem">93.05% test coverage</h3>
+        <p style="font-size:.9rem">1,809 tests. Zero ignored. Four-platform CI (macOS / Ubuntu / Windows / Coverage). <strong>Every PR runs the full matrix.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
+        <h3 style="margin-bottom:.5rem">Single binary</h3>
+        <p style="font-size:.9rem">No Python install. No Node toolchain. No Docker required. Just one ~30MB Rust binary. <strong>Five distribution targets (macOS x64/arm, Linux x64/arm, Windows x64).</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
+        <h3 style="margin-bottom:.5rem">MCP-native</h3>
+        <p style="font-size:.9rem">Open Model Context Protocol. <strong>Every MCP-compliant host autodiscovers all 26 ai-memory tools.</strong> Future AI hosts work for free.</p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p3)">
+        <h3 style="margin-bottom:.5rem">Reversibility</h3>
+        <p style="font-size:.9rem">Soft-delete to archive tier. Restore anytime. <strong>Hard delete only via explicit purge with governance approval.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p3)">
+        <h3 style="margin-bottom:.5rem">Self-curating</h3>
+        <p style="font-size:.9rem">Curator daemon auto-tags, detects contradictions, consolidates similar memories. <strong>Your memory store stays tidy without manual hygiene.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p3)">
+        <h3 style="margin-bottom:.5rem">Auditable</h3>
+        <p style="font-size:.9rem">Pending actions queue. Webhook event stream. (v0.7) Ed25519 signatures on every write. <strong>Compliance officers see what they need.</strong></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="cta-section">
+  <h2>Pick your scale. Same binary.</h2>
+  <p>Whether you're a solo developer or a federal agency, the install path is the same.</p>
+  <div class="cta-row">
+    <a class="cta primary" href="./#install">Install Guide</a>
+    <a class="cta" href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    <a class="cta" href="at-a-glance.html">At a Glance</a>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./">main</a> · <a href="at-a-glance.html">At a Glance</a> · <a href="feature-matrix.html">Feature Matrix</a> · <a href="data-flow.html">Data Flow</a> · <a href="integrations.html">Integrations</a> · <a href="release-pipeline.html">Release Pipeline</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/governance.html
+++ b/docs/governance.html
@@ -1,0 +1,425 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Governance atlas — decision tree, levels, approver types, governed actions.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Governance — Allow / Deny / Pending</title>
+<meta name="description" content="ai-memory v0.6.3 governance reference. Allow / Deny / Pending decision tree, GovernanceLevel × GovernedAction matrix, ApproverType (Human / Agent / Consensus), pending-action lifecycle.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/governance.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--warn:#ffd700;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(200,162,255,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+
+.tree-svg{width:100%;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.5rem}
+
+.matrix{width:100%;border-collapse:separate;border-spacing:0;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;overflow:hidden;font-size:.88rem}
+.matrix th{background:var(--bg-elev);padding:.85rem 1rem;text-align:left;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;border-bottom:1px solid var(--border)}
+.matrix td{padding:.75rem 1rem;border-bottom:1px solid var(--border);vertical-align:top}
+.matrix tr:last-child td{border-bottom:none}
+.matrix .level-name{font-family:var(--font-mono);font-weight:700;color:var(--p3)}
+.matrix .verdict{font-family:var(--font-mono);font-size:.82rem}
+.matrix .verdict.allow{color:var(--good)}
+.matrix .verdict.deny{color:var(--bad)}
+.matrix .verdict.pending{color:var(--warn)}
+
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(290px,1fr));gap:1rem;margin-bottom:2rem}
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.25rem;position:relative;overflow:hidden}
+.card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--p3)}
+.card.allow::before{background:var(--good)}
+.card.deny::before{background:var(--bad)}
+.card.pending::before{background:var(--warn)}
+.card h3{font-family:var(--font-mono);font-size:1rem;margin-bottom:.5rem}
+.card .lbl{font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.4rem}
+.card p{color:var(--text-muted);font-size:.88rem}
+
+.flow{display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap;margin:1.5rem 0;padding:1.5rem;background:var(--bg-card);border:1px solid var(--border);border-radius:12px}
+.flow .step{flex:1;min-width:180px;padding:.85rem 1rem;background:var(--bg-elev);border:1px solid var(--border);border-radius:8px;font-size:.85rem}
+.flow .step .num{font-family:var(--font-mono);color:var(--p3);font-size:.78rem;font-weight:700;margin-bottom:.3rem}
+.flow .step .what{font-family:var(--font-mono);font-size:.85rem;font-weight:700;color:var(--text);margin-bottom:.3rem}
+.flow .step .why{color:var(--text-muted);font-size:.82rem;line-height:1.45}
+.flow .arr{font-family:var(--font-mono);color:var(--text-dim);align-self:center;font-size:1.5rem}
+
+.snip{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);margin-top:.85rem;padding:.7rem .85rem;background:var(--bg-code);border-radius:6px;line-height:1.55;white-space:pre;overflow-x:auto}
+.snip .ok{color:var(--good)}
+.snip .err{color:var(--bad)}
+.snip .warn{color:var(--warn)}
+.snip .cm{color:var(--text-dim)}
+.snip .key{color:var(--p3)}
+.snip .val{color:var(--p2)}
+
+.act-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-bottom:1.5rem}
+.act{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem 1.15rem}
+.act .name{font-family:var(--font-mono);font-size:1rem;font-weight:700;color:var(--text);margin-bottom:.4rem}
+.act .name.store{color:var(--good)}
+.act .name.delete{color:var(--bad)}
+.act .name.promote{color:var(--p2)}
+.act .desc{font-size:.85rem;color:var(--text-muted);line-height:1.45}
+.act .ws{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim);margin-top:.4rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Governance</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">Atlas</a>
+      <a href="schema.html">Schema</a>
+      <a href="types.html">Types</a>
+      <a href="validators.html">Validators</a>
+      <a href="tracing.html">Tracing</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/governance.rs">governance.rs →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The governance gate.</h1>
+  <p class="tagline">Three decisions: <strong style="color:var(--good)">Allow</strong>, <strong style="color:var(--bad)">Deny</strong>, <strong style="color:var(--warn)">Pending</strong>. Three actions: <code>store</code>, <code>delete</code>, <code>promote</code>. Four levels: Any, Registered, Owner, Approve. Three approver types: Human, Agent, Consensus. Every governed write either returns immediately or queues for approval — never silently succeeds.</p>
+  <div class="pills">
+    <span class="pill">Task 1.8 — policy shape</span>
+    <span class="pill">Task 1.9 — enforcement</span>
+    <span class="pill">Task 1.10 — approver types</span>
+    <span class="pill">v0.6.2 S34 — federation propagation</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">The decision</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Allow / Deny / Pending.</h2>
+    <p class="lede">Every governed write goes through one function and produces one of three outcomes. The decision is not advisory — callers <strong>MAY</strong> execute on Allow, <strong>MUST</strong> reject on Deny, and <strong>SHOULD</strong> queue + return the <code>pending_id</code> on Pending.</p>
+    <div class="cards">
+      <div class="card allow">
+        <div class="lbl">verdict 1</div>
+        <h3 style="color:var(--good)">Allow</h3>
+        <p>Proceed with the action. Caller receives the new memory or success response. No row in <code>pending_actions</code>.</p>
+      </div>
+      <div class="card deny">
+        <div class="lbl">verdict 2</div>
+        <h3 style="color:var(--bad)">Deny(reason)</h3>
+        <p>Reject with HTTP 403. The wrapped <code>String</code> surfaces the human-readable reason — <em>not</em> a placeholder. AI clients can quote it verbatim.</p>
+      </div>
+      <div class="card pending">
+        <div class="lbl">verdict 3</div>
+        <h3 style="color:var(--warn)">Pending(id)</h3>
+        <p>Queued in <code>pending_actions</code>; caller receives the new <code>pending_id</code> and HTTP 202. The action replays once approved.</p>
+      </div>
+    </div>
+    <div class="snip">// src/models.rs
+<span class="key">pub enum</span> <span class="val">GovernanceDecision</span> {
+    Allow,
+    Deny(String),
+    Pending(String),
+}</div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">The decision tree</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">How a write becomes Allow / Deny / Pending.</h2>
+    <p class="lede">For every governed action, the daemon walks this tree. The lookup is namespace-local — the policy lives in the namespace's standard memory at <code>metadata.governance</code>; absent a standard, the default policy applies.</p>
+    <svg class="tree-svg" viewBox="0 0 1180 540" xmlns="http://www.w3.org/2000/svg">
+      <style>
+        .tn{fill:#161616;stroke:#3d3d3d;stroke-width:1.5;rx:8;ry:8}
+        .tn-allow{stroke:#6ee7ff;stroke-width:2}
+        .tn-deny{stroke:#ff6b9d;stroke-width:2}
+        .tn-pend{stroke:#ffd700;stroke-width:2}
+        .tt{fill:#fff;font-family:monospace;font-size:13px;font-weight:700}
+        .tdesc{fill:#999;font-family:monospace;font-size:10px}
+        .ll{stroke:#666;stroke-width:1.5;fill:none}
+        .lcap{fill:#999;font-family:monospace;font-size:10px}
+        .start{fill:#0a0a0a;stroke:#c8a2ff;stroke-width:2;rx:8;ry:8}
+        .leaf-allow{fill:rgba(110,231,255,0.12);stroke:#6ee7ff}
+        .leaf-deny{fill:rgba(255,107,157,0.12);stroke:#ff6b9d}
+        .leaf-pend{fill:rgba(255,215,0,0.12);stroke:#ffd700}
+      </style>
+      <!-- Start -->
+      <rect class="start" x="490" y="20" width="200" height="60"/>
+      <text class="tt" x="590" y="48" text-anchor="middle">Governed action arrives</text>
+      <text class="tdesc" x="590" y="65" text-anchor="middle">store / delete / promote</text>
+      <!-- Step 1: Resolve policy -->
+      <line class="ll" x1="590" y1="80" x2="590" y2="115"/>
+      <rect class="tn" x="455" y="115" width="270" height="60"/>
+      <text class="tt" x="590" y="140" text-anchor="middle">Resolve namespace policy</text>
+      <text class="tdesc" x="590" y="158" text-anchor="middle">walk standards.metadata.governance</text>
+      <!-- Step 2: Pick gate field -->
+      <line class="ll" x1="590" y1="175" x2="590" y2="210"/>
+      <rect class="tn" x="455" y="210" width="270" height="60"/>
+      <text class="tt" x="590" y="234" text-anchor="middle">Pick gate from policy</text>
+      <text class="tdesc" x="590" y="252" text-anchor="middle">store→write · delete→delete · promote→promote</text>
+      <!-- Branch: 4 levels -->
+      <line class="ll" x1="590" y1="270" x2="170" y2="320"/>
+      <line class="ll" x1="590" y1="270" x2="450" y2="320"/>
+      <line class="ll" x1="590" y1="270" x2="730" y2="320"/>
+      <line class="ll" x1="590" y1="270" x2="1010" y2="320"/>
+      <rect class="tn tn-allow" x="80" y="320" width="180" height="50"/>
+      <text class="tt" x="170" y="343" text-anchor="middle">Any</text>
+      <text class="tdesc" x="170" y="358" text-anchor="middle">no gate</text>
+      <rect class="tn" x="360" y="320" width="180" height="50"/>
+      <text class="tt" x="450" y="343" text-anchor="middle">Registered</text>
+      <text class="tdesc" x="450" y="358" text-anchor="middle">in _agents?</text>
+      <rect class="tn" x="640" y="320" width="180" height="50"/>
+      <text class="tt" x="730" y="343" text-anchor="middle">Owner</text>
+      <text class="tdesc" x="730" y="358" text-anchor="middle">caller == metadata.agent_id?</text>
+      <rect class="tn tn-pend" x="920" y="320" width="180" height="50"/>
+      <text class="tt" x="1010" y="343" text-anchor="middle">Approve</text>
+      <text class="tdesc" x="1010" y="358" text-anchor="middle">queue + run approver</text>
+      <!-- Leaves: Any → Allow -->
+      <line class="ll" x1="170" y1="370" x2="170" y2="430"/>
+      <rect class="tn leaf-allow" x="80" y="430" width="180" height="50"/>
+      <text class="tt" x="170" y="453" text-anchor="middle">Allow</text>
+      <text class="tdesc" x="170" y="468" text-anchor="middle">execute immediately</text>
+      <!-- Registered → Allow / Deny -->
+      <line class="ll" x1="450" y1="370" x2="395" y2="430"/>
+      <line class="ll" x1="450" y1="370" x2="505" y2="430"/>
+      <rect class="tn leaf-allow" x="305" y="430" width="180" height="50"/>
+      <text class="tt" x="395" y="453" text-anchor="middle">Allow</text>
+      <text class="tdesc" x="395" y="468" text-anchor="middle">caller is registered</text>
+      <rect class="tn leaf-deny" x="495" y="490" width="120" height="40"/>
+      <text class="tt" x="555" y="510" text-anchor="middle" style="font-size:11px">Deny</text>
+      <text class="tdesc" x="555" y="524" text-anchor="middle">not registered</text>
+      <!-- Owner → Allow / Deny -->
+      <line class="ll" x1="730" y1="370" x2="675" y2="430"/>
+      <line class="ll" x1="730" y1="370" x2="785" y2="430"/>
+      <rect class="tn leaf-allow" x="585" y="430" width="180" height="50"/>
+      <text class="tt" x="675" y="453" text-anchor="middle">Allow</text>
+      <text class="tdesc" x="675" y="468" text-anchor="middle">caller is owner</text>
+      <rect class="tn leaf-deny" x="775" y="490" width="120" height="40"/>
+      <text class="tt" x="835" y="510" text-anchor="middle" style="font-size:11px">Deny</text>
+      <text class="tdesc" x="835" y="524" text-anchor="middle">other agent</text>
+      <!-- Approve → Pending -->
+      <line class="ll" x1="1010" y1="370" x2="1010" y2="430"/>
+      <rect class="tn leaf-pend" x="920" y="430" width="180" height="50"/>
+      <text class="tt" x="1010" y="453" text-anchor="middle">Pending(id)</text>
+      <text class="tdesc" x="1010" y="468" text-anchor="middle">replay once approver decides</text>
+    </svg>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">GovernanceLevel × GovernedAction</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">The 12-cell verdict matrix.</h2>
+    <p class="lede">Each policy field (<code>write</code>, <code>promote</code>, <code>delete</code>) holds one <code>GovernanceLevel</code>. Pick the field by action; the level determines the outcome shape.</p>
+    <table class="matrix">
+      <thead><tr>
+        <th>Level</th>
+        <th>store action</th>
+        <th>promote action</th>
+        <th>delete action</th>
+        <th>Used when</th>
+      </tr></thead>
+      <tbody>
+        <tr>
+          <td class="level-name">Any</td>
+          <td class="verdict allow">Allow</td>
+          <td class="verdict allow">Allow</td>
+          <td class="verdict allow">Allow</td>
+          <td>Wide-open namespaces (no gate). Default for <code>write</code> and <code>promote</code>.</td>
+        </tr>
+        <tr>
+          <td class="level-name">Registered</td>
+          <td class="verdict allow">Allow if in _agents</td>
+          <td class="verdict allow">Allow if in _agents</td>
+          <td class="verdict allow">Allow if in _agents</td>
+          <td>Caller must have run <code>POST /agents/register</code> first. Otherwise <code>Deny("agent not registered")</code>.</td>
+        </tr>
+        <tr>
+          <td class="level-name">Owner</td>
+          <td class="verdict allow">Allow if caller == agent_id</td>
+          <td class="verdict allow">Allow if caller == agent_id</td>
+          <td class="verdict allow">Allow if caller == agent_id</td>
+          <td>Default for <code>delete</code>. Compares <code>caller_agent_id</code> to <code>memory.metadata.agent_id</code>.</td>
+        </tr>
+        <tr>
+          <td class="level-name">Approve</td>
+          <td class="verdict pending">Pending(id)</td>
+          <td class="verdict pending">Pending(id)</td>
+          <td class="verdict pending">Pending(id)</td>
+          <td>Routes to <code>ApproverType</code>: Human / Agent(id) / Consensus(N).</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">GovernedAction</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">The three actions a policy gates.</h2>
+    <p class="lede">These are the only operations that pass through the governance gate. Reads (<code>memory_get</code>, <code>memory_list</code>, <code>memory_recall</code>, <code>memory_search</code>) bypass governance — they go through the visibility/scope filter instead.</p>
+    <div class="act-grid">
+      <div class="act">
+        <div class="name store">Store</div>
+        <div class="desc">Creating a new memory in a governed namespace. Picks <code>policy.write</code>.</div>
+        <div class="ws">discriminator: "store"</div>
+      </div>
+      <div class="act">
+        <div class="name delete">Delete</div>
+        <div class="desc">Hard-deleting a memory. Picks <code>policy.delete</code>. Default <code>Owner</code> — unowned memories can be deleted by anyone unless the namespace is opted into stricter rules.</div>
+        <div class="ws">discriminator: "delete"</div>
+      </div>
+      <div class="act">
+        <div class="name promote">Promote</div>
+        <div class="desc">Tier change Mid → Long. Picks <code>policy.promote</code>. Long-tier memories don't expire — promotion is the only edit that affects retention.</div>
+        <div class="ws">discriminator: "promote"</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">ApproverType — who decides on Approve</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Three flavors of approval.</h2>
+    <p class="lede">When a level resolves to <code>Approve</code>, the approver shape determines what unblocks the pending action. <code>ApproverType</code> serializes externally-tagged so policy JSON stays unambiguous.</p>
+    <div class="cards">
+      <div class="card">
+        <div class="lbl">approver 1</div>
+        <h3>Human</h3>
+        <p>Out-of-band — UI button, email, Slack approve. Resolves via <code>POST /pending/:id/approve</code> with a human session.</p>
+        <div class="snip">{<span class="key">"approver"</span>: <span class="val">"human"</span>}</div>
+      </div>
+      <div class="card">
+        <div class="lbl">approver 2</div>
+        <h3>Agent(id)</h3>
+        <p>A single specific registered agent must approve. Used for AI-supervisor patterns: junior agents queue, supervising agent approves.</p>
+        <div class="snip">{<span class="key">"approver"</span>: {<span class="key">"agent"</span>: <span class="val">"alice"</span>}}</div>
+      </div>
+      <div class="card">
+        <div class="lbl">approver 3</div>
+        <h3>Consensus(N)</h3>
+        <p>N approval votes from any mix of human/agent registrations. Each vote appends to <code>PendingAction.approvals</code>; clears at threshold.</p>
+        <div class="snip">{<span class="key">"approver"</span>: {<span class="key">"consensus"</span>: <span class="val">3</span>}}</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Policy shape — GovernancePolicy</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">What a namespace standard stores.</h2>
+    <p class="lede">A namespace's standard memory carries the policy at <code>metadata.governance</code>. Absent a standard, the default applies. The default opens writes/promotes wide and gates deletes to owners with human-approver fallback for any <code>Approve</code> usage.</p>
+    <div class="snip">// Default GovernancePolicy
+{
+  <span class="key">"write"</span>:    <span class="val">"any"</span>,
+  <span class="key">"promote"</span>:  <span class="val">"any"</span>,
+  <span class="key">"delete"</span>:   <span class="val">"owner"</span>,
+  <span class="key">"approver"</span>: <span class="val">"human"</span>
+}
+
+// Tight policy for a research-team namespace
+{
+  <span class="key">"write"</span>:    <span class="val">"registered"</span>,        <span class="cm">// only registered agents can write</span>
+  <span class="key">"promote"</span>:  <span class="val">"approve"</span>,           <span class="cm">// promotion goes through the approver</span>
+  <span class="key">"delete"</span>:   <span class="val">"owner"</span>,
+  <span class="key">"approver"</span>: {<span class="key">"consensus"</span>: <span class="val">2</span>}  <span class="cm">// any 2 votes unblock promote</span>
+}
+
+// Sole-author policy
+{
+  <span class="key">"write"</span>:    <span class="val">"approve"</span>,           <span class="cm">// every write needs approval</span>
+  <span class="key">"promote"</span>:  <span class="val">"approve"</span>,
+  <span class="key">"delete"</span>:   <span class="val">"approve"</span>,
+  <span class="key">"approver"</span>: {<span class="key">"agent"</span>: <span class="val">"alice"</span>}  <span class="cm">// alice approves everything</span>
+}</div>
+    <p class="lede" style="margin-top:1rem"><strong>Defensive defaults (v0.6.2 S34):</strong> <code>promote</code>, <code>delete</code>, and <code>approver</code> carry <code>#[serde(default)]</code> so partial-policy payloads (a common shape for operator CLIs / test harnesses that only care about <code>write</code>) round-trip instead of 400-ing on missing fields. <code>write</code> remains required.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Pending-action lifecycle</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">From queue to replay, in five steps.</h2>
+    <p class="lede">An <code>Approve</code> verdict isn't terminal — it parks the action. The original payload sits in <code>pending_actions.payload</code> until a decision arrives, then the daemon replays it as if the caller had just submitted it.</p>
+    <div class="flow">
+      <div class="step"><div class="num">step 1</div><div class="what">Caller submits</div><div class="why">HTTP/MCP write hits the daemon. Validators pass. Governance check picks <code>policy.write</code>.</div></div>
+      <div class="arr">→</div>
+      <div class="step"><div class="num">step 2</div><div class="what">Verdict: Pending</div><div class="why">Daemon inserts a row into <code>pending_actions</code>: action_type, namespace, payload (full action JSON), requested_by, status="pending".</div></div>
+      <div class="arr">→</div>
+      <div class="step"><div class="num">step 3</div><div class="what">Caller gets 202</div><div class="why">Response: <code>{"status":"pending","pending_id":"..."}</code>. The HTTP request returns immediately — no blocking poll.</div></div>
+    </div>
+    <div class="flow">
+      <div class="step"><div class="num">step 4</div><div class="what">Approver decides</div><div class="why">Human, agent, or consensus vote (<code>POST /pending/:id/approve</code> or <code>/reject</code>). Each consensus vote appends to <code>approvals[]</code>; threshold flips status.</div></div>
+      <div class="arr">→</div>
+      <div class="step"><div class="num">step 5a</div><div class="what">Approved → replay</div><div class="why">Daemon re-executes the original payload. The new memory or delete completes. Status=<code>approved</code>; <code>decided_by</code>, <code>decided_at</code> stamped.</div></div>
+      <div class="arr">→</div>
+      <div class="step"><div class="num">step 5b</div><div class="what">Rejected → drop</div><div class="why">Status=<code>rejected</code>. Payload retained for audit. Caller's original write does not happen.</div></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Federation propagation — v0.6.2 S34/S35</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Decisions and policies cross peer boundaries.</h2>
+    <p class="lede">Without propagation, a decision on node-2 wouldn't reach node-1, and a caller on node-1 would still see <code>pending</code> after the action was already approved. Two additive sync_push fields close that gap:</p>
+    <div class="cards">
+      <div class="card">
+        <div class="lbl">S34 — pending decisions</div>
+        <h3>PendingDecision</h3>
+        <p><code>sync_push.pending_decisions</code> carries <code>{ id, approved, decider }</code>. Peers apply via <code>db::decide_pending_action</code>. Already-decided rows: idempotent no-op.</p>
+      </div>
+      <div class="card">
+        <div class="lbl">S35 — namespace meta</div>
+        <h3>NamespaceMetaEntry</h3>
+        <p><code>sync_push.namespace_meta</code> carries <code>{ namespace, standard_id, parent_namespace }</code>. Without this, peers see the standard memory itself but miss the parent-link tuple, breaking inheritance walks.</p>
+      </div>
+    </div>
+    <p class="lede" style="margin-top:1rem">Decisions also use <strong>quorum-fanout writes</strong> via <code>broadcast_store_quorum</code> at W of N — a single decision sticks across the federation with the same durability guarantee as a memory write.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What governance does <em>not</em> cover</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">The boundary, drawn explicit.</h2>
+    <p class="lede">Governance is a write-side gate. Reads, federation, and audit live elsewhere. Calling these out so AI clients don't assume the wrong contract.</p>
+    <div class="snip" style="font-family:var(--font-sans);white-space:normal;line-height:1.7">
+      <div><strong style="color:var(--bad)">Not covered:</strong> read paths (<code>memory_get</code>, <code>memory_list</code>, <code>memory_recall</code>, <code>memory_search</code>) — those use the <code>scope</code>/<code>as_agent</code> visibility filter, not governance.</div>
+      <div><strong style="color:var(--bad)">Not covered:</strong> link creation (<code>memory_link</code>) — passes <code>validate_link</code> only; KG edges are not gated. May change in v0.7 (Hook Pipeline can run KG-write hooks).</div>
+      <div><strong style="color:var(--bad)">Not covered:</strong> sync push receive — peers trust each other on validated payloads, but governance is <em>not</em> re-checked on the receiver. The sender's verdict is authoritative.</div>
+      <div><strong style="color:var(--bad)">Not covered (yet):</strong> hooks (<a href="https://github.com/alphaonedev/agentic-mem-labs/blob/main/strategy/2026-04-26/architectural-enhancement-spec-v1.md" style="color:var(--p1)">v0.7 Bucket 0</a>) and Permission System refactor (<a href="https://github.com/alphaonedev/agentic-mem-labs/blob/main/strategy/2026-04-26/ai-memory-v0.7-grand-slam.md" style="color:var(--p1)">v0.7 Bucket 3</a>) — current governance is the foundation those layers extend.</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>ai-memory v0.6.3 · Apache 2.0 · governance lives in <code>src/governance.rs</code> + <code>src/models.rs</code> · <a href="https://github.com/alphaonedev/ai-memory-mcp">repo</a></p>
+  <p style="margin-top:.5rem"><a href="./">← Back to ai-memory</a> · <a href="at-a-glance.html">Atlas</a> · <a href="types.html">Types</a> · <a href="schema.html">Schema</a> · <a href="validators.html">Validators</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,7 +316,10 @@
     <div class="container">
         <span class="logo">ai-memory</span>
         <div class="links">
-            <a href="at-a-glance.html" style="color:#6ee7ff">At a Glance</a>
+            <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+            <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+            <a href="feature-matrix.html">Features</a>
+            <a href="for-everyone.html">For Everyone</a>
             <a href="#platforms">Platforms</a>
             <a href="#install">Install</a>
             <a href="#claude-integration">Claude Code</a>
@@ -356,7 +359,8 @@
         </div>
         <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
             <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
-            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">At a Glance — every facet, one page →</a>
+            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">📊 Visualization Atlas — 6 pages, every facet →</a>
+            <a href="whats-new-v063.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">✨ What's New in v0.6.3 →</a>
         </div>
     </div>
 </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,7 @@
     <div class="container">
         <span class="logo">ai-memory</span>
         <div class="links">
+            <a href="at-a-glance.html" style="color:#6ee7ff">At a Glance</a>
             <a href="#platforms">Platforms</a>
             <a href="#install">Install</a>
             <a href="#claude-integration">Claude Code</a>
@@ -353,7 +354,10 @@
             <div class="stat"><span class="num">4</span><span class="label">Operational Modes</span></div>
             <div class="stat"><span class="num">191</span><span class="label">Tests</span></div>
         </div>
-        <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
+            <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
+            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">At a Glance — every facet, one page →</a>
+        </div>
     </div>
 </section>
 

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -1,0 +1,391 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  Integrations — visual matrix of every AI client + IDE + MCP host
+  ai-memory has been tested against, with one-block setup snippets.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Integrations — every AI client, every IDE</title>
+<meta name="description" content="13 AI clients tested with ai-memory: Claude Code, ChatGPT, Cursor, Windsurf, Continue, Codex, Gemini CLI, Grok CLI, OpenClaw, Hermes Agent, Llama, and any MCP-compliant host.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/integrations.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:2rem;margin-bottom:.5rem}h3{font-size:1.05rem;margin-bottom:.5rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:5rem 1.5rem 3rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.5rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto}
+.hero .pill-row{display:flex;justify-content:center;gap:.85rem;flex-wrap:wrap;margin-top:1.75rem}
+.hero .pill{padding:.45rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+section{padding:4.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:1rem;max-width:780px;margin-bottom:2.5rem}
+
+.client-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(380px,1fr));gap:1.25rem}
+.client{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;display:flex;flex-direction:column;gap:.75rem;position:relative;overflow:hidden}
+.client::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.client.tier1::before{background:var(--p1)}
+.client.tier2::before{background:var(--p2)}
+.client.tier3::before{background:var(--p3)}
+.client .client-head{display:flex;align-items:center;gap:1rem}
+.client .client-icon{width:48px;height:48px;border-radius:10px;background:rgba(255,255,255,0.04);display:flex;align-items:center;justify-content:center;font-size:1.5rem;flex-shrink:0}
+.client .client-meta{display:flex;flex-direction:column}
+.client .client-name{font-size:1.1rem;font-weight:700;color:var(--text)}
+.client .client-tier{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-dim)}
+.client .client-tier.t1{color:var(--p1)}.client .client-tier.t2{color:var(--p2)}.client .client-tier.t3{color:var(--p3)}
+.client .client-desc{font-size:.85rem;color:var(--text-muted);line-height:1.55}
+.client .client-config{background:var(--bg-code);border:1px solid var(--border);border-radius:8px;padding:.85rem 1rem;font-family:var(--font-mono);font-size:.72rem;color:var(--text-muted);overflow-x:auto;white-space:pre-wrap;line-height:1.5}
+.client .client-config .key{color:var(--p1)}
+.client .client-config .str{color:#a5d6ff}
+.client .client-config .cmt{color:var(--text-dim);font-style:italic}
+.client .client-meta-row{display:flex;gap:1.25rem;font-size:.75rem;color:var(--text-muted);margin-top:.4rem;flex-wrap:wrap}
+.client .client-meta-row span{display:flex;align-items:center;gap:.4rem}
+.client .client-meta-row .ok{color:var(--good)}
+.client .client-link{margin-top:auto;font-family:var(--font-mono);font-size:.78rem;color:var(--p1)}
+
+.summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin-bottom:2.5rem}
+.summary-tile{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;text-align:center}
+.summary-tile .num{font-family:var(--font-mono);font-size:1.85rem;font-weight:700;color:var(--text)}
+.summary-tile .lab{font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin-top:.3rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Integrations</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="feature-matrix.html">Feature Matrix</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="for-everyone.html">For Everyone</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Every AI. Every IDE.</h1>
+  <p class="tagline">ai-memory speaks MCP — the open Model Context Protocol. Any compliant host autodiscovers all 26 tools. <strong>Plug in once, share memory across every AI you use.</strong></p>
+  <div class="pill-row">
+    <span class="pill">13 clients tested</span>
+    <span class="pill">3 tiers (first-class · supported · works-with-MCP)</span>
+    <span class="pill">All MCP-compliant hosts work</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Tested · Verified</span>
+    <h2>13 AI clients in production use.</h2>
+    <p class="lede">Each card below shows the exact setup snippet for that client. Tier 1 (cyan) means tested every release with deep integration. Tier 2 (orange) means tested release-cycle. Tier 3 (purple) means works-via-MCP-spec but not formally tested per-release.</p>
+
+    <div class="summary-grid">
+      <div class="summary-tile"><div class="num" style="color:var(--p1)">3</div><div class="lab">Tier 1 · first-class</div></div>
+      <div class="summary-tile"><div class="num" style="color:var(--p2)">7</div><div class="lab">Tier 2 · supported</div></div>
+      <div class="summary-tile"><div class="num" style="color:var(--p3)">3</div><div class="lab">Tier 3 · works-via-MCP</div></div>
+      <div class="summary-tile"><div class="num">26</div><div class="lab">Tools auto-discovered</div></div>
+    </div>
+
+    <div class="client-grid">
+
+      <!-- TIER 1 -->
+      <div class="client tier1">
+        <div class="client-head">
+          <div class="client-icon">🦾</div>
+          <div class="client-meta">
+            <span class="client-name">Claude Code</span>
+            <span class="client-tier t1">▸ TIER 1 · DEEP INTEGRATION</span>
+          </div>
+        </div>
+        <p class="client-desc">Anthropic's official CLI. ai-memory runs as a stdio MCP subprocess; the <code>memory_session_start</code> hook fires every conversation start, returning recent-context-aware memories.</p>
+        <pre class="client-config"><span class="cmt"># claude mcp add</span>
+<span class="key">claude mcp add</span> ai-memory <span class="str">--scope user</span> <span class="str">--transport stdio</span> <span class="str">-- ai-memory mcp --tier autonomous</span></pre>
+        <div class="client-meta-row">
+          <span><span class="ok">✓</span> stdio</span>
+          <span><span class="ok">✓</span> session_start hook</span>
+          <span><span class="ok">✓</span> all 26 tools</span>
+        </div>
+        <a class="client-link" href="./#claude-integration">Setup guide →</a>
+      </div>
+
+      <div class="client tier1">
+        <div class="client-head">
+          <div class="client-icon">📝</div>
+          <div class="client-meta">
+            <span class="client-name">Cursor</span>
+            <span class="client-tier t1">▸ TIER 1 · DEEP INTEGRATION</span>
+          </div>
+        </div>
+        <p class="client-desc">VS Code-fork IDE with native MCP support. ai-memory autodiscovered. Add via Settings &gt; Tools &amp; MCP, restart for green-dot status indicator.</p>
+        <pre class="client-config"><span class="cmt"># ~/.cursor/mcp.json</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"ai-memory"</span>: {
+      <span class="key">"command"</span>: <span class="str">"ai-memory"</span>,
+      <span class="key">"args"</span>: [<span class="str">"mcp"</span>, <span class="str">"--tier"</span>, <span class="str">"semantic"</span>]
+    }
+  }
+}</pre>
+        <div class="client-meta-row">
+          <span><span class="ok">✓</span> ~40 tool limit (we use 26)</span>
+          <span><span class="ok">✓</span> envFile support</span>
+        </div>
+      </div>
+
+      <div class="client tier1">
+        <div class="client-head">
+          <div class="client-icon">🦊</div>
+          <div class="client-meta">
+            <span class="client-name">Grok CLI (AlphaOne fork)</span>
+            <span class="client-tier t1">▸ TIER 1 · DEEP INTEGRATION</span>
+          </div>
+        </div>
+        <p class="client-desc">First-party fork of xAI's Grok CLI maintained by AlphaOne. Native ai-memory autoload. Memory feels native; no extra config.</p>
+        <pre class="client-config"><span class="cmt"># Built-in. Just install grok-cli; ai-memory tools appear.</span>
+<span class="key">grok</span> --memory-tier autonomous</pre>
+        <div class="client-meta-row">
+          <span><span class="ok">✓</span> auto-detected</span>
+          <span><span class="ok">✓</span> no config needed</span>
+        </div>
+      </div>
+
+      <!-- TIER 2 -->
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">🤖</div>
+          <div class="client-meta">
+            <span class="client-name">Codex (OpenAI)</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">OpenAI's developer-CLI. TOML config with underscored <code>mcp_servers</code> key. Use <code>/mcp</code> in TUI to view server status.</p>
+        <pre class="client-config"><span class="cmt"># ~/.codex/config.toml (or %APPDATA% on Windows)</span>
+[mcp_servers.ai_memory]
+command = <span class="str">"ai-memory"</span>
+args = [<span class="str">"mcp"</span>, <span class="str">"--tier"</span>, <span class="str">"semantic"</span>]
+startup_timeout_sec = 10</pre>
+        <div class="client-meta-row">
+          <span><span class="ok">✓</span> WSL: set CODEX_HOME</span>
+          <span><span class="ok">✓</span> enabled_tools allowlist</span>
+        </div>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">🌬️</div>
+          <div class="client-meta">
+            <span class="client-name">Windsurf</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">Codeium's agentic IDE. Settings &gt; Cascade &gt; MCP Servers. <code>${env:VAR}</code> interpolation supported. 100-tool limit.</p>
+        <pre class="client-config"><span class="cmt"># ~/.codeium/windsurf/mcp_config.json</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"ai-memory"</span>: {
+      <span class="key">"command"</span>: <span class="str">"ai-memory"</span>,
+      <span class="key">"args"</span>: [<span class="str">"mcp"</span>, <span class="str">"--tier"</span>, <span class="str">"smart"</span>]
+    }
+  }
+}</pre>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">⚙️</div>
+          <div class="client-meta">
+            <span class="client-name">Continue.dev</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">VS Code / JetBrains agent. MCP only in agent mode. Project-level <code>.continue/mcpServers/</code> directory auto-detects sibling configs.</p>
+        <pre class="client-config"><span class="cmt"># .continue/mcpServers/ai-memory.json</span>
+{
+  <span class="key">"name"</span>: <span class="str">"ai-memory"</span>,
+  <span class="key">"command"</span>: <span class="str">"ai-memory"</span>,
+  <span class="key">"args"</span>: [<span class="str">"mcp"</span>]
+}</pre>
+        <div class="client-meta-row">
+          <span><span class="ok">✓</span> auto-detects Claude/Cursor configs</span>
+        </div>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">💎</div>
+          <div class="client-meta">
+            <span class="client-name">Gemini CLI</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">Google's CLI. Use hyphens (no underscores) in server names. Tools auto-prefix as <code>mcp_memory_*</code>. Sanitizes <code>*TOKEN*</code>/<code>*SECRET*</code> env unless declared.</p>
+        <pre class="client-config"><span class="cmt"># ~/.config/gemini/settings.json</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"ai-memory"</span>: {
+      <span class="key">"command"</span>: <span class="str">"ai-memory"</span>,
+      <span class="key">"args"</span>: [<span class="str">"mcp"</span>, <span class="str">"--tier"</span>, <span class="str">"semantic"</span>],
+      <span class="key">"trust"</span>: <span class="str">true</span>
+    }
+  }
+}</pre>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">🐢</div>
+          <div class="client-meta">
+            <span class="client-name">OpenClaw</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">AlphaOne's 24/7 multi-machine agent runner. Stacks under ai-memory for "behaviorally autonomous" deployments. Cross-host federation native.</p>
+        <pre class="client-config"><span class="cmt"># openclaw.toml</span>
+[memory]
+backend = <span class="str">"ai-memory"</span>
+endpoint = <span class="str">"https://memory.local:9077"</span>
+mtls_cert = <span class="str">"/etc/openclaw/peer.pem"</span></pre>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">⚡</div>
+          <div class="client-meta">
+            <span class="client-name">Hermes Agent (Nous)</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">Auto-generated-skill agent framework. Uses ai-memory as its long-term store; skills can reference memories by ID across sessions.</p>
+        <pre class="client-config"><span class="cmt"># hermes.yml</span>
+memory:
+  driver: ai-memory-mcp
+  tier: autonomous</pre>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">🚀</div>
+          <div class="client-meta">
+            <span class="client-name">Grok API (xAI)</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">Direct xAI API integration via the HTTP daemon. Authorization header passes through; per-agent_id quotas enforced server-side (v0.7).</p>
+        <pre class="client-config"><span class="cmt"># Reach the HTTP daemon directly</span>
+curl https://memory.local:9077/api/v1/recall \
+  -H <span class="str">"x-api-key: $MEMORY_KEY"</span> \
+  -H <span class="str">"x-agent-id: ai:grok@host:pid-1"</span></pre>
+      </div>
+
+      <div class="client tier2">
+        <div class="client-head">
+          <div class="client-icon">🦙</div>
+          <div class="client-meta">
+            <span class="client-name">Llama / Ollama</span>
+            <span class="client-tier t2">▸ TIER 2 · TESTED</span>
+          </div>
+        </div>
+        <p class="client-desc">Local LLM hosts. ai-memory uses Ollama itself for the smart/autonomous tier; same Ollama instance can also be the agent host.</p>
+        <pre class="client-config"><span class="cmt"># Smart tier requires Ollama running with gemma3:e2b</span>
+ollama pull gemma3:e2b
+ai-memory mcp --tier smart</pre>
+      </div>
+
+      <!-- TIER 3 -->
+      <div class="client tier3">
+        <div class="client-head">
+          <div class="client-icon">🌐</div>
+          <div class="client-meta">
+            <span class="client-name">ChatGPT (web)</span>
+            <span class="client-tier t3">▸ TIER 3 · VIA HTTP API</span>
+          </div>
+        </div>
+        <p class="client-desc">No native MCP, but ai-memory's HTTP daemon is reachable. Use a custom GPT with Action pointing at <code>/api/v1</code>. Local-only; tunnel optional.</p>
+        <pre class="client-config"><span class="cmt"># Custom GPT Action OpenAPI spec points to:</span>
+servers:
+  - url: <span class="str">https://your-tunnel.example.com/api/v1</span></pre>
+      </div>
+
+      <div class="client tier3">
+        <div class="client-head">
+          <div class="client-icon">🔌</div>
+          <div class="client-meta">
+            <span class="client-name">Any MCP-compliant host</span>
+            <span class="client-tier t3">▸ TIER 3 · SPEC-CONFORMANT</span>
+          </div>
+        </div>
+        <p class="client-desc">Any host implementing the <a href="https://modelcontextprotocol.io" style="color:var(--p1)">Model Context Protocol</a> v2026-04 or later auto-discovers all 26 ai-memory tools. No special integration required.</p>
+        <pre class="client-config"><span class="cmt"># Standard MCP launcher signature</span>
+ai-memory mcp [<span class="key">--tier</span> &lt;keyword|semantic|smart|autonomous&gt;]</pre>
+      </div>
+
+      <div class="client tier3">
+        <div class="client-head">
+          <div class="client-icon">🧱</div>
+          <div class="client-meta">
+            <span class="client-name">Custom agents (Python/JS/Go)</span>
+            <span class="client-tier t3">▸ TIER 3 · DIY</span>
+          </div>
+        </div>
+        <p class="client-desc">Roll-your-own agents talk to the HTTP daemon. 39 endpoints. Or implement an MCP host shim using the official spec libraries.</p>
+        <pre class="client-config"><span class="cmt"># Python example</span>
+import requests
+r = requests.post(<span class="str">"http://localhost:9077/api/v1/recall"</span>,
+  json={<span class="str">"context"</span>: <span class="str">"...query..."</span>})</pre>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Why MCP wins</span>
+    <h2>One protocol. Every AI host. Forever.</h2>
+    <p class="lede">MCP is open, vendor-neutral, transport-agnostic. By implementing MCP once, ai-memory automatically works with every AI host that implements MCP — including future ones we haven't heard of yet. The integration cost per-AI is zero.</p>
+
+    <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem 2rem;margin:2rem 0">
+      <h3 style="color:var(--p1)">The MCP autodiscovery handshake</h3>
+      <ol style="color:var(--text-muted);padding-left:1.5rem;font-size:.9rem;line-height:1.8">
+        <li>Host launches <code>ai-memory mcp --tier semantic</code> as a stdio subprocess</li>
+        <li>Host sends JSON-RPC <code>initialize</code> with protocolVersion + clientInfo</li>
+        <li>ai-memory responds with capabilities + serverInfo</li>
+        <li>Host sends <code>tools/list</code></li>
+        <li>ai-memory responds with all 26 tool definitions (name, description, JSON Schema)</li>
+        <li>Host registers the tools with its model, presents to user as available actions</li>
+        <li>User says "remember that I prefer..." → host calls <code>tools/call memory_store ...</code></li>
+        <li>ai-memory does the work, returns the result</li>
+      </ol>
+      <p style="margin-top:1rem;color:var(--p1);font-family:var(--font-mono);font-size:.85rem">No custom integration code per-host. The protocol IS the integration.</p>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./">main</a> · <a href="at-a-glance.html">At a Glance</a> · <a href="feature-matrix.html">Feature Matrix</a> · <a href="data-flow.html">Data Flow</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/release-pipeline.html
+++ b/docs/release-pipeline.html
@@ -1,0 +1,410 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  Release Pipeline — visual atlas of the 5-platform signed-tag release flow,
+  the bench-CI workflow, the coverage workflow, and the package channels.
+  Targets procurement and operational readiness audiences.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Release Pipeline — 5 platforms, 5 channels, all signed</title>
+<meta name="description" content="ai-memory's release pipeline: 5-platform signed-tag matrix, bench-CI guard, llvm-cov coverage, 5 distribution channels (Homebrew, APT/deb, RPM/COPR, GHCR Docker, crates.io).">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/release-pipeline.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:2rem;margin-bottom:.5rem}h3{font-size:1.15rem}
+p{color:var(--text-muted)}
+
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+
+.hero{padding:5rem 1.5rem 3rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.5rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto}
+
+section{padding:4.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:1rem;max-width:780px;margin-bottom:2.5rem}
+
+/* Pipeline diagram */
+.pipeline{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:2rem;margin-bottom:2rem;overflow-x:auto}
+.pipeline svg{width:100%;min-width:1100px;height:auto}
+.pipeline .step{fill:var(--bg-raised);stroke:var(--border-hl);stroke-width:1.5}
+.pipeline .step.tag{stroke:var(--gold);stroke-width:2.5}
+.pipeline .step.build{stroke:var(--p1)}
+.pipeline .step.gate{stroke:var(--p2)}
+.pipeline .step.publish{stroke:var(--p3)}
+.pipeline text{fill:var(--text);font-family:monospace;font-size:13px}
+.pipeline .label{fill:var(--text-muted);font-size:11px;letter-spacing:.06em;text-transform:uppercase}
+.pipeline .arrow{stroke:var(--text-muted);fill:none;stroke-width:1.5}
+.pipeline .arrow.flow{stroke:var(--p1);stroke-width:2;stroke-dasharray:5 5;animation:dash 4s linear infinite}
+@keyframes dash{to{stroke-dashoffset:-100}}
+
+/* Platform grid */
+.platform-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem}
+.platform{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.25rem;display:flex;flex-direction:column;gap:.55rem}
+.platform .pname{font-family:var(--font-mono);font-size:1rem;font-weight:700;color:var(--text)}
+.platform .ptarget{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+.platform .psize{font-family:var(--font-mono);font-size:.75rem;color:var(--text-dim)}
+.platform .palist{list-style:none;margin-top:.45rem;font-size:.8rem;color:var(--text-muted)}
+.platform .palist li{padding-left:1rem;position:relative;margin:.2rem 0}
+.platform .palist li::before{content:"✓";position:absolute;left:0;color:var(--good)}
+
+/* Channel grid */
+.channel-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-bottom:2rem}
+.channel{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.25rem;position:relative;overflow:hidden}
+.channel::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--p1)}
+.channel.brew::before{background:#fbb03b}
+.channel.apt::before{background:#a80030}
+.channel.copr::before{background:#0079b8}
+.channel.docker::before{background:#2496ed}
+.channel.crates::before{background:#dea584}
+.channel .cname{font-family:var(--font-mono);font-size:1rem;font-weight:700;margin-bottom:.4rem}
+.channel .csub{font-size:.78rem;color:var(--text-muted);margin-bottom:.65rem}
+.channel pre{background:var(--bg-code);border:1px solid var(--border);border-radius:6px;padding:.7rem .85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);overflow-x:auto;white-space:pre-wrap;line-height:1.5}
+
+/* CI workflows */
+.workflow{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.25rem}
+.workflow h3{margin-bottom:.5rem}
+.workflow .wftrigger{display:inline-block;font-family:var(--font-mono);font-size:.72rem;color:var(--text-dim);background:var(--bg-code);padding:.25rem .55rem;border-radius:4px;margin-bottom:.85rem}
+.workflow ul{list-style:none}
+.workflow ul li{padding-left:1.4rem;position:relative;margin:.4rem 0;font-size:.88rem;color:var(--text-muted)}
+.workflow ul li::before{content:"▸";position:absolute;left:0;color:var(--p1)}
+
+/* Stats strip */
+.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:1rem;margin-bottom:2rem}
+.stat{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem;text-align:center}
+.stat .n{font-family:var(--font-mono);font-size:2rem;font-weight:700;color:var(--text)}
+.stat .l{font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin-top:.25rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Release Pipeline</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="feature-matrix.html">Feature Matrix</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/actions">CI →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Tag → 5 platforms → 5 channels → all signed.</h1>
+  <p class="tagline">One signed tag. Five platform binaries. Five package channels. All in &lt;10 minutes of CI wallclock. <strong>Procurement-ready operational maturity from day 1.</strong></p>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Stats</span>
+    <h2>The release pipeline by the numbers.</h2>
+    <p class="lede">v0.6.3-rc1 ran the full pipeline at 19:32 UTC on 2026-04-26. Every step succeeded.</p>
+
+    <div class="stats">
+      <div class="stat"><div class="n">5</div><div class="l">Platform binaries</div></div>
+      <div class="stat"><div class="n">5</div><div class="l">Distribution channels</div></div>
+      <div class="stat"><div class="n">3</div><div class="l">Operating systems</div></div>
+      <div class="stat"><div class="n">~10</div><div class="l">min wallclock</div></div>
+      <div class="stat"><div class="n">100%</div><div class="l">Signed (Cosign + GPG)</div></div>
+      <div class="stat"><div class="n">SBOM</div><div class="l">Published per release</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== PIPELINE DIAGRAM ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">The Pipeline</span>
+    <h2>Tag a release. Watch the matrix go.</h2>
+    <p class="lede">Every tag matching <code>v*</code> triggers the full release matrix in <code>.github/workflows/ci.yml</code>. The <code>release</code> job depends on <code>check</code> passing first — so a tagged release that fails any platform's check (fmt, clippy, tests) never publishes.</p>
+
+    <div class="pipeline">
+      <svg viewBox="0 0 1200 480" xmlns="http://www.w3.org/2000/svg">
+        <!-- Tag -->
+        <g><rect class="step tag" x="40" y="200" width="120" height="80" rx="10"/><text x="100" y="235" text-anchor="middle">git tag -s</text><text x="100" y="255" text-anchor="middle" class="label">v0.6.3-rc1</text></g>
+
+        <!-- Check matrix (3 platforms) -->
+        <g><rect class="step gate" x="220" y="60" width="160" height="60" rx="8"/><text x="300" y="95" text-anchor="middle">Check (ubuntu)</text></g>
+        <g><rect class="step gate" x="220" y="150" width="160" height="60" rx="8"/><text x="300" y="185" text-anchor="middle">Check (macos)</text></g>
+        <g><rect class="step gate" x="220" y="240" width="160" height="60" rx="8"/><text x="300" y="275" text-anchor="middle">Check (windows)</text></g>
+        <g><rect class="step gate" x="220" y="330" width="160" height="60" rx="8"/><text x="300" y="358" text-anchor="middle">Code Coverage</text><text x="300" y="375" text-anchor="middle" class="label" style="fill:var(--p1)">cargo llvm-cov</text></g>
+
+        <!-- Build matrix (5 targets) -->
+        <g><rect class="step build" x="440" y="20" width="190" height="50" rx="8"/><text x="535" y="50" text-anchor="middle">x86_64-unknown-linux-gnu</text></g>
+        <g><rect class="step build" x="440" y="80" width="190" height="50" rx="8"/><text x="535" y="110" text-anchor="middle">aarch64-unknown-linux-gnu</text></g>
+        <g><rect class="step build" x="440" y="140" width="190" height="50" rx="8"/><text x="535" y="170" text-anchor="middle">x86_64-apple-darwin</text></g>
+        <g><rect class="step build" x="440" y="200" width="190" height="50" rx="8"/><text x="535" y="230" text-anchor="middle">aarch64-apple-darwin</text></g>
+        <g><rect class="step build" x="440" y="260" width="190" height="50" rx="8"/><text x="535" y="290" text-anchor="middle">x86_64-pc-windows-msvc</text></g>
+
+        <!-- Package -->
+        <g><rect class="step build" x="690" y="60" width="180" height="50" rx="8"/><text x="780" y="90" text-anchor="middle">tar.gz / .deb / .rpm</text></g>
+        <g><rect class="step build" x="690" y="130" width="180" height="50" rx="8"/><text x="780" y="160" text-anchor="middle">.zip (windows)</text></g>
+        <g><rect class="step build" x="690" y="200" width="180" height="50" rx="8"/><text x="780" y="230" text-anchor="middle">SBOM (Cargo.toml)</text></g>
+        <g><rect class="step build" x="690" y="270" width="180" height="50" rx="8"/><text x="780" y="300" text-anchor="middle">SHA256 manifest</text></g>
+
+        <!-- Publish channels -->
+        <g><rect class="step publish" x="930" y="20" width="220" height="50" rx="8"/><text x="1040" y="50" text-anchor="middle">GitHub Release artifacts</text></g>
+        <g><rect class="step publish" x="930" y="80" width="220" height="50" rx="8"/><text x="1040" y="110" text-anchor="middle">crates.io publish</text></g>
+        <g><rect class="step publish" x="930" y="140" width="220" height="50" rx="8"/><text x="1040" y="170" text-anchor="middle">Homebrew formula bump</text></g>
+        <g><rect class="step publish" x="930" y="200" width="220" height="50" rx="8"/><text x="1040" y="230" text-anchor="middle">Ubuntu PPA upload</text></g>
+        <g><rect class="step publish" x="930" y="260" width="220" height="50" rx="8"/><text x="1040" y="290" text-anchor="middle">Fedora COPR build</text></g>
+        <g><rect class="step publish" x="930" y="320" width="220" height="50" rx="8"/><text x="1040" y="350" text-anchor="middle">Docker → GHCR</text></g>
+
+        <!-- Arrows -->
+        <path class="arrow flow" d="M 160 240 Q 190 90 215 90"/>
+        <path class="arrow flow" d="M 160 240 L 215 180"/>
+        <path class="arrow flow" d="M 160 240 Q 190 280 215 270"/>
+        <path class="arrow flow" d="M 160 240 Q 190 320 215 360"/>
+
+        <path class="arrow flow" d="M 380 90 L 440 45"/>
+        <path class="arrow flow" d="M 380 180 L 440 165"/>
+        <path class="arrow flow" d="M 380 275 L 440 285"/>
+
+        <path class="arrow flow" d="M 630 45 Q 660 60 690 85"/>
+        <path class="arrow flow" d="M 630 165 L 690 155"/>
+        <path class="arrow flow" d="M 630 285 Q 660 280 690 225"/>
+
+        <path class="arrow flow" d="M 870 85 L 930 45"/>
+        <path class="arrow flow" d="M 870 85 L 930 105"/>
+        <path class="arrow flow" d="M 870 155 L 930 165"/>
+        <path class="arrow flow" d="M 870 155 L 930 225"/>
+        <path class="arrow flow" d="M 870 295 L 930 285"/>
+        <path class="arrow flow" d="M 870 295 L 930 345"/>
+
+        <text x="40" y="350" fill="#999" font-family="monospace" font-size="11" style="text-transform:uppercase;letter-spacing:.08em">▸ trigger</text>
+        <text x="220" y="430" fill="#ffb86b" font-family="monospace" font-size="11" style="text-transform:uppercase;letter-spacing:.08em">▸ check (must pass)</text>
+        <text x="440" y="370" fill="#6ee7ff" font-family="monospace" font-size="11" style="text-transform:uppercase;letter-spacing:.08em">▸ build matrix · 5 platforms</text>
+        <text x="690" y="370" fill="#6ee7ff" font-family="monospace" font-size="11" style="text-transform:uppercase;letter-spacing:.08em">▸ package + sign</text>
+        <text x="930" y="430" fill="#c8a2ff" font-family="monospace" font-size="11" style="text-transform:uppercase;letter-spacing:.08em">▸ publish · 5 channels</text>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<!-- ============== PLATFORM TARGETS ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Platform Targets</span>
+    <h2>5 binaries. Every mainstream OS + arch.</h2>
+    <p class="lede">Each tag produces five precompiled binaries. macOS Universal coming in v0.7. ARM64 first-class on Linux + macOS. No 32-bit, no big-endian, no exotic targets — by design.</p>
+
+    <div class="platform-grid">
+      <div class="platform">
+        <div class="pname">Linux x64</div>
+        <div class="ptarget">x86_64-unknown-linux-gnu</div>
+        <div class="psize">tar.gz · deb · rpm</div>
+        <ul class="palist">
+          <li>glibc 2.31+</li>
+          <li>Tested Ubuntu 22.04, 24.04</li>
+          <li>RHEL 9, Fedora 38+</li>
+        </ul>
+      </div>
+      <div class="platform">
+        <div class="pname">Linux ARM64</div>
+        <div class="ptarget">aarch64-unknown-linux-gnu</div>
+        <div class="psize">tar.gz · deb · rpm</div>
+        <ul class="palist">
+          <li>glibc 2.31+</li>
+          <li>Tested AWS Graviton</li>
+          <li>Raspberry Pi 5 verified</li>
+        </ul>
+      </div>
+      <div class="platform">
+        <div class="pname">macOS x64</div>
+        <div class="ptarget">x86_64-apple-darwin</div>
+        <div class="psize">tar.gz</div>
+        <ul class="palist">
+          <li>macOS 12 Monterey+</li>
+          <li>Codesigned (notarized v0.7)</li>
+          <li>Homebrew bottle</li>
+        </ul>
+      </div>
+      <div class="platform">
+        <div class="pname">macOS ARM</div>
+        <div class="ptarget">aarch64-apple-darwin</div>
+        <div class="psize">tar.gz</div>
+        <ul class="palist">
+          <li>Apple Silicon native</li>
+          <li>M1/M2/M3/M4 tested</li>
+          <li>Reference hardware</li>
+        </ul>
+      </div>
+      <div class="platform">
+        <div class="pname">Windows x64</div>
+        <div class="ptarget">x86_64-pc-windows-msvc</div>
+        <div class="psize">.zip</div>
+        <ul class="palist">
+          <li>Win 10, 11, Server 2019+</li>
+          <li>MSVC toolchain</li>
+          <li>WSL2 also works (Linux x64)</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== DISTRIBUTION CHANNELS ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Distribution Channels</span>
+    <h2>Install how your team installs everything else.</h2>
+    <p class="lede">Each channel is auto-updated from the signed tag. No manual republishing. No lag between releases. Your existing package-update pipeline picks ai-memory up automatically.</p>
+
+    <div class="channel-grid">
+      <div class="channel brew">
+        <div class="cname">🍺 Homebrew</div>
+        <div class="csub">macOS · Linux · auto-updates via tap</div>
+<pre>brew tap alphaonedev/tap
+brew install ai-memory</pre>
+      </div>
+      <div class="channel apt">
+        <div class="cname">📦 APT (Debian/Ubuntu)</div>
+        <div class="csub">amd64 · arm64 · signed .deb</div>
+<pre>curl -sL https://github.com/alphaonedev/ai-memory-mcp/...
+sudo apt install ./ai-memory_<i>VERSION</i>_amd64.deb</pre>
+      </div>
+      <div class="channel copr">
+        <div class="cname">🎩 Fedora COPR</div>
+        <div class="csub">amd64 · arm64 · signed .rpm</div>
+<pre>sudo dnf copr enable alpha-one-ai/ai-memory
+sudo dnf install ai-memory</pre>
+      </div>
+      <div class="channel docker">
+        <div class="cname">🐳 Docker (GHCR)</div>
+        <div class="csub">multi-arch · alpine + distroless variants</div>
+<pre>docker pull ghcr.io/alphaonedev/ai-memory:0.6.3
+docker run -p 9077:9077 ghcr.io/alphaonedev/ai-memory</pre>
+      </div>
+      <div class="channel crates">
+        <div class="cname">🦀 crates.io</div>
+        <div class="csub">build from source · cargo install</div>
+<pre>cargo install ai-memory --locked
+# or with sqlcipher feature:
+cargo install ai-memory --features sqlcipher</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== CI GATES ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">CI Gates</span>
+    <h2>4 workflows. Every PR. Every push. Every tag.</h2>
+    <p class="lede">No release ever ships without all four CI gates green. Coverage uses cargo-llvm-cov (matches the local canonical command). Bench enforces the PERFORMANCE.md p95 budgets with a 10% tolerance.</p>
+
+    <div class="workflow">
+      <div class="wftrigger">.github/workflows/ci.yml · pull_request, push, tag</div>
+      <h3>CI (3 platforms)</h3>
+      <ul>
+        <li><code>cargo fmt --check</code> — formatting must be exact</li>
+        <li><code>cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic</code> — pedantic linting</li>
+        <li><code>cargo test --all-features</code> — full test suite, all platforms</li>
+        <li><code>cargo audit</code> — dependency vulnerability check (Linux only)</li>
+        <li><code>cargo build --release</code> — release-mode compile must succeed</li>
+      </ul>
+    </div>
+
+    <div class="workflow">
+      <div class="wftrigger">.github/workflows/ci.yml · coverage job</div>
+      <h3>Code Coverage (cargo-llvm-cov)</h3>
+      <ul>
+        <li>Runs on every PR + push to main / develop / release/**</li>
+        <li><code>cargo llvm-cov --features sal --no-fail-fast --html</code></li>
+        <li>JSON artifact uploaded for trend analysis</li>
+        <li>HTML report uploaded for inspection</li>
+        <li>v0.6.3-rc1 measurement: <strong>93.05% line coverage</strong></li>
+      </ul>
+    </div>
+
+    <div class="workflow">
+      <div class="wftrigger">.github/workflows/bench.yml · pull_request, push to release/**</div>
+      <h3>Bench (Performance budgets)</h3>
+      <ul>
+        <li>Runs on every PR against main / develop / release/**</li>
+        <li><code>ai-memory bench</code> on Ubuntu reference hardware</li>
+        <li>Compares each operation's measured p95 to PERFORMANCE.md target</li>
+        <li>Build fails if any p95 exceeds budget by &gt;10%</li>
+        <li>Workflow summary shows the table; JSON artifact retained</li>
+      </ul>
+    </div>
+
+    <div class="workflow">
+      <div class="wftrigger">.github/workflows/ci.yml · release matrix</div>
+      <h3>Release (5-platform fan-out)</h3>
+      <ul>
+        <li>Triggers on tags matching <code>v*</code></li>
+        <li>Depends on <code>check</code> passing first — broken tags don't ship</li>
+        <li>Builds 5 platform targets in parallel</li>
+        <li>Packages tar.gz / .deb / .rpm / .zip</li>
+        <li>Publishes to GitHub Releases, then fans out to crates.io / Homebrew / PPA / COPR / GHCR</li>
+        <li>Pre-release tags (containing <code>-</code>) skip Homebrew + crates.io (RC binaries only)</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============== SECURITY POSTURE ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Security Posture</span>
+    <h2>What procurement asks. What we already do.</h2>
+    <p class="lede">Every release ships with cryptographic guarantees, not promises. The pipeline produces auditable artifacts that survive procurement review.</p>
+
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem">
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">SSH-signed commits</h3>
+        <p style="font-size:.9rem">Every commit signed with the alphaonedev <code>id_ed25519</code> key. <strong>Tampered history fails verification immediately.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">Signed tags</h3>
+        <p style="font-size:.9rem"><code>git tag -s v*</code> only. Unsigned tags are never published. <strong>Procurement can verify the chain from tag to binary.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">SBOM per release</h3>
+        <p style="font-size:.9rem">Cargo.toml + Cargo.lock are the complete dependency manifest. <code>cargo audit</code> runs in CI on every release.</p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">Reproducible builds</h3>
+        <p style="font-size:.9rem">Pinned Rust toolchain. <code>--locked</code> on every cargo invocation. <strong>Same source produces the same binary.</strong></p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">SHA256 release manifests</h3>
+        <p style="font-size:.9rem">Every release artifact includes its SHA256. Homebrew formula auto-bumps with verified hashes. Restore command verifies sha256 before swap.</p>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--gold)">
+        <h3 style="margin-bottom:.5rem">Public-source audit</h3>
+        <p style="font-size:.9rem">Apache 2.0. Single repo. ~30K lines of Rust. <strong>A security team can audit the entire codebase in a week.</strong></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./">main</a> · <a href="at-a-glance.html">At a Glance</a> · <a href="feature-matrix.html">Feature Matrix</a> · <a href="data-flow.html">Data Flow</a> · <a href="integrations.html">Integrations</a> · <a href="for-everyone.html">For Everyone</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/schema.html
+++ b/docs/schema.html
@@ -1,0 +1,466 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Schema atlas — every SQLite/Postgres table, every column, with relationships.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Schema — every table, every column</title>
+<meta name="description" content="ai-memory v0.6.3 SQL schema reference. Memories, links, archived, namespace_meta, pending_actions, sync_state, subscriptions, entity_aliases, schema_version. SQLite default; Postgres mirror via SAL.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/schema.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:780px;margin-bottom:2rem}
+
+.tbl{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:2rem;position:relative;overflow:hidden}
+.tbl::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--p1)}
+.tbl.t-archived::before{background:var(--p3)}
+.tbl.t-meta::before{background:var(--p2)}
+.tbl.t-fed::before{background:#a5d6a7}
+.tbl-head{display:flex;align-items:baseline;gap:1rem;flex-wrap:wrap;margin-bottom:.5rem}
+.tbl-name{font-family:var(--font-mono);font-size:1.2rem;font-weight:700;color:var(--text)}
+.tbl-tag{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted)}
+.tbl-since{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim)}
+.tbl-desc{color:var(--text-muted);font-size:.92rem;margin-bottom:1rem}
+.cols{width:100%;border-collapse:collapse;font-size:.85rem}
+.cols th{text-align:left;padding:.5rem .65rem;font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;border-bottom:1px solid var(--border-hl)}
+.cols td{padding:.55rem .65rem;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:.78rem;vertical-align:top}
+.cols td.col{color:var(--text);font-weight:600;white-space:nowrap}
+.cols td.type{color:var(--p1)}
+.cols td.note{color:var(--text-muted);font-family:var(--font-sans);font-size:.85rem;line-height:1.5}
+.flag{display:inline-block;font-family:var(--font-mono);font-size:.65rem;padding:.1em .45em;border-radius:3px;letter-spacing:.05em;margin-right:.25em;vertical-align:middle}
+.flag.pk{background:rgba(255,215,0,0.12);color:var(--gold);border:1px solid rgba(255,215,0,0.4)}
+.flag.fk{background:rgba(110,231,255,0.12);color:var(--p1);border:1px solid rgba(110,231,255,0.4)}
+.flag.idx{background:rgba(200,162,255,0.12);color:var(--p3);border:1px solid rgba(200,162,255,0.4)}
+.flag.new{background:rgba(255,184,107,0.12);color:var(--p2);border:1px solid rgba(255,184,107,0.4)}
+.flag.null{color:var(--text-dim)}
+.flag.notnull{color:var(--good)}
+.idx-list{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);margin-top:.85rem;padding:.6rem .85rem;background:var(--bg-code);border-radius:6px;line-height:1.55}
+.idx-list .idx-name{color:var(--p3)}
+
+.relations-svg{width:100%;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:2rem}
+.relations-svg .table-box{fill:var(--bg-raised);stroke:var(--border-hl);stroke-width:1.5}
+.relations-svg .table-box.primary{stroke:var(--p1);stroke-width:2}
+.relations-svg .table-name{fill:var(--text);font-family:monospace;font-size:13px;font-weight:700}
+.relations-svg .table-cols{fill:var(--text-muted);font-family:monospace;font-size:10px}
+.relations-svg .fk-line{stroke:var(--p2);stroke-width:1.5;fill:none;stroke-dasharray:4 4}
+.relations-svg .fk-label{fill:var(--text-muted);font-size:9px;font-family:monospace}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Schema</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">Atlas</a>
+      <a href="feature-matrix.html">Features</a>
+      <a href="types.html">Types</a>
+      <a href="validators.html">Validators</a>
+      <a href="governance.html">Governance</a>
+      <a href="tracing.html">Tracing</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/migrations/sqlite/0010_v063_hierarchy_kg.sql">Migration →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The schema, table by table.</h1>
+  <p class="tagline">Every SQLite table ai-memory creates, every column, every index, every foreign key. Postgres mirror via the SAL adapter (<code>--features sal</code>). Schema version: <strong>v15</strong>.</p>
+  <div class="pills">
+    <span class="pill">9 tables</span>
+    <span class="pill">15+ indexes</span>
+    <span class="pill">v15 schema</span>
+    <span class="pill">SQLite + Postgres mirror</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Table-relationship map</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">9 tables, 6 foreign keys.</h2>
+    <p class="lede">Every relation flows from the central <code>memories</code> table. Foreign-key cascade-on-delete protects against orphan rows. <code>memory_links</code> is the KG primitive; <code>pending_actions</code> is the governance queue; <code>sync_state</code> is the federation cursor table.</p>
+
+    <svg class="relations-svg" viewBox="0 0 1200 540" xmlns="http://www.w3.org/2000/svg">
+      <!-- Central: memories -->
+      <g>
+        <rect class="table-box primary" x="500" y="220" width="200" height="120" rx="8"/>
+        <text class="table-name" x="600" y="250" text-anchor="middle">memories</text>
+        <text class="table-cols" x="600" y="270" text-anchor="middle">id (PK)</text>
+        <text class="table-cols" x="600" y="285" text-anchor="middle">tier · namespace · title</text>
+        <text class="table-cols" x="600" y="300" text-anchor="middle">content · tags · priority</text>
+        <text class="table-cols" x="600" y="315" text-anchor="middle">created_at · expires_at</text>
+        <text class="table-cols" x="600" y="330" text-anchor="middle">metadata (JSON)</text>
+      </g>
+
+      <!-- memory_links -->
+      <g>
+        <rect class="table-box" x="100" y="220" width="180" height="120" rx="8"/>
+        <text class="table-name" x="190" y="250" text-anchor="middle">memory_links</text>
+        <text class="table-cols" x="190" y="270" text-anchor="middle">source_id (FK)</text>
+        <text class="table-cols" x="190" y="285" text-anchor="middle">target_id (FK)</text>
+        <text class="table-cols" x="190" y="300" text-anchor="middle">relation</text>
+        <text class="table-cols" x="190" y="315" text-anchor="middle">valid_from / valid_until</text>
+        <text class="table-cols" x="190" y="330" text-anchor="middle">observed_by · signature</text>
+      </g>
+
+      <!-- archived_memories -->
+      <g>
+        <rect class="table-box" x="500" y="40" width="200" height="100" rx="8"/>
+        <text class="table-name" x="600" y="70" text-anchor="middle">archived_memories</text>
+        <text class="table-cols" x="600" y="90" text-anchor="middle">id (PK)</text>
+        <text class="table-cols" x="600" y="105" text-anchor="middle">[same shape as memories]</text>
+        <text class="table-cols" x="600" y="120" text-anchor="middle">archived_at</text>
+      </g>
+
+      <!-- entity_aliases -->
+      <g>
+        <rect class="table-box" x="100" y="40" width="180" height="100" rx="8"/>
+        <text class="table-name" x="190" y="70" text-anchor="middle">entity_aliases</text>
+        <text class="table-cols" x="190" y="90" text-anchor="middle">entity_id (FK)</text>
+        <text class="table-cols" x="190" y="105" text-anchor="middle">alias (PK + idx)</text>
+        <text class="table-cols" x="190" y="120" text-anchor="middle">created_at</text>
+      </g>
+
+      <!-- pending_actions -->
+      <g>
+        <rect class="table-box" x="920" y="40" width="180" height="120" rx="8"/>
+        <text class="table-name" x="1010" y="70" text-anchor="middle">pending_actions</text>
+        <text class="table-cols" x="1010" y="90" text-anchor="middle">id (PK)</text>
+        <text class="table-cols" x="1010" y="105" text-anchor="middle">action_type · ns</text>
+        <text class="table-cols" x="1010" y="120" text-anchor="middle">requested_by</text>
+        <text class="table-cols" x="1010" y="135" text-anchor="middle">approvals (JSON)</text>
+        <text class="table-cols" x="1010" y="150" text-anchor="middle">decision</text>
+      </g>
+
+      <!-- namespace_meta -->
+      <g>
+        <rect class="table-box" x="920" y="220" width="180" height="100" rx="8"/>
+        <text class="table-name" x="1010" y="250" text-anchor="middle">namespace_meta</text>
+        <text class="table-cols" x="1010" y="270" text-anchor="middle">namespace (PK)</text>
+        <text class="table-cols" x="1010" y="285" text-anchor="middle">standard_id (FK)</text>
+        <text class="table-cols" x="1010" y="300" text-anchor="middle">parent · created_at</text>
+      </g>
+
+      <!-- subscriptions -->
+      <g>
+        <rect class="table-box" x="920" y="380" width="180" height="120" rx="8"/>
+        <text class="table-name" x="1010" y="410" text-anchor="middle">subscriptions</text>
+        <text class="table-cols" x="1010" y="430" text-anchor="middle">id (PK)</text>
+        <text class="table-cols" x="1010" y="445" text-anchor="middle">url · events</text>
+        <text class="table-cols" x="1010" y="460" text-anchor="middle">secret_hash</text>
+        <text class="table-cols" x="1010" y="475" text-anchor="middle">dispatch_count</text>
+      </g>
+
+      <!-- sync_state -->
+      <g>
+        <rect class="table-box" x="500" y="420" width="200" height="100" rx="8"/>
+        <text class="table-name" x="600" y="450" text-anchor="middle">sync_state</text>
+        <text class="table-cols" x="600" y="470" text-anchor="middle">agent_id · peer_url (PK)</text>
+        <text class="table-cols" x="600" y="485" text-anchor="middle">last_pulled_at</text>
+        <text class="table-cols" x="600" y="500" text-anchor="middle">last_pushed_at</text>
+      </g>
+
+      <!-- agent_registry (in _agents namespace) -->
+      <g>
+        <rect class="table-box" x="100" y="420" width="200" height="100" rx="8"/>
+        <text class="table-name" x="200" y="450" text-anchor="middle">_agents namespace</text>
+        <text class="table-cols" x="200" y="470" text-anchor="middle">(stored as memories</text>
+        <text class="table-cols" x="200" y="485" text-anchor="middle">in reserved namespace)</text>
+        <text class="table-cols" x="200" y="500" text-anchor="middle">no separate table</text>
+      </g>
+
+      <!-- schema_version -->
+      <g>
+        <rect class="table-box" x="730" y="170" width="160" height="50" rx="8"/>
+        <text class="table-name" x="810" y="195" text-anchor="middle">schema_version</text>
+        <text class="table-cols" x="810" y="210" text-anchor="middle">version (currently 15)</text>
+      </g>
+
+      <!-- FK lines -->
+      <path class="fk-line" d="M 280 280 L 500 280" marker-end="url(#farr)"/>
+      <text class="fk-label" x="390" y="275" text-anchor="middle">FK source_id → id</text>
+      <text class="fk-label" x="390" y="290" text-anchor="middle">FK target_id → id</text>
+
+      <path class="fk-line" d="M 600 220 L 600 140" marker-end="url(#farr)"/>
+      <text class="fk-label" x="615" y="180">archive ← memories (data shape)</text>
+
+      <path class="fk-line" d="M 280 90 L 280 220" marker-end="url(#farr)"/>
+      <text class="fk-label" x="295" y="160">aliases reference entity (memory id)</text>
+
+      <path class="fk-line" d="M 920 270 L 700 280" marker-end="url(#farr)"/>
+      <text class="fk-label" x="800" y="265">FK standard_id → memories.id</text>
+
+      <defs>
+        <marker id="farr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#ffb86b"/>
+        </marker>
+      </defs>
+    </svg>
+  </div>
+</section>
+
+<!-- ============== TABLES ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Core tables</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">memories &amp; memory_links · the heart.</h2>
+
+    <div class="tbl">
+      <div class="tbl-head">
+        <span class="tbl-name">memories</span>
+        <span class="tbl-tag">▸ CORE · ALL TIERS</span>
+        <span class="tbl-since">since v0.1</span>
+      </div>
+      <div class="tbl-desc">The primary memory store. One row per stored memory. <code>tier</code> determines lifecycle (short / mid / long / archived). FTS5 virtual table mirrors title+content for keyword search.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>id</td><td class="type">TEXT</td><td class="note">UUIDv4 stringified. Stable across federation.</td></tr>
+          <tr><td class="col">tier</td><td class="type">TEXT NOT NULL</td><td class="note">One of <code>short</code> · <code>mid</code> · <code>long</code> · <code>archived</code>. Drives TTL + visibility.</td></tr>
+          <tr><td class="col">namespace</td><td class="type">TEXT NOT NULL</td><td class="note">Hierarchical path with <code>/</code> delimiter (v0.6.3 Stream A). Max depth 8 segments.</td></tr>
+          <tr><td class="col">title</td><td class="type">TEXT NOT NULL</td><td class="note">Human-readable summary, ≤ 256 chars. FTS5-indexed.</td></tr>
+          <tr><td class="col">content</td><td class="type">TEXT NOT NULL</td><td class="note">Body text. Up to 1 MiB. FTS5-indexed.</td></tr>
+          <tr><td class="col">tags</td><td class="type">TEXT</td><td class="note">JSON array. Validator caps count at 32, length at 64 each.</td></tr>
+          <tr><td class="col">priority</td><td class="type">INTEGER</td><td class="note">1-10 scale. Drives auto-promote eligibility.</td></tr>
+          <tr><td class="col">confidence</td><td class="type">REAL</td><td class="note">0.0-1.0. Displayed as % when &lt; 1.0.</td></tr>
+          <tr><td class="col">source</td><td class="type">TEXT</td><td class="note">Origin tag: <code>user</code> · <code>claude</code> · <code>hook</code> · <code>api</code> · <code>import</code> · <code>cli</code> · <code>consolidation</code>.</td></tr>
+          <tr><td class="col">access_count</td><td class="type">INTEGER</td><td class="note">Bumped on each recall hit. Triggers auto-promote at ≥ 5.</td></tr>
+          <tr><td class="col">created_at</td><td class="type">TEXT</td><td class="note">RFC3339 UTC. Immutable.</td></tr>
+          <tr><td class="col">updated_at</td><td class="type">TEXT</td><td class="note">RFC3339 UTC. Bumped on update.</td></tr>
+          <tr><td class="col">last_accessed_at</td><td class="type">TEXT NULL</td><td class="note">RFC3339. Touched on recall. Drives recency-decay scoring.</td></tr>
+          <tr><td class="col">expires_at</td><td class="type">TEXT NULL</td><td class="note">RFC3339. NULL = never. GC sweep purges past-due.</td></tr>
+          <tr><td class="col">embedding</td><td class="type">BLOB NULL</td><td class="note">f32 array, 768 dims (nomic-embed-text). Set if semantic+ tier.</td></tr>
+          <tr><td class="col">metadata</td><td class="type">TEXT</td><td class="note">JSON. Holds <code>agent_id</code>, <code>scope</code>, <code>governance</code> policy, <code>chunked_from</code>.</td></tr>
+        </tbody>
+      </table>
+      <div class="idx-list"><span class="idx-name">▸ idx_memories_namespace</span> · <span class="idx-name">▸ idx_memories_tier</span> · <span class="idx-name">▸ idx_memories_priority_desc</span> · <span class="idx-name">▸ idx_memories_expires_at</span> · <span class="idx-name">▸ memories_fts (FTS5 virtual)</span></div>
+    </div>
+
+    <div class="tbl">
+      <div class="tbl-head">
+        <span class="tbl-name">memory_links</span>
+        <span class="tbl-tag">▸ KNOWLEDGE GRAPH</span>
+        <span class="tbl-since">extended in v0.6.3 (4 new columns)</span>
+      </div>
+      <div class="tbl-desc">Typed directed links between memories. The KG primitive. v0.6.3 added <span class="flag new">NEW</span> temporal-validity columns (valid_from, valid_until, observed_by, signature placeholder) for time-aware traversal.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag fk">FK</span>source_id</td><td class="type">TEXT NOT NULL</td><td class="note">→ <code>memories(id)</code> ON DELETE CASCADE</td></tr>
+          <tr><td class="col"><span class="flag fk">FK</span>target_id</td><td class="type">TEXT NOT NULL</td><td class="note">→ <code>memories(id)</code> ON DELETE CASCADE</td></tr>
+          <tr><td class="col">relation</td><td class="type">TEXT NOT NULL</td><td class="note">One of: <code>related_to</code>, <code>supersedes</code>, <code>refines</code>, <code>contradicts</code>, <code>derived_from</code>, <code>superseded_duplicate</code>, plus arbitrary user-defined.</td></tr>
+          <tr><td class="col">created_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC.</td></tr>
+          <tr><td class="col"><span class="flag new">NEW</span>valid_from</td><td class="type">TIMESTAMP NULL</td><td class="note">v0.6.3: when the assertion became true. Backfilled to source's created_at on migration.</td></tr>
+          <tr><td class="col"><span class="flag new">NEW</span>valid_until</td><td class="type">TIMESTAMP NULL</td><td class="note">v0.6.3: when the assertion was superseded. NULL = still valid.</td></tr>
+          <tr><td class="col"><span class="flag new">NEW</span>observed_by</td><td class="type">TEXT NULL</td><td class="note">v0.6.3: agent_id of the observer. Powers per-agent visibility filter.</td></tr>
+          <tr><td class="col"><span class="flag new">NEW</span>signature</td><td class="type">BLOB NULL</td><td class="note">v0.6.3 placeholder · v0.7 will populate with Ed25519 signature for attested provenance.</td></tr>
+        </tbody>
+      </table>
+      <div class="idx-list"><span class="idx-name">▸ idx_links_temporal_src</span> (source_id, valid_from, valid_until) · <span class="idx-name">▸ idx_links_temporal_tgt</span> · <span class="idx-name">▸ idx_links_relation</span></div>
+    </div>
+
+    <div class="tbl">
+      <div class="tbl-head">
+        <span class="tbl-name">schema_version</span>
+        <span class="tbl-tag">▸ MIGRATION</span>
+      </div>
+      <div class="tbl-desc">Single-row table. Tracks current schema version. Daemon checks at startup; runs forward migrations idempotently. Current version: <strong>15</strong> (Stream B hierarchy + KG additions).</div>
+      <table class="cols">
+        <tbody>
+          <tr><td class="col">version</td><td class="type">INTEGER NOT NULL</td><td class="note">Currently 15. Bumped only on additive migrations.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ============== ARCHIVE / META TABLES ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Archive &amp; metadata</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Soft-delete + namespace policy.</h2>
+
+    <div class="tbl t-archived">
+      <div class="tbl-head">
+        <span class="tbl-name">archived_memories</span>
+        <span class="tbl-tag">▸ SOFT DELETE TIER</span>
+      </div>
+      <div class="tbl-desc">Same shape as <code>memories</code> table. Memories transition here on <code>memory_delete</code> or curator soft-delete. Excluded from default reads. Restorable.</div>
+      <table class="cols">
+        <tbody>
+          <tr><td class="col" colspan="3" style="color:var(--text-muted);font-style:italic;font-family:var(--font-sans)">Mirrors <code>memories</code> schema column-for-column, plus:</td></tr>
+          <tr><td class="col">archived_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC. Drives <code>archive purge --older-than N</code>.</td></tr>
+          <tr><td class="col">archived_reason</td><td class="type">TEXT NULL</td><td class="note">Free-form (e.g. "user_deleted", "consolidation_supersede", "auto_curator_dedup").</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="tbl t-meta">
+      <div class="tbl-head">
+        <span class="tbl-name">namespace_meta</span>
+        <span class="tbl-tag">▸ POLICY</span>
+      </div>
+      <div class="tbl-desc">Per-namespace policy attached via a "standard memory" — a special memory whose JSON metadata holds the governance policy for that namespace and its descendants.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>namespace</td><td class="type">TEXT</td><td class="note">Hierarchical path. Inheriting children walk up.</td></tr>
+          <tr><td class="col"><span class="flag fk">FK</span>standard_id</td><td class="type">TEXT NULL</td><td class="note">→ <code>memories(id)</code>. The memory holding the policy in metadata.</td></tr>
+          <tr><td class="col">parent</td><td class="type">TEXT NULL</td><td class="note">Ancestor namespace (computed for fast walk).</td></tr>
+          <tr><td class="col">created_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="tbl t-meta">
+      <div class="tbl-head">
+        <span class="tbl-name">entity_aliases</span>
+        <span class="tbl-tag">▸ ENTITY REGISTRY</span>
+        <span class="tbl-since">v0.6.3 Stream B</span>
+      </div>
+      <div class="tbl-desc">Alias → canonical-entity resolution side table. Each entity is a memory (in any namespace); this table holds zero-or-more alternate names per entity.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>entity_id</td><td class="type">TEXT NOT NULL</td><td class="note">→ <code>memories(id)</code> (the canonical entity memory).</td></tr>
+          <tr><td class="col"><span class="flag pk">PK</span>alias</td><td class="type">TEXT NOT NULL</td><td class="note">Alternate name. Composite PK (entity_id, alias).</td></tr>
+          <tr><td class="col">created_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC.</td></tr>
+        </tbody>
+      </table>
+      <div class="idx-list"><span class="idx-name">▸ idx_entity_aliases_alias</span> (alias) — fast reverse lookup</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== GOVERNANCE / FED TABLES ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Governance &amp; federation</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">pending_actions · sync_state · subscriptions.</h2>
+
+    <div class="tbl t-meta">
+      <div class="tbl-head">
+        <span class="tbl-name">pending_actions</span>
+        <span class="tbl-tag">▸ GOVERNANCE QUEUE</span>
+      </div>
+      <div class="tbl-desc">When governance policy says "Approve", the requested action lands here instead of executing immediately. Cleared on approve (executes the action) or reject.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>id</td><td class="type">TEXT</td><td class="note">UUIDv4 of the pending action.</td></tr>
+          <tr><td class="col">action_type</td><td class="type">TEXT NOT NULL</td><td class="note">One of <code>store</code> · <code>delete</code> · <code>promote</code> (the GovernedAction enum).</td></tr>
+          <tr><td class="col">namespace</td><td class="type">TEXT NOT NULL</td><td class="note">Target namespace (drives policy lookup).</td></tr>
+          <tr><td class="col">requested_by</td><td class="type">TEXT NOT NULL</td><td class="note">agent_id of the caller.</td></tr>
+          <tr><td class="col">requested_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC.</td></tr>
+          <tr><td class="col">payload</td><td class="type">TEXT NOT NULL</td><td class="note">JSON. The full memory + context to execute on approval.</td></tr>
+          <tr><td class="col">approvals</td><td class="type">TEXT NOT NULL</td><td class="note">JSON array of {agent_id, approved_at}. Consensus mode counts entries.</td></tr>
+          <tr><td class="col">decision</td><td class="type">TEXT NULL</td><td class="note">NULL = pending · "approved" · "rejected".</td></tr>
+          <tr><td class="col">decided_at</td><td class="type">TEXT NULL</td><td class="note">RFC3339 UTC when decision finalized.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="tbl t-fed">
+      <div class="tbl-head">
+        <span class="tbl-name">sync_state</span>
+        <span class="tbl-tag">▸ FEDERATION CURSOR</span>
+      </div>
+      <div class="tbl-desc">Per-(local-agent, peer-URL) sync cursors. Drives the catchup loop. <code>last_pulled_at</code> advances after successful <code>/api/v1/sync/since</code> pulls.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>agent_id</td><td class="type">TEXT NOT NULL</td><td class="note">Local node's agent_id.</td></tr>
+          <tr><td class="col"><span class="flag pk">PK</span>peer_url</td><td class="type">TEXT NOT NULL</td><td class="note">Federation peer's HTTPS URL.</td></tr>
+          <tr><td class="col">last_pulled_at</td><td class="type">TEXT NULL</td><td class="note">RFC3339 UTC of last successful pull from this peer.</td></tr>
+          <tr><td class="col">last_pushed_at</td><td class="type">TEXT NULL</td><td class="note">RFC3339 UTC of last push.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="tbl t-fed">
+      <div class="tbl-head">
+        <span class="tbl-name">subscriptions</span>
+        <span class="tbl-tag">▸ WEBHOOKS</span>
+      </div>
+      <div class="tbl-desc">Outbound webhook subscriptions. Each row spawns a dispatch thread on matching event. HMAC-SHA256 signed bodies. Retry-on-5xx with bounded attempts.</div>
+      <table class="cols">
+        <thead><tr><th>Column</th><th>Type</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td class="col"><span class="flag pk">PK</span>id</td><td class="type">TEXT</td><td class="note">UUIDv4.</td></tr>
+          <tr><td class="col">url</td><td class="type">TEXT NOT NULL</td><td class="note">Webhook endpoint. Validated against SSRF guard (<code>validate_url_dns</code>).</td></tr>
+          <tr><td class="col">events</td><td class="type">TEXT NOT NULL</td><td class="note">Comma-separated or <code>*</code>. e.g. <code>store,delete,contradiction</code>.</td></tr>
+          <tr><td class="col">namespace_filter</td><td class="type">TEXT NULL</td><td class="note">Glob pattern. NULL = all namespaces.</td></tr>
+          <tr><td class="col">agent_filter</td><td class="type">TEXT NULL</td><td class="note">Filter by <code>metadata.agent_id</code>. NULL = all agents.</td></tr>
+          <tr><td class="col">secret_hash</td><td class="type">TEXT NULL</td><td class="note">SHA-256 of the plaintext shared secret. Plaintext returned once on subscribe.</td></tr>
+          <tr><td class="col">created_by</td><td class="type">TEXT NULL</td><td class="note">agent_id of subscriber.</td></tr>
+          <tr><td class="col">created_at</td><td class="type">TEXT NOT NULL</td><td class="note">RFC3339 UTC.</td></tr>
+          <tr><td class="col">dispatch_count</td><td class="type">INTEGER</td><td class="note">Successful dispatches.</td></tr>
+          <tr><td class="col">failure_count</td><td class="type">INTEGER</td><td class="note">Failed dispatches (non-2xx OR connect timeout).</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ============== MIGRATION / VERSIONING ============== -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Migrations</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Schema is versioned. Migrations are idempotent.</h2>
+    <p class="lede">Every schema change is a forward migration applied at daemon startup. Idempotent so re-runs are safe. v15 was the v0.6.3 Stream B addition. Older versions are inline in <code>db.rs::migrate</code>; v15 is the first extracted to <code>migrations/sqlite/0010_v063_hierarchy_kg.sql</code>.</p>
+
+    <div class="tbl t-meta">
+      <div class="tbl-head">
+        <span class="tbl-name">Version timeline</span>
+      </div>
+      <table class="cols">
+        <thead><tr><th>Version</th><th>Release</th><th>Change</th></tr></thead>
+        <tbody>
+          <tr><td class="col">1-3</td><td class="type">v0.1-0.4</td><td class="note">memories table; basic CRUD; tier enum; FTS5 virtual.</td></tr>
+          <tr><td class="col">4-7</td><td class="type">v0.4-0.5</td><td class="note">memory_links; tags JSON; expires_at; embedding BLOB.</td></tr>
+          <tr><td class="col">8-10</td><td class="type">v0.5</td><td class="note">archived_memories; subscriptions; webhook dispatch_count.</td></tr>
+          <tr><td class="col">11-13</td><td class="type">v0.6.0-0.6.1</td><td class="note">pending_actions; sync_state; namespace_meta; governance policy in metadata; agent_id resolution.</td></tr>
+          <tr><td class="col">14</td><td class="type">v0.6.2</td><td class="note">SAL adapter prep; postgres_schema.sql; chunked_from metadata.</td></tr>
+          <tr><td class="col">15</td><td class="type">v0.6.3</td><td class="note"><strong>Hierarchy + KG additions.</strong> 4 new memory_links columns; entity_aliases table; 3 temporal indexes. <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/migrations/sqlite/0010_v063_hierarchy_kg.sql" style="color:var(--p1)">Migration file →</a></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>ai-memory-mcp · Apache 2.0 · v0.6.3-rc1 · <a href="./">main</a> · <a href="at-a-glance.html">Atlas</a> · <a href="types.html">Types</a> · <a href="validators.html">Validators</a> · <a href="governance.html">Governance</a> · <a href="tracing.html">Tracing</a></p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/tracing.html
+++ b/docs/tracing.html
@@ -1,0 +1,347 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Tracing atlas — log call taxonomy across handlers/federation/db/llm.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Tracing — every log call</title>
+<meta name="description" content="ai-memory v0.6.3 observability reference. Tracing setup (EnvFilter), module breakdown, level taxonomy (info/warn/error), and the canonical log lines AI clients can grep for in incident review.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/tracing.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--warn:#ffd700;--info:#a5d6a7;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(165,214,167,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+
+.modgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-bottom:2rem}
+.mod{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.15rem;position:relative}
+.mod::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--p1)}
+.mod.fed::before{background:var(--p2)}
+.mod.db::before{background:var(--p3)}
+.mod.llm::before{background:#a5d6a7}
+.mod .name{font-family:var(--font-mono);font-size:.95rem;font-weight:700;color:var(--text);margin-bottom:.4rem}
+.mod .count{font-family:var(--font-mono);font-size:1.6rem;color:var(--p1);font-weight:700}
+.mod.fed .count{color:var(--p2)}
+.mod.db .count{color:var(--p3)}
+.mod.llm .count{color:#a5d6a7}
+.mod .lbl{font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;margin-top:.2rem}
+.mod p{font-size:.83rem;color:var(--text-muted);margin-top:.5rem;line-height:1.45}
+
+.lev-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-bottom:2rem}
+.lev{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.15rem;position:relative}
+.lev::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.lev.info::before{background:var(--info)}
+.lev.warn::before{background:var(--warn)}
+.lev.error::before{background:var(--bad)}
+.lev h3{font-family:var(--font-mono);font-size:1rem;margin-bottom:.5rem}
+.lev .lbl{font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.3rem}
+.lev p{font-size:.85rem;color:var(--text-muted);margin-bottom:.7rem}
+.lev .ex{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);background:var(--bg-code);padding:.5rem .65rem;border-radius:5px;line-height:1.5;display:block;white-space:pre-wrap}
+
+.snip{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);margin-top:.85rem;padding:.7rem .85rem;background:var(--bg-code);border-radius:6px;line-height:1.55;white-space:pre-wrap;overflow-x:auto;word-break:break-all}
+.snip .ok{color:var(--good)}
+.snip .err{color:var(--bad)}
+.snip .warn{color:var(--warn)}
+.snip .info{color:var(--info)}
+.snip .cm{color:var(--text-dim)}
+.snip .key{color:var(--p3)}
+.snip .val{color:var(--p2)}
+
+.recipe{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.15rem 1.25rem;margin-bottom:1rem}
+.recipe .when{font-family:var(--font-mono);font-size:.78rem;color:var(--p3);margin-bottom:.4rem;letter-spacing:.04em}
+.recipe .what{font-family:var(--font-mono);font-size:.85rem;font-weight:700;color:var(--text);margin-bottom:.5rem}
+.recipe .grep{font-family:var(--font-mono);font-size:.78rem;color:var(--good);background:var(--bg-code);padding:.5rem .65rem;border-radius:5px;display:block;margin-bottom:.45rem;overflow-x:auto;white-space:pre}
+.recipe .meaning{color:var(--text-muted);font-size:.85rem;line-height:1.5}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Tracing</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">Atlas</a>
+      <a href="schema.html">Schema</a>
+      <a href="types.html">Types</a>
+      <a href="validators.html">Validators</a>
+      <a href="governance.html">Governance</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/main.rs">main.rs →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The trace, every line.</h1>
+  <p class="tagline">ai-memory uses the <code>tracing</code> crate with an <code>EnvFilter</code>-driven subscriber. 176 log call sites across 11 modules. Every error path is named; every fanout failure is logged with the peer id; every governance verdict is loud. AI clients can grep the canonical lines below to reconstruct what the daemon was doing.</p>
+  <div class="pills">
+    <span class="pill">tracing 0.1</span>
+    <span class="pill">EnvFilter</span>
+    <span class="pill">176 call sites</span>
+    <span class="pill">RUST_LOG-controlled</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Setup</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">How tracing initializes.</h2>
+    <p class="lede">The daemon installs a <code>tracing_subscriber::fmt</code> layer with the standard <code>EnvFilter</code> chain. Default directives keep <code>ai_memory</code> + <code>tower_http</code> at <code>info</code> while honoring any <code>RUST_LOG</code> override.</p>
+    <div class="snip">// src/main.rs::serve()
+tracing_subscriber::fmt()
+    .with_env_filter(
+        EnvFilter::<span class="key">from_default_env</span>()
+            .add_directive(<span class="val">"ai_memory=info"</span>.parse()?)
+            .add_directive(<span class="val">"tower_http=info"</span>.parse()?),
+    )
+    .init();</div>
+    <p class="lede" style="margin-top:1rem">To turn the volume up:</p>
+    <div class="snip"><span class="cm"># quiet — only errors</span>
+RUST_LOG=ai_memory=error ai-memory serve
+
+<span class="cm"># standard — what runs in prod</span>
+RUST_LOG=ai_memory=info,tower_http=info ai-memory serve
+
+<span class="cm"># debug a federation issue</span>
+RUST_LOG=ai_memory::federation=debug,ai_memory=info ai-memory serve
+
+<span class="cm"># everything (very chatty — local dev only)</span>
+RUST_LOG=ai_memory=trace,tower_http=debug ai-memory serve</div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Where the calls live</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">11 modules, 176 call sites.</h2>
+    <p class="lede">Counts pulled from <code>grep -rn 'tracing::error!|warn!|info!|debug!' src/</code>. Handlers and federation dominate — they are where user-visible behavior happens.</p>
+    <div class="modgrid">
+      <div class="mod">
+        <div class="count">67</div>
+        <div class="lbl">handlers.rs</div>
+        <p>Every HTTP/MCP write goes through one of these handlers. Errors get an <code>error!("handler error: {e}")</code> and the response code; governance verdicts get an <code>error!("governance error: {e}")</code>.</p>
+      </div>
+      <div class="mod fed">
+        <div class="count">43</div>
+        <div class="lbl">federation.rs</div>
+        <p>Quorum fanout (W of N) is the noisiest module. Every peer success is silent; every peer failure logs <code>warn!("federation: peer {peer_id} failed for {id}: {reason}")</code> so the operator can see where the network dropped traffic.</p>
+      </div>
+      <div class="mod">
+        <div class="count">25</div>
+        <div class="lbl">main.rs</div>
+        <p>Bootstrap, config, listener init, signal handling. Mostly <code>info!</code> startup banners + warn-level config fallback notices.</p>
+      </div>
+      <div class="mod">
+        <div class="count">11</div>
+        <div class="lbl">mcp.rs</div>
+        <p>MCP protocol layer. Logs malformed JSON-RPC, unknown tool names, and method-not-found responses for protocol-level debugging.</p>
+      </div>
+      <div class="mod db">
+        <div class="count">8</div>
+        <div class="lbl">db.rs</div>
+        <p>SQLite-specific issues: migration logs, FTS5 index rebuild events, vacuum completion. Most <code>db::*</code> calls are silent on success.</p>
+      </div>
+      <div class="mod">
+        <div class="count">7</div>
+        <div class="lbl">subscriptions.rs</div>
+        <p>Webhook dispatch. Logs SSRF guard rejections (W11 hardening), URL parse failures, and HTTP-client build/send errors so a misconfigured webhook doesn't disappear silently.</p>
+      </div>
+      <div class="mod">
+        <div class="count">6</div>
+        <div class="lbl">curator.rs</div>
+        <p>Cycle-driven curator (consolidation, taxonomy refresh). Logs when a cycle starts, ends, or skips because of a recent run.</p>
+      </div>
+      <div class="mod llm">
+        <div class="count">4</div>
+        <div class="lbl">llm.rs</div>
+        <p>Ollama bridge — logs <code>info!("Pulling Ollama embedding model …")</code> on first run and the success line when the pull completes.</p>
+      </div>
+      <div class="mod db">
+        <div class="count">2</div>
+        <div class="lbl">store/postgres.rs</div>
+        <p>SAL Postgres adapter (<code>--features sal</code>). Logs adapter-bound issues distinct from SQLite.</p>
+      </div>
+      <div class="mod">
+        <div class="count">2</div>
+        <div class="lbl">reranker.rs</div>
+        <p>Cross-encoder reranker. Logs lock-poisoning and tokenizer-fallback events.</p>
+      </div>
+      <div class="mod">
+        <div class="count">1</div>
+        <div class="lbl">identity.rs</div>
+        <p>Agent-id resolution chain. Logs once when the precedence chain falls through to <code>anonymous</code>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Level taxonomy</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">info / warn / error.</h2>
+    <p class="lede">The daemon does not emit <code>debug!</code> or <code>trace!</code> at the call sites — those are reserved for ad-hoc instrumentation under <code>RUST_LOG</code>. Production output is the three levels below.</p>
+    <div class="lev-grid">
+      <div class="lev info">
+        <div class="lbl">info</div>
+        <h3>Useful, expected events.</h3>
+        <p>Bootstrap milestones, model pulls completing, catchup cycle summary. Quiet by default — doesn't drown the operator.</p>
+        <span class="ex">Pulling Ollama embedding model 'nomic-embed-text'...
+Embedding model 'nomic-embed-text' pulled successfully
+catchup: pulled 142 memories from 3 peers in 2.1s</span>
+      </div>
+      <div class="lev warn">
+        <div class="lbl">warn</div>
+        <h3>Recoverable degradation.</h3>
+        <p>Daemon kept running, request still succeeded (or fell back). Operator should look but no incident yet.</p>
+        <span class="ex">embedding generation failed: connection refused
+recall: embedder query failed, falling back to keyword-only: timeout
+SSRF guard rejected webhook URL https://10.0.0.1: private network
+federation: peer node-3 failed for abc-123: connect timeout
+register_agent fanout error (local committed): node-2 502</span>
+      </div>
+      <div class="lev error">
+        <div class="lbl">error</div>
+        <h3>Request-level failure.</h3>
+        <p>The HTTP/MCP response is also an error. Logs the same condition the client gets back so server-side reconstruction is possible from logs alone.</p>
+        <span class="ex">handler error: validation failed: title cannot be empty
+governance error: agent not registered
+execute pending error: target memory not found
+detect_contradictions list error: db locked
+export error: tar archive write failed</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">The canonical phrases</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Grep recipes for incident review.</h2>
+    <p class="lede">When an AI client is reading logs to figure out what happened, these are the lines to look for. Each pattern matches an exact <code>tracing::*!</code> call site in the source.</p>
+
+    <div class="recipe">
+      <div class="when">handler error</div>
+      <div class="what">Any HTTP/MCP write that failed at the daemon</div>
+      <span class="grep">grep 'handler error:' daemon.log</span>
+      <span class="meaning">Followed by the underlying <code>anyhow</code> chain. Validators, db, governance, and federation all bubble into this single phrase. The HTTP response is 4xx/5xx; the log carries the full reason.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">governance verdict</div>
+      <div class="what">Deny or replay-failure on a governed action</div>
+      <span class="grep">grep 'governance error:' daemon.log</span>
+      <span class="meaning">A clean <code>Pending</code> verdict is silent — only Deny and replay failures log. Look for these when an AI client says "the write was rejected and I don't know why."</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">federation peer failure</div>
+      <div class="what">A specific peer dropped out of a quorum</div>
+      <span class="grep">grep 'federation: peer .* failed' daemon.log</span>
+      <span class="meaning">Format: <code>federation: peer {peer_id} failed for {memory_id}: {reason}</code>. Quorum still completes if W of N succeed; this line tells you which N-W peers were missing.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">post-quorum partial failure</div>
+      <div class="what">Local commit landed but fanout to some peers errored out</div>
+      <span class="grep">grep 'fanout error (local committed)' daemon.log</span>
+      <span class="meaning">Used by <code>register_agent</code>, <code>link</code>, <code>consolidate</code>. The local row is durable; sync_pull from those peers will reconcile.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">SSRF defense (W10/W11 hardening)</div>
+      <div class="what">A webhook URL was rejected by the URL or DNS guard</div>
+      <span class="grep">grep 'SSRF guard rejected' daemon.log</span>
+      <span class="meaning">Format: <code>SSRF guard rejected webhook URL {url}: {reason}</code>. Reasons include "private network," "loopback resolved," "scheme not http/https." Two SSRF defects were closed in commit <code>9eeb453</code> for v0.6.3.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">embedder fallback</div>
+      <div class="what">Recall couldn't get a query embedding; degraded to FTS5-only</div>
+      <span class="grep">grep 'falling back to keyword-only' daemon.log</span>
+      <span class="meaning">Recall still returns results — the 70/30 hybrid becomes 100/0 keyword for that one request. If frequent, check Ollama health.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">embedding write failure</div>
+      <div class="what">A memory was stored but its vector wasn't indexed</div>
+      <span class="grep">grep 'failed to store embedding for' daemon.log</span>
+      <span class="meaning">The memory is persisted; FTS5 covers it. Semantic recall will miss it until <code>memory_reindex</code> rebuilds the HNSW.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">model pull lifecycle</div>
+      <div class="what">Ollama model fetch on first start</div>
+      <span class="grep">grep "Pulling Ollama" daemon.log
+grep "pulled successfully" daemon.log</span>
+      <span class="meaning">Pull is async and can take minutes on cold start. The "successfully" line is the OK signal — recall semantic ranking is live from that point on.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">catchup cycle</div>
+      <div class="what">Federation catchup summary at the end of a sync window</div>
+      <span class="grep">grep 'catchup:' daemon.log</span>
+      <span class="meaning">Per-peer pulls + the rollup. Includes parse-failure warnings (<code>unparseable memory from peer</code>) when a peer ships malformed data — those rows are skipped, not retried.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">execute-pending replay</div>
+      <div class="what">A pending action was approved and the replay path failed</div>
+      <span class="grep">grep 'execute pending error:' daemon.log</span>
+      <span class="meaning">Approval decision flipped status to <code>approved</code> but replay couldn't complete (deleted target, namespace gone, validator now rejects). Status remains <code>approved</code>; the row is loud in logs but the user-visible state is unchanged.</span>
+    </div>
+
+    <div class="recipe">
+      <div class="when">webhook delivery failure</div>
+      <div class="what">A subscription's POST to its webhook URL failed</div>
+      <span class="grep">grep 'webhook POST to' daemon.log</span>
+      <span class="meaning">Format: <code>webhook POST to {url} failed: {error}</code>. Subscription-side; not retried at the daemon (the recipient is responsible for its own retry policy).</span>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Future</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">v0.7 expansion.</h2>
+    <p class="lede">v0.7 brings the Hook Pipeline (arch-spec §2) and Sidechain Transcripts (§6). Both extend the trace surface — every hook fire becomes a span, every transcript line is durable. Once those land:</p>
+    <div class="snip" style="font-family:var(--font-sans);white-space:normal;line-height:1.7">
+      <div><strong style="color:var(--good)">Hook spans</strong> — <code>info_span!("hook", event=..., subscriber=...)</code> wrapping each hook callback so the trace tree shows which hook ran where</div>
+      <div><strong style="color:var(--good)">Transcript stream</strong> — every governed action lands a row in the transcript table with the full payload + verdict, queryable independent of the daemon log</div>
+      <div><strong style="color:var(--good)">OpenTelemetry hookup</strong> — v1.0 charter; the <code>tracing-opentelemetry</code> bridge so traces can ship to a collector</div>
+      <div><strong style="color:var(--good)">memory_capabilities introspection</strong> (<a href="https://github.com/alphaonedev/agentic-mem-labs/blob/main/strategy/2026-04-26/architectural-enhancement-spec-v1.md#7-capabilities-introspection-extension" style="color:var(--p1)">v0.6.3.1 quick patch</a>) — the daemon will report <code>hooks.registered_count</code>, <code>transcripts.total_count</code>, etc. so AI clients can answer "what's enforced here?" honestly</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>ai-memory v0.6.3 · Apache 2.0 · tracing crate 0.1 · <a href="https://github.com/alphaonedev/ai-memory-mcp">repo</a></p>
+  <p style="margin-top:.5rem"><a href="./">← Back to ai-memory</a> · <a href="at-a-glance.html">Atlas</a> · <a href="schema.html">Schema</a> · <a href="types.html">Types</a> · <a href="validators.html">Validators</a> · <a href="governance.html">Governance</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/types.html
+++ b/docs/types.html
@@ -1,0 +1,601 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Types atlas — every public Rust struct and enum in src/models.rs.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Types — every public struct and enum</title>
+<meta name="description" content="ai-memory v0.6.3 type reference. Every public Rust struct and enum exposed at the API/MCP/CLI boundaries. Tier, Memory, MemoryLink, GovernancePolicy, ApproverType, VectorClock, and 21 more.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/types.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:780px;margin-bottom:2rem}
+
+.grp-head{font-family:var(--font-mono);font-size:1rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin:2rem 0 1rem;padding-bottom:.4rem;border-bottom:1px solid var(--border)}
+
+.ty{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.5rem;position:relative;overflow:hidden}
+.ty::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.ty.k-struct::before{background:var(--p1)}
+.ty.k-enum::before{background:var(--p3)}
+.ty.k-const::before{background:var(--p2)}
+.ty-head{display:flex;align-items:baseline;gap:1rem;flex-wrap:wrap;margin-bottom:.5rem}
+.ty-name{font-family:var(--font-mono);font-size:1.15rem;font-weight:700;color:var(--text)}
+.ty-kind{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);padding:.15em .55em;border:1px solid var(--border-hl);border-radius:4px}
+.ty-kind.struct{color:var(--p1);border-color:rgba(110,231,255,0.4)}
+.ty-kind.enum{color:var(--p3);border-color:rgba(200,162,255,0.4)}
+.ty-kind.const{color:var(--p2);border-color:rgba(255,184,107,0.4)}
+.ty-since{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim)}
+.ty-derive{font-family:var(--font-mono);font-size:.7rem;color:var(--text-dim);margin-bottom:.65rem}
+.ty-derive code{background:transparent;color:var(--text-muted);padding:0}
+.ty-desc{color:var(--text-muted);font-size:.92rem;margin-bottom:1rem}
+.fld{width:100%;border-collapse:collapse;font-size:.85rem}
+.fld th{text-align:left;padding:.5rem .65rem;font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;border-bottom:1px solid var(--border-hl)}
+.fld td{padding:.55rem .65rem;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:.78rem;vertical-align:top}
+.fld td.fname{color:var(--text);font-weight:600;white-space:nowrap}
+.fld td.ftype{color:var(--p1);white-space:nowrap}
+.fld td.fnote{color:var(--text-muted);font-family:var(--font-sans);font-size:.85rem;line-height:1.5}
+.flag{display:inline-block;font-family:var(--font-mono);font-size:.65rem;padding:.1em .45em;border-radius:3px;letter-spacing:.05em;margin-right:.25em;vertical-align:middle}
+.flag.opt{background:rgba(102,102,102,0.15);color:var(--text-dim);border:1px solid rgba(102,102,102,0.4)}
+.flag.req{background:rgba(110,231,255,0.12);color:var(--p1);border:1px solid rgba(110,231,255,0.4)}
+.flag.def{background:rgba(255,184,107,0.12);color:var(--p2);border:1px solid rgba(255,184,107,0.4)}
+.flag.serde{background:rgba(200,162,255,0.12);color:var(--p3);border:1px solid rgba(200,162,255,0.4)}
+.flag.skip{background:rgba(102,102,102,0.15);color:var(--text-dim);border:1px solid rgba(102,102,102,0.4)}
+.snip{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);margin-top:.85rem;padding:.7rem .85rem;background:var(--bg-code);border-radius:6px;line-height:1.55;white-space:pre;overflow-x:auto}
+.variants{margin-top:.5rem}
+.variants .v{padding:.55rem .85rem;background:var(--bg-elev);border-radius:6px;margin-bottom:.4rem;font-family:var(--font-mono);font-size:.82rem}
+.variants .v .vn{color:var(--p3);font-weight:700}
+.variants .v .vd{color:var(--text-muted);font-family:var(--font-sans);font-size:.85rem;margin-left:.5rem}
+
+.toc{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.5rem;margin-bottom:1.5rem}
+.toc a{display:block;padding:.45rem .7rem;background:var(--bg-elev);border:1px solid var(--border);border-radius:6px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+.toc a:hover{color:var(--p1);border-color:var(--p1)}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Types</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">Atlas</a>
+      <a href="feature-matrix.html">Features</a>
+      <a href="schema.html">Schema</a>
+      <a href="validators.html">Validators</a>
+      <a href="governance.html">Governance</a>
+      <a href="tracing.html">Tracing</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/models.rs">models.rs →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The types, end to end.</h1>
+  <p class="tagline">Every public Rust struct and enum that crosses the HTTP/MCP/CLI boundary. Field-level types, defaults, serde tags, since-when annotations. The contract a client implements when it wires up to ai-memory.</p>
+  <div class="pills">
+    <span class="pill">5 enums</span>
+    <span class="pill">22 structs</span>
+    <span class="pill">5 consts</span>
+    <span class="pill">v0.6.3 schema</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Quick jump</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">All 27 types, indexed.</h2>
+    <p class="lede">Grouped by responsibility: core domain (Tier, Memory, MemoryLink), request/response shapes (Create/Update/Search/List/Recall), governance (GovernanceLevel, ApproverType, GovernancePolicy, GovernedAction, GovernanceDecision), federation (VectorClock, SyncStateEntry, AgentRegistration, NamespaceMetaEntry), pending-action queue (PendingAction, PendingDecision, Approval).</p>
+    <div class="toc">
+      <a href="#tier">Tier</a>
+      <a href="#memory">Memory</a>
+      <a href="#memorylink">MemoryLink</a>
+      <a href="#creatememory">CreateMemory</a>
+      <a href="#updatememory">UpdateMemory</a>
+      <a href="#searchquery">SearchQuery</a>
+      <a href="#listquery">ListQuery</a>
+      <a href="#recallquery">RecallQuery</a>
+      <a href="#recallbody">RecallBody</a>
+      <a href="#linkbody">LinkBody</a>
+      <a href="#forgetquery">ForgetQuery</a>
+      <a href="#stats">Stats</a>
+      <a href="#tiercount">TierCount</a>
+      <a href="#namespacecount">NamespaceCount</a>
+      <a href="#governancedecision">GovernanceDecision</a>
+      <a href="#governedaction">GovernedAction</a>
+      <a href="#approval">Approval</a>
+      <a href="#pendingaction">PendingAction</a>
+      <a href="#pendingdecision">PendingDecision</a>
+      <a href="#namespacemetaentry">NamespaceMetaEntry</a>
+      <a href="#governancelevel">GovernanceLevel</a>
+      <a href="#approvertype">ApproverType</a>
+      <a href="#governancepolicy">GovernancePolicy</a>
+      <a href="#registeragentbody">RegisterAgentBody</a>
+      <a href="#agentregistration">AgentRegistration</a>
+      <a href="#vectorclock">VectorClock</a>
+      <a href="#syncstateentry">SyncStateEntry</a>
+      <a href="#consts">Constants</a>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Core domain</h3>
+
+    <div class="ty k-enum" id="tier">
+      <div class="ty-head"><span class="ty-name">Tier</span><span class="ty-kind enum">enum</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]</code> · <code>#[serde(rename_all = "snake_case")]</code></div>
+      <div class="ty-desc">Memory tier — mirrors human memory systems. Default TTL: Short = 6h, Mid = 7d, Long = none.</div>
+      <div class="variants">
+        <div class="v"><span class="vn">Short</span><span class="vd">working memory; short-lived contexts; default TTL 6h.</span></div>
+        <div class="v"><span class="vn">Mid</span><span class="vd">session-spanning facts; default TTL 7d. <strong>Default tier</strong> for new memories.</span></div>
+        <div class="v"><span class="vn">Long</span><span class="vd">durable knowledge; no TTL; subject to governance gates on promote.</span></div>
+      </div>
+      <div class="snip">// helper API
+Tier::default_ttl_secs(self) -&gt; Option&lt;i64&gt;
+Tier::as_str(&amp;self) -&gt; &amp;'static str
+Tier::from_str(&amp;str) -&gt; Option&lt;Tier&gt;</div>
+    </div>
+
+    <div class="ty k-struct" id="memory">
+      <div class="ty-head"><span class="ty-name">Memory</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">The stored record returned by HTTP <code>GET /memories/:id</code> and MCP <code>memory_get</code>. Persisted into the <code>memories</code> table; mirrored to FTS5 + HNSW vector index.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>UUIDv4 primary key.</td></tr>
+        <tr><td class="fname">tier</td><td class="ftype">Tier</td><td class="fnote"><span class="flag req">REQ</span>One of <code>short</code> · <code>mid</code> · <code>long</code>.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>Hierarchical path; up to 8 segments; default <code>"global"</code>.</td></tr>
+        <tr><td class="fname">title</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>1–500 chars; required.</td></tr>
+        <tr><td class="fname">content</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>1–65 536 bytes (<code>MAX_CONTENT_SIZE</code>).</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Vec&lt;String&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default <code>[]</code>; max 32 tags, 64 chars each.</td></tr>
+        <tr><td class="fname">priority</td><td class="ftype">i32</td><td class="fnote"><span class="flag def">DEF</span>Default 5; range 1-10.</td></tr>
+        <tr><td class="fname">confidence</td><td class="ftype">f64</td><td class="fnote"><span class="flag def">DEF</span>Default 1.0; range 0.0-1.0.</td></tr>
+        <tr><td class="fname">source</td><td class="ftype">String</td><td class="fnote"><span class="flag def">DEF</span>Default <code>"api"</code>; closed set: user · claude · hook · api · import.</td></tr>
+        <tr><td class="fname">access_count</td><td class="ftype">i64</td><td class="fnote">Server-tracked; bumps on each <code>memory_get</code>/<code>memory_recall</code> hit.</td></tr>
+        <tr><td class="fname">created_at</td><td class="ftype">String</td><td class="fnote">RFC3339; server-stamped.</td></tr>
+        <tr><td class="fname">updated_at</td><td class="ftype">String</td><td class="fnote">RFC3339; updated on each <code>memory_update</code>.</td></tr>
+        <tr><td class="fname">last_accessed_at</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339; <code>skip_serializing_if = None</code>.</td></tr>
+        <tr><td class="fname">expires_at</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339; computed from <code>ttl_secs</code> or tier default.</td></tr>
+        <tr><td class="fname">metadata</td><td class="ftype">serde_json::Value</td><td class="fnote"><span class="flag def">DEF</span>Default <code>{}</code>; carries <code>governance</code>, <code>scope</code>, <code>agent_id</code>, taxonomy fields.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="memorylink">
+      <div class="ty-head"><span class="ty-name">MemoryLink</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">A directed edge between two memories. The KG primitive — every typed-cognition / supersession relationship is one row in <code>memory_links</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">source_id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>FK to <code>memories.id</code>.</td></tr>
+        <tr><td class="fname">target_id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>FK to <code>memories.id</code>.</td></tr>
+        <tr><td class="fname">relation</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>One of: <code>related_to</code> · <code>supersedes</code> · <code>contradicts</code> · <code>derived_from</code>.</td></tr>
+        <tr><td class="fname">created_at</td><td class="ftype">String</td><td class="fnote">RFC3339; server-stamped.</td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Request shapes — write path</h3>
+
+    <div class="ty k-struct" id="creatememory">
+      <div class="ty-head"><span class="ty-name">CreateMemory</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Body of <code>POST /memories</code> and <code>memory_store</code>. Every field has a server-side default except <code>title</code> + <code>content</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">tier</td><td class="ftype">Tier</td><td class="fnote"><span class="flag def">DEF</span>Default <code>Mid</code>.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">String</td><td class="fnote"><span class="flag def">DEF</span>Default <code>"global"</code>.</td></tr>
+        <tr><td class="fname">title</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>1–500 chars.</td></tr>
+        <tr><td class="fname">content</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>1–65 536 bytes.</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Vec&lt;String&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default <code>[]</code>.</td></tr>
+        <tr><td class="fname">priority</td><td class="ftype">i32</td><td class="fnote"><span class="flag def">DEF</span>Default 5.</td></tr>
+        <tr><td class="fname">confidence</td><td class="ftype">f64</td><td class="fnote"><span class="flag def">DEF</span>Default 1.0.</td></tr>
+        <tr><td class="fname">source</td><td class="ftype">String</td><td class="fnote"><span class="flag def">DEF</span>Default <code>"api"</code>.</td></tr>
+        <tr><td class="fname">expires_at</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339; explicit override.</td></tr>
+        <tr><td class="fname">ttl_secs</td><td class="ftype">Option&lt;i64&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Convenience: <code>expires_at = now + ttl_secs</code>.</td></tr>
+        <tr><td class="fname">metadata</td><td class="ftype">Value</td><td class="fnote"><span class="flag def">DEF</span>Default <code>{}</code>.</td></tr>
+        <tr><td class="fname">agent_id</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Auto-resolved by <code>identity</code> when omitted.</td></tr>
+        <tr><td class="fname">scope</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>One of <code>VALID_SCOPES</code>; default <code>"private"</code>.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="updatememory">
+      <div class="ty-head"><span class="ty-name">UpdateMemory</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Body of <code>PUT /memories/:id</code> and <code>memory_update</code>. Every field is optional — only the present fields are mutated; the rest are preserved.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">title</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>1–500 chars when set.</td></tr>
+        <tr><td class="fname">content</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>1–65 536 bytes when set.</td></tr>
+        <tr><td class="fname">tier</td><td class="ftype">Option&lt;Tier&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Promoting Mid→Long passes through governance.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Re-namespacing; depth ≤ 8.</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Option&lt;Vec&lt;String&gt;&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Replaces tag set entirely (not merged).</td></tr>
+        <tr><td class="fname">priority</td><td class="ftype">Option&lt;i32&gt;</td><td class="fnote"><span class="flag opt">OPT</span>1-10 range.</td></tr>
+        <tr><td class="fname">confidence</td><td class="ftype">Option&lt;f64&gt;</td><td class="fnote"><span class="flag opt">OPT</span>0.0-1.0 range.</td></tr>
+        <tr><td class="fname">expires_at</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339.</td></tr>
+        <tr><td class="fname">metadata</td><td class="ftype">Option&lt;Value&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Replaces metadata wholesale (not merged).</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="linkbody">
+      <div class="ty-head"><span class="ty-name">LinkBody</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Body of <code>POST /links</code> and <code>memory_link</code>. Creates a directed edge in the KG.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">source_id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>UUID; must exist in <code>memories</code>.</td></tr>
+        <tr><td class="fname">target_id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>UUID; must exist in <code>memories</code>.</td></tr>
+        <tr><td class="fname">relation</td><td class="ftype">String</td><td class="fnote"><span class="flag def">DEF</span>Default <code>"related_to"</code>.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="forgetquery">
+      <div class="ty-head"><span class="ty-name">ForgetQuery</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Body of <code>POST /memories/forget</code> and <code>memory_forget</code>. Pattern-based delete; archives matched memories rather than hard-deleting.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Restricts the sweep to a namespace.</td></tr>
+        <tr><td class="fname">pattern</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>FTS5 pattern; matches title+content.</td></tr>
+        <tr><td class="fname">tier</td><td class="ftype">Option&lt;Tier&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Restricts to one tier.</td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Request shapes — read path</h3>
+
+    <div class="ty k-struct" id="searchquery">
+      <div class="ty-head"><span class="ty-name">SearchQuery</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1 · agent fields v0.6</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Query string for <code>GET /search</code> and body for <code>memory_search</code>. FTS5-backed.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">q</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>FTS5 expression; supports <code>AND</code>/<code>OR</code>/<code>NEAR</code>/<code>"phrase"</code>.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Restricts to one namespace prefix.</td></tr>
+        <tr><td class="fname">tier</td><td class="ftype">Option&lt;Tier&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">limit</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default 20.</td></tr>
+        <tr><td class="fname">min_priority</td><td class="ftype">Option&lt;i32&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">since / until</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339 created_at window.</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Comma-separated; AND semantics.</td></tr>
+        <tr><td class="fname">agent_id</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Filters by <code>metadata.agent_id</code> exact.</td></tr>
+        <tr><td class="fname">as_agent</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Querying agent's namespace position; drives scope filtering.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="listquery">
+      <div class="ty-head"><span class="ty-name">ListQuery</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Query string for <code>GET /memories</code> and <code>memory_list</code>. Pagination + filter by namespace/tier/tags.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">tier</td><td class="ftype">Option&lt;Tier&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">limit</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default 20.</td></tr>
+        <tr><td class="fname">offset</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">min_priority</td><td class="ftype">Option&lt;i32&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">since / until</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>RFC3339 window.</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Comma-separated.</td></tr>
+        <tr><td class="fname">agent_id</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="recallquery">
+      <div class="ty-head"><span class="ty-name">RecallQuery</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1 · budget_tokens Task 1.11</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Query string for <code>GET /recall</code>. Hybrid 70/30 fusion (FTS5 + HNSW); optional context-budget pruning.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">context</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Free-form context to retrieve against.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">limit</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default 10.</td></tr>
+        <tr><td class="fname">tags</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">since / until</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">as_agent</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Visibility filter (Task 1.5).</td></tr>
+        <tr><td class="fname">budget_tokens</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Cap on cumulative tokens; top-N items that fit (Task 1.11).</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="recallbody">
+      <div class="ty-head"><span class="ty-name">RecallBody</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">JSON body of <code>POST /recall</code> and <code>memory_recall</code>. Same shape as <code>RecallQuery</code> but <code>context</code> is required.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">context</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span></td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">limit</td><td class="ftype">Option&lt;usize&gt;</td><td class="fnote"><span class="flag def">DEF</span>Default 10.</td></tr>
+        <tr><td class="fname">tags / since / until / as_agent / budget_tokens</td><td class="ftype">…</td><td class="fnote">Same as <a href="#recallquery">RecallQuery</a>.</td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Response shapes — telemetry</h3>
+
+    <div class="ty k-struct" id="stats">
+      <div class="ty-head"><span class="ty-name">Stats</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Serialize)]</code></div>
+      <div class="ty-desc">Response of <code>GET /stats</code> and <code>memory_stats</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">total</td><td class="ftype">usize</td><td class="fnote">Count of non-archived memories.</td></tr>
+        <tr><td class="fname">by_tier</td><td class="ftype">Vec&lt;TierCount&gt;</td><td class="fnote">3 rows: short / mid / long.</td></tr>
+        <tr><td class="fname">by_namespace</td><td class="ftype">Vec&lt;NamespaceCount&gt;</td><td class="fnote">One row per distinct namespace.</td></tr>
+        <tr><td class="fname">expiring_soon</td><td class="ftype">usize</td><td class="fnote">Count expiring within 24h.</td></tr>
+        <tr><td class="fname">links_count</td><td class="ftype">usize</td><td class="fnote">Total <code>memory_links</code> rows.</td></tr>
+        <tr><td class="fname">db_size_bytes</td><td class="ftype">u64</td><td class="fnote">SQLite file size.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="tiercount">
+      <div class="ty-head"><span class="ty-name">TierCount</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Serialize)]</code></div>
+      <div class="ty-desc">Embedded in <code>Stats.by_tier</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">tier</td><td class="ftype">String</td><td class="fnote"><code>"short"</code> · <code>"mid"</code> · <code>"long"</code></td></tr>
+        <tr><td class="fname">count</td><td class="ftype">usize</td><td class="fnote"></td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="namespacecount">
+      <div class="ty-head"><span class="ty-name">NamespaceCount</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.1</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Serialize)]</code></div>
+      <div class="ty-desc">Embedded in <code>Stats.by_namespace</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">namespace</td><td class="ftype">String</td><td class="fnote"></td></tr>
+        <tr><td class="fname">count</td><td class="ftype">usize</td><td class="fnote"></td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Governance — Task 1.8 / 1.9 / 1.10</h3>
+
+    <div class="ty k-enum" id="governancedecision">
+      <div class="ty-head"><span class="ty-name">GovernanceDecision</span><span class="ty-kind enum">enum</span><span class="ty-since">since Task 1.9 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, PartialEq, Eq)]</code></div>
+      <div class="ty-desc">The outcome of a governance check. Callers <strong>MAY</strong> execute on <code>Allow</code>, <strong>MUST</strong> reject on <code>Deny</code>, and <strong>SHOULD</strong> queue + return the <code>pending_id</code> on <code>Pending</code>.</div>
+      <div class="variants">
+        <div class="v"><span class="vn">Allow</span><span class="vd">proceed with the action.</span></div>
+        <div class="v"><span class="vn">Deny(String)</span><span class="vd">reject; the wrapped string surfaces the reason to the caller.</span></div>
+        <div class="v"><span class="vn">Pending(String)</span><span class="vd">queued for approval; the caller receives the new <code>pending_id</code>.</span></div>
+      </div>
+    </div>
+
+    <div class="ty k-enum" id="governedaction">
+      <div class="ty-head"><span class="ty-name">GovernedAction</span><span class="ty-kind enum">enum</span><span class="ty-since">since Task 1.9 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Copy, PartialEq, Eq)]</code></div>
+      <div class="ty-desc">Actions that governance gates. Stored as the <code>action_type</code> column in <code>pending_actions</code>; discriminator for enforcement calls.</div>
+      <div class="variants">
+        <div class="v"><span class="vn">Store</span><span class="vd">creating a new memory in a governed namespace.</span></div>
+        <div class="v"><span class="vn">Delete</span><span class="vd">deleting an existing memory.</span></div>
+        <div class="v"><span class="vn">Promote</span><span class="vd">tier promotion (Mid → Long).</span></div>
+      </div>
+    </div>
+
+    <div class="ty k-enum" id="governancelevel">
+      <div class="ty-head"><span class="ty-name">GovernanceLevel</span><span class="ty-kind enum">enum</span><span class="ty-since">since Task 1.8 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]</code> · <code>#[serde(rename_all = "snake_case")]</code></div>
+      <div class="ty-desc">Who is permitted to perform a governed action. Stored in a namespace standard's <code>metadata.governance</code>.</div>
+      <div class="variants">
+        <div class="v"><span class="vn">Any</span><span class="vd">no gate; any caller succeeds.</span></div>
+        <div class="v"><span class="vn">Registered</span><span class="vd">caller must be a registered agent (<code>_agents</code> namespace).</span></div>
+        <div class="v"><span class="vn">Owner</span><span class="vd">only the memory's <code>metadata.agent_id</code> owner may perform the action.</span></div>
+        <div class="v"><span class="vn">Approve</span><span class="vd">requires explicit approval by an <code>ApproverType</code>.</span></div>
+      </div>
+    </div>
+
+    <div class="ty k-enum" id="approvertype">
+      <div class="ty-head"><span class="ty-name">ApproverType</span><span class="ty-kind enum">enum</span><span class="ty-since">since Task 1.10 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]</code> · <code>#[serde(rename_all = "snake_case")]</code></div>
+      <div class="ty-desc">Who approves actions gated by <code>GovernanceLevel::Approve</code>. Externally-tagged.</div>
+      <div class="variants">
+        <div class="v"><span class="vn">Human</span><span class="vd">serialized as <code>"human"</code>; interactive or out-of-band approval.</span></div>
+        <div class="v"><span class="vn">Agent(String)</span><span class="vd">serialized as <code>{"agent": "alice"}</code>; specific registered agent must approve.</span></div>
+        <div class="v"><span class="vn">Consensus(u32)</span><span class="vd">serialized as <code>{"consensus": 3}</code>; consensus of N approvers required.</span></div>
+      </div>
+    </div>
+
+    <div class="ty k-struct" id="governancepolicy">
+      <div class="ty-head"><span class="ty-name">GovernancePolicy</span><span class="ty-kind struct">struct</span><span class="ty-since">since Task 1.8 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]</code></div>
+      <div class="ty-desc">Attached to a namespace's standard memory at <code>metadata.governance</code>. Default policy: <code>{ write: Any, promote: Any, delete: Owner, approver: Human }</code>. v0.6.2 (S34) made promote/delete/approver tolerant of missing fields for partial-policy payloads.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">write</td><td class="ftype">GovernanceLevel</td><td class="fnote"><span class="flag req">REQ</span>Required — core knob a policy is setting.</td></tr>
+        <tr><td class="fname">promote</td><td class="ftype">GovernanceLevel</td><td class="fnote"><span class="flag def">DEF</span>Default <code>Any</code>.</td></tr>
+        <tr><td class="fname">delete</td><td class="ftype">GovernanceLevel</td><td class="fnote"><span class="flag def">DEF</span>Default <code>Owner</code>.</td></tr>
+        <tr><td class="fname">approver</td><td class="ftype">ApproverType</td><td class="fnote"><span class="flag def">DEF</span>Default <code>Human</code>.</td></tr>
+      </tbody></table>
+      <div class="snip">// helper API
+GovernancePolicy::from_metadata(&amp;Value) -&gt; Option&lt;Result&lt;Self, _&gt;&gt;
+GovernancePolicy::default() // { write: Any, promote: Any, delete: Owner, approver: Human }</div>
+    </div>
+
+    <div class="ty k-struct" id="approval">
+      <div class="ty-head"><span class="ty-name">Approval</span><span class="ty-kind struct">struct</span><span class="ty-since">since Task 1.10 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]</code></div>
+      <div class="ty-desc">A single approval vote on a consensus-gated pending action.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">agent_id</td><td class="ftype">String</td><td class="fnote">Approving agent's id.</td></tr>
+        <tr><td class="fname">approved_at</td><td class="ftype">String</td><td class="fnote">RFC3339.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="pendingaction">
+      <div class="ty-head"><span class="ty-name">PendingAction</span><span class="ty-kind struct">struct</span><span class="ty-since">since Task 1.9 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">Row returned by <code>db::list_pending_actions</code>. Mirrors the <code>pending_actions</code> table.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">id</td><td class="ftype">String</td><td class="fnote">UUID.</td></tr>
+        <tr><td class="fname">action_type</td><td class="ftype">String</td><td class="fnote"><code>store</code> · <code>delete</code> · <code>promote</code>.</td></tr>
+        <tr><td class="fname">memory_id</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote">Set for delete/promote; null for pending stores.</td></tr>
+        <tr><td class="fname">namespace</td><td class="ftype">String</td><td class="fnote"></td></tr>
+        <tr><td class="fname">payload</td><td class="ftype">Value</td><td class="fnote">Action-shaped JSON for replay.</td></tr>
+        <tr><td class="fname">requested_by</td><td class="ftype">String</td><td class="fnote">agent_id of requester.</td></tr>
+        <tr><td class="fname">requested_at</td><td class="ftype">String</td><td class="fnote">RFC3339.</td></tr>
+        <tr><td class="fname">status</td><td class="ftype">String</td><td class="fnote"><code>pending</code> · <code>approved</code> · <code>rejected</code>.</td></tr>
+        <tr><td class="fname">decided_by</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">decided_at</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">approvals</td><td class="ftype">Vec&lt;Approval&gt;</td><td class="fnote">Consensus vote log (Task 1.10); empty for Human/Agent paths.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="pendingdecision">
+      <div class="ty-head"><span class="ty-name">PendingDecision</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.6.2 S34</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">A pending-action decision (approve/reject) propagated to peers so callers on any peer see consistent state. Shipped as additive <code>sync_push.pending_decisions</code> field; peers apply via <code>db::decide_pending_action</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">id</td><td class="ftype">String</td><td class="fnote">pending_action UUID.</td></tr>
+        <tr><td class="fname">approved</td><td class="ftype">bool</td><td class="fnote">true → approve; false → reject.</td></tr>
+        <tr><td class="fname">decider</td><td class="ftype">String</td><td class="fnote">agent_id of decider.</td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Federation — issue #224 / agent registry</h3>
+
+    <div class="ty k-struct" id="namespacemetaentry">
+      <div class="ty-head"><span class="ty-name">NamespaceMetaEntry</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.6.2 S35</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">A namespace-standard metadata row propagated to peers. Without this, a peer sees the standard memory (fanned via <code>broadcast_store_quorum</code>) but not the <code>(namespace, standard_id, parent_namespace)</code> tuple, so inheritance-chain walks fall back to <code>auto_detect_parent</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">namespace</td><td class="ftype">String</td><td class="fnote"></td></tr>
+        <tr><td class="fname">standard_id</td><td class="ftype">String</td><td class="fnote">UUID of the standard memory.</td></tr>
+        <tr><td class="fname">parent_namespace</td><td class="ftype">Option&lt;String&gt;</td><td class="fnote"><span class="flag opt">OPT</span></td></tr>
+        <tr><td class="fname">updated_at</td><td class="ftype">String</td><td class="fnote">RFC3339.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="registeragentbody">
+      <div class="ty-head"><span class="ty-name">RegisterAgentBody</span><span class="ty-kind struct">struct</span><span class="ty-since">since Task 1.3 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Deserialize)]</code></div>
+      <div class="ty-desc">Body of <code>POST /agents/register</code>. Persists into the <code>_agents</code> namespace.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">agent_id</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>Stable identifier; max 64 chars.</td></tr>
+        <tr><td class="fname">agent_type</td><td class="ftype">String</td><td class="fnote"><span class="flag req">REQ</span>One of <code>VALID_AGENT_TYPES</code>.</td></tr>
+        <tr><td class="fname">capabilities</td><td class="ftype">Option&lt;Vec&lt;String&gt;&gt;</td><td class="fnote"><span class="flag opt">OPT</span>Free-form capability tags.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="agentregistration">
+      <div class="ty-head"><span class="ty-name">AgentRegistration</span><span class="ty-kind struct">struct</span><span class="ty-since">since Task 1.3 (v0.6)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Serialize)]</code></div>
+      <div class="ty-desc">Response to <code>POST /agents/register</code> and rows in <code>GET /agents</code>.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">agent_id</td><td class="ftype">String</td><td class="fnote"></td></tr>
+        <tr><td class="fname">agent_type</td><td class="ftype">String</td><td class="fnote"></td></tr>
+        <tr><td class="fname">capabilities</td><td class="ftype">Vec&lt;String&gt;</td><td class="fnote">Empty when none registered.</td></tr>
+        <tr><td class="fname">registered_at</td><td class="ftype">String</td><td class="fnote">RFC3339.</td></tr>
+        <tr><td class="fname">last_seen_at</td><td class="ftype">String</td><td class="fnote">RFC3339; bumps on agent activity.</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="ty k-struct" id="vectorclock">
+      <div class="ty-head"><span class="ty-name">VectorClock</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.6.0 — Phase 3 foundation (#224)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]</code></div>
+      <div class="ty-desc">Tracks the latest <code>updated_at</code> this peer has seen from each known remote. Populated lazily on <code>/sync/push</code> and <code>/sync/since</code>. CRDT-lite merge semantics arrive in Task 3a.1; the foundation ships the wire format so adding semantics later does not force a schema migration.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">entries</td><td class="ftype">BTreeMap&lt;String, String&gt;</td><td class="fnote"><span class="flag def">DEF</span>peer agent_id → latest RFC3339 updated_at.</td></tr>
+      </tbody></table>
+      <div class="snip">// helper API
+VectorClock::observe(&amp;mut self, peer_id: &amp;str, at: &amp;str)  // monotonic: never overwrite newer
+VectorClock::latest_from(&amp;self, peer_id: &amp;str) -&gt; Option&lt;&amp;str&gt;</div>
+    </div>
+
+    <div class="ty k-struct" id="syncstateentry">
+      <div class="ty-head"><span class="ty-name">SyncStateEntry</span><span class="ty-kind struct">struct</span><span class="ty-since">since v0.6.0 — Phase 3 foundation (#224)</span></div>
+      <div class="ty-derive"><code>#[derive(Debug, Clone, Serialize, Deserialize)]</code></div>
+      <div class="ty-desc">One row of the <code>sync_state</code> table serialized for diagnostic / API responses. Consumed by Task 3b.2 sync diagnostics.</div>
+      <table class="fld"><thead><tr><th>field</th><th>type</th><th>notes</th></tr></thead><tbody>
+        <tr><td class="fname">agent_id</td><td class="ftype">String</td><td class="fnote">Local agent's id.</td></tr>
+        <tr><td class="fname">peer_id</td><td class="ftype">String</td><td class="fnote">Remote peer's id.</td></tr>
+        <tr><td class="fname">last_seen_at</td><td class="ftype">String</td><td class="fnote">RFC3339; latest <code>updated_at</code> seen on receive.</td></tr>
+        <tr><td class="fname">last_pulled_at</td><td class="ftype">String</td><td class="fnote">RFC3339; cursor advanced on send.</td></tr>
+      </tbody></table>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head" id="consts">Constants — wire-format closed sets</h3>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">MAX_CONTENT_SIZE</span><span class="ty-kind const">const</span></div>
+      <div class="ty-desc"><code>usize = 65_536</code> — hard cap on memory <code>content</code> bytes. Validated at write time.</div>
+    </div>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">MAX_NAMESPACE_DEPTH</span><span class="ty-kind const">const</span></div>
+      <div class="ty-desc"><code>usize = 8</code> — maximum number of <code>/</code>-delimited segments in a namespace path. Sample: <code>alphaone/engineering/platform/team/squad/pod/role/agent</code>.</div>
+    </div>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">VALID_SCOPES</span><span class="ty-kind const">const</span></div>
+      <div class="ty-desc"><code>&amp;[&amp;str] = &amp;["private", "team", "unit", "org", "collective"]</code> — closed set stamped into <code>metadata.scope</code> (Task 1.5). Drives hierarchical visibility matching.</div>
+    </div>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">VALID_AGENT_TYPES</span><span class="ty-kind const">const</span></div>
+      <div class="ty-desc">Closed set of agent types accepted by <code>POST /agents/register</code>. Persisted; extend carefully.</div>
+      <div class="snip">&amp;[
+  "ai:claude-opus-4.6",
+  "ai:claude-opus-4.7",
+  "ai:codex-5.4",
+  "ai:grok-4.2",
+  "human",
+  "system",
+]</div>
+    </div>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">AGENTS_NAMESPACE</span><span class="ty-kind const">const</span></div>
+      <div class="ty-desc"><code>&amp;str = "_agents"</code> — namespace reserved for agent registrations (Task 1.3). Listed via <code>memory_agent_list</code>.</div>
+    </div>
+
+    <div class="ty k-const">
+      <div class="ty-head"><span class="ty-name">namespace_depth(ns: &amp;str) → usize</span><span class="ty-kind const">fn</span></div>
+      <div class="ty-desc">Free function. Returns the count of <code>/</code>-delimited segments. Flat namespaces return 1; empty returns 0.</div>
+      <div class="snip">namespace_depth("global")                           // 1
+namespace_depth("alphaone/engineering")             // 2
+namespace_depth("alphaone/engineering/platform")    // 3</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>ai-memory v0.6.3 · Apache 2.0 · src/<a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/models.rs">models.rs</a> is the source of truth · this page is a generated reference for AI clients integrating against the type contract</p>
+  <p style="margin-top:.5rem"><a href="./">← Back to ai-memory</a> · <a href="at-a-glance.html">Atlas</a> · <a href="schema.html">Schema</a> · <a href="validators.html">Validators</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/validators.html
+++ b/docs/validators.html
@@ -1,0 +1,434 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Validators atlas — every validate_* function in src/validate.rs.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Validators — every input check</title>
+<meta name="description" content="ai-memory v0.6.3 input-validation reference. Every validator function, every limit, every accepted value, every rejection reason. Defense in depth at the API boundary.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/validators.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(255,184,107,0.06),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:760px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+
+.limits{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-bottom:1.5rem}
+.limit{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem;text-align:center}
+.limit .num{font-family:var(--font-mono);font-size:1.6rem;font-weight:700;color:var(--p2)}
+.limit .lbl{font-size:.78rem;color:var(--text-muted);margin-top:.25rem}
+
+.grp-head{font-family:var(--font-mono);font-size:1rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin:2rem 0 1rem;padding-bottom:.4rem;border-bottom:1px solid var(--border)}
+
+.v{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;margin-bottom:1.25rem;position:relative;overflow:hidden}
+.v::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--p2)}
+.v.composite::before{background:var(--p3)}
+.v-head{display:flex;align-items:baseline;gap:1rem;flex-wrap:wrap;margin-bottom:.5rem}
+.v-name{font-family:var(--font-mono);font-size:1.1rem;font-weight:700;color:var(--text)}
+.v-sig{font-family:var(--font-mono);font-size:.78rem;color:var(--p1)}
+.v-when{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);padding:.15em .55em;border:1px solid var(--border-hl);border-radius:4px}
+.v-desc{color:var(--text-muted);font-size:.92rem;margin-bottom:1rem}
+.v-rules{margin-top:.5rem}
+.v-rules .lbl{font-family:var(--font-mono);font-size:.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.4rem}
+.v-rules ul{list-style:none;padding-left:0;margin:0}
+.v-rules li{padding:.3rem 0;border-bottom:1px solid var(--border);font-size:.85rem;color:var(--text-muted)}
+.v-rules li:last-child{border-bottom:none}
+.v-rules li::before{content:"▸ ";color:var(--good)}
+.v-rules li.bad::before{content:"× ";color:var(--bad)}
+.snip{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);margin-top:.85rem;padding:.7rem .85rem;background:var(--bg-code);border-radius:6px;line-height:1.55;white-space:pre;overflow-x:auto}
+.snip .ok{color:var(--good)}
+.snip .err{color:var(--bad)}
+.snip .cm{color:var(--text-dim)}
+
+.composed{background:var(--bg-elev);border-left:3px solid var(--p3);padding:.5rem .85rem;border-radius:0 6px 6px 0;font-size:.82rem;color:var(--text-muted);margin-top:.6rem}
+.composed strong{color:var(--p3);font-family:var(--font-mono);font-size:.78rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Validators</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">Atlas</a>
+      <a href="schema.html">Schema</a>
+      <a href="types.html">Types</a>
+      <a href="governance.html">Governance</a>
+      <a href="tracing.html">Tracing</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/validate.rs">validate.rs →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>The validators, every check.</h1>
+  <p class="tagline">Defense in depth at the API boundary. 23 validator functions, every limit explicit, every closed set enumerated. The same checks run on HTTP, MCP, CLI, and inbound federation sync — there is no privileged path that bypasses them.</p>
+  <div class="pills">
+    <span class="pill">23 functions</span>
+    <span class="pill">9 limits</span>
+    <span class="pill">3 closed sets</span>
+    <span class="pill">red-team #235 / #240 hardened</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Hard limits at a glance</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Every numeric ceiling.</h2>
+    <p class="lede">Constants live in <code>src/validate.rs</code> at module top. Bumping any of these is a wire-format change — clients should treat them as the contract.</p>
+    <div class="limits">
+      <div class="limit"><div class="num">512</div><div class="lbl">MAX_TITLE_LEN (chars)</div></div>
+      <div class="limit"><div class="num">65 536</div><div class="lbl">MAX_CONTENT_SIZE (bytes)</div></div>
+      <div class="limit"><div class="num">512</div><div class="lbl">MAX_NAMESPACE_LEN (chars)</div></div>
+      <div class="limit"><div class="num">8</div><div class="lbl">MAX_NAMESPACE_DEPTH (segments)</div></div>
+      <div class="limit"><div class="num">64</div><div class="lbl">MAX_SOURCE_LEN (bytes)</div></div>
+      <div class="limit"><div class="num">128</div><div class="lbl">MAX_TAG_LEN (bytes/tag)</div></div>
+      <div class="limit"><div class="num">50</div><div class="lbl">MAX_TAGS_COUNT (per memory)</div></div>
+      <div class="limit"><div class="num">128</div><div class="lbl">MAX_AGENT_ID_LEN (bytes)</div></div>
+      <div class="limit"><div class="num">64</div><div class="lbl">MAX_RELATION_LEN (bytes)</div></div>
+      <div class="limit"><div class="num">128</div><div class="lbl">MAX_ID_LEN (bytes)</div></div>
+      <div class="limit"><div class="num">64</div><div class="lbl">MAX_AGENT_TYPE_LEN (bytes)</div></div>
+      <div class="limit"><div class="num">65 536</div><div class="lbl">MAX_METADATA_SIZE (bytes)</div></div>
+      <div class="limit"><div class="num">32</div><div class="lbl">MAX_METADATA_DEPTH (nesting)</div></div>
+      <div class="limit"><div class="num">1 yr</div><div class="lbl">MAX TTL_SECS (= 31 536 000)</div></div>
+      <div class="limit"><div class="num">100</div><div class="lbl">MAX consolidation IDs</div></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Field-level validators — strings</h3>
+
+    <div class="v" id="validate_title">
+      <div class="v-head"><span class="v-name">validate_title</span><span class="v-sig">(title: &amp;str) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory · Consolidate</span></div>
+      <div class="v-desc">Memory title. Surfaces in lists, recall hits, and the dashboard. Trimmed length ≤ 512 characters.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Trimmed value must be non-empty</li>
+        <li>Character count ≤ 512</li>
+        <li>No control characters (except <code>\n</code>, <code>\t</code>)</li>
+      </ul></div>
+      <div class="snip"><span class="ok">OK </span> "Q3 OKR review"          <span class="cm">// 14 chars</span>
+<span class="ok">OK </span> "Multi-line\ntitle"      <span class="cm">// \n is allowed</span>
+<span class="err">ERR</span> ""                       <span class="cm">// title cannot be empty</span>
+<span class="err">ERR</span> "   "                    <span class="cm">// trim → empty</span>
+<span class="err">ERR</span> "x".repeat(513)          <span class="cm">// exceeds max length</span>
+<span class="err">ERR</span> "bad\x00null"            <span class="cm">// invalid characters</span></div>
+    </div>
+
+    <div class="v" id="validate_content">
+      <div class="v-head"><span class="v-name">validate_content</span><span class="v-sig">(content: &amp;str) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory · Consolidate (summary)</span></div>
+      <div class="v-desc">Memory body. The size cap protects HNSW (vectors are computed from content) and SQLite WAL.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Trimmed value must be non-empty</li>
+        <li>Byte length (not chars) ≤ 65 536</li>
+        <li>No control characters (except <code>\n</code>, <code>\t</code>)</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_namespace">
+      <div class="v-head"><span class="v-name">validate_namespace</span><span class="v-sig">(ns: &amp;str) → Result&lt;()&gt;</span><span class="v-when">all write paths · sync_push receive</span></div>
+      <div class="v-desc">Flat or hierarchical (Task 1.4). <code>/</code> is the segment delimiter; flat namespaces (<code>"global"</code>, <code>"ai-memory"</code>) remain valid — hierarchy is opt-in.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Non-empty after trim</li>
+        <li>Length ≤ 512 characters</li>
+        <li>No backslash, no null byte, no space, no control char</li>
+        <li>No leading <code>/</code>, no trailing <code>/</code>, no empty segment (<code>//</code>)</li>
+        <li class="bad">Segments <code>.</code> and <code>..</code> rejected — red-team #240 (path-traversal-style scope leak)</li>
+        <li>Depth (segment count) ≤ 8</li>
+      </ul></div>
+      <div class="snip"><span class="ok">OK </span> "global"
+<span class="ok">OK </span> "ai-memory-mcp-dev"                              <span class="cm">// flat with hyphens</span>
+<span class="ok">OK </span> "alphaone/engineering/platform"                  <span class="cm">// 3 levels</span>
+<span class="ok">OK </span> "alphaone/engineering/platform/team/squad/pod/role/agent" <span class="cm">// 8 levels — at cap</span>
+<span class="err">ERR</span> "/global"                                        <span class="cm">// leading /</span>
+<span class="err">ERR</span> "alphaone//eng"                                  <span class="cm">// empty segment</span>
+<span class="err">ERR</span> "alphaone/.."                                    <span class="cm">// path-traversal blocked</span>
+<span class="err">ERR</span> "a/b/c/d/e/f/g/h/i"                              <span class="cm">// depth 9 &gt; 8</span></div>
+      <div class="composed"><strong>helper:</strong> <code>normalize_namespace(input)</code> trims, strips leading/trailing slashes, collapses <code>//</code>, lowercases. Not auto-applied by write paths — opt-in to preserve case sensitivity on existing flat namespaces.</div>
+    </div>
+
+    <div class="v" id="validate_source">
+      <div class="v-head"><span class="v-name">validate_source</span><span class="v-sig">(source: &amp;str) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · sync_push receive</span></div>
+      <div class="v-desc">Closed-set discriminator stored on each memory. Adding a value here is a wire-format change — peers running older versions will reject the new value on sync.</div>
+      <div class="v-rules"><div class="lbl">Accepted values</div><ul>
+        <li><code>user</code> — human-typed</li>
+        <li><code>claude</code> — Claude Code or other Claude client</li>
+        <li><code>hook</code> — emitted by a Claude Code hook</li>
+        <li><code>api</code> — generic HTTP API</li>
+        <li><code>cli</code> — local <code>ai-memory</code> CLI</li>
+        <li><code>import</code> — bulk import path</li>
+        <li><code>consolidation</code> — output of <code>memory_consolidate</code></li>
+        <li><code>system</code> — daemon-internal stamps</li>
+        <li><code>chaos</code> — chaos-engineering test harness</li>
+        <li><code>notify</code> — v0.6.2 (S32) <code>handle_notify</code> inbox stamps</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_agent_id">
+      <div class="v-head"><span class="v-name">validate_agent_id</span><span class="v-sig">(agent_id: &amp;str) → Result&lt;()&gt;</span><span class="v-when">register agent · CreateMemory.agent_id · approval votes</span></div>
+      <div class="v-desc">NHI-hardened identifier. Permits prefixed/scoped forms; rejects shell metacharacters.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Non-empty</li>
+        <li>Length ≤ 128 bytes</li>
+        <li>Allowed chars: ASCII alphanumeric + <code>_ - : @ . /</code></li>
+        <li class="bad">No whitespace, no null, no control char, no shell metacharacter</li>
+      </ul></div>
+      <div class="snip"><span class="ok">OK </span> "ai:claude-code@host-1:pid-123"
+<span class="ok">OK </span> "host:dev-1:pid-9-deadbeef"
+<span class="ok">OK </span> "anonymous:req-abcdef01"
+<span class="ok">OK </span> "spiffe://example.org/ns/team/pod"      <span class="cm">// future SPIFFE</span>
+<span class="err">ERR</span> "alice bob"                              <span class="cm">// space</span>
+<span class="err">ERR</span> "alice;rm -rf /"                         <span class="cm">// shell metachar</span></div>
+    </div>
+
+    <div class="v" id="validate_scope">
+      <div class="v-head"><span class="v-name">validate_scope</span><span class="v-sig">(scope: &amp;str) → Result&lt;()&gt;</span><span class="v-when">CreateMemory.scope (Task 1.5)</span></div>
+      <div class="v-desc">Closed set — drives hierarchical visibility matching. Memories without explicit scope are treated as <code>private</code> by the query layer.</div>
+      <div class="v-rules"><div class="lbl">Accepted values</div><ul>
+        <li><code>private</code> — visible only to the originating agent</li>
+        <li><code>team</code> — visible to agents at the same namespace prefix (one level)</li>
+        <li><code>unit</code> — visible up the hierarchy two levels</li>
+        <li><code>org</code> — visible across the whole organization namespace</li>
+        <li><code>collective</code> — federation-wide visibility</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_agent_type">
+      <div class="v-head"><span class="v-name">validate_agent_type</span><span class="v-sig">(agent_type: &amp;str) → Result&lt;()&gt;</span><span class="v-when">register agent</span></div>
+      <div class="v-desc">Open <code>ai:&lt;name&gt;</code> namespace + curated short-list. Red-team #235: the original closed whitelist blocked future agents — now operators can register <code>ai:claude-opus-4.8</code>, <code>ai:gpt-5</code>, <code>ai:gemini-2.5</code> without a code release.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Non-empty, length ≤ 64 bytes</li>
+        <li>Curated set always wins: <code>human</code>, <code>system</code>, <code>ai:claude-opus-4.6</code>, <code>ai:claude-opus-4.7</code>, <code>ai:codex-5.4</code>, <code>ai:grok-4.2</code></li>
+        <li>Open <code>ai:&lt;name&gt;</code> form: name 1–60 chars, ASCII alphanumeric + <code>_ - .</code></li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_relation">
+      <div class="v-head"><span class="v-name">validate_relation</span><span class="v-sig">(relation: &amp;str) → Result&lt;()&gt;</span><span class="v-when">LinkBody · sync_push links receive</span></div>
+      <div class="v-desc">Closed set — KG relationship type. New relations are a wire-format change.</div>
+      <div class="v-rules"><div class="lbl">Accepted values</div><ul>
+        <li><code>related_to</code> — generic association (default for <code>memory_link</code>)</li>
+        <li><code>supersedes</code> — newer memory replaces older (typed cognition)</li>
+        <li><code>contradicts</code> — explicit disagreement (Task: contradiction detection)</li>
+        <li><code>derived_from</code> — provenance (consolidation outputs)</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_id">
+      <div class="v-head"><span class="v-name">validate_id</span><span class="v-sig">(id: &amp;str) → Result&lt;()&gt;</span><span class="v-when">memory_get · memory_update · LinkBody · consolidate</span></div>
+      <div class="v-desc">Generic memory identifier — accepts UUIDs and any other clean string ≤ 128 bytes. Format-agnostic so legacy/imported ids continue to work.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Non-empty after trim</li>
+        <li>Length ≤ 128 bytes</li>
+        <li>No control characters</li>
+      </ul></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Field-level validators — numeric &amp; structural</h3>
+
+    <div class="v" id="validate_priority">
+      <div class="v-head"><span class="v-name">validate_priority</span><span class="v-sig">(priority: i32) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory</span></div>
+      <div class="v-desc">Recall ranks by priority * confidence * recency. Out-of-band values are rejected so the ranking math stays predictable.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>1 ≤ priority ≤ 10 (inclusive)</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_confidence">
+      <div class="v-head"><span class="v-name">validate_confidence</span><span class="v-sig">(confidence: f64) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory</span></div>
+      <div class="v-desc">How certain a memory is. NaN/Inf are explicitly rejected.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Finite (no NaN, no Inf)</li>
+        <li>0.0 ≤ confidence ≤ 1.0</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_tags">
+      <div class="v-head"><span class="v-name">validate_tags</span><span class="v-sig">(tags: &amp;[String]) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory · register agent (capabilities)</span></div>
+      <div class="v-desc">Free-form tags. Used by recall + list filters; stored as a comma-joined column.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Vec length ≤ 50</li>
+        <li>Each tag (after trim) non-empty</li>
+        <li>Each tag length ≤ 128 bytes</li>
+        <li>Each tag has no control characters</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_capabilities">
+      <div class="v-head"><span class="v-name">validate_capabilities</span><span class="v-sig">(caps: &amp;[String]) → Result&lt;()&gt;</span><span class="v-when">register agent</span></div>
+      <div class="v-desc">Delegates entirely to <code>validate_tags</code>. Same rules.</div>
+    </div>
+
+    <div class="v" id="validate_expires_at">
+      <div class="v-head"><span class="v-name">validate_expires_at</span><span class="v-sig">(expires_at: Option&lt;&amp;str&gt;) → Result&lt;()&gt;</span><span class="v-when">CreateMemory (write path)</span></div>
+      <div class="v-desc">Strict — rejects past dates. Used when accepting fresh user input that should expire in the future.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>If present, must be valid RFC3339</li>
+        <li>If present, must be in the future (now &lt; expires_at)</li>
+        <li>None passes through</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_expires_at_format">
+      <div class="v-head"><span class="v-name">validate_expires_at_format</span><span class="v-sig">(ts: &amp;str) → Result&lt;()&gt;</span><span class="v-when">UpdateMemory</span></div>
+      <div class="v-desc">Lenient — format-only check. Updates allow past dates so callers can use it for programmatic TTL management and GC testing without round-tripping through clock manipulation.</div>
+    </div>
+
+    <div class="v" id="validate_ttl_secs">
+      <div class="v-head"><span class="v-name">validate_ttl_secs</span><span class="v-sig">(ttl: Option&lt;i64&gt;) → Result&lt;()&gt;</span><span class="v-when">CreateMemory</span></div>
+      <div class="v-desc">Convenience input — server computes <code>expires_at = now + ttl_secs</code>. Capped at 1 year so a typo can't accidentally make a memory effectively immortal.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>If present, must be &gt; 0</li>
+        <li>If present, must be ≤ 31 536 000 (1 year)</li>
+      </ul></div>
+    </div>
+
+    <div class="v" id="validate_metadata">
+      <div class="v-head"><span class="v-name">validate_metadata</span><span class="v-sig">(metadata: &amp;serde_json::Value) → Result&lt;()&gt;</span><span class="v-when">CreateMemory · UpdateMemory</span></div>
+      <div class="v-desc">Cap on size + nesting depth — protects the JSON column from runaway payloads. <code>governance</code>, <code>agent_id</code>, <code>scope</code>, taxonomy fields all live here, so the cap has to be high enough for real-world use.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Must be a JSON object (not array, not scalar)</li>
+        <li>Serialized size ≤ 65 536 bytes</li>
+        <li>Nesting depth ≤ 32 — guards against stack overflow on recursive walk</li>
+      </ul></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Governance validators</h3>
+
+    <div class="v" id="validate_governance_policy">
+      <div class="v-head"><span class="v-name">validate_governance_policy</span><span class="v-sig">(policy: &amp;GovernancePolicy) → Result&lt;()&gt;</span><span class="v-when">set_namespace_standard write</span></div>
+      <div class="v-desc">Closed-set tags handled by serde on deserialize; this adds semantic bounds beyond serde's reach.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li><code>ApproverType::Agent(id)</code> → must pass <code>validate_agent_id</code></li>
+        <li><code>ApproverType::Consensus(n)</code> → quorum must be ≥ 1</li>
+        <li>If any of <code>write</code>/<code>promote</code>/<code>delete</code> is <code>Approve</code>, approver must be meaningful (not <code>Consensus(0)</code>)</li>
+        <li><code>ApproverType::Human</code> always valid</li>
+      </ul></div>
+      <div class="snip"><span class="ok">OK </span> { write: Any, promote: Any, delete: Owner, approver: Human }       <span class="cm">// the default</span>
+<span class="ok">OK </span> { write: Approve, promote: Approve, delete: Owner, approver: Consensus(3) }
+<span class="err">ERR</span> { write: Any, promote: Any, delete: Owner, approver: Consensus(0) } <span class="cm">// quorum &lt; 1</span>
+<span class="err">ERR</span> { write: Approve, promote: Any, delete: Owner, approver: Consensus(0) }
+<span class="err">ERR</span> { write: Any, promote: Any, delete: Owner, approver: Agent("alice;rm") } <span class="cm">// bad agent_id</span></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <h3 class="grp-head">Composite validators — full payload checks</h3>
+
+    <div class="v composite" id="validate_create">
+      <div class="v-head"><span class="v-name">validate_create</span><span class="v-sig">(mem: &amp;CreateMemory) → Result&lt;()&gt;</span><span class="v-when">POST /memories · memory_store</span></div>
+      <div class="v-desc">The top-level write-path gate. Composes all single-field validators and short-circuits on first failure.</div>
+      <div class="snip">validate_title(&amp;mem.title)?;
+validate_content(&amp;mem.content)?;
+validate_namespace(&amp;mem.namespace)?;
+validate_source(&amp;mem.source)?;
+validate_tags(&amp;mem.tags)?;
+validate_priority(mem.priority)?;
+validate_confidence(mem.confidence)?;
+validate_expires_at(mem.expires_at.as_deref())?;     <span class="cm">// strict — rejects past</span>
+validate_ttl_secs(mem.ttl_secs)?;
+validate_metadata(&amp;mem.metadata)?;</div>
+    </div>
+
+    <div class="v composite" id="validate_memory">
+      <div class="v-head"><span class="v-name">validate_memory</span><span class="v-sig">(mem: &amp;Memory) → Result&lt;()&gt;</span><span class="v-when">import path · sync_push receive</span></div>
+      <div class="v-desc">Like <code>validate_create</code> but for fully-realized <code>Memory</code> records. Permits past <code>expires_at</code> (importing historical data).</div>
+      <div class="v-rules"><div class="lbl">Adds beyond validate_create</div><ul>
+        <li><code>validate_id(&amp;mem.id)</code></li>
+        <li><code>access_count &gt;= 0</code></li>
+        <li><code>created_at</code>, <code>updated_at</code> are RFC3339</li>
+        <li><code>last_accessed_at</code>, <code>expires_at</code> RFC3339 if present (no chronological check)</li>
+      </ul></div>
+    </div>
+
+    <div class="v composite" id="validate_update">
+      <div class="v-head"><span class="v-name">validate_update</span><span class="v-sig">(update: &amp;UpdateMemory) → Result&lt;()&gt;</span><span class="v-when">PUT /memories/:id · memory_update</span></div>
+      <div class="v-desc">Validates only the fields that are present (every field on <code>UpdateMemory</code> is <code>Option</code>). Uses <code>validate_expires_at_format</code> not <code>validate_expires_at</code> — past dates allowed for programmatic TTL management.</div>
+    </div>
+
+    <div class="v composite" id="validate_link">
+      <div class="v-head"><span class="v-name">validate_link</span><span class="v-sig">(source_id, target_id, relation) → Result&lt;()&gt;</span><span class="v-when">POST /links · memory_link</span></div>
+      <div class="v-desc">KG-edge gate.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>Both ids pass <code>validate_id</code></li>
+        <li>Relation passes <code>validate_relation</code></li>
+        <li>source_id ≠ target_id (no self-loops)</li>
+      </ul></div>
+    </div>
+
+    <div class="v composite" id="validate_consolidate">
+      <div class="v-head"><span class="v-name">validate_consolidate</span><span class="v-sig">(ids, title, summary, namespace) → Result&lt;()&gt;</span><span class="v-when">memory_consolidate</span></div>
+      <div class="v-desc">Bulk consolidation — collapses N memories into 1 derived summary. The cap of 100 keeps the LLM call bounded.</div>
+      <div class="v-rules"><div class="lbl">Rules</div><ul>
+        <li>2 ≤ ids.len() ≤ 100</li>
+        <li>No duplicate ids in the input set</li>
+        <li>Each id passes <code>validate_id</code></li>
+        <li>Title passes <code>validate_title</code></li>
+        <li>Summary passes <code>validate_content</code></li>
+        <li>Namespace passes <code>validate_namespace</code></li>
+      </ul></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Defense in depth</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Where these validators run.</h2>
+    <p class="lede">There is no privileged path that bypasses the validators. Every entry that creates or mutates state on the server runs the same set of checks.</p>
+    <div class="snip" style="font-family:var(--font-sans);white-space:normal;line-height:1.7">
+      <div><strong style="color:var(--good)">HTTP handlers</strong> → <code>validate_create</code> / <code>validate_update</code> / <code>validate_link</code> at request decode</div>
+      <div><strong style="color:var(--good)">MCP handlers</strong> → same validators, ahead of the daemon dispatch</div>
+      <div><strong style="color:var(--good)">CLI</strong> → calls into HTTP daemon → same validators</div>
+      <div><strong style="color:var(--good)">Federation receive (<code>POST /sync/push</code>)</strong> → <code>validate_memory</code> on every received row before insert; rejects malformed peer payloads</div>
+      <div><strong style="color:var(--good)">Hooks (Claude Code)</strong> → calls HTTP daemon → same validators</div>
+      <div><strong style="color:var(--good)">Import (<code>memory_import</code>)</strong> → <code>validate_memory</code> on every row</div>
+    </div>
+    <p class="lede" style="margin-top:1rem">A failed validator returns a 400-class HTTP error with the exact <code>bail!</code> message. AI clients can surface the reason verbatim — there is no "validation failed" placeholder.</p>
+  </div>
+</section>
+
+<footer>
+  <p>ai-memory v0.6.3 · Apache 2.0 · src/<a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/validate.rs">validate.rs</a> is the source of truth · this page is a generated reference</p>
+  <p style="margin-top:.5rem"><a href="./">← Back to ai-memory</a> · <a href="at-a-glance.html">Atlas</a> · <a href="types.html">Types</a> · <a href="governance.html">Governance</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -1,0 +1,452 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  What's New in v0.6.3 — release-spotlight page covering Streams A-F,
+  the W3-W12 coverage campaign, the SSRF security finding+fix, and
+  the v0.6.3.1 capabilities-extension queued patch. Companion to
+  at-a-glance.html.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>What's New in v0.6.3 — Structured Memory + Performance</title>
+<meta name="description" content="v0.6.3 release highlights: hierarchical namespaces, temporal-validity knowledge graph, published performance budgets, 93.05% test coverage, 1809 tests, 2 SSRF defects fixed.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/whats-new-v063.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--warn:#ffb86b;--bad:#ff6b9d;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:2rem;margin-bottom:.5rem}h3{font-size:1.2rem;margin-bottom:.5rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a.active,.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:6rem 1.5rem 4rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%),radial-gradient(ellipse at bottom,rgba(200,162,255,0.05),transparent 70%);border-bottom:1px solid var(--border)}
+.hero .badge{display:inline-block;padding:.4rem 1rem;background:rgba(110,231,255,0.1);border:1px solid var(--p1);color:var(--p1);border-radius:999px;font-family:var(--font-mono);font-size:.85rem;margin-bottom:1.5rem;animation:glow 2.5s infinite ease-in-out}
+@keyframes glow{0%,100%{box-shadow:0 0 0 0 rgba(110,231,255,0.4)}50%{box-shadow:0 0 0 12px rgba(110,231,255,0)}}
+.hero h1{font-size:clamp(2.5rem,5vw,4rem);line-height:1.05;letter-spacing:-0.04em;margin-bottom:1rem}
+.hero .subtitle{font-size:1.2rem;color:var(--text-muted);max-width:720px;margin:0 auto 2rem}
+.hero .meta{display:flex;justify-content:center;gap:2rem;color:var(--text-dim);font-family:var(--font-mono);font-size:.85rem;flex-wrap:wrap}
+section{padding:5rem 0;border-bottom:1px solid var(--border)}
+section .eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+section .lede{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin-bottom:3rem}
+
+/* STREAMS GRID */
+.streams-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1.25rem}
+.stream{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;position:relative;overflow:hidden}
+.stream::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.stream.A::before{background:var(--p1)}.stream.B::before{background:var(--p2)}.stream.C::before{background:var(--p2)}.stream.D::before{background:var(--p2)}.stream.E::before{background:var(--p3)}.stream.F::before{background:var(--p3)}
+.stream .stream-letter{position:absolute;top:1.5rem;right:1.5rem;font-family:var(--font-mono);font-size:3rem;font-weight:900;opacity:.08;color:var(--text)}
+.stream .stream-tag{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;color:var(--text-muted);text-transform:uppercase;margin-bottom:.5rem}
+.stream h3{margin-bottom:.65rem}
+.stream .stream-desc{color:var(--text-muted);font-size:.9rem;margin-bottom:1rem}
+.stream .stream-deliverables{list-style:none;font-size:.85rem;color:var(--text-muted)}
+.stream .stream-deliverables li{padding-left:1.2rem;position:relative;margin:.3rem 0}
+.stream .stream-deliverables li::before{content:"✓";position:absolute;left:0;color:var(--good);font-weight:700}
+.stream .stream-status{margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border);font-family:var(--font-mono);font-size:.78rem;color:var(--good)}
+
+/* CAMPAIGN WAVES */
+.waves-track{position:relative;padding:1rem 0;overflow-x:auto}
+.waves-row{display:flex;gap:.5rem;min-width:900px;align-items:flex-end}
+.wave{flex:1;display:flex;flex-direction:column;align-items:center;gap:.5rem;padding:.85rem .35rem;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;position:relative;min-width:80px}
+.wave .wave-name{font-family:var(--font-mono);font-size:.75rem;font-weight:700;color:var(--text)}
+.wave .wave-cov{font-family:var(--font-mono);font-size:.95rem;font-weight:700}
+.wave .wave-delta{font-family:var(--font-mono);font-size:.65rem;color:var(--good)}
+.wave .wave-bar{width:8px;background:linear-gradient(to top,var(--p1),var(--p3));border-radius:4px;margin-top:.4rem}
+.wave .wave-closers{font-size:.65rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.08em}
+
+/* COVERAGE BAR ANIMATION */
+.cov-progress{display:flex;flex-direction:column;gap:1rem;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem}
+.cov-progress h3{font-family:var(--font-mono);margin-bottom:0}
+.cov-bar-row{display:flex;align-items:center;gap:1rem}
+.cov-bar-label{font-family:var(--font-mono);font-size:.8rem;color:var(--text-muted);min-width:100px}
+.cov-bar-track{flex:1;height:24px;background:var(--bg-code);border-radius:6px;position:relative;overflow:hidden}
+.cov-bar-fill-anim{height:100%;background:linear-gradient(90deg,var(--p3),var(--p1));border-radius:6px;animation:fill-anim 3s ease-out forwards;width:0}
+@keyframes fill-anim{to{width:var(--target)}}
+.cov-bar-pct{font-family:var(--font-mono);font-size:.95rem;font-weight:700;min-width:90px;text-align:right}
+
+/* SECURITY CALLOUT */
+.sec-card{background:linear-gradient(135deg,rgba(255,107,157,0.08),rgba(255,184,107,0.05));border:1px solid rgba(255,107,157,0.3);border-radius:14px;padding:1.75rem;margin:2rem 0}
+.sec-card h3{color:var(--bad);margin-bottom:.5rem}
+.sec-card .sec-body{color:#ffb0c8;margin-bottom:1rem}
+.sec-defect{background:var(--bg-code);border:1px solid rgba(255,107,157,0.2);border-radius:8px;padding:.85rem 1rem;margin:.5rem 0;font-size:.85rem;color:var(--text-muted)}
+.sec-defect .sec-id{font-family:var(--font-mono);color:var(--bad);font-weight:700;margin-right:.5rem}
+.sec-defect .sec-fixed{display:inline-block;color:var(--good);font-family:var(--font-mono);font-size:.75rem;margin-left:.5rem}
+
+/* COMPARISON TWO-UP */
+.beforeafter{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin:2rem 0}
+@media(max-width:800px){.beforeafter{grid-template-columns:1fr}}
+.ba-card{padding:1.5rem;border-radius:12px;border:1px solid var(--border)}
+.ba-card.before{background:rgba(255,107,157,0.04);border-color:rgba(255,107,157,0.2)}
+.ba-card.after{background:rgba(110,231,255,0.04);border-color:rgba(110,231,255,0.2)}
+.ba-tag{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;margin-bottom:.6rem}
+.ba-card.before .ba-tag{color:var(--bad)}
+.ba-card.after .ba-tag{color:var(--p1)}
+.ba-card pre{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);background:transparent;border:none;padding:0;line-height:1.55;white-space:pre-wrap;word-break:break-all}
+
+/* TILES */
+.tile-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem}
+.tile{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.25rem;display:flex;flex-direction:column;gap:.4rem}
+.tile.p1{border-top:3px solid var(--p1)}.tile.p2{border-top:3px solid var(--p2)}.tile.p3{border-top:3px solid var(--p3)}.tile.good{border-top:3px solid var(--good)}
+.tile .tile-num{font-family:var(--font-mono);font-size:1.85rem;font-weight:700;line-height:1}
+.tile .tile-label{font-size:.75rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.1em;margin-bottom:.4rem}
+.tile .tile-sub{font-size:.78rem;color:var(--text-dim)}
+
+/* FOOTER */
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ What's New v0.6.3</span></a>
+    <div class="right">
+      <a href="at-a-glance.html">At a Glance</a>
+      <a href="feature-matrix.html">Feature Matrix</a>
+      <a href="data-flow.html">Data Flow</a>
+      <a href="integrations.html">Integrations</a>
+      <a href="for-everyone.html">For Everyone</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3-rc1">Release →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <div class="badge">v0.6.3-rc1 · TAGGED 2026-04-26</div>
+  <h1>Structured Memory<br>+ Performance.</h1>
+  <p class="subtitle">The grand-slam release. Three pillars shipped in one focused 4-week sprint: hierarchical namespace tree, temporal-validity knowledge graph, and CI-enforced sub-100ms performance budgets.</p>
+  <div class="meta">
+    <span>56.7% → <strong style="color:var(--good)">93.05%</strong> coverage</span>
+    <span style="opacity:.4">·</span>
+    <span><strong style="color:var(--text)">1,809</strong> tests passing</span>
+    <span style="opacity:.4">·</span>
+    <span><strong style="color:var(--text)">26</strong> closers · <strong style="color:var(--text)">9</strong> waves</span>
+    <span style="opacity:.4">·</span>
+    <span><strong style="color:var(--bad)">2</strong> SSRF defects fixed</span>
+  </div>
+</section>
+
+<!-- =============== THE THREE PILLARS, EXPANDED =============== -->
+<section id="streams">
+  <div class="container">
+    <span class="eyebrow">6 Engineering Streams</span>
+    <h2>Streams A–F. Six teams. One release.</h2>
+    <p class="lede">v0.6.3 was scoped as six work-streams, each independently shippable but compounding when released together. All six landed; campaign closed at 93.05% line coverage.</p>
+
+    <div class="streams-grid">
+      <div class="stream A">
+        <div class="stream-letter">A</div>
+        <div class="stream-tag">PILLAR 1 · STREAM A</div>
+        <h3>Hierarchy</h3>
+        <div class="stream-desc">Namespaces gain <code>/</code>-delimited tree paths. Recall walks ancestors. <code>memory_get_taxonomy</code> returns the full tree with per-node memory counts.</div>
+        <ul class="stream-deliverables">
+          <li>MAX_NAMESPACE_DEPTH enforcement</li>
+          <li>Lossless flat → hierarchy migration (existing namespaces become single-segment paths)</li>
+          <li>memory_get_taxonomy MCP tool + HTTP endpoint</li>
+          <li>TaxonomyNode model + recursive walker</li>
+          <li>Subtree-scoped recall via namespace prefix match</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+
+      <div class="stream B">
+        <div class="stream-letter">B</div>
+        <div class="stream-tag">PILLAR 2 · STREAM B</div>
+        <h3>KG Schema + Entities</h3>
+        <div class="stream-desc">memory_links gains four columns (valid_from / valid_until / observed_by / signature). entity_aliases side table. Backfill of existing links to created_at.</div>
+        <ul class="stream-deliverables">
+          <li>Schema v15 migration (sqlite + postgres mirror)</li>
+          <li>Versioned migration files extracted from inline SQL</li>
+          <li>Entity registry with alias resolution</li>
+          <li>memory_entity_register / memory_entity_get_by_alias</li>
+          <li>Indexes: temporal_src, temporal_tgt, relation</li>
+          <li>signature column placeholder ready for v0.7 Ed25519</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+
+      <div class="stream C">
+        <div class="stream-letter">C</div>
+        <div class="stream-tag">PILLAR 2 · STREAM C</div>
+        <h3>KG Query Layer</h3>
+        <div class="stream-desc">Recursive-CTE traversal with time + scope + observed-by filters. memory_kg_query at depth ≤ 5. memory_kg_timeline. memory_kg_invalidate. Cypher stubs for v0.7 AGE.</div>
+        <ul class="stream-deliverables">
+          <li>memory_kg_query MCP tool + HTTP endpoint</li>
+          <li>memory_kg_timeline ordered-fact return</li>
+          <li>memory_kg_invalidate sets valid_until on a link</li>
+          <li>Cypher stubs documented in db.rs for v0.7 AGE wrapper</li>
+          <li>Cycle detection via path-LIKE check</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+
+      <div class="stream D">
+        <div class="stream-letter">D</div>
+        <div class="stream-tag">PILLAR 2 · STREAM D</div>
+        <h3>Duplicate Check</h3>
+        <div class="stream-desc">Pre-write similarity check. Reuses embedding pipeline. Returns nearest-neighbor cosine + above-threshold flag + suggested merge target.</div>
+        <ul class="stream-deliverables">
+          <li>memory_check_duplicate MCP tool + HTTP endpoint</li>
+          <li>Configurable threshold (default 0.85)</li>
+          <li>Tier-aware: requires semantic+ for embeddings</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+
+      <div class="stream E">
+        <div class="stream-letter">E</div>
+        <div class="stream-tag">PILLAR 3 · STREAM E</div>
+        <h3>Performance Instrumentation</h3>
+        <div class="stream-desc">Tracing spans on every MCP tool entrypoint. <code>ai-memory bench</code> subcommand with canonical workload + p50/p95/p99 reporting. <code>--baseline</code> regression detection.</div>
+        <ul class="stream-deliverables">
+          <li>src/bench.rs (97% covered) with 1k-memory canonical workload</li>
+          <li>p50 / p95 / p99 reporting per operation</li>
+          <li>--baseline path.json for regression detection</li>
+          <li>Tracing spans wired throughout mcp.rs and handlers.rs</li>
+          <li>Baseline numbers established on Apple M4 reference</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+
+      <div class="stream F">
+        <div class="stream-letter">F</div>
+        <div class="stream-tag">PILLAR 3 · STREAM F</div>
+        <h3>Performance Budgets + CI Guard</h3>
+        <div class="stream-desc">PERFORMANCE.md authoritative table. bench.yml CI workflow runs the bench on every PR. Build fails if any p95 exceeds budget by &gt;10%.</div>
+        <ul class="stream-deliverables">
+          <li>PERFORMANCE.md with all 13 operation budgets</li>
+          <li>.github/workflows/bench.yml on every PR + push</li>
+          <li>10% tolerance threshold encoded in workflow</li>
+          <li>Workflow summary embeds the table per-run</li>
+          <li>JSON artifact retained for trend analysis</li>
+        </ul>
+        <div class="stream-status">✓ Shipped</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== COVERAGE CAMPAIGN =============== -->
+<section id="coverage-campaign">
+  <div class="container">
+    <span class="eyebrow">W3-W12 Coverage Campaign</span>
+    <h2>56.7% → 93.05% in 9 waves.</h2>
+    <p class="lede">After streams A-F shipped, a parallel-agent coverage campaign drove ai-memory from 56.7% line coverage to 93.05% across nine waves. 26 closers in total. ~1,200 net new tests. Two production SSRF defects discovered + fixed during the work.</p>
+
+    <div class="waves-track">
+      <div class="waves-row">
+        <div class="wave"><div class="wave-name">v0.6.2</div><div class="wave-cov" style="color:var(--text-dim)">56.7%</div><div class="wave-bar" style="height:60px"></div><div class="wave-closers">baseline</div></div>
+        <div class="wave"><div class="wave-name">W2</div><div class="wave-cov" style="color:var(--text-dim)">75.31%</div><div class="wave-delta">+18.6</div><div class="wave-bar" style="height:80px"></div><div class="wave-closers">Pkg C</div></div>
+        <div class="wave"><div class="wave-name">W3</div><div class="wave-cov" style="color:var(--good)">81.02%</div><div class="wave-delta">+5.71</div><div class="wave-bar" style="height:96px"></div><div class="wave-closers">M·M'·F·T</div></div>
+        <div class="wave"><div class="wave-name">W4</div><div class="wave-cov" style="color:var(--good)">81.77%</div><div class="wave-delta">+0.75</div><div class="wave-bar" style="height:98px"></div><div class="wave-closers">T4 (TLS)</div></div>
+        <div class="wave"><div class="wave-name">W5</div><div class="wave-cov" style="color:var(--good)">85.13%</div><div class="wave-delta">+3.36</div><div class="wave-bar" style="height:108px"></div><div class="wave-closers">S5·R5·C5·X5</div></div>
+        <div class="wave"><div class="wave-name">W6</div><div class="wave-cov" style="color:var(--good)">85.61%</div><div class="wave-delta">+0.48</div><div class="wave-bar" style="height:110px"></div><div class="wave-closers">D6 (daemon)</div></div>
+        <div class="wave"><div class="wave-name">W7</div><div class="wave-cov" style="color:var(--good)">85.85%</div><div class="wave-delta">+0.24</div><div class="wave-bar" style="height:111px"></div><div class="wave-closers">I7 (integ)</div></div>
+        <div class="wave"><div class="wave-name">W8</div><div class="wave-cov" style="color:var(--good)">88.15%</div><div class="wave-delta">+2.30</div><div class="wave-bar" style="height:120px"></div><div class="wave-closers">H8a/b/c/d</div></div>
+        <div class="wave"><div class="wave-name">W9</div><div class="wave-cov" style="color:var(--good)">89.29%</div><div class="wave-delta">+1.14</div><div class="wave-bar" style="height:124px"></div><div class="wave-closers">M9·F9·A9</div></div>
+        <div class="wave"><div class="wave-name">W10</div><div class="wave-cov" style="color:var(--good)">89.74%</div><div class="wave-delta">+0.45</div><div class="wave-bar" style="height:126px"></div><div class="wave-closers">L10a·b</div></div>
+        <div class="wave"><div class="wave-name">W11</div><div class="wave-cov" style="color:var(--good)">89.75%</div><div class="wave-delta">+0.01</div><div class="wave-bar" style="height:127px"></div><div class="wave-closers">S11a·b + SSRF</div></div>
+        <div class="wave" style="border-color:var(--good)"><div class="wave-name" style="color:var(--good)">W12</div><div class="wave-cov" style="color:var(--good);font-size:1.05rem">93.05%</div><div class="wave-delta">+3.30</div><div class="wave-bar" style="height:144px;background:linear-gradient(to top,var(--good),var(--p3))"></div><div class="wave-closers" style="color:var(--good)">8 PARALLEL</div></div>
+      </div>
+    </div>
+
+    <div class="cov-progress" style="margin-top:2.5rem">
+      <h3 style="margin-bottom:1rem">Final coverage by metric</h3>
+      <div class="cov-bar-row">
+        <div class="cov-bar-label">Line</div>
+        <div class="cov-bar-track"><div class="cov-bar-fill-anim" style="--target:93.05%"></div></div>
+        <div class="cov-bar-pct" style="color:var(--good)">93.05%</div>
+      </div>
+      <div class="cov-bar-row">
+        <div class="cov-bar-label">Region</div>
+        <div class="cov-bar-track"><div class="cov-bar-fill-anim" style="--target:93.11%"></div></div>
+        <div class="cov-bar-pct" style="color:var(--good)">93.11%</div>
+      </div>
+      <div class="cov-bar-row">
+        <div class="cov-bar-label">Function</div>
+        <div class="cov-bar-track"><div class="cov-bar-fill-anim" style="--target:92.55%"></div></div>
+        <div class="cov-bar-pct" style="color:var(--good)">92.55%</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== SSRF FIXES =============== -->
+<section id="security">
+  <div class="container">
+    <span class="eyebrow">Security · L10b Findings</span>
+    <h2>Two SSRF defects discovered and fixed.</h2>
+    <p class="lede">Closer L10b was tasked with adding SSRF tests to <code>subscriptions::validate_url_dns</code>. The tests revealed two production defects. Both were fixed in commit <code>9eeb453</code> before the rc1 tag — un-ignored tests pass cleanly.</p>
+
+    <div class="sec-card">
+      <h3>What was found</h3>
+      <p class="sec-body">Both defects allowed webhook URLs to bypass the SSRF guard and hit internal addresses. Severity: <strong>Medium</strong>. Discovered during routine test-coverage work; fixed before tag.</p>
+
+      <div class="sec-defect">
+        <span class="sec-id">DEFECT-1</span>
+        <strong>Bracketed IPv6 host without explicit port bypassed validation.</strong>
+        URLs like <code>http://[fe80::1]/</code> produced <code>resolv_target = "[fe80::1]"</code> (no port). <code>to_socket_addrs()</code> errored "invalid port value" and the production DNS-failure fallback returned <code>Ok(())</code> — letting link-local IPv6 through.
+        <span class="sec-fixed">FIXED · 9eeb453</span>
+      </div>
+
+      <div class="sec-defect">
+        <span class="sec-id">DEFECT-2</span>
+        <strong>Unspecified addresses 0.0.0.0 and [::] were accepted.</strong>
+        <code>is_private()</code> didn't check <code>is_unspecified()</code>, so attacker-controlled hostnames resolving to 0.0.0.0 hit the local box (most kernels route 0.0.0.0 to localhost listeners).
+        <span class="sec-fixed">FIXED · 9eeb453</span>
+      </div>
+    </div>
+
+    <div class="beforeafter">
+      <div class="ba-card before">
+        <div class="ba-tag">▼ BEFORE</div>
+        <pre>// is_private — DEFECT-2 path
+fn is_private(ip: IpAddr) -> bool {
+  match ip {
+    IpAddr::V4(v4) =&gt; {
+      v4.is_private() ||
+      v4.is_link_local() ||
+      v4.is_multicast() ||
+      v4.is_broadcast()
+      // ← missing is_unspecified()
+    }
+    IpAddr::V6(v6) =&gt; {
+      let segs = v6.segments();
+      v6.is_multicast()
+      // ← missing is_unspecified()
+      || (segs[0] &amp; 0xfe00) == 0xfc00
+      || (segs[0] &amp; 0xffc0) == 0xfe80
+    }
+  }
+}</pre>
+      </div>
+      <div class="ba-card after">
+        <div class="ba-tag">▲ AFTER (commit 9eeb453)</div>
+        <pre>fn is_private(ip: IpAddr) -&gt; bool {
+  match ip {
+    IpAddr::V4(v4) =&gt; {
+      v4.is_private() ||
+      v4.is_link_local() ||
+      v4.is_multicast() ||
+      v4.is_broadcast() ||
+      v4.is_unspecified()  // ← FIX
+    }
+    IpAddr::V6(v6) =&gt; {
+      let segs = v6.segments();
+      v6.is_multicast() ||
+      v6.is_unspecified()  // ← FIX
+      || (segs[0] &amp; 0xfe00) == 0xfc00
+      || (segs[0] &amp; 0xffc0) == 0xfe80
+    }
+  }
+}</pre>
+      </div>
+    </div>
+
+    <div style="background:var(--bg-card);border:1px solid var(--good);border-radius:12px;padding:1.5rem;margin-top:2rem">
+      <strong style="color:var(--good)">No outstanding security defects post-campaign.</strong>
+      <p style="margin-top:.5rem">The SSRF fixes shipped with rc1. Both <code>#[ignore]</code> tests are un-ignored and passing. <strong>Zero ignored tests across the whole 1,809-test suite.</strong>
+    </p>
+    </div>
+  </div>
+</section>
+
+<!-- =============== HEADLINE NUMBERS =============== -->
+<section id="numbers">
+  <div class="container">
+    <span class="eyebrow">By the Numbers</span>
+    <h2>Every quantitative claim, sourced.</h2>
+    <p class="lede">All numbers from the v0.6.3 W12 consolidated coverage measurement (canonical command in CAMPAIGN-FINAL-METRICS.md). Hardware: Apple M4 / 32 GB / NVMe SSD.</p>
+
+    <div class="tile-grid">
+      <div class="tile p1"><div class="tile-label">Line coverage</div><div class="tile-num">93.05<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">42,894 / 46,099 lines</div></div>
+      <div class="tile p1"><div class="tile-label">Region coverage</div><div class="tile-num">93.11<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">73,150 / 78,564 regions</div></div>
+      <div class="tile p1"><div class="tile-label">Function coverage</div><div class="tile-num">92.55<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">3,527 / 3,811 functions</div></div>
+      <div class="tile good"><div class="tile-label">Tests passing</div><div class="tile-num">1,809</div><div class="tile-sub">0 failed · 0 ignored</div></div>
+      <div class="tile good"><div class="tile-label">Net new tests</div><div class="tile-num">~1,200</div><div class="tile-sub">across W3-W12</div></div>
+      <div class="tile p2"><div class="tile-label">Closers dispatched</div><div class="tile-num">26</div><div class="tile-sub">across 9 waves</div></div>
+      <div class="tile p2"><div class="tile-label">main.rs reduction</div><div class="tile-num">98.3<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">4,511 → 75 lines</div></div>
+      <div class="tile p3"><div class="tile-label">Session-start p95</div><div class="tile-num">42<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 100 ms</div></div>
+      <div class="tile p3"><div class="tile-label">Recall p95 hot</div><div class="tile-num">18<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 50 ms</div></div>
+      <div class="tile p3"><div class="tile-label">Federation ack p99</div><div class="tile-num">850<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 2 s</div></div>
+      <div class="tile"><div class="tile-label">Modules at 100%</div><div class="tile-num">7</div><div class="tile-sub">main · errors · color · ...</div></div>
+      <div class="tile"><div class="tile-label">SSRF fixed</div><div class="tile-num">2</div><div class="tile-sub">found + fixed pre-tag</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- =============== UPGRADE PATH =============== -->
+<section id="upgrade">
+  <div class="container">
+    <span class="eyebrow">Upgrading</span>
+    <h2>v0.6.2 → v0.6.3 in one command.</h2>
+    <p class="lede">SQLite migration is idempotent. The schema-v15 migration runs at first daemon start. Existing flat namespaces become single-segment hierarchical paths losslessly. Postgres backend has a manual procedure documented in MIGRATION-v0.6.2-to-v0.6.3.md.</p>
+
+    <div style="background:var(--bg-code);border:1px solid var(--border);border-radius:12px;padding:1.5rem;font-family:var(--font-mono);font-size:.85rem;line-height:1.7;color:var(--text)">
+<span style="color:var(--text-dim)"># Homebrew</span><br>
+brew upgrade ai-memory<br><br>
+<span style="color:var(--text-dim)"># cargo</span><br>
+cargo install ai-memory --force<br><br>
+<span style="color:var(--text-dim)"># APT (Debian/Ubuntu)</span><br>
+sudo apt update &amp;&amp; sudo apt install --only-upgrade ai-memory<br><br>
+<span style="color:var(--text-dim)"># DNF/YUM (Fedora/RHEL)</span><br>
+sudo dnf upgrade ai-memory<br><br>
+<span style="color:var(--text-dim)"># Verify</span><br>
+ai-memory --version <span style="color:var(--p1)"># → ai-memory 0.6.3-rc1</span>
+    </div>
+
+    <div style="background:var(--bg-card);border:1px solid var(--border-hl);border-radius:12px;padding:1.5rem;margin-top:1.5rem">
+      <strong>What happens at first start:</strong>
+      <ol style="color:var(--text-muted);margin-top:.6rem;padding-left:1.5rem;font-size:.9rem">
+        <li>Daemon detects schema version &lt; 15</li>
+        <li>Runs migrations/sqlite/0010_v063_hierarchy_kg.sql idempotently</li>
+        <li>Backfills <code>memory_links.valid_from</code> from source memory's <code>created_at</code></li>
+        <li>Adds entity_aliases table</li>
+        <li>Bumps schema_version to 15</li>
+        <li>Existing memories untouched. Existing recall continues to work.</li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<!-- =============== WHAT'S NEXT =============== -->
+<section id="next">
+  <div class="container">
+    <span class="eyebrow">Coming Next</span>
+    <h2>v0.6.3.1 patch and v0.7 charter.</h2>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+      <div class="tile p1" style="grid-column:span 1">
+        <div class="tile-label">Patch · within days</div>
+        <div class="tile-num" style="font-size:1.4rem">v0.6.3.1</div>
+        <div class="tile-sub" style="margin-top:.65rem">Capabilities Extension · <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/457" style="color:var(--p1)">#457</a><br>schema_version=2 reports hooks, permissions, compaction status, approval subscribers.</div>
+      </div>
+      <div class="tile p2" style="grid-column:span 1">
+        <div class="tile-label">Major · End Q2 2026</div>
+        <div class="tile-num" style="font-size:1.4rem">v0.7</div>
+        <div class="tile-sub" style="margin-top:.65rem">Trust + A2A Maturity · 4 buckets<br>Hook Pipeline · Ed25519 attest · Apache AGE · A2A maturity + per-agent quotas.</div>
+      </div>
+    </div>
+
+    <p style="margin-top:1.5rem;color:var(--text-muted)">See <a href="at-a-glance.html#roadmap" style="color:var(--p1)">at-a-glance.html roadmap</a> or the <a href="https://github.com/alphaonedev/ai-memory-mcp-dev/blob/develop/ROADMAP.md" style="color:var(--p1)">public ROADMAP.md</a>.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>v0.6.3-rc1 tagged 2026-04-26 · <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3-rc1" style="color:var(--text-muted)">GitHub release</a> · <a href="./" style="color:var(--text-muted)">main</a></p>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Operator directive (2026-04-26)

> create a dedicated web page linked off the GitHub Pages main page - where assess creating a massive visualization in HTML of every aspect and facet of ai-memory such that non-technical, c-level decision makers, subject matter expert software engineers - can visually see and comprehend every aspect and facet of ai-memory and what it does why it does what it does and the value it brings to the table - we need one massive visualization effectively communicating what ai-memory is and what it does for everyone from the individual to the small - mid - large - mega sized businesses and institutions such as federal, state, local, municipal governments

## What this PR ships

A new dedicated GitHub Pages page at `docs/at-a-glance.html` covering — in one scrollable visual atlas — every aspect and facet of ai-memory. **Visualization-heavy, prose-light.** Designed for progressive disclosure across three audience tiers in a single page:

| Top of page (30 second tour) | Middle (5 minute tour) | Bottom (depth) |
|---|---|---|
| Hero animation | Architecture layers | Numbers dashboard |
| Three-pillar cards | Tier ladder | Coverage bars |
| Stats strip | Memory lifecycle SVG | Federation diagram |
| | Performance gauges | Audiences-by-scale |
| | | Roadmap timeline |
| | | Comparison matrix |
| | | Trust ladder |
| | | Why-it-matters |

## Sections (15 total)

1. **Hero** — animated three-pillar SVG with pulse + dash links
2. **30-Second Tour** — three-pillar capability cards (Hierarchy / KG / Performance)
3. **Architecture** — four-layer stacking diagram (Surface / Core / Safety / State)
4. **Tiers** — operational ladder (keyword → semantic → smart → autonomous)
5. **Memory Lifecycle** — inline SVG of memory's life from `store` → `archive`
6. **Performance** — 10 inline gauges showing measured p95 vs published budget
7. **Test Quality** — 1,809 tests headline + 23-module coverage bar table
8. **Federation** — inline SVG diagram of W=2 of N=3 quorum write
9. **Audiences** — 5 personas: solo dev → startup → mid-market → enterprise → government
10. **Roadmap** — v0.6.3 shipped (rc1 today) → v0.7 → v0.8 → v0.9 → v1.0
11. **Comparison Matrix** — ai-memory vs vector DB / SaaS memory / mempalace / raw text
12. **Trust Ladder** — 5-step from local-first to FedRAMP/IL5
13. **Numbers Dashboard** — 18 quantitative tiles, every claim sourced
14. **Why It Matters** — per-audience cost-of-not-having-it argument
15. **CTA + footer**

## Tech notes

- Single HTML file (1,863 lines) with inline CSS + inline SVG
- **No external JS dependencies** (no CDNs, no analytics, no telemetry)
- Mobile-responsive (grid breakpoints at 540px / 800px / 920px / 1080px)
- Print-friendly (`@media print` block at the bottom strips nav/hero CTAs, white background, page-break protection)
- Dark monochrome aesthetic matching existing `index.html`, plus three-color accent palette (cyan / orange / purple) mirroring the v0.6.3 grand-slam pillars
- Animated SVG used sparingly: pulsing nodes, dashed-line flow indicators

## Linked from index.html

- **Nav**: cyan 'At a Glance' link first in the navigation row
- **Hero**: secondary outline CTA next to the primary 'Get Started in 60 Seconds'
  - Reads: `At a Glance — every facet, one page →`

## How to preview locally

```sh
cd docs && python3 -m http.server 8000
# open http://localhost:8000/at-a-glance.html
```

GitHub Pages picks up the new file from `docs/` on main automatically. After merge, the page lives at:

**https://alphaonedev.github.io/ai-memory-mcp/at-a-glance.html**

## Numbers sourced

All numbers in the page (93.05% line coverage, 1,809 tests, 42ms session-start p95, 18ms recall p95 hot, etc.) are pulled from the v0.6.3 W12 consolidated coverage measurement and `PERFORMANCE.md`. The CAMPAIGN-FINAL-METRICS.md document is the source of truth for the test-quality numbers.

## Test plan

- [x] HTML tag balance: all tags close (verified by Python HTMLParser)
- [x] No external dependencies (offline-renderable)
- [x] Mobile responsive (CSS grid breakpoints at 540 / 800 / 920 / 1080)
- [x] Print-friendly (`@media print` strips chrome)
- [ ] CI: standard lint pipeline applies to docs/* (no Rust changes)

## Why merge to main directly

GitHub Pages serves from `/docs/` on `main`. To make the page live for the public-facing v0.6.3 launch, this needs to land on main. Pure docs change — no code, no schema, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)