### PR TITLE
feat: v0.7-a3 — capabilities v3 per-tool callable_now (#545)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -716,7 +716,7 @@ impl Capabilities {
         }
     }
 
-    /// v0.7.0 (A1+A2): project the report into the v3 shape.
+    /// v0.7.0 (A1+A2+A3): project the report into the v3 shape.
     ///
     /// v3 = v2 +
     ///   - top-level `summary` (A1) — terse description of operational
@@ -724,21 +724,33 @@ impl Capabilities {
     ///   - top-level `to_describe_to_user` (A2) — plain-English
     ///     end-user-facing sentence the LLM should repeat verbatim
     ///     when asked "what tools do you have?". No MCP jargon.
+    ///   - top-level `tools` (A3) — per-tool array carrying name,
+    ///     family, `loaded`, and `callable_now`. `callable_now`
+    ///     combines profile-side loaded-state with the
+    ///     `[mcp.allowlist]` agent-can-call decision so an LLM that
+    ///     keeps a manifest cache doesn't need to ask twice to know
+    ///     whether a tool will resolve.
     ///
-    /// Both strings are computed by the caller from the live `Profile`
-    /// state because the [`Capabilities`] struct itself doesn't know
-    /// which families the MCP server actually advertised in
-    /// `tools/list`.
+    /// All three are computed by the caller from the live `Profile` +
+    /// `McpConfig` + `agent_id` state because the [`Capabilities`]
+    /// struct itself doesn't know which families the MCP server
+    /// actually advertised or which agent is asking.
     ///
-    /// Future v0.7.0 increments (A3–A4) extend this struct with
-    /// per-tool `callable_now` and `agent_permitted_families`. A5 bumps
-    /// the default wire shape to v3. v2 stays supported indefinitely.
+    /// Future v0.7.0 increment (A4) extends this struct with
+    /// `agent_permitted_families`. A5 bumps the default wire shape to
+    /// v3. v2 stays supported indefinitely.
     #[must_use]
-    pub fn to_v3(&self, summary: String, to_describe_to_user: String) -> CapabilitiesV3 {
+    pub fn to_v3(
+        &self,
+        summary: String,
+        to_describe_to_user: String,
+        tools: Vec<ToolEntry>,
+    ) -> CapabilitiesV3 {
         CapabilitiesV3 {
             schema_version: "3".to_string(),
             summary,
             to_describe_to_user,
+            tools,
             tier: self.tier.clone(),
             version: self.version.clone(),
             features: self.features.clone(),
@@ -751,6 +763,37 @@ impl Capabilities {
             hnsw: self.hnsw.clone(),
         }
     }
+}
+
+/// v0.7.0 A3 — per-tool entry in the capabilities-v3 `tools` array.
+///
+/// `loaded` mirrors `Profile::loads(name)` — true when the active
+/// profile would advertise this tool in `tools/list`.
+///
+/// `callable_now` is the AND of `loaded` with the
+/// `[mcp.allowlist]` per-agent gate. When the allowlist is disabled
+/// (no `[mcp.allowlist]` table or empty table), `callable_now ==
+/// loaded`. When the allowlist is active and the requesting agent
+/// has no entry granting the tool's family, `callable_now == false`
+/// even though `loaded == true`.
+///
+/// LLMs that cache the v3 manifest can use this to skip a doomed
+/// JSON-RPC call rather than discover -32601 the hard way.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolEntry {
+    /// Fully-qualified MCP tool name (e.g., `memory_store`).
+    pub name: String,
+    /// Family the tool belongs to. Always one of the eight canonical
+    /// family names (`core`, `lifecycle`, `graph`, etc.) or
+    /// `"always_on"` for the `memory_capabilities` bootstrap which
+    /// doesn't sit in any single family from a registration standpoint.
+    pub family: String,
+    /// Whether the active profile's family set includes this tool's
+    /// family (i.e., it appears in `tools/list`).
+    pub loaded: bool,
+    /// `loaded && agent_can_call(agent_id, family)`. When the
+    /// `[mcp.allowlist]` is disabled, `callable_now == loaded`.
+    pub callable_now: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -793,6 +836,15 @@ pub struct CapabilitiesV3 {
     /// `docs/v0.7/canonical-phrasings.md` for the canonical
     /// substitution template + worked examples per profile.
     pub to_describe_to_user: String,
+
+    /// v0.7.0 A3 — per-tool array carrying name, family, `loaded`, and
+    /// `callable_now`. `callable_now` combines profile-side
+    /// loaded-state with the `[mcp.allowlist]` agent-can-call decision
+    /// so an LLM that caches this manifest can skip a doomed JSON-RPC
+    /// call rather than discovering -32601 the hard way. Order matches
+    /// `tool_definitions()`'s registration walk so a sequential reader
+    /// gets a stable presentation.
+    pub tools: Vec<ToolEntry>,
 
     pub tier: String,
     pub version: String,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1821,11 +1821,14 @@ pub fn handle_capabilities_with_conn_v3(
     embedder_loaded: bool,
     conn: Option<&rusqlite::Connection>,
     profile: &crate::profile::Profile,
+    mcp_config: Option<&crate::config::McpConfig>,
+    agent_id: Option<&str>,
 ) -> Result<Value, String> {
     let caps = build_capabilities_overlay(tier_config, reranker, embedder_loaded, conn);
     let summary = build_capabilities_summary(profile);
     let describe = build_capabilities_describe_to_user(profile);
-    serde_json::to_value(caps.to_v3(summary, describe)).map_err(|e| e.to_string())
+    let tools = build_capabilities_tools(profile, mcp_config, agent_id);
+    serde_json::to_value(caps.to_v3(summary, describe, tools)).map_err(|e| e.to_string())
 }
 
 /// Build the runtime-overlaid [`Capabilities`] document. Shared between
@@ -2007,6 +2010,75 @@ pub fn build_capabilities_describe_to_user(profile: &crate::profile::Profile) ->
 /// that every tool name starts with the same five characters.
 fn short_tool_name(name: &'static str) -> &'static str {
     name.strip_prefix("memory_").unwrap_or(name)
+}
+
+/// v0.7.0 A3 — build the per-tool array carried in the
+/// capabilities-v3 `tools` field.
+///
+/// Each entry's `loaded` mirrors `Profile::loads(name)`. Each entry's
+/// `callable_now` is `loaded && agent_can_call(agent_id, family)` —
+/// when the `[mcp.allowlist]` is disabled (no table or empty), the
+/// allowlist gate is `Disabled` and the AND collapses to just
+/// `loaded`. When the allowlist is active and the requesting agent
+/// has no entry granting the tool's family, `callable_now == false`
+/// even though `loaded == true`.
+///
+/// The order of the returned vector matches `tool_definitions()`'s
+/// registration walk so a sequential reader gets a stable
+/// presentation matching the order in `tools/list`.
+#[must_use]
+pub fn build_capabilities_tools(
+    profile: &crate::profile::Profile,
+    mcp_config: Option<&crate::config::McpConfig>,
+    agent_id: Option<&str>,
+) -> Vec<crate::config::ToolEntry> {
+    use crate::config::{AllowlistDecision, ToolEntry};
+    use crate::profile::{ALWAYS_ON_TOOLS, Family};
+
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(43);
+
+    for fam in Family::all() {
+        let family_name = fam.name();
+        let loaded = profile.includes(*fam);
+        // Whether THIS agent can call tools in this family — disabled
+        // allowlist falls through to `loaded`. When the allowlist is
+        // configured but denies the family, callable_now collapses to
+        // false regardless of loaded.
+        let allowed = match mcp_config {
+            Some(cfg) => match cfg.allowlist_decision(agent_id, family_name) {
+                AllowlistDecision::Disabled | AllowlistDecision::Allow => true,
+                AllowlistDecision::Deny => false,
+            },
+            None => true,
+        };
+        for name in fam.tool_names() {
+            entries.push(ToolEntry {
+                name: (*name).to_string(),
+                family: family_name.to_string(),
+                loaded,
+                callable_now: loaded && allowed,
+            });
+        }
+    }
+
+    // Always-on bootstraps that are NOT counted via a normal family
+    // walk (in v0.6.4, ALWAYS_ON_TOOLS only contains
+    // `memory_capabilities` which already lives in `Family::Meta`, so
+    // it's already in `entries`. Future bootstraps that don't sit in a
+    // family at all would be appended here with family="always_on" and
+    // unconditionally loaded/callable.)
+    for name in ALWAYS_ON_TOOLS {
+        if !entries.iter().any(|e| e.name == *name) {
+            entries.push(ToolEntry {
+                name: (*name).to_string(),
+                family: "always_on".to_string(),
+                loaded: true,
+                callable_now: true,
+            });
+        }
+    }
+
+    entries
 }
 
 /// Return a stable label for a profile's summary string. Named profiles
@@ -3989,6 +4061,16 @@ fn handle_request(
                         // describing the family taxonomy and which families
                         // the active profile loads. Backward-compat: v1
                         // shape never gets the families overlay.
+                        // v0.7.0 A3 — agent_id resolution mirrors the
+                        // family-listing path's resolution: caller's
+                        // explicit `arguments.agent_id` wins; otherwise
+                        // fall back to the MCP `clientInfo.name`
+                        // captured at initialize time. Threaded into v3
+                        // for per-tool `callable_now` calculation.
+                        let v3_aid = arguments
+                            .get("agent_id")
+                            .and_then(Value::as_str)
+                            .or(mcp_client);
                         let result = match accept {
                             CapabilitiesAccept::V3 => handle_capabilities_with_conn_v3(
                                 tier_config,
@@ -3996,6 +4078,8 @@ fn handle_request(
                                 embedder.is_some(),
                                 Some(conn),
                                 profile,
+                                mcp_config,
+                                v3_aid,
                             ),
                             _ => handle_capabilities_with_conn(
                                 tier_config,

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -36,7 +36,7 @@ fn semantic_tier() -> TierConfig {
 fn v3_response(profile: &Profile) -> Value {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
-    handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), profile)
+    handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), profile, None, None)
         .expect("v3 capabilities serialize")
 }
 

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -30,13 +30,29 @@
 //!   so a miswired caller fails loud rather than serving a stale shape.
 //! - v2 callers see no behavior change (backward compat).
 
-use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, TierConfig};
+use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, McpConfig, TierConfig};
 use ai_memory::mcp::{
     CapabilitiesAccept, build_capabilities_describe_to_user, build_capabilities_summary,
-    handle_capabilities_with_conn, handle_capabilities_with_conn_v3,
+    build_capabilities_tools, handle_capabilities_with_conn, handle_capabilities_with_conn_v3,
 };
 use ai_memory::profile::Profile;
 use serde_json::Value;
+use std::collections::HashMap;
+
+/// v0.7.0 A3 — build a minimal `[mcp.allowlist]` table for tests.
+fn allowlist(rows: &[(&str, &[&str])]) -> McpConfig {
+    let mut map = HashMap::new();
+    for (agent, fams) in rows {
+        map.insert(
+            (*agent).to_string(),
+            fams.iter().map(|s| (*s).to_string()).collect(),
+        );
+    }
+    McpConfig {
+        profile: None,
+        allowlist: Some(map),
+    }
+}
 
 /// Build a fresh in-memory `rusqlite::Connection` so each test gets a
 /// clean DB state for the live-count overlays.
@@ -104,9 +120,16 @@ fn cap_v3_legacy_entry_point_refuses_v3() {
 fn cap_v3_response_carries_schema_version_and_summary() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
-    let val =
-        handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), &Profile::core())
-            .expect("v3 capabilities serialize");
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
 
     assert_eq!(
         val["schema_version"], "3",
@@ -202,7 +225,11 @@ fn cap_v3_summary_graph_profile_counts() {
 fn cap_v3_struct_round_trips_through_serde() {
     let tier_config = semantic_tier();
     let caps: Capabilities = tier_config.capabilities();
-    let v3 = caps.to_v3("hello operator".to_string(), "hello human".to_string());
+    let v3 = caps.to_v3(
+        "hello operator".to_string(),
+        "hello human".to_string(),
+        Vec::new(),
+    );
 
     let json = serde_json::to_value(&v3).expect("serialize v3");
     let back: CapabilitiesV3 = serde_json::from_value(json.clone()).expect("deserialize v3");
@@ -230,9 +257,16 @@ fn cap_v3_struct_round_trips_through_serde() {
 fn cap_v3_response_carries_to_describe_to_user() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
-    let val =
-        handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), &Profile::core())
-            .expect("v3 capabilities serialize");
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
 
     let describe = val["to_describe_to_user"]
         .as_str()
@@ -345,6 +379,8 @@ fn cap_v3_preserves_v2_sub_blocks() {
         true, // embedder loaded
         Some(&conn),
         &Profile::full(),
+        None,
+        None,
     )
     .expect("v3 capabilities serialize");
 
@@ -378,4 +414,154 @@ fn cap_v3_v2_callers_unaffected_by_a1() {
         val.get("summary").is_none(),
         "v2 must not gain the v3 summary field"
     );
+    assert!(
+        val.get("to_describe_to_user").is_none(),
+        "v2 must not gain the v3 to_describe_to_user field"
+    );
+    assert!(
+        val.get("tools").is_none(),
+        "v2 must not gain the v3 tools array"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 matrix cell — allowlist OFF, loaded TRUE → callable_now=TRUE.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a3_allowlist_off_loaded_true_callable_now_true() {
+    let tools = build_capabilities_tools(&Profile::core(), None, None);
+    let entry = tools
+        .iter()
+        .find(|t| t.name == "memory_store")
+        .expect("memory_store present");
+    assert!(entry.loaded, "core profile loads memory_store");
+    assert!(
+        entry.callable_now,
+        "allowlist OFF + loaded TRUE → callable_now must be TRUE; got {entry:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 matrix cell — allowlist OFF, loaded FALSE → callable_now=FALSE.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a3_allowlist_off_loaded_false_callable_now_false() {
+    let tools = build_capabilities_tools(&Profile::core(), None, None);
+    let entry = tools
+        .iter()
+        .find(|t| t.name == "memory_kg_query")
+        .expect("memory_kg_query present in manifest even when not loaded");
+    assert!(!entry.loaded, "core profile does NOT load memory_kg_query");
+    assert!(
+        !entry.callable_now,
+        "allowlist OFF + loaded FALSE → callable_now must be FALSE; got {entry:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 matrix cell — allowlist ON, agent in pattern, loaded TRUE →
+// callable_now=TRUE.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a3_allowlist_on_agent_in_pattern_callable_now_true() {
+    // Allowlist grants "alice" the core family.
+    let cfg = allowlist(&[("alice", &["core"]), ("*", &["core"])]);
+    let tools = build_capabilities_tools(&Profile::core(), Some(&cfg), Some("alice"));
+    let entry = tools
+        .iter()
+        .find(|t| t.name == "memory_store")
+        .expect("memory_store present");
+    assert!(entry.loaded);
+    assert!(
+        entry.callable_now,
+        "allowlist ON + agent in pattern + loaded TRUE → callable_now TRUE; got {entry:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 matrix cell — allowlist ON, agent NOT in pattern, loaded TRUE →
+// callable_now=FALSE.
+//
+// Setup: allowlist grants "alice" the graph family, falls back to "*"
+// granting only `core`. Agent "bob" hits the wildcard and asks about
+// memory_kg_query (graph family). The graph family is loaded under
+// `Profile::full()` (so loaded=TRUE), but the wildcard rule denies bob
+// access to graph → callable_now=FALSE.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
+    let cfg = allowlist(&[("alice", &["graph"]), ("*", &["core"])]);
+    let tools = build_capabilities_tools(&Profile::full(), Some(&cfg), Some("bob"));
+    let entry = tools
+        .iter()
+        .find(|t| t.name == "memory_kg_query")
+        .expect("memory_kg_query present");
+    assert!(entry.loaded, "full profile loads memory_kg_query");
+    assert!(
+        !entry.callable_now,
+        "allowlist ON + agent NOT in pattern + loaded TRUE → callable_now FALSE; got {entry:?}"
+    );
+
+    // Sanity check: the same agent IS allowed core tools per the
+    // wildcard, so memory_store should still be callable.
+    let core_entry = tools
+        .iter()
+        .find(|t| t.name == "memory_store")
+        .expect("memory_store present");
+    assert!(core_entry.loaded);
+    assert!(
+        core_entry.callable_now,
+        "wildcard grants core to bob → memory_store callable_now TRUE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 — the v3 response surfaces the `tools` array at the top level
+// with one entry per registered tool (43 + always-on bootstrap counted
+// once = 43, since the bootstrap already lives in Family::Meta).
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_response_carries_tools_array_with_43_entries() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::full(),
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
+
+    let tools = val["tools"]
+        .as_array()
+        .expect("top-level tools must be present and an array under v3");
+    assert_eq!(
+        tools.len(),
+        43,
+        "v3 must surface all 43 tools regardless of profile; got {}",
+        tools.len()
+    );
+
+    // Every entry must have name + family + loaded + callable_now.
+    for entry in tools {
+        assert!(entry["name"].is_string(), "tool entry needs name: {entry}");
+        assert!(entry["family"].is_string(), "tool entry needs family");
+        assert!(entry["loaded"].is_boolean(), "tool entry needs loaded bool");
+        assert!(
+            entry["callable_now"].is_boolean(),
+            "tool entry needs callable_now bool"
+        );
+    }
+
+    // Spot-check that under --profile full + no allowlist, every tool
+    // is callable_now.
+    for entry in tools {
+        assert!(
+            entry["callable_now"].as_bool().unwrap(),
+            "full profile + no allowlist → every tool callable_now: {entry}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A3 of the v0.7.0 `attested-cortex` epic. Adds the third top-level v3 field: a `tools` array carrying `{name, family, loaded, callable_now}` per registered tool. `callable_now` combines the profile-side loaded-state with the existing `[mcp.allowlist]` agent gate so an LLM that caches the v3 manifest can skip a doomed JSON-RPC call instead of discovering -32601 the hard way.

When the allowlist is disabled (no `[mcp.allowlist]` table or empty table), `callable_now == loaded`. When the allowlist is active and the requesting agent has no entry granting the tool's family, `callable_now == false` even though `loaded == true`.

### What landed

- **`config.rs`** — new `ToolEntry` struct (name, family, loaded, callable_now); added `tools: Vec<ToolEntry>` to CapabilitiesV3; `to_v3` now takes `(summary, describe, tools)`.
- **`mcp.rs`** — new `build_capabilities_tools(profile, mcp_config, agent_id)` builder. Iterates `Family::all()` in registration order. **Reuses** existing `McpConfig::allowlist_decision` (no duplicate gate logic). `handle_capabilities_with_conn_v3` now takes optional `mcp_config` + `agent_id`; dispatch site threads the active `McpConfig` + the `arguments.agent_id`-or-`clientInfo.name` fallback per the existing family-listing pattern.
- **`tests/capabilities_v3.rs`** — 5 new contract tests (4 matrix cells — allowlist OFF×loaded {T,F} and allowlist ON×agent {in,out} — plus a 43-entries shape test). v2-callers test extended to assert no `tools` leakage.
- **`tests/calibration_t0.rs`** — signature-bumped (None, None for allowlist+agent_id since calibration cells exercise the no-allowlist baseline).

### Backward compat

v2 wire shape unchanged. A4 will add `agent_permitted_families`. A5 flips the default to v3.

### Test plan

- [x] `cargo test --test capabilities_v3` → 19/19 green
- [x] `cargo test --test calibration_t0` → 6/6 green
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo fmt --check` clean

Refs #545.