### PR TITLE
feat: v0.7-h2 — outbound Ed25519 signing on memory_links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "chrono",
+ "ciborium",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,13 @@ sha2 = "0.10"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["std"] }
 base64 = "0.22"
+# v0.7 Track H — H2 outbound link signing. `ciborium` 0.2 provides
+# RFC 8949 §4.2.1 deterministic CBOR encoding via `into_writer`
+# (canonical sort of map keys + smallest-int encoding), the byte
+# shape we sign over for Ed25519 attestation. Already pulled in
+# transitively via the candle stack — promoted to a direct dep here
+# so `src/identity/sign.rs` can rely on a stable version pin.
+ciborium = "0.2"
 
 # Semantic embedding support
 candle-core = "0.10"

--- a/migrations/sqlite/0017_v07_link_attest_level.sql
+++ b/migrations/sqlite/0017_v07_link_attest_level.sql
@@ -1,0 +1,29 @@
+-- v0.7.0 — Outbound link signing (Track H, Task H2 — schema v23).
+--
+-- Adds the `attest_level` TEXT column to `memory_links` so callers can
+-- distinguish three states without poking at the `signature` BLOB:
+--
+--   "unsigned"     — no active keypair on the writer; signature is NULL.
+--   "self_signed"  — writer signed with its own Ed25519 keypair.
+--   "peer_attested" — H3 will set this on inbound links whose signature
+--                     verified against a known peer's public key.
+--
+-- The `signature` BLOB column itself shipped in v0.6.3 (schema v15)
+-- but stayed dead until H2; this migration only adds the level tag.
+--
+-- Backward compat: existing rows are backfilled to `attest_level =
+-- 'unsigned'` because they were written before any keypair plumbing
+-- existed. Callers MUST treat NULL as `unsigned` defensively in case a
+-- post-migration row writer fails to populate the column.
+--
+-- The ALTER TABLE itself runs from Rust (SQLite has no `ADD COLUMN
+-- IF NOT EXISTS`); this file only carries the idempotent backfill
+-- and index. The (attest_level, created_at) index supports the H4
+-- `memory_verify` listing path planned next.
+
+UPDATE memory_links
+   SET attest_level = 'unsigned'
+ WHERE attest_level IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_links_attest_level
+    ON memory_links (attest_level, created_at);

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -54,13 +54,14 @@ use std::time::Instant;
 pub const MIN_SUPPORTED_SCHEMA: u32 = 16;
 
 /// Upper bound of the DB-schema range this binary supports. Mirrors
-/// `db::CURRENT_SCHEMA_VERSION` (22 in v0.7.0 — v21 from K2's
-/// `pending_actions` timeout-sweeper columns + v22 from I1's
-/// `memory_transcripts` BLOB store for the attested-cortex epic).
-/// When a DB's `schema_version` exceeds this, the binary is too old
-/// for a newer DB and we surface a warning. v0.6.3.1 (PR-9h /
-/// issue #487 PR #497 req #72).
-pub const MAX_SUPPORTED_SCHEMA: u32 = 22;
+/// `db::CURRENT_SCHEMA_VERSION` (23 in v0.7.0 — v21 from K2's
+/// `pending_actions` timeout-sweeper columns, v22 from I1's
+/// `memory_transcripts` BLOB store, and v23 from H2's
+/// `memory_links.attest_level` column for outbound link signing in
+/// the attested-cortex epic).  When a DB's `schema_version` exceeds
+/// this, the binary is too old for a newer DB and we surface a warning.
+/// v0.6.3.1 (PR-9h / issue #487 PR #497 req #72).
+pub const MAX_SUPPORTED_SCHEMA: u32 = 23;
 
 /// Pure boundary check: `true` when `v` lies within
 /// `[MIN_SUPPORTED_SCHEMA, MAX_SUPPORTED_SCHEMA]`. Extracted so the

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1058,6 +1058,83 @@ pub fn build_vector_index(conn: &Connection, embedder_present: bool) -> Option<V
 }
 
 // ---------------------------------------------------------------------------
+// v0.7 Track H — H2 active keypair loading
+// ---------------------------------------------------------------------------
+
+/// Best-effort load of the daemon's active Ed25519 signing keypair.
+///
+/// Resolution order:
+///   1. `AI_MEMORY_AGENT_ID` environment variable (set explicitly by
+///      operators who want a specific identity at serve time).
+///   2. Otherwise, `crate::identity::resolve_agent_id(None, None)` —
+///      same NHI-default an HTTP request without `X-Agent-Id` would
+///      resolve to. This produces the `host:` / `anonymous:` shape;
+///      that file is rarely on disk, which is fine — we simply degrade
+///      to unsigned.
+///
+/// Errors at every step are swallowed (logged at INFO/WARN). Missing
+/// keypairs are the common first-run state — we don't want a failed
+/// `keypair::load` to make the daemon refuse to start. Malformed key
+/// files DO log at `WARN` so an operator with a corrupt
+/// `~/.config/ai-memory/keys/<id>.priv` notices.
+fn load_active_keypair_for_serve() -> Option<crate::identity::keypair::AgentKeypair> {
+    let dir = match crate::identity::keypair::default_key_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::info!("identity: no default key dir available, link signing disabled: {e}");
+            return None;
+        }
+    };
+    let agent_id = match crate::identity::resolve_agent_id(None, None) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::info!("identity: agent_id resolution failed, link signing disabled: {e}");
+            return None;
+        }
+    };
+    // Common first-run state: directory doesn't exist yet because the
+    // operator hasn't run `ai-memory identity generate`. Silent skip.
+    if !dir.exists() {
+        tracing::info!(
+            "identity: key dir {} not present, link signing disabled (run \
+             `ai-memory identity generate --agent-id {agent_id}` to enable)",
+            dir.display()
+        );
+        return None;
+    }
+    match crate::identity::keypair::load(&agent_id, &dir) {
+        Ok(kp) if kp.can_sign() => {
+            tracing::info!(
+                "identity: loaded signing keypair for {agent_id} from {}",
+                dir.display()
+            );
+            Some(kp)
+        }
+        Ok(_) => {
+            tracing::info!(
+                "identity: only public key on disk for {agent_id}; link signing disabled"
+            );
+            None
+        }
+        Err(e) => {
+            // File-not-found for the .pub file produces an Err; treat it
+            // the same as missing dir (common first-run). For other
+            // failures (malformed bytes, priv/pub mismatch) WARN so the
+            // operator notices.
+            let msg = format!("{e:#}");
+            if msg.contains("No such file") || msg.contains("not found") {
+                tracing::info!(
+                    "identity: no keypair on disk for {agent_id}; link signing disabled"
+                );
+            } else {
+                tracing::warn!("identity: keypair load failed for {agent_id}: {msg}");
+            }
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Background tasks (GC, WAL checkpoint)
 // ---------------------------------------------------------------------------
 
@@ -1279,6 +1356,14 @@ pub async fn bootstrap_serve(
         .effective_profile(None)
         .unwrap_or_else(|_| crate::profile::Profile::core());
     let mcp_config_for_http = app_config.mcp.clone();
+    // v0.7 Track H — H2: load the active agent's Ed25519 keypair so
+    // outbound link writes can sign. Best-effort: if the keypair file
+    // doesn't exist (operator hasn't run `ai-memory identity generate`
+    // yet) we leave `active_keypair = None` and links go in unsigned —
+    // preserving v0.6.4 behaviour for unmigrated deployments. Errors
+    // other than "file not found" are logged and degraded the same way
+    // so a malformed keypair file doesn't take down the daemon.
+    let active_keypair = load_active_keypair_for_serve();
 
     let app_state = AppState {
         db: db_state.clone(),
@@ -1289,6 +1374,7 @@ pub async fn bootstrap_serve(
         scoring: Arc::new(app_config.effective_scoring()),
         profile: Arc::new(resolved_profile),
         mcp_config: Arc::new(mcp_config_for_http),
+        active_keypair: Arc::new(active_keypair),
     };
 
     // Automatic GC.
@@ -1979,6 +2065,7 @@ mod tests {
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
             profile: Arc::new(crate::profile::Profile::core()),
             mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
         }
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -205,7 +205,13 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
 //       store with zstd-3 content blobs. Substrate for I2 (join
 //       table), I3 (archive→prune lifecycle), I4 (memory_replay),
 //       I5/R5 (pre_store extraction hook).
-const CURRENT_SCHEMA_VERSION: i64 = 22;
+// v23 = v0.7.0 H2 (attested-cortex epic, outbound link signing)
+//       `memory_links.attest_level` TEXT column ("unsigned" |
+//       "self_signed" | "peer_attested"). The companion `signature`
+//       BLOB column shipped dead in v15 and is now live. H3+H4 will
+//       layer inbound verification + the `memory_verify` MCP tool on
+//       top of this column.
+const CURRENT_SCHEMA_VERSION: i64 = 23;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -285,6 +291,12 @@ const MIGRATION_V21_SQLITE: &str =
 // for I2 (join table), I3 (archive→prune lifecycle), I4 (memory_replay),
 // and I5/R5 (pre_store extraction hook).
 const MIGRATION_V22_SQLITE: &str = include_str!("../migrations/sqlite/0016_v07_transcripts.sql");
+// v0.7.0 H2 — outbound link signing. ALTER TABLE adding the
+// `attest_level` column is emitted from Rust (SQLite has no
+// `ADD COLUMN IF NOT EXISTS`); this file holds the idempotent
+// backfill ("unsigned" for legacy rows) plus the supporting index.
+const MIGRATION_V23_SQLITE: &str =
+    include_str!("../migrations/sqlite/0017_v07_link_attest_level.sql");
 
 #[allow(clippy::too_many_lines)]
 fn migrate(conn: &Connection) -> Result<()> {
@@ -783,6 +795,24 @@ fn migrate(conn: &Connection) -> Result<()> {
             // table, I3 archive→prune, I4 memory_replay, I5/R5 pre_store
             // hook) layer on top of this substrate.
             conn.execute_batch(MIGRATION_V22_SQLITE)?;
+        }
+        if version < 23 {
+            // v0.7.0 H2 — outbound link signing. Adds the `attest_level`
+            // TEXT column to `memory_links` ("unsigned" | "self_signed"
+            // | "peer_attested"); the companion `signature` BLOB column
+            // shipped dead in v15 (Stream B) and is now live. ALTER
+            // TABLE done inline (SQLite has no `ADD COLUMN IF NOT
+            // EXISTS`); the SQL file holds the idempotent backfill +
+            // index. H3 will populate `peer_attested` on the inbound
+            // verification path; H4 layers `memory_verify` on top of
+            // this column.
+            let has_attest_level = conn
+                .prepare("SELECT attest_level FROM memory_links LIMIT 0")
+                .is_ok();
+            if !has_attest_level {
+                conn.execute("ALTER TABLE memory_links ADD COLUMN attest_level TEXT", [])?;
+            }
+            conn.execute_batch(MIGRATION_V23_SQLITE)?;
         }
 
         conn.execute("DELETE FROM schema_version", [])?;
@@ -1885,12 +1915,52 @@ pub fn find_contradictions(conn: &Connection, title: &str, namespace: &str) -> R
 
 // --- Links ---
 
+/// Insert a directional `(source_id, target_id, relation)` link.
+///
+/// Backward-compat shim around [`create_link_signed`] with no active
+/// keypair — every call here writes `signature = NULL` and
+/// `attest_level = "unsigned"`. New code that wants signing should
+/// route through [`create_link_signed`] directly.
 pub fn create_link(
     conn: &Connection,
     source_id: &str,
     target_id: &str,
     relation: &str,
 ) -> Result<()> {
+    create_link_signed(conn, source_id, target_id, relation, None).map(|_| ())
+}
+
+/// v0.7 H2 — link write that optionally signs with the active agent's
+/// Ed25519 keypair.
+///
+/// When `keypair` carries a private key, the six signable fields
+/// (`src_id`, `dst_id`, `relation`, `observed_by`, `valid_from`,
+/// `valid_until`) are encoded to deterministic CBOR per RFC 8949
+/// §4.2.1, signed, and the 64-byte signature is persisted in the
+/// existing `signature` BLOB column with `attest_level = "self_signed"`.
+///
+/// When `keypair` is `None` or carries only a public key, the row is
+/// written with `signature = NULL` and `attest_level = "unsigned"` —
+/// preserving v0.6.4 behaviour for callers that haven't generated a
+/// keypair yet.
+///
+/// `observed_by` on the signed payload is set to the keypair's
+/// `agent_id` when a keypair is present (the writer is, by definition,
+/// the observer). The `observed_by` *column* itself is intentionally
+/// left at the v0.6.3 default (NULL on this insert path) so existing
+/// KG queries that join on `observed_by` keep their current shape; H4's
+/// `memory_verify` will surface the signing identity from the keypair
+/// + signature, not from this column.
+///
+/// Returns the chosen attest level so callers (HTTP/MCP wrappers) can
+/// surface it in the wire response without re-querying the row.
+pub fn create_link_signed(
+    conn: &Connection,
+    source_id: &str,
+    target_id: &str,
+    relation: &str,
+    keypair: Option<&crate::identity::keypair::AgentKeypair>,
+) -> Result<&'static str> {
     // Verify both IDs exist before creating link
     let source_exists: bool = conn
         .query_row(
@@ -1917,11 +1987,35 @@ pub fn create_link(
     // populate it on the insert path so newly created links are
     // visible to `memory_kg_timeline` without a downstream backfill.
     let now = Utc::now().to_rfc3339();
+
+    // v0.7 H2 — sign if we have a private key. We compute the signature
+    // BEFORE issuing INSERT so a CBOR/sign failure surfaces as an
+    // outright write error (vs. a silent partial-write). The signed
+    // payload includes `valid_from = now` and matching `observed_by`
+    // so H3's verifier can re-derive the same bytes from the row.
+    let (signature, attest_level): (Option<Vec<u8>>, &'static str) = match keypair {
+        Some(kp) if kp.can_sign() => {
+            let link = crate::identity::sign::SignableLink {
+                src_id: source_id,
+                dst_id: target_id,
+                relation,
+                observed_by: Some(kp.agent_id.as_str()),
+                valid_from: Some(now.as_str()),
+                valid_until: None,
+            };
+            let sig = crate::identity::sign::sign(kp, &link)?;
+            (Some(sig), "self_signed")
+        }
+        _ => (None, "unsigned"),
+    };
+
     conn.execute(
-        "INSERT OR IGNORE INTO memory_links (source_id, target_id, relation, created_at, valid_from) VALUES (?1, ?2, ?3, ?4, ?4)",
-        params![source_id, target_id, relation, now],
+        "INSERT OR IGNORE INTO memory_links \
+            (source_id, target_id, relation, created_at, valid_from, signature, attest_level) \
+         VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?6)",
+        params![source_id, target_id, relation, now, signature, attest_level],
     )?;
-    Ok(())
+    Ok(attest_level)
 }
 
 pub fn get_links(conn: &Connection, id: &str) -> Result<Vec<MemoryLink>> {
@@ -7556,6 +7650,96 @@ mod tests {
             valid_from.is_some(),
             "create_link must populate valid_from so kg_timeline can see new links"
         );
+    }
+
+    // v0.7 H2 — schema v23: `attest_level` column present + populated.
+    #[test]
+    fn schema_v23_memory_links_has_attest_level_column() {
+        let conn = test_db();
+        assert!(
+            column_exists(&conn, "memory_links", "attest_level"),
+            "v23 must add attest_level column to memory_links"
+        );
+    }
+
+    // v0.7 H2 — no-keypair path: signature stays NULL, attest_level
+    // is recorded as "unsigned". This is the v0.6.4 backward-compat
+    // contract — operators that haven't generated a keypair keep the
+    // pre-H2 behaviour.
+    #[test]
+    fn create_link_signed_without_keypair_is_unsigned() {
+        let conn = test_db();
+        let src = make_memory("h2-src-unsigned", "test", Tier::Long, 5);
+        let tgt = make_memory("h2-tgt-unsigned", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+
+        let level = create_link_signed(&conn, &src.id, &tgt.id, "related_to", None).unwrap();
+        assert_eq!(level, "unsigned");
+
+        let (sig, attest): (Option<Vec<u8>>, Option<String>) = conn
+            .query_row(
+                "SELECT signature, attest_level FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2",
+                params![&src.id, &tgt.id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(sig.is_none(), "no keypair → signature must be NULL");
+        assert_eq!(attest.as_deref(), Some("unsigned"));
+    }
+
+    // v0.7 H2 — happy path: with an active keypair, every link write
+    // gets a 64-byte Ed25519 signature in the `signature` column and
+    // attest_level = "self_signed". The signature must verify against
+    // the keypair's public key over the canonical CBOR payload.
+    #[test]
+    fn create_link_signed_with_keypair_persists_valid_signature() {
+        use crate::identity::{keypair, sign as link_sign};
+        use ed25519_dalek::Verifier;
+
+        let conn = test_db();
+        let src = make_memory("h2-src-signed", "test", Tier::Long, 5);
+        let tgt = make_memory("h2-tgt-signed", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &tgt).unwrap();
+
+        let kp = keypair::generate("alice").unwrap();
+        let level = create_link_signed(&conn, &src.id, &tgt.id, "supersedes", Some(&kp)).unwrap();
+        assert_eq!(level, "self_signed");
+
+        // Read back the persisted row and confirm the signature shape.
+        let (sig, attest, valid_from): (Option<Vec<u8>>, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT signature, attest_level, valid_from FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2",
+                params![&src.id, &tgt.id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        let sig_bytes = sig.expect("signature must be present when keypair is provided");
+        assert_eq!(sig_bytes.len(), 64, "Ed25519 signature is 64 bytes");
+        assert_eq!(attest.as_deref(), Some("self_signed"));
+        let valid_from = valid_from.expect("valid_from must be set on the insert path");
+
+        // Re-derive the canonical bytes the writer signed over and
+        // verify with the keypair's public key. This is what H3's
+        // inbound verifier will do on every received link.
+        let signable = link_sign::SignableLink {
+            src_id: &src.id,
+            dst_id: &tgt.id,
+            relation: "supersedes",
+            observed_by: Some(kp.agent_id.as_str()),
+            valid_from: Some(valid_from.as_str()),
+            valid_until: None,
+        };
+        let payload = link_sign::canonical_cbor(&signable).unwrap();
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+        let sig_obj = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        kp.public
+            .verify(&payload, &sig_obj)
+            .expect("persisted signature must verify against the writer's public key");
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -72,6 +72,15 @@ pub struct AppState {
     /// the AppState stays cheap; absent allowlist (the v0.6.4 default)
     /// shows up as `Arc<None>`.
     pub mcp_config: Arc<Option<crate::config::McpConfig>>,
+    /// v0.7 Track H — H2 outbound link signing. The keypair loaded at
+    /// daemon startup (or `None` when the operator hasn't generated
+    /// one yet). When `Some`, every `db::create_link_signed` call from
+    /// HTTP handlers signs the link with this key and stamps
+    /// `attest_level = "self_signed"`; when `None`, links go in
+    /// unsigned, preserving v0.6.4 behaviour for unmigrated deployments.
+    /// H3 will reuse this handle for outbound writes that need to
+    /// carry the same signing identity.
+    pub active_keypair: Arc<Option<crate::identity::keypair::AgentKeypair>>,
 }
 
 impl FromRef<AppState> for Db {
@@ -2668,7 +2677,18 @@ pub async fn create_link(
             .into_response();
     }
     let lock = app.db.lock().await;
-    let create_result = db::create_link(&lock.0, &body.source_id, &body.target_id, &body.relation);
+    // v0.7 H2 — sign with the active keypair when one was loaded at
+    // startup. Falls back to unsigned (signature NULL, attest_level
+    // "unsigned") when no keypair is configured. Either way the chosen
+    // attest level is surfaced on the wire response so callers can
+    // observe whether their link was signed without re-querying.
+    let create_result = db::create_link_signed(
+        &lock.0,
+        &body.source_id,
+        &body.target_id,
+        &body.relation,
+        app.active_keypair.as_ref().as_ref(),
+    );
     // v0.6.4-017 — G9 HTTP webhook parity. Fire `memory_link_created`
     // after db::create_link commits (mirrors mcp.rs:2569). The link
     // itself does not carry a namespace; we look up the source memory
@@ -2708,7 +2728,7 @@ pub async fn create_link(
     // and we'd deadlock on the shared Mutex if we held it.
     drop(lock);
     match create_result {
-        Ok(()) => {
+        Ok(attest_level) => {
             // v0.6.2 (#325): propagate link to peers.
             if let Some(fed) = app.federation.as_ref() {
                 let link = crate::models::MemoryLink {
@@ -2734,7 +2754,13 @@ pub async fn create_link(
                     }
                 }
             }
-            (StatusCode::CREATED, Json(json!({"linked": true}))).into_response()
+            // v0.7 H2 — surface attest_level on the wire so callers
+            // can tell signed vs unsigned without re-querying.
+            (
+                StatusCode::CREATED,
+                Json(json!({"linked": true, "attest_level": attest_level})),
+            )
+                .into_response()
         }
         Err(e) => {
             tracing::error!("handler error: {e}");
@@ -5208,6 +5234,7 @@ mod tests {
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
             profile: Arc::new(crate::profile::Profile::core()),
             mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
         }
     }
 
@@ -5704,6 +5731,7 @@ mod tests {
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
             profile: Arc::new(crate::profile::Profile::core()),
             mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
         };
         let router = Router::new()
             .route("/api/v1/memories/bulk", axum_post(bulk_create))
@@ -13399,6 +13427,7 @@ mod tests {
             scoring: Arc::new(crate::config::ResolvedScoring::default()),
             profile: Arc::new(crate::profile::Profile::core()),
             mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
         }
     }
 

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -43,6 +43,10 @@ use crate::validate;
 // will plumb the loaded `AgentKeypair` through `AppState` for outbound
 // link signing.
 pub mod keypair;
+// H2 — outbound link signing. Canonical CBOR + Ed25519 sign over the
+// six signable link fields. Consumed by `db::create_link_signed` to
+// fill the previously-dead `signature` BLOB column on `memory_links`.
+pub mod sign;
 
 /// Environment variable override for `agent_id` (used by CLI via clap's
 /// `env = "AI_MEMORY_AGENT_ID"`; read directly for MCP fallback).

--- a/src/identity/sign.rs
+++ b/src/identity/sign.rs
@@ -1,0 +1,269 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Outbound Ed25519 signing for `memory_links` (Track H, Task H2).
+//!
+//! Builds on H1 ([`crate::identity::keypair`]) — the per-agent
+//! [`AgentKeypair`] is the signing key. This module provides the two
+//! pieces H2 ships:
+//!
+//! 1. [`canonical_cbor`] — RFC 8949 §4.2.1 deterministic CBOR encoding
+//!    of the six link fields the signature commits to:
+//!    `src_id`, `dst_id`, `relation`, `observed_by`, `valid_from`,
+//!    `valid_until`. Same bytes on every host, every architecture,
+//!    every endianness — the precondition for round-tripping a
+//!    signature through the federation wire.
+//! 2. [`sign`] — wraps `canonical_cbor` + Ed25519 over the resulting
+//!    bytes. Returns the 64-byte signature ready to drop into the
+//!    `signature` BLOB column on `memory_links`.
+//!
+//! H3 will mirror [`canonical_cbor`] on the inbound path so verification
+//! re-derives the same bytes from the inbound row before checking the
+//! signature against the peer's public key.
+//!
+//! # Why CBOR?
+//!
+//! CBOR is the RustCrypto / IETF default for signed payloads (COSE
+//! lives on top of CBOR). RFC 8949 §4.2.1 defines a *deterministic*
+//! encoding: map keys sort lexicographically, integers use the smallest
+//! length, no indefinite-length items, no semantic tags we don't need.
+//! That gives us byte-stable input to Ed25519 without writing a custom
+//! binary format and without depending on `serde_json`'s key-ordering
+//! quirks (which are not part of its public contract).
+//!
+//! # Out of scope here
+//!
+//! - Inbound verification (H3).
+//! - `attest_level` enum + `memory_verify` MCP tool (H4).
+//! - `signed_events` audit table (H5).
+
+use anyhow::{Context, Result};
+use ed25519_dalek::Signer;
+
+use crate::identity::keypair::AgentKeypair;
+
+/// The six fields the link signature commits to.
+///
+/// Decoupled from [`crate::models::MemoryLink`] on purpose: that struct
+/// is the public wire shape for `get_links` (4 columns), while the
+/// signed bundle includes the temporal-validity columns (`valid_from`,
+/// `valid_until`, `observed_by`) added in v0.6.3 schema v15. Keeping
+/// `SignableLink` separate means H3's verifier can deserialize directly
+/// from a row without dragging the entire `MemoryLink` shape — and it
+/// gives the canonical encoder a single, audited shape to commit to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignableLink<'a> {
+    pub src_id: &'a str,
+    pub dst_id: &'a str,
+    pub relation: &'a str,
+    /// Agent that observed / asserted this link. `None` when the link
+    /// was created by an unidentified caller (rare on the signing path
+    /// — the keypair's owner is normally the observer).
+    pub observed_by: Option<&'a str>,
+    /// RFC3339 instant the link became true. Always present on writes
+    /// produced by `db::create_link` (set to "now" at insert time).
+    pub valid_from: Option<&'a str>,
+    /// RFC3339 instant the link was invalidated, or `None` if still
+    /// valid. Almost always `None` at insert time; set later by
+    /// `db::invalidate_link`.
+    pub valid_until: Option<&'a str>,
+}
+
+/// RFC 8949 §4.2.1 deterministic CBOR encoding of the six signable
+/// link fields.
+///
+/// The encoded shape is a CBOR map with 6 entries keyed by the field
+/// names below. Map keys are emitted in sort order (per RFC 8949 §4.2.1
+/// "Core Deterministic Encoding"), integers use the shortest form, and
+/// `Option::None` is encoded as CBOR `null`. Encoding the same
+/// `SignableLink` twice (or on a different host) produces identical
+/// bytes — the precondition Ed25519 needs.
+///
+/// Field order matters at the *byte* level even though `ciborium`
+/// canonicalises map keys for us — we still pass a deterministic
+/// `Vec<(&str, ...)>` shape to keep this function's intent reviewable
+/// without leaning on a non-obvious property of the encoder.
+///
+/// # Errors
+///
+/// Returns an error only when CBOR serialization fails — in practice
+/// unreachable for the fixed-shape input above, but surfaced as a
+/// `Result` so callers don't have to choose between panicking and
+/// silently signing a truncated payload.
+pub fn canonical_cbor(link: &SignableLink<'_>) -> Result<Vec<u8>> {
+    // We model the payload as a plain `BTreeMap<&str, ciborium::Value>`
+    // so map-key ordering is enforced at construction time — the encoder
+    // walks the BTreeMap in iteration order, which matches lexicographic
+    // sort. ciborium's `into_writer` emits canonical (smallest-int,
+    // definite-length) representations by default.
+    use std::collections::BTreeMap;
+    let mut map: BTreeMap<&str, ciborium::Value> = BTreeMap::new();
+    map.insert("src_id", ciborium::Value::Text(link.src_id.to_string()));
+    map.insert("dst_id", ciborium::Value::Text(link.dst_id.to_string()));
+    map.insert("relation", ciborium::Value::Text(link.relation.to_string()));
+    map.insert("observed_by", text_or_null(link.observed_by));
+    map.insert("valid_from", text_or_null(link.valid_from));
+    map.insert("valid_until", text_or_null(link.valid_until));
+
+    // Convert the BTreeMap to a `ciborium::Value::Map` whose entries are
+    // already in lexicographic key order. ciborium will preserve that
+    // order on the wire — the documented default for `into_writer`.
+    let entries: Vec<(ciborium::Value, ciborium::Value)> = map
+        .into_iter()
+        .map(|(k, v)| (ciborium::Value::Text(k.to_string()), v))
+        .collect();
+    let value = ciborium::Value::Map(entries);
+
+    let mut out: Vec<u8> = Vec::with_capacity(128);
+    ciborium::ser::into_writer(&value, &mut out).context("CBOR encode SignableLink")?;
+    Ok(out)
+}
+
+/// Sign `link` with `keypair`'s private key.
+///
+/// Encodes the link via [`canonical_cbor`], then runs Ed25519 over the
+/// resulting bytes. Returns the 64-byte signature, ready to drop into
+/// the `signature` BLOB column on `memory_links`.
+///
+/// # Errors
+///
+/// - `keypair.private` is `None` (public-only handle — verification
+///   only).
+/// - The CBOR encoding step fails (in practice unreachable; surfaced
+///   for completeness).
+pub fn sign(keypair: &AgentKeypair, link: &SignableLink<'_>) -> Result<Vec<u8>> {
+    let signing = keypair.private.as_ref().with_context(|| {
+        format!(
+            "AgentKeypair for {} has no private key — cannot sign",
+            keypair.agent_id
+        )
+    })?;
+    let bytes = canonical_cbor(link)?;
+    let sig = signing.sign(&bytes);
+    Ok(sig.to_bytes().to_vec())
+}
+
+/// Helper: lift `Option<&str>` into a CBOR `Text` or `Null`. Encoding
+/// `None` as `null` (rather than dropping the key) keeps the map's key
+/// set fixed across rows — H3's verifier can re-derive the bytes
+/// without branching on which optional fields were present.
+fn text_or_null(opt: Option<&str>) -> ciborium::Value {
+    match opt {
+        Some(s) => ciborium::Value::Text(s.to_string()),
+        None => ciborium::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::keypair;
+    use ed25519_dalek::Verifier;
+
+    fn link_fixture() -> SignableLink<'static> {
+        SignableLink {
+            src_id: "src-001",
+            dst_id: "dst-002",
+            relation: "related_to",
+            observed_by: Some("alice"),
+            valid_from: Some("2026-05-05T00:00:00+00:00"),
+            valid_until: None,
+        }
+    }
+
+    #[test]
+    fn canonical_cbor_is_deterministic() {
+        // RFC 8949 §4.2.1 — encoding the same logical input twice must
+        // produce identical bytes. This is the round-trip precondition
+        // for Ed25519 signing.
+        let link = link_fixture();
+        let a = canonical_cbor(&link).expect("encode");
+        let b = canonical_cbor(&link).expect("encode");
+        assert_eq!(a, b, "deterministic CBOR must be byte-stable");
+    }
+
+    #[test]
+    fn canonical_cbor_differs_on_field_change() {
+        // Sanity-check that the encoder isn't flattening fields. Any
+        // change in the signed surface should change the byte output.
+        let base = link_fixture();
+        let mut altered = base.clone();
+        altered.relation = "supersedes";
+        let a = canonical_cbor(&base).expect("encode base");
+        let b = canonical_cbor(&altered).expect("encode altered");
+        assert_ne!(a, b, "different relation must produce different bytes");
+    }
+
+    #[test]
+    fn canonical_cbor_handles_all_optionals_none() {
+        let link = SignableLink {
+            src_id: "s",
+            dst_id: "d",
+            relation: "r",
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+        };
+        let bytes = canonical_cbor(&link).expect("encode");
+        assert!(!bytes.is_empty());
+        // Two encodes still match.
+        assert_eq!(bytes, canonical_cbor(&link).expect("re-encode"));
+    }
+
+    #[test]
+    fn sign_and_verify_round_trip() {
+        let kp = keypair::generate("alice").expect("generate");
+        let link = link_fixture();
+        let sig_bytes = sign(&kp, &link).expect("sign");
+        assert_eq!(sig_bytes.len(), 64, "Ed25519 signatures are 64 bytes");
+
+        // Re-derive the canonical bytes and verify with the public key.
+        let payload = canonical_cbor(&link).expect("encode");
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        kp.public.verify(&payload, &sig).expect("verify");
+    }
+
+    #[test]
+    fn sign_refuses_public_only_keypair() {
+        // Public-only handles (load() with no .priv on disk, or list())
+        // must not be silently treated as zero-byte signatures — the
+        // caller has to fall back to the unsigned path explicitly.
+        let kp = keypair::generate("alice").unwrap();
+        let pub_only = AgentKeypair {
+            agent_id: "alice".to_string(),
+            public: kp.public,
+            private: None,
+        };
+        let err = sign(&pub_only, &link_fixture()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no private key"), "got: {msg}");
+    }
+
+    #[test]
+    fn sign_differs_for_different_keys() {
+        // Two keypairs over the same link produce different signatures
+        // (nondeterministic randomness, plus distinct keys).
+        let alice = keypair::generate("alice").unwrap();
+        let bob = keypair::generate("bob").unwrap();
+        let link = link_fixture();
+        let sig_a = sign(&alice, &link).unwrap();
+        let sig_b = sign(&bob, &link).unwrap();
+        assert_ne!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn signature_does_not_verify_against_other_pub() {
+        let alice = keypair::generate("alice").unwrap();
+        let bob = keypair::generate("bob").unwrap();
+        let link = link_fixture();
+        let sig_bytes = sign(&alice, &link).unwrap();
+        let payload = canonical_cbor(&link).unwrap();
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        // Alice's signature must not verify under Bob's public key.
+        assert!(bob.public.verify(&payload, &sig).is_err());
+    }
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3064,6 +3064,7 @@ fn handle_link(
     conn: &rusqlite::Connection,
     db_path: &Path,
     params: &Value,
+    active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
 ) -> Result<Value, String> {
     let source_id = params["source_id"]
         .as_str()
@@ -3074,7 +3075,12 @@ fn handle_link(
     let relation = params["relation"].as_str().unwrap_or("related_to");
 
     validate::validate_link(source_id, target_id, relation).map_err(|e| e.to_string())?;
-    db::create_link(conn, source_id, target_id, relation).map_err(|e| e.to_string())?;
+    // v0.7 H2 — sign with active keypair when present; falls through
+    // to attest_level="unsigned" otherwise. The chosen attest_level is
+    // surfaced in the wire response so callers can tell signed vs
+    // unsigned without re-querying.
+    let attest_level = db::create_link_signed(conn, source_id, target_id, relation, active_keypair)
+        .map_err(|e| e.to_string())?;
 
     // P5 (G9): fire `memory_link_created` webhook AFTER the link is
     // persisted. Resolve the source memory to populate `namespace` /
@@ -3107,9 +3113,17 @@ fn handle_link(
         details,
     );
 
-    Ok(
-        json!({"linked": true, "source_id": source_id, "target_id": target_id, "relation": relation}),
-    )
+    Ok(json!({
+        "linked": true,
+        "source_id": source_id,
+        "target_id": target_id,
+        "relation": relation,
+        // v0.7 H2 — wire-level visibility into whether the link was
+        // signed by an Ed25519 keypair on this writer. "self_signed"
+        // when active_keypair was Some + signing succeeded;
+        // "unsigned" when no keypair was loaded.
+        "attest_level": attest_level,
+    }))
 }
 
 fn handle_get_links(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
@@ -3925,6 +3939,7 @@ pub(crate) fn handle_session_start(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn handle_request(
     conn: &rusqlite::Connection,
     db_path: &Path,
@@ -3941,6 +3956,11 @@ fn handle_request(
     mcp_client: Option<&str>,
     profile: &crate::profile::Profile,
     mcp_config: Option<&crate::config::McpConfig>,
+    // v0.7 Track H — H2 outbound link signing. When `Some`, every
+    // `memory_link` call signs the link with this keypair. When `None`
+    // (operator hasn't generated one), links go in unsigned, preserving
+    // v0.6.4 behaviour.
+    active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
 ) -> RpcResponse {
     let id = req.id.clone().unwrap_or(Value::Null);
 
@@ -4072,7 +4092,7 @@ fn handle_request(
                 "memory_stats" => handle_stats(conn, db_path),
                 "memory_update" => handle_update(conn, arguments, embedder, vector_index),
                 "memory_get" => handle_get(conn, arguments),
-                "memory_link" => handle_link(conn, db_path, arguments),
+                "memory_link" => handle_link(conn, db_path, arguments, active_keypair),
                 "memory_get_links" => handle_get_links(conn, arguments),
                 "memory_consolidate" => handle_consolidate(
                     conn,
@@ -4263,6 +4283,31 @@ fn handle_request(
             }
         }
         _ => err_response(id, -32601, format!("method not found: {}", req.method)),
+    }
+}
+
+/// v0.7 Track H — H2: best-effort load of the active Ed25519 keypair
+/// for the MCP daemon. Mirrors `daemon_runtime::load_active_keypair_for_serve`
+/// but logs to stderr (the MCP convention — stdout owns JSON-RPC).
+/// Missing keypair returns `None` and link writes go in unsigned;
+/// operator opts in by running `ai-memory identity generate`.
+fn load_active_keypair_for_mcp() -> Option<crate::identity::keypair::AgentKeypair> {
+    let dir = crate::identity::keypair::default_key_dir().ok()?;
+    let agent_id = crate::identity::resolve_agent_id(None, None).ok()?;
+    if !dir.exists() {
+        return None;
+    }
+    match crate::identity::keypair::load(&agent_id, &dir) {
+        Ok(kp) if kp.can_sign() => Some(kp),
+        Ok(_) => None,
+        Err(e) => {
+            // WARN on malformed key files; quiet on common file-not-found.
+            let msg = format!("{e:#}");
+            if !(msg.contains("No such file") || msg.contains("not found")) {
+                eprintln!("ai-memory: keypair load failed for {agent_id}: {msg}");
+            }
+            None
+        }
     }
 }
 
@@ -4489,6 +4534,16 @@ pub fn run_mcp_server(
     };
     eprintln!("ai-memory MCP server started (stdio, tier={effective_tier})");
 
+    // v0.7 Track H — H2 outbound link signing. Best-effort load of the
+    // active agent's Ed25519 keypair from the default key dir. Missing
+    // keypair = unsigned link writes (preserves v0.6.4 behaviour);
+    // operator opts in by running `ai-memory identity generate`.
+    let active_keypair: Option<crate::identity::keypair::AgentKeypair> =
+        load_active_keypair_for_mcp();
+    if active_keypair.is_some() {
+        eprintln!("ai-memory: link signing enabled (Ed25519)");
+    }
+
     // Captured from the MCP `initialize` handshake's `clientInfo.name`.
     // Used by `crate::identity` to synthesize an `ai:<client>@<host>:pid-<pid>`
     // agent_id when the caller doesn't supply one explicitly.
@@ -4544,6 +4599,7 @@ pub fn run_mcp_server(
             mcp_client_name.as_deref(),
             profile,
             app_config.mcp.as_ref(),
+            active_keypair.as_ref(),
         );
         let out = serde_json::to_string(&resp)?;
         writeln!(stdout, "{out}")?;
@@ -4969,6 +5025,7 @@ mod tests {
                 None,
                 &crate::profile::Profile::full(),
                 None,
+                None,
             );
             assert!(resp.error.is_none(), "expected ok rpc response");
         });
@@ -5020,6 +5077,7 @@ mod tests {
                 false,
                 None,
                 &crate::profile::Profile::full(),
+                None,
                 None,
             );
             // Handler errs are returned as ok_response with isError=true,
@@ -5299,6 +5357,7 @@ mod tests {
                 None,
                 &crate::profile::Profile::full(),
                 None,
+                None,
             );
             assert!(
                 resp.error.is_none(),
@@ -5336,6 +5395,7 @@ mod tests {
                     false,
                     None,
                     &crate::profile::Profile::full(),
+                    None,
                     None,
                 );
 
@@ -5391,6 +5451,7 @@ mod tests {
             false,
             None,
             &crate::profile::Profile::full(),
+            None,
             None,
         )
     }
@@ -5686,6 +5747,91 @@ mod tests {
             .to_string();
         let val: Value = serde_json::from_str(&text).unwrap();
         assert_eq!(val["linked"], true);
+        // v0.7 H2 — wire response carries attest_level. Default
+        // `invoke_handle_request` passes `active_keypair = None` so
+        // the level is "unsigned" — the v0.6.4 backward-compat shape.
+        assert_eq!(val["attest_level"], "unsigned");
+    }
+
+    // v0.7 H2 — when an active keypair is plumbed through to the
+    // memory_link MCP handler, the wire response reports
+    // attest_level = "self_signed" and the underlying row carries a
+    // 64-byte signature.
+    #[test]
+    fn handle_link_with_active_keypair_returns_self_signed() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let mut ids = Vec::new();
+        for tag in ["a", "b"] {
+            let mem = Memory {
+                id: uuid::Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: "h2-link".into(),
+                title: tag.into(),
+                content: "c".into(),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "test".into(),
+                access_count: 0,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: json!({}),
+            };
+            ids.push(db::insert(&conn, &mem).unwrap());
+        }
+        let req = make_tools_call(
+            "memory_link",
+            json!({"source_id": ids[0], "target_id": ids[1], "relation": "related_to"}),
+        );
+
+        // Drive handle_request directly so we can pass an active keypair.
+        let kp = crate::identity::keypair::generate("alice").unwrap();
+        let tier_config = FeatureTier::Keyword.config();
+        let resolved_ttl = crate::config::ResolvedTtl::default();
+        let resolved_scoring = crate::config::ResolvedScoring::default();
+        let resp = handle_request(
+            &conn,
+            std::path::Path::new(":memory:"),
+            &req,
+            None,
+            None,
+            None,
+            &tier_config,
+            None,
+            &resolved_ttl,
+            &resolved_scoring,
+            true,
+            false,
+            None,
+            &crate::profile::Profile::full(),
+            None,
+            Some(&kp),
+        );
+        assert!(resp.error.is_none(), "MCP error: {:?}", resp.error);
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let val: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(val["linked"], true);
+        assert_eq!(
+            val["attest_level"], "self_signed",
+            "active keypair path must surface self_signed"
+        );
+
+        // The signature column is now populated and 64 bytes.
+        let sig: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT signature FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2",
+                rusqlite::params![&ids[0], &ids[1]],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let sig_bytes = sig.expect("signed link must persist a signature blob");
+        assert_eq!(sig_bytes.len(), 64);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8749,6 +8749,7 @@ impl OneshotDaemon {
             scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
             profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
             mcp_config: std::sync::Arc::new(None),
+            active_keypair: std::sync::Arc::new(None),
         };
         let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
         let router = ai_memory::build_router(api_key_state, app_state);
@@ -12388,6 +12389,7 @@ fn build_serve_state(
         scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
         profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
         mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
     (api_key_state, app_state)

--- a/tests/webhook_http_parity.rs
+++ b/tests/webhook_http_parity.rs
@@ -91,6 +91,7 @@ impl HttpHarness {
             scoring: Arc::new(ResolvedScoring::default()),
             profile: Arc::new(ai_memory::profile::Profile::core()),
             mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
         };
         let api_key_state = ApiKeyState { key: None };
         let router = ai_memory::build_router(api_key_state, app_state);


### PR DESCRIPTION
Track H task H2 of v0.7.0 attested-cortex epic. Builds on H1 (PR #558, merged).

## Summary
- New `src/identity/sign.rs`: `SignableLink` + `canonical_cbor` (RFC 8949 §4.2.1 deterministic CBOR via ciborium 0.2) + `sign` using H1's `AgentKeypair`.
- `db::create_link_signed` signs every outbound link when an active keypair is available; existing `db::create_link` is now a backward-compat shim that delegates with `None` so legacy call sites are untouched.
- New `attest_level` column on `memory_links` tracks `unsigned` vs `self_signed` (H3 will add `peer_attested`).
- Schema **v23** migration adds `attest_level TEXT` + idempotent `unsigned` backfill + `(attest_level, created_at)` index. `MAX_SUPPORTED_SCHEMA` bumped from v22 to v23.
- HTTP `create_link` and MCP `memory_link` now surface `attest_level` on the wire response.
- AppState gains `active_keypair: Arc<Option<AgentKeypair>>`; daemon (`serve`) and MCP (`run_mcp_server`) load it best-effort from `dirs::config_dir()/ai-memory/keys/`. Missing keypair = silent unsigned-only mode (v0.6.4 backward compat).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` clean (lib + `--features sal`); pre-existing test-suite clippy debt is unchanged from main (55 errors on baseline; 55 on this branch)
- [x] `cargo test --lib` — 2017 passed / 0 failed (8 new tests for H2)
- [x] `canonical_cbor` deterministic across encodes
- [x] sign + verify Ed25519 round-trip with public key
- [x] no-keypair path → `signature` NULL, `attest_level = "unsigned"`
- [x] keypair path → 64-byte signature persisted, `attest_level = "self_signed"`, signature verifies against canonical CBOR
- [x] MCP `memory_link` wire response includes `attest_level`
- [x] schema v23 column-exists assertion
- [ ] H3 wires inbound verification (out of scope for this PR)

## Out of scope (separate H-track tasks)
- H3 inbound verification (depends on this PR).
- H4 `attest_level` enum + `memory_verify` MCP tool.
- H5 `signed_events` audit table.
- Hardware-key storage — AgenticMem commercial scope per ROADMAP2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)