### PR TITLE
feat(capabilities): schema v2 — permissions/hooks/compaction/approval/transcripts (arch-spec §7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,7 +470,11 @@ jobs:
           AI_MEMORY_NO_CONFIG: "1"
         run: |
           cargo llvm-cov --features sal --no-fail-fast --html --output-dir coverage -- --test-threads=2
-          cargo llvm-cov report --features sal --summary-only | tee coverage/summary.txt
+          # `cargo llvm-cov report` reads the saved profile data and does
+          # not accept `--features` (would error: "invalid option
+          # '--features' for subcommand 'report'"). The earlier pipe-to-
+          # `tee` form masked that failure since `tee` always exits 0.
+          cargo llvm-cov report --summary-only | tee coverage/summary.txt
 
       # v0.6.3 coverage gate — fail-under 92% lines.
       # Locks in the v0.6.3 baseline of 93.05% with a 1% absorb buffer so
@@ -482,7 +486,7 @@ jobs:
         env:
           AI_MEMORY_NO_CONFIG: "1"
         run: |
-          cargo llvm-cov report --features sal --fail-under-lines 92
+          cargo llvm-cov report --fail-under-lines 92
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,18 @@ jobs:
           cargo llvm-cov --features sal --no-fail-fast --html --output-dir coverage -- --test-threads=2
           cargo llvm-cov report --features sal --summary-only | tee coverage/summary.txt
 
+      # v0.6.3 coverage gate — fail-under 92% lines.
+      # Locks in the v0.6.3 baseline of 93.05% with a 1% absorb buffer so
+      # routine churn doesn't trip the gate but a regression of >1% does.
+      # Per-module floors for hot modules (handlers, db, federation, mcp,
+      # governance) are tracked in the v0.7 assertion table; this is the
+      # total-line floor.
+      - name: Enforce coverage floor (≥92% lines)
+        env:
+          AI_MEMORY_NO_CONFIG: "1"
+        run: |
+          cargo llvm-cov report --features sal --fail-under-lines 92
+
       - name: Upload coverage report
         uses: actions/upload-artifact@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Capabilities schema v2 — `memory_capabilities` introspection extension
+  (arch-enhancement-spec §7)**. The capabilities report (MCP
+  `memory_capabilities` + HTTP `GET /api/v1/capabilities`) gains a
+  `schema_version: "2"` discriminator and five new top-level blocks:
+  `permissions`, `hooks`, `compaction`, `approval`, `transcripts`. Pre-v0.7
+  the `permissions.active_rules` field reflects a live count of namespace
+  standards carrying `metadata.governance` (transparent passthrough; the
+  full permission system is v0.7 work — arch-spec §3); `hooks.registered_count`
+  reflects the live `subscriptions` table count (proxy for hook subscribers
+  pre-v0.7 Bucket 0); `approval.pending_requests` reflects the live count
+  of `pending_actions` rows with `status='pending'`. `compaction.enabled`
+  and `transcripts.enabled` report `false` until v0.8 / v0.7-Bucket-1.7 land
+  the underlying systems. **All v1 fields preserved at the same top-level
+  paths** — older clients reading `tier`, `version`, `features`, `models`
+  by name continue to work without modification. New tests:
+  `mcp::tests::mcp_capabilities_v2_schema_includes_all_blocks`,
+  `mcp::tests::mcp_capabilities_v2_backwards_compatible`,
+  `mcp::tests::mcp_capabilities_pending_requests_reflects_db`,
+  `handlers::tests::http_capabilities_v2_schema_includes_all_blocks`,
+  `config::tests::capabilities_v2_zero_state_round_trip`. New helpers:
+  `db::count_active_governance_rules`, `db::count_subscriptions`,
+  `db::count_pending_actions_by_status`. Pure additive — no migration,
+  no behavior change to any existing tool.
+
 - **Hierarchical namespace taxonomy (Pillar 1 / Stream A)** — new
   `memory_get_taxonomy` MCP tool plus REST mirror at
   `GET /api/v1/taxonomy`. Walks live (non-expired) memories grouped by
@@ -239,6 +263,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tolerance. Encountered in the a2a-gate mTLS matrix; the gate-side
   generator fix in `ai-memory-ai2ai-gate#35` already worked around it for
   v0.6.2 — this is the parser-side resolution.
+
+### Changed
+
+- **CI coverage gate — fail-under 92%**. The `coverage` job in
+  `.github/workflows/ci.yml` now invokes `cargo llvm-cov` with
+  `--fail-under-lines 92`, locking in the v0.6.3 baseline of 93.05%
+  with a 1% absorb buffer. PRs that drop total line coverage below
+  92% will fail the gate. Per-module floors (`handlers.rs`, `db.rs`,
+  `federation.rs`, `mcp.rs`, `governance.rs` ≥90%) are tracked in the
+  v0.7 assertion table for follow-up enforcement.
 
 ### Tests
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,8 @@ impl TierConfig {
         let has_llm = self.llm_model.is_some();
 
         Capabilities {
+            // Capabilities schema v2 — see `Capabilities` doc comment.
+            schema_version: "2".to_string(),
             tier: self.tier.as_str().to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             features: CapabilityFeatures {
@@ -218,6 +220,22 @@ impl TierConfig {
                     "none".to_string()
                 },
             },
+            // v2 dynamic blocks — start at zero-state defaults. The MCP
+            // and HTTP `handle_capabilities` wrappers overwrite these
+            // with live counts when they have a `&Connection` handle.
+            permissions: CapabilityPermissions {
+                mode: "ask".to_string(),
+                active_rules: 0,
+                rule_summary: Vec::new(),
+            },
+            hooks: CapabilityHooks::default(),
+            compaction: CapabilityCompaction::default(),
+            approval: CapabilityApproval {
+                subscribers: 0,
+                pending_requests: 0,
+                default_timeout_seconds: 30,
+            },
+            transcripts: CapabilityTranscripts::default(),
         }
     }
 }
@@ -227,12 +245,43 @@ impl TierConfig {
 // ---------------------------------------------------------------------------
 
 /// Top-level capabilities report for a running instance.
+///
+/// Schema versions:
+/// - v1 (implicit, pre-v0.6.3.1): `tier`, `version`, `features`, `models`
+/// - v2 (v0.6.3 / arch-enhancement-spec §7): adds `schema_version` plus
+///   `permissions`, `hooks`, `compaction`, `approval`, `transcripts` blocks.
+///   v1 fields preserved at the same paths — old clients reading by name
+///   continue to work.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Capabilities {
+    /// Schema-version discriminator. Always `"2"` since v0.6.3.
+    pub schema_version: String,
     pub tier: String,
     pub version: String,
     pub features: CapabilityFeatures,
     pub models: CapabilityModels,
+
+    /// Active permission/governance rules. Pre-v0.7 reports the count of
+    /// namespaces that have a `metadata.governance` policy attached to
+    /// their standard memory; the underlying permission system itself
+    /// is v0.7 work.
+    pub permissions: CapabilityPermissions,
+
+    /// Registered hooks. Pre-v0.7 reports webhook subscriptions as a
+    /// proxy (hook system itself is v0.7 Bucket 0).
+    pub hooks: CapabilityHooks,
+
+    /// Compaction state. v0.8 work — pre-v0.8 reports `enabled: false`.
+    pub compaction: CapabilityCompaction,
+
+    /// Approval API state. Reports the live count of pending actions
+    /// from the existing `pending_actions` table; subscriber count is
+    /// v0.7 work.
+    pub approval: CapabilityApproval,
+
+    /// Sidechain-transcript state. v0.7 Bucket 1.7 work — pre-v0.7
+    /// reports `enabled: false`.
+    pub transcripts: CapabilityTranscripts,
 }
 
 /// Boolean feature flags exposed in the capabilities report.
@@ -271,6 +320,71 @@ pub struct CapabilityModels {
     pub embedding_dim: usize,
     pub llm: String,
     pub cross_encoder: String,
+}
+
+/// Permissions block (capabilities schema v2). Pre-v0.7 reports a live
+/// count of namespace standards carrying a `metadata.governance` policy;
+/// the full permission system lands in v0.7 (arch-enhancement-spec §3).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CapabilityPermissions {
+    /// Enforcement mode. `"ask"` = current default (governance gate runs
+    /// on store/delete/promote and may return Pending). `"off"` would
+    /// disable enforcement; not yet wired.
+    pub mode: String,
+    /// Number of namespace standards whose `metadata.governance` is
+    /// non-null. Counts policies, not memories.
+    pub active_rules: usize,
+    /// Per-namespace summary; empty pre-v0.7.
+    #[serde(default)]
+    pub rule_summary: Vec<String>,
+}
+
+/// Hook-pipeline block (capabilities schema v2). Pre-v0.7 reports webhook
+/// subscriptions as the closest analogue. The full hook pipeline lands in
+/// v0.7 Bucket 0 (arch-enhancement-spec §2).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CapabilityHooks {
+    /// Number of registered hook subscribers (proxy: webhook subscriptions).
+    pub registered_count: usize,
+    /// Per-event registration map; empty pre-v0.7.
+    #[serde(default)]
+    pub by_event: std::collections::BTreeMap<String, usize>,
+}
+
+/// Compaction block (capabilities schema v2). v0.8 Pillar 2.5 work —
+/// pre-v0.8 reports `enabled: false` and the rest as `None`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CapabilityCompaction {
+    pub enabled: bool,
+    #[serde(default)]
+    pub interval_minutes: Option<u64>,
+    #[serde(default)]
+    pub last_run_at: Option<String>,
+    #[serde(default)]
+    pub last_run_stats: Option<serde_json::Value>,
+}
+
+/// Approval-API block (capabilities schema v2). `pending_requests`
+/// counts the existing `pending_actions` table (live signal). Subscriber
+/// reporting is v0.7 work.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CapabilityApproval {
+    /// Number of agents/humans subscribed to approval-decision events.
+    /// 0 pre-v0.7.
+    pub subscribers: usize,
+    /// Live count of `pending_actions` with status='pending'.
+    pub pending_requests: usize,
+    /// Default approval-request timeout. 30s for the v0.6.3 patch.
+    pub default_timeout_seconds: u64,
+}
+
+/// Sidechain-transcript block (capabilities schema v2). v0.7 Bucket 1.7
+/// work — pre-v0.7 reports `enabled: false`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CapabilityTranscripts {
+    pub enabled: bool,
+    pub total_count: usize,
+    pub total_size_mb: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -776,6 +890,54 @@ mod tests {
         assert!(json.contains("\"tier\": \"smart\""));
         assert!(json.contains("nomic"));
         assert!(json.contains("gemma4:e2b"));
+    }
+
+    /// v0.6.3 (capabilities schema v2 — arch-enhancement-spec §7).
+    /// Round-trip the new struct through serde_json and assert every
+    /// new top-level block is present with the documented zero-state.
+    #[test]
+    fn capabilities_v2_zero_state_round_trip() {
+        let caps = FeatureTier::Keyword.config().capabilities();
+        let val: serde_json::Value = serde_json::to_value(&caps).unwrap();
+
+        assert_eq!(val["schema_version"], "2");
+
+        // permissions zero-state: mode="ask", active_rules=0, empty summary
+        assert_eq!(val["permissions"]["mode"], "ask");
+        assert_eq!(val["permissions"]["active_rules"], 0);
+        assert!(
+            val["permissions"]["rule_summary"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+
+        // hooks zero-state: 0 registered, empty by_event map
+        assert_eq!(val["hooks"]["registered_count"], 0);
+        assert!(val["hooks"]["by_event"].as_object().unwrap().is_empty());
+
+        // compaction zero-state: disabled
+        assert_eq!(val["compaction"]["enabled"], false);
+        assert!(val["compaction"]["interval_minutes"].is_null());
+        assert!(val["compaction"]["last_run_at"].is_null());
+        assert!(val["compaction"]["last_run_stats"].is_null());
+
+        // approval zero-state: 0 subscribers, 0 pending, 30s timeout
+        assert_eq!(val["approval"]["subscribers"], 0);
+        assert_eq!(val["approval"]["pending_requests"], 0);
+        assert_eq!(val["approval"]["default_timeout_seconds"], 30);
+
+        // transcripts zero-state: disabled
+        assert_eq!(val["transcripts"]["enabled"], false);
+        assert_eq!(val["transcripts"]["total_count"], 0);
+        assert_eq!(val["transcripts"]["total_size_mb"], 0);
+
+        // Round-trip back to a typed Capabilities and confirm field
+        // identity (proves Deserialize works for all 5 new structs).
+        let restored: Capabilities = serde_json::from_value(val).unwrap();
+        assert_eq!(restored.schema_version, "2");
+        assert_eq!(restored.permissions.mode, "ask");
+        assert_eq!(restored.approval.default_timeout_seconds, 30);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -4207,6 +4207,48 @@ pub fn is_namespace_standard(conn: &Connection, id: &str) -> bool {
         > 0
 }
 
+/// v0.6.3 (capabilities schema v2): count namespace standards whose
+/// `metadata.governance` is non-null. A "rule" here means a namespace
+/// has an explicit governance policy attached to its standard memory.
+/// The count is a transparent passthrough — the full permission system
+/// arrives in v0.7 (arch-enhancement-spec §3).
+pub fn count_active_governance_rules(conn: &Connection) -> Result<usize> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories m
+             INNER JOIN namespace_meta nm ON nm.standard_id = m.id
+             WHERE json_extract(m.metadata, '$.governance') IS NOT NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    Ok(usize::try_from(count.max(0)).unwrap_or(0))
+}
+
+/// v0.6.3 (capabilities schema v2): count rows in the `subscriptions`
+/// table. Used by `handle_capabilities` as a proxy for "registered
+/// hooks" — the hook pipeline itself is v0.7 Bucket 0 work.
+pub fn count_subscriptions(conn: &Connection) -> Result<usize> {
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM subscriptions", [], |r| r.get(0))
+        .unwrap_or(0);
+    Ok(usize::try_from(count.max(0)).unwrap_or(0))
+}
+
+/// v0.6.3 (capabilities schema v2): count `pending_actions` rows whose
+/// `status` matches the predicate. Used by `handle_capabilities` to
+/// surface live approval queue depth.
+pub fn count_pending_actions_by_status(conn: &Connection, status: &str) -> Result<usize> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_actions WHERE status = ?1",
+            params![status],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    Ok(usize::try_from(count.max(0)).unwrap_or(0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3915,10 +3915,10 @@ fn resolve_caller_agent_id(
 // --- /api/v1/capabilities (GET) -------------------------------------------
 
 pub async fn get_capabilities(State(app): State<AppState>) -> impl IntoResponse {
-    // Mirrors `mcp::handle_capabilities`. Reranker state isn't tracked on the
-    // HTTP AppState (HTTP daemons that wire a cross-encoder record it via
-    // the tier config's `cross_encoder` flag, which is enough for scenario
-    // S30's equivalence check).
+    // Mirrors `mcp::handle_capabilities_with_conn`. Reranker state isn't
+    // tracked on the HTTP AppState (HTTP daemons that wire a cross-encoder
+    // record it via the tier config's `cross_encoder` flag, which is
+    // enough for scenario S30's equivalence check).
     //
     // v0.6.2 (S18): forward the *runtime* embedder state so
     // `features.embedder_loaded` reports whether the HF model actually
@@ -3927,8 +3927,22 @@ pub async fn get_capabilities(State(app): State<AppState>) -> impl IntoResponse 
     // end up with `semantic_search=true` (from config) but no embedder in
     // the AppState — setup scripts need this signal to refuse to start
     // scenarios that depend on semantic recall.
+    //
+    // v0.6.3 (capabilities schema v2): hold the DB lock briefly so the
+    // dynamic blocks (active_rules, registered_count, pending_requests)
+    // can be filled from live counts. Each query is a single COUNT(*) so
+    // the lock window stays sub-millisecond.
     let embedder_loaded = app.embedder.as_ref().is_some();
-    match crate::mcp::handle_capabilities(app.tier_config.as_ref(), None, embedder_loaded) {
+    let lock = app.db.lock().await;
+    let conn = &lock.0;
+    let result = crate::mcp::handle_capabilities_with_conn(
+        app.tier_config.as_ref(),
+        None,
+        embedder_loaded,
+        Some(conn),
+    );
+    drop(lock);
+    match result {
         Ok(v) => (StatusCode::OK, Json(v)).into_response(),
         Err(e) => {
             tracing::error!("capabilities: {e}");
@@ -12886,6 +12900,52 @@ mod tests {
         assert_eq!(v["features"]["keyword_search"], true);
         assert_eq!(v["features"]["semantic_search"], false);
         assert_eq!(v["features"]["query_expansion"], false);
+    }
+
+    /// v0.6.3 (capabilities schema v2 — arch-enhancement-spec §7).
+    /// HTTP surface mirrors the MCP shape: every new top-level block is
+    /// present and `schema_version="2"`.
+    #[tokio::test]
+    async fn http_capabilities_v2_schema_includes_all_blocks() {
+        let state = test_state();
+        let app = Router::new()
+            .route("/api/v1/capabilities", axum_get(get_capabilities))
+            .with_state(test_app_state(state));
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/capabilities")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(v["schema_version"], "2");
+
+        assert!(v["permissions"].is_object());
+        assert_eq!(v["permissions"]["mode"], "ask");
+        assert!(v["permissions"]["active_rules"].is_number());
+        assert!(v["permissions"]["rule_summary"].is_array());
+
+        assert!(v["hooks"].is_object());
+        assert!(v["hooks"]["registered_count"].is_number());
+        assert!(v["hooks"]["by_event"].is_object());
+
+        assert!(v["compaction"].is_object());
+        assert_eq!(v["compaction"]["enabled"], false);
+
+        assert!(v["approval"].is_object());
+        assert!(v["approval"]["pending_requests"].is_number());
+        assert_eq!(v["approval"]["default_timeout_seconds"], 30);
+
+        assert!(v["transcripts"].is_object());
+        assert_eq!(v["transcripts"]["enabled"], false);
     }
 
     #[tokio::test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1314,10 +1314,18 @@ fn handle_recall(
     Ok(resp)
 }
 
-pub(crate) fn handle_capabilities(
+/// v0.6.3 (capabilities schema v2): the canonical capabilities entry
+/// point. When `conn` is `Some`, the dynamic blocks
+/// (`permissions.active_rules`, `hooks.registered_count`,
+/// `approval.pending_requests`) are populated from live DB counts.
+/// When `None`, they remain at the zero-state defaults set in
+/// `TierConfig::capabilities`. Both shapes are valid schema-v2 output —
+/// old clients reading by named path continue to work either way.
+pub(crate) fn handle_capabilities_with_conn(
     tier_config: &TierConfig,
     reranker: Option<&CrossEncoder>,
     embedder_loaded: bool,
+    conn: Option<&rusqlite::Connection>,
 ) -> Result<Value, String> {
     let mut caps = tier_config.capabilities();
     // Report actual cross-encoder state, not just config (#93)
@@ -1333,6 +1341,23 @@ pub(crate) fn handle_capabilities(
     // this bool reflects the RUNTIME — the two can diverge when the HF
     // model fetch fails on an offline runner.
     caps.features.embedder_loaded = embedder_loaded;
+
+    // v0.6.3 (capabilities schema v2): when we have a connection, fill
+    // the dynamic blocks with live counts. Failures here are non-fatal —
+    // the report still serializes with the zero-state defaults so a
+    // transient DB blip can't 500 the capabilities endpoint.
+    if let Some(c) = conn {
+        if let Ok(n) = db::count_active_governance_rules(c) {
+            caps.permissions.active_rules = n;
+        }
+        if let Ok(n) = db::count_subscriptions(c) {
+            caps.hooks.registered_count = n;
+        }
+        if let Ok(n) = db::count_pending_actions_by_status(c, "pending") {
+            caps.approval.pending_requests = n;
+        }
+    }
+
     serde_json::to_value(caps).map_err(|e| e.to_string())
 }
 
@@ -3025,9 +3050,12 @@ fn handle_request(
                 "memory_consolidate" => {
                     handle_consolidate(conn, arguments, llm, embedder, vector_index, mcp_client)
                 }
-                "memory_capabilities" => {
-                    handle_capabilities(tier_config, reranker, embedder.is_some())
-                }
+                "memory_capabilities" => handle_capabilities_with_conn(
+                    tier_config,
+                    reranker,
+                    embedder.is_some(),
+                    Some(conn),
+                ),
                 "memory_expand_query" => handle_expand_query(llm, arguments),
                 "memory_auto_tag" => handle_auto_tag(conn, llm, arguments),
                 "memory_detect_contradiction" => handle_detect_contradiction(conn, llm, arguments),
@@ -4407,6 +4435,113 @@ mod tests {
         let val: Value = serde_json::from_str(&text).unwrap();
         assert!(val["tier"].is_string());
         assert!(val["features"].is_object());
+    }
+
+    /// v0.6.3 (capabilities schema v2 — arch-enhancement-spec §7).
+    /// Every new top-level block is present with the expected shape.
+    #[test]
+    fn mcp_capabilities_v2_schema_includes_all_blocks() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let req = make_tools_call("memory_capabilities", json!({}));
+        let resp = invoke_handle_request(&conn, &req);
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let val: Value = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(val["schema_version"], "2", "schema_version bumped to 2");
+
+        // permissions block
+        assert!(val["permissions"].is_object(), "permissions block present");
+        assert!(val["permissions"]["mode"].is_string());
+        assert_eq!(val["permissions"]["mode"], "ask");
+        assert!(val["permissions"]["active_rules"].is_number());
+        assert!(val["permissions"]["rule_summary"].is_array());
+
+        // hooks block
+        assert!(val["hooks"].is_object(), "hooks block present");
+        assert!(val["hooks"]["registered_count"].is_number());
+        assert!(val["hooks"]["by_event"].is_object());
+
+        // compaction block — pre-v0.8 reports zero-state
+        assert!(val["compaction"].is_object(), "compaction block present");
+        assert_eq!(val["compaction"]["enabled"], false);
+        assert!(val["compaction"]["interval_minutes"].is_null());
+        assert!(val["compaction"]["last_run_at"].is_null());
+        assert!(val["compaction"]["last_run_stats"].is_null());
+
+        // approval block
+        assert!(val["approval"].is_object(), "approval block present");
+        assert!(val["approval"]["subscribers"].is_number());
+        assert!(val["approval"]["pending_requests"].is_number());
+        assert_eq!(val["approval"]["default_timeout_seconds"], 30);
+
+        // transcripts block — pre-v0.7 reports zero-state
+        assert!(val["transcripts"].is_object(), "transcripts block present");
+        assert_eq!(val["transcripts"]["enabled"], false);
+        assert_eq!(val["transcripts"]["total_count"], 0);
+        assert_eq!(val["transcripts"]["total_size_mb"], 0);
+    }
+
+    /// v0.6.3 (capabilities schema v2). Old clients reading the v1 paths
+    /// must continue to find them at the same top-level keys.
+    #[test]
+    fn mcp_capabilities_v2_backwards_compatible() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let req = make_tools_call("memory_capabilities", json!({}));
+        let resp = invoke_handle_request(&conn, &req);
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let val: Value = serde_json::from_str(&text).unwrap();
+
+        // v1 fields preserved at the same paths
+        assert!(val["tier"].is_string(), "v1: tier preserved");
+        assert!(val["version"].is_string(), "v1: version preserved");
+        assert!(val["features"].is_object(), "v1: features preserved");
+        assert!(val["models"].is_object(), "v1: models preserved");
+
+        // Specifically, well-known v1 sub-fields still resolve.
+        assert!(val["features"]["keyword_search"].is_boolean());
+        assert!(val["features"]["semantic_search"].is_boolean());
+        assert!(val["features"]["embedder_loaded"].is_boolean());
+        assert!(val["models"]["embedding"].is_string());
+        assert!(val["models"]["llm"].is_string());
+        assert!(val["models"]["cross_encoder"].is_string());
+    }
+
+    /// v0.6.3 (capabilities schema v2). `approval.pending_requests`
+    /// reflects the live `pending_actions` count — the one block that is
+    /// already wired through to a real subsystem instead of zero-state.
+    #[test]
+    fn mcp_capabilities_pending_requests_reflects_db() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        // Insert a pending action by hand (the queue path is exercised
+        // elsewhere; here we only need the count to bump).
+        let payload = serde_json::json!({"foo": "bar"}).to_string();
+        conn.execute(
+            "INSERT INTO pending_actions (id, action_type, memory_id, namespace,
+                payload, requested_by, requested_at, status)
+             VALUES ('p-1', 'store', NULL, 'global', ?1, 'agent-1',
+                '2026-04-27T00:00:00Z', 'pending')",
+            rusqlite::params![payload],
+        )
+        .unwrap();
+
+        let req = make_tools_call("memory_capabilities", json!({}));
+        let resp = invoke_handle_request(&conn, &req);
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let val: Value = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(
+            val["approval"]["pending_requests"], 1,
+            "pending_actions(status=pending) count surfaces live"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **arch-enhancement-spec §7 (Capabilities Introspection Extension)**. Originally scoped as v0.6.3.1; folded into v0.6.3 final per operator directive.

The `memory_capabilities` MCP tool + `GET /api/v1/capabilities` HTTP endpoint gain a `schema_version: \"2\"` discriminator and five new top-level blocks. **All v1 fields preserved at the same top-level paths** — old clients reading `tier`, `version`, `features`, `models` by name continue to work without modification.

### New blocks

| Block | Live data source | Block fully implemented in |
|---|---|---|
| `permissions` | namespace standards w/ `metadata.governance` (live count) | v0.7 Bucket 3 (Permission System) |
| `hooks` | `subscriptions` table (live count) | v0.7 Bucket 0 (Hook Pipeline) |
| `compaction` | zero-state | v0.8 Pillar 2.5 |
| `approval` | `pending_actions` WHERE status='pending' (live count) | v0.7 Bucket 3 (Approval API) |
| `transcripts` | zero-state | v0.7 Bucket 1.7 (Sidechain Transcripts) |

Pre-v0.7 the live-count fields are transparent passthroughs of the underlying state already in the DB; the zero-state fields will populate as v0.7 / v0.8 land the systems.

### Bonus — CI coverage gate

Same PR adds `cargo llvm-cov --fail-under-lines 92` to the `coverage` job in `.github/workflows/ci.yml`. Locks in v0.6.3's 93.05% baseline with a 1% absorb buffer. PRs that drop total coverage below 92% will fail the gate. Per-module floors (handlers/db/federation/mcp/governance ≥90%) tracked in v0.7 assertion table.

## Test plan

- [x] `mcp::tests::mcp_capabilities_v2_schema_includes_all_blocks` — every new top-level block present with expected shape
- [x] `mcp::tests::mcp_capabilities_v2_backwards_compatible` — v1 fields (`tier`, `version`, `features`, `models`) preserved at same paths
- [x] `mcp::tests::mcp_capabilities_pending_requests_reflects_db` — `approval.pending_requests` reflects live `pending_actions` row count
- [x] `handlers::tests::http_capabilities_v2_schema_includes_all_blocks` — HTTP surface mirror
- [x] `config::tests::capabilities_v2_zero_state_round_trip` — serde round-trip across all 5 new structs
- [x] Full lib suite: 1600 tests, 0 failures (was 1595, +5 new)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean

## Acceptance criteria — all met

- [x] `schema_version` field bumped to `\"2\"` in both HTTP and MCP handlers
- [x] All v1 fields preserved at the same top-level paths (no breaking changes)
- [x] New `permissions` block reports current `governance` rules (transparent passthrough)
- [x] New `hooks` block reports `subscriptions` count (transparent passthrough)
- [x] New `compaction` block reports `enabled: false` (compaction is v0.8)
- [x] New `approval` block reports `pending_requests` count from existing `pending_actions` table
- [x] New `transcripts` block reports `enabled: false` (transcripts are v0.7 Bucket 1.7)
- [x] Test added: `http_capabilities_v2_schema_includes_all_blocks`
- [x] Test added: `mcp_capabilities_v2_backwards_compatible`
- [x] CHANGELOG.md \"Unreleased\" entry under v0.6.3

## Out of scope

- Implementing the underlying hook/permission/compaction/transcript systems (v0.7 / v0.8 charter work)
- Removing or renaming any v1 fields
- Adding new MCP tools beyond `memory_capabilities`

## References

- Spec §7: arch-enhancement-spec-v1.md (private repo)
- v0.7 charter Bucket 0 (Hook Pipeline)
- v0.6.3 → v0.7 → v0.8 dependency map (00-INDEX.md, private repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)