### PR TITLE
docs(v0.6.4): release package — quiet-tools sprint

### DIFF
--- a/docs/v0.6.4/README.md
+++ b/docs/v0.6.4/README.md
@@ -1,0 +1,71 @@
+# ai-memory v0.6.4 — `quiet-tools`
+
+**Status:** sprint authorized 2026-05-02; dev cycle Mon 2026-05-04 → Fri 2026-05-08
+**Theme:** cross-harness token economics + AI NHI capability-discovery protocol phase 1
+
+## Why this release
+
+Boris Cherny's published 90-day instrumentation data (May 2026) quantified that 73% of Claude Code tokens go to nine waste patterns. ai-memory is the **#1 contributor to Pattern 6** ("just-in-case" tool definitions) on every coding-agent harness except Claude Code's deferred-tool path: ~25,200 input tokens per request just for tool schemas. v0.6.4 fixes this in one release.
+
+## Headline change
+
+Default profile flips from **42 tools** → **5 tools** (`memory_store`, `memory_recall`, `memory_list`, `memory_get`, `memory_search`). Other 37 tools available via:
+
+- `--profile graph|admin|power|full` for static profile selection
+- `memory_capabilities --include-schema family=<name>` for runtime discovery (NHI canonical path)
+
+**Backward compatibility:** `ai-memory mcp --profile full` reproduces v0.6.3 surface 1:1.
+
+## Documents in this release package
+
+| File | Purpose |
+|---|---|
+| [`rfc-default-tool-surface-collapse.md`](rfc-default-tool-surface-collapse.md) | Design RFC. Profiles, discovery dance, NHI guardrails, tier applicability matrix (T1–T6). |
+| [`v0.6.4-roadmap.md`](v0.6.4-roadmap.md) | 16-issue sprint plan, 5-day schedule, test/cert/release plan, risk register, success metrics. |
+| [`v0.6.4-nhi-prompts.md`](v0.6.4-nhi-prompts.md) | Self-contained AI NHI starter prompts for the dev cycle (Day 0 kickoff + Mon–Fri tracks + emergency-break recovery prompt). |
+
+## Reading order
+
+1. **First time on this release:** read this README, then `rfc-default-tool-surface-collapse.md`.
+2. **Reviewing scope / approving:** read `v0.6.4-roadmap.md`.
+3. **Operating an NHI dev sprint:** read `v0.6.4-nhi-prompts.md`.
+
+## Token economics — projected
+
+| Harness | v0.6.3 baseline | v0.6.4 default (`core`) | Reduction |
+|---|---|---|---|
+| Claude Code (deferred-tools) | ~0 (already lazy) | ~0 | n/a |
+| Claude Desktop (eager) | ~25,200 | ~3,250 | **~87%** |
+| OpenAI Codex CLI (eager) | ~25,200 | ~3,250 | **~87%** |
+| xAI Grok CLI (eager) | ~25,200 | ~3,250 | **~87%** |
+| Google Gemini CLI (eager) | ~25,200 | ~3,250 | **~87%** |
+
+Per-user-year savings on Sonnet 4.6 input pricing for a heavy user (~7,500 turns/year): **~$497/year** for users on eager-loading harnesses.
+
+## NHI guardrails phase 1 (v0.6.4)
+
+- Per-agent capability allowlist (config-driven, `agent_id`-keyed)
+- Capability-expansion audit log (every `--include-schema` call recorded)
+
+## Deferred to v0.7+
+
+- Rate-limit on capability expansion
+- Attestation-tier gating (depends on #238)
+- Tier-6 redacted-discovery mode
+
+## Sprint status
+
+- [x] RFC drafted + approved
+- [x] Roadmap drafted + approved
+- [x] NHI prompt deck drafted + approved
+- [ ] 16 GitHub issues filed (Day 0 — Sat/Sun 2026-05-03)
+- [ ] Branch `feat/v0.6.4` cut (Day 0)
+- [ ] Mon–Fri sprint executes
+- [ ] Tag `v0.6.4` Fri 2026-05-08 EOD
+- [ ] Public announcement Mon 2026-05-11
+
+## Tracking
+
+- Cert matrix cell: `releases/v0.6.4/` in `alphaonedev/ai-memory-test-hub`
+- Memory namespace for cross-NHI continuity: `campaign-v064`
+- Milestone: `v0.6.4` on `alphaonedev/ai-memory-mcp`

--- a/docs/v0.6.4/rfc-default-tool-surface-collapse.md
+++ b/docs/v0.6.4/rfc-default-tool-surface-collapse.md
@@ -1,0 +1,267 @@
+# RFC — Collapse Default MCP Tool Surface to 5 (cross-harness token economics)
+
+**Status:** APPROVED — v0.6.4 sprint authorized 2026-05-02; dev cycle Mon 2026-05-04 → Fri 2026-05-08
+**Author:** strategy session 2026-05-02
+**Target release:** v0.6.4 (full RFC bundled — not split with v0.6.3.2)
+**Related issues:** #311 (targeted share — orthogonal), #318 (grok MCP fanout — orthogonal), #238 (mTLS attestation — gates NHI guardrail phase 2), Boris/Cherny token-waste assessment
+**Reading time:** 12 min
+
+---
+
+## TL;DR
+
+ai-memory's MCP server currently registers ~42 tools. On every coding-agent harness except Claude Code, every request pre-pays **~25,000 input tokens of tool schemas** before the user types a word. That makes ai-memory the single largest contributor to "Pattern 6 / 'just-in-case' tool definitions" in Boris Cherny's 73%-waste taxonomy across Codex, Grok CLI, and Gemini CLI.
+
+This RFC proposes collapsing the **default tool surface to 5** (`store`, `recall`, `list`, `get`, `search`) and gating the remaining 37 behind named profiles + a discovery dance. Net effect on naïve harnesses: drop tool-def overhead from ~25K tokens/request to ~3K tokens/request — an 88% cut that lands on ~95% of agent traffic.
+
+This is the highest-EV single change available in the project for cross-harness adoption.
+
+---
+
+## Background
+
+### Current state — 42 tools, all eagerly loaded
+Verified inventory (2026-05-02 capabilities probe):
+
+```
+Core read/write (5):       store, recall, list, get, search
+Lifecycle (5):             update, delete, forget, gc, promote
+Knowledge graph (8):       kg_query, kg_timeline, kg_invalidate,
+                           link, get_links, entity_register,
+                           entity_get_by_alias, get_taxonomy
+Governance / approvals (8): pending_list, pending_approve, pending_reject,
+                           namespace_set_standard, namespace_get_standard,
+                           namespace_clear_standard, subscribe, unsubscribe
+Power features (6):        consolidate, detect_contradiction,
+                           check_duplicate, auto_tag, expand_query, inbox
+Discovery / meta (4):      capabilities, agent_register, agent_list,
+                           session_start
+Archive (4):               archive_list, archive_purge, archive_restore,
+                           archive_stats
+Other (2):                 list_subscriptions, notify
+```
+
+Average schema size: ~600 input tokens per tool (measured against MiniLM tokenizer; OpenAI tokenizer is within 5%).
+
+### The cross-harness problem
+
+| Harness | Loads MCP tool schemas | Per-request tool-def cost |
+|---|---|---|
+| Claude Code (this session) | **Deferred** (ToolSearch) | ~0 until requested |
+| Claude Desktop | **Eager** | ~25K |
+| OpenAI Codex CLI | **Eager** | ~25K |
+| xAI Grok CLI | **Eager** | ~25K |
+| Google Gemini CLI | **Eager** + breaks implicit cache | ~25K + cache penalty |
+
+For three out of four "first-class" coding agents and stock Claude Desktop, ai-memory is dominating the input prefix. Boris's 90-day instrumentation of his own Claude Code sessions found "just-in-case" tool definitions cost 6% of total tokens with **12 MCP servers averaging ~600 tokens each = 7,200 tokens.** ai-memory alone, on those harnesses, is **3.5× that** with one server.
+
+---
+
+## Goals
+
+1. Drop default tool-def overhead from ~25K to ≤3K tokens per request on naïve harnesses.
+2. Preserve 100% of current capability — nothing removed, only deferred.
+3. Zero breaking change for users on full-feature profiles.
+4. Discoverability: agents can opt into expansion at runtime without restart.
+5. Measurable: ship `ai-memory doctor --tokens` reporting per-session bill before and after.
+
+## Non-goals
+
+- Changing the wire protocol of any existing tool.
+- Removing any tool from the codebase.
+- Forcing any user to migrate — the "full" profile preserves today's behavior.
+- Dynamically loading Rust code at runtime (profiles are pure registration filters).
+
+---
+
+## Proposed design
+
+### 1. Five-tool default ("core" profile)
+
+| Tool | Rationale |
+|---|---|
+| `memory_store` | Write path. Always needed. |
+| `memory_recall` | Semantic retrieval. Primary read path. |
+| `memory_list` | Browse by namespace/tier. Default UX surface. |
+| `memory_get` | Read by ID. Cheap, frequent. |
+| `memory_search` | Keyword/FTS5 fallback for high-precision lookups. |
+
+These five cover the 95th-percentile of agent traffic in observed sessions (assessment-2026-04-25 logs, ai-memory-mcp logs). They are also the minimum surface needed for an agent to be "useful" without pulling additional families.
+
+### 2. Profile system
+
+```
+ai-memory mcp --profile core    # default — 5 tools
+ai-memory mcp --profile graph   # core + 8 KG tools (13 total)
+ai-memory mcp --profile admin   # core + lifecycle + governance (18)
+ai-memory mcp --profile power   # core + power features (11)
+ai-memory mcp --profile full    # all 42 (today's behavior)
+ai-memory mcp --profile <comma,separated,family,list>  # custom
+```
+
+Profile resolution order: CLI flag > `AI_MEMORY_PROFILE` env > `config.toml` `[mcp].profile` > built-in default (`core`).
+
+A profile is a static set of tool families. Implementation: `register_tools()` reads the profile and conditionally calls each family's `register_*` function. Pure compile-time-feasible filter; no runtime cost.
+
+### 3. Discovery dance — `memory_capabilities` always in core
+
+`memory_capabilities` is always registered (it's already in the meta family and is small — ~250 tokens). It returns the list of available families and their tools, including ones not currently loaded into the agent's context.
+
+New optional method: `memory_capabilities --include-schema family=graph` returns the schemas for that family inline, in the format the MCP host expects to register them. The host (Claude Code's deferred-tools path, or a future Codex/Grok extension) can register them mid-session without restart.
+
+For harnesses that don't support runtime registration (Codex/Grok/Gemini today), the agent learns "this family exists, restart with `--profile graph` to use it" — a graceful degradation.
+
+### 4. Heuristic auto-upgrade (opt-in, off by default)
+
+Optional flag `--auto-profile` lets the server escalate profiles based on observed call patterns:
+
+- Three or more `memory_store` calls in the same namespace within 60 seconds → suggest `power` profile (for `consolidate`/`detect_contradiction`).
+- Any failed call to a non-loaded tool name → log structured suggestion.
+
+Off by default. Logs only — never auto-restarts. Removes ambiguity about "why isn't tool X available."
+
+### 5. SDK negotiation
+
+TypeScript and Python SDKs expose `client.requireProfile("graph")` which:
+1. Calls `memory_capabilities` to verify the family exists.
+2. If loaded, no-op.
+3. If not loaded, raises `ProfileNotLoaded` with the exact CLI/env hint to fix.
+
+SDK consumers get a clean error path instead of "tool not found."
+
+---
+
+## Token economics (projected)
+
+### Baseline (today, "full" profile, eager-load harness)
+- 42 tools × ~600 tokens = **~25,200 input tokens per request**
+- At Sonnet 4.6 input pricing (~$3/MT): **~$0.076 per request just for tool defs**
+- Boris's average session: 30 turns/day × 250 working-days = 7,500 turns/year
+- **~$570/year per heavy user, just for ai-memory tool schemas**
+
+### Proposed (default "core" profile, eager-load harness)
+- 5 tools × ~600 + capabilities meta ~250 = **~3,250 input tokens per request**
+- ~$0.010 per request — **87% cut**
+- ~$73/year for the same user
+- Saved: **~$497/year per heavy user**
+
+### Claude Code (deferred-tools harness) — already minimal
+- No change from user perspective. Deferred-tool flow continues to work. `memory_capabilities` keyword search is unchanged.
+
+---
+
+## Migration plan — single-week sprint
+
+v0.6.4 is bundled as one minor release shipping in **5 dev days** (Mon 2026-05-04 → Fri 2026-05-08), not phased across alpha/rc/GA. Aggressive but feasible per AI 24x7 dev sprint methodology. The release-engineering rationale: feature-flagged default flip backed by `--profile full` opt-out gives the same de-risking as a multi-week phased rollout, without the calendar drag.
+
+### Day-by-day
+
+| Day | Track focus | Major deliverables |
+|---|---|---|
+| Mon 05-04 | Mechanism + observability | `--profile` flag + family filter + `core` default, `ai-memory doctor --tokens`, static schema-size table |
+| Tue 05-05 | Discovery + SDK | `memory_capabilities` family enumeration + `--include-schema`, SDK `requireProfile` (TS + Py) |
+| Wed 05-06 | NHI guardrails phase 1 + cross-harness | Per-agent allowlist, capability-expansion audit log, install profiles for 5 harnesses |
+| Thu 05-07 | Cert + benchmarks | A2A scenarios S25–S32, cross-harness token-cost benchmark, backward-compat verification |
+| Fri 05-08 | Docs + release | README + ADMIN_GUIDE + migration guide + release notes + CHANGELOG, semver tag, CI release |
+
+### Out-of-scope for v0.6.4 (defers to v0.7)
+- `--auto-profile` heuristic upgrade
+- NHI guardrail phase 2 (rate-limit + attestation-tier gating — depends on #238 closure)
+- Tier-6 redacted-discovery mode (depends on classification-aware attestation)
+- Runtime tool registration on Codex/Grok/Gemini hosts (depends on host-side support)
+
+---
+
+## Tier applicability matrix
+
+The mechanism is tier-agnostic; the guardrails graduate per tier. v0.6.4 ships everything through Tier 5; Tier 6 redacted-discovery is deferred to v0.7+.
+
+| Tier | Identity model | Profile UX | Discovery UX | Guardrails enforced in v0.6.4 |
+|---|---|---|---|---|
+| 1. Individual dev (SQLite, single-process, no auth) | Anonymous local user | Primary (`--profile` flag) | Optional | None — profile flag is sufficient |
+| 2. Team (shared SQLite, API-key auth) | API-key | Primary | Optional | Per-key allowlist, audit log |
+| 3. Federated (mTLS + sync daemon) | mTLS cert CN/SAN | Hybrid | Hybrid | Cert-tier allowlist + audit; rate-limit + attestation gating WAIT for #238 |
+| 4. AgenticMem Attest (cloud, attested NHI) | Cert pinning + signed assertion | Sugar over discovery | Primary | Allowlist + audit (phase 1); full guardrails phase 2 in v0.7 |
+| 5. AgenticMem Federate (multi-org) | Org-scoped attestation + governance | Sugar | Primary | Allowlist + audit + cross-org policy hooks (governance namespace standards extend cleanly) |
+| 6. Sovereign (gov/defense, E2E encrypted) | Full attestation chain + per-memory crypto | n/a | Primary, but **redacted** | Deferred to v0.7+ — needs classification-aware capability redaction |
+
+**Tier-1 honesty:** at the individual-dev tier, the `--profile` flag IS the right UX. A single human operator setting `--profile graph` once is appropriate; a discovery dance is over-engineered. v0.6.4 supports both. RFC framing: profile flags are Tier 1 / Tier 2 UX; meta-tool discovery is Tier 3+ UX. Both ship; neither replaces the other.
+
+**Tier-6 future requirement (out-of-scope for v0.6.4):** `memory_capabilities --redacted` mode. Standard discovery returns the full family list because that's correct for Tiers 1–5. In Sovereign deployments the capability list itself is OPSEC — knowing "this server has `kg_query`" leaks workflow intel. Tier 6 ships discovery that returns only families the requesting identity is already cleared for. Adds to v0.7 or v0.8 scope; explicit dependency: classification-aware attestation tiers must be concrete first.
+
+## NHI guardrails (phase 1 in v0.6.4; phase 2 in v0.7)
+
+Meta-tool discovery without guardrails is a scope-creep vector. Phase 1 ships in v0.6.4 alongside the mechanism:
+
+### Phase 1 (v0.6.4 — this sprint)
+1. **Per-agent capability allowlists.** Tied to `agent_id` (immutable per #196). Identity → allowed family set. Default for unknown agents = `core`. Config-driven via `[mcp.allowlist]` table in `config.toml`. Anonymous/Tier-1 users effectively bypass (no `agent_id` to bind to → operator profile flag rules).
+2. **Audit on expansion.** Every `memory_capabilities --include-schema` call writes a row to `audit_log`: `(agent_id, requested_family, granted, attestation_tier, timestamp)`. Pairs with existing federation audit work.
+
+### Phase 2 (v0.7 — depends on #238 closure)
+3. **Rate-limit on expansion.** Cap one family upgrade per 5 min per `agent_id`. Burst → log + deny + `notify` channel alert.
+4. **Attestation-tier gating.** NHI requesting `power` family from non-mTLS connection denied with clear upgrade-path error. Requires #238 (body-claimed `sender_agent_id` attested to mTLS cert) to land first — otherwise the binding between identity and capability is advisory only.
+
+## A2A test scenarios (additions to v0.6.4 cert matrix)
+
+Reference: cert campaign tracking in #511.
+
+| ID | Scenario | Expected behavior |
+|---|---|---|
+| S25 | `--profile core` registers exactly 5 tools | Pass: 5 tools present, 37 absent |
+| S26 | `--profile full` matches v0.6.3 baseline | Pass: 42 tools, no regressions |
+| S27 | `memory_capabilities` always available regardless of profile | Pass |
+| S28 | Calling unloaded tool returns `tool_not_found` with profile hint | Pass: error includes "set --profile <name>" |
+| S29 | Token-def cost per harness measured + recorded | Cross-harness budget table populated |
+| S30 | Custom profile (`--profile core,graph`) registers union | Pass: 13 tools |
+| S31 | SDK `requireProfile` raises `ProfileNotLoaded` cleanly | Pass |
+| S32 | Boot manifest cost unchanged across profiles | Pass: profiles affect tool defs only, not boot |
+
+---
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Existing users surprised when tool X disappears | Medium | Release-notes call-out + "set `--profile full` to keep current behavior." Profile resolution honors config file, so existing configs aren't auto-flipped. |
+| SDK callers hardcode tool names not in core | High for power-users | `requireProfile` SDK method. Profile-error responses include the specific CLI/env fix. |
+| Profile choice paralysis | Low | Default = `core`. Five named profiles. No need to think unless escalating. |
+| Family boundaries draw blood (which family does `auto_tag` go in?) | Medium | RFC explicitly enumerates each tool's family; no overlap permitted. Decision rule: "If two families want it, it's its own family." |
+| `memory_capabilities` doesn't ship runtime registration support in any host | High short-term | RFC ships `--profile` immediately for 88% of the win. Runtime registration is future work; profile flag works without it. |
+| Telemetry conflict — boot manifest re-stabilization on Gemini | Low | Out-of-scope here. Tracked in separate Gemini cache-stability item. |
+
+---
+
+## Open questions
+
+1. **Should `memory_update` be in core?** Frequency analysis (assessment-2026-04-25 logs) shows ~8% of write traffic. Current proposal: keep in lifecycle family. **Decision:** confirm via 7-day log audit before v0.6.4-alpha.
+2. **Do we ship `memory_search` and `memory_recall` together, or merge?** They overlap (FTS5 vs vector). Probably keep separate — different latency profiles. **Decision:** keep separate; revisit in v0.7.
+3. **Should profiles be additive or named-exclusive?** Proposal: named with comma-separated custom union (`core,graph`). **Decision:** as proposed.
+4. **What does the install wizard prompt?** Likely: "Which agents will use ai-memory?" → infers profile. **Decision:** post-RFC, install-wizard work.
+
+---
+
+## Approval gate
+
+This RFC requires sign-off on:
+- [ ] The 5-tool core surface (and the rationale for each)
+- [ ] The 6 named profiles (`core`, `graph`, `admin`, `power`, `full`, custom)
+- [ ] Profile resolution order (CLI > env > config > default)
+- [ ] The test-scenario additions to the v0.6.3.2/v0.6.4 cert matrix
+- [ ] Phase timing (alpha → rc → GA in 3 weeks)
+
+On sign-off: convert RFC into v0.6.4 epic, decompose into tracking issues per phase, route through normal v0.6.x ship-gate.
+
+---
+
+## Appendix A — One-liner for users
+
+> ai-memory v0.6.4 ships 5 tools by default, not 42. Saves ~22,000 tokens per request on Codex / Grok / Gemini / Claude Desktop. Run `ai-memory mcp --profile full` to keep the v0.6.3 behavior.
+
+## Appendix B — Why now
+
+Three signals converged in the last week of April 2026:
+1. Boris Cherny's published instrumentation data quantified pattern 6 at 6% of total tokens for 12-MCP setups.
+2. v0.6.3.1 A2A certification (#511) is the first real cross-harness test campaign — exactly when tool-surface bloat becomes visible cross-platform.
+3. Anthropic's late-March cache-bug remediation made users pattern-match all token bloat onto Claude Code rather than the MCP servers downstream. ai-memory's surface size is a credibility issue: shipping 42 tools when 5 cover 95% of traffic looks careless even if technically defensible.
+
+The cost of doing this in v0.6.4 is one engineer-week. The cost of not doing it is ~$500/year/user at scale plus a competitive narrative cost as Codex/Grok/Gemini users notice the bill.

--- a/docs/v0.6.4/v0.6.4-nhi-prompts.md
+++ b/docs/v0.6.4/v0.6.4-nhi-prompts.md
@@ -1,0 +1,527 @@
+# v0.6.4 — AI NHI starter prompts (Mon 2026-05-04 → Fri 2026-05-08)
+
+**Companion to:** `v0.6.4-roadmap.md` (this directory) and `rfc-default-tool-surface-collapse.md` (this directory)
+**Sprint window:** 5 dev days
+**Target:** Friday 2026-05-08 EOD release of `v0.6.4`
+
+These prompts bootstrap AI NHI agents for each track of the v0.6.4 sprint. Each prompt is **self-contained** — an agent reading it cold has all the context, paths, decision rules, acceptance criteria, and handoff state it needs. No prompt assumes the reader has session history.
+
+**Operational pattern:**
+1. Lead human/NHI loads the appropriate day's prompt into a fresh Claude Code (or compatible) session.
+2. Agent acknowledges the prompt, surfaces clarifying questions BEFORE writing code, then executes.
+3. End-of-day: agent writes a "handoff note" memory under namespace `campaign-v064` so the next day's agent picks up cleanly.
+4. If two agents work in parallel on independent tracks, each gets their own prompt; coordination via `campaign-v064` namespace.
+
+**Conventions used:**
+- File paths assume working directory is the `ai-memory-mcp` repo root.
+- Issue references are the `v0.6.4-NNN` IDs from the roadmap (also filed as GitHub issues by Sat Sun 2026-05-03).
+- All commits ride branch `feat/v0.6.4`. NHIs do not push to `main`.
+- "Memory store" instructions reference the running ai-memory MCP server. Use `memory_store` with `namespace: "campaign-v064"`.
+
+---
+
+## DAY 0 — Saturday/Sunday — Sprint kickoff lead NHI
+
+**Use this prompt:** before Monday morning, on Sat 2026-05-03 or Sun 2026-05-03 evening, to set up the work environment for the dev sprint.
+
+**Audience:** lead-coordinator NHI (reasoning-capable, file-system access, GitHub access).
+
+```
+You are the lead coordinator for ai-memory v0.6.4 sprint kickoff. Sprint runs Mon 2026-05-04 → Fri 2026-05-08, ship target Fri 2026-05-08 EOD. Today's job is environment prep — no code, just setup.
+
+Read these three documents in order:
+1. /var/root/agentic-mem-labs/strategy/2026-05-02/rfc-default-tool-surface-collapse.md (design)
+2. /var/root/agentic-mem-labs/strategy/2026-05-02/v0.6.4-roadmap.md (schedule)
+3. /var/root/agentic-mem-labs/strategy/2026-05-02/v0.6.4-nhi-prompts.md (this file — for context)
+
+Then execute, in order:
+
+1. **Branch.** In the ai-memory-mcp repo, cut branch `feat/v0.6.4` from `main`. Push to origin. Confirm CI runs cleanly on the empty branch.
+
+2. **Issues.** Open 16 GitHub issues against repo alphaonedev/ai-memory-mcp with milestone `v0.6.4`. One issue per `v0.6.4-NNN` from the roadmap. Each issue body = the full text of that issue from §"Issue list" in v0.6.4-roadmap.md. Apply labels: `enhancement`, `v0.6.4`, plus per-track label (e.g., `track:mechanism`, `track:observability`, etc.). Set dependencies between issues per the `Dep:` lines.
+
+3. **Cert skeleton.** In repo alphaonedev/ai-memory-test-hub (sibling repo), create the v0.6.4 cell skeleton: directory `releases/v0.6.4/scenarios/`, with empty markdown files for S25 through S32. Each markdown contains only the scenario name as H1 heading + an "Expected" section that quotes the roadmap. Commit + push.
+
+4. **Memory cache.** Store the following memories under namespace `campaign-v064`:
+   - Memory titled "v0.6.4 sprint scope" with content = §"Scope — what's IN" + §"Scope — what's OUT" from roadmap
+   - Memory titled "v0.6.4 issue index" with content = list of all 16 issue IDs + GitHub URLs (after creation in step 2)
+   - Memory titled "v0.6.4 daily schedule" with content = §"Daily schedule" from roadmap
+   - Memory titled "v0.6.4 NHI prompt index" with the names of all DAY-N prompt sections from this file
+   Set `tier: long`, `priority: 8`, `tags: ["sprint", "v0.6.4", "kickoff"]`.
+
+5. **Roster.** Generate a sprint roster proposal (which NHI claims which track). Output as a checklist memory titled "v0.6.4 NHI roster" in namespace `campaign-v064`. Tag each track as `claimed:<agent_id>` or `unclaimed`.
+
+6. **Handoff.** Write a memory titled "v0.6.4 day-0 handoff" summarizing:
+   - Branch ready: yes/no
+   - Issues filed: count + URLs
+   - Cert skeleton: yes/no
+   - Roster gaps: list
+   - Any setup blockers for Monday
+   Tag: `handoff`. Priority 9.
+
+Constraints:
+- Do not write code. Setup only.
+- Do not modify `main`.
+- If a step fails, write the failure to the handoff memory and stop — do not improvise around blockers.
+- Confirm each step's success in your reply before proceeding to the next.
+```
+
+---
+
+## DAY 1 — Monday 2026-05-04 — Mechanism + Observability (Tracks A + B)
+
+**Use this prompt:** Monday morning. Two agents can work in parallel on Track A and Track B; each gets their own copy of the prompt with the relevant track called out. Single-agent execution also works.
+
+**Audience:** Rust-experienced coding NHI with full repo access.
+
+```
+You are implementing v0.6.4 Day 1 for ai-memory: Tracks A (Mechanism) and B (Observability). Branch is already cut at `feat/v0.6.4`. 16 GitHub issues are filed under milestone `v0.6.4`. Sprint roadmap is at /var/root/agentic-mem-labs/strategy/2026-05-02/v0.6.4-roadmap.md — read §"Issue list" Track A + Track B before starting.
+
+Read the v0.6.4 sprint memories from namespace `campaign-v064` for context. Then:
+
+EXECUTE ISSUES IN THIS ORDER (4 issues total, ~6-8 hours of work):
+
+1. **v0.6.4-005 — Static schema-size table (build-time)** — START HERE, blocking everything else
+   - Add `tiktoken-rs` (or equivalent crate matching `cl100k_base`) as a build-dep
+   - In `build.rs`: tokenize every tool's schema JSON at build time
+   - Emit `src/mcp/families/sizes.rs` with a `pub const TOOL_SIZES: &[(&str, usize)]`
+   - CI gate: assert no tool exceeds 1500 tokens (fail build if regression)
+   - Test: build succeeds; `cargo test` includes a check that table is populated
+   - Commit with message: `v0.6.4-005: build-time tool schema size table`
+
+2. **v0.6.4-001 — Profile flag (CLI + env + config)**
+   - Add `--profile <profile>` to `ai-memory mcp` subcommand in `src/cli.rs`
+   - Add `AI_MEMORY_PROFILE` env var support
+   - Add `[mcp].profile` field to config.toml deserialization in `src/config.rs`
+   - Resolution order: CLI > env > config > default ("core")
+   - Validate profile name against known profiles + custom comma-syntax
+   - Test: 4 unit tests, one per resolution path
+   - Commit: `v0.6.4-001: profile flag CLI/env/config resolution`
+
+3. **v0.6.4-002 — Family-scoped tool registration filter**
+   - Refactor `register_tools()` so each family has its own `register_<family>(server)` function in `src/mcp/families/<family>.rs`
+   - Families: core (5), lifecycle (5), graph (8), governance (8), power (6), meta (4), archive (4), other (2)
+   - Master `register_tools(server, profile)` calls each family conditionally based on profile membership
+   - Profile -> family-set map: core={core,meta}, graph={core,meta,graph}, admin={core,meta,lifecycle,governance}, power={core,meta,power}, full=ALL, custom=resolve comma list
+   - Test: 8 unit tests asserting exact tool count per family; 5 integration tests asserting profile→count
+   - Commit: `v0.6.4-002: family-scoped tool registration`
+
+4. **v0.6.4-003 — `core` default flip + backward-compat**
+   - Change default from `full` to `core` in CLI flag default + config default
+   - Ensure `--profile full` produces 1:1 v0.6.3 surface (run cargo test; nothing breaks)
+   - Add CHANGELOG entry under "Unreleased / v0.6.4 / Breaking"
+   - Commit: `v0.6.4-003: flip default profile to core`
+
+5. **v0.6.4-004 — `ai-memory doctor --tokens`** — Track B; can run in parallel with v0.6.4-001/002 if pairing; otherwise after 005
+   - New `--tokens` flag on `doctor` subcommand in `src/cli/doctor.rs`
+   - Read `TOOL_SIZES` from sizes.rs, current active profile, boot manifest size from last boot
+   - Output: human-readable table + JSON via `--format json`
+   - Show: per-tool token cost, per-family total, current profile total, projected savings if downgrading
+   - Test: integration test asserts JSON shape; manual smoke test
+   - Commit: `v0.6.4-004: doctor --tokens cost reporting`
+
+EOD GATE (must achieve before stopping):
+- `ai-memory mcp --profile core` registers exactly 5 tools (verify via MCP `tools/list`)
+- `ai-memory mcp --profile full` registers exactly 42 tools
+- `ai-memory doctor --tokens` returns valid output
+- `cargo test` green; CI green on `feat/v0.6.4` push
+
+HANDOFF (write to memory namespace `campaign-v064`, title "v0.6.4 day-1 handoff", priority 9, tag `handoff`):
+- Each issue's status: complete | in-progress | blocked
+- Test results
+- Any decisions made about ambiguous spec (e.g., custom-profile parsing edge cases)
+- Anything Tuesday's NHI needs to know
+
+DECISION RULES if you hit ambiguity:
+- Empty profile string → treat as default (`core`)
+- Duplicate family in custom (`core,core`) → dedupe silently
+- Unknown family in custom (`core,xyz`) → fail loudly with valid-family list
+- Profile is case-sensitive lowercase; reject mixed case
+- If `tiktoken-rs` mismatches Anthropic's tokenizer by >15% on average → document as known limitation in CHANGELOG; don't try to ship a tokenizer per-provider in v0.6.4
+
+CONSTRAINTS:
+- Do not push to `main`.
+- Do not skip tests with `--no-verify`.
+- Do not introduce new top-level dependencies beyond `tiktoken-rs` without writing a justification memory.
+- If you discover the spec disagrees with reality (e.g., a "family" actually has 9 tools not 8), update the roadmap memory in campaign-v064 with the correction; do not silently change the spec.
+```
+
+---
+
+## DAY 2 — Tuesday 2026-05-05 — Discovery + SDK (Track C)
+
+**Audience:** Rust + TypeScript + Python NHI, or two parallel agents (one for the Rust side, one for the SDKs).
+
+```
+You are implementing v0.6.4 Day 2 for ai-memory: Track C (Discovery + SDK). Day 1 (Tracks A + B) shipped on Mon. Read the day-1 handoff memory from namespace `campaign-v064` before starting.
+
+REPO STATE expected at start of day 2:
+- branch `feat/v0.6.4` has 4 commits: v0.6.4-005, v0.6.4-001, v0.6.4-002, v0.6.4-003, v0.6.4-004
+- `ai-memory mcp --profile core` works
+- `ai-memory doctor --tokens` works
+
+EXECUTE TWO ISSUES IN PARALLEL:
+
+1. **v0.6.4-006 — `memory_capabilities` extension** — Rust side, `src/mcp/families/meta.rs`
+   - Extend the existing `memory_capabilities` tool to:
+     a. Default behavior (no params): return v2 capabilities schema PLUS new `families` field listing every family + its tool names + which families are currently loaded under the active profile
+     b. With param `family=<name>`: return just that family's tool list
+     c. With param `include_schema=true`: return full schemas (JSON) for the requested family inline, in MCP-tool-definition format ready for the host to register
+   - Cap response at one family per call when `include_schema=true` (size limit)
+   - Test: 4 integration tests: no-args, family= alone, family= + include_schema=true, unknown family
+   - Commit: `v0.6.4-006: memory_capabilities family enum + include_schema`
+
+2. **v0.6.4-007 — SDK `requireProfile`** — TypeScript + Python in parallel
+   - **TypeScript** (`sdk/typescript/src/profile.ts`):
+     - Export `class ProfileNotLoaded extends Error` with field `hint: string`
+     - Export `async function requireProfile(client: MemoryClient, profile: string): Promise<void>` that calls `memory_capabilities`, checks if all tools in the requested profile are loaded, throws ProfileNotLoaded with a CLI/env hint if not
+     - Add to public API in `sdk/typescript/src/index.ts`
+     - Test: vitest fixture asserting throw with hint message containing "--profile" and the requested name
+   - **Python** (`sdk/python/src/ai_memory/profile.py`):
+     - Define `class ProfileNotLoaded(Exception)` with `hint: str` attribute
+     - Define `async def require_profile(client: MemoryClient, profile: str) -> None`
+     - Add to `sdk/python/src/ai_memory/__init__.py` public exports
+     - Test: pytest fixture asserting raise with hint
+   - Commit: `v0.6.4-007: SDK requireProfile (TS + Py)`
+
+EOD GATE:
+- `memory_capabilities` returns family list (test in MCP inspector)
+- `memory_capabilities` with `family=graph include_schema=true` returns 8 valid tool schemas
+- TS test green: `requireProfile` throws ProfileNotLoaded with actionable hint
+- Py test green: same
+- `cargo test` + `pnpm test` + `pytest` all green on `feat/v0.6.4` push
+
+HANDOFF (memory `campaign-v064` / "v0.6.4 day-2 handoff" / priority 9):
+- Status of v0.6.4-006 and v0.6.4-007
+- Sample output from `memory_capabilities --include-schema family=graph` (paste structure for Wed's allowlist work)
+- SDK API additions noted (so Wed/Thu work doesn't break the API)
+- Any spec questions for the allowlist work (e.g., does the allowlist gate `family=` listing or only `include_schema=true`?)
+
+DECISION RULES:
+- `include_schema=true` without `family=` → error: "must specify family when include_schema=true"
+- Response size: if a single family's schemas exceed 25K tokens, split internally; for v0.6.4 our families are all under that — assert the property as a runtime check
+- SDK `requireProfile` checks tool *availability via `tools/list`*, not just family enumeration — needs to verify the host actually has them registered
+
+CONSTRAINTS:
+- Same as day 1.
+- Do not break existing SDK consumers — `requireProfile` is additive.
+```
+
+---
+
+## DAY 3 — Wednesday 2026-05-06 — NHI guardrails + Cross-harness (Tracks D + E)
+
+**Audience:** Rust + DevOps NHI; two parallel agents recommended.
+
+```
+You are implementing v0.6.4 Day 3 for ai-memory: Tracks D (NHI guardrails phase 1) and E (Cross-harness install). Days 1 + 2 shipped Mon + Tue. Read both handoff memories from namespace `campaign-v064` before starting.
+
+REPO STATE expected:
+- branch `feat/v0.6.4` has commits through v0.6.4-007
+- `memory_capabilities --include-schema family=X` works
+- TS + Py SDKs have `requireProfile`
+
+EXECUTE THREE ISSUES (parallel where possible):
+
+1. **v0.6.4-008 — Per-agent capability allowlist** (Track D, sequential w/ v0.6.4-009)
+   - Add `[mcp.allowlist]` table to config schema in `src/config.rs`:
+     ```toml
+     [mcp.allowlist]
+     "agent_id_pattern_1" = ["core", "graph"]
+     "agent_id_pattern_2" = ["full"]
+     "*" = ["core"]   # wildcard default
+     ```
+   - In `memory_capabilities` handler (when `include_schema=true`), check requesting agent_id against allowlist; deny with structured error if family not allowed
+   - For unknown agents (no agent_id provided): default to `core` only
+   - For Tier-1 single-process (no auth): allowlist disabled, profile flag rules
+   - Tests: 5 unit tests covering pattern match, wildcard, default-deny, deny path
+   - Commit: `v0.6.4-008: per-agent capability allowlist`
+
+2. **v0.6.4-009 — Capability-expansion audit log** (Track D, after 008)
+   - New schema migration `src/db/migrations/v20_audit_log.sql`:
+     ```sql
+     CREATE TABLE IF NOT EXISTS audit_log (
+       id TEXT PRIMARY KEY,
+       agent_id TEXT,
+       event_type TEXT NOT NULL,    -- 'capability_expansion'
+       requested_family TEXT,
+       granted INTEGER NOT NULL,
+       attestation_tier TEXT,
+       timestamp TEXT NOT NULL
+     );
+     CREATE INDEX idx_audit_log_agent_id ON audit_log(agent_id);
+     CREATE INDEX idx_audit_log_timestamp ON audit_log(timestamp);
+     ```
+   - Bump schema version to v20
+   - In `memory_capabilities --include-schema` handler, write audit row on every grant + deny
+   - New CLI subcommand: `ai-memory audit show --capability-expansions` reads the table
+   - Tests: integration test asserting row written; CLI smoke test
+   - Commit: `v0.6.4-009: capability-expansion audit log + schema v20`
+
+3. **v0.6.4-010 — Per-harness install profiles** (Track E, parallel with above)
+   - Update `ai-memory install --harness <name>` in `src/cli/install.rs`
+   - Per-harness config defaults all use `--profile core`:
+     - claude-code: install hook + writes `core` profile
+     - claude-desktop: writes MCP config with `core` profile in args
+     - codex: writes Codex MCP config with `core` profile
+     - grok-cli: writes Grok MCP config with `core` profile  
+     - gemini-cli: writes Gemini MCP config with `core` profile
+   - Each install path emits a "you can opt into more tools via..." line pointing to ADMIN_GUIDE
+   - For each harness: a fixture file in `installers/<harness>/` showing expected config
+   - Test: install integration test per harness asserts correct config written (does not actually run the harness — just file-output check)
+   - Commit: `v0.6.4-010: per-harness install profiles default to core`
+
+EOD GATE:
+- `[mcp.allowlist]` config respected: test fixture with 3 agents → correct grants/denies
+- `audit_log` table created on first start; rows written on capability calls
+- `ai-memory install --harness codex` writes correct config
+- All 5 harness install paths verified by fixture
+- `cargo test` green; integration tests for each harness install green; CI green
+
+HANDOFF (memory `campaign-v064` / "v0.6.4 day-3 handoff" / priority 9):
+- Status of v0.6.4-008/009/010
+- Sample audit_log rows showing the captured shape (Thursday's cert work consumes this)
+- Sample install-fixture per harness (Thursday's benchmark consumes these)
+- Any harness-specific install gotchas surfaced
+
+DECISION RULES:
+- Wildcard `*` in allowlist: lowest precedence, matches any agent
+- Multiple matching patterns: longest-prefix wins; if tie, first in config order wins
+- Audit log on Tier-1 (no agent_id): write `agent_id="anonymous"` so the table is consistent
+- Schema migration must be idempotent (CREATE TABLE IF NOT EXISTS, etc.) — break-glass requirement, do not skip
+- Per-harness install fails if harness not installed: error with "install <harness> first" message
+
+CONSTRAINTS:
+- Same as days 1+2.
+- Schema migrations are one-way; do not use this pattern for non-migration writes.
+```
+
+---
+
+## DAY 4 — Thursday 2026-05-07 — Cert + Benchmarks (Track F)
+
+**Audience:** QA + benchmarking NHI; full repo + ai-memory-test-hub access.
+
+```
+You are implementing v0.6.4 Day 4 for ai-memory: Track F (Cert + Benchmarks). Days 1-3 shipped Mon-Wed. Read all three handoff memories from namespace `campaign-v064` before starting.
+
+REPO STATE expected:
+- branch `feat/v0.6.4` has commits through v0.6.4-010
+- `--profile` works, allowlist works, audit log works, install profiles work
+- All daily gates passed
+
+EXECUTE THREE ISSUES (sequential — each builds on the previous):
+
+1. **v0.6.4-011 — Cross-harness token-cost benchmark** (start here)
+   - Static benchmark first: in `benchmarks/v0.6.4-cross-harness.md`, build a table:
+     | Harness | v0.6.3 (full) | v0.6.4 (core default) | Reduction |
+     | claude-code | <count> | <count> | <%> |
+     | claude-desktop | ... | ... | ... |
+     | codex | ... | ... | ... |
+     | grok-cli | ... | ... | ... |
+     | gemini-cli | ... | ... | ... |
+     Use `TOOL_SIZES` from sizes.rs for the schema cost; for boot manifest cost use a representative sample from production telemetry (or default config: 4096 token boot budget)
+   - Live spot-check: spin up each harness with v0.6.4 + `--profile core`, capture an actual `tools/list` payload, count tokens with the same tokenizer used at build time, assert within ±10% of static estimate
+   - CI gate: add `.github/workflows/token-budget.yml` that fails if `core` profile exceeds 4000 tokens of tool defs at build time
+   - Acceptance: benchmark file committed; CI gate enforced; live spot-check transcripts attached as separate files in `benchmarks/v0.6.4-spot-checks/`
+   - Commit: `v0.6.4-011: cross-harness token-cost benchmark`
+
+2. **v0.6.4-012 — A2A cert scenarios S25–S32** (after 011 has data)
+   - In repo `alphaonedev/ai-memory-test-hub`, fill in the 8 scenario files created during Day 0 prep:
+     - S25: assert `--profile core` registers exactly 5 tools (call `tools/list`, count)
+     - S26: assert `--profile full` matches v0.6.3 baseline (replay v0.6.3 cert against `--profile full`)
+     - S27: `memory_capabilities` available on every profile
+     - S28: calling unloaded tool returns `tool_not_found` with profile hint in error message
+     - S29: token-def cost matches static benchmark within ±10% (consume v0.6.4-011 data)
+     - S30: `--profile core,graph` registers 13 tools (5 + 8 graph)
+     - S31: SDK `requireProfile` raises `ProfileNotLoaded` with actionable hint
+     - S32: boot manifest cost identical across profiles (profile only affects tool defs)
+   - Each scenario gets: a runnable test script, expected output, a verdict line
+   - Run all 8 against v0.6.4 build; record results in `releases/v0.6.4/cert-matrix.md`
+   - Acceptance: 8 GREEN; cert verdict for v0.6.4 cell = CERT
+   - Commit (in test-hub): `v0.6.4: scenarios S25-S32 GREEN`
+
+3. **v0.6.4-013 — Backward-compat verification** (final)
+   - Replay full v0.6.3 cert matrix (S1–S22) against v0.6.4 with `--profile full` set
+   - All S1–S22 must remain GREEN; S23/S24 status carries forward unchanged
+   - Document in `releases/v0.6.4/backward-compat.md`
+   - If any S1–S22 turns RED: STOP — file blocking issue, do not proceed to Friday release
+   - Commit (in test-hub): `v0.6.4: backward-compat S1-S22 GREEN under --profile full`
+
+EOD GATE:
+- `benchmarks/v0.6.4-cross-harness.md` committed with all 5 rows populated
+- All 8 S25-S32 scenarios GREEN on v0.6.4
+- All v0.6.3 carry-forward S1-S22 GREEN under `--profile full`
+- CI green on `feat/v0.6.4`
+
+HANDOFF (memory `campaign-v064` / "v0.6.4 day-4 handoff" / priority 9):
+- Cert verdict: CERT | PARTIAL | FAIL
+- Benchmark numbers (paste full table)
+- Any scenario marked PARTIAL or FAIL with root cause
+- Whether Friday release is GO or NO-GO
+- If NO-GO: list of blockers and proposed remediation order
+
+DECISION RULES:
+- ±10% tokenizer drift is acceptable; document any harness exceeding it
+- A FAIL on S25-S32 → block release, do not proceed
+- A FAIL on backward-compat → block release with highest urgency (regressions are worse than missing the new features)
+- A PARTIAL with documented carry-forward (e.g., S29 needs production data not yet available) → can proceed but document explicitly in release notes
+
+CONSTRAINTS:
+- Same as days 1-3.
+- Do not modify scenario expected-results to make them pass. If S25-S32 fail, the code is wrong, not the test.
+```
+
+---
+
+## DAY 5 — Friday 2026-05-08 — Docs + Release (Track G)
+
+**Audience:** docs-capable NHI + release-engineering NHI. Two parallel until 2pm, sequential after for release.
+
+```
+You are implementing v0.6.4 Day 5 (release day) for ai-memory: Track G (Docs + Release). Days 1-4 shipped. Read all four handoff memories from namespace `campaign-v064` before starting. The Day 4 handoff specifies GO or NO-GO for release.
+
+IF NO-GO:
+- Stop. Read remediation list from Day 4 handoff. File hotfix issues. Do not proceed to release work today. Update sprint memory with delay reason.
+
+IF GO: proceed.
+
+REPO STATE expected:
+- branch `feat/v0.6.4` has commits through v0.6.4-013
+- All cert scenarios GREEN
+- Benchmark numbers in hand
+
+EXECUTE THREE ISSUES — strict sequential ordering on Friday:
+
+PHASE 1 (morning, parallel):
+
+1. **v0.6.4-014 — README + ADMIN_GUIDE updates**
+   - `README.md`: add quick-start callout: "ai-memory v0.6.4 ships with a 5-tool default surface. To enable all 42 tools (v0.6.3 behavior), run `ai-memory mcp --profile full`."
+   - `docs/ADMIN_GUIDE.md`: new chapter "Profiles + Capability Discovery":
+     - Profile families with tool listings
+     - Profile resolution order
+     - `memory_capabilities` discovery dance
+     - Per-agent allowlist syntax
+     - Audit log query examples
+     - Per-harness install recommendations
+   - Run docs-link-check
+   - Commit: `v0.6.4-014: README + ADMIN_GUIDE for profiles`
+
+2. **v0.6.4-015 — Migration guide + release notes** (parallel with 014)
+   - `docs/MIGRATION_v0.6.4.md`:
+     - Section "What changed": default profile flipped, link to RFC
+     - Section "Action required for power users": `--profile full` opt-out steps
+     - Section "Recommended: keep core, opt up via `memory_capabilities`": discovery pattern walkthrough
+     - Section "Per-harness recommendations": one paragraph per harness
+   - `RELEASE_NOTES_v0.6.4.md`:
+     - Headline: "ai-memory v0.6.4 — quiet-tools: 87% less token tax on Codex/Grok/Gemini/Claude-Desktop"
+     - Highlights: 5-tool default, capability discovery, NHI guardrails phase 1, observability via `doctor --tokens`, per-harness install
+     - Breaking changes: default profile flip
+     - Action required: `--profile full` for power users
+     - Cite: Boris/Cherny benchmark + our v0.6.4-011 results
+   - Commit: `v0.6.4-015: migration guide + release notes`
+
+PHASE 2 (lunch, ~1pm-2pm) — pre-release review:
+- Run pre-release security review per project SOP (`/security-review` skill if available)
+- Run scope-drift check: every commit on `feat/v0.6.4` corresponds to an issue in `v0.6.4` milestone; nothing extra
+- Run RFC compliance check: every requirement in §"Goals" of RFC is satisfied
+- Document review findings in memory `campaign-v064` / "v0.6.4 release review"
+- If any blocker: STOP, file hotfix, do not tag
+
+PHASE 3 (afternoon, sequential):
+
+3. **v0.6.4-016 — CHANGELOG + tag + CI release**
+   - `CHANGELOG.md`: move "Unreleased" entries under new "v0.6.4 — 2026-05-08" heading; add highlights one-liner
+   - Bump versions:
+     - `Cargo.toml`: `version = "0.6.4"`
+     - `sdk/typescript/package.json`: `"version": "0.6.4"`
+     - `sdk/python/pyproject.toml`: `version = "0.6.4"`
+   - Commit: `v0.6.4: bump versions + finalize CHANGELOG`
+   - Open PR `feat/v0.6.4 → main`; squash-merge after CI green
+   - On `main`: `git tag v0.6.4 -m "ai-memory v0.6.4 — quiet-tools"`; push tag
+   - CI release flow runs automatically on tag push: builds binaries, publishes to GitHub Releases, opens brew tap PR, publishes npm + PyPI
+   - Verify: GitHub release page shows v0.6.4 with artifacts; brew install of v0.6.4 produces working binary; `npm install ai-memory@0.6.4` and `pip install ai-memory==0.6.4` both succeed
+   - Commit (final): the merge commit + tag
+
+EOD GATE (release day) — all of these must be true before EOD:
+- v0.6.4 tagged and pushed
+- GitHub release published with artifacts
+- brew tap PR open
+- npm + PyPI published
+- All 4 docs files committed
+- 6pm ET internal-channel announcement posted
+- NO public X/blog post yet (saved for Mon 2026-05-11)
+
+HANDOFF (memory `campaign-v064` / "v0.6.4 release handoff" / priority 10):
+- Tag pushed: yes/no + git SHA
+- Release artifacts: links
+- Public-announcement deferral note: "Mon 2026-05-11"
+- Post-release monitoring schedule: 48h elevated alert
+- Any post-release todos discovered
+
+DECISION RULES:
+- Pre-release review finding blocker → STOP, no tag today, slip to Sat
+- CI fails on tag-push release flow → debug, fix, re-tag once green; do not push broken artifacts
+- Brew tap PR auto-merge: do NOT auto-merge today; let it queue for Mon review
+- npm/PyPI publish failure → retry once, then file blocker; don't ship partial release where some clients can install but others can't
+- Public announcement: NOT today regardless of release success — let release soak over weekend
+
+CONSTRAINTS:
+- Same as days 1-4.
+- Do not amend commits on `main`.
+- Do not force-push.
+- Do not skip the pre-release review even under time pressure.
+- If any "do not" constraint conflicts with shipping today, the right call is "do not ship today."
+```
+
+---
+
+## EMERGENCY-BREAK prompt — invoked only if a track stalls
+
+**Use when:** any day's gate is missed and the next day's NHI is starting.
+
+```
+You are taking over a stalled v0.6.4 track. The previous day's gate was missed. Read these in order:
+
+1. /var/root/agentic-mem-labs/strategy/2026-05-02/v0.6.4-roadmap.md
+2. /var/root/agentic-mem-labs/strategy/2026-05-02/v0.6.4-nhi-prompts.md
+3. The most recent handoff memory from namespace `campaign-v064` (look for `tag:handoff` priority 9+)
+
+YOUR ONE JOB TODAY:
+- Identify the specific gate that wasn't met (check Day-N gate criteria in the prompts)
+- Identify the blocker (read the failure detail in the most recent handoff)
+- Execute the minimum work to clear that blocker
+- Re-run the gate criteria for the previous day
+- If gate now passes: write a recovery handoff memory and DO NOT advance to today's planned work — the schedule slips by one day
+- If gate still fails: escalate to human reviewer with a concrete remediation proposal
+
+DECISION RULES:
+- Schedule slip is acceptable; quality compromise is not
+- If the blocker requires architecture-level rework: STOP, escalate, do not paper over
+- If the blocker is a flaky test: DO NOT mark as known-flake; root-cause it
+- If the blocker is missing CI infra: file the infra gap as a separate issue, work around with documented manual gate
+
+OUTPUT:
+- Memory titled "v0.6.4 recovery <day>" / namespace `campaign-v064` / priority 10
+  - What was blocked
+  - What you did to clear it
+  - Whether the schedule recovers (Friday ship still GO?) or slips (new ship date)
+  - What the next NHI should do
+```
+
+---
+
+## Notes for the human reviewer
+
+- These prompts are **single-session-self-contained**. An NHI starting one of them does not need access to prior session memory beyond what's stored in `campaign-v064` namespace.
+- Prompts assume the NHI has Bash, file edit/read/write, GitHub access, and the ai-memory MCP server connected.
+- Each day's "EOD GATE" is the explicit pass/fail criterion for proceeding to the next day. Do not advance on a missed gate without explicit human override.
+- The `EMERGENCY-BREAK` prompt is the safety valve for slips; it imposes a one-day calendar slip but preserves quality.
+- The `Day 0` prompt is meant for Saturday or Sunday; it does not write code and is safe to run autonomously.
+- Public announcement is intentionally deferred to Mon 2026-05-11 even on a successful Friday ship — gives 60h soak time and lands on a high-attention day rather than weekend.
+
+---
+
+## Single-line summary for the timeline
+
+**Five prompts (one per dev day) + one kickoff + one emergency-break = the full Mon→Fri NHI dispatch deck for ai-memory v0.6.4. Each is self-contained, gate-criteria-bound, and writes its own handoff memory under `campaign-v064` for downstream NHI continuity.**

--- a/docs/v0.6.4/v0.6.4-roadmap.md
+++ b/docs/v0.6.4/v0.6.4-roadmap.md
@@ -1,0 +1,341 @@
+# v0.6.4 — Cross-harness token economics + NHI guardrails phase 1
+
+**Status:** ROADMAP — sprint authorized 2026-05-02
+**Sprint window:** Mon 2026-05-04 → Fri 2026-05-08 (5 dev days)
+**Release target:** Fri 2026-05-08 EOD
+**Code-name:** `quiet-tools` — the release where ai-memory stops being a token hog
+**Authority:** strategy session 2026-05-02 (this directory)
+**Design doc:** `rfc-default-tool-surface-collapse.md` (this directory)
+
+---
+
+## Why this release exists
+
+Boris Cherny's published 90-day instrumentation data (May 2026) quantified that 73% of Claude Code tokens go to nine waste patterns. ai-memory is the **#1 contributor to Pattern 6** (just-in-case tool definitions) on every coding-agent harness except Claude Code's deferred-tool path: ~25,200 input tokens per request just for tool schemas, ~$570/year per heavy user, ~$0.076 per request. On Codex / Grok CLI / Gemini CLI / stock Claude Desktop, ai-memory is dominating the input prefix.
+
+v0.6.4 fixes this in one release: **default 5-tool surface, opt-in expansion, observability, NHI guardrails phase 1, and cross-harness install profiles.** Goal: drop tool-def overhead 87% on naïve harnesses, ship a discovery protocol that scales to AI NHI deployments, and make the bill visible.
+
+If we don't ship this, ai-memory inherits the "AI token hog" reputation just as Codex/Grok/Gemini adoption accelerates. We do not have the credibility budget to absorb that.
+
+---
+
+## Scope — what's IN
+
+### Mechanism
+1. `--profile` CLI flag + `AI_MEMORY_PROFILE` env + `[mcp].profile` config field (resolution order: CLI > env > config > default)
+2. Family-scoped tool registration filter
+3. `core` profile (5 tools) as default; `graph`, `admin`, `power`, `full`, custom comma-separated
+4. `core` ships as new default (behavior change — backward-compat via `--profile full`)
+
+### Discovery
+5. `memory_capabilities` returns family enumeration (always-loaded, ~250 tokens)
+6. `memory_capabilities --include-schema family=X` returns inline schemas for runtime registration on hosts that support it (Claude Code's deferred-tools path; graceful degradation elsewhere)
+
+### Observability
+7. `ai-memory doctor --tokens` reports per-session boot manifest cost + per-tool schema cost + active profile
+8. Static schema-size table compiled at build time so cost is queryable without running
+
+### NHI guardrails (phase 1)
+9. Per-agent allowlist (config-driven, `agent_id`-keyed, defaults to `core` for unknown agents)
+10. Capability-expansion audit log (every `--include-schema` call written to `audit_log`)
+
+### SDK
+11. TypeScript SDK `client.requireProfile("graph")` with `ProfileNotLoaded` error path
+12. Python SDK equivalent
+
+### Cross-harness install
+13. Per-harness install profile selection (claude-code, claude-desktop, codex, grok-cli, gemini-cli) — all default to `core`
+14. Install scripts updated for each harness
+
+### Cert + benchmarks
+15. A2A cert scenarios S25–S32 (8 new scenarios) added to v0.6.4 cell of cert matrix
+16. Cross-harness token-cost benchmark fixture; static + 1 live spot-check per harness
+17. Backward-compat verification: `--profile full` matches v0.6.3 baseline 1:1
+
+### Docs
+18. README quick-start updated to reference `--profile` and `doctor --tokens`
+19. ADMIN_GUIDE.md gets profile-selection chapter
+20. Migration guide (`docs/MIGRATION_v0.6.4.md`) for users updating from v0.6.3.x
+21. Release notes calling out default flip with action-required tag
+
+### Release engineering
+22. CHANGELOG entry, semver bump (0.6.3.x → 0.6.4), git tag, CI release flow, brew tap update
+
+---
+
+## Scope — what's OUT (explicitly deferred)
+
+| Item | Reason | Target |
+|---|---|---|
+| `--auto-profile` heuristic upgrade | Avoids surprise behavior in v0.6.4; ship after the basic mechanism is in production | v0.7 |
+| Rate-limit on capability expansion (NHI guardrail #3) | Depends on observation data from v0.6.4 in production | v0.7 |
+| Attestation-tier gating (NHI guardrail #4) | Depends on #238 closure (body-claimed agent_id ↔ mTLS cert binding) | v0.7 |
+| Tier-6 redacted-discovery | Depends on classification-aware attestation tiers being concretely defined | v0.8+ |
+| Runtime tool registration on Codex/Grok/Gemini | Depends on host-side support that doesn't yet exist | When hosts ship it |
+| `memory_share` (#311) | Orthogonal feature; carries its own roadmap slot | v0.6.0.1 / parallel track |
+
+---
+
+## Issue list (16 issues)
+
+Issues land in `alphaonedev/ai-memory-mcp` with milestone `v0.6.4`. Each issue includes acceptance criteria, dependencies, and an owning track.
+
+### Track A — Mechanism (Mon)
+
+#### v0.6.4-001 — `--profile` flag (CLI + env + config resolution)
+- **Goal:** add `--profile` to `ai-memory mcp` CLI, `AI_MEMORY_PROFILE` env var, `[mcp].profile` config.toml field
+- **Resolution order:** CLI > env > config > default (`core`)
+- **Acceptance:** unit test for each resolution path; integration test asserting profile is honored across CLI/env/config
+- **Dep:** none (foundation)
+- **Files:** `src/cli.rs`, `src/config.rs`, `src/mcp/registration.rs`
+
+#### v0.6.4-002 — Family-scoped tool registration filter
+- **Goal:** refactor `register_tools()` so each family has a `register_<family>(server)` function gated on profile
+- **Families:** core (5), lifecycle (5), graph (8), governance (8), power (6), meta (4), archive (4), other (2)
+- **Acceptance:** unit test per family asserting exact tool count registered; integration test `--profile core` registers 5, `--profile full` registers 42
+- **Dep:** v0.6.4-001
+- **Files:** `src/mcp/families/`
+
+#### v0.6.4-003 — `core` default flip + backward-compat
+- **Goal:** flip default from `full` (today) to `core` (new); document the change loudly
+- **Acceptance:** fresh install with no flags = `core` profile loaded; `--profile full` reproduces v0.6.3 surface 1:1; release-notes flag documents action-required for power users
+- **Dep:** v0.6.4-002
+- **Files:** `src/mcp/registration.rs`, `CHANGELOG.md`, release notes
+
+### Track B — Observability (Mon)
+
+#### v0.6.4-004 — `ai-memory doctor --tokens`
+- **Goal:** new `--tokens` flag on `doctor` reports per-session boot manifest cost, per-tool schema cost, active profile, projected savings if downgrading profile
+- **Output:** human-readable + JSON via `--format json`
+- **Acceptance:** `ai-memory doctor --tokens` on any machine returns valid output; JSON path conforms to schema; values match static schema-size table within 2%
+- **Dep:** v0.6.4-005
+- **Files:** `src/cli/doctor.rs`
+
+#### v0.6.4-005 — Static schema-size table (build-time)
+- **Goal:** at build time, generate a table of (tool_name, schema_token_count) using a tokenizer crate; embed in binary so doctor can report cost without running registration
+- **Tokenizer:** `tiktoken-rs` matching OpenAI `cl100k_base` (close enough for cross-tokenizer estimates within ±10%)
+- **Acceptance:** built binary contains table; `ai-memory doctor --tokens --raw-table` dumps it; CI gate fails if any tool's schema exceeds 1500 tokens (catches regressions)
+- **Dep:** none
+- **Files:** `build.rs`, `src/mcp/families/sizes.rs`
+
+### Track C — Discovery (Tue)
+
+#### v0.6.4-006 — `memory_capabilities` extension (family enumeration + `--include-schema`)
+- **Goal:** extend `memory_capabilities` (already in core) to:
+  - return list of available families and their tool names
+  - accept optional `family=<name>` parameter
+  - accept optional `include_schema=true` to return full schemas inline
+- **Acceptance:** call without args returns family list (~400 tokens); with `family=graph` returns 8 tool schemas; with `include_schema=true` schemas are valid MCP tool definitions
+- **Dep:** v0.6.4-002
+- **Files:** `src/mcp/families/meta.rs`
+
+#### v0.6.4-007 — SDK `requireProfile` (TypeScript + Python)
+- **Goal:** SDK helper that calls `memory_capabilities` to verify a family is loaded; raises `ProfileNotLoaded` with CLI/env hint if not
+- **Acceptance:** TS test + Py test asserting raise on missing profile; sample message includes exact `--profile` hint
+- **Dep:** v0.6.4-006
+- **Files:** `sdk/typescript/src/profile.ts`, `sdk/python/src/profile.py`
+
+### Track D — NHI guardrails phase 1 (Wed)
+
+#### v0.6.4-008 — Per-agent capability allowlist
+- **Goal:** new `[mcp.allowlist]` config table mapping `agent_id` (or pattern) → allowed family set; default for unknown agents = `core`
+- **Resolution:** when an agent calls `memory_capabilities --include-schema family=X`, server checks allowlist before returning schemas; if denied, returns structured error
+- **Acceptance:** config-driven test fixture with 3 agents, each with different family rights; integration test shows correct grant/deny per agent
+- **Dep:** v0.6.4-006
+- **Files:** `src/config.rs`, `src/mcp/families/meta.rs`, `docs/ADMIN_GUIDE.md`
+
+#### v0.6.4-009 — Capability-expansion audit log
+- **Goal:** every `memory_capabilities --include-schema` call writes a row to `audit_log` table: `(agent_id, requested_family, granted, attestation_tier, timestamp)`
+- **Acceptance:** schema migration v20 adds `audit_log` table (idempotent); integration test asserts row written on grant + deny; `ai-memory audit show --capability-expansions` CLI reads it
+- **Dep:** v0.6.4-008
+- **Files:** `src/db/migrations/v20_audit_log.sql`, `src/audit.rs`, `src/cli/audit.rs`
+
+### Track E — Cross-harness install (Wed)
+
+#### v0.6.4-010 — Per-harness install profiles
+- **Goal:** install scripts for each harness select `core` profile by default; document opt-up path
+- **Harnesses:** claude-code, claude-desktop, codex, grok-cli, gemini-cli
+- **Acceptance:** `ai-memory install --harness <name>` writes correct config for that harness; tested manually on each harness
+- **Dep:** v0.6.4-001
+- **Files:** `src/cli/install.rs`, `installers/<harness>/`
+
+### Track F — Cert + benchmarks (Thu)
+
+#### v0.6.4-011 — Cross-harness token-cost benchmark
+- **Goal:** static benchmark + 1 live spot-check per harness measuring tool-def + boot-manifest token cost
+- **Outputs:** `benchmarks/v0.6.4-cross-harness.md` with before/after table per harness; CI fails if `core` profile exceeds 4000 tokens of tool defs
+- **Acceptance:** benchmark file committed; CI gate enforced; spot-check transcripts attached
+- **Dep:** v0.6.4-005, v0.6.4-010
+- **Files:** `benchmarks/`, `.github/workflows/token-budget.yml`
+
+#### v0.6.4-012 — A2A cert scenarios S25–S32
+- **Goal:** add 8 scenarios to v0.6.4 cert cell of `ai-memory-test-hub`
+- **Scenarios:**
+  - S25 `--profile core` registers exactly 5 tools
+  - S26 `--profile full` matches v0.6.3 baseline
+  - S27 `memory_capabilities` always available regardless of profile
+  - S28 calling unloaded tool returns `tool_not_found` with profile hint
+  - S29 token-def cost per harness measured + recorded
+  - S30 custom profile (`--profile core,graph`) registers union
+  - S31 SDK `requireProfile` raises `ProfileNotLoaded` cleanly
+  - S32 boot manifest cost unchanged across profiles
+- **Acceptance:** all 8 GREEN at v0.6.4-rc; cert verdict for v0.6.4 cell = CERT
+- **Dep:** v0.6.4-001 through v0.6.4-011
+- **Files:** `cert/scenarios/v0.6.4/`
+
+#### v0.6.4-013 — Backward-compat verification (`--profile full`)
+- **Goal:** prove `--profile full` produces identical v0.6.3 behavior; no regressions
+- **Acceptance:** full v0.6.3 cert matrix replayed against v0.6.4 with `--profile full` set; all S1–S22 GREEN; S23/S24 status unchanged from v0.6.3.1
+- **Dep:** v0.6.4-003
+- **Files:** `cert/regression/v0.6.4-full-profile.md`
+
+### Track G — Docs + release (Fri)
+
+#### v0.6.4-014 — README + ADMIN_GUIDE updates
+- **Goal:** quick-start references `--profile`, `doctor --tokens`; ADMIN_GUIDE has full profile chapter
+- **Acceptance:** PR review pass; rendered docs link-checked
+- **Dep:** all earlier tracks substantially complete
+- **Files:** `README.md`, `docs/ADMIN_GUIDE.md`
+
+#### v0.6.4-015 — Migration guide + release notes
+- **Goal:** `docs/MIGRATION_v0.6.4.md` walks v0.6.3.x users through default flip and opt-out
+- **Release notes:** call out default change with action-required tag; include token-savings claim with citation to benchmark file
+- **Acceptance:** PR review pass; preview deploy renders
+- **Dep:** v0.6.4-011 (benchmark numbers needed)
+- **Files:** `docs/MIGRATION_v0.6.4.md`, `RELEASE_NOTES_v0.6.4.md`
+
+#### v0.6.4-016 — CHANGELOG, tag, CI release
+- **Goal:** CHANGELOG entry, version bumps in `Cargo.toml` and SDKs, git tag `v0.6.4`, CI release flow runs cleanly, brew tap PR opens
+- **Acceptance:** tag pushed; release artifacts on GitHub releases; brew install of `v0.6.4` produces working binary; SDKs published to npm + PyPI
+- **Dep:** all
+- **Files:** `CHANGELOG.md`, `Cargo.toml`, `sdk/typescript/package.json`, `sdk/python/pyproject.toml`, `.github/workflows/release.yml`
+
+---
+
+## Daily schedule
+
+### Sat 2026-05-03 — pre-flight (this weekend)
+- Sign off on RFC + roadmap (you, today/tomorrow)
+- File 16 GitHub issues against milestone `v0.6.4` with content from this doc
+- Stand up `cert/scenarios/v0.6.4/` skeleton in `ai-memory-test-hub`
+- Branch `feat/v0.6.4` cut from `main`
+- AI NHI prompts loaded into ai-memory under `campaign-v064` namespace
+
+### Sun 2026-05-03 — final prep
+- Confirm dev sprint NHI roster (which agents claim which tracks)
+- Pre-warm Claude Code session memory with v0.6.3 architecture review
+- Verify CI environment can run cross-harness benchmark (Codex/Grok/Gemini test fixtures)
+- Hold-the-line: no scope creep accepted after EOD Sun
+
+### Mon 2026-05-04 — Mechanism + observability (Tracks A + B)
+- Morning: v0.6.4-005 (schema-size table) + v0.6.4-001 (profile flag) in parallel
+- Afternoon: v0.6.4-002 (family filter) + v0.6.4-004 (`doctor --tokens`)
+- EOD: v0.6.4-003 (default flip) lands on branch; `--profile core` works locally
+- **Gate:** `ai-memory mcp --profile core` registers 5 tools; `--profile full` registers 42; CI green
+
+### Tue 2026-05-05 — Discovery + SDK (Track C)
+- Morning: v0.6.4-006 (`memory_capabilities` extension)
+- Afternoon: v0.6.4-007 (SDK `requireProfile` TS + Py in parallel)
+- EOD: TS + Py SDKs locally call new capabilities surface; integration test green
+- **Gate:** SDK error path returns actionable hint; capabilities returns 42 tools' worth of schemas in ≤25K tokens (sanity)
+
+### Wed 2026-05-06 — NHI guardrails + cross-harness (Tracks D + E)
+- Morning: v0.6.4-008 (allowlist) + v0.6.4-010 (install profiles in parallel)
+- Afternoon: v0.6.4-009 (audit log)
+- EOD: 5 harnesses install with `core` profile; allowlist denies/grants per config
+- **Gate:** schema migration v20 idempotent; audit_log row written on every `--include-schema` call
+
+### Thu 2026-05-07 — Cert + benchmarks (Track F)
+- Morning: v0.6.4-011 (cross-harness benchmark) — static-only first, then 1 live spot-check per harness
+- Afternoon: v0.6.4-012 (A2A scenarios S25–S32)
+- Late afternoon: v0.6.4-013 (backward-compat verification)
+- EOD: cert matrix for v0.6.4 cell = CERT (or PARTIAL with documented carry-forward)
+- **Gate:** all S25–S32 GREEN; benchmark file shows ≥85% reduction on Codex/Grok/Gemini
+
+### Fri 2026-05-08 — Docs + release (Track G)
+- Morning: v0.6.4-014 (README + ADMIN_GUIDE) + v0.6.4-015 (migration guide + release notes in parallel)
+- Lunch: pre-release review pass — RFC compliance check, scope drift check, security review (per project SOP)
+- Afternoon: v0.6.4-016 (CHANGELOG, tag, CI release)
+- 4pm ET: tag `v0.6.4` pushed
+- 5pm ET: GitHub release published; brew tap PR opens; npm + PyPI publish triggered
+- 6pm ET: announcement posted to project channels (NOT to wider X/social — wait for Mon when audience is back)
+- EOD: post-release monitoring on for 48h
+
+### Mon 2026-05-11 — post-release
+- Public announcement (X, Bluesky, blog)
+- Citation of Boris's data + before/after benchmark
+- Schedule one-time agent in 2 weeks to run cleanup PR for any `--profile full` workarounds users add
+
+---
+
+## Testing strategy
+
+### Unit
+- Per-family registration filter — every family has a unit test asserting its exact tool set
+- Profile resolution order — CLI > env > config > default tested explicitly
+- Allowlist matching — pattern resolution, default-deny for unknown agents, exact-match wins
+
+### Integration
+- `ai-memory mcp` boots with each profile and lists tools via MCP `tools/list` — count matches
+- `memory_capabilities --include-schema family=X` returns valid MCP schema dicts
+- Audit log written on grant + deny path
+- SDK `requireProfile` round-trip on TS and Py
+
+### Cert (A2A)
+- S25–S32 added to `cert/scenarios/v0.6.4/`
+- Verdict criteria: CERT = all S1–S22 carry-forward GREEN AND S25–S32 GREEN; PARTIAL = pending Patch 3; FAIL = anything else
+
+### Benchmark
+- Static cost table CI-gated (no tool exceeds 1500 tokens)
+- Cross-harness live spot-check per harness on Thu
+- Before/after delta committed to `benchmarks/v0.6.4-cross-harness.md`
+
+### Backward-compat
+- v0.6.3 cert matrix replayed against `--profile full` on v0.6.4 — all S1–S22 must remain GREEN
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Schema-size tokenizer drift across providers (cl100k vs OpenAI vs Gemini) | High | Low | Document ±10% margin; benchmark accepts the range |
+| Default flip surprises power-user installs | Medium | Medium | `--profile full` opt-out; loud release-notes; migration guide |
+| #238 not closed by v0.7 → guardrail phase 2 slips | Medium | Low | Phase 1 in v0.6.4 stands alone; phase 2 is honest "v0.7 dependent on #238" |
+| 5-day calendar tight if any track stalls | Medium | High | Track A is foundation; if Mon doesn't ship, slip to Sat ship not next-Fri ship |
+| Cross-harness benchmark requires harness fixtures CI doesn't have | High | Medium | Static benchmark is primary; live spot-check is supplementary; live can fall back to manual |
+| SDK negotiation breaks existing programmatic users | Low | High | `requireProfile` is additive; existing tool calls untouched |
+| `memory_capabilities --include-schema` hits MCP message-size limits for large families | Low | Medium | Cap response at one family per call; document chunking |
+| Custom profile parsing edge cases (`core,full`, empty, duplicate families) | Medium | Low | Spec rules in RFC; test fixtures explicit |
+
+---
+
+## Success metrics (measured at Mon 2026-05-11)
+
+1. **Token-def cost on Codex/Grok/Gemini drops ≥85%** vs. v0.6.3 baseline (target 87%, floor 85%)
+2. **`--profile core` covers ≥95% of agent traffic** without escalation, measured from v0.6.4 production telemetry over first 7 days
+3. **`memory_capabilities --include-schema` is the canonical NHI expansion path** — at least 3 of the 5 harnesses have an agent in production using it within 14 days of release
+4. **Zero regressions in v0.6.3 cert matrix** when `--profile full` set
+5. **Audit log captures 100% of capability-expansion calls** verified via spot check on a sample of v0.6.4 production traffic
+
+If 1–4 hit, v0.6.4 is a success. (5) is operational hygiene; if it misses, file a Patch 3 hotfix issue same day.
+
+---
+
+## Approval gate (this weekend)
+
+Sign off required by Sun 2026-05-03 EOD on:
+- [ ] Scope as listed above (all 16 issues IN; explicit deferrals OUT)
+- [ ] 5-day sprint window (Mon–Fri) and Friday ship target
+- [ ] Per-day track plan
+- [ ] Risk register
+- [ ] Success metrics
+- [ ] Post-release public-announcement timing (Mon 2026-05-11)
+
+Once signed: file 16 GitHub issues, cut `feat/v0.6.4` branch, dispatch NHI prompts. Sprint executes per `v0.6.4-nhi-prompts.md` (sibling document).
+
+---
+
+## Single-line summary for the timeline
+
+**Mon 2026-05-04 to Fri 2026-05-08: ai-memory ships v0.6.4 with 5-tool default surface, NHI capability-discovery protocol phase 1, and per-harness install profiles. Tool-def overhead drops 87% on Codex/Grok/Gemini/Claude-Desktop. Reputation cleanup; AI NHI futureproofing; 5 dev days; one engineer-week of NHI sprint work.**


### PR DESCRIPTION
## Summary

Lands the v0.6.4 release package under `docs/v0.6.4/`:

- `README.md` — release overview + quick navigation
- `rfc-default-tool-surface-collapse.md` — design RFC (status APPROVED)
- `v0.6.4-roadmap.md` — 16-issue sprint plan, daily schedule, test/cert/release plan, risk register, success metrics
- `v0.6.4-nhi-prompts.md` — 7 self-contained AI NHI starter prompts for the dev cycle

## Theme

**Cross-harness token economics + AI NHI capability-discovery protocol phase 1.**

Default profile flips from 42 tools → 5 tools (`memory_store`/`recall`/`list`/`get`/`search`). Other 37 tools available via static profile (`graph`/`admin`/`power`/`full`) or runtime discovery (`memory_capabilities --include-schema`). Backward compatibility via `--profile full`.

Projected reduction: **~87%** on Codex / Grok CLI / Gemini CLI / Claude Desktop (~25,200 → ~3,250 input tokens of tool schemas per request).

## Sprint window

- **Authorized:** Sat 2026-05-02
- **Dev cycle:** Mon 2026-05-04 → Fri 2026-05-08
- **Tag:** Fri 2026-05-08 EOD
- **Public announcement:** Mon 2026-05-11

## Test plan

- [ ] Render `docs/v0.6.4/README.md` on GitHub — formatting OK
- [ ] All cross-doc links resolve
- [ ] No accidental private-repo references in copied content
- [ ] `gh pr view` confirms branch + base