### PR TITLE
docs: v0.7-b5 — memory_capabilities description for v3

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -637,7 +637,7 @@ pub(crate) fn tool_definitions() -> Value {
             },
             {
                 "name": "memory_capabilities",
-                "description": "Report the active feature tier, loaded models, and available capabilities of the memory system. Returns capabilities schema v2 by default (recommended). Pass accept=\"v1\" for the legacy shape used before v0.6.3.1. v0.6.4 — pass family=<name> to enumerate that family's tools; add include_schema=true to retrieve full schemas inline (NHI runtime-expansion path).",
+                "description": "Capabilities-v3 (v0.7 default, always-on): tier, profile, summary, to_describe_to_user, callable_now per tool, agent_permitted_families, harness detection. family=<name> (+include_schema) enumerates one; accept=v2/v1 for legacy.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Summary
- Updates the `memory_capabilities` tool's own description (the string surfaced to agents in `tools/list`) to reflect v0.7 reality: capabilities-v3 schema (default since A5), per-tool `callable_now`, `agent_permitted_families`, top-level `summary` + `to_describe_to_user`, and harness detection (B4).
- Calls out the always-on bootstrap status (memory_capabilities is in `ALWAYS_ON_TOOLS`) so agents understand it's always callable, regardless of profile.
- The previous text named "capabilities schema v2" as the default and predated every v0.7 Track-A field, so calibrating LLMs were getting stale guidance from the very tool they query for capabilities.

## New description (verbatim)
> Capabilities-v3 (v0.7 default, always-on): tier, profile, summary, to_describe_to_user, callable_now per tool, agent_permitted_families, harness detection. family=<name> (+include_schema) enumerates one; accept=v2/v1 for legacy.

cl100k_base = 59 tokens (≤ 60-token spec target; well under the 1500-tokens-per-tool CI gate in `src/sizes.rs`).

## Cascade safety
- Tool count unchanged (45 today; B1 hasn't landed yet so the post-B1 count of 46 doesn't apply on this branch).
- `inputSchema` left untouched — no `accept` enum change, no new properties, no removed fields.
- No schema, webhook, or `HookEvent` changes.
- Pure description text edit; no test snapshot pinned the old string, so no tests touched.

## Test plan
- [x] `cargo fmt`
- [x] `cargo build --tests` — clean
- [x] `cargo test --lib` — 2160 passed, 0 failed
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` — clean (full `--all-targets` blocked by pre-existing errors in `tests/integration.rs`, `tests/calibration_t0.rs`, `tests/proptest_validate.rs`, `tests/permissions_mode_gate.rs`, `tests/budget_tokens.rs`, and `src/llm.rs::build_client`; verified via `git stash` that those errors exist on `main` independently of this diff)
- [x] `sizes::tests::no_tool_exceeds_1500_tokens` still passes — the new description is 59 cl100k_base tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)