### PR TITLE
chore(release): remove Ubuntu PPA distribution channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,68 +437,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  ppa:
-    name: Ubuntu PPA
-    needs: check
-    # Skip pre-release tags — Launchpad PPA users get stable releases only.
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Install packaging tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y devscripts debhelper dput gnupg pkg-config libssl-dev build-essential
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Import GPG key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: |
-          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
-          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-          gpgconf --reload gpg-agent
-
-      - name: Update changelog version
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          SERIES=noble
-          sed -i "1s/(.*)/(${VERSION}-1) ${SERIES}; urgency=medium/" debian/changelog
-
-      - name: Create orig tarball
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          cd ..
-          tar czf "ai-memory_${VERSION}.orig.tar.gz" \
-            --exclude='.git' \
-            --exclude='target' \
-            --exclude='backup' \
-            ai-memory-mcp
-          ls -la "ai-memory_${VERSION}.orig.tar.gz"
-
-      - name: Build source package
-        env:
-          DEBUILD_DPKG_BUILDPACKAGE_OPTS: "-d"
-        run: |
-          debuild -S -sa -k4BAA63E9957BD865FA881D1E64A81A0A19B5E324 --no-sign -d
-
-      - name: Sign source package
-        run: |
-          cd ..
-          debsign -k4BAA63E9957BD865FA881D1E64A81A0A19B5E324 ai-memory_${{ steps.version.outputs.version }}-1_source.changes
-
-      - name: Upload to PPA
-        run: |
-          cd ..
-          dput ppa:jbridger2021/ppa ai-memory_${{ steps.version.outputs.version }}-1_source.changes
-
   copr:
     name: Fedora COPR
     needs: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1325,9 +1325,8 @@ Successive alphas will be tagged at each track completion (A/B/C/D per
 
 ### Added
 
-- Ubuntu PPA: `sudo add-apt-repository ppa:jbridger2021/ppa && sudo apt install ai-memory`
 - Fedora COPR: `sudo dnf copr enable alpha-one-ai/ai-memory && sudo dnf install ai-memory`
-- CI workflows for automated PPA and COPR uploads on tag push
+- CI workflow for automated COPR upload on tag push
 - debian/ packaging directory (control, rules, changelog, copyright)
 - RPM spec file (ai-memory.spec) for COPR builds
 - OpenClaw as 9th supported AI platform across all docs

--- a/README.md
+++ b/README.md
@@ -99,9 +99,6 @@ Pre-built binaries require no dependencies. Building from source needs Rust and 
 # macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/alphaonedev/ai-memory-mcp/main/install.sh | sh
 
-# Ubuntu (PPA)
-sudo add-apt-repository ppa:jbridger2021/ppa && sudo apt install ai-memory
-
 # Fedora/RHEL (COPR)
 sudo dnf copr enable alpha-one-ai/ai-memory && sudo dnf install ai-memory
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ Delivered:
 - Apache-2.0 license migration, CLA, OIN membership, USPTO trademark filing
 - Pedantic clippy (zero warnings under `-D clippy::all -D clippy::pedantic`)
 - Single-repo consolidation (ai-memory-mcp-dev archived)
-- All package repos live: Homebrew, Ubuntu PPA, Fedora COPR/EPEL
+- All package repos live: Homebrew, Fedora COPR/EPEL
 
 ---
 

--- a/docs/ENGINEERING_STANDARDS.md
+++ b/docs/ENGINEERING_STANDARDS.md
@@ -245,7 +245,6 @@ Every patch/release must be reviewed against these 10 areas:
    - Check phase (fmt, clippy pedantic, test, audit, build) on ubuntu + macos
    - Release phase: 5 platform binaries + `.deb`/`.rpm` packages
    - Docker: push to GHCR (`ghcr.io/alphaonedev/ai-memory:VERSION` + `:latest`)
-   - PPA: Ubuntu PPA upload (`ppa:jbridger2021/ppa`)
    - COPR: Fedora COPR upload (`alpha-one-ai/ai-memory`)
 5. Verify: `gh release view v{VERSION} --repo alphaonedev/ai-memory-mcp`
 6. Update Homebrew tap (manual): `alphaonedev/homebrew-tap` — download platform tarballs, compute SHA256 hashes, update `Formula/ai-memory.rb`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,13 +31,6 @@
    cargo binstall ai-memory
    ```
 
-   **Ubuntu (PPA — recommended):**
-   ```bash
-   sudo add-apt-repository ppa:jbridger2021/ppa
-   sudo apt update
-   sudo apt install ai-memory
-   ```
-
    **Ubuntu/Debian (.deb manual install):**
    ```bash
    # Download from https://github.com/alphaonedev/ai-memory-mcp/releases/latest

--- a/docs/index.html
+++ b/docs/index.html
@@ -728,13 +728,6 @@
                 <pre style="margin:0;font-size:.78rem"><code><span class="tok-cmd">irm</span> <span class="tok-url">https://raw.githubusercontent.com/alphaonedev/ai-memory-mcp/main/install.ps1</span> | <span class="tok-cmd">iex</span></code></pre>
             </div>
             <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.5rem">
-                <h4 style="font-size:1rem;margin-bottom:.25rem;color:var(--text)">Ubuntu <span style="font-size:.7rem;color:var(--text-muted);font-weight:400">(PPA)</span></h4>
-                <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:.75rem">Native apt package. Auto-updates with system.</p>
-                <pre style="margin:0;font-size:.78rem"><code><span class="tok-cmd">sudo</span> add-apt-repository ppa:jbridger2021/ppa
-<span class="tok-cmd">sudo</span> apt update
-<span class="tok-cmd">sudo</span> apt install ai-memory</code></pre>
-            </div>
-            <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1.5rem">
                 <h4 style="font-size:1rem;margin-bottom:.25rem;color:var(--text)">Fedora / RHEL <span style="font-size:.7rem;color:var(--text-muted);font-weight:400">(COPR)</span></h4>
                 <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:.75rem">Native dnf package. Auto-updates with system.</p>
                 <pre style="margin:0;font-size:.78rem"><code><span class="tok-cmd">sudo</span> dnf copr enable alpha-one-ai/ai-memory

--- a/docs/release-pipeline.html
+++ b/docs/release-pipeline.html
@@ -237,9 +237,8 @@ footer a{color:var(--text-muted)}
         <g><rect class="step publish" x="930" y="20" width="220" height="50" rx="8"/><text x="1040" y="50" text-anchor="middle">GitHub Release artifacts</text></g>
         <g><rect class="step publish" x="930" y="80" width="220" height="50" rx="8"/><text x="1040" y="110" text-anchor="middle">crates.io publish</text></g>
         <g><rect class="step publish" x="930" y="140" width="220" height="50" rx="8"/><text x="1040" y="170" text-anchor="middle">Homebrew formula bump</text></g>
-        <g><rect class="step publish" x="930" y="200" width="220" height="50" rx="8"/><text x="1040" y="230" text-anchor="middle">Ubuntu PPA upload</text></g>
-        <g><rect class="step publish" x="930" y="260" width="220" height="50" rx="8"/><text x="1040" y="290" text-anchor="middle">Fedora COPR build</text></g>
-        <g><rect class="step publish" x="930" y="320" width="220" height="50" rx="8"/><text x="1040" y="350" text-anchor="middle">Docker → GHCR</text></g>
+        <g><rect class="step publish" x="930" y="200" width="220" height="50" rx="8"/><text x="1040" y="230" text-anchor="middle">Fedora COPR build</text></g>
+        <g><rect class="step publish" x="930" y="260" width="220" height="50" rx="8"/><text x="1040" y="290" text-anchor="middle">Docker → GHCR</text></g>
 
         <!-- Arrows -->
         <path class="arrow flow" d="M 160 240 Q 190 90 215 90"/>


### PR DESCRIPTION
## Summary

Drops Ubuntu PPA as a supported distribution channel for ai-memory.

## Why

During the v0.6.3.1 release dogfood, the "Ubuntu PPA" CI job was found to be wiring `dput` into a 404. Direct verification against Launchpad:

| URL | HTTP |
|---|---|
| `https://launchpad.net/~alphaonedev/+archive/ubuntu/ai-memory` (advertised) | **404** |
| `https://launchpad.net/~jbridger2021/+archive/ubuntu/ppa` (actual dput target) | **404** |

End users have no working public Ubuntu PPA to install from — the install command in README / docs / GitHub Release notes was a fabrication. Per maintainer direction, drop the channel rather than attempt to fix the upstream Launchpad config.

Ubuntu users continue to install via the **`.deb` packages on the GitHub Release page** — those are already shipping per release as part of the standard binary artifact set (`ai-memory_VERSION_amd64.deb` + `ai-memory_VERSION_arm64.deb`).

## Changes

| File | What |
|---|---|
| `.github/workflows/ci.yml` | Removes the `ppa:` job (62 lines) — was running dput into a non-existent PPA |
| `README.md` | Removes the `sudo add-apt-repository ppa:jbridger2021/ppa && sudo apt install ai-memory` install line |
| `docs/INSTALL.md` | Removes the "Ubuntu (PPA — recommended)" install block (7 lines) |
| `ROADMAP.md` | Updates "All package repos live: Homebrew, Ubuntu PPA, Fedora COPR/EPEL" → "Homebrew, Fedora COPR/EPEL" |
| `docs/ENGINEERING_STANDARDS.md` | Removes the "PPA: Ubuntu PPA upload" line from the release-publishing checklist |
| `docs/index.html` | Removes the Ubuntu (PPA) install card from the homepage |
| `docs/release-pipeline.html` | Removes the "Ubuntu PPA upload" step from the SVG pipeline diagram |
| `CHANGELOG.md` | Removes the current-release "Ubuntu PPA" bullet + adjusts the "CI workflows" line to mention COPR only. Historical entries from prior releases preserved as-is (audit trail). |

Net diff: **8 files changed, 4 insertions(+), 86 deletions(-)** — almost entirely deletions.

## What's NOT changed

- `.deb` packaging in `debian/` directory — preserved (still used to build the .deb files attached to GitHub Releases)
- COPR / Fedora support — unchanged
- Homebrew / ghcr.io / crates.io / GitHub Release — unchanged
- CI matrix (`ubuntu-latest` runner) — unchanged (that's a Linux test runner label, not a distribution channel)

## Test plan

- [x] `cargo build --bin ai-memory` clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses
- [x] `grep -rn "jbridger2021\|add-apt-repository\|Ubuntu PPA" --include="*.md" --include="*.html" --include="*.yml"` — only historical CHANGELOG entries from prior releases remain (intentional)
- [ ] CI runs on this branch — required-status-checks should pass since we removed a job, didn't add one
- [ ] Lifetime suite + recipe contract tests — unaffected (no `ai-memory boot` code path touched)

## Closure

Closes the residual cleanup item from the v0.6.3.1 ship retrospective — the live release page at https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3.1 already had the Ubuntu PPA row removed from the verification table; this PR aligns the repo source-of-truth with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
