### PR TITLE
feat: v0.7-a4 — capabilities v3 agent_permitted_families (#545)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -716,7 +716,7 @@ impl Capabilities {
         }
     }
 
-    /// v0.7.0 (A1+A2+A3): project the report into the v3 shape.
+    /// v0.7.0 (A1+A2+A3+A4): project the report into the v3 shape.
     ///
     /// v3 = v2 +
     ///   - top-level `summary` (A1) — terse description of operational
@@ -730,27 +730,35 @@ impl Capabilities {
     ///     `[mcp.allowlist]` agent-can-call decision so an LLM that
     ///     keeps a manifest cache doesn't need to ask twice to know
     ///     whether a tool will resolve.
+    ///   - top-level `agent_permitted_families` (A4, optional) — when
+    ///     the `[mcp.allowlist]` is enabled AND an `agent_id` is
+    ///     provided, lists the family names the requesting agent is
+    ///     allowed to access (collapses every callable_now=true entry's
+    ///     family to a unique list). When the allowlist is disabled or
+    ///     no agent_id is provided, the field is omitted from the wire
+    ///     (so v2-shaped consumers see no churn from A4 alone).
     ///
-    /// All three are computed by the caller from the live `Profile` +
+    /// All four are computed by the caller from the live `Profile` +
     /// `McpConfig` + `agent_id` state because the [`Capabilities`]
     /// struct itself doesn't know which families the MCP server
     /// actually advertised or which agent is asking.
     ///
-    /// Future v0.7.0 increment (A4) extends this struct with
-    /// `agent_permitted_families`. A5 bumps the default wire shape to
-    /// v3. v2 stays supported indefinitely.
+    /// A5 bumps the default wire shape to v3. v2 stays supported
+    /// indefinitely.
     #[must_use]
     pub fn to_v3(
         &self,
         summary: String,
         to_describe_to_user: String,
         tools: Vec<ToolEntry>,
+        agent_permitted_families: Option<Vec<String>>,
     ) -> CapabilitiesV3 {
         CapabilitiesV3 {
             schema_version: "3".to_string(),
             summary,
             to_describe_to_user,
             tools,
+            agent_permitted_families,
             tier: self.tier.clone(),
             version: self.version.clone(),
             features: self.features.clone(),
@@ -845,6 +853,19 @@ pub struct CapabilitiesV3 {
     /// `tool_definitions()`'s registration walk so a sequential reader
     /// gets a stable presentation.
     pub tools: Vec<ToolEntry>,
+
+    /// v0.7.0 A4 — list of family names this agent is permitted to
+    /// access via the `[mcp.allowlist]` gate. Present (with possibly
+    /// an empty array) only when the allowlist is configured AND an
+    /// `agent_id` was provided. Absent when the allowlist is disabled
+    /// or no agent_id was provided — that absence is meaningful, not a
+    /// drift, hence `Option<Vec<String>>` + `skip_serializing_if`.
+    ///
+    /// LLMs that keep a per-agent manifest cache can use this to
+    /// short-circuit family-level decisions without iterating
+    /// `tools[]` and counting unique families.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_permitted_families: Option<Vec<String>>,
 
     pub tier: String,
     pub version: String,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1828,7 +1828,8 @@ pub fn handle_capabilities_with_conn_v3(
     let summary = build_capabilities_summary(profile);
     let describe = build_capabilities_describe_to_user(profile);
     let tools = build_capabilities_tools(profile, mcp_config, agent_id);
-    serde_json::to_value(caps.to_v3(summary, describe, tools)).map_err(|e| e.to_string())
+    let permitted = build_agent_permitted_families(mcp_config, agent_id);
+    serde_json::to_value(caps.to_v3(summary, describe, tools, permitted)).map_err(|e| e.to_string())
 }
 
 /// Build the runtime-overlaid [`Capabilities`] document. Shared between
@@ -2079,6 +2080,55 @@ pub fn build_capabilities_tools(
     }
 
     entries
+}
+
+/// v0.7.0 A4 — compute the optional `agent_permitted_families` field
+/// for a v3 capabilities response.
+///
+/// Returns:
+/// - `Some(Vec<...>)` (possibly empty) when `[mcp.allowlist]` is
+///   configured AND an `agent_id` was provided. The vector lists the
+///   canonical family names the agent is permitted to access (per the
+///   `Family::all()` registration order).
+/// - `None` when the allowlist is disabled (no table, empty table, or
+///   `mcp_config = None`) OR when no `agent_id` was provided.
+///   `serde(skip_serializing_if = "Option::is_none")` on the field
+///   means a `None` value drops the field from the wire entirely so
+///   v2-shaped consumers don't see drift from A4 alone.
+///
+/// The wildcard pattern `"*"` participates in the per-family
+/// allowlist_decision call — this matches the existing v0.6.4-008
+/// resolution semantics, so a `"*" = ["core"]` row grants every agent
+/// access to `core` even when their explicit row is missing.
+#[must_use]
+pub fn build_agent_permitted_families(
+    mcp_config: Option<&crate::config::McpConfig>,
+    agent_id: Option<&str>,
+) -> Option<Vec<String>> {
+    use crate::config::AllowlistDecision;
+    use crate::profile::Family;
+
+    // A4 spec: omit the field when allowlist disabled OR no agent_id.
+    let cfg = mcp_config?;
+    let aid = agent_id?;
+    let table = cfg.allowlist.as_ref()?;
+    if table.is_empty() {
+        // Allowlist Disabled (per the v0.6.4-008 contract): omit.
+        return None;
+    }
+
+    let permitted: Vec<String> = Family::all()
+        .iter()
+        .filter(|fam| {
+            matches!(
+                cfg.allowlist_decision(Some(aid), fam.name()),
+                AllowlistDecision::Allow
+            )
+        })
+        .map(|fam| fam.name().to_string())
+        .collect();
+
+    Some(permitted)
 }
 
 /// Return a stable label for a profile's summary string. Named profiles

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -32,8 +32,9 @@
 
 use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, McpConfig, TierConfig};
 use ai_memory::mcp::{
-    CapabilitiesAccept, build_capabilities_describe_to_user, build_capabilities_summary,
-    build_capabilities_tools, handle_capabilities_with_conn, handle_capabilities_with_conn_v3,
+    CapabilitiesAccept, build_agent_permitted_families, build_capabilities_describe_to_user,
+    build_capabilities_summary, build_capabilities_tools, handle_capabilities_with_conn,
+    handle_capabilities_with_conn_v3,
 };
 use ai_memory::profile::Profile;
 use serde_json::Value;
@@ -229,6 +230,7 @@ fn cap_v3_struct_round_trips_through_serde() {
         "hello operator".to_string(),
         "hello human".to_string(),
         Vec::new(),
+        None,
     );
 
     let json = serde_json::to_value(&v3).expect("serialize v3");
@@ -564,4 +566,118 @@ fn cap_v3_response_carries_tools_array_with_43_entries() {
             "full profile + no allowlist → every tool callable_now: {entry}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// A4 case 1 — allowlist disabled (no McpConfig OR empty table) →
+// `agent_permitted_families` is OMITTED from the v3 response.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a4_allowlist_disabled_omits_field() {
+    // Sub-case A: mcp_config = None.
+    assert_eq!(build_agent_permitted_families(None, Some("alice")), None);
+    assert_eq!(build_agent_permitted_families(None, None), None);
+
+    // Sub-case B: empty allowlist table → Disabled per the v0.6.4-008
+    // contract → omit.
+    let cfg = McpConfig {
+        profile: None,
+        allowlist: Some(HashMap::new()),
+    };
+    assert_eq!(
+        build_agent_permitted_families(Some(&cfg), Some("alice")),
+        None,
+        "empty allowlist table = disabled = omit field"
+    );
+
+    // Sub-case C: full v3 response with allowlist disabled must NOT
+    // include the field on the wire (skip_serializing_if).
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        Some("alice"),
+    )
+    .expect("v3 capabilities serialize");
+    assert!(
+        val.get("agent_permitted_families").is_none(),
+        "allowlist disabled → field must be absent on wire; got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A4 case 2 — allowlist enabled with agent → field carries the family
+// names the agent is permitted to access.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a4_allowlist_with_agent_lists_families() {
+    let cfg = allowlist(&[
+        ("alice", &["core", "graph"]),
+        ("bob", &["core"]),
+        ("*", &["core"]),
+    ]);
+    // alice → core + graph
+    let alice = build_agent_permitted_families(Some(&cfg), Some("alice")).unwrap();
+    assert_eq!(alice, vec!["core".to_string(), "graph".to_string()]);
+
+    // bob → core only (his explicit row wins over the wildcard)
+    let bob = build_agent_permitted_families(Some(&cfg), Some("bob")).unwrap();
+    assert_eq!(bob, vec!["core".to_string()]);
+
+    // unknown agent → wildcard fallback (core only)
+    let unknown = build_agent_permitted_families(Some(&cfg), Some("eve")).unwrap();
+    assert_eq!(unknown, vec!["core".to_string()]);
+
+    // The field round-trips on the wire.
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::full(),
+        Some(&cfg),
+        Some("alice"),
+    )
+    .expect("v3 capabilities serialize");
+    let permitted = val["agent_permitted_families"]
+        .as_array()
+        .expect("agent_permitted_families must be present when allowlist enabled + agent_id given");
+    let names: Vec<&str> = permitted.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(names, vec!["core", "graph"]);
+}
+
+// ---------------------------------------------------------------------------
+// A4 case 3 — allowlist enabled but no agent_id → field omitted (the
+// v0.6.4-008 default for an unknown caller is restrictive, but A4's
+// contract is "tell the caller what they're allowed only when the
+// caller identified themselves" — present absence is the signal).
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_a4_allowlist_no_agent_id_omits_field() {
+    let cfg = allowlist(&[("alice", &["core"]), ("*", &["core"])]);
+    assert_eq!(build_agent_permitted_families(Some(&cfg), None), None);
+
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        Some(&cfg),
+        None, // no agent_id
+    )
+    .expect("v3 capabilities serialize");
+    assert!(
+        val.get("agent_permitted_families").is_none(),
+        "no agent_id → field must be absent even with allowlist enabled; got: {val}"
+    );
 }


### PR DESCRIPTION
## Summary

A4 of the v0.7.0 `attested-cortex` epic. Adds the optional top-level `agent_permitted_families` array to v3:

- Present (with possibly an empty array) when `[mcp.allowlist]` is configured AND an `agent_id` is provided. Lists the canonical family names the requesting agent is permitted to access (per `Family::all()` registration order).
- Absent when the allowlist is disabled (no table, empty table, or `mcp_config = None`) OR when no `agent_id` is provided. `serde(skip_serializing_if = "Option::is_none")` drops it from the wire entirely so v2-shaped consumers see no churn from A4 alone.

LLMs that keep a per-agent manifest cache can use this to short-circuit family-level decisions without iterating `tools[]` and counting unique families.

### What landed

- **`config.rs`** — added `Option<Vec<String>> agent_permitted_families` to CapabilitiesV3 with `skip_serializing_if`; `to_v3` signature now `(summary, describe, tools, agent_permitted_families)`.
- **`mcp.rs`** — new `build_agent_permitted_families(mcp_config, agent_id)` helper. Reuses existing `McpConfig::allowlist_decision` (no duplicate gate logic). `handle_capabilities_with_conn_v3` now computes + threads the field.
- **`tests/capabilities_v3.rs`** — 3 new contract tests covering all three A4 cases (disabled / enabled-with-agent / enabled-no-agent), each with both unit and wire-shape assertions.

### Backward compat

v2 wire shape unchanged. A5 will flip the default to v3.

### Test plan

- [x] `cargo test --test capabilities_v3` → 22/22 green
- [x] `cargo test --test calibration_t0` → 6/6 green
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo fmt --check` clean

Refs #545.