### PR TITLE
feat: v0.7-i4 — memory_replay MCP tool

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2057,8 +2057,8 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (43 tools loaded)"),
-            "report should include full-profile baseline"
+            stdout.contains("Full   (44 tools loaded)"),
+            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay)"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2114,8 +2114,8 @@ mod tests {
         let tools = v["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            43,
-            "raw_table must include all 43 baseline tools"
+            44,
+            "raw_table must include all 44 baseline tools (43 + v0.7.0 I4 memory_replay)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -597,6 +597,18 @@ pub(crate) fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_replay",
+                "description": "Reconstruct the conversation transcript chain that produced this memory. Returns decompressed text + span metadata for each linked transcript.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "memory_id": {"type": "string", "description": "Memory ID whose transcript chain should be reconstructed."},
+                        "verbose": {"type": "boolean", "default": false, "description": "v0.7.0 I4 — when false (default), any single transcript exceeding 100KB has its content omitted and is flagged with truncated=true. Set to true to opt into a full dump (use with care: transcripts can be multi-MB)."}
+                    },
+                    "required": ["memory_id"]
+                }
+            },
+            {
                 "name": "memory_consolidate",
                 "description": "Consolidate multiple memories into one long-term summary. Deletes source memories and creates derived_from links. If summary is omitted and LLM is available (smart/autonomous tier), auto-generates a summary.",
                 "inputSchema": {
@@ -2060,7 +2072,7 @@ pub fn build_capabilities_tools(
     use crate::config::{AllowlistDecision, ToolEntry};
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let mut entries: Vec<ToolEntry> = Vec::with_capacity(43);
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(44);
 
     for fam in Family::all() {
         let family_name = fam.name();
@@ -3144,6 +3156,133 @@ fn handle_get_links(conn: &rusqlite::Connection, params: &Value) -> Result<Value
     Ok(json!({"links": links, "count": links.len()}))
 }
 
+/// v0.7.0 I4 — single-transcript content threshold above which the
+/// replay tool omits decompressed text unless the caller opted into
+/// `verbose=true`. 100 KB matches the "operators must opt into large
+/// dumps" carve-out called out in the I4 prompt; below that, even a
+/// long chat fits comfortably in an LLM context window without
+/// truncation surprise.
+const REPLAY_VERBOSE_THRESHOLD_BYTES: i64 = 100 * 1024;
+
+/// v0.7.0 I4 — `memory_replay(memory_id, verbose=false)`.
+///
+/// Walks the I2 `memory_transcript_links` join table for `memory_id`,
+/// fetches each linked transcript via I1's [`crate::transcripts::fetch`]
+/// (which transparently decompresses the zstd blob), and returns a
+/// chronologically-sorted JSON array of transcripts with their span
+/// metadata.
+///
+/// Sort order: ascending `created_at` so the replay reads as the
+/// memory's source chain in the order the conversation actually
+/// happened. The I2 helper [`crate::transcripts::transcripts_for_memory`]
+/// orders by `transcript_id` (deterministic but arbitrary), so this
+/// handler re-sorts after pulling per-transcript metadata.
+///
+/// Truncation rule: when `verbose=false` (default) and a transcript's
+/// `original_size` exceeds [`REPLAY_VERBOSE_THRESHOLD_BYTES`], its
+/// `content` field is omitted and `truncated` is set to `true`. Forces
+/// operators to opt into `verbose=true` for multi-MB dumps so an
+/// accidental call from a small-context client doesn't blow the
+/// session budget. The metadata block (`compressed_size`,
+/// `original_size`, `span_start`, `span_end`, `created_at`) is always
+/// returned regardless of truncation so the caller can decide whether
+/// to re-issue with `verbose=true`.
+fn handle_replay(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let memory_id = params["memory_id"]
+        .as_str()
+        .ok_or("memory_id is required")?;
+    validate::validate_id(memory_id).map_err(|e| e.to_string())?;
+    let verbose = params
+        .get("verbose")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    // I2 substrate — pull every (transcript_id, span_start, span_end)
+    // row tied to this memory. The helper orders by `transcript_id` for
+    // determinism; we re-order by `created_at` below for chronological
+    // replay semantics.
+    let links = crate::transcripts::transcripts_for_memory(conn, memory_id)
+        .map_err(|e| format!("transcripts_for_memory failed: {e}"))?;
+
+    // (link, metadata) pairs — `fetch_metadata` is the cheap path that
+    // skips the BLOB. We keep links whose transcript row has vanished
+    // (e.g. pruned by I3 between the join-table read and now) out of
+    // the response so callers never see an id they can't fetch back.
+    let mut entries: Vec<(
+        crate::transcripts::TranscriptLink,
+        crate::transcripts::Transcript,
+    )> = Vec::with_capacity(links.len());
+    for link in links {
+        match crate::transcripts::fetch_metadata(conn, &link.transcript_id) {
+            Ok(Some(meta)) => entries.push((link, meta)),
+            Ok(None) => {
+                // I3 may have pruned the transcript out from under us
+                // since the link row was written. Drop it silently —
+                // surfacing a dangling id to the caller is worse than
+                // returning the live subset.
+                tracing::warn!(
+                    target: "memory_replay",
+                    "dangling transcript_id {} for memory {memory_id}",
+                    link.transcript_id
+                );
+            }
+            Err(e) => return Err(format!("fetch_metadata failed: {e}")),
+        }
+    }
+
+    // Chronological order (oldest first). Ties on `created_at` fall
+    // back to `transcript_id` so the result is fully deterministic
+    // even when two transcripts land in the same RFC3339 millisecond.
+    entries.sort_by(|a, b| {
+        a.1.created_at
+            .cmp(&b.1.created_at)
+            .then_with(|| a.1.id.cmp(&b.1.id))
+    });
+
+    let mut transcripts_json: Vec<Value> = Vec::with_capacity(entries.len());
+    for (link, meta) in entries {
+        let truncate = !verbose && meta.original_size > REPLAY_VERBOSE_THRESHOLD_BYTES;
+        let mut obj = serde_json::Map::new();
+        obj.insert("id".into(), Value::String(meta.id.clone()));
+        obj.insert("created_at".into(), Value::String(meta.created_at.clone()));
+        obj.insert("compressed_size".into(), json!(meta.compressed_size));
+        obj.insert("original_size".into(), json!(meta.original_size));
+        obj.insert(
+            "span_start".into(),
+            link.span_start
+                .map_or(Value::Null, |v| Value::Number(v.into())),
+        );
+        obj.insert(
+            "span_end".into(),
+            link.span_end
+                .map_or(Value::Null, |v| Value::Number(v.into())),
+        );
+        if truncate {
+            // Honest gate: announce the omission so the caller knows to
+            // re-issue with `verbose=true` rather than silently
+            // assuming the transcript is empty.
+            obj.insert("truncated".into(), Value::Bool(true));
+        } else {
+            let content = crate::transcripts::fetch(conn, &meta.id)
+                .map_err(|e| format!("transcripts::fetch failed: {e}"))?
+                .ok_or_else(|| {
+                    format!(
+                        "transcript {} disappeared between metadata read and content fetch",
+                        meta.id
+                    )
+                })?;
+            obj.insert("content".into(), Value::String(content));
+        }
+        transcripts_json.push(Value::Object(obj));
+    }
+
+    Ok(json!({
+        "memory_id": memory_id,
+        "transcripts": transcripts_json,
+        "count": transcripts_json.len(),
+    }))
+}
+
 fn handle_consolidate(
     conn: &rusqlite::Connection,
     db_path: &Path,
@@ -4112,6 +4251,7 @@ fn handle_request(
                 "memory_get" => handle_get(conn, arguments),
                 "memory_link" => handle_link(conn, db_path, arguments, active_keypair),
                 "memory_get_links" => handle_get_links(conn, arguments),
+                "memory_replay" => handle_replay(conn, arguments),
                 "memory_consolidate" => handle_consolidate(
                     conn,
                     db_path,
@@ -4652,16 +4792,17 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_43_tools() {
+    fn tool_definitions_returns_44_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
         // (Pillar 2 / Stream B), and memory_kg_timeline +
         // memory_kg_invalidate + memory_kg_query (Pillar 2 / Stream C)
-        // on top of the 36-tool v0.6.0.0 surface.
+        // on top of the 36-tool v0.6.0.0 surface = 43.
+        // v0.7.0 I4 adds memory_replay (Family::Graph) → 44.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 43);
+        assert_eq!(tools.len(), 44);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
@@ -4708,26 +4849,27 @@ mod tests {
     }
 
     #[test]
-    fn tool_definitions_for_profile_full_registers_43() {
+    fn tool_definitions_for_profile_full_registers_44() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::full());
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            43,
-            "full profile must reproduce v0.6.3 surface 1:1"
+            44,
+            "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay = 44"
         );
     }
 
     #[test]
-    fn tool_definitions_for_profile_graph_registers_thirteen_plus_capabilities() {
+    fn tool_definitions_for_profile_graph_registers_fourteen_plus_capabilities() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::graph());
         let tools = defs["tools"].as_array().unwrap();
-        // 5 core + 8 graph + 1 always-on capabilities = 14 (capabilities
-        // is in meta but loaded as bootstrap; without it we'd have 13).
+        // 5 core + 9 graph (v0.7.0 I4 added memory_replay) + 1 always-on
+        // capabilities = 15 (capabilities is in meta but loaded as
+        // bootstrap; without it we'd have 14).
         assert_eq!(
             tools.len(),
-            14,
-            "graph profile = core(5) + graph(8) + capabilities-bootstrap(1)"
+            15,
+            "graph profile = core(5) + graph(9, with memory_replay) + capabilities-bootstrap(1)"
         );
     }
 
@@ -4737,7 +4879,11 @@ mod tests {
         let p = crate::profile::Profile::parse("core,graph").unwrap();
         let defs = tool_definitions_for_profile(&p);
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 14, "core,graph = 5 + 8 + capabilities");
+        assert_eq!(
+            tools.len(),
+            15,
+            "core,graph = 5 + 9 (v0.7.0 I4 memory_replay) + capabilities"
+        );
     }
 
     // ---- v0.6.4-006 — capabilities family enum + include_schema ----
@@ -4754,7 +4900,8 @@ mod tests {
         assert_eq!(core_row["tool_count"], 5);
         let graph_row = families.iter().find(|r| r["name"] == "graph").unwrap();
         assert_eq!(graph_row["loaded"], false);
-        assert_eq!(graph_row["tool_count"], 8);
+        // v0.7.0 I4 — graph now ships 9 tools (8 baseline + memory_replay).
+        assert_eq!(graph_row["tool_count"], 9);
 
         let always_on = v["always_on"].as_array().unwrap();
         assert_eq!(always_on.len(), 1);
@@ -4768,9 +4915,11 @@ mod tests {
         assert_eq!(v["family"], "graph");
         assert_eq!(v["loaded_under_active_profile"], false);
         let tools = v["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        // v0.7.0 I4 — graph now lists 9 tools (8 baseline + memory_replay).
+        assert_eq!(tools.len(), 9);
         // Spot-check known graph tool present.
         assert!(tools.iter().any(|t| t == "memory_kg_query"));
+        assert!(tools.iter().any(|t| t == "memory_replay"));
     }
 
     #[test]
@@ -4779,7 +4928,8 @@ mod tests {
         let v = handle_capabilities_family("graph", true, &p, None, None, None).unwrap();
         assert_eq!(v["family"], "graph");
         let tools = v["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        // v0.7.0 I4 — graph now ships 9 schemas (8 baseline + memory_replay).
+        assert_eq!(tools.len(), 9);
         // Each row must carry the full MCP tool definition shape.
         for tool in tools {
             assert!(tool.get("name").is_some(), "missing name");
@@ -5140,7 +5290,8 @@ mod tests {
             "missing err outcome in: {captured}"
         );
     }
-    /// Parametrized smoke matrix for all 43 MCP tools (Justice of MCP pathway).
+    /// Parametrized smoke matrix for all 44 MCP tools (Justice of MCP pathway).
+    /// v0.6.3 baseline = 43; v0.7.0 I4 added memory_replay.
     /// Tier 1: happy path with canonical valid args.
     /// Tier 2: required arg validation (missing required arg → error).
     #[test]
@@ -5252,6 +5403,15 @@ mod tests {
                 name: "memory_get_links",
                 valid_args: json!({"id": "fake-id-for-test"}),
                 required_arg: Some("id"),
+            },
+            // v0.7.0 I4 — memory_replay walks the I2 join table; an
+            // unknown memory_id yields an empty `transcripts` list
+            // rather than an error, so the happy path works without
+            // pre-seeding the DB.
+            ToolCase {
+                name: "memory_replay",
+                valid_args: json!({"memory_id": "fake-id-for-test"}),
+                required_arg: Some("memory_id"),
             },
             ToolCase {
                 name: "memory_consolidate",
@@ -9042,5 +9202,266 @@ mod tests {
         assert_eq!(memories.len(), 2);
         assert_eq!(memories[0]["id"], "first");
         assert_eq!(memories[1]["id"], "third");
+    }
+
+    // =====================================================================
+    // v0.7.0 I4 — `memory_replay` tool. Tests cover the four documented
+    // shapes: empty / single / multiple / truncation (verbose=false vs
+    // verbose=true). Each test seeds the I1 transcript table + I2 join
+    // table directly via the public helpers, then dispatches a real
+    // `tools/call` request through the MCP envelope so the response goes
+    // through the JSON wrapping layer the daemon emits in production.
+    // =====================================================================
+
+    /// I4 test helper — INSERT a stub `memories` row so the I2 join
+    /// table FK is satisfied. Mirrors the same helper in
+    /// `transcripts::tests::insert_test_memory` so the I4 test suite
+    /// doesn't need to import the test-only path.
+    fn i4_insert_test_memory(conn: &rusqlite::Connection, id: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO memories (
+                id, tier, namespace, title, content, created_at, updated_at
+             ) VALUES (?1, 'short_term', 'team/eng', ?2, 'body', ?3, ?3)",
+            rusqlite::params![id, format!("title-{id}"), now],
+        )
+        .unwrap();
+    }
+
+    /// I4 test helper — pull the inner JSON out of an MCP wire response
+    /// (which wraps the handler's payload as `result.content[0].text`).
+    fn i4_decode_response_payload(resp: &RpcResponse) -> Value {
+        let text = resp
+            .result
+            .as_ref()
+            .expect("expected ok response")
+            .get("content")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("text"))
+            .and_then(Value::as_str)
+            .expect("response wrapper must have content[0].text");
+        serde_json::from_str(text).expect("response payload must be JSON")
+    }
+
+    /// I4-EMPTY — a memory with no linked transcripts returns an empty
+    /// `transcripts` array (and `count: 0`). Documents the lower
+    /// boundary of the replay surface so an LLM that calls
+    /// `memory_replay` on a memory with no provenance gets an honest
+    /// "nothing to replay" response instead of an error.
+    #[test]
+    fn i4_replay_no_links_returns_empty_array() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-empty");
+
+        let req = make_tools_call("memory_replay", json!({"memory_id": "mem-empty"}));
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        assert_eq!(payload["memory_id"], "mem-empty");
+        assert_eq!(payload["count"], 0);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert!(transcripts.is_empty());
+    }
+
+    /// I4-SINGLE — one linked transcript flows through with
+    /// decompressed content and full span metadata
+    /// (`compressed_size`, `original_size`, `span_start`, `span_end`,
+    /// `created_at`).
+    #[test]
+    fn i4_replay_single_transcript_returns_content_and_metadata() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-single");
+        let body = "the canonical conversation that produced this memory";
+        let t = crate::transcripts::store(&conn, "team/eng", body, None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-single", &t.id, Some(2), Some(20)).unwrap();
+
+        let req = make_tools_call("memory_replay", json!({"memory_id": "mem-single"}));
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        assert_eq!(payload["memory_id"], "mem-single");
+        assert_eq!(payload["count"], 1);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert_eq!(transcripts.len(), 1);
+        let entry = &transcripts[0];
+        assert_eq!(entry["id"], t.id);
+        assert_eq!(entry["content"], body);
+        assert_eq!(entry["span_start"], 2);
+        assert_eq!(entry["span_end"], 20);
+        assert_eq!(entry["original_size"].as_i64().unwrap(), body.len() as i64);
+        // compressed_size is whatever zstd-3 emits; assert it's positive
+        // so a future encoder swap that emits zero-byte blobs gets caught.
+        assert!(entry["compressed_size"].as_i64().unwrap() > 0);
+        assert!(entry["created_at"].is_string());
+        // No truncation flag on a sub-threshold transcript.
+        assert!(entry.get("truncated").is_none());
+    }
+
+    /// I4-MULTI — two linked transcripts come back in chronological
+    /// order (oldest first) regardless of the order they were linked.
+    /// Pins the chronological-replay contract so a future refactor
+    /// can't silently fall back to insertion order.
+    #[test]
+    fn i4_replay_multiple_transcripts_chronological_order() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-multi");
+
+        // Insert the OLDER transcript first, then backdate it so its
+        // `created_at` is unambiguously earlier than the SECOND insert.
+        let older = crate::transcripts::store(&conn, "team/eng", "older body", None).unwrap();
+        let backdate = (chrono::Utc::now() - chrono::Duration::seconds(3600)).to_rfc3339();
+        conn.execute(
+            "UPDATE memory_transcripts SET created_at = ?1 WHERE id = ?2",
+            rusqlite::params![backdate, older.id],
+        )
+        .unwrap();
+
+        let newer = crate::transcripts::store(&conn, "team/eng", "newer body", None).unwrap();
+
+        // Link the NEWER one first so the I2 helper's
+        // ORDER-BY-transcript-id natural ordering doesn't already
+        // happen to give us the right result by accident.
+        crate::transcripts::link_transcript(&conn, "mem-multi", &newer.id, None, None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-multi", &older.id, None, None).unwrap();
+
+        let req = make_tools_call("memory_replay", json!({"memory_id": "mem-multi"}));
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert_eq!(transcripts.len(), 2);
+        // Older first, newer second.
+        assert_eq!(transcripts[0]["id"], older.id);
+        assert_eq!(transcripts[0]["content"], "older body");
+        assert_eq!(transcripts[1]["id"], newer.id);
+        assert_eq!(transcripts[1]["content"], "newer body");
+    }
+
+    /// I4-TRUNCATE-DEFAULT — a > 100 KB transcript with the default
+    /// `verbose=false` returns the metadata block + `truncated: true`
+    /// and OMITS the content field, forcing operators to opt into the
+    /// large-dump path.
+    #[test]
+    fn i4_replay_large_transcript_truncates_when_verbose_false() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-large");
+
+        // 200 KB body — well past the 100 KB threshold.
+        let body: String = "abcdefghij".repeat(20_000); // 200_000 bytes
+        assert!(body.len() > REPLAY_VERBOSE_THRESHOLD_BYTES as usize);
+        let t = crate::transcripts::store(&conn, "team/eng", &body, None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-large", &t.id, None, None).unwrap();
+
+        let req = make_tools_call("memory_replay", json!({"memory_id": "mem-large"}));
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert_eq!(transcripts.len(), 1);
+        let entry = &transcripts[0];
+        assert_eq!(entry["truncated"], true);
+        assert!(
+            entry.get("content").is_none(),
+            "content must be OMITTED when truncated; got: {entry}"
+        );
+        // Metadata is still present so the caller can decide whether
+        // to re-issue with verbose=true.
+        assert_eq!(entry["original_size"].as_i64().unwrap(), body.len() as i64);
+        assert!(entry["compressed_size"].as_i64().unwrap() > 0);
+    }
+
+    /// I4-TRUNCATE-VERBOSE — the same > 100 KB transcript with
+    /// `verbose=true` returns the full content (no `truncated` flag).
+    /// Pins the opt-in-large-dump escape hatch.
+    #[test]
+    fn i4_replay_large_transcript_returns_content_when_verbose_true() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-large-verbose");
+
+        let body: String = "abcdefghij".repeat(20_000);
+        let t = crate::transcripts::store(&conn, "team/eng", &body, None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-large-verbose", &t.id, None, None).unwrap();
+
+        let req = make_tools_call(
+            "memory_replay",
+            json!({"memory_id": "mem-large-verbose", "verbose": true}),
+        );
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert_eq!(transcripts.len(), 1);
+        let entry = &transcripts[0];
+        assert!(
+            entry.get("truncated").is_none(),
+            "verbose=true must NOT set truncated"
+        );
+        assert_eq!(entry["content"].as_str().unwrap(), body);
+    }
+
+    /// I4-MISSING-ARG — omitting the required `memory_id` argument
+    /// returns a handler-level error (wrapped as an isError result),
+    /// not a JSON-RPC -32601. Same shape as the rest of the smoke
+    /// matrix for required-arg validation.
+    #[test]
+    fn i4_replay_missing_memory_id_yields_handler_error() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let req = make_tools_call("memory_replay", json!({}));
+        let resp = invoke_handle_request(&conn, &req);
+        // Handler errors come back as ok_response with isError=true.
+        // The RPC error field stays None so a downstream client can
+        // distinguish "method not found" from "the method ran and
+        // failed".
+        assert!(
+            resp.error.is_none(),
+            "expected handler-level error, not RPC error"
+        );
+        let result = resp.result.expect("must surface a result envelope");
+        assert_eq!(result["isError"], true);
+    }
+
+    /// I4-DANGLING-LINK — a link row whose target transcript was
+    /// pruned (I3) is silently dropped from the replay output.
+    /// Documents the contract so a future refactor that surfaces
+    /// dangling ids to the caller fails this test loudly.
+    #[test]
+    fn i4_replay_skips_dangling_transcript_link() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        i4_insert_test_memory(&conn, "mem-dangling");
+
+        let live = crate::transcripts::store(&conn, "team/eng", "live body", None).unwrap();
+        let pruned = crate::transcripts::store(&conn, "team/eng", "pruned body", None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-dangling", &live.id, None, None).unwrap();
+        crate::transcripts::link_transcript(&conn, "mem-dangling", &pruned.id, None, None).unwrap();
+
+        // Sneak past the I2 ON DELETE CASCADE by disabling foreign keys
+        // for this single DELETE — production won't get here (cascade
+        // would clean up the link), but the handler must still be
+        // robust if the substrate ever surfaces a dangling row.
+        conn.execute("PRAGMA foreign_keys = OFF", []).unwrap();
+        conn.execute(
+            "DELETE FROM memory_transcripts WHERE id = ?1",
+            rusqlite::params![pruned.id],
+        )
+        .unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+
+        let req = make_tools_call("memory_replay", json!({"memory_id": "mem-dangling"}));
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+
+        let payload = i4_decode_response_payload(&resp);
+        let transcripts = payload["transcripts"].as_array().unwrap();
+        assert_eq!(
+            transcripts.len(),
+            1,
+            "only the live transcript should appear; pruned id is silently dropped"
+        );
+        assert_eq!(transcripts[0]["id"], live.id);
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -25,11 +25,11 @@
 //! ## Profile vocabulary
 //!
 //! - `core` — 5 tools, the new v0.6.4 default. Always loaded.
-//! - `graph` — adds the 8 KG/entity tools. ~13 tools.
+//! - `graph` — adds the 9 KG/entity/replay tools. ~14 tools.
 //! - `admin` — adds lifecycle (5) + governance (8). ~18 tools.
 //! - `power` — adds the 6 LLM-augmented tools (consolidate, auto_tag, …).
 //!   ~11 tools.
-//! - `full` — every family. 43 tools, 1:1 v0.6.3 surface.
+//! - `full` — every family. 44 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay`).
 //! - `custom` — comma-separated family list (`core,graph,archive` …).
 //!   `core` is implicitly added if missing — there's no profile that
 //!   ships *less than* the 5 core tools.
@@ -55,7 +55,8 @@
 use std::str::FromStr;
 
 /// A tool family. Source-anchored at `src/mcp.rs::tool_definitions()`
-/// 2026-05-04. Counts must sum to 43 (the v0.6.3.1 baseline).
+/// 2026-05-05. Counts must sum to 44 (the v0.6.3.1 baseline of 43 +
+/// v0.7.0 I4 `memory_replay` in `Family::Graph`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Family {
     /// store, recall, list, get, search — 5
@@ -63,7 +64,9 @@ pub enum Family {
     /// update, delete, forget, gc, promote — 5
     Lifecycle,
     /// kg_query, kg_timeline, kg_invalidate, link, get_links,
-    /// entity_register, entity_get_by_alias, get_taxonomy — 8
+    /// entity_register, entity_get_by_alias, get_taxonomy, replay — 9
+    /// (replay added in v0.7.0 I4 — joins to the I2 transcript-link
+    /// substrate to reconstruct a memory's source transcript chain.)
     Graph,
     /// pending_list/approve/reject, namespace_set/get/clear_standard,
     /// subscribe, unsubscribe — 8
@@ -103,7 +106,7 @@ impl Family {
             // lifecycle (5)
             "memory_update" | "memory_delete" | "memory_forget" | "memory_gc"
             | "memory_promote" => Some(Self::Lifecycle),
-            // graph (8)
+            // graph (9 — v0.7.0 I4 added memory_replay)
             "memory_kg_query"
             | "memory_kg_timeline"
             | "memory_kg_invalidate"
@@ -111,7 +114,8 @@ impl Family {
             | "memory_get_links"
             | "memory_entity_register"
             | "memory_entity_get_by_alias"
-            | "memory_get_taxonomy" => Some(Self::Graph),
+            | "memory_get_taxonomy"
+            | "memory_replay" => Some(Self::Graph),
             // governance (8)
             "memory_pending_list"
             | "memory_pending_approve"
@@ -182,7 +186,9 @@ impl Family {
     pub const fn expected_tool_count(self) -> usize {
         match self {
             Self::Core | Self::Lifecycle | Self::Meta => 5,
-            Self::Graph | Self::Governance => 8,
+            // Graph: 8 baseline + memory_replay (v0.7.0 I4) = 9.
+            Self::Graph => 9,
+            Self::Governance => 8,
             Self::Power => 6,
             Self::Archive => 4,
             Self::Other => 2,
@@ -227,6 +233,9 @@ impl Family {
                 "memory_entity_register",
                 "memory_entity_get_by_alias",
                 "memory_get_taxonomy",
+                // v0.7.0 I4 — traverses memory_transcript_links (I2) to
+                // reconstruct the source-transcript chain for a memory.
+                "memory_replay",
             ],
             Self::Governance => &[
                 "memory_pending_list",
@@ -310,7 +319,7 @@ impl Profile {
         }
     }
 
-    /// `graph` — core + graph. 13 tools.
+    /// `graph` — core + graph. 14 tools (v0.7.0 I4 added `memory_replay`).
     #[must_use]
     pub fn graph() -> Self {
         Self {
@@ -334,7 +343,8 @@ impl Profile {
         }
     }
 
-    /// `full` — every family. 43 tools, 1:1 v0.6.3 surface.
+    /// `full` — every family. 44 tools (v0.6.3 baseline 43 + v0.7.0 I4
+    /// `memory_replay`).
     #[must_use]
     pub fn full() -> Self {
         Self {
@@ -513,12 +523,13 @@ mod tests {
     }
 
     #[test]
-    fn family_expected_tool_counts_sum_to_43() {
+    fn family_expected_tool_counts_sum_to_44() {
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 43,
-            "v0.6.3.1 baseline is 43 tools — if this drifts, update \
-             Family::expected_tool_count and the family map docs together"
+            total, 44,
+            "v0.6.3.1 baseline (43) + v0.7.0 I4 `memory_replay` = 44. If this \
+             drifts, update Family::expected_tool_count and the family map docs \
+             together."
         );
     }
 
@@ -566,15 +577,19 @@ mod tests {
     }
 
     #[test]
-    fn profile_graph_has_thirteen_tools() {
+    fn profile_graph_has_fourteen_tools() {
         let p = Profile::graph();
-        assert_eq!(p.expected_tool_count(), 5 + 8);
+        // v0.7.0 I4 — Graph now ships 9 tools (8 baseline + memory_replay).
+        assert_eq!(p.expected_tool_count(), 5 + 9);
         assert!(p.includes(Family::Graph));
     }
 
     #[test]
     fn profile_admin_has_eighteen_tools() {
         let p = Profile::admin();
+        // admin = core (5) + lifecycle (5) + governance (8). Graph isn't
+        // in admin so the v0.7.0 I4 memory_replay addition doesn't change
+        // this count.
         assert_eq!(p.expected_tool_count(), 5 + 5 + 8);
     }
 
@@ -585,9 +600,10 @@ mod tests {
     }
 
     #[test]
-    fn profile_full_has_forty_three_tools() {
+    fn profile_full_has_forty_four_tools() {
         let p = Profile::full();
-        assert_eq!(p.expected_tool_count(), 43);
+        // v0.7.0 I4 — full surface = 43 baseline + memory_replay.
+        assert_eq!(p.expected_tool_count(), 44);
     }
 
     // ---------- Profile::parse ----------
@@ -609,14 +625,14 @@ mod tests {
 
     #[test]
     fn parse_custom_comma_list_dedup() {
-        // `core,graph` → core (5) + graph (8) = 13 tools.
+        // `core,graph` → core (5) + graph (9, after v0.7.0 I4) = 14 tools.
         // Meta is NOT included — `memory_capabilities` is always-on
         // bootstrapped outside the family map (v0.6.4-002).
         let p = Profile::parse("core,graph").unwrap();
         assert!(p.includes(Family::Core));
         assert!(!p.includes(Family::Meta));
         assert!(p.includes(Family::Graph));
-        assert_eq!(p.expected_tool_count(), 13);
+        assert_eq!(p.expected_tool_count(), 14);
     }
 
     #[test]
@@ -722,6 +738,8 @@ mod tests {
             "memory_entity_register",
             "memory_entity_get_by_alias",
             "memory_get_taxonomy",
+            // graph (v0.7.0 I4 addition)
+            "memory_replay",
             // governance
             "memory_pending_list",
             "memory_pending_approve",
@@ -753,7 +771,11 @@ mod tests {
             "memory_list_subscriptions",
             "memory_notify",
         ];
-        assert_eq!(baseline.len(), 43, "baseline list itself must be 43");
+        assert_eq!(
+            baseline.len(),
+            44,
+            "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) = 44"
+        );
         for name in baseline {
             assert!(
                 Family::for_tool(name).is_some(),

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -140,13 +140,14 @@ mod tests {
     /// `tool_definitions()` regressions that would silently hide other
     /// failures.
     #[test]
-    fn table_has_43_entries_matching_tool_definitions_count() {
+    fn table_has_44_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 43,
-            "expected exactly 43 tools (v0.6.3.1 baseline source-anchored at \
-             src/mcp.rs::tool_definitions); got {n}. If the count changed, \
-             update the v0.6.4 family map and this assertion together."
+            n, 44,
+            "expected exactly 44 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
+             `memory_replay`, source-anchored at src/mcp.rs::tool_definitions); \
+             got {n}. If the count changed, update the family map and this \
+             assertion together."
         );
     }
 

--- a/src/transcripts.rs
+++ b/src/transcripts.rs
@@ -145,6 +145,39 @@ pub fn fetch(conn: &Connection, id: &str) -> Result<Option<String>> {
     Ok(Some(text))
 }
 
+/// v0.7.0 I4 — fetch the lightweight metadata for a transcript without
+/// pulling the (potentially multi-MB) decompressed content blob.
+/// Returns `Ok(None)` when no row matches, mirroring [`fetch`]. The
+/// `Transcript` handle carries `created_at`, `compressed_size`, and
+/// `original_size`, which I4's `memory_replay` joins with the I2
+/// link spans to assemble a per-transcript metadata block.
+///
+/// # Errors
+///
+/// Returns an error when the SELECT fails (disk I/O, schema drift).
+pub fn fetch_metadata(conn: &Connection, id: &str) -> Result<Option<Transcript>> {
+    let row = conn
+        .query_row(
+            "SELECT id, namespace, created_at, expires_at,
+                    compressed_size, original_size
+               FROM memory_transcripts WHERE id = ?1",
+            params![id],
+            |r| {
+                Ok(Transcript {
+                    id: r.get(0)?,
+                    namespace: r.get(1)?,
+                    created_at: r.get(2)?,
+                    expires_at: r.get(3)?,
+                    compressed_size: r.get(4)?,
+                    original_size: r.get(5)?,
+                })
+            },
+        )
+        .optional()
+        .context("SELECT memory_transcripts metadata failed")?;
+    Ok(row)
+}
+
 /// Delete every row whose `expires_at` is in the past (relative to
 /// "now"). Returns the number of rows removed.
 ///

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -60,14 +60,14 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    // 37 = 42 user-relevant tools − 5 core. The bootstrap
-    // (`memory_capabilities`) is excluded from BOTH the loaded and the
-    // unloaded count in `to_describe_to_user` (it's plumbing, not a
-    // feature). The A2 NHI starter prompt's example used 38 because it
-    // assumed bootstrap was counted on the unloaded side; the shipped
-    // builder is more honest.
+    // 38 = 43 user-relevant tools − 5 core. (43 = 44 total tools − 1
+    // always-on bootstrap.) The bootstrap (`memory_capabilities`) is
+    // excluded from BOTH the loaded and the unloaded count in
+    // `to_describe_to_user` (it's plumbing, not a feature). Total
+    // bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
+    // `memory_replay`.
     let expected = "I can directly use 5 memory tools right now \
-                    (store, recall, list, get, search). 37 more \
+                    (store, recall, list, get, search). 38 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -83,7 +83,8 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
 // ---------------------------------------------------------------------------
 // T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
 // "nothing more to load" closing form (excludes the always-on bootstrap
-// from the user-facing 42 count).
+// from the user-facing 43 count). Bumped from 42 to 43 in v0.7.0 I4 —
+// Family::Graph gained `memory_replay`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_full_profile_canonical_phrasing() {
@@ -92,7 +93,7 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use all 42 memory tools right now \
+    let expected = "I can directly use all 43 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -106,7 +107,9 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
 
 // ---------------------------------------------------------------------------
 // T0-A2-GRAPH — `to_describe_to_user` on `--profile graph` uses the
-// preview-with-ellipsis form (5 of 13 loaded shown + ", ...").
+// preview-with-ellipsis form (5 of 14 loaded shown + ", ..."). Loaded
+// bumped from 13 to 14 in v0.7.0 I4 — Family::Graph gained
+// `memory_replay`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_graph_profile_canonical_phrasing() {
@@ -115,7 +118,7 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use 13 memory tools right now \
+    let expected = "I can directly use 14 memory tools right now \
                     (store, recall, list, get, search, ...). 29 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -151,9 +151,10 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `core` profile honestly reports 6 of 43 visible (5 core
+// summary on the `core` profile honestly reports 6 of 44 visible (5 core
 // tools + memory_capabilities always-on bootstrap), labels the profile
-// "core", and references all three named recovery paths.
+// "core", and references all three named recovery paths. (Total bumped
+// from 43 to 44 in v0.7.0 I4 — Family::Graph gained `memory_replay`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
@@ -163,13 +164,13 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     // Family::Meta which the core profile doesn't load, so the bootstrap
     // injection adds it back).
     assert!(
-        summary.starts_with("6 of 43 tools"),
-        "core profile summary should open with \"6 of 43 tools\"; got: {summary}"
+        summary.starts_with("6 of 44 tools"),
+        "core profile summary should open with \"6 of 44 tools\"; got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
-        summary.contains("37 are listed in this manifest"),
-        "core profile must report 37 unloaded (43 - 6); got: {summary}"
+        summary.contains("38 are listed in this manifest"),
+        "core profile must report 38 unloaded (44 - 6); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -181,18 +182,19 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `full` profile reports 43 of 43 visible, 0 unloaded, and
+// summary on the `full` profile reports 44 of 44 visible, 0 unloaded, and
 // labels the profile "full". The recovery paths are still listed —
 // they're the canonical recovery vocabulary the LLM gets calibrated on
-// regardless of the current profile state.
+// regardless of the current profile state. (Total bumped from 43 to 44
+// in v0.7.0 I4 — Family::Graph gained `memory_replay`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_full_profile_reports_all_visible() {
     let summary = build_capabilities_summary(&Profile::full());
 
     assert!(
-        summary.starts_with("43 of 43 tools"),
-        "full profile summary should open with \"43 of 43 tools\"; got: {summary}"
+        summary.starts_with("44 of 44 tools"),
+        "full profile summary should open with \"44 of 44 tools\"; got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -207,16 +209,16 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `graph` profile counts 13 visible (5 core + 8 graph) +
-// the bootstrap, labels the profile "graph", and reports the rest as
-// unloaded.
+// summary on the `graph` profile counts 14 visible (5 core + 9 graph,
+// after v0.7.0 I4) + the bootstrap, labels the profile "graph", and
+// reports the rest as unloaded.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_graph_profile_counts() {
     let summary = build_capabilities_summary(&Profile::graph());
     assert!(
-        summary.starts_with("14 of 43 tools"),
-        "graph profile = 5 core + 8 graph + 1 always-on bootstrap = 14; got: {summary}"
+        summary.starts_with("15 of 44 tools"),
+        "graph profile = 5 core + 9 graph (v0.7.0 I4) + 1 always-on bootstrap = 15; got: {summary}"
     );
     assert!(summary.contains("(graph)"));
     assert!(summary.contains("29 are listed in this manifest"));
@@ -309,12 +311,15 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     // Loaded preview lists the 5 core tool names with the memory_
     // prefix STRIPPED (no MCP jargon for end users).
     assert!(describe.contains("(store, recall, list, get, search)"));
-    // Reports the unloaded count. 37 = 42 user-relevant tools − 5
-    // core. The bootstrap (`memory_capabilities`) is excluded from
-    // both sides for honest user-facing counting.
+    // Reports the unloaded count. 38 = 43 user-relevant tools − 5
+    // core. (43 = 44 total tools − 1 always-on bootstrap.) The
+    // bootstrap (`memory_capabilities`) is excluded from both sides
+    // for honest user-facing counting. Total bumped to 44 in v0.7.0
+    // I4 (Family::Graph gained `memory_replay`), so the unloaded
+    // count under core grew by 1.
     assert!(
-        describe.contains("37 more"),
-        "core profile must report 37 unloaded; got: {describe}"
+        describe.contains("38 more"),
+        "core profile must report 38 unloaded; got: {describe}"
     );
     // Sample of unloaded tools is plain (no memory_ prefix). The first
     // four unloaded under core are lifecycle's update/delete/forget/gc.
@@ -337,18 +342,21 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `full` profile reports all 42 tools loaded
+// A2: to_describe_to_user on `full` profile reports all 43 tools loaded
 // (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
 // uses the "nothing more to load" closing form rather than the recovery
-// hint.
+// hint. (Bumped from 42 to 43 in v0.7.0 I4 — Family::Graph gained
+// `memory_replay`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 42 = 43 total - 1 always-on bootstrap excluded from describe.
+    // 43 = 44 total - 1 always-on bootstrap excluded from describe.
+    // Bumped from 42 to 43 in v0.7.0 I4 (Family::Graph gained
+    // `memory_replay`).
     assert!(
-        describe.starts_with("I can directly use all 42 memory tools right now ("),
+        describe.starts_with("I can directly use all 43 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -358,18 +366,18 @@ fn cap_v3_describe_full_profile_uses_nothing_more_form() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `graph` profile (5 core + 8 graph) lists
-// 13 loaded with a 5-name preview ending in ", ..." since there are
-// more loaded than the preview shows.
+// A2: to_describe_to_user on `graph` profile (5 core + 9 graph after
+// v0.7.0 I4) lists 14 loaded with a 5-name preview ending in ", ..."
+// since there are more loaded than the preview shows.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     let describe = build_capabilities_describe_to_user(&Profile::graph());
     assert!(
-        describe.starts_with("I can directly use 13 memory tools right now ("),
-        "graph profile describe should open with 13 loaded; got: {describe}"
+        describe.starts_with("I can directly use 14 memory tools right now ("),
+        "graph profile describe should open with 14 loaded; got: {describe}"
     );
-    // Preview is the first 5 of the 13 loaded — the 5 core tools.
+    // Preview is the first 5 of the 14 loaded — the 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
     assert!(describe.contains("29 more"));
 }
@@ -527,11 +535,13 @@ fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
 
 // ---------------------------------------------------------------------------
 // A3 — the v3 response surfaces the `tools` array at the top level
-// with one entry per registered tool (43 + always-on bootstrap counted
-// once = 43, since the bootstrap already lives in Family::Meta).
+// with one entry per registered tool (44 + always-on bootstrap counted
+// once = 44, since the bootstrap already lives in Family::Meta).
+// (Bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
+// `memory_replay`.)
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_response_carries_tools_array_with_43_entries() {
+fn cap_v3_response_carries_tools_array_with_44_entries() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
     let val = handle_capabilities_with_conn_v3(
@@ -551,8 +561,9 @@ fn cap_v3_response_carries_tools_array_with_43_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        43,
-        "v3 must surface all 43 tools regardless of profile; got {}",
+        44,
+        "v3 must surface all 44 tools regardless of profile (v0.7.0 I4 added \
+         memory_replay); got {}",
         tools.len()
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1865,7 +1865,11 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 43, "expected 43 MCP tools");
+    assert_eq!(
+        tools.len(),
+        44,
+        "expected 44 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay)"
+    );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -48,9 +48,9 @@ fn spawn_mcp(db: &std::path::Path) -> (McpChild, mpsc::Receiver<String>) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_ai-memory"))
         .env("AI_MEMORY_NO_CONFIG", "1")
         // v0.6.4-002: tests written against the v0.6.3 full surface
-        // (43 tools) — pin --profile full so the v0.6.4 default flip
-        // (--profile core, 6 tools) doesn't shrink what these tests
-        // can exercise. Tests for the new family-scoped behavior live
+        // (43 tools, now 44 with v0.7.0 I4 memory_replay) — pin
+        // --profile full so the v0.6.4 default flip (--profile core,
+        // 6 tools) doesn't shrink what these tests can exercise. Tests for the new family-scoped behavior live
         // in src/mcp.rs::tests + tests/webhook_http_parity.rs.
         .args([
             "--db",
@@ -189,9 +189,10 @@ fn mcp_list_tools_returns_expected_count() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools array missing");
-    // The lib tests assert exactly 43 in v0.6.3 (`tool_definitions_returns_43_tools`).
-    // We assert a lower bound so this test doesn't regress every time
-    // a new tool ships, while still catching an empty/missing list.
+    // The lib tests assert exactly 44 (v0.6.3 baseline 43 + v0.7.0 I4
+    // memory_replay) in `tool_definitions_returns_44_tools`. We assert a
+    // lower bound so this test doesn't regress every time a new tool
+    // ships, while still catching an empty/missing list.
     assert!(
         tools.len() >= 40,
         "expected >=40 tools, got {} ({})",


### PR DESCRIPTION
Track I task I4 of v0.7.0 attested-cortex epic. Builds on I1+I2+I3 (all merged).

## Summary
- New `memory_replay(memory_id, verbose=false)` MCP tool
- Traverses `memory_transcript_links` (I2) to find linked transcripts
- Decompresses transcripts via I1's `transcripts::fetch`
- Sorted chronologically by created_at
- 100KB single-transcript truncation gate when verbose=false; opt-in via verbose=true
- Family: Graph (joins to existing kg_* family)

## Test plan
- [x] cargo fmt --check + clippy --pedantic clean
- [x] cargo test --lib green
- [x] Empty / single / multiple / truncation paths tested