### PR TITLE
feat: v0.7-k2 — pending_actions timeout sweeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **v0.7.0 K2 — `pending_actions` timeout sweeper.** Closes the
+  v0.6.3.1 honest-Capabilities-v2 disclosure that
+  `default_timeout_seconds` was advertised in v1 but unused. Schema
+  bumped to v21: `pending_actions` gains nullable
+  `default_timeout_seconds` (per-row TTL) and `expired_at` (RFC3339
+  stamp set when the sweeper fires) plus a composite
+  `(status, requested_at)` index. New `db::sweep_pending_action_timeouts`
+  helper is driven by a 60-second background tokio task spawned from
+  `daemon_runtime::bootstrap_serve`; per-row override beats the
+  cluster default (24h, matching `doctor`'s CRIT window). Each
+  expired row fires a `pending_action_expired` event through the
+  existing subscription dispatcher. A non-positive global default
+  disables the sweeper entirely (operator escape hatch). 7 new
+  tests cover the unit + integration paths.
 - **Boot follow-ups folded from v0.6.4 into v0.6.3.1 (PR-9h, issue #487
   PR #497 reqs #72 + #73)** — version-drift detection adds
   `MIN_SUPPORTED_SCHEMA = 16` / `MAX_SUPPORTED_SCHEMA = 19` constants in

--- a/migrations/sqlite/0015_v07_pending_action_timeouts.sql
+++ b/migrations/sqlite/0015_v07_pending_action_timeouts.sql
@@ -1,0 +1,20 @@
+-- v0.7.0 K2 — pending_actions timeout sweeper.
+--
+-- Adds two columns to back the v0.7.0 K2 background sweeper that
+-- transitions stale pending_actions rows to status='expired':
+--
+--   default_timeout_seconds  per-row TTL (NULL → use cluster default)
+--   expired_at               RFC3339 timestamp set when the sweeper fires
+--
+-- The ALTER TABLE statements live in db.rs because SQLite has no
+-- `ADD COLUMN IF NOT EXISTS`; this file holds the idempotent indexes.
+
+-- Index speeds the hot path:
+--   SELECT id FROM pending_actions
+--   WHERE status='pending'
+--     AND (julianday('now') - julianday(requested_at)) * 86400
+--         > COALESCE(default_timeout_seconds, ?global_default)
+-- A composite (status, requested_at) index keeps the planner from
+-- scanning the whole table on every 60-second tick.
+CREATE INDEX IF NOT EXISTS idx_pending_status_requested
+    ON pending_actions (status, requested_at);

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -54,11 +54,12 @@ use std::time::Instant;
 pub const MIN_SUPPORTED_SCHEMA: u32 = 16;
 
 /// Upper bound of the DB-schema range this binary supports. Mirrors
-/// `db::CURRENT_SCHEMA_VERSION` (20 in v0.6.4 — bumped by v0.6.4-009
-/// `audit_log` table). When a DB's `schema_version` exceeds this, the
-/// binary is too old for a newer DB and we surface a warning.
+/// `db::CURRENT_SCHEMA_VERSION` (21 in v0.7.0 — bumped by v0.7-K2
+/// `pending_actions` timeout-sweeper columns). When a DB's
+/// `schema_version` exceeds this, the binary is too old for a newer DB
+/// and we surface a warning.
 /// v0.6.3.1 (PR-9h / issue #487 PR #497 req #72).
-pub const MAX_SUPPORTED_SCHEMA: u32 = 20;
+pub const MAX_SUPPORTED_SCHEMA: u32 = 21;
 
 /// Pure boundary check: `true` when `v` lies within
 /// `[MIN_SUPPORTED_SCHEMA, MAX_SUPPORTED_SCHEMA]`. Extracted so the

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -84,6 +84,16 @@ const GC_INTERVAL_SECS: u64 = 1800;
 /// WAL auto-checkpoint cadence in the HTTP daemon. Bounds `*-wal`
 /// file growth between `SQLite`'s internal page-count checkpoints.
 const WAL_CHECKPOINT_INTERVAL_SECS: u64 = 600;
+/// v0.7.0 K2 — pending_actions timeout sweeper cadence. Fires every
+/// 60s and transitions `status='pending'` rows whose age exceeds the
+/// per-row `default_timeout_seconds` (or the global default below) to
+/// `status='expired'`.
+const PENDING_TIMEOUT_SWEEP_INTERVAL_SECS: u64 = 60;
+/// Default per-row TTL applied when a `pending_actions` row has a NULL
+/// `default_timeout_seconds`. 24 hours — matches the operator-facing
+/// `doctor` warning window so a row already classed CRITICAL by
+/// `doctor_oldest_pending_age_secs` is also a sweeper candidate.
+const PENDING_TIMEOUT_DEFAULT_SECS: i64 = 86_400;
 
 // ---------------------------------------------------------------------------
 // Clap-derived CLI surface
@@ -1060,6 +1070,70 @@ pub fn spawn_gc_loop(
     })
 }
 
+/// v0.7.0 K2 — spawn the periodic `pending_actions` timeout sweeper.
+///
+/// Sleeps `interval`, then calls [`db::sweep_pending_action_timeouts`]
+/// against the daemon's shared connection. Per-row
+/// `default_timeout_seconds` overrides the global `default_secs` when
+/// non-NULL. A non-positive `default_secs` disables the sweeper.
+///
+/// Returned [`JoinHandle`] is owned by the caller; `serve()` aborts it
+/// on shutdown — same lifecycle as [`spawn_gc_loop`].
+///
+/// Closes the v0.6.3.1 honest-Capabilities-v2 disclosure that the
+/// `default_timeout_seconds` field was advertised but unused.
+#[must_use]
+pub fn spawn_pending_timeout_sweep_loop(
+    state: Db,
+    db_path: PathBuf,
+    default_secs: i64,
+    interval: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            // Hold the lock just long enough for the sweep call. The
+            // expired ids returned by the sweeper are dispatched to
+            // subscribers AFTER the lock drops so a slow webhook can
+            // never starve write traffic.
+            let expired = {
+                let lock = state.lock().await;
+                match db::sweep_pending_action_timeouts(&lock.0, default_secs) {
+                    Ok(rows) => rows,
+                    Err(e) => {
+                        tracing::warn!("pending_actions sweep failed: {e}");
+                        Vec::new()
+                    }
+                }
+            };
+            if expired.is_empty() {
+                continue;
+            }
+            tracing::info!(
+                "pending_actions sweep: marked {} row(s) expired",
+                expired.len()
+            );
+            // Best-effort fan-out via the existing subscription
+            // dispatcher. K2 piggybacks on the lifecycle event
+            // shape — the namespace + id are enough for downstream
+            // webhook consumers to look the row up. The full
+            // approval-event surface (typed payloads, retry, DLQ)
+            // arrives in K4 / K7.
+            for (id, namespace) in expired {
+                let lock = state.lock().await;
+                crate::subscriptions::dispatch_event(
+                    &lock.0,
+                    "pending_action_expired",
+                    &id,
+                    &namespace,
+                    None,
+                    &db_path,
+                );
+            }
+        }
+    })
+}
+
 /// Spawn the periodic WAL checkpoint loop. First checkpoint runs
 /// `interval / 2` after start (staggered from the GC loop to avoid
 /// lock-contention bursts on cold start), then on a fixed cadence.
@@ -1205,6 +1279,20 @@ pub async fn bootstrap_serve(
     task_handles.push(spawn_wal_checkpoint_loop(
         db_state.clone(),
         Duration::from_secs(WAL_CHECKPOINT_INTERVAL_SECS),
+    ));
+
+    // v0.7.0 K2: pending_actions timeout sweeper. Closes the v0.6.3.1
+    // honest-Capabilities-v2 disclosure that `default_timeout_seconds`
+    // was advertised in v1 but unused. 60-second cadence; per-row
+    // override via the `default_timeout_seconds` column. The global
+    // default below is the fall-through when the per-row column is
+    // NULL — matches the `doctor_oldest_pending_age_secs` 24h CRIT
+    // window so a row that would already be flagged red also expires.
+    task_handles.push(spawn_pending_timeout_sweep_loop(
+        db_state.clone(),
+        db_path.to_path_buf(),
+        PENDING_TIMEOUT_DEFAULT_SECS,
+        Duration::from_secs(PENDING_TIMEOUT_SWEEP_INTERVAL_SECS),
     ));
 
     let api_key_state = ApiKeyState {
@@ -2174,6 +2262,71 @@ mod tests {
         assert!(err.is_cancelled());
     }
 
+    // v0.7.0 K2 — pending_actions timeout sweeper integration test.
+    //
+    // Pre-seed a stale `pending_actions` row, spawn the sweep loop with
+    // a very short interval, await long enough for at least one tick to
+    // run on the real runtime, and assert the row was transitioned to
+    // `status='expired'`. This is the daemon-side end-to-end check that
+    // complements the per-function unit tests in `db::tests`. We use a
+    // real (non-paused) runtime here because the SQL sweep query
+    // (`julianday('now')`) consults the OS wall clock, not tokio's
+    // virtual time — a `start_paused=true` test never observes ticks
+    // against a back-dated row.
+    #[tokio::test]
+    async fn test_spawn_pending_timeout_sweep_loop_marks_stale_expired() {
+        let env = TestEnv::fresh();
+        let conn = db::open(&env.db_path).unwrap();
+        // Seed a 2-hour-old pending row.
+        let two_h_ago = (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+        conn.execute(
+            "INSERT INTO pending_actions
+             (id, action_type, namespace, payload, requested_by, requested_at,
+              status)
+             VALUES ('sweeper-1', 'store', 'ns/a', '{}', 'tester', ?1, 'pending')",
+            rusqlite::params![two_h_ago],
+        )
+        .unwrap();
+        let state: Db = Arc::new(Mutex::new((
+            conn,
+            env.db_path.clone(),
+            ResolvedTtl::default(),
+            true,
+        )));
+        // 1-hour global default; the seeded 2h-old row is stale.
+        // Tick every 50ms so the test wraps in well under a second.
+        let h = spawn_pending_timeout_sweep_loop(
+            state.clone(),
+            env.db_path.clone(),
+            3_600,
+            Duration::from_millis(50),
+        );
+        // Poll the row up to 2s; succeed as soon as the sweep flips it.
+        let mut flipped = false;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let lock = state.lock().await;
+            let status: String = lock
+                .0
+                .query_row(
+                    "SELECT status FROM pending_actions WHERE id = 'sweeper-1'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            if status == "expired" {
+                flipped = true;
+                break;
+            }
+        }
+        h.abort();
+        let _ = h.await;
+        assert!(
+            flipped,
+            "sweeper must transition the stale row to 'expired' within 2s"
+        );
+    }
+
     // ----- passphrase_from_file -----------------------------------------
 
     #[test]
@@ -2294,8 +2447,9 @@ mod tests {
         assert!(bs.app_state.embedder.is_none());
         let vi = bs.app_state.vector_index.lock().await;
         assert!(vi.is_none());
-        // Two task handles spawned (gc + wal_checkpoint).
-        assert_eq!(bs.task_handles.len(), 2);
+        // Three task handles spawned (gc + wal_checkpoint + v0.7 K2
+        // pending_actions timeout sweep).
+        assert_eq!(bs.task_handles.len(), 3);
         // Cleanly abort the spawned tasks so they don't leak across tests.
         for h in bs.task_handles {
             h.abort();

--- a/src/db.rs
+++ b/src/db.rs
@@ -197,7 +197,11 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
 //       per-subscriber filter.
 // v20 = v0.6.4-009 (NHI guardrails phase 1) capability-expansion
 //       audit_log table.
-const CURRENT_SCHEMA_VERSION: i64 = 20;
+// v21 = v0.7.0 K2 pending_actions timeout sweeper:
+//       `default_timeout_seconds` + `expired_at` columns plus a
+//       composite (status, requested_at) index to bound the sweep
+//       cost.
+const CURRENT_SCHEMA_VERSION: i64 = 21;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -267,6 +271,11 @@ const MIGRATION_V19_SQLITE: &str =
 // v0.6.4-009: capability-expansion audit log table. CREATE TABLE IF NOT
 // EXISTS + indexes — fully idempotent.
 const MIGRATION_V20_SQLITE: &str = include_str!("../migrations/sqlite/0014_v064_audit_log.sql");
+// v0.7.0 K2: pending_actions timeout sweeper. ALTER TABLEs are emitted
+// from Rust (see v21 below) because SQLite has no `ADD COLUMN IF NOT
+// EXISTS`; this file just holds the idempotent index batch.
+const MIGRATION_V21_SQLITE: &str =
+    include_str!("../migrations/sqlite/0015_v07_pending_action_timeouts.sql");
 
 #[allow(clippy::too_many_lines)]
 fn migrate(conn: &Connection) -> Result<()> {
@@ -725,6 +734,41 @@ fn migrate(conn: &Connection) -> Result<()> {
         if version < 20 {
             // v0.6.4-009 — fully idempotent (CREATE TABLE IF NOT EXISTS).
             conn.execute_batch(MIGRATION_V20_SQLITE)?;
+        }
+        if version < 21 {
+            // v0.7.0 K2 — pending_actions timeout sweeper.
+            //
+            // Two new columns back the 60-second background sweep:
+            //   default_timeout_seconds  per-row TTL (NULL → cluster default)
+            //   expired_at               RFC3339 stamp set when sweeper fires
+            //
+            // ALTER TABLE done inline (SQLite has no `ADD COLUMN IF NOT
+            // EXISTS`); SQL file holds the idempotent index batch.
+            //
+            // v0.6.3.1 honesty patch: the v2 capabilities response had
+            // dropped `approval.default_timeout_seconds` because no
+            // sweeper enforced it. K2 closes that gap. The capabilities
+            // wire shape is intentionally unchanged here — v0.7-K5 owns
+            // re-introducing the public surface.
+            let has_timeout: bool = conn
+                .prepare("SELECT default_timeout_seconds FROM pending_actions LIMIT 0")
+                .is_ok();
+            if !has_timeout {
+                conn.execute(
+                    "ALTER TABLE pending_actions ADD COLUMN default_timeout_seconds INTEGER",
+                    [],
+                )?;
+            }
+            let has_expired_at: bool = conn
+                .prepare("SELECT expired_at FROM pending_actions LIMIT 0")
+                .is_ok();
+            if !has_expired_at {
+                conn.execute(
+                    "ALTER TABLE pending_actions ADD COLUMN expired_at TEXT",
+                    [],
+                )?;
+            }
+            conn.execute_batch(MIGRATION_V21_SQLITE)?;
         }
 
         conn.execute("DELETE FROM schema_version", [])?;
@@ -5033,6 +5077,77 @@ pub fn count_pending_actions_by_status(conn: &Connection, status: &str) -> Resul
     Ok(usize::try_from(count.max(0)).unwrap_or(0))
 }
 
+/// v0.7.0 K2 — pending_actions timeout sweeper.
+///
+/// Scans `pending_actions` for `status='pending'` rows whose age exceeds
+/// the per-row `default_timeout_seconds` (or `global_default_secs` when
+/// the per-row column is NULL). Transitions matching rows to
+/// `status='expired'` and stamps `expired_at = now`.
+///
+/// Returns the list of `(id, namespace)` tuples that were just expired
+/// so the caller can fan out approval-decision events. Empty queue is a
+/// silent no-op.
+///
+/// Closes the v0.6.3.1 honest-Capabilities-v2 disclosure that
+/// `default_timeout_seconds` was previously advertised but unused (the
+/// v2 honesty patch had dropped it from the wire shape; K2 ships the
+/// backing sweeper so the field is meaningful again).
+///
+/// # Errors
+///
+/// Returns `Err` only on hard SQLite failures (e.g. table missing).
+pub fn sweep_pending_action_timeouts(
+    conn: &Connection,
+    global_default_secs: i64,
+) -> Result<Vec<(String, String)>> {
+    // Step 1 — find candidates. We compute age in SQL via julianday()
+    // arithmetic so the sweep is index-friendly and avoids parsing
+    // every `requested_at` row in Rust. The composite index
+    // `idx_pending_status_requested` (added in migration v21) keeps
+    // the planner from full-scanning the table.
+    //
+    // The `default_timeout_seconds` column is nullable; rows with NULL
+    // fall back to `global_default_secs`. A non-positive global default
+    // disables the sweeper entirely (operator escape hatch).
+    if global_default_secs <= 0 {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT id, namespace FROM pending_actions
+         WHERE status = 'pending'
+           AND (julianday('now') - julianday(requested_at)) * 86400.0
+               > COALESCE(default_timeout_seconds, ?1)",
+    )?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map(params![global_default_secs], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Step 2 — flip status='expired' + stamp expired_at. We update
+    // row-by-row inside a single transaction so a failure mid-batch
+    // rolls back cleanly. The WHERE clause re-checks status='pending'
+    // so a concurrent decide_pending_action wins (its decision is
+    // not overwritten).
+    let now = Utc::now().to_rfc3339();
+    let tx_savepoint = conn.unchecked_transaction()?;
+    {
+        let mut update = tx_savepoint.prepare(
+            "UPDATE pending_actions
+             SET status = 'expired', expired_at = ?1
+             WHERE id = ?2 AND status = 'pending'",
+        )?;
+        for (id, _) in &rows {
+            update.execute(params![now, id])?;
+        }
+    }
+    tx_savepoint.commit()?;
+    Ok(rows)
+}
+
 // ---------------------------------------------------------------------------
 // `ai-memory doctor` (P7 / R7) — query helpers.
 // ---------------------------------------------------------------------------
@@ -8554,5 +8669,138 @@ mod tests {
             cnt, 3,
             "expected 3 audit_log indexes (agent_id, ts, event_type)"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // v0.7.0 K2 — pending_actions timeout sweeper.
+    //
+    // Closes the v0.6.3.1 honest-Capabilities-v2 disclosure that
+    // `default_timeout_seconds` was advertised but unused.
+    // ---------------------------------------------------------------
+
+    /// Insert a `pending_actions` row with a back-dated `requested_at`
+    /// so we can drive the sweeper without `tokio::time` games.
+    fn insert_stale_pending(
+        conn: &Connection,
+        id: &str,
+        namespace: &str,
+        age_secs: i64,
+        per_row_timeout: Option<i64>,
+    ) {
+        let requested_at =
+            (chrono::Utc::now() - chrono::Duration::seconds(age_secs)).to_rfc3339();
+        conn.execute(
+            "INSERT INTO pending_actions
+             (id, action_type, namespace, payload, requested_by, requested_at,
+              status, default_timeout_seconds)
+             VALUES (?1, 'store', ?2, '{}', 'tester', ?3, 'pending', ?4)",
+            params![id, namespace, requested_at, per_row_timeout],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn sweep_marks_stale_pending_row_expired() {
+        let conn = test_db();
+        // 2-hour-old pending row; global default is 1 hour → must expire.
+        insert_stale_pending(&conn, "stale-1", "ns/a", 7_200, None);
+
+        let expired = sweep_pending_action_timeouts(&conn, 3_600).unwrap();
+        assert_eq!(expired.len(), 1, "expected exactly one expiry");
+        assert_eq!(expired[0], ("stale-1".to_string(), "ns/a".to_string()));
+
+        // Row is now status='expired' with expired_at populated.
+        let (status, expired_at): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, expired_at FROM pending_actions WHERE id = ?1",
+                params!["stale-1"],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "expired");
+        assert!(
+            expired_at.is_some(),
+            "expired_at must be stamped by the sweeper"
+        );
+    }
+
+    #[test]
+    fn sweep_leaves_fresh_pending_alone() {
+        let conn = test_db();
+        // 30-second-old pending row; global default is 1 hour → still pending.
+        insert_stale_pending(&conn, "fresh-1", "ns/a", 30, None);
+
+        let expired = sweep_pending_action_timeouts(&conn, 3_600).unwrap();
+        assert!(expired.is_empty());
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM pending_actions WHERE id = ?1",
+                params!["fresh-1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "pending");
+    }
+
+    #[test]
+    fn sweep_per_row_timeout_overrides_global_default() {
+        let conn = test_db();
+        // 5-minute-old row; per-row TTL = 60s → MUST expire even
+        // though the global default (1h) would say "still fresh".
+        insert_stale_pending(&conn, "short-ttl", "ns/a", 300, Some(60));
+        // Same age, no per-row override → still pending under the
+        // 1h global default.
+        insert_stale_pending(&conn, "no-override", "ns/a", 300, None);
+
+        let expired = sweep_pending_action_timeouts(&conn, 3_600).unwrap();
+        let ids: Vec<&String> = expired.iter().map(|(id, _)| id).collect();
+        assert_eq!(ids, vec![&"short-ttl".to_string()]);
+    }
+
+    #[test]
+    fn sweep_skips_already_decided_rows() {
+        let conn = test_db();
+        // Pre-insert an OLD row already approved — must not touch it.
+        let approved_at = (chrono::Utc::now() - chrono::Duration::seconds(7_200)).to_rfc3339();
+        conn.execute(
+            "INSERT INTO pending_actions
+             (id, action_type, namespace, payload, requested_by, requested_at,
+              status, decided_by, decided_at)
+             VALUES ('approved-old', 'store', 'ns/a', '{}', 'alice', ?1,
+                     'approved', 'bob', ?1)",
+            params![approved_at],
+        )
+        .unwrap();
+
+        let expired = sweep_pending_action_timeouts(&conn, 60).unwrap();
+        assert!(expired.is_empty(), "non-pending rows must be ignored");
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM pending_actions WHERE id = 'approved-old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "approved", "decided row status preserved");
+    }
+
+    #[test]
+    fn sweep_disabled_when_global_default_non_positive() {
+        let conn = test_db();
+        // Stale row with no per-row TTL.
+        insert_stale_pending(&conn, "stale-2", "ns/a", 7_200, None);
+        // Operator escape hatch: 0 (or negative) global default
+        // disables the sweep entirely.
+        let expired = sweep_pending_action_timeouts(&conn, 0).unwrap();
+        assert!(expired.is_empty());
+        let expired_neg = sweep_pending_action_timeouts(&conn, -1).unwrap();
+        assert!(expired_neg.is_empty());
+    }
+
+    #[test]
+    fn sweep_empty_queue_is_silent_noop() {
+        let conn = test_db();
+        let expired = sweep_pending_action_timeouts(&conn, 60).unwrap();
+        assert!(expired.is_empty());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -763,10 +763,7 @@ fn migrate(conn: &Connection) -> Result<()> {
                 .prepare("SELECT expired_at FROM pending_actions LIMIT 0")
                 .is_ok();
             if !has_expired_at {
-                conn.execute(
-                    "ALTER TABLE pending_actions ADD COLUMN expired_at TEXT",
-                    [],
-                )?;
+                conn.execute("ALTER TABLE pending_actions ADD COLUMN expired_at TEXT", [])?;
             }
             conn.execute_batch(MIGRATION_V21_SQLITE)?;
         }
@@ -8687,8 +8684,7 @@ mod tests {
         age_secs: i64,
         per_row_timeout: Option<i64>,
     ) {
-        let requested_at =
-            (chrono::Utc::now() - chrono::Duration::seconds(age_secs)).to_rfc3339();
+        let requested_at = (chrono::Utc::now() - chrono::Duration::seconds(age_secs)).to_rfc3339();
         conn.execute(
             "INSERT INTO pending_actions
              (id, action_type, namespace, payload, requested_by, requested_at,

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -193,21 +193,30 @@ CREATE TABLE IF NOT EXISTS namespace_meta (
 -- pending_actions — governance approval queue (Task 1.9–1.10).
 -- ─────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS pending_actions (
-    id            TEXT PRIMARY KEY,
-    action_type   TEXT NOT NULL,
-    memory_id     TEXT,
-    namespace     TEXT NOT NULL,
-    payload       JSONB NOT NULL DEFAULT '{}'::jsonb,
-    requested_by  TEXT NOT NULL,
-    requested_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    status        TEXT NOT NULL DEFAULT 'pending',
-    decided_by    TEXT,
-    decided_at    TIMESTAMPTZ,
-    approvals     JSONB NOT NULL DEFAULT '[]'::jsonb
+    id                       TEXT PRIMARY KEY,
+    action_type              TEXT NOT NULL,
+    memory_id                TEXT,
+    namespace                TEXT NOT NULL,
+    payload                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    requested_by             TEXT NOT NULL,
+    requested_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    status                   TEXT NOT NULL DEFAULT 'pending',
+    decided_by               TEXT,
+    decided_at               TIMESTAMPTZ,
+    approvals                JSONB NOT NULL DEFAULT '[]'::jsonb,
+    -- v0.7.0 K2 — pending_actions timeout sweeper. Per-row TTL
+    -- (NULL → cluster default) and the stamp set when the sweep
+    -- transitions a stale row to status='expired'.
+    default_timeout_seconds  BIGINT,
+    expired_at               TIMESTAMPTZ
 );
 
 CREATE INDEX IF NOT EXISTS pending_actions_status_idx    ON pending_actions (status);
 CREATE INDEX IF NOT EXISTS pending_actions_namespace_idx ON pending_actions (namespace);
+-- v0.7.0 K2 — composite index for the 60-second sweep query
+-- (`WHERE status='pending' AND ...julianday math`).
+CREATE INDEX IF NOT EXISTS pending_actions_status_requested_idx
+    ON pending_actions (status, requested_at);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- sync_state — per-peer vector-clock high-watermarks.


### PR DESCRIPTION
Track K task K2 of v0.7.0 attested-cortex epic.

## Summary
- 60-second background sweeper for `pending_actions`
- Honors per-row `default_timeout_seconds` (closes the v0.6.3.1 honest-disclosure that this field was unused)
- Clean shutdown via `JoinHandle::abort()` (matches the existing `spawn_gc_loop` / `spawn_wal_checkpoint_loop` lifecycle pattern)
- Schema bumped to v21: nullable `default_timeout_seconds` + `expired_at` columns + composite `(status, requested_at)` index
- Operator escape hatch: non-positive global default disables the sweep entirely
- Each expired row fires `pending_action_expired` through the existing subscription dispatcher

## Test plan
- [x] cargo test --lib green (1967 / 1967)
- [x] Unit test: stale row → marked expired (6 db unit tests cover stale/fresh/per-row override/already-decided/disabled/empty)
- [x] Integration: full daemon spawn loop sweeps stale rows (`test_spawn_pending_timeout_sweep_loop_marks_stale_expired`)
- [x] Full integration suite: 2415 tests pass / 0 fail
- [x] `governance_inheritance` + `ship_gate_governance_inheritance` + `capabilities_v2` + `doctor_cli` regression-free