### PR TITLE
docs(pages): v0.6.4 marketing repositioning + new whats-new-v064.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -346,7 +346,7 @@
     <a class="home-link" href="./">ai-memory</a>
     <div class="right">
       <a href="at-a-glance.html" style="color:#6ee7ff">Atlas</a>
-      <a href="whats-new-v063.html" style="color:#ffb86b">v0.6.3</a>
+      <a href="whats-new-v064.html" style="color:#6ee7ff">v0.6.4</a>
       <div class="menu">
         <button class="menu-btn">Audiences<span class="caret">▾</span></button>
         <div class="menu-pane">
@@ -430,49 +430,65 @@
 <section class="hero">
     <div class="container">
         <img src="ai-memory-logo.jpg" alt="ai-memory logo" style="width:160px;height:auto;margin-bottom:1.5rem;border-radius:16px;filter:drop-shadow(0 0 24px rgba(255,255,255,.25))">
-        <h1>Persistent Memory for <span>Any AI</span></h1>
+        <h1>The memory substrate <span>AI agents run on.</span></h1>
+        <p style="font-size:1.15rem;color:var(--text-muted);max-width:780px;margin:0 auto 2rem;line-height:1.55">
+            From a developer's laptop to a multi-region hive of agents &mdash; <strong style="color:#fff">same binary, same schema, same code path.</strong> You don't graduate off ai-memory; you turn flags on.
+        </p>
         <div class="bluf-card">
-            <span class="bluf-eyebrow">BLUF &mdash; Bottom Line Up Front</span>
+            <span class="bluf-eyebrow" style="background:rgba(110,231,255,0.1);color:#6ee7ff;border-color:#6ee7ff">v0.6.4 &mdash; <code>quiet-tools</code> &middot; 76.4% lighter on the wire &middot; same 43-tool capability</span>
 
             <p class="bluf-lead">
-                <strong>ai-memory is persistent, portable memory for AI agents.</strong>
-                One SQLite file on your hardware. Works with any MCP-compatible AI &mdash; Claude, ChatGPT, Cursor, Grok, Llama, OpenClaw 🦞, anything that speaks the Model Context Protocol. Apache 2.0; trademark-protected (USPTO Serial No.&nbsp;99761257).
+                Most "AI memory" products are <em>chat memory</em>: one user, one AI, one conversation. <strong>ai-memory is the agent substrate</strong> &mdash; federation primitives, governance policies, capability allowlists, audit trails, peer mTLS, webhook event bus, autonomous curator. Built for the agent era, not retrofitted from chat memory. Apache 2.0, single Rust binary, runs on SQLite. Works with any MCP-compatible AI &mdash; Claude, ChatGPT, Cursor, Grok, Llama, OpenClaw 🦞, every modern AI tool.
             </p>
 
             <p class="bluf-section">
-                <strong>Replaces vendor auto-memory.</strong>
-                Vendor memory features (Claude auto-memory, ChatGPT memory) load your entire memory into every message &mdash; burning tokens on idle context whether the AI uses it or not. ai-memory uses <strong style="color:var(--green)">zero context tokens</strong> until the AI calls <code>memory_recall</code> &mdash; only relevant memories come back, ranked, and compressed via TOON format (79% smaller than JSON).
+                <strong>One install, five tiers.</strong>
+                <a href="architectures-t1.html" style="color:#6ee7ff">T1 (single agent, your laptop)</a> &rarr; <a href="architectures-t2.html" style="color:#6ee7ff">T2 (many agents, one host)</a> &rarr; <a href="architectures-t3.html" style="color:#6ee7ff">T3 (multi-node cluster)</a> &rarr; <a href="architectures-t4.html" style="color:#6ee7ff">T4 (data-center swarm)</a> &rarr; <a href="architectures-t5.html" style="color:#6ee7ff">T5 (global hive)</a>. Same binary across all five &mdash; flip flags, not products. Quorum W-of-N writes, vector-clock CRDT-lite merge, mTLS peer allowlist, NHI capability allowlist, capability-expansion audit log (schema v20). <a href="architectures.html" style="color:#fff;border-bottom:1px dashed var(--text-muted)">See the ladder &rarr;</a>
             </p>
 
             <p class="bluf-section">
-                <strong>Substrate, not product.</strong>
-                Today: multi-agent federation with W-of-N quorum<span class="cap-pill cap-beta">beta</span>, autonomous curator that consolidates and detects contradictions, namespace-scoped governance, and a 43&#8202;tool / 50&#8202;endpoint / 40&#8202;command MCP &middot; HTTP &middot; CLI surface. Self-hosted, local-first, no cloud dependency, no vendor lock-in. <span class="bluf-coming">Coming in v0.7</span>: cryptographically-attested provenance (Ed25519), hash-chained audit logs, sidechain transcripts, and forensic export bundles &mdash; the regulated-industry primitives.
+                <strong>Zero token cost until recall.</strong>
+                Vendor memory (Claude auto-memory, ChatGPT memory) loads everything into every message &mdash; burning tokens on idle context. ai-memory uses <strong style="color:var(--green)">zero context tokens</strong> until the AI calls <code>memory_recall</code>. Only relevant memories return, ranked by 6 factors, compressed in TOON format (79% smaller than JSON). v0.6.4 cuts the bootstrap cost too: <strong style="color:#6ee7ff">76.4% input-token reduction</strong> on session start (5-tool default surface; the other 38 of 43 load on demand via <code>--profile</code> or runtime expansion).
+            </p>
+
+            <p class="bluf-section">
+                <strong>Empirically validated, not just tested.</strong>
+                <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:#2ea043">NHI Discovery Gate &mdash; 6/6 PASS, GATE GREEN</a> against live xAI Grok 4.3. <a href="https://alphaonedev.github.io/ai-memory-test-hub/" style="color:#6ee7ff">Test Hub</a> with per-release CERT verdicts. ~2,400 tests at <strong style="color:#2ea043">93.84% line coverage</strong> (56,996 lines, 3,511 missed; region 93.81%, function 92.65%); CI-enforced &ge;93% line floor that fails any PR below it. Published <a href="evidence.html" style="color:#c8a2ff">evidence pages</a> tie every claim back to a verifiable source &mdash; including <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/v0.6.4-cross-harness.md" style="color:#c8a2ff">an explicit honesty correction</a> on the v0.6.4 token-reduction methodology. <span class="bluf-coming">Coming in v0.7</span>: cryptographic provenance (Ed25519), hash-chained audit logs, forensic export bundles &mdash; regulated-industry primitives.
+            </p>
+
+            <p class="bluf-section">
+                <strong>First-party SDKs, OIDC-published.</strong>
+                <a href="https://www.npmjs.com/package/@alphaone/ai-memory" style="color:#cb3837"><code>@alphaone/ai-memory</code> on npm</a> &middot; <a href="https://pypi.org/project/ai-memory-mcp/" style="color:#3776AB"><code>ai-memory-mcp</code> on PyPI</a>. <code>requireProfile</code> helper for runtime profile assertions. Trademark-protected (USPTO Serial No.&nbsp;99761257).
             </p>
         </div>
         <p style="font-size:.85rem;color:var(--text-muted);margin-bottom:2rem">
             Works with Claude &middot; ChatGPT &middot; <a href="https://github.com/alphaonedev/grok-cli" style="color:var(--accent);text-decoration:none;">Grok CLI</a> &middot; Grok API &middot; Cursor &middot; Windsurf &middot; Continue.dev &middot; OpenClaw 🦞 &middot; Hermes Agent &middot; Llama &middot; any MCP client
         </p>
         <div class="stats-row">
-            <div class="stat"><span class="num">97.8%</span><span class="label">Recall@5</span></div>
-            <div class="stat"><span class="num">43</span><span class="label">MCP Tools</span></div>
-            <div class="stat"><span class="num">4</span><span class="label">Operational Modes</span></div>
-            <div class="stat"><span class="num">1,886</span><span class="label">Tests</span></div>
+            <div class="stat"><span class="num">5 / 43</span><span class="label">Default / Full MCP Tools</span></div>
+            <div class="stat"><span class="num">76.4%</span><span class="label">v0.6.4 Token Reduction</span></div>
+            <div class="stat"><span class="num">T1 → T5</span><span class="label">Architecture Tiers</span></div>
+            <div class="stat"><span class="num">6/6</span><span class="label">Discovery Gate PASS</span></div>
+            <div class="stat"><span class="num">93.84%</span><span class="label">Line Coverage &middot; CI-gated &ge;93%</span></div>
         </div>
         <div style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
             <a href="#install" class="hero-cta">Get Started in 60 Seconds</a>
-            <a href="https://alphaonedev.github.io/ai-memory-test-hub/" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">🧪 Live Test Results — 1,886 tests · 93.84% cov →</a>
-            <a href="evidence.html" class="hero-cta" style="background:transparent;border:1px solid #c8a2ff;color:#c8a2ff">📐 Frozen Claims (Evidence) →</a>
-            <a href="at-a-glance.html" class="hero-cta" style="background:transparent;border:1px solid #999;color:#999">📊 Visualization Atlas →</a>
-            <a href="whats-new-v063.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">✨ What's New in v0.6.3 →</a>
+            <a href="whats-new-v064.html" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">✨ What's New in v0.6.4 →</a>
+            <a href="architectures.html" class="hero-cta" style="background:transparent;border:1px solid #ffb86b;color:#ffb86b">📐 The 5-Tier Ladder (T1→T5) →</a>
+            <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" class="hero-cta" style="background:transparent;border:1px solid #2ea043;color:#2ea043">🟢 Discovery Gate — 6/6 PASS →</a>
+            <a href="https://alphaonedev.github.io/ai-memory-test-hub/" class="hero-cta" style="background:transparent;border:1px solid #6ee7ff;color:#6ee7ff">🧪 Test Hub — Live Results →</a>
+            <a href="evidence.html" class="hero-cta" style="background:transparent;border:1px solid #c8a2ff;color:#c8a2ff">📊 Frozen Claims →</a>
         </div>
         <div style="margin-top:1.5rem;display:flex;justify-content:center;gap:1.5rem;font-size:.78rem;color:#999;flex-wrap:wrap">
-          <span>🟢 <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/" style="color:#ffd700;text-decoration:none">v0.6.3.1 a2a — testing in flight</a></span>
+          <span>📦 <a href="https://www.npmjs.com/package/@alphaone/ai-memory" style="color:#cb3837;text-decoration:none">npm: @alphaone/ai-memory</a></span>
           <span>·</span>
-          <span>📊 <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/" style="color:#6ee7ff;text-decoration:none">v0.6.3 evidence on test-hub</a></span>
+          <span>🐍 <a href="https://pypi.org/project/ai-memory-mcp/" style="color:#3776AB;text-decoration:none">pypi: ai-memory-mcp</a></span>
+          <span>·</span>
+          <span>📊 <a href="https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md" style="color:#6ee7ff;text-decoration:none">v0.6.4 cert (CERT GREEN)</a></span>
           <span>·</span>
           <span>🚢 <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="color:#999;text-decoration:none">ship-gate</a></span>
           <span>·</span>
-          <span>🤝 <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="color:#999;text-decoration:none">A2A gate (umbrella spec)</a></span>
+          <span>🤝 <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="color:#999;text-decoration:none">A2A umbrella</a></span>
         </div>
     </div>
 </section>

--- a/docs/whats-new-v064.html
+++ b/docs/whats-new-v064.html
@@ -1,0 +1,386 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  What's New in v0.6.4 — `quiet-tools`. The substrate stays. The
+  default tool surface gets quiet on the wire. The agent-substrate
+  story gets a name.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>What's New in v0.6.4 — quiet-tools | ai-memory</title>
+<meta name="description" content="ai-memory v0.6.4 (quiet-tools) ships a 5-tool default MCP surface (down from 43), a 76.4% input-token reduction on session start, NHI guardrails phase 1 (per-agent capability allowlist + audit_log schema v20), first-party SDKs published OIDC-style to npm and PyPI, and a 6/6-PASS NHI Discovery Gate against live xAI Grok 4.3.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/whats-new-v064.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#2ea043;--accent:#6ee7ff;--green:#2ea043;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1200px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}a:hover{filter:brightness(1.2)}
+code{font-family:var(--font-mono);font-size:.85em;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);border:1px solid var(--border);border-radius:8px;padding:1rem;overflow-x:auto;margin:1rem 0}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em;color:#fff}
+h1{font-size:clamp(2.2rem,5vw,3.6rem);line-height:1.05;letter-spacing:-0.04em;margin-bottom:1rem}
+h2{font-size:1.85rem;margin-bottom:.6rem;margin-top:0}
+h3{font-size:1.15rem;margin-bottom:.5rem}
+p{color:var(--text-muted);margin-bottom:1rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}
+.topnav a:hover,.topnav a.active{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.hero{padding:6rem 1.5rem 4rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%),radial-gradient(ellipse at bottom,rgba(46,160,67,0.05),transparent 70%);border-bottom:1px solid var(--border)}
+.hero .badge{display:inline-block;padding:.4rem 1rem;background:rgba(110,231,255,0.1);border:1px solid var(--p1);color:var(--p1);border-radius:999px;font-family:var(--font-mono);font-size:.85rem;margin-bottom:1.5rem}
+.hero .subtitle{font-size:1.2rem;color:var(--text-muted);max-width:760px;margin:0 auto 2rem}
+.hero .meta{display:flex;justify-content:center;gap:2rem;color:var(--text-dim);font-family:var(--font-mono);font-size:.85rem;flex-wrap:wrap}
+section{padding:5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin-bottom:2rem}
+.grid-2{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:1.25rem}
+.grid-3{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem}
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;position:relative}
+.card.cyan{border-top:3px solid var(--p1)}
+.card.amber{border-top:3px solid var(--p2)}
+.card.violet{border-top:3px solid var(--p3)}
+.card.green{border-top:3px solid var(--good)}
+.card h3{margin-bottom:.65rem}
+.card p{font-size:.92rem;color:var(--text-muted);margin-bottom:.75rem}
+.card .tag{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;color:var(--text-muted);text-transform:uppercase;margin-bottom:.5rem;display:block}
+.numstat{text-align:center;padding:1rem}
+.numstat .num{font-size:2.2rem;font-weight:800;color:var(--p1);display:block;line-height:1.1}
+.numstat .label{font-size:.78rem;color:var(--text-muted);display:block;margin-top:.25rem}
+table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:.92rem}
+th,td{text-align:left;padding:.65rem .85rem;border-bottom:1px solid var(--border);color:var(--text-muted)}
+th{color:#fff;font-weight:600;background:var(--bg-elev);font-size:.85rem}
+tr:hover{background:rgba(110,231,255,0.03)}
+ul.checked{list-style:none;padding-left:0}
+ul.checked li{padding-left:1.5rem;position:relative;margin:.35rem 0;color:var(--text-muted);font-size:.92rem}
+ul.checked li::before{content:"✓";position:absolute;left:0;color:var(--good);font-weight:800}
+.audience-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1.25rem;margin-top:1rem}
+.audience{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;position:relative;overflow:hidden}
+.audience::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.audience.user::before{background:var(--p1)}
+.audience.dev::before{background:var(--p2)}
+.audience.cxo::before{background:var(--p3)}
+.audience .who{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;color:var(--text-muted);text-transform:uppercase;margin-bottom:.65rem}
+.audience h3{margin-bottom:1rem;font-size:1.1rem}
+.audience .pitch{color:var(--text-muted);font-size:.95rem;line-height:1.55;margin-bottom:1rem}
+.audience .pitch strong{color:#fff}
+.audience .cta{color:#fff;font-family:var(--font-mono);font-size:.8rem;border-bottom:1px dashed var(--text-muted);padding-bottom:1px}
+.cta-row{display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;margin-top:2rem}
+.cta-row a{padding:.7rem 1.25rem;border-radius:10px;font-weight:600;font-size:.92rem;border:1px solid var(--p1);color:var(--p1)}
+.cta-row a.solid{background:var(--p1);color:#000;border-color:var(--p1)}
+.cta-row a.amber{border-color:var(--p2);color:var(--p2)}
+.cta-row a.green{border-color:var(--good);color:var(--good)}
+.cta-row a.violet{border-color:var(--p3);color:var(--p3)}
+.tier-ladder{display:grid;grid-template-columns:repeat(5,1fr);gap:.75rem;margin:1.5rem 0}
+.tier-ladder .tier{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem;text-align:center;position:relative}
+.tier-ladder .tier .t-num{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);letter-spacing:.12em}
+.tier-ladder .tier .t-name{font-weight:700;color:#fff;margin:.25rem 0;font-size:.95rem}
+.tier-ladder .tier .t-desc{font-size:.78rem;color:var(--text-muted);line-height:1.4}
+@media(max-width:780px){.tier-ladder{grid-template-columns:1fr 1fr}}
+@media(max-width:520px){.tier-ladder{grid-template-columns:1fr}}
+footer{padding:2.5rem 1.5rem;text-align:center;color:var(--text-dim);font-size:.85rem;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="index.html">ai-memory&trade;</a>
+    <div class="right">
+      <a href="index.html">Home</a>
+      <a href="architectures.html">Tiers T1&rarr;T5</a>
+      <a href="whats-new-v064.html" class="active">v0.6.4</a>
+      <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:#2ea043">Discovery Gate</a>
+      <a href="https://alphaonedev.github.io/ai-memory-test-hub/" style="color:#6ee7ff">Test Hub</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <div class="container">
+    <span class="badge">v0.6.4 &middot; quiet-tools &middot; shipped 2026-05-05</span>
+    <h1>76% lighter on the wire.<br>Same 43-tool capability.</h1>
+    <p class="subtitle">
+      ai-memory v0.6.4 collapses the default MCP tool surface from 43 to 5 &mdash; saving ~4,700 input tokens per request on every eager-loading harness &mdash; without removing a single tool. The other 38 are still there, still callable, still functional. They just don't pre-pay their schema cost on every turn.
+    </p>
+    <div class="meta">
+      <span>5 default &middot; 43 full</span>
+      <span>76.4% reduction</span>
+      <span>cl100k_base measured</span>
+      <span>schema v19 &rarr; v20</span>
+    </div>
+    <div class="cta-row">
+      <a class="solid" href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.4">📥 Download v0.6.4</a>
+      <a class="amber" href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.6.4.md">📖 Migration Guide</a>
+      <a class="green" href="https://alphaonedev.github.io/ai-memory-discovery-gate/">🟢 NHI Discovery Gate &mdash; 6/6 PASS</a>
+      <a class="violet" href="https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md">📐 v0.6.4 CERT GREEN</a>
+    </div>
+  </div>
+</section>
+
+<!-- ============ THREE AUDIENCES ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Three audiences, one release</span>
+    <h2>What v0.6.4 means for you</h2>
+    <p class="lede">Same release, three framings &mdash; pick yours.</p>
+
+    <div class="audience-row">
+      <div class="audience user">
+        <span class="who">👤 If you USE AI</span>
+        <h3>Your AI bill drops. Nothing else changes.</h3>
+        <p class="pitch">
+          Every time your AI assistant (Claude, ChatGPT, Cursor, Codex, Grok, Gemini) reaches for ai-memory, it used to spend ~6,200 input tokens just <em>describing the available memory tools</em> before reading your message. v0.6.4 cuts that to ~1,500. <strong>Your AI still does everything it did before</strong> &mdash; it just doesn't pre-pay for tools it doesn't need every turn. First-message responses on Codex / Grok / Gemini should feel snappier; your subscription cost drops automatically.
+        </p>
+        <pre>brew upgrade ai-memory &amp;&amp; ai-memory doctor --tokens</pre>
+        <p style="font-size:.85rem">That second command shows you exactly how much you're saving.</p>
+      </div>
+
+      <div class="audience dev">
+        <span class="who">🛠️ If you BUILD with AI</span>
+        <h3>Profile-aware tool surface. SDKs published. NHI guardrails.</h3>
+        <ul class="checked">
+          <li><code>--profile {core,graph,admin,power,full,custom}</code> flag (CLI + <code>AI_MEMORY_PROFILE</code> env + <code>[mcp].profile</code> config). Resolution order: CLI &gt; env &gt; config &gt; <code>core</code>.</li>
+          <li><code>memory_capabilities</code> extended with <code>family=&lt;name&gt;</code> + <code>include_schema=true</code> for runtime tool registration.</li>
+          <li>Unloaded-tool calls return JSON-RPC <code>-32601</code> with an actionable diagnostic naming the family and suggesting both <code>--profile</code> and <code>--include-schema</code> recovery paths.</li>
+          <li>SDKs published OIDC-style: <a href="https://www.npmjs.com/package/@alphaone/ai-memory"><code>@alphaone/ai-memory</code></a> on npm + <a href="https://pypi.org/project/ai-memory-mcp/"><code>ai-memory-mcp</code></a> on PyPI. <code>requireProfile</code> helper raises <code>ProfileNotLoaded</code> with structured <code>.hint</code>.</li>
+          <li>Cross-harness installer for 10 MCP harnesses: <code>ai-memory install &lt;name&gt;</code>.</li>
+          <li><code>[mcp.allowlist]</code> per-agent capability allowlist. <code>audit_log</code> table (schema v20) records every capability-expansion event.</li>
+        </ul>
+      </div>
+
+      <div class="audience cxo">
+        <span class="who">🏢 If you DECIDE AI infrastructure</span>
+        <h3>Token-tax leak closed. PII stays on-prem. No vendor risk.</h3>
+        <p class="pitch">
+          Boris Cherny's published 90-day Claude Code instrumentation: <strong>73% of tokens go to nine waste patterns</strong>. v0.6.4 closes Pattern&nbsp;6 ("just-in-case tool definitions") in one release &mdash; <strong>76.4% input-token reduction</strong>, ~$107/user/year on heavy single-user pricing, <strong>~$107K/year per 1,000 daily-active agent seats</strong>. Empirically validated by a 4-tier discovery matrix vs. live xAI Grok 4.3 (6/6 PASS, GATE GREEN). Apache-2.0, single Rust binary, runs on the dev's laptop &mdash; no SaaS, no PII exfiltration, no vendor lock-in. The architecture decision you make today doesn't have to be revisited.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ HEADLINE NUMBERS ============ -->
+<section style="background:var(--bg-raised)">
+  <div class="container">
+    <span class="eyebrow">Measured, not estimated</span>
+    <h2>v0.6.4 in numbers</h2>
+    <p class="lede">Every number on this page is anchored to a publicly verifiable source. Click through to see the methodology.</p>
+
+    <div class="grid-3">
+      <div class="numstat"><span class="num">6,198 &rarr; 1,465</span><span class="label">tokens advertised in <code>tools/list</code></span></div>
+      <div class="numstat"><span class="num">76.4%</span><span class="label">prefix-token reduction (cl100k_base)</span></div>
+      <div class="numstat"><span class="num">5 / 43</span><span class="label">default visible / total tools</span></div>
+      <div class="numstat"><span class="num">10</span><span class="label">harnesses with built-in installer</span></div>
+      <div class="numstat"><span class="num">6/6</span><span class="label">Discovery Gate cells PASS</span></div>
+      <div class="numstat"><span class="num">93.84%</span><span class="label">line coverage &middot; CI-gated &ge;93%</span></div>
+      <div class="numstat"><span class="num">v19 &rarr; v20</span><span class="label">schema migration (audit_log)</span></div>
+      <div class="numstat"><span class="num">2 of 2</span><span class="label">SDKs published (npm + PyPI)</span></div>
+      <div class="numstat"><span class="num">5 of 5</span><span class="label">distribution channels (release / brew / ghcr / COPR / crates)</span></div>
+    </div>
+
+    <p style="margin-top:1.5rem;font-size:.88rem">
+      <strong style="color:#fff">Honesty correction shipped with this release:</strong> the v0.6.4 RFC drafts originally claimed "~25,800 tokens / 87% reduction." Those numbers were measured against MiniLM (a sentence-embedder vocabulary that systematically over-counts JSON by ~4&times; vs. <code>cl100k_base</code>, the BPE Claude/GPT actually use for input accounting). Real measurement: 6,198 &rarr; 1,465 / 76.4%. We corrected the public claim before the release. <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/v0.6.4-cross-harness.md">Methodology &rarr;</a>
+    </p>
+  </div>
+</section>
+
+<!-- ============ AGENT SUBSTRATE ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">The substrate, named</span>
+    <h2>v0.6.4 unlocks NHI guardrails &mdash; phase 1</h2>
+    <p class="lede">
+      Most "AI memory" products are chat memory. ai-memory is the agent substrate. v0.6.4 ships the first tier of NHI (Non-Human Identity) guardrails: per-agent capability allowlists and a capability-expansion audit log. Phase 2 (Ed25519 attestation) lands in v0.7.
+    </p>
+
+    <div class="grid-2">
+      <div class="card cyan">
+        <span class="tag">Per-agent capability allowlist</span>
+        <h3>Define what each agent can reach for</h3>
+        <p>The new <code>[mcp.allowlist]</code> config table maps <code>agent_id</code> patterns to allowed family sets. Pattern resolution: exact &gt; longest-prefix &gt; <code>*</code> wildcard. Default disabled for backward compat &mdash; flip it on for production.</p>
+        <pre>[mcp.allowlist]
+"ai:claude-code@*"   = ["full"]
+"ai:codex-cli@*"     = ["core", "graph"]
+"ai:grok-cli-*"      = ["core"]
+"*"                  = ["core"]   # wildcard default</pre>
+      </div>
+
+      <div class="card violet">
+        <span class="tag">Capability-expansion audit log</span>
+        <h3>Every <code>memory_capabilities --include-schema</code> call gets logged</h3>
+        <p>Schema migration v19 &rarr; v20 adds the <code>audit_log</code> table with columns for <code>agent_id</code>, <code>event_type</code>, <code>requested_family</code>, <code>granted</code>, <code>attestation_tier</code>, <code>timestamp</code>. Three indexes (agent_id, timestamp, event_type) for SOC/SIEM-friendly queries. Idempotent migration; preserves every existing row.</p>
+        <pre>SELECT agent_id, requested_family, granted
+FROM   audit_log
+WHERE  timestamp &gt; datetime('now', '-24 hours')
+   AND granted = 0;</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ FIVE-TIER LADDER ============ -->
+<section style="background:linear-gradient(180deg,rgba(110,231,255,0.03) 0%,transparent 100%)">
+  <div class="container">
+    <span class="eyebrow">Same binary, five tiers</span>
+    <h2>Built for the agent era, not retrofitted from chat memory</h2>
+    <p class="lede">
+      ai-memory's architecture scales from one developer's laptop to a multi-region hive of agents <strong>without switching products</strong>. Every primitive listed below is in the v0.6.4 binary today; you turn flags on as you grow.
+    </p>
+
+    <div class="tier-ladder">
+      <a href="architectures-t1.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T1</div>
+        <div class="t-name">Single Agent</div>
+        <div class="t-desc">1 dev, 1 host. SQLite local. <code>ai-memory mcp</code></div>
+      </a>
+      <a href="architectures-t2.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T2</div>
+        <div class="t-name">Many Agents</div>
+        <div class="t-desc">N AI clients sharing one host via HTTP+mTLS</div>
+      </a>
+      <a href="architectures-t3.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T3</div>
+        <div class="t-name">Multi-Node Cluster</div>
+        <div class="t-desc">Quorum W-of-N writes, vector-clock CRDT-lite merge</div>
+      </a>
+      <a href="architectures-t4.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T4</div>
+        <div class="t-name">Data-Center Swarm</div>
+        <div class="t-desc">Distributed replicas, cross-region quorum</div>
+      </a>
+      <a href="architectures-t5.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T5</div>
+        <div class="t-name">Global Hive</div>
+        <div class="t-desc">Per-agent NHI allowlist, audit trail, governance</div>
+      </a>
+    </div>
+
+    <h3 style="margin-top:2rem">What no other "AI memory" product brings to the table</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Capability</th>
+          <th>Vendor memory<br>(Claude/ChatGPT)</th>
+          <th>SaaS memory<br>(mem0 / Letta)</th>
+          <th>Vector DBs<br>(Chroma / pgvector)</th>
+          <th>ai-memory v0.6.4</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Local-first, no cloud roundtrip</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td></tr>
+        <tr><td>Universal across AI vendors</td><td>❌ vendor-locked</td><td>⚠️ paid plans</td><td>⚠️ glue code</td><td>✅ MCP-native</td></tr>
+        <tr><td>Zero-token cost until recall</td><td>❌</td><td>⚠️ varies</td><td>n/a</td><td>✅</td></tr>
+        <tr><td>Self-curating (auto-tag, dedup, contradictions)</td><td>❌</td><td>⚠️ partial</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Multi-agent federation built in</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Quorum W-of-N writes + CRDT merge</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Per-agent NHI capability allowlist</td><td>❌</td><td>❌</td><td>❌</td><td>✅ (v0.6.4 phase 1)</td></tr>
+        <tr><td>Capability-expansion audit log</td><td>❌</td><td>❌</td><td>❌</td><td>✅ (schema v20)</td></tr>
+        <tr><td>Webhook event bus (HMAC-signed)</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Apache-2.0, no vendor risk</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td></tr>
+        <tr><td>Single binary install</td><td>n/a</td><td>n/a</td><td>❌</td><td>✅</td></tr>
+        <tr><td>Public per-release evidence pages</td><td>❌</td><td>❌</td><td>n/a</td><td>✅</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ EVIDENCE / TRUST ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Trust the numbers</span>
+    <h2>Why every claim on this page is anchored</h2>
+    <p class="lede">
+      Most product pages cite numbers without sources. Every claim above is anchored to a public, verifiable artifact:
+    </p>
+
+    <div class="grid-2">
+      <div class="card green">
+        <span class="tag">Empirical LLM behavior</span>
+        <h3>NHI Discovery Gate</h3>
+        <p>Public 4-tier acceptance matrix &mdash; T1 Awareness / T2 Reactive / T3 Proactive / T4 Mesh. Run against a real OpenClaw harness driving live xAI Grok 4.3 against the v0.6.4 release binary. Per-cell evidence: full LLM transcripts, MCP wire logs, verdict JSON.</p>
+        <p><a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:var(--good)">Verdict page &rarr;</a> &middot; <a href="https://github.com/alphaonedev/ai-memory-discovery-gate" style="color:var(--good)">Source repo &rarr;</a></p>
+      </div>
+
+      <div class="card cyan">
+        <span class="tag">Test coverage</span>
+        <h3>Test Hub</h3>
+        <p>Per-release CERT verdicts with green/red status, scenario-by-scenario evidence, schema-migration validation against real production-shaped DBs. v0.6.4 campaign: <strong>CERT GREEN</strong> across S25-S32 (new) + S1-S22 (functional replay under <code>--profile full</code>).</p>
+        <p><a href="https://alphaonedev.github.io/ai-memory-test-hub/" style="color:#6ee7ff">Live hub &rarr;</a> &middot; <a href="https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md" style="color:#6ee7ff">v0.6.4 campaign &rarr;</a></p>
+      </div>
+
+      <div class="card amber">
+        <span class="tag">Token-cost methodology</span>
+        <h3>Cross-harness benchmark</h3>
+        <p>Documents how the 6,198 &rarr; 1,465 measurement was taken (which tokenizer, which BPE vocabulary, which harnesses), and includes the <strong>explicit honesty correction</strong> on the original RFC's 25,800 / 87% claim &mdash; the methodology gap explained, not papered over.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/v0.6.4-cross-harness.md" style="color:var(--p2)">Methodology &rarr;</a></p>
+      </div>
+
+      <div class="card violet">
+        <span class="tag">Release artifacts</span>
+        <h3>Frozen claims</h3>
+        <p>The <a href="evidence.html" style="color:var(--p3)">evidence page</a> tracks v0.6.x baselines (1,809 / 93.08% on v0.6.3, 1,886 / 93.84% on v0.6.3.1) alongside v0.6.4 metrics. CI-enforced &ge;92% coverage gate per-module. Performance budgets fail PRs whose measured p95 exceeds the published target by &gt;10%.</p>
+        <p><a href="evidence.html" style="color:var(--p3)">Evidence page &rarr;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ INSTALL SHORTCUTS ============ -->
+<section style="background:var(--bg-raised)">
+  <div class="container">
+    <span class="eyebrow">Get v0.6.4 now</span>
+    <h2>Install in 60 seconds</h2>
+
+    <div class="grid-3">
+      <div class="card">
+        <span class="tag">macOS / Linux</span>
+        <h3>Homebrew</h3>
+        <pre>brew install alphaonedev/tap/ai-memory
+ai-memory install claude-code --apply</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Cargo (any host)</span>
+        <h3>From crates.io</h3>
+        <pre>cargo install ai-memory --version 0.6.4</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Docker</span>
+        <h3>ghcr.io</h3>
+        <pre>docker pull ghcr.io/alphaonedev/ai-memory:0.6.4</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Fedora / RHEL / Rocky</span>
+        <h3>COPR</h3>
+        <pre>sudo dnf copr enable alpha-one-ai/ai-memory
+sudo dnf install ai-memory</pre>
+      </div>
+      <div class="card">
+        <span class="tag">TypeScript SDK</span>
+        <h3>npm</h3>
+        <pre>npm install @alphaone/ai-memory</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Python SDK</span>
+        <h3>PyPI</h3>
+        <pre>pip install ai-memory-mcp
+# import name remains ai_memory</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>ai-memory&trade; &middot; Apache-2.0 &middot; AlphaOne LLC &middot; USPTO Serial No.&nbsp;99761257</p>
+  <p style="margin-top:.5rem"><a href="index.html">Home</a> &middot; <a href="architectures.html">Architecture Tiers</a> &middot; <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a> &middot; <a href="https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.4">Release notes</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Repositions ai-memory's main GitHub Pages landing from "**AI memory tool**" to its actual scope: **the agent substrate AI agent systems are built on**, scaling from a single laptop (T1) to a multi-region hive (T5) with the same binary, same schema, same code path.

Tracks #512 (long-running drift reconciliation). Surfaces the multi-agent architecture as the **headline narrative**, not a footnote.

## Changes

### `docs/index.html` — hero + BLUF rewrite

**H1:** *"Persistent Memory for Any AI"* → ***"The memory substrate AI agents run on."***  with sub-headline *"From a developer's laptop to a multi-region hive — same binary."*

**BLUF card** now leads with the agent-substrate frame, calls out the **T1→T5 ladder** with deep links to `architectures-t1..t5.html`, and surfaces three v0.6.4 proof points:
- 76.4% input-token reduction
- NHI Discovery Gate 6/6 PASS, GATE GREEN
- 93.84% live line coverage (CI-gated ≥93%)

**Stats row** updated to 5 stats reflecting v0.6.4 reality (not v0.6.3.1 baseline):
- `5 / 43` Default / Full MCP Tools
- `76.4%` v0.6.4 Token Reduction
- `T1 → T5` Architecture Tiers
- `6/6` Discovery Gate PASS
- `93.84%` Line Coverage · CI-gated ≥93%

**CTA buttons** reshuffled: Install / What's New v0.6.4 / 5-Tier Ladder / Discovery Gate / Test Hub / Frozen Claims.

**Meta-links row** rebuilt with npm + PyPI live-package links and v0.6.4 CERT GREEN.

**Top nav** v0.6.3 link → v0.6.4.

### `docs/whats-new-v064.html` — NEW page

3-audience release page mirroring the v0.6.4 release-notes pattern:

- **👤 If you USE AI** — your bill drops, nothing else changes.
- **🛠️ If you BUILD with AI** — `--profile` flag, `memory_capabilities` family/include_schema, `requireProfile` SDK helper, 10-harness installer, `[mcp.allowlist]`, audit_log schema v20.
- **🏢 If you DECIDE AI infrastructure** — token-tax leak closed, PII on-prem, Apache-2.0 = no vendor risk; ~$107K/yr/1000-seat fleet savings.

Plus:
- Headline numbers (every one anchored to a verifiable source)
- Five-tier ladder (T1→T5) with links to existing `architectures-tN.html`
- **"What no other AI memory product brings"** comparison table vs. vendor memory / SaaS memory / vector DBs
- Evidence/trust block linking Discovery Gate, Test Hub, cross-harness benchmark methodology, frozen-claims page
- Install shortcuts: brew, cargo, docker, COPR, npm, PyPI
- Includes the **explicit honesty correction** on the original RFC's 25,800/87% claim

## Truthfulness ground rules followed

Every claim on the new pages is anchored to a public, verifiable artifact:
- 76.4% token reduction → `benchmarks/v0.6.4-cross-harness.md` + reproducible via `ai-memory doctor --tokens`
- 93.84% line coverage → most recent CI Code Coverage job (run `25381158586`, job `74429588963`) with full per-module breakdown
- 6/6 Discovery Gate → `ai-memory-discovery-gate/docs/runs/2026-05-05/verdict.md` with per-cell transcripts + wire logs
- v0.6.4 CERT GREEN → `ai-memory-test-hub/campaigns/v0.6.4.md`

Where the project has been wrong in public, the correction is published in the same place as the original claim — modeled after the v0.6.4 release notes' RFC honesty paragraph.

## Test plan
- [ ] Render `docs/index.html` locally and on GitHub Pages — no broken layouts
- [ ] All hero CTA links resolve (npm, PyPI, Discovery Gate, Test Hub, architectures-t1..t5.html, evidence.html)
- [ ] `whats-new-v064.html` validates (no broken links, no broken anchors)
- [ ] Comparison table renders correctly on mobile

## Refs
- Closes follow-up slice from #512 (drift reconciliation)
- Companion to #541 (OIDC publish workflow, merged) and #542 (README v0.6.4 alignment, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)