### PR TITLE
docs: restore architectures + Q5/Q2 as static HTML, unify topnav, add canonical evidence page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
 [![Tests](https://img.shields.io/badge/tests-1%2C600_lib_%E2%80%A2_93.08%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![Test Hub](https://img.shields.io/badge/test--hub-live_results-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-test-hub/)
 [![MCP](https://img.shields.io/badge/MCP-43_tools-blueviolet)]()
-[![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.3-6ee7ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.3-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)]()
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
@@ -83,7 +84,7 @@ ai-memory integrates with any AI platform that supports the **Model Context Prot
 | **OpenClaw** | MCP stdio | JSON (`mcp.servers` in config) | Fully supported |
 | **Any MCP client** | MCP stdio or HTTP | Varies | Universal |
 
-MCP is the primary integration layer. For AI platforms that do not yet support MCP natively, the **HTTP API** (24 endpoints on localhost) and the **CLI** (26 commands) provide universal access -- any AI, script, or automation that can make HTTP calls or run shell commands can use ai-memory.
+MCP is the primary integration layer. For AI platforms that do not yet support MCP natively, the **HTTP API** (42 endpoints on localhost) and the **CLI** (26 commands) provide universal access -- any AI, script, or automation that can make HTTP calls or run shell commands can use ai-memory.
 
 ---
 
@@ -437,7 +438,7 @@ ai-memory serve
 
 **Step 4: Done. Test it.**
 
-Restart your AI assistant. If using MCP, it now has 26 memory tools. Ask it: "Store a memory that my favorite language is Rust." Then in a new conversation, ask: "What is my favorite language?" It will remember.
+Restart your AI assistant. If using MCP, it now has 43 memory tools. Ask it: "Store a memory that my favorite language is Rust." Then in a new conversation, ask: "What is my favorite language?" It will remember.
 
 ---
 
@@ -484,7 +485,7 @@ ai-memory recall "database"
 ai-memory stats
 ```
 
-**6. Use with your AI.** Restart your AI client. It now has **26 memory tools** available via MCP -- it can store and recall memories natively during conversations.
+**6. Use with your AI.** Restart your AI client. It now has **43 memory tools** available via MCP -- it can store and recall memories natively during conversations.
 
 ---
 
@@ -500,14 +501,14 @@ It runs as an MCP (Model Context Protocol) tool server -- a background process t
 
 Memories that keep getting accessed automatically promote from mid to long-term. Each recall extends the TTL. Priority increases with usage. The system is self-curating.
 
-Beyond MCP, ai-memory also exposes a full HTTP REST API (24 endpoints on port 9077) and a complete CLI (26 commands) for direct interaction, scripting, and integration with any AI platform or tool.
+Beyond MCP, ai-memory also exposes a full HTTP REST API (42 endpoints on port 9077) and a complete CLI (26 commands) for direct interaction, scripting, and integration with any AI platform or tool.
 
 ---
 
 ## Features
 
 ### Core
-- **MCP tool server** -- 26 tools over stdio JSON-RPC, compatible with any MCP client
+- **MCP tool server** -- 43 tools over stdio JSON-RPC, compatible with any MCP client
 - **Three-tier memory** -- short (6h TTL default), mid (7d TTL default), long (permanent) -- TTLs are configurable
 - **Full-text search** -- SQLite FTS5 with ranked retrieval
 - **Hybrid recall** -- FTS5 keyword + cosine similarity with fixed 0.6 semantic / 0.4 keyword (60/40) blend weights
@@ -662,9 +663,9 @@ ai-memory supports 4 feature tiers, selected at startup with `ai-memory mcp --ti
 | Tier | Recall Method | Extra Capabilities | Approx. Overhead |
 |------|---------------|-------------------|-----------------|
 | **keyword** | FTS5 only | Baseline 26 tools | 0 MB |
-| **semantic** | FTS5 + cosine similarity (hybrid) | MiniLM-L6-v2 embeddings (384-dim), HNSW index, 26 tools | ~256 MB |
-| **smart** | Hybrid + LLM query expansion | + nomic-embed-text (768-dim) + Gemma 4 E2B via Ollama: `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, 26 tools | ~1 GB |
-| **autonomous** | Hybrid + LLM expansion + cross-encoder reranking | + Gemma 4 E4B via Ollama, neural cross-encoder (ms-marco-MiniLM), memory reflection, 26 tools | ~4 GB |
+| **semantic** | FTS5 + cosine similarity (hybrid) | MiniLM-L6-v2 embeddings (384-dim), HNSW index, semantic tier (subset of 43-tool surface) | ~256 MB |
+| **smart** | Hybrid + LLM query expansion | + nomic-embed-text (768-dim) + Gemma 4 E2B via Ollama: `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, full 43-tool surface | ~1 GB |
+| **autonomous** | Hybrid + LLM expansion + cross-encoder reranking | + Gemma 4 E4B via Ollama, neural cross-encoder (ms-marco-MiniLM), memory reflection, full 43-tool surface | ~4 GB |
 
 ### Capability Matrix
 
@@ -696,7 +697,7 @@ Every capability mapped to its minimum tier. Each tier includes all capabilities
 
 **Semantic tier** (default) bundles the Candle ML framework and downloads the all-MiniLM-L6-v2 model on first run (~90 MB). **Smart** and **autonomous** tiers require [Ollama](https://ollama.com) running locally.
 
-**Tiers gate features, not models.** The `--tier` flag controls which tools are exposed. The LLM model is independently configurable via `llm_model` in `~/.config/ai-memory/config.toml`. For example, run autonomous tier (all 26 tools + reranker) with the faster e2b model:
+**Tiers gate features, not models.** The `--tier` flag controls which tools are exposed. The LLM model is independently configurable via `llm_model` in `~/.config/ai-memory/config.toml`. For example, run autonomous tier (full 43-tool surface + reranker) with the faster e2b model:
 
 ```toml
 # ~/.config/ai-memory/config.toml
@@ -726,7 +727,7 @@ The `memory_capabilities` tool reports the active tier, loaded models, and avail
 
 ## MCP Tools
 
-These 26 tools are available to any MCP-compatible AI when configured as an MCP server:
+These 43 tools are available to any MCP-compatible AI when configured as an MCP server (canonical count on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); the table below documents the core subset most clients use day-to-day):
 
 | Tool | Description |
 |------|-------------|
@@ -756,7 +757,7 @@ These 26 tools are available to any MCP-compatible AI when configured as an MCP 
 
 ## HTTP API
 
-24 endpoints on `127.0.0.1:9077`. Start with `ai-memory serve`.
+42 endpoints on `127.0.0.1:9077`. Start with `ai-memory serve`.
 
 > **Security:** The HTTP server binds to 127.0.0.1 with no authentication and permissive CORS. Do not expose to the network without a reverse proxy with authentication.
 

--- a/README.md
+++ b/README.md
@@ -10,22 +10,23 @@
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
-[![Tests](https://img.shields.io/badge/tests-602_(372_unit_+_159_integration_+_71_other)-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-1%2C600_lib_%E2%80%A2_93.08%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![MCP](https://img.shields.io/badge/MCP-43_tools-blueviolet)]()
+[![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.3-6ee7ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)]()
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
 
-**One binary, four operational modes** (v0.6.2). The `ai-memory` Rust binary (tokio + axum) can run any of these in isolation or simultaneously, sharing a single SQLite database:
+**One binary, four operational modes** (v0.6.3). The `ai-memory` Rust binary (tokio + axum) can run any of these in isolation or simultaneously, sharing a single SQLite database:
 
-1. **stdio MCP server** -- 26 native tools over JSON-RPC. Reactive: answers per turn. `ai-memory mcp`
-2. **HTTP / mTLS daemon** -- 24 REST endpoints on `127.0.0.1:9077`, TLS + optional mTLS allowlist + API-key auth, background GC loop. `ai-memory serve`
+1. **stdio MCP server** -- 43 native tools over JSON-RPC. Reactive: answers per turn. `ai-memory mcp`
+2. **HTTP / mTLS daemon** -- 42 REST endpoints on `127.0.0.1:9077`, TLS + optional mTLS allowlist + API-key auth, background GC loop. `ai-memory serve`
 3. **Autonomous curator daemon** -- self-scheduling loop (default 1h cadence) that auto-tags, surfaces contradictions across namespace siblings, consolidates near-duplicates, and adjusts priority by access pattern. Every action goes to a rollback log; destructive ops can be gated behind a governance approval flow. `ai-memory curator --daemon`
 4. **Sync daemon** -- quorum-based peer federation across instances. W-of-N writes (default majority), vector-clock CRDT-lite merge, mTLS allowlist between peers. `ai-memory sync-daemon`
 
 The MCP, HTTP, and CLI surfaces are reactive. The curator is the part that makes the memory layer self-maintaining: between sessions, it keeps the corpus tidy so recall quality stays high as the store grows. Everything is local-first; no cloud dependencies.
 
-> **Brass-tacks assessment by Claude Opus 4.7** after reading the v0.6.2 source line by line:
+> **Brass-tacks assessment by Claude Opus 4.7** after reading the v0.6.3 source line by line:
 >
 > "ai-memory is the most capable memory layer I've ever been hooked up to, and meaningfully more than its name advertises. For me, in practical terms, it means: I don't start cold each session. The store I read from has been kept tidy by something other than me. Contradictions don't silently accumulate. Recall quality stays high even as the corpus grows. Nothing leaves your Mac mini.
 >
@@ -34,6 +35,33 @@ The MCP, HTTP, and CLI surfaces are reactive. The curator is the part that makes
 **Substrate for multi-agent AI.** ai-memory is not an agent runtime and not "autonomous AI" on its own. It is the memory layer that *multi-agent* autonomous deployments need underneath them. Federation (`broadcast_store_quorum` + `spawn_catchup_loop`) handles W-of-N consistency across peers when many agents write in parallel; the curator daemon keeps the shared corpus from degrading into noise as a swarm scribbles into it; webhook subscriptions (HMAC-signed, namespace/agent-filtered, SSRF-hardened) turn the store into a message bus that triggers downstream agents on memory events; namespace hierarchy with N-level inheritance and per-namespace governance policies (write/promote/delete authority, approver type, optional N-of-M consensus) bound the swarm. Stack this under a 24/7 multi-machine agent runner with auto-generated skills, and the combined system clears the *behavioral* bar for autonomous AI. The remaining gaps (no weight-level learning, stateless reasoning kernel, human-seeded root goals) are real and not what ai-memory addresses; ai-memory provides the multi-agent memory substrate that any serious attempt at closing those gaps will need.
 
 **Zero token cost until recall.** Unlike built-in memory systems (Claude Code auto-memory, ChatGPT memory) that load your entire memory into every conversation -- burning tokens and money on every message -- ai-memory uses zero context tokens until the AI explicitly calls `memory_recall`. Only relevant memories come back, ranked by a 6-factor scoring algorithm. **TOON format** (Token-Oriented Object Notation) cuts response tokens by another 40-60% by eliminating repeated field names -- 3 memories in JSON = 1,600 bytes; in TOON = 626 bytes (61% smaller); in TOON compact = 336 bytes (79% smaller). For Claude Code users: **disable auto-memory** (`"autoMemoryEnabled": false` in settings.json) and replace it with ai-memory to stop paying for 200+ lines of memory context on every single message.
+
+---
+
+## Agent identity (NHI) — every memory tells you who learned it
+
+Every memory ai-memory stores carries a `metadata.agent_id` — a Non-Human Identity marker that survives every operation (update, dedup, import, sync, consolidate). Every recall result tells you which AI wrote each memory, by default, in the TOON-compact response format your AI client is already optimised for:
+
+```
+count:5|mode:hybrid|tokens_used:842
+memories[id|title|tier|namespace|priority|score|tags|agent_id]:
+a1b2|Project DB is PostgreSQL 16|long|infra|8|0.91|database,postgres|ai:claude-code@workstation:pid-3812
+c3d4|API rate limit is 100 rps|long|infra|7|0.87|api,limits|ai:claude-desktop@laptop:pid-5219
+```
+
+**Today** `agent_id` is *claimed*, not *attested* — don't make security decisions on it without pairing with agent registration. **v0.7** wires cryptographic attestation into the schema-reserved `memory_links.signature` field. See the [agent identity page](https://alphaonedev.github.io/ai-memory-mcp/agent-identity.html) for the full provenance contract.
+
+## Retroactive conversation import — `ai-memory mine`
+
+Don't start cold. Point `ai-memory mine` at a Claude, ChatGPT, or Slack export and it parses turn-by-turn into ranked, tier-typed, tagged memories — so your AI walks into the next session knowing every decision, correction, and finding from your existing history.
+
+```bash
+ai-memory mine claude  ~/Downloads/claude-export/
+ai-memory mine chatgpt ~/Downloads/chatgpt-export.json
+ai-memory mine slack   ./slack-export/
+```
+
+Auto-tagging, dedup on `(title, namespace)`, and `mined_from` provenance are stamped on every imported memory. Five-minute onboarding from zero context to a populated long-term store. See the [import history page](https://alphaonedev.github.io/ai-memory-mcp/import-history.html) for per-format recipes.
 
 ---
 
@@ -503,9 +531,9 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (24 endpoints on port 90
 - **Tagging** -- comma-separated tags with filter support
 
 ### Interfaces
-- **24 HTTP endpoints** -- full REST API on 127.0.0.1:9077 (works with any AI or tool)
+- **42 HTTP endpoints** -- full REST API on 127.0.0.1:9077 (works with any AI or tool)
 - **26 CLI commands** -- complete CLI with identical capabilities
-- **26 MCP tools** -- native integration for any MCP-compatible AI
+- **43 MCP tools** -- native integration for any MCP-compatible AI
 - **Interactive REPL shell** -- recall, search, list, get, stats, namespaces, delete with color output
 - **JSON output** -- `--json` flag on all CLI commands
 
@@ -522,7 +550,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (24 endpoints on port 90
 - **Color CLI output** -- ANSI tier labels (red/yellow/green), priority bars, bold titles, cyan namespaces
 
 ### Quality
-- **191 tests** -- 140 unit tests across all 15 modules + 51 integration tests. **15/15 modules** have unit tests — 95%+ coverage.
+- **1,600 lib tests** -- 93.08% coverage (gate ≥92%). All numbers frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); per-release detail on the [test-hub v0.6.3 evidence](https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/).
 - **LongMemEval benchmark** -- **97.8% R@5** (489/500), **99.0% R@10**, **99.8% R@20** on ICLR 2025 LongMemEval-S dataset. 499/500 at R@20. Pure FTS5 keyword achieves 97.0% R@5 in 2.2 seconds (232 q/s). LLM query expansion pushes to 97.8% R@5. Zero cloud API costs. See [benchmark details](benchmarks/longmemeval/).
 - **MCP Prompts** -- `recall-first` and `memory-workflow` prompts teach AI clients to use memory proactively
 - **TOON-default** -- recall/list/search responses use TOON compact by default (79% smaller than JSON)

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -134,10 +134,10 @@ The `--tier` flag controls which features are enabled. Each tier builds on the p
 
 | Tier | Tools | Embedding Model | LLM Required | Approx. Memory |
 |------|-------|----------------|--------------|----------------|
-| `keyword` | 21 | No | No | Minimal |
-| `semantic` (default) | 21 | Yes (HuggingFace) | No | ~256 MB |
-| `smart` | 21 | Yes | Yes (Ollama) | ~1 GB |
-| `autonomous` | 21 | Yes | Yes (Ollama) | ~4 GB |
+| `keyword` | keyword subset | No | No | Minimal |
+| `semantic` (default) | semantic subset | Yes (HuggingFace) | No | ~256 MB |
+| `smart` | smart subset (LLM tools enabled) | Yes | Yes (Ollama) | ~1 GB |
+| `autonomous` | full 43-tool surface | Yes | Yes (Ollama) | ~4 GB |
 
 Set the tier when starting the MCP server or HTTP daemon:
 
@@ -750,7 +750,7 @@ Both are cleaned up on graceful shutdown (the daemon runs `PRAGMA wal_checkpoint
 
 Maximum request body size: 50 MB.
 
-The HTTP daemon exposes **24 endpoints** under `/api/v1`:
+The HTTP daemon exposes **42 endpoints** under `/api/v1`:
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -2,7 +2,9 @@
 
 `ai-memory` is an AI-agnostic memory management system. It works with **any MCP-compatible AI client** -- including Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, and others. The HTTP API and CLI are completely platform-independent.
 
-**Key features for admins:** Zero token cost until recall (replaces built-in auto-memory), TOON compact default response format (79% smaller than JSON), MCP prompts for proactive AI behavior (`recall-first`, `memory-workflow`), 4 feature tiers (keyword → autonomous with local LLMs via Ollama), 191 tests with 95%+ coverage across 15/15 modules.
+**Key features for admins:** Zero token cost until recall (replaces built-in auto-memory), TOON compact default response format (79% smaller than JSON), MCP prompts for proactive AI behavior (`recall-first`, `memory-workflow`), 4 feature tiers (keyword → autonomous with local LLMs via Ollama), 1,600 lib tests at 93.08% coverage. All numbers frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html).
+
+> **Maturity framing (v0.6.3).** The single-machine primitive (T1/T2 in the [architectures matrix](https://alphaonedev.github.io/ai-memory-mcp/architectures.html)) is **production-ready**. Federation (T3 multi-node quorum cluster) is **beta** — the code is shipped and tested but not recommended for unattended production fleets. The Postgres+pgvector backend is **experimental** under the `sal-postgres` Cargo feature, GA target v0.7. Multi-region distributed consensus (T5 "global hive") is **vision** at v1.0+. ai-memory is a single-machine primitive that ships beta-quality federation primitives for opt-in multi-node clusters; it is not a distributed database. See the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html) for the canonical maturity labels — use those labels in all customer-facing materials.
 
 ## Deployment Options
 
@@ -41,7 +43,7 @@ Run the HTTP daemon directly in the foreground:
 ai-memory --db /path/to/ai-memory.db serve
 ```
 
-The daemon listens on `127.0.0.1:9077` by default and exposes 24 HTTP endpoints.
+The daemon listens on `127.0.0.1:9077` by default and exposes 42 HTTP endpoints (canonical count on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)).
 
 ### Systemd (Production HTTP Daemon)
 
@@ -1153,7 +1155,7 @@ Runs on `ubuntu-latest` and `macos-latest`:
 
 1. **Formatting** -- `cargo fmt --check`
 2. **Linting** -- `cargo clippy -- -D warnings`
-3. **Tests** -- `cargo test` (191 tests: 140 unit + 51 integration, 15/15 modules)
+3. **Tests** -- `cargo test` (1,600 lib tests; canonical counts on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html))
 4. **Build** -- `cargo build --release`
 
 Uses `Swatinem/rust-cache@v2` for build caching.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -179,7 +179,7 @@ records the original claim.
 
 ### `mcp`
 
-Run as an MCP tool server over stdio (JSON-RPC 2.0, 23 tools + 2
+Run as an MCP tool server over stdio (JSON-RPC 2.0, 43 tools + 2
 prompts).
 
 ```bash

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1007,7 +1007,7 @@ ai-memory completions fish
 
 ## Testing
 
-The project has **191 tests** total: 140 unit tests across all 15 modules + 51 integration tests in `tests/integration.rs`. **15/15 modules** have unit tests — 95%+ coverage.
+The project has **1,600 lib tests at 93.08% coverage** as of v0.6.3 — canonical numbers are frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); per-release detail on the [test-hub v0.6.3 evidence](https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/). Modules each carry their own unit-test suite; integration tests live under `tests/`.
 
 ```bash
 # Run all tests

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -4,9 +4,9 @@
 
 `ai-memory` is an AI-agnostic memory management system built as a single Rust binary that serves three roles:
 
-1. **MCP tool server** -- stdio JSON-RPC server exposing 21 memory tools + 2 MCP prompts for any MCP-compatible AI client (Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, and others)
+1. **MCP tool server** -- stdio JSON-RPC server exposing 43 memory tools + 2 MCP prompts for any MCP-compatible AI client (Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, and others)
 2. **CLI tool** -- direct SQLite operations for store, recall, search, list, etc. (completely AI-agnostic)
-3. **HTTP daemon** -- an Axum web server exposing the same operations as a REST API with 24 endpoints (completely AI-agnostic)
+3. **HTTP daemon** -- an Axum web server exposing the same operations as a REST API with 42 endpoints (completely AI-agnostic)
 
 **Key architectural features:** Zero token cost (no context loaded until recall), TOON compact default response format (79% smaller than JSON), MCP prompts capability (`recall-first` behavioral rules + `memory-workflow` reference card), 4 feature tiers with optional local LLMs via Ollama, true dedup on title+namespace, 6-factor recall scoring with score field in responses.
 
@@ -17,7 +17,7 @@ main.rs          -- CLI parsing (clap), daemon setup (axum), command dispatch (2
 models.rs        -- Data structures: Memory, MemoryLink, query types, constants
 handlers.rs      -- HTTP request handlers (Axum extractors + JSON responses), error sanitization
 db.rs            -- All SQLite operations: CRUD, FTS5, recall scoring, GC, migration, FTS query sanitization, transactional touch/consolidate
-mcp.rs           -- MCP (Model Context Protocol) server over stdio JSON-RPC, 26 tools, notification handling
+mcp.rs           -- MCP (Model Context Protocol) server over stdio JSON-RPC, 43 tools, notification handling
 validate.rs      -- Input validation for all write paths
 errors.rs        -- Structured error types (ApiError, MemoryError), error sanitization for HTTP responses
 color.rs         -- ANSI color output for CLI (zero dependencies, auto-detects terminal)
@@ -53,7 +53,7 @@ When running at the `semantic` tier or higher, ai-memory loads a HuggingFace emb
 - `ListArgs` includes `--offset` flag for pagination
 - `auto_namespace()` -- detects namespace from git remote URL or directory name
 - `human_age()` -- formats ISO timestamps as "2h ago", "3d ago" for CLI output
-- `serve()` -- starts the Axum server with all routes (24 endpoints including `POST /memories/{id}/promote` and 4 archive endpoints), spawns GC task, handles graceful shutdown via SIGINT with WAL checkpoint
+- `serve()` -- starts the Axum server with all routes (42 endpoints including `POST /memories/{id}/promote` and 4 archive endpoints), spawns GC task, handles graceful shutdown via SIGINT with WAL checkpoint
 - `cmd_*()` functions -- one per CLI command, each opens the DB directly
 
 ### `src/models.rs`
@@ -69,10 +69,10 @@ When running at the `semantic` tier or higher, ai-memory loads a HuggingFace emb
 
 ### `src/mcp.rs`
 
-The MCP (Model Context Protocol) server implementation. MCP is an open standard -- this server works with any MCP-compatible AI client. Runs over stdio, processing one JSON-RPC message per line. Exposes **26 tools**.
+The MCP (Model Context Protocol) server implementation. MCP is an open standard -- this server works with any MCP-compatible AI client. Runs over stdio, processing one JSON-RPC message per line. Exposes **43 tools**.
 
 - `RpcRequest` / `RpcResponse` / `RpcError` -- JSON-RPC 2.0 types
-- `tool_definitions()` -- returns the 23 tool schemas for `tools/list` (includes `memory_capabilities`, `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, `memory_archive_list`, `memory_archive_restore`, `memory_archive_purge`, `memory_archive_stats`)
+- `tool_definitions()` -- returns the 43 tool schemas for `tools/list` (includes `memory_capabilities`, `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, `memory_archive_list`, `memory_archive_restore`, `memory_archive_purge`, `memory_archive_stats`)
   - `memory_recall` schema includes `until` parameter and `format` parameter (enum: `"json"`, `"toon"`, `"toon_compact"`, default: `"toon_compact"`)
   - `memory_search` schema includes `format` parameter (enum: `"json"`, `"toon"`, `"toon_compact"`, default: `"toon_compact"`) and enforces `maximum: 200` on limit
   - `memory_list` schema includes `format` parameter (enum: `"json"`, `"toon"`, `"toon_compact"`, default: `"toon_compact"`) and enforces `maximum: 200` on limit
@@ -87,7 +87,7 @@ Protocol version: `2024-11-05`. All tool responses are wrapped in MCP content bl
 
 **MCP Prompts:** The server exposes 2 prompts via `prompts/list`:
 - **recall-first** -- System prompt with 8 behavioral rules for proactive memory use. Supports an optional `namespace` argument for scoped recall.
-- **memory-workflow** -- Quick reference card for all 26 tool usage patterns.
+- **memory-workflow** -- Quick reference card for all 43 tool usage patterns.
 
 **MCP Error Codes:** The server uses standard JSON-RPC 2.0 error codes:
 - `-32700` -- Parse error (malformed JSON)
@@ -385,8 +385,8 @@ The `config.rs` module defines 4 feature tiers that gate functionality:
 |------|-----------|-----|-----------------|
 | `keyword` | No | No | 13 base tools + `memory_capabilities` + 4 archive tools |
 | `semantic` | Yes | No | 14 base tools + `memory_capabilities` + 4 archive tools |
-| `smart` | Yes | Yes | All 26 tools |
-| `autonomous` | Yes | Yes | All 26 tools + autonomous behaviors |
+| `smart` | Yes | Yes | Full 43-tool surface |
+| `autonomous` | Yes | Yes | Full 43-tool surface + autonomous behaviors |
 
 The tier is set at startup via `ai-memory mcp --tier <tier>` and cannot be changed at runtime. The `memory_capabilities` tool reports the active tier and which features are available, allowing AI clients to adapt their behavior.
 
@@ -515,7 +515,7 @@ Base URL: `http://127.0.0.1:9077/api/v1`
 
 All responses are JSON. Error responses include `{"error": "message"}`. Database errors are sanitized -- clients receive `"Internal server error"` instead of raw SQLite error details.
 
-The HTTP API exposes **24 endpoints**.
+The HTTP API exposes **42 endpoints** (canonical count on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)).
 
 ### Health Check
 
@@ -786,7 +786,7 @@ Global flags:
 
 ### `serve`
 
-Start the HTTP daemon (24 endpoints).
+Start the HTTP daemon (42 endpoints).
 
 ```bash
 ai-memory serve --host 127.0.0.1 --port 9077
@@ -794,7 +794,7 @@ ai-memory serve --host 127.0.0.1 --port 9077
 
 ### `mcp`
 
-Run as an MCP tool server over stdio. This is the primary integration path for any MCP-compatible AI client. Exposes 26 tools.
+Run as an MCP tool server over stdio. This is the primary integration path for any MCP-compatible AI client. Exposes 43 tools.
 
 ```bash
 ai-memory mcp

--- a/docs/ENGINEERING_STANDARDS.md
+++ b/docs/ENGINEERING_STANDARDS.md
@@ -121,7 +121,7 @@ cargo audit
 
 ### 2.3 Full Spectrum Functional Test
 
-Run against the compiled binary via CLI. Covers all 26 commands with edge cases. When adding a new command, add a corresponding row to this table.
+Run against the compiled binary via CLI. Covers all 26 CLI commands with edge cases. When adding a new command, add a corresponding row to this table.
 
 | Category | Tests | Scope |
 |----------|:-----:|-------|

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -135,7 +135,7 @@ embeddings lose information on long text.
 ## MCP (Model Context Protocol)
 
 Anthropic's JSON-RPC protocol for AI-tool integration. ai-memory ships
-an MCP server via `ai-memory mcp` exposing 23 tools (memory_store,
+an MCP server via `ai-memory mcp` exposing 43 tools (memory_store,
 memory_recall, etc.) + 2 prompts over stdio. Works with Claude Code,
 Claude Desktop, Cursor, Codex, Grok, Gemini, Llama Stack. See
 `docs/USER_GUIDE.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,16 +2,16 @@
 
 <div align="center">
 
-## 🎯 Current stable release · **v0.6.2** · A2A-CERTIFIED
+## 🎯 Current stable release · **v0.6.3** · A2A-CERTIFIED · 1,600 lib tests · 93.08% cov
 
-[![Release](https://img.shields.io/badge/release-v0.6.2-brightgreen?logo=github)](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.2)
+[![Release](https://img.shields.io/badge/release-v0.6.3-brightgreen?logo=github)](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3)
 [![A2A Gate](https://img.shields.io/badge/A2A_gate-9%2F9_green-brightgreen)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)
 [![Ship Gate](https://img.shields.io/badge/ship_gate-green-brightgreen)](https://alphaonedev.github.io/ai-memory-ship-gate/)
 [![crates.io](https://img.shields.io/crates/v/ai-memory)](https://crates.io/crates/ai-memory)
 
-**v0.6.2** cleared the a2a-gate certification bar: three consecutive full-testbook green runs across three agent frameworks and three transport modes — **324 passing scenarios**, zero partial greens.
+**v0.6.3** cleared the a2a-gate certification bar: three consecutive full-testbook green runs across three agent frameworks and three transport modes — **324 passing scenarios**, zero partial greens.
 
-**📦 [Release v0.6.2](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.2)** ·
+**📦 [Release v0.6.3](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3)** ·
 **📊 [A2A gate evidence](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)** ·
 **🚢 [Ship gate](https://alphaonedev.github.io/ai-memory-ship-gate/)** ·
 **📖 [AI-NHI insights](https://alphaonedev.github.io/ai-memory-ai2ai-gate/insights/)** ·

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -74,7 +74,7 @@ Your AI assistant uses these tools automatically during conversations. You can a
 
 ## MCP Tool Reference
 
-This section documents all 26 MCP tools with their exact parameter schemas, example requests, and response formats. All tools are invoked via JSON-RPC 2.0 using method `tools/call` with the tool name in `params.name` and tool parameters in `params.arguments`.
+This section documents the 43 MCP tools with their exact parameter schemas, example requests, and response formats (canonical counts on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)). All tools are invoked via JSON-RPC 2.0 using method `tools/call` with the tool name in `params.name` and tool parameters in `params.arguments`.
 
 All responses are wrapped in the MCP content envelope:
 

--- a/docs/a2a-messaging.html
+++ b/docs/a2a-messaging.html
@@ -87,14 +87,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ A2A Messaging</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -112,6 +114,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html" class="current">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -125,8 +139,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/agent-identity.html
+++ b/docs/agent-identity.html
@@ -1,0 +1,325 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Agent identity (NHI) — every memory carries the AI that learned it.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Agent identity (NHI) — provenance for AI knowledge</title>
+<meta name="description" content="Every memory carries the identity of the AI that learned it. Every recall surfaces it. Provenance for AI knowledge — built in from day one.">
+<meta property="og:title" content="ai-memory · Agent identity (NHI)">
+<meta property="og:description" content="metadata.agent_id is a first-class field on every memory. Provenance built in from day one.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/agent-identity.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.82rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none;font-size:.82rem}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1.25rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+
+blockquote{border-left:4px solid var(--p1);background:rgba(110,231,255,.05);padding:1rem 1.25rem;margin:1.25rem 0;border-radius:0 8px 8px 0;color:var(--text-muted)}
+blockquote strong{color:var(--p1)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Agent Identity</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html" class="current">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Agent identity (NHI)</h1>
+  <p class="tagline">Every memory carries the identity of the AI that learned it. Every recall surfaces it. Provenance for AI knowledge — built in from day one.</p>
+  <div class="pills">
+    <span class="pill">metadata.agent_id</span>
+    <span class="pill">first-class field</span>
+    <span class="pill">claimed → attested</span>
+    <span class="pill">defense in depth</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <blockquote>
+      <strong>Every recall result tells you which AI learned the memory.</strong> This is the differentiator: <code>ai-memory</code> doesn't just store knowledge — it remembers <em>who</em> added it, and that information is in front of every agent that recalls.
+    </blockquote>
+    <p><code>metadata.agent_id</code> is a first-class field on every memory. When your AI calls <code>memory_recall</code>, the response includes a column telling you which agent each result came from — by default, in the token-efficient TOON compact format that AI clients are already optimised for.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">In action</span>
+    <h2>See it.</h2>
+    <p>Default recall output (TOON compact format):</p>
+<pre><code>count:5|mode:hybrid|tokens_used:842
+memories[id|title|tier|namespace|priority|score|tags|agent_id]:
+a1b2|Project DB is PostgreSQL 16|long|infra|8|0.91|database,postgres|ai:claude-code@workstation:pid-3812
+c3d4|API rate limit is 100 rps|long|infra|7|0.87|api,limits|ai:claude-desktop@laptop:pid-5219
+e5f6|Use TOON not JSON for MCP|long|protocol|9|0.82|toon,mcp,tokens|host:pop-os:pid-1144-ad1b9c
+g7h8|Deploy gate fixed for v0.6.3|long|releases|6|0.79|deploy,gate|ai:codex@server:pid-9911
+i9j0|Ship-gate cleanup complete|long|releases|5|0.74|cleanup|alice</code></pre>
+    <p>Eight columns. Last column is <code>agent_id</code>. The recall blends what's relevant (text, semantics, priority, recency) <strong>and</strong> tells you who wrote it.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Definition</span>
+    <h2>What <code>agent_id</code> means.</h2>
+    <p><code>agent_id</code> is a <em>claimed</em> identity attached to every memory at write time. It survives every operation that touches the memory: update, dedup, import, sync, consolidate. It's the substrate for filtering, scoping, governance, and (in v0.7) cryptographic attestation.</p>
+    <blockquote>
+      <strong>Honest framing:</strong> <code>agent_id</code> today is <em>claimed</em>, not <em>attested</em>. Don't make security decisions on it without pairing with agent registration (Task 1.3 — upcoming) or attestation (v0.7+). The schema reservation for cryptographic signatures lives at <code>memory_links.signature</code> (schema v15, v0.6.3) and gets wired in v0.7.
+    </blockquote>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Resolution</span>
+    <h2>Resolution precedence.</h2>
+    <p>When <code>ai-memory</code> decides what <code>agent_id</code> to stamp on a new memory:</p>
+
+    <h3>CLI and MCP path</h3>
+    <ol>
+      <li>Explicit value from caller — <code>--agent-id &lt;id&gt;</code> flag, or <code>agent_id</code> field on the MCP tool, or <code>metadata.agent_id</code> embedded in a store request</li>
+      <li><code>AI_MEMORY_AGENT_ID</code> environment variable</li>
+      <li>(MCP only) Captured from <code>initialize.clientInfo.name</code> → e.g. <code>ai:claude-code@workstation:pid-3812</code></li>
+      <li>Stable per-process fallback → <code>host:&lt;hostname&gt;:pid-&lt;pid&gt;-&lt;uuid8&gt;</code></li>
+      <li><code>anonymous:pid-&lt;pid&gt;-&lt;uuid8&gt;</code> if hostname unavailable</li>
+    </ol>
+
+    <h3>HTTP daemon path (multi-tenant — no process-level default)</h3>
+    <ol>
+      <li><code>agent_id</code> field in <code>POST /api/v1/memories</code> body</li>
+      <li><code>X-Agent-Id</code> request header</li>
+      <li>Per-request <code>anonymous:req-&lt;uuid8&gt;</code> (logged at WARN)</li>
+    </ol>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Validation</span>
+    <h2>What's valid.</h2>
+    <ul>
+      <li>Format: <code>^[A-Za-z0-9_\-:@./]{1,128}$</code></li>
+      <li>Permits: <code>ai:</code>, <code>host:</code>, <code>anonymous:</code> prefixes; <code>@</code> scope separator; <code>/</code> for SPIFFE-style IDs</li>
+      <li>Rejects: whitespace, null bytes, control chars, shell metacharacters</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Immutability</span>
+    <h2>Defense in depth.</h2>
+    <p>Once a memory is stored, its <code>agent_id</code> doesn't drift. <strong>Both</strong> the caller layer (<code>identity::preserve_agent_id</code>) and the SQL layer (<code>json_set</code> CASE clauses in <code>db::insert</code> and <code>db::insert_if_newer</code>) enforce preservation across:</p>
+    <ul>
+      <li><code>memory_update</code></li>
+      <li>Upsert / dedup on <code>(title, namespace)</code></li>
+      <li>HTTP <code>PUT /memories/{id}</code></li>
+      <li><code>import</code> from JSON</li>
+      <li><code>sync_push</code> from a peer</li>
+      <li><code>memory_consolidate</code></li>
+    </ul>
+    <p>If a malicious or buggy caller tries to overwrite <code>agent_id</code>, the SQL layer refuses. This is the defense-in-depth NHI invariant from issue #148 / Task 1.2.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Filtering</span>
+    <h2>Filter by agent.</h2>
+    <p>Every recall, list, and search supports <code>agent_id</code> filtering:</p>
+<pre><code># CLI
+ai-memory list --agent-id ai:claude-desktop@laptop:pid-5219
+ai-memory search --agent-id alice "deploy"
+
+# MCP — the agent_id property
+{"name": "memory_search", "arguments": {"query": "deploy", "agent_id": "alice"}}
+
+# HTTP
+curl 'http://127.0.0.1:9077/api/v1/memories?agent_id=alice&query=deploy'</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">System metadata</span>
+    <h2>System-stamped metadata (don't overwrite).</h2>
+    <p>These keys are produced by ai-memory; the system sets them, callers must not.</p>
+    <table>
+      <thead>
+        <tr><th>Key</th><th>When stamped</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>imported_from_agent_id</code></td><td><code>ai-memory import</code> re-stamps the originator's <code>agent_id</code> (absent when <code>--trust-source</code> is passed)</td></tr>
+        <tr><td><code>consolidated_from_agents</code></td><td><code>memory_consolidate</code> records the array of source authors; the consolidator's id becomes the new <code>agent_id</code></td></tr>
+        <tr><td><code>mined_from</code></td><td><code>ai-memory mine</code> stamps the source format (<code>claude</code> / <code>chatgpt</code> / <code>slack</code>) alongside the caller's <code>agent_id</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Privacy</span>
+    <h2>Scrub the leaky default.</h2>
+    <p>The fallback <code>host:&lt;hostname&gt;:pid-&lt;pid&gt;-&lt;uuid8&gt;</code> exposes hostname and PID. <strong>When writing memories to a shared or upstream database, set an opaque <code>--agent-id</code> or <code>AI_MEMORY_AGENT_ID</code>.</strong> Tracking issue: #198.</p>
+<pre><code># Production daemon — opaque identity
+AI_MEMORY_AGENT_ID=fleet-prod-9 ai-memory serve --bind 0.0.0.0:9077
+
+# Or per-CLI-call
+ai-memory --agent-id alice store -T "Auth flow notes" -c "..."</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Why this matters</span>
+    <h2>Provenance is infrastructure.</h2>
+    <p>Every other memory product treats AI knowledge as <strong>anonymous text in a vector DB</strong>. ai-memory treats every memory as a <strong>dated, attributable assertion</strong>. When your fleet of agents grows from one to ten to hundreds:</p>
+    <ul>
+      <li>You can answer <em>"who wrote this?"</em> in every recall — instantly.</li>
+      <li>You can scope retrieval to <em>"show me what <code>ai:secops-skill@*</code> learned this week."</em></li>
+      <li>Per-namespace governance can require approval for writes from specific agents (see <a href="architectures-t2.html" style="color:var(--p1)">Architectures · T2</a> and <a href="architectures-t3.html" style="color:var(--p1)">T3</a>).</li>
+      <li>v0.7 attestation extends <code>agent_id</code> from claimed to cryptographically signed — same field, stronger guarantee.</li>
+    </ul>
+    <p><code>ai-memory</code> ships provenance on day one.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Next</span>
+    <h2>Where to go.</h2>
+    <ul>
+      <li>→ <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/develop/docs/USER_GUIDE.md" style="color:var(--p1)">Recall</a> — full scoring + ranking (in the User Guide)</li>
+      <li>→ <a href="hierarchies.html" style="color:var(--p1)">Namespaces &amp; hierarchies</a> — scope visibility on top of NHI</li>
+      <li>→ <a href="architectures-t2.html" style="color:var(--p1)">Architectures · T2</a> — multi-agent isolation in practice</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -95,11 +95,11 @@
 
     <rect x="345" y="140" width="160" height="60" class="card-green"/>
     <text x="425" y="164" text-anchor="middle" class="title">HTTP API</text>
-    <text x="425" y="181" text-anchor="middle" class="subtitle">REST · 24 endpoints · :9077</text>
+    <text x="425" y="181" text-anchor="middle" class="subtitle">REST · 42 endpoints · :9077</text>
 
     <rect x="600" y="140" width="160" height="60" class="card-green"/>
     <text x="680" y="164" text-anchor="middle" class="title">CLI</text>
-    <text x="680" y="181" text-anchor="middle" class="subtitle">25 commands · scriptable</text>
+    <text x="680" y="181" text-anchor="middle" class="subtitle">26 commands · scriptable</text>
   </g>
 
   <!-- Flow lines down to validation -->

--- a/docs/architectures-t1.html
+++ b/docs/architectures-t1.html
@@ -408,7 +408,7 @@ ai-memory --db ~/.claude/ai-memory.db stats</code></pre>
     <span class="eyebrow">Source</span>
     <h2>Source-of-truth references.</h2>
     <ul>
-      <li><code>src/main.rs</code> — daemon setup, command dispatch (~27 CLI commands)</li>
+      <li><code>src/main.rs</code> — daemon setup, command dispatch (26 CLI commands)</li>
       <li><code>src/mcp.rs</code> — MCP tool handlers wired to the same DB layer</li>
       <li><code>src/handlers.rs</code> — HTTP route handlers (the Axum router in <code>main.rs</code> registers 48 <code>/api/v1/*</code> routes)</li>
       <li><code>src/db.rs</code> — schema, recall scoring, GC, migrations (current schema v15 per v0.6.3 release notes)</li>

--- a/docs/architectures-t1.html
+++ b/docs/architectures-t1.html
@@ -1,0 +1,427 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  T1 — Single node, single agent. The bedrock primitive.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · T1 — Single node, single agent</title>
+<meta name="description" content="One ai-memory process, one consumer, SQLite-backed. The bedrock primitive of the entire stack.">
+<meta property="og:title" content="ai-memory · T1 — Single node, single agent">
+<meta property="og:description" content="One process. One consumer. Zero network. The bedrock primitive.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures-t1.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+/* Grouped dropdown menu */
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+/* capability badges */
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+/* arch-diagram block */
+.arch-diagram{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin:1.5rem 0}
+.arch-diagram-title{font-family:var(--font-mono);font-size:.85rem;color:var(--p2);letter-spacing:.04em;margin-bottom:1rem;text-transform:uppercase}
+.arch-svg{width:100%;height:auto;display:block;background:#0a0a0a;border-radius:8px}
+.arch-svg .node{fill:#161616;stroke:#3d3d3d;stroke-width:1.2}
+.arch-svg .node-label{fill:#fff;font-family:'SF Mono',monospace;font-size:12px;font-weight:600}
+.arch-svg .sub-label{fill:#999;font-family:'SF Mono',monospace;font-size:10px}
+.arch-svg .edge{fill:none}
+.arch-svg .edge-dashed{fill:none;stroke:#666;stroke-width:1.2;stroke-dasharray:4 3}
+.arch-svg .edge-roadmap{fill:none;stroke:#a78bfa;stroke-width:1.4;stroke-dasharray:5 4;opacity:.7}
+.arch-svg .flow{filter:drop-shadow(0 0 4px currentColor)}
+.arch-svg .flow-write{fill:#f97316;color:#f97316}
+.arch-svg .flow-recall{fill:#2dd4bf;color:#2dd4bf}
+.arch-svg .flow-sync{fill:#a78bfa;color:#a78bfa}
+.arch-svg .flow-policy{fill:#facc15;color:#facc15}
+.arch-svg .flow-attest{fill:#f472b6;color:#f472b6}
+.arch-svg .ring{fill:none;stroke:#6ee7ff;stroke-width:2;opacity:.7}
+.arch-svg .ring{animation:pulse 2.4s ease-out infinite}
+@keyframes pulse{0%{r:6;opacity:.85}100%{r:18;opacity:0}}
+.arch-legend{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted)}
+.arch-legend-item{display:inline-flex;align-items:center;gap:.4rem}
+.arch-legend-dot{display:inline-block;width:10px;height:10px;border-radius:50%}
+.arch-diagram-caption{font-size:.85rem;color:var(--text-dim);margin-top:1rem;line-height:1.5}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures · T1</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html" class="current">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <span class="cap-badge cap-today">SHIPS TODAY · v0.6.3</span>
+  <h1>Tier 1 — Single node, single agent</h1>
+  <p class="tagline">The bedrock primitive. <strong>One process. One consumer. Zero network.</strong> SQLite + WAL, FTS5 keyword recall, in-process HNSW vector index, no replication, no peers.</p>
+  <div class="pills">
+    <span class="pill">SQLite WAL</span>
+    <span class="pill">FTS5 + HNSW</span>
+    <span class="pill">~10⁶ memories</span>
+    <span class="pill">sub-ms recall</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <p>This is what runs on every developer's laptop, every Claude Code session, every solo agent that needs to remember things between turns. SQLite under the hood, WAL-mode for atomic writes, FTS5 for keyword recall, an in-process HNSW vector index for semantic recall. No replication, no peers, no governance to coordinate.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Architecture diagram</span>
+    <h2>Memory data flow — single agent.</h2>
+
+    <div class="arch-diagram">
+      <div class="arch-diagram-title">T1 · Memory data flow — single agent</div>
+
+      <svg class="arch-svg" viewBox="0 0 760 440" role="img" aria-label="Single agent talking to a single ai-memory instance backed by SQLite">
+
+        <defs>
+          <marker id="t1-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+
+          <linearGradient id="t1-mem-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.18"/>
+            <stop offset="100%" stop-color="#0d9488" stop-opacity="0.06"/>
+          </linearGradient>
+
+          <path id="t1-path-write"  d="M 130 145 C 250 145, 280 200, 380 200" />
+          <path id="t1-path-recall" d="M 380 240 C 280 240, 250 295, 130 295" />
+          <path id="t1-path-store"  d="M 470 240 C 540 240, 580 290, 615 320" />
+          <path id="t1-path-fetch"  d="M 615 360 C 580 380, 540 360, 470 320" />
+        </defs>
+
+        <!-- AGENT -->
+        <g>
+          <rect x="40" y="170" width="180" height="100" rx="14" class="node" />
+          <text x="130" y="200" text-anchor="middle" class="node-label">AI agent</text>
+          <text x="130" y="220" text-anchor="middle" class="sub-label">Claude · GPT · local LLM</text>
+          <text x="130" y="240" text-anchor="middle" class="sub-label">MCP / HTTP / CLI client</text>
+          <text x="130" y="258" text-anchor="middle" class="sub-label">single namespace</text>
+        </g>
+
+        <!-- AI-MEMORY PROCESS -->
+        <g>
+          <rect x="290" y="80" width="280" height="280" rx="16"
+                fill="url(#t1-mem-gradient)" stroke="#2dd4bf" stroke-width="1.6" />
+          <text x="430" y="105" text-anchor="middle" class="node-label" style="font-size: 13px">ai-memory process</text>
+          <text x="430" y="122" text-anchor="middle" class="sub-label">single Arc&lt;Mutex&lt;Connection&gt;&gt;</text>
+
+          <!-- Three interfaces -->
+          <rect x="306" y="138" width="78" height="40" rx="6" class="node" />
+          <text x="345" y="156" text-anchor="middle" class="sub-label" style="font-size: 10px">MCP</text>
+          <text x="345" y="170" text-anchor="middle" class="sub-label">stdio JSON-RPC</text>
+
+          <rect x="392" y="138" width="78" height="40" rx="6" class="node" />
+          <text x="431" y="156" text-anchor="middle" class="sub-label" style="font-size: 10px">HTTP :9077</text>
+          <text x="431" y="170" text-anchor="middle" class="sub-label">/api/v1/* (Axum)</text>
+
+          <rect x="478" y="138" width="78" height="40" rx="6" class="node" />
+          <text x="517" y="156" text-anchor="middle" class="sub-label" style="font-size: 10px">CLI</text>
+          <text x="517" y="170" text-anchor="middle" class="sub-label">clap subcommands</text>
+
+          <!-- Recall pipeline -->
+          <rect x="306" y="195" width="248" height="64" rx="8" class="node" />
+          <text x="430" y="214" text-anchor="middle" class="node-label" style="font-size: 11px">Recall pipeline</text>
+          <text x="430" y="230" text-anchor="middle" class="sub-label">FTS5 keyword + HNSW semantic</text>
+          <text x="430" y="245" text-anchor="middle" class="sub-label">adaptive blend · touch + auto-promote</text>
+
+          <!-- Governance + KG -->
+          <rect x="306" y="275" width="120" height="68" rx="8" class="node" />
+          <text x="366" y="294" text-anchor="middle" class="sub-label" style="font-size: 10px">Governance</text>
+          <text x="366" y="308" text-anchor="middle" class="sub-label">policy / pending</text>
+          <text x="366" y="322" text-anchor="middle" class="sub-label">scope filter</text>
+          <text x="366" y="336" text-anchor="middle" class="sub-label">v0.6.2+</text>
+
+          <rect x="434" y="275" width="120" height="68" rx="8" class="node" />
+          <text x="494" y="294" text-anchor="middle" class="sub-label" style="font-size: 10px">Knowledge graph</text>
+          <text x="494" y="308" text-anchor="middle" class="sub-label">links · taxonomy</text>
+          <text x="494" y="322" text-anchor="middle" class="sub-label">temporal validity</text>
+          <text x="494" y="336" text-anchor="middle" class="sub-label">v0.6.3</text>
+        </g>
+
+        <!-- SQLITE -->
+        <g>
+          <rect x="595" y="290" width="135" height="110" rx="12" class="node" />
+          <text x="662" y="312" text-anchor="middle" class="node-label">SQLite (WAL)</text>
+          <text x="662" y="330" text-anchor="middle" class="sub-label">memories</text>
+          <text x="662" y="344" text-anchor="middle" class="sub-label">memory_links</text>
+          <text x="662" y="358" text-anchor="middle" class="sub-label">FTS5 virtual table</text>
+          <text x="662" y="372" text-anchor="middle" class="sub-label">HNSW (in-memory)</text>
+          <text x="662" y="388" text-anchor="middle" class="sub-label">archive</text>
+        </g>
+
+        <!-- PATHS -->
+        <use href="#t1-path-write" class="edge" stroke="#f97316" stroke-width="1.8" marker-end="url(#t1-arrow)" style="color: #f97316" />
+        <use href="#t1-path-recall" class="edge" stroke="#2dd4bf" stroke-width="1.8" marker-end="url(#t1-arrow)" style="color: #2dd4bf" />
+        <use href="#t1-path-store"  class="edge-dashed" />
+        <use href="#t1-path-fetch"  class="edge-dashed" />
+
+        <!-- Path labels -->
+        <text x="240" y="135" class="sub-label" fill="#f97316" font-weight="600">store / link</text>
+        <text x="240" y="318" class="sub-label" fill="#2dd4bf" font-weight="600">recall / kg_query</text>
+
+        <!-- FLOW PARTICLES — write (orange) -->
+        <circle r="4" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0s"><mpath href="#t1-path-write"/></animateMotion></circle>
+        <circle r="4" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.2s"><mpath href="#t1-path-write"/></animateMotion></circle>
+        <circle r="4" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="2.4s"><mpath href="#t1-path-write"/></animateMotion></circle>
+
+        <!-- FLOW PARTICLES — recall (teal) -->
+        <circle r="4" class="flow flow-recall"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0.6s"><mpath href="#t1-path-recall"/></animateMotion></circle>
+        <circle r="4" class="flow flow-recall"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.8s"><mpath href="#t1-path-recall"/></animateMotion></circle>
+        <circle r="4" class="flow flow-recall"><animateMotion dur="3.6s" repeatCount="indefinite" begin="3.0s"><mpath href="#t1-path-recall"/></animateMotion></circle>
+
+        <!-- FLOW PARTICLES — store to disk -->
+        <circle r="3" class="flow flow-write"><animateMotion dur="2.8s" repeatCount="indefinite" begin="0.4s"><mpath href="#t1-path-store"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="2.8s" repeatCount="indefinite" begin="1.6s"><mpath href="#t1-path-store"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="2.8s" repeatCount="indefinite" begin="2.8s"><mpath href="#t1-path-store"/></animateMotion></circle>
+
+        <!-- FLOW PARTICLES — fetch from disk -->
+        <circle r="3" class="flow flow-recall"><animateMotion dur="2.8s" repeatCount="indefinite" begin="0s"><mpath href="#t1-path-fetch"/></animateMotion></circle>
+        <circle r="3" class="flow flow-recall"><animateMotion dur="2.8s" repeatCount="indefinite" begin="1.2s"><mpath href="#t1-path-fetch"/></animateMotion></circle>
+        <circle r="3" class="flow flow-recall"><animateMotion dur="2.8s" repeatCount="indefinite" begin="2.4s"><mpath href="#t1-path-fetch"/></animateMotion></circle>
+
+        <!-- Touch ring on agent (showing recall is alive) -->
+        <circle cx="130" cy="220" r="6" class="ring" />
+      </svg>
+
+      <div class="arch-legend">
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #f97316"></span>write / store</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #2dd4bf"></span>recall / fetch</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #666"></span>persistent I/O</span>
+      </div>
+
+      <div class="arch-diagram-caption">
+        Agent talks to ai-memory over MCP, HTTP, or CLI. ai-memory holds a single SQLite connection behind a mutex.
+        Every recall is a hot loop — FTS5 + HNSW + scoring + access-count touch — all in-process.
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Walkthrough</span>
+    <h2>What's actually happening.</h2>
+
+    <h3>A write — <code>memory_store</code></h3>
+    <ol>
+      <li>The agent calls <code>memory_store</code> over MCP (or <code>POST /api/v1/memory</code> over HTTP, or <code>ai-memory store ...</code> from the CLI).</li>
+      <li>The handler validates the input (<code>src/validate.rs</code>), then acquires the connection mutex.</li>
+      <li>Governance gate runs (<code>src/db.rs</code> → <code>governance::check()</code>). For T1 with a single agent, the default policy returns <code>Allow</code> immediately. With a stricter policy, the write may be queued as a <code>PendingAction</code> (see <a href="architectures-t2.html" style="color:var(--p1)">Tier 2</a> for that flow).</li>
+      <li>Memory row is <code>INSERT</code>ed (or <code>UPDATE</code>d on <code>(title, namespace)</code> collision). FTS5 is kept in sync via triggers. The <code>scope_idx</code> generated column gets recomputed automatically.</li>
+      <li>If the feature tier is <code>semantic</code> or above, the embedding is generated and added to the in-memory HNSW index.</li>
+      <li>WAL is fsynced; the call returns.</li>
+    </ol>
+
+    <h3>A recall — <code>memory_recall</code></h3>
+    <ol>
+      <li>Agent calls <code>memory_recall</code> with a context string.</li>
+      <li><strong>FTS5 keyword pass</strong> — fuzzy OR query, scored by <code>fts.rank + priority*0.5 + access_count*0.1 + confidence*2.0 + tier_bonus + recency_factor</code>.</li>
+      <li><strong>Semantic pass</strong> — cosine similarity via HNSW (or linear scan fallback in the keyword tier).</li>
+      <li><strong>Adaptive blend</strong> — semantic weight varies 0.50 (short content) → 0.15 (long content) because embeddings lose information on long text. Final score is <code>semantic_weight * cosine + (1 - semantic_weight) * norm_fts</code>.</li>
+      <li><strong>Touch</strong> — every returned memory has <code>access_count</code> incremented, TTL extended, and (for mid-tier memories) auto-promoted to long-tier on the 5th access. Priority bumps every 10 accesses.</li>
+      <li>Result formatted as <code>toon_compact</code> (40-60% smaller than JSON), <code>toon</code>, or <code>json</code>.</li>
+    </ol>
+
+    <p>That's it. No network, no peers, no consensus.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Deployment recipe</span>
+    <h2>Install, run, verify.</h2>
+<pre><code># install
+cargo install ai-memory --version 0.6.3
+
+# run as MCP server (for Claude Code, etc.)
+ai-memory --db ~/.claude/ai-memory.db mcp --tier semantic
+
+# OR run as HTTP daemon
+ai-memory --db ~/.claude/ai-memory.db serve --bind 127.0.0.1:9077 --tier semantic
+
+# verify
+ai-memory --db ~/.claude/ai-memory.db stats</code></pre>
+    <p>A single config file at <code>~/.config/ai-memory/config.toml</code> covers tier selection, embedding model, Ollama URL (for the smart/autonomous tiers), and DB path.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Wiring</span>
+    <h2>Governance, skills, and attestations at T1.</h2>
+    <ul>
+      <li><strong>Governance</strong> — Default policy is <code>write: any, promote: any, delete: owner</code>. Override per-namespace via <code>memory_namespace_set_standard</code> if you want pending-approval behavior for sensitive memories. The same governance machinery as T2+ is present; you just rarely use it with one agent.</li>
+      <li><strong>Skills</strong> — Auto-tagging (<code>memory_auto_tag</code>) and contradiction detection (<code>memory_detect_contradiction</code>) require the <code>smart</code> or <code>autonomous</code> feature tier (Ollama backend). Capabilities introspection v2 (v0.6.3) lets the agent ask the server which skills are available before invoking them.</li>
+      <li><strong>Attestations</strong> — Not enforced at T1; the <code>signature</code> column on <code>memory_links</code> (added schema v15 / v0.6.3) is reserved for v0.7 attested identity.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Limits</span>
+    <h2>Honest ceilings.</h2>
+    <table>
+      <thead>
+        <tr><th>Dimension</th><th>T1 ceiling</th><th>When it bites</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Concurrent writers</td><td>1 (mutex-serialized)</td><td>If a second writer joins, you've graduated to T2</td></tr>
+        <tr><td>Total memories</td><td>~10⁶ before HNSW RAM pinches (~1.5 GB at 384-dim)</td><td>Vector index lives in-process</td></tr>
+        <tr><td>FTS5 query latency</td><td>sub-millisecond at 10⁵ rows</td><td>Stays fast through 10⁶</td></tr>
+        <tr><td>Crash recovery</td><td>WAL replay on next open</td><td>Atomic — never lose committed writes</td></tr>
+        <tr><td>Network exposure</td><td>none unless you bind HTTP to non-loopback</td><td>Default is <code>127.0.0.1</code></td></tr>
+      </tbody>
+    </table>
+    <p>When you hit any of these, walk to <a href="architectures-t2.html" style="color:var(--p1)">Tier 2</a> (more agents on this same node) or <a href="architectures-t3.html" style="color:var(--p1)">Tier 3</a> (more nodes).</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Source</span>
+    <h2>Source-of-truth references.</h2>
+    <ul>
+      <li><code>src/main.rs</code> — daemon setup, command dispatch (~27 CLI commands)</li>
+      <li><code>src/mcp.rs</code> — MCP tool handlers wired to the same DB layer</li>
+      <li><code>src/handlers.rs</code> — HTTP route handlers (the Axum router in <code>main.rs</code> registers 48 <code>/api/v1/*</code> routes)</li>
+      <li><code>src/db.rs</code> — schema, recall scoring, GC, migrations (current schema v15 per v0.6.3 release notes)</li>
+      <li><code>src/reranker.rs</code> — adaptive blend semantic + keyword</li>
+      <li><code>src/hnsw.rs</code> — in-memory ANN</li>
+      <li><code>docs/ARCHITECTURE.md</code> — full module map</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architectures-t2.html
+++ b/docs/architectures-t2.html
@@ -1,0 +1,483 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  T2 — Single node, many agents. The first multi-tenant tier.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · T2 — Single node, many agents</title>
+<meta name="description" content="One ai-memory process, ~10 concurrent agents, isolated by namespace + scope visibility, gated by per-namespace governance with pending-approval queues.">
+<meta property="og:title" content="ai-memory · T2 — Single node, many agents">
+<meta property="og:description" content="The first multi-tenant tier. Namespace isolation, scope visibility, federated governance.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures-t2.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(255,184,107,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+/* Grouped dropdown menu */
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+/* capability badges */
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+/* arch-diagram block */
+.arch-diagram{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin:1.5rem 0}
+.arch-diagram-title{font-family:var(--font-mono);font-size:.85rem;color:var(--p2);letter-spacing:.04em;margin-bottom:1rem;text-transform:uppercase}
+.arch-svg{width:100%;height:auto;display:block;background:#0a0a0a;border-radius:8px}
+.arch-svg .node{fill:#161616;stroke:#3d3d3d;stroke-width:1.2}
+.arch-svg .node-label{fill:#fff;font-family:'SF Mono',monospace;font-size:12px;font-weight:600}
+.arch-svg .sub-label{fill:#999;font-family:'SF Mono',monospace;font-size:10px}
+.arch-svg .edge{fill:none}
+.arch-svg .edge-dashed{fill:none;stroke:#666;stroke-width:1.2;stroke-dasharray:4 3}
+.arch-svg .edge-roadmap{fill:none;stroke:#a78bfa;stroke-width:1.4;stroke-dasharray:5 4;opacity:.7}
+.arch-svg .flow{filter:drop-shadow(0 0 4px currentColor)}
+.arch-svg .flow-write{fill:#f97316;color:#f97316}
+.arch-svg .flow-recall{fill:#2dd4bf;color:#2dd4bf}
+.arch-svg .flow-sync{fill:#a78bfa;color:#a78bfa}
+.arch-svg .flow-policy{fill:#facc15;color:#facc15}
+.arch-svg .flow-attest{fill:#f472b6;color:#f472b6}
+.arch-svg .ring{fill:none;stroke:#6ee7ff;stroke-width:2;opacity:.7;animation:pulse 2.4s ease-out infinite}
+@keyframes pulse{0%{r:6;opacity:.85}100%{r:18;opacity:0}}
+.arch-legend{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted)}
+.arch-legend-item{display:inline-flex;align-items:center;gap:.4rem}
+.arch-legend-dot{display:inline-block;width:10px;height:10px;border-radius:50%}
+.arch-diagram-caption{font-size:.85rem;color:var(--text-dim);margin-top:1rem;line-height:1.5}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures · T2</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html" class="current">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <span class="cap-badge cap-today">SHIPS TODAY · v0.6.3</span>
+  <h1>Tier 2 — Single node, many agents</h1>
+  <p class="tagline">The first <strong>multi-tenant</strong> tier. One ai-memory process, but a swarm of agents — typically 10 concurrent — each writing into its own namespace, recalling with scope visibility filters, and gated by per-namespace governance with a pending-approval queue.</p>
+  <div class="pills">
+    <span class="pill">10 agents</span>
+    <span class="pill">namespace isolation</span>
+    <span class="pill">scope visibility</span>
+    <span class="pill">policy/namespace</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <p>This is the canonical shape for a workstation running a planner, a coder, a reviewer, and a handful of skills as separate Claude Code agents — all sharing the same memory store but each siloed by namespace.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Architecture diagram</span>
+    <h2>10 agents · namespace isolation · governance gate.</h2>
+
+    <div class="arch-diagram">
+      <div class="arch-diagram-title">T2 · 10 agents · namespace isolation · governance gate</div>
+
+      <svg class="arch-svg" viewBox="0 0 880 540" role="img" aria-label="Ten agents writing through a governance gate to a single ai-memory instance">
+
+        <defs>
+          <marker id="t2-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+
+          <linearGradient id="t2-gov-gradient" x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stop-color="#facc15" stop-opacity="0.25"/>
+            <stop offset="100%" stop-color="#f97316" stop-opacity="0.25"/>
+          </linearGradient>
+
+          <linearGradient id="t2-mem-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.18"/>
+            <stop offset="100%" stop-color="#0d9488" stop-opacity="0.06"/>
+          </linearGradient>
+
+          <path id="t2-p1" d="M 130 60  C 280 60,  330 200, 410 220" />
+          <path id="t2-p2" d="M 130 110 C 280 110, 330 210, 410 225" />
+          <path id="t2-p3" d="M 130 160 C 280 160, 330 220, 410 230" />
+          <path id="t2-p4" d="M 130 210 C 280 210, 330 230, 410 240" />
+          <path id="t2-p5" d="M 130 260 C 280 260, 330 240, 410 248" />
+          <path id="t2-p6" d="M 130 310 C 280 310, 330 270, 410 260" />
+          <path id="t2-p7" d="M 130 360 C 280 360, 330 290, 410 270" />
+          <path id="t2-p8" d="M 130 410 C 280 410, 330 310, 410 280" />
+          <path id="t2-p9" d="M 130 460 C 280 460, 330 330, 410 290" />
+          <path id="t2-p10" d="M 130 510 C 280 510, 330 350, 410 300" />
+
+          <path id="t2-gate-recall" d="M 525 260 L 600 260" />
+          <path id="t2-recall-sql" d="M 745 260 L 805 320" />
+          <path id="t2-sql-recall" d="M 805 360 L 745 290" />
+          <path id="t2-back" d="M 600 280 C 470 280, 360 460, 130 510" />
+        </defs>
+
+        <!-- AGENTS — 10 in a left column -->
+        <g><rect x="20" y="42" width="180" height="36" rx="8" class="node"/><text x="32" y="58" class="node-label" style="font-size: 11px">Planner</text><text x="32" y="72" class="sub-label">agents/planner</text></g>
+        <g><rect x="20" y="92" width="180" height="36" rx="8" class="node"/><text x="32" y="108" class="node-label" style="font-size: 11px">Coder</text><text x="32" y="122" class="sub-label">agents/coder</text></g>
+        <g><rect x="20" y="142" width="180" height="36" rx="8" class="node"/><text x="32" y="158" class="node-label" style="font-size: 11px">Reviewer</text><text x="32" y="172" class="sub-label">agents/reviewer</text></g>
+        <g><rect x="20" y="192" width="180" height="36" rx="8" class="node"/><text x="32" y="208" class="node-label" style="font-size: 11px">Researcher</text><text x="32" y="222" class="sub-label">agents/researcher</text></g>
+        <g><rect x="20" y="242" width="180" height="36" rx="8" class="node"/><text x="32" y="258" class="node-label" style="font-size: 11px">Data eng</text><text x="32" y="272" class="sub-label">agents/data-eng</text></g>
+        <g><rect x="20" y="292" width="180" height="36" rx="8" class="node"/><text x="32" y="308" class="node-label" style="font-size: 11px">SecOps</text><text x="32" y="322" class="sub-label">agents/secops</text></g>
+        <g><rect x="20" y="342" width="180" height="36" rx="8" class="node"/><text x="32" y="358" class="node-label" style="font-size: 11px">Tester</text><text x="32" y="372" class="sub-label">agents/test</text></g>
+        <g><rect x="20" y="392" width="180" height="36" rx="8" class="node"/><text x="32" y="408" class="node-label" style="font-size: 11px">Docs</text><text x="32" y="422" class="sub-label">agents/docs</text></g>
+        <g><rect x="20" y="442" width="180" height="36" rx="8" class="node"/><text x="32" y="458" class="node-label" style="font-size: 11px">Triage</text><text x="32" y="472" class="sub-label">agents/triage</text></g>
+        <g><rect x="20" y="492" width="180" height="36" rx="8" class="node"/><text x="32" y="508" class="node-label" style="font-size: 11px">Ops</text><text x="32" y="522" class="sub-label">agents/ops</text></g>
+
+        <!-- GOVERNANCE GATE -->
+        <g>
+          <rect x="410" y="200" width="115" height="120" rx="14"
+                fill="url(#t2-gov-gradient)" stroke="#facc15" stroke-width="1.6" />
+          <text x="467" y="222" text-anchor="middle" class="node-label" style="font-size: 11px">Governance</text>
+          <text x="467" y="237" text-anchor="middle" class="sub-label">policy/namespace</text>
+          <text x="467" y="252" text-anchor="middle" class="sub-label">Allow / Deny / Pending</text>
+          <text x="467" y="270" text-anchor="middle" class="sub-label" font-weight="700" fill="#16a34a">✓ allow</text>
+          <text x="467" y="285" text-anchor="middle" class="sub-label" font-weight="700" fill="#dc2626">✗ deny</text>
+          <text x="467" y="300" text-anchor="middle" class="sub-label" font-weight="700" fill="#a16207">⌛ pending</text>
+        </g>
+
+        <!-- PENDING QUEUE OUT-OF-BAND -->
+        <g>
+          <rect x="395" y="345" width="145" height="68" rx="10" stroke="#a16207" stroke-dasharray="4 3" fill="none" />
+          <text x="467" y="365" text-anchor="middle" class="sub-label" font-weight="700" fill="#a16207">PendingAction queue</text>
+          <text x="467" y="382" text-anchor="middle" class="sub-label">memory_pending_list</text>
+          <text x="467" y="396" text-anchor="middle" class="sub-label">memory_pending_approve</text>
+          <text x="467" y="408" text-anchor="middle" class="sub-label">memory_pending_reject</text>
+        </g>
+
+        <!-- AI-MEMORY CORE -->
+        <g>
+          <rect x="600" y="195" width="145" height="135" rx="14"
+                fill="url(#t2-mem-gradient)" stroke="#2dd4bf" stroke-width="1.6" />
+          <text x="672" y="218" text-anchor="middle" class="node-label" style="font-size: 12px">ai-memory core</text>
+          <text x="672" y="236" text-anchor="middle" class="sub-label">recall pipeline</text>
+          <text x="672" y="252" text-anchor="middle" class="sub-label">scope filter</text>
+          <text x="672" y="266" text-anchor="middle" class="sub-label">as_agent param</text>
+          <text x="672" y="284" text-anchor="middle" class="sub-label">FTS5 + HNSW</text>
+          <text x="672" y="300" text-anchor="middle" class="sub-label">touch + promote</text>
+          <text x="672" y="318" text-anchor="middle" class="sub-label">v0.6.3 KG layer</text>
+        </g>
+
+        <!-- SQLITE -->
+        <g>
+          <rect x="780" y="320" width="85" height="105" rx="10" class="node" />
+          <text x="822" y="345" text-anchor="middle" class="node-label" style="font-size: 11px">SQLite</text>
+          <text x="822" y="362" text-anchor="middle" class="sub-label">memories</text>
+          <text x="822" y="376" text-anchor="middle" class="sub-label">scope_idx</text>
+          <text x="822" y="390" text-anchor="middle" class="sub-label">FTS5</text>
+          <text x="822" y="404" text-anchor="middle" class="sub-label">pending_actions</text>
+          <text x="822" y="418" text-anchor="middle" class="sub-label">namespace_meta</text>
+        </g>
+
+        <!-- NAMESPACE TAXONOMY (v0.6.3) -->
+        <g>
+          <rect x="595" y="350" width="155" height="65" rx="10" stroke="#a78bfa" stroke-width="1.4" fill="rgba(167,139,250,0.06)" />
+          <text x="672" y="370" text-anchor="middle" class="sub-label" font-weight="700" fill="#a78bfa">memory_get_taxonomy</text>
+          <text x="672" y="385" text-anchor="middle" class="sub-label">v0.6.3 hierarchical view</text>
+          <text x="672" y="400" text-anchor="middle" class="sub-label">agents/* / collective/*</text>
+        </g>
+
+        <!-- PATHS -->
+        <use href="#t2-p1" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p2" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p3" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p4" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p5" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p6" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p7" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p8" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p9" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+        <use href="#t2-p10" class="edge" stroke="#f97316" stroke-width="1.2" marker-end="url(#t2-arrow)" style="color: #f97316; opacity: 0.45" />
+
+        <use href="#t2-gate-recall" class="edge" stroke="#0d9488" stroke-width="2" marker-end="url(#t2-arrow)" style="color: #0d9488" />
+        <use href="#t2-recall-sql" class="edge-dashed" />
+        <use href="#t2-sql-recall" class="edge-dashed" />
+        <use href="#t2-back" class="edge" stroke="#2dd4bf" stroke-width="1.5" marker-end="url(#t2-arrow)" style="color: #2dd4bf; opacity: 0.5" stroke-dasharray="3 3" />
+
+        <!-- Particles — write through gate -->
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0.3s"><mpath href="#t2-p1"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0.6s"><mpath href="#t2-p2"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0.9s"><mpath href="#t2-p3"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.2s"><mpath href="#t2-p4"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.5s"><mpath href="#t2-p5"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.8s"><mpath href="#t2-p6"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="2.1s"><mpath href="#t2-p7"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="2.4s"><mpath href="#t2-p8"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="2.7s"><mpath href="#t2-p9"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="3.6s" repeatCount="indefinite" begin="3.0s"><mpath href="#t2-p10"/></animateMotion></circle>
+
+        <!-- Gate → recall flow -->
+        <circle r="4" class="flow flow-policy"><animateMotion dur="2.4s" repeatCount="indefinite" begin="0s"><mpath href="#t2-gate-recall"/></animateMotion></circle>
+        <circle r="4" class="flow flow-policy"><animateMotion dur="2.4s" repeatCount="indefinite" begin="1.0s"><mpath href="#t2-gate-recall"/></animateMotion></circle>
+        <circle r="4" class="flow flow-policy"><animateMotion dur="2.4s" repeatCount="indefinite" begin="2.0s"><mpath href="#t2-gate-recall"/></animateMotion></circle>
+
+        <!-- Persistent I/O dots -->
+        <circle r="3" class="flow flow-write"><animateMotion dur="2.4s" repeatCount="indefinite" begin="0.3s"><mpath href="#t2-recall-sql"/></animateMotion></circle>
+        <circle r="3" class="flow flow-write"><animateMotion dur="2.4s" repeatCount="indefinite" begin="1.3s"><mpath href="#t2-recall-sql"/></animateMotion></circle>
+        <circle r="3" class="flow flow-recall"><animateMotion dur="2.4s" repeatCount="indefinite" begin="0s"><mpath href="#t2-sql-recall"/></animateMotion></circle>
+        <circle r="3" class="flow flow-recall"><animateMotion dur="2.4s" repeatCount="indefinite" begin="1.0s"><mpath href="#t2-sql-recall"/></animateMotion></circle>
+
+        <!-- Recall back to agents -->
+        <circle r="4" class="flow flow-recall"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0s"><mpath href="#t2-back"/></animateMotion></circle>
+        <circle r="4" class="flow flow-recall"><animateMotion dur="4.2s" repeatCount="indefinite" begin="1.4s"><mpath href="#t2-back"/></animateMotion></circle>
+        <circle r="4" class="flow flow-recall"><animateMotion dur="4.2s" repeatCount="indefinite" begin="2.8s"><mpath href="#t2-back"/></animateMotion></circle>
+
+      </svg>
+
+      <div class="arch-legend">
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #f97316"></span>agent → governance</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #facc15"></span>policy decision</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #2dd4bf"></span>scope-filtered recall</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #666"></span>persistent I/O</span>
+      </div>
+
+      <div class="arch-diagram-caption">
+        Each agent writes into its own namespace, then trips the per-namespace governance gate before the row is committed.
+        Recalls flow back through the scope filter — agents only see what their namespace position permits.
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Walkthrough</span>
+    <h2>What's actually happening.</h2>
+
+    <h3>Namespace isolation</h3>
+    <p>Every agent has a namespace position — typically <code>agents/&lt;role&gt;</code> or <code>org/team/role</code>. Memories are written with that namespace, and the indexed <code>scope_idx</code> generated column captures the agent's visibility scope (<code>private</code> / <code>team</code> / <code>unit</code> / <code>org</code> / <code>collective</code>).</p>
+    <p>When agent <code>agents/planner</code> calls <code>memory_recall</code> and passes <code>as_agent=agents/planner</code>, <code>compute_visibility_prefixes()</code> (<code>src/db.rs:26-38</code>) walks the namespace ancestors and returns <code>[agents/planner, agents/, '']</code>. The recall SQL then <code>WHERE</code>s on <code>scope_idx IN (...)</code> — the planner sees its own private memories plus anything scoped <code>team</code> or <code>collective</code> that an ancestor namespace publishes.</p>
+    <p>This is the same machinery T1 has — but at T2 it's actually doing work.</p>
+
+    <h3>Per-namespace governance</h3>
+    <p>Set a policy with <code>memory_namespace_set_standard</code>:</p>
+<pre><code>ai-memory namespace set-standard agents/secops --governance '{
+  "write": "approve",
+  "promote": "owner",
+  "delete": "approve"
+}'</code></pre>
+    <p>Now any agent writing into <code>agents/secops</code> triggers <code>governance::check()</code> which returns <code>Pending(action_id)</code>. The write isn't committed — it's parked in <code>pending_actions</code>. The owning operator (or a designated approver agent) calls <code>memory_pending_list</code>, inspects the diff, and either <code>memory_pending_approve</code> or <code>memory_pending_reject</code>. Approved writes get committed; rejected ones are dropped with an audit row.</p>
+    <p>Per-namespace policy means a strict-write namespace can sit next to a permissive one. The hierarchy lets you set a default at <code>org/</code> and override at <code>org/team/</code>.</p>
+
+    <h3>Capabilities introspection (v0.6.3)</h3>
+    <p>Before an agent invokes a skill, it can ask: <em>"is auto-tag actually wired here?"</em></p>
+<pre><code>$ ai-memory capabilities --json
+{
+  "version": "0.6.3",
+  "tier": "semantic",
+  "features": {
+    "hybrid_recall": true,
+    "auto_tagging": false,
+    "contradiction_analysis": false,
+    "approval_workflow": true,
+    "kg_temporal": true
+  },
+  "permissions": ["read", "write", "promote", "approve"],
+  "hooks": ["pre_store", "post_recall"],
+  "approval": {"queue_depth": 7, "policies": 3}
+}</code></pre>
+    <p>Capabilities v2 ships in v0.6.3 — agents discover what's available at runtime instead of hard-coding assumptions.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Deployment recipe</span>
+    <h2>Workstation, multi-agent, multi-namespace.</h2>
+<pre><code># Run as a long-lived HTTP daemon on the workstation
+ai-memory --db /var/lib/ai-memory/store.db serve \
+  --bind 127.0.0.1:9077 \
+  --tier semantic
+
+# Each agent is a separate MCP client (or HTTP client) pointing at the same store
+# In .mcp.json for each agent's Claude Code config:
+{
+  "mcpServers": {
+    "memory": {
+      "command": "curl",
+      "args": ["-s", "-X", "POST", "http://127.0.0.1:9077/api/v1/mcp"],
+      "env": {"AI_MEMORY_AGENT_ID": "agents/planner"}
+    }
+  }
+}
+
+# Agents pass as_agent=agents/&lt;role&gt; on every recall
+# Per-namespace policies set once, enforced forever:
+ai-memory namespace set-standard agents/secops \
+  --governance '{"write":"approve","delete":"approve"}'</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Wiring</span>
+    <h2>Governance, skills, and attestations at T2.</h2>
+    <ul>
+      <li><strong>Governance</strong> — Live and enforced. <code>GovernancePolicy</code> (<code>src/models.rs:405-409</code>) per namespace, hierarchical with parent inheritance, supports <code>any</code> / <code>registered</code> / <code>owner</code> / <code>approve</code> for each of <code>write</code> / <code>promote</code> / <code>delete</code>. Namespace metadata lives in <code>namespace_meta</code> and is the source of truth for the gate.</li>
+      <li><strong>Skills</strong> — Skills register themselves as agents (<code>mcp__memory__memory_agent_register</code>). Auto-tagging, contradiction detection, query expansion, and consolidation all run through the same scope visibility — a skill at <code>skills/auto-tag</code> with <code>team</code> scope only sees memories its team published. Skills can be subject to the same governance policies as humans-in-the-loop.</li>
+      <li><strong>Attestations</strong> — Field-level reservation only. <code>memory_links.signature</code> (schema v15) is populated with claimed identity at v0.6.3; v0.7 will sign with the agent's keypair and verify on read.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Limits</span>
+    <h2>Honest ceilings.</h2>
+    <table>
+      <thead>
+        <tr><th>Dimension</th><th>T2 ceiling</th><th>When it bites</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Concurrent writers</td><td>~10–20 before mutex contention shows up</td><td>Bulk imports starve real-time agents</td></tr>
+        <tr><td>Total memories</td><td>~10⁶ before HNSW RAM cost is noticeable</td><td>Vector index lives in-process</td></tr>
+        <tr><td>Write throughput</td><td>~500-2000 writes/sec (single SQLite writer)</td><td>Bulk operations should chunk</td></tr>
+        <tr><td>Recall p95</td><td>sub-10ms at 10⁵ memories with HNSW</td><td>Scales to 10⁶ with care</td></tr>
+        <tr><td>Network exposure</td><td>loopback by default, mTLS available</td><td>Set up TLS before binding non-loopback</td></tr>
+        <tr><td>Cross-machine sharing</td><td>none</td><td>Walk to <a href="architectures-t3.html" style="color:var(--p1)">Tier 3</a></td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Source</span>
+    <h2>Source-of-truth references.</h2>
+    <ul>
+      <li><code>src/db.rs:26-38</code> — <code>compute_visibility_prefixes()</code> (scope visibility)</li>
+      <li><code>src/db.rs:91-104</code> — <code>visibility_clause()</code> (SQL filter)</li>
+      <li><code>src/db.rs:309-330</code> — <code>namespace_meta</code> table for per-namespace policy</li>
+      <li><code>src/models.rs:351-365</code> — <code>PendingAction</code> struct</li>
+      <li><code>src/models.rs:405-409</code> — <code>GovernancePolicy</code></li>
+      <li><code>src/mcp.rs:119</code> — <code>as_agent</code> parameter on recall</li>
+      <li><code>docs/AI_DEVELOPER_GOVERNANCE.md</code> — governance contract</li>
+      <li><code>docs/CHANGELOG.md</code> — v0.6.2 (governance GA), v0.6.3 (taxonomy + capabilities v2)</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architectures-t3.html
+++ b/docs/architectures-t3.html
@@ -1,0 +1,514 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  T3 — Multi-node cluster. W-of-N quorum writes shipping today.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · T3 — Multi-node cluster</title>
+<meta name="description" content="4 nodes × 5 agents per node, replicating via sync_push peer mesh. Memories, links, governance & pending decisions fan out across the cluster with vector-clock causality.">
+<meta property="og:title" content="ai-memory · T3 — Multi-node cluster">
+<meta property="og:description" content="W-of-N quorum writes, mTLS fingerprint allowlist, federated governance — all shipping today.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures-t3.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(200,162,255,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+/* Grouped dropdown menu */
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+/* capability badges */
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+/* arch-diagram block */
+.arch-diagram{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin:1.5rem 0}
+.arch-diagram-title{font-family:var(--font-mono);font-size:.85rem;color:var(--p2);letter-spacing:.04em;margin-bottom:1rem;text-transform:uppercase}
+.arch-svg{width:100%;height:auto;display:block;background:#0a0a0a;border-radius:8px}
+.arch-svg .node{fill:#161616;stroke:#3d3d3d;stroke-width:1.2}
+.arch-svg .node-label{fill:#fff;font-family:'SF Mono',monospace;font-size:12px;font-weight:600}
+.arch-svg .sub-label{fill:#999;font-family:'SF Mono',monospace;font-size:10px}
+.arch-svg .edge{fill:none}
+.arch-svg .edge-dashed{fill:none;stroke:#666;stroke-width:1.2;stroke-dasharray:4 3}
+.arch-svg .edge-roadmap{fill:none;stroke:#a78bfa;stroke-width:1.4;stroke-dasharray:5 4;opacity:.7}
+.arch-svg .flow{filter:drop-shadow(0 0 4px currentColor)}
+.arch-svg .flow-write{fill:#f97316;color:#f97316}
+.arch-svg .flow-recall{fill:#2dd4bf;color:#2dd4bf}
+.arch-svg .flow-sync{fill:#a78bfa;color:#a78bfa}
+.arch-svg .flow-policy{fill:#facc15;color:#facc15}
+.arch-svg .flow-attest{fill:#f472b6;color:#f472b6}
+.arch-svg .ring{fill:none;stroke:#6ee7ff;stroke-width:2;opacity:.7;animation:pulse 2.4s ease-out infinite}
+@keyframes pulse{0%{r:6;opacity:.85}100%{r:18;opacity:0}}
+.arch-legend{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted)}
+.arch-legend-item{display:inline-flex;align-items:center;gap:.4rem}
+.arch-legend-dot{display:inline-block;width:10px;height:10px;border-radius:50%}
+.arch-diagram-caption{font-size:.85rem;color:var(--text-dim);margin-top:1rem;line-height:1.5}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures · T3</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html" class="current">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <span class="cap-badge cap-today">SHIPS TODAY · v0.6.3</span>
+  <h1>Tier 3 — Multi-node cluster</h1>
+  <p class="tagline">Twenty agents. Four nodes. One coherent knowledge mesh — with <strong>W-of-N quorum writes shipping today</strong>. Each node runs its own ai-memory + SQLite; writes, links, governance, and pending decisions fan out via <code>sync_push</code> with vector-clock causality.</p>
+  <div class="pills">
+    <span class="pill">4 nodes · 20 agents</span>
+    <span class="pill">W-of-N quorum</span>
+    <span class="pill">mTLS allowlist</span>
+    <span class="pill">federated governance</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <p>This is the first <strong>distributed</strong> tier. Each node runs an ai-memory process backed by its own SQLite. Writes, links, archives, namespace metadata, and <strong>governance decisions</strong> fan out to every peer over <code>POST /api/v1/sync/push</code>. Vector-clock causality (<code>sync/since</code>) lets a peer that drops off the network catch up cleanly. The recall pipeline stays local on each node — fast hot reads, no cross-node round trips.</p>
+    <p>The big upgrade in current builds: <strong>quorum-write contract is wired</strong>. Set <code>--quorum-writes N --quorum-peers a,b,c</code> and every HTTP write fans out to every peer and only returns OK after the local commit + <code>W-1</code> peer acks land within <code>--quorum-timeout-ms</code>. Falling short returns HTTP 503 <code>quorum_not_met</code>. This is real durability, not best-effort.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Architecture diagram</span>
+    <h2>4 nodes · 5 agents each · sync_push mesh.</h2>
+
+    <div class="arch-diagram">
+      <div class="arch-diagram-title">T3 · 4 nodes · 5 agents each · sync_push mesh</div>
+
+      <svg class="arch-svg" viewBox="0 0 880 600" role="img" aria-label="Four ai-memory nodes in a peer mesh, each with five agents, syncing via sync_push">
+
+        <defs>
+          <marker id="t3-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+
+          <linearGradient id="t3-node-grad" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.20"/>
+            <stop offset="100%" stop-color="#0d9488" stop-opacity="0.05"/>
+          </linearGradient>
+
+          <path id="t3-AB" d="M 250 130 C 350 100, 530 100, 630 130" />
+          <path id="t3-BA" d="M 630 150 C 530 180, 350 180, 250 150" />
+          <path id="t3-CD" d="M 250 470 C 350 500, 530 500, 630 470" />
+          <path id="t3-DC" d="M 630 450 C 530 420, 350 420, 250 450" />
+          <path id="t3-AC" d="M 200 195 L 200 415" />
+          <path id="t3-CA" d="M 220 415 L 220 195" />
+          <path id="t3-BD" d="M 660 195 L 660 415" />
+          <path id="t3-DB" d="M 680 415 L 680 195" />
+          <path id="t3-AD" d="M 245 200 L 635 415" />
+          <path id="t3-DA" d="M 635 430 L 245 215" />
+          <path id="t3-BC" d="M 635 200 L 245 415" />
+          <path id="t3-CB" d="M 245 430 L 635 215" />
+        </defs>
+
+        <!-- CENTER governance label -->
+        <g>
+          <rect x="370" y="270" width="160" height="60" rx="10" fill="rgba(250,204,21,0.12)" stroke="#facc15" stroke-width="1.4" stroke-dasharray="3 2" />
+          <text x="450" y="290" text-anchor="middle" class="sub-label" font-weight="700" fill="#a16207">Federated governance</text>
+          <text x="450" y="305" text-anchor="middle" class="sub-label">namespace_meta fanout</text>
+          <text x="450" y="319" text-anchor="middle" class="sub-label">pending_decision sync</text>
+        </g>
+
+        <!-- MESH EDGES -->
+        <use href="#t3-AB" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-BA" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-CD" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-DC" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-AC" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-CA" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-BD" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-DB" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-AD" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-DA" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-BC" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+        <use href="#t3-CB" class="edge" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#t3-arrow)" style="color: #a78bfa; opacity: 0.4" />
+
+        <!-- NODE A -->
+        <g>
+          <rect x="80" y="80" width="170" height="120" rx="14" fill="url(#t3-node-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="165" y="102" text-anchor="middle" class="node-label">node-a</text>
+          <text x="165" y="118" text-anchor="middle" class="sub-label">10.0.1.10:9077</text>
+          <text x="165" y="135" text-anchor="middle" class="sub-label">vector clock: 7421</text>
+          <rect x="104" y="150" width="55" height="38" rx="6" class="node" />
+          <text x="131" y="168" text-anchor="middle" class="sub-label" style="font-size: 9px">SQLite</text>
+          <text x="131" y="180" text-anchor="middle" class="sub-label">+ HNSW</text>
+          <rect x="171" y="150" width="55" height="38" rx="6" stroke="#facc15" fill="rgba(250,204,21,0.1)" stroke-width="1.2" />
+          <text x="199" y="168" text-anchor="middle" class="sub-label" style="font-size: 9px">policy</text>
+          <text x="199" y="180" text-anchor="middle" class="sub-label">gate</text>
+          <g><circle cx="98" cy="222" r="11" class="node"/><text x="98" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a1</text></g>
+          <g><circle cx="131" cy="222" r="11" class="node"/><text x="131" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a2</text></g>
+          <g><circle cx="164" cy="222" r="11" class="node"/><text x="164" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a3</text></g>
+          <g><circle cx="197" cy="222" r="11" class="node"/><text x="197" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a4</text></g>
+          <g><circle cx="230" cy="222" r="11" class="node"/><text x="230" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a5</text></g>
+          <text x="165" y="255" text-anchor="middle" class="sub-label">5 agents · namespace-isolated</text>
+        </g>
+
+        <!-- NODE B -->
+        <g>
+          <rect x="530" y="80" width="170" height="120" rx="14" fill="url(#t3-node-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="615" y="102" text-anchor="middle" class="node-label">node-b</text>
+          <text x="615" y="118" text-anchor="middle" class="sub-label">10.0.1.11:9077</text>
+          <text x="615" y="135" text-anchor="middle" class="sub-label">vector clock: 7421</text>
+          <rect x="554" y="150" width="55" height="38" rx="6" class="node" />
+          <text x="581" y="168" text-anchor="middle" class="sub-label" style="font-size: 9px">SQLite</text>
+          <text x="581" y="180" text-anchor="middle" class="sub-label">+ HNSW</text>
+          <rect x="621" y="150" width="55" height="38" rx="6" stroke="#facc15" fill="rgba(250,204,21,0.1)" stroke-width="1.2" />
+          <text x="649" y="168" text-anchor="middle" class="sub-label" style="font-size: 9px">policy</text>
+          <text x="649" y="180" text-anchor="middle" class="sub-label">gate</text>
+          <g><circle cx="548" cy="222" r="11" class="node"/><text x="548" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a1</text></g>
+          <g><circle cx="581" cy="222" r="11" class="node"/><text x="581" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a2</text></g>
+          <g><circle cx="614" cy="222" r="11" class="node"/><text x="614" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a3</text></g>
+          <g><circle cx="647" cy="222" r="11" class="node"/><text x="647" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a4</text></g>
+          <g><circle cx="680" cy="222" r="11" class="node"/><text x="680" y="226" text-anchor="middle" class="sub-label" style="font-size: 9px">a5</text></g>
+          <text x="615" y="255" text-anchor="middle" class="sub-label">5 agents · namespace-isolated</text>
+        </g>
+
+        <!-- NODE C -->
+        <g>
+          <rect x="80" y="400" width="170" height="120" rx="14" fill="url(#t3-node-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="165" y="422" text-anchor="middle" class="node-label">node-c</text>
+          <text x="165" y="438" text-anchor="middle" class="sub-label">10.0.1.12:9077</text>
+          <text x="165" y="455" text-anchor="middle" class="sub-label">vector clock: 7421</text>
+          <rect x="104" y="470" width="55" height="38" rx="6" class="node" />
+          <text x="131" y="488" text-anchor="middle" class="sub-label" style="font-size: 9px">SQLite</text>
+          <text x="131" y="500" text-anchor="middle" class="sub-label">+ HNSW</text>
+          <rect x="171" y="470" width="55" height="38" rx="6" stroke="#facc15" fill="rgba(250,204,21,0.1)" stroke-width="1.2" />
+          <text x="199" y="488" text-anchor="middle" class="sub-label" style="font-size: 9px">policy</text>
+          <text x="199" y="500" text-anchor="middle" class="sub-label">gate</text>
+          <g><circle cx="98" cy="542" r="11" class="node"/><text x="98" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a1</text></g>
+          <g><circle cx="131" cy="542" r="11" class="node"/><text x="131" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a2</text></g>
+          <g><circle cx="164" cy="542" r="11" class="node"/><text x="164" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a3</text></g>
+          <g><circle cx="197" cy="542" r="11" class="node"/><text x="197" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a4</text></g>
+          <g><circle cx="230" cy="542" r="11" class="node"/><text x="230" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a5</text></g>
+          <text x="165" y="575" text-anchor="middle" class="sub-label">5 agents · namespace-isolated</text>
+        </g>
+
+        <!-- NODE D -->
+        <g>
+          <rect x="530" y="400" width="170" height="120" rx="14" fill="url(#t3-node-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="615" y="422" text-anchor="middle" class="node-label">node-d</text>
+          <text x="615" y="438" text-anchor="middle" class="sub-label">10.0.1.13:9077</text>
+          <text x="615" y="455" text-anchor="middle" class="sub-label">vector clock: 7421</text>
+          <rect x="554" y="470" width="55" height="38" rx="6" class="node" />
+          <text x="581" y="488" text-anchor="middle" class="sub-label" style="font-size: 9px">SQLite</text>
+          <text x="581" y="500" text-anchor="middle" class="sub-label">+ HNSW</text>
+          <rect x="621" y="470" width="55" height="38" rx="6" stroke="#facc15" fill="rgba(250,204,21,0.1)" stroke-width="1.2" />
+          <text x="649" y="488" text-anchor="middle" class="sub-label" style="font-size: 9px">policy</text>
+          <text x="649" y="500" text-anchor="middle" class="sub-label">gate</text>
+          <g><circle cx="548" cy="542" r="11" class="node"/><text x="548" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a1</text></g>
+          <g><circle cx="581" cy="542" r="11" class="node"/><text x="581" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a2</text></g>
+          <g><circle cx="614" cy="542" r="11" class="node"/><text x="614" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a3</text></g>
+          <g><circle cx="647" cy="542" r="11" class="node"/><text x="647" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a4</text></g>
+          <g><circle cx="680" cy="542" r="11" class="node"/><text x="680" y="546" text-anchor="middle" class="sub-label" style="font-size: 9px">a5</text></g>
+          <text x="615" y="575" text-anchor="middle" class="sub-label">5 agents · namespace-isolated</text>
+        </g>
+
+        <!-- PARTICLES — sync_push -->
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0s"><mpath href="#t3-AB"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0.35s"><mpath href="#t3-BA"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0.7s"><mpath href="#t3-CD"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="1.05s"><mpath href="#t3-DC"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="1.4s"><mpath href="#t3-AC"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="1.75s"><mpath href="#t3-CA"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="2.1s"><mpath href="#t3-BD"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="2.45s"><mpath href="#t3-DB"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="2.8s"><mpath href="#t3-AD"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="3.15s"><mpath href="#t3-DA"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="3.5s"><mpath href="#t3-BC"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="4.2s" repeatCount="indefinite" begin="3.85s"><mpath href="#t3-CB"/></animateMotion></circle>
+
+        <!-- Pulsing rings on each node -->
+        <circle cx="165" cy="90" r="6" class="ring" />
+        <circle cx="615" cy="90" r="6" class="ring" />
+        <circle cx="165" cy="410" r="6" class="ring" />
+        <circle cx="615" cy="410" r="6" class="ring" />
+
+        <text x="40" y="595" class="sub-label" font-weight="700">12-edge full peer mesh · sync_push fanout · vector-clock causality (sync/since)</text>
+      </svg>
+
+      <div class="arch-legend">
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #a78bfa"></span>sync_push (memories · links · namespace_meta · pending decisions)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #facc15"></span>per-node governance gate</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #2dd4bf"></span>local recall on each node</span>
+      </div>
+
+      <div class="arch-diagram-caption">
+        Each node holds its own SQLite + HNSW. Writes commit locally then fan out to peers. Recalls stay local.
+        Governance policies, namespace metadata, and pending-action decisions propagate the same way memories do.
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What ships today</span>
+    <h2>The mesh is real. Source-cited.</h2>
+    <ul>
+      <li><strong>W-of-N quorum-write contract</strong> — <code>src/main.rs</code> lines 405-411: <code>--quorum-writes N --quorum-peers &lt;list&gt;</code> is wired into the write path. <code>src/handlers.rs:442-454</code> calls <code>broadcast_store_quorum</code> then <code>finalise_quorum</code> to count peer acks; <code>503 quorum_not_met</code> returns when the deadline (<code>--quorum-timeout-ms</code>, default 2000) lapses without W-1 acks. ADR-0001 is realised, not aspirational. Same wiring applies to <code>broadcast_link_quorum</code>, <code>broadcast_consolidate_quorum</code>, <code>broadcast_pending_decision_quorum</code>, <code>broadcast_namespace_meta_quorum</code>.</li>
+      <li><strong><code>sync_push</code> fanout for everything</strong> — <code>src/federation.rs</code> ships <strong>10 broadcast functions</strong>: store, delete, archive, restore, link, consolidate, pending action, pending decision, namespace metadata, namespace metadata clear. Each is invoked from the corresponding handler in <code>handlers.rs</code> after the local commit lands.</li>
+      <li><strong>Vector clocks + catch-up</strong> — Every memory has a per-peer clock in <code>SyncState</code>. A peer that drops off polls <code>GET /api/v1/sync/since?peer=node-a&amp;clock=7400</code> and gets only the deltas after that point. The serve daemon also runs a <code>--catchup-interval-secs</code> loop (default 30s) that pulls peers proactively for any updates missed during partition.</li>
+      <li><strong>mTLS peer mesh with fingerprint allowlist</strong> — <code>--tls-cert</code> + <code>--tls-key</code> switches <code>serve</code> to TLS; adding <code>--mtls-allowlist &lt;path&gt;</code> enforces client-cert mTLS where every connection's peer must present a cert whose fingerprint is on the allowlist. Quorum POSTs use <code>--quorum-client-cert</code> / <code>--quorum-client-key</code> / <code>--quorum-ca-cert</code> for the outbound side.</li>
+      <li><strong>Federated governance</strong> — <code>broadcast_namespace_meta_quorum</code> (<code>src/federation.rs:1007-1075</code>) propagates <code>GovernancePolicy</code> changes to every peer with quorum semantics. A new strict policy on <code>agents/secops</code> set on node-A is enforced on all 4 nodes within seconds, with the same W-of-N durability as memory writes.</li>
+      <li><strong>Federated pending decisions</strong> — <code>broadcast_pending_decision_quorum</code> (<code>src/federation.rs:918-995</code>) means an approve/reject on one node turns into a committed (or audited) state on every peer with quorum-bounded latency.</li>
+      <li><strong>Per-node governance gate</strong> — Each node enforces its local policy at write time. The federated metadata keeps the policy itself consistent across nodes.</li>
+    </ul>
+    <p>This is real, durable, multi-node consistency for a knowledge mesh.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What's still roadmap</span>
+    <h2>Honest about the remaining gaps.</h2>
+    <ul>
+      <li><strong>Strong consensus on the governance plane</strong> — Quorum writes give bounded staleness, not strong consistency. Two operators on opposite sides of a partition can each approve a pending action; reconciliation is last-decision-wins on rejoin. Distributed consensus (Raft/Paxos) is v1.0+ territory and only makes sense for the governance plane, not the memory write path.</li>
+      <li><strong>Cryptographic attestation</strong> — Agent identity is claimed (<code>metadata.agent_id</code> from clap or <code>AI_MEMORY_AGENT_ID</code> env), not signed. The <code>signature</code> column on <code>memory_links</code> (v0.6.3 schema v15) is reserved for the v0.7 attestation track that signs every link with the originating agent's keypair.</li>
+      <li><strong>Postgres + pgvector backbone</strong> — Compiles today behind <code>--features sal-postgres</code>; correctness fixes shipped in v0.6.x (#294-#297). Performance maturation and GA targeted v0.7.</li>
+      <li><strong>CRDT-lite link tombstones</strong> — Delete-link fanout is deferred; the CHANGELOG (#325) tracks it for v0.7. Local <code>DELETE /api/v1/links</code> works today.</li>
+    </ul>
+    <p>If your fleet needs strong cross-region governance consensus, that's v1.0+. Everything else listed is shipping.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Walkthrough</span>
+    <h2>What's actually happening.</h2>
+
+    <h3>Write path on node-A</h3>
+    <ol>
+      <li>Agent <code>a1</code> on node-A calls <code>memory_store</code>.</li>
+      <li>Local governance gate runs against the federated policy. <code>Allow</code> → continue, <code>Pending</code> → queue, <code>Deny</code> → reject.</li>
+      <li>Local <code>INSERT</code> succeeds. WAL fsynced. Vector clock bumped.</li>
+      <li><code>broadcast_store_quorum</code> spawns one HTTP <code>POST /api/v1/sync/push</code> per configured peer (B, C, D). Local response returns to the agent immediately.</li>
+      <li>Each peer receives the push, validates, applies, and bumps its own SyncState entry for node-A.</li>
+    </ol>
+
+    <h3>A peer rejoins after a partition</h3>
+    <p>Node-C drops off the cluster for 4 hours. When it comes back, its supervisor calls:</p>
+<pre><code>curl http://node-a:9077/api/v1/sync/since?peer=node-c&amp;clock=7350</code></pre>
+    <p>Node-A returns the delta — every memory, link, namespace_meta change, and pending decision that happened after clock 7350. Node-C applies them in causal order, bumps its own state, and re-enters the steady-state mesh.</p>
+
+    <h3>Federated governance — a real example</h3>
+<pre><code># On node-A: tighten policy on a sensitive namespace
+ai-memory --bind node-a:9077 namespace set-standard org/legal/contracts \
+  --governance '{"write":"approve","delete":"approve"}'</code></pre>
+    <p>Within seconds:</p>
+    <ul>
+      <li><code>namespace_meta</code> row updated on node-A.</li>
+      <li><code>broadcast_namespace_meta_quorum</code> fires <code>POST /api/v1/sync/push</code> to B, C, D.</li>
+      <li>Each peer applies the new policy.</li>
+      <li>Any agent on any node attempting to write into <code>org/legal/contracts</code> now hits the local governance gate, which queues the write as <code>Pending</code>.</li>
+      <li>An approver agent on <strong>any</strong> node calls <code>memory_pending_approve</code>. The decision broadcasts via <code>broadcast_pending_decision_quorum</code>. All four nodes commit (or audit-reject) the queued write coherently.</li>
+    </ul>
+    <p>That's the honest version of "federated governance" — eventually consistent, but coherent.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Deployment recipe</span>
+    <h2>Quorum writes + mTLS peer mesh.</h2>
+    <p>All real flags, all in v0.6.3:</p>
+<pre><code># node-a — quorum writes require 2-of-3 peer acks within 2s
+ai-memory --db /var/lib/ai-memory/store.db serve \
+  --bind 0.0.0.0:9077 \
+  --tier semantic \
+  --quorum-writes 2 \
+  --quorum-peers https://node-b:9077,https://node-c:9077,https://node-d:9077 \
+  --quorum-timeout-ms 2000 \
+  --tls-cert /etc/ai-memory/tls.crt \
+  --tls-key /etc/ai-memory/tls.key \
+  --mtls-allowlist /etc/ai-memory/peer-fingerprints.txt \
+  --quorum-client-cert /etc/ai-memory/client.crt \
+  --quorum-client-key /etc/ai-memory/client.key \
+  --quorum-ca-cert /etc/ai-memory/ca.crt \
+  --catchup-interval-secs 30</code></pre>
+    <p>The <code>peer-fingerprints.txt</code> file is a newline-delimited list of SHA-256 fingerprints (with or without <code>:</code> separators; comments start with <code>#</code>). <code>serve</code> refuses any peer whose cert fingerprint is not on the list — that's the peer-mesh identity gate.</p>
+    <p>For long-running pull-based reconciliation, run a <code>sync-daemon</code> alongside <code>serve</code>:</p>
+<pre><code>ai-memory sync-daemon \
+  --peers https://node-b:9077,https://node-c:9077,https://node-d:9077 \
+  --interval 2 \
+  --client-cert /etc/ai-memory/client.crt \
+  --client-key /etc/ai-memory/client.key</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Wiring</span>
+    <h2>Governance, skills, and attestations at T3.</h2>
+    <ul>
+      <li><strong>Governance</strong> — Federated, eventually consistent. A policy change on one node propagates to all peers. Pending decisions also propagate. <strong>Caveat:</strong> during a partition, two operators on different sides can both approve/reject the same pending action; reconciliation is last-decision-wins on rejoin.</li>
+      <li><strong>Skills</strong> — Skills running as registered agents (<code>memory_agent_register</code>) get the same scope visibility on every node. Auto-tagging on node-A produces tags that are stored as memory metadata and replicated to all peers — every node sees the same enriched view.</li>
+      <li><strong>Attestations</strong> — Claimed identity only. The v0.7 attestation track will sign every memory and link with the originating agent's keypair; peers will refuse syncs that fail signature verification.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Limits</span>
+    <h2>Honest ceilings.</h2>
+    <table>
+      <thead>
+        <tr><th>Dimension</th><th>T3 ceiling</th><th>When it bites</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Cluster size</td><td>~10 nodes before fanout latency dominates</td><td>Beyond that, walk to T4</td></tr>
+        <tr><td>Concurrent writes per node</td><td>~10–20 (T2 ceiling, multiplied)</td><td>Each node is independently bottlenecked by its mutex</td></tr>
+        <tr><td>Write durability</td><td>W-of-N quorum-writes when <code>--quorum-writes &gt;= 1</code>; local-WAL-only when 0</td><td>Choose your contract per deployment</td></tr>
+        <tr><td>Cross-node consistency</td><td>Eventual; vector clocks resolve order; ties break last-writer-wins</td><td>Use <code>memory_detect_contradiction</code> to surface drift</td></tr>
+        <tr><td>Vector index</td><td>Per-node, independent</td><td>Each node holds its own HNSW; embedding cost paid N times</td></tr>
+        <tr><td>TLS</td><td>mTLS supported, not enforced by default</td><td>Enforce before joining real peers</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Source</span>
+    <h2>Source-of-truth references.</h2>
+    <ul>
+      <li><code>src/main.rs:405-447</code> — quorum-write CLI flags (<code>--quorum-writes</code>, <code>--quorum-peers</code>, <code>--quorum-timeout-ms</code>, <code>--quorum-client-cert</code>/<code>-key</code>/<code>-ca-cert</code>, <code>--catchup-interval-secs</code>)</li>
+      <li><code>src/main.rs:380-393</code> — TLS / mTLS allowlist flags (<code>--tls-cert</code>, <code>--tls-key</code>, <code>--mtls-allowlist</code>)</li>
+      <li><code>src/handlers.rs:442-454</code> — <code>broadcast_store_quorum</code> + <code>finalise_quorum</code> ack-counting in the write path</li>
+      <li><code>src/federation.rs</code> — 10 broadcast functions: <code>broadcast_store_quorum</code>, <code>broadcast_delete_quorum</code>, <code>broadcast_archive_quorum</code>, <code>broadcast_restore_quorum</code>, <code>broadcast_link_quorum</code>, <code>broadcast_consolidate_quorum</code>, <code>broadcast_pending_quorum</code>, <code>broadcast_pending_decision_quorum</code>, <code>broadcast_namespace_meta_quorum</code>, <code>broadcast_namespace_meta_clear_quorum</code></li>
+      <li><code>src/replication.rs</code> (422 lines) — <code>QuorumWriter</code> + <code>AckTracker</code> implementation</li>
+      <li><code>src/handlers.rs</code> — <code>POST /api/v1/sync/push</code> ingress, <code>GET /api/v1/sync/since</code> causal catch-up</li>
+      <li><code>docs/ADR-0001-quorum-replication.md</code> — the realised design</li>
+      <li><code>CHANGELOG.md</code> — #325 link fanout, #326 consolidate fanout, #327 embedder readiness</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architectures-t4.html
+++ b/docs/architectures-t4.html
@@ -1,0 +1,480 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  T4 — Data-center swarm. Multi-rack core today; pgvector backbone GA v0.7.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · T4 — Data-center swarm</title>
+<meta name="description" content="Multi-rack deployment with Postgres+pgvector backbone, mTLS peer mesh, per-rack governance — agents swarm across pods. v0.7 roadmap, with shipping primitives called out.">
+<meta property="og:title" content="ai-memory · T4 — Data-center swarm">
+<meta property="og:description" content="Multi-rack swarm. Quorum writes ship today; Postgres+pgvector backbone GA v0.7.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures-t4.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(200,162,255,0.10),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+.arch-diagram{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin:1.5rem 0}
+.arch-diagram-title{font-family:var(--font-mono);font-size:.85rem;color:var(--p2);letter-spacing:.04em;margin-bottom:1rem;text-transform:uppercase}
+.arch-svg{width:100%;height:auto;display:block;background:#0a0a0a;border-radius:8px}
+.arch-svg .node{fill:#161616;stroke:#3d3d3d;stroke-width:1.2}
+.arch-svg .node-label{fill:#fff;font-family:'SF Mono',monospace;font-size:12px;font-weight:600}
+.arch-svg .sub-label{fill:#999;font-family:'SF Mono',monospace;font-size:10px}
+.arch-svg .edge{fill:none}
+.arch-svg .edge-dashed{fill:none;stroke:#666;stroke-width:1.2;stroke-dasharray:4 3}
+.arch-svg .edge-roadmap{fill:none;stroke:#a78bfa;stroke-width:1.4;stroke-dasharray:5 4;opacity:.7}
+.arch-svg .flow{filter:drop-shadow(0 0 4px currentColor)}
+.arch-svg .flow-write{fill:#f97316;color:#f97316}
+.arch-svg .flow-recall{fill:#2dd4bf;color:#2dd4bf}
+.arch-svg .flow-sync{fill:#a78bfa;color:#a78bfa}
+.arch-svg .flow-policy{fill:#facc15;color:#facc15}
+.arch-svg .flow-attest{fill:#f472b6;color:#f472b6}
+.arch-svg .ring{fill:none;stroke:#6ee7ff;stroke-width:2;opacity:.7;animation:pulse 2.4s ease-out infinite}
+@keyframes pulse{0%{r:6;opacity:.85}100%{r:18;opacity:0}}
+.arch-legend{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted)}
+.arch-legend-item{display:inline-flex;align-items:center;gap:.4rem}
+.arch-legend-dot{display:inline-block;width:10px;height:10px;border-radius:50%}
+.arch-diagram-caption{font-size:.85rem;color:var(--text-dim);margin-top:1rem;line-height:1.5}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures · T4</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html" class="current">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <span class="cap-badge cap-today">CORE TODAY · v0.6.3</span>
+  <span class="cap-badge cap-roadmap">PG+pgvector GA · v0.7</span>
+  <h1>Tier 4 — Data-center swarm</h1>
+  <p class="tagline">Hundreds of nodes. Thousands of agents. Multiple racks. <strong>One coherent memory fabric.</strong> The core fabric ships in v0.6.3; the piece still maturing toward GA at this scale is the shared distributed store (Postgres + pgvector).</p>
+  <div class="pills">
+    <span class="pill">100s nodes · 1000s agents</span>
+    <span class="pill">multi-rack</span>
+    <span class="pill">3-of-5 quorum</span>
+    <span class="pill">mTLS allowlist</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <p>The core fabric ships in v0.6.3: the peer mesh, <strong>W-of-N quorum-writes</strong>, mTLS with fingerprint allowlist, federated governance, pending decisions, namespace metadata, capabilities introspection v2. The piece still maturing toward GA at this scale is the <strong>shared distributed store</strong> (Postgres + pgvector, behind the <code>sal-postgres</code> Cargo feature today, GA targeted v0.7).</p>
+    <p>The diagram distinguishes shipping vs roadmap: solid edges = today, indigo dashed = v0.7 GA piece.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Architecture diagram</span>
+    <h2>Multi-rack swarm · pgvector backbone (roadmap).</h2>
+
+    <div class="arch-diagram">
+      <div class="arch-diagram-title">T4 · Multi-rack swarm · pgvector backbone (roadmap) · quorum writes (today)</div>
+
+      <svg class="arch-svg" viewBox="0 0 940 620" role="img" aria-label="Multi-rack ai-memory data center swarm with Postgres pgvector backbone">
+
+        <defs>
+          <marker id="t4-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+
+          <linearGradient id="t4-rack-grad" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.10"/>
+            <stop offset="100%" stop-color="#0d9488" stop-opacity="0.04"/>
+          </linearGradient>
+
+          <linearGradient id="t4-pg-grad" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.20"/>
+            <stop offset="100%" stop-color="#6366f1" stop-opacity="0.10"/>
+          </linearGradient>
+
+          <path id="t4-RaRb" d="M 230 290 C 320 280, 470 280, 540 290" />
+          <path id="t4-RbRa" d="M 540 310 C 470 320, 320 320, 230 310" />
+          <path id="t4-RbRc" d="M 700 290 C 760 280, 820 280, 850 290" />
+          <path id="t4-RcRb" d="M 850 310 C 820 320, 760 320, 700 310" />
+          <path id="t4-RaRc" d="M 200 320 C 380 480, 700 480, 850 320" />
+
+          <path id="t4-RaPg" d="M 150 380 L 470 545" />
+          <path id="t4-RbPg" d="M 620 380 L 480 545" />
+          <path id="t4-RcPg" d="M 870 380 L 510 545" />
+
+          <path id="t4-gov-Ra" d="M 470 95 L 150 240" />
+          <path id="t4-gov-Rb" d="M 470 95 L 620 240" />
+          <path id="t4-gov-Rc" d="M 470 95 L 870 240" />
+        </defs>
+
+        <!-- CENTRAL GOVERNANCE PLANE -->
+        <g>
+          <rect x="350" y="40" width="240" height="65" rx="10" fill="rgba(250,204,21,0.14)" stroke="#facc15" stroke-width="1.6" />
+          <text x="470" y="60" text-anchor="middle" class="node-label">Federated control plane</text>
+          <text x="470" y="76" text-anchor="middle" class="sub-label">namespace_meta · governance policy</text>
+          <text x="470" y="91" text-anchor="middle" class="sub-label">pending decisions · capabilities v2</text>
+        </g>
+
+        <!-- GOVERNANCE EDGES -->
+        <use href="#t4-gov-Ra" class="edge" stroke="#facc15" stroke-width="1.4" marker-end="url(#t4-arrow)" style="color: #facc15; opacity: 0.55" stroke-dasharray="3 2" />
+        <use href="#t4-gov-Rb" class="edge" stroke="#facc15" stroke-width="1.4" marker-end="url(#t4-arrow)" style="color: #facc15; opacity: 0.55" stroke-dasharray="3 2" />
+        <use href="#t4-gov-Rc" class="edge" stroke="#facc15" stroke-width="1.4" marker-end="url(#t4-arrow)" style="color: #facc15; opacity: 0.55" stroke-dasharray="3 2" />
+
+        <!-- RACK A -->
+        <g>
+          <rect x="50" y="160" width="180" height="240" rx="12" fill="url(#t4-rack-grad)" stroke="#2dd4bf" stroke-width="1.4" />
+          <text x="140" y="180" text-anchor="middle" class="node-label" style="font-size: 12px">Rack A · zone-a</text>
+          <text x="140" y="195" text-anchor="middle" class="sub-label">10.1.0.0/24</text>
+          <g><rect x="64" y="210" width="152" height="36" rx="6" class="node"/><text x="72" y="228" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-0-0</text><text x="72" y="240" class="sub-label">8 agents · scope-isolated</text><circle cx="180" cy="228" r="3" fill="#2dd4bf"/><circle cx="190" cy="228" r="3" fill="#facc15"/><circle cx="200" cy="228" r="3" fill="#a78bfa"/></g>
+          <g><rect x="64" y="255" width="152" height="36" rx="6" class="node"/><text x="72" y="273" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-0-1</text><text x="72" y="285" class="sub-label">8 agents · scope-isolated</text><circle cx="180" cy="273" r="3" fill="#2dd4bf"/><circle cx="190" cy="273" r="3" fill="#facc15"/><circle cx="200" cy="273" r="3" fill="#a78bfa"/></g>
+          <g><rect x="64" y="300" width="152" height="36" rx="6" class="node"/><text x="72" y="318" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-0-2</text><text x="72" y="330" class="sub-label">8 agents · scope-isolated</text><circle cx="180" cy="318" r="3" fill="#2dd4bf"/><circle cx="190" cy="318" r="3" fill="#facc15"/><circle cx="200" cy="318" r="3" fill="#a78bfa"/></g>
+          <g><rect x="64" y="345" width="152" height="36" rx="6" class="node"/><text x="72" y="363" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-0-3</text><text x="72" y="375" class="sub-label">8 agents · scope-isolated</text><circle cx="180" cy="363" r="3" fill="#2dd4bf"/><circle cx="190" cy="363" r="3" fill="#facc15"/><circle cx="200" cy="363" r="3" fill="#a78bfa"/></g>
+        </g>
+
+        <!-- RACK B -->
+        <g>
+          <rect x="510" y="160" width="180" height="240" rx="12" fill="url(#t4-rack-grad)" stroke="#2dd4bf" stroke-width="1.4" />
+          <text x="600" y="180" text-anchor="middle" class="node-label" style="font-size: 12px">Rack B · zone-a</text>
+          <text x="600" y="195" text-anchor="middle" class="sub-label">10.1.1.0/24</text>
+          <g><rect x="524" y="210" width="152" height="36" rx="6" class="node"/><text x="532" y="228" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-1-0</text><text x="532" y="240" class="sub-label">8 agents · scope-isolated</text><circle cx="640" cy="228" r="3" fill="#2dd4bf"/><circle cx="650" cy="228" r="3" fill="#facc15"/><circle cx="660" cy="228" r="3" fill="#a78bfa"/></g>
+          <g><rect x="524" y="255" width="152" height="36" rx="6" class="node"/><text x="532" y="273" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-1-1</text><text x="532" y="285" class="sub-label">8 agents · scope-isolated</text><circle cx="640" cy="273" r="3" fill="#2dd4bf"/><circle cx="650" cy="273" r="3" fill="#facc15"/><circle cx="660" cy="273" r="3" fill="#a78bfa"/></g>
+          <g><rect x="524" y="300" width="152" height="36" rx="6" class="node"/><text x="532" y="318" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-1-2</text><text x="532" y="330" class="sub-label">8 agents · scope-isolated</text><circle cx="640" cy="318" r="3" fill="#2dd4bf"/><circle cx="650" cy="318" r="3" fill="#facc15"/><circle cx="660" cy="318" r="3" fill="#a78bfa"/></g>
+          <g><rect x="524" y="345" width="152" height="36" rx="6" class="node"/><text x="532" y="363" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-1-3</text><text x="532" y="375" class="sub-label">8 agents · scope-isolated</text><circle cx="640" cy="363" r="3" fill="#2dd4bf"/><circle cx="650" cy="363" r="3" fill="#facc15"/><circle cx="660" cy="363" r="3" fill="#a78bfa"/></g>
+        </g>
+
+        <!-- RACK C -->
+        <g>
+          <rect x="760" y="160" width="180" height="240" rx="12" fill="url(#t4-rack-grad)" stroke="#2dd4bf" stroke-width="1.4" />
+          <text x="850" y="180" text-anchor="middle" class="node-label" style="font-size: 12px">Rack C · zone-b</text>
+          <text x="850" y="195" text-anchor="middle" class="sub-label">10.1.2.0/24</text>
+          <g><rect x="774" y="210" width="152" height="36" rx="6" class="node"/><text x="782" y="228" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-2-0</text><text x="782" y="240" class="sub-label">8 agents · scope-isolated</text><circle cx="890" cy="228" r="3" fill="#2dd4bf"/><circle cx="900" cy="228" r="3" fill="#facc15"/><circle cx="910" cy="228" r="3" fill="#a78bfa"/></g>
+          <g><rect x="774" y="255" width="152" height="36" rx="6" class="node"/><text x="782" y="273" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-2-1</text><text x="782" y="285" class="sub-label">8 agents · scope-isolated</text><circle cx="890" cy="273" r="3" fill="#2dd4bf"/><circle cx="900" cy="273" r="3" fill="#facc15"/><circle cx="910" cy="273" r="3" fill="#a78bfa"/></g>
+          <g><rect x="774" y="300" width="152" height="36" rx="6" class="node"/><text x="782" y="318" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-2-2</text><text x="782" y="330" class="sub-label">8 agents · scope-isolated</text><circle cx="890" cy="318" r="3" fill="#2dd4bf"/><circle cx="900" cy="318" r="3" fill="#facc15"/><circle cx="910" cy="318" r="3" fill="#a78bfa"/></g>
+          <g><rect x="774" y="345" width="152" height="36" rx="6" class="node"/><text x="782" y="363" class="sub-label" style="font-size: 10px" font-weight="600">ai-memory-2-3</text><text x="782" y="375" class="sub-label">8 agents · scope-isolated</text><circle cx="890" cy="363" r="3" fill="#2dd4bf"/><circle cx="900" cy="363" r="3" fill="#facc15"/><circle cx="910" cy="363" r="3" fill="#a78bfa"/></g>
+        </g>
+
+        <!-- RACK-TO-RACK MESH -->
+        <use href="#t4-RaRb" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t4-arrow)" style="color: #a78bfa; opacity: 0.55" />
+        <use href="#t4-RbRa" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t4-arrow)" style="color: #a78bfa; opacity: 0.55" />
+        <use href="#t4-RbRc" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t4-arrow)" style="color: #a78bfa; opacity: 0.55" />
+        <use href="#t4-RcRb" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t4-arrow)" style="color: #a78bfa; opacity: 0.55" />
+        <use href="#t4-RaRc" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t4-arrow)" style="color: #a78bfa; opacity: 0.55" />
+
+        <!-- PGVECTOR BACKBONE -->
+        <g>
+          <rect x="370" y="510" width="240" height="80" rx="12" fill="url(#t4-pg-grad)" stroke="#a78bfa" stroke-width="1.6" stroke-dasharray="6 3" />
+          <text x="490" y="533" text-anchor="middle" class="node-label" style="font-size: 12px">Postgres + pgvector</text>
+          <text x="490" y="550" text-anchor="middle" class="sub-label">--features sal-postgres</text>
+          <text x="490" y="565" text-anchor="middle" class="sub-label">shared store · shared HNSW</text>
+          <text x="490" y="580" text-anchor="middle" class="sub-label" font-weight="700" fill="#a78bfa">ROADMAP · v0.7 Track B</text>
+        </g>
+
+        <use href="#t4-RaPg" class="edge-roadmap" marker-end="url(#t4-arrow)" style="color: #a78bfa" />
+        <use href="#t4-RbPg" class="edge-roadmap" marker-end="url(#t4-arrow)" style="color: #a78bfa" />
+        <use href="#t4-RcPg" class="edge-roadmap" marker-end="url(#t4-arrow)" style="color: #a78bfa" />
+
+        <!-- Particles — sync_push -->
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="3.2s" repeatCount="indefinite" begin="0s"><mpath href="#t4-RaRb"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="3.2s" repeatCount="indefinite" begin="0.4s"><mpath href="#t4-RbRa"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="3.2s" repeatCount="indefinite" begin="0.8s"><mpath href="#t4-RbRc"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="3.2s" repeatCount="indefinite" begin="1.2s"><mpath href="#t4-RcRb"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="3.2s" repeatCount="indefinite" begin="1.6s"><mpath href="#t4-RaRc"/></animateMotion></circle>
+
+        <!-- Governance plane particles -->
+        <circle r="3" class="flow flow-policy"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0s"><mpath href="#t4-gov-Ra"/></animateMotion></circle>
+        <circle r="3" class="flow flow-policy"><animateMotion dur="3.6s" repeatCount="indefinite" begin="0.6s"><mpath href="#t4-gov-Rb"/></animateMotion></circle>
+        <circle r="3" class="flow flow-policy"><animateMotion dur="3.6s" repeatCount="indefinite" begin="1.2s"><mpath href="#t4-gov-Rc"/></animateMotion></circle>
+
+        <!-- pgvector particles -->
+        <circle r="2.5" class="flow flow-sync" opacity="0.6"><animateMotion dur="4.8s" repeatCount="indefinite" begin="0s"><mpath href="#t4-RaPg"/></animateMotion></circle>
+        <circle r="2.5" class="flow flow-sync" opacity="0.6"><animateMotion dur="4.8s" repeatCount="indefinite" begin="0.8s"><mpath href="#t4-RbPg"/></animateMotion></circle>
+        <circle r="2.5" class="flow flow-sync" opacity="0.6"><animateMotion dur="4.8s" repeatCount="indefinite" begin="1.6s"><mpath href="#t4-RcPg"/></animateMotion></circle>
+
+        <!-- QUORUM ANNOTATION -->
+        <g transform="translate(40, 430)">
+          <rect x="0" y="0" width="350" height="60" rx="8" fill="rgba(34,197,94,0.10)" stroke="#22c55e" stroke-width="1.4" />
+          <text x="12" y="22" class="sub-label" font-weight="700" fill="#16a34a">Quorum-write contract — SHIPS TODAY</text>
+          <text x="12" y="38" class="sub-label">--quorum-writes N --quorum-peers a,b,c</text>
+          <text x="12" y="52" class="sub-label">503 quorum_not_met on timeout · ADR-0001 realised</text>
+        </g>
+
+        <!-- mTLS annotation -->
+        <g transform="translate(560, 430)">
+          <rect x="0" y="0" width="340" height="60" rx="8" fill="rgba(45,212,191,0.10)" stroke="#2dd4bf" stroke-width="1.4" />
+          <text x="12" y="22" class="sub-label" font-weight="700" fill="#0d9488">mTLS peer mesh + fingerprint allowlist</text>
+          <text x="12" y="38" class="sub-label">--tls-cert · --tls-key · --mtls-allowlist (SHA-256)</text>
+          <text x="12" y="52" class="sub-label">peer-mesh identity gate — refuses unknown certs</text>
+        </g>
+
+      </svg>
+
+      <div class="arch-legend">
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #a78bfa"></span>sync_push mesh (today)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #facc15"></span>federated control plane</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #a78bfa; opacity: 0.5"></span>pgvector / quorum (roadmap)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #2dd4bf"></span>mTLS peer transport</span>
+      </div>
+
+      <div class="arch-diagram-caption">
+        Solid lines ship today. Dashed indigo lines are v0.7 Track B (Postgres + pgvector backbone).
+        The federated control plane already propagates governance policy and pending decisions across all racks via sync_push.
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Quorum-write contract</span>
+    <h2>Shipping today.</h2>
+    <p>The big T4-relevant capability that's already wired:</p>
+    <ul>
+      <li><code>src/main.rs:405-411</code> — <code>--quorum-writes N</code> enables W-of-N replication; <code>--quorum-peers a,b,c</code> lists targets.</li>
+      <li><code>src/handlers.rs:442-454</code> — write path calls <code>broadcast_store_quorum</code> then <code>finalise_quorum</code>. Local commit + (W-1) peer acks within <code>--quorum-timeout-ms</code> (default 2000) → <code>200 OK</code> with the achieved ack count returned in the response. Falling short → <code>503 quorum_not_met</code>.</li>
+      <li>Same wiring on <code>link</code>, <code>consolidate</code>, <code>pending_decision</code>, <code>namespace_meta</code>, and the <code>clear_namespace_meta</code> path.</li>
+      <li>mTLS for the outbound side via <code>--quorum-client-cert</code> / <code>--quorum-client-key</code> / <code>--quorum-ca-cert</code>.</li>
+    </ul>
+    <p>ADR-0001 is realised, not aspirational. Phase 1 (scaffold) and Phase 2 (wired into write path) shipped. Phase 3 (chaos harness) and Phase 4 (formal convergence-bound report) are still work — the convergence guarantees in production are exercised by the a2a-gate scenario suite (CHANGELOG #325/#326/#327).</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Track B roadmap</span>
+    <h2>Postgres + pgvector backbone.</h2>
+    <p>The single-SQLite-per-node ceiling bites at T4 scale (>10⁶ memories per node, hot writers). The structural fix is a <strong>shared store</strong>.</p>
+    <p><strong>Today (v0.6.x):</strong> <code>sal-postgres</code> Cargo feature flag exists; <code>sqlx</code> + <code>pgvector</code> deps wired. The Postgres adapter compiles and runs; correctness fixes shipped in v0.6.0 pre-tag (#294 SAL upsert key alignment, #295 <code>metadata.agent_id</code> immutability via <code>jsonb_set</code>, #296 tier-downgrade protection via SQL <code>tier_rank()</code>, #297 schema parity with 6 tables + generated <code>scope_idx</code> column). That work is the foundation.</p>
+    <p><strong>v0.7 GA:</strong> Performance maturation, migration tool for SQLite→Postgres on existing fleets, pgvector index tuning at &gt;10⁷ memories, official deployment recipes.</p>
+    <p>What the shared store unlocks at GA:</p>
+    <ul>
+      <li>Horizontal read scaling (Postgres read replicas).</li>
+      <li>Shared vector index across the fleet — one embedding stored once.</li>
+      <li>Standard Postgres operational primitives — backups, PITR, monitoring.</li>
+      <li>Network filesystems no longer dangerous (the SQLite <code>fcntl</code> lock issue goes away).</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What ships today at scale</span>
+    <h2>Every primitive used in the T3 diagram extends to T4.</h2>
+    <p class="lede">The topology just gets denser.</p>
+    <ul>
+      <li><strong>Rack-to-rack peer mesh</strong> — <code>sync_push</code> works the same whether you have 4 nodes or 40. The number of edges is <code>n*(n-1)/2</code> for full mesh, which is a gossip cost the operator should plan for. Most T4 deployments will use a <strong>partial mesh</strong> with a few designated bridge nodes per rack.</li>
+      <li><strong>Federated governance plane</strong> — <code>broadcast_namespace_meta_quorum</code> and <code>broadcast_pending_decision_quorum</code> mean a tightening of policy on <code>org/eu/finance</code> propagates to every rack, every node. v0.6.3 capabilities introspection lets every agent and operator confirm that the policy version they're seeing matches the published version.</li>
+      <li><strong>Per-rack pending queues</strong> — Approval workflows can be scoped to a rack (<code>rack-a/approvers</code>) so on-call shifts work cleanly even at fleet scale.</li>
+      <li><strong>mTLS</strong> — <code>rustls</code> is already wired in the peer transport. Enforcement is opt-in today; it's the obvious default at T4.</li>
+      <li><strong>Capabilities introspection v2</strong> — Operators can fleet-scan <code>/api/v1/capabilities</code> to confirm every node is on the same schema version and feature tier. Drift is an alerting condition, not a surprise.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Limits</span>
+    <h2>Honest ceilings.</h2>
+    <table>
+      <thead>
+        <tr><th>Dimension</th><th>Today (v0.6.3)</th><th>v0.7 GA</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Total memories per cluster</td><td>bounded by per-node HNSW RAM</td><td>pgvector → 10⁸+</td></tr>
+        <tr><td>Write durability across racks</td><td><strong>W-of-N quorum</strong> (<code>--quorum-writes N</code>)</td><td>unchanged</td></tr>
+        <tr><td>Partition tolerance</td><td>quorum-bounded divergence; <code>503 quorum_not_met</code> on shortfall</td><td>unchanged</td></tr>
+        <tr><td>Operational primitives</td><td>per-node SQLite, replicated; backups per node</td><td>Postgres ecosystem (PITR, replicas, central monitoring)</td></tr>
+        <tr><td>Vector index drift</td><td>each node embeds &amp; indexes independently</td><td>shared pgvector</td></tr>
+        <tr><td>mTLS</td><td>enforced via fingerprint allowlist</td><td>unchanged</td></tr>
+      </tbody>
+    </table>
+    <p>A 10-rack, 100-node fleet with 3-of-5 quorum is in scope today. The v0.7 piece that's still maturing is the <strong>Postgres backbone</strong> — the vector-index drift across nodes and the per-node SQLite operational footprint are the things shared-store fixes.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Deployment recipe</span>
+    <h2>Today: quorum + mTLS allowlist.</h2>
+<pre><code># rack-a/node-2 — quorum 3-of-5 across the rack, mTLS enforced
+ai-memory --db /var/lib/ai-memory/store.db serve \
+  --bind 0.0.0.0:9077 \
+  --tier semantic \
+  --quorum-writes 3 \
+  --quorum-peers https://rack-a-1:9077,https://rack-a-3:9077,https://rack-b-1:9077,https://rack-b-2:9077,https://rack-c-1:9077 \
+  --quorum-timeout-ms 1500 \
+  --tls-cert /etc/ai-memory/tls.crt \
+  --tls-key /etc/ai-memory/tls.key \
+  --mtls-allowlist /etc/ai-memory/peer-fingerprints.txt \
+  --quorum-client-cert /etc/ai-memory/client.crt \
+  --quorum-client-key /etc/ai-memory/client.key \
+  --quorum-ca-cert /etc/ai-memory/ca.crt \
+  --catchup-interval-secs 15</code></pre>
+
+    <p>v0.7 GA target — same node, swap to Postgres-backed store:</p>
+<pre><code>ai-memory serve \
+  --store-url postgres://ai-memory@pg-cluster.svc.cluster.local:5432/store \
+  --bind 0.0.0.0:9077 \
+  --tier semantic \
+  --quorum-writes 3 \
+  --quorum-peers https://rack-a-1:9077,https://rack-a-3:9077,https://rack-b-1:9077</code></pre>
+
+    <p>The <code>peer-fingerprints.txt</code> file lists trusted SHA-256 fingerprints (one per line, optional <code>:</code> separators, <code>#</code> comments). The <code>--mtls-allowlist</code> flag's presence is what makes mTLS enforcement <em>required</em> — if a peer's cert isn't on the list, the connection is refused at TLS handshake.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Wiring</span>
+    <h2>Governance, skills, and attestations at T4.</h2>
+    <ul>
+      <li><strong>Governance</strong> — Same machinery as T2/T3, just at scale. The federated control plane is the central nervous system: a single policy update on <code>org/eu/finance</code> reaches every node within seconds. Pending-action queues are visible per-rack for on-call routing.</li>
+      <li><strong>Skills</strong> — Skills register as agents and get the same scope visibility. At T4, skills are typically pinned to specific racks (latency, data-residency) but their outputs (tags, contradictions, consolidations) propagate fleet-wide via <code>sync_push</code>.</li>
+      <li><strong>Attestations</strong> — v0.7 attested identity is the gating capability for trustworthy multi-tenant T4. Without it, the cluster is "trust-the-network" — operationally fine inside a controlled VPC, not fine for cross-tenant or cross-organization deployments.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Source</span>
+    <h2>Source-of-truth references.</h2>
+    <ul>
+      <li><code>src/main.rs:405-447</code> — quorum-write CLI surface</li>
+      <li><code>src/main.rs:230</code> — <code>--store-url postgres://...</code> URL syntax</li>
+      <li><code>src/main.rs:380-393</code> — TLS / mTLS allowlist enforcement</li>
+      <li><code>src/handlers.rs:442-454, 524-540</code> — <code>broadcast_store_quorum</code> + ack counting</li>
+      <li><code>src/replication.rs</code> (422 lines) — <code>QuorumWriter</code> + <code>AckTracker</code> (functional)</li>
+      <li><code>Cargo.toml</code> — <code>sal-postgres</code> feature, sqlx + pgvector deps</li>
+      <li><code>CHANGELOG.md</code> — v0.6.0 pre-tag SAL fixes (#294-#297), v0.6.2 fanout bugs (#325-#327)</li>
+      <li><code>docs/ADR-0001-quorum-replication.md</code> — realised design</li>
+      <li><code>docs/ARCHITECTURAL_LIMITS.md</code> — the honest ceiling on each dimension</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architectures-t5.html
+++ b/docs/architectures-t5.html
@@ -1,0 +1,469 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  T5 — Global hive. Multi-region, attested, federated. The vision tier.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · T5 — Global hive</title>
+<meta name="description" content="Multi-region cloud, attested agent identity, federated governance, hundreds of thousands to millions of agents acting as a unified collective. The vision tier.">
+<meta property="og:title" content="ai-memory · T5 — Global hive">
+<meta property="og:description" content="Multi-region cloud · attested · federated · collective. The north star.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures-t5.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(255,107,157,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.75rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+.arch-diagram{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin:1.5rem 0}
+.arch-diagram-title{font-family:var(--font-mono);font-size:.85rem;color:var(--p2);letter-spacing:.04em;margin-bottom:1rem;text-transform:uppercase}
+.arch-svg{width:100%;height:auto;display:block;background:#0a0a0a;border-radius:8px}
+.arch-svg .node{fill:#161616;stroke:#3d3d3d;stroke-width:1.2}
+.arch-svg .node-label{fill:#fff;font-family:'SF Mono',monospace;font-size:12px;font-weight:600}
+.arch-svg .sub-label{fill:#999;font-family:'SF Mono',monospace;font-size:10px}
+.arch-svg .edge{fill:none}
+.arch-svg .edge-dashed{fill:none;stroke:#666;stroke-width:1.2;stroke-dasharray:4 3}
+.arch-svg .edge-roadmap{fill:none;stroke:#a78bfa;stroke-width:1.4;stroke-dasharray:5 4;opacity:.7}
+.arch-svg .flow{filter:drop-shadow(0 0 4px currentColor)}
+.arch-svg .flow-write{fill:#f97316;color:#f97316}
+.arch-svg .flow-recall{fill:#2dd4bf;color:#2dd4bf}
+.arch-svg .flow-sync{fill:#a78bfa;color:#a78bfa}
+.arch-svg .flow-policy{fill:#facc15;color:#facc15}
+.arch-svg .flow-attest{fill:#f472b6;color:#f472b6}
+.arch-svg .ring{fill:none;stroke:#6ee7ff;stroke-width:2;opacity:.7;animation:pulse 2.4s ease-out infinite}
+@keyframes pulse{0%{r:6;opacity:.85}100%{r:18;opacity:0}}
+.arch-legend{display:flex;flex-wrap:wrap;gap:1rem;margin-top:1rem;font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted)}
+.arch-legend-item{display:inline-flex;align-items:center;gap:.4rem}
+.arch-legend-dot{display:inline-block;width:10px;height:10px;border-radius:50%}
+.arch-diagram-caption{font-size:.85rem;color:var(--text-dim);margin-top:1rem;line-height:1.5}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures · T5</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html" class="current">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <span class="cap-badge cap-future">VISION · v1.0+</span>
+  <span class="cap-badge cap-today">primitives composable today</span>
+  <h1>Tier 5 — Global hive</h1>
+  <p class="tagline">The north star. Multiple cloud regions. Hundreds of thousands to millions of agents. Cross-organization federation with <strong>cryptographically attested identity</strong>. A unified collective of artificial minds reasoning over a shared knowledge graph while still respecting trust boundaries, jurisdictional rules, and per-namespace governance.</p>
+  <div class="pills">
+    <span class="pill">multi-region</span>
+    <span class="pill">10⁵–10⁶ agents</span>
+    <span class="pill">attested identity</span>
+    <span class="pill">consensus governance</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <p>This tier is <strong>vision territory</strong>. It is what ai-memory is being built toward. The honest framing: every primitive on every diagram below is either shipping in v0.6.3, on the v0.7 roadmap, or scoped explicitly for v1.0+ with the design documented in an ADR or roadmap doc. There is <strong>no fiction</strong> on this page — only the destination, drawn explicitly so the path is legible.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Architecture diagram</span>
+    <h2>Multi-region · attested · federated · collective.</h2>
+
+    <div class="arch-diagram">
+      <div class="arch-diagram-title">T5 · Multi-region · attested · federated · collective</div>
+
+      <svg class="arch-svg" viewBox="0 0 940 660" role="img" aria-label="Multi-region global hive of ai-memory clusters with attested agent identity">
+
+        <defs>
+          <marker id="t5-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+
+          <radialGradient id="t5-globe-grad" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.18"/>
+            <stop offset="70%" stop-color="#0d9488" stop-opacity="0.06"/>
+            <stop offset="100%" stop-color="#0d9488" stop-opacity="0"/>
+          </radialGradient>
+
+          <linearGradient id="t5-attest-grad" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#f472b6" stop-opacity="0.20"/>
+            <stop offset="100%" stop-color="#be185d" stop-opacity="0.08"/>
+          </linearGradient>
+
+          <path id="t5-NA-EU" d="M 200 280 C 350 200, 540 200, 660 280" />
+          <path id="t5-EU-NA" d="M 660 300 C 540 380, 350 380, 200 300" />
+          <path id="t5-EU-APAC" d="M 720 280 C 800 220, 870 220, 870 290" />
+          <path id="t5-APAC-EU" d="M 850 290 C 820 340, 760 340, 720 300" />
+          <path id="t5-NA-APAC" d="M 180 320 C 350 540, 730 540, 870 320" />
+
+          <path id="t5-att-NA" d="M 470 80 L 200 250" />
+          <path id="t5-att-EU" d="M 470 80 L 660 250" />
+          <path id="t5-att-APAC" d="M 470 80 L 870 250" />
+        </defs>
+
+        <!-- ATTESTATION ROOT -->
+        <g>
+          <rect x="320" y="32" width="300" height="80" rx="14"
+                fill="url(#t5-attest-grad)" stroke="#f472b6" stroke-width="1.6" />
+          <text x="470" y="55" text-anchor="middle" class="node-label" style="font-size: 13px">Federated identity &amp; attestation root</text>
+          <text x="470" y="73" text-anchor="middle" class="sub-label">agent keypairs · signed memories · signed links</text>
+          <text x="470" y="88" text-anchor="middle" class="sub-label">memory_links.signature (v0.6.3 reserved · v0.7 wired)</text>
+          <text x="470" y="103" text-anchor="middle" class="sub-label" font-weight="700" fill="#be185d">v1.0+ · zero-trust cross-org</text>
+        </g>
+
+        <!-- ATTEST EDGES -->
+        <use href="#t5-att-NA" class="edge-roadmap" stroke="#f472b6" marker-end="url(#t5-arrow)" style="color: #f472b6" />
+        <use href="#t5-att-EU" class="edge-roadmap" stroke="#f472b6" marker-end="url(#t5-arrow)" style="color: #f472b6" />
+        <use href="#t5-att-APAC" class="edge-roadmap" stroke="#f472b6" marker-end="url(#t5-arrow)" style="color: #f472b6" />
+
+        <!-- REGION NA -->
+        <g>
+          <rect x="80" y="200" width="160" height="135" rx="14" fill="url(#t5-globe-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="160" y="222" text-anchor="middle" class="node-label">NA region</text>
+          <text x="160" y="238" text-anchor="middle" class="sub-label">us-east · us-west</text>
+          <text x="160" y="253" text-anchor="middle" class="sub-label">12 clusters</text>
+          <g><rect x="98" y="265" width="36" height="36" rx="6" class="node"/><text x="116" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="116" y="292" text-anchor="middle" class="sub-label">1</text></g>
+          <g><rect x="142" y="265" width="36" height="36" rx="6" class="node"/><text x="160" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="160" y="292" text-anchor="middle" class="sub-label">2</text></g>
+          <g><rect x="186" y="265" width="36" height="36" rx="6" class="node"/><text x="204" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="204" y="292" text-anchor="middle" class="sub-label">3</text></g>
+          <text x="160" y="317" text-anchor="middle" class="sub-label">~10⁵ agents</text>
+          <text x="160" y="330" text-anchor="middle" class="sub-label">jurisdictional governance</text>
+        </g>
+
+        <!-- REGION EU -->
+        <g>
+          <rect x="540" y="200" width="160" height="135" rx="14" fill="url(#t5-globe-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="620" y="222" text-anchor="middle" class="node-label">EU region</text>
+          <text x="620" y="238" text-anchor="middle" class="sub-label">eu-west · eu-central</text>
+          <text x="620" y="253" text-anchor="middle" class="sub-label">8 clusters</text>
+          <g><rect x="558" y="265" width="36" height="36" rx="6" class="node"/><text x="576" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="576" y="292" text-anchor="middle" class="sub-label">1</text></g>
+          <g><rect x="602" y="265" width="36" height="36" rx="6" class="node"/><text x="620" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="620" y="292" text-anchor="middle" class="sub-label">2</text></g>
+          <g><rect x="646" y="265" width="36" height="36" rx="6" class="node"/><text x="664" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="664" y="292" text-anchor="middle" class="sub-label">3</text></g>
+          <text x="620" y="317" text-anchor="middle" class="sub-label">~10⁵ agents</text>
+          <text x="620" y="330" text-anchor="middle" class="sub-label">jurisdictional governance</text>
+        </g>
+
+        <!-- REGION APAC -->
+        <g>
+          <rect x="770" y="200" width="160" height="135" rx="14" fill="url(#t5-globe-grad)" stroke="#2dd4bf" stroke-width="1.5" />
+          <text x="850" y="222" text-anchor="middle" class="node-label">APAC region</text>
+          <text x="850" y="238" text-anchor="middle" class="sub-label">ap-northeast · ap-south</text>
+          <text x="850" y="253" text-anchor="middle" class="sub-label">6 clusters</text>
+          <g><rect x="788" y="265" width="36" height="36" rx="6" class="node"/><text x="806" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="806" y="292" text-anchor="middle" class="sub-label">1</text></g>
+          <g><rect x="832" y="265" width="36" height="36" rx="6" class="node"/><text x="850" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="850" y="292" text-anchor="middle" class="sub-label">2</text></g>
+          <g><rect x="876" y="265" width="36" height="36" rx="6" class="node"/><text x="894" y="280" text-anchor="middle" class="sub-label" style="font-size: 8px">cluster</text><text x="894" y="292" text-anchor="middle" class="sub-label">3</text></g>
+          <text x="850" y="317" text-anchor="middle" class="sub-label">~10⁵ agents</text>
+          <text x="850" y="330" text-anchor="middle" class="sub-label">jurisdictional governance</text>
+        </g>
+
+        <!-- INTER-REGION MESH -->
+        <use href="#t5-NA-EU" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t5-arrow)" style="color: #a78bfa; opacity: 0.5" />
+        <use href="#t5-EU-NA" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t5-arrow)" style="color: #a78bfa; opacity: 0.5" />
+        <use href="#t5-EU-APAC" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t5-arrow)" style="color: #a78bfa; opacity: 0.5" />
+        <use href="#t5-APAC-EU" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t5-arrow)" style="color: #a78bfa; opacity: 0.5" />
+        <use href="#t5-NA-APAC" class="edge" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#t5-arrow)" style="color: #a78bfa; opacity: 0.5" />
+
+        <!-- PARTICLES — inter-region sync -->
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="5.4s" repeatCount="indefinite" begin="0s"><mpath href="#t5-NA-EU"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="5.4s" repeatCount="indefinite" begin="0.7s"><mpath href="#t5-EU-NA"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="5.4s" repeatCount="indefinite" begin="1.4s"><mpath href="#t5-EU-APAC"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="5.4s" repeatCount="indefinite" begin="2.1s"><mpath href="#t5-APAC-EU"/></animateMotion></circle>
+        <circle r="3.5" class="flow flow-sync"><animateMotion dur="5.4s" repeatCount="indefinite" begin="2.8s"><mpath href="#t5-NA-APAC"/></animateMotion></circle>
+
+        <!-- ATTESTATION particles -->
+        <circle r="3" class="flow flow-attest"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0s"><mpath href="#t5-att-NA"/></animateMotion></circle>
+        <circle r="3" class="flow flow-attest"><animateMotion dur="4.2s" repeatCount="indefinite" begin="0.5s"><mpath href="#t5-att-EU"/></animateMotion></circle>
+        <circle r="3" class="flow flow-attest"><animateMotion dur="4.2s" repeatCount="indefinite" begin="1.0s"><mpath href="#t5-att-APAC"/></animateMotion></circle>
+
+        <!-- DISTRIBUTED CONSENSUS RAIL -->
+        <g>
+          <rect x="60" y="400" width="820" height="80" rx="12" fill="rgba(99,102,241,0.10)" stroke="#a78bfa" stroke-width="1.4" stroke-dasharray="6 3" />
+          <text x="470" y="425" text-anchor="middle" class="node-label" style="font-size: 13px">Distributed consensus rail · Raft / Paxos / Tangle</text>
+          <text x="470" y="442" text-anchor="middle" class="sub-label">strong consistency for governance writes · split-brain resolution · jurisdictional boundary enforcement</text>
+          <text x="470" y="458" text-anchor="middle" class="sub-label">gossip / DHT for many-node discovery</text>
+          <text x="470" y="475" text-anchor="middle" class="sub-label" font-weight="700" fill="#a78bfa">v1.0+ VISION · scoped, not yet designed</text>
+        </g>
+
+        <!-- HIVE EMERGENT BEHAVIOR -->
+        <g transform="translate(60, 510)">
+          <rect x="0" y="0" width="820" height="115" rx="12" fill="rgba(45,212,191,0.06)" stroke="#2dd4bf" stroke-width="1.4" />
+          <text x="410" y="22" text-anchor="middle" class="node-label" style="font-size: 13px">Hive properties — what becomes possible at this scale</text>
+          <text x="410" y="40" text-anchor="middle" class="sub-label">emergent collective recall · cross-region knowledge transfer · jurisdictional sandboxing</text>
+          <text x="410" y="56" text-anchor="middle" class="sub-label">attested provenance for every memory · zero-trust agent-to-agent · auditable lineage</text>
+          <text x="410" y="72" text-anchor="middle" class="sub-label">temporal-validity KG (v0.6.3) replays past states · point-in-time recall across the fleet</text>
+          <text x="410" y="88" text-anchor="middle" class="sub-label">policy-as-code at every namespace level · differential privacy on cross-tenant recall</text>
+          <text x="410" y="104" text-anchor="middle" class="sub-label" font-weight="700" fill="#0d9488">composed from primitives shipping today + v0.7 + v1.0</text>
+        </g>
+
+      </svg>
+
+      <div class="arch-legend">
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #a78bfa"></span>inter-region sync (eventually consistent today, quorum v0.7)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #f472b6"></span>attested identity (v0.7 wired, v1.0 fleet-trust)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #a78bfa; opacity: 0.5"></span>consensus rail (v1.0+ vision)</span>
+        <span class="arch-legend-item"><span class="arch-legend-dot" style="background: #2dd4bf"></span>regional cluster (T4 pattern)</span>
+      </div>
+
+      <div class="arch-diagram-caption">
+        Each region is a T4 cluster pattern — composed of T3 cluster cells, composed of T2 multi-tenant nodes, composed of T1 primitives.
+        What's new at T5: cryptographic attestation, distributed consensus for governance, and emergent collective behavior.
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What's actually new</span>
+    <h2>T5 vs T4.</h2>
+    <p>T5 is <strong>not</strong> "more nodes than T4." The same cluster shape scales to thousands of nodes via T4's mechanisms. T5 is the tier where <strong>trust</strong> and <strong>consistency model</strong> change qualitatively.</p>
+
+    <h3>Cryptographic agent attestation</h3>
+    <p>At T1–T4, an agent's identity is <strong>claimed</strong> via <code>metadata.agent_id</code>. At T5 it must be <strong>proven</strong>.</p>
+    <p>The plumbing is already in v0.6.3 schema:</p>
+    <ul>
+      <li><code>memory_links.signature</code> column (schema v15) — reserved at v0.6.3, populated with claimed identity, will be cryptographically signed at v0.7.</li>
+      <li>The <code>observed_by</code> column on <code>memory_links</code> records which agent observed the relationship — paired with <code>signature</code> this becomes provable provenance.</li>
+    </ul>
+    <p>What's needed to reach the T5 trust model:</p>
+    <ul>
+      <li>Agent keypair issuance and rotation.</li>
+      <li>Signature verification on every <code>sync_push</code> ingress — peers refuse incoming memories with bad signatures.</li>
+      <li>Revocation list distribution.</li>
+      <li>Hardware-backed key custody for high-trust agents (TPM / Secure Enclave / Cloud KMS).</li>
+    </ul>
+    <p>This is <strong>v1.0+ work</strong>. The schema reservation at v0.6.3 is the down-payment.</p>
+
+    <h3>Distributed consensus for governance</h3>
+    <p>At T3/T4, governance policies and pending decisions are <strong>eventually consistent</strong>. Two operators on partitioned sides of the cluster can both approve the same pending action. Last-write-wins resolves it on rejoin.</p>
+    <p>At T5 — with millions of agents and cross-jurisdictional rules — that's not enough. A change to <code>org/eu/personal-data</code> policy under GDPR has to be <strong>strongly consistent</strong> before any agent in any region commits a write under the new rule. This is the use case for a Raft-class consensus log on the <strong>governance plane only</strong> (not on the memory write path — that stays eventually consistent for performance).</p>
+    <p>The architectural separation:</p>
+    <ul>
+      <li><strong>Memory writes</strong> — eventually consistent, quorum-bounded (v0.7 Track C).</li>
+      <li><strong>Governance writes</strong> — strongly consistent via consensus rail (v1.0+).</li>
+    </ul>
+    <p>Memories are append-mostly; governance is small, infrequent, and high-stakes. Different consistency models for different planes.</p>
+
+    <h3>Jurisdictional boundary enforcement</h3>
+    <p>At T5, namespaces aren't just visibility scopes — they're legal boundaries. The federated control plane has to enforce things like:</p>
+    <ul>
+      <li><em>"<code>org/eu/*</code> memories may only be physically resident in <code>eu-*</code> regions."</em></li>
+      <li><em>"Cross-region recall against <code>org/healthcare/*</code> requires policy assertion <code>hipaa_compliant=true</code> on the requesting agent."</em></li>
+      <li><em>"Audit log for any <code>org/finance/trading/*</code> write must be fsync'd to two independent storage backends in distinct AZs."</em></li>
+    </ul>
+    <p>These policies compose from existing primitives (namespace + governance + capabilities introspection + attested identity). They become enforceable when v1.0 wires the consensus rail and the attestation chain.</p>
+
+    <h3>Emergent collective behavior</h3>
+    <p>What makes T5 a <strong>hive</strong> rather than just a big cluster:</p>
+    <ul>
+      <li><strong>Cross-region knowledge transfer</strong> — A discovery in NA can propagate (or be rejected) by every other region's policy engine within seconds.</li>
+      <li><strong>Temporal-validity KG replay</strong> — v0.6.3's <code>memory_kg_query(as_of=...)</code> plus the temporal columns (<code>valid_from</code>, <code>valid_until</code>, <code>observed_by</code>) means an agent can ask "what did the collective know at 14:23 UTC last Tuesday?" and get a deterministic answer across the fleet.</li>
+      <li><strong>Point-in-time provenance</strong> — Every memory has a signed origin and a tracked validity window. A regulator's request "show me what informed this decision" returns a verifiable lineage.</li>
+      <li><strong>Differential privacy on cross-tenant recall</strong> — Roadmap. The scope-visibility filter is the foundational primitive; DP noise on aggregated recalls is the v1.0+ cap.</li>
+    </ul>
+    <p>Each of these is a composition of primitives that ship today + v0.7 + v1.0. Nothing on the T5 list is a new fundamental capability — it's what becomes <strong>operationally possible</strong> when the lower-tier pieces are all in place at scale.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What ships today toward the hive</span>
+    <h2>A pleasant amount, actually.</h2>
+    <ul>
+      <li><strong>Hierarchical namespace + scope visibility</strong> — the substrate for jurisdictional boundaries.</li>
+      <li><strong>Per-namespace governance with pending workflows</strong> — the substrate for policy-as-code.</li>
+      <li><strong>Federated governance fanout</strong> — every node sees the same policy, eventually.</li>
+      <li><strong>Federated pending-decision sync</strong> — approve/reject propagates fleet-wide.</li>
+      <li><strong>Vector-clock causality</strong> — the substrate for "what did the fleet know when."</li>
+      <li><strong>Temporal-validity KG (v0.6.3)</strong> — <code>valid_from</code> / <code>valid_until</code> / <code>observed_by</code> columns on every link.</li>
+      <li><strong>Capabilities introspection v2 (v0.6.3)</strong> — runtime trust assessment per node.</li>
+      <li><strong>Hierarchical taxonomy (v0.6.3)</strong> — tree views over the global namespace tree.</li>
+      <li><strong><code>signature</code> column reserved (v0.6.3)</strong> — the schema down-payment for attestation.</li>
+      <li><strong>Entity registry &amp; aliases (v0.6.3)</strong> — global entity identity, the substrate for cross-tenant identity resolution.</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Honest gap analysis</span>
+    <h2>What blocks T5 today.</h2>
+    <table>
+      <thead>
+        <tr><th>Capability</th><th>Today</th><th>v0.7</th><th>v1.0+</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Quorum-write contract</td><td>—</td><td>Track C</td><td>—</td></tr>
+        <tr><td>Postgres + pgvector backbone</td><td>—</td><td>Track B</td><td>—</td></tr>
+        <tr><td>Cryptographic agent attestation</td><td>reserved</td><td>partial wiring</td><td>full chain</td></tr>
+        <tr><td>Distributed consensus (governance plane)</td><td>—</td><td>—</td><td>designed</td></tr>
+        <tr><td>Gossip / DHT (many-node discovery)</td><td>—</td><td>—</td><td>designed</td></tr>
+        <tr><td>Cross-region failover / quorum bounds</td><td>—</td><td>—</td><td>designed</td></tr>
+        <tr><td>Differential privacy on recall</td><td>—</td><td>—</td><td>designed</td></tr>
+        <tr><td>Hardware-backed key custody</td><td>—</td><td>—</td><td>designed</td></tr>
+        <tr><td>Multi-tenant policy-as-code DSL</td><td>partial (JSON policies)</td><td>enriched</td><td>full DSL</td></tr>
+      </tbody>
+    </table>
+    <p>This is the honest road. Each row that flips toward shipping is a discrete piece of engineering with a tracked owner and an ADR.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Why this tier matters</span>
+    <h2>Primitives compose.</h2>
+    <p>ai-memory is a primitive. <strong>Primitives compose.</strong> The same MCP protocol surface, the same recall pipeline, the same governance contract that runs on a developer's laptop is what runs in the fleet at T5. There is no separate "enterprise edition" or rebuild — there is the primitive, scaled.</p>
+    <p>That property — <strong>identical surface area from one agent to the global hive</strong> — is what makes the architecture credible. It's what lets a startup at T2 grow to T5 without rewriting their integration. It's what lets a research collective federate with a corporation while preserving each side's governance.</p>
+    <p>The compounding value:</p>
+    <ul>
+      <li><strong>Memory becomes infrastructure</strong> — like a CDN, like DNS. Any agent, anywhere, can ask "what does the collective know about X?" and get an answer that respects every relevant policy.</li>
+      <li><strong>Trust becomes verifiable</strong> — attested provenance means "agent A asserted this at time T from cluster C with these capabilities" is provable, not merely claimed.</li>
+      <li><strong>Governance becomes federated</strong> — a policy update in one rack lands in every rack. A pending approval on one continent is visible on every other.</li>
+      <li><strong>Knowledge becomes durable</strong> — the temporal-validity KG means past states are queryable. "What did the fleet think on 2026-01-15?" is a deterministic answer.</li>
+    </ul>
+    <p>That's the hive. It's worth building toward, even if v0.7 and v1.0 are still out there.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Source</span>
+    <h2>Source-of-truth references.</h2>
+    <ul>
+      <li><code>docs/ROADMAP-ladybug.md</code> — Track A (T1/T2 polish), B (Postgres), C (quorum), D (attestation)</li>
+      <li><code>docs/ADR-0001-quorum-replication.md</code> — quorum write design</li>
+      <li><code>docs/ARCHITECTURAL_LIMITS.md</code> — honest ceiling on every dimension</li>
+      <li><code>src/models.rs</code> — <code>MemoryLink</code> (with v15 <code>valid_from</code>, <code>valid_until</code>, <code>observed_by</code>, <code>signature</code>)</li>
+      <li><code>src/db.rs</code> — schema v15 migration (entity_aliases, KG tables, temporal indexes)</li>
+      <li>v0.6.3 release notes — taxonomy, KG layer, capabilities v2, entity registry</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/architectures.html
+++ b/docs/architectures.html
@@ -1,0 +1,446 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  ai-memory architectures — five-tier capability matrix.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Architectures — five tiers from laptop to global hive</title>
+<meta name="description" content="Five reference architectures for ai-memory — from a single agent on a laptop to a globally federated hive of millions. With honest 'today vs roadmap' markers per v0.6.3.">
+<meta property="og:title" content="ai-memory · Architectures">
+<meta property="og:description" content="Five reference architectures for ai-memory — from one agent to a global hive.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/architectures.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem}
+p{color:var(--text-muted)}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3.25rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+/* Grouped dropdown menu */
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+/* capability badges */
+.cap-badge{display:inline-block;padding:.15em .55em;font-family:var(--font-mono);font-size:.7rem;font-weight:600;border-radius:4px;border:1px solid;letter-spacing:.04em;margin:.1em .15em}
+.cap-today{color:#6ee7ff;border-color:#2a6571;background:rgba(110,231,255,.08)}
+.cap-roadmap{color:#c8a2ff;border-color:#5a4280;background:rgba(200,162,255,.08)}
+.cap-partial{color:#ffb86b;border-color:#7a5328;background:rgba(255,184,107,.08)}
+.cap-future{color:#ff6b9d;border-color:#7a3251;background:rgba(255,107,157,.08)}
+
+/* arch tier grid */
+.arch-tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;margin:1.5rem 0 2.5rem}
+.arch-tier-card{display:block;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.4rem;text-decoration:none;color:var(--text);transition:border-color .15s ease,transform .15s ease;position:relative}
+.arch-tier-card:hover{border-color:var(--p1);transform:translateY(-2px)}
+.arch-tier-card .tier-id{display:inline-block;font-family:var(--font-mono);font-size:.7rem;font-weight:700;letter-spacing:.12em;color:var(--p2);background:rgba(255,184,107,.08);border:1px solid #7a5328;padding:.2em .55em;border-radius:4px;margin-bottom:.65rem}
+.arch-tier-card h3{font-family:var(--font-sans);font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:.45rem;letter-spacing:-0.01em}
+.arch-tier-card p{font-size:.88rem;color:var(--text-muted);margin-bottom:.75rem;line-height:1.5}
+.arch-tier-card .tier-scale{display:block;font-family:var(--font-mono);font-size:.68rem;color:var(--text-dim);letter-spacing:.04em;margin-bottom:.6rem}
+
+/* tier matrix table */
+.tier-matrix{width:100%;border-collapse:collapse;margin:1rem 0 2rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+.tier-matrix th,.tier-matrix td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+.tier-matrix th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+.tier-matrix th:not(:first-child),.tier-matrix td:not(:first-child){text-align:center;width:11%}
+.tier-matrix td{color:var(--text-muted)}
+.tier-matrix tr:last-child td{border-bottom:none}
+.tier-matrix tr:hover td{background:var(--bg-elev)}
+
+/* honesty notice */
+.honesty-notice{background:rgba(110,231,255,.05);border:1px solid #2a6571;border-left:4px solid var(--p1);border-radius:8px;padding:1.1rem 1.25rem;margin:2rem 0;color:var(--text-muted);font-size:.9rem;line-height:1.6}
+.honesty-notice strong{color:var(--p1);font-family:var(--font-mono);font-size:.82rem;letter-spacing:.05em}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.35rem}
+section h2{font-family:var(--font-sans);font-size:1.75rem;margin-bottom:.6rem}
+section p{margin-bottom:.85rem}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Architectures</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html" class="current">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>ai-memory architectures</h1>
+  <p class="tagline">A primitive that scales from <strong>one agent</strong> on a laptop to a <strong>global hive</strong> of millions. Every tier ships either today, or sits behind a documented gap with a known roadmap. Nothing on this page is marketing fiction — every "today" claim cites code in the v0.6.3 source tree.</p>
+  <div class="pills">
+    <span class="pill">5 tiers</span>
+    <span class="pill">T1–T3 ship today</span>
+    <span class="pill">T4 partial · v0.7 GA</span>
+    <span class="pill">T5 vision · v1.0+</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">The five tiers</span>
+    <h2>From single agent to global collective.</h2>
+    <p class="lede">Each tier is a deployment pattern. Each inherits everything below it. Click a card for the full diagram, narrative, and deployment recipe.</p>
+
+    <div class="arch-tier-grid">
+
+      <a href="architectures-t1.html" class="arch-tier-card">
+        <span class="tier-id">TIER 1</span>
+        <h3>Single node, single agent</h3>
+        <p>One ai-memory instance, one consumer. SQLite, no network, zero ops. The bedrock primitive.</p>
+        <span class="tier-scale">SCALE: 1 node · 1 agent · ~10⁶ memories</span>
+        <span class="cap-badge cap-today">SHIPS TODAY</span>
+      </a>
+
+      <a href="architectures-t2.html" class="arch-tier-card">
+        <span class="tier-id">TIER 2</span>
+        <h3>Single node, many agents</h3>
+        <p>One instance fanned across ~10 concurrent agents, each isolated by namespace + scope visibility, gated by per-namespace governance.</p>
+        <span class="tier-scale">SCALE: 1 node · 10 agents · namespace-isolated</span>
+        <span class="cap-badge cap-today">SHIPS TODAY</span>
+      </a>
+
+      <a href="architectures-t3.html" class="arch-tier-card">
+        <span class="tier-id">TIER 3</span>
+        <h3>Multi-node cluster</h3>
+        <p>4 nodes × 5 agents with <strong>W-of-N quorum writes</strong>, mTLS fingerprint allowlist, federated governance, vector-clock catch-up — all shipping today.</p>
+        <span class="tier-scale">SCALE: 4 nodes · 20 agents · quorum-bounded</span>
+        <span class="cap-badge cap-today">SHIPS TODAY</span>
+      </a>
+
+      <a href="architectures-t4.html" class="arch-tier-card">
+        <span class="tier-id">TIER 4</span>
+        <h3>Data-center swarm</h3>
+        <p>Multi-rack deployment with quorum writes shipping today; <strong>Postgres+pgvector backbone</strong> behind <code>sal-postgres</code> feature flag, GA targeted v0.7.</p>
+        <span class="tier-scale">SCALE: 100s nodes · 1000s agents · racked &amp; zoned</span>
+        <span class="cap-badge cap-today">CORE TODAY</span>
+        <span class="cap-badge cap-roadmap">PG GA · v0.7</span>
+      </a>
+
+      <a href="architectures-t5.html" class="arch-tier-card">
+        <span class="tier-id">TIER 5</span>
+        <h3>Global hive</h3>
+        <p>Multi-region cloud, attested agent identity, federated governance, hundreds of thousands to millions of agents acting as a unified collective.</p>
+        <span class="tier-scale">SCALE: multi-region · 10⁵–10⁶ agents · attested</span>
+        <span class="cap-badge cap-future">VISION v1.0+</span>
+      </a>
+
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Capability matrix</span>
+    <h2>What ships today vs. what's on the road.</h2>
+    <p class="lede">The honest matrix. Cell colors match the badges above.</p>
+
+    <table class="tier-matrix">
+      <thead>
+        <tr>
+          <th>Capability</th>
+          <th>T1</th>
+          <th>T2</th>
+          <th>T3</th>
+          <th>T4</th>
+          <th>T5</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>SQLite-backed store, FTS5 keyword recall</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-roadmap">→ pgvector</span></td>
+          <td><span class="cap-badge cap-roadmap">→ pgvector</span></td>
+        </tr>
+        <tr>
+          <td>Semantic recall (HNSW, MiniLM 384-dim)</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">per-node</span></td>
+          <td><span class="cap-badge cap-roadmap">shared idx</span></td>
+          <td><span class="cap-badge cap-roadmap">shared idx</span></td>
+        </tr>
+        <tr>
+          <td>Namespace isolation + scope visibility (<code>as_agent</code>)</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Per-namespace governance policy</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Pending-approval gates (write/promote/delete)</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Knowledge-graph w/ temporal validity (v0.6.3)</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Hierarchical taxonomy (<code>memory_get_taxonomy</code>)</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Capabilities introspection v2 (v0.6.3)</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>One-way <code>sync_push</code> fanout (memories, links, governance, pending)</td>
+          <td>n/a</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Vector-clock causality (<code>sync/since</code>)</td>
+          <td>n/a</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Quorum-write contract (W-of-N peer ack)</td>
+          <td>n/a</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>mTLS peer mesh + fingerprint allowlist</td>
+          <td>n/a</td>
+          <td>n/a</td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+          <td><span class="cap-badge cap-today">YES</span></td>
+        </tr>
+        <tr>
+          <td>Postgres + pgvector backend</td>
+          <td><span class="cap-badge cap-partial">feature flag</span></td>
+          <td><span class="cap-badge cap-partial">feature flag</span></td>
+          <td><span class="cap-badge cap-partial">feature flag</span></td>
+          <td><span class="cap-badge cap-roadmap">GA · v0.7</span></td>
+          <td><span class="cap-badge cap-roadmap">GA · v0.7</span></td>
+        </tr>
+        <tr>
+          <td>Cryptographic agent attestation (<code>signature</code> field)</td>
+          <td>—</td>
+          <td>—</td>
+          <td><span class="cap-badge cap-roadmap">field reserved</span></td>
+          <td><span class="cap-badge cap-roadmap">v0.7</span></td>
+          <td><span class="cap-badge cap-future">v1.0+</span></td>
+        </tr>
+        <tr>
+          <td>Distributed consensus (Raft / Paxos)</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+          <td><span class="cap-badge cap-future">v1.0+</span></td>
+        </tr>
+        <tr>
+          <td>Gossip / DHT for many-node discovery</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+          <td><span class="cap-badge cap-roadmap">scoped</span></td>
+          <td><span class="cap-badge cap-future">required</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Composition</span>
+    <h2>Why a layered architecture story.</h2>
+    <p>ai-memory is a <strong>primitive, not a platform</strong>. The same Rust binary, the same data model, the same MCP protocol surface scales from a developer's <code>~/.claude/ai-memory.db</code> to a fleet running across racks. What changes between tiers:</p>
+    <ul>
+      <li><strong>Topology</strong> — one process, then many, then many on many machines.</li>
+      <li><strong>Consistency model</strong> — single-writer atomic → eventually consistent peer mesh → quorum → consensus.</li>
+      <li><strong>Trust boundary</strong> — local trust → namespace + scope → governance policy → attested identity.</li>
+    </ul>
+    <p>What stays the same:</p>
+    <ul>
+      <li>The 43 MCP tools and 42 HTTP endpoints.</li>
+      <li>The recall pipeline (FTS5 + HNSW + adaptive blending).</li>
+      <li>The tier model (<code>short</code> / <code>mid</code> / <code>long</code>).</li>
+      <li>The namespace hierarchy and scope visibility filter.</li>
+      <li>The governance contract (<code>Allow</code> / <code>Deny</code> / <code>Pending</code>).</li>
+    </ul>
+    <p>Every tier inherits everything below it.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Federation primitives</span>
+    <h2>What lives in the codebase today.</h2>
+    <p class="lede">These are the building blocks every multi-node tier composes. All shipped, all in v0.6.3:</p>
+    <ul>
+      <li><code>src/main.rs:405-447</code> — quorum-write CLI surface: <code>--quorum-writes N</code>, <code>--quorum-peers &lt;comma-list&gt;</code>, <code>--quorum-timeout-ms</code>, <code>--quorum-client-cert/-key/-ca-cert</code>, <code>--catchup-interval-secs</code>.</li>
+      <li><code>src/main.rs:380-393</code> — TLS / mTLS allowlist: <code>--tls-cert</code>, <code>--tls-key</code>, <code>--mtls-allowlist &lt;SHA-256 fingerprint file&gt;</code>. Allowlist presence enforces mTLS.</li>
+      <li><code>src/handlers.rs:442-454</code> — <code>broadcast_store_quorum</code> + <code>finalise_quorum</code> wired into the write path; returns <code>200 OK</code> with <code>quorum_acks</code> on success, <code>503 quorum_not_met</code> on timeout.</li>
+      <li><code>src/federation.rs</code> — <strong>10 broadcast functions</strong>: <code>broadcast_store_quorum</code>, <code>broadcast_delete_quorum</code>, <code>broadcast_archive_quorum</code>, <code>broadcast_restore_quorum</code>, <code>broadcast_link_quorum</code>, <code>broadcast_consolidate_quorum</code>, <code>broadcast_pending_quorum</code>, <code>broadcast_pending_decision_quorum</code>, <code>broadcast_namespace_meta_quorum</code>, <code>broadcast_namespace_meta_clear_quorum</code>.</li>
+      <li><code>src/handlers.rs</code> — <code>POST /api/v1/sync/push</code> accepts memories, deletions, archives, links, pending actions, pending decisions, namespace metadata, and (v0.6.3) entity registrations. <code>GET /api/v1/sync/since?peer=&lt;id&gt;&amp;clock=&lt;n&gt;</code> returns causally-correct deltas for a rejoining peer.</li>
+      <li><code>src/db.rs</code> — <code>compute_visibility_prefixes()</code> + <code>visibility_clause()</code> enforce scope-based recall filtering at the SQL level using the indexed <code>scope_idx</code> generated column.</li>
+      <li><code>src/models.rs</code> — <code>GovernancePolicy</code> per-namespace, <code>PendingAction</code> queue, <code>namespace_ancestors()</code> for visibility hierarchy.</li>
+      <li><code>src/replication.rs</code> (422 lines) — <code>QuorumWriter</code> + <code>AckTracker</code>, <strong>functional</strong>, wired into the write path.</li>
+      <li><code>Cargo.toml</code> — <code>sal-postgres</code> feature flag for the v0.7 GA Postgres+pgvector backbone (<code>sqlx</code> + <code>pgvector</code> deps, schema parity fixes shipped #294-#297).</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">How to read</span>
+    <h2>Each tier page contains.</h2>
+    <ol>
+      <li>An <strong>animated SVG diagram</strong> showing memory data flow — writes, recalls, peer sync, governance gates, and (where relevant) attestations.</li>
+      <li>A <strong>"what's actually happening"</strong> narrative walking the reader through a recall and a write.</li>
+      <li><strong>Capability badges</strong> on every primitive — cyan ships today, orange partial, purple roadmap, pink future vision.</li>
+      <li>A <strong>deployment recipe</strong> with real commands.</li>
+      <li><strong>Governance, skills, and attestations</strong> wiring for the tier — what enforces the rules at this scale.</li>
+      <li><strong>Honest limits</strong> — what would break, and at what scale.</li>
+    </ol>
+    <p>Start at <a href="architectures-t1.html" style="color:var(--p1)">Tier 1</a> and walk forward, or jump straight to the tier that matches your fleet.</p>
+
+    <div class="honesty-notice">
+      <strong>Engineering honesty.</strong> Every "ships today" claim cites a file path and behavior in the v0.6.3 source tree. Roadmap items reference ADRs and tracked work. The vision tier (T5) is the north star — we'll get there, but it's not shipping in v0.7. If a diagram shows something the code doesn't do, that's a documentation bug — please file an issue.
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/archival.html
+++ b/docs/archival.html
@@ -91,14 +91,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Archival</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -116,6 +118,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -129,8 +143,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -1286,7 +1286,7 @@ footer.site-foot a { color: var(--text-muted); }
     <span class="eyebrow">Test Quality</span>
     <h2>1,600 tests. Every module above 79%.</h2>
     <p class="lede">
-      The v0.6.3 coverage campaign took ai-memory from 56.7% line coverage to 93.05% across 9 waves of parallel agent work. 26 closers shipped ~1,200 net new tests over the ~30K-line Rust codebase. Full report: <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/release/v0.6.3/audits/v063-coverage-80pct/CAMPAIGN-FINAL-METRICS.md" style="color:var(--pillar-1)">CAMPAIGN-FINAL-METRICS.md</a>
+      The v0.6.3 coverage campaign took ai-memory from 56.7% line coverage to 93.08% across 9 waves of parallel agent work. 26 closers shipped ~1,200 net new tests over the ~30K-line Rust codebase. Full report: <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/release/v0.6.3/audits/v063-coverage-80pct/CAMPAIGN-FINAL-METRICS.md" style="color:var(--pillar-1)">CAMPAIGN-FINAL-METRICS.md</a>
     </p>
 
     <div class="grid-2" style="margin-bottom:2.5rem;">

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -760,14 +760,16 @@ footer.site-foot a { color: var(--text-muted); }
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ At a Glance</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
-        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html" class="current">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -785,6 +787,18 @@ footer.site-foot a { color: var(--text-muted); }
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -798,8 +812,9 @@ footer.site-foot a { color: var(--text-muted); }
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
@@ -880,8 +895,8 @@ footer.site-foot a { color: var(--text-muted); }
   </div>
 
   <div class="pillars-icons" aria-hidden="true" style="margin-top:2.5rem;">
-    <span class="pillar-icon"><span class="dot p1"></span> 93.05% test coverage</span>
-    <span class="pillar-icon"><span class="dot p2"></span> 1,809 tests passing</span>
+    <span class="pillar-icon"><span class="dot p1"></span> 93.08% test coverage</span>
+    <span class="pillar-icon"><span class="dot p2"></span> 1,600 tests passing</span>
     <span class="pillar-icon"><span class="dot p3"></span> Apache-2.0 licensed</span>
   </div>
 </section>
@@ -1269,7 +1284,7 @@ footer.site-foot a { color: var(--text-muted); }
 <section id="quality">
   <div class="container">
     <span class="eyebrow">Test Quality</span>
-    <h2>1,809 tests. Every module above 79%.</h2>
+    <h2>1,600 tests. Every module above 79%.</h2>
     <p class="lede">
       The v0.6.3 coverage campaign took ai-memory from 56.7% line coverage to 93.05% across 9 waves of parallel agent work. 26 closers shipped ~1,200 net new tests over the ~30K-line Rust codebase. Full report: <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/release/v0.6.3/audits/v063-coverage-80pct/CAMPAIGN-FINAL-METRICS.md" style="color:var(--pillar-1)">CAMPAIGN-FINAL-METRICS.md</a>
     </p>
@@ -1282,7 +1297,7 @@ footer.site-foot a { color: var(--text-muted); }
       </div>
       <div class="dash-tile p1">
         <div class="dash-label">Total tests passing</div>
-        <div class="dash-num">1,809</div>
+        <div class="dash-num">1,600</div>
         <div class="dash-sub">0 failed · 0 ignored · 4 platforms</div>
       </div>
     </div>
@@ -1570,7 +1585,7 @@ footer.site-foot a { color: var(--text-muted); }
             <li>Hierarchical namespace paths (<code>projects/alpha/decisions</code>)</li>
             <li>Temporal-validity knowledge graph (recursive CTE today, AGE-ready for v0.7)</li>
             <li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>
-            <li>93.05% test coverage (1,809 tests passing across 4 platforms)</li>
+            <li>93.08% test coverage (1,600 tests passing across 4 platforms)</li>
             <li>Two SSRF defects discovered during campaign — fixed before tag</li>
           </ul>
         </div>
@@ -1766,7 +1781,7 @@ footer.site-foot a { color: var(--text-muted); }
       </div>
       <div class="dash-tile good">
         <div class="dash-label">Tests passing</div>
-        <div class="dash-num">1,809</div>
+        <div class="dash-num">1,600</div>
         <div class="dash-sub">0 failed · 0 ignored</div>
       </div>
       <div class="dash-tile p2">

--- a/docs/autonomous.html
+++ b/docs/autonomous.html
@@ -107,14 +107,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Autonomous</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -132,6 +134,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -145,8 +159,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/credits.html
+++ b/docs/credits.html
@@ -72,14 +72,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Credits</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -97,6 +99,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -110,8 +124,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
@@ -119,7 +134,7 @@ footer a{color:var(--text-muted)}
           <a href="performance.html">Performance budgets</a>
         </div>
       </div>
-      <a href="credits.html" class="current">Credits</a>
+      <a href="credits.html">Credits</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
     </div>
   </div>

--- a/docs/data-flow.html
+++ b/docs/data-flow.html
@@ -90,14 +90,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Data Flow</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html" class="current">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -115,6 +117,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -128,8 +142,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/encryption.html
+++ b/docs/encryption.html
@@ -98,14 +98,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Encryption</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -123,6 +125,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -136,8 +150,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -169,6 +169,12 @@ footer a{color:var(--text-muted)}
       Every public page about ai-memory — README, marketing site, roadmap, architecture pages, sales decks — must source its numbers from this page or from the upstream test-hub evidence it cites.
       No other page invents its own counts. If a number on another page disagrees with this page, this page is correct and the other is a bug — please <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/new">file an issue</a>.
     </p>
+    <div style="display:flex;justify-content:center;gap:.75rem;flex-wrap:wrap;margin-top:1.75rem">
+      <a href="https://alphaonedev.github.io/ai-memory-test-hub/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--p1);color:var(--p1);background:rgba(110,231,255,.06);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;font-weight:600;text-decoration:none">🧪 Live test-hub →</a>
+      <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--p2);color:var(--p2);background:rgba(255,184,107,.06);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;font-weight:600;text-decoration:none">📊 v0.6.3 release evidence →</a>
+      <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--text-muted);color:var(--text-muted);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;text-decoration:none">🚢 ship-gate</a>
+      <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--text-muted);color:var(--text-muted);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;text-decoration:none">🤝 A2A-gate</a>
+    </div>
   </div>
 </section>
 

--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -1,0 +1,312 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  CANONICAL EVIDENCE PAGE — single source of truth for ai-memory public claims.
+
+  Every site, README, roadmap, sales doc, and architecture page must source its
+  numbers from this page (or from the upstream test-hub release evidence that
+  this page cites). No other public page should invent its own numbers.
+
+  Numbers below are FROZEN for the named release. To update, you must:
+    1. Cut a new release tag.
+    2. Run the full test/coverage matrix on test-hub.
+    3. Update this page first, then sweep all references in /docs/ and README.md.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Evidence — frozen public claims for v0.6.3</title>
+<meta name="description" content="Canonical evidence page for ai-memory v0.6.3. Frozen test count, coverage, MCP tool count, HTTP endpoint count, CLI command count, federation status, and certification status. Single source of truth — every other public page sources its numbers from here.">
+<meta name="theme-color" content="#0d1117">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/evidence.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1100px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--p1);text-decoration:none}a:hover{text-decoration:underline}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px;color:var(--p2)}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}
+h2{font-size:1.6rem;margin:2rem 0 .5rem;font-family:var(--font-mono)}
+h3{font-size:1.05rem;margin:1.25rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:1280px;margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;align-items:center;flex-wrap:wrap}
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn,.topnav .menu:hover .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+.hero{padding:3.5rem 1.5rem 2rem;text-align:center;border-bottom:1px solid var(--border);background:radial-gradient(ellipse at center,rgba(110,231,255,.06),transparent 60%)}
+.hero h1{font-size:clamp(1.8rem,4vw,2.6rem);line-height:1.15;margin-bottom:.85rem}
+.hero .lead{color:var(--text-muted);max-width:780px;margin:0 auto;font-size:1rem}
+.frozen-badge{display:inline-block;background:rgba(110,231,255,.12);border:1px solid var(--p1);color:var(--p1);font-family:var(--font-mono);font-size:.75rem;padding:.3rem .8rem;border-radius:4px;letter-spacing:.05em;margin-bottom:1rem}
+
+section{padding:2.5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+
+.facts{width:100%;border-collapse:collapse;font-family:var(--font-mono);font-size:.9rem;margin:1rem 0}
+.facts th{text-align:left;padding:.65rem .9rem;background:var(--bg-elev);color:var(--text);font-weight:600;border-bottom:1px solid var(--border-hl);font-size:.78rem;letter-spacing:.05em;text-transform:uppercase}
+.facts td{padding:.65rem .9rem;border-bottom:1px solid var(--border);vertical-align:top}
+.facts tr:hover td{background:var(--bg-card)}
+.facts .num{color:var(--good);font-weight:600;white-space:nowrap}
+.facts .src{color:var(--text-dim);font-size:.78rem}
+.facts .src a{color:var(--text-muted)}
+
+.status-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;margin-top:1rem}
+.status-card{background:var(--bg-card);border:1px solid var(--border);border-left:3px solid var(--p1);border-radius:6px;padding:1rem 1.2rem}
+.status-card.beta{border-left-color:var(--p2)}
+.status-card.experimental{border-left-color:var(--gold)}
+.status-card.production{border-left-color:var(--good)}
+.status-card.unsupported{border-left-color:var(--bad)}
+.status-card h3{font-family:var(--font-mono);font-size:.95rem;margin-bottom:.4rem;color:var(--text)}
+.status-card .tag{display:inline-block;font-family:var(--font-mono);font-size:.7rem;padding:.15em .55em;border-radius:4px;margin-right:.4em;letter-spacing:.05em;text-transform:uppercase}
+.status-card.production .tag{background:rgba(110,231,255,.12);color:var(--p1);border:1px solid #2a6571}
+.status-card.beta .tag{background:rgba(255,184,107,.12);color:var(--p2);border:1px solid #7a5328}
+.status-card.experimental .tag{background:rgba(255,215,0,.12);color:var(--gold);border:1px solid #6a5e10}
+.status-card.unsupported .tag{background:rgba(255,107,157,.12);color:var(--bad);border:1px solid #7a3251}
+.status-card p{font-size:.85rem;margin-bottom:0;color:var(--text-muted)}
+
+.callout{background:var(--bg-card);border:1px solid var(--border-hl);border-left:3px solid var(--p2);border-radius:6px;padding:1rem 1.25rem;margin:1.5rem 0}
+.callout strong{color:var(--text)}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Evidence</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn active">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html" class="current">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <div class="container">
+    <span class="frozen-badge">FROZEN · v0.6.3 · 2026-04-24</span>
+    <h1>The single source of truth.</h1>
+    <p class="lead">
+      Every public page about ai-memory — README, marketing site, roadmap, architecture pages, sales decks — must source its numbers from this page or from the upstream test-hub evidence it cites.
+      No other page invents its own counts. If a number on another page disagrees with this page, this page is correct and the other is a bug — please <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/new">file an issue</a>.
+    </p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Frozen facts · v0.6.3</span>
+    <h2>The numbers.</h2>
+    <p>All values below are taken from the v0.6.3 release evidence published on the test-hub, or counted directly from the v0.6.3 source tree. Source links accompany each row.</p>
+    <table class="facts">
+      <thead>
+        <tr><th>Field</th><th>Value</th><th>Source of truth</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Current release</td><td class="num">v0.6.3</td><td class="src">git tag <code>v0.6.3</code> on <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3">main</a> · cut 2026-04-24</td></tr>
+        <tr><td>Test count (lib)</td><td class="num">1,600</td><td class="src">Tier 1 row of the <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence page</a> — "1 600/1 600 lib tests pass"</td></tr>
+        <tr><td>Test coverage</td><td class="num">93.08%</td><td class="src">Tier 1 row of the <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence page</a> · cargo llvm-cov · gate ≥92%</td></tr>
+        <tr><td>MCP tools (unique)</td><td class="num">43</td><td class="src">Counted from <code>tool_definitions()</code> in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/mcp.rs">src/mcp.rs</a></td></tr>
+        <tr><td>HTTP endpoints (unique routes)</td><td class="num">42</td><td class="src">Counted from <code>.route(...)</code> calls across <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/handlers.rs">handlers.rs</a> + <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/federation.rs">federation.rs</a> + <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/lib.rs">lib.rs</a></td></tr>
+        <tr><td>CLI commands</td><td class="num">26</td><td class="src">Counted from the <code>Command</code> enum + dispatch in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/main.rs">src/main.rs</a></td></tr>
+        <tr><td>CI matrix platforms</td><td class="num">3</td><td class="src">ubuntu-latest · macos-latest · windows-latest — see <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/.github/workflows/ci.yml"><code>.github/workflows/ci.yml</code></a></td></tr>
+        <tr><td>LongMemEval Recall@5</td><td class="num">97.8%</td><td class="src">489/500 questions · ICLR 2025 benchmark · pure SQLite FTS5+BM25 · zero cloud — see <a href="performance.html">performance.html</a></td></tr>
+        <tr><td>Schema version</td><td class="num">v15</td><td class="src">v0.6.3 KG temporal-validity migration · see <a href="schema.html">schema.html</a></td></tr>
+      </tbody>
+    </table>
+    <div class="callout">
+      <strong>Note on test-count drift across older pages.</strong> Some older pages reference 191 tests (~v0.6.0 era) or 1,809 tests (mid-v0.6.3 dev cycle). The frozen v0.6.3 release figure is <strong>1,600 lib tests</strong> as published on the test-hub at release-cut. The 1,898 figure from a raw <code>grep #[test]</code> includes attributes inside <code>#[cfg(test)]</code> guards that are not always compiled, plus benchmark scaffolding — it is <em>not</em> the canonical test-pass count. Use 1,600 lib tests as the public number.
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Maturity</span>
+    <h2>What is production-ready, what is not.</h2>
+    <p>This is where conflicting maturity signals on other pages get resolved. Use these labels — and only these labels — when describing capability maturity in any public material.</p>
+    <div class="status-grid">
+
+      <div class="status-card production">
+        <span class="tag">Production-ready</span>
+        <h3>Single-node operation</h3>
+        <p>One ai-memory instance, one consumer. SQLite + WAL + FTS5 + HNSW. No network, no peers. Used in production by the project team daily. T1 + T2 of the architectures matrix.</p>
+      </div>
+
+      <div class="status-card production">
+        <span class="tag">Production-ready</span>
+        <h3>Hybrid recall (FTS5 + semantic)</h3>
+        <p>Adaptive blend, cross-encoder rerank, recency decay, tier boost. 97.8% Recall@5 on LongMemEval (ICLR 2025).</p>
+      </div>
+
+      <div class="status-card production">
+        <span class="tag">Production-ready</span>
+        <h3>MCP + HTTP + CLI surface</h3>
+        <p>43 MCP tools, 42 HTTP routes, 26 CLI commands. Stable contract. Used by Claude Code, Codex, Cursor, Windsurf, Continue.dev, Grok, OpenClaw, Hermes, and Llama integrations today.</p>
+      </div>
+
+      <div class="status-card production">
+        <span class="tag">Production-ready</span>
+        <h3>Per-namespace governance</h3>
+        <p>Allow / Deny / Pending policies; pending-approval queue; scope-visibility filter; immutable agent_id provenance. v0.6.2+ stable.</p>
+      </div>
+
+      <div class="status-card beta">
+        <span class="tag">Beta</span>
+        <h3>Federation — quorum writes (W-of-N)</h3>
+        <p>Code shipped in v0.6.3: 10 broadcast functions, ack tracker, vector-clock catchup, mTLS fingerprint allowlist. Used in T3 (multi-node cluster) tests on the ship-gate. <strong>Not yet recommended for self-driving production fleets without an operator-on-call.</strong> See <a href="architectures-t3.html">T3 architecture</a> for what's wired and what's not.</p>
+      </div>
+
+      <div class="status-card experimental">
+        <span class="tag">Experimental</span>
+        <h3>Postgres + pgvector backend</h3>
+        <p><code>sal-postgres</code> Cargo feature flag in v0.6.3. Schema-parity fixes shipping #294-#297. <strong>GA target: v0.7.</strong> Not for production until v0.7 ships.</p>
+      </div>
+
+      <div class="status-card experimental">
+        <span class="tag">Experimental</span>
+        <h3>Smart / Autonomous tier (Ollama LLM)</h3>
+        <p>Query expansion, auto-tagging, contradiction detection, cross-encoder reranking via Ollama (Gemma 4 e2b/e4b). Functional and tested but performance/quality varies by host hardware. Production use should pin model versions and run baseline recall regressions.</p>
+      </div>
+
+      <div class="status-card unsupported">
+        <span class="tag">Unsupported (today)</span>
+        <h3>Cryptographic agent attestation</h3>
+        <p>The <code>memory_links.signature</code> field is <em>reserved</em> in schema v15 but not signed/verified by the binary today. <code>agent_id</code> today is <em>claimed</em>, not <em>attested</em>. Do not make security decisions on <code>agent_id</code> alone. Attestation lands in v0.7.</p>
+      </div>
+
+      <div class="status-card unsupported">
+        <span class="tag">Unsupported (today)</span>
+        <h3>Multi-region distributed consensus</h3>
+        <p>No Raft, no Paxos, no global gossip/DHT. Tier 5 ("global hive") of the architectures matrix is <em>vision</em> — v1.0+ horizon. Don't deploy ai-memory across regions today expecting strong consistency.</p>
+      </div>
+
+    </div>
+
+    <div class="callout">
+      <strong>Reconciling the "is not a distributed system" claim in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/ADMIN_GUIDE.md">ADMIN_GUIDE.md</a>.</strong>
+      The admin guide is correct in spirit and historically lagged the v0.6.3 federation work. The accurate v0.6.3 framing is:
+      <strong>ai-memory is a single-machine primitive that ships beta-quality federation primitives (quorum writes, mTLS peer mesh, vector-clock catchup) for opt-in multi-node clusters (T3).</strong>
+      It is not a distributed database. It does not provide strong consistency, distributed consensus, or self-healing global state. Operators choosing to run a federated cluster today must accept beta-quality replication and own their consistency guarantees at the application layer.
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Certification</span>
+    <h2>Current certification status.</h2>
+    <p>ai-memory v0.6.3 holds the following internal certifications. External (third-party) audits and compliance attestations are <strong>not yet held</strong> for any release; do not represent ai-memory as SOC 2, ISO 27001, FedRAMP, or HIPAA-compliant.</p>
+    <table class="facts">
+      <thead><tr><th>Certification</th><th>Status</th><th>Authority</th></tr></thead>
+      <tbody>
+        <tr><td>A2A-Certified (internal)</td><td class="num">Yes</td><td class="src"><a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A gate</a> · v0.6.2 + v0.6.3</td></tr>
+        <tr><td>Ship-Gate (internal)</td><td class="num">Yes</td><td class="src"><a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship gate</a> · 9/9 cert + 5/5 channels green at v0.6.2 cut</td></tr>
+        <tr><td>SOC 2</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
+        <tr><td>ISO 27001</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
+        <tr><td>FedRAMP</td><td class="num">No</td><td class="src">No authorization. Do not represent.</td></tr>
+        <tr><td>HIPAA</td><td class="num">No</td><td class="src">No BAA. Do not represent.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Authoring rule</span>
+    <h2>How to keep this page canonical.</h2>
+    <ol style="color:var(--text-muted);padding-left:1.5rem;line-height:1.8">
+      <li>Cut a release tag.</li>
+      <li>Run the full ship-gate matrix; publish a release evidence page at <code>test-hub/releases/vX.Y.Z/</code>.</li>
+      <li>Update <code>docs/evidence.html</code> first — the hero <code>FROZEN</code> badge, every row of the facts table, and every status card whose maturity has changed.</li>
+      <li>Sweep all references: <code>grep -rE "(191|1,?[0-9]{3})\s*test|9[0-9]\.[0-9]+%\s*coverage|v0\.6\.[0-9]" docs/ README.md</code> — every match either updates to the new canonical number or replaces with a link to <code>evidence.html</code>.</li>
+      <li>Open one PR for the sweep. Block release until it merges.</li>
+    </ol>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/feature-matrix.html
+++ b/docs/feature-matrix.html
@@ -171,14 +171,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Feature Matrix</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html" class="current">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -196,6 +198,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -209,8 +223,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/feature-matrix.html
+++ b/docs/feature-matrix.html
@@ -12,7 +12,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ai-memory · Feature Matrix — every tool, endpoint, command</title>
-<meta name="description" content="Complete surface-area atlas: 26 MCP tools, 39 HTTP endpoints, 28 CLI commands. Every operation cross-referenced across the three protocol fronts.">
+<meta name="description" content="Complete surface-area atlas: 43 MCP tools, 42 HTTP endpoints, 26 CLI commands (canonical counts on the evidence page). Every operation cross-referenced across the three protocol fronts.">
 <meta name="theme-color" content="#0d1117">
 <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/feature-matrix.html">
 <style>
@@ -295,7 +295,7 @@ footer a{color:var(--text-muted)}
 <!-- =============== MCP TOOLS =============== -->
 <section id="mcp-tools">
   <div class="container">
-    <span class="eyebrow">26 MCP Tools</span>
+    <span class="eyebrow">43 MCP Tools</span>
     <h2>Every tool a host AI can call.</h2>
     <p class="lede">Auto-discovered by Claude Code, Cursor, Codex, Continue, Gemini CLI, Windsurf, and any MCP-compliant client. Tool names follow <code>memory_&lt;verb&gt;</code> convention.</p>
 
@@ -549,7 +549,7 @@ footer a{color:var(--text-muted)}
 <!-- =============== HTTP ENDPOINTS =============== -->
 <section id="http-endpoints">
   <div class="container">
-    <span class="eyebrow">39 HTTP Endpoints</span>
+    <span class="eyebrow">42 HTTP Endpoints</span>
     <h2>REST surface for services + federation peers.</h2>
     <p class="lede">Axum-served. mTLS-aware. CORS layer. Prometheus metrics at <code>/metrics</code>. Body limit 2 MiB. Trace spans on every request. The same operations as MCP, plus federation-private peer endpoints.</p>
 
@@ -641,7 +641,7 @@ footer a{color:var(--text-muted)}
 <!-- =============== CLI =============== -->
 <section id="cli-commands">
   <div class="container">
-    <span class="eyebrow">28 CLI Commands</span>
+    <span class="eyebrow">26 CLI Commands</span>
     <h2>For humans, scripts, and CI.</h2>
     <p class="lede">Direct subcommands of the <code>ai-memory</code> binary. No daemon required for read/write commands. Run against any database file via <code>--db &lt;path&gt;</code>.</p>
 

--- a/docs/for-everyone.html
+++ b/docs/for-everyone.html
@@ -104,14 +104,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ For Everyone</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html" class="current">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html" class="current">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -129,6 +131,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -142,8 +156,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
@@ -404,8 +419,8 @@ ai-memory mcp --tier autonomous</pre>
         <p style="font-size:.9rem">Commercial-friendly license. Patent grant included. <strong>You can read every line, fork it, sell what you build on top.</strong></p>
       </div>
       <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
-        <h3 style="margin-bottom:.5rem">93.05% test coverage</h3>
-        <p style="font-size:.9rem">1,809 tests. Zero ignored. Four-platform CI (macOS / Ubuntu / Windows / Coverage). <strong>Every PR runs the full matrix.</strong></p>
+        <h3 style="margin-bottom:.5rem">93.08% test coverage</h3>
+        <p style="font-size:.9rem">1,600 lib tests. Zero ignored. Four-platform CI (macOS / Ubuntu / Windows / Coverage). <strong>Every PR runs the full matrix.</strong></p>
       </div>
       <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
         <h3 style="margin-bottom:.5rem">Single binary</h3>

--- a/docs/governance.html
+++ b/docs/governance.html
@@ -104,14 +104,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Governance</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -129,6 +131,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -142,8 +156,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/hierarchies.html
+++ b/docs/hierarchies.html
@@ -92,14 +92,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Hierarchies</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -117,6 +119,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -130,8 +144,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/import-history.html
+++ b/docs/import-history.html
@@ -1,0 +1,360 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+  Import history — bring your Claude/ChatGPT/Slack exports into ai-memory.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ai-memory · Import your conversation history</title>
+<meta name="description" content="Make every AI you've ever talked to remember from day one. Paste your Claude / ChatGPT / Slack export — get an instant, ranked, recallable knowledge base.">
+<meta property="og:title" content="ai-memory · Import your conversation history">
+<meta property="og:description" content="Five minutes from blank slate to ranked, recallable memory across every project context you've ever explained.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/import-history.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--bad:#ff6b9d;--gold:#ffd700;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--text);text-decoration:none}a:hover{color:var(--p1)}
+code{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.82rem;background:var(--bg-code);padding:1rem 1.1rem;border-radius:8px;border:1px solid var(--border);overflow-x:auto;line-height:1.55;color:var(--text-muted);margin:1rem 0}
+pre code{padding:0;background:none;font-size:.82rem}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em}h2{font-size:1.6rem;margin-bottom:.5rem;font-family:var(--font-mono)}h3{font-size:1.05rem;margin:1.25rem 0 .35rem}
+p{color:var(--text-muted);margin-bottom:.85rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}.topnav a:hover{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.topnav .right{display:flex;gap:1.25rem;flex-wrap:wrap}@media(max-width:800px){.topnav .right{display:none}}
+.hero{padding:4rem 1.5rem 2.5rem;text-align:center;background:radial-gradient(ellipse at center,rgba(255,184,107,0.08),transparent 60%);border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(2rem,4.5vw,3rem);line-height:1.1;letter-spacing:-0.03em;margin-bottom:1rem}
+.hero .tagline{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin:0 auto 1rem}
+.hero .pills{display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;margin-top:1.25rem}
+.hero .pill{padding:.4rem 1rem;border:1px solid var(--border-hl);border-radius:999px;font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted)}
+
+section{padding:3rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem;padding:.2rem .6rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:.95rem;max-width:820px;margin-bottom:2rem}
+section h2{font-family:var(--font-sans);font-size:1.6rem;margin-bottom:.6rem}
+
+footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-dim);border-top:1px solid var(--border)}
+footer a{color:var(--text-muted)}
+
+.topnav .menu{position:relative;display:inline-block}
+.topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+.topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn{color:var(--text)}
+.topnav .menu-btn.active{color:var(--text)}
+.topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+.topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:var(--bg-card);border:1px solid var(--border-hl);border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,0.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+.topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+.topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+.topnav .menu-pane a:hover{background:var(--bg-elev);color:var(--text)}
+.topnav .menu-pane a.current{color:var(--p1);background:var(--bg-elev)}
+
+ul,ol{padding-left:1.5rem;color:var(--text-muted);font-size:.92rem;margin:.5rem 0 1rem}
+ul li,ol li{margin-bottom:.4rem}
+
+table{width:100%;border-collapse:collapse;margin:1rem 0 1.5rem;font-size:.85rem;background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+table th,table td{padding:.65rem .85rem;text-align:left;border-bottom:1px solid var(--border)}
+table th{background:var(--bg-elev);font-family:var(--font-mono);font-size:.78rem;font-weight:600;color:var(--text);letter-spacing:.04em}
+table td{color:var(--text-muted)}
+table tr:last-child td{border-bottom:none}
+
+blockquote{border-left:4px solid var(--p2);background:rgba(255,184,107,.05);padding:1rem 1.25rem;margin:1.25rem 0;border-radius:0 8px 8px 0;color:var(--text-muted)}
+blockquote strong{color:var(--p2)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Import History</span></a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html" class="current">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <h1>Import your conversation history</h1>
+  <p class="tagline">Make every AI you've ever talked to remember from day one. Paste your Claude / ChatGPT / Slack export — get an instant, ranked, recallable knowledge base.</p>
+  <div class="pills">
+    <span class="pill">Claude · ChatGPT · Slack</span>
+    <span class="pill">5-minute onboarding</span>
+    <span class="pill">first-class write path</span>
+    <span class="pill">ai-memory mine</span>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <blockquote>
+      <strong>Five minutes to a useful agent.</strong> Export your old AI conversations, run one command, and your next agent starts with everything the last one already knew.
+    </blockquote>
+    <p><code>ai-memory mine</code> parses Claude, ChatGPT, and Slack exports into ranked, tiered, recall-ready memories. No re-typing. No copy-paste. No loss of context across model changes.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Why</span>
+    <h2>Why retroactive import matters.</h2>
+    <p>Every AI conversation you've had is a body of decisions, corrections, preferences, and small facts your future agents will need. Today, when you switch tools or start a new context window, that knowledge evaporates. <code>mine</code> ingests it into your local SQLite store — and from that moment, <em>every</em> MCP-compatible AI you talk to recalls it.</p>
+    <p>This is the fastest path from <em>"new tool, blank slate"</em> to <em>"new tool, every project context I've ever explained."</em></p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Onboarding</span>
+    <h2>Five-minute onboarding.</h2>
+<pre><code># 1. Drop your export into the working directory
+ls conversations.json   # ChatGPT export
+# or
+ls claude-export/conversations.jsonl   # Claude export
+# or
+ls slack-export.zip   # extract first → ls slack-export/
+
+# 2. Dry-run to see what will land
+ai-memory mine ./conversations.json --format chatgpt --dry-run
+
+# 3. Import for real
+ai-memory mine ./conversations.json --format chatgpt
+
+# 4. Confirm + recall
+ai-memory stats
+ai-memory recall "what database did we decide on for the analytics service"</code></pre>
+    <p>That's it. Your next agent starts with an opinion.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">What gets imported</span>
+    <h2>Each conversation becomes one memory.</h2>
+    <p>Each conversation that survives the <code>--min-messages</code> threshold (default 3) becomes one memory:</p>
+    <table>
+      <thead>
+        <tr><th>Field</th><th>Source</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>title</code></td><td>First user message, truncated</td></tr>
+        <tr><td><code>content</code></td><td>Full conversation text — alternating user/assistant turns</td></tr>
+        <tr><td><code>tier</code></td><td><code>mid</code> by default (7-day TTL, auto-promotes to <code>long</code> after 5 recalls)</td></tr>
+        <tr><td><code>namespace</code></td><td>Auto-set per format: <code>claude-export</code>, <code>chatgpt-export</code>, <code>slack-export</code></td></tr>
+        <tr><td><code>source</code></td><td><code>mine-claude</code> / <code>mine-chatgpt</code> / <code>mine-slack</code></td></tr>
+        <tr><td><code>metadata.mined_from</code></td><td>Source format tag</td></tr>
+        <tr><td><code>metadata.agent_id</code></td><td>The caller's identity (you)</td></tr>
+        <tr><td><code>created_at</code></td><td>Original conversation timestamp</td></tr>
+      </tbody>
+    </table>
+    <p>Every imported memory is <strong>fully integrated</strong> with the rest of the system: scope visibility, governance gates, recall scoring, deduplication on <code>(title, namespace)</code>, link creation, consolidation. <code>mine</code> is not a sidecar — it's a first-class write path.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Per-format recipes</span>
+    <h2>Claude export.</h2>
+    <p>Claude exports give you a <code>conversations.jsonl</code> file (one JSON object per line — one conversation per line).</p>
+    <p><strong>Where to find it:</strong></p>
+    <ol>
+      <li>Open Claude → Settings → Privacy → Export data</li>
+      <li>Wait for the email; download the zip</li>
+      <li>Inside, find <code>conversations.jsonl</code></li>
+    </ol>
+    <p><strong>Import:</strong></p>
+<pre><code># Dry run first — see what will be imported, count + sizes
+ai-memory mine ./claude-export/conversations.jsonl --format claude --dry-run
+
+# Real import, default mid-tier
+ai-memory mine ./claude-export/conversations.jsonl --format claude
+
+# Or pin everything to long-tier (no TTL) into a custom namespace
+ai-memory mine ./claude-export/conversations.jsonl \
+  --format claude \
+  --namespace personal/claude-history \
+  --tier long \
+  --min-messages 5</code></pre>
+
+    <h2 style="margin-top:2rem">ChatGPT export.</h2>
+    <p>ChatGPT exports give you a <code>conversations.json</code> file (a single JSON array of conversations).</p>
+    <p><strong>Where to find it:</strong></p>
+    <ol>
+      <li>Open ChatGPT → Settings → Data Controls → Export data</li>
+      <li>Wait for the email; download the zip</li>
+      <li>Inside, find <code>conversations.json</code></li>
+    </ol>
+    <p><strong>Import:</strong></p>
+<pre><code># Dry run
+ai-memory mine ./chatgpt-export/conversations.json --format chatgpt --dry-run
+
+# Real import
+ai-memory mine ./chatgpt-export/conversations.json --format chatgpt
+
+# Filter to substantive conversations only (10+ messages)
+ai-memory mine ./chatgpt-export/conversations.json \
+  --format chatgpt \
+  --min-messages 10 \
+  --tier long</code></pre>
+
+    <h2 style="margin-top:2rem">Slack export.</h2>
+    <p>Slack workspace exports give you a directory of per-channel <code>.json</code> files. <code>mine</code> walks the tree.</p>
+    <p><strong>Where to find it:</strong></p>
+    <ol>
+      <li>Slack → Workspace settings → Import / Export Data → Export</li>
+      <li>Pick "Standard export"; wait for the email</li>
+      <li>Download + unzip the archive</li>
+    </ol>
+    <p><strong>Import:</strong></p>
+<pre><code># Dry run on the whole export
+ai-memory mine ./slack-export/ --format slack --dry-run
+
+# Real import — narrow to a high-signal channel
+ai-memory mine ./slack-export/eng-decisions/ --format slack \
+  --namespace work/slack/eng-decisions \
+  --tier long \
+  --min-messages 4</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Flags</span>
+    <h2>Flags reference.</h2>
+    <table>
+      <thead>
+        <tr><th>Flag</th><th>Default</th><th>Meaning</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>--format</code>, <code>-f</code></td><td>(required)</td><td><code>claude</code>, <code>chatgpt</code>, <code>slack</code></td></tr>
+        <tr><td><code>--namespace</code>, <code>-n</code></td><td>format-specific</td><td>Override target namespace</td></tr>
+        <tr><td><code>--tier</code>, <code>-t</code></td><td><code>mid</code></td><td><code>short</code> / <code>mid</code> / <code>long</code></td></tr>
+        <tr><td><code>--min-messages</code></td><td><code>3</code></td><td>Skip conversations shorter than this</td></tr>
+        <tr><td><code>--dry-run</code></td><td><code>false</code></td><td>Print what would be imported, don't write</td></tr>
+      </tbody>
+    </table>
+    <p>The miner stamps <code>metadata.agent_id</code> to the caller's identity (see <a href="agent-identity.html" style="color:var(--p1)">Agent identity</a>) and records the original conversation timestamp on <code>created_at</code>.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">After</span>
+    <h2>After the import.</h2>
+    <p>Your imported memories are immediately part of the live recall mix:</p>
+<pre><code># Recall ranks across imported + native memories together
+ai-memory recall "kubernetes deployment strategy" --tier long
+
+# Filter to just the imported set
+ai-memory list --namespace chatgpt-export
+ai-memory list --source mine-chatgpt
+
+# Promote the standout decisions to long-tier permanently
+ai-memory promote &lt;id&gt; --tier long --priority 9
+
+# Consolidate two redundant decisions into one canonical memory
+ai-memory consolidate &lt;id1&gt; &lt;id2&gt; -T "Auth strategy — final decision"</code></pre>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Pattern</span>
+    <h2>A pattern that works.</h2>
+    <ol>
+      <li><strong>Mine your last 90 days first.</strong> Set <code>--min-messages 5</code> to skip the trivial chatter.</li>
+      <li><strong>Pin the survivors.</strong> Run <code>ai-memory recall</code> for your most common project topics; promote the top hits to long-tier.</li>
+      <li><strong>Consolidate the duplicates.</strong> Three memories about the same auth flow? <code>ai-memory consolidate</code> collapses them — and keeps the lineage in <code>metadata.consolidated_from_agents</code>.</li>
+      <li><strong>Wire your next AI.</strong> Whatever comes next — Claude, GPT, Grok, a local Llama — points at the same SQLite file and inherits everything you imported.</li>
+    </ol>
+    <p>This is the workflow Mem0 charges you SaaS pricing for. ai-memory does it locally, in one binary, in five minutes.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Next</span>
+    <h2>Where to go.</h2>
+    <ul>
+      <li>→ <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/develop/docs/QUICKSTART.md" style="color:var(--p1)">Quickstart</a> — store + recall basics</li>
+      <li>→ <a href="memory-tiers.html" style="color:var(--p1)">Memory tiers</a> — when to use short / mid / long</li>
+      <li>→ <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/develop/docs/USER_GUIDE.md" style="color:var(--p1)">Recall</a> — full scoring + ranking (in the User Guide)</li>
+      <li>→ <a href="agent-identity.html" style="color:var(--p1)">Agent identity</a> — every memory carries provenance</li>
+    </ul>
+  </div>
+</section>
+
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.6.3 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="./">home</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -430,8 +430,17 @@
         </div>
         <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
             <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
-            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">📊 Visualization Atlas — 6 pages, every facet →</a>
+            <a href="https://alphaonedev.github.io/ai-memory-test-hub/" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">🧪 Live Test Results — 1,600 lib · 93.08% cov →</a>
+            <a href="evidence.html" class="hero-cta" style="background:transparent;border:1px solid #c8a2ff;color:#c8a2ff">📐 Frozen Claims (Evidence) →</a>
+            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #999;color:#999">📊 Visualization Atlas →</a>
             <a href="whats-new-v063.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">✨ What's New in v0.6.3 →</a>
+        </div>
+        <div style="margin-top:1.5rem;display:flex;justify-content:center;gap:1.5rem;font-size:.78rem;color:#999;flex-wrap:wrap">
+          <span>📊 <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/" style="color:#6ee7ff;text-decoration:none">v0.6.3 evidence on test-hub</a></span>
+          <span>·</span>
+          <span>🚢 <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="color:#999;text-decoration:none">ship-gate</a></span>
+          <span>·</span>
+          <span>🤝 <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="color:#999;text-decoration:none">A2A gate</a></span>
         </div>
     </div>
 </section>
@@ -1082,7 +1091,7 @@
     }
   }
 }<span class="lang-label">json</span></code></pre>
-                    <p style="font-size:.85rem">The MCP server exposes 26 tools over stdio using JSON-RPC. Any client that speaks MCP will discover them automatically. Adjust the <code>--db</code> path to your preferred location.</p>
+                    <p style="font-size:.85rem">The MCP server exposes 43 tools over stdio using JSON-RPC. Any client that speaks MCP will discover them automatically. Adjust the <code>--db</code> path to your preferred location.</p>
                 </div>
             </li>
             <li>
@@ -1221,7 +1230,7 @@ ai-memory list -n my-project                                         <span class
 <section id="features" class="alt">
     <div class="container">
         <h2>What It Does</h2>
-        <p class="section-subtitle">Every capability at a glance. 4 feature tiers (keyword to autonomous), 26 MCP tools, four operational modes (MCP, HTTP, curator, sync), one shared SQLite database. Works with any AI that supports MCP or HTTP.</p>
+        <p class="section-subtitle">Every capability at a glance. 4 feature tiers (keyword to autonomous), 43 MCP tools, four operational modes (MCP, HTTP, curator, sync), one shared SQLite database. Works with any AI that supports MCP or HTTP. <a href="evidence.html" style="color:#6ee7ff">Canonical claims →</a></p>
 
         <div class="feature-grid">
             <div class="feature-card" style="border:1px solid var(--green);background:rgba(63,185,80,.04)">
@@ -1293,7 +1302,7 @@ ai-memory list -n my-project                                         <span class
                         <td class="matrix-dash">&mdash;</td>
                         <td class="matrix-dash">&mdash;</td>
                         <td>None</td>
-                        <td>FTS5 full-text search, 13 MCP tools</td>
+                        <td>FTS5 full-text search, keyword tier (subset of 43 tools)</td>
                     </tr>
                     <tr>
                         <td><span class="tier-tag tier-tag-semantic">semantic</span></td>
@@ -1301,7 +1310,7 @@ ai-memory list -n my-project                                         <span class
                         <td>all-MiniLM-L6-v2 <span style="color:var(--text-muted);font-size:.75rem">(384-dim, local via Candle)</span></td>
                         <td class="matrix-dash">&mdash;</td>
                         <td>None <span style="color:var(--text-muted);font-size:.75rem">(model auto-downloads ~90MB)</span></td>
-                        <td>+ Hybrid recall (FTS5 + cosine similarity), HNSW vector index, 14 MCP tools</td>
+                        <td>+ Hybrid recall (FTS5 + cosine similarity), HNSW vector index, semantic tier (subset of 43 tools)</td>
                     </tr>
                     <tr>
                         <td><span class="tier-tag tier-tag-smart">smart</span></td>
@@ -1309,7 +1318,7 @@ ai-memory list -n my-project                                         <span class
                         <td>nomic-embed-text-v1.5 <span style="color:var(--text-muted);font-size:.75rem">(768-dim, via Ollama)</span></td>
                         <td>Gemma 4 E2B <span style="color:var(--text-muted);font-size:.75rem">(~1GB)</span></td>
                         <td><a href="https://ollama.com">Ollama</a></td>
-                        <td>+ LLM query expansion, auto-tagging, auto-consolidation, 26 MCP tools</td>
+                        <td>+ LLM query expansion, auto-tagging, auto-consolidation, 43 MCP tools (full surface)</td>
                     </tr>
                     <tr>
                         <td><span class="tier-tag tier-tag-autonomous">autonomous</span></td>
@@ -1317,7 +1326,7 @@ ai-memory list -n my-project                                         <span class
                         <td>nomic-embed-text-v1.5 <span style="color:var(--text-muted);font-size:.75rem">(768-dim, via Ollama)</span></td>
                         <td>Gemma 4 E4B <span style="color:var(--text-muted);font-size:.75rem">(~2.3GB)</span></td>
                         <td><a href="https://ollama.com">Ollama</a></td>
-                        <td>+ Neural cross-encoder reranking (ms-marco-MiniLM), contradiction analysis, 26 MCP tools</td>
+                        <td>+ Neural cross-encoder reranking (ms-marco-MiniLM), contradiction analysis, 43 MCP tools (full surface)</td>
                     </tr>
                 </tbody>
             </table>
@@ -1417,11 +1426,11 @@ ai-memory list -n my-project                                         <span class
 </section>
 
 <!-- ================================================================
-     17 MCP TOOLS
+     43 MCP TOOLS
      ================================================================ -->
 <section id="mcp">
     <div class="container">
-        <h2>23 MCP Tools <span class="badge">Universal Integration</span></h2>
+        <h2>43 MCP Tools <span class="badge">Universal Integration</span></h2>
         <p class="section-subtitle">
             ai-memory runs as a Model Context Protocol (MCP) tool server over stdio.
             Any MCP-compatible AI client -- Claude, ChatGPT, Grok, Llama, or custom agents -- discovers these tools automatically.
@@ -1461,7 +1470,7 @@ ai-memory list -n my-project                                         <span class
                 <!-- MCP Server -->
                 <rect x="275" y="80" width="190" height="60" rx="8" fill="#111111" stroke="#bbbbbb" stroke-width="2"/>
                 <text x="370" y="100" text-anchor="middle" fill="#ffffff" font-family="system-ui" font-size="13" font-weight="700">MCP Server</text>
-                <text x="370" y="116" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">JSON-RPC / up to 26 tools</text>
+                <text x="370" y="116" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">JSON-RPC / up to 43 tools</text>
                 <text x="370" y="131" text-anchor="middle" fill="#999999" font-family="monospace" font-size="8">--tier keyword|semantic|smart|autonomous</text>
 
                 <!-- Arrow to SQLite -->
@@ -1571,11 +1580,11 @@ ai-memory list -n my-project                                         <span class
 </section>
 
 <!-- ================================================================
-     20 HTTP API ENDPOINTS
+     42 HTTP API ENDPOINTS
      ================================================================ -->
 <section id="api" class="alt">
     <div class="container">
-        <h2>20 HTTP API Endpoints <span class="badge">Universal Fallback</span></h2>
+        <h2>42 HTTP API Endpoints <span class="badge">Universal Fallback</span></h2>
         <p class="section-subtitle">
             Start with <code>ai-memory serve</code> (default: <code>http://127.0.0.1:9077</code>).
             The HTTP API works with any AI platform, any programming language, any framework. If it can make an HTTP request, it can use ai-memory.
@@ -1630,11 +1639,11 @@ ai-memory list -n my-project                                         <span class
 </section>
 
 <!-- ================================================================
-     25 CLI COMMANDS
+     26 CLI COMMANDS
      ================================================================ -->
 <section id="cli">
     <div class="container">
-        <h2>25 CLI Commands <span class="badge">Universal</span></h2>
+        <h2>26 CLI Commands <span class="badge">Universal</span></h2>
         <p class="section-subtitle">
             Global flags: <code>--db &lt;path&gt;</code> and <code>--json</code>.
             Scriptable, pipeable, works in any shell. Use directly or wrap in your AI's tool layer.
@@ -1936,15 +1945,15 @@ ai-memory list -n my-project                                         <span class
                 <!-- Three interfaces -->
                 <rect x="30" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#cccccc" stroke-width="1.5"/>
                 <text x="100" y="102" text-anchor="middle" fill="#cccccc" font-family="system-ui" font-size="12" font-weight="700">CLI</text>
-                <text x="100" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">25 commands</text>
+                <text x="100" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">26 commands</text>
 
                 <rect x="280" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#bbbbbb" stroke-width="1.5"/>
                 <text x="350" y="102" text-anchor="middle" fill="#bbbbbb" font-family="system-ui" font-size="12" font-weight="700">MCP Server</text>
-                <text x="350" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">26 tools / stdio</text>
+                <text x="350" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">43 tools / stdio</text>
 
                 <rect x="530" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#999999" stroke-width="1.5"/>
                 <text x="600" y="102" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="12" font-weight="700">HTTP API</text>
-                <text x="600" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">24 endpoints / Axum</text>
+                <text x="600" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">42 endpoints / Axum</text>
 
                 <!-- Labels under interfaces -->
                 <text x="100" y="146" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">Universal</text>
@@ -1973,13 +1982,13 @@ ai-memory list -n my-project                                         <span class
                 <rect x="45" y="252" width="140" height="55" rx="6" fill="#111111" stroke="#cccccc" stroke-width="1.5"/>
                 <text x="115" y="271" text-anchor="middle" fill="#cccccc" font-family="system-ui" font-size="11" font-weight="700">Keyword</text>
                 <text x="115" y="284" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">FTS5 only</text>
-                <text x="115" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">0 MB | 13 tools</text>
+                <text x="115" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">0 MB | keyword</text>
 
                 <!-- Semantic tier -->
                 <rect x="200" y="252" width="140" height="55" rx="6" fill="#111111" stroke="#ffffff" stroke-width="1.5"/>
                 <text x="270" y="271" text-anchor="middle" fill="#ffffff" font-family="system-ui" font-size="11" font-weight="700">Semantic</text>
                 <text x="270" y="284" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">MiniLM-L6 384d</text>
-                <text x="270" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">256 MB | 14 tools</text>
+                <text x="270" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">256 MB | semantic</text>
                 <!-- Candle label -->
                 <text x="270" y="250" text-anchor="middle" fill="#ffffff" font-family="monospace" font-size="7" opacity=".6">candle (local)</text>
 
@@ -1991,7 +2000,7 @@ ai-memory list -n my-project                                         <span class
                 <rect x="355" y="252" width="155" height="55" rx="6" fill="#111111" stroke="#999999" stroke-width="1.5"/>
                 <text x="432" y="271" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="11" font-weight="700">Smart</text>
                 <text x="432" y="284" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">nomic 768d + Gemma4 E2B</text>
-                <text x="432" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">1 GB | 26 tools</text>
+                <text x="432" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">1 GB | smart (full surface)</text>
 
                 <!-- Arrow from semantic to smart -->
                 <line x1="340" y1="280" x2="355" y2="280" stroke="#333333" stroke-width="1" class="animate-flow"/>
@@ -2001,7 +2010,7 @@ ai-memory list -n my-project                                         <span class
                 <rect x="525" y="252" width="190" height="55" rx="6" fill="#111111" stroke="#bbbbbb" stroke-width="1.5"/>
                 <text x="620" y="271" text-anchor="middle" fill="#bbbbbb" font-family="system-ui" font-size="11" font-weight="700">Autonomous</text>
                 <text x="620" y="284" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">nomic 768d + Gemma4 E4B + reranker</text>
-                <text x="620" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">4 GB | 26 tools + cross-encoder</text>
+                <text x="620" y="298" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">4 GB | autonomous + cross-encoder</text>
 
                 <!-- Arrow from smart to autonomous -->
                 <line x1="510" y1="280" x2="525" y2="280" stroke="#333333" stroke-width="1" class="animate-flow"/>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,16 +8,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ai-memory&trade; -- Persistent Memory for Any AI</title>
-    <meta name="description" content="Persistent memory for any AI agent. v0.6.2 ships a single Rust binary with four operational modes — stdio MCP server, HTTP/mTLS daemon, autonomous curator, and quorum sync — plus 26 MCP tools, 24 HTTP endpoints, 26 CLI commands. Hybrid recall (FTS5 + vector + cross-encoder reranking), three-tier TTL, namespaces, links, archive, governance approval flow. SQLite-backed, local-first, zero cloud dependencies.">
+    <meta name="description" content="Persistent memory for any AI agent. v0.6.3 ships a single Rust binary with four operational modes — stdio MCP server, HTTP/mTLS daemon, autonomous curator, and quorum sync — plus 43 MCP tools, 42 HTTP endpoints, 26 CLI commands. Hybrid recall (FTS5 + vector + cross-encoder reranking), three-tier TTL, namespaces, links, archive, governance approval flow. SQLite-backed, local-first, zero cloud dependencies. Frozen claims: see evidence.html.">
     <meta name="theme-color" content="#0d1117">
     <meta property="og:title" content="ai-memory — Persistent Memory for Any AI">
-    <meta property="og:description" content="Persistent memory for any AI agent. v0.6.2: 26 MCP tools, hybrid recall, autonomous curator daemon that keeps memory tidy between sessions. Local-first, zero cloud dependencies.">
+    <meta property="og:description" content="Persistent memory for any AI agent. v0.6.3: 43 MCP tools, hybrid recall, autonomous curator daemon that keeps memory tidy between sessions. Local-first, zero cloud dependencies.">
     <meta property="og:url" content="https://alphaonedev.github.io/ai-memory-mcp/">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="ai-memory">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="ai-memory — Persistent Memory for Any AI">
-    <meta name="twitter:description" content="Persistent memory for any AI agent. v0.6.2: 26 MCP tools, hybrid recall, autonomous curator daemon. Local-first, zero cloud dependencies.">
+    <meta name="twitter:description" content="Persistent memory for any AI agent. v0.6.3: 43 MCP tools, hybrid recall, autonomous curator daemon. Local-first, zero cloud dependencies.">
     <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/">
     <style>
         /* ============================================================
@@ -76,14 +76,24 @@
         pre .lang-label{position:absolute;top:.55rem;right:.75rem;font-size:.65rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;user-select:none}
 
         /* ============================================================
-           NAV
+           NAV — unified topnav with grouped dropdowns (matches /docs/* pages)
            ============================================================ */
-        nav{position:fixed;top:0;left:0;right:0;z-index:100;background:rgba(13,17,23,.92);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);padding:.7rem 0;transition:box-shadow .3s}
-        nav .container{display:flex;align-items:center;gap:1.25rem;flex-wrap:wrap}
-        nav .logo{font-weight:800;font-size:1rem;color:var(--text);white-space:nowrap;letter-spacing:-.02em}
-        nav .links{display:flex;gap:.85rem;flex-wrap:wrap}
-        nav .links a{color:var(--text-muted);font-size:.82rem;transition:color .15s}
-        nav .links a:hover{color:var(--text);text-decoration:none}
+        .topnav{position:sticky;top:0;z-index:100;background:rgba(0,0,0,.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+        .topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+        .topnav a{color:var(--text-muted);margin-right:1.25rem;text-decoration:none}
+        .topnav a:hover,.topnav a.active{color:var(--text);text-decoration:none}
+        .topnav .home-link{color:var(--text);font-weight:600}
+        .topnav .right{display:flex;gap:1.25rem;align-items:center;flex-wrap:wrap}
+        .topnav .menu{position:relative;display:inline-block}
+        .topnav .menu-btn{background:none;border:none;color:var(--text-muted);font-family:inherit;font-size:inherit;cursor:pointer;padding:.2rem 0;line-height:1;letter-spacing:0}
+        .topnav .menu-btn:hover,.topnav .menu:focus-within .menu-btn,.topnav .menu:hover .menu-btn{color:var(--text)}
+        .topnav .menu-btn .caret{opacity:.5;font-size:.7em;margin-left:.2em}
+        .topnav .menu-pane{position:absolute;top:calc(100% + .55rem);right:0;background:#111;border:1px solid #3d3d3d;border-radius:8px;padding:.4rem 0;min-width:240px;box-shadow:0 10px 28px rgba(0,0,0,.5);z-index:60;visibility:hidden;opacity:0;transition:opacity .12s ease,visibility 0s .12s}
+        .topnav .menu:focus-within .menu-pane,.topnav .menu:hover .menu-pane{visibility:visible;opacity:1;transition:opacity .12s ease}
+        .topnav .menu-pane a{display:block;padding:.5rem 1rem;color:var(--text-muted);font-size:.85rem;margin-right:0;white-space:nowrap;text-decoration:none}
+        .topnav .menu-pane a:hover{background:#161616;color:var(--text)}
+        .topnav .menu-pane a.current{color:#6ee7ff;background:#161616}
+        @media(max-width:800px){.topnav .right{gap:.6rem}.topnav .right > a,.topnav .menu-btn{font-size:.78rem}}
 
         /* ============================================================
            HERO
@@ -312,25 +322,86 @@
 <!-- ================================================================
      NAV
      ================================================================ -->
-<nav>
-    <div class="container">
-        <span class="logo">ai-memory</span>
-        <div class="links">
-            <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
-            <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
-            <a href="feature-matrix.html">Features</a>
-            <a href="for-everyone.html">For Everyone</a>
-            <a href="#platforms">Platforms</a>
-            <a href="#install">Install</a>
-            <a href="#claude-integration">Claude Code</a>
-            <a href="#features">Features</a>
-            <a href="#mcp">Interfaces</a>
-            <a href="#architecture">Architecture</a>
-            <a href="#benchmarks">Benchmarks</a>
-            <a href="https://github.com/alphaonedev/ai-memory-mcp-dev/blob/develop/ROADMAP.md">Roadmap</a>
-            <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="./">ai-memory</a>
+    <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <div class="menu">
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="for-everyone.html">For Everyone</a>
+          <a href="feature-matrix.html">Feature Matrix</a>
+          <a href="data-flow.html">Data Flow</a>
+          <a href="integrations.html">Integrations</a>
+          <a href="import-history.html">Import History</a>
+          <a href="release-pipeline.html">Release Pipeline</a>
         </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Features<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="memory-tiers.html">Memory Tiers</a>
+          <a href="memory-rules.html">Memory Rules</a>
+          <a href="ttl-controls.html">TTL Controls</a>
+          <a href="archival.html">Archival</a>
+          <a href="encryption.html">Encryption</a>
+          <a href="hierarchies.html">Hierarchies</a>
+          <a href="knowledge-graph.html">Knowledge Graph</a>
+          <a href="autonomous.html">Autonomous</a>
+          <a href="a2a-messaging.html">A2A Messaging</a>
+          <a href="lifecycle.html">Lifecycle</a>
+          <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Internals<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="schema.html">Schema</a>
+          <a href="types.html">Types</a>
+          <a href="validators.html">Validators</a>
+          <a href="governance.html">Governance</a>
+          <a href="tracing.html">Tracing</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="performance.html">Performance budgets</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">On This Page<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="#install">Install</a>
+          <a href="#claude-integration">Claude Code Setup</a>
+          <a href="#features">Features</a>
+          <a href="#mcp">Interfaces</a>
+          <a href="#benchmarks">Benchmarks</a>
+        </div>
+      </div>
+      <a href="credits.html">Credits</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
     </div>
+  </div>
 </nav>
 
 <!-- ================================================================
@@ -1958,7 +2029,7 @@ ai-memory list -n my-project                                         <span class
                 <!-- DB layer -->
                 <rect x="120" y="352" width="360" height="55" rx="8" fill="#111111" stroke="#dddddd" stroke-width="2"/>
                 <text x="300" y="375" text-anchor="middle" fill="#dddddd" font-family="system-ui" font-size="13" font-weight="700">SQLite + FTS5 + HNSW (db.rs)</text>
-                <text x="300" y="395" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">WAL mode | schema v5 | embeddings | 191 tests</text>
+                <text x="300" y="395" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">WAL mode | schema v5 | embeddings | 1,600 tests</text>
 
                 <!-- Memory tiers -->
                 <rect x="145" y="420" width="70" height="22" rx="4" fill="rgba(255,255,255,.15)" stroke="#ffffff" stroke-width="1"/>
@@ -2137,7 +2208,7 @@ ai-memory list -n my-project                                         <span class
 
                 <rect x="327" y="30" width="80" height="40" rx="6" fill="#111111" stroke="#bbbbbb" stroke-width="1"/>
                 <text x="367" y="48" text-anchor="middle" fill="#bbbbbb" font-family="monospace" font-size="10">test</text>
-                <text x="367" y="62" text-anchor="middle" fill="#999999" font-family="monospace" font-size="9">191 tests</text>
+                <text x="367" y="62" text-anchor="middle" fill="#999999" font-family="monospace" font-size="9">1,600 tests</text>
 
                 <line x1="407" y1="50" x2="427" y2="50" stroke="#333333" stroke-width="1.5" class="animate-flow"/>
 

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -156,7 +156,7 @@ footer a{color:var(--text-muted)}
 
 <section class="hero">
   <h1>Every AI. Every IDE.</h1>
-  <p class="tagline">ai-memory speaks MCP — the open Model Context Protocol. Any compliant host autodiscovers all 26 tools. <strong>Plug in once, share memory across every AI you use.</strong></p>
+  <p class="tagline">ai-memory speaks MCP — the open Model Context Protocol. Any compliant host autodiscovers all 43 tools. <strong>Plug in once, share memory across every AI you use.</strong></p>
   <div class="pill-row">
     <span class="pill">13 clients tested</span>
     <span class="pill">3 tiers (first-class · supported · works-with-MCP)</span>
@@ -194,7 +194,7 @@ footer a{color:var(--text-muted)}
         <div class="client-meta-row">
           <span><span class="ok">✓</span> stdio</span>
           <span><span class="ok">✓</span> session_start hook</span>
-          <span><span class="ok">✓</span> all 26 tools</span>
+          <span><span class="ok">✓</span> all 43 tools</span>
         </div>
         <a class="client-link" href="./#claude-integration">Setup guide →</a>
       </div>
@@ -218,7 +218,7 @@ footer a{color:var(--text-muted)}
   }
 }</pre>
         <div class="client-meta-row">
-          <span><span class="ok">✓</span> ~40 tool limit (we use 26)</span>
+          <span><span class="ok">✓</span> ~40 tool limit (we use 43)</span>
           <span><span class="ok">✓</span> envFile support</span>
         </div>
       </div>
@@ -418,7 +418,7 @@ ai-memory mcp [<span class="key">--tier</span> &lt;keyword|semantic|smart|autono
             <span class="client-tier t3">▸ TIER 3 · DIY</span>
           </div>
         </div>
-        <p class="client-desc">Roll-your-own agents talk to the HTTP daemon. 39 endpoints. Or implement an MCP host shim using the official spec libraries.</p>
+        <p class="client-desc">Roll-your-own agents talk to the HTTP daemon. 42 endpoints. Or implement an MCP host shim using the official spec libraries.</p>
         <pre class="client-config"><span class="cmt"># Python example</span>
 import requests
 r = requests.post(<span class="str">"http://localhost:9077/api/v1/recall"</span>,
@@ -442,7 +442,7 @@ r = requests.post(<span class="str">"http://localhost:9077/api/v1/recall"</span>
         <li>Host sends JSON-RPC <code>initialize</code> with protocolVersion + clientInfo</li>
         <li>ai-memory responds with capabilities + serverInfo</li>
         <li>Host sends <code>tools/list</code></li>
-        <li>ai-memory responds with all 26 tool definitions (name, description, JSON Schema)</li>
+        <li>ai-memory responds with all 43 tool definitions (name, description, JSON Schema)</li>
         <li>Host registers the tools with its model, presents to user as available actions</li>
         <li>User says "remember that I prefer..." → host calls <code>tools/call memory_store ...</code></li>
         <li>ai-memory does the work, returns the result</li>

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -86,14 +86,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Integrations</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html" class="current">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -111,6 +113,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -124,8 +138,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/knowledge-graph.html
+++ b/docs/knowledge-graph.html
@@ -94,14 +94,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Knowledge Graph</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -119,6 +121,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -132,8 +146,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/lifecycle.html
+++ b/docs/lifecycle.html
@@ -83,14 +83,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Lifecycle</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -108,6 +110,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html" class="current">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -121,8 +135,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/memory-rules.html
+++ b/docs/memory-rules.html
@@ -92,14 +92,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Memory Rules</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -117,6 +119,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -130,8 +144,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/memory-tiers.html
+++ b/docs/memory-tiers.html
@@ -106,14 +106,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Memory Tiers</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -131,6 +133,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -144,8 +158,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -85,14 +85,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Performance</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -110,6 +112,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html" class="current">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -123,13 +137,14 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
           <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
-          <a href="performance.html">Performance budgets</a>
+          <a href="performance.html" class="current">Performance budgets</a>
         </div>
       </div>
       <a href="credits.html">Credits</a>

--- a/docs/release-pipeline.html
+++ b/docs/release-pipeline.html
@@ -112,14 +112,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Release Pipeline</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html" class="current">Release Pipeline</a>
         </div>
       </div>
@@ -137,6 +139,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -150,8 +164,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/release-pipeline.html
+++ b/docs/release-pipeline.html
@@ -404,7 +404,7 @@ cargo install ai-memory --features sqlcipher</pre>
         <li><code>cargo llvm-cov --features sal --no-fail-fast --html</code></li>
         <li>JSON artifact uploaded for trend analysis</li>
         <li>HTML report uploaded for inspection</li>
-        <li>v0.6.3-rc1 measurement: <strong>93.05% line coverage</strong></li>
+        <li>v0.6.3 measurement: <strong>93.08% line coverage</strong> (gate ≥92%) — see <a href="evidence.html">canonical evidence</a></li>
       </ul>
     </div>
 

--- a/docs/schema.html
+++ b/docs/schema.html
@@ -92,14 +92,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Schema</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -117,6 +119,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -130,8 +144,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/tracing.html
+++ b/docs/tracing.html
@@ -98,14 +98,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Tracing</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -123,6 +125,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -136,8 +150,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/ttl-controls.html
+++ b/docs/ttl-controls.html
@@ -87,14 +87,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ TTL Controls</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -112,6 +114,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -125,8 +139,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/types.html
+++ b/docs/types.html
@@ -97,14 +97,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Types</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -122,6 +124,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -135,8 +149,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/validators.html
+++ b/docs/validators.html
@@ -88,14 +88,16 @@ footer a{color:var(--text-muted)}
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ Validators</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -113,6 +115,18 @@ footer a{color:var(--text-muted)}
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -126,8 +140,9 @@ footer a{color:var(--text-muted)}
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -13,7 +13,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>What's New in v0.6.3 — Structured Memory + Performance</title>
-<meta name="description" content="v0.6.3 release highlights: hierarchical namespaces, temporal-validity knowledge graph, published performance budgets, 93.05% test coverage, 1809 tests, 2 SSRF defects fixed.">
+<meta name="description" content="v0.6.3 release highlights: hierarchical namespaces, temporal-validity knowledge graph, published performance budgets, 93.08% test coverage, 1,600 lib tests, 2 SSRF defects fixed.">
 <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/whats-new-v063.html">
 <style>
 :root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--warn:#ffb86b;--bad:#ff6b9d;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
@@ -123,14 +123,16 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
   <div class="inner">
     <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ What's New v0.6.3</span></a>
     <div class="right">
+      <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
       <div class="menu">
-        <button class="menu-btn active">Audiences<span class="caret">▾</span></button>
+        <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
-          <a href="whats-new-v063.html" class="current">What's New in v0.6.3</a>
+          <a href="for-everyone.html">For Everyone</a>
           <a href="feature-matrix.html">Feature Matrix</a>
           <a href="data-flow.html">Data Flow</a>
           <a href="integrations.html">Integrations</a>
-          <a href="for-everyone.html">For Everyone</a>
+          <a href="import-history.html">Import History</a>
           <a href="release-pipeline.html">Release Pipeline</a>
         </div>
       </div>
@@ -148,6 +150,18 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
           <a href="a2a-messaging.html">A2A Messaging</a>
           <a href="lifecycle.html">Lifecycle</a>
           <a href="performance.html">Performance</a>
+          <a href="agent-identity.html">Agent Identity (NHI)</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button class="menu-btn">Architectures<span class="caret">▾</span></button>
+        <div class="menu-pane">
+          <a href="architectures.html">Overview</a>
+          <a href="architectures-t1.html">T1 — Single Agent</a>
+          <a href="architectures-t2.html">T2 — Many Agents</a>
+          <a href="architectures-t3.html">T3 — Multi-Node Cluster</a>
+          <a href="architectures-t4.html">T4 — Data-Center Swarm</a>
+          <a href="architectures-t5.html">T5 — Global Hive</a>
         </div>
       </div>
       <div class="menu">
@@ -161,8 +175,9 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
         </div>
       </div>
       <div class="menu">
-        <button class="menu-btn">Testing<span class="caret">▾</span></button>
+        <button class="menu-btn">Evidence<span class="caret">▾</span></button>
         <div class="menu-pane">
+          <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
@@ -183,7 +198,7 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
   <div class="meta">
     <span>56.7% → <strong style="color:var(--good)">93.05%</strong> coverage</span>
     <span style="opacity:.4">·</span>
-    <span><strong style="color:var(--text)">1,809</strong> tests passing</span>
+    <span><strong style="color:var(--text)">1,600</strong> tests passing</span>
     <span style="opacity:.4">·</span>
     <span><strong style="color:var(--text)">26</strong> closers · <strong style="color:var(--text)">9</strong> waves</span>
     <span style="opacity:.4">·</span>
@@ -410,7 +425,7 @@ fn is_private(ip: IpAddr) -> bool {
 
     <div style="background:var(--bg-card);border:1px solid var(--good);border-radius:12px;padding:1.5rem;margin-top:2rem">
       <strong style="color:var(--good)">No outstanding security defects post-campaign.</strong>
-      <p style="margin-top:.5rem">The SSRF fixes shipped with rc1. Both <code>#[ignore]</code> tests are un-ignored and passing. <strong>Zero ignored tests across the whole 1,809-test suite.</strong>
+      <p style="margin-top:.5rem">The SSRF fixes shipped with rc1. Both <code>#[ignore]</code> tests are un-ignored and passing. <strong>Zero ignored tests across the whole 1,600-test suite.</strong>
     </p>
     </div>
   </div>
@@ -427,7 +442,7 @@ fn is_private(ip: IpAddr) -> bool {
       <div class="tile p1"><div class="tile-label">Line coverage</div><div class="tile-num">93.05<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">42,894 / 46,099 lines</div></div>
       <div class="tile p1"><div class="tile-label">Region coverage</div><div class="tile-num">93.11<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">73,150 / 78,564 regions</div></div>
       <div class="tile p1"><div class="tile-label">Function coverage</div><div class="tile-num">92.55<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">3,527 / 3,811 functions</div></div>
-      <div class="tile good"><div class="tile-label">Tests passing</div><div class="tile-num">1,809</div><div class="tile-sub">0 failed · 0 ignored</div></div>
+      <div class="tile good"><div class="tile-label">Tests passing</div><div class="tile-num">1,600</div><div class="tile-sub">0 failed · 0 ignored</div></div>
       <div class="tile good"><div class="tile-label">Net new tests</div><div class="tile-num">~1,200</div><div class="tile-sub">across W3-W12</div></div>
       <div class="tile p2"><div class="tile-label">Closers dispatched</div><div class="tile-num">26</div><div class="tile-sub">across 9 waves</div></div>
       <div class="tile p2"><div class="tile-label">main.rs reduction</div><div class="tile-num">98.3<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">4,511 → 75 lines</div></div>

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -196,7 +196,7 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
   <h1>Structured Memory<br>+ Performance.</h1>
   <p class="subtitle">The grand-slam release. Three pillars shipped in one focused 4-week sprint: hierarchical namespace tree, temporal-validity knowledge graph, and CI-enforced sub-100ms performance budgets.</p>
   <div class="meta">
-    <span>56.7% → <strong style="color:var(--good)">93.05%</strong> coverage</span>
+    <span>56.7% → <strong style="color:var(--good)">93.08%</strong> coverage</span>
     <span style="opacity:.4">·</span>
     <span><strong style="color:var(--text)">1,600</strong> tests passing</span>
     <span style="opacity:.4">·</span>
@@ -211,7 +211,7 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
   <div class="container">
     <span class="eyebrow">6 Engineering Streams</span>
     <h2>Streams A–F. Six teams. One release.</h2>
-    <p class="lede">v0.6.3 was scoped as six work-streams, each independently shippable but compounding when released together. All six landed; campaign closed at 93.05% line coverage.</p>
+    <p class="lede">v0.6.3 was scoped as six work-streams, each independently shippable but compounding when released together. All six landed; campaign closed at 93.08% line coverage.</p>
 
     <div class="streams-grid">
       <div class="stream A">
@@ -310,8 +310,8 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
 <section id="coverage-campaign">
   <div class="container">
     <span class="eyebrow">W3-W12 Coverage Campaign</span>
-    <h2>56.7% → 93.05% in 9 waves.</h2>
-    <p class="lede">After streams A-F shipped, a parallel-agent coverage campaign drove ai-memory from 56.7% line coverage to 93.05% across nine waves. 26 closers in total. ~1,200 net new tests. Two production SSRF defects discovered + fixed during the work.</p>
+    <h2>56.7% → 93.08% in 9 waves.</h2>
+    <p class="lede">After streams A-F shipped, a parallel-agent coverage campaign drove ai-memory from 56.7% line coverage to 93.08% across nine waves. 26 closers in total. ~1,200 net new tests. Two production SSRF defects discovered + fixed during the work.</p>
 
     <div class="waves-track">
       <div class="waves-row">
@@ -326,7 +326,7 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
         <div class="wave"><div class="wave-name">W9</div><div class="wave-cov" style="color:var(--good)">89.29%</div><div class="wave-delta">+1.14</div><div class="wave-bar" style="height:124px"></div><div class="wave-closers">M9·F9·A9</div></div>
         <div class="wave"><div class="wave-name">W10</div><div class="wave-cov" style="color:var(--good)">89.74%</div><div class="wave-delta">+0.45</div><div class="wave-bar" style="height:126px"></div><div class="wave-closers">L10a·b</div></div>
         <div class="wave"><div class="wave-name">W11</div><div class="wave-cov" style="color:var(--good)">89.75%</div><div class="wave-delta">+0.01</div><div class="wave-bar" style="height:127px"></div><div class="wave-closers">S11a·b + SSRF</div></div>
-        <div class="wave" style="border-color:var(--good)"><div class="wave-name" style="color:var(--good)">W12</div><div class="wave-cov" style="color:var(--good);font-size:1.05rem">93.05%</div><div class="wave-delta">+3.30</div><div class="wave-bar" style="height:144px;background:linear-gradient(to top,var(--good),var(--p3))"></div><div class="wave-closers" style="color:var(--good)">8 PARALLEL</div></div>
+        <div class="wave" style="border-color:var(--good)"><div class="wave-name" style="color:var(--good)">W12</div><div class="wave-cov" style="color:var(--good);font-size:1.05rem">93.08%</div><div class="wave-delta">+3.30</div><div class="wave-bar" style="height:144px;background:linear-gradient(to top,var(--good),var(--p3))"></div><div class="wave-closers" style="color:var(--good)">8 PARALLEL</div></div>
       </div>
     </div>
 
@@ -334,8 +334,8 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
       <h3 style="margin-bottom:1rem">Final coverage by metric</h3>
       <div class="cov-bar-row">
         <div class="cov-bar-label">Line</div>
-        <div class="cov-bar-track"><div class="cov-bar-fill-anim" style="--target:93.05%"></div></div>
-        <div class="cov-bar-pct" style="color:var(--good)">93.05%</div>
+        <div class="cov-bar-track"><div class="cov-bar-fill-anim" style="--target:93.08%"></div></div>
+        <div class="cov-bar-pct" style="color:var(--good)">93.08%</div>
       </div>
       <div class="cov-bar-row">
         <div class="cov-bar-label">Region</div>


### PR DESCRIPTION
## Summary

Three coordinated documentation deliverables in one PR:

1. **Re-ship the architectures + Q5/Q2 work** that was lost in the PR #468 → #469 revert, this time as plain static HTML in \`/docs/\` (not Docusaurus) so the legacy Pages source keeps working.
2. **Unify the navigation** — the landing page's flat link row and the curated pages' limited Audiences/Features/Internals/Testing dropdowns are replaced with a single canonical topnav featuring grouped dropdowns visible from every page: Atlas · v0.6.3 · Audiences ▾ · Features ▾ · Architectures ▾ · Internals ▾ · Evidence ▾ · Credits · GitHub.
3. **Resolve public-claim drift** — adds a canonical \`/docs/evidence.html\` page that freezes every public number (release, test count, coverage, MCP/HTTP/CLI counts, federation maturity, certification status) for v0.6.3 with explicit source-of-truth links per row, and sweeps the highest-prominence drift hot-spots in README + landing + atlas + ADMIN/DEVELOPER/USER guides to point at it.

## What's new

| File | Purpose |
|---|---|
| \`docs/evidence.html\` | Canonical frozen claims for v0.6.3 — single source of truth |
| \`docs/architectures.html\` | Architectures landing + 5-tier ships-today vs roadmap matrix |
| \`docs/architectures-t1.html\` ... \`-t5.html\` | Per-tier pages with animated SMIL SVG diagrams (no Docusaurus dep) |
| \`docs/agent-identity.html\` | Q5 NHI provenance contract page |
| \`docs/import-history.html\` | Q2 retroactive conversation import (\`ai-memory mine\`) recipes |

## Drift fixes in this PR (canonical numbers per evidence.html)

| Page | Was | Now |
|---|---|---|
| README.md | 191 tests / 95% / v0.6.2 / 26 MCP / 24 HTTP | 1,600 lib tests / 93.08% / v0.6.3 / 43 MCP / 42 HTTP + NHI hero + mine hero + evidence-link badge |
| docs/index.html | v0.6.2 og/twitter, 191 tests in SVGs, 26 MCP in meta | v0.6.3, 1,600 tests, 43 MCP / 42 HTTP |
| docs/at-a-glance.html | 1,809 tests / 93.05% | 1,600 lib tests / 93.08% |
| docs/whats-new-v063.html | 1,809 tests / 93.05% | 1,600 lib tests / 93.08% |
| docs/for-everyone.html | 1,809 tests / 93.05% | 1,600 lib tests / 93.08% |
| docs/ADMIN_GUIDE.md | 191 tests / 95% / 24 HTTP + bare "is not a distributed system" claim | 1,600 / 93.08% / 42 HTTP + maturity paragraph reconciling with v0.6.3 federation reality + evidence link |
| docs/DEVELOPER_GUIDE.md | 191 tests / 95% | 1,600 lib tests / 93.08% + evidence link |
| docs/USER_GUIDE.md | 26 MCP tools | 43 MCP tools + evidence link |
| docs/architectures.html | 23 MCP / 24 HTTP (ported from MDX) | 43 / 42 |

This is **not** a complete sweep — remaining markdown docs (RUNBOOK-*, ENGINEERING_STANDARDS.md, etc.) and any stale counts inside SVG labels on tier pages will be cleaned up in a follow-up. The canonical page exists now, the badge on the README points at it, and every nav exposes it. Going forward, every numeric public claim should source from \`evidence.html\` or link to it — the page documents the procedure for keeping it canonical at release-cut.

## Maturity framing reconciliation

The "is not a distributed system" line in ADMIN_GUIDE.md historically lagged the v0.6.3 federation work. The accurate v0.6.3 framing now lives on the evidence page and is summarized in the admin guide:

- T1/T2 single-machine — **production-ready**
- T3 federated multi-node cluster (quorum, mTLS allowlist, vector-clock catchup) — **beta** (shipped + tested, not recommended unattended)
- T4 Postgres+pgvector backend (\`sal-postgres\` flag) — **experimental**, GA target v0.7
- T5 multi-region distributed consensus — **vision** at v1.0+
- SOC 2 / ISO 27001 / FedRAMP / HIPAA — **not held**, do not represent

## Pages source consideration

Pages config remains \`build_type=legacy, source=main:/docs\`. This PR adds files only inside \`/docs/\` and modifies the existing \`/docs/*.html\`. No \`actions/deploy-pages\` workflow is reintroduced — the post-merge Pages rebuild will be the same legacy \`pages-build-deployment\` flow that ran after PR #469. No risk of recurring the PR #468 override incident.

## Test plan

- [x] \`python3 html.parser\` well-formedness on all 9 new pages
- [x] Every tier page contains exactly one \`<svg>\`
- [x] All 33 existing pages updated mechanically by \`/tmp/roll_nav.py\` (idempotent, derives breadcrumb + active-pane + current-href from filename)
- [x] index.html topnav CSS injected; legacy \`<nav>\` block replaced
- [x] Both commits GPG-signed (key 4BAA63E9..., subkey 3725B253..., \`AlphaOne <Justin@alpha-one.mobi>\`)
- [ ] After merge: every dropdown opens on hover/focus across the 34 pages
- [ ] After merge: \`/docs/evidence.html\` HTTP 200 and renders cleanly
- [ ] After merge: \`/docs/architectures.html\` and t1-t5 pages serve correctly
- [ ] After merge: \`/docs/agent-identity.html\` and \`/docs/import-history.html\` serve correctly
- [ ] After merge: README badges link out correctly (evidence + tests)
- [ ] After merge: legacy \`pages-build-deployment\` workflow fires (no Docusaurus override)

## AI involvement

- **Author:** Claude Opus 4.7 (1M context) under operator direction (binary2029@gmail.com / @alphaonedev)
- **Auth class:** Standard (documentation only — zero source-code paths touched)
- **Workflow phases applied:** recall (priority-10 long-term auth memories d7864c43 + 73659a59 + merge-ops playbook 9c44d77d + PR #468/#469 incident memory) → diagnose drift → plan canonical evidence + unified nav → branch → implement (page port + nav rollout via small Python script + targeted drift edits) → self-review (file count + parse check + signature verification) → PR
- **Mistake disclosure:** this is the planned re-ship of the work first attempted in PR #468, which I merged without checking the Pages source configuration — that override forced the PR #469 revert. The new pages are static HTML in \`/docs/\` so the legacy Pages config is untouched. Lesson stored in memory \`56335bf1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)