### PR TITLE
docs(integrations): extended agent coverage — Gemini, Aider, Goose, Zed, Cody, Roo-Code for #487 PR-7

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -79,10 +79,16 @@ proper session-start hook (see issue #487 cross-files).
 | [`claude-code.md`](claude-code.md) | Claude Code (CLI, Mac/Win desktop, IDE) | 1 (hook) | reference recipe |
 | [`cursor.md`](cursor.md) | Cursor | 2 (MCP + rules) | recipe |
 | [`cline.md`](cline.md) | Cline (VS Code extension) | 2 (MCP + custom instructions) | recipe |
+| [`roo-code.md`](roo-code.md) | Roo Code (Cline fork) | 2 (MCP + custom instructions) | recipe |
 | [`continue.md`](continue.md) | Continue (VS Code / JetBrains) | 2 (MCP + systemMessage) | recipe |
 | [`windsurf.md`](windsurf.md) | Windsurf (Codeium) | 2 (MCP + rules) | recipe |
+| [`zed.md`](zed.md) | Zed assistant | 2 (MCP + assistant directive) | recipe |
+| [`goose.md`](goose.md) | Block Goose | 2 (MCP + system instructions) | recipe |
 | [`openclaw.md`](openclaw.md) | OpenClaw CLI | 2 (MCP + system message) | recipe |
 | [`codex-cli.md`](codex-cli.md) | OpenAI Codex CLI | 3 (programmatic) | recipe |
+| [`gemini.md`](gemini.md) | Google Gemini CLI / Gemini Code Assist | 3 (programmatic) | recipe |
+| [`aider.md`](aider.md) | Aider | 3 (programmatic via `--message-file`) | recipe |
+| [`cody.md`](cody.md) | Sourcegraph Cody | 3 (programmatic) | recipe |
 | [`claude-agent-sdk.md`](claude-agent-sdk.md) | Claude Agent SDK | 3 (programmatic) | recipe (TS + Python) |
 | [`openai-apps-sdk.md`](openai-apps-sdk.md) | OpenAI Apps SDK / Assistants / Responses | 3 (programmatic) | recipe |
 | [`grok-and-xai.md`](grok-and-xai.md) | xAI Grok | 3 (programmatic) | recipe |
@@ -119,9 +125,10 @@ bug and the fix lands in this directory.
 
 ## Cross-org follow-ups
 
-Category 2 agents (Cursor, Cline, Continue, Windsurf, OpenClaw) all need
-native session-start hooks to reach 100% remediation. Cross-files tracking
-those upstream requests live in #487's comments.
+Category 2 agents (Cursor, Cline, Roo Code, Continue, Windsurf, Zed,
+Goose, OpenClaw) all need native session-start hooks to reach 100%
+remediation. Cross-files tracking those upstream requests live in
+#487's comments.
 
 The MCP spec proposal at
 `modelcontextprotocol/specification` for a `session/initialize` server

--- a/docs/integrations/aider.md
+++ b/docs/integrations/aider.md
@@ -1,0 +1,118 @@
+# Aider — programmatic system-message prepend via `--message-file`
+
+**Category 3 (programmatic).** 100% reliable when implemented.
+
+[Aider](https://aider.chat) is a CLI pair-programmer that drives the
+edit loop against a local repo. It does not host MCP servers and does
+not document a session-start hook, but it does support
+`--message-file <path>` to inject a primer message at conversation start
+— exactly the surface the boot recipe needs.
+
+The recipe: write `ai-memory boot` output to a tempfile and pass that
+file to `aider --message-file`. The Rust-native cross-platform
+equivalent is `ai-memory wrap aider` (PR-6 of issue #487) — same
+semantics, no shell required.
+
+## Wrapper script
+
+Save as `~/.local/bin/aider-with-memory` and make it executable:
+
+```bash
+#!/usr/bin/env bash
+# Wraps `aider` with ai-memory boot context injected via --message-file.
+# Recipe shown in bash for clarity; PR-6 of issue #487 ships an
+# `ai-memory wrap aider` Rust subcommand with identical semantics.
+set -euo pipefail
+
+TMP=$(mktemp -t ai-memory-boot.XXXXXX)
+trap 'rm -f "$TMP"' EXIT
+
+# Header is preserved so the user sees ok/info/warn status in the chat
+# transcript. --message-file content becomes the first user-side turn,
+# so we phrase it as context rather than a directive.
+{
+  echo "## Recent context from ai-memory (read-only, prepended at session start)"
+  echo
+  ai-memory boot --quiet --format text --limit 10 || true
+  echo
+  echo "Reference the above when relevant to the user's request."
+} > "$TMP"
+
+exec aider --message-file "$TMP" "$@"
+```
+
+Then alias `aider` to this wrapper, or invoke `aider-with-memory`
+instead. For the Rust-native version (works on Windows, no shell,
+no tempfile lifetime issues):
+
+```bash
+ai-memory wrap aider -- <aider args>
+```
+
+## Why `--message-file` and not `--read`
+
+Aider also supports `--read <file>` to add files to the chat context as
+read-only sources. That would also work, but `--message-file` is closer
+to the semantic the recipe wants: a primer turn at session start, not a
+permanent file in the edit window. `--read` would surface boot context
+in every subsequent file diff, which is noisier than the recipe needs.
+
+If you specifically want the boot context to persist across `/clear`
+inside an aider session, use `--read` against a stable path instead of
+the tempfile pattern above:
+
+```bash
+ai-memory boot --quiet --format text --limit 10 > ~/.aider/memory-boot.txt
+exec aider --read ~/.aider/memory-boot.txt "$@"
+```
+
+Trade-off: stale context until you re-run `ai-memory boot`. The
+tempfile pattern always reflects current memory state at launch.
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+aider support. The wrapper script above is the manual form; track the
+installer issue for one-line bootstrap.
+
+## End-user diagnostic
+
+Aider streams the `--message-file` contents into the chat as the first
+turn, so the `ai-memory boot` status header is visible in the
+transcript. The four headers documented in [`README.md`](README.md)
+tell `ok` / `info-empty` / `info-greenfield` / `warn-db` apart. If you
+see neither header nor body, the wrapper didn't run — check `which
+aider` resolves to the wrapper.
+
+## Limitations
+
+- Aider does not host MCP servers; `ai-memory-mcp` cannot be registered
+  as a tool here. Mid-session recall (beyond the boot prepend) would
+  require Aider to grow MCP support upstream.
+- `--message-file` content counts against the context window of the
+  underlying model. Tune `--budget-tokens` if you see truncation.
+- The tempfile is cleaned up via `trap` on shell exit; if `aider`
+  daemonizes (it doesn't today, but version-dependent), you may need to
+  switch to a stable path.
+- Aider's `/clear` command wipes the chat — including the
+  `--message-file` primer. Re-run aider (or use the `--read` pattern
+  above) to reload boot context.
+
+## Better, when Aider lands a session-start hook
+
+We have an open feature request at the Aider repo to add a documented
+session-start hook (cross-filed from issue #487). When that ships,
+replace the wrapper with a hook entry pointing at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`codex-cli.md`](codex-cli.md) — same wrapper-script pattern.
+- Issue #487 — RCA + cross-files for the Aider hook request.

--- a/docs/integrations/cody.md
+++ b/docs/integrations/cody.md
@@ -1,0 +1,162 @@
+# Sourcegraph Cody — programmatic system-message prepend
+
+**Category 3 (programmatic).** 100% reliable when implemented.
+
+[Cody](https://sourcegraph.com/cody) is Sourcegraph's AI coding
+assistant. It ships as VS Code / JetBrains extensions and a CLI
+(`cody`), and exposes a programmatic chat API for Sourcegraph
+Enterprise customers. There is no documented session-start hook and no
+MCP host today, so the integration is at the application boundary:
+shell out to `ai-memory boot` and prepend the result to the system
+message of the Cody chat request.
+
+## Cody CLI wrapper
+
+If you drive Cody via its CLI, save as `~/.local/bin/cody-with-memory`
+and make it executable:
+
+```bash
+#!/usr/bin/env bash
+# Wraps `cody chat` with ai-memory boot context on the system message.
+set -euo pipefail
+
+BOOT_CONTEXT=$(ai-memory boot --quiet --no-header --format text --limit 10 || true)
+
+# Cody CLI's chat surface accepts a custom prompt via --message or
+# --context-file in some builds. Check `cody chat --help` for the
+# flag your install supports.
+if [[ -n "$BOOT_CONTEXT" ]]; then
+  PREAMBLE="You have access to ai-memory. Recent context follows; reference it when relevant to the request."
+  CONTEXT_FILE=$(mktemp -t cody-memory.XXXXXX)
+  trap 'rm -f "$CONTEXT_FILE"' EXIT
+  printf '%s\n\n%s\n' "$PREAMBLE" "$BOOT_CONTEXT" > "$CONTEXT_FILE"
+  exec cody chat --context-file "$CONTEXT_FILE" "$@"
+else
+  exec cody chat "$@"
+fi
+```
+
+## Programmatic — Cody chat API directly
+
+If you call the Cody chat API from your own application (Sourcegraph
+Enterprise customers using the GraphQL or REST surface), inject the
+boot context as a system-role message at the head of `messages`:
+
+```python
+import os
+import subprocess
+import requests
+
+def boot_context() -> str:
+    try:
+        return subprocess.check_output(
+            ["ai-memory", "boot", "--quiet", "--no-header",
+             "--format", "text", "--limit", "10"],
+            text=True,
+        ).strip()
+    except Exception:
+        return ""
+
+memory = boot_context()
+system_content = "You are a helpful coding assistant."
+if memory:
+    system_content += f"\n\n## Recent context (ai-memory)\n{memory}\n"
+
+# Cody Enterprise chat API endpoint — adjust to your instance.
+endpoint = f"{os.environ['SOURCEGRAPH_URL']}/.api/completions/stream"
+headers = {
+    "Authorization": f"token {os.environ['SOURCEGRAPH_TOKEN']}",
+    "Content-Type": "application/json",
+}
+body = {
+    "messages": [
+        {"speaker": "system", "text": system_content},
+        {"speaker": "human", "text": user_message},
+    ],
+}
+response = requests.post(endpoint, json=body, headers=headers)
+```
+
+100% reliable when implemented.
+
+```typescript
+import { execSync } from "node:child_process";
+
+function bootContext(): string {
+  try {
+    return execSync(
+      "ai-memory boot --quiet --no-header --format text --limit 10",
+      { encoding: "utf-8" }
+    ).trim();
+  } catch {
+    return "";
+  }
+}
+
+const memory = bootContext();
+let systemContent = "You are a helpful coding assistant.";
+if (memory) {
+  systemContent += `\n\n## Recent context (ai-memory)\n${memory}\n`;
+}
+
+const body = {
+  messages: [
+    { speaker: "system", text: systemContent },
+    { speaker: "human", text: userMessage },
+  ],
+};
+// POST body to your Sourcegraph instance's /.api/completions/stream
+```
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+Cody support. The wrapper / API recipe above is the manual form.
+
+## End-user diagnostic
+
+When using the wrapper script with the header preserved, the
+`ai-memory boot` status header appears in stdout / the chat
+transcript. The four headers documented in [`README.md`](README.md)
+tell `ok` / `info-empty` / `info-greenfield` / `warn-db` apart. For
+the programmatic API recipe, add a logging line after `boot_context()`
+returns — the empty string vs a populated payload is itself a
+diagnostic.
+
+## Limitations
+
+- Cody does not host MCP servers; `ai-memory-mcp` cannot be registered
+  as a tool here. Mid-session recall (beyond the boot prepend) would
+  require Cody to grow MCP support upstream.
+- The Cody chat API surface differs between Sourcegraph Cloud
+  (managed, OAuth) and Sourcegraph Enterprise (self-hosted, token
+  auth). The recipe above targets Enterprise; for Cloud, adapt the
+  auth header and endpoint accordingly.
+- The Cody VS Code / JetBrains extensions do not yet expose a
+  user-configurable system prompt or hook, so the wrapper does not
+  apply to those surfaces — track upstream for a developer hook.
+- This recipe loads memory **once per CLI invocation / API call**.
+  Multi-turn conversations within one invocation share the boot
+  context.
+
+## Better, when Cody lands a session-start hook
+
+We have an open feature request at the Sourcegraph Cody repo to add
+a documented session-start hook (cross-filed from issue #487). When
+that ships, replace the wrapper / prepend with a hook entry pointing
+at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`claude-agent-sdk.md`](claude-agent-sdk.md),
+  [`openai-apps-sdk.md`](openai-apps-sdk.md) — same prepend pattern
+  for other programmatic SDKs.
+- Issue #487 — RCA + cross-files for the Cody hook request.

--- a/docs/integrations/gemini.md
+++ b/docs/integrations/gemini.md
@@ -1,0 +1,134 @@
+# Google Gemini CLI / Gemini Code Assist — programmatic prepend
+
+**Category 3 (programmatic).** 100% reliable when implemented.
+
+Google's Gemini CLI is the reference command-line entry point for the
+Gemini API and Gemini Code Assist. There is no documented session-start
+hook today, and MCP support is not native (the CLI is partially
+OpenAI-API-compatible in some variants but not an MCP host). The
+integration is at the application boundary: shell out to `ai-memory boot`
+and prepend the result to the system instruction (or the first message
+of the conversation when no system slot exists).
+
+The canonical Rust-native cross-platform replacement for the wrapper
+script below is `ai-memory wrap gemini` (PR-6 of issue #487) — same
+semantics, no shell required, works on Windows / Docker / Kubernetes.
+
+## Wrapper script
+
+Save as `~/.local/bin/gemini-with-memory` and make it executable:
+
+```bash
+#!/usr/bin/env bash
+# Wraps `gemini` (Google Gemini CLI) with ai-memory boot context on the
+# system instruction. Recipe shown in bash for clarity; PR-6 of issue
+# #487 ships an `ai-memory wrap gemini` Rust subcommand with identical
+# semantics.
+set -euo pipefail
+
+BOOT_CONTEXT=$(ai-memory boot --quiet --no-header --format text --limit 10 || true)
+
+# Some Gemini CLI builds accept --system, others use GEMINI_SYSTEM_INSTRUCTION
+# env var or a -s short form. Check `gemini --help` to confirm. The
+# OpenAI-compatible variants accept --system verbatim.
+if [[ -n "$BOOT_CONTEXT" ]]; then
+  PREAMBLE="You have access to ai-memory. Recent context follows; reference it when relevant to the request."
+  exec gemini --system "${PREAMBLE}
+
+${BOOT_CONTEXT}" "$@"
+else
+  exec gemini "$@"
+fi
+```
+
+Then alias `gemini` to this wrapper, or invoke `gemini-with-memory`
+instead. For the Rust-native version (no shell, works on Windows):
+
+```bash
+ai-memory wrap gemini -- <gemini args>
+```
+
+## Programmatic — Gemini API directly
+
+If you are calling the Gemini API from your own application (Python, Go,
+TypeScript, etc.), prepend the boot context to `system_instruction` on
+session start:
+
+```python
+import subprocess
+import google.generativeai as genai
+
+def boot_context() -> str:
+    try:
+        return subprocess.check_output(
+            ["ai-memory", "boot", "--quiet", "--no-header",
+             "--format", "text", "--limit", "10"],
+            text=True,
+        ).strip()
+    except Exception:
+        return ""
+
+memory = boot_context()
+system_instruction = "You are a helpful assistant."
+if memory:
+    system_instruction += f"\n\n## Recent context (ai-memory)\n{memory}\n"
+
+model = genai.GenerativeModel(
+    model_name="gemini-2.0-flash",
+    system_instruction=system_instruction,
+)
+response = model.generate_content(user_message)
+```
+
+100% reliable when implemented.
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+Gemini support. The wrapper script above is the manual form; track the
+installer issue for one-line bootstrap.
+
+## End-user diagnostic
+
+Every wrapper invocation emits `ai-memory boot`'s status header on
+stdout (when `--no-header` is omitted). The four headers documented in
+[`README.md`](README.md) tell `ok` / `info-empty` / `info-greenfield`
+/ `warn-db` apart. If you see no header at all, the wrapper itself
+isn't firing — check `which gemini` resolves to the wrapper and not the
+upstream binary.
+
+## Limitations
+
+- The exact flag (`--system`, `-s`, `GEMINI_SYSTEM_INSTRUCTION` env var)
+  varies across Gemini CLI builds. Check `gemini --help` for your
+  install before committing the wrapper to production.
+- Gemini CLI does not have an MCP host today. `ai-memory-mcp` cannot be
+  registered as an MCP server here. Mid-session recall would require
+  adding function-calling support pointing at `ai-memory`'s HTTP API —
+  out of scope for the boot recipe.
+- This recipe loads memory **once per CLI invocation**. Multi-turn
+  conversations within one invocation share the boot context.
+- Gemini Code Assist (the IDE plug-in surface) does not yet expose a
+  user-configurable system prompt or hook, so the wrapper recipe does
+  not apply to that surface — track upstream for developer hooks.
+
+## Better, when Gemini CLI lands a session-start hook
+
+We have an open feature request at the Google Gemini CLI repo to add a
+documented session-start hook (cross-filed from issue #487). When that
+ships, replace the wrapper with a hook entry pointing at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`codex-cli.md`](codex-cli.md) — same wrapper pattern, OpenAI variant.
+- [`openai-apps-sdk.md`](openai-apps-sdk.md) — same prepend pattern for
+  any OpenAI-compatible API.
+- Issue #487 — RCA + cross-files for the Gemini CLI hook request.

--- a/docs/integrations/goose.md
+++ b/docs/integrations/goose.md
@@ -1,0 +1,131 @@
+# Block Goose — MCP server + system-instructions directive
+
+**Category 2 (MCP-capable, no native session-start hook).**
+Reference: <https://block.github.io/goose/>
+
+[Block Goose](https://block.github.io/goose/) is an open-source CLI /
+desktop AI agent from Block (Square / Cash App). It has documented MCP
+support, but no session-start hook today — so the recipe is two-part:
+register `ai-memory-mcp` as an MCP server (so the model can call memory
+tools at any time), and add a one-line system-instructions directive
+telling the model to call `memory_session_start` before responding to
+the first user turn.
+
+## Part 1 — register `ai-memory-mcp` as an MCP server
+
+Goose stores its config in a YAML / JSON file. The canonical path
+varies across Goose versions and platforms (commonly
+`~/.config/goose/config.yaml` on Linux/macOS), so verify with
+`goose --help` or the Goose docs before editing. If your install uses
+a non-default path, pass `--config <path>` to override (the same
+pattern PR-2's installer uses).
+
+Add an `ai-memory` entry under MCP servers (YAML form, since that's
+Goose's idiomatic config):
+
+```yaml
+extensions:
+  ai-memory:
+    type: stdio
+    cmd: ai-memory
+    args:
+      - mcp
+    envs:
+      AI_MEMORY_DB: ${HOME}/.claude/ai-memory.db
+    enabled: true
+```
+
+If your Goose version uses JSON config instead, the equivalent block
+(illustrative — the exact key names vary by version, do not blindly
+paste):
+
+```text
+{
+  "extensions": {
+    "ai-memory": {
+      "type": "stdio",
+      "cmd": "ai-memory",
+      "args": ["mcp"],
+      "envs": { "AI_MEMORY_DB": "${HOME}/.claude/ai-memory.db" },
+      "enabled": true
+    }
+  }
+}
+```
+
+Notes:
+
+- `cmd: "ai-memory"` requires the binary to be on Goose's `$PATH`.
+  If it isn't, use the absolute path (`/opt/homebrew/bin/ai-memory` on
+  macOS Homebrew, `/usr/local/bin/ai-memory` typical on Linux).
+- `AI_MEMORY_DB` defaults to a path inside the user's home — set it
+  explicitly to whichever DB you want shared with Claude Code or other
+  agents. Sharing one DB across agents is the whole point of the
+  design.
+- Restart Goose after editing the config so the MCP server is picked
+  up. `goose info` should list `ai-memory` under available extensions.
+
+## Part 2 — system-instructions directive (best-effort fallback)
+
+Goose supports per-agent system instructions via its profile / preset
+config. Add the following directive to the system instructions for the
+agent you use as your default driver:
+
+> Before responding to any user message in a fresh conversation, call
+> the `ai-memory.memory_session_start` MCP tool and a `memory_recall`
+> against the relevant project namespace (default: the current working
+> directory's basename). Surface the recalled titles in your first
+> reply so the user can confirm continuity.
+
+Caveat: text directives are best-effort (issue #487 layer 6) — the
+model may skip the call under load or competing instructions.
+Mechanical hook support upstream is the only path to "100%."
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+Goose support. The YAML / JSON edit above is the manual form; track
+the installer issue for one-line bootstrap that handles both config
+shapes.
+
+## End-user diagnostic
+
+Goose surfaces MCP tool calls in its transcript, so when the directive
+fires you will see `memory_session_start` in the tool-call log on the
+first turn. If you don't, the directive isn't firing — usually means
+the system instructions aren't being applied to the active profile.
+The `ai-memory boot` status-header diagnostic (see
+[`README.md`](README.md)) does not apply here because Goose's
+integration is MCP-only, not boot-shellout-based.
+
+## Limitations
+
+- Category-2: text-directive in system instructions is subject to
+  model compliance.
+- Goose's config schema has evolved across releases; a recipe pinned
+  to one schema can break on upgrade. The `--config <path>` override
+  insulates against the canonical-path drift but not against schema
+  drift.
+- Some Goose builds gate MCP behind an experimental flag — confirm
+  with `goose --help` / `goose info` that MCP is enabled before
+  expecting the recipe to fire.
+
+## Better, when Goose lands a session-start hook
+
+We have an open feature request at the Block Goose repo to add a
+documented session-start hook (cross-filed from issue #487). When that
+ships, replace Part 2 with a hook entry pointing at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`cline.md`](cline.md), [`continue.md`](continue.md) — same
+  category-2 pattern for VS Code MCP hosts.
+- Issue #487 — RCA + cross-files for category-2 native-hook requests.

--- a/docs/integrations/roo-code.md
+++ b/docs/integrations/roo-code.md
@@ -1,0 +1,126 @@
+# Roo Code (Cline fork) — MCP server + custom instructions
+
+**Category 2 (MCP-capable, no native session-start hook).**
+
+[Roo Code](https://github.com/RooCodeInc/Roo-Code) (formerly Roo Cline)
+is a fork of Cline maintained by the Roo team. The recipe is
+**largely identical to [`cline.md`](cline.md)** — same MCP-server
+registration shape, same custom-instructions surface — with the
+divergences noted below. If you have already installed the Cline
+recipe, you can copy the same MCP-server JSON across; only the config
+file path differs.
+
+## Part 1 — MCP server
+
+Roo Code's MCP config path differs from upstream Cline. Recent
+versions store it under the VS Code extension storage:
+
+- macOS:
+  `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`
+  (the "rooveterinaryinc" publisher id is the historical Roo Cline id;
+  newer builds may use a `roo-code` slug — check
+  `~/Library/Application Support/Code/User/globalStorage/` for the
+  active directory)
+- Linux:
+  `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`
+- Windows:
+  `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json`
+
+If the canonical path varies on your install, the Roo Code Settings
+panel (Command Palette → "Roo Code: Open MCP Settings") opens the
+active file — preferred over hand-typing the path. The schema is
+identical to Cline's:
+
+```json
+{
+  "mcpServers": {
+    "ai-memory": {
+      "command": "ai-memory",
+      "args": ["mcp"],
+      "env": { "AI_MEMORY_DB": "${HOME}/.claude/ai-memory.db" },
+      "disabled": false,
+      "autoApprove": ["memory_session_start", "memory_recall", "memory_capabilities"]
+    }
+  }
+}
+```
+
+`autoApprove` lets the model call read-only memory tools without
+prompting for permission on every call — required for a smooth boot
+path.
+
+## Part 2 — Custom Instructions (best-effort)
+
+Roo Code's custom-instructions surface is reachable via Settings →
+Roo Code → Custom Instructions (same UI affordance as Cline). Roo Code
+also supports per-mode instructions (the "Mode" abstraction is a Roo
+addition not present in upstream Cline) — if you use modes, set the
+directive on the default / "Code" mode for first-turn coverage.
+
+> At the start of every conversation, before responding to the user's
+> first message, call `memory_session_start` then `memory_recall`
+> against the current project's namespace. Reference recalled titles
+> in your first reply.
+
+## Divergence from Cline
+
+| Aspect | Cline | Roo Code |
+|---|---|---|
+| Extension publisher id | `saoudrizwan.claude-dev` | `rooveterinaryinc.roo-cline` (historical) / `roo-code` (newer) |
+| MCP settings file | `~/.cline/mcp_settings.json` (varies by version) | VS Code extension storage path (see above) |
+| Modes / personas | Single agent | Per-mode customization (Code / Architect / Ask / Debug) |
+| Custom Instructions surface | Single textbox | Per-mode + global textboxes |
+
+Otherwise the shapes are identical. If a future Roo Code release
+diverges further (e.g., changes the MCP settings schema), this recipe
+will pick up the delta and re-document.
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+Roo Code support. The MCP-settings JSON edit above is the manual form;
+track the installer issue for one-line bootstrap that handles the
+publisher-id variance and per-mode instructions.
+
+## End-user diagnostic
+
+Roo Code surfaces MCP tool calls in its chat transcript, so when the
+directive fires you will see `memory_session_start` in the tool-call
+log on the first turn. If you don't, either MCP is not loading the
+server (check the Roo Code output panel in VS Code: View → Output →
+"Roo Code") or the directive is not being applied to the active mode.
+The `ai-memory boot` status-header diagnostic (see
+[`README.md`](README.md)) does not apply here because Roo Code's
+integration is MCP-only.
+
+## Limitations
+
+- Category-2: text-directive in custom instructions is subject to
+  model compliance.
+- Roo Code's per-mode instructions are powerful but easy to
+  misconfigure — verify the directive is in the active mode, not just
+  the global textbox.
+- The publisher id and storage path have changed at least once across
+  Roo Code's history (Roo Cline → Roo Code rename). The recipe pins
+  the historical id; on a fresh install confirm the active directory
+  before pasting.
+
+## Better, when Roo Code lands a session-start hook
+
+We have an open feature request at the Roo Code repo to add a
+documented session-start hook (cross-filed from issue #487). When that
+ships, replace Part 2 with a hook entry pointing at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`cline.md`](cline.md) — the upstream parent recipe; most of the
+  shape is shared.
+- Issue #487 — RCA + cross-files for category-2 native-hook requests.

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -1,0 +1,118 @@
+# Zed assistant — MCP server + assistant directive
+
+**Category 2 (MCP-capable, no native session-start hook).**
+Reference: <https://zed.dev/docs/assistant>
+
+[Zed](https://zed.dev/) is a high-performance editor with a built-in
+AI assistant panel. Recent Zed builds have MCP support; configuration
+lives in Zed's `settings.json`. There is no documented session-start
+hook today, so the recipe is two-part: register `ai-memory-mcp` as an
+MCP server **plus** add an assistant-rules directive telling the model
+to call `memory_session_start` before responding to the first user
+turn.
+
+## Part 1 — register `ai-memory-mcp` as an MCP context server
+
+Zed's settings live at `~/.config/zed/settings.json` (Linux/macOS) or
+`%APPDATA%\Zed\settings.json` (Windows). The MCP key name has shifted
+across Zed versions — recent builds use `context_servers`, earlier
+experimental builds used variants under `assistant`. The canonical
+path varies; if your build does not pick up the entry under
+`context_servers`, consult `Cmd+,` (Settings) → search for "mcp" or
+"context server" to confirm the key name.
+
+Add to `~/.config/zed/settings.json`:
+
+```json
+{
+  "context_servers": {
+    "ai-memory": {
+      "command": {
+        "path": "ai-memory",
+        "args": ["mcp"],
+        "env": {
+          "AI_MEMORY_DB": "${HOME}/.claude/ai-memory.db"
+        }
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `path: "ai-memory"` requires the binary to be on Zed's `$PATH` at
+  launch. macOS GUI launches inherit a minimal PATH, so prefer the
+  absolute path (`/opt/homebrew/bin/ai-memory`) here.
+- Restart Zed after editing settings so the context server is picked
+  up.
+- If you launch Zed from a terminal (`zed .`) the inherited PATH is
+  richer and the bare command form usually works.
+
+## Part 2 — assistant directive (best-effort fallback)
+
+Zed's assistant panel supports a per-workspace or global default
+prompt / system instruction surface (Settings → Assistant → Default
+Model / Default Prompt). Add the following directive there:
+
+> Before responding to any user message in a fresh conversation, call
+> the `ai-memory.memory_session_start` MCP tool and a `memory_recall`
+> against the relevant project namespace (default: the current working
+> directory's basename). Surface the recalled titles in your first
+> reply so the user can confirm continuity.
+
+Caveat: text directives are best-effort (issue #487 layer 6) — the
+model may skip the call under load or competing instructions.
+
+## Quick install
+
+Manual install only until PR-2's installer follow-up adds explicit
+Zed support. The settings.json edit above is the manual form; track
+the installer issue for one-line bootstrap that handles the platform
+path differences (`~/.config/zed/` vs `%APPDATA%\Zed\`).
+
+## End-user diagnostic
+
+Zed surfaces MCP tool calls in the assistant panel transcript, so
+when the directive fires you will see `memory_session_start` in the
+tool-call log on the first turn. If you don't, either MCP is not
+loading the server (check the Zed log: `zed --foreground` on
+Linux/macOS, or the bottom panel on launch) or the directive is not
+being applied. The `ai-memory boot` status-header diagnostic (see
+[`README.md`](README.md)) does not apply here because Zed's
+integration is MCP-only, not boot-shellout-based.
+
+## Limitations
+
+- Category-2: text-directive in assistant settings is subject to
+  model compliance.
+- The `context_servers` key is current at time of writing but Zed's
+  MCP surface is evolving rapidly — verify with the Zed docs before
+  filing bugs against the recipe.
+- Zed's assistant supports multiple models (Anthropic, OpenAI,
+  others); the directive applies regardless of underlying model, but
+  tool-call format varies and the user-visible transcript will look
+  different across providers.
+- Zed launched from Spotlight / Launchpad inherits a minimal PATH;
+  prefer the absolute `path` form to avoid "command not found" on
+  macOS GUI starts.
+
+## Better, when Zed lands a session-start hook
+
+We have an open feature request at the Zed repo to add a documented
+session-start hook for the assistant panel (cross-filed from issue
+#487). When that ships, replace Part 2 with a hook entry pointing at:
+
+```bash
+ai-memory boot --quiet --no-header --limit 10 --budget-tokens 4096
+```
+
+This recipe will be updated in place once the hook lands.
+
+## Related
+
+- [`README.md`](README.md) — integration matrix and the universal
+  primitive.
+- [`cursor.md`](cursor.md), [`cline.md`](cline.md) — same category-2
+  pattern for editor-hosted MCP clients.
+- Issue #487 — RCA + cross-files for category-2 native-hook requests.


### PR DESCRIPTION
## Summary

PR-7 of issue #487. Extends per-agent recipe coverage from PR-1's 11 entries to 17 by adding 6 new integration docs:

- **`docs/integrations/gemini.md`** (category 3): wrapper script + direct Gemini API system-instruction prepend. Cross-refs `ai-memory wrap gemini` (PR-6).
- **`docs/integrations/aider.md`** (category 3): tempfile + `--message-file` injection (also documents `--read` alternative for `/clear`-survival). Cross-refs `ai-memory wrap aider` (PR-6).
- **`docs/integrations/goose.md`** (category 2): Block Goose MCP-server YAML config + system-instructions directive. Notes `--config <path>` override since the canonical YAML location varies across Goose versions.
- **`docs/integrations/zed.md`** (category 2): `context_servers` block in `~/.config/zed/settings.json` + assistant directive. Calls out the macOS-GUI minimal-PATH gotcha for the binary path.
- **`docs/integrations/cody.md`** (category 3): Sourcegraph Cody — CLI wrapper plus chat-API system-role prepend in both Python and TypeScript (Sourcegraph Enterprise endpoint shape).
- **`docs/integrations/roo-code.md`** (category 2): documents as a Cline alias with explicit divergence table (publisher id, MCP settings file path, per-mode instructions surface).

`docs/integrations/README.md` per-agent recipes table extended from 11 to 17 entries plus 2 reference docs. Cross-org follow-ups paragraph updated to include Roo Code, Zed, and Goose alongside the existing category-2 list.

## Test plan

- [x] All six new files follow the cline.md / cursor.md template: category header → MCP-server (if applicable) → text directive (if applicable) → programmatic snippet (cat 3) → quick install → end-user diagnostic → limitations → "better when X lands a hook" → related links.
- [x] JSON gate passes — every fenced \`json\` block parses under jq:
  ```bash
  for f in docs/integrations/{gemini,aider,goose,zed,cody,roo-code}.md; do
    awk '/^```json$/{flag=1;next}/^```$/{flag=0}flag' "$f" | jq . >/dev/null 2>&1 || echo INVALID
  done
  # all OK; only zed.md and roo-code.md ship `json` fences
  ```
- [x] Illustrative-only blocks fenced as `text` not `json` (Goose alternate JSON shape) so PR-3's recipe-contract test (#489) does not parse them.
- [x] No code changes — pure documentation.
- [x] Quick-install sections all note "manual install only until PR-2 follow-up adds support" — no false promises.
- [x] Canonical config paths cited only where stable; `--config <path>` override fallback called out where schemas drift across versions (Goose, Zed, Roo Code).
- [ ] Verifying-a-recipe cold-start test from README.md §"Verifying a recipe" against any of the new agents the maintainer has installed locally (left for review-time spot-check).

## AI involvement

- Drafted by Claude Opus 4.7 (1M context) under the workflow in \`docs/AI_DEVELOPER_WORKFLOW.md\`.
- Co-author trailer present on the single commit.

## Related

- Issue #487 — RCA + agent matrix.
- PR #488 — base branch (PR-1 of the #487 series).
- PR-2 (installer) — referenced from each new recipe's "Quick install" section.
- PR-6 (\`ai-memory wrap\` subcommand) — referenced from gemini.md and aider.md.