### PR TITLE
feat: v0.7-b4 — detect harness from MCP clientInfo

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -771,6 +771,7 @@ impl Capabilities {
         to_describe_to_user: String,
         tools: Vec<ToolEntry>,
         agent_permitted_families: Option<Vec<String>>,
+        your_harness_supports_deferred_registration: Option<bool>,
     ) -> CapabilitiesV3 {
         CapabilitiesV3 {
             schema_version: "3".to_string(),
@@ -778,6 +779,7 @@ impl Capabilities {
             to_describe_to_user,
             tools,
             agent_permitted_families,
+            your_harness_supports_deferred_registration,
             tier: self.tier.clone(),
             version: self.version.clone(),
             features: self.features.clone(),
@@ -889,6 +891,26 @@ pub struct CapabilitiesV3 {
     /// `tools[]` and counting unique families.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_permitted_families: Option<Vec<String>>,
+
+    /// v0.7.0 B4 — whether the active MCP harness exposes tools
+    /// registered *after* the initial `tools/list` to the LLM. Computed
+    /// at response time from the harness detected at the
+    /// `initialize.clientInfo.name` handshake (see `crate::harness`).
+    ///
+    /// `Some(true)` only for Claude Code today (deferred registration
+    /// via `ToolSearch`). `Some(false)` for every other named harness.
+    /// `None` (omitted from the wire via `skip_serializing_if`) when
+    /// no `clientInfo` was captured — typically HTTP callers, or an
+    /// MCP client that issued `memory_capabilities` before
+    /// `initialize` (malformed but defensively handled by absence).
+    ///
+    /// Track B's runtime loaders (B1 `memory_load_family`, B2
+    /// `memory_smart_load`) key off this bit to shape their
+    /// `to_invoke` text — on `false` harnesses they advise the LLM to
+    /// ask the operator for a `--profile <family>` restart rather
+    /// than expect the new tools to appear mid-session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub your_harness_supports_deferred_registration: Option<bool>,
 
     pub tier: String,
     pub version: String,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4220,6 +4220,11 @@ pub async fn get_capabilities(
             app.profile.as_ref(),
             app.mcp_config.as_ref().as_ref(),
             None,
+            // v0.7.0 B4 — HTTP path has no MCP `initialize` handshake,
+            // so harness is always None here. The
+            // `your_harness_supports_deferred_registration` field is
+            // omitted on the wire via `skip_serializing_if`.
+            None,
         ),
         _ => crate::mcp::handle_capabilities_with_conn(
             app.tier_config.as_ref(),

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,0 +1,338 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7 Track B (B4) — Harness detection from MCP `clientInfo.name`.
+//!
+//! When an MCP client opens a JSON-RPC `initialize` handshake, it sends
+//! a `clientInfo` object with a `name` field that identifies the
+//! harness — e.g. `"claude-code"`, `"codex"`, `"cursor"`, `"cline"`.
+//! The substrate captures that string at handshake time
+//! (`src/mcp.rs::serve_stdio` already stashes it as `mcp_client_name`)
+//! and then needs to make a behavioural decision: does this harness
+//! surface tools registered *after* the initial `tools/list` to the
+//! LLM, or does it cache the manifest at session start?
+//!
+//! Track B's runtime loaders (B1 `memory_load_family`, B2
+//! `memory_smart_load`) only deliver value on harnesses with deferred
+//! registration — on eager-load harnesses (Codex, Cursor, etc.) they
+//! still return the schemas, but the LLM has to know it should ask the
+//! operator to restart with `--profile <family>` rather than expect
+//! the new tools to appear mid-session. The harness layer carries
+//! that bit so the loaders, the capabilities-v3 response, and the
+//! `to_invoke` helper text can all agree on the contract per harness.
+//!
+//! # Compatibility matrix
+//!
+//! Source of truth: `docs/v0.7/compatibility-matrix.html` (shipped
+//! with Track D2). Today only Claude Code supports deferred-tool
+//! registration via its `ToolSearch` mechanism. Every other harness
+//! defaults to **false** (conservative) so the LLM doesn't promise an
+//! end-user that a tool will appear mid-session and then strand the
+//! conversation when the cached manifest never gets refreshed.
+//!
+//! Unknown harnesses (`Generic(name)`) also default to false. If an
+//! operator runs the substrate behind a custom MCP client that *does*
+//! support deferred registration, they can either (a) add the harness
+//! name to `Harness::detect`'s match arms or (b) wait for a future
+//! release that exposes a runtime override (out of scope for B4).
+//!
+//! # Wire surface
+//!
+//! The detected harness's `supports_deferred_registration()` value is
+//! surfaced verbatim in the v3 capabilities response as the top-level
+//! field `your_harness_supports_deferred_registration` (boolean). When
+//! no `clientInfo` was provided (e.g. an HTTP caller or a malformed
+//! handshake), the field is omitted (`Option::None` +
+//! `skip_serializing_if`) so legacy callers see no schema drift.
+//!
+//! # Example
+//!
+//! ```
+//! use ai_memory::harness::Harness;
+//!
+//! // Fuzzy + case-insensitive substring matching.
+//! assert_eq!(Harness::detect("claude-code"), Harness::ClaudeCode);
+//! assert_eq!(Harness::detect("Claude Code"), Harness::ClaudeCode);
+//! assert_eq!(Harness::detect("claude_code"), Harness::ClaudeCode);
+//!
+//! assert!(Harness::ClaudeCode.supports_deferred_registration());
+//! assert!(!Harness::Codex.supports_deferred_registration());
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// MCP harness detected from the `initialize.clientInfo.name` field.
+///
+/// The variants cover the harnesses called out in
+/// `docs/v0.7/compatibility-matrix.html` (Track D2). Unknown harnesses
+/// fall through to `Generic(String)` carrying the original
+/// `clientInfo.name` so downstream logging / metrics can attribute
+/// behaviour to the unrecognised client without losing the name.
+///
+/// `serde` uses `snake_case` so the wire shape matches the rest of the
+/// v3 capabilities document. `Generic` carries an inner string and
+/// serialises as `{"generic": "<name>"}` per serde's default
+/// externally-tagged enum representation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Harness {
+    /// Anthropic Claude Code — supports deferred-tool registration via
+    /// `ToolSearch`. The only first-class harness today where B1's
+    /// `memory_load_family` actually surfaces new tools mid-session.
+    ClaudeCode,
+    /// OpenAI Codex CLI — eager-load only.
+    Codex,
+    /// Anysphere Cursor — MCP via stdio, eager-load only.
+    Cursor,
+    /// VS Code Cline extension — MCP via stdio, eager-load only.
+    Cline,
+    /// Continue.dev (VS Code / JetBrains) — MCP via stdio, eager-load only.
+    Continue,
+    /// Aider CLI pair-programmer — MCP via stdio, eager-load only.
+    Aider,
+    /// Block / Square Goose — MCP via stdio, eager-load only.
+    Goose,
+    /// Anthropic Claude Desktop — eager-load only.
+    ClaudeDesktop,
+    /// Unknown harness; carries the original `clientInfo.name` so the
+    /// operator can grep logs for "this is the harness I forgot to
+    /// register" without losing the identifying string.
+    Generic(String),
+}
+
+impl Harness {
+    /// Detect a harness from the `clientInfo.name` field of the MCP
+    /// `initialize` request.
+    ///
+    /// Matching is **case-insensitive** and **fuzzy substring** — the
+    /// raw name is normalised by lower-casing and stripping the
+    /// punctuation harnesses use as separators (`-`, `_`, ` `,
+    /// `.`) before comparison. So `"claude-code"`, `"Claude Code"`,
+    /// `"claude_code"`, and `"CLAUDE.CODE"` all detect as
+    /// `Harness::ClaudeCode`.
+    ///
+    /// Unknown names round-trip into `Generic(<original>)` preserving
+    /// the input verbatim so logging / metrics keep a useful label.
+    #[must_use]
+    pub fn detect(client_name: &str) -> Self {
+        let normalised = client_name
+            .chars()
+            .filter(|c| !matches!(c, '-' | '_' | ' ' | '.'))
+            .flat_map(char::to_lowercase)
+            .collect::<String>();
+
+        // Order matters: `claudecode` and `claudedesktop` both contain
+        // `claude`, so the more-specific match must come first. The
+        // substring check is `contains`, so `claudecodecli` (a
+        // hypothetical wrapper) still detects as ClaudeCode.
+        if normalised.contains("claudecode") {
+            Self::ClaudeCode
+        } else if normalised.contains("claudedesktop") {
+            Self::ClaudeDesktop
+        } else if normalised.contains("codex") {
+            Self::Codex
+        } else if normalised.contains("cursor") {
+            Self::Cursor
+        } else if normalised.contains("cline") {
+            Self::Cline
+        } else if normalised.contains("continue") {
+            Self::Continue
+        } else if normalised.contains("aider") {
+            Self::Aider
+        } else if normalised.contains("goose") {
+            Self::Goose
+        } else {
+            Self::Generic(client_name.to_string())
+        }
+    }
+
+    /// Whether this harness exposes tools registered *after* the
+    /// initial `tools/list` to the LLM mid-session.
+    ///
+    /// `true` only for harnesses with documented deferred-tool
+    /// registration support. Today that's just Claude Code via its
+    /// `ToolSearch` mechanism. Every other known harness eager-loads
+    /// the manifest at session start and won't surface a tool added
+    /// later — so B1's `memory_load_family` falls back to a
+    /// "restart with `--profile <family>`" hint on those harnesses.
+    ///
+    /// **Default for unknown harnesses (`Generic`)**: `false`
+    /// (conservative). It's better to under-promise than to claim a
+    /// tool will appear and have the conversation strand on a stale
+    /// cached manifest.
+    #[must_use]
+    pub fn supports_deferred_registration(&self) -> bool {
+        match self {
+            Self::ClaudeCode => true,
+            Self::Codex
+            | Self::Cursor
+            | Self::Cline
+            | Self::Continue
+            | Self::Aider
+            | Self::Goose
+            | Self::ClaudeDesktop
+            | Self::Generic(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------
+    // detect() — Claude Code matches under every common spelling.
+    // -----------------------------------------------------------------
+    #[test]
+    fn detect_claude_code_canonical_kebab() {
+        assert_eq!(Harness::detect("claude-code"), Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn detect_claude_code_title_case_with_space() {
+        assert_eq!(Harness::detect("Claude Code"), Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn detect_claude_code_snake_case() {
+        assert_eq!(Harness::detect("claude_code"), Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn detect_claude_code_screaming_with_dots() {
+        assert_eq!(Harness::detect("CLAUDE.CODE"), Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn detect_claude_code_versioned_suffix() {
+        // A real-world harness sometimes ships its name as
+        // `claude-code/1.2.3` or `claude-code-cli`; substring match
+        // catches both without per-version updates.
+        assert_eq!(Harness::detect("claude-code-cli"), Harness::ClaudeCode);
+        assert_eq!(Harness::detect("claude-code/1.2.3"), Harness::ClaudeCode);
+    }
+
+    // -----------------------------------------------------------------
+    // detect() — every other named harness round-trips.
+    // -----------------------------------------------------------------
+    #[test]
+    fn detect_codex_variants() {
+        assert_eq!(Harness::detect("codex"), Harness::Codex);
+        assert_eq!(Harness::detect("Codex"), Harness::Codex);
+        assert_eq!(Harness::detect("codex-cli"), Harness::Codex);
+        assert_eq!(Harness::detect("openai-codex"), Harness::Codex);
+    }
+
+    #[test]
+    fn detect_cursor_variants() {
+        assert_eq!(Harness::detect("cursor"), Harness::Cursor);
+        assert_eq!(Harness::detect("Cursor"), Harness::Cursor);
+        assert_eq!(Harness::detect("cursor-mcp"), Harness::Cursor);
+    }
+
+    #[test]
+    fn detect_cline_variants() {
+        assert_eq!(Harness::detect("cline"), Harness::Cline);
+        assert_eq!(Harness::detect("Cline"), Harness::Cline);
+        assert_eq!(Harness::detect("vscode-cline"), Harness::Cline);
+    }
+
+    #[test]
+    fn detect_continue_variants() {
+        assert_eq!(Harness::detect("continue"), Harness::Continue);
+        assert_eq!(Harness::detect("Continue"), Harness::Continue);
+        assert_eq!(Harness::detect("continue.dev"), Harness::Continue);
+    }
+
+    #[test]
+    fn detect_aider_variants() {
+        assert_eq!(Harness::detect("aider"), Harness::Aider);
+        assert_eq!(Harness::detect("Aider"), Harness::Aider);
+        assert_eq!(Harness::detect("aider-cli"), Harness::Aider);
+    }
+
+    #[test]
+    fn detect_goose_variants() {
+        assert_eq!(Harness::detect("goose"), Harness::Goose);
+        assert_eq!(Harness::detect("Goose"), Harness::Goose);
+        assert_eq!(Harness::detect("block-goose"), Harness::Goose);
+    }
+
+    #[test]
+    fn detect_claude_desktop_variants() {
+        // Claude Desktop must NOT be misclassified as ClaudeCode even
+        // though its name is a superstring of "claude". The match
+        // ordering in `detect()` checks `claudecode` first.
+        assert_eq!(Harness::detect("claude-desktop"), Harness::ClaudeDesktop);
+        assert_eq!(Harness::detect("Claude Desktop"), Harness::ClaudeDesktop);
+        assert_eq!(Harness::detect("ClaudeDesktop"), Harness::ClaudeDesktop);
+    }
+
+    // -----------------------------------------------------------------
+    // detect() — unknown names round-trip into Generic preserving
+    // the original string verbatim (no normalisation, no truncation).
+    // -----------------------------------------------------------------
+    #[test]
+    fn detect_unknown_preserves_original_name() {
+        let raw = "MyCustomMcpClient/0.1";
+        let h = Harness::detect(raw);
+        match h {
+            Harness::Generic(s) => assert_eq!(s, raw),
+            other => panic!("expected Generic; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_empty_name_is_generic() {
+        // An empty clientInfo.name is malformed but defensively
+        // mapped to Generic("") rather than panicking.
+        assert_eq!(Harness::detect(""), Harness::Generic(String::new()));
+    }
+
+    // -----------------------------------------------------------------
+    // supports_deferred_registration — compat matrix per docs/v0.7.
+    // -----------------------------------------------------------------
+    #[test]
+    fn deferred_registration_only_claude_code_today() {
+        assert!(Harness::ClaudeCode.supports_deferred_registration());
+
+        assert!(!Harness::Codex.supports_deferred_registration());
+        assert!(!Harness::Cursor.supports_deferred_registration());
+        assert!(!Harness::Cline.supports_deferred_registration());
+        assert!(!Harness::Continue.supports_deferred_registration());
+        assert!(!Harness::Aider.supports_deferred_registration());
+        assert!(!Harness::Goose.supports_deferred_registration());
+        assert!(!Harness::ClaudeDesktop.supports_deferred_registration());
+    }
+
+    #[test]
+    fn deferred_registration_unknown_defaults_false() {
+        // Conservative: unknown harnesses default to false so we
+        // never promise mid-session tool surfacing we can't deliver.
+        assert!(
+            !Harness::Generic("some-random-mcp-client".to_string())
+                .supports_deferred_registration()
+        );
+        assert!(!Harness::Generic(String::new()).supports_deferred_registration());
+    }
+
+    // -----------------------------------------------------------------
+    // serde — round-trip through JSON for the wire shape.
+    // -----------------------------------------------------------------
+    #[test]
+    fn serde_round_trips_named_variants() {
+        let h = Harness::ClaudeCode;
+        let s = serde_json::to_string(&h).expect("serialize");
+        assert_eq!(s, "\"claude_code\"");
+        let back: Harness = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, Harness::ClaudeCode);
+    }
+
+    #[test]
+    fn serde_round_trips_generic_variant() {
+        let h = Harness::Generic("foo".to_string());
+        let s = serde_json::to_string(&h).expect("serialize");
+        let back: Harness = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(back, h);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@ pub mod embeddings;
 pub mod errors;
 pub mod federation;
 pub mod handlers;
+// v0.7 Track B — harness detection. B4 reads the MCP `clientInfo.name`
+// captured at the JSON-RPC `initialize` handshake and maps it to a
+// `Harness` enum so downstream paths (capabilities-v3, B1's
+// `memory_load_family`, B2's `memory_smart_load`) can shape responses
+// based on whether the harness supports deferred-tool registration.
+pub mod harness;
 pub mod hnsw;
 // v0.7 Track G — programmable lifecycle hook pipeline. G1 lands
 // the config schema + SIGHUP hot-reload plumbing; the executor

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1836,13 +1836,24 @@ pub fn handle_capabilities_with_conn_v3(
     profile: &crate::profile::Profile,
     mcp_config: Option<&crate::config::McpConfig>,
     agent_id: Option<&str>,
+    // v0.7.0 B4 — the harness detected from `initialize.clientInfo.name`
+    // at MCP handshake time. `None` when no handshake has happened
+    // (HTTP callers, or a malformed MCP session that issued
+    // `memory_capabilities` before `initialize`); the resulting
+    // `your_harness_supports_deferred_registration` field is omitted
+    // from the wire via `skip_serializing_if = Option::is_none`.
+    harness: Option<&crate::harness::Harness>,
 ) -> Result<Value, String> {
     let caps = build_capabilities_overlay(tier_config, reranker, embedder_loaded, conn);
     let summary = build_capabilities_summary(profile);
     let describe = build_capabilities_describe_to_user(profile);
     let tools = build_capabilities_tools(profile, mcp_config, agent_id);
     let permitted = build_agent_permitted_families(mcp_config, agent_id);
-    serde_json::to_value(caps.to_v3(summary, describe, tools, permitted)).map_err(|e| e.to_string())
+    // B4 — present only when we know the harness; otherwise omit so
+    // unaware callers and HTTP callers see no schema drift.
+    let deferred = harness.map(crate::harness::Harness::supports_deferred_registration);
+    serde_json::to_value(caps.to_v3(summary, describe, tools, permitted, deferred))
+        .map_err(|e| e.to_string())
 }
 
 /// Build the runtime-overlaid [`Capabilities`] document. Shared between
@@ -3961,6 +3972,13 @@ fn handle_request(
     // (operator hasn't generated one), links go in unsigned, preserving
     // v0.6.4 behaviour.
     active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
+    // v0.7 Track B (B4) — harness detected from `clientInfo.name` at
+    // MCP `initialize` handshake time. Threaded into the
+    // capabilities-v3 dispatch so the response can carry
+    // `your_harness_supports_deferred_registration` (presence + value
+    // both signal). `None` when no `initialize` has been observed yet
+    // — the field is omitted from the wire on that fall-through.
+    harness: Option<&crate::harness::Harness>,
 ) -> RpcResponse {
     let id = req.id.clone().unwrap_or(Value::Null);
 
@@ -4164,6 +4182,11 @@ fn handle_request(
                                 profile,
                                 mcp_config,
                                 v3_aid,
+                                // v0.7.0 B4 — pass the detected
+                                // harness through so the response
+                                // surfaces
+                                // `your_harness_supports_deferred_registration`.
+                                harness,
                             ),
                             _ => handle_capabilities_with_conn(
                                 tier_config,
@@ -4549,6 +4572,13 @@ pub fn run_mcp_server(
     // agent_id when the caller doesn't supply one explicitly.
     let mut mcp_client_name: Option<String> = None;
 
+    // v0.7.0 B4 — Harness detected from `clientInfo.name` at handshake
+    // time. Stays `None` until we observe an `initialize` so the
+    // capabilities-v3 response omits
+    // `your_harness_supports_deferred_registration` (presence is
+    // itself meaningful — absence means "we don't know").
+    let mut detected_harness: Option<crate::harness::Harness> = None;
+
     for line in stdin.lock().lines() {
         let line = line?;
         if line.trim().is_empty() {
@@ -4572,6 +4602,10 @@ pub fn run_mcp_server(
             && !name.is_empty()
         {
             mcp_client_name = Some(name.to_string());
+            // v0.7.0 B4 — detect the harness so capabilities-v3 +
+            // future B1/B2 loaders can shape responses based on
+            // whether the harness supports deferred-tool registration.
+            detected_harness = Some(crate::harness::Harness::detect(name));
         }
 
         // Notifications have no id — no response expected per JSON-RPC spec
@@ -4600,6 +4634,7 @@ pub fn run_mcp_server(
             profile,
             app_config.mcp.as_ref(),
             active_keypair.as_ref(),
+            detected_harness.as_ref(),
         );
         let out = serde_json::to_string(&resp)?;
         writeln!(stdout, "{out}")?;
@@ -5026,6 +5061,7 @@ mod tests {
                 &crate::profile::Profile::full(),
                 None,
                 None,
+                None,
             );
             assert!(resp.error.is_none(), "expected ok rpc response");
         });
@@ -5077,6 +5113,7 @@ mod tests {
                 false,
                 None,
                 &crate::profile::Profile::full(),
+                None,
                 None,
                 None,
             );
@@ -5358,6 +5395,7 @@ mod tests {
                 &crate::profile::Profile::full(),
                 None,
                 None,
+                None,
             );
             assert!(
                 resp.error.is_none(),
@@ -5395,6 +5433,7 @@ mod tests {
                     false,
                     None,
                     &crate::profile::Profile::full(),
+                    None,
                     None,
                     None,
                 );
@@ -5451,6 +5490,7 @@ mod tests {
             false,
             None,
             &crate::profile::Profile::full(),
+            None,
             None,
             None,
         )
@@ -5808,6 +5848,7 @@ mod tests {
             &crate::profile::Profile::full(),
             None,
             Some(&kp),
+            None,
         );
         assert!(resp.error.is_none(), "MCP error: {:?}", resp.error);
         let text = resp.result.unwrap()["content"][0]["text"]

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -36,8 +36,17 @@ fn semantic_tier() -> TierConfig {
 fn v3_response(profile: &Profile) -> Value {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
-    handle_capabilities_with_conn_v3(&tier_config, None, false, Some(&conn), profile, None, None)
-        .expect("v3 capabilities serialize")
+    handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        profile,
+        None,
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize")
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -31,6 +31,7 @@
 //! - v2 callers see no behavior change (backward compat).
 
 use ai_memory::config::{Capabilities, CapabilitiesV3, FeatureTier, McpConfig, TierConfig};
+use ai_memory::harness::Harness;
 use ai_memory::mcp::{
     CapabilitiesAccept, build_agent_permitted_families, build_capabilities_describe_to_user,
     build_capabilities_summary, build_capabilities_tools, handle_capabilities_with_conn,
@@ -130,6 +131,7 @@ fn cap_v3_response_carries_schema_version_and_summary() {
         false,
         Some(&conn),
         &Profile::core(),
+        None,
         None,
         None,
     )
@@ -234,6 +236,7 @@ fn cap_v3_struct_round_trips_through_serde() {
         "hello human".to_string(),
         Vec::new(),
         None,
+        None,
     );
 
     let json = serde_json::to_value(&v3).expect("serialize v3");
@@ -268,6 +271,7 @@ fn cap_v3_response_carries_to_describe_to_user() {
         false,
         Some(&conn),
         &Profile::core(),
+        None,
         None,
         None,
     )
@@ -384,6 +388,7 @@ fn cap_v3_preserves_v2_sub_blocks() {
         true, // embedder loaded
         Some(&conn),
         &Profile::full(),
+        None,
         None,
         None,
     )
@@ -537,6 +542,7 @@ fn cap_v3_response_carries_tools_array_with_43_entries() {
         &Profile::full(),
         None,
         None,
+        None,
     )
     .expect("v3 capabilities serialize");
 
@@ -605,6 +611,7 @@ fn cap_v3_a4_allowlist_disabled_omits_field() {
         &Profile::core(),
         None,
         Some("alice"),
+        None,
     )
     .expect("v3 capabilities serialize");
     assert!(
@@ -647,6 +654,7 @@ fn cap_v3_a4_allowlist_with_agent_lists_families() {
         &Profile::full(),
         Some(&cfg),
         Some("alice"),
+        None,
     )
     .expect("v3 capabilities serialize");
     let permitted = val["agent_permitted_families"]
@@ -677,10 +685,155 @@ fn cap_v3_a4_allowlist_no_agent_id_omits_field() {
         &Profile::core(),
         Some(&cfg),
         None, // no agent_id
+        None,
     )
     .expect("v3 capabilities serialize");
     assert!(
         val.get("agent_permitted_families").is_none(),
         "no agent_id → field must be absent even with allowlist enabled; got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B4 case 1 — when the detected harness supports deferred-tool
+// registration (Claude Code today), the v3 response carries
+// `your_harness_supports_deferred_registration: true` so the LLM can
+// reason about whether B1's `memory_load_family` will actually surface
+// new tools mid-session.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_b4_claude_code_harness_advertises_deferred_true() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let harness = Harness::ClaudeCode;
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        Some(&harness),
+    )
+    .expect("v3 capabilities serialize");
+    assert_eq!(
+        val.get("your_harness_supports_deferred_registration")
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "Claude Code → field must be present and true; got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B4 case 2 — when the detected harness does NOT support deferred
+// registration (Codex today), the field is present but false. Presence
+// is the signal that the substrate did detect a harness; the value
+// tells the LLM that mid-session loading won't surface new tools.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_b4_codex_harness_advertises_deferred_false() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let harness = Harness::Codex;
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        Some(&harness),
+    )
+    .expect("v3 capabilities serialize");
+    assert_eq!(
+        val.get("your_harness_supports_deferred_registration")
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "Codex → field must be present and false; got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B4 case 3 — when no clientInfo was captured (HTTP callers, or an MCP
+// session that issued `memory_capabilities` before `initialize`), the
+// field is OMITTED from the wire entirely. Absence carries meaning
+// distinct from `false`: false means "we know your harness can't",
+// absent means "we don't know your harness".
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_b4_no_harness_omits_field_from_wire() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        None, // no harness detected
+    )
+    .expect("v3 capabilities serialize");
+    assert!(
+        val.get("your_harness_supports_deferred_registration")
+            .is_none(),
+        "no harness → field must be absent on wire (skip_serializing_if); got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B4 case 4 — unknown harness (Generic) defaults to false. Conservative
+// because we'd rather under-promise mid-session loading than have an
+// LLM tell an end-user "I just loaded the graph tools" and have those
+// tools never appear because the harness cached the manifest.
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_b4_generic_harness_defaults_deferred_false() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let harness = Harness::Generic("some-unknown-mcp-client".to_string());
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        Some(&harness),
+    )
+    .expect("v3 capabilities serialize");
+    assert_eq!(
+        val.get("your_harness_supports_deferred_registration")
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "unknown harness → field must be present and false (conservative default); got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B4 case 5 — the v2 wire shape is unaffected by B4. v2 callers must
+// not gain the field even when a harness is in scope (the field lives
+// on `CapabilitiesV3` only).
+// ---------------------------------------------------------------------------
+#[test]
+fn cap_v3_b4_v2_callers_unaffected() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        CapabilitiesAccept::V2,
+    )
+    .expect("v2 capabilities still work");
+    assert!(
+        val.get("your_harness_supports_deferred_registration")
+            .is_none(),
+        "v2 must not gain the B4 field"
     );
 }


### PR DESCRIPTION
Track B task B4 of v0.7.0 attested-cortex epic. Substrate for B1 (memory_load_family) which needs to know whether it can surface new tools mid-session.

## Summary
- New `src/harness.rs`: `Harness` enum + `detect()` (case-insensitive fuzzy substring match on `clientInfo.name`) + `supports_deferred_registration()`.
- Captured at MCP `initialize` time from `clientInfo.name`, stored alongside `mcp_client_name` in the stdio loop, threaded through `handle_request` into the v3 dispatch.
- Surfaced in v3 capabilities as `your_harness_supports_deferred_registration` (`Option<bool>`, `skip_serializing_if = Option::is_none`).
- Compat matrix: Claude Code = true (only first-class deferred-registration harness today via ToolSearch); Codex / Cursor / Cline / Continue / Aider / Goose / Claude Desktop = false; unknown (`Generic`) defaults to false (conservative).
- HTTP path passes `None` for harness — no MCP handshake there, so the field is omitted from the wire (presence is the signal we know).

## Test plan
- [x] cargo fmt --check + clippy --pedantic clean (bin + lib + tests)
- [x] cargo test --lib green (2059 passed; +18 new harness module tests)
- [x] cargo test --test capabilities_v3 green (27 passed; +5 new B4 tests covering Claude Code, Codex, missing harness, Generic, v2 wire unaffected)
- [x] cargo test --test calibration_t0 green (6 passed; updated for new arg)
- [x] cargo test (full suite) green across all integration test files
- [x] Harness fuzzy-detection across kebab/snake/title/dotted/versioned spellings
- [x] Capability field present/absent per harness presence (skip_serializing_if behaviour pinned by test)
- [ ] B1 will key off the deferred-registration bool

🤖 Generated with [Claude Code](https://claude.com/claude-code)