### PR TITLE
feat: v0.7-a5 — bump capabilities default to v3 (#545)

### DIFF
--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1270,6 +1270,16 @@ pub async fn bootstrap_serve(
         }
     }
 
+    // v0.7.0 A5 — resolve the effective MCP tool profile for the HTTP
+    // path so `/capabilities` v3 reports honest loaded/total counts.
+    // Mirrors the MCP-mode resolution at src/daemon_runtime.rs:501;
+    // unresolvable profile (e.g., bad config.toml) falls back to
+    // Profile::core() rather than blocking HTTP boot.
+    let resolved_profile = app_config
+        .effective_profile(None)
+        .unwrap_or_else(|_| crate::profile::Profile::core());
+    let mcp_config_for_http = app_config.mcp.clone();
+
     let app_state = AppState {
         db: db_state.clone(),
         embedder: Arc::new(embedder),
@@ -1277,6 +1287,8 @@ pub async fn bootstrap_serve(
         federation: Arc::new(federation),
         tier_config: Arc::new(tier_config),
         scoring: Arc::new(app_config.effective_scoring()),
+        profile: Arc::new(resolved_profile),
+        mcp_config: Arc::new(mcp_config_for_http),
     };
 
     // Automatic GC.
@@ -1965,6 +1977,8 @@ mod tests {
             federation: Arc::new(None),
             tier_config: Arc::new(FeatureTier::Keyword.config()),
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
+            profile: Arc::new(crate::profile::Profile::core()),
+            mcp_config: Arc::new(None),
         }
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -58,6 +58,20 @@ pub struct AppState {
     /// Prior to this, HTTP recall was keyword-only regardless of
     /// embedder availability — scenario-18 surfaced the gap.
     pub scoring: Arc<crate::config::ResolvedScoring>,
+    /// v0.7.0 A5 — resolved tool [`Profile`] for this daemon. The
+    /// HTTP `/capabilities` endpoint needs it to compute the v3
+    /// `summary` / `to_describe_to_user` / `tools[].callable_now`
+    /// fields, which reflect the profile the running server actually
+    /// advertises in `tools/list`. Mirrors the MCP-dispatch threading
+    /// at `src/mcp.rs:3760`.
+    pub profile: Arc<crate::profile::Profile>,
+    /// v0.7.0 A5 — resolved [`McpConfig`] for this daemon. Carries
+    /// the optional `[mcp.allowlist]` table that v3's per-tool
+    /// `callable_now` and top-level `agent_permitted_families` honor.
+    /// `Arc<Option<...>>` rather than `Option<Arc<...>>` so cloning
+    /// the AppState stays cheap; absent allowlist (the v0.6.4 default)
+    /// shows up as `Arc<None>`.
+    pub mcp_config: Arc<Option<crate::config::McpConfig>>,
 }
 
 impl FromRef<AppState> for Db {
@@ -4155,28 +4169,40 @@ pub async fn get_capabilities(
     let accept = headers
         .get("accept-capabilities")
         .and_then(|v| v.to_str().ok())
-        .map_or(crate::mcp::CapabilitiesAccept::V2, |raw| {
+        .map_or(crate::mcp::CapabilitiesAccept::V3, |raw| {
             crate::mcp::CapabilitiesAccept::parse(raw)
         });
-    // v0.7.0 A1 — HTTP wiring for v3 lands with A5 (which threads the
-    // active `Profile` through `AppState`). Until then, downgrade
-    // `Accept-Capabilities: v3` to v2 over HTTP so a curious client
-    // doesn't 500 the endpoint. MCP callers reach v3 directly via
-    // `accept="v3"`; the HTTP path is a documented A5 gap.
-    let accept = match accept {
-        crate::mcp::CapabilitiesAccept::V3 => crate::mcp::CapabilitiesAccept::V2,
-        other => other,
-    };
+    // v0.7.0 A5 — HTTP path now serves v3 by default (A5 flips the
+    // default + threads `Profile` + `McpConfig` through `AppState`).
+    // Old clients that pinned `Accept-Capabilities: v2` keep getting
+    // the v2 shape unchanged; everyone else gets v3 (additive over
+    // v2, so reading-by-name stays compatible).
+    //
+    // v0.7.0 A4 — `agent_permitted_families` requires an `agent_id`.
+    // HTTP doesn't yet thread one (it would come from a future
+    // session-bound auth header); for now pass None and the field is
+    // omitted from the wire per the A4 contract.
     let embedder_loaded = app.embedder.as_ref().is_some();
     let lock = app.db.lock().await;
     let conn = &lock.0;
-    let result = crate::mcp::handle_capabilities_with_conn(
-        app.tier_config.as_ref(),
-        None,
-        embedder_loaded,
-        Some(conn),
-        accept,
-    );
+    let result = match accept {
+        crate::mcp::CapabilitiesAccept::V3 => crate::mcp::handle_capabilities_with_conn_v3(
+            app.tier_config.as_ref(),
+            None,
+            embedder_loaded,
+            Some(conn),
+            app.profile.as_ref(),
+            app.mcp_config.as_ref().as_ref(),
+            None,
+        ),
+        _ => crate::mcp::handle_capabilities_with_conn(
+            app.tier_config.as_ref(),
+            None,
+            embedder_loaded,
+            Some(conn),
+            accept,
+        ),
+    };
     drop(lock);
     match result {
         Ok(v) => (StatusCode::OK, Json(v)).into_response(),
@@ -5180,6 +5206,8 @@ mod tests {
             federation: Arc::new(None),
             tier_config: Arc::new(crate::config::FeatureTier::Keyword.config()),
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
+            profile: Arc::new(crate::profile::Profile::core()),
+            mcp_config: Arc::new(None),
         }
     }
 
@@ -5674,6 +5702,8 @@ mod tests {
             federation: Arc::new(Some(fed)),
             tier_config: Arc::new(crate::config::FeatureTier::Keyword.config()),
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
+            profile: Arc::new(crate::profile::Profile::core()),
+            mcp_config: Arc::new(None),
         };
         let router = Router::new()
             .route("/api/v1/memories/bulk", axum_post(bulk_create))
@@ -13165,10 +13195,15 @@ mod tests {
         let app = Router::new()
             .route("/api/v1/capabilities", axum_get(get_capabilities))
             .with_state(test_app_state(state));
+        // v0.7.0 A5: HTTP `/capabilities` defaults to v3 now; pin v2
+        // explicitly via `Accept-Capabilities` to keep this test
+        // exercising the v2 backward-compat contract. v2 wire shape
+        // stays unchanged indefinitely; this test is the proof.
         let resp = app
             .oneshot(
                 axum::http::Request::builder()
                     .uri("/api/v1/capabilities")
+                    .header("accept-capabilities", "v2")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -13362,6 +13397,8 @@ mod tests {
             federation: Arc::new(Some(fed)),
             tier_config: Arc::new(crate::config::FeatureTier::Keyword.config()),
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
+            profile: Arc::new(crate::profile::Profile::core()),
+            mcp_config: Arc::new(None),
         }
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1719,40 +1719,53 @@ pub fn handle_recall(
     Ok(resp)
 }
 
-/// Capabilities schema selector (v0.6.3.1 P1 honesty patch; extended for
-/// v0.7.0 A1).
+/// Capabilities schema selector (v0.6.3.1 P1 honesty patch; extended
+/// through v0.7.0 A1–A5).
 ///
 /// HTTP callers send `Accept-Capabilities: v1`/`v2`/`v3` to request a
 /// shape; MCP callers pass `accept: "v1"`/`"v2"`/`"v3"` to
-/// `memory_capabilities`. Default remains v2 in the A1 increment;
-/// v0.7.0 A5 will flip the default to v3 once the full A1–A4 surface
-/// is in place.
+/// `memory_capabilities`. **As of v0.7.0 A5, the default is v3.** v2
+/// stays supported indefinitely for backward compat — clients that
+/// pin v2 explicitly continue to get the v2 shape unchanged.
 ///
-/// v3 carries pre-computed calibration fields (top-level `summary` from
-/// A1; `to_describe_to_user`, per-tool `callable_now`, and
-/// `agent_permitted_families` land in A2–A4). v3 requires the live
-/// `Profile` for summary computation, so callers that opt in must reach
-/// for [`handle_capabilities_with_conn_v3`] instead of the v1/v2 entry
-/// point.
+/// v3 carries pre-computed calibration fields stacked from the A1–A4
+/// increments (top-level `summary` from A1; `to_describe_to_user`
+/// from A2; per-tool `tools[].callable_now` from A3;
+/// `agent_permitted_families` from A4). v3 is **additive** over v2 —
+/// no v2 fields are removed or retyped — so v0.6.4 SDK clients
+/// reading v3 by name still resolve every field they used to. The
+/// `schema_version` discriminator does change from `"2"` to `"3"`,
+/// which is why clients that strict-equality-asserted on it must
+/// either relax that or pin `accept="v2"` explicitly.
+///
+/// v3 requires the live `Profile` (and optionally `McpConfig` +
+/// `agent_id`) for the new pre-computed fields, so callers that opt
+/// in must reach for [`handle_capabilities_with_conn_v3`] instead of
+/// the v1/v2 entry point.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilitiesAccept {
     V1,
     V2,
-    /// v0.7.0 A1 — additive on top of v2 (top-level `summary`). Requires
-    /// profile context; opt-in via `accept="v3"` or
-    /// `Accept-Capabilities: v3`.
+    /// v0.7.0 A1–A4 — additive on top of v2: `summary`,
+    /// `to_describe_to_user`, per-tool `tools[].callable_now`,
+    /// optional `agent_permitted_families`. **Default since A5.**
     V3,
 }
 
 impl CapabilitiesAccept {
-    /// Parse the wire value sent by the client. Unknown values fall back
-    /// to v2 (the default). Whitespace and case insensitive.
+    /// Parse the wire value sent by the client. Unknown / missing
+    /// values fall back to v3 (the default since v0.7.0 A5).
+    /// Whitespace and case insensitive. Explicit `"v2"`/`"2"` still
+    /// returns `V2`; explicit `"v1"`/`"1"` still returns `V1`.
     #[must_use]
     pub fn parse(s: &str) -> Self {
         match s.trim().to_ascii_lowercase().as_str() {
             "v1" | "1" => Self::V1,
-            "v3" | "3" => Self::V3,
-            _ => Self::V2,
+            "v2" | "2" => Self::V2,
+            // v0.7.0 A5 — unknown / missing default flips from V2 → V3.
+            // Explicit `"v2"` above keeps the v2 wire shape for clients
+            // that pin it; everyone else gets v3 (additive over v2).
+            _ => Self::V3,
         }
     }
 }
@@ -4099,13 +4112,14 @@ fn handle_request(
                     } else {
                         // P1 honesty patch: optional `accept` argument lets MCP
                         // clients opt into the legacy v1 shape, mirroring the
-                        // HTTP `Accept-Capabilities` header. v0.7.0 A1 adds
-                        // `accept="v3"` for the additive v3 schema (top-level
-                        // `summary` + future A2-A4 fields).
+                        // HTTP `Accept-Capabilities` header. v0.7.0 A5 makes
+                        // v3 the default (additive over v2); explicit
+                        // `accept="v2"` keeps the v2 wire shape unchanged
+                        // for clients that pin it.
                         let accept = arguments
                             .get("accept")
                             .and_then(Value::as_str)
-                            .map_or(CapabilitiesAccept::V2, CapabilitiesAccept::parse);
+                            .map_or(CapabilitiesAccept::V3, CapabilitiesAccept::parse);
                         // v0.6.4-006 — when no family is requested, augment
                         // the v2/v3 response with a top-level `families` field
                         // describing the family taxonomy and which families
@@ -5729,10 +5743,14 @@ mod tests {
     /// Every new top-level block is present with the expected shape.
     /// Dropped fields (`rule_summary`, `by_event`, `subscribers`,
     /// `default_timeout_seconds`) must be absent from v2 output.
+    ///
+    /// v0.7.0 A5: this test pins v2 explicitly via `accept="v2"` since
+    /// the default is now v3. v2 backward-compat is preserved
+    /// indefinitely; this test is the contract that proves it.
     #[test]
     fn mcp_capabilities_v2_schema_includes_all_blocks() {
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
-        let req = make_tools_call("memory_capabilities", json!({}));
+        let req = make_tools_call("memory_capabilities", json!({"accept": "v2"}));
         let resp = invoke_handle_request(&conn, &req);
         let text = resp.result.unwrap()["content"][0]["text"]
             .as_str()

--- a/tests/capabilities_v2.rs
+++ b/tests/capabilities_v2.rs
@@ -302,20 +302,22 @@ fn cap_v2_recall_mode_degraded_when_embedder_configured_but_not_loaded() {
 }
 
 // ---------------------------------------------------------------------------
-// Accept-string parsing: case + whitespace tolerant; unknown values fall
-// back to v2 (the default).
+// Accept-string parsing: case + whitespace tolerant. Explicit `"v1"`/`"v2"`
+// still resolve to V1/V2; v0.7.0 A5 flips the unknown/missing default from
+// V2 to V3, so any non-explicit value now resolves to V3 instead.
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_accept_parse_is_case_insensitive_and_defaults_to_v2() {
+fn cap_accept_parse_is_case_insensitive_and_defaults_to_v3() {
     assert_eq!(CapabilitiesAccept::parse("v1"), CapabilitiesAccept::V1);
     assert_eq!(CapabilitiesAccept::parse(" V1 "), CapabilitiesAccept::V1);
     assert_eq!(CapabilitiesAccept::parse("1"), CapabilitiesAccept::V1);
     assert_eq!(CapabilitiesAccept::parse("v2"), CapabilitiesAccept::V2);
     assert_eq!(CapabilitiesAccept::parse("V2"), CapabilitiesAccept::V2);
-    // Unknown / empty falls back to v2.
-    assert_eq!(CapabilitiesAccept::parse(""), CapabilitiesAccept::V2);
-    assert_eq!(CapabilitiesAccept::parse("v9"), CapabilitiesAccept::V2);
-    assert_eq!(CapabilitiesAccept::parse("garbage"), CapabilitiesAccept::V2);
+    assert_eq!(CapabilitiesAccept::parse("2"), CapabilitiesAccept::V2);
+    // v0.7.0 A5: unknown / empty falls back to v3 (was v2 pre-A5).
+    assert_eq!(CapabilitiesAccept::parse(""), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse("v9"), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse("garbage"), CapabilitiesAccept::V3);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -77,15 +77,18 @@ fn cap_v3_accept_parses_v3_alias() {
 }
 
 // ---------------------------------------------------------------------------
-// CapabilitiesAccept::parse on unknown values still falls back to V2 (A1
-// preserves v0.6.3.1 behavior — only "v1"/"1" and "v3"/"3" route away from
-// the v2 default).
+// CapabilitiesAccept::parse on unknown / missing values falls back to V3
+// since v0.7.0 A5 (was V2 in A1–A4). Explicit `"v1"`/`"v2"` still resolve
+// to their respective shapes.
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_unknown_accept_still_falls_back_to_v2() {
-    assert_eq!(CapabilitiesAccept::parse("bogus"), CapabilitiesAccept::V2);
-    assert_eq!(CapabilitiesAccept::parse(""), CapabilitiesAccept::V2);
-    assert_eq!(CapabilitiesAccept::parse("v9"), CapabilitiesAccept::V2);
+fn cap_v3_unknown_accept_falls_back_to_v3_after_a5() {
+    assert_eq!(CapabilitiesAccept::parse("bogus"), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse(""), CapabilitiesAccept::V3);
+    assert_eq!(CapabilitiesAccept::parse("v9"), CapabilitiesAccept::V3);
+    // Sanity: explicit pinning still works.
+    assert_eq!(CapabilitiesAccept::parse("v2"), CapabilitiesAccept::V2);
+    assert_eq!(CapabilitiesAccept::parse("v1"), CapabilitiesAccept::V1);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8747,6 +8747,8 @@ impl OneshotDaemon {
             federation: std::sync::Arc::new(federation),
             tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
             scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+            profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+            mcp_config: std::sync::Arc::new(None),
         };
         let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
         let router = ai_memory::build_router(api_key_state, app_state);
@@ -12384,6 +12386,8 @@ fn build_serve_state(
         federation: std::sync::Arc::new(None),
         tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
         scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
     (api_key_state, app_state)

--- a/tests/webhook_http_parity.rs
+++ b/tests/webhook_http_parity.rs
@@ -89,6 +89,8 @@ impl HttpHarness {
             federation: Arc::new(None),
             tier_config: Arc::new(FeatureTier::Keyword.config()),
             scoring: Arc::new(ResolvedScoring::default()),
+            profile: Arc::new(ai_memory::profile::Profile::core()),
+            mcp_config: Arc::new(None),
         };
         let api_key_state = ApiKeyState { key: None };
         let router = ai_memory::build_router(api_key_state, app_state);


### PR DESCRIPTION
## Summary

A5 / final Track A increment. Flips the capabilities default wire shape from v2 to v3 — completing the A1–A5 sequence.

v2 + v1 stay supported indefinitely. Clients that pin \`accept=\"v2\"\` (or \`Accept-Capabilities: v2\`) keep getting the v2 shape unchanged.

### What landed

- **`mcp.rs`** — `CapabilitiesAccept::parse` unknown/missing now → V3 (was V2). Explicit \`\"v2\"\`/\`\"2\"\` still resolves to V2.
- **`handlers.rs`** — HTTP `/capabilities` now serves v3 by default; routes v3 through `handle_capabilities_with_conn_v3` with the new AppState-threaded Profile + McpConfig.
- **`AppState`** — adds `pub profile: Arc<Profile>` and `pub mcp_config: Arc<Option<McpConfig>>`. Mirrors the MCP-side threading.
- **`daemon_runtime.rs`** — resolves the active Profile + McpConfig at bootstrap time. Falls back to `Profile::core()` if config-side resolution fails (doesn't block HTTP boot).
- **All 5 AppState construction sites updated** (3 in handlers.rs, 2 in daemon_runtime.rs, plus tests/integration.rs + tests/webhook_http_parity.rs).
- **Tests** — pinned the v2 contract (`mcp_capabilities_v2_schema_includes_all_blocks` now passes `accept=\"v2\"` explicitly); renamed `_defaults_to_v2` → `_defaults_to_v3` to match new behavior.

### Backward compat

v3 is **additive** over v2: same v2 sub-blocks unchanged, plus A1–A4's pre-computed fields. Field-by-name access works as before. Only \`schema_version\` discriminator changes (`\"2\"` → `\"3\"`); SDK clients that strict-asserted on it must relax or pin v2 (verified Python + TypeScript SDKs don't strict-assert).

### Test plan

- [x] `cargo test --lib mcp::tests` → 196/196 green
- [x] `cargo test --test capabilities_v3` → 19/19 green
- [x] `cargo test --test capabilities_v2` → 9/9 green (v2 contract preserved)
- [x] `cargo test --test calibration_t0` → 6/6 green
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo fmt --check` clean

Closes Track A. Refs #545.