### PR TITLE
feat(boot): enriched diagnostic manifest — version, db_path, schema, tier, latency for #487 PR-4

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -26,19 +26,37 @@ but **a status header always appears on stdout** so the agent (and the
 human running it) can see whether boot fired and why context might be
 missing. See `ai-memory boot --help` for the full surface.
 
-### End-user diagnostic — always-visible status header
+### End-user diagnostic — always-visible manifest header
 
-Every invocation emits exactly one of these four headers (per [#487
-addendum](https://github.com/alphaonedev/ai-memory-mcp/issues/487)):
+Every invocation emits a transparent multi-field manifest (per [#487
+addendum](https://github.com/alphaonedev/ai-memory-mcp/issues/487), PR-4):
+agents and humans always know exactly what's loaded and what's configured.
 
-| Header | Meaning |
-|---|---|
-| `# ai-memory boot: ok — loaded N memories from ns=X` | Normal happy path. |
-| `# ai-memory boot: info — namespace empty; loaded N memories from global Long tier fallback` | Requested namespace empty; surfacing cross-project context instead. |
-| `# ai-memory boot: info — namespace 'X' is empty and no global Long-tier fallback found — nothing to load (this is normal on a fresh install)` | First-run / greenfield. |
-| `# ai-memory boot: warn — db unavailable at /path — proceeding without memory context. Run \`ai-memory doctor\` to diagnose.` | DB couldn't be opened. The hook fired but found no DB. |
+```text
+# ai-memory boot: ok
+#   version:    0.6.3+patch.1
+#   db:         /home/u/.claude/ai-memory.db (schema=v19, 161 memories)
+#   tier:       autonomous (embedder=nomic-ai/nomic-embed-text-v1.5, reranker=ms-marco-MiniLM-L-6-v2, llm=gemma4:e4b)
+#   latency:    12ms
+#   namespace:  ai-memory-mcp/v0631-release (loaded 3 memories)
+```
 
-**If no status header appears at all**, the integration recipe didn't
+The four status variants share the same manifest shape; only the first
+line's status word and the `namespace:` line's parenthetical change:
+
+| Status | First line | `namespace:` line |
+|---|---|---|
+| Happy path | `# ai-memory boot: ok` | `(loaded N memories)` |
+| Namespace empty, fell back | `# ai-memory boot: info` | `(fallback: loaded N memories from global Long tier)` |
+| First-run / greenfield | `# ai-memory boot: info` | `(empty — nothing to load; this is normal on a fresh install)` |
+| DB unavailable | `# ai-memory boot: warn` | `(db unavailable — see `ai-memory doctor`)` |
+
+In the warn variant, `db:` reports `<unavailable>` for `schema` and
+the live-memories count, while `version`, `tier`, and `latency` still
+surface — the manifest never disappears, only what depends on a live
+DB is sentinelled.
+
+**If no manifest appears at all**, the integration recipe didn't
 fire the hook — the agent host either skipped the hook, the binary isn't
 on `$PATH`, or the recipe is misconfigured. This absence is itself a
 diagnostic: silent vs. "warn" vs. "ok" tell the user three different
@@ -48,14 +66,16 @@ failure modes apart.
 suppressing the header makes silent failure indistinguishable from "no
 memories yet."
 
-The output body (after the header, when memories are loaded) is one of
+The output body (after the manifest, when memories are loaded) is one of
 three formats:
 
 - `text` (default) — human-readable bulleted list. Works in any agent's
   system message. Easiest to scan.
-- `json` — single object containing `status`, `namespace`, `count`,
-  `memories`, `note` for programmatic ingest (Claude Agent SDK, OpenAI
-  Apps SDK, Codex CLI prepend).
+- `json` — single object containing every manifest field as a top-level
+  key (`status`, `version`, `db_path`, `schema_version`, `total_memories`,
+  `tier`, `embedder`, `reranker`, `llm`, `latency_ms`, `namespace`,
+  `count`, `note`, `memories`, `fell_back_to_global`) for programmatic
+  ingest (Claude Agent SDK, OpenAI Apps SDK, Codex CLI prepend).
 - `toon` — the canonical token-efficient memory format, byte-identical
   to a `memory_recall` MCP response.
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -56,24 +56,45 @@ mode issue #487 is fixing.
 
 ## End-user diagnostic — how to know boot fired
 
-Every boot invocation emits one of four status headers:
+Every boot invocation emits a transparent multi-field manifest. Agents
+and humans always see exactly what version ran, which DB / schema it
+opened, the configured tier and models, and the wall-clock latency —
+no black-box behaviour:
 
-| Header prefix | Meaning |
-|---|---|
-| `# ai-memory boot: ok — loaded N memories from ns=X` | Normal happy path. |
-| `# ai-memory boot: info — namespace empty; loaded N memories from global Long tier fallback` | Requested namespace was empty; we surfaced cross-project context. |
-| `# ai-memory boot: info — namespace 'X' is empty and no global Long-tier fallback found — nothing to load (this is normal on a fresh install)` | First-run / greenfield. Not an error. |
-| `# ai-memory boot: warn — db unavailable at /path — proceeding without memory context. Run \`ai-memory doctor\` to diagnose.` | The hook fired but the DB couldn't be opened. Common causes: wrong `AI_MEMORY_DB` path, permission denied, brand-new install before first `ai-memory store`. |
+```text
+# ai-memory boot: ok
+#   version:    0.6.3+patch.1
+#   db:         /home/u/.claude/ai-memory.db (schema=v19, 161 memories)
+#   tier:       autonomous (embedder=nomic-ai/nomic-embed-text-v1.5, reranker=ms-marco-MiniLM-L-6-v2, llm=gemma4:e4b)
+#   latency:    12ms
+#   namespace:  ai-memory-mcp (loaded 10 memories)
+```
 
-If you see **no header at all** in your session log, the hook never fired.
-Run the diagnostic from the same shell Claude Code launched from:
+The first line's status word is one of `ok` / `info` / `warn`; the
+`namespace:` line's parenthetical varies by status. The four variants:
+
+| Status | First line | `namespace:` line |
+|---|---|---|
+| Happy path | `# ai-memory boot: ok` | `(loaded N memories)` |
+| Namespace empty, fell back | `# ai-memory boot: info` | `(fallback: loaded N memories from global Long tier)` |
+| First-run / greenfield | `# ai-memory boot: info` | `(empty — nothing to load; this is normal on a fresh install)` |
+| DB unavailable | `# ai-memory boot: warn` | `(db unavailable — see `ai-memory doctor`)` |
+
+The manifest is *never* a black box: the warn variant still surfaces
+`version`, `tier`, and `latency`, with `<unavailable>` standing in for
+the live-DB-only fields (`schema`, `total memories`). Common causes for
+the warn variant: wrong `AI_MEMORY_DB` path, permission denied,
+brand-new install before first `ai-memory store`.
+
+If you see **no manifest at all** in your session log, the hook never
+fired. Run the diagnostic from the same shell Claude Code launched from:
 
 ```bash
 ai-memory boot --limit 1
-# Should emit one of the four headers above.
+# Should emit the manifest with one of the four status words above.
 # If it errors instead, the binary or DB is misconfigured.
-# If it works but Claude Code never sees a header, the SessionStart hook
-#   isn't installed correctly — re-check ~/.claude/settings.json.
+# If it works but Claude Code never sees a manifest, the SessionStart
+#   hook isn't installed correctly — re-check ~/.claude/settings.json.
 ```
 
 ## Project-scoped namespace override

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -22,14 +22,29 @@
 //!   the header on stdout, still exit 0.
 //! - No memories found: emit the header (or nothing with `--no-header`),
 //!   exit 0.
+//!
+//! ## Diagnostic manifest (PR-4 of #487)
+//!
+//! Boot's header is a transparent, multi-field manifest — never a black box.
+//! Every field reflects a fact about *this* invocation so agents and humans
+//! always know exactly what was loaded and what's configured. Fields:
+//!
+//! - `version`     — binary version (`CARGO_PKG_VERSION` at compile time)
+//! - `db`          — resolved DB path + schema version + total live memories
+//! - `tier`        — active feature tier and *configured* (not loaded)
+//!                   embedder / reranker / llm models
+//! - `latency`     — wall-clock from `run()` entry to header emit
+//! - `namespace`   — resolved namespace + how many memories matched
 
 use crate::cli::CliOutput;
 use crate::cli::helpers::{auto_namespace, human_age, id_short};
+use crate::config::AppConfig;
 use crate::{db, models, toon};
 use anyhow::Result;
 use clap::Args;
 use models::Tier;
 use std::path::Path;
+use std::time::Instant;
 
 /// Default budget — large enough for ~10 toon-compact rows, small enough that
 /// a misconfigured hook can't wedge the first turn with megabytes of context.
@@ -40,6 +55,11 @@ const DEFAULT_BUDGET_TOKENS: usize = 4096;
 /// boot's budget is advisory and only needs to be in the right order of
 /// magnitude to bound output cost.
 const TOKENS_PER_CHAR: f32 = 0.25;
+
+/// Sentinel used in manifest fields that couldn't be resolved on this
+/// invocation — most often because the DB itself is unreachable, so
+/// schema/total/etc. simply don't have an answer.
+const UNAVAILABLE: &str = "<unavailable>";
 
 /// Output formats supported by `ai-memory boot`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -207,9 +227,151 @@ enum BootStatus {
     WarnDbUnavailable,
 }
 
+impl BootStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::OkLoaded => "ok",
+            Self::InfoFallback | Self::InfoEmpty => "info",
+            Self::WarnDbUnavailable => "warn",
+        }
+    }
+}
+
+/// Read the schema version from the DB's `schema_version` table. Returns
+/// the sentinel string when the DB is unreachable or the table is empty —
+/// the manifest is best-effort, never an error.
+fn read_schema_version(conn: &rusqlite::Connection) -> String {
+    conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+        [],
+        |r| r.get::<_, i64>(0),
+    )
+    .map_or_else(|_| UNAVAILABLE.to_string(), |v| format!("v{v}"))
+}
+
+/// Cheap COUNT of live (non-expired) memories. Same expiry semantics as
+/// the recall pipeline: NULL `expires_at` is permanent, otherwise must be
+/// in the future. Errors degrade to the sentinel rather than fail boot.
+fn count_live_memories(conn: &rusqlite::Connection) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE expires_at IS NULL OR expires_at > ?1",
+        rusqlite::params![now],
+        |r| r.get::<_, i64>(0),
+    )
+    .map_or_else(|_| UNAVAILABLE.to_string(), |v| v.to_string())
+}
+
+/// Diagnostic manifest assembled before each header emit. Every field is
+/// a string so the same struct can carry both real values and the
+/// `<unavailable>` sentinel without branching downstream.
+///
+/// Field semantics:
+/// - `version`         — `env!("CARGO_PKG_VERSION")` at compile time
+/// - `db_path`         — resolved path the boot ran against
+/// - `schema_version`  — `vN` from the DB's `schema_version` table
+/// - `total_memories`  — count of live (non-expired) rows
+/// - `tier`            — active feature tier name
+/// - `embedder`        — *configured* embedder (boot does NOT load it)
+/// - `reranker`        — *configured* cross-encoder (or "none")
+/// - `llm`             — *configured* LLM model id (or "none")
+/// - `latency_ms`      — wall-clock from `run()` entry to emit
+/// - `namespace`       — the namespace the body actually came from
+/// - `count`           — number of memories included in the body
+struct BootManifest {
+    version: String,
+    db_path: String,
+    schema_version: String,
+    total_memories: String,
+    tier: String,
+    embedder: String,
+    reranker: String,
+    llm: String,
+    latency_ms: u128,
+    namespace: String,
+    count: usize,
+    // The status note, used by JSON `note` and (for InfoEmpty / Warn) the
+    // multi-line text/toon header expansion.
+    note: String,
+    status: BootStatus,
+}
+
+impl BootManifest {
+    fn build(
+        status: BootStatus,
+        namespace: &str,
+        count: usize,
+        db_path: &Path,
+        app_config: &AppConfig,
+        schema_version: String,
+        total_memories: String,
+        latency_ms: u128,
+    ) -> Self {
+        // Resolve the *configured* tier. Boot doesn't materialize the
+        // embedder / LLM / reranker handles, so these reflect what would
+        // load — not what actually loaded.
+        let feature_tier = app_config.effective_tier(None);
+        let tier_config = feature_tier.config();
+        let embedder = tier_config
+            .embedding_model
+            .map_or_else(|| "none".to_string(), |m| m.hf_model_id().to_string());
+        let llm = tier_config
+            .llm_model
+            .map_or_else(|| "none".to_string(), |m| m.ollama_model_id().to_string());
+        let reranker = if tier_config.cross_encoder {
+            "ms-marco-MiniLM-L-6-v2".to_string()
+        } else {
+            "none".to_string()
+        };
+
+        let note = match status {
+            BootStatus::OkLoaded => format!(
+                "loaded {count} memor{plural} from ns={namespace}",
+                plural = if count == 1 { "y" } else { "ies" }
+            ),
+            BootStatus::InfoFallback => format!(
+                "namespace empty; loaded {count} memor{plural} from global Long tier fallback",
+                plural = if count == 1 { "y" } else { "ies" }
+            ),
+            BootStatus::InfoEmpty => format!(
+                "namespace '{namespace}' is empty and no global Long-tier fallback found — \
+                 nothing to load (this is normal on a fresh install)"
+            ),
+            BootStatus::WarnDbUnavailable => format!(
+                "db unavailable at {} — proceeding without memory context. \
+                 Run `ai-memory doctor` to diagnose. \
+                 See https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/integrations/README.md",
+                db_path.display()
+            ),
+        };
+
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            db_path: db_path.display().to_string(),
+            schema_version,
+            total_memories,
+            tier: feature_tier.as_str().to_string(),
+            embedder,
+            reranker,
+            llm,
+            latency_ms,
+            namespace: namespace.to_string(),
+            count,
+            note,
+            status,
+        }
+    }
+}
+
 /// `ai-memory boot` entry point.
 #[allow(clippy::too_many_lines)]
-pub fn run(db_path: &Path, args: &BootArgs, out: &mut CliOutput<'_>) -> Result<()> {
+pub fn run(
+    db_path: &Path,
+    args: &BootArgs,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let start = Instant::now();
     let format = BootFormat::parse(&args.format)?;
     let limit = args.limit.clamp(1, 50);
     let namespace = resolve_namespace(args);
@@ -228,18 +390,26 @@ pub fn run(db_path: &Path, args: &BootArgs, out: &mut CliOutput<'_>) -> Result<(
                 )?;
             }
             if !args.no_header {
-                emit_status_header(
-                    out,
+                let manifest = BootManifest::build(
                     BootStatus::WarnDbUnavailable,
                     &namespace,
                     0,
                     db_path,
-                    format,
-                )?;
+                    app_config,
+                    UNAVAILABLE.to_string(),
+                    UNAVAILABLE.to_string(),
+                    start.elapsed().as_millis(),
+                );
+                emit_status_header(out, &manifest, format)?;
             }
             return Ok(());
         }
     };
+
+    // Cheap diagnostic lookups. Both degrade to the sentinel rather than
+    // fail the boot — the manifest is best-effort.
+    let schema_version = read_schema_version(&conn);
+    let total_memories = count_live_memories(&conn);
 
     let (mems, used_namespace) = fetch_boot_memories(&conn, &namespace, limit)?;
     let mems = clamp_to_budget(mems, args.budget_tokens);
@@ -247,7 +417,17 @@ pub fn run(db_path: &Path, args: &BootArgs, out: &mut CliOutput<'_>) -> Result<(
 
     if mems.is_empty() {
         if !args.no_header {
-            emit_status_header(out, BootStatus::InfoEmpty, &namespace, 0, db_path, format)?;
+            let manifest = BootManifest::build(
+                BootStatus::InfoEmpty,
+                &namespace,
+                0,
+                db_path,
+                app_config,
+                schema_version,
+                total_memories,
+                start.elapsed().as_millis(),
+            );
+            emit_status_header(out, &manifest, format)?;
         }
         return Ok(());
     }
@@ -272,18 +452,48 @@ pub fn run(db_path: &Path, args: &BootArgs, out: &mut CliOutput<'_>) -> Result<(
                     serde_json::to_string(&serde_json::json!({"memories": mems}))?
                 )?;
             } else {
-                emit_json_with_status(out, status, displayed_ns, &mems, fell_back)?;
+                let manifest = BootManifest::build(
+                    status,
+                    displayed_ns,
+                    mems.len(),
+                    db_path,
+                    app_config,
+                    schema_version,
+                    total_memories,
+                    start.elapsed().as_millis(),
+                );
+                emit_json_with_status(out, &manifest, &mems, fell_back)?;
             }
         }
         BootFormat::Text => {
             if !args.no_header {
-                emit_status_header(out, status, displayed_ns, mems.len(), db_path, format)?;
+                let manifest = BootManifest::build(
+                    status,
+                    displayed_ns,
+                    mems.len(),
+                    db_path,
+                    app_config,
+                    schema_version,
+                    total_memories,
+                    start.elapsed().as_millis(),
+                );
+                emit_status_header(out, &manifest, format)?;
             }
             emit_text(out, &mems)?;
         }
         BootFormat::Toon => {
             if !args.no_header {
-                emit_status_header(out, status, displayed_ns, mems.len(), db_path, format)?;
+                let manifest = BootManifest::build(
+                    status,
+                    displayed_ns,
+                    mems.len(),
+                    db_path,
+                    app_config,
+                    schema_version,
+                    total_memories,
+                    start.elapsed().as_millis(),
+                );
+                emit_status_header(out, &manifest, format)?;
             }
             emit_toon(out, &mems)?;
         }
@@ -294,66 +504,103 @@ pub fn run(db_path: &Path, args: &BootArgs, out: &mut CliOutput<'_>) -> Result<(
 
 /// Always-visible diagnostic header. Agents see this in their session log
 /// even when the body is empty, so the absence of memory context is a
-/// surfaced signal rather than a silent failure. Format:
-///   text/toon: `# ai-memory boot: <STATUS> — <human readable reason>`
-///   json:      single JSON object with `status`, `namespace`, `count`,
-///              optional `memories` and `note`.
+/// surfaced signal rather than a silent failure.
+///
+/// **Format (text/toon)** — multi-line manifest, every field labelled:
+/// ```text
+/// # ai-memory boot: ok
+/// #   version:    0.6.3+patch.1
+/// #   db:         /home/u/.claude/ai-memory.db (schema=v19, 161 memories)
+/// #   tier:       autonomous (embedder=..., reranker=..., llm=...)
+/// #   latency:    12ms
+/// #   namespace:  ns-x (loaded 3 memories)
+/// ```
+///
+/// **Format (json)** — single JSON object with every manifest field as a
+/// top-level key (`version`, `db_path`, `schema_version`, `total_memories`,
+/// `tier`, `embedder`, `reranker`, `llm`, `latency_ms`, `namespace`,
+/// `count`, `status`, `note`).
 fn emit_status_header(
     out: &mut CliOutput<'_>,
-    status: BootStatus,
-    namespace: &str,
-    count: usize,
-    db_path: &Path,
+    manifest: &BootManifest,
     format: BootFormat,
 ) -> Result<()> {
-    let (label, note) = match status {
-        BootStatus::OkLoaded => (
-            "ok",
-            format!(
-                "loaded {count} memor{plural} from ns={namespace}",
-                plural = if count == 1 { "y" } else { "ies" }
-            ),
-        ),
-        BootStatus::InfoFallback => (
-            "info",
-            format!(
-                "namespace empty; loaded {count} memor{plural} from global Long tier fallback",
-                plural = if count == 1 { "y" } else { "ies" }
-            ),
-        ),
-        BootStatus::InfoEmpty => (
-            "info",
-            format!(
-                "namespace '{namespace}' is empty and no global Long-tier fallback found — \
-                 nothing to load (this is normal on a fresh install)"
-            ),
-        ),
-        BootStatus::WarnDbUnavailable => (
-            "warn",
-            format!(
-                "db unavailable at {} — proceeding without memory context. \
-                 Run `ai-memory doctor` to diagnose. \
-                 See https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/integrations/README.md",
-                db_path.display()
-            ),
-        ),
-    };
-
     match format {
         BootFormat::Json => {
             writeln!(
                 out.stdout,
                 "{}",
                 serde_json::json!({
-                    "status": label,
-                    "namespace": namespace,
-                    "count": count,
-                    "note": note,
+                    "status": manifest.status.label(),
+                    "version": manifest.version,
+                    "db_path": manifest.db_path,
+                    "schema_version": manifest.schema_version,
+                    "total_memories": manifest.total_memories,
+                    "tier": manifest.tier,
+                    "embedder": manifest.embedder,
+                    "reranker": manifest.reranker,
+                    "llm": manifest.llm,
+                    "latency_ms": manifest.latency_ms,
+                    "namespace": manifest.namespace,
+                    "count": manifest.count,
+                    "note": manifest.note,
                 })
             )?;
         }
         _ => {
-            writeln!(out.stdout, "# ai-memory boot: {label} — {note}")?;
+            // Multi-line transparent manifest. Each field is on its own
+            // line so a grep / log scrape can pick them out individually,
+            // and the human reader sees a top-down summary.
+            writeln!(out.stdout, "# ai-memory boot: {}", manifest.status.label())?;
+            writeln!(out.stdout, "#   version:    {}", manifest.version)?;
+            writeln!(
+                out.stdout,
+                "#   db:         {} (schema={}, {} memories)",
+                manifest.db_path, manifest.schema_version, manifest.total_memories
+            )?;
+            writeln!(
+                out.stdout,
+                "#   tier:       {} (embedder={}, reranker={}, llm={})",
+                manifest.tier, manifest.embedder, manifest.reranker, manifest.llm
+            )?;
+            writeln!(out.stdout, "#   latency:    {}ms", manifest.latency_ms)?;
+            // Namespace line carries the same status-specific note the
+            // single-line PR-1 header used to carry — so a reader can see
+            // *why* a particular count showed up.
+            match manifest.status {
+                BootStatus::OkLoaded => {
+                    writeln!(
+                        out.stdout,
+                        "#   namespace:  {} (loaded {} memor{})",
+                        manifest.namespace,
+                        manifest.count,
+                        if manifest.count == 1 { "y" } else { "ies" }
+                    )?;
+                }
+                BootStatus::InfoFallback => {
+                    writeln!(
+                        out.stdout,
+                        "#   namespace:  {} (fallback: loaded {} memor{} from global Long tier)",
+                        manifest.namespace,
+                        manifest.count,
+                        if manifest.count == 1 { "y" } else { "ies" }
+                    )?;
+                }
+                BootStatus::InfoEmpty => {
+                    writeln!(
+                        out.stdout,
+                        "#   namespace:  {} (empty — nothing to load; this is normal on a fresh install)",
+                        manifest.namespace
+                    )?;
+                }
+                BootStatus::WarnDbUnavailable => {
+                    writeln!(
+                        out.stdout,
+                        "#   namespace:  {} (db unavailable — see `ai-memory doctor`)",
+                        manifest.namespace
+                    )?;
+                }
+            }
         }
     }
     Ok(())
@@ -378,21 +625,29 @@ fn emit_text(out: &mut CliOutput<'_>, mems: &[models::Memory]) -> Result<()> {
 
 fn emit_json_with_status(
     out: &mut CliOutput<'_>,
-    status: BootStatus,
-    namespace: &str,
+    manifest: &BootManifest,
     mems: &[models::Memory],
     fell_back: bool,
 ) -> Result<()> {
-    let label = match status {
-        BootStatus::OkLoaded => "ok",
-        BootStatus::InfoFallback | BootStatus::InfoEmpty => "info",
-        BootStatus::WarnDbUnavailable => "warn",
-    };
+    // Same shape as `emit_status_header` JSON path, plus `memories` and
+    // `fell_back_to_global`. Agents that ingest JSON get every manifest
+    // field as a top-level key so they can reason about the runtime
+    // without parsing a free-text header.
     let body = serde_json::json!({
-        "status": label,
-        "namespace": namespace,
+        "status": manifest.status.label(),
+        "version": manifest.version,
+        "db_path": manifest.db_path,
+        "schema_version": manifest.schema_version,
+        "total_memories": manifest.total_memories,
+        "tier": manifest.tier,
+        "embedder": manifest.embedder,
+        "reranker": manifest.reranker,
+        "llm": manifest.llm,
+        "latency_ms": manifest.latency_ms,
+        "namespace": manifest.namespace,
+        "count": manifest.count,
+        "note": manifest.note,
         "fell_back_to_global": fell_back,
-        "count": mems.len(),
         "memories": mems,
     });
     writeln!(out.stdout, "{}", serde_json::to_string(&body)?)?;
@@ -429,6 +684,10 @@ mod tests {
         }
     }
 
+    fn default_config() -> AppConfig {
+        AppConfig::default()
+    }
+
     #[test]
     fn boot_format_parse_accepts_aliases() {
         assert_eq!(BootFormat::parse("text").unwrap(), BootFormat::Text);
@@ -446,18 +705,173 @@ mod tests {
         seed_memory(&env.db_path, "ns-x", "second", "content two");
         seed_memory(&env.db_path, "ns-y", "elsewhere", "content three");
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("ns-x".to_string());
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        // Status line + every manifest field appears.
         assert!(
-            stdout.contains("# ai-memory boot: ok") && stdout.contains("ns=ns-x"),
+            stdout.contains("# ai-memory boot: ok"),
             "expected ok status header, got: {stdout}"
         );
+        assert!(
+            stdout.contains("#   version:"),
+            "manifest missing version line: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   db:"),
+            "manifest missing db line: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   tier:"),
+            "manifest missing tier line: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   latency:"),
+            "manifest missing latency line: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   namespace:") && stdout.contains("ns-x"),
+            "namespace line should contain ns-x: {stdout}"
+        );
+        assert!(stdout.contains("loaded 2 memories"));
         assert!(stdout.contains("first"));
         assert!(stdout.contains("second"));
         assert!(!stdout.contains("elsewhere"));
+    }
+
+    #[test]
+    fn boot_header_includes_version() {
+        let mut env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-v", "row", "x");
+        let db_path = env.db_path.clone();
+        let cfg = default_config();
+        let mut args = default_args();
+        args.namespace = Some("ns-v".to_string());
+        let mut out = env.output();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
+        let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        // CARGO_PKG_VERSION is "0.6.3+patch.1" or similar; assert the
+        // crate constant surfaces verbatim, not a hardcoded string.
+        let version = env!("CARGO_PKG_VERSION");
+        assert!(
+            stdout.contains(version),
+            "expected version `{version}` in header: {stdout}"
+        );
+    }
+
+    #[test]
+    fn boot_header_includes_db_path() {
+        let mut env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-d", "row", "x");
+        let db_path = env.db_path.clone();
+        let cfg = default_config();
+        let mut args = default_args();
+        args.namespace = Some("ns-d".to_string());
+        let mut out = env.output();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
+        let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        let db_str = db_path.display().to_string();
+        assert!(
+            stdout.contains(&db_str),
+            "expected db path `{db_str}` in header: {stdout}"
+        );
+    }
+
+    #[test]
+    fn boot_header_includes_schema_version() {
+        let mut env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-s", "row", "x");
+        let db_path = env.db_path.clone();
+        let cfg = default_config();
+        let mut args = default_args();
+        args.namespace = Some("ns-s".to_string());
+        let mut out = env.output();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
+        let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        assert!(
+            stdout.contains("schema=v"),
+            "expected `schema=vN` in header: {stdout}"
+        );
+    }
+
+    #[test]
+    fn boot_header_includes_latency_ms() {
+        let mut env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-lat", "row", "x");
+        let db_path = env.db_path.clone();
+        let cfg = default_config();
+        let mut args = default_args();
+        args.namespace = Some("ns-lat".to_string());
+        let mut out = env.output();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
+        let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        // Latency line must exist; the value must end with `ms` and be
+        // numeric (we don't pin a value because wall-clock varies).
+        let latency_line = stdout
+            .lines()
+            .find(|l| l.contains("latency:"))
+            .expect("latency line must exist in manifest");
+        let suffix = latency_line.split("latency:").nth(1).unwrap().trim();
+        assert!(
+            suffix.ends_with("ms"),
+            "latency value should end with `ms`: {suffix}"
+        );
+        let num_str = suffix.trim_end_matches("ms");
+        assert!(
+            num_str.parse::<u128>().is_ok(),
+            "latency must parse as integer ms: {num_str}"
+        );
+    }
+
+    #[test]
+    fn boot_json_includes_all_manifest_fields() {
+        let mut env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-jm", "row", "x");
+        let db_path = env.db_path.clone();
+        let cfg = default_config();
+        let mut args = default_args();
+        args.namespace = Some("ns-jm".to_string());
+        args.format = "json".to_string();
+        let mut out = env.output();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
+        let stdout = std::str::from_utf8(&env.stdout).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+        // Status fields (PR-1 contract preserved).
+        assert_eq!(parsed["status"], "ok");
+        assert_eq!(parsed["namespace"], "ns-jm");
+        assert_eq!(parsed["count"], 1);
+        assert_eq!(parsed["fell_back_to_global"], false);
+        assert!(parsed["memories"].is_array());
+        // PR-4 manifest fields.
+        for key in [
+            "version",
+            "db_path",
+            "schema_version",
+            "total_memories",
+            "tier",
+            "embedder",
+            "reranker",
+            "llm",
+            "latency_ms",
+            "note",
+        ] {
+            assert!(
+                parsed.get(key).is_some(),
+                "json output missing manifest field `{key}`: {stdout}"
+            );
+        }
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["latency_ms"].is_number());
+        assert!(
+            parsed["schema_version"]
+                .as_str()
+                .unwrap_or("")
+                .starts_with('v'),
+            "schema_version should be `vN` form"
+        );
     }
 
     #[test]
@@ -467,11 +881,12 @@ mod tests {
             seed_memory(&env.db_path, "ns-l", &format!("m{i}"), "x");
         }
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("ns-l".to_string());
         args.limit = 2;
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         assert!(stdout.contains("loaded 2 memories"));
         let row_count = stdout.lines().filter(|l| l.starts_with("- [")).count();
@@ -483,11 +898,12 @@ mod tests {
         let mut env = TestEnv::fresh();
         seed_memory(&env.db_path, "ns-h", "row-one", "x");
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("ns-h".to_string());
         args.no_header = true;
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         assert!(!stdout.contains("# ai-memory boot"));
         assert!(stdout.contains("row-one"));
@@ -498,11 +914,12 @@ mod tests {
         let mut env = TestEnv::fresh();
         seed_memory(&env.db_path, "ns-j", "row", "x");
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("ns-j".to_string());
         args.format = "json".to_string();
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
         assert_eq!(parsed["status"], "ok");
@@ -517,16 +934,19 @@ mod tests {
         // The user-facing diagnostic header MUST appear so the agent (and
         // a human looking at the agent log) sees that boot ran but
         // couldn't load context. --quiet suppresses *only* stderr.
+        // PR-4: the warn variant still emits the manifest fields, with
+        // `<unavailable>` in slots that need a live DB to fill.
         let mut env = TestEnv::fresh();
         let bad_path = env
             .db_path
             .parent()
             .unwrap()
             .join("subdir/that/does/not/exist/db.sqlite");
+        let cfg = default_config();
         let mut args = default_args();
         args.quiet = true;
         let mut out = env.output();
-        run(&bad_path, &args, &mut out).unwrap();
+        run(&bad_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         assert!(
             stdout.contains("# ai-memory boot: warn"),
@@ -535,6 +955,28 @@ mod tests {
         assert!(
             stdout.contains("db unavailable"),
             "header should explain the warning cause: {stdout}"
+        );
+        // What the warn variant CAN surface even without the DB.
+        assert!(
+            stdout.contains("#   version:"),
+            "warn manifest should still carry version: {stdout}"
+        );
+        assert!(
+            stdout.contains(env!("CARGO_PKG_VERSION")),
+            "warn manifest version should be CARGO_PKG_VERSION: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   tier:"),
+            "warn manifest should still carry tier: {stdout}"
+        );
+        assert!(
+            stdout.contains("#   latency:"),
+            "warn manifest should still carry latency: {stdout}"
+        );
+        // Slots that need a live DB degrade to the sentinel.
+        assert!(
+            stdout.contains(UNAVAILABLE),
+            "warn manifest should mark unreachable fields as <unavailable>: {stdout}"
         );
         assert!(
             env.stderr.is_empty(),
@@ -550,10 +992,11 @@ mod tests {
             .parent()
             .unwrap()
             .join("subdir/that/does/not/exist/db.sqlite");
-        let mut args = default_args();
+        let cfg = default_config();
+        let args = default_args();
         // quiet = false (default) — error goes to stderr too.
         let mut out = env.output();
-        run(&bad_path, &args, &mut out).unwrap();
+        run(&bad_path, &args, &cfg, &mut out).unwrap();
         let stderr = std::str::from_utf8(&env.stderr).unwrap();
         assert!(
             stderr.contains("ai-memory boot: db unavailable"),
@@ -571,11 +1014,12 @@ mod tests {
             .parent()
             .unwrap()
             .join("subdir/that/does/not/exist/db.sqlite");
+        let cfg = default_config();
         let mut args = default_args();
         args.quiet = true;
         args.no_header = true;
         let mut out = env.output();
-        run(&bad_path, &args, &mut out).unwrap();
+        run(&bad_path, &args, &cfg, &mut out).unwrap();
         assert!(env.stdout.is_empty());
         assert!(env.stderr.is_empty());
     }
@@ -592,10 +1036,11 @@ mod tests {
         .unwrap();
         drop(conn);
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("nonexistent-ns".to_string());
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         assert!(
             stdout.contains("# ai-memory boot: info") && stdout.contains("fallback"),
@@ -608,10 +1053,11 @@ mod tests {
     fn boot_empty_namespace_emits_info_empty_status() {
         let mut env = TestEnv::fresh();
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("nothing-here".to_string());
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         assert!(
             stdout.contains("# ai-memory boot: info")
@@ -633,12 +1079,13 @@ mod tests {
             );
         }
         let db_path = env.db_path.clone();
+        let cfg = default_config();
         let mut args = default_args();
         args.namespace = Some("ns-budget".to_string());
         args.limit = 50;
         args.budget_tokens = 100;
         let mut out = env.output();
-        run(&db_path, &args, &mut out).unwrap();
+        run(&db_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         let row_count = stdout.lines().filter(|l| l.starts_with("- [")).count();
         assert!(
@@ -655,15 +1102,21 @@ mod tests {
             .parent()
             .unwrap()
             .join("subdir/that/does/not/exist/db.sqlite");
+        let cfg = default_config();
         let mut args = default_args();
         args.format = "json".to_string();
         args.quiet = true;
         let mut out = env.output();
-        run(&bad_path, &args, &mut out).unwrap();
+        run(&bad_path, &args, &cfg, &mut out).unwrap();
         let stdout = std::str::from_utf8(&env.stdout).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
         assert_eq!(parsed["status"], "warn");
         assert_eq!(parsed["count"], 0);
         assert!(parsed["note"].as_str().unwrap().contains("db unavailable"));
+        // PR-4: warn JSON variant carries the manifest with sentinels in
+        // slots that need a live DB.
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(parsed["schema_version"], UNAVAILABLE);
+        assert_eq!(parsed["total_memories"], UNAVAILABLE);
     }
 }

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -712,7 +712,7 @@ pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
             let mut so = stdout.lock();
             let mut se = stderr.lock();
             let mut out = cli::CliOutput::from_std(&mut so, &mut se);
-            cli::boot::run(&db_path, &a, &mut out)
+            cli::boot::run(&db_path, &a, app_config, &mut out)
         }
     };
 


### PR DESCRIPTION
## Summary

PR-4 of issue #487. Replaces the single-line PR-1 boot header with a
**transparent multi-field manifest** so agents and humans always know
exactly what's loaded and what's configured — never a black box.
Per the user directive on #487: "we want a transparent implementation —
never a blackbox — agents AND humans always know exactly what's loaded."

### Manifest

```text
# ai-memory boot: ok
#   version:    0.6.3+patch.1
#   db:         /Users/fate/.claude/ai-memory.db (schema=v19, 159 memories)
#   tier:       autonomous (embedder=nomic-ai/nomic-embed-text-v1.5, reranker=ms-marco-MiniLM-L-6-v2, llm=gemma4:e4b)
#   latency:    8ms
#   namespace:  ai-memory-mcp/v0631-release (loaded 3 memories)
```

For `--format json`: every manifest field lands as a top-level key
(`version`, `db_path`, `schema_version`, `total_memories`, `tier`,
`embedder`, `reranker`, `llm`, `latency_ms`, `namespace`, `count`,
`status`, `note`, `fell_back_to_global`, `memories`).

### Why each field

- **version** — `env!("CARGO_PKG_VERSION")` at compile time
- **db_path** — resolved DB path the boot ran against
- **schema_version** — `vN` from the DB's `schema_version` table
- **total_memories** — cheap COUNT of live (non-expired) rows
- **tier** — `app_config.effective_tier(None)`
- **embedder / reranker / llm** — *configured* models from the active
  tier_config (boot does NOT load them; this reflects "configured" not
  "loaded")
- **latency_ms** — wall-clock from `run()` entry to header emit (`Instant`)

### Backward compatibility

- The `# ai-memory boot:` prefix is preserved verbatim, so PR-3's
  `contains`-based contract tests in #489 (boot_primitive_contract,
  recipe_contract) keep matching once they land.
- All PR-1 JSON keys remain (`status`, `namespace`, `count`,
  `fell_back_to_global`, `memories`, `note`); manifest fields are
  added alongside, not replacing.
- All four status variants (ok / info-fallback / info-empty / warn)
  carry the same manifest shape. The warn (DB unavailable) variant
  surfaces version / tier / latency and uses the `<unavailable>`
  sentinel for fields that need a live DB.

### Implementation notes

- `BootManifest` struct centralises field assembly so all four code
  paths emit consistent output.
- `read_schema_version` / `count_live_memories` degrade to the sentinel
  on any DB error rather than failing boot — the manifest is best-effort.
- `run()` now takes `&AppConfig` to resolve the configured tier; the
  daemon_runtime dispatch passes `app_config` into the call.
- No new dependencies; `chrono`, `rusqlite`, `serde_json`,
  `std::time::Instant` already in tree.

### PR-3 test updates

PR-3 (#489) is not on this branch's base history yet — its
`boot_primitive_contract` / `recipe_contract` tests don't exist locally.
The header prefix `# ai-memory boot:` is preserved, so its planned
`contains`-based asserts will remain green when #489 merges. No PR-3
test updates required from this PR.

### Tests added

In `src/cli/boot.rs::tests`:

- `boot_emits_ok_header_with_loaded_memories` — updated to assert every
  manifest line
- `boot_header_includes_version` — `CARGO_PKG_VERSION` surfaces verbatim
- `boot_header_includes_db_path` — resolved path appears in `db:` line
- `boot_header_includes_schema_version` — `schema=vN` appears
- `boot_header_includes_latency_ms` — `latency: <int>ms` parses
- `boot_json_includes_all_manifest_fields` — every JSON key present
  and correctly typed
- `boot_quiet_with_unreachable_db_emits_warn_header_no_stderr` —
  warn variant retains version / tier / latency and uses sentinels
- `boot_json_warn_status_when_db_unavailable` — JSON warn shape with
  `<unavailable>` for `schema_version` / `total_memories`

### Docs updated

- `docs/integrations/README.md` — replaces single-line header table
  with manifest example + status-variant table reflecting the new shape
- `docs/integrations/claude-code.md` — `## End-user diagnostic` section
  shows enriched manifest

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 1622 passed (gate ≥ 1617)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --tests` — all integration suites green
- [x] Live smoke: `cargo run --bin ai-memory -- boot --db /Users/fate/.claude/ai-memory.db --namespace ai-memory-mcp/v0631-release --limit 3 --quiet` produces the multi-field manifest exactly as specified

## AI involvement

Implemented by Claude (Opus 4.7, 1M context) in autonomous mode.
Single commit, co-author trailer present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)