### PR TITLE
docs(hero): swap OpenClaw pixel-lobster.svg → unicode 🦞 across landing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,6 @@
         .bluf-lead strong,.bluf-section strong{color:var(--text);font-weight:700}
         .bluf-section{font-size:.98rem;line-height:1.7;color:var(--text-muted);margin:1rem 0 0 0;padding-top:1rem;border-top:1px solid var(--border)}
         .bluf-section code{font-family:var(--font-mono);font-size:.85em;background:var(--bg-code);color:var(--cyan);padding:.12em .45em;border-radius:4px;border:1px solid var(--border)}
-        .bluf-lobster{height:1.15em;width:auto;vertical-align:-0.18em;margin:0 .12em}
         .bluf-trademark{display:block;margin-top:.6rem;font-size:.78rem;color:var(--text-muted);font-family:var(--font-mono);letter-spacing:.02em}
         .cap-pill{display:inline-block;font-family:var(--font-mono);font-size:.62em;padding:.18em .55em;border-radius:3px;margin:0 .2em 0 .35em;letter-spacing:.08em;text-transform:uppercase;font-weight:700;vertical-align:2px}
         .cap-pill.cap-beta{color:var(--orange);background:rgba(255,184,107,.1);border:1px solid rgba(255,184,107,.45)}
@@ -436,7 +435,7 @@
 
             <p class="bluf-lead">
                 <strong>ai-memory is persistent, portable memory for AI agents.</strong>
-                One SQLite file on your hardware. Works with any MCP-compatible AI &mdash; Claude, ChatGPT, Cursor, Grok, Llama, OpenClaw <img src="pixel-lobster.svg" alt="OpenClaw" class="bluf-lobster">, anything that speaks the Model Context Protocol. Apache 2.0; trademark-protected (USPTO Serial No.&nbsp;99761257).
+                One SQLite file on your hardware. Works with any MCP-compatible AI &mdash; Claude, ChatGPT, Cursor, Grok, Llama, OpenClaw 🦞, anything that speaks the Model Context Protocol. Apache 2.0; trademark-protected (USPTO Serial No.&nbsp;99761257).
             </p>
 
             <p class="bluf-section">
@@ -450,7 +449,7 @@
             </p>
         </div>
         <p style="font-size:.85rem;color:var(--text-muted);margin-bottom:2rem">
-            Works with Claude &middot; ChatGPT &middot; <a href="https://github.com/alphaonedev/grok-cli" style="color:var(--accent);text-decoration:none;">Grok CLI</a> &middot; Grok API &middot; Cursor &middot; Windsurf &middot; Continue.dev &middot; OpenClaw <img src="pixel-lobster.svg" alt="OpenClaw lobster" style="height:1.2em;vertical-align:middle"> &middot; Hermes Agent &middot; Llama &middot; any MCP client
+            Works with Claude &middot; ChatGPT &middot; <a href="https://github.com/alphaonedev/grok-cli" style="color:var(--accent);text-decoration:none;">Grok CLI</a> &middot; Grok API &middot; Cursor &middot; Windsurf &middot; Continue.dev &middot; OpenClaw 🦞 &middot; Hermes Agent &middot; Llama &middot; any MCP client
         </p>
         <div class="stats-row">
             <div class="stat"><span class="num">97.8%</span><span class="label">Recall@5</span></div>
@@ -681,7 +680,7 @@
             </div>
             <div class="platform-card">
                 <span class="platform-icon" style="font-size:1.8rem">🦞</span>
-                <h4>OpenClaw <img src="pixel-lobster.svg" alt="lobster" style="height:1.2em;vertical-align:middle"></h4>
+                <h4>OpenClaw 🦞</h4>
                 <p>Self-hosted AI assistant with MCP via <code>mcp.servers</code> config</p>
                 <span class="platform-tag tag-mcp">MCP Native</span>
             </div>
@@ -861,7 +860,7 @@
                     <span class="integration-tab" onclick="switchTab('tab-grok-cli')">Grok CLI</span>
                     <span class="integration-tab" onclick="switchTab('tab-grok')">Grok API</span>
                     <span class="integration-tab" onclick="switchTab('tab-llama')">Llama</span>
-                    <span class="integration-tab" onclick="switchTab('tab-openclaw')">OpenClaw <img src="pixel-lobster.svg" alt="lobster" style="height:1em;vertical-align:middle"></span>
+                    <span class="integration-tab" onclick="switchTab('tab-openclaw')">OpenClaw 🦞</span>
                     <span class="integration-tab" onclick="switchTab('tab-hermes')">Hermes Agent</span>
                     <span class="integration-tab" onclick="switchTab('tab-mcp-generic')">Any MCP Client</span>
                 </div>
@@ -2367,7 +2366,7 @@ ai-memory list -n my-project                                         <span class
         </p>
         <p style="margin-top:.25rem;font-size:.78rem">
             Licensed under the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/LICENSE">Apache License, Version 2.0</a>.
-            Built with Rust, SQLite, FTS5, and Axum. Works with Claude, ChatGPT, Grok, Llama, OpenClaw <img src="pixel-lobster.svg" alt="OpenClaw lobster" style="height:1em;vertical-align:middle">, and any MCP-compatible AI.
+            Built with Rust, SQLite, FTS5, and Axum. Works with Claude, ChatGPT, Grok, Llama, OpenClaw 🦞, and any MCP-compatible AI.
         </p>
         <p style="margin-top:.75rem;font-size:.72rem;color:#6e7681;max-width:700px;margin-left:auto;margin-right:auto;line-height:1.5">
             THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.


### PR DESCRIPTION
## Summary

Operator request: render OpenClaw with the unicode lobster emoji 🦞 instead of the inlined \`pixel-lobster.svg\` image across the landing page.

## Changes

| Location | Before | After |
|---|---|---|
| BLUF section 1 (MCP-client list) | \`<img src="pixel-lobster.svg" alt="OpenClaw" class="bluf-lobster">\` | 🦞 |
| Hero "Works with..." link row | \`<img src="pixel-lobster.svg" ...>\` | 🦞 |
| Integration card heading (h4) | \`<img src="pixel-lobster.svg" ...>\` | 🦞 |
| "Configure your AI platform" tab span | \`<img src="pixel-lobster.svg" ...>\` | 🦞 |
| Footer "Built with..." sentence | \`<img src="pixel-lobster.svg" ...>\` | 🦞 |
| (cleanup) \`.bluf-lobster\` CSS rule | defined but no longer used | removed |

## Asset retention

\`pixel-lobster.svg\` stays in \`/docs/\` since it's referenced from other pages (\`integrations.html\`, \`feature-matrix.html\`, etc.). If a follow-up sweep moves all pages to unicode, the asset can be removed at that point.

## Test plan

- [x] \`grep -c pixel-lobster docs/index.html\` returns 0
- [x] \`grep -c '🦞' docs/index.html\` returns 6 (5 new + 1 in original "OpenClaw 🦞" reference)
- [x] HTML well-formedness via \`html.parser\`
- [ ] After merge: visual review on the live landing — emoji renders cleanly across browsers, no missing-glyph fallback boxes

## CI expectation

Docs-only PR. Fast-path CI from PR #471 should clear in ~30 s — \`Classify changes\` detects docs/** + nothing else, the three required \`Check (X)\` matrix jobs return SUCCESS via per-step no-op, advisory jobs skip cleanly.

## AI involvement

- **Author:** Claude Opus 4.7 (1M context) under operator direction
  > "fix the openclaw icon on the GitHub Pages front page - OpenClaw - unnicode 🦞"
- **Auth class:** Standard (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)