### PR TITLE
feat: v0.7-a1 — capabilities v3 summary field (#545)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -715,6 +715,84 @@ impl Capabilities {
             models: self.models.clone(),
         }
     }
+
+    /// v0.7.0 (A1): project the report into the v3 shape.
+    ///
+    /// v3 = v2 + a top-level `summary` string carrying a pre-computed,
+    /// plain-language description of the LLM's operational tool surface
+    /// (loaded count, total count, the three named recovery paths an LLM
+    /// can take to reach unloaded families). The summary is computed by
+    /// the caller from the live `Profile` state because the
+    /// [`Capabilities`] struct itself doesn't know which families the
+    /// MCP server actually advertised in `tools/list`.
+    ///
+    /// Future v0.7.0 increments (A2–A4) extend this struct with
+    /// `to_describe_to_user`, per-tool `callable_now`, and
+    /// `agent_permitted_families`. A5 bumps the default wire shape to v3.
+    /// v2 stays supported indefinitely.
+    #[must_use]
+    pub fn to_v3(&self, summary: String) -> CapabilitiesV3 {
+        CapabilitiesV3 {
+            schema_version: "3".to_string(),
+            summary,
+            tier: self.tier.clone(),
+            version: self.version.clone(),
+            features: self.features.clone(),
+            models: self.models.clone(),
+            permissions: self.permissions.clone(),
+            hooks: self.hooks.clone(),
+            compaction: self.compaction.clone(),
+            approval: self.approval.clone(),
+            transcripts: self.transcripts.clone(),
+            hnsw: self.hnsw.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities v3 — v0.7.0 attested-cortex schema (additive over v2)
+// ---------------------------------------------------------------------------
+
+/// v0.7.0 capabilities schema (A1 increment). Additive over [`Capabilities`]
+/// (v2): the top-level `summary` field carries a pre-computed,
+/// plain-language description of the LLM's operational tool surface so
+/// reasoning-class LLMs converge on accurate first-answer descriptions
+/// without having to traverse `families[]` and count manually.
+///
+/// Wire selection: clients opt in via `accept="v3"` on the MCP
+/// `memory_capabilities` call, or `Accept-Capabilities: v3` over HTTP
+/// (HTTP wiring lands with A5). Default response remains v2 until A5
+/// flips the default. v2 stays supported indefinitely.
+///
+/// Increment plan: A2 adds `to_describe_to_user`, A3 adds per-tool
+/// `callable_now`, A4 adds `agent_permitted_families`. A5 bumps the
+/// default wire shape and seals v3 as the recommended client target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilitiesV3 {
+    /// Schema-version discriminator. Always `"3"` in v0.7.0.
+    pub schema_version: String,
+
+    /// Pre-computed plain-language summary of operational access.
+    /// Carries the loaded vs total tool counts under the active profile
+    /// plus the three named recovery paths (`--profile`,
+    /// `memory_load_family`, `memory_smart_load`). Computed at response
+    /// time from the live profile state — never cached at build time
+    /// because the count of advertised tools depends on the running
+    /// server's `--profile` flag.
+    pub summary: String,
+
+    pub tier: String,
+    pub version: String,
+    pub features: CapabilityFeatures,
+    pub models: CapabilityModels,
+    pub permissions: CapabilityPermissions,
+    pub hooks: CapabilityHooks,
+    pub compaction: CapabilityCompaction,
+    pub approval: CapabilityApproval,
+    pub transcripts: CapabilityTranscripts,
+
+    #[serde(default)]
+    pub hnsw: CapabilityHnsw,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4158,6 +4158,15 @@ pub async fn get_capabilities(
         .map_or(crate::mcp::CapabilitiesAccept::V2, |raw| {
             crate::mcp::CapabilitiesAccept::parse(raw)
         });
+    // v0.7.0 A1 — HTTP wiring for v3 lands with A5 (which threads the
+    // active `Profile` through `AppState`). Until then, downgrade
+    // `Accept-Capabilities: v3` to v2 over HTTP so a curious client
+    // doesn't 500 the endpoint. MCP callers reach v3 directly via
+    // `accept="v3"`; the HTTP path is a documented A5 gap.
+    let accept = match accept {
+        crate::mcp::CapabilitiesAccept::V3 => crate::mcp::CapabilitiesAccept::V2,
+        other => other,
+    };
     let embedder_loaded = app.embedder.as_ref().is_some();
     let lock = app.db.lock().await;
     let conn = &lock.0;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1892,10 +1892,7 @@ fn build_capabilities_overlay(
 pub fn build_capabilities_summary(profile: &crate::profile::Profile) -> String {
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let total: usize = Family::all()
-        .iter()
-        .map(|f| f.expected_tool_count())
-        .sum();
+    let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
 
     // Tools advertised in tools/list = sum of family counts the profile
     // includes, plus any always-on bootstrap tool whose owning family is

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1719,15 +1719,29 @@ pub fn handle_recall(
     Ok(resp)
 }
 
-/// Capabilities schema selector (v0.6.3.1 P1 honesty patch).
+/// Capabilities schema selector (v0.6.3.1 P1 honesty patch; extended for
+/// v0.7.0 A1).
 ///
-/// HTTP callers send `Accept-Capabilities: v1` (or `v2`) to request a
-/// shape; MCP callers pass `accept: "v1"` (or `"v2"`) to
-/// `memory_capabilities`. Default is v2.
+/// HTTP callers send `Accept-Capabilities: v1`/`v2`/`v3` to request a
+/// shape; MCP callers pass `accept: "v1"`/`"v2"`/`"v3"` to
+/// `memory_capabilities`. Default remains v2 in the A1 increment;
+/// v0.7.0 A5 will flip the default to v3 once the full A1–A4 surface
+/// is in place.
+///
+/// v3 carries pre-computed calibration fields (top-level `summary` from
+/// A1; `to_describe_to_user`, per-tool `callable_now`, and
+/// `agent_permitted_families` land in A2–A4). v3 requires the live
+/// `Profile` for summary computation, so callers that opt in must reach
+/// for [`handle_capabilities_with_conn_v3`] instead of the v1/v2 entry
+/// point.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilitiesAccept {
     V1,
     V2,
+    /// v0.7.0 A1 — additive on top of v2 (top-level `summary`). Requires
+    /// profile context; opt-in via `accept="v3"` or
+    /// `Accept-Capabilities: v3`.
+    V3,
 }
 
 impl CapabilitiesAccept {
@@ -1737,6 +1751,7 @@ impl CapabilitiesAccept {
     pub fn parse(s: &str) -> Self {
         match s.trim().to_ascii_lowercase().as_str() {
             "v1" | "1" => Self::V1,
+            "v3" | "3" => Self::V3,
             _ => Self::V2,
         }
     }
@@ -1774,12 +1789,57 @@ pub fn handle_capabilities_with_conn(
     conn: Option<&rusqlite::Connection>,
     accept: CapabilitiesAccept,
 ) -> Result<Value, String> {
+    let caps = build_capabilities_overlay(tier_config, reranker, embedder_loaded, conn);
+
+    // --- Schema selection ---
+    match accept {
+        CapabilitiesAccept::V2 => serde_json::to_value(caps).map_err(|e| e.to_string()),
+        CapabilitiesAccept::V1 => serde_json::to_value(caps.to_v1()).map_err(|e| e.to_string()),
+        CapabilitiesAccept::V3 => Err(
+            "capabilities v3 requires profile context — call handle_capabilities_with_conn_v3"
+                .to_string(),
+        ),
+    }
+}
+
+/// v0.7.0 A1 — the v3-shaped capabilities entry point.
+///
+/// Same overlay logic as [`handle_capabilities_with_conn`] (factored
+/// into [`build_capabilities_overlay`]); additionally computes the
+/// top-level `summary` string from the live `profile` state so the
+/// LLM gets a pre-computed, plain-language description of its
+/// operational tool surface (loaded count, total count, the three
+/// named recovery paths for unloaded families).
+///
+/// HTTP callers reach this path through `Accept-Capabilities: v3`;
+/// MCP callers via `accept: "v3"`. The HTTP wire-up is deferred until
+/// A5 (which flips the default and threads the profile through
+/// `AppState`); A1 lights up the MCP dispatch path only.
+pub fn handle_capabilities_with_conn_v3(
+    tier_config: &TierConfig,
+    reranker: Option<&CrossEncoder>,
+    embedder_loaded: bool,
+    conn: Option<&rusqlite::Connection>,
+    profile: &crate::profile::Profile,
+) -> Result<Value, String> {
+    let caps = build_capabilities_overlay(tier_config, reranker, embedder_loaded, conn);
+    let summary = build_capabilities_summary(profile);
+    serde_json::to_value(caps.to_v3(summary)).map_err(|e| e.to_string())
+}
+
+/// Build the runtime-overlaid [`Capabilities`] document. Shared between
+/// the v1/v2 entry point [`handle_capabilities_with_conn`] and the v3
+/// entry point [`handle_capabilities_with_conn_v3`] so the overlay
+/// logic stays single-sourced.
+fn build_capabilities_overlay(
+    tier_config: &TierConfig,
+    reranker: Option<&CrossEncoder>,
+    embedder_loaded: bool,
+    conn: Option<&rusqlite::Connection>,
+) -> crate::config::Capabilities {
     let mut caps = tier_config.capabilities();
 
     // --- Reranker live state (P1) ---
-    // The old (#93) handler flipped `cross_encoder_reranking` to false
-    // when the neural model fell back to lexical. The honesty patch
-    // additionally surfaces the runtime variant in `reranker_active`.
     caps.features.reranker_active = match reranker {
         Some(ce) if ce.is_neural() => RerankerMode::Neural,
         Some(_) => {
@@ -1796,10 +1856,6 @@ pub fn handle_capabilities_with_conn(
     caps.features.recall_mode_active = compute_recall_mode(tier_config, embedder_loaded);
 
     // --- HNSW eviction surface (P3, G2) ---
-    // Mirror the per-process HNSW eviction counters into the capabilities
-    // surface so a `memory_capabilities` poll can tell operators whether
-    // the index is currently shedding embeddings. Same values surfaced in
-    // `memory_stats.index_evictions_total`.
     caps.hnsw.evictions_total = crate::hnsw::index_evictions_total();
     caps.hnsw.evicted_recently = crate::hnsw::evicted_recently(60);
 
@@ -1816,10 +1872,80 @@ pub fn handle_capabilities_with_conn(
         }
     }
 
-    // --- Schema selection ---
-    match accept {
-        CapabilitiesAccept::V2 => serde_json::to_value(caps).map_err(|e| e.to_string()),
-        CapabilitiesAccept::V1 => serde_json::to_value(caps.to_v1()).map_err(|e| e.to_string()),
+    caps
+}
+
+/// v0.7.0 A1 — build the capabilities-v3 `summary` string from the live
+/// `Profile` state.
+///
+/// The summary names: how many tools are advertised in `tools/list`
+/// under the active profile vs how many exist in total, and the three
+/// recovery paths an LLM can take to reach unloaded tools (`--profile`
+/// CLI flag, [`memory_load_family`](#) — landing in B1, and
+/// [`memory_smart_load`](#) — landing in B2).
+///
+/// The result is a single plain-language string, intentionally written
+/// for an LLM to repeat verbatim when an end-user asks "what tools do
+/// you have?" — see the A2 increment for the explicit
+/// `to_describe_to_user` field.
+#[must_use]
+pub fn build_capabilities_summary(profile: &crate::profile::Profile) -> String {
+    use crate::profile::{ALWAYS_ON_TOOLS, Family};
+
+    let total: usize = Family::all()
+        .iter()
+        .map(|f| f.expected_tool_count())
+        .sum();
+
+    // Tools advertised in tools/list = sum of family counts the profile
+    // includes, plus any always-on bootstrap tool whose owning family is
+    // NOT included (so it isn't double-counted). In v0.6.4
+    // `memory_capabilities` lives in `Family::Meta` and is also in
+    // `ALWAYS_ON_TOOLS`; on `--profile core` the meta family isn't
+    // loaded, so the bootstrap injection adds it back here.
+    let from_families: usize = profile.expected_tool_count();
+    let always_on_extra: usize = ALWAYS_ON_TOOLS
+        .iter()
+        .filter(|name| Family::for_tool(name).is_none_or(|f| !profile.includes(f)))
+        .count();
+    let visible = from_families + always_on_extra;
+    let unloaded = total.saturating_sub(visible);
+    let label = profile_summary_label(profile);
+
+    format!(
+        "{visible} of {total} tools are advertised in tools/list under the current profile \
+         ({label}). The other {unloaded} are listed in this manifest but NOT directly \
+         callable. To use any unloaded tool, choose one of: \
+         (a) restart the server with --profile <family> or --profile full, \
+         (b) call memory_load_family(family=<name>) — preferred, \
+         (c) call memory_smart_load(intent='<plain language>') — easiest, \
+         (d) call the tool by name and recover from JSON-RPC -32601."
+    )
+}
+
+/// Return a stable label for a profile's summary string. Named profiles
+/// (core/graph/admin/power/full) use their canonical name; custom
+/// profiles use the comma-joined family list (matches the
+/// `--profile core,graph,archive` CLI form).
+fn profile_summary_label(profile: &crate::profile::Profile) -> String {
+    use crate::profile::Profile;
+    if *profile == Profile::full() {
+        "full".to_string()
+    } else if *profile == Profile::core() {
+        "core".to_string()
+    } else if *profile == Profile::graph() {
+        "graph".to_string()
+    } else if *profile == Profile::admin() {
+        "admin".to_string()
+    } else if *profile == Profile::power() {
+        "power".to_string()
+    } else {
+        profile
+            .families()
+            .iter()
+            .map(|f| f.name())
+            .collect::<Vec<_>>()
+            .join(",")
     }
 }
 
@@ -3765,25 +3891,36 @@ fn handle_request(
                     } else {
                         // P1 honesty patch: optional `accept` argument lets MCP
                         // clients opt into the legacy v1 shape, mirroring the
-                        // HTTP `Accept-Capabilities` header.
+                        // HTTP `Accept-Capabilities` header. v0.7.0 A1 adds
+                        // `accept="v3"` for the additive v3 schema (top-level
+                        // `summary` + future A2-A4 fields).
                         let accept = arguments
                             .get("accept")
                             .and_then(Value::as_str)
                             .map_or(CapabilitiesAccept::V2, CapabilitiesAccept::parse);
                         // v0.6.4-006 — when no family is requested, augment
-                        // the v2 response with a top-level `families` field
+                        // the v2/v3 response with a top-level `families` field
                         // describing the family taxonomy and which families
                         // the active profile loads. Backward-compat: v1
                         // shape never gets the families overlay.
-                        let result = handle_capabilities_with_conn(
-                            tier_config,
-                            reranker,
-                            embedder.is_some(),
-                            Some(conn),
-                            accept,
-                        );
+                        let result = match accept {
+                            CapabilitiesAccept::V3 => handle_capabilities_with_conn_v3(
+                                tier_config,
+                                reranker,
+                                embedder.is_some(),
+                                Some(conn),
+                                profile,
+                            ),
+                            _ => handle_capabilities_with_conn(
+                                tier_config,
+                                reranker,
+                                embedder.is_some(),
+                                Some(conn),
+                                accept,
+                            ),
+                        };
                         result.map(|mut value| {
-                            if matches!(accept, CapabilitiesAccept::V2) {
+                            if matches!(accept, CapabilitiesAccept::V2 | CapabilitiesAccept::V3) {
                                 if let Some(obj) = value.as_object_mut() {
                                     obj.insert("families".to_string(), families_overview(profile));
                                 }

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -1,0 +1,269 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the **Capabilities v3 schema** — A1 increment of
+//! the v0.7.0 `attested-cortex` epic (track A, issue #545).
+//!
+//! v3 is additive over v2 and adds a top-level `summary` field carrying a
+//! pre-computed plain-language description of the LLM's operational tool
+//! surface (loaded count, total count, three named recovery paths for
+//! reaching unloaded families). Computed at response time from the live
+//! `Profile` state so the count of advertised tools always matches what
+//! the running server actually advertises in `tools/list`.
+//!
+//! Future v0.7.0 increments (A2-A4) extend v3 with `to_describe_to_user`,
+//! per-tool `callable_now`, and `agent_permitted_families`. A5 bumps the
+//! default wire shape and seals v3 as the recommended client target.
+//!
+//! These tests pin the A1 contract:
+//! - `accept="v3"` returns a document with `schema_version="3"` and a
+//!   non-empty `summary` field.
+//! - `summary` carries the live profile's loaded vs total tool counts and
+//!   names the three recovery paths.
+//! - The v1/v2 entry point refuses `V3` (with a clear error message) so a
+//!   miswired caller fails loud rather than serving a stale shape.
+//! - v2 callers see no behavior change (backward compat).
+
+use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, TierConfig};
+use ai_memory::mcp::{
+    CapabilitiesAccept, build_capabilities_summary, handle_capabilities_with_conn,
+    handle_capabilities_with_conn_v3,
+};
+use ai_memory::profile::Profile;
+use serde_json::Value;
+
+/// Build a fresh in-memory `rusqlite::Connection` so each test gets a
+/// clean DB state for the live-count overlays.
+fn fresh_conn() -> rusqlite::Connection {
+    ai_memory::db::open(std::path::Path::new(":memory:")).expect("open in-memory db")
+}
+
+fn semantic_tier() -> TierConfig {
+    FeatureTier::Semantic.config()
+}
+
+// ---------------------------------------------------------------------------
+// CapabilitiesAccept::parse("v3") and ("3") both resolve to V3.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_accept_parses_v3_alias() {
+    assert_eq!(CapabilitiesAccept::parse("v3"), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse("3"), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse("V3"), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse(" v3 "), CapabilitiesAccept::V3);
+}
+
+// ---------------------------------------------------------------------------
+// CapabilitiesAccept::parse on unknown values still falls back to V2 (A1
+// preserves v0.6.3.1 behavior — only "v1"/"1" and "v3"/"3" route away from
+// the v2 default).
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_unknown_accept_still_falls_back_to_v2() {
+    assert_eq!(CapabilitiesAccept::parse("bogus"), CapabilitiesAccept::V2);
+    assert_eq!(CapabilitiesAccept::parse(""), CapabilitiesAccept::V2);
+    assert_eq!(CapabilitiesAccept::parse("v9"), CapabilitiesAccept::V2);
+}
+
+// ---------------------------------------------------------------------------
+// The v1/v2 entry point refuses V3 with a clear error message — v3 needs
+// the live `Profile` for summary computation, which the legacy signature
+// can't carry. A miswired caller must fail loud rather than serve a stale
+// v2 shape under the v3 label.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_legacy_entry_point_refuses_v3() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let err = handle_capabilities_with_conn(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        CapabilitiesAccept::V3,
+    )
+    .expect_err("legacy entry point must refuse V3");
+    assert!(
+        err.contains("v3 requires profile context"),
+        "error must direct caller to handle_capabilities_with_conn_v3, got: {err}"
+    );
+    assert!(err.contains("handle_capabilities_with_conn_v3"));
+}
+
+// ---------------------------------------------------------------------------
+// v3 entry point returns a document with schema_version="3" and a
+// non-empty summary field.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_response_carries_schema_version_and_summary() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+    )
+    .expect("v3 capabilities serialize");
+
+    assert_eq!(
+        val["schema_version"], "3",
+        "v3 must carry schema_version=\"3\"; got {val}"
+    );
+    let summary = val["summary"]
+        .as_str()
+        .expect("summary must be present and stringy");
+    assert!(
+        !summary.is_empty(),
+        "summary must be non-empty under v3, got: {summary:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// summary on the `core` profile honestly reports 6 of 43 visible (5 core
+// tools + memory_capabilities always-on bootstrap), labels the profile
+// "core", and references all three named recovery paths.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
+    let summary = build_capabilities_summary(&Profile::core());
+
+    // Visible = 5 core + 1 always-on (`memory_capabilities` lives in
+    // Family::Meta which the core profile doesn't load, so the bootstrap
+    // injection adds it back).
+    assert!(
+        summary.starts_with("6 of 43 tools"),
+        "core profile summary should open with \"6 of 43 tools\"; got: {summary}"
+    );
+    assert!(summary.contains("(core)"), "must label the profile as core");
+    assert!(
+        summary.contains("37 are listed in this manifest"),
+        "core profile must report 37 unloaded (43 - 6); got: {summary}"
+    );
+
+    // Three named recovery paths must all appear (verbatim names — these
+    // are the strings reasoning-class LLMs are expected to repeat back).
+    assert!(summary.contains("--profile <family>"));
+    assert!(summary.contains("memory_load_family(family=<name>)"));
+    assert!(summary.contains("memory_smart_load(intent="));
+    assert!(summary.contains("JSON-RPC -32601"));
+}
+
+// ---------------------------------------------------------------------------
+// summary on the `full` profile reports 43 of 43 visible, 0 unloaded, and
+// labels the profile "full". The recovery paths are still listed —
+// they're the canonical recovery vocabulary the LLM gets calibrated on
+// regardless of the current profile state.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_summary_full_profile_reports_all_visible() {
+    let summary = build_capabilities_summary(&Profile::full());
+
+    assert!(
+        summary.starts_with("43 of 43 tools"),
+        "full profile summary should open with \"43 of 43 tools\"; got: {summary}"
+    );
+    assert!(summary.contains("(full)"));
+    assert!(
+        summary.contains("0 are listed in this manifest"),
+        "full profile must report 0 unloaded; got: {summary}"
+    );
+    // Even when nothing is unloaded, the recovery vocabulary stays present
+    // so an LLM exposed only to the full-profile summary still learns the
+    // names of the loader tools.
+    assert!(summary.contains("memory_load_family"));
+    assert!(summary.contains("memory_smart_load"));
+}
+
+// ---------------------------------------------------------------------------
+// summary on the `graph` profile counts 13 visible (5 core + 8 graph) +
+// the bootstrap, labels the profile "graph", and reports the rest as
+// unloaded.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_summary_graph_profile_counts() {
+    let summary = build_capabilities_summary(&Profile::graph());
+    assert!(
+        summary.starts_with("14 of 43 tools"),
+        "graph profile = 5 core + 8 graph + 1 always-on bootstrap = 14; got: {summary}"
+    );
+    assert!(summary.contains("(graph)"));
+    assert!(summary.contains("29 are listed in this manifest"));
+}
+
+// ---------------------------------------------------------------------------
+// CapabilitiesV3 round-trips through serde — schema_version, summary, and
+// every v2 field must survive serialize → deserialize.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_struct_round_trips_through_serde() {
+    let tier_config = semantic_tier();
+    let caps: Capabilities = tier_config.capabilities();
+    let v3 = caps.to_v3("hello operator".to_string());
+
+    let json = serde_json::to_value(&v3).expect("serialize v3");
+    let back: CapabilitiesV3 = serde_json::from_value(json.clone()).expect("deserialize v3");
+
+    assert_eq!(back.schema_version, "3");
+    assert_eq!(back.summary, "hello operator");
+    assert_eq!(back.tier, v3.tier);
+    assert_eq!(back.version, v3.version);
+    // Sanity that the v2 sub-blocks are present.
+    assert!(json.get("features").is_some());
+    assert!(json.get("models").is_some());
+    assert!(json.get("permissions").is_some());
+    assert!(json.get("hooks").is_some());
+    assert!(json.get("compaction").is_some());
+    assert!(json.get("approval").is_some());
+    assert!(json.get("transcripts").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// v3 response includes the same v2 sub-blocks (features.embedder_loaded,
+// permissions, hooks, etc.) so a v3 client doesn't lose any v2 data.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_preserves_v2_sub_blocks() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val: Value = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        true, // embedder loaded
+        Some(&conn),
+        &Profile::full(),
+    )
+    .expect("v3 capabilities serialize");
+
+    assert_eq!(val["features"]["embedder_loaded"], true);
+    assert_eq!(val["features"]["recall_mode_active"], "hybrid");
+    assert!(val["models"]["embedding"].is_string());
+    assert_eq!(val["permissions"]["active_rules"], 0);
+    assert_eq!(val["hooks"]["registered_count"], 0);
+    assert_eq!(val["approval"]["pending_requests"], 0);
+}
+
+// ---------------------------------------------------------------------------
+// v2 callers still get the v2 shape (no schema_version="3", no summary
+// field) — A1 is additive; A5 will be the schema bump.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_v2_callers_unaffected_by_a1() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        CapabilitiesAccept::V2,
+    )
+    .expect("v2 capabilities still work");
+
+    assert_eq!(val["schema_version"], "2");
+    assert!(
+        val.get("summary").is_none(),
+        "v2 must not gain the v3 summary field"
+    );
+}

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -98,14 +98,9 @@ fn cap_v3_legacy_entry_point_refuses_v3() {
 fn cap_v3_response_carries_schema_version_and_summary() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
-    let val = handle_capabilities_with_conn_v3(
-        &tier_config,
-        None,
-        false,
-        Some(&conn),
-        &Profile::core(),
-    )
-    .expect("v3 capabilities serialize");
+    let val =
+        handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), &Profile::core())
+            .expect("v3 capabilities serialize");
 
     assert_eq!(
         val["schema_version"], "3",


### PR DESCRIPTION
## Summary

A1 of the v0.7.0 `attested-cortex` epic. First increment of capabilities v3: a top-level `summary` string carrying a pre-computed plain-language description of the LLM's operational tool surface (loaded vs total tool counts under the active `--profile`, plus the three named recovery paths: `--profile`, `memory_load_family`, `memory_smart_load`).

Reasoning-class LLMs converge on accurate first-answer descriptions of what's available without traversing `families[]` and counting manually.

### What landed

- **`config.rs`** — new `CapabilitiesV3` struct (additive over v2) + `Capabilities::to_v3(summary)`.
- **`mcp.rs`** — `CapabilitiesAccept::V3` variant + `parse(\"v3\"|\"3\")` + new `handle_capabilities_with_conn_v3` entry point. Refactored to share overlay logic via `build_capabilities_overlay` helper so v1/v2/v3 stay single-sourced. Dispatch wires `accept=\"v3\"` to the new path with the live `Profile`.
- **`handlers.rs`** — HTTP downgrades `Accept-Capabilities: v3` → v2 for now (full HTTP wire-up lands with A5 once `Profile` is threaded through `AppState`). Documented inline.
- **`tests/capabilities_v3.rs`** — 10 contract tests.

### Backward compat

v2 wire shape unchanged (no schema_version bump, no extra fields). Existing 9 cap-v2 tests stay green. A5 will flip the default to v3.

### Test plan

- [x] `cargo test --test capabilities_v3` → 10/10 green
- [x] `cargo test --test capabilities_v2` → 9/9 green (no regression)
- [x] `cargo test --lib mcp::tests` → 196/196 green
- [x] Builds clean against the existing surface (only pre-existing dead-code warning in `llm.rs`)

### Cutline notes

- K1 (G1 namespace inheritance) discovered already shipped in v0.6.3.1 — `tests/governance_inheritance.rs` (8) + `tests/ship_gate_governance_inheritance.rs` (6) all green. Marked complete in the v0.7 task ledger.

Refs #545.