### PR TITLE
feat: v0.7-h4 — attest_level enum + memory_verify MCP tool

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2057,8 +2057,9 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (43 tools loaded)"),
-            "report should include full-profile baseline"
+            // v0.7 H4 grew the surface from 43 → 44 (added memory_verify).
+            stdout.contains("Full   (44 tools loaded)"),
+            "report should include full-profile baseline (44 post-H4): {stdout}"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2112,10 +2113,11 @@ mod tests {
         assert_eq!(exit, 0);
         let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
         let tools = v["tools"].as_array().unwrap();
+        // v0.7 H4: 43 v0.6.3 baseline + memory_verify = 44.
         assert_eq!(
             tools.len(),
-            43,
-            "raw_table must include all 43 baseline tools"
+            44,
+            "raw_table must include all 44 baseline tools (43 + memory_verify)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/db.rs
+++ b/src/db.rs
@@ -2224,6 +2224,74 @@ pub fn delete_link(conn: &Connection, source_id: &str, target_id: &str) -> Resul
     Ok(changed > 0)
 }
 
+/// v0.7 H4 — full row-projection used by the `memory_verify` MCP tool.
+///
+/// `get_links` (above) was deliberately scoped to the four columns the
+/// graph-traversal callers care about; H4 needs the *signed bundle* —
+/// the raw signature blob, the agent_id that signed (`observed_by`),
+/// and the temporal-validity columns the signature commits to. Splitting
+/// it from `get_links` keeps the existing read path's wire shape
+/// unchanged (and its column-count tested by callers).
+///
+/// Returns `Ok(None)` when the row is absent so the caller can shape a
+/// "not found" response instead of bubbling up a generic SQL error.
+#[derive(Debug, Clone)]
+pub struct LinkVerifyRecord {
+    pub source_id: String,
+    pub target_id: String,
+    pub relation: String,
+    pub signature: Option<Vec<u8>>,
+    pub observed_by: Option<String>,
+    pub valid_from: Option<String>,
+    pub valid_until: Option<String>,
+    /// Raw column value as stored by H2/H3 (`"unsigned"`, `"self_signed"`,
+    /// `"peer_attested"`, or rarely `NULL` for very old rows that
+    /// pre-date the H2 `attest_level` column). H4's MCP handler
+    /// normalises a `NULL` to the `Unsigned` enum variant.
+    pub attest_level: Option<String>,
+}
+
+/// Fetch the single link identified by the `(source_id, target_id, relation)`
+/// composite primary key — the only unique identifier `memory_links`
+/// exposes today.
+///
+/// Used by the H4 `memory_verify` MCP tool to re-derive the canonical
+/// CBOR payload from the stored row before re-checking the signature.
+///
+/// # Errors
+///
+/// Bubbles up rusqlite errors. Returns `Ok(None)` when the row is
+/// absent — this is the load-bearing distinction `memory_verify` needs
+/// to surface a structured "link not found" response to its caller.
+pub fn get_link_for_verify(
+    conn: &Connection,
+    source_id: &str,
+    target_id: &str,
+    relation: &str,
+) -> Result<Option<LinkVerifyRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT source_id, target_id, relation, signature, observed_by, \
+                valid_from, valid_until, attest_level \
+         FROM memory_links \
+         WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+    )?;
+    let mut rows = stmt.query(params![source_id, target_id, relation])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(LinkVerifyRecord {
+            source_id: row.get(0)?,
+            target_id: row.get(1)?,
+            relation: row.get(2)?,
+            signature: row.get::<_, Option<Vec<u8>>>(3)?,
+            observed_by: row.get::<_, Option<String>>(4)?,
+            valid_from: row.get::<_, Option<String>>(5)?,
+            valid_until: row.get::<_, Option<String>>(6)?,
+            attest_level: row.get::<_, Option<String>>(7)?,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
 // --- Consolidation ---
 
 /// Consolidate multiple memories into one. Returns the new memory ID.

--- a/src/identity/keypair.rs
+++ b/src/identity/keypair.rs
@@ -113,7 +113,20 @@ impl AgentKeypair {
 ///
 /// Errors when the OS does not advertise a config dir (extremely rare;
 /// every supported target — Linux, macOS, Windows — returns one).
+///
+/// `AI_MEMORY_KEY_DIR` env-var override: when set and non-empty, that
+/// path is returned verbatim. This mirrors the env-override pattern
+/// other paths in `ai-memory` use (`AI_MEMORY_DB_PATH`,
+/// `AI_MEMORY_AGENT_ID`) and lets H4's `memory_verify` integration
+/// tests stand up an isolated key dir per test without shelling out to
+/// the operator's real `~/.config/ai-memory/keys/`. Operators who want
+/// to relocate the key store in production can use the same override.
 pub fn default_key_dir() -> Result<PathBuf> {
+    if let Ok(v) = std::env::var("AI_MEMORY_KEY_DIR")
+        && !v.is_empty()
+    {
+        return Ok(PathBuf::from(v));
+    }
     let base = dirs::config_dir()
         .ok_or_else(|| anyhow!("OS did not advertise a config directory for key storage"))?;
     Ok(base.join("ai-memory").join("keys"))
@@ -563,8 +576,32 @@ mod tests {
 
     #[test]
     fn default_key_dir_ends_in_ai_memory_keys() {
+        // SAFETY: single-threaded test block; no concurrent env::var
+        // mutations. The H4 env-var override (`AI_MEMORY_KEY_DIR`) is
+        // scrubbed up-front so this test asserts the *fallback* path.
+        unsafe {
+            std::env::remove_var("AI_MEMORY_KEY_DIR");
+        }
         let p = default_key_dir().expect("default dir");
         let s = p.to_string_lossy();
         assert!(s.ends_with("ai-memory/keys") || s.ends_with("ai-memory\\keys"));
+    }
+
+    #[test]
+    fn default_key_dir_honours_env_override() {
+        // v0.7 H4 — the override exists so `memory_verify` integration
+        // tests can populate a hermetic key dir per test process. Pin
+        // the contract here so a future refactor doesn't quietly drop
+        // the override.
+        // SAFETY: single-threaded test block; no concurrent env writes.
+        unsafe {
+            std::env::set_var("AI_MEMORY_KEY_DIR", "/tmp/h4-override-test");
+        }
+        let p = default_key_dir().expect("default dir");
+        assert_eq!(p, PathBuf::from("/tmp/h4-override-test"));
+        // SAFETY: scoped cleanup so other tests see the unset value.
+        unsafe {
+            std::env::remove_var("AI_MEMORY_KEY_DIR");
+        }
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -597,6 +597,19 @@ pub(crate) fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_verify",
+                "description": "v0.7 Track H4 — re-verify a stored memory_links row's Ed25519 signature on demand. Returns {signature_verified, attest_level, signed_by, signed_at}. attest_level is one of unsigned/self_signed/peer_attested. Pass either the link_id composite ('source--relation-->target') or the explicit source_id+target_id (+optional relation, default related_to).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "link_id": {"type": "string", "description": "Composite link identifier in the form 'source_id--relation-->target_id'. Equivalent to passing source_id+target_id+relation explicitly."},
+                        "source_id": {"type": "string", "description": "Source memory ID. Required when link_id is omitted."},
+                        "target_id": {"type": "string", "description": "Target memory ID. Required when link_id is omitted."},
+                        "relation": {"type": "string", "enum": ["related_to", "supersedes", "contradicts", "derived_from"], "default": "related_to", "description": "Link relation. Defaults to related_to when omitted (matches memory_link's default)."}
+                    }
+                }
+            },
+            {
                 "name": "memory_consolidate",
                 "description": "Consolidate multiple memories into one long-term summary. Deletes source memories and creates derived_from links. If summary is omitted and LLM is available (smart/autonomous tier), auto-generates a summary.",
                 "inputSchema": {
@@ -2060,7 +2073,7 @@ pub fn build_capabilities_tools(
     use crate::config::{AllowlistDecision, ToolEntry};
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let mut entries: Vec<ToolEntry> = Vec::with_capacity(43);
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(44);
 
     for fam in Family::all() {
         let family_name = fam.name();
@@ -3144,6 +3157,201 @@ fn handle_get_links(conn: &rusqlite::Connection, params: &Value) -> Result<Value
     Ok(json!({"links": links, "count": links.len()}))
 }
 
+/// v0.7 H4 — parse the composite link_id form
+/// `"<source_id>--<relation>-->\<target_id>"` into the three components
+/// the SQL composite primary key uses. Returns `None` if the shape does
+/// not match — callers fall back to the explicit `source_id`/`target_id`
+/// parameter form.
+///
+/// Why this shape: `memory_links` has no synthetic surrogate key (the PK
+/// is the composite tuple). H4's MCP tool needs *some* string-shaped
+/// link identifier so a caller can name a link in one argument; this
+/// form reads naturally in logs and is unambiguous because `--` and
+/// `-->` are not valid characters inside a memory id (memory ids are
+/// validated by `validate::validate_id`).
+fn parse_link_id(s: &str) -> Option<(String, String, String)> {
+    // Returns `(source_id, target_id, relation)` to match the
+    // destructuring shape `handle_verify` uses below.
+    //
+    // Split on the relation marker first (the only multi-char arrow in
+    // the form) so a relation containing `--` would still parse — none
+    // of the four valid relations contain it, but we keep the parser
+    // permissive against future relation additions.
+    let (left, target) = s.split_once("-->")?;
+    let (source, relation) = left.split_once("--")?;
+    if source.is_empty() || target.is_empty() || relation.is_empty() {
+        return None;
+    }
+    Some((source.to_string(), target.to_string(), relation.to_string()))
+}
+
+/// v0.7 H4 — `memory_verify` MCP tool handler.
+///
+/// Looks up the named link by composite PK, re-derives the canonical
+/// CBOR payload via [`crate::identity::sign::canonical_cbor`], looks up
+/// the `observed_by` public key via
+/// [`crate::identity::verify::lookup_peer_public_key`], and re-checks
+/// the stored signature with [`crate::identity::verify::verify`].
+///
+/// Wire shape (always returned, even on the unsigned path):
+///
+/// ```json
+/// {
+///   "signature_verified": bool,
+///   "attest_level": "unsigned" | "self_signed" | "peer_attested",
+///   "signed_by": <observed_by string or null>,
+///   "signed_at": <valid_from string or null>
+/// }
+/// ```
+///
+/// `signed_by` and `signed_at` are sourced from the `observed_by` and
+/// `valid_from` columns respectively — the same columns the H2/H3
+/// signature commits to. They are returned `null` on the unsigned path
+/// so callers can drop them without a None-check.
+///
+/// `pub` so the H4 integration test in `tests/memory_verify.rs` can
+/// drive the handler directly without standing up the JSON-RPC
+/// envelope or spawning the daemon binary. Other handlers in this
+/// module stay private because the dispatcher is their sole caller.
+///
+/// # Errors
+///
+/// Returned as JSON-RPC error strings (the dispatcher wraps them as
+/// `-32602` invalid params). Specifically:
+/// - missing required arguments (no `link_id` and no
+///   `source_id`+`target_id`)
+/// - `link_id` shape doesn't match the composite form
+/// - link tuple does not exist in `memory_links`
+pub fn handle_verify(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    // Two callable shapes:
+    //   1. link_id="<src>--<rel>-->\<dst>"
+    //   2. source_id=… target_id=… [relation="related_to"]
+    let (source_id, target_id, relation): (String, String, String) =
+        if let Some(lid) = params.get("link_id").and_then(Value::as_str) {
+            parse_link_id(lid).ok_or_else(|| {
+                format!(
+                    "link_id '{lid}' is not in the expected form \
+                         'source_id--relation-->target_id'"
+                )
+            })?
+        } else {
+            let src = params
+                .get("source_id")
+                .and_then(Value::as_str)
+                .ok_or("link_id or source_id+target_id is required")?;
+            let dst = params
+                .get("target_id")
+                .and_then(Value::as_str)
+                .ok_or("link_id or source_id+target_id is required")?;
+            let rel = params
+                .get("relation")
+                .and_then(Value::as_str)
+                .unwrap_or("related_to");
+            (src.to_string(), dst.to_string(), rel.to_string())
+        };
+
+    // Validate the IDs / relation through the same gate `memory_link`
+    // uses on the write path — keeps the verify surface from being a
+    // back-door past the validator.
+    validate::validate_link(&source_id, &target_id, &relation).map_err(|e| e.to_string())?;
+
+    let record = db::get_link_for_verify(conn, &source_id, &target_id, &relation)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("link not found: ({source_id}, {relation}, {target_id})"))?;
+
+    // Decision matrix mirrors `decide_attest_level` from the H3 tests:
+    //   - signature is None → unsigned, signature_verified=false
+    //   - signature is Some + observed_by is None → unsigned (no claim
+    //     to verify against)
+    //   - signature is Some + observed_by is Some + no enrolled
+    //     pubkey on this host → return the column's stored attest_level
+    //     (which the inbound path already wrote as either "unsigned" on
+    //     enrolled-but-tampered, or whatever it landed as) but report
+    //     `signature_verified = false` because *we* cannot verify
+    //     without the public key.
+    //   - signature is Some + observed_by is Some + pubkey enrolled →
+    //     verify and report the actual outcome. We deliberately recheck
+    //     here even when the column already says "self_signed" or
+    //     "peer_attested": the whole point of `memory_verify` is on-
+    //     demand re-validation, not a stored-flag readback.
+    let stored_attest = record
+        .attest_level
+        .as_deref()
+        .and_then(crate::models::AttestLevel::from_str)
+        .unwrap_or(crate::models::AttestLevel::Unsigned);
+
+    let (verified, attest_out): (bool, crate::models::AttestLevel) =
+        match (record.signature.as_deref(), record.observed_by.as_deref()) {
+            (None, _) | (_, None) => (false, crate::models::AttestLevel::Unsigned),
+            (Some(sig_bytes), Some(observed_by)) => {
+                let signable = crate::identity::sign::SignableLink {
+                    src_id: &record.source_id,
+                    dst_id: &record.target_id,
+                    relation: &record.relation,
+                    observed_by: Some(observed_by),
+                    valid_from: record.valid_from.as_deref(),
+                    valid_until: record.valid_until.as_deref(),
+                };
+                match crate::identity::verify::lookup_peer_public_key(observed_by) {
+                    Some(pubkey) => {
+                        let ok =
+                            crate::identity::verify::verify(&pubkey, &signable, sig_bytes).is_ok();
+                        if ok {
+                            // On a successful re-verify, prefer the stored
+                            // attest_level — it distinguishes self_signed
+                            // (this host wrote+signed) from peer_attested
+                            // (a peer signed and we accepted on inbound).
+                            // If the column drifted to None on a very old
+                            // row, fall back to PeerAttested (the only
+                            // attestation we can re-derive without
+                            // knowing whether the signing key is our own).
+                            let level = match stored_attest {
+                                crate::models::AttestLevel::Unsigned => {
+                                    crate::models::AttestLevel::PeerAttested
+                                }
+                                other => other,
+                            };
+                            (true, level)
+                        } else {
+                            (false, crate::models::AttestLevel::Unsigned)
+                        }
+                    }
+                    None => {
+                        // Signature is present but we can't look up the
+                        // pubkey on this host — surface as not-verified.
+                        // Keep the stored attest_level so callers can see
+                        // what the inbound path originally decided.
+                        (false, stored_attest)
+                    }
+                }
+            }
+        };
+
+    let signed_by: Value = if verified {
+        record
+            .observed_by
+            .as_deref()
+            .map_or(Value::Null, |s| Value::String(s.to_string()))
+    } else {
+        Value::Null
+    };
+    let signed_at: Value = if verified {
+        record
+            .valid_from
+            .as_deref()
+            .map_or(Value::Null, |s| Value::String(s.to_string()))
+    } else {
+        Value::Null
+    };
+
+    Ok(json!({
+        "signature_verified": verified,
+        "attest_level": attest_out.as_str(),
+        "signed_by": signed_by,
+        "signed_at": signed_at,
+    }))
+}
+
 fn handle_consolidate(
     conn: &rusqlite::Connection,
     db_path: &Path,
@@ -4112,6 +4320,7 @@ fn handle_request(
                 "memory_get" => handle_get(conn, arguments),
                 "memory_link" => handle_link(conn, db_path, arguments, active_keypair),
                 "memory_get_links" => handle_get_links(conn, arguments),
+                "memory_verify" => handle_verify(conn, arguments),
                 "memory_consolidate" => handle_consolidate(
                     conn,
                     db_path,
@@ -4652,22 +4861,23 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_43_tools() {
+    fn tool_definitions_returns_44_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
         // (Pillar 2 / Stream B), and memory_kg_timeline +
         // memory_kg_invalidate + memory_kg_query (Pillar 2 / Stream C)
-        // on top of the 36-tool v0.6.0.0 surface.
+        // on top of the 36-tool v0.6.0.0 surface = 43.
+        // v0.7 H4 adds memory_verify (graph family) → 44.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 43);
+        assert_eq!(tools.len(), 44);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
     /// registers exactly 5 family tools + 1 always-on bootstrap
     /// (memory_capabilities) = 6 visible tools. `--profile full`
-    /// registers all 43.
+    /// registers all 44 (43 v0.6.3 baseline + memory_verify from v0.7 H4).
     #[test]
     fn tool_definitions_for_profile_core_registers_5_plus_capabilities() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::core());
@@ -4708,26 +4918,27 @@ mod tests {
     }
 
     #[test]
-    fn tool_definitions_for_profile_full_registers_43() {
+    fn tool_definitions_for_profile_full_registers_44() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::full());
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            43,
-            "full profile must reproduce v0.6.3 surface 1:1"
+            44,
+            "full profile = v0.6.3 surface (43) + v0.7 H4 memory_verify (1) = 44"
         );
     }
 
     #[test]
-    fn tool_definitions_for_profile_graph_registers_thirteen_plus_capabilities() {
+    fn tool_definitions_for_profile_graph_registers_fifteen() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::graph());
         let tools = defs["tools"].as_array().unwrap();
-        // 5 core + 8 graph + 1 always-on capabilities = 14 (capabilities
-        // is in meta but loaded as bootstrap; without it we'd have 13).
+        // 5 core + 9 graph (post-H4) + 1 always-on capabilities = 15
+        // (capabilities is in meta but loaded as bootstrap; without it
+        // we'd have 14).
         assert_eq!(
             tools.len(),
-            14,
-            "graph profile = core(5) + graph(8) + capabilities-bootstrap(1)"
+            15,
+            "graph profile = core(5) + graph(9, post-H4) + capabilities-bootstrap(1) = 15"
         );
     }
 
@@ -4737,7 +4948,11 @@ mod tests {
         let p = crate::profile::Profile::parse("core,graph").unwrap();
         let defs = tool_definitions_for_profile(&p);
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 14, "core,graph = 5 + 8 + capabilities");
+        assert_eq!(
+            tools.len(),
+            15,
+            "core,graph = 5 + 9 (post-H4) + capabilities = 15"
+        );
     }
 
     // ---- v0.6.4-006 — capabilities family enum + include_schema ----
@@ -4754,7 +4969,8 @@ mod tests {
         assert_eq!(core_row["tool_count"], 5);
         let graph_row = families.iter().find(|r| r["name"] == "graph").unwrap();
         assert_eq!(graph_row["loaded"], false);
-        assert_eq!(graph_row["tool_count"], 8);
+        // v0.7 H4: graph grew from 8 → 9 with `memory_verify`.
+        assert_eq!(graph_row["tool_count"], 9);
 
         let always_on = v["always_on"].as_array().unwrap();
         assert_eq!(always_on.len(), 1);
@@ -4768,9 +4984,11 @@ mod tests {
         assert_eq!(v["family"], "graph");
         assert_eq!(v["loaded_under_active_profile"], false);
         let tools = v["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        // v0.7 H4: graph grew from 8 → 9 with `memory_verify`.
+        assert_eq!(tools.len(), 9);
         // Spot-check known graph tool present.
         assert!(tools.iter().any(|t| t == "memory_kg_query"));
+        assert!(tools.iter().any(|t| t == "memory_verify"));
     }
 
     #[test]
@@ -4779,7 +4997,8 @@ mod tests {
         let v = handle_capabilities_family("graph", true, &p, None, None, None).unwrap();
         assert_eq!(v["family"], "graph");
         let tools = v["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        // v0.7 H4: graph grew from 8 → 9 with `memory_verify`.
+        assert_eq!(tools.len(), 9);
         // Each row must carry the full MCP tool definition shape.
         for tool in tools {
             assert!(tool.get("name").is_some(), "missing name");
@@ -5140,7 +5359,8 @@ mod tests {
             "missing err outcome in: {captured}"
         );
     }
-    /// Parametrized smoke matrix for all 43 MCP tools (Justice of MCP pathway).
+    /// Parametrized smoke matrix for all 44 MCP tools (Justice of MCP pathway).
+    /// v0.7 H4 added `memory_verify` to the surface (43 → 44).
     /// Tier 1: happy path with canonical valid args.
     /// Tier 2: required arg validation (missing required arg → error).
     #[test]
@@ -5252,6 +5472,23 @@ mod tests {
                 name: "memory_get_links",
                 valid_args: json!({"id": "fake-id-for-test"}),
                 required_arg: Some("id"),
+            },
+            ToolCase {
+                name: "memory_verify",
+                // Happy-path arg shape — the link won't be found in the
+                // empty in-memory DB but the dispatcher path is what the
+                // smoke matrix covers; the "not found" branch is still
+                // an Err result, which the matrix tolerates because it
+                // already classifies dispatch outcomes.
+                valid_args: json!({
+                    "source_id": "fake-src-id",
+                    "target_id": "fake-dst-id",
+                    "relation": "related_to"
+                }),
+                // No "single required arg" — the tool is reachable via
+                // either link_id OR (source_id+target_id), so the
+                // smoke matrix's required-arg branch is not applicable.
+                required_arg: None,
             },
             ToolCase {
                 name: "memory_consolidate",

--- a/src/models.rs
+++ b/src/models.rs
@@ -80,6 +80,70 @@ pub struct Memory {
     pub metadata: Value,
 }
 
+/// v0.7 Track H — attestation level for a `memory_links` row.
+///
+/// H2 (#566) and H3 (#572) already write the three string variants
+/// directly into the `memory_links.attest_level` TEXT column
+/// (`"unsigned"`, `"self_signed"`, `"peer_attested"`). H4 formalises
+/// the enum so the `memory_verify` MCP tool — and any future verifier
+/// surface — can reason in terms of a closed set rather than an
+/// open-ended string.
+///
+/// `#[serde(rename_all = "snake_case")]` keeps the wire shape byte-
+/// identical to what the database column already holds. The
+/// [`AttestLevel::from_str`] / [`AttestLevel::as_str`] helpers exist
+/// because the column is read as a `String` in many call sites that
+/// are not deserialising through serde (e.g. `rusqlite::Row::get`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestLevel {
+    /// No signature on the row, or no key enrolled for `observed_by` on
+    /// the receiver. Federation back-compat default — unsigned rows
+    /// still land but downstream consumers know they cannot verify.
+    Unsigned,
+    /// Row was signed locally by this writer (H2 outbound path).
+    SelfSigned,
+    /// Row arrived from a peer with a signature that verified against
+    /// the enrolled `observed_by` public key on this host (H3 inbound
+    /// path).
+    PeerAttested,
+}
+
+impl AttestLevel {
+    /// Parse the string form stored in `memory_links.attest_level`.
+    ///
+    /// Returns `None` for unknown values so callers can decide whether
+    /// to treat the column as legacy/`unsigned` or surface an error.
+    /// Keeps the unit-of-truth on the database column shape — H2/H3
+    /// already write the canonical lowercase snake_case strings.
+    #[must_use]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "unsigned" => Some(Self::Unsigned),
+            "self_signed" => Some(Self::SelfSigned),
+            "peer_attested" => Some(Self::PeerAttested),
+            _ => None,
+        }
+    }
+
+    /// Canonical wire string for this variant. Mirrors the `serde`
+    /// rename_all and the literals H2/H3 already write to the DB.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unsigned => "unsigned",
+            Self::SelfSigned => "self_signed",
+            Self::PeerAttested => "peer_attested",
+        }
+    }
+}
+
+impl std::fmt::Display for AttestLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryLink {
     pub source_id: String,
@@ -1027,6 +1091,69 @@ mod tests {
         assert_eq!(Tier::Short.rank(), 0);
         assert_eq!(Tier::Mid.rank(), 1);
         assert_eq!(Tier::Long.rank(), 2);
+    }
+
+    // ---- v0.7 Track H4 — AttestLevel enum -----------------------------------
+
+    #[test]
+    fn attest_level_from_str_canonical_strings() {
+        // The three strings H2/H3 already write to the
+        // `memory_links.attest_level` column must round-trip.
+        assert_eq!(
+            AttestLevel::from_str("unsigned"),
+            Some(AttestLevel::Unsigned)
+        );
+        assert_eq!(
+            AttestLevel::from_str("self_signed"),
+            Some(AttestLevel::SelfSigned)
+        );
+        assert_eq!(
+            AttestLevel::from_str("peer_attested"),
+            Some(AttestLevel::PeerAttested)
+        );
+    }
+
+    #[test]
+    fn attest_level_from_str_unknown_returns_none() {
+        assert_eq!(AttestLevel::from_str(""), None);
+        assert_eq!(AttestLevel::from_str("Unsigned"), None); // case-sensitive
+        assert_eq!(AttestLevel::from_str("self-signed"), None); // hyphen wrong
+        assert_eq!(AttestLevel::from_str("attested"), None);
+    }
+
+    #[test]
+    fn attest_level_as_str_round_trips_through_from_str() {
+        for lvl in [
+            AttestLevel::Unsigned,
+            AttestLevel::SelfSigned,
+            AttestLevel::PeerAttested,
+        ] {
+            let s = lvl.as_str();
+            assert_eq!(
+                AttestLevel::from_str(s),
+                Some(lvl),
+                "round-trip failed for {lvl:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn attest_level_display_matches_as_str() {
+        assert_eq!(format!("{}", AttestLevel::Unsigned), "unsigned");
+        assert_eq!(format!("{}", AttestLevel::SelfSigned), "self_signed");
+        assert_eq!(format!("{}", AttestLevel::PeerAttested), "peer_attested");
+    }
+
+    #[test]
+    fn attest_level_serde_wire_shape_matches_db_column() {
+        // Wire shape = the literal column value. If this drifts, H2/H3
+        // outputs and H4 inputs decouple silently.
+        let json = serde_json::to_string(&AttestLevel::PeerAttested).unwrap();
+        assert_eq!(json, "\"peer_attested\"");
+        let back: AttestLevel = serde_json::from_str("\"self_signed\"").unwrap();
+        assert_eq!(back, AttestLevel::SelfSigned);
+        // Unknown string must fail deserialization (closed-set enum).
+        assert!(serde_json::from_str::<AttestLevel>("\"bogus\"").is_err());
     }
 
     // Task 1.4 — hierarchical namespace helpers --------------------------------

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -25,11 +25,13 @@
 //! ## Profile vocabulary
 //!
 //! - `core` — 5 tools, the new v0.6.4 default. Always loaded.
-//! - `graph` — adds the 8 KG/entity tools. ~13 tools.
+//! - `graph` — adds the 9 KG/entity/verify tools. ~14 tools (v0.7 H4
+//!   added `memory_verify`).
 //! - `admin` — adds lifecycle (5) + governance (8). ~18 tools.
 //! - `power` — adds the 6 LLM-augmented tools (consolidate, auto_tag, …).
 //!   ~11 tools.
-//! - `full` — every family. 43 tools, 1:1 v0.6.3 surface.
+//! - `full` — every family. 44 tools post-v0.7-H4 (43 v0.6.3 baseline +
+//!   `memory_verify`).
 //! - `custom` — comma-separated family list (`core,graph,archive` …).
 //!   `core` is implicitly added if missing — there's no profile that
 //!   ships *less than* the 5 core tools.
@@ -55,7 +57,8 @@
 use std::str::FromStr;
 
 /// A tool family. Source-anchored at `src/mcp.rs::tool_definitions()`
-/// 2026-05-04. Counts must sum to 43 (the v0.6.3.1 baseline).
+/// 2026-05-04. Counts must sum to 44 (43 v0.6.3.1 baseline + 1 from
+/// v0.7 H4 — `memory_verify`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Family {
     /// store, recall, list, get, search — 5
@@ -63,7 +66,11 @@ pub enum Family {
     /// update, delete, forget, gc, promote — 5
     Lifecycle,
     /// kg_query, kg_timeline, kg_invalidate, link, get_links,
-    /// entity_register, entity_get_by_alias, get_taxonomy — 8
+    /// entity_register, entity_get_by_alias, get_taxonomy, verify — 9
+    /// (v0.7 H4 added `memory_verify` — re-verifies a stored link's
+    /// Ed25519 signature on demand; lives with the other graph tools
+    /// because every other link surface — `link`, `get_links`,
+    /// `kg_query` — already routes through Graph).
     Graph,
     /// pending_list/approve/reject, namespace_set/get/clear_standard,
     /// subscribe, unsubscribe — 8
@@ -103,7 +110,7 @@ impl Family {
             // lifecycle (5)
             "memory_update" | "memory_delete" | "memory_forget" | "memory_gc"
             | "memory_promote" => Some(Self::Lifecycle),
-            // graph (8)
+            // graph (9 — v0.7 H4 added memory_verify)
             "memory_kg_query"
             | "memory_kg_timeline"
             | "memory_kg_invalidate"
@@ -111,7 +118,8 @@ impl Family {
             | "memory_get_links"
             | "memory_entity_register"
             | "memory_entity_get_by_alias"
-            | "memory_get_taxonomy" => Some(Self::Graph),
+            | "memory_get_taxonomy"
+            | "memory_verify" => Some(Self::Graph),
             // governance (8)
             "memory_pending_list"
             | "memory_pending_approve"
@@ -182,7 +190,9 @@ impl Family {
     pub const fn expected_tool_count(self) -> usize {
         match self {
             Self::Core | Self::Lifecycle | Self::Meta => 5,
-            Self::Graph | Self::Governance => 8,
+            // v0.7 H4 — Graph grew from 8 → 9 with `memory_verify`.
+            Self::Graph => 9,
+            Self::Governance => 8,
             Self::Power => 6,
             Self::Archive => 4,
             Self::Other => 2,
@@ -227,6 +237,9 @@ impl Family {
                 "memory_entity_register",
                 "memory_entity_get_by_alias",
                 "memory_get_taxonomy",
+                // v0.7 H4 — re-verify a stored link's Ed25519 signature
+                // on demand. Same family as the other link surfaces.
+                "memory_verify",
             ],
             Self::Governance => &[
                 "memory_pending_list",
@@ -334,7 +347,8 @@ impl Profile {
         }
     }
 
-    /// `full` — every family. 43 tools, 1:1 v0.6.3 surface.
+    /// `full` — every family. 44 tools post-v0.7-H4 (43 v0.6.3 baseline
+    /// + `memory_verify` from the v0.7 H4 attest_level enum task).
     #[must_use]
     pub fn full() -> Self {
         Self {
@@ -513,12 +527,14 @@ mod tests {
     }
 
     #[test]
-    fn family_expected_tool_counts_sum_to_43() {
+    fn family_expected_tool_counts_sum_to_44() {
+        // v0.7 H4 added `memory_verify` to Family::Graph (8 → 9).
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 43,
-            "v0.6.3.1 baseline is 43 tools — if this drifts, update \
-             Family::expected_tool_count and the family map docs together"
+            total, 44,
+            "v0.7 H4 baseline is 44 tools (43 v0.6.3.1 + 1 memory_verify) \
+             — if this drifts, update Family::expected_tool_count and \
+             the family map docs together"
         );
     }
 
@@ -566,14 +582,17 @@ mod tests {
     }
 
     #[test]
-    fn profile_graph_has_thirteen_tools() {
+    fn profile_graph_has_fourteen_tools() {
+        // v0.7 H4: graph family = 9 (was 8) so graph profile = 5 + 9.
         let p = Profile::graph();
-        assert_eq!(p.expected_tool_count(), 5 + 8);
+        assert_eq!(p.expected_tool_count(), 5 + 9);
         assert!(p.includes(Family::Graph));
     }
 
     #[test]
     fn profile_admin_has_eighteen_tools() {
+        // admin = core(5) + lifecycle(5) + governance(8) = 18.
+        // Unaffected by H4 because graph isn't in admin.
         let p = Profile::admin();
         assert_eq!(p.expected_tool_count(), 5 + 5 + 8);
     }
@@ -585,9 +604,10 @@ mod tests {
     }
 
     #[test]
-    fn profile_full_has_forty_three_tools() {
+    fn profile_full_has_forty_four_tools() {
+        // v0.7 H4 added `memory_verify`: 43 → 44.
         let p = Profile::full();
-        assert_eq!(p.expected_tool_count(), 43);
+        assert_eq!(p.expected_tool_count(), 44);
     }
 
     // ---------- Profile::parse ----------
@@ -609,14 +629,14 @@ mod tests {
 
     #[test]
     fn parse_custom_comma_list_dedup() {
-        // `core,graph` → core (5) + graph (8) = 13 tools.
+        // `core,graph` → core (5) + graph (9, post-H4) = 14 tools.
         // Meta is NOT included — `memory_capabilities` is always-on
         // bootstrapped outside the family map (v0.6.4-002).
         let p = Profile::parse("core,graph").unwrap();
         assert!(p.includes(Family::Core));
         assert!(!p.includes(Family::Meta));
         assert!(p.includes(Family::Graph));
-        assert_eq!(p.expected_tool_count(), 13);
+        assert_eq!(p.expected_tool_count(), 14);
     }
 
     #[test]
@@ -722,6 +742,8 @@ mod tests {
             "memory_entity_register",
             "memory_entity_get_by_alias",
             "memory_get_taxonomy",
+            // graph (v0.7 H4)
+            "memory_verify",
             // governance
             "memory_pending_list",
             "memory_pending_approve",
@@ -753,7 +775,11 @@ mod tests {
             "memory_list_subscriptions",
             "memory_notify",
         ];
-        assert_eq!(baseline.len(), 43, "baseline list itself must be 43");
+        assert_eq!(
+            baseline.len(),
+            44,
+            "baseline list itself must be 44 (43 + memory_verify)"
+        );
         for name in baseline {
             assert!(
                 Family::for_tool(name).is_some(),

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -138,15 +138,17 @@ mod tests {
 
     /// Sanity: the table must be populated. Catches accidental empty
     /// `tool_definitions()` regressions that would silently hide other
-    /// failures.
+    /// failures. v0.7 H4 grew the surface from 43 → 44 (added
+    /// `memory_verify`); update both this assertion and the family
+    /// map together when the count changes again.
     #[test]
-    fn table_has_43_entries_matching_tool_definitions_count() {
+    fn table_has_44_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 43,
-            "expected exactly 43 tools (v0.6.3.1 baseline source-anchored at \
-             src/mcp.rs::tool_definitions); got {n}. If the count changed, \
-             update the v0.6.4 family map and this assertion together."
+            n, 44,
+            "expected exactly 44 tools (v0.7 H4 baseline = 43 + memory_verify, \
+             source-anchored at src/mcp.rs::tool_definitions); got {n}. \
+             If the count changed, update the family map and this assertion together."
         );
     }
 

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -60,14 +60,14 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    // 37 = 42 user-relevant tools − 5 core. The bootstrap
+    // 38 = 43 user-relevant tools − 5 core. v0.7 H4 grew the surface
+    // from 43 → 44 (added `memory_verify`); the bootstrap
     // (`memory_capabilities`) is excluded from BOTH the loaded and the
     // unloaded count in `to_describe_to_user` (it's plumbing, not a
-    // feature). The A2 NHI starter prompt's example used 38 because it
-    // assumed bootstrap was counted on the unloaded side; the shipped
-    // builder is more honest.
+    // feature), so user-facing total = 44 − 1 = 43, and unloaded
+    // under core = 43 − 5 = 38.
     let expected = "I can directly use 5 memory tools right now \
-                    (store, recall, list, get, search). 37 more \
+                    (store, recall, list, get, search). 38 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -83,7 +83,7 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
 // ---------------------------------------------------------------------------
 // T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
 // "nothing more to load" closing form (excludes the always-on bootstrap
-// from the user-facing 42 count).
+// from the user-facing 43 count post-v0.7-H4).
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_full_profile_canonical_phrasing() {
@@ -92,7 +92,9 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use all 42 memory tools right now \
+    // 43 = 44 total - 1 always-on bootstrap (memory_capabilities) excluded.
+    // v0.7 H4 grew the total from 43 → 44 with `memory_verify`.
+    let expected = "I can directly use all 43 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -106,7 +108,10 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
 
 // ---------------------------------------------------------------------------
 // T0-A2-GRAPH — `to_describe_to_user` on `--profile graph` uses the
-// preview-with-ellipsis form (5 of 13 loaded shown + ", ...").
+// preview-with-ellipsis form (5 of 14 loaded shown + ", ...").
+// v0.7 H4 grew graph profile from 13 → 14 with `memory_verify`; total
+// surface 43 → 44; unloaded = 44 − 1 (bootstrap) − 14 (graph profile
+// loaded) = 29 (unchanged because both numerator and denominator grew).
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_graph_profile_canonical_phrasing() {
@@ -115,7 +120,7 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use 13 memory tools right now \
+    let expected = "I can directly use 14 memory tools right now \
                     (store, recall, list, get, search, ...). 29 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -151,9 +151,10 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `core` profile honestly reports 6 of 43 visible (5 core
+// summary on the `core` profile honestly reports 6 of 44 visible (5 core
 // tools + memory_capabilities always-on bootstrap), labels the profile
 // "core", and references all three named recovery paths.
+// v0.7 H4 grew the surface from 43 to 44 (added `memory_verify`).
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
@@ -163,13 +164,13 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     // Family::Meta which the core profile doesn't load, so the bootstrap
     // injection adds it back).
     assert!(
-        summary.starts_with("6 of 43 tools"),
-        "core profile summary should open with \"6 of 43 tools\"; got: {summary}"
+        summary.starts_with("6 of 44 tools"),
+        "core profile summary should open with \"6 of 44 tools\"; got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
-        summary.contains("37 are listed in this manifest"),
-        "core profile must report 37 unloaded (43 - 6); got: {summary}"
+        summary.contains("38 are listed in this manifest"),
+        "core profile must report 38 unloaded (44 - 6); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -181,18 +182,19 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `full` profile reports 43 of 43 visible, 0 unloaded, and
+// summary on the `full` profile reports 44 of 44 visible, 0 unloaded, and
 // labels the profile "full". The recovery paths are still listed —
 // they're the canonical recovery vocabulary the LLM gets calibrated on
 // regardless of the current profile state.
+// v0.7 H4 grew the surface from 43 to 44 (added `memory_verify`).
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_full_profile_reports_all_visible() {
     let summary = build_capabilities_summary(&Profile::full());
 
     assert!(
-        summary.starts_with("43 of 43 tools"),
-        "full profile summary should open with \"43 of 43 tools\"; got: {summary}"
+        summary.starts_with("44 of 44 tools"),
+        "full profile summary should open with \"44 of 44 tools\"; got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -214,9 +216,12 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
 #[test]
 fn cap_v3_summary_graph_profile_counts() {
     let summary = build_capabilities_summary(&Profile::graph());
+    // v0.7 H4: graph grew from 8 → 9 with `memory_verify`. Total
+    // surface grew from 43 → 44. Visible under `graph` profile is now
+    // 5 core + 9 graph + 1 bootstrap = 15.
     assert!(
-        summary.starts_with("14 of 43 tools"),
-        "graph profile = 5 core + 8 graph + 1 always-on bootstrap = 14; got: {summary}"
+        summary.starts_with("15 of 44 tools"),
+        "graph profile = 5 core + 9 graph (post-H4) + 1 always-on bootstrap = 15; got: {summary}"
     );
     assert!(summary.contains("(graph)"));
     assert!(summary.contains("29 are listed in this manifest"));
@@ -309,12 +314,13 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     // Loaded preview lists the 5 core tool names with the memory_
     // prefix STRIPPED (no MCP jargon for end users).
     assert!(describe.contains("(store, recall, list, get, search)"));
-    // Reports the unloaded count. 37 = 42 user-relevant tools − 5
-    // core. The bootstrap (`memory_capabilities`) is excluded from
-    // both sides for honest user-facing counting.
+    // Reports the unloaded count. 38 = 43 user-relevant tools − 5
+    // core (post-H4: total 44, bootstrap excluded → 43 user-facing).
+    // The bootstrap (`memory_capabilities`) is excluded from both
+    // sides for honest user-facing counting.
     assert!(
-        describe.contains("37 more"),
-        "core profile must report 37 unloaded; got: {describe}"
+        describe.contains("38 more"),
+        "core profile must report 38 unloaded post-H4; got: {describe}"
     );
     // Sample of unloaded tools is plain (no memory_ prefix). The first
     // four unloaded under core are lifecycle's update/delete/forget/gc.
@@ -337,18 +343,19 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `full` profile reports all 42 tools loaded
+// A2: to_describe_to_user on `full` profile reports all 43 tools loaded
 // (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
 // uses the "nothing more to load" closing form rather than the recovery
-// hint.
+// hint. v0.7 H4 grew the surface from 43 → 44; the user-facing count is
+// 43 = 44 total - 1 always-on bootstrap.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 42 = 43 total - 1 always-on bootstrap excluded from describe.
+    // 43 = 44 total - 1 always-on bootstrap excluded from describe.
     assert!(
-        describe.starts_with("I can directly use all 42 memory tools right now ("),
+        describe.starts_with("I can directly use all 43 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -358,18 +365,18 @@ fn cap_v3_describe_full_profile_uses_nothing_more_form() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `graph` profile (5 core + 8 graph) lists
-// 13 loaded with a 5-name preview ending in ", ..." since there are
-// more loaded than the preview shows.
+// A2: to_describe_to_user on `graph` profile (5 core + 9 graph post-H4)
+// lists 14 loaded with a 5-name preview ending in ", ..." since there
+// are more loaded than the preview shows.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     let describe = build_capabilities_describe_to_user(&Profile::graph());
     assert!(
-        describe.starts_with("I can directly use 13 memory tools right now ("),
-        "graph profile describe should open with 13 loaded; got: {describe}"
+        describe.starts_with("I can directly use 14 memory tools right now ("),
+        "graph profile describe should open with 14 loaded post-H4; got: {describe}"
     );
-    // Preview is the first 5 of the 13 loaded — the 5 core tools.
+    // Preview is the first 5 of the 14 loaded — the 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
     assert!(describe.contains("29 more"));
 }
@@ -527,11 +534,12 @@ fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
 
 // ---------------------------------------------------------------------------
 // A3 — the v3 response surfaces the `tools` array at the top level
-// with one entry per registered tool (43 + always-on bootstrap counted
-// once = 43, since the bootstrap already lives in Family::Meta).
+// with one entry per registered tool (44 post-v0.7-H4 + always-on
+// bootstrap counted once = 44, since the bootstrap already lives in
+// Family::Meta).
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_response_carries_tools_array_with_43_entries() {
+fn cap_v3_response_carries_tools_array_with_44_entries() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
     let val = handle_capabilities_with_conn_v3(
@@ -551,8 +559,8 @@ fn cap_v3_response_carries_tools_array_with_43_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        43,
-        "v3 must surface all 43 tools regardless of profile; got {}",
+        44,
+        "v3 must surface all 44 tools regardless of profile (43 v0.6.3 + memory_verify); got {}",
         tools.len()
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1865,7 +1865,12 @@ fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("tools should be array");
-    assert_eq!(tools.len(), 43, "expected 43 MCP tools");
+    // v0.7 H4: 43 v0.6.3 baseline + memory_verify = 44.
+    assert_eq!(
+        tools.len(),
+        44,
+        "expected 44 MCP tools (43 + memory_verify)"
+    );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(tool_names.contains(&"memory_store"));
@@ -1887,6 +1892,8 @@ fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"memory_get"));
     assert!(tool_names.contains(&"memory_link"));
     assert!(tool_names.contains(&"memory_get_links"));
+    // v0.7 H4 — pin the new tool's presence in the registered surface.
+    assert!(tool_names.contains(&"memory_verify"));
     assert!(tool_names.contains(&"memory_consolidate"));
     assert!(tool_names.contains(&"memory_agent_register"));
     assert!(tool_names.contains(&"memory_agent_list"));

--- a/tests/memory_verify.rs
+++ b/tests/memory_verify.rs
@@ -1,0 +1,384 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7 Track H4 — `memory_verify` MCP tool integration tests.
+//!
+//! H4 formalises the `attest_level` enum (Unsigned / SelfSigned /
+//! PeerAttested) that H2 (#566) and H3 (#572) already write as raw
+//! strings to the `memory_links.attest_level` column. The new
+//! `memory_verify(link_id)` MCP tool re-derives the canonical CBOR
+//! payload from the stored row and re-checks the signature on demand,
+//! returning `{signature_verified, attest_level, signed_by, signed_at}`.
+//!
+//! Scenarios pinned here:
+//! 1. Unsigned link (no signature blob) → `signature_verified=false`,
+//!    `attest_level="unsigned"`, `signed_by`/`signed_at` both `null`.
+//! 2. Self-signed link (H2 outbound path) → `signature_verified=true`,
+//!    `attest_level="self_signed"`, `signed_by`/`signed_at` populated.
+//! 3. Tampered signature byte → `signature_verified=false`,
+//!    `attest_level="unsigned"`.
+//! 4. Peer-attested link (simulating H3's inbound path) →
+//!    `signature_verified=true`, `attest_level="peer_attested"`.
+//! 5. link_id composite form parses identically to explicit-args.
+//! 6. Missing link tuple → handler returns Err.
+//!
+//! Hermeticity: each test sets `AI_MEMORY_KEY_DIR` to a per-test
+//! tempdir before invoking the handler so the on-disk lookup never
+//! touches the operator's real `~/.config/ai-memory/keys/`. The env
+//! var is consumed by `crate::identity::keypair::default_key_dir`
+//! (added in H4) which the production handler calls through.
+//!
+//! Concurrency: cross-test `env::set_var` is racy. The cases below
+//! gate through a single `Mutex` so the suite runs serially even
+//! when `cargo test` parallelises across test fns.
+
+use std::sync::Mutex;
+
+use ai_memory::db;
+use ai_memory::identity::keypair as kp_mod;
+use ai_memory::identity::sign;
+use ai_memory::mcp;
+use ai_memory::models::{self, MemoryLink};
+use chrono::Utc;
+use rusqlite::params;
+use serde_json::json;
+use tempfile::TempDir;
+
+/// Single-process gate against parallel `env::set_var` racing. Every
+/// test below acquires this mutex before touching `AI_MEMORY_KEY_DIR`.
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    conn: rusqlite::Connection,
+    /// Dropped at the end of the test; keeps the DB file alive.
+    #[allow(dead_code)]
+    db_tmp: TempDir,
+    /// Dropped at the end of the test; keeps the key dir alive.
+    keys_tmp: TempDir,
+    src_id: String,
+    dst_id: String,
+}
+
+fn setup() -> Fixture {
+    let db_tmp = TempDir::new().expect("db tempdir");
+    let keys_tmp = TempDir::new().expect("keys tempdir");
+
+    // Point the production-code lookup path at the per-test key dir.
+    // SAFETY: caller acquired `ENV_GUARD` before invoking setup.
+    unsafe {
+        std::env::set_var("AI_MEMORY_KEY_DIR", keys_tmp.path());
+    }
+
+    let db_path = db_tmp.path().join("ai-memory.db");
+    let conn = db::open(&db_path).expect("db::open");
+
+    let src_id = seed(&conn, "h4-src");
+    let dst_id = seed(&conn, "h4-dst");
+
+    Fixture {
+        conn,
+        db_tmp,
+        keys_tmp,
+        src_id,
+        dst_id,
+    }
+}
+
+fn seed(conn: &rusqlite::Connection, title: &str) -> String {
+    let now = Utc::now().to_rfc3339();
+    let id = uuid::Uuid::new_v4().to_string();
+    let mem = models::Memory {
+        id: id.clone(),
+        tier: models::Tier::Mid,
+        namespace: "h4-test".to_string(),
+        title: title.to_string(),
+        content: "x".to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "import".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: models::default_metadata(),
+    };
+    db::insert(conn, &mem).expect("db::insert")
+}
+
+fn read_attest_level(conn: &rusqlite::Connection, src: &str, dst: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT attest_level FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+        params![src, dst],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Unsigned link → signature_verified=false, attest_level=unsigned
+// ---------------------------------------------------------------------------
+#[test]
+fn unsigned_link_reports_unsigned_and_not_verified() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    // Insert an unsigned link via the H2 helper with `keypair=None` —
+    // exactly what callers without a generated keypair already produce.
+    let attest = db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", None)
+        .expect("create_link_signed (unsigned)");
+    assert_eq!(attest, "unsigned", "H2 must land an unsigned row");
+    assert_eq!(
+        read_attest_level(&f.conn, &f.src_id, &f.dst_id).as_deref(),
+        Some("unsigned")
+    );
+
+    let body = mcp::handle_verify(
+        &f.conn,
+        &json!({
+            "source_id": f.src_id,
+            "target_id": f.dst_id,
+            "relation": "related_to",
+        }),
+    )
+    .expect("handle_verify Ok");
+
+    assert_eq!(body["signature_verified"], json!(false));
+    assert_eq!(body["attest_level"], json!("unsigned"));
+    assert_eq!(body["signed_by"], json!(null));
+    assert_eq!(body["signed_at"], json!(null));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Self-signed link → signature_verified=true, attest_level=self_signed
+// ---------------------------------------------------------------------------
+#[test]
+fn self_signed_link_verifies_and_reports_self_signed() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    // Generate alice's keypair under the per-test key dir so the
+    // production lookup path can find alice's public key on the verify
+    // round-trip.
+    let alice = kp_mod::generate("alice").unwrap();
+    kp_mod::save(&alice, f.keys_tmp.path()).expect("save alice");
+
+    // H2 outbound path: signs the link before insert. Observed_by is
+    // alice (from the keypair); valid_from is "now".
+    let attest = db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", Some(&alice))
+        .expect("create_link_signed (self-signed)");
+    assert_eq!(attest, "self_signed");
+
+    let body = mcp::handle_verify(
+        &f.conn,
+        &json!({
+            "source_id": f.src_id,
+            "target_id": f.dst_id,
+            "relation": "related_to",
+        }),
+    )
+    .expect("handle_verify Ok");
+
+    assert_eq!(body["signature_verified"], json!(true));
+    assert_eq!(body["attest_level"], json!("self_signed"));
+    assert_eq!(body["signed_by"], json!("alice"));
+    assert!(
+        body["signed_at"].is_string(),
+        "signed_at must be RFC3339 string when verified, got: {:?}",
+        body["signed_at"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Tampered signature byte → signature_verified=false
+// ---------------------------------------------------------------------------
+#[test]
+fn tampered_signature_byte_does_not_verify() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    let alice = kp_mod::generate("alice").unwrap();
+    kp_mod::save(&alice, f.keys_tmp.path()).expect("save alice");
+
+    // Land a self-signed row first via the H2 path so the column
+    // shape (observed_by, valid_from, attest_level) matches a real
+    // signed insert.
+    db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", Some(&alice))
+        .expect("create_link_signed");
+
+    // Now flip the first byte of the persisted signature blob (XOR
+    // 0xFF — guaranteed-different value). The verifier must reject;
+    // the `attest_level` column still says "self_signed" (writes never
+    // go back) but the on-demand re-verification reports the truth.
+    let original_sig: Vec<u8> = f
+        .conn
+        .query_row(
+            "SELECT signature FROM memory_links \
+             WHERE source_id = ?1 AND target_id = ?2",
+            params![f.src_id, f.dst_id],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .expect("read signature back");
+    assert_eq!(
+        original_sig.len(),
+        64,
+        "Ed25519 signature must be 64 bytes, got {}",
+        original_sig.len()
+    );
+    let mut tampered = original_sig.clone();
+    tampered[0] ^= 0xFF;
+    f.conn
+        .execute(
+            "UPDATE memory_links SET signature = ?3 \
+             WHERE source_id = ?1 AND target_id = ?2",
+            params![f.src_id, f.dst_id, tampered],
+        )
+        .expect("write tampered signature");
+
+    let body = mcp::handle_verify(
+        &f.conn,
+        &json!({
+            "source_id": f.src_id,
+            "target_id": f.dst_id,
+            "relation": "related_to",
+        }),
+    )
+    .expect("handle_verify Ok (tampered → false, not Err)");
+
+    assert_eq!(body["signature_verified"], json!(false));
+    assert_eq!(
+        body["attest_level"],
+        json!("unsigned"),
+        "tampered → on-demand verify reports unsigned regardless of stored column"
+    );
+    assert_eq!(body["signed_by"], json!(null));
+    assert_eq!(body["signed_at"], json!(null));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Peer-attested link → signature_verified=true, attest_level=peer_attested
+// ---------------------------------------------------------------------------
+#[test]
+fn peer_attested_link_verifies_and_reports_peer_attested() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    // Peer "bob" exists on a different host. We import only bob's
+    // public key on this host — the H3 inbound path's enrolled-key
+    // pattern.
+    let bob = kp_mod::generate("bob").unwrap();
+    let bob_pub = kp_mod::AgentKeypair {
+        agent_id: "bob".to_string(),
+        public: bob.public,
+        private: None,
+    };
+    kp_mod::save_public_only(&bob_pub, f.keys_tmp.path()).expect("import bob.pub");
+
+    // Bob signs a link off-host.
+    let valid_from = Utc::now().to_rfc3339();
+    let signable = sign::SignableLink {
+        src_id: &f.src_id,
+        dst_id: &f.dst_id,
+        relation: "related_to",
+        observed_by: Some("bob"),
+        valid_from: Some(&valid_from),
+        valid_until: None,
+    };
+    let sig = sign::sign(&bob, &signable).expect("bob signs");
+
+    // The link arrives over federation; H3's inbound path persists it
+    // with attest_level="peer_attested" after running verify(). We
+    // call `create_link_inbound` directly with the matching attest
+    // level — the same shape `handlers::sync_push` produces.
+    let inbound = MemoryLink {
+        source_id: f.src_id.clone(),
+        target_id: f.dst_id.clone(),
+        relation: "related_to".to_string(),
+        created_at: Utc::now().to_rfc3339(),
+        signature: Some(sig),
+        observed_by: Some("bob".to_string()),
+        valid_from: Some(valid_from.clone()),
+        valid_until: None,
+    };
+    db::create_link_inbound(&f.conn, &inbound, "peer_attested").expect("create_link_inbound");
+    assert_eq!(
+        read_attest_level(&f.conn, &f.src_id, &f.dst_id).as_deref(),
+        Some("peer_attested")
+    );
+
+    let body = mcp::handle_verify(
+        &f.conn,
+        &json!({
+            "source_id": f.src_id,
+            "target_id": f.dst_id,
+            "relation": "related_to",
+        }),
+    )
+    .expect("handle_verify Ok");
+
+    assert_eq!(body["signature_verified"], json!(true));
+    assert_eq!(body["attest_level"], json!("peer_attested"));
+    assert_eq!(body["signed_by"], json!("bob"));
+    assert_eq!(body["signed_at"], json!(valid_from));
+}
+
+// ---------------------------------------------------------------------------
+// 5. link_id composite form parses identically to explicit-args form
+// ---------------------------------------------------------------------------
+#[test]
+fn link_id_composite_form_resolves_same_link() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", None)
+        .expect("create_link_signed");
+
+    let composite = format!("{}--related_to-->{}", f.src_id, f.dst_id);
+    let body =
+        mcp::handle_verify(&f.conn, &json!({ "link_id": composite })).expect("handle_verify Ok");
+
+    assert_eq!(body["signature_verified"], json!(false));
+    assert_eq!(body["attest_level"], json!("unsigned"));
+}
+
+// ---------------------------------------------------------------------------
+// 6. Missing link tuple → handler returns Err
+// ---------------------------------------------------------------------------
+#[test]
+fn missing_link_returns_err() {
+    // PoisonError-tolerant lock: a panic in a sibling test would
+    // otherwise cascade-fail every other test in the file.
+    let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let f = setup();
+
+    // Look up a relation we never inserted on this fixture.
+    let err = mcp::handle_verify(
+        &f.conn,
+        &json!({
+            "source_id": f.src_id,
+            "target_id": f.dst_id,
+            "relation": "supersedes",
+        }),
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("link not found"),
+        "err message should name the failure mode: {err}"
+    );
+}


### PR DESCRIPTION
Track H task H4 of v0.7.0 attested-cortex epic. Builds on H1+H2+H3 (all merged).

## Summary
- AttestLevel enum (Unsigned / SelfSigned / PeerAttested) with snake_case serde matching the strings H2/H3 already write
- New `memory_verify(link_id)` MCP tool returning {signature_verified, attest_level, signed_by, signed_at}
- Family: Graph (lives with the other link surfaces — `link`, `get_links`, `kg_query`)
- Re-verifies on demand via H2's canonical_cbor + H3's lookup_peer_public_key + verify
- link_id form: `<source_id>--<relation>-->\<target_id>` composite, OR explicit `source_id`+`target_id`(+`relation`) pair
- Tool surface grew 43 → 44; graph family 8 → 9

## Identity / lookup hermeticity
Added `AI_MEMORY_KEY_DIR` env-var override to `keypair::default_key_dir` so integration tests can stand up an isolated key dir per process without touching the operator's real `~/.config/ai-memory/keys/`. Mirrors the env-override pattern other paths use.

## Test plan
- [x] cargo fmt --check + clippy (-D warnings -D clippy::all -D clippy::pedantic) clean on production binary
- [x] cargo test --lib green (2118 passed)
- [x] cargo test --tests green across all integration suites
- [x] tests/memory_verify.rs covers the four required scenarios:
  - Unsigned link → signature_verified=false, attest_level="unsigned"
  - Self-signed link → signature_verified=true, attest_level="self_signed"
  - Tampered signature byte → signature_verified=false (column says self_signed but on-demand re-verify reports the truth)
  - Peer-attested link → signature_verified=true, attest_level="peer_attested"
- [x] Bonus coverage: link_id composite form parses, missing-link returns Err

🤖 Generated with [Claude Code](https://claude.com/claude-code)