### PR TITLE
feat: v0.7-h3 — inbound verification on federated links

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2017,29 +2017,139 @@ pub fn create_link_signed(
     // outright write error (vs. a silent partial-write). The signed
     // payload includes `valid_from = now` and matching `observed_by`
     // so H3's verifier can re-derive the same bytes from the row.
-    let (signature, attest_level): (Option<Vec<u8>>, &'static str) = match keypair {
-        Some(kp) if kp.can_sign() => {
-            let link = crate::identity::sign::SignableLink {
-                src_id: source_id,
-                dst_id: target_id,
-                relation,
-                observed_by: Some(kp.agent_id.as_str()),
-                valid_from: Some(now.as_str()),
-                valid_until: None,
-            };
-            let sig = crate::identity::sign::sign(kp, &link)?;
-            (Some(sig), "self_signed")
-        }
-        _ => (None, "unsigned"),
+    //
+    // v0.7 H3 follow-up: the `observed_by` *column* is now populated
+    // from the keypair's `agent_id` on signed inserts so federation
+    // export (`export_links`) ships the same claim the signature
+    // commits to. Receivers re-derive `SignableLink` from the wire
+    // record (see `verify::verify`); without populating the column,
+    // verification would always fail with `Tampered` because the
+    // sender signed `Some(agent_id)` but exported `None`.
+    let (signature, attest_level, observed_by_col): (Option<Vec<u8>>, &'static str, Option<&str>) =
+        match keypair {
+            Some(kp) if kp.can_sign() => {
+                let link = crate::identity::sign::SignableLink {
+                    src_id: source_id,
+                    dst_id: target_id,
+                    relation,
+                    observed_by: Some(kp.agent_id.as_str()),
+                    valid_from: Some(now.as_str()),
+                    valid_until: None,
+                };
+                let sig = crate::identity::sign::sign(kp, &link)?;
+                (Some(sig), "self_signed", Some(kp.agent_id.as_str()))
+            }
+            _ => (None, "unsigned", None),
+        };
+
+    conn.execute(
+        "INSERT OR IGNORE INTO memory_links \
+            (source_id, target_id, relation, created_at, valid_from, signature, attest_level, observed_by) \
+         VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?6, ?7)",
+        params![
+            source_id,
+            target_id,
+            relation,
+            now,
+            signature,
+            attest_level,
+            observed_by_col
+        ],
+    )?;
+    Ok(attest_level)
+}
+
+/// v0.7 H3 — insert an inbound (federation-replicated) link with a
+/// pre-computed signature and attest level.
+///
+/// Distinct from [`create_link_signed`] because the receiver is *not*
+/// the signer: it must persist whatever bytes the peer signed
+/// (signature + observed_by + valid_from + valid_until) verbatim, so a
+/// later `memory_verify` (H4) can re-derive the same canonical CBOR
+/// from the stored row and re-check against the peer's public key. We
+/// can't re-sign on the receiver — we don't hold the peer's private
+/// key, by design.
+///
+/// The caller (federation `sync_push` link loop) is responsible for:
+/// 1. Looking up the peer's public key via
+///    [`crate::identity::verify::lookup_peer_public_key`].
+/// 2. Calling [`crate::identity::verify::verify`] when a public key is
+///    known, and rejecting the link when verification fails.
+/// 3. Choosing the `attest_level` literal:
+///    - `"peer_attested"` — verified successfully against an enrolled key,
+///    - `"unsigned"` — no public key enrolled for `observed_by`, or the
+///      sender shipped no signature (legacy peer).
+///
+/// Idempotent on the unique `(source_id, target_id, relation)` index —
+/// duplicate inbound replays collapse to a no-op without error.
+///
+/// Both `source_id` and `target_id` must already exist locally; the
+/// receiver is expected to apply incoming `memories` *before* incoming
+/// `links` in the same `sync_push` request, which the existing handler
+/// already does.
+///
+/// `valid_from` defaults to "now" only when the inbound row carries
+/// `None` (legacy peer that never populated the column); otherwise the
+/// peer's value is preserved so the signature still verifies.
+///
+/// # Errors
+///
+/// Bubbles up the same DB / FK errors as `create_link_signed`. Pre-flight
+/// existence checks mirror the outbound path so the receiver fails loud
+/// on missing memories rather than silently dropping the link.
+pub fn create_link_inbound(conn: &Connection, link: &MemoryLink, attest_level: &str) -> Result<()> {
+    // Same FK guard as create_link_signed — a missing memory means the
+    // peer raced ahead of us; we surface that to the caller's warn log
+    // rather than papering over with INSERT OR IGNORE silently.
+    let source_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM memories WHERE id = ?1)",
+            params![link.source_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(false);
+    if !source_exists {
+        anyhow::bail!("source memory not found: {}", link.source_id);
+    }
+    let target_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM memories WHERE id = ?1)",
+            params![link.target_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(false);
+    if !target_exists {
+        anyhow::bail!("target memory not found: {}", link.target_id);
+    }
+
+    let now = Utc::now().to_rfc3339();
+    // Preserve peer's `valid_from` byte-identical so `memory_verify`
+    // (H4) can re-derive the signed payload from the stored row.
+    let valid_from = link.valid_from.clone().unwrap_or_else(|| now.clone());
+    let created_at = if link.created_at.is_empty() {
+        now
+    } else {
+        link.created_at.clone()
     };
 
     conn.execute(
         "INSERT OR IGNORE INTO memory_links \
-            (source_id, target_id, relation, created_at, valid_from, signature, attest_level) \
-         VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?6)",
-        params![source_id, target_id, relation, now, signature, attest_level],
+            (source_id, target_id, relation, created_at, valid_from, valid_until, \
+             signature, attest_level, observed_by) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            link.source_id,
+            link.target_id,
+            link.relation,
+            created_at,
+            valid_from,
+            link.valid_until,
+            link.signature,
+            attest_level,
+            link.observed_by,
+        ],
     )?;
-    Ok(attest_level)
+    Ok(())
 }
 
 pub fn get_links(conn: &Connection, id: &str) -> Result<Vec<MemoryLink>> {
@@ -2053,6 +2163,16 @@ pub fn get_links(conn: &Connection, id: &str) -> Result<Vec<MemoryLink>> {
             target_id: row.get(1)?,
             relation: row.get(2)?,
             created_at: row.get(3)?,
+            // get_links is a local read-only view; the H3 wire-extra
+            // fields stay None here. Federation export uses
+            // `export_links` (which mirrors the same shape) and inbound
+            // verification consumes the wire shape directly via
+            // `SyncPushBody.links`. Plumbing signature/observed_by into
+            // this read path is an H4 concern (memory_verify MCP tool).
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
         })
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -3621,8 +3741,14 @@ pub fn export_all(conn: &Connection) -> Result<Vec<Memory>> {
 
 pub fn export_links(conn: &Connection) -> Result<Vec<MemoryLink>> {
     let now = Utc::now().to_rfc3339();
+    // v0.7 H3 — also pull the signature blob, the `observed_by` claim,
+    // and the temporal-validity columns. Federation peers consume these
+    // through `verify::verify` to gate inbound replication; legacy
+    // unsigned rows surface NULL for `signature` / `observed_by` and
+    // the inbound path falls back to `attest_level = "unsigned"`.
     let mut stmt = conn.prepare(
-        "SELECT ml.source_id, ml.target_id, ml.relation, ml.created_at
+        "SELECT ml.source_id, ml.target_id, ml.relation, ml.created_at,
+                ml.signature, ml.observed_by, ml.valid_from, ml.valid_until
          FROM memory_links ml
          JOIN memories ms ON ms.id = ml.source_id AND (ms.expires_at IS NULL OR ms.expires_at > ?1)
          JOIN memories mt ON mt.id = ml.target_id AND (mt.expires_at IS NULL OR mt.expires_at > ?1)",
@@ -3633,6 +3759,10 @@ pub fn export_links(conn: &Connection) -> Result<Vec<MemoryLink>> {
             target_id: row.get(1)?,
             relation: row.get(2)?,
             created_at: row.get(3)?,
+            signature: row.get::<_, Option<Vec<u8>>>(4)?,
+            observed_by: row.get::<_, Option<String>>(5)?,
+            valid_from: row.get::<_, Option<String>>(6)?,
+            valid_until: row.get::<_, Option<String>>(7)?,
         })
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -2051,6 +2051,10 @@ mod tests {
             target_id: "mem-b".to_string(),
             relation: "related_to".to_string(),
             created_at: chrono::Utc::now().to_rfc3339(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
         }
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2736,6 +2736,17 @@ pub async fn create_link(
                     target_id: body.target_id.clone(),
                     relation: body.relation.clone(),
                     created_at: chrono::Utc::now().to_rfc3339(),
+                    // H3 wire fields are populated by `export_links`
+                    // on the next bulk re-sync; the immediate fanout
+                    // path stays unsigned to avoid a redundant DB
+                    // round-trip just to fish out the freshly-written
+                    // signature row. Receivers will land this as
+                    // `unsigned` until a periodic reconciliation pulls
+                    // the signed row via `export_links`.
+                    signature: None,
+                    observed_by: None,
+                    valid_from: None,
+                    valid_until: None,
                 };
                 match crate::federation::broadcast_link_quorum(fed, &link).await {
                     Ok(tracker) => {
@@ -3790,6 +3801,14 @@ pub async fn sync_push(
     // retry / re-sync and collapse to a no-op via the unique index on
     // (source_id, target_id, relation). Invalid ids are skipped silently
     // — same posture as deletions.
+    //
+    // v0.7 H3: when a link arrives with a signature + observed_by claim,
+    // verify it against the public key associated with that claim before
+    // landing the row. Tampered signatures → reject with a warn log.
+    // Unknown observed_by (no enrolled key on this host) → accept-and-
+    // flag as `unsigned` so federation back-compat holds for peers that
+    // haven't enrolled yet. Successful verify → land with attest_level
+    // `peer_attested`.
     let mut links_applied = 0usize;
     for link in &body.links {
         if validate::validate_link(&link.source_id, &link.target_id, &link.relation).is_err() {
@@ -3800,11 +3819,62 @@ pub async fn sync_push(
             noop += 1;
             continue;
         }
-        match db::create_link(&lock.0, &link.source_id, &link.target_id, &link.relation) {
+
+        // Decide attest_level via the H3 verify path before insert.
+        let attest_level = match (link.signature.as_deref(), link.observed_by.as_deref()) {
+            (Some(sig_bytes), Some(observed_by)) => {
+                match crate::identity::verify::lookup_peer_public_key(observed_by) {
+                    Some(pubkey) => {
+                        let signable = crate::identity::sign::SignableLink {
+                            src_id: &link.source_id,
+                            dst_id: &link.target_id,
+                            relation: &link.relation,
+                            observed_by: Some(observed_by),
+                            valid_from: link.valid_from.as_deref(),
+                            valid_until: link.valid_until.as_deref(),
+                        };
+                        match crate::identity::verify::verify(&pubkey, &signable, sig_bytes) {
+                            Ok(()) => "peer_attested",
+                            Err(e) => {
+                                // Tampered / malformed-sig: refuse to land
+                                // the row. The receiver-side warn log is
+                                // the operator's signal that a peer is
+                                // misbehaving (or that a key rotation
+                                // got out of sync).
+                                tracing::warn!(
+                                    "sync_push: signature rejected for link \
+                                     ({} -> {} / {}) from observed_by={}: {e}",
+                                    link.source_id,
+                                    link.target_id,
+                                    link.relation,
+                                    observed_by
+                                );
+                                skipped += 1;
+                                continue;
+                            }
+                        }
+                    }
+                    None => {
+                        // No public key enrolled for this peer →
+                        // accept-and-flag as unsigned. Operators can
+                        // later enroll the key (`identity import`) and
+                        // re-sync to upgrade the row's attest_level on
+                        // a subsequent re-send.
+                        "unsigned"
+                    }
+                }
+            }
+            // No signature on the wire (legacy v0.6.x peer) or no
+            // observed_by claim → treat as unsigned. Same posture as
+            // pre-H3 federation.
+            _ => "unsigned",
+        };
+
+        match db::create_link_inbound(&lock.0, link, attest_level) {
             Ok(()) => links_applied += 1,
             Err(e) => {
                 tracing::warn!(
-                    "sync_push: create_link failed ({} -> {} / {}): {e}",
+                    "sync_push: create_link_inbound failed ({} -> {} / {}): {e}",
                     link.source_id,
                     link.target_id,
                     link.relation

--- a/src/hooks/events.rs
+++ b/src/hooks/events.rs
@@ -627,6 +627,10 @@ mod tests {
             target_id: "tgt".into(),
             relation: "related_to".into(),
             created_at: "2026-05-05T00:00:00Z".into(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
         };
         let json = serde_json::to_string(&post).expect("encode Link");
         let back: Link = serde_json::from_str(&json).expect("decode Link");

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -47,6 +47,12 @@ pub mod keypair;
 // six signable link fields. Consumed by `db::create_link_signed` to
 // fill the previously-dead `signature` BLOB column on `memory_links`.
 pub mod sign;
+// H3 — inbound link verification. Mirror of `sign`: re-derives the
+// canonical CBOR bytes from a wire `SignableLink` and verifies the
+// 64-byte signature against the public key associated with the link's
+// `observed_by` claim. Consumed by federation `sync_push` link replay
+// so tampered or forged links never land in `memory_links`.
+pub mod verify;
 
 /// Environment variable override for `agent_id` (used by CLI via clap's
 /// `env = "AI_MEMORY_AGENT_ID"`; read directly for MCP fallback).

--- a/src/identity/verify.rs
+++ b/src/identity/verify.rs
@@ -1,0 +1,374 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Inbound Ed25519 verification for federated `memory_links` (Track H,
+//! Task H3).
+//!
+//! Builds on H1 ([`crate::identity::keypair`]) and H2
+//! ([`crate::identity::sign`]). H2 sealed the canonical CBOR encoding and
+//! the outbound signing path; this module is the mirror — when a link
+//! arrives from a peer over `sync_push`, we re-derive the same canonical
+//! CBOR bytes and verify the 64-byte signature against the public key
+//! associated with the link's `observed_by` claim.
+//!
+//! # Trust model
+//!
+//! - The peer's public key is read from the *receiver's* on-disk key
+//!   directory ([`crate::identity::keypair::default_key_dir`]) — i.e. the
+//!   peer was previously enrolled (`identity import` or `identity
+//!   generate` for a peer agent_id) by this host's operator. This keeps
+//!   the trust root local: a peer cannot upgrade its own attest_level by
+//!   sending us a fresh public key.
+//! - If `observed_by` has no enrolled key on this host, the link is still
+//!   accepted (`attest_level = "unsigned"`) so federation back-compat
+//!   holds for peers that haven't enrolled yet. This degraded posture is
+//!   intentional — H3 brings opt-in attestation, not a hard cutover.
+//! - If the peer *is* enrolled and the signature does not verify, the
+//!   link is rejected with a `tracing::warn!` log line. Tampered or
+//!   forged inbound links never land in the receiver's `memory_links`
+//!   table.
+//!
+//! # Out of scope here
+//!
+//! - `attest_level` enum + `memory_verify` MCP tool (H4). H3 stays on
+//!   the existing TEXT column with the literal `"peer_attested"` /
+//!   `"unsigned"` strings already documented in [`crate::db`].
+//! - `signed_events` audit table (H5).
+//! - End-to-end federation integration test (H6).
+
+use std::path::Path;
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+use crate::identity::keypair;
+use crate::identity::sign::{SignableLink, canonical_cbor};
+
+/// Length of an Ed25519 signature in bytes. Mirrors the constant
+/// [`ed25519_dalek::SIGNATURE_LENGTH`] but pinned locally so the verify
+/// path doesn't pull a pub-use dependency on the crate's surface.
+pub const SIGNATURE_LEN: usize = ed25519_dalek::SIGNATURE_LENGTH;
+
+/// Outcome of an inbound verify attempt.
+///
+/// Hand-rolled `Display` + `Error` (no `thiserror`) per repo convention:
+/// the OSS substrate keeps its dependency surface deliberately small so
+/// the AgenticMem commercial layer can lift the same error shape without
+/// re-vendoring proc-macros.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifyError {
+    /// Signature did not validate against the supplied public key over
+    /// the link's canonical CBOR. Either the link content was tampered
+    /// with in flight, the signature bytes themselves were flipped, or
+    /// the wrong public key was supplied for `observed_by`.
+    Tampered,
+    /// `lookup_peer_public_key` returned `None` — the receiver has no
+    /// enrolled key for `observed_by`. Callers may choose to treat this
+    /// as accept-and-flag-as-unsigned (the federation inbound path) or
+    /// as a hard reject (a future strict-mode operator opt-in).
+    NoPublicKey,
+    /// The supplied signature blob was not exactly 64 bytes — Ed25519
+    /// signatures are fixed-length, so any other length is structurally
+    /// invalid before we even try the verify.
+    MalformedSignature,
+}
+
+impl std::fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tampered => f.write_str(
+                "Ed25519 signature did not validate against the supplied public key — \
+                 link content or signature bytes do not match what observed_by signed",
+            ),
+            Self::NoPublicKey => {
+                f.write_str("no public key enrolled for observed_by — receiver cannot verify")
+            }
+            Self::MalformedSignature => f.write_str(
+                "signature is not exactly 64 bytes — not a well-formed Ed25519 signature",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VerifyError {}
+
+/// Verify `signature` over the canonical CBOR encoding of `link` using
+/// `public`.
+///
+/// The verifier re-derives the exact byte sequence H2's
+/// [`crate::identity::sign::sign`] hashed before signing. Any divergence
+/// between the inbound link content and what the peer originally signed
+/// — even a single byte flip in `relation`, `observed_by`, etc. —
+/// changes the CBOR output and makes Ed25519 reject the signature.
+///
+/// # Errors
+///
+/// - [`VerifyError::MalformedSignature`] — `signature.len() != 64`.
+/// - [`VerifyError::Tampered`] — signature does not validate against
+///   `public` over the canonical CBOR. Same variant covers all
+///   "validation failed" cases (wrong key, flipped sig byte, mutated
+///   link field) on purpose: the inbound posture is "reject" regardless
+///   of *which* of those happened, and surfacing the distinction would
+///   leak verification-side timing/structure to a misbehaving peer.
+pub fn verify(
+    public: &VerifyingKey,
+    link: &SignableLink<'_>,
+    signature: &[u8],
+) -> Result<(), VerifyError> {
+    if signature.len() != SIGNATURE_LEN {
+        return Err(VerifyError::MalformedSignature);
+    }
+    let mut sig_arr = [0u8; SIGNATURE_LEN];
+    sig_arr.copy_from_slice(signature);
+    let sig = Signature::from_bytes(&sig_arr);
+
+    // CBOR encode failures are surfaced as Tampered too — the only way
+    // canonical_cbor errors today is a serialization bug, which from the
+    // verifier's perspective is functionally equivalent to "we cannot
+    // re-derive the bytes the peer signed, so we cannot trust this link".
+    let payload = canonical_cbor(link).map_err(|_| VerifyError::Tampered)?;
+
+    public
+        .verify(&payload, &sig)
+        .map_err(|_| VerifyError::Tampered)
+}
+
+/// Look up the public key associated with `observed_by` on this host's
+/// on-disk key store.
+///
+/// Reuses the H1 [`keypair::load`] loader (same path layout: `<key_dir>/
+/// <agent_id>.pub`). The loader will succeed for any `agent_id` whose
+/// public-key file is present — it does not require the `.priv` file
+/// (this host has no reason to hold a peer's private key, only the
+/// matching public key it received via `identity import`).
+///
+/// Returns `None` when:
+/// - `observed_by` is the empty string,
+/// - the key directory cannot be resolved (extremely rare; only when the
+///   OS does not advertise a config dir),
+/// - no `<observed_by>.pub` file exists under the key directory,
+/// - the on-disk file is malformed (length mismatch, etc.).
+///
+/// In every `None` case the caller should fall back to the
+/// accept-and-flag-as-unsigned posture rather than rejecting the link.
+#[must_use]
+pub fn lookup_peer_public_key(observed_by: &str) -> Option<VerifyingKey> {
+    if observed_by.is_empty() {
+        return None;
+    }
+    let dir = keypair::default_key_dir().ok()?;
+    lookup_peer_public_key_in(observed_by, &dir)
+}
+
+/// Variant of [`lookup_peer_public_key`] that takes an explicit key
+/// directory. Used by tests so we can populate a tempdir with peer
+/// public keys without touching the operator's real `~/.config/ai-memory`.
+/// Callers in production code should prefer [`lookup_peer_public_key`]
+/// so the storage location stays uniform across `keypair`, `sign`, and
+/// `verify`.
+#[must_use]
+pub fn lookup_peer_public_key_in(observed_by: &str, dir: &Path) -> Option<VerifyingKey> {
+    if observed_by.is_empty() {
+        return None;
+    }
+    keypair::load(observed_by, dir).ok().map(|kp| kp.public)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::keypair as kp_mod;
+    use crate::identity::sign;
+    use tempfile::TempDir;
+
+    fn link_fixture() -> SignableLink<'static> {
+        SignableLink {
+            src_id: "src-001",
+            dst_id: "dst-002",
+            relation: "related_to",
+            observed_by: Some("alice"),
+            valid_from: Some("2026-05-05T00:00:00+00:00"),
+            valid_until: None,
+        }
+    }
+
+    #[test]
+    fn verify_accepts_valid_signature() {
+        // Happy path: alice signs, verifier holds alice.pub → accept.
+        let alice = kp_mod::generate("alice").unwrap();
+        let link = link_fixture();
+        let sig = sign::sign(&alice, &link).unwrap();
+        verify(&alice.public, &link, &sig).expect("happy-path verify must succeed");
+    }
+
+    #[test]
+    fn verify_rejects_flipped_signature_byte() {
+        // Single bit flip in the signature → Tampered. Ed25519 has no
+        // malleability window — any altered byte invalidates.
+        let alice = kp_mod::generate("alice").unwrap();
+        let link = link_fixture();
+        let mut sig = sign::sign(&alice, &link).unwrap();
+        sig[0] ^= 0x01;
+        let err = verify(&alice.public, &link, &sig).unwrap_err();
+        assert_eq!(err, VerifyError::Tampered, "flipped sig byte must reject");
+    }
+
+    #[test]
+    fn verify_rejects_mutated_link_content() {
+        // Re-sign with relation=related_to, but verifier sees relation=
+        // supersedes (same other fields). CBOR re-encoding produces a
+        // different byte stream → Ed25519 rejects.
+        let alice = kp_mod::generate("alice").unwrap();
+        let original = link_fixture();
+        let sig = sign::sign(&alice, &original).unwrap();
+
+        let mut tampered = original.clone();
+        tampered.relation = "supersedes";
+        let err = verify(&alice.public, &tampered, &sig).unwrap_err();
+        assert_eq!(
+            err,
+            VerifyError::Tampered,
+            "mutated link content must reject"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_pubkey() {
+        // Signed by alice, attempted-verified with bob's pubkey →
+        // Tampered. The variant deliberately doesn't distinguish "wrong
+        // key" from "tampered content" so a misbehaving peer can't
+        // probe which fields the verifier touched.
+        let alice = kp_mod::generate("alice").unwrap();
+        let bob = kp_mod::generate("bob").unwrap();
+        let link = link_fixture();
+        let sig = sign::sign(&alice, &link).unwrap();
+        let err = verify(&bob.public, &link, &sig).unwrap_err();
+        assert_eq!(err, VerifyError::Tampered);
+    }
+
+    #[test]
+    fn verify_rejects_short_signature() {
+        let alice = kp_mod::generate("alice").unwrap();
+        let link = link_fixture();
+        // 32 bytes is wrong (Ed25519 wants 64).
+        let short = vec![0u8; 32];
+        let err = verify(&alice.public, &link, &short).unwrap_err();
+        assert_eq!(err, VerifyError::MalformedSignature);
+    }
+
+    #[test]
+    fn verify_rejects_long_signature() {
+        let alice = kp_mod::generate("alice").unwrap();
+        let link = link_fixture();
+        // 128 bytes is wrong (Ed25519 wants 64).
+        let long = vec![0u8; 128];
+        let err = verify(&alice.public, &link, &long).unwrap_err();
+        assert_eq!(err, VerifyError::MalformedSignature);
+    }
+
+    #[test]
+    fn verify_rejects_empty_signature() {
+        let alice = kp_mod::generate("alice").unwrap();
+        let link = link_fixture();
+        let err = verify(&alice.public, &link, &[]).unwrap_err();
+        assert_eq!(err, VerifyError::MalformedSignature);
+    }
+
+    #[test]
+    fn lookup_peer_public_key_in_returns_none_for_unknown() {
+        let dir = TempDir::new().unwrap();
+        // Empty key dir → no enrolled peer.
+        assert!(lookup_peer_public_key_in("alice", dir.path()).is_none());
+    }
+
+    #[test]
+    fn lookup_peer_public_key_in_returns_none_for_empty_id() {
+        let dir = TempDir::new().unwrap();
+        assert!(lookup_peer_public_key_in("", dir.path()).is_none());
+    }
+
+    #[test]
+    fn lookup_peer_public_key_in_finds_enrolled_pubkey() {
+        // Mirror an `identity import` for a peer: write only the .pub
+        // file under the key dir. lookup must return the same key.
+        let dir = TempDir::new().unwrap();
+        let alice = kp_mod::generate("alice").unwrap();
+        let pub_only = kp_mod::AgentKeypair {
+            agent_id: "alice".to_string(),
+            public: alice.public,
+            private: None,
+        };
+        kp_mod::save_public_only(&pub_only, dir.path()).unwrap();
+        let found = lookup_peer_public_key_in("alice", dir.path()).expect("lookup hit");
+        assert_eq!(found.to_bytes(), alice.public.to_bytes());
+    }
+
+    #[test]
+    fn lookup_peer_public_key_in_finds_full_keypair_pub() {
+        // A self-generated agent (with both .pub and .priv on disk) is
+        // also a valid lookup target — useful in single-host loopback
+        // tests where the same agent both signs and verifies.
+        let dir = TempDir::new().unwrap();
+        let alice = kp_mod::generate("alice").unwrap();
+        kp_mod::save(&alice, dir.path()).unwrap();
+        let found = lookup_peer_public_key_in("alice", dir.path()).expect("lookup hit");
+        assert_eq!(found.to_bytes(), alice.public.to_bytes());
+    }
+
+    #[test]
+    fn lookup_peer_public_key_in_skips_invalid_agent_id() {
+        // `keypair::load` validates the agent_id; lookup should not
+        // panic and should report `None` for invalid input.
+        let dir = TempDir::new().unwrap();
+        assert!(lookup_peer_public_key_in("has space", dir.path()).is_none());
+        assert!(lookup_peer_public_key_in("has\0null", dir.path()).is_none());
+    }
+
+    #[test]
+    fn end_to_end_peer_a_signs_peer_b_verifies() {
+        // Two-host simulation: alice signs on host A; host B has only
+        // alice.pub enrolled (no .priv). Host B looks up alice's pubkey
+        // and verifies — passes.
+        let host_b_keys = TempDir::new().unwrap();
+        let alice = kp_mod::generate("alice").unwrap();
+
+        // Host B operator imports alice's public key.
+        let alice_pub_for_b = kp_mod::AgentKeypair {
+            agent_id: "alice".to_string(),
+            public: alice.public,
+            private: None,
+        };
+        kp_mod::save_public_only(&alice_pub_for_b, host_b_keys.path()).unwrap();
+
+        // Alice signs a link on host A.
+        let link = link_fixture();
+        let sig = sign::sign(&alice, &link).unwrap();
+
+        // Host B receives the link, looks up alice's pubkey, verifies.
+        let key_on_b =
+            lookup_peer_public_key_in("alice", host_b_keys.path()).expect("alice enrolled on B");
+        verify(&key_on_b, &link, &sig).expect("cross-host verify must succeed");
+    }
+
+    #[test]
+    fn end_to_end_no_pubkey_returns_none_for_caller_to_handle() {
+        // Host B has no key enrolled for alice → lookup returns None.
+        // The caller (federation inbound) is responsible for the
+        // accept-and-flag-as-unsigned posture; verify() is not invoked.
+        let host_b_keys = TempDir::new().unwrap();
+        assert!(lookup_peer_public_key_in("alice", host_b_keys.path()).is_none());
+    }
+
+    #[test]
+    fn verify_error_display_messages_are_distinct() {
+        // Sanity: each variant has a non-empty, distinct human message.
+        let m_t = format!("{}", VerifyError::Tampered);
+        let m_n = format!("{}", VerifyError::NoPublicKey);
+        let m_m = format!("{}", VerifyError::MalformedSignature);
+        assert!(!m_t.is_empty());
+        assert!(!m_n.is_empty());
+        assert!(!m_m.is_empty());
+        assert_ne!(m_t, m_n);
+        assert_ne!(m_n, m_m);
+        assert_ne!(m_t, m_m);
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -86,6 +86,32 @@ pub struct MemoryLink {
     pub target_id: String,
     pub relation: String, // "related_to", "supersedes", "contradicts", "derived_from"
     pub created_at: String,
+    /// v0.7 H3 — optional 64-byte Ed25519 signature carried over the
+    /// federation wire. `None` for legacy peers (pre-v0.7) that do not
+    /// sign outbound links; receivers in that case land the row with
+    /// `attest_level = "unsigned"`. When `Some`, it is verified against
+    /// the public key associated with `observed_by` before insert.
+    /// `skip_serializing_if` keeps the wire shape byte-identical to
+    /// pre-H3 for unsigned rows so v0.6.x peers continue to deserialize
+    /// without surprise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Vec<u8>>,
+    /// v0.7 H3 — agent_id that asserts this link. Mirrors the H2
+    /// `SignableLink.observed_by` field. Required when `signature` is
+    /// `Some` (it is the lookup key for the verifying public key);
+    /// `None` is treated as "no claim" and short-circuits to unsigned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_by: Option<String>,
+    /// v0.7 H3 — RFC3339 instant the link became true (matches the
+    /// homonymous column in `memory_links`). Part of the signed bundle;
+    /// must round-trip byte-identical with what the sender signed for
+    /// verification to succeed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_from: Option<String>,
+    /// v0.7 H3 — RFC3339 instant the link was invalidated, or `None` if
+    /// still valid. Part of the signed bundle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/federation_inbound_verify.rs
+++ b/tests/federation_inbound_verify.rs
@@ -1,0 +1,311 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7 Track H3 — federation inbound link verification.
+//!
+//! These tests model the two-host federation flow without spawning the
+//! HTTP daemon. The daemon-spawn integration tests in
+//! `tests/integration.rs` are the right place for full HTTP wire
+//! coverage, but they cost O(seconds) per test and serialise on a
+//! single child process; the verification primitive is small enough to
+//! exercise with a direct `db::create_link_inbound` call after running
+//! the same `verify::verify` decision the `sync_push` handler runs.
+//!
+//! Scenarios covered:
+//! 1. Happy path — peer A signs, peer B has A's pubkey enrolled →
+//!    accepts as `peer_attested`.
+//! 2. Tampered signature — flipped sig byte → `Tampered` → reject.
+//! 3. Tampered link content — flipped relation byte → CBOR re-encoding
+//!    diverges → `Tampered` → reject.
+//! 4. No public key — peer A signs, peer B has no enrolled key for A
+//!    → accepted with `attest_level = "unsigned"`.
+
+use ai_memory::db;
+use ai_memory::identity::keypair as kp_mod;
+use ai_memory::identity::sign;
+use ai_memory::identity::verify;
+use ai_memory::models::{self, MemoryLink};
+use chrono::Utc;
+use tempfile::TempDir;
+
+/// Two-host topology: each host has its own DB and (separately) its
+/// own on-disk key directory. The signer (`alice`) lives on host A;
+/// host B optionally enrols alice's public key under its own keys dir
+/// to simulate `identity import` after a peer onboarding handshake.
+struct TwoHosts {
+    /// Host B's database — receives inbound links.
+    receiver_db: rusqlite::Connection,
+    /// Host B's key dir — what `verify::lookup_peer_public_key_in` reads.
+    receiver_keys: TempDir,
+    /// Host A's signing keypair (private + public).
+    alice: kp_mod::AgentKeypair,
+    /// IDs of two memories that exist on host B so link inserts pass
+    /// the FK check inside `db::create_link_inbound`.
+    src_id: String,
+    dst_id: String,
+    // Hold the receiver tempdir so the file path stays valid for the test.
+    #[allow(dead_code)]
+    receiver_tmp: TempDir,
+}
+
+fn setup() -> TwoHosts {
+    let receiver_tmp = TempDir::new().expect("receiver tempdir");
+    let receiver_keys = TempDir::new().expect("receiver keys tempdir");
+
+    let db_path = receiver_tmp.path().join("ai-memory.db");
+    let receiver_db = db::open(&db_path).expect("db::open");
+
+    // Seed two memories on the receiver so the link's FK check passes.
+    let src_id = seed(&receiver_db, "src");
+    let dst_id = seed(&receiver_db, "dst");
+
+    let alice = kp_mod::generate("alice").expect("generate alice");
+
+    TwoHosts {
+        receiver_db,
+        receiver_keys,
+        alice,
+        src_id,
+        dst_id,
+        receiver_tmp,
+    }
+}
+
+fn seed(conn: &rusqlite::Connection, title: &str) -> String {
+    let now = Utc::now().to_rfc3339();
+    let id = uuid::Uuid::new_v4().to_string();
+    let mem = models::Memory {
+        id: id.clone(),
+        tier: models::Tier::Mid,
+        namespace: "h3-test".to_string(),
+        title: title.to_string(),
+        content: "x".to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "import".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: models::default_metadata(),
+    };
+    db::insert(conn, &mem).expect("db::insert")
+}
+
+/// Mimic the federation inbound decision logic from `handlers::sync_push`
+/// using the explicit-key-dir variant of `lookup_peer_public_key`.
+/// Returns the `attest_level` string the handler would persist (or
+/// `Err` to mean the handler would skip this link with a warn log).
+fn decide_attest_level(
+    link: &MemoryLink,
+    receiver_keys: &std::path::Path,
+) -> Result<&'static str, verify::VerifyError> {
+    match (link.signature.as_deref(), link.observed_by.as_deref()) {
+        (Some(sig_bytes), Some(observed_by)) => {
+            match verify::lookup_peer_public_key_in(observed_by, receiver_keys) {
+                Some(pubkey) => {
+                    let signable = sign::SignableLink {
+                        src_id: &link.source_id,
+                        dst_id: &link.target_id,
+                        relation: &link.relation,
+                        observed_by: Some(observed_by),
+                        valid_from: link.valid_from.as_deref(),
+                        valid_until: link.valid_until.as_deref(),
+                    };
+                    verify::verify(&pubkey, &signable, sig_bytes)?;
+                    Ok("peer_attested")
+                }
+                None => Ok("unsigned"),
+            }
+        }
+        _ => Ok("unsigned"),
+    }
+}
+
+fn build_link(
+    h: &TwoHosts,
+    relation: &str,
+    observed_by: Option<&str>,
+    valid_from: Option<&str>,
+) -> MemoryLink {
+    MemoryLink {
+        source_id: h.src_id.clone(),
+        target_id: h.dst_id.clone(),
+        relation: relation.to_string(),
+        created_at: Utc::now().to_rfc3339(),
+        signature: None,
+        observed_by: observed_by.map(str::to_string),
+        valid_from: valid_from.map(str::to_string),
+        valid_until: None,
+    }
+}
+
+fn read_attest_level(conn: &rusqlite::Connection, src: &str, dst: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT attest_level FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+        rusqlite::params![src, dst],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+}
+
+#[test]
+fn happy_path_peer_attested() {
+    // Peer A signs, peer B has A's pubkey enrolled → accepts as
+    // peer_attested.
+    let h = setup();
+
+    // Host B operator imports alice's public key.
+    let alice_pub = kp_mod::AgentKeypair {
+        agent_id: h.alice.agent_id.clone(),
+        public: h.alice.public,
+        private: None,
+    };
+    kp_mod::save_public_only(&alice_pub, h.receiver_keys.path()).unwrap();
+
+    // Alice signs a link on host A.
+    let valid_from = Utc::now().to_rfc3339();
+    let mut link = build_link(&h, "related_to", Some(&h.alice.agent_id), Some(&valid_from));
+    let signable = sign::SignableLink {
+        src_id: &link.source_id,
+        dst_id: &link.target_id,
+        relation: &link.relation,
+        observed_by: Some(&h.alice.agent_id),
+        valid_from: Some(&valid_from),
+        valid_until: None,
+    };
+    link.signature = Some(sign::sign(&h.alice, &signable).unwrap());
+
+    // Run the decision + insert.
+    let attest =
+        decide_attest_level(&link, h.receiver_keys.path()).expect("happy path must not error out");
+    assert_eq!(attest, "peer_attested");
+    db::create_link_inbound(&h.receiver_db, &link, attest).expect("inbound insert");
+
+    // Confirm the row landed with the right attest level.
+    let stored = read_attest_level(&h.receiver_db, &h.src_id, &h.dst_id);
+    assert_eq!(stored.as_deref(), Some("peer_attested"));
+}
+
+#[test]
+fn tampered_signature_byte_is_rejected() {
+    // Peer A signs; flip a single bit in the sig before B sees it.
+    // Decision logic must return Tampered; row must not land.
+    let h = setup();
+
+    let alice_pub = kp_mod::AgentKeypair {
+        agent_id: h.alice.agent_id.clone(),
+        public: h.alice.public,
+        private: None,
+    };
+    kp_mod::save_public_only(&alice_pub, h.receiver_keys.path()).unwrap();
+
+    let valid_from = Utc::now().to_rfc3339();
+    let mut link = build_link(&h, "related_to", Some(&h.alice.agent_id), Some(&valid_from));
+    let signable = sign::SignableLink {
+        src_id: &link.source_id,
+        dst_id: &link.target_id,
+        relation: &link.relation,
+        observed_by: Some(&h.alice.agent_id),
+        valid_from: Some(&valid_from),
+        valid_until: None,
+    };
+    let mut sig = sign::sign(&h.alice, &signable).unwrap();
+    sig[10] ^= 0xff;
+    link.signature = Some(sig);
+
+    let err = decide_attest_level(&link, h.receiver_keys.path()).unwrap_err();
+    assert_eq!(err, verify::VerifyError::Tampered);
+
+    // Receiver-side handler skips on Tampered; confirm by NOT inserting
+    // and asserting the row is absent.
+    let stored = read_attest_level(&h.receiver_db, &h.src_id, &h.dst_id);
+    assert!(stored.is_none(), "tampered link must not land");
+}
+
+#[test]
+fn tampered_link_content_is_rejected() {
+    // Sign with relation=related_to but ship relation=supersedes.
+    // CBOR re-encoding diverges → Ed25519 rejects.
+    let h = setup();
+
+    let alice_pub = kp_mod::AgentKeypair {
+        agent_id: h.alice.agent_id.clone(),
+        public: h.alice.public,
+        private: None,
+    };
+    kp_mod::save_public_only(&alice_pub, h.receiver_keys.path()).unwrap();
+
+    let valid_from = Utc::now().to_rfc3339();
+    // Sign over relation=related_to.
+    let signable_signed = sign::SignableLink {
+        src_id: &h.src_id,
+        dst_id: &h.dst_id,
+        relation: "related_to",
+        observed_by: Some(&h.alice.agent_id),
+        valid_from: Some(&valid_from),
+        valid_until: None,
+    };
+    let sig = sign::sign(&h.alice, &signable_signed).unwrap();
+
+    // Ship relation=supersedes — verifier re-derives different bytes.
+    let mut link = build_link(&h, "supersedes", Some(&h.alice.agent_id), Some(&valid_from));
+    link.signature = Some(sig);
+
+    let err = decide_attest_level(&link, h.receiver_keys.path()).unwrap_err();
+    assert_eq!(err, verify::VerifyError::Tampered);
+
+    let stored = read_attest_level(&h.receiver_db, &h.src_id, &h.dst_id);
+    assert!(stored.is_none(), "mutated link content must not land");
+}
+
+#[test]
+fn no_public_key_for_observed_by_lands_as_unsigned() {
+    // Peer A signs; receiver B has NO enrolled key for alice. We don't
+    // reject — federation back-compat is preserved by accept-and-flag.
+    let h = setup();
+    // NB: receiver_keys directory is empty; no `save_public_only` call.
+
+    let valid_from = Utc::now().to_rfc3339();
+    let mut link = build_link(&h, "related_to", Some(&h.alice.agent_id), Some(&valid_from));
+    let signable = sign::SignableLink {
+        src_id: &link.source_id,
+        dst_id: &link.target_id,
+        relation: &link.relation,
+        observed_by: Some(&h.alice.agent_id),
+        valid_from: Some(&valid_from),
+        valid_until: None,
+    };
+    link.signature = Some(sign::sign(&h.alice, &signable).unwrap());
+
+    let attest =
+        decide_attest_level(&link, h.receiver_keys.path()).expect("no-key path must accept");
+    assert_eq!(
+        attest, "unsigned",
+        "unknown observed_by must accept as unsigned, not reject"
+    );
+
+    db::create_link_inbound(&h.receiver_db, &link, attest).expect("inbound insert");
+    let stored = read_attest_level(&h.receiver_db, &h.src_id, &h.dst_id);
+    assert_eq!(stored.as_deref(), Some("unsigned"));
+}
+
+#[test]
+fn legacy_unsigned_link_lands_as_unsigned() {
+    // Pre-H3 peer ships a link with no signature / no observed_by →
+    // `decide_attest_level` returns "unsigned" without invoking verify.
+    let h = setup();
+    let link = build_link(&h, "related_to", None, None);
+    assert!(link.signature.is_none());
+
+    let attest =
+        decide_attest_level(&link, h.receiver_keys.path()).expect("legacy path must accept");
+    assert_eq!(attest, "unsigned");
+
+    db::create_link_inbound(&h.receiver_db, &link, attest).expect("inbound insert");
+    let stored = read_attest_level(&h.receiver_db, &h.src_id, &h.dst_id);
+    assert_eq!(stored.as_deref(), Some("unsigned"));
+}


### PR DESCRIPTION
Track H task H3 of v0.7.0 attested-cortex epic. Builds on H1 (PR #558) + H2 (PR #566), both merged.

## Summary
- New `src/identity/verify.rs`: `verify()` + `lookup_peer_public_key()` + `VerifyError` enum (`Tampered` / `NoPublicKey` / `MalformedSignature`)
- Federation inbound path (`handlers::sync_push` link loop) verifies every signature against `observed_by`'s enrolled pubkey
- Tampered signature or mutated link content -> reject + `tracing::warn!`
- No enrolled pubkey for `observed_by` -> accept with `attest_level = "unsigned"` (back-compat for peers that haven't enrolled yet)
- Successful verify -> `attest_level = "peer_attested"` (literal already documented in H2; no enum stub needed)
- `MemoryLink` wire shape gains optional `signature` / `observed_by` / `valid_from` / `valid_until` fields with `skip_serializing_if=None` so v0.6.x peers continue to deserialize byte-identically
- `db::create_link_signed` now also populates the `observed_by` *column* on signed inserts so `export_links` can ship the same claim the signature commits to (without this, peer-side verify would always `Tampered`)
- New `db::create_link_inbound` persists peer signatures verbatim with the verifier's chosen attest level

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] 14 unit tests in `src/identity/verify.rs::tests` covering verify happy / tamper-sig / tamper-content / wrong-key / malformed-len paths plus key-lookup
- [x] 5 integration tests in `tests/federation_inbound_verify.rs` covering the two-host federation flow (happy / tamper-sig / tamper-content / no-key / legacy-unsigned)
- [x] Lib total: 2063 passing
- [ ] H4 will add the `memory_verify` MCP tool + finalize the `attest_level` enum

Note on clippy: `cargo clippy --all-targets` surfaces ~20 doc-markdown errors in `tests/webhook_*.rs`, `tests/proptest_*.rs`, `tests/budget_tokens.rs` and one dead-code in `src/llm.rs`. These are pre-existing on `main` (verified via `git stash`) — toolchain drift on rustc 1.95.0 / clippy 0.1.95. Lib + new test file are pedantic-clean.