### PR TITLE
feat: v0.7-k7 — subscription reliability (replay + DLQ + HMAC)

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2069,8 +2069,8 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (46 tools loaded)"),
-            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
+            stdout.contains("Full   (48 tools loaded)"),
+            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2126,8 +2126,8 @@ mod tests {
         let tools = v["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            46,
-            "raw_table must include all 46 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
+            48,
+            "raw_table must include all 48 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1504,6 +1504,95 @@ pub struct AppConfig {
     /// Unset → compiled defaults apply globally
     /// ([`DEFAULT_TRANSCRIPT_TTL_SECS`] / [`DEFAULT_TRANSCRIPT_ARCHIVE_GRACE_SECS`]).
     pub transcripts: Option<TranscriptsConfig>,
+    /// v0.7.0 K7 — `[hooks]` block. Currently carries the
+    /// `[hooks.subscription] hmac_secret` server-wide override that
+    /// signs every outgoing webhook payload regardless of whether the
+    /// individual subscription supplied a per-subscription secret.
+    /// When unset, only per-subscription secrets are used (legacy
+    /// pre-K7 behaviour).
+    pub hooks: Option<HooksConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Hooks / subscription HMAC (K7)
+// ---------------------------------------------------------------------------
+
+/// `[hooks]` config block. v0.7.0 K7 — operator-facing knobs for the
+/// outgoing-webhook surface.
+///
+/// Wire format:
+/// ```toml
+/// [hooks.subscription]
+/// hmac_secret = "<plaintext-secret>"
+/// ```
+///
+/// When `hmac_secret` is set, EVERY outbound webhook payload is signed
+/// with `HMAC-SHA256(hmac_secret, "<timestamp>.<body>")` and the hex
+/// digest is sent as the `X-AI-Memory-Signature: sha256=<hex>` header.
+/// The override applies even to subscriptions that did not register a
+/// per-subscription secret. When both are set, the per-subscription
+/// secret wins (subscription-scoped trust beats server-scoped trust).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HooksConfig {
+    /// `[hooks.subscription]` sub-block. Optional — when omitted, no
+    /// server-wide HMAC override applies.
+    pub subscription: Option<HooksSubscriptionConfig>,
+}
+
+/// `[hooks.subscription]` sub-block. K7 ships one knob today
+/// (`hmac_secret`); future K-track work may add per-event opt-out
+/// filters or alternate signing algorithms.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HooksSubscriptionConfig {
+    /// Server-wide HMAC secret. Plaintext on disk — operators are
+    /// expected to chmod 600 the config file (same posture as the
+    /// existing `api_key` field).
+    pub hmac_secret: Option<String>,
+}
+
+impl AppConfig {
+    /// v0.7.0 K7 — resolved server-wide webhook HMAC secret. `None`
+    /// means no server-wide override (per-subscription secrets still
+    /// apply via the legacy code path).
+    #[must_use]
+    pub fn effective_hooks_hmac_secret(&self) -> Option<String> {
+        self.hooks
+            .as_ref()
+            .and_then(|h| h.subscription.as_ref())
+            .and_then(|s| s.hmac_secret.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide handle for the K7 server-wide HMAC override.
+// Mirrors the `ACTIVE_PERMISSIONS_MODE` pattern: set once at boot,
+// read by `subscriptions::dispatch_event_with_details` without an
+// API churn through every callsite. Stored behind a `RwLock<Option<…>>`
+// so the K7 integration tests can flip the value mid-process without
+// the `OnceLock`'s set-once contract getting in the way.
+// ---------------------------------------------------------------------------
+
+use std::sync::RwLock;
+
+static ACTIVE_HOOKS_HMAC_SECRET: RwLock<Option<String>> = RwLock::new(None);
+
+/// v0.7.0 K7 — set the process-wide webhook HMAC override. Called from
+/// `main`/daemon bootstrap with the value from
+/// `[hooks.subscription] hmac_secret`. Last writer wins — this is
+/// production-safe because boot only invokes it once; tests use the
+/// same setter to flip mid-process.
+pub fn set_active_hooks_hmac_secret(secret: Option<String>) {
+    if let Ok(mut w) = ACTIVE_HOOKS_HMAC_SECRET.write() {
+        *w = secret;
+    }
+}
+
+/// v0.7.0 K7 — read the process-wide webhook HMAC override. Returns
+/// `None` when unset (the K6-and-earlier behaviour: only
+/// per-subscription secrets sign outgoing payloads).
+#[must_use]
+pub fn active_hooks_hmac_secret() -> Option<String> {
+    ACTIVE_HOOKS_HMAC_SECRET.read().ok().and_then(|g| g.clone())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,13 @@ async fn main() -> Result<()> {
     // Idempotent (`OnceLock::set`); first writer wins.
     config::set_active_permissions_mode(app_config.effective_permissions_mode());
 
+    // v0.7.0 K7 — pin the process-wide webhook HMAC override (if any)
+    // before the daemon spawns any subscription-dispatch worker thread.
+    // Idempotent; the dispatcher reads via
+    // `crate::config::active_hooks_hmac_secret` and falls back to the
+    // per-subscription secret when unset.
+    config::set_active_hooks_hmac_secret(app_config.effective_hooks_hmac_secret());
+
     // PR-5 (issue #487): bootstrap operational logging + security
     // audit trail. Both are default-OFF; init returns silently when
     // disabled. The `_log_guard` MUST stay in scope for the lifetime

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -931,6 +931,29 @@ pub(crate) fn tool_definitions() -> Value {
                     "type": "object",
                     "properties": {}
                 }
+            },
+            {
+                "name": "memory_subscription_replay",
+                "description": "v0.7 K7 — replay subscription_events for one subscription since an RFC3339 timestamp. Returns ordered audit envelope (delivered_at asc). Operator/governance tool.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "subscription_id": {"type": "string", "description": "Subscription id from memory_subscribe."},
+                        "since": {"type": "string", "description": "RFC3339 lower bound on delivered_at (inclusive)."}
+                    },
+                    "required": ["subscription_id", "since"]
+                }
+            },
+            {
+                "name": "memory_subscription_dlq_list",
+                "description": "v0.7 K7 — list subscription_dlq rows (deliveries that exhausted the retry ladder). Filter by subscription_id; cap with limit. Operator/governance inspector.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "subscription_id": {"type": "string", "description": "Optional — restrict to one subscription."},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100}
+                    }
+                }
             }
         ]
     })
@@ -2154,7 +2177,7 @@ pub fn build_capabilities_tools(
     use crate::config::{AllowlistDecision, ToolEntry};
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let mut entries: Vec<ToolEntry> = Vec::with_capacity(46);
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(48);
 
     for fam in Family::all() {
         let family_name = fam.name();
@@ -4334,6 +4357,49 @@ pub(crate) fn handle_list_subscriptions(conn: &rusqlite::Connection) -> Result<V
     Ok(json!({"count": subs.len(), "subscriptions": subs}))
 }
 
+/// v0.7 K7 — MCP handler for `memory_subscription_replay`. Thin
+/// wrapper around [`crate::subscriptions::memory_subscription_replay`]
+/// that exposes the operator/governance reliability tool over the
+/// MCP wire. Family: `Power` (operator-scoped, not data-plane).
+pub(crate) fn handle_subscription_replay(
+    conn: &rusqlite::Connection,
+    params: &Value,
+) -> Result<Value, String> {
+    let subscription_id = params["subscription_id"]
+        .as_str()
+        .ok_or("subscription_id is required")?;
+    let since = params["since"]
+        .as_str()
+        .ok_or("since is required (RFC3339)")?;
+    crate::subscriptions::memory_subscription_replay(conn, subscription_id, since)
+        .map_err(|e| e.to_string())
+}
+
+/// v0.7 K7 — MCP handler for `memory_subscription_dlq_list`. Wraps
+/// [`crate::subscriptions::list_dlq`] and applies the optional
+/// `limit` cap (default 100, max 1000) so an operator inspecting a
+/// runaway DLQ can't blow the response size budget. Family: `Power`.
+pub(crate) fn handle_subscription_dlq_list(
+    conn: &rusqlite::Connection,
+    params: &Value,
+) -> Result<Value, String> {
+    let subscription_id = params["subscription_id"].as_str();
+    let limit = usize::try_from(params["limit"].as_u64().unwrap_or(100))
+        .unwrap_or(100)
+        .clamp(1, 1000);
+    let mut rows =
+        crate::subscriptions::list_dlq(conn, subscription_id).map_err(|e| e.to_string())?;
+    if rows.len() > limit {
+        rows.truncate(limit);
+    }
+    Ok(json!({
+        "count": rows.len(),
+        "subscription_id": subscription_id,
+        "limit": limit,
+        "entries": rows,
+    }))
+}
+
 fn handle_pending_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let status = params["status"].as_str();
     let limit = usize::try_from(params["limit"].as_u64().unwrap_or(100))
@@ -4790,6 +4856,8 @@ fn handle_request(
                 "memory_subscribe" => handle_subscribe(conn, arguments, mcp_client),
                 "memory_unsubscribe" => handle_unsubscribe(conn, arguments),
                 "memory_list_subscriptions" => handle_list_subscriptions(conn),
+                "memory_subscription_replay" => handle_subscription_replay(conn, arguments),
+                "memory_subscription_dlq_list" => handle_subscription_dlq_list(conn, arguments),
                 // Ultrareview #349: unknown tool is a JSON-RPC 2.0
                 // "method not found" condition — return -32601, not
                 // an ok_response with `isError: true`. Clients that
@@ -5215,7 +5283,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_46_tools() {
+    fn tool_definitions_returns_48_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
@@ -5225,15 +5293,17 @@ mod tests {
         // v0.7.0 I4 adds memory_replay (Family::Graph) → 44.
         // v0.7 H4 adds memory_verify (Family::Graph) → 45.
         // v0.7 B1 adds memory_load_family (Family::Core) → 46.
+        // v0.7 K7 adds memory_subscription_replay +
+        // memory_subscription_dlq_list (Family::Power) → 48.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 46);
+        assert_eq!(tools.len(), 48);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
     /// registers exactly 6 family tools (5 baseline + v0.7 B1
     /// memory_load_family) + 1 always-on bootstrap (memory_capabilities)
-    /// = 7 visible tools. `--profile full` registers all 46.
+    /// = 7 visible tools. `--profile full` registers all 48.
     #[test]
     fn tool_definitions_for_profile_core_registers_6_plus_capabilities() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::core());
@@ -5275,14 +5345,15 @@ mod tests {
     }
 
     #[test]
-    fn tool_definitions_for_profile_full_registers_46() {
+    fn tool_definitions_for_profile_full_registers_48() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::full());
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            46,
+            48,
             "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay (1) + \
-             v0.7 H4 memory_verify (1) + v0.7 B1 memory_load_family (1) = 46"
+             v0.7 H4 memory_verify (1) + v0.7 B1 memory_load_family (1) + \
+             v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list (2) = 48"
         );
     }
 
@@ -5724,9 +5795,10 @@ mod tests {
             "missing err outcome in: {captured}"
         );
     }
-    /// Parametrized smoke matrix for all 46 MCP tools (Justice of MCP pathway).
+    /// Parametrized smoke matrix for all 48 MCP tools (Justice of MCP pathway).
     /// v0.6.3 baseline = 43; v0.7.0 I4 added memory_replay (44);
-    /// v0.7 H4 added memory_verify (45); v0.7 B1 added memory_load_family (46).
+    /// v0.7 H4 added memory_verify (45); v0.7 B1 added memory_load_family (46);
+    /// v0.7 K7 added memory_subscription_replay + memory_subscription_dlq_list (48).
     /// Tier 1: happy path with canonical valid args.
     /// Tier 2: required arg validation (missing required arg → error).
     #[test]
@@ -5987,6 +6059,20 @@ mod tests {
             },
             ToolCase {
                 name: "memory_list_subscriptions",
+                valid_args: json!({}),
+                required_arg: None,
+            },
+            // v0.7 K7 — subscription reliability inspection tools.
+            ToolCase {
+                name: "memory_subscription_replay",
+                valid_args: json!({
+                    "subscription_id": "smoke-id",
+                    "since": "1970-01-01T00:00:00Z"
+                }),
+                required_arg: Some("subscription_id"),
+            },
+            ToolCase {
+                name: "memory_subscription_dlq_list",
                 valid_args: json!({}),
                 required_arg: None,
             },

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -28,9 +28,10 @@
 //!   `memory_load_family`). Always loaded.
 //! - `graph` — adds the 10 KG/entity/replay/verify tools. ~16 tools.
 //! - `admin` — adds lifecycle (5) + governance (8). ~19 tools.
-//! - `power` — adds the 6 LLM-augmented tools (consolidate, auto_tag, …).
-//!   ~12 tools.
-//! - `full` — every family. 46 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 `memory_load_family`).
+//! - `power` — adds the 8 LLM-augmented + operator tools (consolidate,
+//!   auto_tag, …, plus the v0.7 K7 subscription-reliability pair).
+//!   ~14 tools.
+//! - `full` — every family. 48 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 K7 `memory_subscription_replay` + `memory_subscription_dlq_list`).
 //! - `custom` — comma-separated family list (`core,graph,archive` …).
 //!   `core` is implicitly added if missing — there's no profile that
 //!   ships *less than* the 5 core tools.
@@ -56,9 +57,11 @@
 use std::str::FromStr;
 
 /// A tool family. Source-anchored at `src/mcp.rs::tool_definitions()`
-/// 2026-05-05. Counts must sum to 46 (the v0.6.3.1 baseline of 43 +
+/// 2026-05-05. Counts must sum to 48 (the v0.6.3.1 baseline of 43 +
 /// v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` (both in
-/// `Family::Graph`) + v0.7 B1 `memory_load_family` in `Family::Core`).
+/// `Family::Graph`) + v0.7 B1 `memory_load_family` in `Family::Core` +
+/// v0.7 K7 `memory_subscription_replay` and `memory_subscription_dlq_list`
+/// in `Family::Power`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Family {
     /// store, recall, list, get, search, load_family — 6
@@ -79,7 +82,9 @@ pub enum Family {
     /// subscribe, unsubscribe — 8
     Governance,
     /// consolidate, detect_contradiction, check_duplicate, auto_tag,
-    /// expand_query, inbox — 6
+    /// expand_query, inbox, subscription_replay, subscription_dlq_list — 8
+    /// (v0.7 K7 added the two operator/governance subscription-reliability
+    /// tools — replay events from the audit log + inspect the DLQ.)
     Power,
     /// capabilities, agent_register, agent_list, session_start, stats — 5
     Meta,
@@ -134,13 +139,17 @@ impl Family {
             | "memory_namespace_clear_standard"
             | "memory_subscribe"
             | "memory_unsubscribe" => Some(Self::Governance),
-            // power (6)
+            // power (8 — v0.7 K7 added the subscription-reliability pair:
+            // `memory_subscription_replay` + `memory_subscription_dlq_list`,
+            // both operator/governance tools, not data-plane.)
             "memory_consolidate"
             | "memory_detect_contradiction"
             | "memory_check_duplicate"
             | "memory_auto_tag"
             | "memory_expand_query"
-            | "memory_inbox" => Some(Self::Power),
+            | "memory_inbox"
+            | "memory_subscription_replay"
+            | "memory_subscription_dlq_list" => Some(Self::Power),
             // meta (5)
             "memory_capabilities"
             | "memory_agent_register"
@@ -199,8 +208,7 @@ impl Family {
             Self::Lifecycle | Self::Meta => 5,
             // Graph: 8 baseline + memory_replay (v0.7.0 I4) + memory_verify (v0.7 H4) = 10.
             Self::Graph => 10,
-            Self::Governance => 8,
-            Self::Power => 6,
+            Self::Governance | Self::Power => 8,
             Self::Archive => 4,
             Self::Other => 2,
         }
@@ -271,6 +279,12 @@ impl Family {
                 "memory_auto_tag",
                 "memory_expand_query",
                 "memory_inbox",
+                // v0.7 K7 — operator/governance subscription-reliability
+                // tools. Replay reads back the audit row series for one
+                // subscription since an RFC3339 cursor; dlq_list inspects
+                // payloads that exhausted the [200ms, 1s, 5s] retry ladder.
+                "memory_subscription_replay",
+                "memory_subscription_dlq_list",
             ],
             Self::Meta => &[
                 "memory_capabilities",
@@ -356,8 +370,9 @@ impl Profile {
         }
     }
 
-    /// `power` — core + power. 12 tools (v0.7 B1 added
-    /// `memory_load_family` to core).
+    /// `power` — core + power. 14 tools (v0.7 B1 added
+    /// `memory_load_family` to core; v0.7 K7 added the two
+    /// subscription-reliability tools to `Family::Power`).
     #[must_use]
     pub fn power() -> Self {
         Self {
@@ -365,9 +380,10 @@ impl Profile {
         }
     }
 
-    /// `full` — every family. 46 tools (v0.6.3 baseline 43 + v0.7.0 I4
+    /// `full` — every family. 48 tools (v0.6.3 baseline 43 + v0.7.0 I4
     /// `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1
-    /// `memory_load_family`).
+    /// `memory_load_family` + v0.7 K7 `memory_subscription_replay`
+    /// + `memory_subscription_dlq_list`).
     #[must_use]
     pub fn full() -> Self {
         Self {
@@ -546,14 +562,15 @@ mod tests {
     }
 
     #[test]
-    fn family_expected_tool_counts_sum_to_46() {
+    fn family_expected_tool_counts_sum_to_48() {
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 46,
+            total, 48,
             "v0.6.3.1 baseline (43) + v0.7.0 I4 `memory_replay` + v0.7 H4 \
-             `memory_verify` + v0.7 B1 `memory_load_family` = 46. If this \
-             drifts, update Family::expected_tool_count and the family \
-             map docs together."
+             `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 K7 \
+             `memory_subscription_replay` + `memory_subscription_dlq_list` \
+             = 48. If this drifts, update Family::expected_tool_count and \
+             the family map docs together."
         );
     }
 
@@ -621,18 +638,26 @@ mod tests {
     }
 
     #[test]
-    fn profile_power_has_twelve_tools() {
+    fn profile_power_has_fourteen_tools() {
         let p = Profile::power();
         // v0.7 B1 — Core now ships 6 tools (was 5).
-        assert_eq!(p.expected_tool_count(), 6 + 6);
+        // v0.7 K7 — Power now ships 8 tools (was 6) after the
+        // subscription-reliability pair landed.
+        assert_eq!(p.expected_tool_count(), 6 + 8);
     }
 
     #[test]
-    fn profile_full_has_forty_six_tools() {
+    fn profile_full_has_forty_eight_tools() {
         let p = Profile::full();
-        // v0.7 B1 — full surface = 43 baseline + memory_replay (I4) +
-        // memory_verify (H4) + memory_load_family (B1) = 46.
-        assert_eq!(p.expected_tool_count(), 46);
+        // v0.7 K7 — full surface = 43 baseline + memory_replay (I4) +
+        // memory_verify (H4) + memory_load_family (B1) +
+        // memory_subscription_replay (K7) + memory_subscription_dlq_list
+        // (K7) = 48.
+        assert_eq!(p.expected_tool_count(), 48);
+
+        // The K7 additions live in Family::Power (operator/governance),
+        // so the `power` profile picks them up too.
+        assert_eq!(Profile::power().expected_tool_count(), 6 + 8);
     }
 
     // ---------- Profile::parse ----------
@@ -789,6 +814,9 @@ mod tests {
             "memory_auto_tag",
             "memory_expand_query",
             "memory_inbox",
+            // power (v0.7 K7 additions — subscription reliability)
+            "memory_subscription_replay",
+            "memory_subscription_dlq_list",
             // meta
             "memory_capabilities",
             "memory_agent_register",
@@ -806,9 +834,10 @@ mod tests {
         ];
         assert_eq!(
             baseline.len(),
-            46,
+            48,
             "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) + \
-             1 (v0.7 H4 memory_verify) + 1 (v0.7 B1 memory_load_family) = 46"
+             1 (v0.7 H4 memory_verify) + 1 (v0.7 B1 memory_load_family) + \
+             2 (v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list) = 48"
         );
         for name in baseline {
             assert!(

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -73,7 +73,7 @@ pub fn full_profile_total_tokens() -> usize {
     tool_sizes().iter().map(|t| t.total_tokens).sum()
 }
 
-/// Lookup a single tool by name. `O(n)` but `n ≤ 43`.
+/// Lookup a single tool by name. `O(n)` but `n ≤ 48` (v0.7 K7).
 pub fn tool_size(name: &str) -> Option<&'static ToolSize> {
     tool_sizes().iter().find(|t| t.name == name)
 }
@@ -140,13 +140,14 @@ mod tests {
     /// `tool_definitions()` regressions that would silently hide other
     /// failures.
     #[test]
-    fn table_has_46_entries_matching_tool_definitions_count() {
+    fn table_has_48_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 46,
-            "expected exactly 46 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
+            n, 48,
+            "expected exactly 48 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
              `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 \
-             `memory_load_family`, source-anchored at \
+             `memory_load_family` + v0.7 K7 `memory_subscription_replay` \
+             + `memory_subscription_dlq_list`, source-anchored at \
              src/mcp.rs::tool_definitions); got {n}. If the count changed, \
              update the family map and this assertion together."
         );

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -586,10 +586,24 @@ pub fn dispatch_event_with_details(
             // the DB-stored secret hash. Receivers verify by computing
             // SHA256(plaintext_secret) and then
             // HMAC-SHA256(key, "<timestamp>.<body>").
+            //
+            // v0.7.0 K7 — when no per-subscription secret is set, fall
+            // back to the process-wide `[hooks.subscription] hmac_secret`
+            // override so operators can sign EVERY outgoing payload
+            // without round-tripping each receiver through `memory_subscribe`.
+            // The plaintext server-wide secret is itself SHA-256-hashed
+            // first so the keying material on the wire matches the
+            // per-subscription path (receivers compute the same
+            // `SHA256(plaintext_secret)` regardless of which path
+            // configured it).
             let canonical = format!("{ts}.{body}");
-            let signature = secret_hash
-                .as_deref()
-                .map(|h| hmac_sha256_hex(h, &canonical));
+            let signature = match secret_hash.as_deref() {
+                Some(h) => Some(hmac_sha256_hex(h, &canonical)),
+                None => crate::config::active_hooks_hmac_secret().map(|plain| {
+                    let key_hash = sha256_hex(&plain);
+                    hmac_sha256_hex(&key_hash, &canonical)
+                }),
+            };
             let outcome =
                 deliver_with_retry(&url, &body, &ts, signature.as_deref(), &correlation_id);
             let ok = outcome.success;

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -60,18 +60,19 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    // 39 = 45 user-relevant tools − 6 core. (45 = 46 total tools − 1
+    // 41 = 47 user-relevant tools − 6 core. (47 = 48 total tools − 1
     // always-on bootstrap.) The bootstrap (`memory_capabilities`) is
     // excluded from BOTH the loaded and the unloaded count in
     // `to_describe_to_user` (it's plumbing, not a feature). Total
     // bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
     // `memory_replay`; to 45 in v0.7 H4 — Family::Graph gained
     // `memory_verify`; to 46 in v0.7 B1 — Family::Core gained
-    // `memory_load_family`. Loaded under core bumped from 5 to 6 with
-    // B1, so the preview now overflows the 5-name cap (ends in
-    // ", ...").
+    // `memory_load_family`; to 48 in v0.7 K7 — Family::Power gained
+    // `memory_subscription_replay` + `memory_subscription_dlq_list`.
+    // Loaded under core bumped from 5 to 6 with B1, so the preview
+    // now overflows the 5-name cap (ends in ", ...").
     let expected = "I can directly use 6 memory tools right now \
-                    (store, recall, list, get, search, ...). 39 more \
+                    (store, recall, list, get, search, ...). 41 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -87,10 +88,12 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
 // ---------------------------------------------------------------------------
 // T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
 // "nothing more to load" closing form (excludes the always-on bootstrap
-// from the user-facing 45 count). Bumped from 42 to 43 in v0.7.0 I4 —
+// from the user-facing 47 count). Bumped from 42 to 43 in v0.7.0 I4 —
 // Family::Graph gained `memory_replay`; to 44 in v0.7 H4 —
 // Family::Graph gained `memory_verify`; to 45 in v0.7 B1 —
-// Family::Core gained `memory_load_family`.
+// Family::Core gained `memory_load_family`; to 47 in v0.7 K7 —
+// Family::Power gained `memory_subscription_replay` +
+// `memory_subscription_dlq_list`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_full_profile_canonical_phrasing() {
@@ -99,7 +102,7 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use all 45 memory tools right now \
+    let expected = "I can directly use all 47 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -127,7 +130,7 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
         .expect("describe present");
 
     let expected = "I can directly use 16 memory tools right now \
-                    (store, recall, list, get, search, ...). 29 more \
+                    (store, recall, list, get, search, ...). 31 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -151,13 +151,15 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `core` profile honestly reports 7 of 46 visible (6 core
+// summary on the `core` profile honestly reports 7 of 48 visible (6 core
 // tools — including v0.7 B1 `memory_load_family` — plus the
 // memory_capabilities always-on bootstrap), labels the profile "core",
 // and references all three named recovery paths. (Total bumped from 43
 // to 44 in v0.7.0 I4 — Family::Graph gained `memory_replay`; 44 to 45
 // in v0.7 H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7
-// B1 — Family::Core gained `memory_load_family`.)
+// B1 — Family::Core gained `memory_load_family`; 46 to 48 in v0.7 K7
+// — Family::Power gained `memory_subscription_replay` +
+// `memory_subscription_dlq_list`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
@@ -167,13 +169,13 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     // (`memory_capabilities` lives in Family::Meta which the core
     // profile doesn't load, so the bootstrap injection adds it back).
     assert!(
-        summary.starts_with("7 of 46 tools"),
-        "core profile summary should open with \"7 of 46 tools\"; got: {summary}"
+        summary.starts_with("7 of 48 tools"),
+        "core profile summary should open with \"7 of 48 tools\"; got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
-        summary.contains("39 are listed in this manifest"),
-        "core profile must report 39 unloaded (46 - 7); got: {summary}"
+        summary.contains("41 are listed in this manifest"),
+        "core profile must report 41 unloaded (48 - 7); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -185,21 +187,23 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `full` profile reports 46 of 46 visible, 0 unloaded, and
+// summary on the `full` profile reports 48 of 48 visible, 0 unloaded, and
 // labels the profile "full". The recovery paths are still listed —
 // they're the canonical recovery vocabulary the LLM gets calibrated on
 // regardless of the current profile state. (Total bumped from 43 to 44
 // in v0.7.0 I4 — Family::Graph gained `memory_replay`; 44 to 45 in v0.7
 // H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7 B1 —
-// Family::Core gained `memory_load_family`.)
+// Family::Core gained `memory_load_family`; 46 to 48 in v0.7 K7 —
+// Family::Power gained `memory_subscription_replay` +
+// `memory_subscription_dlq_list`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_full_profile_reports_all_visible() {
     let summary = build_capabilities_summary(&Profile::full());
 
     assert!(
-        summary.starts_with("46 of 46 tools"),
-        "full profile summary should open with \"46 of 46 tools\"; got: {summary}"
+        summary.starts_with("48 of 48 tools"),
+        "full profile summary should open with \"48 of 48 tools\"; got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -222,11 +226,11 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
 fn cap_v3_summary_graph_profile_counts() {
     let summary = build_capabilities_summary(&Profile::graph());
     assert!(
-        summary.starts_with("17 of 46 tools"),
+        summary.starts_with("17 of 48 tools"),
         "graph profile = 6 core (v0.7 B1) + 10 graph (v0.7 H4) + 1 always-on bootstrap = 17; got: {summary}"
     );
     assert!(summary.contains("(graph)"));
-    assert!(summary.contains("29 are listed in this manifest"));
+    assert!(summary.contains("31 are listed in this manifest"));
 }
 
 // ---------------------------------------------------------------------------
@@ -320,16 +324,18 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     // memory_ prefix STRIPPED (no MCP jargon for end users), followed
     // by ", ..." since core now ships 6 tools (v0.7 B1).
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
-    // Reports the unloaded count. 39 = 45 user-relevant tools − 6
-    // core. (45 = 46 total tools − 1 always-on bootstrap.) The
+    // Reports the unloaded count. 41 = 47 user-relevant tools − 6
+    // core. (47 = 48 total tools − 1 always-on bootstrap.) The
     // bootstrap (`memory_capabilities`) is excluded from both sides
     // for honest user-facing counting. Total bumped to 44 in v0.7.0
     // I4 (Family::Graph gained `memory_replay`), to 45 in v0.7 H4
-    // (Family::Graph gained `memory_verify`), and to 46 in v0.7 B1
-    // (Family::Core gained `memory_load_family`).
+    // (Family::Graph gained `memory_verify`), to 46 in v0.7 B1
+    // (Family::Core gained `memory_load_family`), and to 48 in v0.7
+    // K7 (Family::Power gained `memory_subscription_replay` +
+    // `memory_subscription_dlq_list`).
     assert!(
-        describe.contains("39 more"),
-        "core profile must report 39 unloaded; got: {describe}"
+        describe.contains("41 more"),
+        "core profile must report 41 unloaded; got: {describe}"
     );
     // Sample of unloaded tools is plain (no memory_ prefix). The first
     // four unloaded under core are lifecycle's update/delete/forget/gc.
@@ -352,25 +358,27 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `full` profile reports all 45 tools loaded
+// A2: to_describe_to_user on `full` profile reports all 47 tools loaded
 // (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
 // uses the "nothing more to load" closing form rather than the recovery
 // hint. (Bumped from 42 to 43 in v0.7.0 I4 — Family::Graph gained
 // `memory_replay`; 43 to 44 in v0.7 H4 — Family::Graph gained
 // `memory_verify`; 44 to 45 in v0.7 B1 — Family::Core gained
-// `memory_load_family`.)
+// `memory_load_family`; 45 to 47 in v0.7 K7 — Family::Power gained
+// the subscription-reliability pair.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 45 = 46 total - 1 always-on bootstrap excluded from describe.
+    // 47 = 48 total - 1 always-on bootstrap excluded from describe.
     // Bumped from 42 to 43 in v0.7.0 I4 (Family::Graph gained
     // `memory_replay`); 43 to 44 in v0.7 H4 (Family::Graph gained
     // `memory_verify`); 44 to 45 in v0.7 B1 (Family::Core gained
-    // `memory_load_family`).
+    // `memory_load_family`); 45 to 47 in v0.7 K7 (Family::Power
+    // gained `memory_subscription_replay` + `memory_subscription_dlq_list`).
     assert!(
-        describe.starts_with("I can directly use all 45 memory tools right now ("),
+        describe.starts_with("I can directly use all 47 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -393,7 +401,7 @@ fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     );
     // Preview is the first 5 of the 16 loaded — the first 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
-    assert!(describe.contains("29 more"));
+    assert!(describe.contains("31 more"));
 }
 
 // ---------------------------------------------------------------------------
@@ -549,15 +557,16 @@ fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
 
 // ---------------------------------------------------------------------------
 // A3 — the v3 response surfaces the `tools` array at the top level
-// with one entry per registered tool (46 + always-on bootstrap counted
-// once = 46, since the bootstrap already lives in Family::Meta).
+// with one entry per registered tool (48 + always-on bootstrap counted
+// once = 48, since the bootstrap already lives in Family::Meta).
 // (Bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
 // `memory_replay`; 44 to 45 in v0.7 H4 — Family::Graph gained
 // `memory_verify`; 45 to 46 in v0.7 B1 — Family::Core gained
-// `memory_load_family`.)
+// `memory_load_family`; 46 to 48 in v0.7 K7 — Family::Power gained
+// `memory_subscription_replay` + `memory_subscription_dlq_list`.)
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_response_carries_tools_array_with_46_entries() {
+fn cap_v3_response_carries_tools_array_with_48_entries() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
     let val = handle_capabilities_with_conn_v3(
@@ -577,10 +586,11 @@ fn cap_v3_response_carries_tools_array_with_46_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        46,
-        "v3 must surface all 46 tools regardless of profile (v0.7.0 I4 added \
+        48,
+        "v3 must surface all 48 tools regardless of profile (v0.7.0 I4 added \
          memory_replay; v0.7 H4 added memory_verify; v0.7 B1 added \
-         memory_load_family); got {}",
+         memory_load_family; v0.7 K7 added memory_subscription_replay + \
+         memory_subscription_dlq_list); got {}",
         tools.len()
     );
 

--- a/tests/harness_integration.rs
+++ b/tests/harness_integration.rs
@@ -136,7 +136,7 @@ fn round_trip(
 /// We re-pin it here so a regression in the harness path that
 /// accidentally swapped the profile or stripped the field would
 /// surface as a D4 failure too (defense in depth).
-const CORE_DESCRIBE_OPENING: &str = "I can directly use 5 memory tools right now (";
+const CORE_DESCRIBE_OPENING: &str = "I can directly use 6 memory tools right now (";
 
 // ---------------------------------------------------------------------------
 // D4 — five harness identity tests + one negative.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1867,8 +1867,8 @@ fn test_mcp_tools_list() {
         .expect("tools should be array");
     assert_eq!(
         tools.len(),
-        46,
-        "expected 46 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family)"
+        48,
+        "expected 48 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
     );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();

--- a/tests/k7_dlq_list_tool.rs
+++ b/tests/k7_dlq_list_tool.rs
@@ -1,0 +1,151 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K7 — `memory_subscription_dlq_list` MCP-tool wiring test.
+//!
+//! K6 shipped the writer (`subscriptions::record_dlq` lands a row when
+//! the [200ms, 1s, 5s] retry ladder is exhausted) but no inspector
+//! tool. K7 ships the inspector — `memory_subscription_dlq_list` lives
+//! in `Family::Power` and surfaces DLQ rows ordered by `id` ascending
+//! so an operator scanning the DLQ sees the oldest unhandled failure
+//! first.
+//!
+//! The test seeds three DLQ rows directly (avoiding the network +
+//! retry-ladder latency) and pins:
+//!   - the underlying `subscriptions::list_dlq` returns rows in
+//!     insertion order (the contract `memory_subscription_dlq_list`
+//!     wraps);
+//!   - the `subscription_id` filter scopes the result correctly;
+//!   - the omitted-filter case returns the full set.
+
+use ai_memory::profile::{Family, Profile};
+use ai_memory::subscriptions::{self, NewSubscription};
+use rusqlite::Connection;
+use tempfile::NamedTempFile;
+
+fn fresh_db() -> (NamedTempFile, std::path::PathBuf) {
+    let f = NamedTempFile::new().expect("tempfile");
+    let p = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&p).expect("db::open");
+    (f, p)
+}
+
+fn subscribe(db_path: &std::path::Path, url: &str) -> String {
+    let conn = Connection::open(db_path).unwrap();
+    subscriptions::insert(
+        &conn,
+        &NewSubscription {
+            url,
+            events: "*",
+            secret: None,
+            namespace_filter: None,
+            agent_filter: None,
+            created_by: Some("k7-dlq-test"),
+            event_types: None,
+        },
+    )
+    .expect("insert subscription")
+}
+
+#[test]
+fn k7_dlq_list_tool_registered_under_power_family() {
+    assert_eq!(
+        Family::for_tool("memory_subscription_dlq_list"),
+        Some(Family::Power),
+        "memory_subscription_dlq_list must live in Family::Power"
+    );
+    assert!(Profile::full().loads("memory_subscription_dlq_list"));
+    assert!(Profile::power().loads("memory_subscription_dlq_list"));
+    assert!(!Profile::core().loads("memory_subscription_dlq_list"));
+}
+
+#[test]
+fn k7_dlq_list_returns_three_rows_ordered_by_insertion() {
+    let (_keep, db_path) = fresh_db();
+    let sub_a = subscribe(&db_path, "https://example.invalid/a");
+    let sub_b = subscribe(&db_path, "https://example.invalid/b");
+
+    // Seed three DLQ rows: two for sub_a, one for sub_b. The K6 writer
+    // signature pins the column ordering (correlation_id, event_type,
+    // payload, retry_count, last_error, first_failed_at, last_failed_at).
+    let series = [
+        (
+            sub_a.as_str(),
+            "corr-a-001",
+            "memory_store",
+            r#"{"id":"a-001"}"#,
+            4i64,
+            "http-500",
+        ),
+        (
+            sub_a.as_str(),
+            "corr-a-002",
+            "memory_promote",
+            r#"{"id":"a-002"}"#,
+            4,
+            "ack-corr-mismatch",
+        ),
+        (
+            sub_b.as_str(),
+            "corr-b-001",
+            "memory_delete",
+            r#"{"id":"b-001"}"#,
+            4,
+            "network: timeout",
+        ),
+    ];
+    for (sub_id, corr, event, payload, retries, err) in &series {
+        subscriptions::record_dlq(
+            &db_path,
+            sub_id,
+            corr,
+            event,
+            payload,
+            *retries,
+            err,
+            "2026-04-01T00:00:00Z",
+            "2026-04-01T00:00:06Z",
+        )
+        .expect("seed DLQ row");
+    }
+
+    // Unfiltered: all three rows back in insertion order.
+    let rows = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::list_dlq(&conn, None).expect("list_dlq")
+    };
+    assert_eq!(rows.len(), 3);
+    let observed: Vec<&str> = rows.iter().map(|r| r.correlation_id.as_str()).collect();
+    assert_eq!(observed, vec!["corr-a-001", "corr-a-002", "corr-b-001"]);
+
+    // Filtered to sub_a: two rows, both belonging to sub_a, in
+    // insertion order.
+    let rows_a = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::list_dlq(&conn, Some(&sub_a)).expect("list_dlq sub_a")
+    };
+    assert_eq!(rows_a.len(), 2);
+    for r in &rows_a {
+        assert_eq!(r.subscription_id, sub_a);
+    }
+    let order_a: Vec<&str> = rows_a.iter().map(|r| r.correlation_id.as_str()).collect();
+    assert_eq!(order_a, vec!["corr-a-001", "corr-a-002"]);
+
+    // Filtered to sub_b: one row.
+    let rows_b = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::list_dlq(&conn, Some(&sub_b)).expect("list_dlq sub_b")
+    };
+    assert_eq!(rows_b.len(), 1);
+    assert_eq!(rows_b[0].correlation_id, "corr-b-001");
+    assert_eq!(rows_b[0].retry_count, 4);
+    assert_eq!(rows_b[0].last_error, "network: timeout");
+}
+
+#[test]
+fn k7_dlq_list_empty_when_no_rows_seeded() {
+    let (_keep, db_path) = fresh_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = subscriptions::list_dlq(&conn, None).expect("list_dlq empty");
+    assert!(rows.is_empty(), "fresh DB must have zero DLQ rows");
+}

--- a/tests/k7_hmac.rs
+++ b/tests/k7_hmac.rs
@@ -1,0 +1,370 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K7 — server-wide webhook HMAC override.
+//!
+//! K6-and-earlier signed outbound webhook payloads with the
+//! per-subscription `secret` registered via `memory_subscribe`. K7
+//! adds a server-wide `[hooks.subscription] hmac_secret` config knob
+//! that signs EVERY outbound payload — even subscriptions that didn't
+//! register a per-subscription secret — so a paranoid operator can
+//! attach a fleet-wide signing key without round-tripping each
+//! receiver through `memory_subscribe`.
+//!
+//! These tests pin:
+//!   1. configuration plumbing — `set_active_hooks_hmac_secret` /
+//!      `active_hooks_hmac_secret` round-trip cleanly;
+//!   2. effective dispatch — when the override is set and a
+//!      subscription has no per-sub secret, the wiremock POST carries
+//!      the `x-ai-memory-signature: sha256=<hex>` header;
+//!   3. the signature payload matches `HMAC-SHA256(SHA256(secret),
+//!      "<timestamp>.<body>")` — the same construction the
+//!      per-subscription path produces, so receiver verification is
+//!      identical regardless of which path configured the secret.
+//!
+//! The K7 wiring lives in `src/subscriptions.rs::dispatch_event_with_details`
+//! (the `signature = match secret_hash {...}` block).
+
+use ai_memory::config::{
+    HooksConfig, HooksSubscriptionConfig, active_hooks_hmac_secret, set_active_hooks_hmac_secret,
+};
+use ai_memory::subscriptions::{self, NewSubscription};
+use rusqlite::Connection;
+use std::sync::Mutex;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Serialize the four tests that mutate the process-wide K7 HMAC
+/// override. `cargo test` parallelizes by default; without this lock,
+/// `..._signed` and `..._unsigned` race on the global state and one of
+/// them sees stale config when its dispatch thread runs.
+static K7_HMAC_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
+
+fn fresh_db() -> (NamedTempFile, std::path::PathBuf) {
+    let f = NamedTempFile::new().expect("tempfile");
+    let p = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&p).expect("db::open");
+    (f, p)
+}
+
+/// Wiremock responder mirroring the production K6 ACK contract:
+/// 200 + JSON body `{"status":"ack","correlation_id":"<echoed>"}`.
+struct AckEcho;
+impl wiremock::Respond for AckEcho {
+    fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+        let corr = request
+            .headers
+            .get("x-ai-memory-correlation-id")
+            .map(|v| v.to_str().unwrap_or("").to_string())
+            .unwrap_or_default();
+        let body = serde_json::json!({"status": "ack", "correlation_id": corr});
+        ResponseTemplate::new(200).set_body_json(body)
+    }
+}
+
+#[test]
+fn k7_hooks_subscription_config_round_trips_through_serde() {
+    // Operator-visible TOML deserializes cleanly into the K7
+    // `HooksConfig` shape. Asserting this here pins the wire format
+    // operators are expected to put in `~/.config/ai-memory/config.toml`.
+    let toml_src = r#"
+[hooks.subscription]
+hmac_secret = "fleet-wide-secret"
+"#;
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        hooks: HooksConfig,
+    }
+    let cfg: Wrapper = toml::from_str(toml_src).expect("parse [hooks.subscription]");
+    let secret = cfg
+        .hooks
+        .subscription
+        .as_ref()
+        .and_then(|s| s.hmac_secret.clone());
+    assert_eq!(secret.as_deref(), Some("fleet-wide-secret"));
+
+    // The constructor compiles cleanly when used programmatically —
+    // mirrors how AppConfig serializes the field.
+    let _ = HooksConfig {
+        subscription: Some(HooksSubscriptionConfig {
+            hmac_secret: Some("x".into()),
+        }),
+    };
+}
+
+#[test]
+fn k7_active_hmac_secret_setter_and_getter_round_trip() {
+    let _guard = K7_HMAC_GLOBAL_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    set_active_hooks_hmac_secret(Some("k7-test-secret".into()));
+    assert_eq!(
+        active_hooks_hmac_secret().as_deref(),
+        Some("k7-test-secret")
+    );
+
+    set_active_hooks_hmac_secret(None);
+    assert_eq!(active_hooks_hmac_secret(), None);
+}
+
+// Justification for `#[allow(clippy::await_holding_lock)]` on the two
+// async K7 tests: we deliberately hold a `std::sync::Mutex` across
+// `.await` points to serialize tests that mutate the process-wide
+// `ACTIVE_HOOKS_HMAC_SECRET` static. The lint exists to prevent
+// deadlocks when async tasks are scheduled on the same OS thread, but
+// these tests run with `flavor = "multi_thread"` and never call back
+// into themselves while the guard is held. A `tokio::sync::Mutex` would
+// satisfy the lint but would also force the synchronous setter test
+// (`k7_active_hmac_secret_setter_and_getter_round_trip`) into an
+// async context for no semantic gain.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "multi_thread")]
+async fn k7_hmac_signature_header_present_when_global_secret_configured() {
+    let _guard = K7_HMAC_GLOBAL_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    // ----------------------------------------------------------------
+    // Setup: stand up a wiremock POST listener with the K6 ACK
+    // responder. Register a subscription pointing at it WITHOUT a
+    // per-subscription secret. Configure the K7 server-wide HMAC
+    // override and dispatch one event. Assert the recorded request
+    // carries a `x-ai-memory-signature: sha256=<hex>` header even
+    // though the subscription itself was unsigned.
+    // ----------------------------------------------------------------
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/k7-hmac"))
+        .respond_with(AckEcho)
+        .mount(&server)
+        .await;
+
+    let (_keep, db_path) = fresh_db();
+    let url = format!("{}/k7-hmac", server.uri());
+    let _sub_id = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::insert(
+            &conn,
+            &NewSubscription {
+                url: &url,
+                events: "*",
+                // No per-sub secret — the K7 global override is the
+                // only signing key. Pre-K7 this would have produced an
+                // unsigned payload.
+                secret: None,
+                namespace_filter: None,
+                agent_filter: None,
+                created_by: Some("k7-hmac-test"),
+                event_types: None,
+            },
+        )
+        .expect("insert subscription")
+    };
+
+    set_active_hooks_hmac_secret(Some("k7-fleet-secret".into()));
+
+    // Dispatch a `memory_store` event. The dispatcher spawns a
+    // background thread for the actual HTTP send + retry ladder.
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::dispatch_event(
+            &conn,
+            "memory_store",
+            "memory-k7-hmac",
+            "ns-k7",
+            None,
+            &db_path,
+        );
+    }
+
+    // Poll the mock server for ~5s for the dispatch thread to land.
+    let req: Request = poll_for_first_request(&server).await;
+
+    // The header must be present and shaped `sha256=<64-hex-chars>`.
+    let sig_header = req
+        .headers
+        .get("x-ai-memory-signature")
+        .expect("signature header must be present when global secret is set")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        sig_header.starts_with("sha256="),
+        "signature header malformed: {sig_header}"
+    );
+    let hex_part = sig_header.trim_start_matches("sha256=");
+    assert_eq!(
+        hex_part.len(),
+        64,
+        "sha256 hex digest must be 64 chars; got {hex_part:?}"
+    );
+    assert!(
+        hex_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "sha256 digest must be lowercase hex; got {hex_part:?}"
+    );
+
+    // Assert the digest matches the K7 canonical construction:
+    // HMAC-SHA256(SHA256(secret), "<timestamp>.<body>"). We
+    // reconstruct the canonical string from the recorded request
+    // headers (timestamp) + body and the configured secret, then
+    // expect bit-for-bit equality.
+    let timestamp = req
+        .headers
+        .get("x-ai-memory-timestamp")
+        .expect("timestamp header must be present")
+        .to_str()
+        .unwrap();
+    let body = std::str::from_utf8(&req.body).expect("request body utf8");
+    let canonical = format!("{timestamp}.{body}");
+    let expected = expected_k7_signature("k7-fleet-secret", &canonical);
+    assert_eq!(
+        hex_part, expected,
+        "K7 server-wide signature must equal HMAC-SHA256(SHA256(secret), \"<ts>.<body>\")"
+    );
+
+    // Tear down the override so subsequent tests in the same process
+    // don't observe stale state.
+    set_active_hooks_hmac_secret(None);
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "multi_thread")]
+async fn k7_hmac_unset_means_unsigned_payload_when_no_per_sub_secret() {
+    let _guard = K7_HMAC_GLOBAL_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    // Sanity counter-test: when neither the per-subscription secret
+    // nor the K7 global override is set, the payload is unsigned
+    // (preserves pre-K7 behaviour).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/k7-unsigned"))
+        .respond_with(AckEcho)
+        .mount(&server)
+        .await;
+
+    let (_keep, db_path) = fresh_db();
+    let url = format!("{}/k7-unsigned", server.uri());
+    let _sub_id = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::insert(
+            &conn,
+            &NewSubscription {
+                url: &url,
+                events: "*",
+                secret: None,
+                namespace_filter: None,
+                agent_filter: None,
+                created_by: Some("k7-unsigned-test"),
+                event_types: None,
+            },
+        )
+        .expect("insert subscription")
+    };
+
+    set_active_hooks_hmac_secret(None);
+
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::dispatch_event(
+            &conn,
+            "memory_store",
+            "memory-k7-unsigned",
+            "ns-k7",
+            None,
+            &db_path,
+        );
+    }
+
+    let req: Request = poll_for_first_request(&server).await;
+    assert!(
+        req.headers.get("x-ai-memory-signature").is_none(),
+        "signature header must be absent when no per-sub secret AND no global override"
+    );
+}
+
+/// Poll the wiremock server for ~5s waiting for at least one request to
+/// land. Panics on timeout so the failure mode is loud.
+async fn poll_for_first_request(server: &MockServer) -> Request {
+    for _ in 0..50 {
+        let received = server.received_requests().await.unwrap_or_default();
+        if let Some(req) = received.into_iter().next() {
+            return req;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("K7 dispatch thread never reached wiremock");
+}
+
+/// Independent reference implementation of the K7 canonical signature
+/// — `HMAC-SHA256(SHA256(secret), canonical)` — using `sha2` directly
+/// so the test can't accidentally pass by sharing the production
+/// `hmac_sha256_hex` with itself.
+fn expected_k7_signature(plaintext_secret: &str, canonical: &str) -> String {
+    use sha2::{Digest, Sha256};
+    // Step 1: SHA-256 the plaintext secret to produce the keying
+    // material the K7 dispatcher passes into the HMAC keyed-hash
+    // construction. The dispatcher then hex-decodes that string back
+    // to bytes, so we mirror it.
+    let key_hex = {
+        let mut h = Sha256::new();
+        h.update(plaintext_secret.as_bytes());
+        format!("{:x}", h.finalize())
+    };
+    let key_bytes = hex_decode(&key_hex);
+
+    // Step 2: RFC 2104 HMAC-SHA256.
+    const BLOCK: usize = 64;
+    let mut key = if key_bytes.len() > BLOCK {
+        let mut h = Sha256::new();
+        h.update(&key_bytes);
+        h.finalize().to_vec()
+    } else {
+        key_bytes
+    };
+    key.resize(BLOCK, 0);
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= key[i];
+        opad[i] ^= key[i];
+    }
+    let inner = {
+        let mut h = Sha256::new();
+        h.update(ipad);
+        h.update(canonical.as_bytes());
+        h.finalize()
+    };
+    let outer = {
+        let mut h = Sha256::new();
+        h.update(opad);
+        h.update(inner);
+        h.finalize()
+    };
+    format!("{outer:x}")
+}
+
+fn hex_decode(s: &str) -> Vec<u8> {
+    let bytes = s.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return s.as_bytes().to_vec();
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        let hi = match pair[0] {
+            b'0'..=b'9' => pair[0] - b'0',
+            b'a'..=b'f' => pair[0] - b'a' + 10,
+            b'A'..=b'F' => pair[0] - b'A' + 10,
+            _ => return s.as_bytes().to_vec(),
+        };
+        let lo = match pair[1] {
+            b'0'..=b'9' => pair[1] - b'0',
+            b'a'..=b'f' => pair[1] - b'a' + 10,
+            b'A'..=b'F' => pair[1] - b'A' + 10,
+            _ => return s.as_bytes().to_vec(),
+        };
+        out.push((hi << 4) | lo);
+    }
+    out
+}

--- a/tests/k7_replay_tool.rs
+++ b/tests/k7_replay_tool.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K7 — `memory_subscription_replay` MCP-tool wiring test.
+//!
+//! K6 implemented the handler in `src/subscriptions.rs` but deferred the
+//! MCP registration (and dispatch wiring) to K7 to avoid colliding with
+//! the v0.7 B1 tool-count cascade. K7 ships the registration; this
+//! integration test pins the wired surface end-to-end:
+//!
+//! 1. `memory_subscription_replay` appears in `tool_definitions()` under
+//!    the full profile (and is reachable for `--profile power`).
+//! 2. The handler exposed at `crate::subscriptions::memory_subscription_replay`
+//!    returns a stable, ordered envelope when fed a synthetic event
+//!    series (delivered_at ascending, plus a `count` field equal to
+//!    `events.len()`).
+//!
+//! The test deliberately avoids spinning the full MCP stdio harness —
+//! the smoke matrix in `src/mcp.rs::mcp_tools_smoke_matrix` already
+//! covers JSON-RPC dispatch parity. Here we exercise the replay
+//! semantics that operators rely on for incident reconstruction.
+
+use ai_memory::profile::{Family, Profile};
+use ai_memory::subscriptions::{self, NewSubscription};
+use rusqlite::Connection;
+use tempfile::NamedTempFile;
+
+/// Stand up a fresh on-disk SQLite at a tempfile path with the
+/// production schema applied (incl. K6 subscription_dlq /
+/// subscription_events migrations).
+fn fresh_db() -> (NamedTempFile, std::path::PathBuf) {
+    let f = NamedTempFile::new().expect("tempfile");
+    let p = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&p).expect("db::open");
+    (f, p)
+}
+
+#[test]
+fn k7_replay_tool_registered_under_power_family() {
+    // K7: the tool must resolve to Family::Power so `--profile power`
+    // surfaces it. Source-anchored at src/profile.rs::Family::for_tool.
+    assert_eq!(
+        Family::for_tool("memory_subscription_replay"),
+        Some(Family::Power),
+        "memory_subscription_replay must live in Family::Power"
+    );
+
+    // Full profile loads it; core does not (it's an operator tool, not
+    // a data-plane tool).
+    assert!(Profile::full().loads("memory_subscription_replay"));
+    assert!(Profile::power().loads("memory_subscription_replay"));
+    assert!(!Profile::core().loads("memory_subscription_replay"));
+}
+
+#[test]
+fn k7_replay_returns_ordered_envelope_for_synthetic_event_series() {
+    let (_keep, db_path) = fresh_db();
+
+    // 1. Register one subscription so we have a stable subscription_id
+    //    to scope the replay against. URL doesn't need to resolve —
+    //    we never dispatch, only seed the audit table directly.
+    let sub_id = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::insert(
+            &conn,
+            &NewSubscription {
+                url: "https://example.invalid/k7-replay",
+                events: "*",
+                secret: None,
+                namespace_filter: None,
+                agent_filter: None,
+                created_by: Some("k7-replay-test"),
+                event_types: None,
+            },
+        )
+        .expect("insert subscription")
+    };
+
+    // 2. Seed three audit rows with strictly-increasing delivered_at
+    //    timestamps so we can assert the replay order is stable.
+    let series = [
+        ("corr-001", "memory_store", "2026-04-01T00:00:00Z"),
+        ("corr-002", "memory_promote", "2026-04-02T00:00:00Z"),
+        ("corr-003", "memory_delete", "2026-04-03T00:00:00Z"),
+    ];
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        for (corr, event, _) in &series {
+            // record_subscription_event stamps `delivered_at = Utc::now`
+            // internally — we override that below to get the deterministic
+            // timestamps the ordering assertion needs.
+            subscriptions::record_subscription_event(
+                &db_path,
+                &sub_id,
+                corr,
+                event,
+                "{\"k7-replay\":true}",
+            )
+            .expect("seed subscription_events row");
+            // Force the timestamp so the test is deterministic.
+            conn.execute(
+                "UPDATE subscription_events SET delivered_at = ?1 WHERE correlation_id = ?2",
+                rusqlite::params![series.iter().find(|s| s.0 == *corr).unwrap().2, corr],
+            )
+            .unwrap();
+        }
+    }
+
+    // 3. Replay everything since the epoch and pin the envelope shape.
+    let envelope = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::memory_subscription_replay(&conn, &sub_id, "1970-01-01T00:00:00Z")
+            .expect("replay should succeed")
+    };
+
+    // Envelope: { subscription_id, since, count, events: [...] }
+    assert_eq!(envelope["subscription_id"].as_str(), Some(sub_id.as_str()));
+    assert_eq!(envelope["since"].as_str(), Some("1970-01-01T00:00:00Z"));
+    assert_eq!(envelope["count"].as_u64(), Some(3));
+
+    let events = envelope["events"].as_array().expect("events array");
+    assert_eq!(events.len(), 3);
+
+    // Order is delivered_at ASC — same as the seed order.
+    let observed: Vec<&str> = events
+        .iter()
+        .map(|e| e["correlation_id"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(observed, vec!["corr-001", "corr-002", "corr-003"]);
+
+    // Replay with a `since` cutoff that excludes the first row.
+    let envelope_partial = {
+        let conn = Connection::open(&db_path).unwrap();
+        subscriptions::memory_subscription_replay(&conn, &sub_id, "2026-04-02T00:00:00Z")
+            .expect("partial replay should succeed")
+    };
+    assert_eq!(envelope_partial["count"].as_u64(), Some(2));
+    let partial: Vec<&str> = envelope_partial["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["correlation_id"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(partial, vec!["corr-002", "corr-003"]);
+}
+
+#[test]
+fn k7_replay_unknown_subscription_returns_empty_envelope() {
+    // Operator hits replay for a subscription that has no audit rows
+    // (or never existed). The handler returns count=0 with an empty
+    // events array — the operator-facing distinction between
+    // "no events yet" and "unknown subscription" is recoverable from
+    // the parallel `memory_list_subscriptions` view.
+    let (_keep, db_path) = fresh_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let envelope =
+        subscriptions::memory_subscription_replay(&conn, "does-not-exist", "1970-01-01T00:00:00Z")
+            .expect("replay must not fail on unknown subscription");
+    assert_eq!(envelope["count"].as_u64(), Some(0));
+    assert!(envelope["events"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

K6 (#594) shipped the on-disk substrate for the v0.7 subscription reliability epic — UUIDv7 correlation ids, the K6 ACK contract, the [200ms, 1s, 5s] retry ladder, and the `subscription_dlq` table — but deferred the MCP-tool registration to K7 to avoid colliding with the v0.7 B1 tool-count cascade (`memory_load_family`, #595). B1 has now landed at tool-count 46, so K7 ships the registration:

- **Register `memory_subscription_replay`** under `Family::Power`. Replays the K6 audit trail (`subscription_events`) for one subscription since an RFC3339 cursor, ordered by `delivered_at` asc — the operator-facing handle for incident reconstruction.
- **Register `memory_subscription_dlq_list`** under `Family::Power`. Inspector for the K6 DLQ; supports an optional `subscription_id` filter and a `limit` cap (default 100, max 1000).
- **Server-wide HMAC override** via `[hooks.subscription] hmac_secret` in `config.toml`. When set, every outgoing payload is signed with `HMAC-SHA256(SHA256(secret), "<timestamp>.<body>")` — the same keying the per-subscription path uses, so receiver verification is identical regardless of which path configured the secret. Per-sub secrets still win over the global override.

Tool count: 46 → 48. Cascade updated in `src/profile.rs`, `src/sizes.rs`, `src/cli/doctor.rs`, and the four test files (`capabilities_v3`, `calibration_t0`, `integration`, `harness_integration` — the last had a stale 5-vs-6 assertion left over from B1).

## Test plan

- [x] `cargo build --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 2174 passed, 0 failed
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --tests` — 2728 passed, 0 failed
- [x] `cargo test --test k7_replay_tool` — 3 / 3 passed
- [x] `cargo test --test k7_dlq_list_tool` — 3 / 3 passed
- [x] `cargo test --test k7_hmac` — 4 / 4 passed (signature header, unsigned-when-unset, setter round-trip, TOML deserialize)

## AI involvement

Implementation was authored end-to-end by Claude (Opus 4.7, 1M context) under the K7 task spec. All four engineering gates (fmt, clippy on the lib surface, tests, no `--no-verify`) were run locally before commit. No new schema migration was needed — K6 already added the `subscription_dlq` and `subscription_events` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)