### PR TITLE
feat: v0.7-h1 — per-agent Ed25519 keypair CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,49 @@ certification run (v3r30 DO + local-docker r3).
 
 ## [Unreleased] — v0.6.1 + v0.7 tracks
 
+### Added — v0.7 attested-cortex (Track H, Task H1)
+
+- **Per-agent Ed25519 keypair CLI (`ai-memory identity`).** OSS substrate
+  for the v0.7 attested-cortex epic. New `src/identity/keypair.rs`
+  exposes the four-verb lifecycle (`generate / save / load / list`) plus
+  a `save_public_only` path for importing peer allowlist entries. Keys
+  are persisted under `<config>/ai-memory/keys/<agent_id>.{pub,priv}` —
+  `~/.config/ai-memory/keys/` on Linux, `~/Library/Application
+  Support/ai-memory/keys/` on macOS, `%APPDATA%\ai-memory\keys\` on
+  Windows. On Unix the public file is written with mode `0o644` and
+  the private file with mode `0o600`; on Windows the files inherit the
+  parent ACL. The on-disk format is the raw 32-byte key (no PEM/DER
+  wrapper) so the format is byte-identical to the COSE/CBOR shape H2
+  will sign with.
+- **`ai-memory identity` clap subcommand** wires the lifecycle into
+  the CLI: `generate --agent-id <id>` (defaults to the same NHI-hardened
+  id the rest of the CLI synthesizes via `identity::resolve_agent_id`),
+  `import --agent-id <id> --pub <path> --priv <path>` (private optional;
+  cross-checks `.priv` derives `.pub` and refuses mismatches),
+  `list` (public-only — never loads private material, safe for
+  dashboards), and `export-pub --agent-id <id>` (URL-safe-no-padding
+  base64 of the 32-byte public key, pipe-friendly for peer-allowlist
+  bootstrapping). `--key-dir <path>` is a global override for the
+  default key directory.
+- **Hardware-backed key storage is OUT of OSS scope.** TPM 2.0,
+  PKCS#11 HSMs, Apple Secure Enclave / TEE, and AWS/GCP/Azure cloud
+  KMS adapters are intentionally **not** implemented in this crate. The
+  OSS path stops at file-based 0600 storage; certified hardware-backed
+  deployments live in the AgenticMem™ commercial layer per
+  `ROADMAP2.md`. The OSS code never imports a hardware-token library.
+- **New deps (pure-Rust, MIT/Apache):** `ed25519-dalek = "2"` (with
+  the `rand_core` feature for `SigningKey::generate`), `rand_core =
+  "0.6"` (CSPRNG bound — we use `OsRng`), `base64 = "0.22"` (for the
+  `export-pub` wire format).
+- **16 new unit tests in `src/identity/keypair`** — generate-save-load
+  round-trip with sign+verify, Unix mode 0600 / 0644 enforcement, list
+  enumeration + sort + private-skip semantics, list-on-missing-dir
+  returns empty, truncated/mismatched key file rejection, base64
+  round-trip (URL-safe and padded), and a `save_public_only` happy
+  path. **5 new unit tests in `src/cli/identity`** drive the four CLI
+  verbs through the standard `CliOutput` capture harness, including
+  `generate --no-overwrite` refusal and JSON-mode emission.
+
 ### Fixed — v0.6.0 pre-tag SAL blocker punchlist (#293)
 
 Five correctness blockers surfaced by the v0.6.0 code-review (meta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "base64 0.22.1",
  "bitflags",
  "candle-core",
  "candle-nn",
@@ -50,6 +51,7 @@ dependencies = [
  "clap_mangen",
  "criterion",
  "dirs",
+ "ed25519-dalek",
  "gethostname",
  "hf-hub",
  "instant-distance",
@@ -58,6 +60,7 @@ dependencies = [
  "predicates",
  "prometheus",
  "proptest",
+ "rand_core 0.6.4",
  "rcgen",
  "reqwest",
  "rusqlite",
@@ -914,6 +917,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1174,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1320,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -3310,6 +3371,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,21 @@ rustls = { version = "0.23", features = ["ring"] }
 # for Layer 3 E2E encryption (#228).
 sha2 = "0.10"
 
+# v0.7 Track H — per-agent Ed25519 attested identity (H1). `ed25519-dalek`
+# 2.x is the RustCrypto-maintained, pure-Rust, audit-friendly Ed25519
+# implementation; same crate Solana, Diem, and the IETF COSE crowd use.
+# Pulled in for the keypair lifecycle (`generate / save / load / list /
+# export-pub`) under `src/identity/keypair.rs`. `rand_core = "0.6"` is
+# its CSPRNG bound; we use its `OsRng` for keygen (matches the rest of
+# RustCrypto's expectations). `base64` (URL-safe, no-padding) is the
+# wire format for `export-pub` so an operator can paste a key into a
+# remote allowlist without binary copy hazards. Hardware-backed key
+# storage (TPM/HSM/Secure Enclave) is out of OSS scope per ROADMAP2.md
+# and lives in the AgenticMem commercial layer.
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand_core = { version = "0.6", features = ["std"] }
+base64 = "0.22"
+
 # Semantic embedding support
 candle-core = "0.10"
 candle-nn = "0.10"

--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -1,0 +1,511 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ai-memory identity` subcommand — per-agent Ed25519 keypair lifecycle
+//! (Track H, Task H1).
+//!
+//! See [`crate::identity::keypair`] for the underlying lifecycle. This
+//! module is the thin clap wrapper that turns command-line input into
+//! the four verbs (`generate / import / list / export-pub`) and prints
+//! the result via the standard [`CliOutput`] writer pair.
+//!
+//! ## Hardware-backed key storage is OUT of OSS scope
+//!
+//! TPM 2.0, PKCS#11 HSMs, Apple Secure Enclave, and cloud KMS adapters
+//! are intentionally not in this subcommand. See the module-level
+//! comment on [`crate::identity::keypair`] and `ROADMAP2.md` —
+//! AgenticMem™ is the commercial home for those backends.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand};
+use ed25519_dalek::SigningKey;
+
+use crate::cli::CliOutput;
+use crate::identity::{self, keypair};
+
+#[derive(Args)]
+pub struct IdentityArgs {
+    /// Override the default key storage directory
+    /// (`<config>/ai-memory/keys`).
+    #[arg(long, value_name = "PATH", global = true)]
+    pub key_dir: Option<PathBuf>,
+    #[command(subcommand)]
+    pub action: IdentityAction,
+}
+
+#[derive(Subcommand)]
+pub enum IdentityAction {
+    /// Generate a fresh Ed25519 keypair for `--agent-id` (or the
+    /// NHI-hardened default if omitted) and persist it under the key
+    /// storage directory with strict 0600/0644 modes on Unix.
+    Generate {
+        /// Agent identifier. Defaults to the same NHI-hardened id the
+        /// rest of the CLI synthesizes (e.g. `host:<host>:pid-<pid>-<uuid8>`).
+        #[arg(long)]
+        agent_id: Option<String>,
+        /// Refuse to overwrite an existing keypair for `--agent-id`.
+        /// Without this flag a `generate` for an existing id replaces
+        /// the on-disk material — useful for rotation; dangerous for
+        /// fingers.
+        #[arg(long, default_value_t = false)]
+        no_overwrite: bool,
+    },
+    /// Import a keypair from on-disk files written by another tool.
+    /// `--pub` is required; `--priv` is optional (omit it to import a
+    /// public-only handle for verification, e.g., a peer's allowlist
+    /// entry).
+    Import {
+        /// Agent identifier the imported material will be saved under.
+        #[arg(long)]
+        agent_id: String,
+        /// Path to a 32-byte raw Ed25519 public key file.
+        #[arg(long = "pub", value_name = "PATH")]
+        public: PathBuf,
+        /// Optional path to a 32-byte raw Ed25519 private key file.
+        #[arg(long = "priv", value_name = "PATH")]
+        private: Option<PathBuf>,
+    },
+    /// List every keypair stored under the key storage directory.
+    /// Private keys are never loaded — `list` is safe to wire into
+    /// dashboards and shell autocompletion.
+    List,
+    /// Print a base64-encoded public key for `--agent-id` to stdout.
+    /// Stable URL-safe-no-padding form so the output can be pasted
+    /// into a Slack message or a peer allowlist file without binary
+    /// hazards.
+    ExportPub {
+        /// Agent identifier whose public key should be exported.
+        #[arg(long)]
+        agent_id: String,
+    },
+}
+
+/// Resolve the key storage directory from `--key-dir` (caller override)
+/// or the OSS default at `<config>/ai-memory/keys`.
+fn resolve_key_dir(override_dir: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = override_dir {
+        return Ok(p.to_path_buf());
+    }
+    keypair::default_key_dir()
+}
+
+/// Resolve the agent_id for a CLI invocation: explicit `--agent-id`
+/// wins, otherwise fall back to the NHI default. We pass `None` for
+/// the MCP client so the resolution stops at the host-or-anonymous
+/// branch (CLI is not an MCP handshake).
+fn resolve_id(explicit: Option<&str>) -> Result<String> {
+    identity::resolve_agent_id(explicit, None)
+}
+
+/// `identity` handler.
+///
+/// Returns `Ok(())` on success, propagates errors otherwise. The
+/// caller is `daemon_runtime::dispatch_command` which prints the error
+/// + exits non-zero in the standard way.
+pub fn run(args: IdentityArgs, json_out: bool, out: &mut CliOutput<'_>) -> Result<()> {
+    let dir = resolve_key_dir(args.key_dir.as_deref())?;
+    match args.action {
+        IdentityAction::Generate {
+            agent_id,
+            no_overwrite,
+        } => generate(&dir, agent_id.as_deref(), no_overwrite, json_out, out),
+        IdentityAction::Import {
+            agent_id,
+            public,
+            private,
+        } => import(&dir, &agent_id, &public, private.as_deref(), json_out, out),
+        IdentityAction::List => list(&dir, json_out, out),
+        IdentityAction::ExportPub { agent_id } => export_pub(&dir, &agent_id, json_out, out),
+    }
+}
+
+fn generate(
+    dir: &Path,
+    explicit_agent_id: Option<&str>,
+    no_overwrite: bool,
+    json_out: bool,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let id = resolve_id(explicit_agent_id)?;
+    let pub_path = dir.join(format!("{id}.pub"));
+    if no_overwrite && pub_path.exists() {
+        bail!(
+            "keypair for {id} already exists at {} (pass without --no-overwrite to rotate)",
+            pub_path.display()
+        );
+    }
+    let kp = keypair::generate(&id)?;
+    keypair::save(&kp, dir)?;
+    if json_out {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "generated": true,
+                "agent_id": id,
+                "key_dir": dir,
+                "public_key_b64": kp.public_base64(),
+            })
+        )?;
+    } else {
+        writeln!(out.stdout, "generated keypair for {id}")?;
+        writeln!(out.stdout, "  key_dir = {}", dir.display())?;
+        writeln!(out.stdout, "  pub_b64 = {}", kp.public_base64())?;
+    }
+    Ok(())
+}
+
+fn import(
+    dir: &Path,
+    agent_id: &str,
+    pub_path: &Path,
+    priv_path: Option<&Path>,
+    json_out: bool,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    crate::validate::validate_agent_id(agent_id)?;
+    let pub_bytes = keypair::read_raw_key_file(pub_path)
+        .with_context(|| format!("reading --pub {}", pub_path.display()))?;
+    let public = ed25519_dalek::VerifyingKey::from_bytes(&pub_bytes)
+        .with_context(|| "decoding imported public key".to_string())?;
+
+    let private = if let Some(p) = priv_path {
+        let priv_bytes = keypair::read_raw_key_file(p)
+            .with_context(|| format!("reading --priv {}", p.display()))?;
+        let signing = SigningKey::from_bytes(&priv_bytes);
+        // Cross-check before persisting — refuse mismatched pairs.
+        if signing.verifying_key().to_bytes() != public.to_bytes() {
+            bail!(
+                "imported --priv {} does not match --pub {}",
+                p.display(),
+                pub_path.display()
+            );
+        }
+        Some(signing)
+    } else {
+        None
+    };
+
+    let kp = keypair::AgentKeypair {
+        agent_id: agent_id.to_string(),
+        public,
+        private,
+    };
+    if kp.private.is_some() {
+        keypair::save(&kp, dir)?;
+    } else {
+        keypair::save_public_only(&kp, dir)?;
+    }
+
+    if json_out {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "imported": true,
+                "agent_id": agent_id,
+                "key_dir": dir,
+                "private_imported": kp.private.is_some(),
+                "public_key_b64": kp.public_base64(),
+            })
+        )?;
+    } else {
+        writeln!(
+            out.stdout,
+            "imported keypair for {agent_id} (private={})",
+            if kp.private.is_some() { "yes" } else { "no" }
+        )?;
+        writeln!(out.stdout, "  key_dir = {}", dir.display())?;
+        writeln!(out.stdout, "  pub_b64 = {}", kp.public_base64())?;
+    }
+    Ok(())
+}
+
+fn list(dir: &Path, json_out: bool, out: &mut CliOutput<'_>) -> Result<()> {
+    let keys = keypair::list(dir)?;
+    if json_out {
+        let entries: Vec<_> = keys
+            .iter()
+            .map(|k| {
+                serde_json::json!({
+                    "agent_id": k.agent_id,
+                    "public_key_b64": k.public_base64(),
+                })
+            })
+            .collect();
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "count": entries.len(),
+                "key_dir": dir,
+                "keys": entries,
+            })
+        )?;
+    } else if keys.is_empty() {
+        writeln!(out.stdout, "no keypairs in {}", dir.display())?;
+    } else {
+        for k in &keys {
+            writeln!(out.stdout, "{}  {}", k.agent_id, k.public_base64())?;
+        }
+        writeln!(out.stdout, "{} keypair(s) in {}", keys.len(), dir.display())?;
+    }
+    Ok(())
+}
+
+fn export_pub(dir: &Path, agent_id: &str, json_out: bool, out: &mut CliOutput<'_>) -> Result<()> {
+    let kp = keypair::load(agent_id, dir)?;
+    if json_out {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "public_key_b64": kp.public_base64(),
+            })
+        )?;
+    } else {
+        // Plain text path: just the base64 — pipe-friendly for
+        // `ai-memory identity export-pub --agent-id alice | xclip`.
+        writeln!(out.stdout, "{}", kp.public_base64())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::test_utils::TestEnv;
+
+    fn fresh_env() -> (TestEnv, tempfile::TempDir) {
+        let env = TestEnv::fresh();
+        let dir = tempfile::TempDir::new().unwrap();
+        (env, dir)
+    }
+
+    #[test]
+    fn generate_then_list_then_export() {
+        let (mut env, dir) = fresh_env();
+        let dir_path = dir.path().to_path_buf();
+
+        // generate
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path.clone()),
+                    action: IdentityAction::Generate {
+                        agent_id: Some("alice".to_string()),
+                        no_overwrite: false,
+                    },
+                },
+                false,
+                &mut out,
+            )
+            .unwrap();
+        }
+        let stdout = env.stdout_str().to_string();
+        assert!(
+            stdout.contains("generated keypair for alice"),
+            "got: {stdout}"
+        );
+
+        // list
+        env.stdout.clear();
+        env.stderr.clear();
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path.clone()),
+                    action: IdentityAction::List,
+                },
+                false,
+                &mut out,
+            )
+            .unwrap();
+        }
+        let stdout = env.stdout_str().to_string();
+        assert!(stdout.contains("alice"), "got: {stdout}");
+        assert!(stdout.contains("1 keypair(s)"), "got: {stdout}");
+
+        // export-pub (text mode prints just the base64)
+        env.stdout.clear();
+        env.stderr.clear();
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path),
+                    action: IdentityAction::ExportPub {
+                        agent_id: "alice".to_string(),
+                    },
+                },
+                false,
+                &mut out,
+            )
+            .unwrap();
+        }
+        let stdout = env.stdout_str().trim().to_string();
+        // Should round-trip through the keypair decoder.
+        let decoded = keypair::decode_public_base64(&stdout).expect("decode");
+        assert_eq!(decoded.to_bytes().len(), 32);
+    }
+
+    #[test]
+    fn generate_no_overwrite_refuses_existing() {
+        let (mut env, dir) = fresh_env();
+        let dir_path = dir.path().to_path_buf();
+        // First generate
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path.clone()),
+                    action: IdentityAction::Generate {
+                        agent_id: Some("alice".to_string()),
+                        no_overwrite: false,
+                    },
+                },
+                false,
+                &mut out,
+            )
+            .unwrap();
+        }
+        env.stdout.clear();
+        env.stderr.clear();
+        // Second generate with --no-overwrite should error.
+        let result = {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path),
+                    action: IdentityAction::Generate {
+                        agent_id: Some("alice".to_string()),
+                        no_overwrite: true,
+                    },
+                },
+                false,
+                &mut out,
+            )
+        };
+        let err = result.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("already exists"), "got: {msg}");
+    }
+
+    #[test]
+    fn list_json_emits_keys_array() {
+        let (mut env, dir) = fresh_env();
+        let dir_path = dir.path().to_path_buf();
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path.clone()),
+                    action: IdentityAction::Generate {
+                        agent_id: Some("alice".to_string()),
+                        no_overwrite: false,
+                    },
+                },
+                true,
+                &mut out,
+            )
+            .unwrap();
+        }
+        env.stdout.clear();
+        env.stderr.clear();
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path),
+                    action: IdentityAction::List,
+                },
+                true,
+                &mut out,
+            )
+            .unwrap();
+        }
+        let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+        assert_eq!(v["count"].as_u64().unwrap(), 1);
+        assert_eq!(v["keys"][0]["agent_id"].as_str().unwrap(), "alice");
+        assert!(v["keys"][0]["public_key_b64"].as_str().unwrap().len() > 10);
+    }
+
+    #[test]
+    fn import_round_trip_through_raw_files() {
+        let (mut env, dir) = fresh_env();
+        let dir_path = dir.path().to_path_buf();
+
+        // Create a fresh keypair, dump raw bytes to disk, then `import`.
+        let kp = keypair::generate("alice").unwrap();
+        let pub_bytes = kp.public.to_bytes();
+        let priv_bytes = kp.private.as_ref().unwrap().to_bytes();
+        let staging = tempfile::TempDir::new().unwrap();
+        let pub_file = staging.path().join("a.pub");
+        let priv_file = staging.path().join("a.priv");
+        std::fs::write(&pub_file, pub_bytes).unwrap();
+        std::fs::write(&priv_file, priv_bytes).unwrap();
+
+        {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path.clone()),
+                    action: IdentityAction::Import {
+                        agent_id: "alice".to_string(),
+                        public: pub_file.clone(),
+                        private: Some(priv_file.clone()),
+                    },
+                },
+                false,
+                &mut out,
+            )
+            .unwrap();
+        }
+        let stdout = env.stdout_str().to_string();
+        assert!(
+            stdout.contains("imported keypair for alice"),
+            "got: {stdout}"
+        );
+        // Round-trip through load.
+        let loaded = keypair::load("alice", &dir_path).unwrap();
+        assert_eq!(loaded.public.to_bytes(), pub_bytes);
+        assert!(loaded.can_sign());
+    }
+
+    #[test]
+    fn import_refuses_priv_pub_mismatch() {
+        let (mut env, dir) = fresh_env();
+        let dir_path = dir.path().to_path_buf();
+        let alice = keypair::generate("alice").unwrap();
+        let bob = keypair::generate("bob").unwrap();
+        let staging = tempfile::TempDir::new().unwrap();
+        let pub_file = staging.path().join("alice.pub");
+        let priv_file = staging.path().join("bob.priv");
+        std::fs::write(&pub_file, alice.public.to_bytes()).unwrap();
+        std::fs::write(&priv_file, bob.private.as_ref().unwrap().to_bytes()).unwrap();
+
+        let result = {
+            let mut out = env.output();
+            run(
+                IdentityArgs {
+                    key_dir: Some(dir_path),
+                    action: IdentityAction::Import {
+                        agent_id: "alice".to_string(),
+                        public: pub_file,
+                        private: Some(priv_file),
+                    },
+                },
+                false,
+                &mut out,
+            )
+        };
+        let err = result.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("does not match"), "got: {msg}");
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub mod forget;
 pub mod gc;
 pub mod governance;
 pub mod helpers;
+pub mod identity;
 pub mod install;
 pub mod io;
 pub mod io_writer;

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -58,6 +58,7 @@ use crate::cli::consolidate::{AutoConsolidateArgs, ConsolidateArgs};
 use crate::cli::crud::{DeleteArgs, GetArgs, ListArgs};
 use crate::cli::curator::CuratorArgs;
 use crate::cli::forget::ForgetArgs;
+use crate::cli::identity::IdentityArgs;
 use crate::cli::install::InstallArgs;
 use crate::cli::io::{ImportArgs, MineArgs};
 use crate::cli::link::{LinkArgs, ResolveArgs};
@@ -207,6 +208,12 @@ pub enum Command {
     Archive(ArchiveArgs),
     /// Register or list agents (Task 1.3)
     Agents(AgentsArgs),
+    /// v0.7 (Track H, Task H1) — per-agent Ed25519 keypair lifecycle.
+    /// `generate` / `import` / `list` / `export-pub` against the local
+    /// key directory (default `<config>/ai-memory/keys`). Hardware-backed
+    /// key storage (TPM/HSM/Secure Enclave) is out of OSS scope and
+    /// lives in the AgenticMem commercial layer.
+    Identity(IdentityArgs),
     /// List / approve / reject governance-pending actions (Task 1.9)
     Pending(PendingArgs),
     /// v0.6.0.0: snapshot the `SQLite` database to a timestamped backup
@@ -707,6 +714,17 @@ pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
             let mut se = stderr.lock();
             let mut out = cli::CliOutput::from_std(&mut so, &mut se);
             cli::agents::run_agents(&db_path, a, j, &mut out)
+        }
+        Command::Identity(a) => {
+            // v0.7 H1 — keypair lifecycle is DB-free. The handler
+            // resolves the key directory itself (via --key-dir or the
+            // default <config>/ai-memory/keys).
+            let stdout = std::io::stdout();
+            let stderr = std::io::stderr();
+            let mut so = stdout.lock();
+            let mut se = stderr.lock();
+            let mut out = cli::CliOutput::from_std(&mut so, &mut se);
+            cli::identity::run(a, j, &mut out)
         }
         Command::Pending(a) => {
             let stdout = std::io::stdout();

--- a/src/identity/keypair.rs
+++ b/src/identity/keypair.rs
@@ -1,0 +1,570 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-agent Ed25519 keypair lifecycle (Track H, Task H1).
+//!
+//! This module is the OSS substrate for v0.7's "attested cortex" track.
+//! Every agent that wants to sign outbound writes (links in H2, memories
+//! in H3+, audit events in H5) needs a stable Ed25519 keypair. The four
+//! verbs ([`generate`], [`save`], [`load`], [`list`]) plus the CLI
+//! wrapper at [`crate::cli::identity`] are the entire OSS surface.
+//!
+//! # Storage layout
+//!
+//! Keys live under `<key_dir>/<agent_id>.{pub,priv}`:
+//!
+//! | File                  | Mode (Unix) | Contents                                    |
+//! |-----------------------|-------------|---------------------------------------------|
+//! | `<agent_id>.pub`      | `0o644`     | 32 raw bytes — `VerifyingKey::to_bytes()`   |
+//! | `<agent_id>.priv`     | `0o600`     | 32 raw bytes — `SigningKey::to_bytes()`     |
+//!
+//! On Windows the mode bits do not apply; the files are created with
+//! the inherited ACL of the parent directory. This is a known coverage
+//! gap for the OSS layer — see "Hardware-backed key storage" below.
+//!
+//! The default key directory is `dirs::config_dir().join("ai-memory/keys/")`
+//! on every platform (`~/.config/ai-memory/keys/` on Linux,
+//! `~/Library/Application Support/ai-memory/keys/` on macOS,
+//! `%APPDATA%\ai-memory\keys\` on Windows). The CLI will create it on
+//! first use.
+//!
+//! # Hardware-backed key storage is OUT of OSS scope
+//!
+//! Per [`ROADMAP2.md`](../../../ROADMAP2.md) and
+//! [`docs/v0.7/V0.7-EPIC.md`](../../../docs/v0.7/V0.7-EPIC.md), the
+//! OSS path stops at file-based 0600 storage. TPM 2.0, PKCS#11 HSMs,
+//! Apple Secure Enclave / TEE, AWS KMS / GCP KMS / Azure Key Vault
+//! are intentionally **not** implemented in this crate. Operators who
+//! need any of those should look at the **AgenticMem™** commercial
+//! layer — same `AgentKeypair` shape, same wire format, hardware-backed
+//! signing under the hood.
+//!
+//! The OSS code never imports a hardware-token library and never
+//! depends on a non-pure-Rust dependency for key material. This is a
+//! deliberate licensing + portability decision, not a "we'll get to it"
+//! gap.
+//!
+//! # Format & interop
+//!
+//! - The on-disk format is the raw 32-byte key, no PEM, no DER, no
+//!   header, no length prefix. This is the smallest possible shape
+//!   that round-trips through `ed25519-dalek` and matches the COSE /
+//!   CBOR wire format H2 will use.
+//! - `export_pub` emits URL-safe, no-padding base64 of the public
+//!   key bytes — short enough to paste into a Slack message or a
+//!   peer's allowlist file.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+
+use crate::validate;
+
+/// Suffix for the public-key file (`<agent_id>.pub`).
+const PUB_SUFFIX: &str = ".pub";
+/// Suffix for the private-key file (`<agent_id>.priv`).
+const PRIV_SUFFIX: &str = ".priv";
+
+/// Length of an Ed25519 public key in bytes.
+const PUBLIC_KEY_LEN: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+/// Length of an Ed25519 private/signing key seed in bytes.
+const SECRET_KEY_LEN: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+
+/// Per-agent Ed25519 keypair.
+///
+/// `private` is `Option` because two of the lifecycle verbs ([`load`]
+/// when no `.priv` exists and [`list`] which always skips private
+/// material) yield a public-only handle. Code that needs to sign must
+/// match on `private` and refuse with a clear error when missing.
+#[derive(Debug, Clone)]
+pub struct AgentKeypair {
+    /// Logical agent identifier — same vocabulary as
+    /// `crate::identity::resolve_agent_id`.
+    pub agent_id: String,
+    /// Public verifying key. Always loaded.
+    pub public: VerifyingKey,
+    /// Optional private signing key. `None` for public-only loads.
+    pub private: Option<SigningKey>,
+}
+
+impl AgentKeypair {
+    /// Returns `true` when the private key is present and the keypair
+    /// can therefore sign.
+    #[must_use]
+    pub fn can_sign(&self) -> bool {
+        self.private.is_some()
+    }
+
+    /// URL-safe, no-padding base64 encoding of the public key bytes.
+    /// Stable wire format for `export-pub` and for peer allowlists.
+    #[must_use]
+    pub fn public_base64(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.public.to_bytes())
+    }
+}
+
+/// Returns the default key storage directory:
+/// `dirs::config_dir().join("ai-memory/keys/")`.
+///
+/// Errors when the OS does not advertise a config dir (extremely rare;
+/// every supported target — Linux, macOS, Windows — returns one).
+pub fn default_key_dir() -> Result<PathBuf> {
+    let base = dirs::config_dir()
+        .ok_or_else(|| anyhow!("OS did not advertise a config directory for key storage"))?;
+    Ok(base.join("ai-memory").join("keys"))
+}
+
+/// Generate a fresh Ed25519 keypair for `agent_id` using `OsRng`.
+///
+/// `agent_id` is validated against [`crate::validate::validate_agent_id`]
+/// so callers cannot smuggle invalid characters into the on-disk filename.
+pub fn generate(agent_id: &str) -> Result<AgentKeypair> {
+    validate::validate_agent_id(agent_id)?;
+    // ed25519-dalek 2.x consumes a `CryptoRngCore` (rand_core 0.6).
+    // `OsRng` is the platform CSPRNG; it never blocks on modern OSes.
+    let mut csprng = rand_core::OsRng;
+    let private = SigningKey::generate(&mut csprng);
+    let public = private.verifying_key();
+    Ok(AgentKeypair {
+        agent_id: agent_id.to_string(),
+        public,
+        private: Some(private),
+    })
+}
+
+/// Persist `keypair` to `dir`.
+///
+/// Creates the directory tree (recursive `mkdir`) on first use. On
+/// Unix the public file is written with mode `0o644` and the private
+/// file with mode `0o600`. Both files are written atomically by the
+/// underlying `fs::write` (single syscall on the modern OSes we
+/// target — no temp-file rename dance because the file shape is fixed
+/// 32 bytes and a partial write is recoverable by `generate` again).
+///
+/// Refuses if `keypair.private` is `None` — there is nothing to save
+/// beyond a public key, and saving a public-only file is the job of
+/// [`save_public_only`] (used by `import` when `--priv` is omitted).
+pub fn save(keypair: &AgentKeypair, dir: &Path) -> Result<()> {
+    let private = keypair.private.as_ref().ok_or_else(|| {
+        anyhow!(
+            "AgentKeypair for {} has no private key to save",
+            keypair.agent_id
+        )
+    })?;
+    fs::create_dir_all(dir).with_context(|| format!("creating key directory {}", dir.display()))?;
+
+    let pub_path = dir.join(format!("{}{PUB_SUFFIX}", keypair.agent_id));
+    let priv_path = dir.join(format!("{}{PRIV_SUFFIX}", keypair.agent_id));
+
+    write_with_mode(&pub_path, &keypair.public.to_bytes(), 0o644)
+        .with_context(|| format!("writing public key {}", pub_path.display()))?;
+    write_with_mode(&priv_path, &private.to_bytes(), 0o600)
+        .with_context(|| format!("writing private key {}", priv_path.display()))?;
+    Ok(())
+}
+
+/// Persist only the public-key file. Used by `identity import` when the
+/// caller supplies a public key without a private key (e.g., importing
+/// a peer's allowlist entry). The corresponding `.priv` is left absent;
+/// [`load`] will then return a public-only [`AgentKeypair`].
+pub fn save_public_only(keypair: &AgentKeypair, dir: &Path) -> Result<()> {
+    fs::create_dir_all(dir).with_context(|| format!("creating key directory {}", dir.display()))?;
+    let pub_path = dir.join(format!("{}{PUB_SUFFIX}", keypair.agent_id));
+    write_with_mode(&pub_path, &keypair.public.to_bytes(), 0o644)
+        .with_context(|| format!("writing public key {}", pub_path.display()))?;
+    Ok(())
+}
+
+/// Load `agent_id`'s keypair from `dir`.
+///
+/// The public file must exist (errors otherwise). The private file is
+/// optional — if absent the returned `AgentKeypair.private` is `None`
+/// and the caller can verify but not sign.
+pub fn load(agent_id: &str, dir: &Path) -> Result<AgentKeypair> {
+    validate::validate_agent_id(agent_id)?;
+    let pub_path = dir.join(format!("{agent_id}{PUB_SUFFIX}"));
+    let priv_path = dir.join(format!("{agent_id}{PRIV_SUFFIX}"));
+
+    let pub_bytes = fs::read(&pub_path)
+        .with_context(|| format!("reading public key {}", pub_path.display()))?;
+    if pub_bytes.len() != PUBLIC_KEY_LEN {
+        bail!(
+            "public key {} has {} bytes, expected {PUBLIC_KEY_LEN}",
+            pub_path.display(),
+            pub_bytes.len()
+        );
+    }
+    let mut pub_arr = [0u8; PUBLIC_KEY_LEN];
+    pub_arr.copy_from_slice(&pub_bytes);
+    let public = VerifyingKey::from_bytes(&pub_arr)
+        .with_context(|| format!("decoding public key {}", pub_path.display()))?;
+
+    let private = match fs::read(&priv_path) {
+        Ok(priv_bytes) => {
+            if priv_bytes.len() != SECRET_KEY_LEN {
+                bail!(
+                    "private key {} has {} bytes, expected {SECRET_KEY_LEN}",
+                    priv_path.display(),
+                    priv_bytes.len()
+                );
+            }
+            let mut priv_arr = [0u8; SECRET_KEY_LEN];
+            priv_arr.copy_from_slice(&priv_bytes);
+            let signing = SigningKey::from_bytes(&priv_arr);
+            // Cross-check: the private key must derive the same public
+            // key we just loaded. Mismatch means file tampering or a
+            // stale .pub — refuse loudly rather than sign with the
+            // wrong identity.
+            if signing.verifying_key().to_bytes() != public.to_bytes() {
+                bail!(
+                    "private key {} does not match public key {}",
+                    priv_path.display(),
+                    pub_path.display()
+                );
+            }
+            Some(signing)
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(anyhow!(e))
+                .with_context(|| format!("reading private key {}", priv_path.display()));
+        }
+    };
+
+    Ok(AgentKeypair {
+        agent_id: agent_id.to_string(),
+        public,
+        private,
+    })
+}
+
+/// Enumerate every `<agent_id>.pub` under `dir` and return the
+/// public-only keypairs. Private keys are **not** loaded — `list` is
+/// the safe verb for ops dashboards and shell autocompletion.
+///
+/// Returns an empty `Vec` (not an error) when `dir` does not exist —
+/// "no keys generated yet" is the common first-run state.
+pub fn list(dir: &Path) -> Result<Vec<AgentKeypair>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in
+        fs::read_dir(dir).with_context(|| format!("reading key directory {}", dir.display()))?
+    {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        let Some(stem) = name_str.strip_suffix(PUB_SUFFIX) else {
+            continue;
+        };
+        // Skip .pub files whose stem is not a valid agent_id — they
+        // can't have been written by this module's `save`.
+        if validate::validate_agent_id(stem).is_err() {
+            continue;
+        }
+        let path = entry.path();
+        let pub_bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if pub_bytes.len() != PUBLIC_KEY_LEN {
+            continue;
+        }
+        let mut pub_arr = [0u8; PUBLIC_KEY_LEN];
+        pub_arr.copy_from_slice(&pub_bytes);
+        let Ok(public) = VerifyingKey::from_bytes(&pub_arr) else {
+            continue;
+        };
+        out.push(AgentKeypair {
+            agent_id: stem.to_string(),
+            public,
+            private: None,
+        });
+    }
+    out.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+    Ok(out)
+}
+
+/// Decode a base64-encoded public key (URL-safe-no-pad **or** standard
+/// padded) into a [`VerifyingKey`]. Used by `identity import` so
+/// operators can paste either flavor of base64 they were sent.
+pub fn decode_public_base64(s: &str) -> Result<VerifyingKey> {
+    let trimmed = s.trim();
+    let bytes = URL_SAFE_NO_PAD
+        .decode(trimmed)
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(trimmed))
+        .with_context(|| "decoding base64 public key".to_string())?;
+    if bytes.len() != PUBLIC_KEY_LEN {
+        bail!(
+            "decoded public key has {} bytes, expected {PUBLIC_KEY_LEN}",
+            bytes.len()
+        );
+    }
+    let mut arr = [0u8; PUBLIC_KEY_LEN];
+    arr.copy_from_slice(&bytes);
+    VerifyingKey::from_bytes(&arr).with_context(|| "decoding public key bytes".to_string())
+}
+
+/// Read a 32-byte raw key file and return the bytes. Used by
+/// `identity import` for `--pub <path> --priv <path>` when the operator
+/// hands us files instead of base64. Errors loudly on a length mismatch.
+pub fn read_raw_key_file(path: &Path) -> Result<[u8; SECRET_KEY_LEN]> {
+    let bytes = fs::read(path).with_context(|| format!("reading key file {}", path.display()))?;
+    if bytes.len() != SECRET_KEY_LEN {
+        bail!(
+            "key file {} has {} bytes, expected {SECRET_KEY_LEN}",
+            path.display(),
+            bytes.len()
+        );
+    }
+    let mut arr = [0u8; SECRET_KEY_LEN];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+/// Cross-platform `fs::write` with an explicit Unix mode. On non-Unix
+/// targets `mode` is ignored and the file inherits the parent ACL.
+#[cfg(unix)]
+fn write_with_mode(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    // Best-effort remove first so a previous, possibly stricter mode
+    // on the same name doesn't block an `open` with `create_new`.
+    let _ = fs::remove_file(path);
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(mode)
+        .open(path)?;
+    use std::io::Write;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_with_mode(path: &Path, bytes: &[u8], _mode: u32) -> io::Result<()> {
+    // Windows/non-Unix: mode bits don't apply. The file inherits the
+    // parent directory ACL. Hardware-backed key storage on Windows is
+    // out of OSS scope — see the AgenticMem commercial layer.
+    fs::write(path, bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer;
+    use ed25519_dalek::Verifier;
+    use tempfile::TempDir;
+
+    fn tmp_dir() -> TempDir {
+        TempDir::new().expect("tempdir")
+    }
+
+    #[test]
+    fn generate_yields_signing_keypair() {
+        let kp = generate("alice").expect("generate");
+        assert_eq!(kp.agent_id, "alice");
+        assert!(
+            kp.can_sign(),
+            "freshly generated keypair must have private key"
+        );
+        // Public derives from private.
+        let priv_pub = kp.private.as_ref().unwrap().verifying_key().to_bytes();
+        assert_eq!(priv_pub, kp.public.to_bytes());
+    }
+
+    #[test]
+    fn generate_rejects_invalid_agent_id() {
+        assert!(generate("has space").is_err());
+        assert!(generate("has\0null").is_err());
+    }
+
+    #[test]
+    fn round_trip_save_then_load() {
+        let dir = tmp_dir();
+        let kp = generate("alice").unwrap();
+        save(&kp, dir.path()).expect("save");
+        let loaded = load("alice", dir.path()).expect("load");
+        assert_eq!(loaded.agent_id, "alice");
+        assert_eq!(loaded.public.to_bytes(), kp.public.to_bytes());
+        assert!(loaded.can_sign(), "private key should round-trip");
+        // Sign with loaded key, verify with original public.
+        let msg = b"hello world";
+        let sig = loaded.private.as_ref().unwrap().sign(msg);
+        assert!(kp.public.verify(msg, &sig).is_ok());
+    }
+
+    #[test]
+    fn load_without_private_yields_public_only() {
+        let dir = tmp_dir();
+        let kp = generate("alice").unwrap();
+        save(&kp, dir.path()).expect("save");
+        // Drop the private file.
+        let priv_path = dir.path().join("alice.priv");
+        fs::remove_file(&priv_path).expect("rm priv");
+        let loaded = load("alice", dir.path()).expect("load");
+        assert!(!loaded.can_sign(), "missing .priv must yield None private");
+        assert_eq!(loaded.public.to_bytes(), kp.public.to_bytes());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_writes_unix_mode_0600_and_0644() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tmp_dir();
+        let kp = generate("alice").unwrap();
+        save(&kp, dir.path()).expect("save");
+
+        let pub_meta = fs::metadata(dir.path().join("alice.pub")).unwrap();
+        let priv_meta = fs::metadata(dir.path().join("alice.priv")).unwrap();
+
+        // Mask off the file-type bits; we only care about the perm bits.
+        let pub_mode = pub_meta.permissions().mode() & 0o777;
+        let priv_mode = priv_meta.permissions().mode() & 0o777;
+        assert_eq!(
+            priv_mode, 0o600,
+            "private key must be 0600, got {priv_mode:o}"
+        );
+        assert_eq!(pub_mode, 0o644, "public key must be 0644, got {pub_mode:o}");
+    }
+
+    #[test]
+    fn list_enumerates_saved_keypairs() {
+        let dir = tmp_dir();
+        let alice = generate("alice").unwrap();
+        let bob = generate("bob").unwrap();
+        save(&alice, dir.path()).unwrap();
+        save(&bob, dir.path()).unwrap();
+
+        let listed = list(dir.path()).expect("list");
+        assert_eq!(listed.len(), 2);
+        // Sorted by agent_id.
+        assert_eq!(listed[0].agent_id, "alice");
+        assert_eq!(listed[1].agent_id, "bob");
+        // No private keys in list output.
+        for kp in &listed {
+            assert!(!kp.can_sign(), "list must not load private keys");
+        }
+        // Public bytes match.
+        assert_eq!(listed[0].public.to_bytes(), alice.public.to_bytes());
+        assert_eq!(listed[1].public.to_bytes(), bob.public.to_bytes());
+    }
+
+    #[test]
+    fn list_on_missing_dir_returns_empty() {
+        let dir = tmp_dir();
+        let nonexistent = dir.path().join("does-not-exist");
+        let listed = list(&nonexistent).expect("list");
+        assert!(listed.is_empty());
+    }
+
+    #[test]
+    fn list_skips_unrelated_files() {
+        let dir = tmp_dir();
+        let kp = generate("alice").unwrap();
+        save(&kp, dir.path()).unwrap();
+        // Drop noise that should be skipped.
+        fs::write(dir.path().join("README.txt"), b"ignore me").unwrap();
+        fs::write(dir.path().join("not-a-key.pub"), b"too short").unwrap();
+
+        let listed = list(dir.path()).expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].agent_id, "alice");
+    }
+
+    #[test]
+    fn load_rejects_truncated_public_key() {
+        let dir = tmp_dir();
+        fs::write(dir.path().join("alice.pub"), b"short").unwrap();
+        let err = load("alice", dir.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("expected 32"), "got: {msg}");
+    }
+
+    #[test]
+    fn load_rejects_priv_pub_mismatch() {
+        let dir = tmp_dir();
+        let alice = generate("alice").unwrap();
+        let bob = generate("alice").unwrap();
+        save(&alice, dir.path()).unwrap();
+        // Overwrite .priv with a different keypair's private bytes.
+        fs::remove_file(dir.path().join("alice.priv")).unwrap();
+        // Use save_public_only path effectively: write a .priv that
+        // doesn't match alice's .pub.
+        let bob_priv = bob.private.as_ref().unwrap().to_bytes();
+        write_with_mode(&dir.path().join("alice.priv"), &bob_priv, 0o600).unwrap();
+        let err = load("alice", dir.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("does not match"), "got: {msg}");
+    }
+
+    #[test]
+    fn export_pub_round_trips_through_base64() {
+        let kp = generate("alice").unwrap();
+        let b64 = kp.public_base64();
+        let decoded = decode_public_base64(&b64).expect("decode");
+        assert_eq!(decoded.to_bytes(), kp.public.to_bytes());
+    }
+
+    #[test]
+    fn decode_public_base64_accepts_padded_form() {
+        let kp = generate("alice").unwrap();
+        let padded = base64::engine::general_purpose::STANDARD.encode(kp.public.to_bytes());
+        let decoded = decode_public_base64(&padded).expect("decode padded");
+        assert_eq!(decoded.to_bytes(), kp.public.to_bytes());
+    }
+
+    #[test]
+    fn read_raw_key_file_validates_length() {
+        let dir = tmp_dir();
+        let p = dir.path().join("short.bin");
+        fs::write(&p, b"short").unwrap();
+        let err = read_raw_key_file(&p).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("expected 32"), "got: {msg}");
+    }
+
+    #[test]
+    fn save_refuses_public_only_keypair() {
+        let dir = tmp_dir();
+        let kp = AgentKeypair {
+            agent_id: "alice".to_string(),
+            public: generate("alice").unwrap().public,
+            private: None,
+        };
+        let err = save(&kp, dir.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no private key to save"), "got: {msg}");
+    }
+
+    #[test]
+    fn save_public_only_writes_pub_only() {
+        let dir = tmp_dir();
+        let kp = generate("alice").unwrap();
+        let pub_only = AgentKeypair {
+            agent_id: "alice".to_string(),
+            public: kp.public,
+            private: None,
+        };
+        save_public_only(&pub_only, dir.path()).expect("save_public_only");
+        assert!(dir.path().join("alice.pub").exists());
+        assert!(!dir.path().join("alice.priv").exists());
+        let loaded = load("alice", dir.path()).expect("load");
+        assert!(!loaded.can_sign());
+    }
+
+    #[test]
+    fn default_key_dir_ends_in_ai_memory_keys() {
+        let p = default_key_dir().expect("default dir");
+        let s = p.to_string_lossy();
+        assert!(s.ends_with("ai-memory/keys") || s.ends_with("ai-memory\\keys"));
+    }
+}

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -37,6 +37,13 @@ use anyhow::Result;
 
 use crate::validate;
 
+// v0.7 Track H — Ed25519 attested identity. The keypair lifecycle
+// (generate / save / load / list / export-pub) lives in its own
+// submodule so this file stays focused on `agent_id` resolution. H2+
+// will plumb the loaded `AgentKeypair` through `AppState` for outbound
+// link signing.
+pub mod keypair;
+
 /// Environment variable override for `agent_id` (used by CLI via clap's
 /// `env = "AI_MEMORY_AGENT_ID"`; read directly for MCP fallback).
 const ENV_AGENT_ID: &str = "AI_MEMORY_AGENT_ID";


### PR DESCRIPTION
Track H task H1 of v0.7.0 attested-cortex epic. Substrate for H2-H6.

## Summary
- New module for Ed25519 keypair lifecycle (generate / import / list / export-pub)
- File-based storage at `~/.config/ai-memory/keys/<agent_id>.{pub,priv}` with 0600/0644 modes on Unix
- CLI subcommand wired under `ai-memory identity`
- Hardware-key storage doc-commented as out-of-OSS-scope (AgenticMem commercial layer)

## Test plan
- [x] cargo fmt --check clean
- [x] cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic clean
- [x] cargo test --lib identity green
- [x] Round-trip: generate -> save -> load -> verify
- [x] File permissions enforced on Unix
- [ ] H2 wires the keypair into outbound link signing