### PR TITLE
docs(v0.6.5): epic — cortex-fluent (Path 2 + Path 3 scope)

### DIFF
--- a/docs/v0.6.5/V0.6.5-EPIC.md
+++ b/docs/v0.6.5/V0.6.5-EPIC.md
@@ -1,0 +1,1354 @@
+# v0.6.5 Epic — `cortex-fluent`
+
+> **One sentence:** v0.6.5 closes the cortex-on-core loop end-to-end across LLMs and harnesses — the loader gets a name that says "load," the full profile drops to half its token cost, and per-harness deferred-registration becomes a first-class affordance.
+
+**Status:** PLANNED · 2026-05-05
+**Target ship:** ~4 weeks (1 month focused engineer time)
+**Predecessor:** [v0.6.4 — `quiet-tools`](../v0.6.4/V0.6.4-EPIC.md) — shipped 2026-05-05
+**Tracking issues:** [#545](https://github.com/alphaonedev/ai-memory-mcp/issues/545) (substrate response shape) · [#546](https://github.com/alphaonedev/ai-memory-mcp/issues/546) (cortex experience under core-tier token cost) · [#512](https://github.com/alphaonedev/ai-memory-mcp/issues/512) (drift)
+**Discovery Gate companion:** [alphaonedev/ai-memory-discovery-gate#1](https://github.com/alphaonedev/ai-memory-discovery-gate/pull/1) (T0 calibration cells)
+
+---
+
+## Why this release exists
+
+The 2026-05-05 NHI Discovery Gate verdict on v0.6.4 came back **6/6 PASS, GATE GREEN** — but three real-world LLM observation cells captured the same day surfaced one specific *legibility* gap that the gate's prompts had implicitly cued past:
+
+> A reasoning-class LLM (Grok 4.2 reasoning), given the v0.6.4 substrate, **did not find the runtime loader** — because the loader is hidden inside an introspection tool's parameter set (`memory_capabilities(family=X, include_schema=true)`). The name connotes *introspection*, not *loading*. Grok hypothesized a separate loader must exist, looked, didn't find one, and concluded a "bootstrap limitation" existed instead.
+
+The substrate did its job in v0.6.4. The language hadn't quite caught up. v0.6.5 closes that gap by:
+
+1. **Giving the loader a name that says load** (`memory_load_family`, `memory_smart_load(intent)`)
+2. **Making the response shape pre-compute the calibration work** the LLM is doing today (`summary`, `to_describe_to_user`, `callable_now`)
+3. **Cutting `--profile full` in half** through schema compaction (~6,200 → ~3,500 tokens)
+4. **Surfacing harness deferred-registration support** in the substrate response itself, so agents on capable harnesses know they can opt up cheaply
+
+After v0.6.5, the marketing claim *"cortex-on-core works today on Claude Code / OpenClaw"* is robust across LLMs — not curiosity-gated.
+
+---
+
+## Goals (in priority order)
+
+1. **REQUIRED** — Loader-of-last-resort gets a name that says "load." Reasoning-class LLMs, unprompted, find it on first ask.
+2. **REQUIRED** — `memory_capabilities` v3 response carries pre-computed calibration (LLMs don't have to choose between literal-data and operational answers).
+3. **STRONGLY RECOMMENDED** — `--profile full` drops to ≤ 3,500 input tokens via schema compaction. Helps eager-loading harnesses (Codex / Grok CLI / Gemini CLI / Claude Desktop) that can't use deferred registration.
+4. **STRONGLY RECOMMENDED** — Harness deferred-registration support detected from MCP `clientInfo` and surfaced in substrate responses.
+5. **STRONGLY RECOMMENDED** — Discovery Gate T0 calibration cells re-run after ship and converge across all named LLMs.
+
+## Non-goals
+
+- Not removing `--profile core` or `--profile full` (both stay; v0.6.5 is additive)
+- Not training/fine-tuning any LLMs (every fix is response-shape and naming, not model-side)
+- Not breaking the v0.6.4 SDK clients (`@alphaone/ai-memory` 0.6.4 + `ai-memory-mcp` 0.6.4 must work against a v0.6.5 server)
+- Not implementing intent-aware `--profile auto` (deferred to v0.7; Path 3 covers ~80% of the same ground)
+- Not implementing per-agent profile pre-warm (deferred to v0.7 as part of NHI guardrails phase 2)
+- Not rewriting core tool descriptions to leak deeper graph (feature creep risk)
+
+---
+
+## Workstream summary
+
+| Track | Scope | Effort | Required? |
+|---|---|---|---|
+| **A** — Substrate response shape (memory_capabilities v3) | 5 tasks (A1–A5) | ~1 week | 🔴 REQUIRED |
+| **B** — Loader tools (memory_load_family + memory_smart_load) | 5 tasks (B1–B5) | ~2-3 weeks | 🔴 REQUIRED |
+| **C** — Schema compaction | 5 tasks (C1–C5) | ~1 week | 🟢 STRONGLY RECOMMENDED |
+| **D** — Per-harness positioning + tests | 4 tasks (D1–D4) | ~3-5 days | 🟢 STRONGLY RECOMMENDED |
+| **E** — Discovery Gate T0 cells (orchestrated) | 3 tasks (E1–E3) | ~3 days | 🟢 STRONGLY RECOMMENDED |
+| **F** — Docs + release | 5 tasks (F1–F5) | ~3 days | 🔴 REQUIRED (every release) |
+
+**Total:** ~27 tasks across 6 tracks. Tracks A + B are the strategic bottleneck. Track C is the highest-ROI ride-along. Track D + E are the validation layer. Track F is the ship-it layer.
+
+---
+
+## How to use the NHI starter prompts
+
+Every task below has a **self-contained NHI starter prompt**. Hand it verbatim to a Claude Code, Grok, Codex, or any MCP-capable agent and the agent has enough context to begin work without further briefing.
+
+Conventions:
+- Each prompt names the **target files** and **acceptance criteria** explicitly
+- Each prompt names the **branch convention** for the task
+- Each prompt cites the relevant issue numbers
+- Each prompt ends with a **definition of done** the agent can self-check against
+- Wherever a task depends on another task's deliverable, the dependency is named explicitly so the agent can sequence its own work
+
+**Branch naming:** `feat/v0.6.5-<track>-<task>-<short-name>` (e.g., `feat/v0.6.5-a-1-summary-field`)
+
+**Commit convention:** `feat(<scope>): <imperative summary> (#<task-id>)`
+
+**PR title:** `feat: v0.6.5-<track><number> — <one-line title>`
+
+---
+
+## Track A — Substrate response shape
+
+> **Track goal:** `memory_capabilities` v3 response shape pre-computes the calibration work LLMs do today, so agents converge on accurate first-answer descriptions regardless of calibration bias.
+
+### Task A1: Add top-level `summary` field to `memory_capabilities` v3
+
+**File(s):** `src/mcp.rs` (capabilities response builder), `src/profile.rs` (state inspection helpers)
+**Schema bump:** `accept="v2"` stays unchanged; `accept="v3"` adds the new field.
+**Branch:** `feat/v0.6.5-a-1-summary-field`
+
+**Deliverable:** When the capabilities tool is called with `accept="v3"`, the response includes a top-level `summary` field — a single string the LLM has to read before it can describe access. The string is dynamically built from the live profile state and reads roughly:
+
+```
+"5 of 43 tools are advertised in tools/list under the current profile (core).
+The other 38 are listed in this manifest but NOT directly callable.
+To use any unloaded tool, choose one of:
+  (a) restart the server with --profile <family> or --profile full,
+  (b) call memory_load_family(family=<name>) — preferred, returns
+      schemas + harness-aware loading instructions,
+  (c) call the tool by name and recover from JSON-RPC -32601."
+```
+
+The exact string is computed; numbers reflect the active profile state.
+
+**Acceptance criteria:**
+- [ ] `accept="v3"` returns `summary` at top level; `accept="v2"` does not (backward compat)
+- [ ] String contains: active profile name, count of advertised tools, count of total tools, three named recovery paths
+- [ ] Unit test asserts the string is well-formed across all 6 named profiles (core, graph, admin, power, full, custom)
+- [ ] CI test: a calibration prompt over MCP returns a v3 response containing the canonical phrasing
+- [ ] No regression in existing v2 callers (run `cargo test --lib mcp::capabilities -- --exact`)
+
+#### NHI starter prompt for A1
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task A1 (#545).
+
+Goal: add a top-level `summary` field to the memory_capabilities v3 response.
+The field carries a single pre-computed string that describes the LLM's
+operational access — the count of currently-advertised tools, the count of
+total tools, and the three named recovery paths for loading unloaded
+families.
+
+Current state: src/mcp.rs builds the capabilities document via a
+`build_capabilities_v2(...)` function. v2 returns a manifest with
+loaded:bool per tool but does NOT include a top-level summary string.
+
+What to do:
+1. Add a `build_capabilities_v3(...)` function alongside v2. v3 = v2 +
+   one new top-level `summary` field of type String.
+2. The summary string is dynamically built from the live profile state
+   (use src/profile.rs for inspection). Its content must follow the
+   template in v0.6.5 epic task A1 — see docs/v0.6.5/V0.6.5-EPIC.md.
+3. Wire `accept="v3"` to the new builder; `accept="v2"` keeps the old
+   builder. Default for new clients: v3.
+4. Add unit tests in src/mcp.rs::tests covering each named profile
+   (core, graph, admin, power, full, custom) — assert the summary
+   string contains the expected counts and the three recovery-path
+   markers.
+5. Add an integration test in tests/mcp_integration that wires a real
+   MCP request through stdio and asserts the response shape.
+6. Do not modify v2 behavior. Backward compat is required.
+
+Branch: feat/v0.6.5-a-1-summary-field
+Commit: feat(mcp): add v3 capabilities summary field (#545)
+PR title: feat: v0.6.5-A1 — memory_capabilities v3 summary field
+
+Definition of done:
+- `cargo test --lib mcp::` passes
+- `cargo test --test mcp_integration` passes
+- Calibration prompt produces a response with `summary` field present
+- v2 response shape unchanged (verified by existing tests)
+```
+
+---
+
+### Task A2: Add `to_describe_to_user` field
+
+**File(s):** same as A1 (extends the v3 builder)
+**Branch:** `feat/v0.6.5-a-2-describe-to-user`
+
+**Deliverable:** Top-level `to_describe_to_user` field — the canonical sentence the agent should say when asked "what tools do you have." Pre-computed from active profile state.
+
+**Acceptance criteria:**
+- [ ] Field present in v3 response only
+- [ ] String reads e.g.: *"I can directly use 5 memory tools right now (store, recall, search, list, get). 38 more (link, kg_query, consolidate, delete, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile."*
+- [ ] Tone is plain-language; no MCP jargon
+- [ ] CI: a multi-LLM calibration test (under `tests/calibration_t0.rs`, new file) confirms responses across LLMs converge on the canonical phrasing or paraphrase within 80% Jaccard similarity
+
+#### NHI starter prompt for A2
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task A2 (#545).
+Depends on: A1 (build_capabilities_v3 function exists).
+
+Goal: add a `to_describe_to_user` field to the v3 response. This is the
+canonical plain-language sentence the agent should parrot when asked
+"what tools do you have access to." Removing the calibration ambiguity
+between Claude (under-claims) and Grok (over-claims) by giving the
+LLM the words.
+
+What to do:
+1. Extend src/mcp.rs::build_capabilities_v3 to add the new field.
+2. Build the string from active profile state — count of loaded tools,
+   names of those tools, count of unloaded tools, two example unloaded
+   tool names, plain-English description of how to load more.
+3. Tone constraint: NO mcp jargon (no "advertised", "tools/list", "schemas").
+   Use plain language an end-user would understand.
+4. Add tests/calibration_t0.rs (new file) — a calibration test that
+   simulates an MCP call and asserts the canonical phrasing is present.
+5. Document the canonical phrasing in
+   docs/v0.6.5/canonical-phrasings.md so doc reviewers can audit it.
+
+Branch: feat/v0.6.5-a-2-describe-to-user
+Commit: feat(mcp): add v3 to_describe_to_user field (#545)
+
+Definition of done:
+- v3 response carries the new field across all 6 profiles
+- v2 response shape unchanged
+- New tests/calibration_t0.rs passes
+- canonical-phrasings.md exists and is reviewed
+```
+
+---
+
+### Task A3: Add per-tool `callable_now: bool` flag
+
+**File(s):** `src/mcp.rs`, `src/profile.rs`
+**Branch:** `feat/v0.6.5-a-3-callable-now`
+
+**Deliverable:** Each tool object in the v3 response gains a `callable_now: bool` field, distinct from existing `loaded: bool`:
+- `loaded=true` means the server has registered the tool internally
+- `callable_now=true` means **this agent**, given its `agent_id` and the active `[mcp.allowlist]`, can actually invoke the tool right now without any recovery dance
+
+**Acceptance criteria:**
+- [ ] When allowlist is disabled (default), `callable_now == loaded` for every tool
+- [ ] When allowlist applies, `callable_now=false` for tools forbidden by the agent's allowlist scope, even if `loaded=true`
+- [ ] Unit tests cover all combinations: allowlist on/off × loaded true/false × agent in/out of pattern
+
+#### NHI starter prompt for A3
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task A3 (#545).
+Depends on: A1.
+
+Goal: add per-tool `callable_now: bool` field to v3 response.
+
+`loaded` and `callable_now` are subtly different:
+- loaded = server has the tool registered
+- callable_now = THIS agent, given its agent_id and the [mcp.allowlist],
+  can actually call this tool right now without any recovery dance
+
+When allowlist is disabled (v0.6.4 default), they're identical. When
+allowlist applies, callable_now reflects per-agent permission.
+
+What to do:
+1. Look at how src/profile.rs interacts with [mcp.allowlist] — extract a
+   helper `agent_can_call(agent_id, family) -> bool` that mirrors the
+   allowlist resolution rules (exact > longest-prefix > * wildcard).
+2. In src/mcp.rs::build_capabilities_v3, populate callable_now for each
+   tool by combining loaded-state with agent_can_call(agent_id, family).
+3. Add unit tests covering the four matrix cells:
+   - allowlist OFF, loaded TRUE  -> callable_now=TRUE
+   - allowlist OFF, loaded FALSE -> callable_now=FALSE
+   - allowlist ON, agent in pattern, loaded TRUE   -> callable_now=TRUE
+   - allowlist ON, agent NOT in pattern, loaded TRUE -> callable_now=FALSE
+4. Update v2 backward-compat path to NOT include callable_now.
+
+Branch: feat/v0.6.5-a-3-callable-now
+Commit: feat(mcp): add per-tool callable_now flag in v3 (#545)
+
+Definition of done:
+- 4-cell matrix unit tests pass
+- v2 callers see no change
+- Integration test confirms callable_now=loaded when no allowlist set
+```
+
+---
+
+### Task A4: Add `agent_permitted_families` (when allowlist applies)
+
+**File(s):** `src/mcp.rs`
+**Branch:** `feat/v0.6.5-a-4-agent-permitted-families`
+
+**Deliverable:** Top-level `agent_permitted_families: ["core", "graph"]` field in v3 response, populated only when the requesting `agent_id` matches a pattern in `[mcp.allowlist]`. When allowlist is disabled, field is omitted (optional).
+
+**Acceptance criteria:**
+- [ ] When allowlist disabled: field absent
+- [ ] When allowlist applies + agent in pattern: field is `[<allowed families>]`
+- [ ] When allowlist applies + agent NOT in pattern: field is `["core"]` (default fallback)
+- [ ] Hides families the agent has no access to from `agent_permitted_families` even if loaded for other agents
+
+#### NHI starter prompt for A4
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task A4 (#545).
+Depends on: A1, A3 (allowlist resolution helpers).
+
+Goal: add agent_permitted_families top-level field to v3, surfaces
+per-agent allowlist scope so multi-agent (T4-T5) deployments don't
+get a global picture they can't act on.
+
+What to do:
+1. Reuse the agent_can_call helper from A3.
+2. In src/mcp.rs::build_capabilities_v3, when [mcp.allowlist] is enabled,
+   compute the list of families the requesting agent can access and
+   include it as `agent_permitted_families`.
+3. When the allowlist is disabled OR no agent_id was provided in the
+   MCP initialize handshake, omit the field entirely.
+4. Unit tests cover the three cases: disabled / enabled-with-agent /
+   enabled-without-agent-id.
+
+Branch: feat/v0.6.5-a-4-agent-permitted-families
+Commit: feat(mcp): surface agent_permitted_families in v3 response (#545)
+
+Definition of done:
+- 3-case unit tests pass
+- Field correctly omitted when allowlist disabled
+- Field correctly populated for matching/wildcard agent patterns
+```
+
+---
+
+### Task A5: Bump capabilities schema to v3, preserve v2 backward compat
+
+**File(s):** `src/mcp.rs`, `tests/mcp_integration.rs`, `docs/API_REFERENCE.md`
+**Branch:** `feat/v0.6.5-a-5-schema-v3`
+
+**Deliverable:** `accept="v3"` is the new default for all new MCP `tools/call` requests; `accept="v2"` and `accept="v1"` remain valid; SDK clients (TS + Py) get a v3 capabilities type.
+
+**Acceptance criteria:**
+- [ ] All A1-A4 fields gated on `accept="v3"`
+- [ ] CI test: existing v2-asking clients see no change
+- [ ] CI test: new v3 default exercises all four new fields
+- [ ] SDK package versions bump to 0.6.5 with `MemoryCapabilitiesV3` type added; v2 type retained
+- [ ] API_REFERENCE.md gets a "v3 schema" subsection
+
+#### NHI starter prompt for A5
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task A5 (#545).
+Depends on: A1, A2, A3, A4 (all four v3 fields exist).
+
+Goal: bump the capabilities schema to v3 in API_REFERENCE.md, SDKs, and
+defaults. v2 + v1 remain valid for backward compat.
+
+What to do:
+1. Update src/mcp.rs `accept` enum: ["v1", "v2", "v3"], default = "v3"
+   (was default = "v2" in v0.6.4).
+2. Update sdk/typescript/src/types.ts: add MemoryCapabilitiesV3 type
+   carrying the new fields. Retain MemoryCapabilitiesV2 type.
+3. Update sdk/python/ai_memory/models.py: add MemoryCapabilitiesV3
+   pydantic model. Retain V2.
+4. Update docs/API_REFERENCE.md: new "v3 schema" subsection with
+   field-by-field documentation of summary / to_describe_to_user /
+   callable_now / agent_permitted_families. Add a "v2 → v3 diff"
+   section near the top.
+5. Add an integration test that asserts v3 is the new default when no
+   `accept` parameter is supplied.
+6. Update tests/mcp_integration.rs::test_capabilities_default_is_v3.
+
+Branch: feat/v0.6.5-a-5-schema-v3
+Commit: feat(mcp): bump capabilities schema to v3 default (#545)
+
+Definition of done:
+- v3 is the new default
+- v2 clients see no behavior change (gated explicit accept="v2")
+- SDKs build with new V3 types
+- API_REFERENCE.md updated with v3 section
+```
+
+---
+
+## Track B — Loader tools
+
+> **Track goal:** the loader of last resort gets a name that says "load." Reasoning-class LLMs find it on first ask. Path 1's reliability stops being curiosity-gated.
+
+### Task B1: Add `memory_load_family(family)` tool to always-on family
+
+**File(s):** `src/mcp.rs`, `src/tool_registry.rs` (or equivalent)
+**Branch:** `feat/v0.6.5-b-1-memory-load-family`
+
+**Deliverable:** A new tool `memory_load_family(family: enum)` registered in the always-on family alongside `memory_capabilities`. Same wire-level behavior as `memory_capabilities(family=X, include_schema=true)` but **the name tells the LLM what it does**.
+
+**Tool schema:**
+```json
+{
+  "name": "memory_load_family",
+  "description": "Load a tool family at runtime. Returns the schemas for that family; on harnesses with deferred-tool registration (Claude Code, OpenClaw), the tools become directly callable for the rest of the session. On other harnesses, returns the schemas plus a hint to restart the server with --profile <family>.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["family"],
+    "properties": {
+      "family": {
+        "type": "string",
+        "enum": ["core", "lifecycle", "graph", "governance", "power", "meta", "archive", "other"]
+      }
+    }
+  }
+}
+```
+
+**Response shape:**
+```json
+{
+  "family": "graph",
+  "schemas": [<full MCP tool schemas for the graph family>],
+  "your_harness_supports_deferred_registration": true,
+  "to_invoke": "Your harness (claude-code) supports deferred-tool registration. The schemas above are now callable directly by name (memory_link, memory_kg_query, memory_entity_register, ...). No restart needed."
+}
+```
+
+**Acceptance criteria:**
+- [ ] Tool is in always-on family (loaded under any profile)
+- [ ] Wire behavior identical to `memory_capabilities(family=X, include_schema=true)` for the schema payload
+- [ ] Adds the harness-aware `to_invoke` field per Task B4
+- [ ] Tool description tested against all 4 named LLMs in `tests/calibration_t0.rs` — does the LLM find this tool when asked "how do I load a family?"
+
+#### NHI starter prompt for B1
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task B1 (#545, #546).
+
+Goal: add memory_load_family tool to the always-on family. The loader of
+last resort gets a name that says "load."
+
+Why: three real LLM observation cells in 2026-05-05 showed reasoning-class
+agents looked for an explicitly-named loader, hypothesized one must exist,
+didn't find one, and concluded a bootstrap limitation existed. The substrate
+already has the loader (memory_capabilities with family= + include_schema=true)
+but its name connotes introspection, not loading.
+
+What to do:
+1. Look at how src/mcp.rs registers the always-on family. Add memory_load_family
+   to that registry.
+2. The tool's schema is in the V0.6.5-EPIC task B1 description -- start with that.
+3. The handler logic is mostly delegation: same logic as memory_capabilities
+   when called with family=X, include_schema=true. Factor out a helper
+   `build_family_schemas(family, harness_info)` that both tools call.
+4. Add the harness_info detection (Task B4) — read MCP `clientInfo` from
+   the server's MCP state; map known harness names to a HarnessProfile
+   struct that knows whether deferred registration is supported.
+5. Build the to_invoke field from harness_info: branch on
+   supports_deferred_registration to produce the right hint.
+6. Add unit tests in src/mcp.rs::tests covering each family.
+7. Add integration tests that load a family from a Grok-CLI-shaped client
+   (no deferred registration) and assert the to_invoke text recommends
+   --profile X.
+8. Add tests/calibration_t0.rs case that simulates "agent asks: how do I
+   load a family?" and asserts the response references memory_load_family.
+
+Branch: feat/v0.6.5-b-1-memory-load-family
+Commit: feat(mcp): add memory_load_family tool to always-on family (#545, #546)
+
+Definition of done:
+- memory_load_family loadable + callable under every profile
+- Returns schemas + to_invoke + your_harness_supports_deferred_registration
+- Unit + integration tests pass
+- t0-calibration test confirms LLMs find this tool when asked
+```
+
+---
+
+### Task B2: Add `memory_smart_load(intent: string)` tool
+
+**File(s):** `src/mcp.rs`, `src/intent_classifier.rs` (new file)
+**Branch:** `feat/v0.6.5-b-2-memory-smart-load`
+
+**Deliverable:** A new tool `memory_smart_load(intent: string)` registered in always-on. Takes a plain-language intent and returns the matched family/families with their schemas. Closes the curiosity gap completely — agent doesn't need to know the family taxonomy; it asks by intent.
+
+**Tool schema:**
+```json
+{
+  "name": "memory_smart_load",
+  "description": "Load tool families matched to a natural-language intent. Examples: 'consolidate memories and detect contradictions' loads power+meta. 'link memories and traverse knowledge graph' loads graph. 'show me deletion and lifecycle controls' loads lifecycle.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["intent"],
+    "properties": {
+      "intent": {"type": "string"}
+    }
+  }
+}
+```
+
+**Response shape:**
+```json
+{
+  "intent": "consolidate memories and detect contradictions",
+  "matched_families": ["power", "meta"],
+  "matched_tools": ["memory_consolidate", "memory_detect_contradiction", "memory_stats"],
+  "schemas": [...],
+  "your_harness_supports_deferred_registration": true,
+  "to_invoke": "..."
+}
+```
+
+**Implementation:**
+- Intent → family mapping via embedding-similarity against pre-computed family descriptors (see Task B3)
+- Falls back to keyword matching if the embedder isn't loaded (keyword tier)
+- Pre-computed family descriptors are bundled in the binary
+
+#### NHI starter prompt for B2
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task B2 (#546).
+Depends on: B1 (memory_load_family + harness detection).
+
+Goal: add memory_smart_load(intent) — the intent-aware loader that closes
+the curiosity gap completely. Agent asks "what do I need for X" in plain
+language; substrate matches intent to family/families, returns schemas.
+
+What to do:
+1. Create src/intent_classifier.rs with:
+   - A trait IntentClassifier { fn classify(intent: &str) -> Vec<Family>; }
+   - An impl EmbeddingClassifier that uses sentence-transformers cosine
+     similarity against pre-computed family descriptors (Task B3 ships
+     the descriptors).
+   - An impl KeywordClassifier as fallback when embedding tier is off.
+   - A facade `pick_classifier()` that returns the right impl based on
+     active feature tier.
+2. Add memory_smart_load tool to src/mcp.rs's always-on registry. Its
+   handler:
+     - calls classifier.classify(intent) → Vec<Family>
+     - for each family, calls build_family_schemas (from B1)
+     - aggregates results into a single response
+3. Build the to_invoke field with the same harness-aware branching as B1.
+4. Unit test: a fixed corpus of 30 intent strings → expected family lists.
+   Test asserts top-match accuracy >= 80% on the labelled corpus.
+5. Integration test: end-to-end MCP call with intent="consolidate memories
+   and detect contradictions" → response includes power and meta families
+   with their full schemas.
+6. Add tests/calibration_t0.rs case "agent asks: what tools do I need to
+   consolidate memories?" → assert the agent's tool call is
+   memory_smart_load, not memory_capabilities.
+
+Branch: feat/v0.6.5-b-2-memory-smart-load
+Commit: feat(mcp): add memory_smart_load intent-aware loader (#546)
+
+Definition of done:
+- Tool callable from every profile
+- Intent-classifier corpus test >= 80% top-match accuracy
+- Integration test passes end-to-end
+- Calibration test confirms LLMs reach for memory_smart_load on intent prompts
+```
+
+---
+
+### Task B3: Pre-compute family-descriptor embeddings at build time
+
+**File(s):** `build.rs` (or new `scripts/build-family-descriptors.rs`), `src/intent_classifier.rs`, `assets/family-descriptors.bin` (new)
+**Branch:** `feat/v0.6.5-b-3-family-descriptor-embeddings`
+
+**Deliverable:** A build-time script that computes sentence-transformer embeddings for each of the 8 family descriptors and bundles them in the binary. Runtime classifier loads them from the binary (zero IO at hot path).
+
+**Family descriptors (one per family) — short paragraphs the embedder operates on:**
+- core: "Store, recall, search, list, and get individual memories. Basic CRUD."
+- lifecycle: "Delete, update, promote memories. Manage memory existence and tier transitions."
+- graph: "Link memories together. Query the knowledge graph. Register entities. Traverse memory relationships."
+- governance: "Approve, reject, or flag memory operations. N-of-M consensus on destructive ops."
+- power: "Consolidate near-duplicates. Detect contradictions. Auto-tag. Expand queries with semantic siblings."
+- meta: "Introspect the memory system. Statistics, configuration, session-state, audit-log queries."
+- archive: "Archive, restore, purge old memories. Manage long-term storage."
+- other: "Miscellaneous tools that don't fit a primary family — usually deprecated or experimental."
+
+#### NHI starter prompt for B3
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task B3 (#546).
+Required by: B2.
+
+Goal: pre-compute embeddings for the 8 family descriptors at build time
+and bundle them in the binary. Runtime intent classifier reads them with
+zero IO.
+
+What to do:
+1. Create src/family_descriptors.rs with the canonical descriptor strings
+   (per task B3 in V0.6.5-EPIC.md).
+2. Create build.rs (or scripts/build-family-descriptors.rs invoked by
+   build.rs):
+   - At build time, run sentence-transformers/all-MiniLM-L6-v2 over the
+     8 descriptors.
+   - Serialize the embeddings (fp16, 384 dims each = 6.1KB total) to
+     assets/family-descriptors.bin.
+3. In src/intent_classifier.rs::EmbeddingClassifier:
+   - Load assets/family-descriptors.bin via include_bytes! at compile time.
+   - At classify() time, embed the user-provided intent string with the
+     same MiniLM model, compute cosine similarity to each descriptor,
+     return the top-1 (default) or top-K families.
+4. Unit test: cosine similarity matrix of all 8 descriptors against each
+   other — assert each is its own top-1 match.
+5. Cargo build matrix test: cargo build --release succeeds with the
+   build.rs in place; the binary doesn't grow by more than 50KB.
+
+Branch: feat/v0.6.5-b-3-family-descriptor-embeddings
+Commit: feat(mcp): pre-compute family-descriptor embeddings at build (#546)
+
+Definition of done:
+- assets/family-descriptors.bin exists and is reproducible
+- Embedding-classifier loads it without IO at hot path
+- Self-similarity test passes (each descriptor is its own top-1)
+- Binary size growth < 50KB
+```
+
+---
+
+### Task B4: Detect harness from MCP `clientInfo`; surface `your_harness_supports_deferred_registration`
+
+**File(s):** `src/mcp.rs`, `src/harness.rs` (new)
+**Branch:** `feat/v0.6.5-b-4-harness-detection`
+
+**Deliverable:** On MCP `initialize`, read the `clientInfo.name` field. Map it to a `HarnessProfile { name, supports_deferred_registration: bool, suggested_action: String }`. Surface in all relevant capabilities and load-family responses.
+
+**Harness mapping table (initial):**
+
+| `clientInfo.name` | `supports_deferred_registration` |
+|---|---|
+| `claude-code` | true (via ToolSearch) |
+| `openclaw` | true (native) |
+| `claude-desktop` | false |
+| `codex-cli` | false |
+| `grok-cli` | false |
+| `gemini-cli` | false |
+| `cursor` | false (until they ship deferred-tools) |
+| `cline` | false |
+| `continue` | false |
+| `windsurf` | false |
+| `unknown` | false (conservative default) |
+
+#### NHI starter prompt for B4
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task B4 (#546).
+
+Goal: detect harness from MCP clientInfo and surface its deferred-tool
+registration capability in substrate responses, so agents on capable
+harnesses know they can opt up cheaply.
+
+What to do:
+1. Create src/harness.rs:
+   - struct HarnessProfile { name: String, supports_deferred_registration: bool, suggested_action: String }
+   - fn detect_harness(client_info: &ClientInfo) -> HarnessProfile
+   - Hardcoded mapping table per V0.6.5-EPIC task B4. Conservative
+     default: false for unknown harnesses.
+2. Plumb the detected HarnessProfile through MCP session state — store
+   it on the session at initialize time.
+3. Tasks B1, B2 use this profile to populate
+   your_harness_supports_deferred_registration + to_invoke fields.
+4. Unit test: each row in the mapping table.
+5. Add a registry-update mechanism — a const HARNESS_REGISTRY array that
+   future PRs add to without modifying the detect logic.
+
+Branch: feat/v0.6.5-b-4-harness-detection
+Commit: feat(mcp): harness-aware response shaping via clientInfo (#546)
+
+Definition of done:
+- Hardcoded harness map for the 11 known clients
+- `supports_deferred_registration` correctly populated on session init
+- B1 and B2 use the profile to build `to_invoke` text
+- Tests cover all rows of the mapping
+```
+
+---
+
+### Task B5: Update `memory_capabilities` description to point at the new loaders
+
+**File(s):** `src/mcp.rs` (the `memory_capabilities` tool description string)
+**Branch:** `feat/v0.6.5-b-5-capabilities-description-pointer`
+
+**Deliverable:** The current `memory_capabilities` tool description ends with: *"To LOAD an unloaded family at runtime, use `memory_load_family(family=X)` (preferred) or pass `family=X, include_schema=true` to this tool (legacy path). For intent-based loading, use `memory_smart_load(intent='...')`."*
+
+**Acceptance criteria:**
+- [ ] Description string explicitly names both new tools
+- [ ] Legacy path retained but marked legacy
+- [ ] Tool-description size doesn't exceed the 1,500-token-per-tool ceiling enforced by `.github/workflows/token-budget.yml`
+
+#### NHI starter prompt for B5
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task B5 (#545).
+Depends on: B1, B2.
+
+Goal: update memory_capabilities tool's description string to explicitly
+point at the new loader tools. Closes the discoverability gap on the
+introspection-tool side itself.
+
+What to do:
+1. In src/mcp.rs, find the description string for the memory_capabilities
+   tool registration.
+2. Replace the description with text that explicitly says: "To LOAD an
+   unloaded family at runtime, use memory_load_family(family=X) (preferred)
+   or pass family=X, include_schema=true to this tool (legacy path).
+   For intent-based loading, use memory_smart_load(intent='...')."
+3. Verify the new description fits under the per-tool 1,500-token ceiling
+   enforced by .github/workflows/token-budget.yml. Run:
+   cargo test --lib sizes::tests::no_tool_exceeds_1500_tokens -- --exact
+4. Update the v3 capabilities response to reflect this new description.
+
+Branch: feat/v0.6.5-b-5-capabilities-description-pointer
+Commit: feat(mcp): point memory_capabilities at memory_load_family + memory_smart_load (#545)
+
+Definition of done:
+- Description names both new tools
+- Token-budget CI test passes
+- Calibration test confirms LLMs find the loaders via this description
+```
+
+---
+
+## Track C — Schema compaction
+
+> **Track goal:** `--profile full` drops from ~6,200 input tokens to ~3,500. Every harness benefits — especially the eager-loading ones where Path 1 doesn't apply.
+
+### Task C1: Audit all 43 tool descriptions for verbosity
+
+**File(s):** `src/mcp.rs`, `docs/v0.6.5/schema-compaction-audit.md` (new)
+**Branch:** `feat/v0.6.5-c-1-audit`
+
+**Deliverable:** A markdown document listing all 43 tools with their current description token cost (per `cl100k_base`) and a column flagging which are over the 200-token verbosity hotspot threshold. Sorted by cost descending.
+
+#### NHI starter prompt for C1
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task C1 (#546).
+
+Goal: audit all 43 tool descriptions and identify the verbosity hotspots
+that drive the --profile full cost above 6,000 tokens.
+
+What to do:
+1. Run `ai-memory doctor --tokens --raw-table --json` to get the
+   per-tool token cost.
+2. Sort by cost descending.
+3. Flag any tool whose description alone (not inputSchema) is over 200
+   tokens — these are verbosity hotspots.
+4. Write docs/v0.6.5/schema-compaction-audit.md with:
+   - Table: tool name | family | description tokens | inputSchema tokens
+     | total | flagged?
+   - Sorted by total descending
+   - Top 5-10 flagged candidates for compaction in C2-C5
+
+Branch: feat/v0.6.5-c-1-audit
+Commit: docs(v0.6.5): schema compaction audit (#546)
+
+Definition of done:
+- audit.md exists with per-tool table
+- Top hotspots clearly identified
+- Total full-profile cost reproduced (matches doctor --tokens)
+```
+
+---
+
+### Task C2: Move docstrings to a separate `docs` field included only with `verbose=true`
+
+**File(s):** `src/mcp.rs` (tool registration), tool definition macros
+**Branch:** `feat/v0.6.5-c-2-docs-field`
+
+**Deliverable:** Each tool's `description` field becomes the essential one-liner; long-form docstrings move to a `docs` field returned only when the request explicitly includes `verbose=true`. Default response is short.
+
+**Acceptance criteria:**
+- [ ] `tools/list` response excludes `docs` field by default
+- [ ] `memory_capabilities(verbose=true)` response includes `docs` field for each tool
+- [ ] No agent-facing tool description loses information; just relocates it
+
+#### NHI starter prompt for C2
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task C2 (#546).
+Depends on: C1.
+
+Goal: move long docstrings to a separate `docs` field returned only on
+verbose=true. The default tools/list response gets the essential one-liner.
+
+What to do:
+1. For each tool flagged in C1's audit:
+   - Identify the essential one-liner (1-2 sentences)
+   - Move the rest of the original description text to a new `docs`
+     field on the tool definition struct
+2. Update src/mcp.rs to omit `docs` from tools/list by default.
+3. Add `verbose: bool` parameter to memory_capabilities. When true,
+   include `docs` in the per-tool response.
+4. Verify the new `description` strings remain meaningful — run a sanity
+   test: ask Claude Code, given only the new descriptions, "what does
+   memory_consolidate do?" The answer should be substantively correct.
+5. Run token-budget CI: --profile full total drops by at least 1,500
+   tokens.
+
+Branch: feat/v0.6.5-c-2-docs-field
+Commit: feat(mcp): split tool descriptions from long-form docs (#546)
+
+Definition of done:
+- All 43 tools have description (essential) + docs (verbose-only)
+- tools/list response is shorter
+- memory_capabilities(verbose=true) returns docs
+- Full-profile token cost drops by ≥1,500
+```
+
+---
+
+### Task C3: Drop redundant examples from JSON-schema description fields
+
+**File(s):** all JSON-schema description fields under `src/mcp.rs`
+**Branch:** `feat/v0.6.5-c-3-drop-redundant-examples`
+
+**Deliverable:** Inline examples in property descriptions ("e.g., 'Project DB is PostgreSQL 16'") are removed from the schema description text. Examples belong in the docs page (already exists), not in the per-turn schema overhead.
+
+**Acceptance criteria:**
+- [ ] Every property's description retains its essential meaning
+- [ ] No `e.g.,` or `for example,` in any description
+- [ ] Full-profile token cost drops by ≥500 additional tokens
+
+#### NHI starter prompt for C3
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task C3 (#546).
+Depends on: C2.
+
+Goal: strip redundant inline examples from JSON-schema description fields.
+Examples are great for humans reading the docs site; they're token-tax on
+every MCP turn.
+
+What to do:
+1. grep src/mcp.rs for "e.g.," and "for example," — these are the redundant
+   inline-example markers.
+2. For each match: rewrite the description to be self-explanatory without
+   needing the example. The example itself moves to docs (already-existing
+   field from C2) if not already there.
+3. Run cargo test --lib mcp::tests — no regressions.
+4. Check token-budget CI:
+   cargo test --lib sizes::tests::full_profile_total_in_honest_measured_range
+   Full-profile total should drop by ≥500.
+
+Branch: feat/v0.6.5-c-3-drop-redundant-examples
+Commit: feat(mcp): drop redundant inline examples from schemas (#546)
+
+Definition of done:
+- Zero "e.g.," or "for example," in src/mcp.rs schemas
+- Full-profile cost drops ≥500 tokens
+- Tests pass
+```
+
+---
+
+### Task C4: Optional parameters not advertised by default; surface via `verbose=true`
+
+**File(s):** `src/mcp.rs`, JSON-schema `properties` fields
+**Branch:** `feat/v0.6.5-c-4-optional-params-hidden-by-default`
+
+**Deliverable:** Optional parameters (those without `required` flag) are split: the most-commonly-used 2-3 stay in the default schema; the rest move to a separate map shown only when `verbose=true`.
+
+#### NHI starter prompt for C4
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task C4 (#546).
+Depends on: C3.
+
+Goal: hide rarely-used optional parameters from the default schema. They're
+still accepted at runtime; just not advertised on every turn.
+
+What to do:
+1. For each tool in src/mcp.rs, list its optional parameters (those NOT in
+   `required: []`).
+2. Categorize each as "common" (used in >50% of canonical examples) or
+   "rare" (advanced flags rarely set).
+3. The `inputSchema.properties` shown in tools/list keeps required + common.
+   Rare parameters move to a side-list `extended_properties` returned only
+   on memory_capabilities(verbose=true).
+4. Runtime acceptance is unchanged — the tool handler still accepts rare
+   parameters if provided. Just not advertised.
+5. Run token-budget CI; full-profile drops ≥300 more tokens.
+
+Branch: feat/v0.6.5-c-4-optional-params-hidden-by-default
+Commit: feat(mcp): hide rarely-used params from default schema (#546)
+
+Definition of done:
+- Per-tool token cost drops as predicted
+- Existing callers using rare parameters still work
+- Token-budget CI green at the new floor
+```
+
+---
+
+### Task C5: CI gate enforces full-profile ≤ 3,500 tokens
+
+**File(s):** `.github/workflows/token-budget.yml`, `src/sizes.rs`
+**Branch:** `feat/v0.6.5-c-5-ci-gate-3500`
+
+**Deliverable:** The existing `full_profile_total_in_honest_measured_range` CI gate has its upper bound reduced from 8,000 to 3,500 tokens. Lower bound stays at 3,000. Future PRs that re-bloat full-profile schema fail the gate.
+
+#### NHI starter prompt for C5
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task C5 (#546).
+Depends on: C2, C3, C4.
+
+Goal: lock in the schema-compaction win with a CI gate. Future PRs can't
+re-bloat the schema without explicit gate updates.
+
+What to do:
+1. In src/sizes.rs, update the constant FULL_PROFILE_HONEST_RANGE from
+   (5000, 8000) to (3000, 3500).
+2. Run cargo test --lib sizes::tests::full_profile_total_in_honest_measured_range
+   to verify the live full-profile cost falls in the new range.
+3. If it doesn't (cost is too high), the C2-C4 work is incomplete — flag
+   for review.
+4. Update .github/workflows/token-budget.yml comments to reference the
+   new bound.
+5. Update docs/MIGRATION_v0.6.4.md and docs/v0.6.5/V0.6.5-EPIC.md with
+   the new measured range.
+
+Branch: feat/v0.6.5-c-5-ci-gate-3500
+Commit: feat(ci): lock full-profile schema cost at <=3,500 tokens (#546)
+
+Definition of done:
+- New (3000, 3500) range
+- Test passes against live cost
+- Token-budget CI honest about the new ceiling
+- Docs updated with the new claim
+```
+
+---
+
+## Track D — Per-harness positioning + tests
+
+> **Track goal:** v0.6.5's harness-aware response shape is exercised end-to-end and documented. The cortex-on-core compatibility matrix becomes verifiable, not narrative.
+
+### Task D1: Cross-harness benchmark (in test-hub)
+
+**Branch:** `feat/v0.6.5-d-1-cross-harness-benchmark`
+
+**Deliverable:** New `benchmarks/v0.6.5-cortex-on-core.md` documenting:
+- Per-harness `tools/list` cost under `--profile core` + after first `memory_load_family` call (cumulative)
+- Per-harness Pareto position (token cost vs. capability surface)
+- Reproduction commands
+
+#### NHI starter prompt for D1
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task D1 (#546).
+Depends on: B1 (memory_load_family ships).
+
+Goal: produce a reproducible benchmark showing cortex-on-core token cost
+across harnesses, before and after a representative load_family call.
+
+What to do:
+1. Create benchmarks/v0.6.5-cortex-on-core.md.
+2. Document the methodology: for each harness in {claude-code, openclaw,
+   claude-desktop, codex-cli, grok-cli, gemini-cli}, simulate an MCP
+   session that:
+   - Calls tools/list (record cost as boot_cost)
+   - Calls memory_load_family(family="graph") (record post_load_cost)
+   - Computes net = boot_cost + (post_load_cost - boot_cost) only on
+     deferred-registration-capable harnesses; otherwise = boot_cost
+3. Build a table per harness showing:
+   - Boot cost
+   - Post-load cost
+   - Net session cost (cortex-on-core or just core)
+4. Tie the numbers back to the v0.6.4 cross-harness benchmark
+   methodology in benchmarks/v0.6.4-cross-harness.md.
+5. Add a "reproduction" subsection with the exact `ai-memory doctor` and
+   `ai-memory mcp` commands.
+
+Branch: feat/v0.6.5-d-1-cross-harness-benchmark
+Commit: bench(v0.6.5): cross-harness cortex-on-core benchmark (#546)
+
+Definition of done:
+- benchmarks/v0.6.5-cortex-on-core.md exists
+- Reproducible numbers across at least 4 harnesses
+- Methodology section explicit; cross-references v0.6.4 benchmark
+```
+
+---
+
+### Task D2: Add per-harness compatibility matrix to landing page
+
+**File(s):** `docs/index.html`, `docs/whats-new-v065.html` (new in F2)
+**Branch:** `feat/v0.6.5-d-2-compat-matrix-on-landing`
+
+**Deliverable:** The `cortex-on-core` section on `docs/index.html` (added in v0.6.4 PR #548) gets a v0.6.5 update reflecting the new memory_load_family + memory_smart_load tools and the schema-compacted full-profile cost.
+
+#### NHI starter prompt for D2
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task D2 (#546).
+Depends on: B1, B2, C5.
+
+Goal: update landing-page cortex-on-core section with v0.6.5 numbers.
+
+What to do:
+1. Find the `cortex-on-core` section in docs/index.html (added 2026-05-05
+   via PR #548).
+2. Update the 3-column cost table:
+   - --profile full column: 6,200 → ≤3,500 (new ceiling from C5)
+   - "core + deferred-registration" column: same ~1,500 boot but now also
+     mentions memory_load_family / memory_smart_load by name
+3. Update the harness compatibility table: Claude Code + OpenClaw rows
+   now reference memory_smart_load(intent="…") as the natural-language
+   loader.
+4. Ensure all link targets resolve (Discovery Gate v0.6.5 cells, issue
+   #545 closed status, issue #546 closed status, MIGRATION_v0.6.5.md).
+
+Branch: feat/v0.6.5-d-2-compat-matrix-on-landing
+Commit: docs(pages): update cortex-on-core section for v0.6.5 (#546)
+
+Definition of done:
+- Numbers reflect post-compaction reality
+- New tool names (memory_load_family, memory_smart_load) referenced
+- All cross-links resolve
+```
+
+---
+
+### Task D3: Update `ai-memory install` to bake `--profile core` + suggest `memory_smart_load` system-prompt snippet
+
+**File(s):** `src/cli/install.rs`
+**Branch:** `feat/v0.6.5-d-3-install-snippet`
+
+**Deliverable:** When `ai-memory install <harness>` writes the canonical mcpServers JSON, it also outputs a recommended system-prompt snippet for the harness (printed to stdout, not written to harness files since most don't accept system-prompt edits via config). The snippet includes guidance like:
+
+```
+You have access to ai-memory v0.6.5 with a 5-tool default surface.
+If you need a tool not currently loaded (e.g., memory_link, memory_consolidate, memory_delete),
+call memory_smart_load(intent="<plain-language description>") to load the right family.
+This is the natural-language loader; you don't need to know the family taxonomy.
+```
+
+#### NHI starter prompt for D3
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task D3 (#546).
+Depends on: B2.
+
+Goal: when ai-memory install writes the harness MCP config, also print a
+recommended system-prompt snippet to stdout. This primes any harness
+manually pasting prompts into a system-prompt slot.
+
+What to do:
+1. In src/cli/install.rs, after the canonical config write, print to stdout:
+   ===
+   Recommended system-prompt addition for this harness:
+   <<<
+   You have access to ai-memory v0.6.5 with a 5-tool default surface.
+   If you need a tool not currently loaded (e.g., memory_link,
+   memory_consolidate, memory_delete), call
+   memory_smart_load(intent="<plain-language description>") to
+   load the right family. You don't need to know the family taxonomy.
+   >>>
+   Drop this into your harness's system prompt (location varies; see
+   docs/integrations/v0.6.5-system-prompt-snippet.md).
+   ===
+2. Create docs/integrations/v0.6.5-system-prompt-snippet.md with per-
+   harness placement instructions for the snippet.
+3. Add unit tests asserting the snippet is printed for every install
+   subcommand.
+
+Branch: feat/v0.6.5-d-3-install-snippet
+Commit: feat(cli): print system-prompt snippet on install (#546)
+
+Definition of done:
+- Snippet printed for every install
+- Doc file exists with per-harness placement
+- Unit tests assert printout
+```
+
+---
+
+### Task D4: Integration tests for the harness-aware to_invoke text
+
+**File(s):** `tests/harness_integration.rs` (new)
+**Branch:** `feat/v0.6.5-d-4-harness-integration-tests`
+
+**Deliverable:** New integration test file that simulates each of the 11 known harnesses' `clientInfo.name`, calls `memory_load_family(family="graph")`, and asserts the response's `to_invoke` text correctly branches on deferred-registration support.
+
+#### NHI starter prompt for D4
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task D4 (#546).
+Depends on: B1, B4.
+
+Goal: integration-test harness detection across all 11 known harnesses.
+
+What to do:
+1. Create tests/harness_integration.rs.
+2. For each harness in the HARNESS_REGISTRY (per B4):
+   - Open an MCP session with clientInfo.name = harness name
+   - Call memory_load_family(family="graph")
+   - Assert: response.your_harness_supports_deferred_registration
+     matches the registry expectation
+   - Assert: to_invoke text contains the right hint (deferred-registration
+     supported -> "now callable directly by name"; not supported ->
+     "restart with --profile graph")
+3. Add a "unknown harness" case asserting conservative-default behavior.
+4. Run cargo test --test harness_integration in CI.
+
+Branch: feat/v0.6.5-d-4-harness-integration-tests
+Commit: test(integration): per-harness to_invoke text branching (#546)
+
+Definition of done:
+- 12 tests (11 known harnesses + 1 unknown), all green
+- Conservative default for unknown harness
+- CI runs the new integration target
+```
+
+---
+
+## Track E — Discovery Gate T0 cells (orchestrated)
+
+> **Track goal:** the T0 calibration tier added in [alphaonedev/ai-memory-discovery-gate#1](https://github.com/alphaonedev/ai-memory-discovery-gate/pull/1) gets full LLM coverage and re-runs against the v0.6.5 build to verify convergence.
+
+### Task E1: Orchestrate T0 cells across LLMs (Claude Opus, Grok 4.3, GPT-4-class, Gemini Pro)
+
+**Branch (in discovery-gate repo):** `feat/v0.6.5-e-1-t0-orchestrated`
+
+**Deliverable:** `scripts/run-t0-cells.sh` that drives each named LLM through the T0 calibration prompt suite and produces gate-grade cells (replacing the v0.6.4 observation cells with deterministic ones).
+
+#### NHI starter prompt for E1
+
+```
+You are working on alphaonedev/ai-memory-discovery-gate toward v0.6.5
+calibration coverage.
+
+Goal: lift T0 from observation-mode (3 cells captured 2026-05-05) to
+gate-grade orchestration. Run T0 prompts deterministically across at
+least 4 LLMs.
+
+What to do:
+1. In scripts/run-t0-cells.sh, parameterize LLM driver by env var:
+   T0_LLM=claude-opus-4.7  → uses anthropic-sdk via API
+   T0_LLM=grok-4.3          → uses xAI api
+   T0_LLM=gpt-4.5           → uses openai-sdk
+   T0_LLM=gemini-pro-2      → uses google-generative-ai sdk
+2. The prompt suite is two prompts per cell:
+   - "What memory tools do you have access to right now?"
+   - "How would you know if you needed one not loaded?"
+3. Pass criteria match docs/tiers/t0-calibration.md.
+4. Output cells named docs/runs/<date>/cells/<llm>-<harness>-t0-calibration-core.{json,md,transcript.jsonl,wire.jsonl}
+5. Update docs/runs/<date>/verdict.md to include T0 row.
+
+Branch: feat/v0.6.5-e-1-t0-orchestrated
+Commit: feat(t0): orchestrated cells across 4 LLMs (#1)
+
+Definition of done:
+- run-t0-cells.sh works with any of the 4 named LLMs
+- Cells are deterministic (replay produces same scoring)
+- verdict.md includes T0 row
+```
+
+---
+
+### Task E2: Re-run T0 cells against v0.6.5 binary; confirm convergence
+
+**Branch (in discovery-gate repo):** `feat/v0.6.5-e-2-t0-postship`
+
+**Deliverable:** After v0.6.5 ships, run T0 cells against the new binary. Expected: with `summary` + `to_describe_to_user` + `memory_load_family` + `memory_smart_load`, all 4 LLMs converge on accurate first-answer descriptions. Pass rate target: ≥95% (up from the ~50% observation-mode estimate on v0.6.4).
+
+#### NHI starter prompt for E2
+
+```
+You are working on alphaonedev/ai-memory-discovery-gate after v0.6.5 ships.
+
+Goal: validate that the substrate-side fixes (summary + to_describe_to_user
++ memory_load_family + memory_smart_load) closed the calibration gap.
+
+What to do:
+1. Pull the v0.6.5 binary as DISCOVERY_GATE_BINARY.
+2. Re-run T0 cells via the orchestrator from E1 across all 4 LLMs.
+3. Update the docs/runs/<v0.6.5-ship-date>/verdict.md with the new
+   pass rates.
+4. Compare against the v0.6.4 baseline:
+   - v0.6.4: ~50% calibration accuracy (observed across the 3 cells)
+   - v0.6.5 target: ≥95% across all 4 LLMs
+5. If convergence target NOT met: open a follow-up issue against
+   alphaonedev/ai-memory-mcp identifying the still-misaligned cell.
+
+Branch: feat/v0.6.5-e-2-t0-postship
+Commit: feat(t0): post-ship convergence verification (#1)
+
+Definition of done:
+- T0 cells re-run against v0.6.5 binary
+- Pass rate ≥95% per LLM (or follow-up issues filed for misses)
+- Verdict.md updated with the new run
+```
+
+---
+
+### Task E3: Add `memory_load_family` + `memory_smart_load` cells to T1-T3 tiers
+
+**Branch (in discovery-gate repo):** `feat/v0.6.5-e-3-loader-cells`
+
+**Deliverable:** New gate cells that explicitly test the new loaders:
+- T1 awareness — does the agent know `memory_load_family` exists?
+- T2 reactive — does the agent recover from a loader-not-yet-known scenario by reading the memory_capabilities description?
+- T3 proactive — does the agent reach for `memory_smart_load(intent=...)` instead of `memory_capabilities(family=X, include_schema=true)` when given an intent prompt?
+
+#### NHI starter prompt for E3
+
+```
+You are working on alphaonedev/ai-memory-discovery-gate.
+
+Goal: add gate cells that explicitly test the v0.6.5 loaders.
+
+What to do:
+1. Add three new cells under docs/tiers/:
+   - t1-awareness-loaders.md — pass criterion: agent names
+     memory_load_family OR memory_smart_load when asked
+     "how do I load a tool family?"
+   - t2-reactive-loaders.md — pass criterion: agent calls memory_capabilities
+     and reads the description, then proceeds with memory_load_family.
+   - t3-proactive-smart-load.md — pass criterion: when given an intent
+     ("I want to consolidate memories"), agent reaches for memory_smart_load
+     before memory_capabilities.
+2. Implement in scripts/run-llm-cells.sh.
+3. Run against v0.6.5 binary across all 4 LLMs.
+
+Branch: feat/v0.6.5-e-3-loader-cells
+Commit: feat(t1-t3): cells for new v0.6.5 loaders (#1)
+
+Definition of done:
+- 3 new cells implemented
+- All 4 LLMs scored
+- Verdict.md updated
+```
+
+---
+
+## Track F — Docs + release
+
+### Task F1: Migration guide `docs/MIGRATION_v0.6.5.md`
+
+**File(s):** `docs/MIGRATION_v0.6.5.md` (new)
+**Branch:** `feat/v0.6.5-f-1-migration-guide`
+
+**Deliverable:** Standard migration walkthrough modeled on `MIGRATION_v0.6.4.md`. Covers v3 schema, new loaders, schema-compaction impact on schema-frozen integrations.
+
+#### NHI starter prompt for F1
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task F1.
+
+Goal: produce docs/MIGRATION_v0.6.5.md.
+
+Cover:
+1. memory_capabilities v3 schema (summary + to_describe_to_user +
+   callable_now + agent_permitted_families). Backward compat statement.
+2. New tools: memory_load_family + memory_smart_load. Where they're
+   loaded (always-on). What they replace (legacy memory_capabilities
+   with include_schema). Backward compat statement: legacy path
+   retained.
+3. Schema compaction impact: any integration that hashed tool
+   descriptions for fingerprinting will see hash changes. Tool functional
+   contracts unchanged.
+4. SDK version 0.6.4 still works against v0.6.5 server. Upgrade
+   recommendation: bump SDK to 0.6.5 to access MemoryCapabilitiesV3
+   types.
+
+Style: match docs/MIGRATION_v0.6.4.md tone and structure exactly.
+
+Branch: feat/v0.6.5-f-1-migration-guide
+Commit: docs: v0.6.5 migration guide (#546)
+```
+
+---
+
+### Task F2: New `docs/whats-new-v065.html` (Pages page)
+
+**File(s):** `docs/whats-new-v065.html` (new)
+**Branch:** `feat/v0.6.5-f-2-whats-new-page`
+
+**Deliverable:** Pages-side what's-new page modeled on `docs/whats-new-v064.html`. Same 3-audience pattern; updates the headline number to ≤3,500-token full profile + names the new loaders.
+
+#### NHI starter prompt for F2
+
+```
+You are working on alphaonedev/ai-memory-mcp toward v0.6.5 — task F2.
+
+Goal: produce docs/whats-new-v065.html (Pages-side).
+
+Style + structure: copy docs/whats-new-v064.html exactly; rewrite
+content for v0.6.5.
+
+Three-audience pattern:
+- 👤 If you USE AI: cortex experience now reliably arrives across LLMs;
+  no more "fancy notebook" first-answer if your harness has deferred-tool
+  registration.
+- 🛠️ If you BUILD with AI: memory_load_family + memory_smart_load.
+  v3 capabilities response. ~3,500-token full profile.
+- 🏢 If you DECIDE AI infrastructure: T4-T5 multi-agent positioning
+  closer to ready (per-agent pre-warm in v0.7).
+
+Branch: feat/v0.6.5-f-2-whats-new-page
+Commit: docs(pages): whats-new-v065 (#546)
+```
+
+---
+
+### Task F3: Update topnav links + landing page badges for v0.6.5
+
+**File(s):** `docs/index.html`
+**Branch:** `feat/v0.6.5-f-3-landing-version-bump`
+
+**Deliverable:** Topnav v0.6.4 link → v0.6.5; badge block test count + coverage updated; "v0.6.4 cert" badge → "v0.6.5 cert"; meta tags v0.6.4 → v0.6.5.
+
+---
+
+### Task F4: README + ADMIN_GUIDE updates
+
+**File(s):** `README.md`, `docs/ADMIN_GUIDE.md`
+**Branch:** `feat/v0.6.5-f-4-readme-admin-guide`
+
+**Deliverable:** Both docs updated to reference the new tools, updated full-profile cost, updated capabilities v3 shape.
+
+---
+
+### Task F5: CHANGELOG, version bumps, tag, CI release
+
+**File(s):** `CHANGELOG.md`, `Cargo.toml`, `sdk/python/pyproject.toml`, `sdk/typescript/package.json`
+**Branch:** `feat/v0.6.5-f-5-release-prep`
+
+**Deliverable:** v0.6.5 entry in CHANGELOG; all version strings bumped; tag pushed; CI release pipeline triggered.
+
+---
+
+## Critical-path sequencing
+
+```
+Week 1:   A1 → A2 → A3 → A4 → A5     (track A complete)
+          C1 (audit) — runs parallel
+          F1 (migration guide) — starts late week 1
+
+Week 2:   B4 (harness detection) → B1 (memory_load_family)
+          C2 → C3                    (compaction begins)
+          E1 (T0 orchestrator)       (parallel)
+
+Week 3:   B3 (embeddings) → B2 (memory_smart_load) → B5
+          C4 → C5
+          D1 (cross-harness benchmark)
+
+Week 4:   D2, D3, D4 (integration + positioning)
+          E3 (loader cells)
+          F2, F3, F4 (docs)
+          F5 (release prep)
+
+Post-ship: E2 (T0 convergence verification)
+```
+
+Total ~4 weeks for the minimal-but-sufficient v0.6.5. Cuts to 3 weeks if track C (compaction) is deferred or cuts to 5-6 weeks if more contributors join (mostly parallelizes well).
+
+---
+
+## Definition of release-ready
+
+v0.6.5 ships when **all of these are true**:
+
+- [ ] All A1-A5 + B1-B5 + F1-F5 tasks merged to main
+- [ ] CI green on main, all required checks passing
+- [ ] Schema-compaction CI gate (C5) green at ≤3,500 tokens
+- [ ] T0 calibration cells (E2) re-run against the v0.6.5 binary, ≥95% pass rate across all 4 LLMs
+- [ ] Migration guide reviewed
+- [ ] Cross-harness benchmark (D1) reproduced
+- [ ] No new SDK breakage (existing 0.6.4 SDKs still work against v0.6.5 server)
+- [ ] Same release-quality bar as v0.6.4: 5/5 distribution channels, SHA256SUMS, OIDC SDK publish via existing publish-sdks.yml workflow
+
+## Refs
+
+- [v0.6.4 Epic](../v0.6.4/V0.6.4-EPIC.md) — predecessor
+- [v0.6.4 release notes](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.4) — current state
+- [Issue #545](https://github.com/alphaonedev/ai-memory-mcp/issues/545) — substrate response shape
+- [Issue #546](https://github.com/alphaonedev/ai-memory-mcp/issues/546) — cortex experience under core-tier token cost
+- [Issue #512](https://github.com/alphaonedev/ai-memory-mcp/issues/512) — long-running drift tracker
+- [Discovery Gate PR #1](https://github.com/alphaonedev/ai-memory-discovery-gate/pull/1) — T0 calibration cells
+
+---
+
+**Codename:** `cortex-fluent` — same release binary, more legible. The substrate doesn't get more powerful; it gets more articulate.


### PR DESCRIPTION
## Summary

Detailed v0.6.5 roadmap with self-contained AI NHI starter prompts for every task. Confirms the minimal-sufficient scope:

- **Path 2** (schema compaction) — Track C, ~1 week
- **Path 3** (memory_smart_load + memory_load_family) — Track B + supporting Track A, ~3-4 weeks

Path 1 (deferred-tool registration on Claude Code / OpenClaw) is already shipped + marketed via PR #547 + #548 + the v0.6.4 release-notes top callout. Paths 4-6 deferred to v0.7 or skipped.

## What's in this PR

A single new file: \`docs/v0.6.5/V0.6.5-EPIC.md\` — 1,354 lines, 6 tracks, ~27 tasks. Each task has a self-contained NHI starter prompt that any agent (Claude Code, Grok, Codex, etc.) can take and begin work on without further briefing. Branch naming, commit convention, and definition-of-done all standardized across tasks.

## Six tracks at a glance

| Track | Scope | Effort | Required? |
|---|---|---|---|
| **A** — Substrate response shape (memory_capabilities v3) | 5 tasks | ~1 week | 🔴 REQUIRED |
| **B** — Loader tools (memory_load_family + memory_smart_load) | 5 tasks | ~2-3 weeks | 🔴 REQUIRED |
| **C** — Schema compaction (~6,200 → ≤3,500 tokens for full) | 5 tasks | ~1 week | 🟢 STRONGLY RECOMMENDED |
| **D** — Per-harness positioning + tests | 4 tasks | ~3-5 days | 🟢 STRONGLY RECOMMENDED |
| **E** — Discovery Gate T0 cells (orchestrated across 4 LLMs) | 3 tasks | ~3 days | 🟢 STRONGLY RECOMMENDED |
| **F** — Docs + release | 5 tasks | ~3 days | 🔴 REQUIRED (every release) |

**Total:** ~4 weeks focused engineer time. Cuts to 3 weeks if track C deferred or to 5-6 if more contributors join (parallelizes well).

## Codename

\`cortex-fluent\` — same release binary, more legible. The substrate doesn't get more powerful; it gets more articulate.

The 2026-05-05 NHI Discovery Gate verdict on v0.6.4 came back **6/6 PASS, GATE GREEN** — but three real-world LLM observation cells captured the same day surfaced a *legibility* gap. A reasoning-class LLM (Grok 4.2 reasoning), given the v0.6.4 substrate, did not find the runtime loader because the loader is hidden inside an introspection tool's parameter set (\`memory_capabilities(family=X, include_schema=true)\`). The name connotes introspection, not loading. v0.6.5 closes that gap.

## Test plan
- [x] Markdown renders cleanly on GitHub
- [x] All inter-task dependencies named explicitly
- [x] All cross-issue references resolve (#545, #546, #512, discovery-gate#1)
- [x] All NHI starter prompts are self-contained (no "see briefing above")

## Refs

- Tracks: #545 (substrate response shape), #546 (cortex experience under core-tier token cost), #512 (long-running drift)
- Discovery Gate: alphaonedev/ai-memory-discovery-gate#1 (T0 calibration cells)
- v0.6.4 predecessor: #538 (merged 2026-05-05)
- v0.6.4 release notes: https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)