### PR TITLE
docs: drift remediation pass 5 (v0.6.3.1) — full-spectrum capability sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,9 @@ Reverting to the brew-managed binary: `brew link --overwrite ai-memory`.
 
 **ai-memory** is a Rust-based persistent memory system exposing three interfaces over a shared SQLite database layer:
 
-1. **MCP Server** (`src/mcp.rs`) — stdio JSON-RPC 2.0 with 23 tools + 2 prompts
-2. **HTTP API** (`src/handlers.rs`) — Axum REST server on port 9077, 24 endpoints at `/api/v1/`
-3. **CLI** (`src/main.rs`) — clap-based, 26 commands with optional `--json` output
+1. **MCP Server** (`src/mcp.rs`) — stdio JSON-RPC 2.0 with 43 tools + 2 prompts
+2. **HTTP API** (`src/handlers.rs`) — Axum REST server on port 9077, 50 endpoints at `/api/v1/`
+3. **CLI** (`src/main.rs`) — clap-based, 40 subcommands with optional `--json` output
 
 All three interfaces share the same database (`src/db.rs`) and validation (`src/validate.rs`) layers. Shared state is `Arc<Mutex<(Connection, PathBuf, ResolvedTtl, bool)>>` — a single SQLite connection protected by a mutex. Lock contention is the bottleneck under concurrent HTTP + MCP load.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
-[![Tests](https://img.shields.io/badge/tests-1%2C809_%E2%80%A2_93.08%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![Tests](https://img.shields.io/badge/tests-1%2C886_%E2%80%A2_93.84%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Test Hub](https://img.shields.io/badge/test--hub-live_results-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-test-hub/)
 [![MCP](https://img.shields.io/badge/MCP-43_tools-blueviolet)]()
 [![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.3-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
@@ -85,7 +85,7 @@ ai-memory integrates with any AI platform that supports the **Model Context Prot
 | **OpenClaw** | MCP stdio | JSON (`mcp.servers` in config) | Fully supported |
 | **Any MCP client** | MCP stdio or HTTP | Varies | Universal |
 
-MCP is the primary integration layer. For AI platforms that do not yet support MCP natively, the **HTTP API** (42 endpoints on localhost) and the **CLI** (26 commands) provide universal access -- any AI, script, or automation that can make HTTP calls or run shell commands can use ai-memory.
+MCP is the primary integration layer. For AI platforms that do not yet support MCP natively, the **HTTP API** (50 endpoints on localhost) and the **CLI** (40 subcommands) provide universal access -- any AI, script, or automation that can make HTTP calls or run shell commands can use ai-memory.
 
 ---
 
@@ -499,7 +499,7 @@ It runs as an MCP (Model Context Protocol) tool server -- a background process t
 
 Memories that keep getting accessed automatically promote from mid to long-term. Each recall extends the TTL. Priority increases with usage. The system is self-curating.
 
-Beyond MCP, ai-memory also exposes a full HTTP REST API (42 endpoints on port 9077) and a complete CLI (26 commands) for direct interaction, scripting, and integration with any AI platform or tool.
+Beyond MCP, ai-memory also exposes a full HTTP REST API (50 endpoints on port 9077) and a complete CLI (40 subcommands) for direct interaction, scripting, and integration with any AI platform or tool.
 
 ---
 
@@ -549,7 +549,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (42 endpoints on port 90
 - **Color CLI output** -- ANSI tier labels (red/yellow/green), priority bars, bold titles, cyan namespaces
 
 ### Quality
-- **1,809 tests** (1,600 lib + 209 integration) -- 93.08% line coverage (gate ≥92%). All numbers frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); per-release detail on the [test-hub v0.6.3 evidence](https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/).
+- **1,886 lib tests + 49+ integration tests** -- 93.84% line coverage (gate ≥93%, buffer +0.84pp; v0.6.3.1). v0.6.3 baseline numbers (1,809 / 93.08%) are frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.3.1 metrics in the release notes.
 - **LongMemEval benchmark** -- **97.8% R@5** (489/500), **99.0% R@10**, **99.8% R@20** on ICLR 2025 LongMemEval-S dataset. 499/500 at R@20. Pure FTS5 keyword achieves 97.0% R@5 in 2.2 seconds (232 q/s). LLM query expansion pushes to 97.8% R@5. Zero cloud API costs. See [benchmark details](benchmarks/longmemeval/).
 - **MCP Prompts** -- `recall-first` and `memory-workflow` prompts teach AI clients to use memory proactively
 - **TOON-default** -- recall/list/search responses use TOON compact by default (79% smaller than JSON)
@@ -755,7 +755,7 @@ These 43 tools are available to any MCP-compatible AI when configured as an MCP 
 
 ## HTTP API
 
-42 endpoints on `127.0.0.1:9077`. Start with `ai-memory serve`.
+50 endpoints on `127.0.0.1:9077`. Start with `ai-memory serve`.
 
 > **Security:** The HTTP server binds to 127.0.0.1 with no authentication and permissive CORS. Do not expose to the network without a reverse proxy with authentication.
 
@@ -790,7 +790,7 @@ These 43 tools are available to any MCP-compatible AI when configured as an MCP 
 
 ## CLI Commands
 
-26 commands. Run `ai-memory <command> --help` for details on any command.
+40 subcommands. Run `ai-memory <command> --help` for details on any command.
 
 | Command | Description |
 |---------|-------------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,7 +150,7 @@ Every level of the hierarchy has a governance model: who can store, who can prom
 
 | Task | Sessions | Deliverable |
 |------|:--------:|-------------|
-| Context-budget-aware recall | 1-2 | `budget_tokens` parameter — return as many memories as fit in N tokens. **No competitor has this.** LLMs have finite context windows. "Give me the most relevant memories that fit in 4K tokens" is the killer feature. |
+| Context-budget-aware recall | ✅ shipped (v0.6.3.1 R1) | `budget_tokens` parameter — return as many memories as fit in N tokens. **No competitor has this.** LLMs have finite context windows. "Give me the most relevant memories that fit in 4K tokens" is the killer feature. v0.6.3.1 ships cl100k_base BPE tokenization on the survivors. |
 | Hierarchy-aware recall | 0.5 | Recall automatically includes memories from the agent's level + all ancestor namespaces. An agent in `alphaone/engineering/platform` gets platform memories + engineering policies + org standards in one recall. |
 
 ---
@@ -227,7 +227,7 @@ ai-memory stops being reactive and becomes **self-improving.**
 | Background curator daemon | 1-2 | `ai-memory curator` — runs periodically. Auto-consolidates related memories, detects contradictions proactively, suggests promotions/demotions. Uses existing Ollama integration. |
 | Auto-extraction | 2 | Watch conversations (via MCP hooks) and auto-store facts, decisions, and corrections. Auto-stored memories get confidence < 1.0, human-stored get 1.0. |
 | Consensus memory | 1 | When multiple agents store conflicting facts, use confidence + agent count to determine truth. If 4 of 5 agents agree, confidence is 0.95. |
-| Memory health dashboard | 0.5 | `ai-memory doctor` — fragmentation, stale memories, unresolved contradictions, sync lag. |
+| Memory health dashboard | ✅ shipped (v0.6.3.1 R7) | `ai-memory doctor` — 7-section severity-tagged dashboard (Storage / Index / Recall / Governance / Sync / Webhook / Capabilities). Fragmentation, stale memories, unresolved contradictions, sync lag. JSON mode. Exit codes 0/1/2 for healthy/warning/critical. |
 
 ---
 
@@ -252,8 +252,8 @@ For agent teams that need a central sync point. SQLite remains the default for i
 | Task | Sessions | Deliverable |
 |------|:--------:|-------------|
 | API stability guarantee | 1 | Freeze all MCP tools, HTTP endpoints, CLI commands — semver contract |
-| Plugin SDK (TypeScript) | 1-2 | `@alphaone/ai-memory` npm package |
-| Plugin SDK (Python) | 1-2 | `ai-memory-sdk` PyPI package |
+| ~~Plugin SDK (TypeScript)~~ | **FORMALLY CUT** | MCP is the SDK. See `ROADMAP2.md` §10 for the rationale. |
+| ~~Plugin SDK (Python)~~ | **FORMALLY CUT** | MCP is the SDK. See `ROADMAP2.md` §10 for the rationale. |
 | Memory portability spec | 1 | Export format as a published specification. If ai-memory dies in 10 years, users can read their data with any tool. |
 | Security audit | 1 | Full code review, fuzzing, dependency audit |
 | TOON v2 | 0.5 | Schema inference compression, target 85%+ token reduction |

--- a/ROADMAP2.md
+++ b/ROADMAP2.md
@@ -5,7 +5,7 @@
 > **Supersedes:** the prior `ROADMAP.md` (Phase 0–6, drafted at v0.5.4.4) and the 2026-04-29 charter-set roadmap. Where they conflict, this document wins.
 > **Trademark:** ai-memory™ — USPTO Serial No. 99761257
 > **License:** Apache 2.0 — permanent, non-revocable, non-relicenseable.
-> **Production version at write time:** v0.6.3 (shipped 2026-04-27).
+> **Production version at write time:** v0.6.3.1 (shipped 2026-04-30; this audit's text dates 2026-04-29 use "v0.6.3" inline because Patch 1 had not yet shipped at the time of writing — the contract has since landed and §7.2 is now SHIPPED).
 
 ---
 
@@ -60,14 +60,14 @@ This is the floor every plan below builds on. Numbers are sourced from the publi
 
 | Metric | Result | Source |
 |---|---|---|
-| Library tests passing | 1,600 / 1,600 | evidence.html |
-| Total tests (lib + integration) | 1,809 | evidence.html |
-| Line coverage | **93.08%** (gate ≥92%) | evidence.html |
-| Region coverage | 93.11% | release notes |
-| Function coverage | 92.55% | release notes |
-| Modules ≥ 90% coverage | 39 of 47 (7 at 100%) | release notes |
+| Library tests passing (v0.6.3.1) | 1,886 / 1,886 (was 1,600 on v0.6.3) | release notes |
+| Total tests (lib + integration, v0.6.3.1) | 1,886 lib + 49+ integration | release notes |
+| Line coverage (v0.6.3.1) | **93.84%** (gate ≥93%, buffer +0.84pp) | release notes |
+| Region coverage (v0.6.3 baseline) | 93.11% | evidence.html |
+| Function coverage (v0.6.3 baseline) | 92.55% | evidence.html |
+| Modules ≥ 90% coverage (v0.6.3 baseline) | 39 of 47 (7 at 100%) | evidence.html |
 | Platform CI matrix | ubuntu-latest, macos-latest, windows-latest | evidence.html |
-| Schema version | v15 (temporal-validity migration) | evidence.html |
+| Schema version (v0.6.3.1) | v19 (was v15 on v0.6.3; ladder v15→v17→v18→v19) | release notes |
 
 ### 4.2 Ship-gate (4 phases on 4-node DigitalOcean)
 
@@ -233,7 +233,7 @@ The `ROADMAP.md` (Phase 0–6, drafted at v0.5.4.4) made commitments that did no
 | Hierarchical namespace paths, visibility prefixes, vertical promote | 1b | ✅ shipped | done |
 | **N-level rule inheritance** | 1b | ⚠️ display only — gate uses leaf only | **G1 fix in v0.7 Bucket 3** |
 | Governance metadata, roles, approval workflow, approver types | 1c | ✅ shipped | done |
-| **`budget_tokens` parameter for context-budget-aware recall** | 1d | ❌ MIA | **R1 — recover in v0.6.3.1** |
+| **`budget_tokens` parameter for context-budget-aware recall** | 1d | ✅ shipped (v0.6.3.1 R1, with cl100k_base BPE tokenization) | done |
 | Hierarchy-aware recall (auto-include ancestors) | 1d | ✅ shipped (FTS expansion) | done |
 | `memory_graph_query` (multi-hop) | 2 | ✅ shipped as `memory_kg_query` | done |
 | **`memory_find_paths` (A→B path discovery)** | 2 | ❌ MIA | **R2 — recover in v0.7 Bucket 2 alongside AGE** |
@@ -244,7 +244,7 @@ The `ROADMAP.md` (Phase 0–6, drafted at v0.5.4.4) made commitments that did no
 | Background curator daemon | 4 | ⚠️ code in `autonomy.rs`/`curator.rs` but no standalone CLI surface | **R4 — surface as `ai-memory curator` daemon in v0.8 Pillar 2.5** |
 | **Auto-extraction from conversations** | 4 | ❌ MIA | **R5 — recover in v0.7 Bucket 1.7 as `pre_store` hook on transcripts** |
 | **Consensus memory** (4-of-5 → confidence 0.95) | 4 | ❌ MIA (Approval has Consensus(N) for *write authorization*, not *truth determination*) | **R6 — recover in v0.8 Pillar 3** |
-| **`ai-memory doctor` health dashboard** | 4 | ❌ MIA | **R7 — recover in v0.6.3.1** |
+| **`ai-memory doctor` health dashboard** | 4 | ✅ shipped (v0.6.3.1 R7, 7-section severity-tagged dashboard) | done |
 | PostgreSQL + pgvector hub, hub-spoke topology, migration CLI | 5 | ✅ shipped (Postgres SAL adapter; AGE planned for v0.7) | done |
 | API stability guarantee | 6 | pending v1.0 | v1.0 |
 | **Plugin SDK Python + TypeScript** | 6 | ❌ explicitly cut | **stays cut — MCP is the SDK** |
@@ -262,7 +262,7 @@ The grand-slam. Six streams (A: hierarchy taxonomy · B: schema v15 with tempora
 
 Status: **done**. See §4 for evidence.
 
-### 7.2 v0.6.3.1 — Honesty Patch + Recovered Commitments + Doc Currency — Q2 2026 (~4 weeks)
+### 7.2 v0.6.3.1 — Honesty Patch + Recovered Commitments + Doc Currency — SHIPPED 2026-04-30
 
 Existing scope: **Capabilities v2 + Memory Portability Spec v1**. (LongMemEval already shipped at v0.6.3 — replaced with reranker-variant disclosure.)
 
@@ -614,7 +614,7 @@ If any of these commitments are ever broken, OSS users have the right to fork th
 
 ## 16. Net
 
-ai-memory v0.6.3 shipped clean: 1,809 tests, 93.08% coverage, ship-gate 4/4, A2A 48/48 mTLS, 5/5 channels, LongMemEval R@5 97.8% / R@10 99.0% / R@20 99.8%, 43 MCP tools, schema v15.
+ai-memory v0.6.3 shipped clean: 1,809 tests, 93.08% coverage, ship-gate 4/4, A2A 48/48 mTLS, 5/5 channels, LongMemEval R@5 97.8% / R@10 99.0% / R@20 99.8%, 43 MCP tools, schema v15. v0.6.3.1 then landed (2026-04-30) with the never-lose-context release: 1,886 lib tests (+281), 93.84% line coverage, schema v19 (ladder v15→v17→v18→v19), 7 new CLI surfaces (boot/install/wrap/logs/audit/doctor/bench), and 17 documented integrations across 10 platforms.
 
 The audit found 22 distinct gaps. None block the published v0.6.3 claims. One (G1 — namespace-inheritance enforcement) is a security-shaped bug that gets a cutline-protected slot in v0.7 Bucket 3. Eight are capabilities-JSON theater that v0.6.3.1 Capabilities v2 makes honest. The remaining thirteen distribute cleanly across v0.6.3.1 / v0.7 / v0.8 / v0.9 / v1.0.
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -2,7 +2,7 @@
 
 `ai-memory` is an AI-agnostic memory management system. It works with **any MCP-compatible AI client** -- including Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, and others. The HTTP API and CLI are completely platform-independent.
 
-**Key features for admins:** Zero token cost until recall (replaces built-in auto-memory), TOON compact default response format (79% smaller than JSON), MCP prompts for proactive AI behavior (`recall-first`, `memory-workflow`), 4 feature tiers (keyword → autonomous with local LLMs via Ollama), 1,600 lib tests at 93.08% coverage. All numbers frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html).
+**Key features for admins:** Zero token cost until recall (replaces built-in auto-memory), TOON compact default response format (79% smaller than JSON), MCP prompts for proactive AI behavior (`recall-first`, `memory-workflow`), 4 feature tiers (keyword → autonomous with local LLMs via Ollama), 1,886 lib tests + 49+ integration tests at 93.84% line coverage (v0.6.3.1). v0.6.3 baseline numbers (1,600 lib / 93.08%) are frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.3.1 deltas are documented in `CHANGELOG.md` and the v0.6.3.1 release notes.
 
 > **Maturity framing (v0.6.3).** The single-machine primitive (T1/T2 in the [architectures matrix](https://alphaonedev.github.io/ai-memory-mcp/architectures.html)) is **production-ready**. Federation (T3 multi-node quorum cluster) is **beta** — the code is shipped and tested but not recommended for unattended production fleets. The Postgres+pgvector backend is **experimental** under the `sal-postgres` Cargo feature, GA target v0.7. Multi-region distributed consensus (T5 "global hive") is **vision** at v1.0+. ai-memory is a single-machine primitive that ships beta-quality federation primitives for opt-in multi-node clusters; it is not a distributed database. See the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html) for the canonical maturity labels — use those labels in all customer-facing materials.
 
@@ -750,7 +750,7 @@ Both are cleaned up on graceful shutdown (the daemon runs `PRAGMA wal_checkpoint
 
 Maximum request body size: 50 MB.
 
-The HTTP daemon exposes **42 endpoints** under `/api/v1`:
+The HTTP daemon exposes **50 endpoints** under `/api/v1`:
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -6,14 +6,14 @@
 
 1. **MCP tool server** -- stdio JSON-RPC server exposing 43 memory tools + 2 MCP prompts for any MCP-compatible AI client (Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, and others)
 2. **CLI tool** -- direct SQLite operations for store, recall, search, list, etc. (completely AI-agnostic)
-3. **HTTP daemon** -- an Axum web server exposing the same operations as a REST API with 42 endpoints (completely AI-agnostic)
+3. **HTTP daemon** -- an Axum web server exposing the same operations as a REST API with 50 endpoints (completely AI-agnostic)
 
 **Key architectural features:** Zero token cost (no context loaded until recall), TOON compact default response format (79% smaller than JSON), MCP prompts capability (`recall-first` behavioral rules + `memory-workflow` reference card), 4 feature tiers with optional local LLMs via Ollama, true dedup on title+namespace, 6-factor recall scoring with score field in responses.
 
 All three interfaces share the same database layer (`db.rs`) and validation layer (`validate.rs`). The daemon adds automatic garbage collection (every 30 minutes) and graceful shutdown with WAL checkpointing.
 
 ```
-main.rs          -- CLI parsing (clap), daemon setup (axum), command dispatch (26 commands)
+main.rs          -- CLI parsing (clap), daemon setup (axum), command dispatch (40 subcommands)
 models.rs        -- Data structures: Memory, MemoryLink, query types, constants
 handlers.rs      -- HTTP request handlers (Axum extractors + JSON responses), error sanitization
 db.rs            -- All SQLite operations: CRUD, FTS5, recall scoring, GC, migration, FTS query sanitization, transactional touch/consolidate
@@ -47,13 +47,13 @@ When running at the `semantic` tier or higher, ai-memory loads a HuggingFace emb
 ### `src/main.rs`
 
 - `Cli` struct with `clap` derive -- defines all CLI commands and global flags (`--db`, `--json`)
-- `Command` enum -- `Serve`, `Mcp`, `Store`, `Update`, `Recall`, `Search`, `Get`, `List`, `Delete`, `Promote`, `Forget`, `Link`, `Consolidate`, `Resolve`, `Shell`, `Sync`, `AutoConsolidate`, `Gc`, `Stats`, `Namespaces`, `Export`, `Import`, `Completions`, `Man`, `Mine`, `Archive` (26 commands)
+- `Command` enum -- `Serve`, `Mcp`, `Store`, `Update`, `Recall`, `Search`, `Get`, `List`, `Delete`, `Promote`, `Forget`, `Link`, `Consolidate`, `Resolve`, `Shell`, `Sync`, `SyncDaemon`, `AutoConsolidate`, `Gc`, `Stats`, `Namespaces`, `Export`, `Import`, `Completions`, `Man`, `Mine`, `Archive`, `Agents`, `Pending`, `Backup`, `Restore`, `Curator`, `Bench`, `Migrate` (gated `--features sal`), `Doctor`, `Boot`, `Install`, `Wrap`, `Logs`, `Audit` — 40 subcommands total in v0.6.3.1.
 - `StoreArgs` includes `--expires-at` and `--ttl-secs` flags for custom expiration
 - `UpdateArgs` includes `--expires-at` flag for setting expiration on existing memories
 - `ListArgs` includes `--offset` flag for pagination
 - `auto_namespace()` -- detects namespace from git remote URL or directory name
 - `human_age()` -- formats ISO timestamps as "2h ago", "3d ago" for CLI output
-- `serve()` -- starts the Axum server with all routes (42 endpoints including `POST /memories/{id}/promote` and 4 archive endpoints), spawns GC task, handles graceful shutdown via SIGINT with WAL checkpoint
+- `serve()` -- starts the Axum server with all routes (50 endpoints including `POST /memories/{id}/promote`, the 4 archive endpoints, the namespace-standard endpoints, and the webhook subscription endpoints), spawns GC task, handles graceful shutdown via SIGINT with WAL checkpoint
 - `cmd_*()` functions -- one per CLI command, each opens the DB directly
 
 ### `src/models.rs`
@@ -515,7 +515,7 @@ Base URL: `http://127.0.0.1:9077/api/v1`
 
 All responses are JSON. Error responses include `{"error": "message"}`. Database errors are sanitized -- clients receive `"Internal server error"` instead of raw SQLite error details.
 
-The HTTP API exposes **42 endpoints** (canonical count on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)).
+The HTTP API exposes **50 endpoints** in v0.6.3.1 (canonical count from `src/lib.rs:68-194` Router builder; v0.6.3 baseline of 42 is frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)).
 
 ### Health Check
 
@@ -786,7 +786,7 @@ Global flags:
 
 ### `serve`
 
-Start the HTTP daemon (42 endpoints).
+Start the HTTP daemon (50 endpoints).
 
 ```bash
 ai-memory serve --host 127.0.0.1 --port 9077
@@ -1007,7 +1007,7 @@ ai-memory completions fish
 
 ## Testing
 
-The project has **1,600 lib tests at 93.08% coverage** as of v0.6.3 — canonical numbers are frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); per-release detail on the [test-hub v0.6.3 evidence](https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/). Modules each carry their own unit-test suite; integration tests live under `tests/`.
+The project has **1,886 lib tests + 49+ integration tests at 93.84% line coverage** as of v0.6.3.1 (was 1,600 lib / 93.08% on v0.6.3). v0.6.3 baseline numbers are frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.3.1 deltas are documented in the release notes. Modules each carry their own unit-test suite; integration tests live under `tests/`.
 
 ```bash
 # Run all tests

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-> **BLUF (Bottom Line Up Front):** `ai-memory` is an AI-agnostic memory management system that works with **any MCP-compatible AI client** -- including Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, OpenClaw, and others. Install the binary, configure your AI client's MCP settings, and you get 21 memory tools instantly. The default `semantic` tier includes embedding-based hybrid recall out of the box. Total time: ~60 seconds (pre-built binary + fast internet; first semantic-tier run also downloads a ~100MB embedding model).
+> **BLUF (Bottom Line Up Front):** `ai-memory` is an AI-agnostic memory management system that works with **any MCP-compatible AI client** -- including Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, OpenClaw, and others. Install the binary, configure your AI client's MCP settings, and you get **43 MCP memory tools** instantly. The default `semantic` tier includes embedding-based hybrid recall out of the box. Total time: ~60 seconds (pre-built binary + fast internet; first semantic-tier run also downloads a ~100MB embedding model).
 
 ## Install in 60 Seconds (pre-built binary + fast internet)
 
@@ -93,7 +93,7 @@
 
 3. **Restart your AI client.**
 
-4. **Verify** -- you should see 21 new tools: `memory_store`, `memory_recall`, `memory_search`, `memory_list`, `memory_delete`, `memory_promote`, `memory_forget`, `memory_stats`, `memory_update`, `memory_get`, `memory_link`, `memory_get_links`, `memory_consolidate`, `memory_capabilities`, `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, `memory_archive_list`, `memory_archive_restore`, `memory_archive_purge`, `memory_archive_stats`.
+4. **Verify** -- you should see **43 new tools** registered. Highlights: `memory_store`, `memory_recall`, `memory_search`, `memory_list`, `memory_get`, `memory_update`, `memory_delete`, `memory_promote`, `memory_forget`, `memory_stats`, `memory_link`, `memory_get_links`, `memory_consolidate`, `memory_capabilities`, `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, `memory_archive_list`, `memory_archive_restore`, `memory_archive_purge`, `memory_archive_stats`, `memory_check_duplicate`, `memory_entity_register`, `memory_entity_get_by_alias`, `memory_kg_query`, `memory_kg_timeline`, `memory_kg_invalidate`, `memory_get_taxonomy`, `memory_namespace_set_standard`, `memory_namespace_get_standard`, `memory_namespace_clear_standard`, `memory_pending_list`, `memory_pending_approve`, `memory_pending_reject`, `memory_agent_register`, `memory_agent_list`, `memory_notify`, `memory_inbox`, `memory_subscribe`, `memory_unsubscribe`, `memory_list_subscriptions`, `memory_session_start`, `memory_gc`. Full per-tool reference: [API_REFERENCE.md](API_REFERENCE.md).
 
 5. **Test** -- ask your AI assistant to store a memory. It should use `memory_store` automatically.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -18,7 +18,7 @@ Verify:
 
 ```bash
 ai-memory --version
-# ai-memory 0.6.0
+# ai-memory 0.6.3+patch.1   (release tag: v0.6.3.1; +patch.N is the crates.io-compatible encoding)
 ```
 
 Full install reference including Windows, Docker, Fedora COPR, Ubuntu

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-## 🎯 Current stable release · **v0.6.3.1** · A2A-CERTIFIED · 1,600 lib tests · 93.08% cov
+## 🎯 Current stable release · **v0.6.3.1** · A2A-CERTIFIED · 1,886 lib tests + 49+ integration · 93.84% line coverage
 
 [![Release](https://img.shields.io/badge/release-v0.6.3.1-brightgreen?logo=github)](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3.1)
 [![A2A Gate](https://img.shields.io/badge/A2A_gate-9%2F9_green-brightgreen)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -91,15 +91,15 @@
   <g class="fade2">
     <rect x="90" y="140" width="160" height="60" class="card-green"/>
     <text x="170" y="164" text-anchor="middle" class="title">MCP Server</text>
-    <text x="170" y="181" text-anchor="middle" class="subtitle">stdio · JSON-RPC · 21 tools</text>
+    <text x="170" y="181" text-anchor="middle" class="subtitle">stdio · JSON-RPC · 43 tools</text>
 
     <rect x="345" y="140" width="160" height="60" class="card-green"/>
     <text x="425" y="164" text-anchor="middle" class="title">HTTP API</text>
-    <text x="425" y="181" text-anchor="middle" class="subtitle">REST · 42 endpoints · :9077</text>
+    <text x="425" y="181" text-anchor="middle" class="subtitle">REST · 50 endpoints · :9077</text>
 
     <rect x="600" y="140" width="160" height="60" class="card-green"/>
     <text x="680" y="164" text-anchor="middle" class="title">CLI</text>
-    <text x="680" y="181" text-anchor="middle" class="subtitle">26 commands · scriptable</text>
+    <text x="680" y="181" text-anchor="middle" class="subtitle">40 commands · scriptable</text>
   </g>
 
   <!-- Flow lines down to validation -->
@@ -130,7 +130,7 @@
     <!-- DB -->
     <text x="220" y="355" text-anchor="middle" class="title">SQLite + FTS5</text>
     <text x="220" y="372" text-anchor="middle" class="subtitle">WAL mode · 3 tables</text>
-    <text x="220" y="398" text-anchor="middle" class="subtitle">db.rs · schema v4</text>
+    <text x="220" y="398" text-anchor="middle" class="subtitle">db.rs · schema v19</text>
 
     <!-- Divider -->
     <line x1="330" y1="340" x2="330" y2="400" class="line" style="opacity:0.3"/>

--- a/docs/architectures.html
+++ b/docs/architectures.html
@@ -389,7 +389,7 @@ section p{margin-bottom:.85rem}
     </ul>
     <p>What stays the same:</p>
     <ul>
-      <li>The 43 MCP tools and 42 HTTP endpoints.</li>
+      <li>The 43 MCP tools and 50 HTTP endpoints.</li>
       <li>The recall pipeline (FTS5 + HNSW + adaptive blending).</li>
       <li>The tier model (<code>short</code> / <code>mid</code> / <code>long</code>).</li>
       <li>The namespace hierarchy and scope visibility filter.</li>

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -897,8 +897,8 @@ footer.site-foot a { color: var(--text-muted); }
   </div>
 
   <div class="pillars-icons" aria-hidden="true" style="margin-top:2.5rem;">
-    <span class="pillar-icon"><span class="dot p1"></span> 93.08% test coverage</span>
-    <span class="pillar-icon"><span class="dot p2"></span> 1,809 tests passing</span>
+    <span class="pillar-icon"><span class="dot p1"></span> 93.84% test coverage</span>
+    <span class="pillar-icon"><span class="dot p2"></span> 1,886 tests passing</span>
     <span class="pillar-icon"><span class="dot p3"></span> Apache-2.0 licensed</span>
   </div>
 </section>
@@ -1587,7 +1587,7 @@ footer.site-foot a { color: var(--text-muted); }
             <li>Hierarchical namespace paths (<code>projects/alpha/decisions</code>)</li>
             <li>Temporal-validity knowledge graph (recursive CTE today, AGE-ready for v0.7)</li>
             <li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>
-            <li>93.08% test coverage (1,809 tests passing across 4 platforms)</li>
+            <li>93.84% test coverage (1,886 lib tests + 49+ integration, across the ubuntu/macos/windows CI matrix; v0.6.3.1)</li>
             <li>Two SSRF defects discovered during campaign — fixed before tag</li>
           </ul>
         </div>

--- a/docs/feature-matrix.html
+++ b/docs/feature-matrix.html
@@ -549,7 +549,7 @@ footer a{color:var(--text-muted)}
 <!-- =============== HTTP ENDPOINTS =============== -->
 <section id="http-endpoints">
   <div class="container">
-    <span class="eyebrow">42 HTTP Endpoints</span>
+    <span class="eyebrow">50 HTTP Endpoints</span>
     <h2>REST surface for services + federation peers.</h2>
     <p class="lede">Axum-served. mTLS-aware. CORS layer. Prometheus metrics at <code>/metrics</code>. Body limit 2 MiB. Trace spans on every request. The same operations as MCP, plus federation-private peer endpoints.</p>
 
@@ -641,7 +641,7 @@ footer a{color:var(--text-muted)}
 <!-- =============== CLI =============== -->
 <section id="cli-commands">
   <div class="container">
-    <span class="eyebrow">26 CLI Commands</span>
+    <span class="eyebrow">40 CLI Commands</span>
     <h2>For humans, scripts, and CI.</h2>
     <p class="lede">Direct subcommands of the <code>ai-memory</code> binary. No daemon required for read/write commands. Run against any database file via <code>--db &lt;path&gt;</code>.</p>
 

--- a/docs/for-everyone.html
+++ b/docs/for-everyone.html
@@ -419,8 +419,8 @@ ai-memory mcp --tier autonomous</pre>
         <p style="font-size:.9rem">Commercial-friendly license. Patent grant included. <strong>You can read every line, fork it, sell what you build on top.</strong></p>
       </div>
       <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
-        <h3 style="margin-bottom:.5rem">93.08% test coverage</h3>
-        <p style="font-size:.9rem">1,809 tests (1,600 lib + 209 integration). Zero ignored. Four-platform CI (macOS / Ubuntu / Windows / Coverage). <strong>Every PR runs the full matrix.</strong></p>
+        <h3 style="margin-bottom:.5rem">93.84% test coverage</h3>
+        <p style="font-size:.9rem">1,886 lib tests + 49+ integration tests (v0.6.3.1; +281 net from v0.6.3 baseline). Zero ignored. CI matrix: macOS / Ubuntu / Windows. <strong>Every PR runs the full matrix.</strong></p>
       </div>
       <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;border-top:3px solid var(--p2)">
         <h3 style="margin-bottom:.5rem">Single binary</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -445,7 +445,7 @@
 
             <p class="bluf-section">
                 <strong>Substrate, not product.</strong>
-                Today: multi-agent federation with W-of-N quorum<span class="cap-pill cap-beta">beta</span>, autonomous curator that consolidates and detects contradictions, namespace-scoped governance, and a 43&#8202;tool / 42&#8202;endpoint / 26&#8202;command MCP &middot; HTTP &middot; CLI surface. Self-hosted, local-first, no cloud dependency, no vendor lock-in. <span class="bluf-coming">Coming in v0.7</span>: cryptographically-attested provenance (Ed25519), hash-chained audit logs, sidechain transcripts, and forensic export bundles &mdash; the regulated-industry primitives.
+                Today: multi-agent federation with W-of-N quorum<span class="cap-pill cap-beta">beta</span>, autonomous curator that consolidates and detects contradictions, namespace-scoped governance, and a 43&#8202;tool / 50&#8202;endpoint / 40&#8202;command MCP &middot; HTTP &middot; CLI surface. Self-hosted, local-first, no cloud dependency, no vendor lock-in. <span class="bluf-coming">Coming in v0.7</span>: cryptographically-attested provenance (Ed25519), hash-chained audit logs, sidechain transcripts, and forensic export bundles &mdash; the regulated-industry primitives.
             </p>
         </div>
         <p style="font-size:.85rem;color:var(--text-muted);margin-bottom:2rem">
@@ -455,11 +455,11 @@
             <div class="stat"><span class="num">97.8%</span><span class="label">Recall@5</span></div>
             <div class="stat"><span class="num">43</span><span class="label">MCP Tools</span></div>
             <div class="stat"><span class="num">4</span><span class="label">Operational Modes</span></div>
-            <div class="stat"><span class="num">1,809</span><span class="label">Tests</span></div>
+            <div class="stat"><span class="num">1,886</span><span class="label">Tests</span></div>
         </div>
         <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
             <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
-            <a href="https://alphaonedev.github.io/ai-memory-test-hub/" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">🧪 Live Test Results — 1,809 tests · 93.08% cov →</a>
+            <a href="https://alphaonedev.github.io/ai-memory-test-hub/" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">🧪 Live Test Results — 1,886 tests · 93.84% cov →</a>
             <a href="evidence.html" class="hero-cta" style="background:transparent;border:1px solid #c8a2ff;color:#c8a2ff">📐 Frozen Claims (Evidence) →</a>
             <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #999;color:#999">📊 Visualization Atlas →</a>
             <a href="whats-new-v063.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">✨ What's New in v0.6.3 →</a>
@@ -1602,11 +1602,11 @@ ai-memory list -n my-project                                         <span class
 </section>
 
 <!-- ================================================================
-     42 HTTP API ENDPOINTS
+     50 HTTP API ENDPOINTS
      ================================================================ -->
 <section id="api" class="alt">
     <div class="container">
-        <h2>42 HTTP API Endpoints <span class="badge">Universal Fallback</span></h2>
+        <h2>50 HTTP API Endpoints <span class="badge">Universal Fallback</span></h2>
         <p class="section-subtitle">
             Start with <code>ai-memory serve</code> (default: <code>http://127.0.0.1:9077</code>).
             The HTTP API works with any AI platform, any programming language, any framework. If it can make an HTTP request, it can use ai-memory.
@@ -1661,11 +1661,11 @@ ai-memory list -n my-project                                         <span class
 </section>
 
 <!-- ================================================================
-     26 CLI COMMANDS
+     40 CLI COMMANDS
      ================================================================ -->
 <section id="cli">
     <div class="container">
-        <h2>26 CLI Commands <span class="badge">Universal</span></h2>
+        <h2>40 CLI Commands <span class="badge">Universal</span></h2>
         <p class="section-subtitle">
             Global flags: <code>--db &lt;path&gt;</code> and <code>--json</code>.
             Scriptable, pipeable, works in any shell. Use directly or wrap in your AI's tool layer.
@@ -1967,7 +1967,7 @@ ai-memory list -n my-project                                         <span class
                 <!-- Three interfaces -->
                 <rect x="30" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#cccccc" stroke-width="1.5"/>
                 <text x="100" y="102" text-anchor="middle" fill="#cccccc" font-family="system-ui" font-size="12" font-weight="700">CLI</text>
-                <text x="100" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">26 commands</text>
+                <text x="100" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">40 commands</text>
 
                 <rect x="280" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#bbbbbb" stroke-width="1.5"/>
                 <text x="350" y="102" text-anchor="middle" fill="#bbbbbb" font-family="system-ui" font-size="12" font-weight="700">MCP Server</text>
@@ -1975,7 +1975,7 @@ ai-memory list -n my-project                                         <span class
 
                 <rect x="530" y="80" width="140" height="48" rx="8" fill="#111111" stroke="#999999" stroke-width="1.5"/>
                 <text x="600" y="102" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="12" font-weight="700">HTTP API</text>
-                <text x="600" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">42 endpoints / Axum</text>
+                <text x="600" y="118" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">50 endpoints / Axum</text>
 
                 <!-- Labels under interfaces -->
                 <text x="100" y="146" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="8">Universal</text>
@@ -2060,7 +2060,7 @@ ai-memory list -n my-project                                         <span class
                 <!-- DB layer -->
                 <rect x="120" y="352" width="360" height="55" rx="8" fill="#111111" stroke="#dddddd" stroke-width="2"/>
                 <text x="300" y="375" text-anchor="middle" fill="#dddddd" font-family="system-ui" font-size="13" font-weight="700">SQLite + FTS5 + HNSW (db.rs)</text>
-                <text x="300" y="395" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">WAL mode | schema v5 | embeddings | 1,809 tests</text>
+                <text x="300" y="395" text-anchor="middle" fill="#999999" font-family="system-ui" font-size="10">WAL mode | schema v19 | embeddings | 1,886 lib tests</text>
 
                 <!-- Memory tiers -->
                 <rect x="145" y="420" width="70" height="22" rx="4" fill="rgba(255,255,255,.15)" stroke="#ffffff" stroke-width="1"/>
@@ -2239,7 +2239,7 @@ ai-memory list -n my-project                                         <span class
 
                 <rect x="327" y="30" width="80" height="40" rx="6" fill="#111111" stroke="#bbbbbb" stroke-width="1"/>
                 <text x="367" y="48" text-anchor="middle" fill="#bbbbbb" font-family="monospace" font-size="10">test</text>
-                <text x="367" y="62" text-anchor="middle" fill="#999999" font-family="monospace" font-size="9">1,809 tests</text>
+                <text x="367" y="62" text-anchor="middle" fill="#999999" font-family="monospace" font-size="9">1,886 lib tests</text>
 
                 <line x1="407" y1="50" x2="427" y2="50" stroke="#333333" stroke-width="1.5" class="animate-flow"/>
 

--- a/docs/schema.html
+++ b/docs/schema.html
@@ -162,11 +162,11 @@ footer a{color:var(--text-muted)}
 
 <section class="hero">
   <h1>The schema, table by table.</h1>
-  <p class="tagline">Every SQLite table ai-memory creates, every column, every index, every foreign key. Postgres mirror via the SAL adapter (<code>--features sal</code>). Schema version: <strong>v15</strong>.</p>
+  <p class="tagline">Every SQLite table ai-memory creates, every column, every index, every foreign key. Postgres mirror via the SAL adapter (<code>--features sal</code>). Schema version: <strong>v19</strong> (Patch 1; ladder v15→v17→v18→v19 is automatic on first run).</p>
   <div class="pills">
     <span class="pill">9 tables</span>
     <span class="pill">15+ indexes</span>
-    <span class="pill">v15 schema</span>
+    <span class="pill">v19 schema</span>
     <span class="pill">SQLite + Postgres mirror</span>
   </div>
 </section>
@@ -364,7 +364,7 @@ footer a{color:var(--text-muted)}
       <div class="tbl-desc">Single-row table. Tracks current schema version. Daemon checks at startup; runs forward migrations idempotently. Current version: <strong>15</strong> (Stream B hierarchy + KG additions).</div>
       <table class="cols">
         <tbody>
-          <tr><td class="col">version</td><td class="type">INTEGER NOT NULL</td><td class="note">Currently 15. Bumped only on additive migrations.</td></tr>
+          <tr><td class="col">version</td><td class="type">INTEGER NOT NULL</td><td class="note">Currently 19 (Patch 1). Bumped only on additive migrations. Migration ladder v15→v17→v18→v19 runs automatically at daemon start.</td></tr>
         </tbody>
       </table>
     </div>
@@ -504,7 +504,7 @@ footer a{color:var(--text-muted)}
   <div class="container">
     <span class="eyebrow">Migrations</span>
     <h2 style="font-family:var(--font-sans);font-size:1.75rem">Schema is versioned. Migrations are idempotent.</h2>
-    <p class="lede">Every schema change is a forward migration applied at daemon startup. Idempotent so re-runs are safe. v15 was the v0.6.3 Stream B addition. Older versions are inline in <code>db.rs::migrate</code>; v15 is the first extracted to <code>migrations/sqlite/0010_v063_hierarchy_kg.sql</code>.</p>
+    <p class="lede">Every schema change is a forward migration applied at daemon startup. Idempotent so re-runs are safe. v15 was the v0.6.3 Stream B addition (KG temporal-validity columns + entity_aliases). v0.6.3.1 added the v17/v18/v19 ladder: v17 adds governance.inherit backfill (`migrations/sqlite/0012_governance_inherit.sql`), v18 adds embedding_dim guard + archive lossless (`0011_v0631_data_integrity.sql`), v19 adds webhook event_types column + index (`0013_webhook_event_types.sql`). Older versions (≤ v14) remain inline in <code>db.rs::migrate</code>.</p>
 
     <div class="tbl t-meta">
       <div class="tbl-head">

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -2,18 +2,20 @@
   Copyright 2026 AlphaOne LLC
   SPDX-License-Identifier: Apache-2.0
 
-  What's New in v0.6.3 — release-spotlight page covering Streams A-F,
-  the W3-W12 coverage campaign, the SSRF security finding+fix, and
-  the v0.6.3.1 capabilities-extension queued patch. Companion to
-  at-a-glance.html.
+  What's New page — primary surface for v0.6.3.1 (current release,
+  shipped 2026-04-30) plus the v0.6.3 GA baseline (Streams A-F, the
+  W3-W12 coverage campaign, the SSRF security finding+fix). The
+  Patch 1 section at the top covers the seven new CLI surfaces, the
+  schema v15→v19 ladder, the 17-integration matrix, and the 5
+  distribution channels. Companion to at-a-glance.html.
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>What's New in v0.6.3 — Structured Memory + Performance</title>
-<meta name="description" content="v0.6.3 release highlights: hierarchical namespaces, temporal-validity knowledge graph, published performance budgets, 93.08% test coverage, 1,809 tests (1,600 lib + 209 integration), 2 SSRF defects fixed.">
+<title>What's New in v0.6.3 / v0.6.3.1 — The Never-Lose-Context Release</title>
+<meta name="description" content="v0.6.3.1 release highlights: 7 new CLI surfaces (boot, install, wrap, logs, audit, doctor, bench), schema v19 (ladder v15→v17→v18→v19), 1,886 lib tests + 49+ integration at 93.84% line coverage, 17 documented integrations across 10 platforms, 5 distribution channels. Builds on v0.6.3's three pillars (hierarchy, knowledge graph, performance budgets).">
 <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/whats-new-v063.html">
 <style>
 :root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#6ee7ff;--warn:#ffb86b;--bad:#ff6b9d;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1280px}
@@ -121,10 +123,10 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
 
 <nav class="topnav">
   <div class="inner">
-    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ What's New v0.6.3</span></a>
+    <a class="home-link" href="./">ai-memory <span style="opacity:.5">▸ What's New v0.6.3 / v0.6.3.1</span></a>
     <div class="right">
       <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
-      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3 / v0.6.3.1</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
@@ -192,26 +194,57 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
 </nav>
 
 <section class="hero">
-  <div class="badge">v0.6.3-rc1 · TAGGED 2026-04-26</div>
-  <h1>Structured Memory<br>+ Performance.</h1>
-  <p class="subtitle">The grand-slam release. Three pillars shipped in one focused 4-week sprint: hierarchical namespace tree, temporal-validity knowledge graph, and CI-enforced sub-100ms performance budgets.</p>
+  <div class="badge">v0.6.3.1 · SHIPPED 2026-04-30</div>
+  <h1>Never Lose<br>Context.</h1>
+  <p class="subtitle">The current release. v0.6.3 shipped the three-pillar grand slam — hierarchy, knowledge graph, performance budgets. v0.6.3.1 (Patch 1) ships 16 PRs resolving issue #487: cold-start AI sessions auto-load memory context. Schema v19, seven new CLI surfaces, 17 documented integrations.</p>
   <div class="meta">
-    <span>56.7% → <strong style="color:var(--good)">93.08%</strong> coverage</span>
+    <span>93.08% → <strong style="color:var(--good)">93.84%</strong> coverage</span>
     <span style="opacity:.4">·</span>
-    <span><strong style="color:var(--text)">1,809</strong> tests passing</span>
+    <span><strong style="color:var(--text)">1,886</strong> lib tests + 49+ integration</span>
     <span style="opacity:.4">·</span>
-    <span><strong style="color:var(--text)">26</strong> closers · <strong style="color:var(--text)">9</strong> waves</span>
+    <span>schema <strong style="color:var(--text)">v15 → v19</strong></span>
     <span style="opacity:.4">·</span>
-    <span><strong style="color:var(--bad)">2</strong> SSRF defects fixed</span>
+    <span><strong style="color:var(--text)">17</strong> integrations · <strong style="color:var(--text)">10</strong> platforms · <strong style="color:var(--text)">5</strong> channels</span>
+  </div>
+</section>
+
+<!-- =============== PATCH 1 (v0.6.3.1) — NEVER-LOSE-CONTEXT ============== -->
+<section id="patch1" style="background:linear-gradient(135deg,rgba(110,231,255,0.04),rgba(200,162,255,0.04))">
+  <div class="container">
+    <span class="eyebrow">Patch 1 · v0.6.3.1 · Shipped 2026-04-30</span>
+    <h2>What v0.6.3.1 ships.</h2>
+    <p class="lede">Patch 1 closes <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/487" style="color:var(--p1)">issue #487</a> — every AI session now starts memory-aware. 16 PRs land seven new CLI surfaces, the v15→v19 schema ladder, and the integration matrix that gets ai-memory into Claude / Cursor / Codex / Cline / Continue / Windsurf / OpenClaw / Aider / Gemini / Cody and 7 more — all with one command.</p>
+
+    <div class="tile-grid">
+      <div class="tile p1"><div class="tile-label">New CLI surface</div><div class="tile-num" style="font-size:1.4rem">ai-memory boot</div><div class="tile-sub" style="margin-top:.5rem">Universal session-boot primitive. 5-field diagnostic manifest. 4 status variants (<code>ok</code> / <code>info-fallback</code> / <code>info-empty</code> / <code>warn</code>) — never silent. <code>text</code> / <code>json</code> / <code>toon</code> output.</div></div>
+      <div class="tile p1"><div class="tile-label">New CLI surface</div><div class="tile-num" style="font-size:1.4rem">ai-memory install</div><div class="tile-sub" style="margin-top:.5rem">6 targets: <code>claude-code</code>, <code>openclaw</code>, <code>cursor</code>, <code>cline</code>, <code>continue</code>, <code>windsurf</code>. Idempotent marker block, <code>--dry-run</code> default with unified-diff, <code>--apply</code> opt-in, <code>--uninstall</code> round-trip.</div></div>
+      <div class="tile p1"><div class="tile-label">New CLI surface</div><div class="tile-num" style="font-size:1.4rem">ai-memory wrap</div><div class="tile-sub" style="margin-top:.5rem">Cross-platform Rust replacement for shell glue. Strategies: <code>SystemFlag</code> / <code>SystemEnv</code> / <code>MessageFile</code> / <code>Auto</code>. Same binary on macOS / Linux / Windows / Docker / Kubernetes.</div></div>
+      <div class="tile p2"><div class="tile-label">New CLI surface</div><div class="tile-num" style="font-size:1.4rem">ai-memory logs</div><div class="tile-sub" style="margin-top:.5rem">Operational logging CLI. <code>tail</code> / <code>cat</code> / <code>archive</code> / <code>purge</code> with <code>--since</code> / <code>--until</code> / <code>--level</code> / <code>--namespace</code> / <code>--actor</code> filters. Default-OFF (privacy).</div></div>
+      <div class="tile p2"><div class="tile-label">New CLI surface</div><div class="tile-num" style="font-size:1.4rem">ai-memory audit verify</div><div class="tile-sub" style="margin-top:.5rem">Walks the hash-chained audit log. Exit <code>0</code> on integrity, <code>2</code> on tamper detection. Append-only at the OS level (<code>chattr +a</code> / <code>fs_chflags UF_APPEND</code>).</div></div>
+      <div class="tile p2"><div class="tile-label">Hardened</div><div class="tile-num" style="font-size:1.4rem">ai-memory doctor</div><div class="tile-sub" style="margin-top:.5rem">7-section health dashboard: Storage / Index / Recall / Governance / Sync / Webhook / Capabilities. Severity-tagged. JSON mode. Exit codes <code>0</code>/<code>1</code>/<code>2</code>.</div></div>
+      <div class="tile p3"><div class="tile-label">Schema</div><div class="tile-num">v19</div><div class="tile-sub" style="margin-top:.5rem">Ladder v15→v17→v18→v19 runs automatically at first start. v17: governance.inherit backfill. v18: embedding_dim guard + archive lossless. v19: subscriptions.event_types.</div></div>
+      <div class="tile p3"><div class="tile-label">Integrations documented</div><div class="tile-num">17</div><div class="tile-sub" style="margin-top:.5rem">3 categories: hook-capable (Claude Code) · MCP+rules (Cursor, Cline, Continue, Windsurf, OpenClaw, Goose, Zed, Roo-Code) · programmatic (Codex CLI, Claude SDK, OpenAI Apps/Assistants/Responses, Grok, Gemini, Aider, Cody, Hermes/Llama/Mistral/Qwen via LM Studio/Ollama/vLLM).</div></div>
+      <div class="tile p3"><div class="tile-label">Platforms documented</div><div class="tile-num">10</div><div class="tile-sub" style="margin-top:.5rem">macOS (Apple Silicon + Intel), Linux glibc x86_64 + aarch64, Linux musl (Alpine), Windows native (10/11), WSL2, Docker, Kubernetes, ARM Linux, Commercial Unix (best-effort), Embedded Linux (best-effort).</div></div>
+      <div class="tile good"><div class="tile-label">Distribution channels (verified live)</div><div class="tile-num">5</div><div class="tile-sub" style="margin-top:.5rem">GitHub Release (11 assets), Homebrew tap, ghcr.io, Fedora COPR (build #10412670), crates.io. crates.io anchor at <code>0.6.3+patch.1</code> (SemVer build metadata; crates.io rejects 4-segment versions).</div></div>
+      <div class="tile good"><div class="tile-label">Tests (v0.6.3.1)</div><div class="tile-num">1,886</div><div class="tile-sub" style="margin-top:.5rem">+281 from v0.6.3 baseline (1,605). Plus 49+ integration tests. E2E smoke 7/7 PASS via the audit phase. Zero ignored.</div></div>
+      <div class="tile good"><div class="tile-label">Coverage (v0.6.3.1)</div><div class="tile-num">93.84<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub" style="margin-top:.5rem">Line coverage. Gate ≥ 93%, buffer +0.84pp. <code>cargo llvm-cov --features sal --no-fail-fast --fail-under-lines 93</code>.</div></div>
+      <div class="tile" style="border-top:3px solid var(--warn)"><div class="tile-label">Known issue</div><div class="tile-num" style="font-size:1.4rem;color:var(--warn)">#507</div><div class="tile-sub" style="margin-top:.5rem">config.toml <code>db</code> field does not expand <code>~</code> to <code>$HOME</code>. Workaround: use absolute path. Fix scheduled for v0.6.3.2. CLI flag <code>--db</code> already expands correctly.</div></div>
+    </div>
+
+    <div style="margin-top:2.5rem;background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem">
+      <strong>One-command setup for Claude Code:</strong>
+      <pre style="font-family:var(--font-mono);font-size:.9rem;background:var(--bg-code);padding:.85rem 1rem;margin-top:.6rem;border-radius:6px;color:var(--good);white-space:pre">brew install ai-memory && ai-memory install claude-code --apply</pre>
+      <p style="margin-top:.85rem;font-size:.85rem">Restart Claude Code. Every fresh session now starts memory-aware. Run <code>ai-memory boot</code> from any shell to see the diagnostic manifest. For other agents, see the per-host recipes in <a href="https://github.com/alphaonedev/ai-memory-mcp/tree/main/docs/integrations" style="color:var(--p1)">docs/integrations/</a>.</p>
+    </div>
   </div>
 </section>
 
 <!-- =============== THE THREE PILLARS, EXPANDED =============== -->
 <section id="streams">
   <div class="container">
-    <span class="eyebrow">6 Engineering Streams</span>
+    <span class="eyebrow">6 Engineering Streams (v0.6.3 GA baseline)</span>
     <h2>Streams A–F. Six teams. One release.</h2>
-    <p class="lede">v0.6.3 was scoped as six work-streams, each independently shippable but compounding when released together. All six landed; campaign closed at 93.08% line coverage.</p>
+    <p class="lede">The v0.6.3 GA was scoped as six work-streams, each independently shippable but compounding when released together. All six landed; campaign closed at 93.08% line coverage / 1,809 tests. v0.6.3.1 (Patch 1, see above) builds on this baseline, raising coverage to 93.84% and adding the seven CLI surfaces.</p>
 
     <div class="streams-grid">
       <div class="stream A">
@@ -309,9 +342,9 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
 <!-- =============== COVERAGE CAMPAIGN =============== -->
 <section id="coverage-campaign">
   <div class="container">
-    <span class="eyebrow">W3-W12 Coverage Campaign</span>
-    <h2>56.7% → 93.08% in 9 waves.</h2>
-    <p class="lede">After streams A-F shipped, a parallel-agent coverage campaign drove ai-memory from 56.7% line coverage to 93.08% across nine waves. 26 closers in total. ~1,200 net new tests. Two production SSRF defects discovered + fixed during the work.</p>
+    <span class="eyebrow">W3-W12 Coverage Campaign (v0.6.3 GA baseline)</span>
+    <h2>56.7% → 93.08% in 9 waves; v0.6.3.1 raised it to 93.84%.</h2>
+    <p class="lede">After streams A-F shipped for v0.6.3, a parallel-agent coverage campaign drove ai-memory from 56.7% line coverage to 93.08% across nine waves. 26 closers in total. ~1,200 net new tests. Two production SSRF defects discovered + fixed during the work. v0.6.3.1 added 281 net new lib tests on top of this baseline (final: 1,886 lib + 49+ integration), raising line coverage to 93.84%.</p>
 
     <div class="waves-track">
       <div class="waves-row">
@@ -425,7 +458,7 @@ fn is_private(ip: IpAddr) -> bool {
 
     <div style="background:var(--bg-card);border:1px solid var(--good);border-radius:12px;padding:1.5rem;margin-top:2rem">
       <strong style="color:var(--good)">No outstanding security defects post-campaign.</strong>
-      <p style="margin-top:.5rem">The SSRF fixes shipped with rc1. Both <code>#[ignore]</code> tests are un-ignored and passing. <strong>Zero ignored tests across the whole 1,809-test suite (1,600 lib + 209 integration).</strong>
+      <p style="margin-top:.5rem">The SSRF fixes shipped with rc1. Both <code>#[ignore]</code> tests are un-ignored and passing. <strong>Zero ignored tests in the v0.6.3 1,809-test baseline; the v0.6.3.1 suite stands at 1,886 lib + 49+ integration tests, also zero ignored.</strong>
     </p>
     </div>
   </div>
@@ -436,21 +469,21 @@ fn is_private(ip: IpAddr) -> bool {
   <div class="container">
     <span class="eyebrow">By the Numbers</span>
     <h2>Every quantitative claim, sourced.</h2>
-    <p class="lede">All numbers from the v0.6.3 W12 consolidated coverage measurement (canonical command in CAMPAIGN-FINAL-METRICS.md). Hardware: Apple M4 / 32 GB / NVMe SSD.</p>
+    <p class="lede">v0.6.3.1 numbers are from the release notes (published 2026-04-30). v0.6.3 GA baseline numbers are from the W12 consolidated coverage measurement and remain frozen on the <a href="evidence.html" style="color:var(--p1)">evidence page</a>. Hardware: Apple M4 / 32 GB / NVMe SSD.</p>
 
     <div class="tile-grid">
-      <div class="tile p1"><div class="tile-label">Line coverage</div><div class="tile-num">93.08<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">42,894 / 46,099 lines (release-cut 93.05%)</div></div>
-      <div class="tile p1"><div class="tile-label">Region coverage</div><div class="tile-num">93.11<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">73,150 / 78,564 regions</div></div>
-      <div class="tile p1"><div class="tile-label">Function coverage</div><div class="tile-num">92.55<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">3,527 / 3,811 functions</div></div>
-      <div class="tile good"><div class="tile-label">Tests passing</div><div class="tile-num">1,809</div><div class="tile-sub">1,600 lib + 209 integration · 0 failed · 0 ignored</div></div>
-      <div class="tile good"><div class="tile-label">Net new tests</div><div class="tile-num">~1,200</div><div class="tile-sub">across W3-W12</div></div>
-      <div class="tile p2"><div class="tile-label">Closers dispatched</div><div class="tile-num">26</div><div class="tile-sub">across 9 waves</div></div>
+      <div class="tile p1"><div class="tile-label">Line coverage (v0.6.3.1)</div><div class="tile-num">93.84<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">gate ≥ 93%, buffer +0.84pp · v0.6.3 baseline 93.08%</div></div>
+      <div class="tile p1"><div class="tile-label">Region coverage (v0.6.3 baseline)</div><div class="tile-num">93.11<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">73,150 / 78,564 regions</div></div>
+      <div class="tile p1"><div class="tile-label">Function coverage (v0.6.3 baseline)</div><div class="tile-num">92.55<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">3,527 / 3,811 functions</div></div>
+      <div class="tile good"><div class="tile-label">Lib tests (v0.6.3.1)</div><div class="tile-num">1,886</div><div class="tile-sub">+281 from v0.6.3 baseline (1,605) · 0 ignored</div></div>
+      <div class="tile good"><div class="tile-label">Integration tests (v0.6.3.1)</div><div class="tile-num">49+</div><div class="tile-sub">boot primitive contract + recipe + lifecycle + dispatch · E2E 7/7 PASS</div></div>
+      <div class="tile p2"><div class="tile-label">Net new tests (W3-W12 baseline)</div><div class="tile-num">~1,200</div><div class="tile-sub">across the v0.6.3 coverage campaign</div></div>
+      <div class="tile p2"><div class="tile-label">Closers dispatched (W3-W12)</div><div class="tile-num">26</div><div class="tile-sub">across 9 waves</div></div>
       <div class="tile p2"><div class="tile-label">main.rs reduction</div><div class="tile-num">98.3<span style="font-size:1rem;color:var(--text-dim)">%</span></div><div class="tile-sub">4,511 → 75 lines</div></div>
-      <div class="tile p3"><div class="tile-label">Session-start p95</div><div class="tile-num">42<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 100 ms</div></div>
-      <div class="tile p3"><div class="tile-label">Recall p95 hot</div><div class="tile-num">18<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 50 ms</div></div>
-      <div class="tile p3"><div class="tile-label">Federation ack p99</div><div class="tile-num">850<span style="font-size:1rem;color:var(--text-dim)">ms</span></div><div class="tile-sub">budget &lt; 2 s</div></div>
-      <div class="tile"><div class="tile-label">Modules at 100%</div><div class="tile-num">7</div><div class="tile-sub">main · errors · color · ...</div></div>
-      <div class="tile"><div class="tile-label">SSRF fixed</div><div class="tile-num">2</div><div class="tile-sub">found + fixed pre-tag</div></div>
+      <div class="tile p3"><div class="tile-label">Schema (v0.6.3.1)</div><div class="tile-num">v19</div><div class="tile-sub">ladder v15→v17→v18→v19 automatic on first run</div></div>
+      <div class="tile p3"><div class="tile-label">MCP tools / HTTP / CLI</div><div class="tile-num" style="font-size:1.4rem">43 / 50 / 40</div><div class="tile-sub">tools / endpoints / subcommands · 133 ops total</div></div>
+      <div class="tile p3"><div class="tile-label">Integrations · Platforms · Channels</div><div class="tile-num" style="font-size:1.4rem">17 / 10 / 5</div><div class="tile-sub">documented in v0.6.3.1 release notes</div></div>
+      <div class="tile good"><div class="tile-label">SSRF fixed (v0.6.3 W11)</div><div class="tile-num">2</div><div class="tile-sub">found + fixed pre-tag · zero outstanding</div></div>
     </div>
   </div>
 </section>
@@ -459,32 +492,35 @@ fn is_private(ip: IpAddr) -> bool {
 <section id="upgrade">
   <div class="container">
     <span class="eyebrow">Upgrading</span>
-    <h2>v0.6.2 → v0.6.3 in one command.</h2>
-    <p class="lede">SQLite migration is idempotent. The schema-v15 migration runs at first daemon start. Existing flat namespaces become single-segment hierarchical paths losslessly. Postgres backend has a manual procedure documented in MIGRATION-v0.6.2-to-v0.6.3.md.</p>
+    <h2>v0.6.2 / v0.6.3 / v0.6.3+patch.x → v0.6.3.1 in one command.</h2>
+    <p class="lede">SQLite migration is idempotent. The schema ladder v15→v17→v18→v19 runs automatically at first daemon start. Existing flat namespaces become single-segment hierarchical paths losslessly. Postgres backend has a manual procedure documented in <code>MIGRATION-v0.6.3-to-v0.6.3.1.md</code>.</p>
 
     <div style="background:var(--bg-code);border:1px solid var(--border);border-radius:12px;padding:1.5rem;font-family:var(--font-mono);font-size:.85rem;line-height:1.7;color:var(--text)">
-<span style="color:var(--text-dim)"># Homebrew</span><br>
-brew upgrade ai-memory<br><br>
-<span style="color:var(--text-dim)"># cargo</span><br>
+<span style="color:var(--text-dim)"># Homebrew tap (recommended)</span><br>
+brew install alphaonedev/tap/ai-memory     <span style="color:var(--text-dim)"># first-time install</span><br>
+brew upgrade ai-memory                     <span style="color:var(--text-dim)"># subsequent upgrades</span><br><br>
+<span style="color:var(--text-dim)"># cargo (any Rust target)</span><br>
 cargo install ai-memory --force<br><br>
-<span style="color:var(--text-dim)"># APT (Debian/Ubuntu)</span><br>
-sudo apt update &amp;&amp; sudo apt install --only-upgrade ai-memory<br><br>
-<span style="color:var(--text-dim)"># DNF/YUM (Fedora/RHEL)</span><br>
-sudo dnf upgrade ai-memory<br><br>
+<span style="color:var(--text-dim)"># Docker (ghcr.io)</span><br>
+docker pull ghcr.io/alphaonedev/ai-memory:0.6.3.1<br><br>
+<span style="color:var(--text-dim)"># Fedora COPR</span><br>
+sudo dnf copr enable alpha-one-ai/ai-memory &amp;&amp; sudo dnf install ai-memory<br><br>
 <span style="color:var(--text-dim)"># Verify</span><br>
-ai-memory --version <span style="color:var(--p1)"># → ai-memory 0.6.3-rc1</span>
+ai-memory --version <span style="color:var(--p1)"># → ai-memory 0.6.3+patch.1   (release tag: v0.6.3.1)</span>
     </div>
 
     <div style="background:var(--bg-card);border:1px solid var(--border-hl);border-radius:12px;padding:1.5rem;margin-top:1.5rem">
-      <strong>What happens at first start:</strong>
+      <strong>What happens at first start (schema ladder v15 → v19):</strong>
       <ol style="color:var(--text-muted);margin-top:.6rem;padding-left:1.5rem;font-size:.9rem">
-        <li>Daemon detects schema version &lt; 15</li>
-        <li>Runs migrations/sqlite/0010_v063_hierarchy_kg.sql idempotently</li>
-        <li>Backfills <code>memory_links.valid_from</code> from source memory's <code>created_at</code></li>
-        <li>Adds entity_aliases table</li>
-        <li>Bumps schema_version to 15</li>
+        <li>Daemon detects schema version &lt; 19</li>
+        <li>Runs <code>migrations/sqlite/0010_v063_hierarchy_kg.sql</code> (v15: KG temporal-validity columns + entity_aliases)</li>
+        <li>Runs <code>migrations/sqlite/0012_governance_inherit.sql</code> (v17: governance.inherit backfill)</li>
+        <li>Runs <code>migrations/sqlite/0011_v0631_data_integrity.sql</code> (v18: embedding_dim guard + archive lossless)</li>
+        <li>Runs <code>migrations/sqlite/0013_webhook_event_types.sql</code> (v19: subscriptions.event_types column + index)</li>
+        <li>Bumps <code>schema_version</code> to 19</li>
         <li>Existing memories untouched. Existing recall continues to work.</li>
       </ol>
+      <p style="margin-top:.85rem;font-size:.85rem"><strong style="color:var(--warn)">Known issue (#507):</strong> if your <code>~/.config/ai-memory/config.toml</code> has a tilde-prefixed <code>db</code> path (<code>db = "~/..."</code>), CLI subcommands can't expand it; the MCP server is unaffected. Workaround: switch to an absolute path until v0.6.3.2.</p>
     </div>
   </div>
 </section>
@@ -493,28 +529,28 @@ ai-memory --version <span style="color:var(--p1)"># → ai-memory 0.6.3-rc1</spa
 <section id="next">
   <div class="container">
     <span class="eyebrow">Coming Next</span>
-    <h2>v0.6.3.1 patch and v0.7 charter.</h2>
+    <h2>v0.6.3.2 (patch fix) and v0.7 (major).</h2>
 
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
-      <div class="tile p1" style="grid-column:span 1">
-        <div class="tile-label">Patch · within days</div>
-        <div class="tile-num" style="font-size:1.4rem">v0.6.3.1</div>
-        <div class="tile-sub" style="margin-top:.65rem">Capabilities Extension · <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/457" style="color:var(--p1)">#457</a><br>schema_version=2 reports hooks, permissions, compaction status, approval subscribers.</div>
+      <div class="tile" style="grid-column:span 1;border-top:3px solid var(--warn)">
+        <div class="tile-label">Patch · scheduled</div>
+        <div class="tile-num" style="font-size:1.4rem">v0.6.3.2</div>
+        <div class="tile-sub" style="margin-top:.65rem">Fix #507 — config.toml <code>db</code> field tilde-expansion. CLI flag <code>--db</code> already expands; only the config-file path is affected. Tracked at <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/507" style="color:var(--warn)">#507</a>. Not blocking the v0.6.3.1 ship-gate.</div>
       </div>
       <div class="tile p2" style="grid-column:span 1">
         <div class="tile-label">Major · End Q2 2026</div>
         <div class="tile-num" style="font-size:1.4rem">v0.7</div>
-        <div class="tile-sub" style="margin-top:.65rem">Trust + A2A Maturity · 4 buckets<br>Hook Pipeline · Ed25519 attest · Apache AGE · A2A maturity + per-agent quotas.</div>
+        <div class="tile-sub" style="margin-top:.65rem">Trust + A2A Maturity · 4 buckets<br>Hook Pipeline · Ed25519 attest · Apache AGE · A2A maturity + per-agent quotas. Cleans up <code>memory_reflection</code> capabilities theater (planned-vs-shipped honesty).</div>
       </div>
     </div>
 
-    <p style="margin-top:1.5rem;color:var(--text-muted)">See <a href="at-a-glance.html#roadmap" style="color:var(--p1)">at-a-glance.html roadmap</a> or the <a href="https://github.com/alphaonedev/ai-memory-mcp-dev/blob/develop/ROADMAP.md" style="color:var(--p1)">public ROADMAP.md</a>.</p>
+    <p style="margin-top:1.5rem;color:var(--text-muted)">See <a href="at-a-glance.html#roadmap" style="color:var(--p1)">at-a-glance.html roadmap</a> or the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/ROADMAP.md" style="color:var(--p1)">public ROADMAP.md</a>.</p>
   </div>
 </section>
 
 <footer>
   <div class="container">
-    <p>v0.6.3-rc1 tagged 2026-04-26 · <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3-rc1" style="color:var(--text-muted)">GitHub release</a> · <a href="./" style="color:var(--text-muted)">main</a></p>
+    <p>v0.6.3.1 tagged 2026-04-30 · <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3.1" style="color:var(--text-muted)">GitHub release</a> · v0.6.3 GA tagged 2026-04-27 · <a href="./" style="color:var(--text-muted)">main</a></p>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

Full-spectrum docs-only sweep against the canonical v0.6.3.1 release ([release notes](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3.1)). Targets capability inventory drift (what features actually exist in v0.6.3.1) and quantitative drift (counts, schema, coverage, tests).

17 files changed, +158/−122. Strictly docs and GitHub Pages — every changed path matches `^(docs/|.*\.md$)`. The `ci.yml` `classify` job will short-circuit the Rust matrix; the release job (gated `refs/tags/v*`) cannot fire on PR merge. No `.rs`, `Cargo.toml`, `migrations/`, `.github/workflows/` changes.

## Ground truth applied

| Item | Pre-Patch 1 | v0.6.3.1 |
|---|---|---|
| Schema | v15 | **v19** (ladder v15→v17→v18→v19 automatic) |
| Lib tests | 1,605 | **1,886** (+281 net) |
| Integration tests | 209 | **49+** (newer test set; counts the new boot/lifecycle/dispatch suites) |
| Line coverage | 93.08% | **93.84%** (gate ≥93%, buffer +0.84pp) |
| MCP tools | 23 / 26 / 21 (various stale) | **43** |
| HTTP endpoints | 42 | **50** |
| CLI subcommands | 26 | **40** |
| New CLI surfaces | — | **boot, install (6 targets), wrap, logs, audit, doctor (hardened), bench** |
| Documented integrations | scattered | **17** (3 categories) |
| Documented platforms | partial | **10** |
| Distribution channels | — | **5** (GitHub / Homebrew / ghcr.io / Fedora COPR / crates.io) |
| Known issue | — | **#507** (config.toml db tilde-expansion; v0.6.3.2 fix) |

## What changed

**`docs/whats-new-v063.html` — major rework**
- New top-of-page "Patch 1 (v0.6.3.1)" section with a tile grid covering all 7 new CLI surfaces, schema ladder, 17/10/5 inventory counts, the one-command Claude Code install, and the #507 known issue.
- Hero / title / meta / nav updated to reflect v0.6.3.1 as the current release.
- Coverage campaign section retitled (v0.6.3 GA baseline + v0.6.3.1 raise).
- "By the Numbers" tile grid rewritten with v0.6.3.1 metrics.
- Upgrade path: schema v15→v19 ladder documented with migration file paths; homebrew tap / ghcr.io / Fedora COPR commands; #507 callout.
- "What's Next" updated: v0.6.3.2 (#507 fix) + v0.7 charter.
- Footer tag and date updated.

**HTML pages (10 files):** index.html, feature-matrix.html, architectures.html, at-a-glance.html, for-everyone.html, schema.html — all stale capability counts and coverage/test numbers updated. Inline SVG labels updated where present (schema v5→v19, 26→40 CLI commands, 42→50 endpoints, 1,809→1,886 tests).

**SVG diagrams:** `architecture.svg` — 21 tools→43, 42→50, 26→40, schema v4→v19.

**Markdown (8 files):** README.md, CLAUDE.md, QUICKSTART.md, INSTALL.md, ADMIN_GUIDE.md, DEVELOPER_GUIDE.md, docs/README.md, ROADMAP.md, ROADMAP2.md — capability counts, test/coverage metrics, BLUF copy, and architecture summaries all aligned to v0.6.3.1.

**ROADMAP.md status updates:**
- `budget_tokens` (Phase 1 Task) marked **SHIPPED v0.6.3.1 R1**.
- `ai-memory doctor` (Phase 4) marked **SHIPPED v0.6.3.1 R7**.
- Plugin SDK (TypeScript and Python) **FORMALLY CUT** per ROADMAP2 §10 (MCP is the SDK).

**ROADMAP2.md alignment:**
- Production-version line updated.
- §4 metrics block split into v0.6.3 baseline + v0.6.3.1 deltas.
- R1 (`budget_tokens`) and R7 (`ai-memory doctor`) marked shipped.
- §7.2 header changed from "Q2 2026 ~4 weeks" to "SHIPPED 2026-04-30".
- §16 net summary appends the v0.6.3.1 delta.

## Deferred (low-priority, will be picked up by the weekly scanner)

- `docs/evidence.html` — intentionally FROZEN per its source comment until test/coverage re-attestation for v0.6.3.1.
- Per-tool USER_GUIDE.md sections for the 15 tools without dedicated coverage there (cosmetic — `API_REFERENCE.md` covers them all from pass 3).
- ARCHITECTURAL_LIMITS.md `(v0.6.0 GA, schema v10)` annotations — historical context, not drift.

## Test plan

- [ ] CI: confirm `classify` job sets `docs_only=true`, Rust matrix short-circuits to no-op SUCCESS.
- [ ] CI: confirm `bench.yml` does NOT trigger (paths-ignore on `docs/**` and `**/*.md`).
- [ ] Render `docs/whats-new-v063.html` on GitHub Pages preview — verify the new Patch 1 section renders cleanly.
- [ ] Spot-check `docs/index.html`, `docs/feature-matrix.html`, `docs/at-a-glance.html` headers/stats on Pages.
- [ ] Open `docs/architecture.svg` directly — verify schema v19 / 43 / 50 / 40 labels.
- [ ] On merge, confirm no release tag is pushed and no release workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)