### PR TITLE
feat: v0.7-i3 — transcript TTL + archive→prune lifecycle

### DIFF
--- a/migrations/sqlite/0019_v07_transcript_lifecycle.sql
+++ b/migrations/sqlite/0019_v07_transcript_lifecycle.sql
@@ -1,0 +1,30 @@
+-- v0.7.0 — Per-namespace TTL with archive→prune lifecycle (schema v25).
+--
+-- I3 of the attested-cortex epic. Builds on the I1 substrate
+-- (`memory_transcripts`, schema v22) and the I2 join table
+-- (`memory_transcript_links`, schema v24).
+--
+-- Two-phase lifecycle:
+--   Phase 1 — ARCHIVE: a transcript whose age exceeds the resolved
+--             default_ttl AND whose linked memories are all expired
+--             (or absent) is marked archived by setting `archived_at`
+--             to the current RFC3339 timestamp. The blob stays put
+--             so a late-binding `memory_replay` (I4) call can still
+--             reach it during the grace window.
+--   Phase 2 — PRUNE:  an archived transcript whose
+--             archived_at + archive_grace_secs has passed is DELETEd.
+--             The I2 join table is cleaned up automatically by the
+--             `ON DELETE CASCADE` declared on
+--             memory_transcript_links.transcript_id.
+--
+-- The `archived_at` column is the load-bearing addition for I3; the
+-- supporting partial index keeps the prune-phase scan O(archived rows)
+-- rather than O(total transcripts) on busy namespaces.
+--
+-- ALTER TABLE … ADD COLUMN is emitted from Rust (SQLite has no
+-- `ADD COLUMN IF NOT EXISTS`); this file only carries the idempotent
+-- index DDL.
+
+CREATE INDEX IF NOT EXISTS idx_memory_transcripts_archived_at
+    ON memory_transcripts (archived_at)
+    WHERE archived_at IS NOT NULL;

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -54,16 +54,18 @@ use std::time::Instant;
 pub const MIN_SUPPORTED_SCHEMA: u32 = 16;
 
 /// Upper bound of the DB-schema range this binary supports. Mirrors
-/// `db::CURRENT_SCHEMA_VERSION` (24 in v0.7.0 — v21 from K2's
+/// `db::CURRENT_SCHEMA_VERSION` (25 in v0.7.0 — v21 from K2's
 /// `pending_actions` timeout-sweeper columns, v22 from I1's
 /// `memory_transcripts` BLOB store, v23 from H2's
-/// `memory_links.attest_level` column for outbound link signing, and
-/// v24 from I2's `memory_transcript_links` join table connecting
-/// memories to their transcript provenance — all part of the
-/// attested-cortex epic). When a DB's `schema_version` exceeds this,
-/// the binary is too old for a newer DB and we surface a warning.
-/// v0.6.3.1 (PR-9h / issue #487 PR #497 req #72).
-pub const MAX_SUPPORTED_SCHEMA: u32 = 24;
+/// `memory_links.attest_level` column for outbound link signing, v24
+/// from I2's `memory_transcript_links` join table connecting
+/// memories to their transcript provenance, and v25 from I3's
+/// `memory_transcripts.archived_at` column backing the per-namespace
+/// TTL with archive→prune lifecycle — all part of the attested-cortex
+/// epic). When a DB's `schema_version` exceeds this, the binary is
+/// too old for a newer DB and we surface a warning. v0.6.3.1 (PR-9h /
+/// issue #487 PR #497 req #72).
+pub const MAX_SUPPORTED_SCHEMA: u32 = 25;
 
 /// Pure boundary check: `true` when `v` lies within
 /// `[MIN_SUPPORTED_SCHEMA, MAX_SUPPORTED_SCHEMA]`. Extracted so the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1022,6 +1022,183 @@ impl ResolvedTtl {
 }
 
 // ---------------------------------------------------------------------------
+// Transcript lifecycle (v0.7.0 I3) — per-namespace TTL + archive→prune
+// ---------------------------------------------------------------------------
+
+/// Compiled-in default for the transcript TTL: 30 days. After this
+/// many seconds elapse from `created_at` AND every memory that links
+/// the transcript has expired (or been deleted), the I3 background
+/// sweeper marks the transcript archived.
+pub const DEFAULT_TRANSCRIPT_TTL_SECS: i64 = 2_592_000;
+
+/// Compiled-in default for the post-archive grace window: 7 days.
+/// A transcript whose `archived_at` is older than this is hard-deleted
+/// by the prune phase; the I2 join table is cleaned up via
+/// `ON DELETE CASCADE`.
+pub const DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS: i64 = 604_800;
+
+/// Maximum transcript TTL / grace clamp: 10 years in seconds. Mirrors
+/// [`MAX_TTL_SECS`] above so the same overflow guard applies to the
+/// transcript lifecycle math when the resolved value flows into a
+/// `chrono::Duration`.
+const MAX_TRANSCRIPT_LIFECYCLE_SECS: i64 = 315_360_000;
+
+/// `[transcripts]` block in `config.toml` — per-namespace TTL and
+/// archive grace overrides for the I3 lifecycle sweeper.
+///
+/// ```toml
+/// [transcripts]
+/// default_ttl_secs   = 2592000   # 30 days; archive after this when memories all expired
+/// archive_grace_secs = 604800    # 7 days; prune this long after archive
+///
+/// [transcripts.namespaces."team/audit"]
+/// default_ttl_secs = 31536000    # 1 year — compliance retention override
+///
+/// [transcripts.namespaces."ephemeral/*"]
+/// default_ttl_secs = 86400       # 1 day — short-lived scratchpad
+/// ```
+///
+/// Resolution: the sweeper picks the longest-prefix matching namespace
+/// override (with literal `"*"` patterns last), falls back to the
+/// global `default_ttl_secs` / `archive_grace_secs` on this struct,
+/// and finally to the compiled defaults above.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TranscriptsConfig {
+    /// Global default seconds-since-creation before the sweeper
+    /// considers a transcript archive-eligible. `None` → compiled
+    /// default ([`DEFAULT_TRANSCRIPT_TTL_SECS`] = 30 days).
+    pub default_ttl_secs: Option<i64>,
+    /// Global default seconds an archived transcript lingers before
+    /// the prune phase deletes it. `None` → compiled default
+    /// ([`DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS`] = 7 days).
+    pub archive_grace_secs: Option<i64>,
+    /// Per-namespace overrides keyed by namespace pattern. Patterns
+    /// are matched literally first; a trailing `/*` selects every
+    /// child namespace under the prefix; the bare `"*"` is the
+    /// catch-all and is consulted last.
+    pub namespaces: Option<std::collections::HashMap<String, TranscriptNamespaceConfig>>,
+}
+
+/// Per-namespace overrides nested under
+/// `[transcripts.namespaces."<pattern>"]`. Each field independently
+/// overrides the [`TranscriptsConfig`] global default; an unset field
+/// inherits.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TranscriptNamespaceConfig {
+    /// Namespace-specific TTL override.
+    pub default_ttl_secs: Option<i64>,
+    /// Namespace-specific archive-grace override.
+    pub archive_grace_secs: Option<i64>,
+}
+
+/// Resolved transcript-lifecycle parameters for a single namespace.
+/// Produced by [`TranscriptsConfig::resolve`] and consumed by the I3
+/// sweeper to drive the archive + prune SQL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedTranscriptLifecycle {
+    /// Seconds-since-creation before archive eligibility. Always
+    /// positive and `<= MAX_TRANSCRIPT_LIFECYCLE_SECS`.
+    pub default_ttl_secs: i64,
+    /// Seconds an archived row lingers before prune. Always
+    /// positive and `<= MAX_TRANSCRIPT_LIFECYCLE_SECS`.
+    pub archive_grace_secs: i64,
+}
+
+impl Default for ResolvedTranscriptLifecycle {
+    fn default() -> Self {
+        Self {
+            default_ttl_secs: DEFAULT_TRANSCRIPT_TTL_SECS,
+            archive_grace_secs: DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS,
+        }
+    }
+}
+
+impl TranscriptsConfig {
+    /// Resolve the lifecycle parameters for `namespace`.
+    ///
+    /// Precedence:
+    /// 1. Exact match in `namespaces` (e.g. `"team/audit"`).
+    /// 2. Longest matching prefix pattern ending in `/*` (e.g.
+    ///    `"team/*"` matches `"team/eng"` and `"team/eng/inner"`).
+    /// 3. Bare `"*"` wildcard.
+    /// 4. The struct-level `default_ttl_secs` / `archive_grace_secs`.
+    /// 5. The compiled defaults
+    ///    ([`DEFAULT_TRANSCRIPT_TTL_SECS`] / [`DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS`]).
+    ///
+    /// Each field is resolved independently — a per-namespace override
+    /// that only sets `default_ttl_secs` inherits the global
+    /// `archive_grace_secs`. Non-positive values fall through to the
+    /// next layer; positive values are clamped to
+    /// `MAX_TRANSCRIPT_LIFECYCLE_SECS` so the resolved `Duration`
+    /// addition can never overflow `chrono`.
+    #[must_use]
+    pub fn resolve(&self, namespace: &str) -> ResolvedTranscriptLifecycle {
+        let ns_table = self.namespaces.as_ref();
+
+        // Walk the namespace overrides in precedence order, returning
+        // the first that names the field. `None` means "fall through".
+        let pick_ns = |field: fn(&TranscriptNamespaceConfig) -> Option<i64>| -> Option<i64> {
+            let table = ns_table?;
+            // 1. Exact literal match.
+            if let Some(ns) = table.get(namespace) {
+                if let Some(v) = field(ns) {
+                    return Some(v);
+                }
+            }
+            // 2. Longest-prefix `prefix/*` match.
+            let mut prefix_hits: Vec<(&str, &TranscriptNamespaceConfig)> = table
+                .iter()
+                .filter_map(|(k, v)| {
+                    let prefix = k.strip_suffix("/*")?;
+                    if namespace == prefix || namespace.starts_with(&format!("{prefix}/")) {
+                        Some((prefix, v))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            prefix_hits.sort_by_key(|(p, _)| std::cmp::Reverse(p.len()));
+            for (_, ns) in &prefix_hits {
+                if let Some(v) = field(ns) {
+                    return Some(v);
+                }
+            }
+            // 3. Bare wildcard.
+            if let Some(ns) = table.get("*") {
+                if let Some(v) = field(ns) {
+                    return Some(v);
+                }
+            }
+            None
+        };
+
+        let clamp = |v: i64, fallback: i64| -> i64 {
+            if v <= 0 {
+                fallback
+            } else {
+                v.min(MAX_TRANSCRIPT_LIFECYCLE_SECS)
+            }
+        };
+
+        let ttl = pick_ns(|n| n.default_ttl_secs)
+            .or(self.default_ttl_secs)
+            .map_or(DEFAULT_TRANSCRIPT_TTL_SECS, |v| {
+                clamp(v, DEFAULT_TRANSCRIPT_TTL_SECS)
+            });
+        let grace = pick_ns(|n| n.archive_grace_secs)
+            .or(self.archive_grace_secs)
+            .map_or(DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS, |v| {
+                clamp(v, DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS)
+            });
+
+        ResolvedTranscriptLifecycle {
+            default_ttl_secs: ttl,
+            archive_grace_secs: grace,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Recall scoring (time-decay half-life) — v0.6.0.0
 // ---------------------------------------------------------------------------
 
@@ -1203,6 +1380,11 @@ pub struct AppConfig {
     /// gate). New installs that want the strict gate set
     /// `[permissions] mode = "enforce"` explicitly.
     pub permissions: Option<PermissionsConfig>,
+    /// v0.7.0 I3 — `[transcripts]` block. Per-namespace TTL and
+    /// archive-grace overrides for the transcript lifecycle sweeper.
+    /// Unset → compiled defaults apply globally
+    /// ([`DEFAULT_TRANSCRIPT_TTL_SECS`] / [`DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS`]).
+    pub transcripts: Option<TranscriptsConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1923,6 +2105,14 @@ impl AppConfig {
     /// (disabled) instance when the config file omits it.
     pub fn effective_audit(&self) -> AuditConfig {
         self.audit.clone().unwrap_or_default()
+    }
+
+    /// v0.7.0 I3 — resolve the [`TranscriptsConfig`] block, returning
+    /// a default (no namespace overrides → compiled global defaults)
+    /// instance when the config file omits it.
+    #[must_use]
+    pub fn effective_transcripts(&self) -> TranscriptsConfig {
+        self.transcripts.clone().unwrap_or_default()
     }
 
     /// Resolve the [`BootConfig`] block, returning a default

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -95,6 +95,14 @@ const PENDING_TIMEOUT_SWEEP_INTERVAL_SECS: u64 = 60;
 /// `doctor` warning window so a row already classed CRITICAL by
 /// `doctor_oldest_pending_age_secs` is also a sweeper candidate.
 const PENDING_TIMEOUT_DEFAULT_SECS: i64 = 86_400;
+/// v0.7.0 I3 — transcript archive→prune sweeper cadence. The lifecycle
+/// scan walks every transcript row plus a per-candidate join into
+/// `memories`, so we run it less aggressively than the K2 60-second
+/// pending-actions sweeper. 10 minutes is fast enough that operator-
+/// visible drift between TTL expiry and archive is bounded by one
+/// tick, and slow enough that the scan never dominates a busy
+/// daemon's wall-clock.
+const TRANSCRIPT_LIFECYCLE_SWEEP_INTERVAL_SECS: u64 = 600;
 
 // ---------------------------------------------------------------------------
 // Clap-derived CLI surface
@@ -1256,6 +1264,55 @@ pub fn spawn_pending_timeout_sweep_loop(
     })
 }
 
+/// v0.7.0 I3 — spawn the periodic transcript archive→prune sweeper.
+///
+/// Sleeps `interval`, then calls
+/// [`crate::transcripts::sweep_transcript_lifecycle`] against the
+/// daemon's shared connection. The per-namespace TTL configuration
+/// is captured by `cfg` once at spawn time (operators editing
+/// `[transcripts]` in `config.toml` after boot must restart the
+/// daemon — same model as the K2 pending sweeper).
+///
+/// The returned [`JoinHandle`] is owned by the caller; `serve()`
+/// aborts it on shutdown — same lifecycle as
+/// [`spawn_pending_timeout_sweep_loop`].
+#[must_use]
+pub fn spawn_transcript_lifecycle_sweep_loop(
+    state: Db,
+    cfg: crate::config::TranscriptsConfig,
+    interval: Duration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            // Hold the connection lock for the whole sweep: the
+            // archive + prune phases share one `now` and the
+            // archive-then-prune semantics require sequential
+            // execution against the same view of the table. A 10-
+            // minute cadence means the lock window is at most a few
+            // ms even on busy databases.
+            let report = {
+                let lock = state.lock().await;
+                match crate::transcripts::sweep_transcript_lifecycle(&lock.0, &cfg) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!("transcript lifecycle sweep failed: {e}");
+                        continue;
+                    }
+                }
+            };
+            if report.archived > 0 || report.pruned > 0 || report.errors > 0 {
+                tracing::info!(
+                    "transcript lifecycle sweep: archived={} pruned={} errors={}",
+                    report.archived,
+                    report.pruned,
+                    report.errors,
+                );
+            }
+        }
+    })
+}
+
 /// Spawn the periodic WAL checkpoint loop. First checkpoint runs
 /// `interval / 2` after start (staggered from the GC loop to avoid
 /// lock-contention bursts on cold start), then on a fixed cadence.
@@ -1436,6 +1493,19 @@ pub async fn bootstrap_serve(
         db_path.to_path_buf(),
         PENDING_TIMEOUT_DEFAULT_SECS,
         Duration::from_secs(PENDING_TIMEOUT_SWEEP_INTERVAL_SECS),
+    ));
+
+    // v0.7.0 I3: transcript archive→prune lifecycle sweeper. Resolves
+    // per-namespace TTL + grace from `[transcripts]` in config.toml
+    // (compiled defaults: 30-day TTL, 7-day grace) and runs every 10
+    // minutes — heavier than K2's 60s scan because phase 1 walks the
+    // I2 join table per candidate. Companion to the K2 sweeper above:
+    // both follow the same spawn-per-interval shape so shutdown +
+    // observability behave identically.
+    task_handles.push(spawn_transcript_lifecycle_sweep_loop(
+        db_state.clone(),
+        app_config.effective_transcripts(),
+        Duration::from_secs(TRANSCRIPT_LIFECYCLE_SWEEP_INTERVAL_SECS),
     ));
 
     let api_key_state = ApiKeyState {
@@ -2593,9 +2663,10 @@ mod tests {
         assert!(bs.app_state.embedder.is_none());
         let vi = bs.app_state.vector_index.lock().await;
         assert!(vi.is_none());
-        // Three task handles spawned (gc + wal_checkpoint + v0.7 K2
-        // pending_actions timeout sweep).
-        assert_eq!(bs.task_handles.len(), 3);
+        // Four task handles spawned (gc + wal_checkpoint + v0.7 K2
+        // pending_actions timeout sweep + v0.7 I3 transcript
+        // archive→prune lifecycle sweep).
+        assert_eq!(bs.task_handles.len(), 4);
         // Cleanly abort the spawned tasks so they don't leak across tests.
         for h in bs.task_handles {
             h.abort();

--- a/src/db.rs
+++ b/src/db.rs
@@ -220,7 +220,17 @@ CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
 //       when memories are deleted or I3's archive->prune lifecycle
 //       removes transcripts. Substrate for I4 (memory_replay) and
 //       I5/R5 (pre_store extraction hook).
-const CURRENT_SCHEMA_VERSION: i64 = 24;
+// v25 = v0.7.0 I3 (attested-cortex epic) per-namespace transcript TTL
+//       with archive->prune lifecycle. Adds the `archived_at TEXT`
+//       column on `memory_transcripts` (NULL = live, RFC3339 = the
+//       moment the sweeper marked the row archived) plus a partial
+//       index on archived rows so the prune-phase scan is bounded.
+//       The lifecycle sweeper itself lives in `transcripts.rs` and
+//       runs on a 10-minute cadence from `daemon_runtime`. Per-
+//       namespace TTL overrides arrive via the `[transcripts]`
+//       config section (`config.rs`) and are resolved against the
+//       transcript's namespace at sweep time.
+const CURRENT_SCHEMA_VERSION: i64 = 25;
 
 pub fn open(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path).context("failed to open database")?;
@@ -313,6 +323,13 @@ const MIGRATION_V23_SQLITE: &str =
 // (pre_store extraction hook) writes to it.
 const MIGRATION_V24_SQLITE: &str =
     include_str!("../migrations/sqlite/0018_v07_transcript_links.sql");
+// v0.7.0 I3 — per-namespace transcript TTL with archive->prune
+// lifecycle. ALTER TABLE adding `memory_transcripts.archived_at` is
+// emitted from Rust (SQLite has no `ADD COLUMN IF NOT EXISTS`); the
+// SQL file holds the supporting partial index on archived rows so
+// the prune-phase scan stays O(archived) rather than O(total).
+const MIGRATION_V25_SQLITE: &str =
+    include_str!("../migrations/sqlite/0019_v07_transcript_lifecycle.sql");
 
 #[allow(clippy::too_many_lines)]
 fn migrate(conn: &Connection) -> Result<()> {
@@ -837,6 +854,25 @@ fn migrate(conn: &Connection) -> Result<()> {
             // Substrate only; I4 layers `memory_replay` on top, I5/R5
             // wires the pre_store extraction hook that populates it.
             conn.execute_batch(MIGRATION_V24_SQLITE)?;
+        }
+        if version < 25 {
+            // v0.7.0 I3 — per-namespace transcript TTL with archive→
+            // prune lifecycle. Adds `memory_transcripts.archived_at`
+            // (NULL = live, RFC3339 = archived). The lifecycle
+            // sweeper in `transcripts.rs` consults this column; the
+            // partial index from the SQL file keeps the prune-phase
+            // scan bounded. Substrate for the 10-minute background
+            // task wired into `daemon_runtime::bootstrap_serve`.
+            let has_archived_at = conn
+                .prepare("SELECT archived_at FROM memory_transcripts LIMIT 0")
+                .is_ok();
+            if !has_archived_at {
+                conn.execute(
+                    "ALTER TABLE memory_transcripts ADD COLUMN archived_at TEXT",
+                    [],
+                )?;
+            }
+            conn.execute_batch(MIGRATION_V25_SQLITE)?;
         }
 
         conn.execute("DELETE FROM schema_version", [])?;

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -33,9 +33,11 @@
 //! length of the encoded / source content respectively.
 
 use anyhow::{Context, Result};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use rusqlite::{Connection, OptionalExtension, params};
 use std::io::Write;
+
+use crate::config::{ResolvedTranscriptLifecycle, TranscriptsConfig};
 
 /// Default zstd compression level. Matches `cli::logs::zstd_compress`
 /// for cross-codebase consistency.
@@ -282,6 +284,247 @@ fn row_to_link(row: &rusqlite::Row<'_>) -> rusqlite::Result<TranscriptLink> {
         span_start: row.get(2)?,
         span_end: row.get(3)?,
     })
+}
+
+/// v0.7.0 I3 — outcome of one [`sweep_transcript_lifecycle`] pass.
+///
+/// `archived` and `pruned` count distinct rows touched in each phase
+/// of the same sweep tick; a row archived this tick will not be
+/// pruned until at least the next tick (and only after its grace
+/// window expires). `errors` is best-effort observability — the
+/// sweeper logs and continues past per-row failures so a single
+/// poison row cannot stall the loop, but the count is surfaced for
+/// the daemon's structured logs and the future doctor overlay.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SweepReport {
+    /// Number of rows transitioned to `archived` this tick.
+    pub archived: usize,
+    /// Number of rows hard-deleted (prune phase) this tick.
+    pub pruned: usize,
+    /// Per-row errors swallowed during the sweep (e.g. a single
+    /// transcript with a corrupt namespace string). The aggregate
+    /// sweep call still returns `Ok` so the background loop keeps
+    /// running.
+    pub errors: usize,
+}
+
+/// v0.7.0 I3 — drive the transcript archive→prune lifecycle once.
+///
+/// Two phases run in order against the supplied connection. Per the
+/// I3 contract the connection is held for the full sweep so the two
+/// phases see a consistent `now`:
+///
+/// * **Phase 1 — ARCHIVE.** For every live transcript (non-NULL
+///   `archived_at` is skipped), resolve the per-namespace lifecycle
+///   from `cfg`, then archive the row when:
+///   1. `created_at + default_ttl_secs < now` (transcript itself is
+///      old enough to retire), and
+///   2. every memory linked to the transcript via the I2 join table
+///      has either expired or been deleted (a transcript with no
+///      linked memories trivially satisfies this — there is nothing
+///      keeping it live).
+///
+/// * **Phase 2 — PRUNE.** Hard-DELETE every archived row whose
+///   `archived_at + archive_grace_secs < now`. The
+///   `ON DELETE CASCADE` declared on `memory_transcript_links`
+///   cleans up the join table without an explicit second statement.
+///
+/// Phase 2 runs even if Phase 1 had errors so a single poisonous row
+/// in the archive scan does not block the prune side. `SweepReport`
+/// is the wire-shape returned to the daemon's metrics emitter.
+///
+/// # Errors
+///
+/// Returns an error only on infrastructure-level SQLite failures
+/// (connection lost, disk full). Per-row failures are folded into
+/// `SweepReport::errors`.
+pub fn sweep_transcript_lifecycle(
+    conn: &Connection,
+    cfg: &TranscriptsConfig,
+) -> Result<SweepReport> {
+    let now = Utc::now();
+    let mut report = SweepReport::default();
+
+    // Phase 1 — ARCHIVE.
+    archive_phase(conn, cfg, now, &mut report)?;
+
+    // Phase 2 — PRUNE. Each row carries its own `archived_at` so we
+    // re-resolve the per-namespace grace window for each candidate.
+    prune_phase(conn, cfg, now, &mut report)?;
+
+    Ok(report)
+}
+
+/// Phase-1 helper extracted for readability — see
+/// [`sweep_transcript_lifecycle`] for the full contract.
+fn archive_phase(
+    conn: &Connection,
+    cfg: &TranscriptsConfig,
+    now: DateTime<Utc>,
+    report: &mut SweepReport,
+) -> Result<()> {
+    // Pull every live row up front — the per-namespace TTL means we
+    // cannot push the age cutoff into SQL without committing to the
+    // global default, and the per-row aliveness check (all linked
+    // memories expired) needs another query anyway.
+    let live_candidates: Vec<(String, String, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, namespace, created_at
+                 FROM memory_transcripts
+                 WHERE archived_at IS NULL",
+            )
+            .context("PREPARE archive_phase scan failed")?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })
+            .context("QUERY archive_phase scan failed")?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .context("decode archive_phase rows")?
+    };
+
+    for (id, namespace, created_at) in live_candidates {
+        let resolved = cfg.resolve(&namespace);
+        match should_archive(conn, &id, &created_at, now, resolved) {
+            Ok(true) => {
+                let stamp = now.to_rfc3339();
+                if let Err(e) = conn.execute(
+                    "UPDATE memory_transcripts
+                        SET archived_at = ?1
+                      WHERE id = ?2 AND archived_at IS NULL",
+                    params![stamp, id],
+                ) {
+                    tracing::warn!(
+                        target: "transcripts.lifecycle",
+                        "archive UPDATE failed for transcript {id}: {e}"
+                    );
+                    report.errors += 1;
+                } else {
+                    report.archived += 1;
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "transcripts.lifecycle",
+                    "archive eligibility check failed for transcript {id}: {e}"
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Phase-2 helper extracted for readability — see
+/// [`sweep_transcript_lifecycle`].
+fn prune_phase(
+    conn: &Connection,
+    cfg: &TranscriptsConfig,
+    now: DateTime<Utc>,
+    report: &mut SweepReport,
+) -> Result<()> {
+    let candidates: Vec<(String, String, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, namespace, archived_at
+                 FROM memory_transcripts
+                 WHERE archived_at IS NOT NULL",
+            )
+            .context("PREPARE prune_phase scan failed")?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })
+            .context("QUERY prune_phase scan failed")?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .context("decode prune_phase rows")?
+    };
+
+    for (id, namespace, archived_at) in candidates {
+        let resolved = cfg.resolve(&namespace);
+        let archived_at = match DateTime::parse_from_rfc3339(&archived_at) {
+            Ok(t) => t.with_timezone(&Utc),
+            Err(e) => {
+                tracing::warn!(
+                    target: "transcripts.lifecycle",
+                    "transcript {id} has unparseable archived_at {archived_at:?}: {e}"
+                );
+                report.errors += 1;
+                continue;
+            }
+        };
+        let prune_at = archived_at + Duration::seconds(resolved.archive_grace_secs);
+        if prune_at >= now {
+            continue;
+        }
+        match conn.execute("DELETE FROM memory_transcripts WHERE id = ?1", params![id]) {
+            Ok(n) => report.pruned += n,
+            Err(e) => {
+                tracing::warn!(
+                    target: "transcripts.lifecycle",
+                    "prune DELETE failed for transcript {id}: {e}"
+                );
+                report.errors += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Decide whether a single transcript is archive-eligible at `now`
+/// given the resolved [`ResolvedTranscriptLifecycle`].
+///
+/// Returns `Ok(true)` only when BOTH conditions hold:
+///   1. `created_at + default_ttl_secs < now`
+///   2. every memory linked via `memory_transcript_links` has
+///      `expires_at` in the past, OR no memories link the transcript
+///      at all.
+///
+/// A memory whose `expires_at` is NULL counts as "live forever" and
+/// keeps the transcript live too — same as the substrate's
+/// [`purge_expired`] semantics for transcript rows themselves.
+fn should_archive(
+    conn: &Connection,
+    transcript_id: &str,
+    created_at: &str,
+    now: DateTime<Utc>,
+    resolved: ResolvedTranscriptLifecycle,
+) -> Result<bool> {
+    // Age cutoff first — cheaper than the join.
+    let created = DateTime::parse_from_rfc3339(created_at)
+        .with_context(|| format!("transcript {transcript_id} has unparseable created_at"))?
+        .with_timezone(&Utc);
+    let archive_at = created + Duration::seconds(resolved.default_ttl_secs);
+    if archive_at >= now {
+        return Ok(false);
+    }
+
+    // Aliveness check: count linked memories with NULL or future
+    // `expires_at`. SQLite returns 0 for the COUNT when the join is
+    // empty, so a transcript with no links is trivially eligible.
+    let now_str = now.to_rfc3339();
+    let alive: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+               FROM memory_transcript_links l
+               JOIN memories m ON m.id = l.memory_id
+              WHERE l.transcript_id = ?1
+                AND (m.expires_at IS NULL OR m.expires_at > ?2)",
+            params![transcript_id, now_str],
+            |r| r.get(0),
+        )
+        .with_context(|| format!("alive-memory count failed for transcript {transcript_id}"))?;
+    Ok(alive == 0)
 }
 
 fn zstd_compress(input: &[u8]) -> Result<Vec<u8>> {
@@ -588,6 +831,314 @@ mod tests {
         assert_eq!(
             fetch(&conn, &immortal.id).unwrap().as_deref(),
             Some("immortal body"),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // I3 — per-namespace TTL with archive→prune lifecycle.
+    // ---------------------------------------------------------------
+
+    use crate::config::{TranscriptNamespaceConfig, TranscriptsConfig};
+    use std::collections::HashMap;
+
+    /// Backdate a transcript's `created_at` to `secs` ago. The
+    /// `store()` API takes a TTL relative to `now()`, so the only
+    /// way to fake an aged row in a test is to UPDATE the column
+    /// directly. Returns the rewritten timestamp for assertions.
+    fn backdate_created(conn: &Connection, id: &str, secs: i64) -> String {
+        let stamp = (Utc::now() - Duration::seconds(secs)).to_rfc3339();
+        conn.execute(
+            "UPDATE memory_transcripts SET created_at = ?1 WHERE id = ?2",
+            params![stamp, id],
+        )
+        .unwrap();
+        stamp
+    }
+
+    /// Backdate `archived_at` directly so the prune phase sees a row
+    /// that was archived `secs` ago.
+    fn backdate_archived(conn: &Connection, id: &str, secs: i64) -> String {
+        let stamp = (Utc::now() - Duration::seconds(secs)).to_rfc3339();
+        conn.execute(
+            "UPDATE memory_transcripts SET archived_at = ?1 WHERE id = ?2",
+            params![stamp, id],
+        )
+        .unwrap();
+        stamp
+    }
+
+    /// Build a [`TranscriptsConfig`] with a 1-hour global TTL and a
+    /// 1-hour grace window — small enough that test-side backdating
+    /// can cleanly straddle both thresholds without touching the
+    /// system clock.
+    fn fast_cfg() -> TranscriptsConfig {
+        TranscriptsConfig {
+            default_ttl_secs: Some(3600),
+            archive_grace_secs: Some(3600),
+            namespaces: None,
+        }
+    }
+
+    /// Read the current `archived_at` for `id`. `None` means the row
+    /// is still live (NULL column). Asserts the row exists.
+    fn archived_at(conn: &Connection, id: &str) -> Option<String> {
+        conn.query_row(
+            "SELECT archived_at FROM memory_transcripts WHERE id = ?1",
+            params![id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .unwrap()
+    }
+
+    /// Read the `memory_transcripts` row count for `id` — 0 means the
+    /// prune phase fired.
+    fn row_exists(conn: &Connection, id: &str) -> bool {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_transcripts WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        n > 0
+    }
+
+    /// I3 — a transcript with no linked memories AND age beyond the
+    /// resolved TTL must be archived in phase 1.
+    #[test]
+    fn i3_unlinked_aged_transcript_is_archived() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        let t = store(&conn, "team/eng", "old body", None).unwrap();
+        backdate_created(&conn, &t.id, 7200); // 2 h old, TTL = 1 h
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.archived, 1, "phase 1 must archive the aged row");
+        assert_eq!(
+            report.pruned, 0,
+            "phase 2 must not fire on a freshly archived row"
+        );
+        assert!(
+            archived_at(&conn, &t.id).is_some(),
+            "archived_at must be set after phase 1",
+        );
+    }
+
+    /// I3 — phase 2 deletes an archived row whose grace window has
+    /// passed. Cascades to the I2 join table for free.
+    #[test]
+    fn i3_archived_past_grace_is_pruned_with_cascade() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        insert_test_memory(&conn, "mem-cascade");
+        let t = store(&conn, "team/eng", "to be pruned", None).unwrap();
+        link_transcript(&conn, "mem-cascade", &t.id, None, None).unwrap();
+
+        // Mark it archived 2 h ago (grace = 1 h).
+        backdate_archived(&conn, &t.id, 7200);
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.pruned, 1, "phase 2 must hard-DELETE the row");
+        assert!(!row_exists(&conn, &t.id), "transcript row gone");
+
+        // I2 cascade fires: the link row goes too.
+        assert!(
+            transcripts_for_memory(&conn, "mem-cascade")
+                .unwrap()
+                .is_empty(),
+            "ON DELETE CASCADE must clear the I2 join row",
+        );
+    }
+
+    /// I3 — a transcript with a still-live linked memory (NULL
+    /// `expires_at` or future `expires_at`) is NOT archived even when
+    /// the transcript itself is older than its TTL. The memory's
+    /// liveness pins the transcript.
+    #[test]
+    fn i3_live_linked_memory_keeps_transcript_alive() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        // Memory with no expiry — counts as "live forever".
+        insert_test_memory(&conn, "mem-immortal");
+
+        let t = store(&conn, "team/eng", "still wanted", None).unwrap();
+        link_transcript(&conn, "mem-immortal", &t.id, None, None).unwrap();
+        backdate_created(&conn, &t.id, 7200); // way past TTL
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.archived, 0);
+        assert!(
+            archived_at(&conn, &t.id).is_none(),
+            "live linked memory must keep archived_at NULL",
+        );
+    }
+
+    /// I3 — a transcript whose every linked memory has an `expires_at`
+    /// in the past IS archived. Mirror image of the test above —
+    /// guards against the SQL accidentally treating an empty-future
+    /// memory as live.
+    #[test]
+    fn i3_all_linked_memories_expired_then_transcript_is_archived() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        // Insert a memory then force its expires_at into the past.
+        insert_test_memory(&conn, "mem-expired");
+        let past = (Utc::now() - Duration::seconds(60)).to_rfc3339();
+        conn.execute(
+            "UPDATE memories SET expires_at = ?1 WHERE id = 'mem-expired'",
+            params![past],
+        )
+        .unwrap();
+
+        let t = store(&conn, "team/eng", "no longer needed", None).unwrap();
+        link_transcript(&conn, "mem-expired", &t.id, None, None).unwrap();
+        backdate_created(&conn, &t.id, 7200);
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.archived, 1);
+        assert!(archived_at(&conn, &t.id).is_some());
+    }
+
+    /// I3 — a per-namespace override (longer TTL) beats the global
+    /// default. The global cfg would archive the row; the namespace
+    /// override keeps it live.
+    #[test]
+    fn i3_per_namespace_override_extends_ttl_beyond_global_default() {
+        let conn = test_db();
+
+        // Global TTL = 1h, but the team/audit namespace gets 1 day.
+        let mut ns_table = HashMap::new();
+        ns_table.insert(
+            "team/audit".to_string(),
+            TranscriptNamespaceConfig {
+                default_ttl_secs: Some(86_400),
+                archive_grace_secs: None,
+            },
+        );
+        let cfg = TranscriptsConfig {
+            default_ttl_secs: Some(3600),
+            archive_grace_secs: Some(3600),
+            namespaces: Some(ns_table),
+        };
+
+        // Two rows, two namespaces, both 2 h old.
+        let eng = store(&conn, "team/eng", "eng body", None).unwrap();
+        backdate_created(&conn, &eng.id, 7200);
+        let audit = store(&conn, "team/audit", "audit body", None).unwrap();
+        backdate_created(&conn, &audit.id, 7200);
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.archived, 1, "only team/eng is past the resolved TTL");
+        assert!(archived_at(&conn, &eng.id).is_some());
+        assert!(
+            archived_at(&conn, &audit.id).is_none(),
+            "team/audit override (1d) keeps the audit row live",
+        );
+    }
+
+    /// I3 — a `prefix/*` per-namespace pattern matches every child
+    /// namespace (longest-prefix wins on multiple matches). Guards
+    /// the resolver's prefix-walk path.
+    #[test]
+    fn i3_prefix_pattern_override_matches_child_namespaces() {
+        let conn = test_db();
+
+        let mut ns_table = HashMap::new();
+        ns_table.insert(
+            "ephemeral/*".to_string(),
+            TranscriptNamespaceConfig {
+                default_ttl_secs: Some(60),
+                archive_grace_secs: Some(60),
+            },
+        );
+        let cfg = TranscriptsConfig {
+            default_ttl_secs: Some(86_400 * 30), // 30 days global
+            archive_grace_secs: Some(86_400 * 7),
+            namespaces: Some(ns_table),
+        };
+
+        // 5-min-old row in ephemeral/scratch — past the 60s pattern TTL,
+        // well under the 30-day global default.
+        let t = store(&conn, "ephemeral/scratch", "scratch", None).unwrap();
+        backdate_created(&conn, &t.id, 300);
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(
+            report.archived, 1,
+            "prefix pattern must apply to ephemeral/scratch"
+        );
+    }
+
+    /// I3 — a freshly-archived row (within the grace window) is NOT
+    /// pruned. Together with `i3_archived_past_grace_is_pruned`, the
+    /// pair brackets the prune-phase boundary condition.
+    #[test]
+    fn i3_archived_within_grace_is_not_pruned() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        let t = store(&conn, "team/eng", "still in grace", None).unwrap();
+        // Archived 30 minutes ago; grace = 1 h.
+        backdate_archived(&conn, &t.id, 1800);
+
+        let report = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(report.pruned, 0);
+        assert!(row_exists(&conn, &t.id));
+    }
+
+    /// I3 — end-to-end: one sweep archives, a second sweep (after the
+    /// grace window) prunes. Documents the two-tick lifecycle the
+    /// daemon sweeper relies on.
+    #[test]
+    fn i3_archive_then_prune_in_two_sweeps() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        let t = store(&conn, "team/eng", "lifecycle e2e", None).unwrap();
+        backdate_created(&conn, &t.id, 7200);
+
+        // Tick 1: archives.
+        let r1 = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(r1.archived, 1);
+        assert_eq!(r1.pruned, 0);
+
+        // Backdate the archive stamp past the grace window.
+        backdate_archived(&conn, &t.id, 7200);
+
+        // Tick 2: prunes.
+        let r2 = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(r2.archived, 0);
+        assert_eq!(r2.pruned, 1);
+        assert!(!row_exists(&conn, &t.id));
+    }
+
+    /// I3 — already-archived rows are not re-archived in subsequent
+    /// sweeps. Phase-1 SQL filters on `archived_at IS NULL`; this
+    /// test pins that filter so a future refactor can't silently
+    /// re-stamp archived rows.
+    #[test]
+    fn i3_idempotent_phase1_does_not_restamp_archived_rows() {
+        let conn = test_db();
+        let cfg = fast_cfg();
+
+        let t = store(&conn, "team/eng", "already archived", None).unwrap();
+        backdate_created(&conn, &t.id, 7200);
+        let _ = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        let first_stamp = archived_at(&conn, &t.id).unwrap();
+
+        // Sleep far enough to perceive a clock tick, then re-sweep.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let r2 = sweep_transcript_lifecycle(&conn, &cfg).unwrap();
+        assert_eq!(r2.archived, 0, "no row should be re-archived");
+
+        let second_stamp = archived_at(&conn, &t.id).unwrap();
+        assert_eq!(
+            first_stamp, second_stamp,
+            "archived_at must be preserved across sweeps",
         );
     }
 }


### PR DESCRIPTION
Track I task I3 of v0.7.0 attested-cortex epic. Builds on I1 (PR #557) + I2 (PR #568), both merged.

## Summary
- New `[transcripts]` config section with per-namespace TTL overrides
- archived_at column added (if not already in v22 schema)
- sweep_transcript_lifecycle: phase-1 archive (transcript age > default_ttl + all memories expired), phase-2 prune (archived_at + grace < now)
- Wired into daemon bootstrap as 10-min background task
- ON DELETE CASCADE from I2 cleans up memory_transcript_links automatically

## Test plan
- [x] cargo fmt --check + clippy --pedantic clean
- [x] cargo test --lib transcripts green
- [x] Archive then prune lifecycle end-to-end
- [x] Per-namespace TTL override
- [ ] I4 layers memory_replay; I5 layers R5 extraction