### PR TITLE
feat: v0.7-i2 — memory_transcript_links join table (v24)

### DIFF
--- a/migrations/sqlite/0018_v07_transcript_links.sql
+++ b/migrations/sqlite/0018_v07_transcript_links.sql
@@ -1,0 +1,48 @@
+-- v0.7.0 — Attested-cortex transcript links join table (schema v24).
+--
+-- I2 of the I-track. Establishes the m:n relationship between
+-- `memories` (stored insights) and `memory_transcripts` (compressed
+-- conversation source material from I1, schema v22). One memory can be
+-- derived from a single transcript span (or several), and one transcript
+-- can be the source for many memories. The optional `span_start` /
+-- `span_end` byte offsets address a sub-region of the decompressed
+-- transcript so I4's `memory_replay` can return the precise excerpt.
+--
+-- Substrate only — no MCP tool wiring lands here. Subsequent tasks layer
+-- on:
+--   I3 — archive->prune lifecycle for transcripts (rows in this table
+--        are removed transitively via ON DELETE CASCADE).
+--   I4 — memory_replay MCP tool that joins memories <-> transcripts via
+--        this table to return the source span.
+--   I5/R5 — pre_store hook that populates this table at extraction time.
+--
+-- Notes:
+--   * PRIMARY KEY (memory_id, transcript_id) — a memory can only be
+--     linked to a given transcript once. If callers need multiple spans
+--     from the same transcript, they should concatenate / merge into a
+--     single (start, end) pair upstream. Keeping the PK narrow keeps
+--     the join cardinality bounded for I4's replay path.
+--   * BOTH foreign keys are ON DELETE CASCADE: deleting a memory wipes
+--     its provenance edges, and pruning a transcript (I3) wipes the
+--     dangling links so `transcripts_for_memory` never returns ids that
+--     can no longer be fetched.
+--   * Two separate indexes cover the two access patterns: lookup by
+--     memory (provenance fan-out) and lookup by transcript (replay
+--     fan-in). The composite PK already covers (memory_id, *) so the
+--     `idx_mtl_memory` single-column index is technically redundant
+--     with the PK prefix — kept explicit for clarity and to make the
+--     `PRAGMA index_list` test stable across SQLite versions that may
+--     not expose the auto-PK index by name.
+
+CREATE TABLE IF NOT EXISTS memory_transcript_links (
+    memory_id     TEXT NOT NULL,
+    transcript_id TEXT NOT NULL,
+    span_start    INTEGER,
+    span_end      INTEGER,
+    PRIMARY KEY (memory_id, transcript_id),
+    FOREIGN KEY (memory_id)     REFERENCES memories(id)           ON DELETE CASCADE,
+    FOREIGN KEY (transcript_id) REFERENCES memory_transcripts(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mtl_transcript ON memory_transcript_links(transcript_id);
+CREATE INDEX IF NOT EXISTS idx_mtl_memory     ON memory_transcript_links(memory_id);

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -54,14 +54,16 @@ use std::time::Instant;
 pub const MIN_SUPPORTED_SCHEMA: u32 = 16;
 
 /// Upper bound of the DB-schema range this binary supports. Mirrors
-/// `db::CURRENT_SCHEMA_VERSION` (23 in v0.7.0 — v21 from K2's
+/// `db::CURRENT_SCHEMA_VERSION` (24 in v0.7.0 — v21 from K2's
 /// `pending_actions` timeout-sweeper columns, v22 from I1's
-/// `memory_transcripts` BLOB store, and v23 from H2's
-/// `memory_links.attest_level` column for outbound link signing in
-/// the attested-cortex epic).  When a DB's `schema_version` exceeds
-/// this, the binary is too old for a newer DB and we surface a warning.
+/// `memory_transcripts` BLOB store, v23 from H2's
+/// `memory_links.attest_level` column for outbound link signing, and
+/// v24 from I2's `memory_transcript_links` join table connecting
+/// memories to their transcript provenance — all part of the
+/// attested-cortex epic). When a DB's `schema_version` exceeds this,
+/// the binary is too old for a newer DB and we surface a warning.
 /// v0.6.3.1 (PR-9h / issue #487 PR #497 req #72).
-pub const MAX_SUPPORTED_SCHEMA: u32 = 23;
+pub const MAX_SUPPORTED_SCHEMA: u32 = 24;
 
 /// Pure boundary check: `true` when `v` lies within
 /// `[MIN_SUPPORTED_SCHEMA, MAX_SUPPORTED_SCHEMA]`. Extracted so the

--- a/src/db.rs
+++ b/src/db.rs
@@ -211,7 +211,16 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
 //       BLOB column shipped dead in v15 and is now live. H3+H4 will
 //       layer inbound verification + the `memory_verify` MCP tool on
 //       top of this column.
-const CURRENT_SCHEMA_VERSION: i64 = 23;
+// v24 = v0.7.0 I2 (attested-cortex epic) `memory_transcript_links`
+//       join table establishing the m:n relationship between
+//       `memories` and the `memory_transcripts` substrate from I1
+//       (v22). Optional (span_start, span_end) byte offsets address a
+//       sub-region of the decompressed transcript. ON DELETE CASCADE
+//       on both foreign keys keeps the table free of dangling rows
+//       when memories are deleted or I3's archive->prune lifecycle
+//       removes transcripts. Substrate for I4 (memory_replay) and
+//       I5/R5 (pre_store extraction hook).
+const CURRENT_SCHEMA_VERSION: i64 = 24;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -297,6 +306,13 @@ const MIGRATION_V22_SQLITE: &str = include_str!("../migrations/sqlite/0016_v07_t
 // backfill ("unsigned" for legacy rows) plus the supporting index.
 const MIGRATION_V23_SQLITE: &str =
     include_str!("../migrations/sqlite/0017_v07_link_attest_level.sql");
+// v0.7.0 I2 — `memory_transcript_links` join table connecting
+// `memories` to the `memory_transcripts` substrate from I1 (v22).
+// CREATE TABLE IF NOT EXISTS + indexes — fully idempotent. Substrate
+// only; I4 (memory_replay) reads from this table and I5/R5
+// (pre_store extraction hook) writes to it.
+const MIGRATION_V24_SQLITE: &str =
+    include_str!("../migrations/sqlite/0018_v07_transcript_links.sql");
 
 #[allow(clippy::too_many_lines)]
 fn migrate(conn: &Connection) -> Result<()> {
@@ -813,6 +829,14 @@ fn migrate(conn: &Connection) -> Result<()> {
                 conn.execute("ALTER TABLE memory_links ADD COLUMN attest_level TEXT", [])?;
             }
             conn.execute_batch(MIGRATION_V23_SQLITE)?;
+        }
+        if version < 24 {
+            // v0.7.0 I2 — `memory_transcript_links` join table tying
+            // memories to the `memory_transcripts` substrate from I1.
+            // CREATE TABLE IF NOT EXISTS + indexes — fully idempotent.
+            // Substrate only; I4 layers `memory_replay` on top, I5/R5
+            // wires the pre_store extraction hook that populates it.
+            conn.execute_batch(MIGRATION_V24_SQLITE)?;
         }
 
         conn.execute("DELETE FROM schema_version", [])?;

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -165,6 +165,125 @@ pub fn purge_expired(conn: &Connection) -> Result<usize> {
     Ok(n)
 }
 
+/// v0.7.0 I2 — provenance edge between a memory and a transcript span.
+///
+/// Establishes that `memory_id` was extracted (or otherwise derived)
+/// from the transcript identified by `transcript_id`. The optional
+/// (`span_start`, `span_end`) byte offsets address a sub-region of the
+/// decompressed transcript; both `None` means "the whole transcript".
+/// Offsets are 0-based byte positions into the UTF-8 decompressed
+/// bytes, half-open `[start, end)` per the usual Rust slicing
+/// convention.
+///
+/// The PRIMARY KEY on the join table is `(memory_id, transcript_id)`,
+/// so a memory can only be linked to a given transcript once. Callers
+/// that need to record multiple disjoint spans from the same transcript
+/// should merge them into a single bounding pair upstream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptLink {
+    pub memory_id: String,
+    pub transcript_id: String,
+    pub span_start: Option<i64>,
+    pub span_end: Option<i64>,
+}
+
+/// Insert (or replace) a provenance edge between a memory and a
+/// transcript. Both ids must already exist in their respective tables —
+/// the foreign keys are enforced (`PRAGMA foreign_keys = ON` is set on
+/// every connection opened by [`crate::db::open`]).
+///
+/// Uses `INSERT OR REPLACE` so re-linking the same `(memory_id,
+/// transcript_id)` pair with a different span is a no-fuss update; the
+/// I-track currently has no caller that needs to detect the duplicate.
+///
+/// # Errors
+///
+/// Returns an error when the INSERT fails — most commonly a foreign-key
+/// violation (one of the ids is unknown or has been deleted), or a
+/// disk-write failure.
+pub fn link_transcript(
+    conn: &Connection,
+    memory_id: &str,
+    transcript_id: &str,
+    span_start: Option<i64>,
+    span_end: Option<i64>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO memory_transcript_links (
+            memory_id, transcript_id, span_start, span_end
+         ) VALUES (?1, ?2, ?3, ?4)",
+        params![memory_id, transcript_id, span_start, span_end],
+    )
+    .context("INSERT into memory_transcript_links failed")?;
+    Ok(())
+}
+
+/// Return every transcript provenance edge for a given memory.
+///
+/// Order is stable on `transcript_id` so callers (notably I4's
+/// `memory_replay`) get a deterministic replay sequence.
+///
+/// # Errors
+///
+/// Returns an error when the SELECT or row decoding fails.
+pub fn transcripts_for_memory(conn: &Connection, memory_id: &str) -> Result<Vec<TranscriptLink>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT memory_id, transcript_id, span_start, span_end
+             FROM memory_transcript_links
+             WHERE memory_id = ?1
+             ORDER BY transcript_id",
+        )
+        .context("PREPARE transcripts_for_memory failed")?;
+    let rows = stmt
+        .query_map(params![memory_id], row_to_link)
+        .context("QUERY transcripts_for_memory failed")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("decode transcripts_for_memory row")?);
+    }
+    Ok(out)
+}
+
+/// Return every memory derived from a given transcript.
+///
+/// Order is stable on `memory_id` so the fan-in is deterministic for
+/// downstream tooling (e.g. archive sweepers in I3).
+///
+/// # Errors
+///
+/// Returns an error when the SELECT or row decoding fails.
+pub fn memories_for_transcript(
+    conn: &Connection,
+    transcript_id: &str,
+) -> Result<Vec<TranscriptLink>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT memory_id, transcript_id, span_start, span_end
+             FROM memory_transcript_links
+             WHERE transcript_id = ?1
+             ORDER BY memory_id",
+        )
+        .context("PREPARE memories_for_transcript failed")?;
+    let rows = stmt
+        .query_map(params![transcript_id], row_to_link)
+        .context("QUERY memories_for_transcript failed")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("decode memories_for_transcript row")?);
+    }
+    Ok(out)
+}
+
+fn row_to_link(row: &rusqlite::Row<'_>) -> rusqlite::Result<TranscriptLink> {
+    Ok(TranscriptLink {
+        memory_id: row.get(0)?,
+        transcript_id: row.get(1)?,
+        span_start: row.get(2)?,
+        span_end: row.get(3)?,
+    })
+}
+
 fn zstd_compress(input: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::with_capacity(input.len() / 4 + 64);
     {
@@ -277,6 +396,163 @@ mod tests {
                 .any(|n| n == "idx_memory_transcripts_namespace_created"),
             "expected idx_memory_transcripts_namespace_created in {names:?}"
         );
+    }
+
+    /// v0.7.0 I2 — insert a stub `memories` row so the join-table FK
+    /// can be satisfied without dragging in the full `store::create`
+    /// pipeline (capabilities, governance, embeddings...). The minimal
+    /// column set mirrors the SCHEMA defaults at the top of `db.rs`.
+    fn insert_test_memory(conn: &Connection, id: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO memories (
+                id, tier, namespace, title, content, created_at, updated_at
+             ) VALUES (?1, 'short_term', 'team/eng', ?2, 'body', ?3, ?3)",
+            params![id, format!("title-{id}"), now],
+        )
+        .unwrap();
+    }
+
+    /// v0.7.0 I2 — round-trip: `link_transcript` writes an edge,
+    /// `transcripts_for_memory` reads it back with span fidelity.
+    #[test]
+    fn i2_link_then_transcripts_for_memory_round_trip() {
+        let conn = test_db();
+        insert_test_memory(&conn, "mem-1");
+        let t = store(&conn, "team/eng", "abcdefghij", None).unwrap();
+
+        link_transcript(&conn, "mem-1", &t.id, Some(2), Some(7)).unwrap();
+
+        let got = transcripts_for_memory(&conn, "mem-1").unwrap();
+        assert_eq!(
+            got,
+            vec![TranscriptLink {
+                memory_id: "mem-1".into(),
+                transcript_id: t.id.clone(),
+                span_start: Some(2),
+                span_end: Some(7),
+            }],
+        );
+    }
+
+    /// v0.7.0 I2 — fan-in: a single transcript referenced by multiple
+    /// memories. `memories_for_transcript` returns every link, ordered
+    /// by `memory_id` for deterministic downstream consumption.
+    #[test]
+    fn i2_memories_for_transcript_returns_all_linked_memories() {
+        let conn = test_db();
+        insert_test_memory(&conn, "mem-a");
+        insert_test_memory(&conn, "mem-b");
+        insert_test_memory(&conn, "mem-c");
+        let t = store(&conn, "team/eng", "shared transcript body", None).unwrap();
+
+        link_transcript(&conn, "mem-a", &t.id, None, None).unwrap();
+        link_transcript(&conn, "mem-b", &t.id, Some(0), Some(10)).unwrap();
+        link_transcript(&conn, "mem-c", &t.id, Some(11), Some(22)).unwrap();
+
+        let got = memories_for_transcript(&conn, &t.id).unwrap();
+        let ids: Vec<&str> = got.iter().map(|l| l.memory_id.as_str()).collect();
+        assert_eq!(ids, vec!["mem-a", "mem-b", "mem-c"]);
+    }
+
+    /// v0.7.0 I2 — `NULL` spans (whole-transcript provenance) survive
+    /// the round-trip cleanly. Guards against a future refactor that
+    /// might silently coerce them to 0.
+    #[test]
+    fn i2_null_spans_round_trip_as_none() {
+        let conn = test_db();
+        insert_test_memory(&conn, "mem-null");
+        let t = store(&conn, "team/eng", "body", None).unwrap();
+
+        link_transcript(&conn, "mem-null", &t.id, None, None).unwrap();
+
+        let got = transcripts_for_memory(&conn, "mem-null").unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].span_start, None);
+        assert_eq!(got[0].span_end, None);
+    }
+
+    /// v0.7.0 I2 — deleting a memory must cascade to its provenance
+    /// edges. Without this, the join table would accumulate dangling
+    /// rows that point at vanished memories and confuse I4's replay.
+    #[test]
+    fn i2_delete_memory_cascades_to_links() {
+        let conn = test_db();
+        insert_test_memory(&conn, "mem-doomed");
+        insert_test_memory(&conn, "mem-survives");
+        let t = store(&conn, "team/eng", "body", None).unwrap();
+
+        link_transcript(&conn, "mem-doomed", &t.id, None, None).unwrap();
+        link_transcript(&conn, "mem-survives", &t.id, None, None).unwrap();
+        assert_eq!(memories_for_transcript(&conn, &t.id).unwrap().len(), 2);
+
+        conn.execute("DELETE FROM memories WHERE id = ?1", params!["mem-doomed"])
+            .unwrap();
+
+        let remaining = memories_for_transcript(&conn, &t.id).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].memory_id, "mem-survives");
+    }
+
+    /// v0.7.0 I2 — deleting a transcript must cascade to its links.
+    /// I3's archive->prune lifecycle relies on this so callers of
+    /// `transcripts_for_memory` never see an id that can no longer be
+    /// fetched.
+    #[test]
+    fn i2_delete_transcript_cascades_to_links() {
+        let conn = test_db();
+        insert_test_memory(&conn, "mem-x");
+        let t = store(&conn, "team/eng", "ephemeral", None).unwrap();
+
+        link_transcript(&conn, "mem-x", &t.id, None, None).unwrap();
+        assert_eq!(transcripts_for_memory(&conn, "mem-x").unwrap().len(), 1);
+
+        conn.execute(
+            "DELETE FROM memory_transcripts WHERE id = ?1",
+            params![t.id],
+        )
+        .unwrap();
+
+        assert!(transcripts_for_memory(&conn, "mem-x").unwrap().is_empty());
+    }
+
+    /// v0.7.0 I2 — the migration is idempotent: opening the same DB
+    /// path twice in succession must not error on the join table's
+    /// CREATE TABLE / CREATE INDEX statements.
+    #[test]
+    fn i2_migration_is_idempotent() {
+        let p = tempfile::NamedTempFile::new().unwrap();
+        let path = p.path().to_path_buf();
+        let _ = db::open(&path).unwrap();
+        let conn = db::open(&path).unwrap();
+        let cnt: i64 = conn
+            .query_row("SELECT count(*) FROM memory_transcript_links", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cnt, 0);
+    }
+
+    /// v0.7.0 I2 — both supporting indexes are present. Guards against
+    /// a future migration that drops the SQL file's `CREATE INDEX` and
+    /// silently regresses I4's replay path to a table scan.
+    #[test]
+    fn i2_join_table_indexes_exist() {
+        let conn = test_db();
+        let mut stmt = conn
+            .prepare("PRAGMA index_list('memory_transcript_links')")
+            .unwrap();
+        let names: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .map(std::result::Result::unwrap)
+            .collect();
+        for expected in ["idx_mtl_transcript", "idx_mtl_memory"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "expected {expected} in {names:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Track I task I2 of v0.7.0 attested-cortex epic. Builds on I1 (PR #557, merged).

## Summary
- New `memory_transcript_links` join table — m:n with span_start/span_end
- Schema bumped to v24 (after H2's v23); idempotent migration
- ON DELETE CASCADE for both memory and transcript foreign keys
- Helpers: link_transcript, transcripts_for_memory, memories_for_transcript

## Test plan
- [x] cargo fmt --check + clippy --pedantic clean
- [x] cargo test --lib green; transcripts module tests added
- [x] Idempotent migration; CASCADE behavior verified
- [ ] I3 layers archive→prune; I4 layers memory_replay; I5/R5 layers pre_store hook