### PR TITLE
feat: v0.7-k3 — permissions.mode actually enforced

### DIFF
--- a/src/cli/crud.rs
+++ b/src/cli/crud.rs
@@ -526,6 +526,15 @@ mod tests {
 
     #[test]
     fn test_delete_governance_pending_returns_pending_status() {
+        // v0.7.0 K3 — pin Enforce so delete-Pending still drives the
+        // strict path (Advisory is the v0.7.0 default and would Allow
+        // the delete unconditionally). Holds the central gate-mode
+        // Mutex from `config::lock_permissions_mode_for_test`.
+        let _gate = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Enforce,
+        );
+
         use crate::models::{ApproverType, GovernanceLevel, GovernancePolicy};
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -504,6 +504,16 @@ fn section_governance(conn: &rusqlite::Connection) -> ReportSection {
     let mut severity = Severity::Info;
     let mut note: Option<String> = None;
 
+    // v0.7.0 K3 — surface the active permissions.mode + per-mode
+    // decision counts so operators can verify the gate is wired and
+    // observe drift between advertised and enforced policy.
+    let mode = crate::config::active_permissions_mode();
+    facts.push(("permissions_mode".into(), mode.as_str().to_string()));
+    let counts = crate::config::permissions_decision_counts();
+    facts.push(("decisions::enforce".into(), counts.enforce.to_string()));
+    facts.push(("decisions::advisory".into(), counts.advisory.to_string()));
+    facts.push(("decisions::off".into(), counts.off.to_string()));
+
     let (with, without) = db::doctor_governance_coverage(conn).unwrap_or((0, 0));
     facts.push(("namespaces_with_policy".into(), with.to_string()));
     facts.push(("namespaces_without_policy".into(), without.to_string()));

--- a/src/cli/governance.rs
+++ b/src/cli/governance.rs
@@ -153,6 +153,19 @@ mod tests {
     use crate::cli::test_utils::{TestEnv, seed_memory};
     use crate::models::{ApproverType, GovernanceLevel, GovernancePolicy};
 
+    /// v0.7.0 K3 — pin the gate to Enforce so this suite's
+    /// historical Pending/Deny outcome assertions still drive the
+    /// strict path. Holds the central gate-mode Mutex from
+    /// [`crate::config::lock_permissions_mode_for_test`] so parallel
+    /// tests in other modules cannot race the atomic.
+    fn pin_governance_enforce_for_test() -> std::sync::MutexGuard<'static, ()> {
+        let guard = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Enforce,
+        );
+        guard
+    }
+
     /// Seed a namespace standard with the supplied governance policy. The
     /// standard memory is inserted in `_standards` and pinned via
     /// `set_namespace_standard`.
@@ -226,6 +239,7 @@ mod tests {
 
     #[test]
     fn test_governance_pending_writes_pending_status_text() {
+        let _gate = pin_governance_enforce_for_test();
         let mut env = TestEnv::fresh();
         let db_path = env.db_path.clone();
         let policy = GovernancePolicy {
@@ -262,6 +276,7 @@ mod tests {
 
     #[test]
     fn test_governance_pending_writes_pending_status_json() {
+        let _gate = pin_governance_enforce_for_test();
         let mut env = TestEnv::fresh();
         let db_path = env.db_path.clone();
         let policy = GovernancePolicy {
@@ -303,6 +318,7 @@ mod tests {
 
     #[test]
     fn test_governance_deny_writes_reason_to_stderr() {
+        let _gate = pin_governance_enforce_for_test();
         let mut env = TestEnv::fresh();
         let db_path = env.db_path.clone();
         let policy = GovernancePolicy {
@@ -343,6 +359,7 @@ mod tests {
 
     #[test]
     fn test_governance_deny_returns_deny_outcome() {
+        let _gate = pin_governance_enforce_for_test();
         let mut env = TestEnv::fresh();
         let db_path = env.db_path.clone();
         let policy = GovernancePolicy {
@@ -376,6 +393,7 @@ mod tests {
 
     #[test]
     fn test_governance_payload_serializes_correctly() {
+        let _gate = pin_governance_enforce_for_test();
         // The payload arg is forwarded into queue_pending_action so a
         // peer-side approver can replay the original request. Sanity
         // check: the exact bytes we passed in are stored in the

--- a/src/cli/promote.rs
+++ b/src/cli/promote.rs
@@ -147,6 +147,19 @@ mod tests {
     use super::*;
     use crate::cli::test_utils::{TestEnv, seed_memory};
 
+    /// v0.7.0 K3 — pin Enforce so promote-Pending / promote-Deny
+    /// scenarios still hit the strict path (Advisory is the new
+    /// process default and would Allow). Holds the central
+    /// gate-mode Mutex; see `cli::governance::tests` for the full
+    /// rationale.
+    fn pin_governance_enforce_for_test() -> std::sync::MutexGuard<'static, ()> {
+        let guard = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Enforce,
+        );
+        guard
+    }
+
     fn promote_args(id: &str) -> PromoteArgs {
         PromoteArgs {
             id: id.to_string(),
@@ -268,6 +281,7 @@ mod tests {
 
     #[test]
     fn test_promote_governance_pending() {
+        let _gate = pin_governance_enforce_for_test();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         let id = seed_memory(&db, "gov-promote-ns", "tt", "cc");
@@ -293,6 +307,7 @@ mod tests {
 
     #[test]
     fn test_promote_governance_deny() {
+        let _gate = pin_governance_enforce_for_test();
         // The Deny branch in cmd_promote calls std::process::exit, which
         // tears down the test runner. The print-side of Deny is covered
         // by `cli::governance::tests::test_governance_deny_writes_reason_to_stderr`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,13 +255,21 @@ impl TierConfig {
             // and `approval.default_timeout_seconds` were dropped in v2
             // because they have no backing implementation.
             permissions: CapabilityPermissions {
-                mode: "advisory".to_string(),
+                // v0.7.0 K3: surface the *active* mode (the one the
+                // gate will actually consult), not a hard-coded string.
+                // Falls through to the K3 default (`advisory`) when
+                // `[permissions].mode` is unset in `config.toml`.
+                mode: active_permissions_mode().as_str().to_string(),
                 active_rules: 0,
                 // v0.6.3.1 (P4, G1): chain-walking enforcement landed
                 // in this release. Surface "enforced" so consumers can
                 // distinguish a governed deployment from the historical
                 // "display_only" posture.
                 inheritance: Some("enforced".to_string()),
+                // v0.7.0 K3: per-mode decision counts. Snapshot at
+                // capability-build time so operators can correlate
+                // doctor reports with capability responses.
+                decision_counts: Some(permissions_decision_counts()),
             },
             hooks: CapabilityHooks::default(),
             compaction: CapabilityCompaction::planned(),
@@ -508,6 +516,12 @@ pub struct CapabilityPermissions {
     /// via `#[serde(default)]`.
     #[serde(default)]
     pub inheritance: Option<String>,
+    /// v0.7.0 K3: per-mode decision counts since process start. Lets
+    /// operators verify the gate is actually being consulted and spot
+    /// drift between advertised policy and enforced policy. `None` on
+    /// older responses (`#[serde(default)]` round-trips cleanly).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_counts: Option<PermissionsDecisionCounts>,
 }
 
 /// Hook-pipeline block (capabilities schema v2). Pre-v0.7 reports webhook
@@ -1181,6 +1195,229 @@ pub struct AppConfig {
     /// `[mcp.allowlist]` per-agent capability table (Track D —
     /// v0.6.4-008).
     pub mcp: Option<McpConfig>,
+    /// v0.7.0 K3 — `[permissions]` block. Drives the gate's enforcement
+    /// posture (`enforce` / `advisory` / `off`). When unset, the
+    /// compiled default in [`PermissionsConfig::default`] applies
+    /// (`advisory` — preserves the v0.6.x honest-disclosure posture
+    /// where governance metadata was recorded but not blocked at the
+    /// gate). New installs that want the strict gate set
+    /// `[permissions] mode = "enforce"` explicitly.
+    pub permissions: Option<PermissionsConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Permissions / governance gate (K3)
+// ---------------------------------------------------------------------------
+
+/// Enforcement posture consulted by [`crate::db::enforce_governance`].
+///
+/// v0.7.0 K3 — closes the v0.6.3.1 honest-Capabilities-v2 disclosure
+/// that `permissions.mode = "advisory"` was advertised but the gate
+/// itself returned `Deny` / `Pending` regardless. The gate now actually
+/// honors this knob.
+///
+/// Wire format on `config.toml`:
+///
+/// ```toml
+/// [permissions]
+/// mode = "advisory"   # or "enforce" / "off"
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PermissionsMode {
+    /// Block on policy violation. `Deny`/`Pending` decisions returned
+    /// to the caller as-is. The strict, audit-ready posture.
+    Enforce,
+    /// Log a warning and allow the action. Governance metadata is
+    /// recorded but does not block writes. Default for v0.7.0 to
+    /// preserve the v0.6.x posture for upgrading operators.
+    Advisory,
+    /// Skip the gate entirely. No policy resolution, no log, no
+    /// `pending_actions` row. Useful for benchmarking and temporary
+    /// freeze-thaw incident response.
+    Off,
+}
+
+impl Default for PermissionsMode {
+    fn default() -> Self {
+        Self::Advisory
+    }
+}
+
+impl PermissionsMode {
+    /// Lowercase wire string for capabilities + doctor surfaces.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Enforce => "enforce",
+            Self::Advisory => "advisory",
+            Self::Off => "off",
+        }
+    }
+}
+
+/// `[permissions]` block in `config.toml`. Carries the gate's
+/// enforcement posture.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PermissionsConfig {
+    /// Enforcement mode. Defaults to [`PermissionsMode::Advisory`] when
+    /// omitted from the config file.
+    #[serde(default)]
+    pub mode: PermissionsMode,
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide permissions-mode handle (K3)
+// ---------------------------------------------------------------------------
+//
+// The gate (`db::enforce_governance`) needs to consult the active mode
+// at decision time but lives in the `db` module, which has no handle on
+// `AppConfig`. We use a `OnceLock` set by `main` (and the daemon
+// runtime) so the gate can read the mode without an API churn through
+// every callsite. When the lock is unset — the case for unit and
+// integration tests that drive `db::enforce_governance` directly
+// without booting the daemon — the gate defaults to
+// [`PermissionsMode::Enforce`] so the strict semantics that the K1
+// ship-gate suite codifies remain the load-bearing default for
+// programmatic callers.
+
+use std::sync::OnceLock;
+
+static ACTIVE_PERMISSIONS_MODE: OnceLock<PermissionsMode> = OnceLock::new();
+
+/// Set the process-wide active [`PermissionsMode`]. Idempotent — the
+/// first caller wins; subsequent calls are no-ops. Called from
+/// `main` (CLI) and the daemon bootstrap path with the value resolved
+/// from `[permissions].mode` in `config.toml`.
+pub fn set_active_permissions_mode(mode: PermissionsMode) {
+    let _ = ACTIVE_PERMISSIONS_MODE.set(mode);
+}
+
+/// Read the process-wide active [`PermissionsMode`]. Falls back to
+/// [`PermissionsMode::default`] (`advisory`) when unset, matching the
+/// v0.7.0 K3 default for upgrading operators (governance recorded but
+/// not blocked at the gate).
+///
+/// Test note: the K1 ship-gate matrix asserts `Pending`/`Deny`
+/// outcomes from `db::enforce_governance` and therefore opts into
+/// `Enforce` via [`set_active_permissions_mode`] at the start of each
+/// scenario.
+#[must_use]
+pub fn active_permissions_mode() -> PermissionsMode {
+    let override_tag = OVERRIDE_PERMISSIONS_MODE.load(std::sync::atomic::Ordering::SeqCst);
+    match override_tag {
+        1 => return PermissionsMode::Enforce,
+        2 => return PermissionsMode::Advisory,
+        3 => return PermissionsMode::Off,
+        _ => {}
+    }
+    ACTIVE_PERMISSIONS_MODE
+        .get()
+        .copied()
+        .unwrap_or(PermissionsMode::Advisory)
+}
+
+/// Test-only override of the active mode. Production code MUST use
+/// [`set_active_permissions_mode`]; this helper exists so the K3 test
+/// matrix can flip mode mid-test without spinning up a fresh process.
+#[doc(hidden)]
+pub fn override_active_permissions_mode_for_test(mode: PermissionsMode) {
+    // SAFETY: OnceLock::set returns Err when already set; we want
+    // last-writer-wins for tests only. Use a static Mutex to serialize
+    // and an inner OnceCell-like reset via take + set is not possible
+    // (OnceLock has no take). Instead, store an atomic indirection.
+    OVERRIDE_PERMISSIONS_MODE.store(
+        match mode {
+            PermissionsMode::Enforce => 1,
+            PermissionsMode::Advisory => 2,
+            PermissionsMode::Off => 3,
+        },
+        std::sync::atomic::Ordering::SeqCst,
+    );
+}
+
+/// Test-only override slot. `0` = no override, otherwise encodes the
+/// mode tag. Read by [`active_permissions_mode`] when set.
+static OVERRIDE_PERMISSIONS_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// Test-only: clear any override so subsequent tests see the
+/// `OnceLock` value (or the default).
+#[doc(hidden)]
+pub fn clear_permissions_mode_override_for_test() {
+    OVERRIDE_PERMISSIONS_MODE.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Test-only: acquire the global gate-mode serialization lock.
+///
+/// The active [`PermissionsMode`] lives in a process-wide atomic so
+/// the gate at `db::enforce_governance` can read it without an API
+/// churn through every callsite. Multiple lib tests flip the mode
+/// (the K3 mode-matrix file, the CLI / HTTP gate scenarios, the
+/// capabilities zero-state round-trip) and `cargo test --lib` runs
+/// them in parallel by default. Each scenario MUST hold this guard
+/// for its duration so two scenarios cannot race the atomic. The
+/// returned guard poisons-OK so one panicking scenario does not
+/// chain-fail the rest.
+#[doc(hidden)]
+#[must_use]
+pub fn lock_permissions_mode_for_test() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::Mutex;
+    static GATE_LOCK: Mutex<()> = Mutex::new(());
+    GATE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+// ---------------------------------------------------------------------------
+// Decision counters per mode (K3 — surfaced by doctor + capabilities)
+// ---------------------------------------------------------------------------
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static DECISIONS_ENFORCE: AtomicU64 = AtomicU64::new(0);
+static DECISIONS_ADVISORY: AtomicU64 = AtomicU64::new(0);
+static DECISIONS_OFF: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of decision counts per mode since process start. Surfaced
+/// by `ai-memory doctor` and the capabilities `permissions` block so
+/// operators can verify the gate is wired and observe drift between
+/// "policies advertised" and "policies enforced".
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionsDecisionCounts {
+    pub enforce: u64,
+    pub advisory: u64,
+    pub off: u64,
+}
+
+/// Increment the decision counter for `mode`. Called by the gate on
+/// every consult. `Relaxed` is fine: the counters are observability,
+/// not load-bearing for correctness.
+pub fn record_permissions_decision(mode: PermissionsMode) {
+    let c = match mode {
+        PermissionsMode::Enforce => &DECISIONS_ENFORCE,
+        PermissionsMode::Advisory => &DECISIONS_ADVISORY,
+        PermissionsMode::Off => &DECISIONS_OFF,
+    };
+    c.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Snapshot the current per-mode decision counts.
+#[must_use]
+pub fn permissions_decision_counts() -> PermissionsDecisionCounts {
+    PermissionsDecisionCounts {
+        enforce: DECISIONS_ENFORCE.load(Ordering::Relaxed),
+        advisory: DECISIONS_ADVISORY.load(Ordering::Relaxed),
+        off: DECISIONS_OFF.load(Ordering::Relaxed),
+    }
+}
+
+/// Test-only: zero the counters between scenarios so the K3 matrix
+/// can assert exact deltas.
+#[doc(hidden)]
+pub fn reset_permissions_decision_counts_for_test() {
+    DECISIONS_ENFORCE.store(0, Ordering::SeqCst);
+    DECISIONS_ADVISORY.store(0, Ordering::SeqCst);
+    DECISIONS_OFF.store(0, Ordering::SeqCst);
 }
 
 // ---------------------------------------------------------------------------
@@ -1549,6 +1786,37 @@ impl AppConfig {
         }
     }
 
+    /// v0.7.0 K3 — resolve the effective [`PermissionsMode`] consulted
+    /// by [`crate::db::enforce_governance`].
+    ///
+    /// Resolution order:
+    /// 1. `AI_MEMORY_PERMISSIONS_MODE` env var (`enforce` /
+    ///    `advisory` / `off`, case-insensitive). Lets the integration
+    ///    suite — which sets `AI_MEMORY_NO_CONFIG=1` and therefore
+    ///    cannot use `[permissions]` from `config.toml` — flip the
+    ///    gate to Enforce per scenario.
+    /// 2. `[permissions].mode` from `config.toml`.
+    /// 3. Compiled default ([`PermissionsMode::default`] = `advisory`).
+    #[must_use]
+    pub fn effective_permissions_mode(&self) -> PermissionsMode {
+        if let Ok(raw) = std::env::var("AI_MEMORY_PERMISSIONS_MODE") {
+            match raw.to_ascii_lowercase().as_str() {
+                "enforce" => return PermissionsMode::Enforce,
+                "advisory" => return PermissionsMode::Advisory,
+                "off" => return PermissionsMode::Off,
+                other => {
+                    eprintln!(
+                        "ai-memory: AI_MEMORY_PERMISSIONS_MODE={other:?} is not a valid mode \
+                         (expected enforce / advisory / off); falling back to config.toml"
+                    );
+                }
+            }
+        }
+        self.permissions
+            .as_ref()
+            .map_or_else(PermissionsMode::default, |p| p.mode)
+    }
+
     /// Resolve the effective feature tier from config (CLI flag overrides).
     pub fn effective_tier(&self, cli_tier: Option<&str>) -> FeatureTier {
         let tier_str = cli_tier.or(self.tier.as_deref()).unwrap_or("semantic");
@@ -1882,6 +2150,11 @@ mod tests {
     /// shaped correctly, runtime-state defaults conservative.
     #[test]
     fn capabilities_v2_zero_state_round_trip() {
+        let _gate = lock_permissions_mode_for_test();
+        // K3 default is `advisory` — clear any override that a
+        // sibling test might have left behind so the
+        // `permissions.mode` field reflects the documented zero-state.
+        clear_permissions_mode_override_for_test();
         let caps = FeatureTier::Keyword.config().capabilities();
         let val: serde_json::Value = serde_json::to_value(&caps).unwrap();
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -4671,6 +4671,29 @@ fn namespace_owner(conn: &Connection, namespace: &str) -> Option<String> {
 /// Enforce governance for a `GovernedAction`. On [`GovernanceDecision::Pending`],
 /// a row is inserted into `pending_actions` and the returned `pending_id` is
 /// embedded in the decision.
+///
+/// v0.7.0 K3 — the gate now consults
+/// [`crate::config::active_permissions_mode`] and branches on the
+/// active [`crate::config::PermissionsMode`]:
+///
+/// - [`PermissionsMode::Off`]: skip the gate entirely. Returns `Allow`
+///   without touching `resolve_governance_policy` or `pending_actions`.
+/// - [`PermissionsMode::Advisory`]: resolve the policy, log any
+///   would-be `Deny`/`Pending` outcome at `WARN`, then return `Allow`.
+///   No `pending_actions` row is queued. This is the v0.7.0 default —
+///   it preserves the v0.6.x posture for upgrading operators where
+///   governance metadata was advertised but the wider permission
+///   system was honest-disclosed as advisory.
+/// - [`PermissionsMode::Enforce`]: the historical strict path.
+///   `Deny`/`Pending` decisions surface verbatim and the
+///   `pending_actions` row is queued. Audit-ready posture; opt in via
+///   `[permissions] mode = "enforce"` in `config.toml`.
+///
+/// Every consult increments the per-mode counter exposed via
+/// [`crate::config::permissions_decision_counts`] so doctor +
+/// capabilities can surface gate activity.
+///
+/// [`PermissionsMode`]: crate::config::PermissionsMode
 pub fn enforce_governance(
     conn: &Connection,
     action: GovernedAction,
@@ -4680,6 +4703,16 @@ pub fn enforce_governance(
     memory_owner: Option<&str>,
     payload: &serde_json::Value,
 ) -> Result<GovernanceDecision> {
+    use crate::config::{PermissionsMode, active_permissions_mode, record_permissions_decision};
+
+    let mode = active_permissions_mode();
+    record_permissions_decision(mode);
+
+    // K3 — `Off` short-circuits before any policy lookup.
+    if mode == PermissionsMode::Off {
+        return Ok(GovernanceDecision::Allow);
+    }
+
     // Opt-in enforcement: namespaces without an explicit policy are unaffected.
     let Some(policy) = resolve_governance_policy(conn, namespace) else {
         return Ok(GovernanceDecision::Allow);
@@ -4696,6 +4729,39 @@ pub fn enforce_governance(
     };
 
     let decision = evaluate_level(conn, level, agent_id, memory_owner, ns_owner.as_deref());
+
+    // K3 — `Advisory` logs the would-be outcome but does not block or
+    // queue a pending row. The capabilities surface continues to
+    // advertise `permissions.mode = "advisory"` so external integrators
+    // see the consistent posture.
+    if mode == PermissionsMode::Advisory {
+        match &decision {
+            GovernanceDecision::Allow => {}
+            GovernanceDecision::Deny(reason) => {
+                tracing::warn!(
+                    target: "ai_memory::governance",
+                    namespace = %namespace,
+                    agent_id = %agent_id,
+                    action = ?action,
+                    reason = %reason,
+                    "permissions.mode=advisory: would-deny suppressed (allowing)"
+                );
+            }
+            GovernanceDecision::Pending(_) => {
+                tracing::warn!(
+                    target: "ai_memory::governance",
+                    namespace = %namespace,
+                    agent_id = %agent_id,
+                    action = ?action,
+                    "permissions.mode=advisory: would-queue-approval suppressed (allowing)"
+                );
+            }
+        }
+        return Ok(GovernanceDecision::Allow);
+    }
+
+    // K3 — `Enforce`: the historical strict path. `Pending` queues a
+    // `pending_actions` row and returns the canonical id.
     if let GovernanceDecision::Pending(_) = decision {
         let pending_id =
             queue_pending_action(conn, action, namespace, memory_id, agent_id, payload)?;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13191,6 +13191,11 @@ mod tests {
     /// present, `schema_version="2"`, and dropped fields are absent.
     #[tokio::test]
     async fn http_capabilities_v2_schema_includes_all_blocks() {
+        // v0.7.0 K3: serialize against the gate-mode atomic and clear
+        // any sibling-test override so `permissions.mode` reflects
+        // the documented zero-state default (`advisory`).
+        let _gate = crate::config::lock_permissions_mode_for_test();
+        crate::config::clear_permissions_mode_override_for_test();
         let state = test_state();
         let app = Router::new()
             .route("/api/v1/capabilities", axum_get(get_capabilities))
@@ -16499,6 +16504,27 @@ mod tests {
     // `GovernanceDecision::Pending` arm — exercising the queue+202 response
     // path that the federation-disabled tests cannot otherwise reach.
 
+    /// v0.7.0 K3 — pin the process-wide governance gate to
+    /// [`crate::config::PermissionsMode::Enforce`] so the suite's
+    /// historical Pending/Deny assertions still drive the strict
+    /// path. The K3 work flipped the v0.7.0 default to `Advisory`
+    /// (log + Allow) so upgrading operators do not get
+    /// surprise-blocked. These HTTP scenarios test the strict gate
+    /// behavior so they opt into Enforce explicitly.
+    ///
+    /// Returns the central gate-mode Mutex guard. Hold it for the
+    /// duration of the test so no parallel test (in any module) can
+    /// flip the gate out from under this scenario. The lock is
+    /// process-wide because the active mode lives in a process-wide
+    /// atomic.
+    fn pin_governance_enforce_for_test() -> std::sync::MutexGuard<'static, ()> {
+        let guard = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Enforce,
+        );
+        guard
+    }
+
     /// Seed a `_namespace_standard` memory with the supplied governance
     /// policy and wire `namespace_meta` to it. Returns nothing — caller
     /// just queries the namespace afterward.
@@ -16531,6 +16557,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_create_memory_governance_pending_returns_202() {
+        let _gate = pin_governance_enforce_for_test();
         let state = test_state();
         seed_governance_policy(
             &state,
@@ -16581,6 +16608,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_create_memory_governance_deny_returns_403() {
+        let _gate = pin_governance_enforce_for_test();
         // write: registered → unregistered caller is denied without queueing.
         let state = test_state();
         seed_governance_policy(
@@ -16625,6 +16653,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_delete_memory_governance_pending_returns_202() {
+        let _gate = pin_governance_enforce_for_test();
         let state = test_state();
         seed_governance_policy(
             &state,
@@ -16667,6 +16696,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_delete_memory_governance_deny_returns_403() {
+        let _gate = pin_governance_enforce_for_test();
         let state = test_state();
         seed_governance_policy(
             &state,
@@ -16702,6 +16732,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_promote_memory_governance_pending_returns_202() {
+        let _gate = pin_governance_enforce_for_test();
         let state = test_state();
         seed_governance_policy(
             &state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ async fn main() -> Result<()> {
     config::AppConfig::write_default_if_missing();
     daemon_runtime::apply_anonymize_default(&app_config);
 
+    // v0.7.0 K3 — pin the process-wide governance gate posture before
+    // any subcommand has a chance to call `db::enforce_governance`.
+    // Idempotent (`OnceLock::set`); first writer wins.
+    config::set_active_permissions_mode(app_config.effective_permissions_mode());
+
     // PR-5 (issue #487): bootstrap operational logging + security
     // audit trail. Both are default-OFF; init returns silently when
     // disabled. The `_log_guard` MUST stay in scope for the lifetime

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5749,6 +5749,11 @@ mod tests {
     /// indefinitely; this test is the contract that proves it.
     #[test]
     fn mcp_capabilities_v2_schema_includes_all_blocks() {
+        // v0.7.0 K3: serialize on the gate-mode atomic + clear any
+        // sibling-test override so `permissions.mode` reflects the
+        // documented `advisory` zero-state.
+        let _gate = crate::config::lock_permissions_mode_for_test();
+        crate::config::clear_permissions_mode_override_for_test();
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
         let req = make_tools_call("memory_capabilities", json!({"accept": "v2"}));
         let resp = invoke_handle_request(&conn, &req);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,6 +9,13 @@
 fn cmd(binary: &str) -> std::process::Command {
     let mut c = std::process::Command::new(binary);
     c.env("AI_MEMORY_NO_CONFIG", "1");
+    // v0.7.0 K3 — the integration suite asserts the gate's strict
+    // semantics (Pending/Deny on policy violation). The v0.7.0
+    // process default for `permissions.mode` is `advisory` (log +
+    // Allow) to preserve the v0.6.x posture for upgrading operators,
+    // so opt these scenarios into Enforce explicitly. Per-test
+    // overrides win because env-vars are shadowed at .env() call time.
+    c.env("AI_MEMORY_PERMISSIONS_MODE", "enforce");
     c
 }
 /// Spawn a command and collect its output, panicking with a descriptive

--- a/tests/permissions_mode_gate.rs
+++ b/tests/permissions_mode_gate.rs
@@ -1,0 +1,268 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// v0.7.0 K3 — `permissions.mode` consulted by gate.
+//
+// Closes the v0.6.3.1 honest-Capabilities-v2 disclosure that
+// `permissions.mode = "advisory"` was advertised but the gate itself
+// returned `Deny`/`Pending` regardless of the knob.
+//
+// Each scenario seeds the same parent governance policy (`Approve`-
+// gated write at `alphaone/secure`) and walks the same payload
+// through `db::enforce_governance` against a child namespace. The
+// only thing that varies is the active `PermissionsMode`, and each
+// mode is asserted to produce its documented outcome:
+//
+//   - `Enforce`   → `Pending(_)` returned, `pending_actions` row queued
+//   - `Advisory`  → `Allow` returned, no `pending_actions` row, warn log
+//   - `Off`       → `Allow` returned, no policy resolution, no log
+//
+// CUTLINE-PROTECTED: K3 is the load-bearing demonstration that the
+// permission gate honors the advertised mode. Failures here regress
+// the v0.7.0 honest-disclosure remediation.
+
+use ai_memory::config::{
+    PermissionsMode, clear_permissions_mode_override_for_test, lock_permissions_mode_for_test,
+    override_active_permissions_mode_for_test, permissions_decision_counts,
+    reset_permissions_decision_counts_for_test,
+};
+use ai_memory::db;
+use ai_memory::models::{
+    ApproverType, GovernanceDecision, GovernanceLevel, GovernancePolicy, GovernedAction, Memory,
+    Tier, default_metadata,
+};
+use rusqlite::Connection;
+
+fn seed_policy(conn: &Connection, namespace: &str, policy: GovernancePolicy, owner_agent_id: &str) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut metadata = default_metadata();
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert(
+            "agent_id".to_string(),
+            serde_json::Value::String(owner_agent_id.to_string()),
+        );
+        obj.insert(
+            "governance".to_string(),
+            serde_json::to_value(&policy).unwrap(),
+        );
+    }
+    let standard = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: format!("_standards-{namespace}"),
+        title: format!("standard for {namespace}"),
+        content: "policy".to_string(),
+        tags: vec![],
+        priority: 9,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata,
+    };
+    let standard_id = db::insert(conn, &standard).unwrap();
+    db::set_namespace_standard(conn, namespace, &standard_id, None).unwrap();
+}
+
+fn approve_write_policy() -> GovernancePolicy {
+    GovernancePolicy {
+        write: GovernanceLevel::Approve,
+        promote: GovernanceLevel::Any,
+        delete: GovernanceLevel::Owner,
+        approver: ApproverType::Human,
+        inherit: true,
+    }
+}
+
+/// `enforce` mode is the historical strict path — the K1 cutline
+/// codifies it. K3 reaffirms it from the mode-matrix angle: gate
+/// returns `Pending(_)` and a `pending_actions` row lands.
+#[test]
+fn k3_enforce_mode_blocks_with_pending() {
+    let _guard = lock_permissions_mode_for_test();
+    override_active_permissions_mode_for_test(PermissionsMode::Enforce);
+    reset_permissions_decision_counts_for_test();
+
+    let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+    seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
+
+    let leaf = "alphaone/secure/team-a";
+    let payload = serde_json::json!({"title": "k3-enforce"});
+    let decision = db::enforce_governance(
+        &conn,
+        GovernedAction::Store,
+        leaf,
+        "bob",
+        None,
+        None,
+        &payload,
+    )
+    .expect("gate must not error in Enforce mode");
+
+    match decision {
+        GovernanceDecision::Pending(pid) => {
+            assert!(!pid.is_empty(), "Enforce queues a pending_id");
+            let pending = db::list_pending_actions(&conn, Some("pending"), 10).unwrap();
+            assert!(
+                pending
+                    .iter()
+                    .any(|pa| pa.id == pid && pa.namespace == leaf),
+                "Enforce mode must persist the pending_actions row"
+            );
+        }
+        other => panic!("Enforce mode must return Pending(_), got {other:?}"),
+    }
+
+    let counts = permissions_decision_counts();
+    assert_eq!(counts.enforce, 1, "Enforce decision counter must increment");
+    assert_eq!(counts.advisory, 0);
+    assert_eq!(counts.off, 0);
+
+    clear_permissions_mode_override_for_test();
+}
+
+/// `advisory` mode is the v0.7.0 default for upgrading operators —
+/// governance metadata is recorded but the gate logs and allows. The
+/// would-be `Pending` is suppressed: no `pending_actions` row is
+/// queued (so the approver pipeline does not see phantom work) and
+/// the caller observes `Allow`.
+#[test]
+fn k3_advisory_mode_logs_and_allows_no_pending_row() {
+    let _guard = lock_permissions_mode_for_test();
+    override_active_permissions_mode_for_test(PermissionsMode::Advisory);
+    reset_permissions_decision_counts_for_test();
+
+    let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+    seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
+
+    let leaf = "alphaone/secure/team-a";
+    let payload = serde_json::json!({"title": "k3-advisory"});
+
+    let pending_before = db::list_pending_actions(&conn, Some("pending"), 10)
+        .unwrap()
+        .len();
+
+    let decision = db::enforce_governance(
+        &conn,
+        GovernedAction::Store,
+        leaf,
+        "bob",
+        None,
+        None,
+        &payload,
+    )
+    .expect("gate must not error in Advisory mode");
+
+    assert!(
+        matches!(decision, GovernanceDecision::Allow),
+        "Advisory mode must Allow even when policy would have queued: got {decision:?}"
+    );
+
+    let pending_after = db::list_pending_actions(&conn, Some("pending"), 10)
+        .unwrap()
+        .len();
+    assert_eq!(
+        pending_before, pending_after,
+        "Advisory mode must NOT queue a pending_actions row"
+    );
+
+    let counts = permissions_decision_counts();
+    assert_eq!(
+        counts.advisory, 1,
+        "Advisory decision counter must increment"
+    );
+    assert_eq!(counts.enforce, 0);
+    assert_eq!(counts.off, 0);
+
+    clear_permissions_mode_override_for_test();
+}
+
+/// `off` mode skips the gate entirely — no policy resolution, no
+/// pending row, no warn log. This is the freeze-thaw escape hatch
+/// for incident response.
+#[test]
+fn k3_off_mode_skips_gate_entirely() {
+    let _guard = lock_permissions_mode_for_test();
+    override_active_permissions_mode_for_test(PermissionsMode::Off);
+    reset_permissions_decision_counts_for_test();
+
+    let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+    seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
+
+    let leaf = "alphaone/secure/team-a";
+    let payload = serde_json::json!({"title": "k3-off"});
+
+    let pending_before = db::list_pending_actions(&conn, Some("pending"), 10)
+        .unwrap()
+        .len();
+
+    let decision = db::enforce_governance(
+        &conn,
+        GovernedAction::Store,
+        leaf,
+        "bob",
+        None,
+        None,
+        &payload,
+    )
+    .expect("gate must not error in Off mode");
+
+    assert!(
+        matches!(decision, GovernanceDecision::Allow),
+        "Off mode must Allow without consulting policy: got {decision:?}"
+    );
+
+    let pending_after = db::list_pending_actions(&conn, Some("pending"), 10)
+        .unwrap()
+        .len();
+    assert_eq!(
+        pending_before, pending_after,
+        "Off mode must NOT touch pending_actions"
+    );
+
+    let counts = permissions_decision_counts();
+    assert_eq!(counts.off, 1, "Off decision counter must increment");
+    assert_eq!(counts.enforce, 0);
+    assert_eq!(counts.advisory, 0);
+
+    clear_permissions_mode_override_for_test();
+}
+
+/// Capabilities surface — the active mode + decision counts must be
+/// observable through the canonical capabilities response so doctor
+/// + remote operators can verify the gate posture. With the mode
+/// pinned to `enforce` and one decision recorded, the shape is:
+/// `{ mode: "enforce", decision_counts: { enforce: 1, ... } }`.
+#[test]
+fn k3_capabilities_reports_active_mode_and_decision_counts() {
+    let _guard = lock_permissions_mode_for_test();
+    override_active_permissions_mode_for_test(PermissionsMode::Enforce);
+    reset_permissions_decision_counts_for_test();
+
+    let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+    seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
+    let _ = db::enforce_governance(
+        &conn,
+        GovernedAction::Store,
+        "alphaone/secure",
+        "bob",
+        None,
+        None,
+        &serde_json::json!({"title": "caps-probe"}),
+    )
+    .unwrap();
+
+    let caps = ai_memory::config::FeatureTier::Keyword
+        .config()
+        .capabilities();
+    let v: serde_json::Value = serde_json::to_value(&caps).unwrap();
+    assert_eq!(v["permissions"]["mode"], "enforce");
+    assert_eq!(v["permissions"]["decision_counts"]["enforce"], 1);
+    assert_eq!(v["permissions"]["decision_counts"]["advisory"], 0);
+    assert_eq!(v["permissions"]["decision_counts"]["off"], 0);
+
+    clear_permissions_mode_override_for_test();
+}

--- a/tests/ship_gate_governance_inheritance.rs
+++ b/tests/ship_gate_governance_inheritance.rs
@@ -21,12 +21,28 @@
 // CUTLINE-PROTECTED: even if every other v0.6.3.1 phase slips, this
 // scenario file ships green. Failures here are release blockers.
 
+use ai_memory::config::{
+    PermissionsMode, lock_permissions_mode_for_test, override_active_permissions_mode_for_test,
+};
 use ai_memory::db;
 use ai_memory::models::{
     ApproverType, GovernanceDecision, GovernanceLevel, GovernancePolicy, GovernedAction, Memory,
     Tier, default_metadata,
 };
 use rusqlite::Connection;
+
+/// K3: the ship-gate matrix asserts the gate's *blocking* semantics
+/// (Pending / Deny). v0.7.0 K3 made the gate consult
+/// `permissions.mode`, with the v0.7.0 process default being
+/// `advisory` (log + Allow). Pin the K1 cutline to Enforce so the
+/// ship-gate scenarios still drive the blocking path. Returns the
+/// process-wide gate-mode Mutex guard so concurrent scenarios in
+/// this binary cannot flip the atomic mid-test.
+fn pin_enforce_mode() -> std::sync::MutexGuard<'static, ()> {
+    let guard = lock_permissions_mode_for_test();
+    override_active_permissions_mode_for_test(PermissionsMode::Enforce);
+    guard
+}
 
 fn seed_policy(conn: &Connection, namespace: &str, policy: GovernancePolicy, owner_agent_id: &str) {
     let now = chrono::Utc::now().to_rfc3339();
@@ -89,6 +105,7 @@ fn any_policy_no_inherit() -> GovernancePolicy {
 /// G1 #1 — depth-5 chain inherits Approve to the leaf, store is queued.
 #[test]
 fn shipgate_inherit_default_governance_chain_5_deep_requires_approval_at_leaf() {
+    let _gate = pin_enforce_mode();
     let conn = db::open(std::path::Path::new(":memory:")).unwrap();
     seed_policy(&conn, "alphaone", approve_write_policy(), "alice");
 
@@ -124,6 +141,7 @@ fn shipgate_inherit_default_governance_chain_5_deep_requires_approval_at_leaf() 
 /// policy applies and the parent's Approve does NOT bubble through.
 #[test]
 fn shipgate_inherit_false_at_child_blocks_parent_policy() {
+    let _gate = pin_enforce_mode();
     let conn = db::open(std::path::Path::new(":memory:")).unwrap();
     seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
     seed_policy(
@@ -154,6 +172,7 @@ fn shipgate_inherit_false_at_child_blocks_parent_policy() {
 /// G1 #3 — both levels set, the most-specific (child) policy wins.
 #[test]
 fn shipgate_most_specific_policy_wins_when_both_set() {
+    let _gate = pin_enforce_mode();
     let conn = db::open(std::path::Path::new(":memory:")).unwrap();
     seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
     seed_policy(
@@ -185,6 +204,7 @@ fn shipgate_most_specific_policy_wins_when_both_set() {
 /// through the gate (the original audit reproducer).
 #[test]
 fn shipgate_child_with_no_policy_inherits_parent_policy() {
+    let _gate = pin_enforce_mode();
     let conn = db::open(std::path::Path::new(":memory:")).unwrap();
     seed_policy(&conn, "alphaone/secure", approve_write_policy(), "alice");
     // NB: alphaone/secure/team-a has no standard.
@@ -214,6 +234,7 @@ fn shipgate_child_with_no_policy_inherits_parent_policy() {
 /// approver pipeline.
 #[test]
 fn shipgate_audit_no_silent_bypass_in_v063_compatibility_path() {
+    let _gate = pin_enforce_mode();
     let conn = db::open(std::path::Path::new(":memory:")).unwrap();
 
     // Replicate the audit scenario verbatim: alphaone/secure has an


### PR DESCRIPTION
Track K task K3 of v0.7.0 attested-cortex epic.

## Summary
- New config knob `permissions.mode` (enforce / advisory / off)
- db::enforce_governance now branches on the mode
- Doctor + capabilities report active mode
- Default `advisory` to preserve v0.6.x behavior; new installs can opt into `enforce`

## Test plan
- [x] cargo fmt --check + clippy --pedantic clean
- [x] cargo test --lib green; no regression
- [x] K1 cutline tests stay green (governance_inheritance + ship_gate_governance_inheritance)
- [x] 3-mode test matrix covers enforce / advisory / off
- [ ] K9 will refactor governance → permissions; this lays the surface