### PR TITLE
release(v0.6.3): clean re-release — fold distribution fixes into v0.6.3 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,44 @@ jobs:
           git commit -m "Update ai-memory to ${{ steps.version.outputs.version }}"
           git push
 
+  # v0.6.5 — Dockerfile-build smoke. Runs on EVERY push to main / develop /
+  # release/** AND on EVERY PR. Builds the Docker image; does NOT push to
+  # GHCR. Catches Dockerfile drift (missing COPY of new files referenced
+  # by include_str!, glibc mismatch from build/runtime base drift, etc.)
+  # BEFORE we cut a release tag.
+  #
+  # Retrospective: v0.6.3 added include_str! refs to migrations/sqlite/
+  # but the Dockerfile didn't COPY migrations/. v0.6.4's image built
+  # but used rust:1.94-slim (trixie, glibc 2.41) on top of bookworm
+  # runtime (glibc 2.36) — built but failed at runtime with
+  # "version GLIBC_2.39 not found". Both bugs were caught at release
+  # time, not PR time. This job closes that gap.
+  dockerfile-validate:
+    name: Dockerfile build (no push)
+    runs-on: ubuntu-latest
+    # Skip on tag pushes — the docker job below handles those (with push).
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (validation only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ai-memory:ci-validate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the built image
+        run: |
+          docker run --rm ai-memory:ci-validate --version
+          docker run --rm ai-memory:ci-validate --help | head -20
+
   docker:
     name: Docker (GHCR)
     needs: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,35 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Publish to crates.io
+      - name: Publish to crates.io (with retry)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --allow-dirty || echo "::warning::crates.io publish skipped (version may already exist)"
+        # v0.6.5 — replace silent-failure `|| echo "warning"` with proper retry.
+        # crates.io's Fastly cache returns 503 + sigsci WAF rejection under
+        # transient load (v0.6.3 + v0.6.4 both hit this — silently). The
+        # `version may already exist` swallow is detected explicitly so a
+        # genuine "already published" doesn't fail the job, but everything
+        # else (5xx, network errors, oversized package) fails loudly.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if output=$(cargo publish --allow-dirty 2>&1); then
+              echo "::notice::crates.io publish succeeded on attempt $attempt"
+              echo "$output" | tail -10
+              exit 0
+            fi
+            echo "$output" | tail -20
+            if echo "$output" | grep -q "already exists\|crate version .* is already uploaded"; then
+              echo "::notice::crates.io: version already published (idempotent no-op)"
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::crates.io publish failed on attempt $attempt — retrying after 30s"
+              sleep 30
+            fi
+          done
+          echo "::error::crates.io publish failed on all 3 attempts"
+          exit 1
 
   homebrew:
     name: Update Homebrew formula

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,77 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.6.5] — 2026-04-27 — Distribution-channel hardening (3-bug patch)
-
-Patch release that closes three real distribution defects discovered
-by the post-v0.6.4 audit. **No source-code feature changes** — same
-ai-memory binary as v0.6.3 modulo the version stamp. Operators on
-v0.6.4 should upgrade if they use Docker or installed via crates.io;
-Homebrew / Ubuntu PPA / Fedora COPR users at v0.6.4 are unaffected.
-
-### Fixed
-
-- **Docker GHCR — broken at runtime in v0.6.4.** The build stage used
-  `rust:1.94-slim` which now resolves to a trixie-based image
-  (glibc 2.41) while the runtime stage uses `debian:bookworm-slim`
-  (glibc 2.36). `docker run ghcr.io/alphaonedev/ai-memory:0.6.4`
-  failed at startup with `GLIBC_2.39 not found`. **Fix:** pin build
-  stage to `rust:1.94-slim-bookworm`.
-
-- **crates.io — silently absent in v0.6.3 + v0.6.4.** Both publishes
-  failed with HTTP 503 from crates.io's WAF (the 22.1 MiB compressed
-  package exceeded the 10 MiB upload limit) but the CI workflow's
-  `cargo publish || echo "warning"` masking pattern reported `success`.
-  `audits/` directory alone was 140 MiB unpacked. **Fix:**
-  `package.include` in `Cargo.toml` restricts the published crate to
-  `src/`, `benches/`, `examples/`, `migrations/`, `Cargo.{toml,lock}`,
-  `README.md`, `LICENSE`, `CHANGELOG.md`, `PERFORMANCE.md`, and
-  `build.rs` — package now 558 KiB compressed (73 files), well under
-  the limit.
-
-- **CI silent-failure on crates.io publish.** Replaced
-  `cargo publish || echo "warning"` with proper retry-with-backoff
-  (3 attempts, 30s sleep). Genuine "version already exists" detected
-  explicitly via stderr grep so re-runs of the same tag are
-  idempotent; everything else (5xx, network errors, oversized package)
-  fails the job loudly. Class of bug: **silent CI failures masking
-  real distribution defects** is the kind of issue that prompted the
-  v0.6.5 patch in the first place.
-
-### Added
-
-- **`dockerfile-validate` CI job** runs on every push and PR. Builds
-  the Dockerfile via `docker build` and smoke-tests with
-  `docker run --rm ai-memory:ci-validate --version` + `--help`. Does
-  NOT push to GHCR (the existing `docker` job handles tag pushes).
-  Catches the Dockerfile-drift class of bugs (new `include_str!` for
-  missing dir, missing system dep, glibc mismatch, etc.) at PR time,
-  not at release time. **This job caught the v0.6.4 glibc bug above.**
-
-## [v0.6.4] — 2026-04-27 — Docker-only patch on top of v0.6.3
-
-Single-fix patch release. v0.6.3 published successfully to crates.io,
-Homebrew, Ubuntu PPA, and Fedora COPR; the Docker GHCR build failed
-at compile time because the `Dockerfile` build context did not include
-the `migrations/` directory. v0.6.3 introduced new `include_str!`
-references to `migrations/sqlite/0010_v063_hierarchy_kg.sql` (Streams
-A-C schema v15) — the gap was pre-existing in the Dockerfile but
-v0.6.2 did not surface it (no new migrations).
-
-### Fixed
-
-- **Dockerfile** — added `COPY migrations/ migrations/` to the build
-  stage so cargo build can resolve the v0.6.3 schema migration file
-  references at compile time. Restores Docker GHCR publishing.
-
-### Carries forward from v0.6.3
-
-All v0.6.3 features + validation evidence carry forward unchanged.
-See `[v0.6.3]` section below for the full grand-slam feature set,
-1 600 unit tests at 93.08% line coverage, ship-gate 4-phase pass,
-a2a-gate 48-scenario pass, and live test-hub evidence at
-<https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/>.
-
 ## [v0.6.3] — 2026-04-27 — STRUCTURED MEMORY + PERFORMANCE
 
 The grand-slam release. Hierarchical namespace taxonomy + temporal-validity
@@ -99,6 +28,36 @@ introspection) and a CI coverage gate locking in 93.05% baseline.
 
 Live evidence:
 <https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/>
+
+### Distribution-channel hardening (folded into v0.6.3 final cut)
+
+- **Dockerfile — `COPY migrations/`** added so cargo build can resolve
+  the new Stream A-C `include_str!` references at compile time. Without
+  it, the Docker build failed before publish.
+- **Dockerfile — pin build stage to `rust:1.94-slim-bookworm`** so the
+  produced binary's glibc matches the runtime stage
+  (`debian:bookworm-slim`, glibc 2.36). Without the explicit bookworm
+  pin, `rust:1.94-slim` resolves to a trixie-based image (glibc 2.41)
+  and the binary fails at startup with `version GLIBC_2.39 not found`.
+- **`Cargo.toml` `package.include`** restricts the published crate to
+  source-only (src, benches, examples, migrations, build.rs,
+  Cargo.{toml,lock}, README.md, LICENSE, CHANGELOG.md, PERFORMANCE.md).
+  Without it, the crate weighs 22 MiB compressed (140 MiB unpacked,
+  thanks to `audits/`) — over crates.io's 10 MiB upload limit; uploads
+  hit HTTP 503 from the Fastly WAF. Trimmed crate is 558 KiB compressed
+  (73 files), well under the limit.
+- **CI silent-failure on `cargo publish`** — replaced
+  `cargo publish || echo "warning"` with proper retry-with-backoff
+  (3 attempts × 30s sleep). Genuine "version already exists" detected
+  via stderr grep (idempotent re-run); everything else (5xx, network
+  errors, oversized package) fails the job loudly. This is the masking
+  bug that hid the crates.io 503s during initial v0.6.3 publish.
+- **New `dockerfile-validate` CI job** runs on every push + PR. Builds
+  the Docker image (no GHCR push) and smoke-tests with
+  `docker run --rm ai-memory:ci-validate --version` + `--help`. Closes
+  the Dockerfile-drift class of bugs (new `include_str!` for missing
+  dir, missing system dep, glibc mismatch, etc.) at PR time, not at
+  release time.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.5] — 2026-04-27 — Distribution-channel hardening (3-bug patch)
+
+Patch release that closes three real distribution defects discovered
+by the post-v0.6.4 audit. **No source-code feature changes** — same
+ai-memory binary as v0.6.3 modulo the version stamp. Operators on
+v0.6.4 should upgrade if they use Docker or installed via crates.io;
+Homebrew / Ubuntu PPA / Fedora COPR users at v0.6.4 are unaffected.
+
+### Fixed
+
+- **Docker GHCR — broken at runtime in v0.6.4.** The build stage used
+  `rust:1.94-slim` which now resolves to a trixie-based image
+  (glibc 2.41) while the runtime stage uses `debian:bookworm-slim`
+  (glibc 2.36). `docker run ghcr.io/alphaonedev/ai-memory:0.6.4`
+  failed at startup with `GLIBC_2.39 not found`. **Fix:** pin build
+  stage to `rust:1.94-slim-bookworm`.
+
+- **crates.io — silently absent in v0.6.3 + v0.6.4.** Both publishes
+  failed with HTTP 503 from crates.io's WAF (the 22.1 MiB compressed
+  package exceeded the 10 MiB upload limit) but the CI workflow's
+  `cargo publish || echo "warning"` masking pattern reported `success`.
+  `audits/` directory alone was 140 MiB unpacked. **Fix:**
+  `package.include` in `Cargo.toml` restricts the published crate to
+  `src/`, `benches/`, `examples/`, `migrations/`, `Cargo.{toml,lock}`,
+  `README.md`, `LICENSE`, `CHANGELOG.md`, `PERFORMANCE.md`, and
+  `build.rs` — package now 558 KiB compressed (73 files), well under
+  the limit.
+
+- **CI silent-failure on crates.io publish.** Replaced
+  `cargo publish || echo "warning"` with proper retry-with-backoff
+  (3 attempts, 30s sleep). Genuine "version already exists" detected
+  explicitly via stderr grep so re-runs of the same tag are
+  idempotent; everything else (5xx, network errors, oversized package)
+  fails the job loudly. Class of bug: **silent CI failures masking
+  real distribution defects** is the kind of issue that prompted the
+  v0.6.5 patch in the first place.
+
+### Added
+
+- **`dockerfile-validate` CI job** runs on every push and PR. Builds
+  the Dockerfile via `docker build` and smoke-tests with
+  `docker run --rm ai-memory:ci-validate --version` + `--help`. Does
+  NOT push to GHCR (the existing `docker` job handles tag pushes).
+  Catches the Dockerfile-drift class of bugs (new `include_str!` for
+  missing dir, missing system dep, glibc mismatch, etc.) at PR time,
+  not at release time. **This job caught the v0.6.4 glibc bug above.**
+
 ## [v0.6.4] — 2026-04-27 — Docker-only patch on top of v0.6.3
 
 Single-fix patch release. v0.6.3 published successfully to crates.io,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ai-memory"
-version = "0.6.5"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.6.5"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["AlphaOne LLC"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-memory"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.88"
 authors = ["AlphaOne LLC"]
@@ -10,6 +10,25 @@ repository = "https://github.com/alphaonedev/ai-memory-mcp"
 homepage = "https://alphaonedev.github.io/ai-memory-mcp/"
 keywords = ["mcp", "ai", "memory", "sqlite", "llm"]
 categories = ["artificial-intelligence", "command-line-utilities", "database"]
+# v0.6.5 — keep the published crate under crates.io's 10 MiB compressed
+# upload limit. v0.6.3 + v0.6.4 publishes failed silently with HTTP 503
+# from the WAF because the package was 22 MiB compressed (140 MiB
+# unpacked) — `audits/` alone was 140 MiB. We exclude everything that
+# isn't required to compile the crate. include explicitly lists what
+# stays so any new top-level directory must be opted in.
+include = [
+    "src/**/*",
+    "benches/**/*",
+    "examples/**/*",
+    "migrations/**/*",
+    "build.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "PERFORMANCE.md",
+]
 
 [dependencies]
 anyhow = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # ---- Build stage ----
-FROM rust:1.94-slim AS builder
+# Pin to bookworm so the produced binary's glibc matches the runtime
+# stage (debian:bookworm-slim, glibc 2.36). Without the explicit
+# bookworm tag, rust:1.94-slim resolves to a trixie-based image
+# (glibc 2.41) and the binary fails at startup with
+# `version GLIBC_2.39 not found` — caught by the dockerfile-validate
+# CI job (PR #465 retrospective; v0.6.5 bake).
+FROM rust:1.94-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \


### PR DESCRIPTION
## Summary

Operator decision: collapse v0.6.4 (Docker-only patch) and v0.6.5 (distribution-channel hardening) into a single clean **v0.6.3** cut. The intermediate v0.6.4 + v0.6.5 tags + release pages were deleted. v0.6.3 is the only release that ships.

## What v0.6.3 final contains

**All v0.6.3 grand-slam content** — 6 streams (A through F), capabilities schema v2, CI coverage gate at 92% — unchanged.

**Plus 4 distribution-plumbing fixes** that the original v0.6.3 attempt surfaced:

1. **Dockerfile `COPY migrations/`** — resolves Stream A-C \`include_str!\` references at compile time
2. **Dockerfile `rust:1.94-slim-bookworm`** — pins build stage so produced binary's glibc matches `debian:bookworm-slim` runtime (glibc 2.36); prevents `GLIBC_2.39 not found` runtime failure
3. **`Cargo.toml` `package.include`** — restricts published crate to source-only (558 KiB compressed vs 22 MiB before; was breaking crates.io's 10 MiB upload limit)
4. **CI `cargo publish` retry-with-backoff** — replaces silent-failure `|| echo "warning"` masking pattern; failures now fail loudly

**Plus 1 structural prevention** — new `dockerfile-validate` CI job runs on every push + PR, builds image + smoke-tests with `docker run --version`, catches Dockerfile drift at PR time, not release time.

## What did NOT change

The ai-memory binary's user-visible surface is **identical to the originally-tagged v0.6.3**. No new MCP tools, no new HTTP routes, no schema changes. Only build + distribution plumbing has been hardened.

## Validation

- 1 600 lib tests pass; coverage 93.08% (gate floor 92%)
- Cargo package: 73 files / **558 KiB compressed** (well under 10 MiB limit)
- Local cargo build at v0.6.3 — binary stamps `ai-memory 0.6.3`
- The new `dockerfile-validate` job will run on this PR's CI and prove the Docker pipeline actually produces a runnable image

## Test plan

- [x] Local cargo build succeeds at v0.6.3
- [x] Local cargo package produces 558 KiB crate
- [ ] CI: all 6 jobs pass (Check ×3 + Coverage + Bench + dockerfile-validate)
- [ ] After merge + tag v0.6.3: release pipeline publishes to all 5 channels
- [ ] After v0.6.3 publish: `cargo install ai-memory --version 0.6.3` works
- [ ] After v0.6.3 publish: `docker run ghcr.io/alphaonedev/ai-memory:0.6.3 --version` works
- [ ] Old v0.6.4-1 packages on PPA, COPR, GHCR get cleaned up post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)