### PR TITLE
feat: v0.7-j1 — AGE detection in Postgres SAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at the memory operation points — that's G3-G11. New round-trip JSON
   tests cover all 20 variants and one representative payload per
   family.
+- **v0.7.0 J1 — Apache AGE detection in Postgres SAL.** New
+  `KgBackend { Cte, Age }` enum (snake-case serde) lives at
+  `src/store/mod.rs`; the Postgres adapter probes
+  `SELECT 1 FROM pg_extension WHERE extname='age'` at connect time and
+  records the resolved tag on the `PostgresStore` handle. AGE is
+  opt-in: a missing extension OR a probe error falls back to
+  `KgBackend::Cte` (logged at `debug`, never blocks bootstrap). The
+  resolved backend is exposed via `PostgresStore::kg_backend()` so
+  Track J's downstream tasks (J2 `kg_query`, J3 `kg_timeline`,
+  J4 `kg_invalidate`, J7 `find_paths`) can dispatch on it. Added an
+  optional `kg_backend: Option<String>` field on the v2 + v3
+  `Capabilities` documents (skipped from the JSON wire when `None`)
+  so `ai-memory doctor` and `memory_capabilities` can surface the
+  active path once the SAL adapter is threaded through `AppState` in
+  J2. Substrate only — no behavioural change to existing
+  `memory_kg_*` MCP tools in this PR. New tests: 4 unit
+  (snake-case wire shape, default tag pin, accessor wiring) plus 3
+  live tests gated on `AI_MEMORY_TEST_AGE_URL` /
+  `AI_MEMORY_TEST_POSTGRES_URL`.
 - **v0.7.0 K2 — `pending_actions` timeout sweeper.** Closes the
   v0.6.3.1 honest-Capabilities-v2 disclosure that
   `default_timeout_seconds` was advertised in v1 but unused. Schema

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,12 @@ impl TierConfig {
             },
             transcripts: CapabilityTranscripts::planned(),
             hnsw: CapabilityHnsw::default(),
+            // v0.7 J1 — populated by the SAL wrapper at runtime when a
+            // Postgres adapter is active. None at config-construction
+            // time (no SAL handle here); the MCP/HTTP wrapper overlays
+            // the live tag from `PostgresStore::kg_backend()` once
+            // J2 wires the SAL into AppState.
+            kg_backend: None,
         }
     }
 }
@@ -341,6 +347,19 @@ pub struct Capabilities {
     /// has run an eviction.
     #[serde(default)]
     pub hnsw: CapabilityHnsw,
+
+    /// v0.7 J1 — knowledge-graph backend tag. `"age"` when a Postgres
+    /// SAL adapter probed Apache AGE successfully at connect time;
+    /// `"cte"` when the deployment falls back to the recursive-CTE
+    /// path (every SQLite deployment + Postgres without AGE
+    /// installed). `None` when no SAL adapter is wired (the active
+    /// dispatch path through the legacy `crate::db` free functions
+    /// pre-J2). Operators consult this through `ai-memory doctor` and
+    /// `memory_capabilities` to verify which traversal path their
+    /// daemon actually runs. Skipped from the JSON wire when `None`
+    /// so v1 / v2 clients that don't know the field round-trip cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kg_backend: Option<String>,
 }
 
 /// Live recall-mode tag (P1 honesty patch). Reflects the *runtime*
@@ -769,6 +788,10 @@ impl Capabilities {
             approval: self.approval.clone(),
             transcripts: self.transcripts.clone(),
             hnsw: self.hnsw.clone(),
+            // v0.7 J1 — propagate the resolved KG backend tag verbatim.
+            // None when no SAL adapter is wired (every pre-J2 build);
+            // `Some("age" | "cte")` once the SAL handle is threaded.
+            kg_backend: self.kg_backend.clone(),
         }
     }
 }
@@ -879,6 +902,14 @@ pub struct CapabilitiesV3 {
 
     #[serde(default)]
     pub hnsw: CapabilityHnsw,
+
+    /// v0.7 J1 — knowledge-graph backend tag forwarded from the v2
+    /// projection. `Some("age" | "cte")` once the SAL handle is
+    /// threaded through `AppState`; `None` while no SAL adapter is
+    /// wired. Skipped from the JSON wire when `None` so older clients
+    /// that don't know the field round-trip cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kg_backend: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1938,6 +1969,14 @@ mod tests {
         assert_eq!(val["features"]["recall_mode_active"], "disabled");
         assert_eq!(val["features"]["reranker_active"], "off");
 
+        // v0.7 J1 — kg_backend zero-state: no SAL adapter wired yet,
+        // so the field is None and elided from the JSON wire. Older
+        // clients that don't know the field round-trip cleanly.
+        assert!(
+            val.get("kg_backend").is_none(),
+            "kg_backend must be skipped from JSON when None (pre-J2 zero-state)"
+        );
+
         // Round-trip back to a typed Capabilities and confirm field
         // identity (proves Deserialize works for all reshaped structs).
         let restored: Capabilities = serde_json::from_value(val).unwrap();
@@ -1947,6 +1986,28 @@ mod tests {
         assert!(restored.transcripts.status.planned);
         assert_eq!(restored.features.recall_mode_active, RecallMode::Disabled);
         assert_eq!(restored.features.reranker_active, RerankerMode::Off);
+        assert!(restored.kg_backend.is_none());
+    }
+
+    /// v0.7 J1 — when a SAL adapter populates `kg_backend`, the wire
+    /// shape must serialise the literal snake-case tag and round-trip
+    /// cleanly. Operators read this through `ai-memory doctor` and
+    /// `memory_capabilities` to verify which traversal path their
+    /// daemon actually runs.
+    #[test]
+    fn capabilities_kg_backend_serialises_when_set() {
+        let mut caps = FeatureTier::Keyword.config().capabilities();
+        caps.kg_backend = Some("age".to_string());
+        let val: serde_json::Value = serde_json::to_value(&caps).unwrap();
+        assert_eq!(val["kg_backend"], "age");
+
+        caps.kg_backend = Some("cte".to_string());
+        let val: serde_json::Value = serde_json::to_value(&caps).unwrap();
+        assert_eq!(val["kg_backend"], "cte");
+
+        // Round-trip the populated field for Deserialize coverage.
+        let restored: Capabilities = serde_json::from_value(val).unwrap();
+        assert_eq!(restored.kg_backend.as_deref(), Some("cte"));
     }
 
     /// P1 honesty patch: legacy v1 projection preserves the old shape

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -55,8 +55,52 @@ pub mod sqlite;
 pub mod postgres;
 
 use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
 
 use crate::models::{AgentRegistration, Memory, MemoryLink, Tier};
+
+/// Knowledge-graph backend resolved at adapter init.
+///
+/// v0.7 Track J substrate: Postgres adapters detect Apache AGE at
+/// connect time and dispatch knowledge-graph traversals (J2 `kg_query`,
+/// J3 `kg_timeline`, J4 `kg_invalidate`, J7 `find_paths`) on the
+/// resolved value. SQLite-class adapters always report
+/// [`KgBackend::Cte`] — they fall back to the recursive-CTE path that
+/// has been the production wire-format since v0.6.3.
+///
+/// Wire shape: serialised as snake-case (`"age"` / `"cte"`) to match
+/// the `kg_backend` field projected through `memory_capabilities` and
+/// `ai-memory doctor`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KgBackend {
+    /// Recursive-CTE traversal over `memory_links`. The default path
+    /// for SQLite and for Postgres deployments without Apache AGE.
+    Cte,
+    /// Apache AGE Cypher traversal over the `memory_graph` projection.
+    /// Resolved when the Postgres adapter detects the `age` extension
+    /// installed at connect time.
+    Age,
+}
+
+impl KgBackend {
+    /// Stable string tag for logs, capabilities surface, and the
+    /// `ai-memory doctor` report. Mirrors the snake-case serde rename
+    /// above so the wire and log shapes never drift.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cte => "cte",
+            Self::Age => "age",
+        }
+    }
+}
+
+impl std::fmt::Display for KgBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// The single error type returned by every `MemoryStore` method.
 ///
@@ -356,5 +400,33 @@ mod tests {
         assert!(f.namespace.is_none());
         assert!(f.tier.is_none());
         assert!(f.tags_any.is_empty());
+    }
+
+    #[test]
+    fn kg_backend_serializes_snake_case() {
+        // Wire-shape contract: `kg_backend` is always projected as the
+        // lowercase tag so the capabilities surface, doctor report, and
+        // log lines can never drift from the enum.
+        let cte = serde_json::to_string(&KgBackend::Cte).unwrap();
+        let age = serde_json::to_string(&KgBackend::Age).unwrap();
+        assert_eq!(cte, "\"cte\"");
+        assert_eq!(age, "\"age\"");
+
+        // Round-trip via deserialize so the same strings parse back.
+        let cte_round: KgBackend = serde_json::from_str("\"cte\"").unwrap();
+        let age_round: KgBackend = serde_json::from_str("\"age\"").unwrap();
+        assert_eq!(cte_round, KgBackend::Cte);
+        assert_eq!(age_round, KgBackend::Age);
+    }
+
+    #[test]
+    fn kg_backend_as_str_matches_display() {
+        // `Display` and `as_str` must agree — log lines and the doctor
+        // report use whichever is closer to hand and must produce the
+        // same bytes.
+        assert_eq!(KgBackend::Cte.as_str(), "cte");
+        assert_eq!(KgBackend::Age.as_str(), "age");
+        assert_eq!(format!("{}", KgBackend::Cte), "cte");
+        assert_eq!(format!("{}", KgBackend::Age), "age");
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -52,8 +52,8 @@ use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{PgPool, Row};
 
 use super::{
-    CallerContext, Capabilities, Filter, MemoryStore, StoreError, StoreResult, UpdatePatch,
-    VerifyReport,
+    CallerContext, Capabilities, Filter, KgBackend, MemoryStore, StoreError, StoreResult,
+    UpdatePatch, VerifyReport,
 };
 use crate::models::{AgentRegistration, Memory, MemoryLink, Tier};
 
@@ -74,6 +74,12 @@ const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub struct PostgresStore {
     pool: PgPool,
+    /// Resolved knowledge-graph backend tag — set at [`Self::connect`]
+    /// time by probing `pg_extension` for Apache AGE. Substrate for
+    /// Track J: J2-J7 dispatch their KG queries on this value, falling
+    /// back to the recursive-CTE path when AGE is absent. See
+    /// [`Self::kg_backend`].
+    kg_backend: KgBackend,
 }
 
 impl PostgresStore {
@@ -156,11 +162,40 @@ impl PostgresStore {
             );
         }
 
+        // v0.7 J1 — detect Apache AGE so Track J can dispatch
+        // knowledge-graph traversals through Cypher when the extension
+        // is installed. Falls back to the recursive-CTE path on
+        // missing extension OR query error: AGE is opt-in, never a
+        // bootstrap blocker. The resolved tag is surfaced on the SAL
+        // handle via [`Self::kg_backend`] for J2-J7.
+        let kg_backend = detect_kg_backend(&pool).await;
+        tracing::info!(
+            target = "store::postgres",
+            kg_backend = %kg_backend,
+            "Postgres KG backend: {}",
+            match kg_backend {
+                KgBackend::Age => "AGE",
+                KgBackend::Cte => "CTE",
+            }
+        );
+
         // Run schema migrations after bootstrap schema is loaded.
-        let store = Self { pool };
+        let store = Self { pool, kg_backend };
         store.migrate().await?;
 
         Ok(store)
+    }
+
+    /// Knowledge-graph backend resolved at [`Self::connect`] time.
+    ///
+    /// v0.7 J1 substrate. J2-J7 dispatch on this value so the same
+    /// `memory_kg_*` MCP wire shape can route to either Cypher (when
+    /// AGE is installed) or the recursive-CTE fallback. The resolution
+    /// is sticky for the life of the pool — adapters do not re-probe
+    /// per call.
+    #[must_use]
+    pub fn kg_backend(&self) -> KgBackend {
+        self.kg_backend
     }
 
     /// Run schema migrations on the connection. Called after bootstrap schema
@@ -421,6 +456,35 @@ fn to_store_err(what: &str, e: sqlx::Error) -> StoreError {
     StoreError::BackendUnavailable {
         backend: "postgres".to_string(),
         detail: format!("{what}: {e}"),
+    }
+}
+
+/// v0.7 J1 — probe Apache AGE.
+///
+/// Runs `SELECT 1 FROM pg_extension WHERE extname = 'age'` against the
+/// pool and reports the resolved [`KgBackend`]. Errors are *not*
+/// surfaced — a transient probe failure (replica lag, permissions on
+/// `pg_extension` in a hardened deployment) MUST NOT block adapter
+/// bootstrap. We log a debug line and fall back to
+/// [`KgBackend::Cte`] which every Postgres install supports.
+///
+/// Factored out of [`PostgresStore::connect`] so unit tests can hit
+/// the SQL builder branch without standing up a real Postgres pool.
+pub(crate) async fn detect_kg_backend(pool: &PgPool) -> KgBackend {
+    match sqlx::query_scalar::<_, i32>("SELECT 1 FROM pg_extension WHERE extname = 'age'")
+        .fetch_optional(pool)
+        .await
+    {
+        Ok(Some(_)) => KgBackend::Age,
+        Ok(None) => KgBackend::Cte,
+        Err(e) => {
+            tracing::debug!(
+                target = "store::postgres",
+                error = %e,
+                "AGE detection probe failed; defaulting to CTE backend"
+            );
+            KgBackend::Cte
+        }
     }
 }
 
@@ -779,6 +843,91 @@ mod tests {
         // Verify the schema_version table is created for migration tracking.
         assert!(INIT_SCHEMA.contains("CREATE TABLE IF NOT EXISTS schema_version"));
         assert!(INIT_SCHEMA.contains("version    INTEGER PRIMARY KEY"));
+    }
+
+    // ------------------------------------------------------------------
+    // v0.7 J1 — AGE detection unit + live tests.
+    //
+    // The pool-less unit tests here only exercise the static surface
+    // (default tag, accessor wiring through the type) so they can run
+    // on any host. The live AGE probe runs iff `AI_MEMORY_TEST_AGE_URL`
+    // is set; otherwise it skips cleanly. CI configures the env var
+    // for the AGE-postgres job (see Track J5 plan).
+    // ------------------------------------------------------------------
+
+    fn age_url() -> Option<String> {
+        std::env::var("AI_MEMORY_TEST_AGE_URL").ok()
+    }
+
+    #[test]
+    fn kg_backend_default_tag_is_cte() {
+        // Substrate sanity: the fallback path is `Cte`. J2-J7 dispatch
+        // on this — flipping the default would silently route every
+        // SQLite-class deployment through Cypher and crash on first
+        // call. Pin the default so a future refactor can't drift it.
+        assert_eq!(KgBackend::Cte.as_str(), "cte");
+        assert_eq!(KgBackend::Age.as_str(), "age");
+    }
+
+    #[tokio::test]
+    async fn live_kg_backend_resolves_to_age_when_extension_present() {
+        // Runs against a real AGE-enabled Postgres ONLY when
+        // AI_MEMORY_TEST_AGE_URL is set. Skips cleanly otherwise so
+        // the default `cargo test` flow stays offline. Contract: the
+        // SAL handle must report `KgBackend::Age` against this URL.
+        let Some(url) = age_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_AGE_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        assert_eq!(
+            store.kg_backend(),
+            KgBackend::Age,
+            "AGE-enabled Postgres must resolve to KgBackend::Age"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_kg_backend_resolves_to_cte_without_age() {
+        // Runs against a Postgres WITHOUT the AGE extension installed.
+        // CI may set AI_MEMORY_TEST_POSTGRES_URL to a vanilla pgvector
+        // Postgres while AI_MEMORY_TEST_AGE_URL points at the AGE
+        // image — when the vanilla URL is set and AGE is NOT, we get
+        // a real-Postgres-real-fallback assertion. Skips cleanly
+        // otherwise.
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        // If the operator points the same URL at both, this assertion
+        // would be wrong — guard with an early-skip when AGE_URL == URL.
+        if age_url().as_deref() == Some(url.as_str()) {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL points at the AGE fixture");
+            return;
+        }
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        assert_eq!(
+            store.kg_backend(),
+            KgBackend::Cte,
+            "Postgres without AGE must resolve to KgBackend::Cte"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_detect_kg_backend_returns_cte_on_missing_extension() {
+        // Same fallback assertion through the lower-level helper,
+        // which J2-J7 will reach when they want to re-probe (e.g.
+        // post-CREATE EXTENSION operator action). Skips cleanly when
+        // no Postgres URL is set.
+        let Some(url) = postgres_url() else {
+            return;
+        };
+        if age_url().as_deref() == Some(url.as_str()) {
+            return;
+        }
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let probed = detect_kg_backend(&store.pool).await;
+        assert_eq!(probed, KgBackend::Cte);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Track J task J1 of v0.7.0 attested-cortex epic. Substrate for J2-J8.

## Summary
- New `KgBackend { Cte, Age }` (snake-case serde) lives at `src/store/mod.rs`; the Postgres adapter probes `SELECT 1 FROM pg_extension WHERE extname='age'` at connect time and records the resolved tag on the `PostgresStore` handle.
- AGE is opt-in: a missing extension OR a probe error falls back to `KgBackend::Cte` (logged at `debug`, never blocks bootstrap).
- Surfaced on the SAL handle via `PostgresStore::kg_backend()` so J2-J7 dispatch can route through Cypher when AGE is present.
- Added an optional `kg_backend: Option<String>` field on the v2 + v3 `Capabilities` documents (skipped when `None`) so `ai-memory doctor` and `memory_capabilities` can surface the active path once the SAL handle is threaded through `AppState` in J2.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` (default features) clean with `-D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo clippy --features sal-postgres` clean with the same lint set
- [x] Unit tests for both backend resolutions (snake-case wire shape, `Display`/`as_str` parity, default-tag pin)
- [x] Live Postgres tests gated on `AI_MEMORY_TEST_AGE_URL` / `AI_MEMORY_TEST_POSTGRES_URL` (skip cleanly when env unset)
- [x] `cargo test --lib` (default features): 1986 passed, no regression
- [x] `cargo test --features sal-postgres --lib`: 2021 passed
- [ ] J2-J4 dispatch on this; J5 tests parity