### PR TITLE
docs: cross-link v0.6.3.1 a2a campaign (in flight) to landing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
 [![Tests](https://img.shields.io/badge/tests-1%2C886_%E2%80%A2_93.84%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Test Hub](https://img.shields.io/badge/test--hub-live_results-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-test-hub/)
+[![v0.6.3.1 A2A](https://img.shields.io/badge/v0.6.3.1_a2a-testing_in_flight-ffd700?logo=githubpages)](https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/)
 [![MCP](https://img.shields.io/badge/MCP-43_tools-blueviolet)]()
 [![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.3-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)]()

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@
 **v0.6.3** cleared the a2a-gate certification bar: three consecutive full-testbook green runs across three agent frameworks and three transport modes — **324 passing scenarios**, zero partial greens.
 
 **📦 [Release v0.6.3.1](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.3.1)** ·
-**📊 [A2A gate evidence](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)** ·
+**🟢 [v0.6.3.1 a2a campaign — testing in flight](https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/)** ·
+**📊 [A2A gate (umbrella spec)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)** ·
 **🚢 [Ship gate](https://alphaonedev.github.io/ai-memory-ship-gate/)** ·
 **📖 [AI-NHI insights](https://alphaonedev.github.io/ai-memory-ai2ai-gate/insights/)** ·
 **🐳 [Reproduce locally](https://alphaonedev.github.io/ai-memory-ai2ai-gate/local-docker-mesh/)**

--- a/docs/index.html
+++ b/docs/index.html
@@ -401,9 +401,10 @@
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/" style="color:#ffd700">v0.6.3.1 a2a (live)</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate (umbrella spec)</a>
           <a href="performance.html">Performance budgets</a>
         </div>
       </div>
@@ -465,11 +466,13 @@
             <a href="whats-new-v063.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">✨ What's New in v0.6.3 →</a>
         </div>
         <div style="margin-top:1.5rem;display:flex;justify-content:center;gap:1.5rem;font-size:.78rem;color:#999;flex-wrap:wrap">
+          <span>🟢 <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/" style="color:#ffd700;text-decoration:none">v0.6.3.1 a2a — testing in flight</a></span>
+          <span>·</span>
           <span>📊 <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/" style="color:#6ee7ff;text-decoration:none">v0.6.3 evidence on test-hub</a></span>
           <span>·</span>
           <span>🚢 <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="color:#999;text-decoration:none">ship-gate</a></span>
           <span>·</span>
-          <span>🤝 <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="color:#999;text-decoration:none">A2A gate</a></span>
+          <span>🤝 <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="color:#999;text-decoration:none">A2A gate (umbrella spec)</a></span>
         </div>
     </div>
 </section>

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -181,9 +181,10 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
+          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/" style="color:#ffd700">v0.6.3.1 a2a (live)</a>
           <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence</a>
           <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
+          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate (umbrella spec)</a>
           <a href="performance.html">Performance budgets</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Cross-links the in-flight [v0.6.3.1 per-release A2A campaign](https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/) from the ai-memory landing surfaces. Companion to test-hub commit [`70d1f61`](https://github.com/alphaonedev/ai-memory-test-hub/commit/70d1f61) which adds the v0.6.3.1 entry to the Test Hub's per-release grid.

4 files changed, +10/−4. Strictly docs — every changed path matches `^(docs/|.*\.md$)`. Release job (gated `refs/tags/v*`) cannot fire on PR merge.

## What changed

- **`README.md`**: adds a v0.6.3.1 a2a "testing in flight" badge alongside the Test Hub badge.
- **`docs/README.md`**: adds a v0.6.3.1 a2a CTA next to the v0.6.3.1 release link, ahead of the umbrella ai2ai-gate evidence link.
- **`docs/index.html`**: adds a v0.6.3.1 a2a "live" entry to the Evidence dropdown (gold) and a top-of-fold "v0.6.3.1 a2a — testing in flight" callout to the secondary footer. Renames the umbrella ai2ai-gate link to "A2A Gate (umbrella spec)" so the umbrella-spec / per-release-execution split is visible.
- **`docs/whats-new-v063.html`**: same treatment in the Evidence dropdown of the v0.6.3.1 release-spotlight page.

## Context

Per-release execution lives in `ai-memory-a2a-v<version>` repos. The umbrella `ai-memory-ai2ai-gate` keeps the spec (testbook, scenario contracts, v1-GA criteria). v0.6.3.1's campaign exercises 24 scenarios — S1-S8 carry-forward + S9-S22 v0.6.3.1-specific surfaces (boot / install / wrap / logs / audit / doctor / R1 `budget_tokens` / Capabilities v2 / G4 embedding-dim / G5 archive / G6 on_conflict / G9 webhook fanout / G13 endianness / schema v19 migration). S23 (#507 tilde-expansion) and S24 (#318 MCP stdio fanout) are expected-RED on v0.6.3.1; expected GREEN on Patch 2. Findings funnel into Patch 2 umbrella issue #511.

## Test plan

- [ ] CI: `classify` job sets `docs_only=true`, Rust matrix short-circuits to no-op SUCCESS.
- [ ] Pages preview: confirm v0.6.3.1 a2a links are visible from `index.html` Evidence menu, secondary footer, and `whats-new-v063.html`.
- [ ] On merge, confirm no release tag is pushed and no release workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)