### PR TITLE
test(doctor): coverage uplift to restore 93% gate (PR-9f)

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -730,8 +730,16 @@ fn render_text(report: &Report, out: &mut CliOutput<'_>) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::too_many_lines, clippy::similar_names)]
 mod tests {
     use super::*;
+    use crate::cli::CliOutput;
+    use crate::cli::test_utils::{TestEnv, seed_memory};
+    use rusqlite::params;
+
+    // -------------------------------------------------------------------
+    // Severity / Report helpers (pure, no DB)
+    // -------------------------------------------------------------------
 
     #[test]
     fn severity_rank_orders_critical_highest() {
@@ -741,60 +749,988 @@ mod tests {
     }
 
     #[test]
-    fn compute_overall_picks_critical_when_present() {
-        let mut r = Report {
+    fn severity_label_renders_for_every_variant() {
+        assert_eq!(Severity::Info.label(), "INFO");
+        assert_eq!(Severity::Warning.label(), "WARN");
+        assert_eq!(Severity::Critical.label(), "CRIT");
+        assert_eq!(Severity::NotAvailable.label(), "N/A ");
+    }
+
+    #[test]
+    fn severity_serializes_lowercase_and_round_trips() {
+        // The Serialize derive uses `rename_all = "lowercase"`. We don't
+        // derive Deserialize, so we round-trip via the JSON Value form.
+        let s = serde_json::to_value(Severity::Critical).unwrap();
+        assert_eq!(s, serde_json::Value::String("critical".into()));
+        let s = serde_json::to_value(Severity::NotAvailable).unwrap();
+        assert_eq!(s, serde_json::Value::String("notavailable".into()));
+    }
+
+    fn mk_section(name: &str, severity: Severity) -> ReportSection {
+        ReportSection {
+            name: name.into(),
+            severity,
+            facts: vec![("k".into(), "v".into())],
+            note: None,
+        }
+    }
+
+    fn mk_report(sections: Vec<ReportSection>) -> Report {
+        Report {
             mode: "local".into(),
             source: ":memory:".into(),
             generated_at: "now".into(),
-            sections: vec![
-                ReportSection {
-                    name: "A".into(),
-                    severity: Severity::Info,
-                    facts: vec![],
-                    note: None,
-                },
-                ReportSection {
-                    name: "B".into(),
-                    severity: Severity::Critical,
-                    facts: vec![],
-                    note: None,
-                },
-                ReportSection {
-                    name: "C".into(),
-                    severity: Severity::Warning,
-                    facts: vec![],
-                    note: None,
-                },
-            ],
+            sections,
             overall: Severity::Info,
-        };
+        }
+    }
+
+    #[test]
+    fn compute_overall_picks_critical_when_present() {
+        let mut r = mk_report(vec![
+            mk_section("A", Severity::Info),
+            mk_section("B", Severity::Critical),
+            mk_section("C", Severity::Warning),
+        ]);
         r.compute_overall();
         assert_eq!(r.overall, Severity::Critical);
     }
 
     #[test]
     fn compute_overall_picks_warning_when_no_critical() {
-        let mut r = Report {
-            mode: "local".into(),
-            source: ":memory:".into(),
-            generated_at: "now".into(),
-            sections: vec![
-                ReportSection {
-                    name: "A".into(),
-                    severity: Severity::Info,
-                    facts: vec![],
-                    note: None,
-                },
-                ReportSection {
-                    name: "B".into(),
-                    severity: Severity::Warning,
-                    facts: vec![],
-                    note: None,
-                },
-            ],
-            overall: Severity::Info,
-        };
+        let mut r = mk_report(vec![
+            mk_section("A", Severity::Info),
+            mk_section("B", Severity::Warning),
+        ]);
         r.compute_overall();
         assert_eq!(r.overall, Severity::Warning);
+    }
+
+    #[test]
+    fn compute_overall_picks_info_when_no_warnings_or_critical() {
+        let mut r = mk_report(vec![
+            mk_section("A", Severity::NotAvailable),
+            mk_section("B", Severity::Info),
+        ]);
+        r.compute_overall();
+        assert_eq!(r.overall, Severity::Info);
+    }
+
+    #[test]
+    fn compute_overall_handles_empty_sections() {
+        let mut r = mk_report(vec![]);
+        r.compute_overall();
+        // unwrap_or fallback path — empty iterator collapses to Info.
+        assert_eq!(r.overall, Severity::Info);
+    }
+
+    #[test]
+    fn compute_overall_only_n_a_yields_n_a() {
+        let mut r = mk_report(vec![
+            mk_section("A", Severity::NotAvailable),
+            mk_section("B", Severity::NotAvailable),
+        ]);
+        r.compute_overall();
+        assert_eq!(r.overall, Severity::NotAvailable);
+    }
+
+    // -------------------------------------------------------------------
+    // ReportSection / Report serde shape
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn report_section_serializes_with_expected_keys() {
+        let section = ReportSection {
+            name: "Storage".into(),
+            severity: Severity::Warning,
+            facts: vec![("total".into(), "5".into())],
+            note: Some("hello".into()),
+        };
+        let v = serde_json::to_value(&section).unwrap();
+        assert_eq!(v["name"], "Storage");
+        assert_eq!(v["severity"], "warning");
+        // Facts is a list of 2-tuples encoded as JSON arrays.
+        assert!(v["facts"].is_array());
+        assert_eq!(v["facts"][0][0], "total");
+        assert_eq!(v["facts"][0][1], "5");
+        assert_eq!(v["note"], "hello");
+    }
+
+    #[test]
+    fn report_section_skips_note_when_none() {
+        let section = ReportSection {
+            name: "Recall".into(),
+            severity: Severity::Info,
+            facts: vec![],
+            note: None,
+        };
+        let v = serde_json::to_value(&section).unwrap();
+        assert!(
+            v.get("note").is_none(),
+            "note=None must be skipped per #[serde(skip_serializing_if)]"
+        );
+    }
+
+    #[test]
+    fn report_top_level_serialization_has_all_fields() {
+        let r = mk_report(vec![mk_section("S", Severity::Info)]);
+        let v = serde_json::to_value(&r).unwrap();
+        for k in ["mode", "source", "generated_at", "sections", "overall"] {
+            assert!(v.get(k).is_some(), "expected key {k} in JSON");
+        }
+        assert_eq!(v["sections"].as_array().unwrap().len(), 1);
+    }
+
+    // -------------------------------------------------------------------
+    // Local-DB mode — basic happy path
+    // -------------------------------------------------------------------
+
+    fn run_local_collect(db_path: &Path) -> Report {
+        let mut report = run_local(db_path);
+        report.compute_overall();
+        report
+    }
+
+    fn find<'a>(report: &'a Report, name: &str) -> &'a ReportSection {
+        report
+            .sections
+            .iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("section {name} not found"))
+    }
+
+    fn fact<'a>(section: &'a ReportSection, key: &str) -> &'a str {
+        section
+            .facts
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+            .unwrap_or_else(|| panic!("fact {key} not found in section {}", section.name))
+    }
+
+    #[test]
+    fn local_run_on_empty_db_produces_seven_sections() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        assert_eq!(report.mode, "local");
+        assert_eq!(report.sections.len(), 7);
+        let names: Vec<&str> = report.sections.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "Storage",
+                "Index",
+                "Recall",
+                "Governance",
+                "Sync",
+                "Webhook",
+                "Capabilities"
+            ]
+        );
+    }
+
+    #[test]
+    fn local_run_empty_db_storage_section_is_info() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let storage = find(&report, "Storage");
+        assert_eq!(storage.severity, Severity::Info);
+        assert_eq!(fact(storage, "total_memories"), "0");
+        // Pre-P2 schema (current release) has no `embedding_dim` column —
+        // `db::doctor_dim_violations` returns Ok(None), rendered as
+        // "not_observed (pre-P2 schema)".
+        let dim = fact(storage, "dim_violations");
+        assert!(
+            dim.contains("not_observed") || dim == "0",
+            "unexpected dim_violations value: {dim}"
+        );
+    }
+
+    #[test]
+    fn local_run_with_seeded_memory_reports_total() {
+        let env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns-a", "title-1", "content one");
+        seed_memory(&env.db_path, "ns-a", "title-2", "content two");
+        seed_memory(&env.db_path, "ns-b", "title-3", "content three");
+        let report = run_local_collect(&env.db_path);
+        let storage = find(&report, "Storage");
+        assert_eq!(fact(storage, "total_memories"), "3");
+        // Tier breakdown — seed_memory inserts at tier=mid.
+        let tier_mid = storage
+            .facts
+            .iter()
+            .find(|(k, _)| k == "tier::mid")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(tier_mid, Some("3"));
+        // Namespace breakdown caps at 10 entries; 2 namespaces fit.
+        let ns_a = storage
+            .facts
+            .iter()
+            .find(|(k, _)| k == "ns::ns-a")
+            .map(|(_, v)| v.as_str());
+        let ns_b = storage
+            .facts
+            .iter()
+            .find(|(k, _)| k == "ns::ns-b")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(ns_a, Some("2"));
+        assert_eq!(ns_b, Some("1"));
+    }
+
+    #[test]
+    fn local_run_index_section_reports_hnsw_estimate() {
+        let env = TestEnv::fresh();
+        seed_memory(&env.db_path, "ns", "t1", "c1");
+        let report = run_local_collect(&env.db_path);
+        let index = find(&report, "Index");
+        // seed_memory does not write an embedding so hnsw_size_estimate=0.
+        assert_eq!(fact(index, "hnsw_size_estimate"), "0");
+        // Cold-start estimate is rendered with two decimals.
+        let cs = fact(index, "cold_start_rebuild_secs_estimate");
+        assert!(
+            cs.contains('.'),
+            "cold_start_secs_estimate should be float-like, got {cs}"
+        );
+        assert_eq!(index.severity, Severity::Info);
+    }
+
+    #[test]
+    fn local_run_recall_section_documents_pre_p3_state() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let recall = find(&report, "Recall");
+        assert_eq!(recall.severity, Severity::Info);
+        assert!(fact(recall, "recall_mode_distribution").contains("pre-P3"));
+        assert!(fact(recall, "reranker_used_distribution").contains("pre-P3"));
+        // Hint nudges the operator toward --remote for the live feed.
+        assert!(fact(recall, "hint").contains("--remote"));
+    }
+
+    #[test]
+    fn local_run_sync_section_n_a_when_no_peers() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let sync = find(&report, "Sync");
+        // Empty sync_state => NotAvailable + note.
+        assert_eq!(sync.severity, Severity::NotAvailable);
+        assert_eq!(fact(sync, "peer_count"), "0");
+        assert!(sync.note.is_some());
+    }
+
+    #[test]
+    fn local_run_capabilities_local_section_n_a() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::NotAvailable);
+        assert!(fact(cap, "capabilities").contains("--remote"));
+    }
+
+    #[test]
+    fn local_run_governance_section_empty_is_info() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let gov = find(&report, "Governance");
+        assert_eq!(gov.severity, Severity::Info);
+        assert_eq!(fact(gov, "namespaces_with_policy"), "0");
+        assert_eq!(fact(gov, "namespaces_without_policy"), "0");
+        assert_eq!(fact(gov, "inheritance_depth"), "empty");
+        assert_eq!(fact(gov, "oldest_pending_age_secs"), "queue_empty");
+        assert_eq!(fact(gov, "pending_actions_total"), "0");
+    }
+
+    #[test]
+    fn local_run_webhook_section_empty_no_deliveries() {
+        let env = TestEnv::fresh();
+        let report = run_local_collect(&env.db_path);
+        let wh = find(&report, "Webhook");
+        assert_eq!(wh.severity, Severity::Info);
+        assert_eq!(fact(wh, "subscription_count"), "0");
+        assert_eq!(fact(wh, "dispatched_total"), "0");
+        assert_eq!(fact(wh, "failed_total"), "0");
+        assert_eq!(fact(wh, "success_rate_pct"), "no_deliveries_yet");
+    }
+
+    // -------------------------------------------------------------------
+    // Severity rule cases — DB-backed
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn governance_section_critical_when_pending_older_than_24h() {
+        let env = TestEnv::fresh();
+        // Open the DB once to materialize schema, then write a pending row.
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let twenty_five_hours_ago =
+                (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO pending_actions \
+                 (id, action_type, namespace, payload, requested_by, requested_at, status) \
+                 VALUES ('p1', 'store', 'ns', '{}', 'agent', ?1, 'pending')",
+                params![twenty_five_hours_ago],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let gov = find(&report, "Governance");
+        assert_eq!(gov.severity, Severity::Critical);
+        assert!(gov.note.as_ref().unwrap().contains("24h"));
+        // pending_actions_total reflects the row.
+        assert_eq!(fact(gov, "pending_actions_total"), "1");
+        // overall picks the Critical from Governance.
+        assert_eq!(report.overall, Severity::Critical);
+    }
+
+    #[test]
+    fn governance_section_info_when_pending_younger_than_24h() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let one_hour_ago = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO pending_actions \
+                 (id, action_type, namespace, payload, requested_by, requested_at, status) \
+                 VALUES ('p2', 'store', 'ns', '{}', 'agent', ?1, 'pending')",
+                params![one_hour_ago],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let gov = find(&report, "Governance");
+        // 1h pending — under the 24h threshold; Info, no critical bump.
+        assert_eq!(gov.severity, Severity::Info);
+        assert_eq!(fact(gov, "pending_actions_total"), "1");
+        // The age fact is set to a numeric string, not "queue_empty".
+        let age_str = fact(gov, "oldest_pending_age_secs");
+        assert!(
+            age_str.parse::<i64>().is_ok(),
+            "expected numeric age, got {age_str}"
+        );
+    }
+
+    #[test]
+    fn sync_section_critical_when_skew_exceeds_600s() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            // last_seen_at = now, last_pulled_at = 1 hour ago → 3600s skew.
+            let now = chrono::Utc::now();
+            let now_s = now.to_rfc3339();
+            let earlier = (now - chrono::Duration::seconds(3600)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO sync_state (agent_id, peer_id, last_seen_at, last_pulled_at) \
+                 VALUES ('me', 'peer-1', ?1, ?2)",
+                params![now_s, earlier],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let sync = find(&report, "Sync");
+        assert_eq!(sync.severity, Severity::Critical);
+        assert!(sync.note.as_ref().unwrap().contains("600s"));
+        assert_eq!(fact(sync, "peer_count"), "1");
+        assert_eq!(report.overall, Severity::Critical);
+    }
+
+    #[test]
+    fn sync_section_info_when_skew_under_threshold() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let now = chrono::Utc::now();
+            let now_s = now.to_rfc3339();
+            let close = (now - chrono::Duration::seconds(60)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO sync_state (agent_id, peer_id, last_seen_at, last_pulled_at) \
+                 VALUES ('me', 'peer-1', ?1, ?2)",
+                params![now_s, close],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let sync = find(&report, "Sync");
+        assert_eq!(sync.severity, Severity::Info);
+        // peer_count=1, skew column rendered as a numeric string.
+        assert_eq!(fact(sync, "peer_count"), "1");
+        let skew = fact(sync, "max_skew_secs");
+        assert!(
+            skew.parse::<i64>().is_ok(),
+            "expected numeric skew, got {skew}"
+        );
+    }
+
+    #[test]
+    fn webhook_section_warning_when_success_rate_below_95() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            // 100 dispatches, 10 failures = 90% success → < 95% threshold.
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO subscriptions \
+                 (id, url, events, created_at, dispatch_count, failure_count) \
+                 VALUES ('s1', 'http://example/x', '*', ?1, 100, 10)",
+                params![now],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let wh = find(&report, "Webhook");
+        assert_eq!(wh.severity, Severity::Warning);
+        assert!(wh.note.as_ref().unwrap().contains("95%"));
+        assert_eq!(fact(wh, "subscription_count"), "1");
+        assert_eq!(fact(wh, "dispatched_total"), "100");
+        assert_eq!(fact(wh, "failed_total"), "10");
+        assert_eq!(fact(wh, "success_rate_pct"), "90.00");
+    }
+
+    #[test]
+    fn webhook_section_info_when_success_rate_at_or_above_95() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            // 100 dispatches, 3 failures = 97% success.
+            conn.execute(
+                "INSERT INTO subscriptions \
+                 (id, url, events, created_at, dispatch_count, failure_count) \
+                 VALUES ('s1', 'http://example/x', '*', ?1, 100, 3)",
+                params![now],
+            )
+            .unwrap();
+        }
+        let report = run_local_collect(&env.db_path);
+        let wh = find(&report, "Webhook");
+        assert_eq!(wh.severity, Severity::Info);
+        assert!(wh.note.is_none());
+        assert_eq!(fact(wh, "success_rate_pct"), "97.00");
+    }
+
+    #[test]
+    fn governance_section_with_namespace_chain_reports_depths() {
+        let env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            for (ns, parent) in [
+                ("root", None::<&str>),
+                ("a", Some("root")),
+                ("a/b", Some("a")),
+            ] {
+                conn.execute(
+                    "INSERT INTO namespace_meta (namespace, parent_namespace, updated_at) \
+                     VALUES (?1, ?2, ?3)",
+                    params![ns, parent, now],
+                )
+                .unwrap();
+            }
+        }
+        let report = run_local_collect(&env.db_path);
+        let gov = find(&report, "Governance");
+        assert_eq!(gov.severity, Severity::Info);
+        let depth = fact(gov, "inheritance_depth");
+        assert!(depth.contains("d0=") && depth.contains("d1=") && depth.contains("d2="));
+        assert_eq!(fact(gov, "namespaces_without_policy"), "3");
+    }
+
+    // -------------------------------------------------------------------
+    // run() entry point — JSON / text / exit code branches
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn run_emits_json_when_json_flag_set() {
+        let mut env = TestEnv::fresh();
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: true,
+                fail_on_warn: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        // Healthy fresh DB → exit 0.
+        assert_eq!(exit, 0);
+        let s = env.stdout_str();
+        let v: serde_json::Value = serde_json::from_str(s).expect("JSON output must parse");
+        assert_eq!(v["mode"], "local");
+        assert!(v["sections"].is_array());
+        assert!(v["overall"].is_string());
+    }
+
+    #[test]
+    fn run_emits_text_by_default() {
+        let mut env = TestEnv::fresh();
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: false,
+                fail_on_warn: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 0);
+        let s = env.stdout_str();
+        // Header + section labels.
+        assert!(s.contains("ai-memory doctor — local mode"));
+        assert!(s.contains("[INFO] Storage"));
+        assert!(s.contains("[INFO] Index"));
+        assert!(s.contains("[N/A ] Capabilities"));
+        // The label-prefixed fact key column is left-padded to 32 chars
+        // (smoke check that the format string compiles).
+        assert!(s.contains("total_memories"));
+    }
+
+    #[test]
+    fn run_returns_exit_2_on_critical() {
+        let mut env = TestEnv::fresh();
+        // Inject a 25h-old pending action → Governance CRIT → overall CRIT.
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let twenty_five_hours_ago =
+                (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO pending_actions \
+                 (id, action_type, namespace, payload, requested_by, requested_at, status) \
+                 VALUES ('p1', 'store', 'ns', '{}', 'agent', ?1, 'pending')",
+                params![twenty_five_hours_ago],
+            )
+            .unwrap();
+        }
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: true,
+                fail_on_warn: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 2);
+        // JSON overall is "critical".
+        let v: serde_json::Value = serde_json::from_str(env.stdout_str()).unwrap();
+        assert_eq!(v["overall"], "critical");
+    }
+
+    #[test]
+    fn run_warning_keeps_exit_0_without_fail_on_warn() {
+        let mut env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO subscriptions \
+                 (id, url, events, created_at, dispatch_count, failure_count) \
+                 VALUES ('s1', 'http://x', '*', ?1, 10, 5)",
+                params![now],
+            )
+            .unwrap();
+        }
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: false,
+                fail_on_warn: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 0, "warning without --fail-on-warn must keep exit 0");
+        assert!(env.stdout_str().contains("[WARN] Webhook"));
+    }
+
+    #[test]
+    fn run_warning_returns_exit_1_with_fail_on_warn() {
+        let mut env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO subscriptions \
+                 (id, url, events, created_at, dispatch_count, failure_count) \
+                 VALUES ('s1', 'http://x', '*', ?1, 10, 5)",
+                params![now],
+            )
+            .unwrap();
+        }
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: false,
+                fail_on_warn: true,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 1, "--fail-on-warn must promote warning to exit 1");
+    }
+
+    #[test]
+    fn run_critical_is_exit_2_even_without_fail_on_warn() {
+        let mut env = TestEnv::fresh();
+        {
+            let conn = crate::db::open(&env.db_path).unwrap();
+            let twenty_five_hours_ago =
+                (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+            conn.execute(
+                "INSERT INTO pending_actions \
+                 (id, action_type, namespace, payload, requested_by, requested_at, status) \
+                 VALUES ('p1', 'store', 'ns', '{}', 'agent', ?1, 'pending')",
+                params![twenty_five_hours_ago],
+            )
+            .unwrap();
+        }
+        let db_path = env.db_path.clone();
+        let mut out = env.output();
+        let exit = run(
+            &db_path,
+            &DoctorArgs {
+                remote: None,
+                json: false,
+                fail_on_warn: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 2);
+    }
+
+    // -------------------------------------------------------------------
+    // run() — corrupt DB path: db::open() fails → CRITICAL Storage section.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn local_run_on_unopenable_db_returns_critical_storage_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bad = tmp.path().join("not-a-db.db");
+        // Write garbage so SQLite refuses to open it.
+        std::fs::write(&bad, b"this is not a sqlite database, it's just text").unwrap();
+        let report = run_local_collect(&bad);
+        // The error path appends a single Storage section and returns.
+        assert_eq!(report.sections.len(), 1);
+        let storage = &report.sections[0];
+        assert_eq!(storage.name, "Storage");
+        assert_eq!(storage.severity, Severity::Critical);
+        // overall is computed from the single section.
+        assert_eq!(report.overall, Severity::Critical);
+        assert!(storage.note.as_ref().unwrap().contains("could not open"));
+    }
+
+    // -------------------------------------------------------------------
+    // Render helpers
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn render_text_emits_section_note_when_present() {
+        let r = mk_report(vec![ReportSection {
+            name: "Sync".into(),
+            severity: Severity::Critical,
+            facts: vec![("max_skew_secs".into(), "9999".into())],
+            note: Some("peer mesh is drifting".into()),
+        }]);
+        let mut stdout = Vec::<u8>::new();
+        let mut stderr = Vec::<u8>::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        render_text(&r, &mut out).unwrap();
+        let s = String::from_utf8(stdout).unwrap();
+        assert!(s.contains("[CRIT] Sync"));
+        assert!(s.contains("note: peer mesh is drifting"));
+        assert!(s.contains("max_skew_secs"));
+        assert!(s.contains("9999"));
+    }
+
+    // -------------------------------------------------------------------
+    // Remote (--remote) mode — wiremock-driven HTTP fixtures
+    // -------------------------------------------------------------------
+
+    /// Helper: run `run_remote` from a multi-thread tokio test by spawning
+    /// the blocking reqwest call onto the spawn_blocking pool.
+    async fn run_remote_in_blocking(url: String, db_path: PathBuf) -> Report {
+        tokio::task::spawn_blocking(move || {
+            let mut r = run_remote(&url, &db_path);
+            r.compute_overall();
+            r
+        })
+        .await
+        .unwrap()
+    }
+
+    use std::path::PathBuf;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_section_capabilities_parses_v2_fields() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "feature_tier": "smart",
+                "features": {
+                    "recall_mode_active": "hybrid",
+                    "reranker_active": "cross_encoder"
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total": 42,
+                "expiring_soon": 1,
+                "links_count": 3
+            })))
+            .mount(&server)
+            .await;
+
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(server.uri(), env.db_path.clone()).await;
+        assert_eq!(report.mode, "remote");
+        assert!(report.source.starts_with(&server.uri()));
+        // Sections: 7 total — Capabilities, Recall, Storage, Index, Governance, Sync, Webhook.
+        assert_eq!(report.sections.len(), 7);
+
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::Info);
+        assert_eq!(fact(cap, "schema_version"), "2");
+        assert_eq!(fact(cap, "recall_mode_active"), "hybrid");
+        assert_eq!(fact(cap, "reranker_active"), "cross_encoder");
+
+        let recall = find(&report, "Recall");
+        assert_eq!(fact(recall, "active_recall_mode"), "hybrid");
+        assert_eq!(fact(recall, "active_reranker"), "cross_encoder");
+
+        let storage = find(&report, "Storage");
+        assert_eq!(fact(storage, "total_memories"), "42");
+        assert_eq!(fact(storage, "expiring_within_1h"), "1");
+        assert_eq!(fact(storage, "links"), "3");
+
+        // Raw-SQL sections must be NotAvailable in remote mode.
+        for raw in ["Index", "Governance", "Sync", "Webhook"] {
+            let s = find(&report, raw);
+            assert_eq!(s.severity, Severity::NotAvailable);
+            assert!(fact(s, "hint").contains("--db mode"));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_capabilities_silent_degrade_warns_on_capable_tier() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "feature_tier": "semantic",
+                "features": {
+                    "recall_mode_active": "keyword_only",
+                    "reranker_active": "none"
+                }
+            })))
+            .mount(&server)
+            .await;
+        // /api/v1/stats not mocked → 404 → Storage carries an error fact
+        // but no severity bump (severity stays Info per the code path).
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(server.uri(), env.db_path.clone()).await;
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::Warning);
+        assert!(cap.note.as_ref().unwrap().contains("silent degradation"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_capabilities_degraded_on_keyword_tier_does_not_warn() {
+        // recall_mode=degraded but feature_tier=keyword → no silent-degrade
+        // (keyword tier was never expected to run hybrid in the first place).
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "feature_tier": "keyword",
+                "features": {
+                    "recall_mode_active": "keyword_only",
+                    "reranker_active": "none"
+                }
+            })))
+            .mount(&server)
+            .await;
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(server.uri(), env.db_path.clone()).await;
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::Info);
+        assert!(cap.note.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_capabilities_unreachable_endpoint_is_critical() {
+        // Reserve a free port and immediately drop the listener so the
+        // connection refusal is deterministic. Doctor's HTTP timeout is
+        // 5s; the kernel rejects almost immediately so the test stays
+        // well under the per-test timeout.
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let url = format!("http://127.0.0.1:{port}");
+
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(url, env.db_path.clone()).await;
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::Critical);
+        assert!(cap.note.as_ref().unwrap().contains("could not reach"));
+        assert_eq!(report.overall, Severity::Critical);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_capabilities_legacy_v1_renders_not_in_response() {
+        // Legacy v0.6.3 capabilities responses don't carry the v2 fields.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "1"
+            })))
+            .mount(&server)
+            .await;
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(server.uri(), env.db_path.clone()).await;
+        let cap = find(&report, "Capabilities");
+        // Legacy v1 → no severity bump, but missing fields are rendered.
+        assert_eq!(cap.severity, Severity::Info);
+        assert_eq!(fact(cap, "schema_version"), "1");
+        assert_eq!(fact(cap, "recall_mode_active"), "not_in_response");
+        assert_eq!(fact(cap, "reranker_active"), "not_in_response");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_run_via_run_entry_uses_remote_mode_string() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "feature_tier": "semantic",
+                "features": {
+                    "recall_mode_active": "hybrid",
+                    "reranker_active": "none"
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total": 0
+            })))
+            .mount(&server)
+            .await;
+
+        let env_db = TestEnv::fresh().db_path;
+        let url = server.uri();
+        let (exit, stdout) = tokio::task::spawn_blocking(move || {
+            let mut stdout = Vec::<u8>::new();
+            let mut stderr = Vec::<u8>::new();
+            let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+            let exit = run(
+                &env_db,
+                &DoctorArgs {
+                    remote: Some(url),
+                    json: true,
+                    fail_on_warn: false,
+                },
+                &mut out,
+            )
+            .unwrap();
+            (exit, stdout)
+        })
+        .await
+        .unwrap();
+        assert_eq!(exit, 0);
+        let v: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+        assert_eq!(v["mode"], "remote");
+        // Trailing slash on the URL must be normalized.
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_url_trailing_slash_is_trimmed() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "features": {}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        let env = TestEnv::fresh();
+        // Append a trailing slash; format!("{base}/api/v1/...") would
+        // otherwise produce a `//api/v1/` path that wiremock would 404.
+        let report =
+            run_remote_in_blocking(format!("{}/", server.uri()), env.db_path.clone()).await;
+        let cap = find(&report, "Capabilities");
+        assert_eq!(cap.severity, Severity::Info);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_storage_500_renders_error_without_severity_bump() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "schema_version": "2",
+                "features": {}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/stats"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let env = TestEnv::fresh();
+        let report = run_remote_in_blocking(server.uri(), env.db_path.clone()).await;
+        let storage = find(&report, "Storage");
+        // Storage section preserves Info severity even on 5xx — by spec
+        // (remote storage is best-effort; sql truth is the local mode).
+        assert_eq!(storage.severity, Severity::Info);
+        let err = fact(storage, "error");
+        assert!(
+            err.contains("HTTP 500"),
+            "expected HTTP 500 message, got {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`src/cli/doctor.rs` was the **single largest drag** on the v0.6.3.1 line coverage report — 13.59% with 477 missed lines. The 93% line coverage gate in `.github/workflows/ci.yml` was failing on `release/v0.6.3.1` after issue #487's 8 PRs landed and shipped a much larger test corpus that exposed this pre-existing gap.

This PR closes that gap by adding 40 co-located unit tests (43 total in the module). It does **not** touch any file other than `src/cli/doctor.rs` — no production code change, no new dependency (wiremock was already a dev-dep). PR-9e and PR-9g are handling the remaining gaps in `cli/audit`, `cli/logs`, `logging`, and `daemon_runtime`.

### Coverage delta (cargo llvm-cov --lib)

| File | Before | After | Missed (lines) |
|---|---|---|---|
| `src/cli/doctor.rs` | 13.59% | **97.16%** | 477 → 37 |
| TOTAL (lib) | 89.05% | **90.05%** | (this PR alone moves the global ~+1.0pp) |

The remaining 37 missed lines in `doctor.rs` are the `Err` arms of `db::doctor_*` helpers — those branches are infeasible to trigger from outside the SQL layer (they only fire on hard SQLite failures like a missing system table).

### Test count delta

`AI_MEMORY_NO_CONFIG=1 cargo test --lib`: **1729 → 1769** (+40)

### New tests

**Severity / Report (pure)**
- `severity_label_renders_for_every_variant`
- `severity_serializes_lowercase_and_round_trips`
- `compute_overall_picks_info_when_no_warnings_or_critical`
- `compute_overall_handles_empty_sections`
- `compute_overall_only_n_a_yields_n_a`
- `report_section_serializes_with_expected_keys`
- `report_section_skips_note_when_none`
- `report_top_level_serialization_has_all_fields`

**Local-DB mode**
- `local_run_on_empty_db_produces_seven_sections`
- `local_run_empty_db_storage_section_is_info`
- `local_run_with_seeded_memory_reports_total`
- `local_run_index_section_reports_hnsw_estimate`
- `local_run_recall_section_documents_pre_p3_state`
- `local_run_sync_section_n_a_when_no_peers`
- `local_run_capabilities_local_section_n_a`
- `local_run_governance_section_empty_is_info`
- `local_run_webhook_section_empty_no_deliveries`
- `local_run_on_unopenable_db_returns_critical_storage_only`

**Severity rules (DB-backed)**
- `governance_section_critical_when_pending_older_than_24h`
- `governance_section_info_when_pending_younger_than_24h`
- `sync_section_critical_when_skew_exceeds_600s`
- `sync_section_info_when_skew_under_threshold`
- `webhook_section_warning_when_success_rate_below_95`
- `webhook_section_info_when_success_rate_at_or_above_95`
- `governance_section_with_namespace_chain_reports_depths`

**run() entry point (text / JSON / exit codes)**
- `run_emits_json_when_json_flag_set`
- `run_emits_text_by_default`
- `run_returns_exit_2_on_critical`
- `run_warning_keeps_exit_0_without_fail_on_warn`
- `run_warning_returns_exit_1_with_fail_on_warn`
- `run_critical_is_exit_2_even_without_fail_on_warn`
- `render_text_emits_section_note_when_present`

**Remote mode (wiremock)**
- `remote_section_capabilities_parses_v2_fields`
- `remote_capabilities_silent_degrade_warns_on_capable_tier`
- `remote_capabilities_degraded_on_keyword_tier_does_not_warn`
- `remote_capabilities_unreachable_endpoint_is_critical`
- `remote_capabilities_legacy_v1_renders_not_in_response`
- `remote_run_via_run_entry_uses_remote_mode_string`
- `remote_url_trailing_slash_is_trimmed`
- `remote_storage_500_renders_error_without_severity_bump`

### Gates

- `cargo fmt --check` — passes for `doctor.rs` (pre-existing `wrap.rs` issue is upstream and out of scope)
- `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` — passes
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 1769 passed
- `cargo llvm-cov --lib --fail-under-lines 93` — fails at 90.05% (will pass once PR-9e + PR-9g land)

### Constraints honored

- Only `src/cli/doctor.rs` modified. No `Cargo.toml` change (wiremock was already a dev-dep).
- All tests use `tempfile::TempDir` via `cli::test_utils::TestEnv` — no `/tmp` literals, no host DB pollution.
- All tests are deterministic. Time-sensitive assertions (24h/600s thresholds) seed timestamps relative to `Utc::now()` and assert on rule-class outcomes (Critical / Info), not on the exact age value.
- Wiremock-driven HTTP tests run on `tokio::test(flavor = "multi_thread")` and call the blocking reqwest path through `spawn_blocking`, mirroring the existing `subscriptions::tests::send_*` and `llm::wiremock_tests` patterns.
- Cross-platform (no platform-conditional code; uses TCP localhost only for the connection-refused fixture).

## Test plan

- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib cli::doctor::tests::` — 43 passed
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 1769 passed
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `cargo llvm-cov --lib --summary-only` — `cli/doctor.rs` 97.16%
- [ ] CI: 93% gate will pass once PR-9e + PR-9g merge alongside this one

## AI involvement

Authored by Claude Opus 4.7 (1M context) under PR-9f scope from the v0.6.3.1 issue #487 coverage uplift program. Test cases were derived from a static read of `src/cli/doctor.rs` plus the severity rules documented in its module-level rustdoc — every assertion maps to a rule that's spelled out in code comments, so the tests harden the doc as much as the impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)