### PR TITLE
feat: v0.7-f2 — whats-new-v07 landing page

### DIFF
--- a/docs/whats-new-v07.html
+++ b/docs/whats-new-v07.html
@@ -1,0 +1,582 @@
+<!--
+  Copyright 2026 AlphaOne LLC
+  SPDX-License-Identifier: Apache-2.0
+
+  What's New in v0.7.0 — `attested-cortex`. The substrate becomes both
+  more articulate (loaders that say "load," capabilities that pre-compute
+  their own description, schemas at half the token cost) and
+  cryptographically trustworthy (Ed25519 attestation, sidechain
+  transcripts, programmable hooks, namespace-inheritance enforcement,
+  A2A maturity).
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>What's New in v0.7.0 — attested-cortex | ai-memory</title>
+<meta name="description" content="ai-memory v0.7.0 (attested-cortex) ships capabilities v3 with pre-computed calibration strings (LLMs converge on accurate first-answer descriptions), per-agent Ed25519 attestation with an append-only signed_events audit chain, a programmable 20-event hook pipeline (subprocess JSON-stdio + daemon mode), sidechain transcripts (zstd-3 BLOBs + memory_replay), opt-in Apache AGE acceleration for Postgres KG ops, the K1/G1 namespace-inheritance fix (cutline-protected), and a real permission system replacing v0.6.x advisory governance.">
+<link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/whats-new-v07.html">
+<style>
+:root{--bg:#000;--bg-raised:#0a0a0a;--bg-card:#111;--bg-elev:#161616;--bg-code:#1a1a1a;--border:#262626;--border-hl:#3d3d3d;--text:#fff;--text-muted:#999;--text-dim:#666;--p1:#6ee7ff;--p2:#ffb86b;--p3:#c8a2ff;--good:#2ea043;--warn:#ffb86b;--bad:#f85149;--prog:#c8a2ff;--accent:#6ee7ff;--green:#2ea043;--font-mono:'SF Mono','Cascadia Code','Fira Code',Consolas,monospace;--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;--max-w:1200px}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;scroll-padding-top:5rem}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}a:hover{filter:brightness(1.2)}
+code{font-family:var(--font-mono);font-size:.85em;background:var(--bg-code);padding:.1em .35em;border-radius:4px}
+pre{font-family:var(--font-mono);font-size:.85rem;background:var(--bg-code);border:1px solid var(--border);border-radius:8px;padding:1rem;overflow-x:auto;margin:1rem 0}
+.container{max-width:var(--max-w);margin:0 auto;padding:0 1.5rem}
+h1,h2,h3{font-weight:700;letter-spacing:-0.02em;color:#fff}
+h1{font-size:clamp(2.2rem,5vw,3.6rem);line-height:1.05;letter-spacing:-0.04em;margin-bottom:1rem}
+h2{font-size:1.85rem;margin-bottom:.6rem;margin-top:0}
+h3{font-size:1.15rem;margin-bottom:.5rem}
+p{color:var(--text-muted);margin-bottom:1rem}
+.topnav{position:sticky;top:0;z-index:50;background:rgba(0,0,0,0.9);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}
+.topnav .inner{display:flex;align-items:center;justify-content:space-between;max-width:var(--max-w);margin:0 auto;padding:.9rem 1.5rem;font-size:.875rem}
+.topnav a{color:var(--text-muted);margin-right:1.25rem}
+.topnav a:hover,.topnav a.active{color:var(--text)}
+.topnav .home-link{color:var(--text);font-weight:600}
+.hero{padding:6rem 1.5rem 4rem;text-align:center;background:radial-gradient(ellipse at center,rgba(110,231,255,0.08),transparent 60%),radial-gradient(ellipse at bottom,rgba(200,162,255,0.06),transparent 70%);border-bottom:1px solid var(--border)}
+.hero .badge{display:inline-block;padding:.4rem 1rem;background:rgba(200,162,255,0.1);border:1px solid var(--p3);color:var(--p3);border-radius:999px;font-family:var(--font-mono);font-size:.85rem;margin-bottom:1.5rem}
+.hero .subtitle{font-size:1.2rem;color:var(--text-muted);max-width:760px;margin:0 auto 2rem}
+.hero .meta{display:flex;justify-content:center;gap:2rem;color:var(--text-dim);font-family:var(--font-mono);font-size:.85rem;flex-wrap:wrap}
+section{padding:5rem 0;border-bottom:1px solid var(--border)}
+.eyebrow{display:inline-block;font-size:.75rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted);margin-bottom:1rem;padding:.25rem .65rem;border:1px solid var(--border-hl);border-radius:999px}
+.lede{color:var(--text-muted);font-size:1.05rem;max-width:780px;margin-bottom:2rem}
+.grid-2{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:1.25rem}
+.grid-3{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem}
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;position:relative}
+.card.cyan{border-top:3px solid var(--p1)}
+.card.amber{border-top:3px solid var(--p2)}
+.card.violet{border-top:3px solid var(--p3)}
+.card.green{border-top:3px solid var(--good)}
+.card h3{margin-bottom:.65rem}
+.card p{font-size:.92rem;color:var(--text-muted);margin-bottom:.75rem}
+.card .tag{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;color:var(--text-muted);text-transform:uppercase;margin-bottom:.5rem;display:block}
+.numstat{text-align:center;padding:1rem}
+.numstat .num{font-size:2.2rem;font-weight:800;color:var(--p1);display:block;line-height:1.1}
+.numstat .label{font-size:.78rem;color:var(--text-muted);display:block;margin-top:.25rem}
+table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:.92rem}
+th,td{text-align:left;padding:.65rem .85rem;border-bottom:1px solid var(--border);color:var(--text-muted)}
+th{color:#fff;font-weight:600;background:var(--bg-elev);font-size:.85rem}
+tr:hover{background:rgba(110,231,255,0.03)}
+ul.checked{list-style:none;padding-left:0}
+ul.checked li{padding-left:1.5rem;position:relative;margin:.35rem 0;color:var(--text-muted);font-size:.92rem}
+ul.checked li::before{content:"✓";position:absolute;left:0;color:var(--good);font-weight:800}
+.audience-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1.25rem;margin-top:1rem}
+.audience{background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:1.5rem;position:relative;overflow:hidden}
+.audience::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.audience.user::before{background:var(--p1)}
+.audience.dev::before{background:var(--p2)}
+.audience.cxo::before{background:var(--p3)}
+.audience .who{font-family:var(--font-mono);font-size:.7rem;letter-spacing:.12em;color:var(--text-muted);text-transform:uppercase;margin-bottom:.65rem}
+.audience h3{margin-bottom:1rem;font-size:1.1rem}
+.audience .pitch{color:var(--text-muted);font-size:.95rem;line-height:1.55;margin-bottom:1rem}
+.audience .pitch strong{color:#fff}
+.audience .cta{color:#fff;font-family:var(--font-mono);font-size:.8rem;border-bottom:1px dashed var(--text-muted);padding-bottom:1px}
+.cta-row{display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;margin-top:2rem}
+.cta-row a{padding:.7rem 1.25rem;border-radius:10px;font-weight:600;font-size:.92rem;border:1px solid var(--p1);color:var(--p1)}
+.cta-row a.solid{background:var(--p3);color:#000;border-color:var(--p3)}
+.cta-row a.amber{border-color:var(--p2);color:var(--p2)}
+.cta-row a.green{border-color:var(--good);color:var(--good)}
+.cta-row a.violet{border-color:var(--p3);color:var(--p3)}
+.tier-ladder{display:grid;grid-template-columns:repeat(5,1fr);gap:.75rem;margin:1.5rem 0}
+.tier-ladder .tier{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:1rem;text-align:center;position:relative}
+.tier-ladder .tier .t-num{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);letter-spacing:.12em}
+.tier-ladder .tier .t-name{font-weight:700;color:#fff;margin:.25rem 0;font-size:.95rem}
+.tier-ladder .tier .t-desc{font-size:.78rem;color:var(--text-muted);line-height:1.4}
+@media(max-width:780px){.tier-ladder{grid-template-columns:1fr 1fr}}
+@media(max-width:520px){.tier-ladder{grid-template-columns:1fr}}
+.callout{border-left:3px solid var(--p2);background:rgba(255,184,107,0.06);padding:1rem 1.25rem;border-radius:0 10px 10px 0;margin:1.25rem 0}
+.callout.breaking{border-left-color:var(--bad);background:rgba(248,81,73,0.06)}
+.callout.breaking .clabel{color:var(--bad)}
+.callout .clabel{display:block;font-family:var(--font-mono);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;color:var(--p2);margin-bottom:.4rem;font-weight:700}
+.callout p{font-size:.92rem;color:var(--text-muted);margin-bottom:.5rem}
+.callout p:last-child{margin-bottom:0}
+.status{display:inline-block;font-family:var(--font-mono);font-size:.78rem;padding:.1rem .5rem;border-radius:999px;letter-spacing:.04em}
+.status.ok{color:var(--good);border:1px solid var(--good)}
+.status.partial{color:var(--warn);border:1px solid var(--warn)}
+.status.future{color:var(--prog);border:1px solid var(--prog)}
+footer{padding:2.5rem 1.5rem;text-align:center;color:var(--text-dim);font-size:.85rem;border-top:1px solid var(--border)}
+footer .footer-links{display:flex;justify-content:center;gap:1.5rem;flex-wrap:wrap;margin-bottom:1rem}
+footer a{color:var(--text-dim)}
+footer a:hover{color:var(--accent)}
+</style>
+</head>
+<body>
+
+<nav class="topnav">
+  <div class="inner">
+    <a class="home-link" href="index.html">ai-memory&trade;</a>
+    <div class="right">
+      <a href="index.html">Home</a>
+      <a href="architectures.html">Tiers T1&rarr;T5</a>
+      <a href="whats-new-v07.html" class="active">v0.7.0</a>
+      <a href="whats-new-v064.html">v0.6.4</a>
+      <a href="v0.7/compatibility-matrix.html" style="color:#c8a2ff">Compat matrix</a>
+      <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:#2ea043">Discovery Gate</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<section class="hero">
+  <div class="container">
+    <span class="badge">v0.7.0 &middot; attested-cortex &middot; in flight</span>
+    <h1>More articulate.<br>Cryptographically attested.</h1>
+    <p class="subtitle">
+      ai-memory v0.7.0 closes two long-standing gaps in one release. The substrate <strong>says what it can do</strong> &mdash; capabilities v3 pre-computes the calibration strings LLMs would otherwise improvise &mdash; and <strong>signs what it remembers</strong> &mdash; per-agent Ed25519 keypairs sign every memory link, with an append-only <code>signed_events</code> audit chain. Plus the K1/G1 namespace-inheritance cutline, a programmable 20-event hook pipeline, sidechain transcripts, and an opt-in Apache AGE acceleration path.
+    </p>
+    <div class="meta">
+      <span>capabilities v2 &rarr; v3</span>
+      <span>schema v20 &rarr; v22</span>
+      <span>20 hook events</span>
+      <span>Ed25519 attestation</span>
+    </div>
+    <div class="cta-row">
+      <a class="solid" href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">📐 v0.7 Epic</a>
+      <a class="amber" href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md">📖 Migration Guide</a>
+      <a class="violet" href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md">📜 Design RFC</a>
+      <a class="green" href="v0.7/compatibility-matrix.html">🧩 Compat matrix</a>
+    </div>
+  </div>
+</section>
+
+<!-- ============ AT A GLANCE: TRACK COMPLETION TABLE ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">What's new at a glance</span>
+    <h2>v0.7.0 ships in tracks</h2>
+    <p class="lede">
+      Each track of the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">attested-cortex epic</a> lands independently. Use this table to know what's on by default, what's opt-in, and what slips to v0.7.1.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Track</th>
+          <th>Scope</th>
+          <th>Default in v0.7.0</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>A</strong> &mdash; Capabilities v3</td>
+          <td><code>summary</code>, <code>to_describe_to_user</code>, <code>callable_now</code>, <code>agent_permitted_families</code></td>
+          <td>Default response shape (v2 still served on <code>schema_version: 2</code>)</td>
+          <td><span class="status ok">✅ shipping</span></td>
+        </tr>
+        <tr>
+          <td><strong>B</strong> &mdash; Loader tools</td>
+          <td><code>memory_load_family</code>, <code>memory_smart_load(intent)</code></td>
+          <td>Always-on, callable from any harness</td>
+          <td><span class="status partial">⚠️ partial &mdash; B-track lands progressively</span></td>
+        </tr>
+        <tr>
+          <td><strong>C</strong> &mdash; Schema compaction</td>
+          <td><code>--profile full</code> drops to &le;3,500 input tokens</td>
+          <td>CI-gated</td>
+          <td><span class="status partial">⚠️ partial &mdash; C-track lands progressively</span></td>
+        </tr>
+        <tr>
+          <td><strong>D</strong> &mdash; Per-harness positioning</td>
+          <td>Cross-harness benchmark + <a href="v0.7/compatibility-matrix.html">compat matrix</a></td>
+          <td>Published as a standalone page</td>
+          <td><span class="status ok">✅ shipping (D2 merged)</span></td>
+        </tr>
+        <tr>
+          <td><strong>E</strong> &mdash; Discovery Gate T0</td>
+          <td>Calibration cells re-run across 4 LLMs post-ship</td>
+          <td>External run after release</td>
+          <td><span class="status future">🚧 v0.7.1+</span></td>
+        </tr>
+        <tr>
+          <td><strong>F</strong> &mdash; Docs + release</td>
+          <td>Migration guide, RFC, this page, top-nav refresh, CHANGELOG</td>
+          <td>Released alongside the binary</td>
+          <td><span class="status partial">⚠️ partial (F1, F2, F6, D2 merged; F3-F5 in flight)</span></td>
+        </tr>
+        <tr>
+          <td><strong>G</strong> &mdash; Hook pipeline</td>
+          <td>20 lifecycle events, exec + daemon modes, decision contract, chain ordering</td>
+          <td><strong>No hooks fire</strong> until <code>~/.config/ai-memory/hooks.toml</code> exists</td>
+          <td><span class="status ok">✅ shipping</span></td>
+        </tr>
+        <tr>
+          <td><strong>H</strong> &mdash; Ed25519 attestation</td>
+          <td>Per-agent keypair, link signing, <code>attest_level</code> enum, <code>signed_events</code> audit table</td>
+          <td>Opt-in via <code>ai-memory identity generate</code>; legacy callers stay <code>unsigned</code></td>
+          <td><span class="status ok">✅ shipping</span></td>
+        </tr>
+        <tr>
+          <td><strong>I</strong> &mdash; Sidechain transcripts</td>
+          <td>zstd-3 BLOB store, <code>memory_transcript_links</code>, <code>memory_replay</code>, archive&rarr;prune</td>
+          <td>Off (per-namespace TTL opt-in)</td>
+          <td><span class="status partial">⚠️ partial &mdash; I1+I2 in v0.7.0; I3-I5 spillover</span></td>
+        </tr>
+        <tr>
+          <td><strong>J</strong> &mdash; Apache AGE acceleration</td>
+          <td>Cypher backend on Postgres-with-AGE; recursive CTE on SQLite</td>
+          <td>Auto-detected if AGE extension present; CTE fallback otherwise</td>
+          <td><span class="status future">🚧 v0.7.1+ (CTE path stays default in v0.7.0)</span></td>
+        </tr>
+        <tr>
+          <td><strong>K</strong> &mdash; Permissions + G1 cutline</td>
+          <td>K1 namespace-inheritance enforcement (mandatory); rules + modes + hooks &rarr; decision; approval API</td>
+          <td>K1 enforces inheritance; <code>permissions.mode = "advisory"</code> preserves v0.6.4 semantics on first boot</td>
+          <td><span class="status ok">✅ K1 shipping</span> &middot; <span class="status partial">⚠️ K6-K11 partial</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ THREE AUDIENCES ============ -->
+<section style="background:var(--bg-raised)">
+  <div class="container">
+    <span class="eyebrow">Three audiences, one release</span>
+    <h2>What v0.7.0 means for you</h2>
+    <p class="lede">Same release, three framings &mdash; pick yours.</p>
+
+    <div class="audience-row">
+      <div class="audience user">
+        <span class="who">👤 If you USE AI</span>
+        <h3>Your AI describes its memory accurately. And signs it.</h3>
+        <p class="pitch">
+          When your AI assistant (Claude, ChatGPT, Cursor, Codex, Grok, Gemini) reaches for ai-memory v0.7.0, the cortex experience now <strong>reliably arrives across LLMs</strong>. Capabilities v3 ships pre-computed <code>summary</code> and <code>to_describe_to_user</code> strings &mdash; reasoning-class LLMs converge on the same accurate first-answer descriptions instead of improvising. Hooks let your agents react to memory operations (<code>post_store</code>, <code>post_link</code>, &hellip;). And every memory link is <strong>cryptographically attested</strong> &mdash; per-agent Ed25519 keypairs, signed <code>memory_links</code>, and an append-only <code>signed_events</code> audit chain back every change. Permissions actually enforce now (was advisory-only in v0.6.x; opt into <code>enforce</code> mode).
+        </p>
+        <pre>brew upgrade ai-memory
+ai-memory identity generate --agent-id ai:claude-code@$(hostname)</pre>
+        <p style="font-size:.85rem">That second command opts your agent into Ed25519 attestation; legacy callers continue working as <code>unsigned</code>.</p>
+      </div>
+
+      <div class="audience dev">
+        <span class="who">🛠️ If you BUILD with AI</span>
+        <h3>Programmable hooks. Real attestation. New loaders. Tighter token budget.</h3>
+        <ul class="checked">
+          <li><strong>Hook pipeline:</strong> 20 lifecycle events (<code>pre_store</code>, <code>post_store</code>, <code>pre_recall</code>, <code>post_recall</code>, &hellip;), subprocess + daemon-mode IPC, <code>Allow</code>/<code>Modify</code>/<code>Deny</code>/<code>AskUser</code> decision contract, chain ordering with <strong>first-deny-wins</strong> short-circuit. Hot-path events default to daemon mode to preserve the v0.6.3 50ms recall budget.</li>
+          <li><strong>Ed25519 attestation:</strong> per-agent keypair (<code>ai-memory identity generate</code>), outbound link signing, inbound verification against <code>observed_by</code>, <code>signed_events</code> append-only audit table (schema migration v20 &rarr; v22).</li>
+          <li><strong>Sidechain transcripts:</strong> zstd-3 compressed BLOBs in <code>memory_transcripts</code>, joined to memories via <code>memory_transcript_links</code>, per-namespace TTL with archive&rarr;prune lifecycle, <code>memory_replay(memory_id)</code> reconstructs the chain.</li>
+          <li><strong>Apache AGE:</strong> opt-in property graph backend (Postgres only); auto-detected via <code>pg_extension</code>. SQLite installs fall back to recursive CTE. Cypher implementations of <code>memory_kg_query</code>, <code>memory_kg_timeline</code>, <code>memory_kg_invalidate</code> &mdash; and the new <code>memory_find_paths(source, target, max_depth=5)</code> tool (recovers commitment R2).</li>
+          <li><strong>New permission system:</strong> replaces v0.6.x advisory governance. Rules + modes (<code>enforce</code>/<code>advisory</code>/<code>off</code>) + hooks &rarr; <code>Decision</code>; deny-first semantics. Migration tool: <code>ai-memory governance migrate-to-permissions</code> (idempotent, dry-run by default).</li>
+          <li><strong>Loader tools:</strong> <code>memory_load_family(family)</code> (always-on) and <code>memory_smart_load(intent)</code> (embedding-matched) &mdash; reasoning-class LLMs find the loader of last resort on first ask. <em>(B-track lands progressively.)</em></li>
+          <li><strong>Token-budget compaction:</strong> <code>--profile full</code> drops to &le;3,500 tokens (CI-gated). <em>(C-track lands progressively.)</em></li>
+        </ul>
+      </div>
+
+      <div class="audience cxo">
+        <span class="who">🏢 If you DECIDE AI infrastructure</span>
+        <h3>Signed audit chains. T4-T5 closer to ready. Cross-harness compat published.</h3>
+        <p class="pitch">
+          Every link write is <strong>logged with a cryptographic signature</strong> in an append-only <code>signed_events</code> table &mdash; the audit chain compliance teams have been asking for. T4-T5 multi-agent positioning gets closer to ready: Discovery Gate T0 calibration cells lock the user-facing phrasings so a 3-LLM swarm aligned on capability descriptions <strong>doesn't drift</strong> across vendors. The <a href="v0.7/compatibility-matrix.html" style="color:#fff;border-bottom:1px dashed">cross-harness compatibility matrix</a> (per-feature &times; per-harness) is published as a Pages doc you can link operators at. K1 (G1 inheritance) cutline shipped: parent namespace policies now enforce on child writes &mdash; enables N-level governance hierarchies. SDK back-compat preserved: existing v0.6.4 SDKs <strong>still work</strong> against the v0.7.0 server (v3 is additive over v2; <code>schema_version: 2</code> still answered).
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ BREAKING CHANGES / CALLOUTS ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Read this before you upgrade</span>
+    <h2>Breaking changes &amp; behavior callouts</h2>
+    <p class="lede">
+      v0.7.0 is <strong>additive</strong> in most surfaces. These two callouts are the exceptions worth reading first.
+    </p>
+
+    <div class="callout breaking">
+      <span class="clabel">⚠ Breaking &mdash; capabilities default flips v2 &rarr; v3</span>
+      <p>
+        <code>memory_capabilities</code> v3 is now the <strong>default response shape</strong>. The change is additive over v2 (every v2 field stays at its current path), <strong>but</strong> the top-level <code>schema_version</code> discriminator changes from <code>"2"</code> to <code>"3"</code>. SDK consumers who pin <code>schema_version === "2"</code> continue receiving the v2 shape (v2 stays supported through v0.7.x); consumers who switch on <code>schema_version</code> without an unknown-version fallback should add v3 handling or pin v2 explicitly.
+      </p>
+      <p>
+        <strong>Mitigation:</strong> read v3 fields if present; ignore unknown top-level keys. Existing v0.6.4 SDKs already do this and need no changes. See <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md#capabilities-v3-schema-additions">MIGRATION_v0.7.md &sect;Capabilities v3 schema additions</a> and the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/canonical-phrasings.md">canonical phrasings</a> for the pinned v3 strings.
+      </p>
+    </div>
+
+    <div class="callout breaking">
+      <span class="clabel">⚠ Behavior change &mdash; G1 namespace-inheritance enforcement</span>
+      <p>
+        The K1/G1 cutline fix means <code>resolve_governance_policy</code> now <strong>walks the namespace chain</strong> instead of consulting only the leaf namespace. <strong>Child writes that v0.6.x silently approved may now require approval</strong> &mdash; if a parent namespace has an <code>Approve</code> policy and a child namespace had no policy of its own, v0.6.x let the write through; v0.7.0 routes it to the approval queue.
+      </p>
+      <p>
+        <strong>Mitigation:</strong> set <code>inherit = false</code> on a child policy to opt that branch out of inheritance, or run <code>ai-memory governance migrate-to-permissions --dry-run</code> to preview which writes will change behavior under your existing rules. See <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md#g1-inheritance-fix-behavior-change">MIGRATION_v0.7.md &sect;G1 inheritance fix</a>.
+      </p>
+    </div>
+
+    <div class="callout">
+      <span class="clabel">ℹ Compatibility note &mdash; SDK back-compat preserved</span>
+      <p>
+        Existing <a href="https://www.npmjs.com/package/@alphaone/ai-memory">@alphaone/ai-memory</a> (npm) and <a href="https://pypi.org/project/ai-memory-mcp/">ai-memory-mcp</a> (PyPI) SDKs published for v0.6.4 continue to work against the v0.7.0 server. v3 is additive over v2; the v2 wire shape stays supported through the v0.7.x line. Per-harness coverage is in the <a href="v0.7/compatibility-matrix.html">v0.7 compatibility matrix</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ============ ATTESTED-CORTEX HEADLINE FEATURES ============ -->
+<section style="background:var(--bg-raised)">
+  <div class="container">
+    <span class="eyebrow">The five interlocking substrates</span>
+    <h2>Headline features in v0.7.0</h2>
+    <p class="lede">
+      Every card below is anchored to a track in the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">attested-cortex epic</a> and a section in the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md">design RFC</a>.
+    </p>
+
+    <div class="grid-2">
+      <div class="card cyan">
+        <span class="tag">Track A &middot; Capabilities v3</span>
+        <h3>Pre-computed calibration strings</h3>
+        <p>The v3 response carries <code>summary</code> (operator-facing &mdash; names the loader vocabulary) and <code>to_describe_to_user</code> (plain English &mdash; no MCP jargon). LLMs converge on accurate first-answer descriptions instead of improvising. Per-tool <code>callable_now: bool</code> + <code>agent_permitted_families</code> array honor the <code>[mcp.allowlist]</code> from v0.6.4 phase 1.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/canonical-phrasings.md">Canonical phrasings &rarr;</a></p>
+      </div>
+
+      <div class="card violet">
+        <span class="tag">Track H &middot; Ed25519 attestation</span>
+        <h3>The dead column gets filled</h3>
+        <p>The <code>signature</code> column shipped in v0.6.3 finally carries real Ed25519 signatures. Per-agent keypairs at <code>~/.config/ai-memory/keys/&lt;agent_id&gt;.{pub,priv}</code> (mode 0600 / 0644). Outbound link writes sign canonical-CBOR-encoded link content. <code>attest_level</code> enum: <code>unsigned</code> / <code>self_signed</code> / <code>peer_attested</code>. Append-only <code>signed_events</code> audit table (schema migration v20 &rarr; v22).</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md">RFC &sect;Why Ed25519 over X25519+ChaCha20 &rarr;</a></p>
+      </div>
+
+      <div class="card amber">
+        <span class="tag">Track G &middot; Hook pipeline</span>
+        <h3>20 lifecycle events, two execution modes</h3>
+        <p>Programmable extension surface at every memory operation point. <strong>Exec mode</strong>: subprocess per fire; JSON over stdin&rarr;stdout. <strong>Daemon mode</strong>: long-lived child with JSON-RPC framing, reconnect-on-crash, backpressure metrics. Decision contract: <code>Allow</code> / <code>Modify(delta)</code> (pre- events only) / <code>Deny{reason, code}</code> / <code>AskUser{prompt, options, default}</code>. Chain ordering is priority-desc; first <code>Deny</code> short-circuits. R3 (auto-link inference) and R5 (auto-extraction) ship as reference daemon-mode hooks.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md#track-g--hook-pipeline-bucket-0">Track G tasks &rarr;</a></p>
+      </div>
+
+      <div class="card green">
+        <span class="tag">Track K &middot; G1 cutline</span>
+        <h3>Namespace inheritance actually enforces</h3>
+        <p>v0.6.x's <code>resolve_governance_policy</code> consulted only the leaf namespace &mdash; a parent <code>Approve</code> policy didn't block a child write. v0.7.0 walks the chain via <code>build_namespace_chain</code>; first non-null policy wins. Per-policy <code>inherit: bool</code> flag (default <code>true</code>) lets child branches opt out. Backfill migration sets <code>inherit = true</code> on every existing row. Mandatory cutline: <em>"even if everything else slips, this fix ships."</em></p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md#g1-inheritance-fix-behavior-change">Migration &sect;G1 inheritance fix &rarr;</a></p>
+      </div>
+
+      <div class="card cyan">
+        <span class="tag">Track I &middot; Sidechain transcripts</span>
+        <h3>Compressed reasoning trails, replayable</h3>
+        <p>Raw conversation/reasoning trail in zstd-3 BLOBs. <code>memory_transcripts</code> table (schema v22) joined to memories via <code>memory_transcript_links(memory_id, transcript_id, span_start, span_end)</code>. Per-namespace TTL with archive&rarr;prune sweeper. <code>memory_replay(memory_id)</code> traverses the join and reconstructs the chain. Substrate for R5 auto-extraction.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md#track-i--sidechain-transcripts-bucket-17">Track I tasks &rarr;</a></p>
+      </div>
+
+      <div class="card violet">
+        <span class="tag">Track J &middot; Apache AGE</span>
+        <h3>Cypher when AGE is present, CTE when not</h3>
+        <p>Postgres SAL detects Apache AGE via <code>pg_extension</code> at boot. When present: Cypher implementations of <code>memory_kg_query</code>, <code>memory_kg_timeline</code>, <code>memory_kg_invalidate</code>. When absent (or SQLite): recursive CTE path stays as fallback. Bench-gated: AGE p95 must beat CTE p95 by &ge;30% at depth=5 to justify shipping. New <code>memory_find_paths(source, target, max_depth=5)</code> tool recovers commitment R2.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md#track-j--apache-age-acceleration-bucket-2">Track J tasks &rarr;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ FIVE-TIER LADDER ============ -->
+<section style="background:linear-gradient(180deg,rgba(200,162,255,0.04) 0%,transparent 100%)">
+  <div class="container">
+    <span class="eyebrow">Same binary, five tiers</span>
+    <h2>v0.7.0 brings T4-T5 closer to production-ready</h2>
+    <p class="lede">
+      ai-memory's architecture scales from one developer's laptop to a multi-region hive of agents <strong>without switching products</strong>. v0.7.0's attestation + permission + inheritance work lands the substrates T4-T5 multi-agent deployments need. Every primitive listed below is in the v0.7.0 binary; you turn flags on as you grow.
+    </p>
+
+    <div class="tier-ladder">
+      <a href="architectures-t1.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T1</div>
+        <div class="t-name">Single Agent</div>
+        <div class="t-desc">1 dev, 1 host. SQLite local. <code>ai-memory mcp</code></div>
+      </a>
+      <a href="architectures-t2.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T2</div>
+        <div class="t-name">Many Agents</div>
+        <div class="t-desc">N AI clients sharing one host via HTTP+mTLS</div>
+      </a>
+      <a href="architectures-t3.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T3</div>
+        <div class="t-name">Multi-Node Cluster</div>
+        <div class="t-desc">Quorum W-of-N writes, vector-clock CRDT-lite merge</div>
+      </a>
+      <a href="architectures-t4.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T4</div>
+        <div class="t-name">Data-Center Swarm</div>
+        <div class="t-desc">Ed25519 attestation, signed audit chain, A2A maturity</div>
+      </a>
+      <a href="architectures-t5.html" class="tier" style="text-decoration:none;color:inherit">
+        <div class="t-num">T5</div>
+        <div class="t-name">Global Hive</div>
+        <div class="t-desc">Per-agent allowlist + N-level inherited policies + signed events</div>
+      </a>
+    </div>
+
+    <h3 style="margin-top:2rem">What v0.7.0 adds beyond v0.6.4</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Capability</th>
+          <th>v0.6.4 (quiet-tools)</th>
+          <th>v0.7.0 (attested-cortex)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Pre-computed capabilities calibration</td><td>n/a (v2)</td><td>✅ v3 default (<code>summary</code>, <code>to_describe_to_user</code>)</td></tr>
+        <tr><td>Named loader tools</td><td>via <code>memory_capabilities --include-schema</code></td><td>✅ <code>memory_load_family</code>, <code>memory_smart_load(intent)</code></td></tr>
+        <tr><td>Per-agent capability allowlist</td><td>✅ phase 1 (<code>[mcp.allowlist]</code>)</td><td>✅ + <code>callable_now</code> + <code>agent_permitted_families</code></td></tr>
+        <tr><td>Capability-expansion audit log</td><td>✅ schema v20 (<code>audit_log</code>)</td><td>✅ + <code>signed_events</code> append-only chain (schema v22)</td></tr>
+        <tr><td>Ed25519 link signing</td><td>❌ dead column</td><td>✅ filled (per-agent keypair, canonical-CBOR signing)</td></tr>
+        <tr><td>Inbound signature verification</td><td>❌</td><td>✅ verified against <code>observed_by</code> claim</td></tr>
+        <tr><td>Programmable lifecycle hooks</td><td>❌ (subscriptions only)</td><td>✅ 20 events, exec + daemon modes, decision contract</td></tr>
+        <tr><td>Sidechain transcripts (zstd-3)</td><td>❌</td><td>✅ <code>memory_transcripts</code> + <code>memory_replay</code></td></tr>
+        <tr><td>Apache AGE Cypher backend</td><td>❌</td><td>✅ opt-in (Postgres only); SQLite/CTE fallback unchanged</td></tr>
+        <tr><td>Namespace policy inheritance enforcement</td><td>❌ leaf-only</td><td>✅ walks the chain (K1/G1 cutline)</td></tr>
+        <tr><td>Permissions actually enforce</td><td>⚠️ advisory-only</td><td>✅ <code>enforce</code> / <code>advisory</code> / <code>off</code> modes</td></tr>
+        <tr><td>Approval API (HTTP + SSE + MCP)</td><td>❌</td><td>✅ <code>memory_approval_*</code> tools + HMAC-mandatory</td></tr>
+        <tr><td>SDK back-compat (v0.6.4 clients)</td><td>baseline</td><td>✅ preserved &mdash; v3 additive over v2</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ NEW MCP TOOLS ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Surface area</span>
+    <h2>New MCP tools in v0.7.0</h2>
+    <p class="lede">
+      Each tool is described in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/API_REFERENCE.md"><code>docs/API_REFERENCE.md</code></a> once its track lands. The track column points at <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">V0.7-EPIC.md</a>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Tool</th>
+          <th>Track</th>
+          <th>Purpose</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><code>memory_load_family(family)</code></td><td>B1</td><td>Always-on loader &mdash; registers the named family's tools without restarting the MCP server</td></tr>
+        <tr><td><code>memory_smart_load(intent)</code></td><td>B2</td><td>Embedding-matched loader &mdash; picks the family that best fits a natural-language intent string</td></tr>
+        <tr><td><code>memory_find_paths(source, target, max_depth=5)</code></td><td>J7 (R2)</td><td>Returns paths through the knowledge graph &mdash; Cypher on AGE, recursive CTE on SQLite</td></tr>
+        <tr><td><code>memory_replay(memory_id)</code></td><td>I4</td><td>Reconstructs the transcript chain for a memory by traversing <code>memory_transcript_links</code></td></tr>
+        <tr><td><code>memory_verify(link_id)</code></td><td>H4</td><td>Returns <code>{signature_verified, attest_level, signed_by, signed_at}</code> for a link</td></tr>
+        <tr><td><code>memory_approval_pending</code></td><td>K10</td><td>Lists pending approval requests</td></tr>
+        <tr><td><code>memory_approval_decide(id, decision, remember=forever?)</code></td><td>K10</td><td>Decides a pending approval; <code>remember=forever</code> enables progressive trust</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ============ EVIDENCE / TRUST ============ -->
+<section style="background:var(--bg-raised)">
+  <div class="container">
+    <span class="eyebrow">Built with AI &middot; verified against AI</span>
+    <h2>Why every claim on this page is anchored</h2>
+    <p class="lede">
+      v0.7.0 follows the same evidence discipline established in v0.6.4 &mdash; every claim above resolves to a public, verifiable artifact:
+    </p>
+
+    <div class="grid-2">
+      <div class="card violet">
+        <span class="tag">Design rationale</span>
+        <h3>Attested-cortex RFC</h3>
+        <p>The design RFC documents <strong>why</strong> each v0.7.0 decision shipped in the shape it did: why Ed25519 over X25519 + ChaCha20 (separate concern; X25519 lives in v0.8 end-to-end encryption), why subprocess-stdio + daemon-mode for hooks (vs. dynamic library plugins), why AGE behind a feature flag (vs. hard dependency), why permission system replaces governance instead of augmenting (and the migration story).</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md" style="color:var(--p3)">Read the RFC &rarr;</a></p>
+      </div>
+
+      <div class="card cyan">
+        <span class="tag">Cross-harness compat</span>
+        <h3>v0.7 compatibility matrix</h3>
+        <p>Per-feature &times; per-harness grid covering Claude Code, Claude Desktop, Codex, Cursor, Cline, Continue, Aider, Goose, generic JSON-RPC. Status emojis: ✅ supported, ⚠️ partial, 🚧 in progress, ❌ not yet, n/a not applicable. Cross-linked back to the RFC, migration guide, and Discovery Gate.</p>
+        <p><a href="v0.7/compatibility-matrix.html" style="color:var(--p1)">Open the matrix &rarr;</a></p>
+      </div>
+
+      <div class="card amber">
+        <span class="tag">Operator upgrade path</span>
+        <h3>v0.6.4 &rarr; v0.7.0 migration guide</h3>
+        <p>What's new at a glance, action required (most users see no behavior change), capabilities v3 schema additions, new tools, hook pipeline opt-in, Ed25519 attestation opt-in, sidechain transcripts opt-in, Apache AGE opt-in, the G1 inheritance fix and its mitigation (<code>inherit = false</code> on child policies), and the permissions migration via <code>ai-memory governance migrate-to-permissions</code>.</p>
+        <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md" style="color:var(--p2)">Open the migration guide &rarr;</a></p>
+      </div>
+
+      <div class="card green">
+        <span class="tag">Empirical LLM behavior</span>
+        <h3>Discovery Gate (post-ship)</h3>
+        <p>v0.6.4 came back <strong>6/6 PASS, GATE GREEN</strong> against live xAI Grok 4.3. v0.7.0 re-runs the T0 calibration cells across 4 LLMs after release; convergence target is &ge;95% across all 4 models. The cells lock the user-facing canonical phrasings so a 3-LLM swarm doesn't drift across vendors.</p>
+        <p><a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:var(--good)">Discovery Gate &rarr;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ INSTALL SHORTCUTS ============ -->
+<section>
+  <div class="container">
+    <span class="eyebrow">Install shortcuts (when v0.7.0 lands)</span>
+    <h2>Stay on v0.6.4 today; upgrade when v0.7.0 ships</h2>
+    <p class="lede">v0.7.0 is in flight. The <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">epic</a> tracks remaining work. v0.6.4 install paths below remain canonical until v0.7.0 is tagged; the same channels publish v0.7.0 once F5 lands the release.</p>
+
+    <div class="grid-3">
+      <div class="card">
+        <span class="tag">macOS / Linux</span>
+        <h3>Homebrew</h3>
+        <pre>brew install alphaonedev/tap/ai-memory
+ai-memory install claude-code --apply</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Cargo (any host)</span>
+        <h3>From crates.io</h3>
+        <pre>cargo install ai-memory</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Docker</span>
+        <h3>ghcr.io</h3>
+        <pre>docker pull ghcr.io/alphaonedev/ai-memory:latest</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Fedora / RHEL / Rocky</span>
+        <h3>COPR</h3>
+        <pre>sudo dnf copr enable alpha-one-ai/ai-memory
+sudo dnf install ai-memory</pre>
+      </div>
+      <div class="card">
+        <span class="tag">TypeScript SDK</span>
+        <h3>npm</h3>
+        <pre>npm install @alphaone/ai-memory</pre>
+      </div>
+      <div class="card">
+        <span class="tag">Python SDK</span>
+        <h3>PyPI</h3>
+        <pre>pip install ai-memory-mcp
+# import name remains ai_memory</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div class="footer-links">
+      <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/V0.7-EPIC.md">v0.7 Epic</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/MIGRATION_v0.7.md">Migration guide</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md">Design RFC</a>
+      <a href="v0.7/compatibility-matrix.html">Compat matrix</a>
+      <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/INSTALL.md">Install Guide</a>
+    </div>
+    <p>
+      <strong>ai-memory&trade;</strong> v0.7.0 &mdash; AI-Agnostic MCP Memory Server &middot; codename <code>attested-cortex</code>
+    </p>
+    <p style="margin-top:.5rem">
+      Copyright &copy; 2026 <strong>AlphaOne LLC</strong>. ai-memory is a trademark of AlphaOne LLC (USPTO Serial No.&nbsp;99761257).
+    </p>
+    <p style="margin-top:.25rem;font-size:.78rem">
+      Licensed under the <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/LICENSE">Apache License, Version 2.0</a>.
+      Built with Rust, SQLite, FTS5, Postgres (optional Apache AGE), and Axum. Works with Claude, ChatGPT, Grok, Llama, OpenClaw 🦞, and any MCP-compatible AI.
+    </p>
+    <p style="margin-top:.75rem;font-size:.72rem;color:#6e7681;max-width:700px;margin-left:auto;margin-right:auto;line-height:1.5">
+      THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+      The authors and AlphaOne LLC accept no liability for any use, misuse, or consequence arising from this software.
+      See <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/LICENSE">LICENSE</a> for full terms.
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Track F task F2 of v0.7.0 attested-cortex epic.

## Summary
- New `docs/whats-new-v07.html` mirroring `docs/whats-new-v064.html` structure
- Three-audience layout (USE / BUILD / DECIDE)
- Track-completion table (per-track ✅/⚠️/🚧 status)
- Breaking-change callouts: v3 default + G1 inheritance enforcement
- Cross-links to V0.7-EPIC, MIGRATION_v0.7, rfc-attested-cortex, compatibility-matrix

## Test plan
- [x] Renders cleanly in GitHub markdown / Pages preview
- [x] All cross-links resolve
- [ ] F3 will refresh top-nav + landing-page badges to point here