### PR TITLE
feat: v0.7-b1 — memory_load_family always-on tool

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2069,8 +2069,8 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (45 tools loaded)"),
-            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify)"
+            stdout.contains("Full   (46 tools loaded)"),
+            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2126,8 +2126,8 @@ mod tests {
         let tools = v["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            45,
-            "raw_table must include all 45 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify)"
+            46,
+            "raw_table must include all 46 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/db.rs
+++ b/src/db.rs
@@ -895,7 +895,7 @@ fn migrate(conn: &Connection) -> Result<()> {
     }
 }
 
-fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
+pub(crate) fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     let tags_json: String = row.get("tags")?;
     let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
     let tier_str: String = row.get("tier")?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -405,6 +405,19 @@ pub(crate) fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_load_family",
+                "description": "v0.7 B1 — load top-k recent + high-priority memories tagged with metadata.family=<family>. Always-on alternative to memory_recall when the family is known.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "family": {"type": "string", "enum": ["core", "lifecycle", "graph", "governance", "power", "meta", "archive", "other"], "description": "Family taxonomy enum (one of the eight)."},
+                        "namespace": {"type": "string", "description": "Restrict to this namespace. Defaults to all namespaces when omitted."},
+                        "k": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20, "description": "Top-k to return. Capped at 100."}
+                    },
+                    "required": ["family"]
+                }
+            },
+            {
                 "name": "memory_get_taxonomy",
                 "description": "Pillar 1 / Stream A — return a hierarchical tree of namespaces with memory counts. Walks the `/`-delimited namespace paths grouped from live memories (expired rows excluded). Each node carries `count` (memories at exactly that namespace) and `subtree_count` (count plus all descendants visible within `depth`); the response also exposes `total_count` for the prefix and a `truncated` flag set when `limit` forced rows to be dropped from the tree.",
                 "inputSchema": {
@@ -2141,7 +2154,7 @@ pub fn build_capabilities_tools(
     use crate::config::{AllowlistDecision, ToolEntry};
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let mut entries: Vec<ToolEntry> = Vec::with_capacity(45);
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(46);
 
     for fam in Family::all() {
         let family_name = fam.name();
@@ -2745,6 +2758,102 @@ fn handle_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, Str
     )
     .map_err(|e| e.to_string())?;
     Ok(json!({"memories": results, "count": results.len()}))
+}
+
+/// v0.7 B1 — `memory_load_family(family, namespace?, k?)`.
+///
+/// Always-on alternative to `memory_recall` for the case where the agent
+/// already knows which `Family` taxonomy bucket it wants. Returns the
+/// top-k recent + high-priority memories whose `metadata.family` matches
+/// the requested enum, ordered by `priority DESC, updated_at DESC`,
+/// optionally restricted to a single namespace.
+///
+/// Conventions:
+///
+/// - `family` is required. Validated against the eight-family enum
+///   (core/lifecycle/graph/governance/power/meta/archive/other) — anything
+///   else returns the same `ProfileParseError::UnknownFamily` diagnostic
+///   the rest of the codebase uses, so the error message lists the valid
+///   options.
+/// - `namespace` is optional. When omitted the query spans every
+///   namespace; this matches `memory_list`'s "no namespace = all"
+///   convention.
+/// - `k` defaults to 20 (mirroring `memory_list`'s default `limit`) and
+///   is capped at 100 to bound the response payload. Values outside
+///   `[1, 100]` are clamped silently rather than rejected — the cap is
+///   for response budget, not for correctness.
+///
+/// Filter shape: `json_extract(memories.metadata, '$.family') = ?` —
+/// no schema change is needed because v0.7 B1 stores the family tag in
+/// the existing free-form `metadata` JSON column. Memories that don't
+/// carry a `metadata.family` are invisible to this tool by design (the
+/// caller would use `memory_list` or `memory_recall` for the unfiltered
+/// case).
+///
+/// Response shape:
+/// ```json
+/// {
+///   "family": "core",
+///   "namespace": "projects/alpha",   // or null when omitted
+///   "k": 20,
+///   "count": 3,
+///   "memories": [<MemoryRow>, ...]
+/// }
+/// ```
+pub fn handle_load_family(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    use crate::profile::Family;
+    use std::str::FromStr;
+
+    let family_raw = params["family"].as_str().ok_or("family is required")?;
+    // Reuse the canonical enum parser so the diagnostic on a bad
+    // `family` value lists the valid options verbatim. Lowercase only,
+    // matching the rest of the family vocabulary.
+    let family = Family::from_str(family_raw).map_err(|e| e.to_string())?;
+    let family_name = family.name();
+
+    let namespace = params.get("namespace").and_then(Value::as_str);
+    if let Some(ns) = namespace {
+        validate::validate_namespace(ns).map_err(|e| e.to_string())?;
+    }
+
+    // Default 20, cap at 100 (per spec). Anything below 1 collapses to 1
+    // — calling `memory_load_family(k=0)` is almost always a bug, and
+    // the always-return-at-least-one shape lines up with R1's recall
+    // budget guarantee.
+    let k_raw = params.get("k").and_then(Value::as_u64).unwrap_or(20);
+    let k = usize::try_from(k_raw).unwrap_or(usize::MAX).clamp(1, 100);
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, tier, namespace, title, content, tags, priority, confidence, source, \
+                    access_count, created_at, updated_at, last_accessed_at, expires_at, metadata \
+             FROM memories \
+             WHERE (?1 IS NULL OR namespace = ?1) \
+               AND json_extract(metadata, '$.family') = ?2 \
+               AND (expires_at IS NULL OR expires_at > ?3) \
+             ORDER BY priority DESC, updated_at DESC \
+             LIMIT ?4",
+        )
+        .map_err(|e| format!("prepare memory_load_family failed: {e}"))?;
+
+    let rows = stmt
+        .query_map(
+            rusqlite::params![namespace, family_name, now, k],
+            db::row_to_memory,
+        )
+        .map_err(|e| format!("query memory_load_family failed: {e}"))?;
+    let memories: Vec<Memory> = rows
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| format!("collect memory_load_family rows failed: {e}"))?;
+
+    Ok(json!({
+        "family": family_name,
+        "namespace": namespace,
+        "k": k,
+        "count": memories.len(),
+        "memories": memories,
+    }))
 }
 
 fn handle_delete(
@@ -4499,6 +4608,7 @@ fn handle_request(
                 ),
                 "memory_search" => handle_search(conn, arguments),
                 "memory_list" => handle_list(conn, arguments),
+                "memory_load_family" => handle_load_family(conn, arguments),
                 "memory_get_taxonomy" => handle_get_taxonomy(conn, arguments),
                 "memory_check_duplicate" => handle_check_duplicate(conn, arguments, embedder),
                 "memory_entity_register" => handle_entity_register(conn, arguments, mcp_client),
@@ -5061,7 +5171,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_45_tools() {
+    fn tool_definitions_returns_46_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
@@ -5070,25 +5180,26 @@ mod tests {
         // on top of the 36-tool v0.6.0.0 surface = 43.
         // v0.7.0 I4 adds memory_replay (Family::Graph) → 44.
         // v0.7 H4 adds memory_verify (Family::Graph) → 45.
+        // v0.7 B1 adds memory_load_family (Family::Core) → 46.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 45);
+        assert_eq!(tools.len(), 46);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
-    /// registers exactly 5 family tools + 1 always-on bootstrap
-    /// (memory_capabilities) = 6 visible tools. `--profile full`
-    /// registers all 45 (43 v0.6.3 + memory_replay + memory_verify).
+    /// registers exactly 6 family tools (5 baseline + v0.7 B1
+    /// memory_load_family) + 1 always-on bootstrap (memory_capabilities)
+    /// = 7 visible tools. `--profile full` registers all 46.
     #[test]
-    fn tool_definitions_for_profile_core_registers_5_plus_capabilities() {
+    fn tool_definitions_for_profile_core_registers_6_plus_capabilities() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::core());
         let tools = defs["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-        // Exactly the 5 core tools + memory_capabilities bootstrap.
+        // Exactly the 6 core tools + memory_capabilities bootstrap.
         assert_eq!(
             tools.len(),
-            6,
-            "core profile should register 5 core tools + memory_capabilities; got {names:?}"
+            7,
+            "core profile should register 6 core tools + memory_capabilities; got {names:?}"
         );
         for required in [
             "memory_store",
@@ -5096,6 +5207,7 @@ mod tests {
             "memory_list",
             "memory_get",
             "memory_search",
+            "memory_load_family",
             "memory_capabilities",
         ] {
             assert!(
@@ -5119,27 +5231,30 @@ mod tests {
     }
 
     #[test]
-    fn tool_definitions_for_profile_full_registers_45() {
+    fn tool_definitions_for_profile_full_registers_46() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::full());
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            45,
-            "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay (1) + v0.7 H4 memory_verify (1) = 45"
+            46,
+            "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay (1) + \
+             v0.7 H4 memory_verify (1) + v0.7 B1 memory_load_family (1) = 46"
         );
     }
 
     #[test]
-    fn tool_definitions_for_profile_graph_registers_sixteen() {
+    fn tool_definitions_for_profile_graph_registers_seventeen() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::graph());
         let tools = defs["tools"].as_array().unwrap();
-        // 5 core + 10 graph (8 baseline + memory_replay + memory_verify)
-        // + 1 always-on capabilities = 16 (capabilities is in meta but
-        // loaded as bootstrap; without it we'd have 15).
+        // 6 core (with v0.7 B1 memory_load_family) + 10 graph (8
+        // baseline + memory_replay + memory_verify) + 1 always-on
+        // capabilities = 17 (capabilities is in meta but loaded as
+        // bootstrap; without it we'd have 16).
         assert_eq!(
             tools.len(),
-            16,
-            "graph profile = core(5) + graph(10, with memory_replay+memory_verify) + capabilities-bootstrap(1)"
+            17,
+            "graph profile = core(6, with memory_load_family) + \
+             graph(10, with memory_replay+memory_verify) + capabilities-bootstrap(1)"
         );
     }
 
@@ -5151,8 +5266,8 @@ mod tests {
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            16,
-            "core,graph = 5 + 10 (I4 memory_replay + H4 memory_verify) + capabilities = 16"
+            17,
+            "core,graph = 6 (B1 memory_load_family) + 10 (I4 memory_replay + H4 memory_verify) + capabilities = 17"
         );
     }
 
@@ -5167,7 +5282,8 @@ mod tests {
 
         let core_row = families.iter().find(|r| r["name"] == "core").unwrap();
         assert_eq!(core_row["loaded"], true);
-        assert_eq!(core_row["tool_count"], 5);
+        // v0.7 B1 — Core now ships 6 tools (5 baseline + memory_load_family).
+        assert_eq!(core_row["tool_count"], 6);
         let graph_row = families.iter().find(|r| r["name"] == "graph").unwrap();
         assert_eq!(graph_row["loaded"], false);
         // v0.7 H4 — graph now ships 10 tools (8 baseline + memory_replay
@@ -5564,9 +5680,9 @@ mod tests {
             "missing err outcome in: {captured}"
         );
     }
-    /// Parametrized smoke matrix for all 45 MCP tools (Justice of MCP pathway).
+    /// Parametrized smoke matrix for all 46 MCP tools (Justice of MCP pathway).
     /// v0.6.3 baseline = 43; v0.7.0 I4 added memory_replay (44);
-    /// v0.7 H4 added memory_verify (45).
+    /// v0.7 H4 added memory_verify (45); v0.7 B1 added memory_load_family (46).
     /// Tier 1: happy path with canonical valid args.
     /// Tier 2: required arg validation (missing required arg → error).
     #[test]
@@ -5603,6 +5719,11 @@ mod tests {
                 name: "memory_list",
                 valid_args: json!({}),
                 required_arg: None,
+            },
+            ToolCase {
+                name: "memory_load_family",
+                valid_args: json!({"family": "core"}),
+                required_arg: Some("family"),
             },
             ToolCase {
                 name: "memory_get_taxonomy",

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -24,12 +24,13 @@
 //!
 //! ## Profile vocabulary
 //!
-//! - `core` — 5 tools, the new v0.6.4 default. Always loaded.
-//! - `graph` — adds the 10 KG/entity/replay/verify tools. ~15 tools.
-//! - `admin` — adds lifecycle (5) + governance (8). ~18 tools.
+//! - `core` — 6 tools, the new v0.6.4 default (v0.7 B1 added
+//!   `memory_load_family`). Always loaded.
+//! - `graph` — adds the 10 KG/entity/replay/verify tools. ~16 tools.
+//! - `admin` — adds lifecycle (5) + governance (8). ~19 tools.
 //! - `power` — adds the 6 LLM-augmented tools (consolidate, auto_tag, …).
-//!   ~11 tools.
-//! - `full` — every family. 45 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify`).
+//!   ~12 tools.
+//! - `full` — every family. 46 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 `memory_load_family`).
 //! - `custom` — comma-separated family list (`core,graph,archive` …).
 //!   `core` is implicitly added if missing — there's no profile that
 //!   ships *less than* the 5 core tools.
@@ -55,12 +56,15 @@
 use std::str::FromStr;
 
 /// A tool family. Source-anchored at `src/mcp.rs::tool_definitions()`
-/// 2026-05-05. Counts must sum to 45 (the v0.6.3.1 baseline of 43 +
-/// v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify`, both in
-/// `Family::Graph`).
+/// 2026-05-05. Counts must sum to 46 (the v0.6.3.1 baseline of 43 +
+/// v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` (both in
+/// `Family::Graph`) + v0.7 B1 `memory_load_family` in `Family::Core`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Family {
-    /// store, recall, list, get, search — 5
+    /// store, recall, list, get, search, load_family — 6
+    /// (load_family added in v0.7 B1 — always-on family loader that
+    /// returns the top-k recent + high-priority memories whose
+    /// `metadata.family` matches one of the eight enum names.)
     Core,
     /// update, delete, forget, gc, promote — 5
     Lifecycle,
@@ -102,10 +106,11 @@ impl Family {
     #[must_use]
     pub fn for_tool(name: &str) -> Option<Self> {
         match name {
-            // core (5)
-            "memory_store" | "memory_recall" | "memory_list" | "memory_get" | "memory_search" => {
-                Some(Self::Core)
-            }
+            // core (6 — v0.7 B1 added memory_load_family as the always-on
+            // alternative to memory_recall when the agent already knows
+            // which family taxonomy it wants).
+            "memory_store" | "memory_recall" | "memory_list" | "memory_get" | "memory_search"
+            | "memory_load_family" => Some(Self::Core),
             // lifecycle (5)
             "memory_update" | "memory_delete" | "memory_forget" | "memory_gc"
             | "memory_promote" => Some(Self::Lifecycle),
@@ -189,7 +194,9 @@ impl Family {
     #[must_use]
     pub const fn expected_tool_count(self) -> usize {
         match self {
-            Self::Core | Self::Lifecycle | Self::Meta => 5,
+            // Core: 5 baseline + memory_load_family (v0.7 B1) = 6.
+            Self::Core => 6,
+            Self::Lifecycle | Self::Meta => 5,
             // Graph: 8 baseline + memory_replay (v0.7.0 I4) + memory_verify (v0.7 H4) = 10.
             Self::Graph => 10,
             Self::Governance => 8,
@@ -220,6 +227,9 @@ impl Family {
                 "memory_list",
                 "memory_get",
                 "memory_search",
+                // v0.7 B1 — always-on alternative to memory_recall when
+                // the agent already knows the Family taxonomy it wants.
+                "memory_load_family",
             ],
             Self::Lifecycle => &[
                 "memory_update",
@@ -309,8 +319,9 @@ pub struct Profile {
 }
 
 impl Profile {
-    /// `core` — 5 tools (`store, recall, list, get, search`). The new
-    /// v0.6.4 default. Registers exactly the `Core` family.
+    /// `core` — 6 tools (`store, recall, list, get, search, load_family`).
+    /// The new v0.6.4 default; v0.7 B1 added `memory_load_family` as the
+    /// always-on family loader. Registers exactly the `Core` family.
     ///
     /// **Design note (v0.6.4-002 hook):** `memory_capabilities` is
     /// **always-on** regardless of profile per RFC scenario S27. It is
@@ -326,8 +337,9 @@ impl Profile {
         }
     }
 
-    /// `graph` — core + graph. 15 tools (v0.7.0 I4 added `memory_replay`;
-    /// v0.7 H4 added `memory_verify`).
+    /// `graph` — core + graph. 16 tools (v0.7.0 I4 added `memory_replay`;
+    /// v0.7 H4 added `memory_verify`; v0.7 B1 added `memory_load_family`
+    /// to core).
     #[must_use]
     pub fn graph() -> Self {
         Self {
@@ -335,7 +347,8 @@ impl Profile {
         }
     }
 
-    /// `admin` — core + lifecycle + governance. 18 tools.
+    /// `admin` — core + lifecycle + governance. 19 tools (v0.7 B1
+    /// added `memory_load_family` to core).
     #[must_use]
     pub fn admin() -> Self {
         Self {
@@ -343,7 +356,8 @@ impl Profile {
         }
     }
 
-    /// `power` — core + power. 11 tools.
+    /// `power` — core + power. 12 tools (v0.7 B1 added
+    /// `memory_load_family` to core).
     #[must_use]
     pub fn power() -> Self {
         Self {
@@ -351,8 +365,9 @@ impl Profile {
         }
     }
 
-    /// `full` — every family. 45 tools (v0.6.3 baseline 43 + v0.7.0 I4
-    /// `memory_replay` + v0.7 H4 `memory_verify`).
+    /// `full` — every family. 46 tools (v0.6.3 baseline 43 + v0.7.0 I4
+    /// `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1
+    /// `memory_load_family`).
     #[must_use]
     pub fn full() -> Self {
         Self {
@@ -531,13 +546,14 @@ mod tests {
     }
 
     #[test]
-    fn family_expected_tool_counts_sum_to_45() {
+    fn family_expected_tool_counts_sum_to_46() {
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 45,
+            total, 46,
             "v0.6.3.1 baseline (43) + v0.7.0 I4 `memory_replay` + v0.7 H4 \
-             `memory_verify` = 45. If this drifts, update \
-             Family::expected_tool_count and the family map docs together."
+             `memory_verify` + v0.7 B1 `memory_load_family` = 46. If this \
+             drifts, update Family::expected_tool_count and the family \
+             map docs together."
         );
     }
 
@@ -572,9 +588,10 @@ mod tests {
     // ---------- Profile named ----------
 
     #[test]
-    fn profile_core_has_five_tools() {
+    fn profile_core_has_six_tools() {
         let p = Profile::core();
-        assert_eq!(p.expected_tool_count(), 5);
+        // v0.7 B1 — Core now ships 6 tools (5 baseline + memory_load_family).
+        assert_eq!(p.expected_tool_count(), 6);
         assert!(p.includes(Family::Core));
         // meta is NOT in core's family list — `memory_capabilities`
         // is bootstrapped separately as always-on per RFC S27. The
@@ -585,35 +602,37 @@ mod tests {
     }
 
     #[test]
-    fn profile_graph_has_fifteen_tools() {
+    fn profile_graph_has_sixteen_tools() {
         let p = Profile::graph();
         // v0.7 H4 — Graph now ships 10 tools (8 baseline + memory_replay
-        // [I4] + memory_verify [H4]).
-        assert_eq!(p.expected_tool_count(), 5 + 10);
+        // [I4] + memory_verify [H4]); v0.7 B1 added memory_load_family
+        // to core (6 instead of 5).
+        assert_eq!(p.expected_tool_count(), 6 + 10);
         assert!(p.includes(Family::Graph));
     }
 
     #[test]
-    fn profile_admin_has_eighteen_tools() {
+    fn profile_admin_has_nineteen_tools() {
         let p = Profile::admin();
-        // admin = core (5) + lifecycle (5) + governance (8). Graph isn't
-        // in admin so the v0.7.0 I4 memory_replay addition doesn't change
-        // this count.
-        assert_eq!(p.expected_tool_count(), 5 + 5 + 8);
+        // admin = core (6, with v0.7 B1 memory_load_family) + lifecycle
+        // (5) + governance (8) = 19. Graph isn't in admin so the v0.7.0
+        // I4 memory_replay addition doesn't change this count.
+        assert_eq!(p.expected_tool_count(), 6 + 5 + 8);
     }
 
     #[test]
-    fn profile_power_has_eleven_tools() {
+    fn profile_power_has_twelve_tools() {
         let p = Profile::power();
-        assert_eq!(p.expected_tool_count(), 5 + 6);
+        // v0.7 B1 — Core now ships 6 tools (was 5).
+        assert_eq!(p.expected_tool_count(), 6 + 6);
     }
 
     #[test]
-    fn profile_full_has_forty_five_tools() {
+    fn profile_full_has_forty_six_tools() {
         let p = Profile::full();
-        // v0.7 H4 — full surface = 43 baseline + memory_replay (I4) +
-        // memory_verify (H4) = 45.
-        assert_eq!(p.expected_tool_count(), 45);
+        // v0.7 B1 — full surface = 43 baseline + memory_replay (I4) +
+        // memory_verify (H4) + memory_load_family (B1) = 46.
+        assert_eq!(p.expected_tool_count(), 46);
     }
 
     // ---------- Profile::parse ----------
@@ -635,14 +654,14 @@ mod tests {
 
     #[test]
     fn parse_custom_comma_list_dedup() {
-        // `core,graph` → core (5) + graph (10, after v0.7 H4) = 15 tools.
-        // Meta is NOT included — `memory_capabilities` is always-on
-        // bootstrapped outside the family map (v0.6.4-002).
+        // `core,graph` → core (6, after v0.7 B1) + graph (10, after v0.7
+        // H4) = 16 tools. Meta is NOT included — `memory_capabilities`
+        // is always-on bootstrapped outside the family map (v0.6.4-002).
         let p = Profile::parse("core,graph").unwrap();
         assert!(p.includes(Family::Core));
         assert!(!p.includes(Family::Meta));
         assert!(p.includes(Family::Graph));
-        assert_eq!(p.expected_tool_count(), 15);
+        assert_eq!(p.expected_tool_count(), 16);
     }
 
     #[test]
@@ -733,6 +752,8 @@ mod tests {
             "memory_list",
             "memory_get",
             "memory_search",
+            // core (v0.7 B1 addition)
+            "memory_load_family",
             // lifecycle
             "memory_update",
             "memory_delete",
@@ -785,8 +806,9 @@ mod tests {
         ];
         assert_eq!(
             baseline.len(),
-            45,
-            "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) + 1 (v0.7 H4 memory_verify) = 45"
+            46,
+            "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) + \
+             1 (v0.7 H4 memory_verify) + 1 (v0.7 B1 memory_load_family) = 46"
         );
         for name in baseline {
             assert!(

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -140,12 +140,13 @@ mod tests {
     /// `tool_definitions()` regressions that would silently hide other
     /// failures.
     #[test]
-    fn table_has_45_entries_matching_tool_definitions_count() {
+    fn table_has_46_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 45,
-            "expected exactly 45 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
-             `memory_replay` + v0.7 H4 `memory_verify`, source-anchored at \
+            n, 46,
+            "expected exactly 46 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
+             `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 \
+             `memory_load_family`, source-anchored at \
              src/mcp.rs::tool_definitions); got {n}. If the count changed, \
              update the family map and this assertion together."
         );

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -60,15 +60,18 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    // 39 = 44 user-relevant tools − 5 core. (44 = 45 total tools − 1
+    // 39 = 45 user-relevant tools − 6 core. (45 = 46 total tools − 1
     // always-on bootstrap.) The bootstrap (`memory_capabilities`) is
     // excluded from BOTH the loaded and the unloaded count in
     // `to_describe_to_user` (it's plumbing, not a feature). Total
     // bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
-    // `memory_replay`; then to 45 in v0.7 H4 — Family::Graph gained
-    // `memory_verify`.
-    let expected = "I can directly use 5 memory tools right now \
-                    (store, recall, list, get, search). 39 more \
+    // `memory_replay`; to 45 in v0.7 H4 — Family::Graph gained
+    // `memory_verify`; to 46 in v0.7 B1 — Family::Core gained
+    // `memory_load_family`. Loaded under core bumped from 5 to 6 with
+    // B1, so the preview now overflows the 5-name cap (ends in
+    // ", ...").
+    let expected = "I can directly use 6 memory tools right now \
+                    (store, recall, list, get, search, ...). 39 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -84,9 +87,10 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
 // ---------------------------------------------------------------------------
 // T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
 // "nothing more to load" closing form (excludes the always-on bootstrap
-// from the user-facing 44 count). Bumped from 42 to 43 in v0.7.0 I4 —
-// Family::Graph gained `memory_replay`; then to 44 in v0.7 H4 —
-// Family::Graph gained `memory_verify`.
+// from the user-facing 45 count). Bumped from 42 to 43 in v0.7.0 I4 —
+// Family::Graph gained `memory_replay`; to 44 in v0.7 H4 —
+// Family::Graph gained `memory_verify`; to 45 in v0.7 B1 —
+// Family::Core gained `memory_load_family`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_full_profile_canonical_phrasing() {
@@ -95,7 +99,7 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use all 44 memory tools right now \
+    let expected = "I can directly use all 45 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -109,10 +113,11 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
 
 // ---------------------------------------------------------------------------
 // T0-A2-GRAPH — `to_describe_to_user` on `--profile graph` uses the
-// preview-with-ellipsis form (5 of 15 loaded shown + ", ..."). Loaded
+// preview-with-ellipsis form (5 of 16 loaded shown + ", ..."). Loaded
 // bumped from 13 to 14 in v0.7.0 I4 — Family::Graph gained
-// `memory_replay`; then to 15 in v0.7 H4 — Family::Graph gained
-// `memory_verify`.
+// `memory_replay`; to 15 in v0.7 H4 — Family::Graph gained
+// `memory_verify`; to 16 in v0.7 B1 — Family::Core gained
+// `memory_load_family`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_graph_profile_canonical_phrasing() {
@@ -121,7 +126,7 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use 15 memory tools right now \
+    let expected = "I can directly use 16 memory tools right now \
                     (store, recall, list, get, search, ...). 29 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -151,27 +151,29 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `core` profile honestly reports 6 of 45 visible (5 core
-// tools + memory_capabilities always-on bootstrap), labels the profile
-// "core", and references all three named recovery paths. (Total bumped
-// from 43 to 44 in v0.7.0 I4 — Family::Graph gained `memory_replay`; then
-// 44 to 45 in v0.7 H4 — Family::Graph gained `memory_verify`.)
+// summary on the `core` profile honestly reports 7 of 46 visible (6 core
+// tools — including v0.7 B1 `memory_load_family` — plus the
+// memory_capabilities always-on bootstrap), labels the profile "core",
+// and references all three named recovery paths. (Total bumped from 43
+// to 44 in v0.7.0 I4 — Family::Graph gained `memory_replay`; 44 to 45
+// in v0.7 H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7
+// B1 — Family::Core gained `memory_load_family`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     let summary = build_capabilities_summary(&Profile::core());
 
-    // Visible = 5 core + 1 always-on (`memory_capabilities` lives in
-    // Family::Meta which the core profile doesn't load, so the bootstrap
-    // injection adds it back).
+    // Visible = 6 core (with v0.7 B1 memory_load_family) + 1 always-on
+    // (`memory_capabilities` lives in Family::Meta which the core
+    // profile doesn't load, so the bootstrap injection adds it back).
     assert!(
-        summary.starts_with("6 of 45 tools"),
-        "core profile summary should open with \"6 of 45 tools\"; got: {summary}"
+        summary.starts_with("7 of 46 tools"),
+        "core profile summary should open with \"7 of 46 tools\"; got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
         summary.contains("39 are listed in this manifest"),
-        "core profile must report 39 unloaded (45 - 6); got: {summary}"
+        "core profile must report 39 unloaded (46 - 7); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -183,20 +185,21 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `full` profile reports 45 of 45 visible, 0 unloaded, and
+// summary on the `full` profile reports 46 of 46 visible, 0 unloaded, and
 // labels the profile "full". The recovery paths are still listed —
 // they're the canonical recovery vocabulary the LLM gets calibrated on
 // regardless of the current profile state. (Total bumped from 43 to 44
-// in v0.7.0 I4 — Family::Graph gained `memory_replay`; then 44 to 45 in
-// v0.7 H4 — Family::Graph gained `memory_verify`.)
+// in v0.7.0 I4 — Family::Graph gained `memory_replay`; 44 to 45 in v0.7
+// H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7 B1 —
+// Family::Core gained `memory_load_family`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_full_profile_reports_all_visible() {
     let summary = build_capabilities_summary(&Profile::full());
 
     assert!(
-        summary.starts_with("45 of 45 tools"),
-        "full profile summary should open with \"45 of 45 tools\"; got: {summary}"
+        summary.starts_with("46 of 46 tools"),
+        "full profile summary should open with \"46 of 46 tools\"; got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -211,16 +214,16 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `graph` profile counts 15 visible (5 core + 10 graph,
-// after v0.7 H4) + the bootstrap, labels the profile "graph", and
-// reports the rest as unloaded.
+// summary on the `graph` profile counts 16 visible (6 core after v0.7 B1
+// + 10 graph after v0.7 H4) + the bootstrap, labels the profile
+// "graph", and reports the rest as unloaded.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_graph_profile_counts() {
     let summary = build_capabilities_summary(&Profile::graph());
     assert!(
-        summary.starts_with("16 of 45 tools"),
-        "graph profile = 5 core + 10 graph (v0.7 H4) + 1 always-on bootstrap = 16; got: {summary}"
+        summary.starts_with("17 of 46 tools"),
+        "graph profile = 6 core (v0.7 B1) + 10 graph (v0.7 H4) + 1 always-on bootstrap = 17; got: {summary}"
     );
     assert!(summary.contains("(graph)"));
     assert!(summary.contains("29 are listed in this manifest"));
@@ -305,21 +308,25 @@ fn cap_v3_response_carries_to_describe_to_user() {
 fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     let describe = build_capabilities_describe_to_user(&Profile::core());
 
-    // Opens with the canonical "I can directly use N memory tool(s)" form.
+    // Opens with the canonical "I can directly use N memory tool(s)"
+    // form. v0.7 B1 — Core gained memory_load_family so loaded count
+    // is now 6, and the preview overflows the 5-name cap (ends in
+    // ", ...").
     assert!(
-        describe.starts_with("I can directly use 5 memory tools right now ("),
+        describe.starts_with("I can directly use 6 memory tools right now ("),
         "core profile describe must open canonically; got: {describe}"
     );
-    // Loaded preview lists the 5 core tool names with the memory_
-    // prefix STRIPPED (no MCP jargon for end users).
-    assert!(describe.contains("(store, recall, list, get, search)"));
-    // Reports the unloaded count. 39 = 44 user-relevant tools − 5
-    // core. (44 = 45 total tools − 1 always-on bootstrap.) The
+    // Loaded preview lists the first 5 core tool names with the
+    // memory_ prefix STRIPPED (no MCP jargon for end users), followed
+    // by ", ..." since core now ships 6 tools (v0.7 B1).
+    assert!(describe.contains("(store, recall, list, get, search, ...)"));
+    // Reports the unloaded count. 39 = 45 user-relevant tools − 6
+    // core. (45 = 46 total tools − 1 always-on bootstrap.) The
     // bootstrap (`memory_capabilities`) is excluded from both sides
     // for honest user-facing counting. Total bumped to 44 in v0.7.0
-    // I4 (Family::Graph gained `memory_replay`), then to 45 in v0.7
-    // H4 (Family::Graph gained `memory_verify`), so the unloaded
-    // count under core grew by 2 from the original 37.
+    // I4 (Family::Graph gained `memory_replay`), to 45 in v0.7 H4
+    // (Family::Graph gained `memory_verify`), and to 46 in v0.7 B1
+    // (Family::Core gained `memory_load_family`).
     assert!(
         describe.contains("39 more"),
         "core profile must report 39 unloaded; got: {describe}"
@@ -345,23 +352,25 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `full` profile reports all 44 tools loaded
+// A2: to_describe_to_user on `full` profile reports all 45 tools loaded
 // (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
 // uses the "nothing more to load" closing form rather than the recovery
 // hint. (Bumped from 42 to 43 in v0.7.0 I4 — Family::Graph gained
-// `memory_replay`; then 43 to 44 in v0.7 H4 — Family::Graph gained
-// `memory_verify`.)
+// `memory_replay`; 43 to 44 in v0.7 H4 — Family::Graph gained
+// `memory_verify`; 44 to 45 in v0.7 B1 — Family::Core gained
+// `memory_load_family`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 44 = 45 total - 1 always-on bootstrap excluded from describe.
+    // 45 = 46 total - 1 always-on bootstrap excluded from describe.
     // Bumped from 42 to 43 in v0.7.0 I4 (Family::Graph gained
     // `memory_replay`); 43 to 44 in v0.7 H4 (Family::Graph gained
-    // `memory_verify`).
+    // `memory_verify`); 44 to 45 in v0.7 B1 (Family::Core gained
+    // `memory_load_family`).
     assert!(
-        describe.starts_with("I can directly use all 44 memory tools right now ("),
+        describe.starts_with("I can directly use all 45 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -371,18 +380,18 @@ fn cap_v3_describe_full_profile_uses_nothing_more_form() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `graph` profile (5 core + 10 graph after
-// v0.7 H4) lists 15 loaded with a 5-name preview ending in ", ..."
-// since there are more loaded than the preview shows.
+// A2: to_describe_to_user on `graph` profile (6 core after v0.7 B1 + 10
+// graph after v0.7 H4) lists 16 loaded with a 5-name preview ending in
+// ", ..." since there are more loaded than the preview shows.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     let describe = build_capabilities_describe_to_user(&Profile::graph());
     assert!(
-        describe.starts_with("I can directly use 15 memory tools right now ("),
-        "graph profile describe should open with 15 loaded; got: {describe}"
+        describe.starts_with("I can directly use 16 memory tools right now ("),
+        "graph profile describe should open with 16 loaded; got: {describe}"
     );
-    // Preview is the first 5 of the 15 loaded — the 5 core tools.
+    // Preview is the first 5 of the 16 loaded — the first 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
     assert!(describe.contains("29 more"));
 }
@@ -540,14 +549,15 @@ fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
 
 // ---------------------------------------------------------------------------
 // A3 — the v3 response surfaces the `tools` array at the top level
-// with one entry per registered tool (45 + always-on bootstrap counted
-// once = 45, since the bootstrap already lives in Family::Meta).
+// with one entry per registered tool (46 + always-on bootstrap counted
+// once = 46, since the bootstrap already lives in Family::Meta).
 // (Bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
-// `memory_replay`; then 44 to 45 in v0.7 H4 — Family::Graph gained
-// `memory_verify`.)
+// `memory_replay`; 44 to 45 in v0.7 H4 — Family::Graph gained
+// `memory_verify`; 45 to 46 in v0.7 B1 — Family::Core gained
+// `memory_load_family`.)
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_response_carries_tools_array_with_45_entries() {
+fn cap_v3_response_carries_tools_array_with_46_entries() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
     let val = handle_capabilities_with_conn_v3(
@@ -567,9 +577,10 @@ fn cap_v3_response_carries_tools_array_with_45_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        45,
-        "v3 must surface all 45 tools regardless of profile (v0.7.0 I4 added \
-         memory_replay; v0.7 H4 added memory_verify); got {}",
+        46,
+        "v3 must surface all 46 tools regardless of profile (v0.7.0 I4 added \
+         memory_replay; v0.7 H4 added memory_verify; v0.7 B1 added \
+         memory_load_family); got {}",
         tools.len()
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1867,8 +1867,8 @@ fn test_mcp_tools_list() {
         .expect("tools should be array");
     assert_eq!(
         tools.len(),
-        45,
-        "expected 45 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify)"
+        46,
+        "expected 46 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
     );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();

--- a/tests/memory_load_family.rs
+++ b/tests/memory_load_family.rs
@@ -1,0 +1,183 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7 Track B1 — `memory_load_family` MCP tool integration tests.
+//!
+//! B1 ships an always-on alternative to `memory_recall` for the case
+//! where the agent already knows the `Family` taxonomy bucket it cares
+//! about. The handler filters memories by `metadata.family` (one of the
+//! eight enum names) and returns the top-k recent + high-priority
+//! matches inside the requested namespace.
+//!
+//! Scenarios pinned here:
+//! 1. Family filter is exact — three memories with different families
+//!    seeded; loading one family returns only its match.
+//! 2. Namespace filter narrows the result set (cross-namespace
+//!    bleed-through is a regression).
+//! 3. `k` defaults to 20 and caps at 100 (silent clamp, not error).
+//! 4. Unknown family returns the canonical `UnknownFamily` diagnostic.
+
+use ai_memory::db;
+use ai_memory::mcp::handle_load_family;
+use ai_memory::models::{self, Memory, Tier};
+use chrono::Utc;
+use serde_json::{Value, json};
+
+fn open_db() -> rusqlite::Connection {
+    db::open(std::path::Path::new(":memory:")).expect("open in-memory db")
+}
+
+/// Seed a memory tagged with `metadata.family = <family>` and the given
+/// namespace. The B1 handler walks `json_extract(metadata, '$.family')`,
+/// so the family-string must land inside the metadata JSON.
+fn seed_family_memory(
+    conn: &rusqlite::Connection,
+    title: &str,
+    namespace: &str,
+    family: &str,
+    priority: i32,
+) -> String {
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Mid,
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        content: format!("seeded for {family}"),
+        tags: vec![],
+        priority,
+        confidence: 1.0,
+        source: "import".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"family": family}),
+    };
+    let _ = models::default_metadata(); // keep the import live for parity with sibling tests
+    db::insert(conn, &mem).expect("db::insert")
+}
+
+// ---------------------------------------------------------------------------
+// 1. Family filter is exact — only the matching family is returned.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_family_returns_only_matching_family() {
+    let conn = open_db();
+
+    // Three memories under the same namespace but with three different
+    // family tags. memory_load_family(family=core) must return only the
+    // first one.
+    let core_id = seed_family_memory(&conn, "core-mem", "ns-a", "core", 5);
+    let _graph_id = seed_family_memory(&conn, "graph-mem", "ns-a", "graph", 5);
+    let _power_id = seed_family_memory(&conn, "power-mem", "ns-a", "power", 5);
+
+    let resp: Value = handle_load_family(&conn, &json!({"family": "core", "namespace": "ns-a"}))
+        .expect("memory_load_family must succeed");
+
+    assert_eq!(resp["family"], "core");
+    assert_eq!(resp["namespace"], "ns-a");
+    assert_eq!(
+        resp["count"], 1,
+        "only the core memory must come back; got: {resp}"
+    );
+    let memories = resp["memories"].as_array().expect("memories array");
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0]["id"], core_id);
+    assert_eq!(memories[0]["title"], "core-mem");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Namespace filter narrows the result set — cross-namespace
+//    bleed-through is a regression.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_family_namespace_filter_narrows_result_set() {
+    let conn = open_db();
+
+    // Two `core` memories in two different namespaces.
+    let here_id = seed_family_memory(&conn, "here-core", "ns-a", "core", 5);
+    let _there_id = seed_family_memory(&conn, "there-core", "ns-b", "core", 5);
+
+    let resp: Value = handle_load_family(&conn, &json!({"family": "core", "namespace": "ns-a"}))
+        .expect("memory_load_family must succeed");
+
+    assert_eq!(
+        resp["count"], 1,
+        "namespace must filter cross-ns rows out; got: {resp}"
+    );
+    let memories = resp["memories"].as_array().expect("memories array");
+    assert_eq!(memories[0]["id"], here_id);
+
+    // Without the namespace filter, both rows must come back.
+    let resp_all: Value =
+        handle_load_family(&conn, &json!({"family": "core"})).expect("must succeed without ns");
+    assert_eq!(
+        resp_all["count"], 2,
+        "no-namespace must span all; got: {resp_all}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Priority + recency ordering — higher-priority rows come first;
+//    `k` caps the response.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_family_orders_by_priority_then_recency_and_caps_k() {
+    let conn = open_db();
+
+    // Seed three core memories with descending priorities.
+    let _low = seed_family_memory(&conn, "low", "ns", "core", 1);
+    let _mid = seed_family_memory(&conn, "mid", "ns", "core", 5);
+    let _hi = seed_family_memory(&conn, "hi", "ns", "core", 9);
+
+    let resp: Value = handle_load_family(&conn, &json!({"family": "core", "k": 2})).unwrap();
+    assert_eq!(resp["count"], 2, "k=2 must cap to two rows");
+    let memories = resp["memories"].as_array().unwrap();
+    assert_eq!(memories[0]["title"], "hi");
+    assert_eq!(memories[1]["title"], "mid");
+    assert_eq!(resp["k"], 2);
+
+    // k clamps silently at 100 — passing 9999 is treated as 100, not an
+    // error. We only have 3 rows so the count is 3 either way; the
+    // payload's reported `k` is the clamped value.
+    let resp_big: Value = handle_load_family(&conn, &json!({"family": "core", "k": 9999})).unwrap();
+    assert_eq!(resp_big["k"], 100, "k must clamp to 100");
+    assert_eq!(resp_big["count"], 3);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Unknown family → canonical UnknownFamily diagnostic (lists valid
+//    family names so the caller can self-correct).
+// ---------------------------------------------------------------------------
+#[test]
+fn load_family_unknown_family_yields_diagnostic_error() {
+    let conn = open_db();
+    let err = handle_load_family(&conn, &json!({"family": "xyz"})).unwrap_err();
+    assert!(
+        err.contains("xyz"),
+        "diagnostic must echo the bad value; got: {err}"
+    );
+    assert!(
+        err.contains("core"),
+        "diagnostic must list valid families; got: {err}"
+    );
+    assert!(
+        err.contains("graph"),
+        "diagnostic must list valid families; got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Missing required `family` arg → handler returns Err.
+// ---------------------------------------------------------------------------
+#[test]
+fn load_family_missing_family_arg_errors() {
+    let conn = open_db();
+    let err = handle_load_family(&conn, &json!({})).unwrap_err();
+    assert!(
+        err.contains("family"),
+        "error must mention missing arg; got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **v0.7 B1** of the [v0.7 attested-cortex epic](docs/v0.7/V0.7-EPIC.md): introduces `memory_load_family(family, namespace?, k?)` as an always-on alternative to `memory_recall` for the case where the agent already knows which `Family` taxonomy bucket it wants. Returns the top-k recent + high-priority memories whose `metadata.family` matches one of the eight enum names (`core/lifecycle/graph/governance/power/meta/archive/other`), ordered by `priority DESC, updated_at DESC`. `k` defaults to 20 and clamps silently to `[1, 100]`.

- New tool descriptor in `src/mcp.rs::tool_definitions()` (description ≤ 50 tokens per the C-track budget).
- Tool dispatch wired into the MCP request matcher; handler is `pub` so the new integration test can drive it.
- `Family::Core` grows from 5 → 6 tools (load_family is the always-on bootstrap loader); `tool_names`, `for_tool`, and `expected_tool_count` follow.
- **Tool count cascade:** 45 → 46 across `src/mcp.rs`, `src/profile.rs`, `src/sizes.rs`, `src/cli/doctor.rs`, `tests/capabilities_v3.rs`, `tests/calibration_t0.rs`, and `tests/integration.rs`. Webhook event count, HookEvent variant count, and schema_version (v25) are unchanged per cascade-safety rule.
- Capabilities-v3 phrasings re-pinned: `core` profile now reports `7 of 46` visible (was `6 of 45`); `full` reports `46 of 46`; describe-to-user under `--profile core` becomes `6 memory tools` with `, ...` since core now exceeds the 5-name preview cap.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` clean (the CI gate command)
- [x] `cargo test --tests` — 2685 passed, 0 failed
- [x] New `tests/memory_load_family.rs` (5 cases) covers:
  - Family filter exactness (only matching family returned)
  - Namespace filter narrowing (cross-ns bleed-through is a regression)
  - Priority + recency ordering, `k` clamp at 100
  - `UnknownFamily` diagnostic on a bad family enum
  - Missing required `family` arg → `Err`

🤖 Generated with [Claude Code](https://claude.com/claude-code)