### PR TITLE
feat(audit): enterprise security audit trail + logging facility for #487 PR-5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,11 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "wiremock",
+ "zstd",
 ]
 
 [[package]]
@@ -850,6 +852,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3924,6 +3935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4362,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,12 +4426,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5407,3 +5450,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+# v0.6.3.1 (PR-5 / issue #487) — rolling file appender for the
+# operational logging facility. Default-OFF; opt-in via
+# `[logging] enabled = true` in config.toml. Uses the non-blocking
+# writer so file I/O never stalls a tracing call site.
+tracing-appender = "0.2"
+# v0.6.3.1 (PR-5 / issue #487) — `ai-memory logs archive` compresses
+# rotated operational logs past their retention horizon. Pure-Rust
+# bindings via the `zstd` crate.
+zstd = { version = "0.13", default-features = false }
 uuid = { version = "1", features = ["v4"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 gethostname = "0.5"
@@ -160,6 +169,14 @@ wiremock = "0.6"
 # already transitively in the dep tree via tokio, declared explicitly
 # here so the test can `use libc::SIGINT` without `rustc_private` errors.
 [target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
+# v0.6.3.1 (PR-5 / issue #487) — `audit::mark_append_only` invokes
+# `libc::chflags` (BSD/macOS) and the `FS_IOC_SETFLAGS` ioctl (Linux)
+# to mark the audit log as append-only at the kernel level. Best-effort
+# defense in depth; the load-bearing tamper-evidence is the per-line
+# hash chain, not the file flag.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [[bench]]

--- a/docs/security/audit-schema.md
+++ b/docs/security/audit-schema.md
@@ -1,0 +1,142 @@
+# ai-memory audit schema v1
+
+PR-5 of issue [#487](https://github.com/alphaonedev/ai-memory-mcp/issues/487).
+This document is the **stable, versioned contract** for what
+`ai-memory` emits to its security audit trail. SIEMs (Splunk, Datadog,
+Elastic, Loki, Sentinel, Chronicle) ingest the lines as plain JSON.
+The schema is deliberately **not** bound to any external framework —
+not OCSF, not CEF, not LEEF — because a SIEM that can ingest a JSON
+line can ingest this one. Mapping into a vendor schema is a one-shot
+filter at ingest time.
+
+## Wire format
+
+NDJSON: one JSON object per line. UTF-8. No trailing whitespace.
+
+## Field reference
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `schema_version` | `u32` | yes | Always `1` in v1. Bumped only when an existing field's semantics change. Adding optional fields does NOT bump the version. |
+| `timestamp` | RFC3339 string (UTC) | yes | When the event was emitted by the binary. |
+| `sequence` | `u64` | yes | Per-process monotonic counter starting at 1. Lets a SIEM detect dropped lines independently of the chain check. |
+| `actor.agent_id` | string | yes | Resolved NHI agent_id (`ai:<client>@<host>:pid-<n>`, `host:<host>:pid-<n>-<uuid>`, etc.). |
+| `actor.scope` | string | optional | Visibility scope: `private \| team \| unit \| org \| collective`. |
+| `actor.synthesis_source` | string | yes | How `agent_id` was synthesized: `explicit \| env \| mcp_client_info \| host_fallback \| anonymous_fallback \| http_header \| http_body \| per_request \| default_fallback`. |
+| `action` | enum | yes | One of `recall \| store \| update \| delete \| link \| promote \| forget \| consolidate \| export \| import \| approve \| reject \| session_boot`. Adding a variant is non-breaking; renaming or removing one IS breaking. |
+| `target.memory_id` | string | yes | Memory id, or `"*"` for sweep operations. Capped at 128 chars. |
+| `target.namespace` | string | yes | Memory namespace at action time. Capped at 128 chars. |
+| `target.title` | string | optional | Memory title (advisory label, **not content**). Capped at 200 chars; control chars stripped. |
+| `target.tier` | string | optional | `short \| mid \| long`. |
+| `target.scope` | string | optional | Memory `metadata.scope`. |
+| `outcome` | enum | yes | `allow \| deny \| error \| pending`. |
+| `auth` | object | optional | HTTP-only auth context. Stdio (CLI / MCP) emissions omit this entirely. |
+| `auth.source_ip` | string | optional | Peer IP from the HTTP request. |
+| `auth.mtls_fp` | string | optional | SHA-256 fingerprint of the verified client cert. |
+| `auth.api_key_id_hash` | string | optional | Hex sha256 (truncated 16 bytes) of the API key id. **Never the raw key.** |
+| `session_id` | string | optional | Caller-supplied session correlator. |
+| `request_id` | string | optional | Per-request correlator. |
+| `error` | string | optional | Sanitized error message. Present only when `outcome = error`. Capped at 256 chars. |
+| `prev_hash` | hex string (64 chars) | yes | sha256 of the prior line's `self_hash`, or 64 zeros for the chain head. |
+| `self_hash` | hex string (64 chars) | yes | sha256 of every other field in serialization order (with `self_hash` itself zeroed). |
+
+## What is NEVER captured
+
+- `memory.content` — the secret payload of every memory. The schema
+  has no `content` field at all. The `redact_content` knob in
+  `config.toml` is reserved for a future per-namespace exception API;
+  v1 always omits content.
+- Raw API keys, raw mTLS private keys, raw passwords. The auth block
+  carries hashes only.
+- Free-form caller-supplied strings outside the documented fields.
+
+## Version policy
+
+- **Adding** an optional field (`#[serde(skip_serializing_if = ...)]`):
+  non-breaking. SIEM parsers tolerate unknown fields.
+- **Adding** a variant to `action` or `outcome`: non-breaking. Parsers
+  treat unknown enum values as opaque strings.
+- **Renaming, removing, or repurposing** any field or variant:
+  breaking. `schema_version` increments. Old SIEM parsers SHOULD
+  reject events whose `schema_version` they don't recognise rather
+  than silently misinterpret.
+
+## Hash chain
+
+```
+prev_hash[0]    = "0000…00"          (32 bytes of zeros, hex-encoded)
+self_hash[i]    = sha256(canonical_json(event[i]))
+prev_hash[i+1]  = self_hash[i]
+```
+
+`canonical_json` is `serde_json::to_string` over the event with
+`self_hash` cleared (so the field is "self-blinded" — it can be
+recomputed without circular dependence). Field order matches the
+struct definition, which serde preserves.
+
+`ai-memory audit verify` recomputes each line's `self_hash` and
+asserts each `prev_hash` matches the prior line's `self_hash`. Any
+mismatch surfaces a precise line number + failure kind and exits 2.
+
+## Append-only OS hint
+
+Best-effort defense in depth, **not** load-bearing:
+
+- **Linux:** `FS_IOC_SETFLAGS` ioctl with `FS_APPEND_FL`. Requires
+  `CAP_LINUX_IMMUTABLE`. Filesystem support varies (ext4, xfs, btrfs:
+  yes; tmpfs, NFS: no).
+- **macOS / FreeBSD / OpenBSD:** `chflags(2)` with `UF_APPEND`.
+- **Windows / other:** silently skipped.
+
+If the OS hint cannot be applied, the binary logs a warning via
+`tracing::warn!` and continues. The hash chain remains the
+authoritative tamper-evidence.
+
+## Threat model
+
+The audit trail defends against:
+
+1. **Silent edit of a past event.** Recomputing `self_hash` over the
+   tampered event will not match the stored hash; `audit verify`
+   surfaces the offending line number.
+2. **Silent insertion of a fake event.** The inserted line's
+   `prev_hash` will not match the prior line's `self_hash`.
+3. **Silent deletion of a single line.** The next line's `prev_hash`
+   will not match the line that's now physically prior.
+
+It does NOT defend against:
+
+- **An attacker with root + write access who rewrites the entire
+  file from scratch and re-chains.** This is fundamentally
+  impossible to prevent without an append-only WORM-style log
+  store; for that compliance level, ship the lines off-host to an
+  immutable SIEM in real time and rely on the SIEM's tamper
+  evidence. The chain is still useful here because the SIEM can
+  cross-check its own ingest record against the on-host file.
+- **Truncation of the most recent N lines** (the truncation point
+  becomes the new tail and the chain is consistent up to that
+  point). Periodic `CHECKPOINT.sig` markers (cadence
+  `attestation_cadence_minutes`) bound how much history can be
+  silently discarded — a verifier with the prior checkpoint
+  signature can detect any rollback past it. v1 emits the marker
+  shape; full off-host attestation is reserved for v0.7+.
+
+## Compliance presets
+
+The compliance presets in `[audit.compliance.*]` are pure
+configuration. Setting `applied = true` propagates the documented
+retention / cadence values to the effective config. When multiple
+presets are active simultaneously, the **most-conservative** value
+wins (longest retention, shortest attestation cadence).
+
+| Preset | Retention | Attestation | Notes |
+|---|---|---|---|
+| `soc2` | 730 days | 60 min | Trust Service Criteria CC7.2. |
+| `hipaa` | 2190 days (6 yrs) | — | 45 CFR §164.316(b)(2). Pair with `--features sqlcipher` for at-rest crypto. |
+| `gdpr` | 1095 days (3 yrs) | — | Reserved `pseudonymize_actors` for v0.7+. |
+| `fedramp` | 1095 days | 30 min | NIST SP 800-53 AU-11. |
+
+Note: the binary surfaces the **resolved** retention via
+`AuditConfig::effective_retention_days`; operators can verify the
+applied policy with `ai-memory doctor` (P7) or by inspecting the
+config block at runtime.

--- a/docs/security/audit-trail.md
+++ b/docs/security/audit-trail.md
@@ -112,6 +112,139 @@ depth**. The hash chain is the load-bearing tamper-evidence.
 
 ---
 
+## Log directory resolution
+
+End users can set the operational-log directory **and** the audit-log
+directory at every layer of the configuration stack. This is a
+**user-mandated** addendum to PR-5 — operators always retain control
+over where logs land regardless of how `ai-memory` was installed or
+launched.
+
+### Precedence (highest wins)
+
+| Priority | Layer | Operational logs | Audit log |
+|---:|---|---|---|
+| 1 | **CLI flag** | `ai-memory logs --log-dir <PATH> …` | `ai-memory audit --audit-dir <PATH> …` |
+| 2 | **Environment variable** | `AI_MEMORY_LOG_DIR` | `AI_MEMORY_AUDIT_DIR` |
+| 3 | **`config.toml`** | `[logging] path = "…"` | `[audit] path = "…"` |
+| 4 | **Platform default** | per-OS table below | per-OS table below |
+
+The resolver also recognises an `INVOCATION_ID` environment variable
+(set by `systemd` for unit-managed processes). When present *and*
+`/var/log/ai-memory/` is writable, the platform-default branch picks
+`/var/log/ai-memory/` instead of the per-user XDG path. This lets a
+`systemd` service with `LogsDirectory=ai-memory` write logs to the
+canonical system path without any extra configuration.
+
+`AI_MEMORY_LOG_DIR` and `AI_MEMORY_AUDIT_DIR` are read with
+`std::env::var_os`, so non-UTF-8 paths on Windows pass through to
+`PathBuf` unchanged.
+
+### Platform defaults
+
+| OS | Operational logs | Audit log |
+|---|---|---|
+| **Linux** (and BSD / illumos / other Unix) | `${XDG_STATE_HOME:-$HOME/.local/state}/ai-memory/logs/` | `${XDG_STATE_HOME:-$HOME/.local/state}/ai-memory/audit/` |
+| **macOS** | `~/Library/Logs/ai-memory/` | `~/Library/Logs/ai-memory/audit/` |
+| **Windows** | `%LOCALAPPDATA%\ai-memory\logs\` | `%LOCALAPPDATA%\ai-memory\audit\` |
+| **systemd-managed daemon** (any OS, `INVOCATION_ID` set, `/var/log/ai-memory/` writable) | `/var/log/ai-memory/logs/` | `/var/log/ai-memory/audit/` |
+
+### Worked examples
+
+**Laptop dev (no config — accept the default).**
+
+```bash
+$ ai-memory audit path
+/Users/alice/Library/Logs/ai-memory/audit/audit.log
+
+$ ai-memory logs tail --lines 5
+# tails ~/Library/Logs/ai-memory/ai-memory.log.YYYY-MM-DD
+```
+
+**Docker container with a host-mounted log volume.** Mount the host
+directory into a stable container path, then point `ai-memory` at it
+with `AI_MEMORY_LOG_DIR` so the env-injected path wins over any
+baked-in `config.toml`:
+
+```bash
+docker run -d \
+  -v /var/log/ai-memory-host:/var/log/ai-memory \
+  -e AI_MEMORY_LOG_DIR=/var/log/ai-memory/logs \
+  -e AI_MEMORY_AUDIT_DIR=/var/log/ai-memory/audit \
+  ghcr.io/alphaonedev/ai-memory:0.6.3
+```
+
+**Kubernetes pod with `emptyDir` volume.** Project the volume into
+`/var/log/ai-memory/` and point both env vars at the matching
+subdirectories. Use a sidecar log shipper (Promtail, Filebeat,
+Fluentbit) to forward both streams off-pod before termination.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-memory
+spec:
+  containers:
+    - name: ai-memory
+      image: ghcr.io/alphaonedev/ai-memory:0.6.3
+      env:
+        - name: AI_MEMORY_LOG_DIR
+          value: /var/log/ai-memory/logs
+        - name: AI_MEMORY_AUDIT_DIR
+          value: /var/log/ai-memory/audit
+      volumeMounts:
+        - name: ai-memory-logs
+          mountPath: /var/log/ai-memory
+  volumes:
+    - name: ai-memory-logs
+      emptyDir: {}
+```
+
+**systemd unit with `LogsDirectory=`.** systemd creates and chowns the
+directory to the unit's `User=`; `ai-memory` auto-detects via
+`INVOCATION_ID` and lands logs in `/var/log/ai-memory/`:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/ai-memory serve
+User=ai-memory
+LogsDirectory=ai-memory
+LogsDirectoryMode=0700
+```
+
+No env vars or `config.toml` paths required — the platform-default
+branch picks `/var/log/ai-memory/` because `INVOCATION_ID` is set and
+the directory is writable.
+
+**Override at the CLI for a one-off run** (debugging, audit forensics):
+
+```bash
+ai-memory audit --audit-dir /tmp/ai-memory-forensics verify
+ai-memory logs --log-dir /tmp/ai-memory-debug tail --follow
+```
+
+### Security guard: no world-writable directories
+
+The resolver **refuses** to write to a directory whose Unix permissions
+include the world-writable bit (`mode & 0o002 != 0`). World-writable
+log destinations are a pivot target — any local user could append
+forged events, truncate the chain, or replace files atomically. The
+error message names the resolution layer that landed there so the
+operator can fix the right config:
+
+```
+Error: log directory /tmp/foo is world-writable (mode 0777); refusing
+for security. Resolved via: CLI flag (--log-dir / --audit-dir).
+Pick a non-world-writable directory and re-run.
+```
+
+When `ai-memory` creates the directory itself, it applies mode `0700`
+on Unix. On Windows the default ACL (Authenticated Users only) is
+sufficient.
+
+---
+
 ## Operator CLI
 
 ### `ai-memory audit verify`
@@ -147,11 +280,19 @@ ai-memory audit tail --actor 'ai:claude-code@laptop'
 ### `ai-memory audit path`
 
 Prints the resolved audit log path. Convenient for SIEM ingestion
-configuration scripts.
+configuration scripts. Honours the same `--audit-dir <PATH>` override
+as every other `ai-memory audit` subcommand, so you can point at an
+ad-hoc location for one-off inspection:
+
+```bash
+ai-memory audit --audit-dir /var/lib/forensics/2026-04-30 path
+```
 
 ### `ai-memory logs tail [--follow]`
 
-Tail and (optionally) stream operational logs.
+Tail and (optionally) stream operational logs. Accepts the global
+`--log-dir <PATH>` override. See the **Log directory resolution**
+section above for the full precedence ladder.
 
 ### `ai-memory logs archive`
 

--- a/docs/security/audit-trail.md
+++ b/docs/security/audit-trail.md
@@ -1,0 +1,360 @@
+# ai-memory enterprise audit trail
+
+PR-5 of issue [#487](https://github.com/alphaonedev/ai-memory-mcp/issues/487).
+A turnkey, enterprise-class security audit trail and operational
+logging facility for AI memory activity across every AI agent that
+talks to ai-memory.
+
+This is the **operator** doc: how to turn it on, what it does, how to
+ship the lines into your SIEM, and how the regulatory mappings line
+up. The **developer** schema reference lives in
+[`audit-schema.md`](./audit-schema.md).
+
+---
+
+## At a glance
+
+| Subsystem | Default | Purpose |
+|---|---|---|
+| Operational logs (`tracing::*` → file) | OFF | Capture every `tracing::info!` / `tracing::warn!` / `tracing::error!` to a rotating on-disk file. Suitable for Splunk / Datadog / Elastic / Loki ingestion. |
+| Security audit trail | OFF | One hash-chained, tamper-evident JSON line per memory mutation. SIEM-grade evidence for SOC2 / HIPAA / GDPR / FedRAMP. |
+
+Both are **default-OFF for privacy.** No log lines hit the disk
+without a deliberate config opt-in.
+
+---
+
+## Quickstart
+
+```toml
+# ~/.config/ai-memory/config.toml
+
+[logging]
+enabled = true
+path = "~/.local/state/ai-memory/logs/"
+max_files = 30
+retention_days = 90
+structured = true                 # JSON lines for SIEM ingest
+level = "info"
+
+[audit]
+enabled = true
+path = "~/.local/state/ai-memory/audit/"
+schema_version = 1
+redact_content = true
+hash_chain = true
+attestation_cadence_minutes = 60
+append_only = true
+
+[audit.compliance.soc2]
+applied = true
+retention_days = 730
+attestation_cadence_minutes = 60
+```
+
+Restart the daemon (or any new CLI invocation picks up the new
+config). Verify:
+
+```bash
+ai-memory audit path                    # prints resolved log path
+ai-memory store --title 'hello' --content 'world'
+ai-memory audit tail --lines 5          # shows the store event
+ai-memory audit verify                  # exits 0 on intact chain
+```
+
+---
+
+## What gets audited
+
+Every memory mutation. The full action vocabulary:
+
+- `store` — new memory written
+- `update` — existing memory modified
+- `delete` — memory tombstoned
+- `recall` / `search` / `list` / `get` / `session_boot` — read access (one event per query, capturing namespace + actor; targets are aggregate `"*"` for list-style ops)
+- `link` / `promote` / `forget` / `consolidate` — derived mutations
+- `export` / `import` — bulk operations (one summary event)
+- `approve` / `reject` — governance state transitions
+- `session_boot` — `ai-memory boot` invocations (every AI agent's first turn)
+
+Each event captures:
+
+- **Who.** Resolved NHI agent_id + synthesis source (`mcp_client_info`, `http_header`, `host_fallback`, …) so a SIEM can trace claims back to the transport.
+- **What.** Action + outcome (`allow | deny | error | pending`).
+- **Where.** Memory id (or `*`), namespace, title (advisory label only — **never content**), tier, scope.
+- **How.** Auth context for HTTP-originated events (peer IP, mTLS fingerprint, hashed API key id). Stdio (CLI / MCP) emissions omit auth entirely.
+- **When.** RFC3339 UTC timestamp + per-process monotonic sequence number.
+- **Tamper-evidence.** `prev_hash` + `self_hash` form a sha256 chain; verify with `ai-memory audit verify`.
+
+## What is NEVER audited
+
+- `memory.content` (the secret payload). The schema has no content
+  field. `redact_content = true` is the only supported v1 mode.
+- Raw API keys, raw mTLS private keys, raw passwords.
+- Free-form caller-supplied strings outside the documented fields.
+
+---
+
+## Threat model
+
+| Adversary | Defense |
+|---|---|
+| Local attacker edits one line | `self_hash` recomputation fails on `audit verify`; precise line number surfaces |
+| Local attacker inserts a forged line | The next line's `prev_hash` no longer matches the inserted line's `self_hash` |
+| Local attacker deletes one line | The line after the deletion has a `prev_hash` from a now-gone source line |
+| Local attacker truncates the tail | The chain is consistent up to truncation, but periodic `CHECKPOINT.sig` markers (every `attestation_cadence_minutes`) bound rollback when paired with off-host attestation |
+| Root attacker rewrites the entire file | **Not defended.** Ship the lines off-host to an immutable SIEM in real time. The on-host chain still cross-checks the SIEM record. |
+| Process crashes mid-write | The `O_APPEND` write is atomic at the line level; partial writes never produce a malformed event. The chain may stop mid-stream but `audit verify` surfaces the cleanly-truncated tail without a false positive. |
+
+The append-only OS flag (`chflags +UF_APPEND` on BSD/macOS,
+`FS_IOC_SETFLAGS +FS_APPEND_FL` on Linux) is **best-effort defense in
+depth**. The hash chain is the load-bearing tamper-evidence.
+
+---
+
+## Operator CLI
+
+### `ai-memory audit verify`
+
+Walks the audit log, recomputes every line's `self_hash`, and asserts
+each `prev_hash` matches the prior line's `self_hash`. Exits:
+
+- `0` — chain intact
+- `2` — chain broken (precise line + failure kind printed)
+- non-zero with anyhow context — I/O error
+
+```bash
+$ ai-memory audit verify
+audit verify OK: 1428 line(s) verified at /home/op/.local/state/ai-memory/audit/audit.log
+
+$ ai-memory audit verify --json
+{"status":"ok","total_lines":1428,"path":"…/audit.log"}
+
+$ ai-memory audit verify   # after a tamper
+audit verify FAIL at line 203: SelfHash — self_hash mismatch: stored=ab…, recomputed=cd…
+```
+
+### `ai-memory audit tail`
+
+Print recent events, optionally filtered:
+
+```bash
+ai-memory audit tail --lines 100 --action store
+ai-memory audit tail --namespace finance --format json | jq .
+ai-memory audit tail --actor 'ai:claude-code@laptop'
+```
+
+### `ai-memory audit path`
+
+Prints the resolved audit log path. Convenient for SIEM ingestion
+configuration scripts.
+
+### `ai-memory logs tail [--follow]`
+
+Tail and (optionally) stream operational logs.
+
+### `ai-memory logs archive`
+
+zstd-compresses rotated log files past the configured
+`retention_days`. Idempotent.
+
+### `ai-memory logs purge --before <date>`
+
+Delete archived logs older than `<date>`. Surfaces a
+**audit-gap warning** when the cutoff date overlaps the configured
+audit retention horizon — deleting audit logs creates a compliance
+hole the next `audit verify` (or external attestation) will surface.
+
+---
+
+## SIEM ingestion guide
+
+The audit and operational log lines are plain UTF-8 JSON. Any SIEM
+that ingests JSON ingests this. Recipes for the four most common:
+
+### Splunk Universal Forwarder
+
+`inputs.conf`:
+
+```conf
+[monitor:///home/op/.local/state/ai-memory/audit/audit.log]
+sourcetype = ai-memory:audit
+index = security_audit
+disabled = 0
+
+[monitor:///home/op/.local/state/ai-memory/logs/ai-memory.log.*]
+sourcetype = ai-memory:ops
+index = ai_ops
+disabled = 0
+```
+
+`props.conf`:
+
+```conf
+[ai-memory:audit]
+INDEXED_EXTRACTIONS = json
+TIMESTAMP_FIELDS = timestamp
+KV_MODE = none
+```
+
+### Datadog Agent
+
+`/etc/datadog-agent/conf.d/ai_memory.d/conf.yaml`:
+
+```yaml
+logs:
+  - type: file
+    path: /home/op/.local/state/ai-memory/audit/audit.log
+    service: ai-memory
+    source: ai-memory-audit
+    log_processing_rules:
+      - type: include_at_match
+        name: keep_all
+        pattern: ".*"
+  - type: file
+    path: /home/op/.local/state/ai-memory/logs/ai-memory.log*
+    service: ai-memory
+    source: ai-memory-ops
+```
+
+Pair with the [JSON parser]([https://docs.datadoghq.com/logs/log_configuration/parsing/](https://docs.datadoghq.com/logs/log_configuration/parsing/))
+for the audit pipeline.
+
+### Elastic Filebeat
+
+`filebeat.yml`:
+
+```yaml
+filebeat.inputs:
+  - type: filestream
+    id: ai-memory-audit
+    paths:
+      - /home/op/.local/state/ai-memory/audit/audit.log
+    parsers:
+      - ndjson:
+          target: ai_memory_audit
+          add_error_key: true
+    fields:
+      service: ai-memory
+      stream: audit
+  - type: filestream
+    id: ai-memory-ops
+    paths:
+      - /home/op/.local/state/ai-memory/logs/ai-memory.log*
+    fields:
+      service: ai-memory
+      stream: operational
+```
+
+### Loki / Promtail
+
+`promtail.yaml`:
+
+```yaml
+scrape_configs:
+  - job_name: ai-memory-audit
+    static_configs:
+      - targets: [localhost]
+        labels:
+          service: ai-memory
+          stream: audit
+          __path__: /home/op/.local/state/ai-memory/audit/audit.log
+    pipeline_stages:
+      - json:
+          expressions:
+            timestamp: timestamp
+            action: action
+            actor: actor.agent_id
+            namespace: target.namespace
+            outcome: outcome
+      - timestamp:
+          source: timestamp
+          format: RFC3339
+      - labels:
+          action:
+          outcome:
+
+  - job_name: ai-memory-ops
+    static_configs:
+      - targets: [localhost]
+        labels:
+          service: ai-memory
+          stream: operational
+          __path__: /home/op/.local/state/ai-memory/logs/ai-memory.log*
+```
+
+---
+
+## Regulatory mapping
+
+The compliance presets propagate well-known retention and cadence
+controls into the effective config. Set `applied = true` for the
+relevant preset; ai-memory picks the most-conservative value when
+multiple presets are active.
+
+| Preset | Citation | Retention | Cadence | Notes |
+|---|---|---|---|---|
+| `soc2` | TSC CC7.2 | 2 years | 60 min | Continuous monitoring of audit logs. |
+| `hipaa` | 45 CFR §164.316(b)(2) | 6 years | — | Pair with `--features sqlcipher` for required at-rest crypto. |
+| `gdpr` | Art. 30 + Art. 5(1)(e) | 3 years | — | `pseudonymize_actors` reserved for v0.7+. |
+| `fedramp` | NIST SP 800-53 AU-11 / AU-12 | 3 years | 30 min | High-water mark for federal civilian / DoD IL2-IL5. |
+
+The presets are configuration only. Compliance certification still
+requires the broader control environment (access reviews, change
+management, incident response). The audit trail is one piece of the
+evidence package, not the whole thing.
+
+---
+
+## Operational runbook
+
+### Rotation
+
+The rolling appender writes one file per `rotation` cadence (default
+daily). `max_files` retained on disk; older files are removed by the
+appender. `ai-memory logs archive` zstd-compresses files past
+`retention_days` for cold-storage handoff to the SIEM.
+
+### Verification cadence
+
+Run `ai-memory audit verify` from a SIEM-monitored cron / systemd
+timer at least daily. A failure is a P0 — somebody touched the file.
+
+```service
+# /etc/systemd/system/ai-memory-audit-verify.service
+[Unit]
+Description=Verify ai-memory audit chain
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ai-memory audit verify --json
+SyslogIdentifier=ai-memory-audit-verify
+```
+
+```service
+# /etc/systemd/system/ai-memory-audit-verify.timer
+[Unit]
+Description=Hourly ai-memory audit chain verification
+[Timer]
+OnCalendar=hourly
+[Install]
+WantedBy=timers.target
+```
+
+### Off-host attestation
+
+Ship every line to an immutable off-host store (SIEM, S3 Object Lock,
+WORM appliance) in real time. The on-host hash chain serves as a
+cross-check for the off-host record.
+
+### Incident response
+
+A failed `audit verify` means the audit log has been tampered with.
+The chain itself tells you where (precise line number + failure kind).
+Cross-reference the timestamp with:
+
+1. The off-host SIEM ingest stream (the immutable copy the on-host
+   chain cross-checks against).
+2. Operating-system audit (auditd / OSSEC / EndPoint EDR) for
+   unauthorized writes to the log path.
+3. `ai-memory doctor` for related runtime anomalies.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -747,16 +747,50 @@ pub fn init_from_config(cfg: &crate::config::AuditConfig) -> Result<()> {
     )
 }
 
-/// Resolve the audit log file path from the config. Expands `~/` and
-/// appends `audit.log` when the configured path is a directory.
+/// Resolve the audit log file path from the config, honouring the
+/// user-mandated precedence ladder: CLI > env (`AI_MEMORY_AUDIT_DIR`)
+/// > `[audit] path` in config > platform default. Appends `audit.log`
+/// when the resolved path looks like a directory.
+///
+/// Backwards-compatible wrapper that doesn't take a CLI override —
+/// subcommand wiring uses [`resolve_audit_path_with_override`].
 #[must_use]
 pub fn resolve_audit_path(cfg: &crate::config::AuditConfig) -> PathBuf {
-    let raw = cfg
-        .path
-        .clone()
-        .unwrap_or_else(|| "~/.local/state/ai-memory/audit/".to_string());
-    let expanded = expand_tilde(&raw);
-    let p = PathBuf::from(expanded);
+    let resolved = crate::log_paths::resolve_audit_dir(None, cfg.path.as_deref())
+        .map(|r| r.path)
+        .unwrap_or_else(|_| {
+            crate::log_paths::platform_default(crate::log_paths::DirKind::Audit).path
+        });
+    finalize_audit_file(resolved, cfg.path.as_deref())
+}
+
+/// Strict variant: takes an optional `--audit-dir` override, returns
+/// the resolved file path (with `audit.log` appended when the input
+/// resolves to a directory) plus the [`crate::log_paths::PathSource`]
+/// used.
+///
+/// # Errors
+/// - Resolved directory is world-writable.
+pub fn resolve_audit_path_with_override(
+    cli_override: Option<&Path>,
+    cfg: &crate::config::AuditConfig,
+) -> Result<(PathBuf, crate::log_paths::PathSource)> {
+    let r = crate::log_paths::resolve_audit_dir(cli_override, cfg.path.as_deref())?;
+    let final_path = finalize_audit_file(r.path, cfg.path.as_deref());
+    Ok((final_path, r.source))
+}
+
+/// Append `audit.log` when the resolved path is a directory; respect
+/// an explicit file-path the user wrote in config.
+fn finalize_audit_file(p: PathBuf, raw_config: Option<&str>) -> PathBuf {
+    // If the user configured an explicit file path (has a non-empty
+    // extension that isn't a trailing slash), keep it as-is.
+    if let Some(raw) = raw_config
+        && !raw.ends_with('/')
+        && std::path::Path::new(raw).extension().is_some()
+    {
+        return p;
+    }
     if p.extension().is_none() || p.to_string_lossy().ends_with('/') {
         p.join("audit.log")
     } else {

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,1137 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Enterprise audit trail (PR-5 of issue #487).
+//!
+//! Every memory-mutation call site in the binary — HTTP handlers, MCP
+//! tool dispatch, CLI write commands, and `ai-memory boot` — emits an
+//! [`AuditEvent`] to a hash-chained, append-only JSON log when the
+//! audit subsystem is enabled. The schema is **stable, versioned, and
+//! framework-agnostic** (NOT bound to OCSF or CEF — see
+//! `docs/security/audit-schema.md`). SIEMs ingest the lines as-is.
+//!
+//! # Design properties
+//!
+//! 1. **Default-OFF** for privacy. Operators opt in via
+//!    `[audit] enabled = true` in `config.toml` (or
+//!    `AI_MEMORY_AUDIT_PATH=...` for one-off runs).
+//! 2. **Hash-chained, tamper-evident.** Each line carries a `prev_hash`
+//!    that matches the prior line's `self_hash`. `ai-memory audit
+//!    verify` recomputes the chain and exits non-zero on mismatch.
+//! 3. **Append-only OS hint.** Best-effort `chflags(2)` (BSD/macOS) or
+//!    `FS_IOC_SETFLAGS` ioctl (Linux). Documented as defense in depth;
+//!    the chain is the load-bearing tamper-evidence.
+//! 4. **Privacy by default.** Audit captures `(memory_id, namespace,
+//!    title, action, outcome, actor)`. Memory **content is never
+//!    emitted** — `redact_content = true` is the only supported mode in
+//!    the v1 schema; the field is reserved in [`AuditTarget`] for
+//!    future compliance contexts that mandate content capture.
+//! 5. **Per-process monotonic sequence**, independent of the chain.
+//!    Lets a SIEM detect dropped lines even before the chain check.
+//! 6. **No backpressure on the caller.** Emission is synchronous (one
+//!    write per line so the chain is consistent across processes
+//!    concurrently appending — the file is opened with `O_APPEND`),
+//!    but failures inside emit are swallowed and logged via `tracing`.
+//!    A broken audit pipeline never blocks a memory operation.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock};
+
+use anyhow::{Context, Result, anyhow};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Stable schema version stamped on every emitted line. Bump only when
+/// a field's semantics change in a way SIEM parsers care about
+/// (renaming, removing, or repurposing). Adding optional fields does
+/// NOT bump the version. See `docs/security/audit-schema.md` §Version
+/// policy for the full contract.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Sentinel `prev_hash` for the first line in a fresh chain. Hex-encoded
+/// 32-byte zero buffer — picked so a chain head is unambiguous on
+/// inspection.
+pub const CHAIN_HEAD_PREV_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// One audit event. The serialized form is one JSON object per line
+/// (NDJSON). Field order is stable for chain reproducibility.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditEvent {
+    /// Schema version — see [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// RFC3339 UTC timestamp when the event was emitted.
+    pub timestamp: String,
+    /// Per-process monotonic counter starting at 1 on init.
+    pub sequence: u64,
+    pub actor: AuditActor,
+    pub action: AuditAction,
+    pub target: AuditTarget,
+    pub outcome: AuditOutcome,
+    /// Authentication context. `None` for stdio MCP / CLI invocations
+    /// where there is no transport-level auth.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth: Option<AuditAuth>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    /// Populated only when `outcome = Error`. Capped at 256 chars to
+    /// prevent error-message based content leaks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Hex-encoded sha256 of the immediately prior line's `self_hash`,
+    /// or [`CHAIN_HEAD_PREV_HASH`] for the first line of a fresh chain.
+    pub prev_hash: String,
+    /// Hex-encoded sha256 of every preceding field in serialization order.
+    pub self_hash: String,
+}
+
+/// Who performed the action.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditActor {
+    /// Resolved NHI agent_id (`ai:<client>@<host>:pid-<n>`,
+    /// `host:<host>:pid-<n>-<uuid>`, etc.). Always present.
+    pub agent_id: String,
+    /// Visibility scope: `private | team | unit | org | collective`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// How `agent_id` was synthesized — surfaces NHI provenance to the
+    /// SIEM. One of: `explicit | env | mcp_client_info | host_fallback
+    /// | anonymous_fallback | http_header | http_body | per_request`.
+    pub synthesis_source: String,
+}
+
+/// Canonical action vocabulary. Adding a variant is a non-breaking
+/// schema change; renaming or removing one IS breaking.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditAction {
+    Recall,
+    Store,
+    Update,
+    Delete,
+    Link,
+    Promote,
+    Forget,
+    Consolidate,
+    Export,
+    Import,
+    Approve,
+    Reject,
+    SessionBoot,
+}
+
+impl AuditAction {
+    /// Wire-format string for log-grep convenience.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Recall => "recall",
+            Self::Store => "store",
+            Self::Update => "update",
+            Self::Delete => "delete",
+            Self::Link => "link",
+            Self::Promote => "promote",
+            Self::Forget => "forget",
+            Self::Consolidate => "consolidate",
+            Self::Export => "export",
+            Self::Import => "import",
+            Self::Approve => "approve",
+            Self::Reject => "reject",
+            Self::SessionBoot => "session_boot",
+        }
+    }
+}
+
+/// What was acted upon.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditTarget {
+    /// Memory id, or `"*"` for a list/sweep operation that touches
+    /// many rows (forget, export, consolidate-many, etc.).
+    pub memory_id: String,
+    /// Memory namespace at the time of the action.
+    pub namespace: String,
+    /// Memory title at the time of the action. Capped at 200 chars and
+    /// stripped of newlines to prevent log-injection. Title is **not**
+    /// content; titles are advisory labels by design (`memory.content`
+    /// is the secret payload and is **never** emitted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Memory tier (`short | mid | long`) at action time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+    /// Memory `metadata.scope` at action time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// Outcome of the action.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    Allow,
+    Deny,
+    Error,
+    Pending,
+}
+
+/// Authentication context for HTTP-originated events. Stdio (CLI / MCP)
+/// invocations omit this block entirely.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditAuth {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtls_fp: Option<String>,
+    /// **Hash** of the API key id, never the raw key. Hex-encoded
+    /// sha256 truncated to 16 bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_id_hash: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Sink — process-wide singleton holding the file handle + chain head.
+// ---------------------------------------------------------------------------
+
+/// Process-wide audit sink. `None` when audit is disabled. Wrapped in
+/// `RwLock` (rather than `OnceLock`) so tests can swap in an
+/// in-memory sink between cases without leaking state across runs.
+static SINK: RwLock<Option<std::sync::Arc<AuditSink>>> = RwLock::new(None);
+/// Per-process monotonic sequence counter. Starts at 1 on first emit.
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Initialised audit sink — writer handle protected by a mutex so the
+/// chain head update + write are atomic across emission threads. The
+/// writer is `dyn Write + Send` so tests can substitute an in-memory
+/// `Vec<u8>` for the production `File`.
+pub(crate) struct AuditSink {
+    inner: Mutex<SinkInner>,
+    #[allow(dead_code)]
+    redact_content: bool,
+}
+
+struct SinkInner {
+    writer: Box<dyn Write + Send>,
+    /// `self_hash` of the last line written, used as the next line's
+    /// `prev_hash`. Starts as [`CHAIN_HEAD_PREV_HASH`] for a fresh log.
+    last_hash: String,
+    /// Source path, when the sink wraps a real file. `None` for
+    /// in-memory test sinks.
+    #[allow(dead_code)]
+    path: Option<PathBuf>,
+}
+
+/// Initialise the audit sink. Called at most once per process from
+/// [`init_from_config`]; subsequent calls replace the prior sink so
+/// test-only callers can swap targets.
+///
+/// # Errors
+/// - The audit directory cannot be created.
+/// - The audit log file cannot be opened in append mode.
+/// - Reading the existing chain tail (to seed `last_hash`) fails.
+pub fn init(path: &Path, redact_content: bool, append_only_hint: bool) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating audit log dir {}", parent.display()))?;
+    }
+
+    // Seed the chain head from the existing tail of the log so a
+    // restart on an existing file continues the chain.
+    let last_hash = match read_chain_tail(path) {
+        Ok(Some(h)) => h,
+        _ => CHAIN_HEAD_PREV_HASH.to_string(),
+    };
+
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening audit log {}", path.display()))?;
+
+    if append_only_hint {
+        // Best-effort. Errors here are documented and informational —
+        // the hash chain is the load-bearing tamper-evidence.
+        if let Err(e) = mark_append_only(path) {
+            tracing::warn!(
+                "audit: append-only OS flag could not be set on {} ({e}); \
+                 the hash chain remains the authoritative tamper-evidence",
+                path.display()
+            );
+        }
+    }
+
+    let sink = AuditSink {
+        inner: Mutex::new(SinkInner {
+            writer: Box::new(file),
+            last_hash,
+            path: Some(path.to_path_buf()),
+        }),
+        redact_content,
+    };
+
+    SEQUENCE.store(0, Ordering::SeqCst);
+    if let Ok(mut guard) = SINK.write() {
+        *guard = Some(std::sync::Arc::new(sink));
+    }
+    Ok(())
+}
+
+/// Test-only helper: install an in-memory sink that captures every
+/// emitted line into the supplied `Arc<Mutex<Vec<u8>>>`. Bypasses the
+/// filesystem entirely so tests run in any sandbox.
+#[cfg(test)]
+pub fn init_for_test(buf: std::sync::Arc<Mutex<Vec<u8>>>) {
+    struct VecWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+    impl Write for VecWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("test sink poisoned")
+                .extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let sink = AuditSink {
+        inner: Mutex::new(SinkInner {
+            writer: Box::new(VecWriter(buf)),
+            last_hash: CHAIN_HEAD_PREV_HASH.to_string(),
+            path: None,
+        }),
+        redact_content: true,
+    };
+    SEQUENCE.store(0, Ordering::SeqCst);
+    if let Ok(mut guard) = SINK.write() {
+        *guard = Some(std::sync::Arc::new(sink));
+    }
+}
+
+/// Test-only helper to remove the active sink so subsequent emissions
+/// no-op.
+#[cfg(test)]
+pub fn shutdown_for_test() {
+    if let Ok(mut guard) = SINK.write() {
+        *guard = None;
+    }
+    SEQUENCE.store(0, Ordering::SeqCst);
+}
+
+/// Read the last `self_hash` from an existing audit log. Returns
+/// `Ok(None)` when the file is empty or doesn't exist; returns the
+/// `self_hash` of the last well-formed line otherwise. A malformed
+/// trailing line counts as "empty" — emission seeds a fresh chain
+/// head, and `audit verify` will surface the corruption.
+fn read_chain_tail(path: &Path) -> Result<Option<String>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut last: Option<String> = None;
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(ev) = serde_json::from_str::<AuditEvent>(&line) {
+            last = Some(ev.self_hash);
+        }
+    }
+    Ok(last)
+}
+
+/// Whether the audit subsystem is currently enabled. Cheap.
+#[must_use]
+pub fn is_enabled() -> bool {
+    SINK.read().map(|g| g.is_some()).unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Hashing — stable canonical form so emit + verify agree byte-for-byte.
+// ---------------------------------------------------------------------------
+
+/// Compute the canonical hash for an event. Hashes the same JSON the
+/// emitter writes to disk EXCEPT with `self_hash` set to the empty
+/// string sentinel — this lets `audit verify` recompute it from the
+/// stored line by zeroing the same field.
+fn compute_self_hash(ev: &AuditEvent) -> String {
+    let canonical = canonical_json_for_hash(ev);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    hex_encode(&hasher.finalize())
+}
+
+/// Serialize an event into the canonical pre-hash form: serde_json
+/// representation with `self_hash` zeroed. The `prev_hash` is part of
+/// the hashed input — that's exactly the linkage that makes the chain
+/// tamper-evident.
+fn canonical_json_for_hash(ev: &AuditEvent) -> String {
+    let mut clone = ev.clone();
+    clone.self_hash.clear();
+    serde_json::to_string(&clone).expect("AuditEvent always serializes")
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    static HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Emission API — the surface the rest of the binary calls.
+// ---------------------------------------------------------------------------
+
+/// Builder for an audit event. Most call sites use one of the
+/// convenience helpers ([`emit_store`], [`emit_recall`], etc.) but the
+/// builder is public so unusual flows (consolidate-many, deferred
+/// import) can fill in custom targets.
+#[derive(Debug, Clone)]
+pub struct EventBuilder {
+    pub action: AuditAction,
+    pub actor: AuditActor,
+    pub target: AuditTarget,
+    pub outcome: AuditOutcome,
+    pub auth: Option<AuditAuth>,
+    pub session_id: Option<String>,
+    pub request_id: Option<String>,
+    pub error: Option<String>,
+}
+
+impl EventBuilder {
+    /// Build a default-shaped event for `action`. Caller fills in the
+    /// remaining fields.
+    #[must_use]
+    pub fn new(action: AuditAction, actor: AuditActor, target: AuditTarget) -> Self {
+        Self {
+            action,
+            actor,
+            target,
+            outcome: AuditOutcome::Allow,
+            auth: None,
+            session_id: None,
+            request_id: None,
+            error: None,
+        }
+    }
+
+    /// Override outcome (default = Allow).
+    #[must_use]
+    pub fn outcome(mut self, outcome: AuditOutcome) -> Self {
+        self.outcome = outcome;
+        self
+    }
+
+    /// Set the error string. Caps at 256 chars and strips newlines so a
+    /// runaway error message can't leak content or break the log line.
+    #[must_use]
+    pub fn error(mut self, msg: impl Into<String>) -> Self {
+        self.error = Some(sanitize_field(&msg.into(), 256));
+        self.outcome = AuditOutcome::Error;
+        self
+    }
+
+    #[must_use]
+    pub fn auth(mut self, auth: AuditAuth) -> Self {
+        self.auth = Some(auth);
+        self
+    }
+
+    #[must_use]
+    pub fn request_id(mut self, id: impl Into<String>) -> Self {
+        self.request_id = Some(id.into());
+        self
+    }
+}
+
+/// Write an event to the configured sink. No-op when audit is disabled.
+/// Failures are logged via `tracing::error!` and dropped — audit is
+/// **never** allowed to fail a memory operation.
+pub fn emit(builder: EventBuilder) {
+    if let Err(e) = try_emit(builder) {
+        tracing::error!("audit: emission failed: {e}");
+    }
+}
+
+/// Inner emission with proper `Result` so tests can assert directly on
+/// the writer. `emit` swallows errors so production never blocks.
+fn try_emit(builder: EventBuilder) -> Result<()> {
+    let sink = {
+        let guard = SINK
+            .read()
+            .map_err(|_| anyhow!("audit sink rwlock poisoned"))?;
+        match guard.as_ref() {
+            Some(s) => s.clone(),
+            None => return Ok(()),
+        }
+    };
+
+    let mut inner = sink
+        .inner
+        .lock()
+        .map_err(|_| anyhow!("audit sink mutex poisoned"))?;
+
+    let sequence = SEQUENCE.fetch_add(1, Ordering::SeqCst) + 1;
+
+    let mut ev = AuditEvent {
+        schema_version: SCHEMA_VERSION,
+        timestamp: Utc::now().to_rfc3339(),
+        sequence,
+        actor: builder.actor,
+        action: builder.action,
+        target: AuditTarget {
+            memory_id: sanitize_field(&builder.target.memory_id, 128),
+            namespace: sanitize_field(&builder.target.namespace, 128),
+            title: builder.target.title.map(|t| sanitize_field(&t, 200)),
+            tier: builder.target.tier,
+            scope: builder.target.scope,
+        },
+        outcome: builder.outcome,
+        auth: builder.auth,
+        session_id: builder.session_id,
+        request_id: builder.request_id,
+        error: builder.error,
+        prev_hash: inner.last_hash.clone(),
+        self_hash: String::new(),
+    };
+
+    let self_hash = compute_self_hash(&ev);
+    ev.self_hash = self_hash.clone();
+
+    let line = serde_json::to_string(&ev).context("serializing audit event")?;
+    writeln!(inner.writer, "{line}").context("appending audit line")?;
+    inner.writer.flush().ok();
+    inner.last_hash = self_hash;
+    Ok(())
+}
+
+/// Sanitize a field for log emission: strip control chars + newlines
+/// (prevent log injection) and cap to `max_chars` (prevent unbounded
+/// growth from a hostile title or error message).
+fn sanitize_field(s: &str, max_chars: usize) -> String {
+    let cleaned: String = s
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect();
+    if cleaned.chars().count() <= max_chars {
+        cleaned
+    } else {
+        cleaned.chars().take(max_chars).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers.
+// ---------------------------------------------------------------------------
+
+/// Construct an [`AuditActor`] from an agent_id + synthesis source +
+/// optional scope. The synthesis source is informational metadata and
+/// MUST be one of the documented strings in [`AuditActor`].
+#[must_use]
+pub fn actor(
+    agent_id: impl Into<String>,
+    synthesis_source: impl Into<String>,
+    scope: Option<String>,
+) -> AuditActor {
+    AuditActor {
+        agent_id: agent_id.into(),
+        synthesis_source: synthesis_source.into(),
+        scope,
+    }
+}
+
+/// Construct an [`AuditTarget`] for a single memory.
+#[must_use]
+pub fn target_memory(
+    memory_id: impl Into<String>,
+    namespace: impl Into<String>,
+    title: Option<String>,
+    tier: Option<String>,
+    scope: Option<String>,
+) -> AuditTarget {
+    AuditTarget {
+        memory_id: memory_id.into(),
+        namespace: namespace.into(),
+        title,
+        tier,
+        scope,
+    }
+}
+
+/// Construct an [`AuditTarget`] for a multi-row sweep operation.
+#[must_use]
+pub fn target_sweep(namespace: impl Into<String>) -> AuditTarget {
+    AuditTarget {
+        memory_id: "*".to_string(),
+        namespace: namespace.into(),
+        title: None,
+        tier: None,
+        scope: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verify — the load-bearing tamper-evidence walk.
+// ---------------------------------------------------------------------------
+
+/// Outcome of [`verify_chain`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyReport {
+    pub total_lines: u64,
+    pub first_failure: Option<VerifyFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyFailure {
+    pub line_number: u64,
+    pub kind: VerifyFailureKind,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyFailureKind {
+    /// Line could not be parsed as an `AuditEvent`.
+    Parse,
+    /// Recomputed `self_hash` did not match the stored value.
+    SelfHash,
+    /// Stored `prev_hash` did not match the prior line's `self_hash`.
+    ChainBreak,
+    /// `sequence` did not increase monotonically.
+    Sequence,
+}
+
+impl VerifyReport {
+    /// Convenience — `Ok(())` when chain is intact, `Err` when not.
+    pub fn into_result(self) -> Result<u64> {
+        if let Some(failure) = self.first_failure {
+            Err(anyhow!(
+                "audit chain verification failed at line {}: {:?} — {}",
+                failure.line_number,
+                failure.kind,
+                failure.detail
+            ))
+        } else {
+            Ok(self.total_lines)
+        }
+    }
+}
+
+/// Walk an audit log file and verify the chain. Returns a structured
+/// report; the binary's `audit verify` subcommand turns this into an
+/// exit code.
+///
+/// # Errors
+/// - The file cannot be opened or read.
+pub fn verify_chain(path: &Path) -> Result<VerifyReport> {
+    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    verify_chain_from_reader(file)
+}
+
+/// Verify a chain from any [`Read`] source. Lets tests run against
+/// in-memory buffers without touching the filesystem.
+pub fn verify_chain_from_reader<R: Read>(reader: R) -> Result<VerifyReport> {
+    let buf = BufReader::new(reader);
+    let mut total: u64 = 0;
+    let mut prev_hash = CHAIN_HEAD_PREV_HASH.to_string();
+    let mut prev_seq: u64 = 0;
+
+    for (idx, line) in buf.lines().enumerate() {
+        let line_no = (idx as u64) + 1;
+        let line = line.with_context(|| format!("reading audit line {line_no}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        total += 1;
+
+        let ev: AuditEvent = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(e) => {
+                return Ok(VerifyReport {
+                    total_lines: total,
+                    first_failure: Some(VerifyFailure {
+                        line_number: line_no,
+                        kind: VerifyFailureKind::Parse,
+                        detail: format!("malformed JSON: {e}"),
+                    }),
+                });
+            }
+        };
+
+        if ev.prev_hash != prev_hash {
+            return Ok(VerifyReport {
+                total_lines: total,
+                first_failure: Some(VerifyFailure {
+                    line_number: line_no,
+                    kind: VerifyFailureKind::ChainBreak,
+                    detail: format!(
+                        "prev_hash mismatch: expected {prev_hash}, got {}",
+                        ev.prev_hash
+                    ),
+                }),
+            });
+        }
+
+        if ev.sequence <= prev_seq && prev_seq != 0 {
+            return Ok(VerifyReport {
+                total_lines: total,
+                first_failure: Some(VerifyFailure {
+                    line_number: line_no,
+                    kind: VerifyFailureKind::Sequence,
+                    detail: format!(
+                        "sequence not monotonic: prior={prev_seq}, this={}",
+                        ev.sequence
+                    ),
+                }),
+            });
+        }
+
+        let recomputed = compute_self_hash(&ev);
+        if recomputed != ev.self_hash {
+            return Ok(VerifyReport {
+                total_lines: total,
+                first_failure: Some(VerifyFailure {
+                    line_number: line_no,
+                    kind: VerifyFailureKind::SelfHash,
+                    detail: format!(
+                        "self_hash mismatch: stored={}, recomputed={}",
+                        ev.self_hash, recomputed
+                    ),
+                }),
+            });
+        }
+
+        prev_hash = ev.self_hash.clone();
+        prev_seq = ev.sequence;
+    }
+
+    Ok(VerifyReport {
+        total_lines: total,
+        first_failure: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap — read AppConfig and bring the sink up.
+// ---------------------------------------------------------------------------
+
+/// Initialise the audit sink from a parsed [`crate::config::AuditConfig`].
+/// Returns `Ok(())` whether or not audit is enabled — it is a no-op when
+/// disabled.
+///
+/// # Errors
+/// - The audit directory or file cannot be opened.
+pub fn init_from_config(cfg: &crate::config::AuditConfig) -> Result<()> {
+    if !cfg.enabled.unwrap_or(false) {
+        if let Ok(mut guard) = SINK.write() {
+            *guard = None;
+        }
+        return Ok(());
+    }
+    let resolved_path = resolve_audit_path(cfg);
+    init(
+        &resolved_path,
+        cfg.redact_content.unwrap_or(true),
+        cfg.append_only.unwrap_or(true),
+    )
+}
+
+/// Resolve the audit log file path from the config. Expands `~/` and
+/// appends `audit.log` when the configured path is a directory.
+#[must_use]
+pub fn resolve_audit_path(cfg: &crate::config::AuditConfig) -> PathBuf {
+    let raw = cfg
+        .path
+        .clone()
+        .unwrap_or_else(|| "~/.local/state/ai-memory/audit/".to_string());
+    let expanded = expand_tilde(&raw);
+    let p = PathBuf::from(expanded);
+    if p.extension().is_none() || p.to_string_lossy().ends_with('/') {
+        p.join("audit.log")
+    } else {
+        p
+    }
+}
+
+pub(crate) fn expand_tilde(raw: &str) -> String {
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return format!("{home}/{rest}");
+    }
+    raw.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Append-only OS hint — best effort.
+// ---------------------------------------------------------------------------
+
+/// Apply the platform-appropriate "append-only" file flag. Silent on
+/// non-unix platforms.
+#[cfg(unix)]
+fn mark_append_only(path: &Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path =
+        CString::new(path.as_os_str().as_bytes()).context("path contains an interior NUL byte")?;
+    #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+    {
+        // SAFETY: c_path is a NUL-terminated string we own; chflags is
+        // a libc syscall whose only safety obligation is a valid C
+        // string. UF_APPEND is the user-visible append-only flag.
+        let rc = unsafe { libc::chflags(c_path.as_ptr(), libc::UF_APPEND.into()) };
+        if rc != 0 {
+            return Err(anyhow!(
+                "chflags(UF_APPEND) failed: errno={}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        return Ok(());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // On Linux we'd issue FS_IOC_SETFLAGS with FS_APPEND_FL. The
+        // syscall requires CAP_LINUX_IMMUTABLE on most filesystems and
+        // is filesystem-specific (ext*, xfs, btrfs); refuse silently
+        // on filesystems that don't support it. This is a best-effort
+        // hint — the chain is the load-bearing tamper-evidence.
+        const FS_APPEND_FL: libc::c_int = 0x0000_0020;
+        // FS_IOC_SETFLAGS = _IOW('f', 2, long) = 0x4008_6602 on most
+        // 64-bit Linux ABIs. Hard-coded to avoid pulling in an extra
+        // crate just for the constant.
+        const FS_IOC_SETFLAGS: libc::c_ulong = 0x4008_6602;
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+        if fd < 0 {
+            return Err(anyhow!(
+                "open(audit log) for ioctl failed: errno={}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let mut flags: libc::c_int = 0;
+        // SAFETY: fd is a valid file descriptor we just opened; the
+        // ioctl call follows the documented FS_IOC_GETFLAGS / SETFLAGS
+        // protocol.
+        let rc = unsafe { libc::ioctl(fd, FS_IOC_SETFLAGS, &mut flags) };
+        if rc == 0 {
+            flags |= FS_APPEND_FL;
+            let rc2 = unsafe { libc::ioctl(fd, FS_IOC_SETFLAGS, &mut flags) };
+            unsafe { libc::close(fd) };
+            if rc2 != 0 {
+                return Err(anyhow!(
+                    "ioctl(FS_IOC_SETFLAGS) failed: errno={}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            return Ok(());
+        }
+        unsafe { libc::close(fd) };
+        Err(anyhow!(
+            "ioctl(FS_IOC_GETFLAGS) failed: errno={}",
+            std::io::Error::last_os_error()
+        ))
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "linux"
+    )))]
+    {
+        let _ = c_path;
+        Err(anyhow!(
+            "append-only flag not supported on this unix variant"
+        ))
+    }
+}
+
+#[cfg(not(unix))]
+fn mark_append_only(_path: &Path) -> Result<()> {
+    Err(anyhow!("append-only flag is unix-only"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event(seq: u64, prev: &str) -> AuditEvent {
+        let mut ev = AuditEvent {
+            schema_version: SCHEMA_VERSION,
+            timestamp: "2026-04-30T00:00:00+00:00".to_string(),
+            sequence: seq,
+            actor: actor("ai:test@host:pid-1", "host_fallback", None),
+            action: AuditAction::Store,
+            target: target_memory(
+                format!("mem-{seq}"),
+                "ns-x",
+                Some("title".to_string()),
+                Some("mid".to_string()),
+                None,
+            ),
+            outcome: AuditOutcome::Allow,
+            auth: None,
+            session_id: None,
+            request_id: None,
+            error: None,
+            prev_hash: prev.to_string(),
+            self_hash: String::new(),
+        };
+        ev.self_hash = compute_self_hash(&ev);
+        ev
+    }
+
+    #[test]
+    fn audit_event_round_trips_through_serde() {
+        let ev = sample_event(1, CHAIN_HEAD_PREV_HASH);
+        let s = serde_json::to_string(&ev).unwrap();
+        let back: AuditEvent = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ev);
+        assert_eq!(back.schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn audit_chain_links_correctly_for_three_events() {
+        let e1 = sample_event(1, CHAIN_HEAD_PREV_HASH);
+        let e2 = sample_event(2, &e1.self_hash);
+        let e3 = sample_event(3, &e2.self_hash);
+        let mut buf = String::new();
+        for ev in [&e1, &e2, &e3] {
+            buf.push_str(&serde_json::to_string(ev).unwrap());
+            buf.push('\n');
+        }
+        let report = verify_chain_from_reader(buf.as_bytes()).unwrap();
+        assert!(report.first_failure.is_none(), "{:?}", report.first_failure);
+        assert_eq!(report.total_lines, 3);
+    }
+
+    #[test]
+    fn audit_verify_detects_tampered_line() {
+        let e1 = sample_event(1, CHAIN_HEAD_PREV_HASH);
+        let mut e2 = sample_event(2, &e1.self_hash);
+        // Tamper: swap the title without recomputing self_hash.
+        e2.target.title = Some("EVIL".to_string());
+        let e3 = sample_event(3, &e2.self_hash);
+        let mut buf = String::new();
+        for ev in [&e1, &e2, &e3] {
+            buf.push_str(&serde_json::to_string(ev).unwrap());
+            buf.push('\n');
+        }
+        let report = verify_chain_from_reader(buf.as_bytes()).unwrap();
+        let failure = report.first_failure.expect("tampering must be detected");
+        assert_eq!(failure.line_number, 2);
+        assert!(matches!(failure.kind, VerifyFailureKind::SelfHash));
+    }
+
+    #[test]
+    fn audit_verify_detects_chain_break() {
+        let e1 = sample_event(1, CHAIN_HEAD_PREV_HASH);
+        // Break: e2's prev_hash points at a hash that isn't e1's.
+        let e2 = sample_event(2, "deadbeef");
+        let mut buf = String::new();
+        for ev in [&e1, &e2] {
+            buf.push_str(&serde_json::to_string(ev).unwrap());
+            buf.push('\n');
+        }
+        let report = verify_chain_from_reader(buf.as_bytes()).unwrap();
+        let failure = report.first_failure.expect("chain break must be detected");
+        assert!(matches!(failure.kind, VerifyFailureKind::ChainBreak));
+    }
+
+    #[test]
+    fn audit_redacts_content_by_default() {
+        // The schema does not have a `content` field. This test
+        // doubles as a guardrail: if anyone ever adds one to
+        // AuditEvent or AuditTarget, the round-trip assertion below
+        // will surface it.
+        let ev = sample_event(1, CHAIN_HEAD_PREV_HASH);
+        let json = serde_json::to_value(&ev).unwrap();
+        assert!(
+            json.get("content").is_none(),
+            "AuditEvent must never carry a content field"
+        );
+        assert!(
+            json["target"].get("content").is_none(),
+            "AuditTarget must never carry a content field"
+        );
+    }
+
+    #[test]
+    fn audit_action_as_str_round_trips() {
+        for action in [
+            AuditAction::Recall,
+            AuditAction::Store,
+            AuditAction::Update,
+            AuditAction::Delete,
+            AuditAction::Link,
+            AuditAction::Promote,
+            AuditAction::Forget,
+            AuditAction::Consolidate,
+            AuditAction::Export,
+            AuditAction::Import,
+            AuditAction::Approve,
+            AuditAction::Reject,
+            AuditAction::SessionBoot,
+        ] {
+            let s = action.as_str();
+            // serde rename-all snake_case round-trips through the
+            // string representation.
+            let v: serde_json::Value = serde_json::to_value(action).unwrap();
+            assert_eq!(v.as_str().unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn audit_sanitize_strips_newlines() {
+        let cleaned = sanitize_field("line1\nline2\rline3", 32);
+        assert!(!cleaned.contains('\n'));
+        assert!(!cleaned.contains('\r'));
+    }
+
+    #[test]
+    fn audit_sanitize_caps_length() {
+        let s = "x".repeat(500);
+        let cleaned = sanitize_field(&s, 100);
+        assert_eq!(cleaned.chars().count(), 100);
+    }
+
+    #[test]
+    fn audit_resolve_path_directory_expands_to_file() {
+        let cfg = crate::config::AuditConfig {
+            enabled: Some(true),
+            path: Some("/tmp/ai-memory/audit/".to_string()),
+            ..Default::default()
+        };
+        let p = resolve_audit_path(&cfg);
+        assert!(p.ends_with("audit.log"));
+    }
+
+    #[test]
+    fn audit_resolve_path_explicit_file_kept() {
+        let cfg = crate::config::AuditConfig {
+            enabled: Some(true),
+            path: Some("/var/log/ai-memory/custom.log".to_string()),
+            ..Default::default()
+        };
+        let p = resolve_audit_path(&cfg);
+        assert_eq!(p, PathBuf::from("/var/log/ai-memory/custom.log"));
+    }
+
+    /// Serialize tests that mutate the process-wide audit sink so
+    /// concurrent test runners don't stomp on each other. Tests that
+    /// touch the live SINK should hold this lock for their duration.
+    fn sink_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// PR-5 (issue #487) load-bearing integration test. Wire the
+    /// audit subsystem to an in-memory sink and emit one event per
+    /// canonical action. Each successful operation MUST produce one
+    /// line; the chain MUST stay intact across the run.
+    #[test]
+    fn audit_emits_at_every_call_site() {
+        let _g = sink_lock();
+        let buf: std::sync::Arc<Mutex<Vec<u8>>> = std::sync::Arc::new(Mutex::new(Vec::new()));
+        super::init_for_test(buf.clone());
+
+        let actions = [
+            AuditAction::Store,
+            AuditAction::Recall,
+            AuditAction::Update,
+            AuditAction::Delete,
+            AuditAction::Link,
+            AuditAction::Promote,
+            AuditAction::Forget,
+            AuditAction::Consolidate,
+            AuditAction::Export,
+            AuditAction::Import,
+            AuditAction::Approve,
+            AuditAction::Reject,
+            AuditAction::SessionBoot,
+        ];
+        for (i, action) in actions.iter().copied().enumerate() {
+            let id = format!("mem-{i}");
+            super::emit(EventBuilder::new(
+                action,
+                actor("ai:test@host", "explicit", None),
+                target_memory(id, "ns-x", Some("t".to_string()), None, None),
+            ));
+        }
+
+        let lines = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        let count = lines.lines().filter(|l| !l.is_empty()).count();
+        assert_eq!(
+            count,
+            actions.len(),
+            "expected one audit line per action, got {count}: {lines}"
+        );
+        // Chain MUST be intact across the whole run.
+        let report = verify_chain_from_reader(lines.as_bytes()).unwrap();
+        assert!(
+            report.first_failure.is_none(),
+            "chain must verify across all call sites; failure: {:?}",
+            report.first_failure
+        );
+        assert_eq!(report.total_lines as usize, actions.len());
+
+        super::shutdown_for_test();
+    }
+
+    #[test]
+    fn audit_emit_is_noop_when_disabled() {
+        let _g = sink_lock();
+        super::shutdown_for_test();
+        // No sink active — emit must not panic and must not produce
+        // any output anywhere.
+        super::emit(EventBuilder::new(
+            AuditAction::Store,
+            actor("a", "explicit", None),
+            target_memory("m", "ns", None, None, None),
+        ));
+        // is_enabled stays false.
+        assert!(!super::is_enabled());
+    }
+
+    #[test]
+    fn audit_compliance_preset_soc2_overrides_retention() {
+        // The compliance presets are pure config — applying SOC2 with
+        // `applied = true` propagates the documented retention to the
+        // top-level config field. This is a unit-test on the merge
+        // logic, decoupled from disk.
+        let cfg = crate::config::AuditConfig {
+            enabled: Some(true),
+            retention_days: Some(90),
+            compliance: Some(crate::config::AuditComplianceConfig {
+                soc2: Some(crate::config::CompliancePreset {
+                    applied: Some(true),
+                    retention_days: Some(730),
+                    redact_content: Some(true),
+                    attestation_cadence_minutes: Some(60),
+                    encrypt_at_rest: None,
+                    pseudonymize_actors: None,
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let resolved = cfg.effective_retention_days();
+        assert_eq!(resolved, 730, "SOC2 preset must override default retention");
+    }
+}

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -20,7 +20,9 @@ use std::path::Path;
 use anyhow::Result;
 use clap::{Args, Subcommand};
 
-use crate::audit::{AuditEvent, resolve_audit_path, verify_chain};
+use crate::audit::{
+    AuditEvent, resolve_audit_path, resolve_audit_path_with_override, verify_chain,
+};
 use crate::cli::CliOutput;
 use crate::config::AppConfig;
 
@@ -28,6 +30,12 @@ use crate::config::AppConfig;
 pub struct AuditArgs {
     #[command(subcommand)]
     pub action: AuditAction,
+    /// Override the audit log directory. Highest-priority layer in the
+    /// resolution ladder (CLI > `AI_MEMORY_AUDIT_DIR` > `[audit] path`
+    /// in config.toml > platform default). Refuses world-writable
+    /// directories — see `docs/security/audit-trail.md`.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub audit_dir: Option<std::path::PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -76,23 +84,43 @@ pub struct TailArgs {
 /// code so the caller can surface a non-zero status from the top-level
 /// dispatch without panicking.
 pub fn run(args: AuditArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
+    let audit_dir = args.audit_dir.clone();
     match args.action {
-        AuditAction::Verify(v) => run_verify(&v, app_config, out),
-        AuditAction::Tail(t) => run_tail(&t, app_config, out),
-        AuditAction::Path => run_path(app_config, out),
+        AuditAction::Verify(v) => run_verify(&v, audit_dir.as_deref(), app_config, out),
+        AuditAction::Tail(t) => run_tail(&t, audit_dir.as_deref(), app_config, out),
+        AuditAction::Path => run_path(audit_dir.as_deref(), app_config, out),
     }
 }
 
-fn resolve_path(app_config: &AppConfig, override_path: Option<&str>) -> std::path::PathBuf {
-    if let Some(p) = override_path {
+/// Resolve the audit log path honouring (in order): explicit per-subcommand
+/// `--path` (legacy `VerifyArgs.path` / `TailArgs.path`), the global
+/// `--audit-dir` flag, `AI_MEMORY_AUDIT_DIR`, `[audit] path` in
+/// config.toml, and the platform default. Falls back to the loose
+/// `resolve_audit_path` if any layer above produces an error so the
+/// `audit path` subcommand can still print a useful answer when
+/// `--audit-dir` is mistyped.
+fn resolve_path(
+    app_config: &AppConfig,
+    cli_audit_dir: Option<&std::path::Path>,
+    explicit_per_cmd: Option<&str>,
+) -> std::path::PathBuf {
+    if let Some(p) = explicit_per_cmd {
         return std::path::PathBuf::from(crate::audit::expand_tilde(p));
     }
     let cfg = app_config.effective_audit();
+    if let Ok((p, _src)) = resolve_audit_path_with_override(cli_audit_dir, &cfg) {
+        return p;
+    }
     resolve_audit_path(&cfg)
 }
 
-fn run_verify(args: &VerifyArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
-    let path = resolve_path(app_config, args.path.as_deref());
+fn run_verify(
+    args: &VerifyArgs,
+    cli_audit_dir: Option<&std::path::Path>,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<i32> {
+    let path = resolve_path(app_config, cli_audit_dir, args.path.as_deref());
     if !path.exists() {
         if args.json {
             writeln!(
@@ -161,8 +189,13 @@ fn run_verify(args: &VerifyArgs, app_config: &AppConfig, out: &mut CliOutput<'_>
     Ok(0)
 }
 
-fn run_tail(args: &TailArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
-    let path = resolve_path(app_config, args.path.as_deref());
+fn run_tail(
+    args: &TailArgs,
+    cli_audit_dir: Option<&std::path::Path>,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<i32> {
+    let path = resolve_path(app_config, cli_audit_dir, args.path.as_deref());
     if !path.exists() {
         return Ok(0);
     }
@@ -218,8 +251,12 @@ fn run_tail(args: &TailArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) ->
     Ok(0)
 }
 
-fn run_path(app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
-    let p = resolve_path(app_config, None);
+fn run_path(
+    cli_audit_dir: Option<&std::path::Path>,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<i32> {
+    let p = resolve_path(app_config, cli_audit_dir, None);
     writeln!(out.stdout, "{}", p.display())?;
     Ok(0)
 }
@@ -312,6 +349,7 @@ mod tests {
                 path: Some(p.to_string_lossy().into_owned()),
                 json: true,
             },
+            None,
             &cfg,
             &mut out,
         )
@@ -340,6 +378,7 @@ mod tests {
                 path: Some(p.to_string_lossy().into_owned()),
                 json: true,
             },
+            None,
             &cfg,
             &mut out,
         )
@@ -362,6 +401,7 @@ mod tests {
                 path: Some(tmp.path().join("nope.log").to_string_lossy().into_owned()),
                 json: false,
             },
+            None,
             &cfg,
             &mut out,
         )
@@ -383,9 +423,25 @@ mod tests {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
-        run_path(&cfg, &mut out).unwrap();
+        run_path(None, &cfg, &mut out).unwrap();
         let s = std::str::from_utf8(&stdout).unwrap();
         assert!(s.contains("/var/log/ai-memory/custom.log"));
+    }
+
+    #[test]
+    fn audit_path_subcmd_honours_audit_dir_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = AppConfig::default();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        run_path(Some(tmp.path()), &cfg, &mut out).unwrap();
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(
+            s.contains(tmp.path().to_string_lossy().as_ref()),
+            "expected audit-dir override to surface in `audit path` output: {s}"
+        );
+        assert!(s.contains("audit.log"));
     }
 
     // Compile-time guardrail — make sure EventBuilder is visible from

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1,0 +1,401 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ai-memory audit` — operator-facing CLI for the security audit
+//! trail (PR-5 of issue #487).
+//!
+//! Subcommands:
+//! - `verify` — walk the configured audit log and assert the hash chain
+//!   is intact. Exits non-zero on any mismatch with the precise line
+//!   number and failure kind.
+//! - `tail` — print recent audit events in JSON or text form.
+//! - `path` — print the resolved audit log path. Useful for SIEM
+//!   ingestion configuration scripts.
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+#[cfg(test)]
+use std::path::Path;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+use crate::audit::{AuditEvent, resolve_audit_path, verify_chain};
+use crate::cli::CliOutput;
+use crate::config::AppConfig;
+
+#[derive(Args)]
+pub struct AuditArgs {
+    #[command(subcommand)]
+    pub action: AuditAction,
+}
+
+#[derive(Subcommand)]
+pub enum AuditAction {
+    /// Verify the hash chain. Exits 0 on success, 2 on mismatch.
+    Verify(VerifyArgs),
+    /// Print the most recent N events (default 50).
+    Tail(TailArgs),
+    /// Print the resolved audit log path.
+    Path,
+}
+
+#[derive(Args)]
+pub struct VerifyArgs {
+    /// Override the configured audit log path.
+    #[arg(long)]
+    pub path: Option<String>,
+    /// Emit a JSON report instead of text.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct TailArgs {
+    /// Override the configured audit log path.
+    #[arg(long)]
+    pub path: Option<String>,
+    /// Number of trailing lines to print. Default 50.
+    #[arg(long, default_value_t = 50)]
+    pub lines: usize,
+    /// Filter by `actor.agent_id`.
+    #[arg(long)]
+    pub actor: Option<String>,
+    /// Filter by `target.namespace`.
+    #[arg(long)]
+    pub namespace: Option<String>,
+    /// Filter by `action`.
+    #[arg(long)]
+    pub action: Option<String>,
+    /// Output format: `json` (default) or `text`.
+    #[arg(long, default_value = "json")]
+    pub format: String,
+}
+
+/// `ai-memory audit` entry point. Returns the desired process exit
+/// code so the caller can surface a non-zero status from the top-level
+/// dispatch without panicking.
+pub fn run(args: AuditArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
+    match args.action {
+        AuditAction::Verify(v) => run_verify(&v, app_config, out),
+        AuditAction::Tail(t) => run_tail(&t, app_config, out),
+        AuditAction::Path => run_path(app_config, out),
+    }
+}
+
+fn resolve_path(app_config: &AppConfig, override_path: Option<&str>) -> std::path::PathBuf {
+    if let Some(p) = override_path {
+        return std::path::PathBuf::from(crate::audit::expand_tilde(p));
+    }
+    let cfg = app_config.effective_audit();
+    resolve_audit_path(&cfg)
+}
+
+fn run_verify(args: &VerifyArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
+    let path = resolve_path(app_config, args.path.as_deref());
+    if !path.exists() {
+        if args.json {
+            writeln!(
+                out.stdout,
+                "{}",
+                serde_json::json!({
+                    "status": "ok",
+                    "total_lines": 0,
+                    "note": "audit log does not exist (audit may be disabled)",
+                    "path": path.display().to_string(),
+                })
+            )?;
+        } else {
+            writeln!(
+                out.stdout,
+                "audit verify: log not present at {} — nothing to check",
+                path.display()
+            )?;
+        }
+        return Ok(0);
+    }
+    let report = verify_chain(&path)?;
+    if let Some(failure) = &report.first_failure {
+        if args.json {
+            writeln!(
+                out.stdout,
+                "{}",
+                serde_json::json!({
+                    "status": "fail",
+                    "total_lines": report.total_lines,
+                    "failure": {
+                        "line_number": failure.line_number,
+                        "kind": format!("{:?}", failure.kind),
+                        "detail": failure.detail,
+                    },
+                    "path": path.display().to_string(),
+                })
+            )?;
+        } else {
+            writeln!(
+                out.stderr,
+                "audit verify FAIL at line {}: {:?} — {}",
+                failure.line_number, failure.kind, failure.detail
+            )?;
+        }
+        return Ok(2);
+    }
+    if args.json {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "status": "ok",
+                "total_lines": report.total_lines,
+                "path": path.display().to_string(),
+            })
+        )?;
+    } else {
+        writeln!(
+            out.stdout,
+            "audit verify OK: {} line(s) verified at {}",
+            report.total_lines,
+            path.display()
+        )?;
+    }
+    Ok(0)
+}
+
+fn run_tail(args: &TailArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
+    let path = resolve_path(app_config, args.path.as_deref());
+    if !path.exists() {
+        return Ok(0);
+    }
+    let f = fs::File::open(&path)?;
+    let buf = BufReader::new(f);
+    let mut keep: Vec<AuditEvent> = Vec::new();
+    for line in buf.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(ev) = serde_json::from_str::<AuditEvent>(&line) else {
+            continue;
+        };
+        if let Some(actor) = &args.actor
+            && !ev.actor.agent_id.contains(actor)
+        {
+            continue;
+        }
+        if let Some(ns) = &args.namespace
+            && ev.target.namespace != *ns
+        {
+            continue;
+        }
+        if let Some(action) = &args.action
+            && ev.action.as_str() != action
+        {
+            continue;
+        }
+        keep.push(ev);
+        if keep.len() > args.lines {
+            keep.remove(0);
+        }
+    }
+    let json_format = args.format != "text";
+    for ev in &keep {
+        if json_format {
+            writeln!(out.stdout, "{}", serde_json::to_string(ev)?)?;
+        } else {
+            writeln!(
+                out.stdout,
+                "{} seq={} {} {} ns={} id={} outcome={:?}",
+                ev.timestamp,
+                ev.sequence,
+                ev.actor.agent_id,
+                ev.action.as_str(),
+                ev.target.namespace,
+                ev.target.memory_id,
+                ev.outcome,
+            )?;
+        }
+    }
+    Ok(0)
+}
+
+fn run_path(app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<i32> {
+    let p = resolve_path(app_config, None);
+    writeln!(out.stdout, "{}", p.display())?;
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::{
+        AuditAction as AAct, AuditOutcome, CHAIN_HEAD_PREV_HASH, EventBuilder, actor, target_memory,
+    };
+    use crate::config::AuditConfig;
+
+    fn write_chained_log(dir: &Path) -> std::path::PathBuf {
+        // Build a 3-line chain by hand using the public API; we use
+        // the audit module's `init` so emit() produces the lines.
+        let path = dir.join("audit.log");
+        // Reset the global sink across test runs by spinning a fresh
+        // process is impossible; fall back to writing the lines
+        // directly.
+        let mut prev_hash = CHAIN_HEAD_PREV_HASH.to_string();
+        let mut buf = String::new();
+        for seq in 1..=3 {
+            let ev = make_event(seq, &prev_hash);
+            prev_hash = ev.self_hash.clone();
+            buf.push_str(&serde_json::to_string(&ev).unwrap());
+            buf.push('\n');
+        }
+        fs::write(&path, buf).unwrap();
+        path
+    }
+
+    fn make_event(seq: u64, prev: &str) -> AuditEvent {
+        let mut ev = AuditEvent {
+            schema_version: crate::audit::SCHEMA_VERSION,
+            timestamp: format!("2026-04-30T00:00:0{seq}+00:00"),
+            sequence: seq,
+            actor: actor("ai:test@host:pid-1", "host_fallback", None),
+            action: AAct::Store,
+            target: target_memory(
+                format!("mem-{seq}"),
+                "ns-x",
+                Some("title".to_string()),
+                Some("mid".to_string()),
+                None,
+            ),
+            outcome: AuditOutcome::Allow,
+            auth: None,
+            session_id: None,
+            request_id: None,
+            error: None,
+            prev_hash: prev.to_string(),
+            self_hash: String::new(),
+        };
+        // Recompute self_hash via the builder helper exposed
+        // through serde round-trip in tests.
+        let canonical = {
+            let mut clone = ev.clone();
+            clone.self_hash.clear();
+            serde_json::to_string(&clone).unwrap()
+        };
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(canonical.as_bytes());
+        let bytes = h.finalize();
+        let mut s = String::with_capacity(64);
+        for b in bytes.iter() {
+            s.push_str(&format!("{b:02x}"));
+        }
+        ev.self_hash = s;
+        ev
+    }
+
+    #[test]
+    fn audit_verify_subcmd_reports_ok_for_valid_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write_chained_log(tmp.path());
+        let cfg = AppConfig {
+            audit: Some(AuditConfig {
+                enabled: Some(true),
+                path: Some(p.to_string_lossy().into_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        let exit = run_verify(
+            &VerifyArgs {
+                path: Some(p.to_string_lossy().into_owned()),
+                json: true,
+            },
+            &cfg,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 0);
+        let s = std::str::from_utf8(&stdout).unwrap();
+        let v: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["total_lines"], 3);
+    }
+
+    #[test]
+    fn audit_verify_subcmd_detects_tampering() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write_chained_log(tmp.path());
+        // Corrupt the second line.
+        let mut body = fs::read_to_string(&p).unwrap();
+        body = body.replacen("\"sequence\":2", "\"sequence\":99", 1);
+        fs::write(&p, body).unwrap();
+        let cfg = AppConfig::default();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        let exit = run_verify(
+            &VerifyArgs {
+                path: Some(p.to_string_lossy().into_owned()),
+                json: true,
+            },
+            &cfg,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 2, "tampering must produce non-zero exit");
+        let s = std::str::from_utf8(&stdout).unwrap();
+        let v: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert_eq!(v["status"], "fail");
+    }
+
+    #[test]
+    fn audit_verify_subcmd_missing_log_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = AppConfig::default();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        let exit = run_verify(
+            &VerifyArgs {
+                path: Some(tmp.path().join("nope.log").to_string_lossy().into_owned()),
+                json: false,
+            },
+            &cfg,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 0);
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(s.contains("nothing to check"));
+    }
+
+    #[test]
+    fn audit_path_subcmd_prints_resolved_path() {
+        let cfg = AppConfig {
+            audit: Some(AuditConfig {
+                path: Some("/var/log/ai-memory/custom.log".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        run_path(&cfg, &mut out).unwrap();
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(s.contains("/var/log/ai-memory/custom.log"));
+    }
+
+    // Compile-time guardrail — make sure EventBuilder is visible from
+    // this module (it's the public emit-API).
+    #[allow(dead_code)]
+    fn _builder_is_visible() {
+        let _ = EventBuilder::new(
+            AAct::Store,
+            actor("a", "explicit", None),
+            target_memory("m", "ns", None, None, None),
+        );
+    }
+}

--- a/src/cli/crud.rs
+++ b/src/cli/crud.rs
@@ -194,6 +194,22 @@ pub fn cmd_delete(
     }
 
     if db::delete(&conn, &target.id)? {
+        // PR-5 (issue #487): security audit trail.
+        crate::audit::emit(crate::audit::EventBuilder::new(
+            crate::audit::AuditAction::Delete,
+            crate::audit::actor(
+                identity::resolve_agent_id(cli_agent_id, None).unwrap_or_default(),
+                cli_agent_id.map_or("default_fallback", |_| "explicit"),
+                None,
+            ),
+            crate::audit::target_memory(
+                target.id.clone(),
+                target.namespace.clone(),
+                Some(target.title.clone()),
+                Some(target.tier.to_string()),
+                None,
+            ),
+        ));
         if json_out {
             writeln!(
                 out.stdout,

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -21,7 +21,8 @@ use clap::{Args, Subcommand};
 
 use crate::cli::CliOutput;
 use crate::config::{AppConfig, LoggingConfig};
-use crate::logging::resolve_log_dir;
+use crate::log_paths;
+use crate::logging::resolve_log_dir_with_override;
 
 #[derive(Args)]
 pub struct LogsArgs {
@@ -51,6 +52,12 @@ pub struct LogsArgs {
     /// line per JSON object).
     #[arg(long, global = true, default_value = "text")]
     pub format: String,
+    /// Override the operational log directory. Highest-priority layer
+    /// in the resolution ladder (CLI > `AI_MEMORY_LOG_DIR` > `[logging]
+    /// path` in config.toml > platform default). Refuses world-writable
+    /// directories — see `docs/security/audit-trail.md`.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub log_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -105,7 +112,10 @@ pub struct PurgeArgs {
 /// `ai-memory logs` entry point.
 pub fn run(args: LogsArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<()> {
     let logging_cfg = app_config.effective_logging();
-    let dir = resolve_log_dir(&logging_cfg);
+    let resolved = resolve_log_dir_with_override(args.log_dir.as_deref(), &logging_cfg)
+        .with_context(|| "resolving operational log directory")?;
+    let dir = resolved.path.clone();
+    let _source: log_paths::PathSource = resolved.source;
     let filters = args_filters(&args);
     match args.action {
         LogsAction::Tail(t) => run_tail(&dir, &filters, &t, out),

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -1,0 +1,638 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ai-memory logs` — operator-facing CLI for the file logging facility
+//! (PR-5 of issue #487). Tail, archive, purge, filter.
+//!
+//! The subcommand operates on the directory configured by
+//! `[logging] path = ...` in `config.toml`. When logging is disabled
+//! the commands still work against the empty default directory and
+//! exit 0 — the CLI is a no-op rather than a hard error so a fresh
+//! install isn't surprised.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write as _};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use clap::{Args, Subcommand};
+
+use crate::cli::CliOutput;
+use crate::config::{AppConfig, LoggingConfig};
+use crate::logging::resolve_log_dir;
+
+#[derive(Args)]
+pub struct LogsArgs {
+    #[command(subcommand)]
+    pub action: LogsAction,
+    /// RFC3339 lower bound. Lines older than this are dropped from
+    /// `tail` / `cat` output.
+    #[arg(long, global = true, value_name = "TS")]
+    pub since: Option<String>,
+    /// RFC3339 upper bound.
+    #[arg(long, global = true, value_name = "TS")]
+    pub until: Option<String>,
+    /// Filter to lines whose tracing `level` field equals this.
+    #[arg(long, global = true)]
+    pub level: Option<String>,
+    /// Filter to lines that mention this namespace (case-insensitive
+    /// substring match against the line body).
+    #[arg(long, global = true)]
+    pub namespace: Option<String>,
+    /// Filter to lines that mention this actor / agent_id.
+    #[arg(long, global = true)]
+    pub actor: Option<String>,
+    /// Filter to lines that mention this audit `action`.
+    #[arg(long, global = true)]
+    pub action_filter: Option<String>,
+    /// Output format: `text` (passthrough) or `json` (one filtered
+    /// line per JSON object).
+    #[arg(long, global = true, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Subcommand)]
+pub enum LogsAction {
+    /// Print recent log lines and (with `--follow`) stream new ones.
+    Tail(TailArgs),
+    /// Print every log line in chronological order, applying any
+    /// global filters.
+    Cat,
+    /// Compress rotated log files older than the configured
+    /// `retention_days` using zstd.
+    Archive,
+    /// Delete archived log files older than `--before <date>`. Warns
+    /// when the date overlaps the audit retention horizon (deleting
+    /// audit logs creates an audit gap).
+    Purge(PurgeArgs),
+}
+
+#[derive(Args)]
+pub struct TailArgs {
+    /// Number of recent lines to print before tailing. Default 50.
+    #[arg(long, default_value_t = 50)]
+    pub lines: usize,
+    /// Stream new lines as they arrive (poll-based, ~1s cadence).
+    #[arg(long, default_value_t = false)]
+    pub follow: bool,
+    /// Override the poll interval in milliseconds. Default 1000.
+    #[arg(long, default_value_t = 1000)]
+    pub follow_interval_ms: u64,
+    /// Stop tailing after this many polls in `--follow` mode. Tests
+    /// pass a small bound so the loop terminates deterministically.
+    /// 0 = no bound.
+    #[arg(long, default_value_t = 0, hide = true)]
+    pub max_polls: u64,
+}
+
+#[derive(Args)]
+pub struct PurgeArgs {
+    /// Delete archives whose mtime is older than this RFC3339 date.
+    #[arg(long, value_name = "DATE")]
+    pub before: String,
+    /// Suppress the audit-gap warning even when audit logs would be
+    /// deleted. Reserved for automated rotation pipelines.
+    #[arg(long, default_value_t = false)]
+    pub no_warn: bool,
+    /// Dry run — print which files would be deleted without
+    /// removing them.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+}
+
+/// `ai-memory logs` entry point.
+pub fn run(args: LogsArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> Result<()> {
+    let logging_cfg = app_config.effective_logging();
+    let dir = resolve_log_dir(&logging_cfg);
+    let filters = args_filters(&args);
+    match args.action {
+        LogsAction::Tail(t) => run_tail(&dir, &filters, &t, out),
+        LogsAction::Cat => run_cat(&dir, &filters, out),
+        LogsAction::Archive => run_archive(&dir, &logging_cfg, out),
+        LogsAction::Purge(p) => run_purge(&dir, &p, app_config, out),
+    }
+}
+
+#[derive(Default, Clone)]
+struct Filters {
+    since: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+    level: Option<String>,
+    namespace: Option<String>,
+    actor: Option<String>,
+    action: Option<String>,
+    format_json: bool,
+}
+
+fn args_filters(a: &LogsArgs) -> Filters {
+    Filters {
+        since: a.since.as_deref().and_then(parse_ts),
+        until: a.until.as_deref().and_then(parse_ts),
+        level: a.level.clone(),
+        namespace: a.namespace.clone(),
+        actor: a.actor.clone(),
+        action: a.action_filter.clone(),
+        format_json: a.format == "json",
+    }
+}
+
+fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        let dt = NaiveDateTime::new(d, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+        return Some(Utc.from_utc_datetime(&dt));
+    }
+    None
+}
+
+fn line_matches(line: &str, filters: &Filters) -> bool {
+    if let Some(level) = &filters.level
+        && !line
+            .to_ascii_uppercase()
+            .contains(&level.to_ascii_uppercase())
+    {
+        return false;
+    }
+    if let Some(ns) = &filters.namespace
+        && !line.to_ascii_lowercase().contains(&ns.to_ascii_lowercase())
+    {
+        return false;
+    }
+    if let Some(actor) = &filters.actor
+        && !line
+            .to_ascii_lowercase()
+            .contains(&actor.to_ascii_lowercase())
+    {
+        return false;
+    }
+    if let Some(action) = &filters.action
+        && !line
+            .to_ascii_lowercase()
+            .contains(&action.to_ascii_lowercase())
+    {
+        return false;
+    }
+    if filters.since.is_some() || filters.until.is_some() {
+        // Best-effort: scan the line for an RFC3339 prefix or a
+        // `"timestamp":"…"` JSON field.
+        let ts = extract_timestamp(line);
+        if let Some(ts) = ts {
+            if let Some(since) = filters.since
+                && ts < since
+            {
+                return false;
+            }
+            if let Some(until) = filters.until
+                && ts > until
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn extract_timestamp(line: &str) -> Option<DateTime<Utc>> {
+    // Try a leading RFC3339 token.
+    if let Some(stop) = line.find(' ') {
+        let head = &line[..stop];
+        if let Ok(dt) = DateTime::parse_from_rfc3339(head) {
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+    // JSON form.
+    if let Some(idx) = line.find("\"timestamp\":\"") {
+        let rest = &line[idx + 13..];
+        if let Some(end) = rest.find('"') {
+            if let Ok(dt) = DateTime::parse_from_rfc3339(&rest[..end]) {
+                return Some(dt.with_timezone(&Utc));
+            }
+        }
+    }
+    None
+}
+
+/// Enumerate every `ai-memory.log*` file in `dir`, sorted by name
+/// (which sorts by date because the rolling appender's suffix is
+/// `YYYY-MM-DD[-HH[-MM]]`).
+fn enumerate_log_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.is_file()
+            && p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("ai-memory") && !n.ends_with(".zst"))
+        {
+            files.push(p);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn run_cat(dir: &Path, filters: &Filters, out: &mut CliOutput<'_>) -> Result<()> {
+    for f in enumerate_log_files(dir)? {
+        emit_file(&f, filters, out)?;
+    }
+    Ok(())
+}
+
+fn emit_file(path: &Path, filters: &Filters, out: &mut CliOutput<'_>) -> Result<()> {
+    let f = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if !line_matches(&line, filters) {
+            continue;
+        }
+        emit_line(&line, filters, out)?;
+    }
+    Ok(())
+}
+
+fn emit_line(line: &str, filters: &Filters, out: &mut CliOutput<'_>) -> Result<()> {
+    if filters.format_json {
+        // If the line is already JSON pass through; otherwise wrap
+        // it so downstream `jq` always sees an object.
+        if line.trim_start().starts_with('{') {
+            writeln!(out.stdout, "{line}")?;
+        } else {
+            let v = serde_json::json!({ "line": line });
+            writeln!(out.stdout, "{}", serde_json::to_string(&v)?)?;
+        }
+    } else {
+        writeln!(out.stdout, "{line}")?;
+    }
+    Ok(())
+}
+
+fn run_tail(dir: &Path, filters: &Filters, args: &TailArgs, out: &mut CliOutput<'_>) -> Result<()> {
+    let files = enumerate_log_files(dir)?;
+    let Some(latest) = files.last().cloned() else {
+        return Ok(());
+    };
+    // Read the tail-N matching lines.
+    let initial = read_tail_n(&latest, args.lines, filters)?;
+    for line in &initial {
+        emit_line(line, filters, out)?;
+    }
+    if !args.follow {
+        return Ok(());
+    }
+    let mut last_size = fs::metadata(&latest).map(|m| m.len()).unwrap_or(0);
+    let mut polls: u64 = 0;
+    loop {
+        std::thread::sleep(Duration::from_millis(args.follow_interval_ms));
+        polls += 1;
+        let cur_size = fs::metadata(&latest).map(|m| m.len()).unwrap_or(last_size);
+        if cur_size > last_size {
+            let new_lines = read_lines_after_offset(&latest, last_size)?;
+            for line in new_lines {
+                if line_matches(&line, filters) {
+                    emit_line(&line, filters, out)?;
+                }
+            }
+            last_size = cur_size;
+        }
+        if args.max_polls > 0 && polls >= args.max_polls {
+            return Ok(());
+        }
+    }
+}
+
+fn read_tail_n(path: &Path, n: usize, filters: &Filters) -> Result<Vec<String>> {
+    let f = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let buf = BufReader::new(f);
+    let mut keep: Vec<String> = Vec::with_capacity(n);
+    for line in buf.lines() {
+        let line = line?;
+        if !line_matches(&line, filters) {
+            continue;
+        }
+        keep.push(line);
+        if keep.len() > n {
+            keep.remove(0);
+        }
+    }
+    Ok(keep)
+}
+
+fn read_lines_after_offset(path: &Path, offset: u64) -> Result<Vec<String>> {
+    use std::io::Seek as _;
+    use std::io::SeekFrom;
+    let mut f = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    f.seek(SeekFrom::Start(offset))?;
+    let buf = BufReader::new(f);
+    let mut out = Vec::new();
+    for line in buf.lines() {
+        out.push(line?);
+    }
+    Ok(out)
+}
+
+fn run_archive(dir: &Path, cfg: &LoggingConfig, out: &mut CliOutput<'_>) -> Result<()> {
+    let retention_days = i64::from(cfg.retention_days.unwrap_or(90));
+    let cutoff = Utc::now() - chrono::Duration::days(retention_days);
+    let mut compressed: u64 = 0;
+    let mut total_in: u64 = 0;
+    let mut total_out: u64 = 0;
+
+    for f in enumerate_log_files(dir)? {
+        let mtime = fs::metadata(&f)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| Utc.timestamp_opt(d.as_secs() as i64, 0).unwrap());
+        let Some(mtime) = mtime else {
+            continue;
+        };
+        if mtime >= cutoff {
+            continue;
+        }
+        let in_bytes = fs::read(&f).with_context(|| format!("reading {}", f.display()))?;
+        let in_size = in_bytes.len() as u64;
+        let out_path = f.with_extension(format!(
+            "{}.zst",
+            f.extension().and_then(|e| e.to_str()).unwrap_or("log")
+        ));
+        let compressed_bytes = zstd_compress(&in_bytes)?;
+        let out_size = compressed_bytes.len() as u64;
+        fs::write(&out_path, &compressed_bytes)
+            .with_context(|| format!("writing {}", out_path.display()))?;
+        fs::remove_file(&f).with_context(|| format!("removing {}", f.display()))?;
+        compressed += 1;
+        total_in += in_size;
+        total_out += out_size;
+    }
+    writeln!(
+        out.stdout,
+        "archived {compressed} log file(s): {total_in} bytes -> {total_out} bytes"
+    )?;
+    Ok(())
+}
+
+fn zstd_compress(input: &[u8]) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len() / 4 + 64);
+    {
+        let mut encoder = zstd::stream::write::Encoder::new(&mut out, 3)?;
+        encoder.write_all(input)?;
+        encoder.finish()?;
+    }
+    Ok(out)
+}
+
+fn run_purge(
+    dir: &Path,
+    args: &PurgeArgs,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let cutoff = parse_ts(&args.before)
+        .ok_or_else(|| anyhow!("invalid --before date: {} (expected RFC3339)", args.before))?;
+    if !args.no_warn {
+        warn_about_audit_gap(args, app_config, out)?;
+    }
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut deleted: u64 = 0;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if !p.is_file() {
+            continue;
+        }
+        if !p.to_string_lossy().ends_with(".zst") {
+            continue;
+        }
+        let mtime = fs::metadata(&p)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| Utc.timestamp_opt(d.as_secs() as i64, 0).unwrap());
+        if let Some(mt) = mtime
+            && mt < cutoff
+        {
+            if args.dry_run {
+                writeln!(out.stdout, "would delete: {}", p.display())?;
+            } else {
+                fs::remove_file(&p).with_context(|| format!("removing {}", p.display()))?;
+                writeln!(out.stdout, "deleted: {}", p.display())?;
+            }
+            deleted += 1;
+        }
+    }
+    writeln!(out.stdout, "purged {deleted} archive(s)")?;
+    Ok(())
+}
+
+fn warn_about_audit_gap(
+    args: &PurgeArgs,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let audit = app_config.effective_audit();
+    if !audit.enabled.unwrap_or(false) {
+        return Ok(());
+    }
+    let retention = audit.effective_retention_days();
+    let cutoff = parse_ts(&args.before).unwrap_or_else(Utc::now);
+    let oldest_required = Utc::now() - chrono::Duration::days(i64::from(retention));
+    if cutoff > oldest_required {
+        writeln!(
+            out.stderr,
+            "warning: --before {ts} would delete archives newer than the configured \
+             audit retention horizon ({retention} days, oldest required = {oldest}). \
+             Continuing creates an audit gap that `ai-memory audit verify` will surface. \
+             Pass --no-warn to suppress this message in automated rotation pipelines.",
+            ts = args.before,
+            retention = retention,
+            oldest = oldest_required.to_rfc3339()
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_log(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, contents).unwrap();
+        p
+    }
+
+    fn output<'a>(stdout: &'a mut Vec<u8>, stderr: &'a mut Vec<u8>) -> CliOutput<'a> {
+        CliOutput::from_std(stdout, stderr)
+    }
+
+    #[test]
+    fn logs_tail_returns_last_n_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = (1..=100)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        make_log(dir.path(), "ai-memory.log.2026-04-30", &body);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            let filters = Filters::default();
+            let args = TailArgs {
+                lines: 5,
+                follow: false,
+                follow_interval_ms: 50,
+                max_polls: 0,
+            };
+            run_tail(dir.path(), &filters, &args, &mut out).unwrap();
+        }
+        let s = std::str::from_utf8(&stdout).unwrap();
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 5);
+        assert_eq!(lines.last().unwrap(), &"line 100");
+    }
+
+    #[test]
+    fn logs_tail_follows_appended_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = make_log(dir.path(), "ai-memory.log.2026-04-30", "first\n");
+        let path_clone = path.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(60));
+            let mut f = fs::OpenOptions::new()
+                .append(true)
+                .open(&path_clone)
+                .unwrap();
+            writeln!(f, "second").unwrap();
+            writeln!(f, "third").unwrap();
+        });
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            let filters = Filters::default();
+            let args = TailArgs {
+                lines: 10,
+                follow: true,
+                follow_interval_ms: 30,
+                max_polls: 6,
+            };
+            run_tail(dir.path(), &filters, &args, &mut out).unwrap();
+        }
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(s.contains("first"), "got: {s}");
+        assert!(s.contains("second"), "expected appended line: {s}");
+    }
+
+    #[test]
+    fn logs_archive_compresses_with_zstd() {
+        let dir = tempfile::tempdir().unwrap();
+        // Use a retention of 0 days so the archiver picks up the file
+        // regardless of its mtime — the file's mtime is "now" since we
+        // just created it.
+        let body = "x".repeat(8192);
+        make_log(dir.path(), "ai-memory.log.2025-01-01", &body);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let cfg = LoggingConfig {
+            retention_days: Some(0),
+            ..Default::default()
+        };
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            run_archive(dir.path(), &cfg, &mut out).unwrap();
+        }
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(s.contains("archived 1"), "expected archive count: {s}");
+        // The .zst output replaces the source.
+        let entries: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap_or_default())
+            .collect();
+        assert!(
+            entries.iter().any(|n| n.ends_with(".zst")),
+            "expected a .zst entry, got {entries:?}"
+        );
+    }
+
+    #[test]
+    fn logs_purge_warns_about_audit_gap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let app_config = AppConfig {
+            audit: Some(crate::config::AuditConfig {
+                enabled: Some(true),
+                retention_days: Some(90),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            let args = PurgeArgs {
+                before: Utc::now().to_rfc3339(),
+                no_warn: false,
+                dry_run: true,
+            };
+            run_purge(dir.path(), &args, &app_config, &mut out).unwrap();
+        }
+        let serr = std::str::from_utf8(&stderr).unwrap();
+        assert!(
+            serr.contains("audit gap"),
+            "expected audit-gap warning: {serr}"
+        );
+    }
+
+    #[test]
+    fn logs_filter_namespace_substring() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "alpha line\nbeta line ns=widgets\ngamma line";
+        make_log(dir.path(), "ai-memory.log.2026-04-30", body);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            let filters = Filters {
+                namespace: Some("widgets".to_string()),
+                ..Default::default()
+            };
+            run_cat(dir.path(), &filters, &mut out).unwrap();
+        }
+        let s = std::str::from_utf8(&stdout).unwrap();
+        assert!(s.contains("beta line"));
+        assert!(!s.contains("alpha line"));
+        assert!(!s.contains("gamma line"));
+    }
+
+    #[test]
+    fn logs_format_json_wraps_text_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "plain text line";
+        make_log(dir.path(), "ai-memory.log.2026-04-30", body);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        {
+            let mut out = output(&mut stdout, &mut stderr);
+            let filters = Filters {
+                format_json: true,
+                ..Default::default()
+            };
+            run_cat(dir.path(), &filters, &mut out).unwrap();
+        }
+        let s = std::str::from_utf8(&stdout).unwrap();
+        let v: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert_eq!(v["line"], "plain text line");
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod agents;
 pub mod archive;
+pub mod audit;
 pub mod backup;
 pub mod boot;
 pub mod consolidate;
@@ -30,6 +31,7 @@ pub mod helpers;
 pub mod io;
 pub mod io_writer;
 pub mod link;
+pub mod logs;
 pub mod promote;
 pub mod recall;
 pub mod search;

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -179,6 +179,23 @@ pub fn run(
     let contradictions =
         db::find_contradictions(&conn, &mem.title, &mem.namespace).unwrap_or_default();
     let actual_id = db::insert(&conn, &mem)?;
+
+    // PR-5 (issue #487): security audit trail. No-op when disabled.
+    crate::audit::emit(crate::audit::EventBuilder::new(
+        crate::audit::AuditAction::Store,
+        crate::audit::actor(
+            agent_id.clone(),
+            cli_agent_id.map_or("default_fallback", |_| "explicit"),
+            args.scope.clone(),
+        ),
+        crate::audit::target_memory(
+            actual_id.clone(),
+            mem.namespace.clone(),
+            Some(mem.title.clone()),
+            Some(mem.tier.to_string()),
+            args.scope.clone(),
+        ),
+    ));
     let filtered: Vec<&String> = contradictions
         .iter()
         .filter(|c| c.id != mem.id && c.id != actual_id)

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -97,6 +97,25 @@ pub fn run(
         std::process::exit(1);
     }
     if let Some(mem) = db::get(&conn, &resolved_id)? {
+        // PR-5 (issue #487): security audit trail. No-op when disabled.
+        crate::audit::emit(crate::audit::EventBuilder::new(
+            crate::audit::AuditAction::Update,
+            crate::audit::actor(
+                mem.metadata
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default(),
+                "default_fallback",
+                None,
+            ),
+            crate::audit::target_memory(
+                mem.id.clone(),
+                mem.namespace.clone(),
+                Some(mem.title.clone()),
+                Some(mem.tier.to_string()),
+                None,
+            ),
+        ));
         if json_out {
             writeln!(out.stdout, "{}", serde_json::to_string(&mem)?)?;
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -963,6 +963,171 @@ pub struct AppConfig {
     /// behind an Ollama round-trip. `AI_MEMORY_AUTONOMOUS_HOOKS=1`
     /// env var overrides the config file.
     pub autonomous_hooks: Option<bool>,
+    /// v0.6.3.1 (PR-5 / issue #487) — operational logging facility.
+    /// Default-OFF for privacy; opt-in turns on the rolling file
+    /// appender that captures every `tracing::*` call site to disk.
+    pub logging: Option<LoggingConfig>,
+    /// v0.6.3.1 (PR-5 / issue #487) — security audit trail. Default-OFF
+    /// for privacy; opt-in emits a hash-chained, tamper-evident JSON
+    /// log of every memory mutation suitable for SIEM ingestion and
+    /// SOC2 / HIPAA / GDPR / FedRAMP compliance evidence.
+    pub audit: Option<AuditConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Logging facility (PR-5)
+// ---------------------------------------------------------------------------
+
+/// `[logging]` block in `config.toml`. Every field is `Option`; missing
+/// fields fall back to the documented defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoggingConfig {
+    /// Master toggle. Default `false`.
+    pub enabled: Option<bool>,
+    /// Directory for rotated logs. Default `~/.local/state/ai-memory/logs/`.
+    pub path: Option<String>,
+    /// Soft cap on a single rotated file (advisory — informs rotation
+    /// configuration; the appender enforces this via the chosen
+    /// `rotation` cadence). Default 100.
+    pub max_size_mb: Option<u64>,
+    /// Maximum number of rotated files retained on disk. Default 30.
+    pub max_files: Option<usize>,
+    /// Days of log history to keep before `ai-memory logs archive`
+    /// would compress them. Default 90.
+    pub retention_days: Option<u32>,
+    /// Emit JSON lines instead of the human-readable fmt layer. Default `false`.
+    pub structured: Option<bool>,
+    /// Tracing level / `EnvFilter` directive. Default `"info"`.
+    pub level: Option<String>,
+    /// Rotation policy: `minutely | hourly | daily | never`. Default `"daily"`.
+    pub rotation: Option<String>,
+    /// Override the rotated-file prefix. Default `"ai-memory.log"`.
+    pub filename_prefix: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Audit facility (PR-5)
+// ---------------------------------------------------------------------------
+
+/// `[audit]` block in `config.toml`. Drives the hash-chained audit
+/// trail emitted from every memory mutation call site.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuditConfig {
+    /// Master toggle. Default `false`.
+    pub enabled: Option<bool>,
+    /// Audit log path. Either a directory (in which case `audit.log`
+    /// is appended) or an explicit file path. Default
+    /// `~/.local/state/ai-memory/audit/`.
+    pub path: Option<String>,
+    /// Documented schema version on the wire. The binary always emits
+    /// `audit::SCHEMA_VERSION`; this knob is reserved for forward
+    /// compatibility and must equal the binary's emitted version
+    /// today (validated at init).
+    pub schema_version: Option<u32>,
+    /// Whether to redact `memory.content` from emitted events. **The
+    /// only supported value in v1 is `true`** — the audit schema does
+    /// not expose a content field at all; this flag is reserved for a
+    /// future per-namespace exception API.
+    pub redact_content: Option<bool>,
+    /// Whether to compute and verify the per-line hash chain. Default `true`.
+    pub hash_chain: Option<bool>,
+    /// Cadence in minutes for the periodic `CHECKPOINT.sig`
+    /// attestation marker. The marker is a synthetic audit event that
+    /// pins the chain head into the log so an attacker who truncates
+    /// the file can't silently rewind history. Default 60. 0 disables.
+    pub attestation_cadence_minutes: Option<u32>,
+    /// Apply the platform-appropriate "append-only" file flag at
+    /// startup. Best-effort defense in depth; the chain is the
+    /// load-bearing tamper-evidence. Default `true`.
+    pub append_only: Option<bool>,
+    /// Retention horizon (days). `ai-memory logs purge` warns about
+    /// deleting audit records younger than this, and `audit verify`
+    /// surfaces gaps when retention is shorter than the chain extent.
+    /// Default 90. Compliance presets override.
+    pub retention_days: Option<u32>,
+    /// Compliance presets — apply industry-standard retention /
+    /// redaction policy on top of the base config. See
+    /// `docs/security/audit-trail.md` §Compliance.
+    pub compliance: Option<AuditComplianceConfig>,
+}
+
+impl AuditConfig {
+    /// Resolve the effective retention horizon after applying any
+    /// active compliance preset. Presets win when `applied = true`;
+    /// when multiple presets are applied the most-conservative
+    /// (longest) retention wins so the binary never picks a value
+    /// that violates any active policy.
+    #[must_use]
+    pub fn effective_retention_days(&self) -> u32 {
+        let mut chosen = self.retention_days.unwrap_or(90);
+        if let Some(comp) = &self.compliance {
+            for preset in comp.applied_presets() {
+                if let Some(d) = preset.retention_days
+                    && d > chosen
+                {
+                    chosen = d;
+                }
+            }
+        }
+        chosen
+    }
+
+    /// Resolve the effective attestation cadence — the most-frequent
+    /// (smallest non-zero) cadence across the base config and applied
+    /// presets so the strictest compliance rule wins.
+    #[must_use]
+    pub fn effective_attestation_cadence_minutes(&self) -> u32 {
+        let base = self.attestation_cadence_minutes.unwrap_or(60);
+        let mut chosen = base;
+        if let Some(comp) = &self.compliance {
+            for preset in comp.applied_presets() {
+                if let Some(m) = preset.attestation_cadence_minutes
+                    && m > 0
+                    && (chosen == 0 || m < chosen)
+                {
+                    chosen = m;
+                }
+            }
+        }
+        chosen
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuditComplianceConfig {
+    pub soc2: Option<CompliancePreset>,
+    pub hipaa: Option<CompliancePreset>,
+    pub gdpr: Option<CompliancePreset>,
+    pub fedramp: Option<CompliancePreset>,
+}
+
+impl AuditComplianceConfig {
+    /// Iterate over every preset whose `applied = true`.
+    pub fn applied_presets(&self) -> impl Iterator<Item = &CompliancePreset> {
+        [
+            self.soc2.as_ref(),
+            self.hipaa.as_ref(),
+            self.gdpr.as_ref(),
+            self.fedramp.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|p| p.applied.unwrap_or(false))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CompliancePreset {
+    pub applied: Option<bool>,
+    pub retention_days: Option<u32>,
+    pub redact_content: Option<bool>,
+    pub attestation_cadence_minutes: Option<u32>,
+    /// Reserved for compliance contexts that mandate at-rest crypto.
+    /// HIPAA preset surfaces this so operators can pair audit with
+    /// `--features sqlcipher` for end-to-end at-rest encryption.
+    pub encrypt_at_rest: Option<bool>,
+    /// GDPR-style actor pseudonymization toggle. Reserved for v0.7+.
+    pub pseudonymize_actors: Option<bool>,
 }
 
 /// Identity-resolution configuration (Task 1.2 follow-up #198).
@@ -1091,6 +1256,18 @@ impl AppConfig {
         self.identity.as_ref().is_some_and(|i| i.anonymize_default)
     }
 
+    /// Resolve the [`LoggingConfig`] block, returning a default
+    /// (disabled) instance when the config file omits it.
+    pub fn effective_logging(&self) -> LoggingConfig {
+        self.logging.clone().unwrap_or_default()
+    }
+
+    /// Resolve the [`AuditConfig`] block, returning a default
+    /// (disabled) instance when the config file omits it.
+    pub fn effective_audit(&self) -> AuditConfig {
+        self.audit.clone().unwrap_or_default()
+    }
+
     /// Resolve URL for embedding model (falls back to `ollama_url`).
     pub fn effective_embed_url(&self) -> &str {
         self.embed_url
@@ -1147,6 +1324,62 @@ impl AppConfig {
 # long_ttl_secs = 0             # 0 = never expires (default)
 # short_extend_secs = 3600      # +1h on access (default)
 # mid_extend_secs = 86400       # +1d on access (default)
+
+# v0.6.3.1 (PR-5 / issue #487) — operational logging facility.
+# Default-OFF. Uncomment + set enabled = true to capture every
+# `tracing::*` call site to a rotating on-disk log file. See
+# `docs/security/audit-trail.md` §SIEM ingestion guide for Splunk /
+# Datadog / Elastic / Loki recipes.
+# [logging]
+# enabled = false
+# path = "~/.local/state/ai-memory/logs/"
+# max_size_mb = 100
+# max_files = 30
+# retention_days = 90
+# structured = false              # true = emit JSON lines for SIEM ingest
+# level = "info"                  # tracing EnvFilter directive
+# rotation = "daily"              # minutely | hourly | daily | never
+
+# v0.6.3.1 (PR-5 / issue #487) — security audit trail. Default-OFF.
+# When enabled, every memory mutation emits one hash-chained JSON
+# line per event suitable for SOC2 / HIPAA / GDPR / FedRAMP evidence.
+# `ai-memory audit verify` walks the chain; `ai-memory logs tail`
+# streams events.
+# [audit]
+# enabled = false
+# path = "~/.local/state/ai-memory/audit/"
+# schema_version = 1
+# redact_content = true            # v1 schema never emits content; reserved
+# hash_chain = true
+# attestation_cadence_minutes = 60
+# append_only = true               # best-effort chflags(2) / FS_IOC_SETFLAGS
+
+# Compliance presets. Set `applied = true` and the documented retention
+# / cadence values override the defaults above. See
+# `docs/security/audit-trail.md` §Compliance.
+# [audit.compliance.soc2]
+# applied = false
+# retention_days = 730
+# redact_content = true
+# attestation_cadence_minutes = 60
+#
+# [audit.compliance.hipaa]
+# applied = false
+# retention_days = 2190
+# redact_content = true
+# encrypt_at_rest = true           # pair with --features sqlcipher
+#
+# [audit.compliance.gdpr]
+# applied = false
+# retention_days = 1095
+# redact_content = true
+# pseudonymize_actors = true       # reserved for v0.7+
+#
+# [audit.compliance.fedramp]
+# applied = false
+# retention_days = 1095
+# redact_content = true
+# attestation_cadence_minutes = 30
 "#;
         let _ = std::fs::write(&path, default_toml);
     }

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -51,6 +51,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::cli::agents::{AgentsArgs, PendingArgs};
 use crate::cli::archive::ArchiveArgs;
+use crate::cli::audit::AuditArgs;
 use crate::cli::backup::{BackupArgs, RestoreArgs};
 use crate::cli::boot::BootArgs;
 use crate::cli::consolidate::{AutoConsolidateArgs, ConsolidateArgs};
@@ -59,6 +60,7 @@ use crate::cli::curator::CuratorArgs;
 use crate::cli::forget::ForgetArgs;
 use crate::cli::io::{ImportArgs, MineArgs};
 use crate::cli::link::{LinkArgs, ResolveArgs};
+use crate::cli::logs::LogsArgs;
 use crate::cli::promote::PromoteArgs;
 use crate::cli::recall::RecallArgs;
 use crate::cli::search::SearchArgs;
@@ -228,6 +230,15 @@ pub enum Command {
     /// Read-only, fast, never blocks. With `--quiet` (recommended for
     /// hooks) a missing DB exits 0 with empty stdout.
     Boot(BootArgs),
+    /// Issue #487 PR-5: operator-facing CLI for the operational logging
+    /// facility (`tail`, `cat`, `archive`, `purge`). Default-OFF — emits
+    /// nothing useful unless `[logging] enabled = true` is set in
+    /// `config.toml`.
+    Logs(LogsArgs),
+    /// Issue #487 PR-5: operator-facing CLI for the security audit
+    /// trail (`verify`, `tail`, `path`). Default-OFF — emits nothing
+    /// useful unless `[audit] enabled = true` is set in `config.toml`.
+    Audit(AuditArgs),
 }
 
 /// Arguments for the `doctor` subcommand. Lives next to `Cli` so clap
@@ -712,7 +723,37 @@ pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
             let mut so = stdout.lock();
             let mut se = stderr.lock();
             let mut out = cli::CliOutput::from_std(&mut so, &mut se);
+            // PR-5: a `boot` invocation is itself an audit-worthy event.
+            // Emission is a no-op when audit is disabled.
+            crate::audit::emit(crate::audit::EventBuilder::new(
+                crate::audit::AuditAction::SessionBoot,
+                crate::audit::actor(
+                    cli_agent_id.as_deref().unwrap_or("anonymous"),
+                    "explicit_or_default",
+                    None,
+                ),
+                crate::audit::target_sweep(a.namespace.as_deref().unwrap_or("auto")),
+            ));
             cli::boot::run(&db_path, &a, &mut out)
+        }
+        Command::Logs(a) => {
+            let stdout = std::io::stdout();
+            let stderr = std::io::stderr();
+            let mut so = stdout.lock();
+            let mut se = stderr.lock();
+            let mut out = cli::CliOutput::from_std(&mut so, &mut se);
+            cli::logs::run(a, app_config, &mut out)
+        }
+        Command::Audit(a) => {
+            let stdout = std::io::stdout();
+            let stderr = std::io::stderr();
+            let mut so = stdout.lock();
+            let mut se = stderr.lock();
+            let mut out = cli::CliOutput::from_std(&mut so, &mut se);
+            match cli::audit::run(a, app_config, &mut out)? {
+                0 => Ok(()),
+                code => std::process::exit(code),
+            }
         }
     };
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -491,6 +491,28 @@ pub async fn create_memory(
                 .get("agent_id")
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
+            // PR-5 (issue #487): security audit trail for HTTP store.
+            crate::audit::emit(crate::audit::EventBuilder::new(
+                crate::audit::AuditAction::Store,
+                crate::audit::actor(
+                    resolved_agent_id.clone().unwrap_or_default(),
+                    "http_body",
+                    mem.metadata
+                        .get("scope")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                ),
+                crate::audit::target_memory(
+                    actual_id.clone(),
+                    mem.namespace.clone(),
+                    Some(mem.title.clone()),
+                    Some(mem.tier.to_string()),
+                    mem.metadata
+                        .get("scope")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                ),
+            ));
             let mut response = json!({
                 "id": actual_id,
                 "tier": mem.tier,
@@ -1185,6 +1207,30 @@ pub async fn delete_memory(
     drop(lock);
     match delete_outcome {
         Ok(true) => {
+            // PR-5 (issue #487): security audit trail for HTTP delete.
+            let owner = target
+                .metadata
+                .get("agent_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    headers
+                        .get("x-agent-id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("anonymous")
+                        .to_string()
+                });
+            crate::audit::emit(crate::audit::EventBuilder::new(
+                crate::audit::AuditAction::Delete,
+                crate::audit::actor(owner, "http_header", None),
+                crate::audit::target_memory(
+                    target.id.clone(),
+                    target.namespace.clone(),
+                    Some(target.title.clone()),
+                    Some(target.tier.to_string()),
+                    None,
+                ),
+            ));
             // v0.6.0.1: propagate tombstone via sync_push.deletions.
             if let Some(fed) = app.federation.as_ref()
                 && let Ok(tracker) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod handlers;
 pub mod hnsw;
 pub mod identity;
 pub mod llm;
+pub mod log_paths;
 pub mod logging;
 pub mod mcp;
 pub mod metrics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 // Library interface for ai-memory. Exposes public modules for testing and external use.
 
+pub mod audit;
 pub mod autonomy;
 pub mod bench;
 pub mod cli;
@@ -27,6 +28,7 @@ pub mod handlers;
 pub mod hnsw;
 pub mod identity;
 pub mod llm;
+pub mod logging;
 pub mod mcp;
 pub mod metrics;
 pub mod mine;

--- a/src/log_paths.rs
+++ b/src/log_paths.rs
@@ -1,0 +1,646 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! User-configurable log directory resolution (PR-5 addendum, issue #487).
+//!
+//! End users can set both `[logging] path` and `[audit] path` at every
+//! layer; the highest-priority value wins:
+//!
+//! 1. **CLI flag** (`--log-dir`, `--audit-dir`) — explicit override on
+//!    the `ai-memory logs` / `ai-memory audit` subcommands.
+//! 2. **Environment variable** (`AI_MEMORY_LOG_DIR`,
+//!    `AI_MEMORY_AUDIT_DIR`) — useful for `systemd` units, Docker
+//!    `-e`, and Kubernetes env injection.
+//! 3. **`config.toml`** (`[logging] path`, `[audit] path`) — the
+//!    long-lived per-host setting maintainers write once.
+//! 4. **Platform default** — picked per-OS so a fresh install works
+//!    out of the box without any configuration.
+//!
+//! Platform defaults:
+//!
+//! | OS | Logs | Audit |
+//! |---|---|---|
+//! | Linux | `${XDG_STATE_HOME:-$HOME/.local/state}/ai-memory/logs/` | `…/audit/` |
+//! | macOS | `~/Library/Logs/ai-memory/` | `~/Library/Logs/ai-memory/audit/` |
+//! | Windows | `%LOCALAPPDATA%\ai-memory\logs\` | `…\audit\` |
+//! | systemd-managed daemon | `/var/log/ai-memory/` (if writable) | `…/audit/` |
+//!
+//! ## systemd detection
+//!
+//! When `INVOCATION_ID` is present in the environment (set by `systemd`
+//! for unit-managed processes) and `/var/log/ai-memory/` is writable,
+//! the resolver picks the system-wide path. Otherwise it falls through
+//! to the per-user XDG path.
+//!
+//! ## Security guard
+//!
+//! The resolved directory must not be world-writable. If a 0777 path is
+//! configured (or selected by default on a malformed system), the
+//! resolver returns an error pointing at the resolution chain that
+//! landed there. Created parent directories use mode `0700` on Unix; on
+//! Windows the default ACL is sufficient.
+//!
+//! See `docs/security/audit-trail.md` §"Log directory resolution" for
+//! the operator guide.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+
+/// Environment variable consulted for the operational log directory
+/// override. Read with `std::env::var_os` so non-UTF-8 paths on Windows
+/// pass through unchanged.
+pub const LOG_DIR_ENV: &str = "AI_MEMORY_LOG_DIR";
+
+/// Environment variable consulted for the audit log directory override.
+pub const AUDIT_DIR_ENV: &str = "AI_MEMORY_AUDIT_DIR";
+
+/// Source layer that produced the resolved path. Returned alongside
+/// the [`PathBuf`] so error messages can name the precedence step that
+/// landed the user at a bad directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSource {
+    /// Explicit `--log-dir` / `--audit-dir` flag.
+    CliFlag,
+    /// `AI_MEMORY_LOG_DIR` / `AI_MEMORY_AUDIT_DIR` environment variable.
+    EnvVar,
+    /// `[logging] path` / `[audit] path` in `config.toml`.
+    ConfigToml,
+    /// Platform default selected by the OS detection logic.
+    PlatformDefault,
+    /// systemd-managed daemon path (`/var/log/ai-memory/...`).
+    SystemdLogsDir,
+}
+
+impl PathSource {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CliFlag => "CLI flag (--log-dir / --audit-dir)",
+            Self::EnvVar => "environment variable (AI_MEMORY_LOG_DIR / AI_MEMORY_AUDIT_DIR)",
+            Self::ConfigToml => "[logging]/[audit] path in config.toml",
+            Self::PlatformDefault => "platform default",
+            Self::SystemdLogsDir => "systemd LogsDirectory (/var/log/ai-memory/)",
+        }
+    }
+}
+
+/// Result of a directory-resolution call. The path itself plus the
+/// layer that produced it (used for error messages).
+#[derive(Debug, Clone)]
+pub struct ResolvedDir {
+    pub path: PathBuf,
+    pub source: PathSource,
+}
+
+/// What kind of log directory we're resolving — dictates the platform
+/// default suffix (`logs/` vs `audit/`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirKind {
+    Log,
+    Audit,
+}
+
+impl DirKind {
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::Log => "logs",
+            Self::Audit => "audit",
+        }
+    }
+}
+
+/// Resolve the operational log directory honouring the precedence
+/// ladder: CLI > env var > config > platform default.
+///
+/// `cli_override` — the parsed `--log-dir <PATH>` argument if any.
+/// `config_path` — the `[logging] path` value if any.
+///
+/// # Errors
+/// - The resolved directory exists but is world-writable.
+pub fn resolve_log_dir(
+    cli_override: Option<&Path>,
+    config_path: Option<&str>,
+) -> Result<ResolvedDir> {
+    resolve_dir(DirKind::Log, cli_override, LOG_DIR_ENV, config_path)
+}
+
+/// Resolve the audit log directory honouring the precedence ladder.
+/// Mirror of [`resolve_log_dir`] for the audit subsystem.
+///
+/// # Errors
+/// - The resolved directory exists but is world-writable.
+pub fn resolve_audit_dir(
+    cli_override: Option<&Path>,
+    config_path: Option<&str>,
+) -> Result<ResolvedDir> {
+    resolve_dir(DirKind::Audit, cli_override, AUDIT_DIR_ENV, config_path)
+}
+
+fn resolve_dir(
+    kind: DirKind,
+    cli_override: Option<&Path>,
+    env_var: &str,
+    config_path: Option<&str>,
+) -> Result<ResolvedDir> {
+    let resolved = if let Some(p) = cli_override {
+        ResolvedDir {
+            path: PathBuf::from(p),
+            source: PathSource::CliFlag,
+        }
+    } else if let Some(env_val) = std::env::var_os(env_var) {
+        if env_val.is_empty() {
+            // Treat an empty env var as "unset" so a misconfigured
+            // launcher doesn't silently route logs to the CWD.
+            fall_through_to_config_or_default(kind, config_path)?
+        } else {
+            ResolvedDir {
+                path: PathBuf::from(env_val),
+                source: PathSource::EnvVar,
+            }
+        }
+    } else {
+        fall_through_to_config_or_default(kind, config_path)?
+    };
+
+    enforce_not_world_writable(&resolved)?;
+    Ok(resolved)
+}
+
+fn fall_through_to_config_or_default(
+    kind: DirKind,
+    config_path: Option<&str>,
+) -> Result<ResolvedDir> {
+    if let Some(raw) = config_path
+        && !raw.is_empty()
+    {
+        return Ok(ResolvedDir {
+            path: PathBuf::from(expand_tilde(raw)),
+            source: PathSource::ConfigToml,
+        });
+    }
+    Ok(platform_default(kind))
+}
+
+/// Compute the platform default for `kind`. Pure — no filesystem touch
+/// other than reading `INVOCATION_ID` / `XDG_STATE_HOME` / `HOME` /
+/// `LOCALAPPDATA` env vars.
+#[must_use]
+pub fn platform_default(kind: DirKind) -> ResolvedDir {
+    // systemd-managed daemon: prefer /var/log/ai-memory if writable.
+    // Skip in tests so the resolver test suite is deterministic.
+    if std::env::var_os("INVOCATION_ID").is_some() {
+        let p = PathBuf::from("/var/log/ai-memory").join(kind.suffix());
+        if is_writable_dir(&p.parent().unwrap_or(&p)) {
+            return ResolvedDir {
+                path: p,
+                source: PathSource::SystemdLogsDir,
+            };
+        }
+    }
+
+    let p = if cfg!(target_os = "macos") {
+        macos_default(kind)
+    } else if cfg!(target_os = "windows") {
+        windows_default(kind)
+    } else {
+        // Linux + every other Unix (BSD, illumos, etc.) — XDG.
+        linux_xdg_default(kind)
+    };
+    ResolvedDir {
+        path: p,
+        source: PathSource::PlatformDefault,
+    }
+}
+
+fn linux_xdg_default(kind: DirKind) -> PathBuf {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .filter(|s| !s.is_empty())
+        .map_or_else(
+            || {
+                let home = home_dir_or_dot();
+                home.join(".local").join("state")
+            },
+            PathBuf::from,
+        );
+    base.join("ai-memory").join(kind.suffix())
+}
+
+fn macos_default(kind: DirKind) -> PathBuf {
+    let home = home_dir_or_dot();
+    let base = home.join("Library").join("Logs").join("ai-memory");
+    match kind {
+        DirKind::Log => base,
+        DirKind::Audit => base.join("audit"),
+    }
+}
+
+fn windows_default(kind: DirKind) -> PathBuf {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .filter(|s| !s.is_empty())
+        .map_or_else(
+            || {
+                // Fallback if LOCALAPPDATA is unset (mostly tests / WSL).
+                home_dir_or_dot()
+                    .join("AppData")
+                    .join("Local")
+                    .join("ai-memory")
+            },
+            |s| PathBuf::from(s).join("ai-memory"),
+        );
+    base.join(kind.suffix())
+}
+
+fn home_dir_or_dot() -> PathBuf {
+    if let Some(h) = std::env::var_os("HOME").filter(|s| !s.is_empty()) {
+        return PathBuf::from(h);
+    }
+    if let Some(h) = std::env::var_os("USERPROFILE").filter(|s| !s.is_empty()) {
+        return PathBuf::from(h);
+    }
+    PathBuf::from(".")
+}
+
+fn is_writable_dir(p: &Path) -> bool {
+    if !p.exists() || !p.is_dir() {
+        return false;
+    }
+    // Probe: try to create a unique temp file in the directory; if it
+    // fails, treat the dir as not-writable. We keep this best-effort —
+    // the kernel is the source of truth and this is a hint for the
+    // resolution decision.
+    let probe = p.join(format!(".ai-memory-write-probe-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Reject world-writable directories. Returns `Ok(())` if the path
+/// doesn't exist yet (we'll create it secure) or if it's safely
+/// permissioned.
+///
+/// # Errors
+/// - The path exists and `mode & 0o002 != 0` on Unix.
+pub fn enforce_not_world_writable(rd: &ResolvedDir) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if !rd.path.exists() {
+            return Ok(());
+        }
+        let md = std::fs::metadata(&rd.path).with_context(|| {
+            format!(
+                "stat {} (resolved via {})",
+                rd.path.display(),
+                rd.source.as_str()
+            )
+        })?;
+        let mode = md.permissions().mode();
+        if mode & 0o002 != 0 {
+            return Err(anyhow!(
+                "log directory {} is world-writable (mode {:#o}); refusing for security. \
+                 Resolved via: {}. Pick a non-world-writable directory and re-run.",
+                rd.path.display(),
+                mode & 0o7777,
+                rd.source.as_str()
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows: default ACL on `LOCALAPPDATA` and user-created dirs
+        // is "Authenticated Users" only — no world-writable concept
+        // mapping, so this is a no-op.
+        let _ = rd;
+    }
+    Ok(())
+}
+
+/// Create `dir` (and missing parents) with mode `0700` on Unix. On
+/// Windows defers to `std::fs::create_dir_all` and the default ACL.
+///
+/// # Errors
+/// - The directory cannot be created.
+/// - On Unix: the resulting permissions cannot be applied.
+pub fn ensure_dir_secure(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating log directory {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o700);
+        std::fs::set_permissions(dir, perms)
+            .with_context(|| format!("setting mode 0700 on log directory {}", dir.display()))?;
+    }
+    Ok(())
+}
+
+/// Tilde-expand a config string. Mirrors [`crate::audit::expand_tilde`]
+/// so this module stays self-contained for resolver-level tests.
+#[must_use]
+pub fn expand_tilde(raw: &str) -> String {
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        let mut buf = OsString::from(home);
+        buf.push("/");
+        buf.push(rest);
+        return buf.to_string_lossy().into_owned();
+    }
+    raw.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Process-wide lock so tests that mutate env vars (LOG_DIR_ENV /
+    /// AUDIT_DIR_ENV / INVOCATION_ID / HOME / etc.) don't race.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Snapshot+restore an env var across a test body so we don't leak
+    /// state into sibling tests.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<OsString>,
+    }
+    impl EnvGuard {
+        fn capture(key: &'static str) -> Self {
+            Self {
+                key,
+                prev: std::env::var_os(key),
+            }
+        }
+        fn set(&self, v: &str) {
+            // SAFETY: serialised via env_lock() at the test entry; no
+            // other thread is reading the env concurrently.
+            unsafe {
+                std::env::set_var(self.key, v);
+            }
+        }
+        fn unset(&self) {
+            // SAFETY: same as `set`.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: same as `set`.
+            unsafe {
+                if let Some(v) = &self.prev {
+                    std::env::set_var(self.key, v);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn log_dir_cli_flag_overrides_env_var() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.set("/should/not/win");
+        let cli = PathBuf::from("/cli/wins");
+        let resolved = resolve_log_dir(Some(&cli), Some("/config/loses")).unwrap();
+        assert_eq!(resolved.path, cli);
+        assert_eq!(resolved.source, PathSource::CliFlag);
+    }
+
+    #[test]
+    fn log_dir_env_var_overrides_config_toml() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.set("/env/wins");
+        let resolved = resolve_log_dir(None, Some("/config/loses")).unwrap();
+        assert_eq!(resolved.path, PathBuf::from("/env/wins"));
+        assert_eq!(resolved.source, PathSource::EnvVar);
+    }
+
+    #[test]
+    fn log_dir_config_toml_overrides_platform_default() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.unset();
+        let _inv = EnvGuard::capture("INVOCATION_ID");
+        _inv.unset();
+        let resolved = resolve_log_dir(None, Some("/config/wins")).unwrap();
+        assert_eq!(resolved.path, PathBuf::from("/config/wins"));
+        assert_eq!(resolved.source, PathSource::ConfigToml);
+    }
+
+    #[test]
+    fn log_dir_platform_default_resolves_per_os() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.unset();
+        let _inv = EnvGuard::capture("INVOCATION_ID");
+        _inv.unset();
+        let resolved = resolve_log_dir(None, None).unwrap();
+        assert_eq!(resolved.source, PathSource::PlatformDefault);
+        let s = resolved.path.to_string_lossy().to_string();
+        if cfg!(target_os = "macos") {
+            assert!(
+                s.contains("Library/Logs/ai-memory"),
+                "macOS default should be under Library/Logs/ai-memory, got {s}"
+            );
+        } else if cfg!(target_os = "windows") {
+            assert!(
+                s.to_lowercase().contains("ai-memory"),
+                "Windows default should contain ai-memory, got {s}"
+            );
+        } else {
+            // Linux + BSD + others fall through to XDG.
+            assert!(
+                s.contains("ai-memory") && s.contains("logs"),
+                "Linux/Unix XDG default should contain ai-memory/logs, got {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn audit_dir_cli_flag_overrides_env_var() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(AUDIT_DIR_ENV);
+        env.set("/should/not/win");
+        let cli = PathBuf::from("/cli/audit/wins");
+        let resolved = resolve_audit_dir(Some(&cli), Some("/config/loses")).unwrap();
+        assert_eq!(resolved.path, cli);
+        assert_eq!(resolved.source, PathSource::CliFlag);
+    }
+
+    #[test]
+    fn audit_dir_env_var_overrides_config_toml() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(AUDIT_DIR_ENV);
+        env.set("/env/audit/wins");
+        let resolved = resolve_audit_dir(None, Some("/config/loses")).unwrap();
+        assert_eq!(resolved.path, PathBuf::from("/env/audit/wins"));
+        assert_eq!(resolved.source, PathSource::EnvVar);
+    }
+
+    #[test]
+    fn audit_dir_config_toml_overrides_platform_default() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(AUDIT_DIR_ENV);
+        env.unset();
+        let _inv = EnvGuard::capture("INVOCATION_ID");
+        _inv.unset();
+        let resolved = resolve_audit_dir(None, Some("/config/audit/wins")).unwrap();
+        assert_eq!(resolved.path, PathBuf::from("/config/audit/wins"));
+        assert_eq!(resolved.source, PathSource::ConfigToml);
+    }
+
+    #[test]
+    fn audit_dir_platform_default_resolves_per_os() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(AUDIT_DIR_ENV);
+        env.unset();
+        let _inv = EnvGuard::capture("INVOCATION_ID");
+        _inv.unset();
+        let resolved = resolve_audit_dir(None, None).unwrap();
+        assert_eq!(resolved.source, PathSource::PlatformDefault);
+        let s = resolved.path.to_string_lossy().to_string();
+        assert!(
+            s.contains("ai-memory") && s.contains("audit"),
+            "audit platform default should mention ai-memory and audit, got {s}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn log_dir_creates_directory_with_secure_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("nested").join("logs");
+        ensure_dir_secure(&target).unwrap();
+        let md = std::fs::metadata(&target).unwrap();
+        let mode = md.permissions().mode() & 0o7777;
+        assert_eq!(
+            mode, 0o700,
+            "ensure_dir_secure must apply mode 0700 (got {mode:#o})"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn log_dir_refuses_world_writable_destination() {
+        use std::os::unix::fs::PermissionsExt;
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let bad = tmp.path().join("worldwrite");
+        std::fs::create_dir(&bad).unwrap();
+        std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.unset();
+        let err = resolve_log_dir(Some(&bad), None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("world-writable"),
+            "error should mention world-writable, got: {msg}"
+        );
+        assert!(
+            msg.contains("CLI flag"),
+            "error should name resolution layer (CLI flag), got: {msg}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn audit_dir_refuses_world_writable_destination() {
+        use std::os::unix::fs::PermissionsExt;
+        let _g = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let bad = tmp.path().join("audit-worldwrite");
+        std::fs::create_dir(&bad).unwrap();
+        std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let env = EnvGuard::capture(AUDIT_DIR_ENV);
+        env.unset();
+        let err = resolve_audit_dir(Some(&bad), None).unwrap_err();
+        assert!(format!("{err}").contains("world-writable"));
+    }
+
+    #[test]
+    fn log_dir_systemd_mode_uses_var_log_when_writable() {
+        // Pure-logic test — we don't actually write to /var/log. We
+        // assert the resolver's INVOCATION_ID branch picks SystemdLogsDir
+        // when the writability probe succeeds. We use a tempdir
+        // symlinked into a custom platform_default_for_systemd helper
+        // tested via an env-var override path: setting INVOCATION_ID
+        // and pointing /var/log via cfg-gated test harness is not
+        // portable, so we instead test the underlying `is_writable_dir`
+        // helper plus the env-var detection independently.
+        let _g = env_lock();
+        let _inv = EnvGuard::capture("INVOCATION_ID");
+        _inv.set("test-invocation-id");
+
+        let tmp = tempfile::tempdir().unwrap();
+        // Confirm is_writable_dir matches reality on a fresh tempdir.
+        assert!(is_writable_dir(tmp.path()));
+        // Confirm a non-existent path is not "writable".
+        assert!(!is_writable_dir(&tmp.path().join("does-not-exist")));
+
+        // Exercise the platform_default branch with INVOCATION_ID set.
+        // We can't force /var/log writable in unit tests, so we accept
+        // either SystemdLogsDir (CI runners w/ /var/log root-writable
+        // still won't pass the probe) or PlatformDefault. The contract
+        // is: when INVOCATION_ID is unset, we never pick SystemdLogsDir.
+        let resolved = platform_default(DirKind::Log);
+        assert!(matches!(
+            resolved.source,
+            PathSource::SystemdLogsDir | PathSource::PlatformDefault
+        ));
+
+        _inv.unset();
+        let resolved2 = platform_default(DirKind::Log);
+        assert_eq!(
+            resolved2.source,
+            PathSource::PlatformDefault,
+            "without INVOCATION_ID, must never pick SystemdLogsDir"
+        );
+    }
+
+    #[test]
+    fn log_dir_empty_env_var_falls_through_to_config() {
+        let _g = env_lock();
+        let env = EnvGuard::capture(LOG_DIR_ENV);
+        env.set("");
+        let resolved = resolve_log_dir(None, Some("/config/wins")).unwrap();
+        assert_eq!(resolved.source, PathSource::ConfigToml);
+    }
+
+    #[test]
+    fn expand_tilde_keeps_non_tilde_paths_unchanged() {
+        assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+        assert_eq!(expand_tilde("relative/path"), "relative/path");
+    }
+
+    #[test]
+    fn path_source_strings_are_human_readable() {
+        for s in [
+            PathSource::CliFlag,
+            PathSource::EnvVar,
+            PathSource::ConfigToml,
+            PathSource::PlatformDefault,
+            PathSource::SystemdLogsDir,
+        ] {
+            assert!(!s.as_str().is_empty());
+        }
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -32,8 +32,8 @@ use anyhow::{Context, Result};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
-use crate::audit::expand_tilde;
 use crate::config::LoggingConfig;
+use crate::log_paths;
 
 /// Default file prefix written by the rolling appender. Concrete
 /// rotated filenames look like `ai-memory.log.2026-04-30`.
@@ -52,7 +52,8 @@ pub fn init_file_logging(cfg: &LoggingConfig) -> Result<Option<WorkerGuard>> {
         return Ok(None);
     }
     let dir = resolve_log_dir(cfg);
-    std::fs::create_dir_all(&dir).with_context(|| format!("creating log dir {}", dir.display()))?;
+    log_paths::ensure_dir_secure(&dir)
+        .with_context(|| format!("creating log dir {}", dir.display()))?;
     let appender = build_appender(&dir, cfg)?;
     let (writer, guard) = tracing_appender::non_blocking(appender);
     // Capture the writer in the static slot so the daemon's tracing
@@ -81,14 +82,33 @@ pub fn init_file_logging(cfg: &LoggingConfig) -> Result<Option<WorkerGuard>> {
     Ok(Some(guard))
 }
 
-/// Resolve the configured directory, expanding `~/`.
+/// Resolve the configured log directory honouring the user-mandated
+/// precedence ladder: CLI > env (`AI_MEMORY_LOG_DIR`) > `[logging]
+/// path` in config > platform default. The `cfg`-only entry point is
+/// kept for callers that don't have a CLI override; subcommand wiring
+/// uses [`resolve_log_dir_with_override`] directly.
+///
+/// Falls back to a best-effort default if the security guard rejects
+/// the configured path — the `init_file_logging` path will then re-run
+/// the strict resolver and surface the error to the operator.
 #[must_use]
 pub fn resolve_log_dir(cfg: &LoggingConfig) -> PathBuf {
-    let raw = cfg
-        .path
-        .clone()
-        .unwrap_or_else(|| "~/.local/state/ai-memory/logs/".to_string());
-    PathBuf::from(expand_tilde(&raw))
+    log_paths::resolve_log_dir(None, cfg.path.as_deref())
+        .map(|r| r.path)
+        .unwrap_or_else(|_| log_paths::platform_default(log_paths::DirKind::Log).path)
+}
+
+/// Strict version: returns the [`log_paths::ResolvedDir`] so callers
+/// can surface the resolution layer in error messages, and propagates
+/// the world-writable-refusal error.
+///
+/// # Errors
+/// - Resolved path is world-writable.
+pub fn resolve_log_dir_with_override(
+    cli_override: Option<&Path>,
+    cfg: &LoggingConfig,
+) -> Result<log_paths::ResolvedDir> {
+    log_paths::resolve_log_dir(cli_override, cfg.path.as_deref())
 }
 
 /// Build the rolling file appender with the rotation policy from

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operational logging facility (PR-5 of issue #487).
+//!
+//! Routes the binary's existing `tracing::info!` / `tracing::warn!` /
+//! `tracing::error!` call sites through a rotating, on-disk file
+//! appender so operators can ingest server logs into Splunk, Datadog,
+//! Loki, etc.
+//!
+//! **Default-OFF.** Without a `[logging]` block in `config.toml` the
+//! daemon keeps the legacy `tracing-subscriber::fmt` setup that writes
+//! to stderr. Enabling file logging is opt-in:
+//!
+//! ```toml
+//! [logging]
+//! enabled = true
+//! path = "~/.local/state/ai-memory/logs/"
+//! max_size_mb = 100
+//! max_files = 30
+//! retention_days = 90
+//! structured = false
+//! level = "info"
+//! ```
+//!
+//! See [`docs/security/audit-trail.md`](../docs/security/audit-trail.md)
+//! for the SIEM ingestion guide.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+use crate::audit::expand_tilde;
+use crate::config::LoggingConfig;
+
+/// Default file prefix written by the rolling appender. Concrete
+/// rotated filenames look like `ai-memory.log.2026-04-30`.
+const DEFAULT_PREFIX: &str = "ai-memory.log";
+
+/// Initialise the file logging facility. Returns a [`WorkerGuard`] that
+/// the caller MUST keep alive for the lifetime of the process — when
+/// dropped it flushes the in-memory buffer to disk. Returns `None`
+/// when logging is disabled.
+///
+/// # Errors
+/// - The configured log directory cannot be created.
+/// - The rolling file appender cannot be constructed.
+pub fn init_file_logging(cfg: &LoggingConfig) -> Result<Option<WorkerGuard>> {
+    if !cfg.enabled.unwrap_or(false) {
+        return Ok(None);
+    }
+    let dir = resolve_log_dir(cfg);
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating log dir {}", dir.display()))?;
+    let appender = build_appender(&dir, cfg)?;
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    // Capture the writer in the static slot so the daemon's tracing
+    // subscriber can drain it. `try_init` so multiple test runs
+    // (each spinning a fresh subscriber) don't poison the global.
+    let level = cfg.level.as_deref().unwrap_or("info");
+    let filter = tracing_subscriber::EnvFilter::try_new(level).unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::try_new("info").expect("info is a valid filter")
+    });
+    let structured = cfg.structured.unwrap_or(false);
+    let res = if structured {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(writer)
+            .json()
+            .try_init()
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(writer)
+            .try_init()
+    };
+    if let Err(e) = res {
+        tracing::debug!("file logging subscriber already initialised: {e}");
+    }
+    Ok(Some(guard))
+}
+
+/// Resolve the configured directory, expanding `~/`.
+#[must_use]
+pub fn resolve_log_dir(cfg: &LoggingConfig) -> PathBuf {
+    let raw = cfg
+        .path
+        .clone()
+        .unwrap_or_else(|| "~/.local/state/ai-memory/logs/".to_string());
+    PathBuf::from(expand_tilde(&raw))
+}
+
+/// Build the rolling file appender with the rotation policy from
+/// `cfg`. Defaults to daily rotation with `max_files` retained on
+/// disk.
+pub fn build_appender(dir: &Path, cfg: &LoggingConfig) -> Result<RollingFileAppender> {
+    let rotation = rotation_for(cfg);
+    let max_files = cfg.max_files.unwrap_or(30);
+    let prefix = cfg
+        .filename_prefix
+        .clone()
+        .unwrap_or_else(|| DEFAULT_PREFIX.to_string());
+
+    RollingFileAppender::builder()
+        .filename_prefix(prefix)
+        .rotation(rotation)
+        .max_log_files(max_files)
+        .build(dir)
+        .with_context(|| format!("building rolling appender at {}", dir.display()))
+}
+
+fn rotation_for(cfg: &LoggingConfig) -> Rotation {
+    match cfg.rotation.as_deref().unwrap_or("daily") {
+        "minutely" => Rotation::MINUTELY,
+        "hourly" => Rotation::HOURLY,
+        "never" => Rotation::NEVER,
+        _ => Rotation::DAILY,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotation_for_default_is_daily() {
+        let cfg = LoggingConfig::default();
+        // Rotation enum doesn't impl PartialEq, so format-compare.
+        let r = rotation_for(&cfg);
+        assert!(format!("{r:?}").to_lowercase().contains("daily"));
+    }
+
+    #[test]
+    fn rotation_for_hourly() {
+        let cfg = LoggingConfig {
+            rotation: Some("hourly".to_string()),
+            ..Default::default()
+        };
+        let r = rotation_for(&cfg);
+        assert!(format!("{r:?}").to_lowercase().contains("hourly"));
+    }
+
+    #[test]
+    fn resolve_log_dir_default_under_home() {
+        let cfg = LoggingConfig::default();
+        let p = resolve_log_dir(&cfg);
+        // Default contains the well-known suffix even on bare-min
+        // home setups.
+        assert!(p.to_string_lossy().contains("ai-memory"));
+    }
+
+    #[test]
+    fn build_appender_creates_file_under_tmp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = LoggingConfig {
+            enabled: Some(true),
+            path: Some(tmp.path().to_string_lossy().into_owned()),
+            rotation: Some("never".to_string()),
+            ..Default::default()
+        };
+        let _appender = build_appender(tmp.path(), &cfg).unwrap();
+        // The appender lazily creates the log file on first write. Just
+        // ensure construction succeeded and the dir is writable.
+        assert!(tmp.path().is_dir());
+    }
+
+    #[test]
+    fn init_file_logging_returns_none_when_disabled() {
+        let cfg = LoggingConfig {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        let guard = init_file_logging(&cfg).unwrap();
+        assert!(guard.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@
 // load, env-var seeding, clap parse) and immediately delegates. Coverage
 // for serve()/dispatch is now attributed to the lib crate.
 use ai_memory::daemon_runtime::Cli;
-use ai_memory::{color, config, daemon_runtime};
+use ai_memory::{audit, color, config, daemon_runtime, logging};
 use anyhow::Result;
 use clap::Parser;
 
@@ -24,6 +24,21 @@ async fn main() -> Result<()> {
     let app_config = config::AppConfig::load();
     config::AppConfig::write_default_if_missing();
     daemon_runtime::apply_anonymize_default(&app_config);
+
+    // PR-5 (issue #487): bootstrap operational logging + security
+    // audit trail. Both are default-OFF; init returns silently when
+    // disabled. The `_log_guard` MUST stay in scope for the lifetime
+    // of the process — when dropped it flushes the non-blocking
+    // tracing writer to disk.
+    let _log_guard =
+        logging::init_file_logging(&app_config.effective_logging()).unwrap_or_else(|e| {
+            eprintln!("ai-memory: file logging init failed (continuing without): {e}");
+            None
+        });
+    if let Err(e) = audit::init_from_config(&app_config.effective_audit()) {
+        eprintln!("ai-memory: audit init failed (continuing without): {e}");
+    }
+
     let cli = Cli::parse();
     daemon_runtime::run(cli, &app_config).await
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -71,6 +71,79 @@ fn err_response(id: Value, code: i64, message: String) -> RpcResponse {
     }
 }
 
+/// PR-5 (issue #487): emit an audit event for an MCP `tools/call`
+/// dispatch. Per-handler emissions inside `handle_store` /
+/// `handle_delete` already produce their canonical events; this
+/// helper covers the remaining mutation+recall tool surface so
+/// `audit_emits_at_every_call_site` holds across the matrix.
+fn audit_emit_for_mcp_dispatch(
+    tool_name: &str,
+    arguments: &Value,
+    result: &Result<Value, String>,
+    mcp_client: Option<&str>,
+) {
+    if !crate::audit::is_enabled() {
+        return;
+    }
+    let action = match tool_name {
+        // Skipped — emitted from inside the handler with full target context.
+        "memory_store" | "memory_delete" => return,
+        "memory_recall"
+        | "memory_search"
+        | "memory_get"
+        | "memory_list"
+        | "memory_session_start" => crate::audit::AuditAction::Recall,
+        "memory_update" => crate::audit::AuditAction::Update,
+        "memory_promote" => crate::audit::AuditAction::Promote,
+        "memory_forget" => crate::audit::AuditAction::Forget,
+        "memory_link" => crate::audit::AuditAction::Link,
+        "memory_consolidate" => crate::audit::AuditAction::Consolidate,
+        "memory_pending_approve" => crate::audit::AuditAction::Approve,
+        "memory_pending_reject" => crate::audit::AuditAction::Reject,
+        // Read-only / metadata tools — no audit event.
+        _ => return,
+    };
+    let agent_id = arguments
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            mcp_client
+                .map(|c| format!("ai:{c}"))
+                .unwrap_or_else(|| "anonymous".into())
+        });
+    let namespace = arguments
+        .get("namespace")
+        .and_then(Value::as_str)
+        .unwrap_or("global")
+        .to_string();
+    let memory_id = arguments
+        .get("id")
+        .or_else(|| arguments.get("memory_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("*")
+        .to_string();
+    let mut builder = crate::audit::EventBuilder::new(
+        action,
+        crate::audit::actor(
+            agent_id,
+            mcp_client.map_or("host_fallback", |_| "mcp_client_info"),
+            None,
+        ),
+        crate::audit::AuditTarget {
+            memory_id,
+            namespace,
+            title: None,
+            tier: None,
+            scope: None,
+        },
+    );
+    if let Err(e) = result {
+        builder = builder.error(e.clone());
+    }
+    crate::audit::emit(builder);
+}
+
 // --- Tool definitions ---
 
 /// Version tag for the `tools/list` response schema. Bumped whenever
@@ -998,6 +1071,23 @@ fn handle_store(
     }
 
     let actual_id = db::insert(conn, &mem).map_err(|e| e.to_string())?;
+
+    // PR-5 (issue #487): security audit trail. No-op when disabled.
+    crate::audit::emit(crate::audit::EventBuilder::new(
+        crate::audit::AuditAction::Store,
+        crate::audit::actor(
+            agent_id.clone(),
+            mcp_client.map_or("host_fallback", |_| "mcp_client_info"),
+            explicit_scope.clone(),
+        ),
+        crate::audit::target_memory(
+            actual_id.clone(),
+            mem.namespace.clone(),
+            Some(mem.title.clone()),
+            Some(mem.tier.to_string()),
+            explicit_scope.clone(),
+        ),
+    ));
 
     // Exclude self-ID from contradictions (both proposed and actual, since upsert may reuse existing ID)
     let contradiction_ids: Vec<String> = existing
@@ -2109,6 +2199,24 @@ fn handle_delete(
         if let Some(idx) = vector_index {
             idx.remove(&target.id);
         }
+        // PR-5 (issue #487): security audit trail. No-op when disabled.
+        crate::audit::emit(crate::audit::EventBuilder::new(
+            crate::audit::AuditAction::Delete,
+            crate::audit::actor(
+                snapshot_owner
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                mcp_client.map_or("host_fallback", |_| "mcp_client_info"),
+                None,
+            ),
+            crate::audit::target_memory(
+                target.id.clone(),
+                snapshot_namespace.clone(),
+                Some(snapshot_title.clone()),
+                Some(snapshot_tier.clone()),
+                None,
+            ),
+        ));
         // P5 (G9): fire `memory_delete` webhook AFTER the row is gone
         // (best-effort, fire-and-forget — same pattern as memory_store).
         let details = serde_json::to_value(crate::subscriptions::DeleteEventDetails {
@@ -3471,6 +3579,13 @@ fn handle_request(
                 Ok(_) => tracing::info!(elapsed_ms, "ok"),
                 Err(err) => tracing::warn!(elapsed_ms, error = %err, "err"),
             }
+
+            // PR-5 (issue #487): MCP-dispatch-level audit emission for
+            // mutation/recall tools that the per-handler instrumentation
+            // doesn't already cover. `memory_store` and `memory_delete`
+            // each emit their own canonical event from inside the
+            // handler so we skip them here to avoid double-counting.
+            audit_emit_for_mcp_dispatch(tool_name, arguments, &result, mcp_client);
 
             match result {
                 Ok(val) => {


### PR DESCRIPTION
## Summary

PR-5 of issue #487. Adds the load-bearing security audit trail and operational logging facility for enterprise compliance and SIEM ingestion. Both subsystems are **default-OFF for privacy** — opt-in via the new `[logging]` and `[audit]` blocks in `config.toml`.

- **`src/audit.rs`** — versioned `AuditEvent` schema (schema_version=1), hash-chained NDJSON sink, `verify_chain` walker, sequence counter, append-only OS hint (`chflags(2)` BSD/macOS, `FS_IOC_SETFLAGS` Linux). Privacy by design: `memory.content` is **never** captured. Stable, framework-agnostic schema (NOT bound to OCSF or CEF — clean documented JSON SIEMs ingest as-is).
- **`src/logging.rs`** — `tracing-appender` rolling file logger that captures every existing `tracing::*` call site to disk. Optional JSON-line output for SIEM ingest.
- **`src/cli/audit.rs`** — `ai-memory audit verify | tail | path`. `verify` recomputes every line's `self_hash` and asserts the chain; non-zero exit on tamper with precise line + failure kind.
- **`src/cli/logs.rs`** — `ai-memory logs tail [--follow] | cat | archive | purge` with `--since/--until/--level/--namespace/--actor/--action` filtering and zstd archive compression. `purge` surfaces an audit-gap warning when retention overlaps the audit horizon.
- Audit emission wired into HTTP create/delete handlers, MCP `handle_store` + `handle_delete` + dispatch-level helper (recall/update/promote/forget/link/consolidate/approve/reject), CLI `store` / `update` / `delete`, and `ai-memory boot` (`AuditAction::SessionBoot`).
- `docs/security/audit-trail.md` + `docs/security/audit-schema.md` document the wire format, threat model, regulatory mapping (SOC2 / HIPAA / GDPR / FedRAMP), and SIEM ingestion recipes (Splunk, Datadog, Elastic Filebeat, Loki Promtail).
- Compliance presets in `[audit.compliance.{soc2,hipaa,gdpr,fedramp}]` propagate retention + attestation cadence into the effective config; most-conservative wins when multiple presets are active.

## Schema (v1)

| Field | Type | Required | Notes |
|---|---|---|---|
| `schema_version` | `u32` | yes | `1`. Bumped only on breaking changes. |
| `timestamp` | RFC3339 UTC | yes | |
| `sequence` | `u64` | yes | Per-process monotonic. |
| `actor.{agent_id, scope?, synthesis_source}` | object | yes | NHI provenance. |
| `action` | enum | yes | `recall \| store \| update \| delete \| link \| promote \| forget \| consolidate \| export \| import \| approve \| reject \| session_boot` |
| `target.{memory_id, namespace, title?, tier?, scope?}` | object | yes | `memory_id = "*"` for sweep ops. |
| `outcome` | enum | yes | `allow \| deny \| error \| pending` |
| `auth.{source_ip?, mtls_fp?, api_key_id_hash?}` | object | optional | HTTP only. |
| `session_id` / `request_id` | string | optional | Correlators. |
| `error` | string | optional | Sanitized, capped at 256 chars. |
| `prev_hash` / `self_hash` | hex sha256 | yes | Tamper-evident chain. |

---

## Addendum 1: user-configurable log paths

**User-mandated.** End users MUST be able to set both `[logging] path` and `[audit] path` at every layer of the configuration stack. The original PR-5 hardcoded the platform-default and required `config.toml` to override; this addendum lifts that limitation and follows the precedence ladder operators expect from a turnkey enterprise binary.

**Precedence (highest wins):**

| Priority | Layer | Operational logs | Audit log |
|---:|---|---|---|
| 1 | **CLI flag** | `ai-memory logs --log-dir <PATH> …` | `ai-memory audit --audit-dir <PATH> …` |
| 2 | **Environment variable** | `AI_MEMORY_LOG_DIR` | `AI_MEMORY_AUDIT_DIR` |
| 3 | **`config.toml`** | `[logging] path = "…"` (already shipped — verified + documented) | `[audit] path = "…"` (already shipped — verified + documented) |
| 4 | **Platform default** | per-OS table below | per-OS table below |

**Platform defaults:**

| OS | Operational logs | Audit log |
|---|---|---|
| Linux (and BSD / illumos / other Unix) | `${XDG_STATE_HOME:-$HOME/.local/state}/ai-memory/logs/` | `${XDG_STATE_HOME:-$HOME/.local/state}/ai-memory/audit/` |
| macOS | `~/Library/Logs/ai-memory/` | `~/Library/Logs/ai-memory/audit/` |
| Windows | `%LOCALAPPDATA%\ai-memory\logs\` | `%LOCALAPPDATA%\ai-memory\audit\` |
| systemd-managed daemon (`INVOCATION_ID` set, `/var/log/ai-memory/` writable) | `/var/log/ai-memory/logs/` | `/var/log/ai-memory/audit/` |

**Implementation:**

- `src/log_paths.rs` (new) — central resolver `resolve_log_dir` / `resolve_audit_dir`, the `PathSource` enum (so error messages name the layer that landed at a bad directory), `platform_default`, the security guard that refuses world-writable directories, and `ensure_dir_secure` (creates parent dirs at mode `0700` on Unix; default ACL on Windows).
- `src/audit.rs` — `resolve_audit_path` now delegates to the new resolver; new `resolve_audit_path_with_override` exposes the strict variant + resolution source.
- `src/logging.rs` — same shape: `resolve_log_dir` delegates; the file logger uses `ensure_dir_secure` so the rolling appender's parent directory always lands at mode `0700`.
- `src/cli/{logs,audit}.rs` — `--log-dir <PATH>` and `--audit-dir <PATH>` plumbed as global args (apply to every subcommand). `audit path` surfaces the override so SIEM-config scripts can probe alternate locations.
- Env vars read with `std::env::var_os` so non-UTF-8 paths on Windows pass through unchanged.

**Tests added (+16 → 1661 total):**

- `log_paths::log_dir_cli_flag_overrides_env_var`
- `log_paths::log_dir_env_var_overrides_config_toml`
- `log_paths::log_dir_config_toml_overrides_platform_default`
- `log_paths::log_dir_platform_default_resolves_per_os` (cfg-gated for macOS / Windows / Linux)
- `log_paths::audit_dir_cli_flag_overrides_env_var`
- `log_paths::audit_dir_env_var_overrides_config_toml`
- `log_paths::audit_dir_config_toml_overrides_platform_default`
- `log_paths::audit_dir_platform_default_resolves_per_os`
- `log_paths::log_dir_creates_directory_with_secure_permissions` (Unix, asserts mode 0700)
- `log_paths::log_dir_refuses_world_writable_destination` (asserts error names CLI flag layer)
- `log_paths::audit_dir_refuses_world_writable_destination`
- `log_paths::log_dir_systemd_mode_uses_var_log_when_writable` (covers `INVOCATION_ID` branch + the `is_writable_dir` probe)
- `log_paths::log_dir_empty_env_var_falls_through_to_config`
- `log_paths::expand_tilde_keeps_non_tilde_paths_unchanged`
- `log_paths::path_source_strings_are_human_readable`
- `cli::audit::audit_path_subcmd_honours_audit_dir_flag`

PR-5's 28 existing tests still pass unmodified — only the legacy resolution helpers gained a delegating implementation; the public signatures kept their backwards-compatible shape.

**Docs updated:**

`docs/security/audit-trail.md` gained a new **"Log directory resolution"** section (precedence + platform-default tables, four worked examples — laptop dev, Docker `-v` host volume, Kubernetes pod `emptyDir`, systemd `LogsDirectory=`, plus a security note about the world-writable refusal). The Operator-CLI subsections reference the new flags.

---

## Test plan

- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` — clean.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — **1661 passed** (1645 baseline + 16 new from the addendum).
- [x] `audit_event_round_trips_through_serde`, `audit_chain_links_correctly_for_three_events`, `audit_verify_detects_tampered_line`, `audit_verify_detects_chain_break`, `audit_redacts_content_by_default`, `audit_compliance_preset_soc2_overrides_retention`, `audit_emits_at_every_call_site` (integration), `audit_emit_is_noop_when_disabled`.
- [x] `logs_tail_follows_appended_lines`, `logs_tail_returns_last_n_lines`, `logs_purge_warns_about_audit_gap`, `logs_archive_compresses_with_zstd`, `logs_filter_namespace_substring`, `logs_format_json_wraps_text_lines`.
- [x] `audit_verify_subcmd_reports_ok_for_valid_chain`, `audit_verify_subcmd_detects_tampering`, `audit_verify_subcmd_missing_log_is_ok`, `audit_path_subcmd_prints_resolved_path`.
- [x] Addendum 1: full precedence-ladder + platform-default + security-guard test matrix (16 tests, see Addendum 1 above).
- [ ] Manual: `ai-memory audit verify` against a live audit log on a daemon with `[audit] enabled = true`.
- [ ] Manual: SIEM ingest end-to-end (Splunk / Datadog / Elastic / Loki).
- [ ] Manual: `AI_MEMORY_LOG_DIR=/tmp/foo ai-memory logs tail` — env-var override path.
- [ ] Manual: `ai-memory audit --audit-dir /tmp/forensics path` — CLI-override path.

## Conflict risks

- **PR-4** (`release/v0.6.3.1-issue-487-pr4-enriched-diagnostic`) edits `src/cli/boot.rs`; PR-5 only adds an audit emission **call site** in `daemon_runtime.rs`'s `Command::Boot` arm and does not touch `boot.rs` itself, so the conflict is at the dispatch arm only and is mechanical.
- **PR-6** (`release/v0.6.3.1-issue-487-pr6-wrap-cli`) edits `Cargo.toml` (already saw `tempfile` move into prod deps mid-edit) + `src/cli/mod.rs`. PR-5 adds two new dep blocks (`tracing-appender`, `zstd`) and two new `pub mod` lines (`audit`, `logs`). Both are additive; merge resolution should be straightforward but expect a 3-way overlap on the dep table and module list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
