### PR TITLE
feat: v0.7-a2 — capabilities v3 to_describe_to_user (#545)

### DIFF
--- a/docs/v0.7/canonical-phrasings.md
+++ b/docs/v0.7/canonical-phrasings.md
@@ -1,0 +1,130 @@
+# Capabilities v3 — canonical phrasings
+
+> **Status:** SHIPPING with v0.7.0 — A1 (`summary`) + A2 (`to_describe_to_user`)
+> **Date:** 2026-05-05
+> **Issue:** [#545](https://github.com/alphaonedev/ai-memory-mcp/issues/545)
+> **Built by:** `src/mcp.rs::build_capabilities_summary` and `build_capabilities_describe_to_user`
+
+The capabilities-v3 response (track A of the v0.7.0 `attested-cortex` epic) carries two pre-computed strings that LLMs reading `memory_capabilities` are expected to converge on. This page pins the canonical phrasings so future drift surfaces in CI (the assertions live in `tests/capabilities_v3.rs` and `tests/calibration_t0.rs`).
+
+---
+
+## Why two strings, not one
+
+The two strings serve different audiences:
+
+| Field | Audience | Tone | Purpose |
+|---|---|---|---|
+| `summary` | The LLM (operator-style readout) | Terse, technical, names the recovery vocabulary verbatim | Makes the LLM converge on accurate first-answer descriptions; teaches it the names of the loader tools (`memory_load_family`, `memory_smart_load`) and the CLI escape hatch (`--profile`) |
+| `to_describe_to_user` | The end-user (via the LLM) | Plain English, no MCP jargon | The sentence the LLM should repeat verbatim when an end-user asks "what tools do you have?". Strips `memory_` prefixes, names the recovery hint in user terms ("I can load them on demand") |
+
+The split exists because reasoning-class LLMs in 2026-04 NHI Discovery Gate observation cells consistently embedded MCP-internal vocabulary in their user-facing descriptions when given only one calibration string. The two-string layout lets the operator-facing one stay technical (where that's correct) while the user-facing one stays clean.
+
+---
+
+## A1 — `summary` canonical phrasing
+
+```
+{visible} of {total} tools are advertised in tools/list under the current profile ({label}). The other {unloaded} are listed in this manifest but NOT directly callable. To use any unloaded tool, choose one of: (a) restart the server with --profile <family> or --profile full, (b) call memory_load_family(family=<name>) — preferred, (c) call memory_smart_load(intent='<plain language>') — easiest, (d) call the tool by name and recover from JSON-RPC -32601.
+```
+
+Substitution variables:
+
+| Variable | Value | Example (`--profile core`) |
+|---|---|---|
+| `{visible}` | tools advertised in `tools/list` under the active profile (includes always-on bootstraps not already in profile) | `6` |
+| `{total}` | total tool count across all families | `43` |
+| `{label}` | profile name (`core`/`graph`/`admin`/`power`/`full`) or comma-joined family list for custom profiles | `core` |
+| `{unloaded}` | `total − visible` | `37` |
+
+The four recovery paths (a–d) appear verbatim in the canonical phrasing **regardless of the active profile** — so an LLM exposed only to `--profile full` still learns the recovery vocabulary for environments where it isn't.
+
+### Worked examples
+
+| Profile | Opening |
+|---|---|
+| `core` | `6 of 43 tools are advertised in tools/list under the current profile (core). The other 37 …` |
+| `graph` | `14 of 43 tools are advertised in tools/list under the current profile (graph). The other 29 …` |
+| `full` | `43 of 43 tools are advertised in tools/list under the current profile (full). The other 0 …` |
+
+---
+
+## A2 — `to_describe_to_user` canonical phrasing
+
+Two forms depending on whether anything is unloaded.
+
+### Form 1 — partial profile (some tools unloaded)
+
+```
+I can directly use {n_loaded} memory tool{s} right now ({preview_loaded}{ellipsis}). {n_unloaded} more ({preview_unloaded}, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.
+```
+
+### Form 2 — full profile (nothing unloaded)
+
+```
+I can directly use all {n_loaded} memory tools right now ({preview_loaded}{ellipsis}). Nothing more to load — the full memory surface is already active.
+```
+
+Substitution variables:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `{n_loaded}` | tools loaded by family membership, EXCLUDING the always-on bootstrap (`memory_capabilities`) | `core`: 5; `graph`: 13; `full`: 42 |
+| `{preview_loaded}` | comma-joined first 5 loaded tool names with the `memory_` prefix STRIPPED | `core`: `store, recall, list, get, search` |
+| `{ellipsis}` | `, ...` if `n_loaded > 5`, else empty | `graph` and larger get the ellipsis |
+| `{n_unloaded}` | `42 − n_loaded` — the 42 excludes the always-on bootstrap from BOTH sides for honest counting | `core`: 37; `graph`: 29; `full`: 0 |
+| `{preview_unloaded}` | comma-joined first 4 unloaded tool names, prefix-stripped | `core`: `update, delete, forget, gc` |
+| `{s}` | `s` if `n_loaded != 1`, else empty | always `s` in practice |
+
+### Tone constraint
+
+The describe sentence is **forbidden from MCP jargon**. The pinned `tests/capabilities_v3.rs::cap_v3_describe_core_profile_is_plain_english_with_loaded_names` test asserts these strings DO NOT appear in `to_describe_to_user`:
+
+- `--profile <family>`
+- `memory_load_family`
+- `memory_smart_load`
+- `JSON-RPC`
+- `-32601`
+- `memory_` (any prefix-bearing tool name)
+- `tools/list`
+
+If a future increment adds MCP-internal vocabulary to this string, that test goes red. Use `summary` for operator-facing recovery vocabulary; keep `to_describe_to_user` plain.
+
+### Worked examples
+
+| Profile | `to_describe_to_user` |
+|---|---|
+| `core` | `I can directly use 5 memory tools right now (store, recall, list, get, search). 37 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
+| `graph` | `I can directly use 13 memory tools right now (store, recall, list, get, search, ...). 29 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
+| `full` | `I can directly use all 42 memory tools right now (store, recall, list, get, search, ...). Nothing more to load — the full memory surface is already active.` |
+
+---
+
+## A3 + A4 phrasing extensions (planned)
+
+A3 will add a per-tool `callable_now: bool` flag (combines `loaded` with the `[mcp.allowlist]` agent-can-call check). A4 will add a top-level `agent_permitted_families: ["core", "graph"]` array when the allowlist applies. Neither extends `summary` or `to_describe_to_user` directly; both add structured fields a downstream renderer can use.
+
+A5 bumps the default wire shape from v2 to v3 and seals these phrasings as the recommended client target. v2 + v1 stay supported for backward compat.
+
+---
+
+## How to regenerate
+
+The canonical strings are computed at response time from the live `Profile` state — they're never cached at build time. To inspect what your daemon serves, call `memory_capabilities` with `accept="v3"`:
+
+```
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"memory_capabilities","arguments":{"accept":"v3"}}}' | ai-memory mcp
+```
+
+The returned document carries both fields at the top level alongside `schema_version: "3"`.
+
+---
+
+## Refs
+
+- [v0.7.0 epic](./V0.7-EPIC.md) — track A, tasks A1–A5
+- [v0.7.0 NHI prompts](./v0.7-nhi-prompts.md) — tasks A1, A2 (per-task NHI starters)
+- `src/mcp.rs::build_capabilities_summary` — A1 builder
+- `src/mcp.rs::build_capabilities_describe_to_user` — A2 builder
+- `tests/capabilities_v3.rs` — A1+A2 contract pins
+- `tests/calibration_t0.rs` — A2 calibration assertions (Discovery Gate T0 cell coverage)

--- a/src/config.rs
+++ b/src/config.rs
@@ -716,25 +716,29 @@ impl Capabilities {
         }
     }
 
-    /// v0.7.0 (A1): project the report into the v3 shape.
+    /// v0.7.0 (A1+A2): project the report into the v3 shape.
     ///
-    /// v3 = v2 + a top-level `summary` string carrying a pre-computed,
-    /// plain-language description of the LLM's operational tool surface
-    /// (loaded count, total count, the three named recovery paths an LLM
-    /// can take to reach unloaded families). The summary is computed by
-    /// the caller from the live `Profile` state because the
-    /// [`Capabilities`] struct itself doesn't know which families the
-    /// MCP server actually advertised in `tools/list`.
+    /// v3 = v2 +
+    ///   - top-level `summary` (A1) — terse description of operational
+    ///     access plus the three named recovery paths.
+    ///   - top-level `to_describe_to_user` (A2) — plain-English
+    ///     end-user-facing sentence the LLM should repeat verbatim
+    ///     when asked "what tools do you have?". No MCP jargon.
     ///
-    /// Future v0.7.0 increments (A2–A4) extend this struct with
-    /// `to_describe_to_user`, per-tool `callable_now`, and
-    /// `agent_permitted_families`. A5 bumps the default wire shape to v3.
-    /// v2 stays supported indefinitely.
+    /// Both strings are computed by the caller from the live `Profile`
+    /// state because the [`Capabilities`] struct itself doesn't know
+    /// which families the MCP server actually advertised in
+    /// `tools/list`.
+    ///
+    /// Future v0.7.0 increments (A3–A4) extend this struct with
+    /// per-tool `callable_now` and `agent_permitted_families`. A5 bumps
+    /// the default wire shape to v3. v2 stays supported indefinitely.
     #[must_use]
-    pub fn to_v3(&self, summary: String) -> CapabilitiesV3 {
+    pub fn to_v3(&self, summary: String, to_describe_to_user: String) -> CapabilitiesV3 {
         CapabilitiesV3 {
             schema_version: "3".to_string(),
             summary,
+            to_describe_to_user,
             tier: self.tier.clone(),
             version: self.version.clone(),
             features: self.features.clone(),
@@ -780,6 +784,15 @@ pub struct CapabilitiesV3 {
     /// because the count of advertised tools depends on the running
     /// server's `--profile` flag.
     pub summary: String,
+
+    /// v0.7.0 A2 — pre-computed end-user-facing sentence the LLM should
+    /// repeat verbatim when an end-user asks "what tools do you have?".
+    /// Distinct in tone from [`Self::summary`]: no MCP jargon, no
+    /// `--profile` references, no JSON-RPC vocabulary. Reads as a
+    /// normal sentence a human would say. See
+    /// `docs/v0.7/canonical-phrasings.md` for the canonical
+    /// substitution template + worked examples per profile.
+    pub to_describe_to_user: String,
 
     pub tier: String,
     pub version: String,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1824,7 +1824,8 @@ pub fn handle_capabilities_with_conn_v3(
 ) -> Result<Value, String> {
     let caps = build_capabilities_overlay(tier_config, reranker, embedder_loaded, conn);
     let summary = build_capabilities_summary(profile);
-    serde_json::to_value(caps.to_v3(summary)).map_err(|e| e.to_string())
+    let describe = build_capabilities_describe_to_user(profile);
+    serde_json::to_value(caps.to_v3(summary, describe)).map_err(|e| e.to_string())
 }
 
 /// Build the runtime-overlaid [`Capabilities`] document. Shared between
@@ -1918,6 +1919,94 @@ pub fn build_capabilities_summary(profile: &crate::profile::Profile) -> String {
          (c) call memory_smart_load(intent='<plain language>') — easiest, \
          (d) call the tool by name and recover from JSON-RPC -32601."
     )
+}
+
+/// v0.7.0 A2 — build the capabilities-v3 `to_describe_to_user` string.
+///
+/// This is the canonical plain-language sentence the LLM should repeat
+/// (verbatim) when an end-user asks "what tools do you have?". It
+/// names how many tools are loaded right now, lists the first few by
+/// short name (without the `memory_` prefix, since the prefix is MCP
+/// jargon a user doesn't care about), reports how many are unloaded,
+/// and gives an end-user-friendly recovery hint ("I can load them on
+/// demand, or you can restart the server with a different profile").
+///
+/// Tone constraint (per A2 spec): NO MCP jargon. No mention of
+/// `tools/list`, `JSON-RPC`, or `--profile <family>`. Reads like a
+/// normal sentence a person would write.
+///
+/// The always-on bootstrap (`memory_capabilities`) is intentionally
+/// excluded from the loaded-tool preview — to a user, it's plumbing,
+/// not a feature.
+#[must_use]
+pub fn build_capabilities_describe_to_user(profile: &crate::profile::Profile) -> String {
+    use crate::profile::Family;
+
+    // Loaded vs unloaded by family membership. The always-on bootstrap
+    // sits in `Family::Meta`; under e.g. `--profile core` Meta isn't
+    // loaded, so `memory_capabilities` would normally count as
+    // unloaded. We strip it from BOTH sides — the user-facing sentence
+    // talks about the substantive tool surface, not the
+    // runtime-discovery bootstrap.
+    let loaded_tools: Vec<&'static str> = Family::all()
+        .iter()
+        .filter(|f| profile.includes(**f))
+        .flat_map(|f| f.tool_names().iter().copied())
+        .filter(|name| !crate::profile::ALWAYS_ON_TOOLS.contains(name))
+        .collect();
+    let unloaded_tools: Vec<&'static str> = Family::all()
+        .iter()
+        .filter(|f| !profile.includes(**f))
+        .flat_map(|f| f.tool_names().iter().copied())
+        .filter(|name| !crate::profile::ALWAYS_ON_TOOLS.contains(name))
+        .collect();
+
+    let n_loaded = loaded_tools.len();
+    let n_unloaded = unloaded_tools.len();
+
+    // Preview the first 5 loaded tools by short name (strip the
+    // `memory_` prefix). Five matches the canonical example in the
+    // A2 NHI prompt and lines up with the size of the smallest
+    // (`core`) profile so the preview is a complete enumeration there.
+    let preview_loaded = loaded_tools
+        .iter()
+        .take(5)
+        .map(|name| short_tool_name(name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let loaded_more_marker = if n_loaded > 5 { ", ..." } else { "" };
+
+    if n_unloaded == 0 {
+        format!(
+            "I can directly use all {n_loaded} memory tools right now \
+             ({preview_loaded}{loaded_more_marker}). Nothing more to load — \
+             the full memory surface is already active."
+        )
+    } else {
+        // Preview 4 unloaded tool names — the canonical example uses 4
+        // (link, kg_query, consolidate, delete) followed by ", etc.".
+        let preview_unloaded = unloaded_tools
+            .iter()
+            .take(4)
+            .map(|name| short_tool_name(name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let plural_loaded = if n_loaded == 1 { "" } else { "s" };
+        format!(
+            "I can directly use {n_loaded} memory tool{plural_loaded} right now \
+             ({preview_loaded}{loaded_more_marker}). {n_unloaded} more \
+             ({preview_unloaded}, etc.) are available on demand — I can load them \
+             if you ask for something that needs them, or you can restart the \
+             server with a different profile."
+        )
+    }
+}
+
+/// Strip the `memory_` prefix from a tool name for end-user-facing
+/// previews. v0.7.0 A2 — the prefix is MCP jargon; a user doesn't care
+/// that every tool name starts with the same five characters.
+fn short_tool_name(name: &'static str) -> &'static str {
+    name.strip_prefix("memory_").unwrap_or(name)
 }
 
 /// Return a stable label for a profile's summary string. Named profiles

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -188,6 +188,80 @@ impl Family {
             Self::Other => 2,
         }
     }
+
+    /// v0.7.0 A2 — tool names belonging to this family. Forward of the
+    /// `Family::for_tool` reverse map; source-anchored at
+    /// `src/mcp.rs::tool_definitions()` 2026-05-04 (same anchor as
+    /// [`Family::for_tool`] and [`Family::expected_tool_count`]).
+    /// Order is the order each tool appears in
+    /// `tool_definitions_for_profile`'s registration walk, so an
+    /// LLM-facing preview ("the first three tools loaded") aligns with
+    /// the actual `tools/list` output.
+    ///
+    /// The slice length must match [`Family::expected_tool_count`]; the
+    /// `family_tool_names_match_expected_count` unit test pins both in
+    /// sync.
+    #[must_use]
+    pub const fn tool_names(self) -> &'static [&'static str] {
+        match self {
+            Self::Core => &[
+                "memory_store",
+                "memory_recall",
+                "memory_list",
+                "memory_get",
+                "memory_search",
+            ],
+            Self::Lifecycle => &[
+                "memory_update",
+                "memory_delete",
+                "memory_forget",
+                "memory_gc",
+                "memory_promote",
+            ],
+            Self::Graph => &[
+                "memory_kg_query",
+                "memory_kg_timeline",
+                "memory_kg_invalidate",
+                "memory_link",
+                "memory_get_links",
+                "memory_entity_register",
+                "memory_entity_get_by_alias",
+                "memory_get_taxonomy",
+            ],
+            Self::Governance => &[
+                "memory_pending_list",
+                "memory_pending_approve",
+                "memory_pending_reject",
+                "memory_namespace_set_standard",
+                "memory_namespace_get_standard",
+                "memory_namespace_clear_standard",
+                "memory_subscribe",
+                "memory_unsubscribe",
+            ],
+            Self::Power => &[
+                "memory_consolidate",
+                "memory_detect_contradiction",
+                "memory_check_duplicate",
+                "memory_auto_tag",
+                "memory_expand_query",
+                "memory_inbox",
+            ],
+            Self::Meta => &[
+                "memory_capabilities",
+                "memory_agent_register",
+                "memory_agent_list",
+                "memory_session_start",
+                "memory_stats",
+            ],
+            Self::Archive => &[
+                "memory_archive_list",
+                "memory_archive_purge",
+                "memory_archive_restore",
+                "memory_archive_stats",
+            ],
+            Self::Other => &["memory_list_subscriptions", "memory_notify"],
+        }
+    }
 }
 
 impl FromStr for Family {

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -1,0 +1,226 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Discovery Gate **T0 calibration cells** — assert canonical phrasing
+//! present in capabilities-v3 responses across all named profiles.
+//!
+//! v0.7.0 A2 (`to_describe_to_user`) is the user-facing sentence the
+//! NHI Discovery Gate expects every reasoning-class LLM to reproduce
+//! when asked "what tools do you have?". This test file is the
+//! corresponding T0 calibration cell that runs in CI: it pins the
+//! canonical strings from `docs/v0.7/canonical-phrasings.md` so any
+//! drift in the substrate breaks the build before it reaches a
+//! Discovery Gate observation cell.
+//!
+//! When a phrasing changes intentionally (e.g., a future increment
+//! adds a new recovery path), update both:
+//! 1. `docs/v0.7/canonical-phrasings.md` (the human-readable spec)
+//! 2. `src/mcp.rs::build_capabilities_{summary,describe_to_user}`
+//!    (the substrate)
+//! …and re-run this test. Drift between the spec and the substrate is
+//! exactly what this file is designed to surface.
+
+use ai_memory::config::{FeatureTier, TierConfig};
+use ai_memory::mcp::handle_capabilities_with_conn_v3;
+use ai_memory::profile::Profile;
+use serde_json::Value;
+
+fn fresh_conn() -> rusqlite::Connection {
+    ai_memory::db::open(std::path::Path::new(":memory:")).expect("open in-memory db")
+}
+
+fn semantic_tier() -> TierConfig {
+    FeatureTier::Semantic.config()
+}
+
+fn v3_response(profile: &Profile) -> Value {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), profile)
+        .expect("v3 capabilities serialize")
+}
+
+// ---------------------------------------------------------------------------
+// T0-A2-CORE — `to_describe_to_user` on `--profile core` matches the
+// canonical phrasing pinned in docs/v0.7/canonical-phrasings.md verbatim.
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_describe_to_user_core_profile_canonical_phrasing() {
+    let val = v3_response(&Profile::core());
+    let describe = val["to_describe_to_user"]
+        .as_str()
+        .expect("describe present");
+
+    // 37 = 42 user-relevant tools − 5 core. The bootstrap
+    // (`memory_capabilities`) is excluded from BOTH the loaded and the
+    // unloaded count in `to_describe_to_user` (it's plumbing, not a
+    // feature). The A2 NHI starter prompt's example used 38 because it
+    // assumed bootstrap was counted on the unloaded side; the shipped
+    // builder is more honest.
+    let expected = "I can directly use 5 memory tools right now \
+                    (store, recall, list, get, search). 37 more \
+                    (update, delete, forget, gc, etc.) are available on demand — \
+                    I can load them if you ask for something that needs them, \
+                    or you can restart the server with a different profile.";
+
+    assert_eq!(
+        describe, expected,
+        "T0-A2-CORE: describe_to_user drifted from canonical phrasing.\n\
+         expected: {expected}\n\
+         actual:   {describe}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
+// "nothing more to load" closing form (excludes the always-on bootstrap
+// from the user-facing 42 count).
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_describe_to_user_full_profile_canonical_phrasing() {
+    let val = v3_response(&Profile::full());
+    let describe = val["to_describe_to_user"]
+        .as_str()
+        .expect("describe present");
+
+    let expected = "I can directly use all 42 memory tools right now \
+                    (store, recall, list, get, search, ...). Nothing more to load — \
+                    the full memory surface is already active.";
+
+    assert_eq!(
+        describe, expected,
+        "T0-A2-FULL: describe_to_user drifted from canonical phrasing.\n\
+         expected: {expected}\n\
+         actual:   {describe}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T0-A2-GRAPH — `to_describe_to_user` on `--profile graph` uses the
+// preview-with-ellipsis form (5 of 13 loaded shown + ", ...").
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_describe_to_user_graph_profile_canonical_phrasing() {
+    let val = v3_response(&Profile::graph());
+    let describe = val["to_describe_to_user"]
+        .as_str()
+        .expect("describe present");
+
+    let expected = "I can directly use 13 memory tools right now \
+                    (store, recall, list, get, search, ...). 29 more \
+                    (update, delete, forget, gc, etc.) are available on demand — \
+                    I can load them if you ask for something that needs them, \
+                    or you can restart the server with a different profile.";
+
+    assert_eq!(
+        describe, expected,
+        "T0-A2-GRAPH: describe_to_user drifted from canonical phrasing.\n\
+         expected: {expected}\n\
+         actual:   {describe}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T0-A2-NO-JARGON — `to_describe_to_user` MUST NOT contain MCP-internal
+// vocabulary across ANY profile. This is the tone gate from
+// docs/v0.7/canonical-phrasings.md §"Tone constraint".
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_describe_to_user_omits_mcp_jargon_across_profiles() {
+    for profile in &[
+        Profile::core(),
+        Profile::graph(),
+        Profile::admin(),
+        Profile::power(),
+        Profile::full(),
+    ] {
+        let val = v3_response(profile);
+        let describe = val["to_describe_to_user"]
+            .as_str()
+            .expect("describe present");
+
+        for forbidden in &[
+            "--profile <family>",
+            "--profile full",
+            "memory_load_family",
+            "memory_smart_load",
+            "JSON-RPC",
+            "-32601",
+            "tools/list",
+            "memory_",
+        ] {
+            assert!(
+                !describe.contains(forbidden),
+                "T0-A2-NO-JARGON: profile={profile:?}: describe_to_user contains MCP jargon \
+                 \"{forbidden}\" — keep it plain for end users.\nfull: {describe}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T0-A1-CORE — the `summary` (operator-facing) string on `--profile core`
+// names the four recovery paths verbatim (a, b, c, d). This is the
+// counterpart calibration cell for the A1 phrasing — operators get the
+// recovery vocabulary even when LLMs mute it from the user-facing
+// describe sentence.
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_summary_core_profile_lists_four_recovery_paths() {
+    let val = v3_response(&Profile::core());
+    let summary = val["summary"].as_str().expect("summary present");
+
+    // Path (a) — CLI escape hatch
+    assert!(
+        summary.contains("(a) restart the server with --profile <family>"),
+        "T0-A1-CORE: summary missing recovery path (a); got: {summary}"
+    );
+    // Path (b) — preferred runtime loader (B1, lands later in v0.7.0)
+    assert!(
+        summary.contains("(b) call memory_load_family(family=<name>) — preferred"),
+        "T0-A1-CORE: summary missing recovery path (b); got: {summary}"
+    );
+    // Path (c) — easiest runtime loader (B2, lands later in v0.7.0)
+    assert!(
+        summary.contains("(c) call memory_smart_load(intent='<plain language>') — easiest"),
+        "T0-A1-CORE: summary missing recovery path (c); got: {summary}"
+    );
+    // Path (d) — call-by-name fallback for harnesses without runtime loaders
+    assert!(
+        summary.contains("(d) call the tool by name and recover from JSON-RPC -32601"),
+        "T0-A1-CORE: summary missing recovery path (d); got: {summary}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T0-CONTRACT — both calibration strings are present and well-typed in
+// every named profile's v3 response. Catches structural regressions
+// (missing field, null instead of string, etc.) ahead of the per-string
+// content tests above.
+// ---------------------------------------------------------------------------
+#[test]
+fn t0_v3_contract_both_strings_present_under_every_named_profile() {
+    for profile in &[
+        Profile::core(),
+        Profile::graph(),
+        Profile::admin(),
+        Profile::power(),
+        Profile::full(),
+    ] {
+        let val = v3_response(profile);
+        assert_eq!(
+            val["schema_version"], "3",
+            "T0-CONTRACT profile={profile:?}: schema_version missing or wrong"
+        );
+        assert!(
+            val["summary"].as_str().is_some_and(|s| !s.is_empty()),
+            "T0-CONTRACT profile={profile:?}: summary missing/empty"
+        );
+        assert!(
+            val["to_describe_to_user"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "T0-CONTRACT profile={profile:?}: to_describe_to_user missing/empty"
+        );
+    }
+}

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -1,33 +1,39 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//! Integration tests for the **Capabilities v3 schema** — A1 increment of
-//! the v0.7.0 `attested-cortex` epic (track A, issue #545).
+//! Integration tests for the **Capabilities v3 schema** — A1+A2 increments
+//! of the v0.7.0 `attested-cortex` epic (track A, issue #545).
 //!
-//! v3 is additive over v2 and adds a top-level `summary` field carrying a
-//! pre-computed plain-language description of the LLM's operational tool
-//! surface (loaded count, total count, three named recovery paths for
-//! reaching unloaded families). Computed at response time from the live
-//! `Profile` state so the count of advertised tools always matches what
-//! the running server actually advertises in `tools/list`.
+//! v3 is additive over v2 and adds two top-level pre-computed strings:
+//! - `summary` (A1) — terse description of operational access plus the
+//!   three named recovery paths.
+//! - `to_describe_to_user` (A2) — plain-English, end-user-facing
+//!   sentence the LLM should repeat verbatim when an end-user asks
+//!   "what tools do you have?". No MCP jargon.
 //!
-//! Future v0.7.0 increments (A2-A4) extend v3 with `to_describe_to_user`,
-//! per-tool `callable_now`, and `agent_permitted_families`. A5 bumps the
-//! default wire shape and seals v3 as the recommended client target.
+//! Both are computed at response time from the live `Profile` state so
+//! the count of advertised tools always matches what the running server
+//! actually advertises in `tools/list`.
 //!
-//! These tests pin the A1 contract:
-//! - `accept="v3"` returns a document with `schema_version="3"` and a
-//!   non-empty `summary` field.
-//! - `summary` carries the live profile's loaded vs total tool counts and
-//!   names the three recovery paths.
-//! - The v1/v2 entry point refuses `V3` (with a clear error message) so a
-//!   miswired caller fails loud rather than serving a stale shape.
+//! Future v0.7.0 increments (A3-A4) extend v3 with per-tool
+//! `callable_now` and `agent_permitted_families`. A5 bumps the default
+//! wire shape and seals v3 as the recommended client target.
+//!
+//! These tests pin the A1+A2 contract:
+//! - `accept="v3"` returns a document with `schema_version="3"`, a
+//!   non-empty `summary`, and a non-empty `to_describe_to_user`.
+//! - `summary` carries the live profile's loaded vs total tool counts
+//!   and names the three recovery paths.
+//! - `to_describe_to_user` reads as plain English, omits MCP jargon,
+//!   and accurately reports the loaded-tool count + names.
+//! - The v1/v2 entry point refuses `V3` (with a clear error message)
+//!   so a miswired caller fails loud rather than serving a stale shape.
 //! - v2 callers see no behavior change (backward compat).
 
 use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, TierConfig};
 use ai_memory::mcp::{
-    CapabilitiesAccept, build_capabilities_summary, handle_capabilities_with_conn,
-    handle_capabilities_with_conn_v3,
+    CapabilitiesAccept, build_capabilities_describe_to_user, build_capabilities_summary,
+    handle_capabilities_with_conn, handle_capabilities_with_conn_v3,
 };
 use ai_memory::profile::Profile;
 use serde_json::Value;
@@ -188,20 +194,22 @@ fn cap_v3_summary_graph_profile_counts() {
 }
 
 // ---------------------------------------------------------------------------
-// CapabilitiesV3 round-trips through serde — schema_version, summary, and
-// every v2 field must survive serialize → deserialize.
+// CapabilitiesV3 round-trips through serde — schema_version, summary,
+// to_describe_to_user (A2), and every v2 sub-block must survive
+// serialize → deserialize.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_struct_round_trips_through_serde() {
     let tier_config = semantic_tier();
     let caps: Capabilities = tier_config.capabilities();
-    let v3 = caps.to_v3("hello operator".to_string());
+    let v3 = caps.to_v3("hello operator".to_string(), "hello human".to_string());
 
     let json = serde_json::to_value(&v3).expect("serialize v3");
     let back: CapabilitiesV3 = serde_json::from_value(json.clone()).expect("deserialize v3");
 
     assert_eq!(back.schema_version, "3");
     assert_eq!(back.summary, "hello operator");
+    assert_eq!(back.to_describe_to_user, "hello human");
     assert_eq!(back.tier, v3.tier);
     assert_eq!(back.version, v3.version);
     // Sanity that the v2 sub-blocks are present.
@@ -212,6 +220,115 @@ fn cap_v3_struct_round_trips_through_serde() {
     assert!(json.get("compaction").is_some());
     assert!(json.get("approval").is_some());
     assert!(json.get("transcripts").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// A2: v3 response carries a non-empty top-level `to_describe_to_user`
+// field, distinct from the A1 `summary` field.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_response_carries_to_describe_to_user() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val =
+        handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), &Profile::core())
+            .expect("v3 capabilities serialize");
+
+    let describe = val["to_describe_to_user"]
+        .as_str()
+        .expect("to_describe_to_user must be present and stringy under v3");
+    assert!(
+        !describe.is_empty(),
+        "to_describe_to_user must be non-empty under v3, got: {describe:?}"
+    );
+    let summary = val["summary"].as_str().expect("summary present");
+    assert_ne!(
+        describe, summary,
+        "to_describe_to_user must be a distinct sentence from summary"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A2: to_describe_to_user on `core` profile reads as plain English,
+// names the loaded tools by short name (no `memory_` prefix), reports
+// 38 unloaded with a sample, and ends with the canonical end-user
+// recovery hint.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
+    let describe = build_capabilities_describe_to_user(&Profile::core());
+
+    // Opens with the canonical "I can directly use N memory tool(s)" form.
+    assert!(
+        describe.starts_with("I can directly use 5 memory tools right now ("),
+        "core profile describe must open canonically; got: {describe}"
+    );
+    // Loaded preview lists the 5 core tool names with the memory_
+    // prefix STRIPPED (no MCP jargon for end users).
+    assert!(describe.contains("(store, recall, list, get, search)"));
+    // Reports the unloaded count. 37 = 42 user-relevant tools − 5
+    // core. The bootstrap (`memory_capabilities`) is excluded from
+    // both sides for honest user-facing counting.
+    assert!(
+        describe.contains("37 more"),
+        "core profile must report 37 unloaded; got: {describe}"
+    );
+    // Sample of unloaded tools is plain (no memory_ prefix). The first
+    // four unloaded under core are lifecycle's update/delete/forget/gc.
+    assert!(describe.contains("update, delete, forget, gc"));
+    // Ends with the end-user-facing recovery hint, not the operator
+    // recovery vocabulary used by `summary`.
+    assert!(describe.contains("available on demand"));
+    assert!(describe.contains("restart the server with a different profile"));
+
+    // Tone constraint (A2): NO MCP jargon. The describe sentence must
+    // not surface CLI flags, JSON-RPC error codes, or runtime tool
+    // names a user wouldn't recognize.
+    assert!(!describe.contains("--profile <family>"));
+    assert!(!describe.contains("memory_load_family"));
+    assert!(!describe.contains("memory_smart_load"));
+    assert!(!describe.contains("JSON-RPC"));
+    assert!(!describe.contains("-32601"));
+    assert!(!describe.contains("memory_"));
+    assert!(!describe.contains("tools/list"));
+}
+
+// ---------------------------------------------------------------------------
+// A2: to_describe_to_user on `full` profile reports all 42 tools loaded
+// (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
+// uses the "nothing more to load" closing form rather than the recovery
+// hint.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_describe_full_profile_uses_nothing_more_form() {
+    let describe = build_capabilities_describe_to_user(&Profile::full());
+
+    // 42 = 43 total - 1 always-on bootstrap excluded from describe.
+    assert!(
+        describe.starts_with("I can directly use all 42 memory tools right now ("),
+        "full profile describe must open with all-loaded form; got: {describe}"
+    );
+    assert!(describe.contains("Nothing more to load"));
+    assert!(describe.contains("full memory surface is already active"));
+    // Closing form omits the on-demand recovery hint (nothing to load).
+    assert!(!describe.contains("available on demand"));
+}
+
+// ---------------------------------------------------------------------------
+// A2: to_describe_to_user on `graph` profile (5 core + 8 graph) lists
+// 13 loaded with a 5-name preview ending in ", ..." since there are
+// more loaded than the preview shows.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
+    let describe = build_capabilities_describe_to_user(&Profile::graph());
+    assert!(
+        describe.starts_with("I can directly use 13 memory tools right now ("),
+        "graph profile describe should open with 13 loaded; got: {describe}"
+    );
+    // Preview is the first 5 of the 13 loaded — the 5 core tools.
+    assert!(describe.contains("(store, recall, list, get, search, ...)"));
+    assert!(describe.contains("29 more"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A2 of the v0.7.0 `attested-cortex` epic. Adds the second pre-computed string to capabilities v3: `to_describe_to_user` — the plain-English, end-user-facing sentence the LLM should repeat verbatim when asked "what tools do you have?".

The split between `summary` (operator vocabulary) and `to_describe_to_user` (end-user vocabulary) lets the operator-facing calibration stay technical (it names `memory_load_family`, `memory_smart_load`, `--profile`, JSON-RPC -32601) while the user-facing one stays plain (no `memory_` prefix on tool names, no CLI flags, no JSON-RPC vocabulary).

### What landed

- **`profile.rs`** — new `Family::tool_names()` forward map (source-anchored to the existing `for_tool` reverse map; expected_tool_count invariant pinned by a new unit test).
- **`config.rs`** — `CapabilitiesV3.to_describe_to_user` field; `Capabilities::to_v3` signature now takes both strings.
- **`mcp.rs`** — new `build_capabilities_describe_to_user(profile)` builder + `short_tool_name` helper. Wired through `handle_capabilities_with_conn_v3`.
- **`tests/capabilities_v3.rs`** — 4 new contract tests (presence, plain-English form on core, "nothing-more-to-load" form on full, preview-with-ellipsis form on graph, no-MCP-jargon tone gate).
- **`tests/calibration_t0.rs`** — NEW Discovery Gate T0 calibration cell: 6 tests pinning the canonical phrasings verbatim across all named profiles + the no-jargon tone gate + the operator-facing recovery vocabulary.
- **`docs/v0.7/canonical-phrasings.md`** — NEW canonical phrasing spec with worked examples per profile, substitution table, tone constraint, and regeneration recipe.

### Honest counting

The user-facing sentence excludes the always-on bootstrap (`memory_capabilities`) from BOTH the loaded and the unloaded count — to a user, it's plumbing, not a feature. Core profile reports "5 of 42 user-relevant tools" (37 unloaded), not the original NHI prompt's "38".

### Backward compat

v2 wire shape unchanged. A5 will flip the default to v3.

### Test plan

- [x] `cargo test --test capabilities_v3` → 14/14 green
- [x] `cargo test --test calibration_t0` → 6/6 green
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo fmt --check` clean

Refs #545.