### PR TITLE
feat: v0.7-k5 — capabilities rule_summary populated

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -261,6 +261,13 @@ impl TierConfig {
                 // `[permissions].mode` is unset in `config.toml`.
                 mode: active_permissions_mode().as_str().to_string(),
                 active_rules: 0,
+                // v0.7.0 K5: zero-state — no policies known until the
+                // overlay queries the live DB. `Vec::is_empty` means
+                // the field is omitted from the wire entirely (matches
+                // the v0.6.3.1 honesty disclosure that this field was
+                // previously dropped because no per-rule serializer
+                // existed; K5 ships the serializer).
+                rule_summary: Vec::new(),
                 // v0.6.3.1 (P4, G1): chain-walking enforcement landed
                 // in this release. Surface "enforced" so consumers can
                 // distinguish a governed deployment from the historical
@@ -503,8 +510,26 @@ pub struct CapabilityPermissions {
     /// Number of namespace standards whose `metadata.governance` is
     /// non-null. Counts policies, not memories.
     pub active_rules: usize,
-    // P1 honesty patch: `rule_summary` was always empty — no per-rule
-    // serializer existed. Dropped from the v2 wire schema.
+    /// v0.7.0 K5: ordered list of one-line summaries — one entry per
+    /// active governance policy, sorted lexicographically by namespace.
+    /// Each entry names the namespace plus the policy's `write`,
+    /// `promote`, `delete`, `approver`, and `inherit` values so an
+    /// operator (or LLM) can see the live ruleset at a glance without
+    /// fanning out per-namespace `memory_namespace_get_standard` calls.
+    ///
+    /// **Wire shape.** `skip_serializing_if = "Vec::is_empty"` keeps the
+    /// field absent from v2 responses (which historically had no per-rule
+    /// serializer — the v0.6.3.1 honesty patch dropped the field from
+    /// the v2 wire entirely) when no policies are configured. v3 callers
+    /// see the field on every response with policies, matching the K5
+    /// spec contract that v3 brings the field back with a backing
+    /// implementation.
+    ///
+    /// Closes the v0.6.3.1 honest-Capabilities-v2 disclosure that this
+    /// field was a placeholder — the K5 increment ships the per-rule
+    /// serializer that was previously missing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rule_summary: Vec<String>,
     /// v0.6.3.1 (P4, audit G1): governance-inheritance posture.
     /// `"enforced"` = `resolve_governance_policy` walks the namespace
     /// chain leaf-first and returns the most-specific policy (with

--- a/src/db.rs
+++ b/src/db.rs
@@ -5495,6 +5495,65 @@ pub fn count_active_governance_rules(conn: &Connection) -> Result<usize> {
     Ok(usize::try_from(count.max(0)).unwrap_or(0))
 }
 
+/// v0.7.0 K5 — enumerate every namespace whose standard memory carries an
+/// explicit `metadata.governance` policy and return `(namespace, policy)`
+/// pairs sorted lexicographically by namespace.
+///
+/// Companion to [`count_active_governance_rules`] (which returns just the
+/// count). Powers the `permissions.rule_summary` field surfaced by
+/// capabilities v3 — the K5 increment closes the v0.6.3.1 honesty
+/// disclosure that the field was previously dropped from the wire because
+/// no per-rule serializer existed.
+///
+/// Rows whose `metadata.governance` payload fails to round-trip through
+/// `GovernancePolicy::from_metadata` are silently skipped — the
+/// capabilities surface is best-effort and a malformed policy must not
+/// take down the entire response. The wider gate
+/// (`enforce_governance` → `read_namespace_policy`) already swallows the
+/// same parse failures, so the surfaces stay consistent.
+///
+/// # Errors
+///
+/// Returns `Err` only on hard SQLite failures (e.g. table missing); the
+/// row-level parse failures noted above are handled internally.
+pub fn list_active_governance_policies(
+    conn: &Connection,
+) -> Result<Vec<(String, GovernancePolicy)>> {
+    // Pull the raw `(namespace, metadata)` tuples for every namespace
+    // whose standard memory has a non-null `metadata.governance`. We
+    // ORDER BY at the SQL layer so the lex sort comes free and the
+    // caller doesn't have to re-sort.
+    let mut stmt = conn.prepare(
+        "SELECT nm.namespace, m.metadata
+         FROM namespace_meta nm
+         INNER JOIN memories m ON m.id = nm.standard_id
+         WHERE json_extract(m.metadata, '$.governance') IS NOT NULL
+         ORDER BY nm.namespace ASC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        let ns: String = r.get(0)?;
+        let meta_str: String = r.get(1)?;
+        Ok((ns, meta_str))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows.flatten() {
+        let (ns, meta_str) = row;
+        // Parse the metadata blob; skip rows that don't deserialize.
+        let Ok(meta) = serde_json::from_str::<serde_json::Value>(&meta_str) else {
+            continue;
+        };
+        // `from_metadata` returns `None` when the field is missing/null
+        // (the SQL filter already excludes that path) and
+        // `Some(Err(_))` on a malformed policy payload — skip both.
+        match GovernancePolicy::from_metadata(&meta) {
+            Some(Ok(policy)) => out.push((ns, policy)),
+            _ => continue,
+        }
+    }
+    Ok(out)
+}
+
 /// v0.6.3 (capabilities schema v2): count rows in the `subscriptions`
 /// table. Used by `handle_capabilities` as a proxy for "registered
 /// hooks" — the hook pipeline itself is v0.7 Bucket 0 work.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1905,6 +1905,22 @@ fn build_capabilities_overlay(
         if let Ok(n) = db::count_active_governance_rules(c) {
             caps.permissions.active_rules = n;
         }
+        // v0.7.0 K5 — populate `permissions.rule_summary` with a
+        // one-line summary per active governance policy, sorted lex by
+        // namespace. The DB layer returns the rows already sorted, so
+        // the format pass preserves order. Failure is silent (best-
+        // effort): a malformed policy must not take down the whole
+        // capabilities response. `Vec::is_empty` + `skip_serializing_if`
+        // means an unconfigured deployment sees the field omitted from
+        // the wire entirely (matching the v0.6.3.1 honesty disclosure
+        // that the field was previously dropped because no per-rule
+        // serializer existed).
+        if let Ok(rules) = db::list_active_governance_policies(c) {
+            caps.permissions.rule_summary = rules
+                .into_iter()
+                .map(|(ns, p)| format_rule_summary(&ns, &p))
+                .collect();
+        }
         if let Ok(n) = db::count_subscriptions(c) {
             caps.hooks.registered_count = n;
         }
@@ -1914,6 +1930,39 @@ fn build_capabilities_overlay(
     }
 
     caps
+}
+
+/// v0.7.0 K5 — format a single [`GovernancePolicy`] as a one-line
+/// human-readable summary, prefixed with the namespace it governs.
+///
+/// Output shape:
+/// ```text
+/// "alphaone/eng — write=approve, promote=any, delete=owner, approver=human, inherit=true"
+/// ```
+///
+/// The `approver` rendering follows the [`ApproverType`] discriminator
+/// tag (`human` / `agent:<id>` / `consensus:<n>`) so an operator can tell
+/// apart a `Human` policy from a `Consensus(3)` policy without fanning
+/// out to `memory_namespace_get_standard`. `inherit` is rendered as a
+/// boolean string so the line stays scan-friendly.
+///
+/// Public so the capabilities-v3 integration tests (track A, K5) can
+/// pin the exact wire shape without re-implementing the formatter.
+#[must_use]
+pub fn format_rule_summary(namespace: &str, policy: &crate::models::GovernancePolicy) -> String {
+    use crate::models::ApproverType;
+    let approver = match &policy.approver {
+        ApproverType::Human => "human".to_string(),
+        ApproverType::Agent(id) => format!("agent:{id}"),
+        ApproverType::Consensus(n) => format!("consensus:{n}"),
+    };
+    format!(
+        "{namespace} — write={write}, promote={promote}, delete={delete}, approver={approver}, inherit={inherit}",
+        write = policy.write.as_str(),
+        promote = policy.promote.as_str(),
+        delete = policy.delete.as_str(),
+        inherit = policy.inherit,
+    )
 }
 
 /// v0.7.0 A1 — build the capabilities-v3 `summary` string from the live

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -848,3 +848,265 @@ fn cap_v3_b4_v2_callers_unaffected() {
         "v2 must not gain the B4 field"
     );
 }
+
+// ---------------------------------------------------------------------------
+// K5 — `permissions.rule_summary` is populated from the live governance
+// configuration: ordered (lex) one-line summaries, one per active
+// policy. The field is omitted from the wire when no policies exist
+// (skip_serializing_if = "Vec::is_empty") so v2 callers continue to see
+// the v0.6.3.1 honesty disclosure shape, and v3 callers gain a real
+// per-rule serializer (closes the K5 spec).
+// ---------------------------------------------------------------------------
+
+/// Helper: seed a namespace standard memory with an explicit
+/// `metadata.governance` policy attached. Mirrors the production path
+/// (`db::insert` + `db::set_namespace_standard`) used by the
+/// ship-gate scenarios so the capabilities surface walks the same
+/// rows the gate would.
+fn seed_governance_policy(
+    conn: &rusqlite::Connection,
+    namespace: &str,
+    policy: &ai_memory::models::GovernancePolicy,
+) {
+    use ai_memory::models::{Memory, Tier, default_metadata};
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut metadata = default_metadata();
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert(
+            "agent_id".to_string(),
+            serde_json::Value::String("test-owner".to_string()),
+        );
+        obj.insert(
+            "governance".to_string(),
+            serde_json::to_value(policy).unwrap(),
+        );
+    }
+    let standard = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: format!("_standards-{namespace}"),
+        title: format!("standard for {namespace}"),
+        content: "policy".to_string(),
+        tags: vec![],
+        priority: 9,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata,
+    };
+    let standard_id = ai_memory::db::insert(conn, &standard).unwrap();
+    ai_memory::db::set_namespace_standard(conn, namespace, &standard_id, None).unwrap();
+}
+
+/// K5 — empty governance state: `permissions.rule_summary` is absent
+/// from the wire (`skip_serializing_if = "Vec::is_empty"`). This is the
+/// v0.6.3.1 honesty-disclosure shape preserved when no policies are
+/// configured.
+#[test]
+fn cap_v3_k5_rule_summary_empty_state_omits_field() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
+
+    assert!(
+        val["permissions"].get("rule_summary").is_none(),
+        "K5: empty governance state must omit `rule_summary` from the wire \
+         (skip_serializing_if = Vec::is_empty); got: {val}"
+    );
+    // `active_rules` still surfaces (it's a count, not a per-rule list)
+    // and must be zero in the empty state.
+    assert_eq!(val["permissions"]["active_rules"], 0);
+}
+
+/// K5 — single policy at `team`: `rule_summary` carries one entry
+/// naming the namespace plus all five policy levels. Pins the wire
+/// format an LLM/operator can parse without an extra round-trip.
+#[test]
+fn cap_v3_k5_rule_summary_single_policy_carries_one_entry() {
+    use ai_memory::models::{ApproverType, GovernanceLevel, GovernancePolicy};
+
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let policy = GovernancePolicy {
+        write: GovernanceLevel::Approve,
+        promote: GovernanceLevel::Any,
+        delete: GovernanceLevel::Owner,
+        approver: ApproverType::Human,
+        inherit: true,
+    };
+    seed_governance_policy(&conn, "team", &policy);
+
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
+
+    let arr = val["permissions"]["rule_summary"]
+        .as_array()
+        .expect("rule_summary must be present and an array under K5; got missing/non-array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "K5: single policy must surface as exactly one rule_summary entry; got: {arr:?}"
+    );
+    let line = arr[0].as_str().expect("entry is a stringy summary");
+    assert!(
+        line.starts_with("team — "),
+        "K5: rule_summary entry must lead with the namespace; got: {line}"
+    );
+    assert!(
+        line.contains("write=approve"),
+        "missing write=; got: {line}"
+    );
+    assert!(
+        line.contains("promote=any"),
+        "missing promote=; got: {line}"
+    );
+    assert!(
+        line.contains("delete=owner"),
+        "missing delete=; got: {line}"
+    );
+    assert!(
+        line.contains("approver=human"),
+        "missing approver=; got: {line}"
+    );
+    assert!(
+        line.contains("inherit=true"),
+        "missing inherit=; got: {line}"
+    );
+    // `active_rules` count must agree with the per-rule list length.
+    assert_eq!(val["permissions"]["active_rules"], 1);
+}
+
+/// K5 — multiple policies: `rule_summary` is sorted lexicographically
+/// by namespace. The DB layer returns rows already ORDER BY-sorted, so
+/// this test pins the contract end-to-end through the capabilities
+/// builder.
+#[test]
+fn cap_v3_k5_rule_summary_multiple_policies_lex_ordered() {
+    use ai_memory::models::{ApproverType, GovernanceLevel, GovernancePolicy};
+
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    // Seed in deliberately non-lex order so a buggy implementation
+    // that preserves insertion order would fail this test.
+    let zeta = GovernancePolicy {
+        write: GovernanceLevel::Owner,
+        promote: GovernanceLevel::Any,
+        delete: GovernanceLevel::Owner,
+        approver: ApproverType::Agent("maintainer".to_string()),
+        inherit: false,
+    };
+    let alpha = GovernancePolicy {
+        write: GovernanceLevel::Any,
+        promote: GovernanceLevel::Approve,
+        delete: GovernanceLevel::Owner,
+        approver: ApproverType::Consensus(3),
+        inherit: true,
+    };
+    let middle = GovernancePolicy::default();
+    seed_governance_policy(&conn, "zeta", &zeta);
+    seed_governance_policy(&conn, "alpha", &alpha);
+    seed_governance_policy(&conn, "middle", &middle);
+
+    let val = handle_capabilities_with_conn_v3(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        &Profile::core(),
+        None,
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
+
+    let arr = val["permissions"]["rule_summary"]
+        .as_array()
+        .expect("rule_summary must be present and an array under K5");
+    assert_eq!(arr.len(), 3, "expected 3 rule entries; got: {arr:?}");
+
+    // Lex order: alpha < middle < zeta.
+    let lines: Vec<&str> = arr.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(
+        lines[0].starts_with("alpha — "),
+        "first entry must be alpha; got: {lines:?}"
+    );
+    assert!(
+        lines[1].starts_with("middle — "),
+        "second entry must be middle; got: {lines:?}"
+    );
+    assert!(
+        lines[2].starts_with("zeta — "),
+        "third entry must be zeta; got: {lines:?}"
+    );
+
+    // Spot-check the discriminator-tagged approver rendering — the
+    // `Consensus(N)` and `Agent(id)` variants must surface their inner
+    // value so an operator can tell them apart from `Human`.
+    assert!(
+        lines[0].contains("approver=consensus:3"),
+        "Consensus approver must render with the count; got: {}",
+        lines[0]
+    );
+    assert!(
+        lines[2].contains("approver=agent:maintainer"),
+        "Agent approver must render with the id; got: {}",
+        lines[2]
+    );
+    // `inherit=false` must round-trip so the no-inherit override is
+    // visible at a glance.
+    assert!(
+        lines[2].contains("inherit=false"),
+        "inherit=false override must surface; got: {}",
+        lines[2]
+    );
+
+    // Active count agrees.
+    assert_eq!(val["permissions"]["active_rules"], 3);
+}
+
+/// K5 — v2 callers continue to see the field omitted from the wire
+/// when no policies are configured (the v0.6.3.1 honesty-disclosure
+/// shape). When policies *are* configured, v2 surfaces the same field
+/// (the permissions block is shared between v2 + v3) — the contract
+/// is "no drift in the empty case", not "v2 hides it forever".
+#[test]
+fn cap_v3_k5_v2_callers_see_omitted_field_when_empty() {
+    let tier_config = semantic_tier();
+    let conn = fresh_conn();
+    let val = handle_capabilities_with_conn(
+        &tier_config,
+        None,
+        false,
+        Some(&conn),
+        CapabilitiesAccept::V2,
+    )
+    .expect("v2 capabilities serialize");
+    assert!(
+        val["permissions"].get("rule_summary").is_none(),
+        "K5: v2 wire shape must keep the empty-state honesty disclosure \
+         (rule_summary omitted when no policies); got: {val}"
+    );
+}


### PR DESCRIPTION
Track K task K5 of v0.7.0 attested-cortex epic.

## Summary
- New CapabilityPermissions.rule_summary field (Vec<String> with `skip_serializing_if = "Vec::is_empty"`)
- Built from active governance policies at capabilities-build time
- One-line per-rule summary (namespace + level values + approver discriminator + inherit)
- Sorted lex by namespace (ORDER BY at the SQL layer)
- Closes the v0.6.3.1 honest-disclosure that this field was a placeholder

## Test plan
- [x] cargo fmt --check + lib clippy --pedantic clean
- [x] cargo test --lib green (2143 passed)
- [x] Empty / single / multi-policy paths tested