### PR TITLE
feat: v0.7-j7 — memory_find_paths (BFS over KG, dual backend)

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2069,8 +2069,8 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (48 tools loaded)"),
-            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
+            stdout.contains("Full   (49 tools loaded)"),
+            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths)"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2126,8 +2126,8 @@ mod tests {
         let tools = v["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            48,
-            "raw_table must include all 48 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
+            49,
+            "raw_table must include all 49 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/db.rs
+++ b/src/db.rs
@@ -3430,6 +3430,138 @@ pub fn kg_query(
         .map_err(Into::into)
 }
 
+/// Default cap on paths returned by [`find_paths`] when the caller does
+/// not specify one. Matches the v0.7 J7 charter.
+pub const FIND_PATHS_DEFAULT_LIMIT: usize = 10;
+
+/// Hard ceiling on paths returned by [`find_paths`]. A crafted call
+/// asking for more than this many paths is clamped down. Matches the
+/// v0.7 J7 charter.
+pub const FIND_PATHS_MAX_LIMIT: usize = 50;
+
+/// Hard ceiling on traversal depth supported by [`find_paths`].
+/// Distinct from [`KG_QUERY_MAX_SUPPORTED_DEPTH`] because path
+/// enumeration is more expensive than reachability — we can afford a
+/// slightly deeper budget for the BFS but not by much.
+pub const FIND_PATHS_MAX_DEPTH: usize = 7;
+
+/// Default depth used when the caller omits `max_depth`. Mirrors the
+/// v0.7 J7 charter's "shallow by default, opt-in deep traversal" rule.
+pub const FIND_PATHS_DEFAULT_DEPTH: usize = 4;
+
+/// v0.7 J7 — enumerate up to N undirected paths between two memories.
+///
+/// Walks `memory_links` with a recursive CTE that carries the full
+/// visited-id chain on each row, both as the outbound `path` rendered
+/// for callers and as the cycle-detection set so the traversal cannot
+/// loop on a cyclic link graph. Each row of the CTE represents one
+/// candidate prefix; rows that reach `target_id` are projected out as
+/// completed paths.
+///
+/// Treated as undirected: we traverse `memory_links` in both directions
+/// at every hop. The KG corpus uses directional links to model temporal
+/// ordering of an assertion (`source → target`), but path queries are
+/// asking "are these two memories connected via *any* relation chain?",
+/// which requires the symmetric closure. The CTE achieves that by
+/// `UNION ALL` over the original edge and the reverse edge at each hop.
+///
+/// `max_depth` defaults to [`FIND_PATHS_DEFAULT_DEPTH`] and is clamped
+/// at [`FIND_PATHS_MAX_DEPTH`]; passing a larger value yields an
+/// explicit error rather than silent truncation. `max_results`
+/// defaults to [`FIND_PATHS_DEFAULT_LIMIT`] and is clamped at
+/// [`FIND_PATHS_MAX_LIMIT`]; passing a larger value collapses to the
+/// ceiling without error (paths beyond the cap are dropped, the
+/// shortest paths win on the `ORDER BY`).
+///
+/// Returns `Vec<Vec<String>>` — one inner vector per discovered path,
+/// each carrying the chain of memory ids from `source_id` (first) to
+/// `target_id` (last). Self-paths (`source_id == target_id`) collapse
+/// to a single one-element path. Disconnected pairs return an empty
+/// outer vector.
+pub fn find_paths(
+    conn: &Connection,
+    source_id: &str,
+    target_id: &str,
+    max_depth: Option<usize>,
+    max_results: Option<usize>,
+) -> Result<Vec<Vec<String>>> {
+    let depth = max_depth.unwrap_or(FIND_PATHS_DEFAULT_DEPTH);
+    if depth == 0 {
+        anyhow::bail!("max_depth must be >= 1");
+    }
+    if depth > FIND_PATHS_MAX_DEPTH {
+        anyhow::bail!("max_depth={depth} exceeds supported depth={FIND_PATHS_MAX_DEPTH}");
+    }
+    let cap = max_results
+        .unwrap_or(FIND_PATHS_DEFAULT_LIMIT)
+        .clamp(1, FIND_PATHS_MAX_LIMIT);
+
+    // Self-path short-circuit. The recursive CTE below requires depth>=1
+    // before it can match `target_id`; the trivial chain is just the
+    // single-element path through the start node.
+    if source_id == target_id {
+        return Ok(vec![vec![source_id.to_string()]]);
+    }
+
+    // The CTE walks symmetric edges: for each row in `memory_links` we
+    // also generate its reverse so the traversal is undirected. Cycle
+    // detection uses the JSON-encoded path array (same trick as
+    // `kg_query`) — `NOT EXISTS (... json_each ...)` short-circuits the
+    // recursion as soon as the next hop would revisit a node already in
+    // the prefix.
+    //
+    // The completed-path filter sits in the outer SELECT rather than
+    // the recursive member because a partial prefix that lands on
+    // `target_id` should be reported AND continue to extend (a longer
+    // path through `target_id` might reach itself through a different
+    // route — though for the KG that should be rare, the CTE doesn't
+    // need to know that). `ORDER BY depth, path` keeps the shortest
+    // paths first so the `LIMIT` cap drops the longest tail.
+    let sql = format!(
+        "WITH RECURSIVE traversal(current_id, depth, path) AS (
+            SELECT ?1, 0, json_array(?1)
+            UNION ALL
+            SELECT next_id, t.depth + 1,
+                   json_insert(t.path, '$[' || json_array_length(t.path) || ']', next_id)
+            FROM traversal t
+            JOIN (
+                SELECT source_id AS from_id, target_id AS next_id FROM memory_links
+                UNION
+                SELECT target_id AS from_id, source_id AS next_id FROM memory_links
+            ) edges ON edges.from_id = t.current_id
+            WHERE t.depth < ?3
+              AND NOT EXISTS (
+                  SELECT 1 FROM json_each(t.path) WHERE value = next_id
+              )
+         )
+         SELECT path
+         FROM traversal
+         WHERE current_id = ?2 AND depth >= 1
+         ORDER BY depth ASC, path ASC
+         LIMIT ?4"
+    );
+
+    let depth_i64 = i64::try_from(depth).unwrap_or(i64::MAX);
+    let cap_i64 = i64::try_from(cap).unwrap_or(i64::MAX);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![source_id, target_id, depth_i64, cap_i64], |row| {
+        let json_path: String = row.get(0)?;
+        Ok(json_path)
+    })?;
+
+    let mut paths: Vec<Vec<String>> = Vec::new();
+    for row in rows {
+        let json = row?;
+        let parsed: Vec<String> = serde_json::from_str(&json).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+        paths.push(parsed);
+    }
+
+    Ok(paths)
+}
+
 /// List all aliases registered for an entity, ordered by registration
 /// time then alphabetical for stable display.
 fn list_entity_aliases(conn: &Connection, entity_id: &str) -> Result<Vec<String>> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -514,6 +514,20 @@ pub(crate) fn tool_definitions() -> Value {
                 }
             },
             {
+                "name": "memory_find_paths",
+                "description": "v0.7 J7 — enumerate up to N paths through the KG between two memories. BFS with cycle detection over `memory_links` (treated as undirected). Returns paths as id chains, source first, target last. `max_depth` ≤ 7, `max_results` ≤ 50.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "source_id": {"type": "string", "description": "Path origin memory ID."},
+                        "target_id": {"type": "string", "description": "Path destination memory ID."},
+                        "max_depth": {"type": "integer", "minimum": 1, "maximum": 7, "default": 4, "description": "Maximum hops between source and target. Default 4, ceiling 7."},
+                        "max_results": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10, "description": "Maximum paths returned (shortest-first). Default 10, ceiling 50."}
+                    },
+                    "required": ["source_id", "target_id"]
+                }
+            },
+            {
                 "name": "memory_delete",
                 "description": "Delete a memory by ID.",
                 "inputSchema": {
@@ -2177,7 +2191,7 @@ pub fn build_capabilities_tools(
     use crate::config::{AllowlistDecision, ToolEntry};
     use crate::profile::{ALWAYS_ON_TOOLS, Family};
 
-    let mut entries: Vec<ToolEntry> = Vec::with_capacity(48);
+    let mut entries: Vec<ToolEntry> = Vec::with_capacity(49);
 
     for fam in Family::all() {
         let family_name = fam.name();
@@ -2798,6 +2812,48 @@ fn handle_kg_query(conn: &rusqlite::Connection, params: &Value) -> Result<Value,
         "memories": memories_json,
         "paths": paths_json,
         "count": nodes.len(),
+    }))
+}
+
+/// v0.7 J7 — `memory_find_paths` handler. Enumerates up to `max_results`
+/// paths through the KG between two memories using BFS with cycle
+/// detection. Backend dispatch lives in the SAL — the SQLite path goes
+/// through `db::find_paths` (recursive CTE); a Postgres deployment
+/// would route through `PostgresStore::find_paths` which dispatches on
+/// the resolved [`crate::store::KgBackend`] (Cypher when AGE is
+/// installed, recursive CTE otherwise). The wire shape is identical
+/// across backends: `paths` is a list of id chains where each chain
+/// has `source_id` first and `target_id` last.
+pub fn handle_find_paths(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
+    let source_id = params["source_id"]
+        .as_str()
+        .ok_or("source_id is required")?;
+    let target_id = params["target_id"]
+        .as_str()
+        .ok_or("target_id is required")?;
+    validate::validate_id(source_id).map_err(|e| e.to_string())?;
+    validate::validate_id(target_id).map_err(|e| e.to_string())?;
+
+    let max_depth = params["max_depth"]
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok());
+    let max_results = params["max_results"]
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok());
+
+    let paths =
+        db::find_paths(conn, source_id, target_id, max_depth, max_results).map_err(|e| {
+            // Match the kg_query convention: depth-budget violations
+            // surface their error message verbatim so callers can
+            // distinguish "you asked for too much" from a real fault.
+            e.to_string()
+        })?;
+
+    Ok(json!({
+        "source_id": source_id,
+        "target_id": target_id,
+        "paths": paths,
+        "count": paths.len(),
     }))
 }
 
@@ -4726,6 +4782,7 @@ fn handle_request(
                 "memory_kg_timeline" => handle_kg_timeline(conn, arguments),
                 "memory_kg_invalidate" => handle_kg_invalidate(conn, db_path, arguments),
                 "memory_kg_query" => handle_kg_query(conn, arguments),
+                "memory_find_paths" => handle_find_paths(conn, arguments),
                 "memory_delete" => {
                     handle_delete(conn, db_path, arguments, vector_index, mcp_client)
                 }
@@ -5283,7 +5340,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn tool_definitions_returns_48_tools() {
+    fn tool_definitions_returns_49_tools() {
         // v0.6.3 adds memory_get_taxonomy (Pillar 1 / Stream A),
         // memory_check_duplicate (Pillar 2 / Stream D),
         // memory_entity_register + memory_entity_get_by_alias
@@ -5295,15 +5352,16 @@ mod tests {
         // v0.7 B1 adds memory_load_family (Family::Core) → 46.
         // v0.7 K7 adds memory_subscription_replay +
         // memory_subscription_dlq_list (Family::Power) → 48.
+        // v0.7 J7 adds memory_find_paths (Family::Graph) → 49.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 48);
+        assert_eq!(tools.len(), 49);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
     /// registers exactly 6 family tools (5 baseline + v0.7 B1
     /// memory_load_family) + 1 always-on bootstrap (memory_capabilities)
-    /// = 7 visible tools. `--profile full` registers all 48.
+    /// = 7 visible tools. `--profile full` registers all 49.
     #[test]
     fn tool_definitions_for_profile_core_registers_6_plus_capabilities() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::core());
@@ -5345,31 +5403,32 @@ mod tests {
     }
 
     #[test]
-    fn tool_definitions_for_profile_full_registers_48() {
+    fn tool_definitions_for_profile_full_registers_49() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::full());
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            48,
+            49,
             "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay (1) + \
              v0.7 H4 memory_verify (1) + v0.7 B1 memory_load_family (1) + \
-             v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list (2) = 48"
+             v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list (2) + \
+             v0.7 J7 memory_find_paths (1) = 49"
         );
     }
 
     #[test]
-    fn tool_definitions_for_profile_graph_registers_seventeen() {
+    fn tool_definitions_for_profile_graph_registers_eighteen() {
         let defs = tool_definitions_for_profile(&crate::profile::Profile::graph());
         let tools = defs["tools"].as_array().unwrap();
-        // 6 core (with v0.7 B1 memory_load_family) + 10 graph (8
-        // baseline + memory_replay + memory_verify) + 1 always-on
-        // capabilities = 17 (capabilities is in meta but loaded as
-        // bootstrap; without it we'd have 16).
+        // 6 core (with v0.7 B1 memory_load_family) + 11 graph (8
+        // baseline + memory_replay + memory_verify + v0.7 J7
+        // memory_find_paths) + 1 always-on capabilities = 18.
         assert_eq!(
             tools.len(),
-            17,
+            18,
             "graph profile = core(6, with memory_load_family) + \
-             graph(10, with memory_replay+memory_verify) + capabilities-bootstrap(1)"
+             graph(11, with memory_replay+memory_verify+memory_find_paths) + \
+             capabilities-bootstrap(1)"
         );
     }
 
@@ -5381,8 +5440,8 @@ mod tests {
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            17,
-            "core,graph = 6 (B1 memory_load_family) + 10 (I4 memory_replay + H4 memory_verify) + capabilities = 17"
+            18,
+            "core,graph = 6 (B1 memory_load_family) + 11 (I4 memory_replay + H4 memory_verify + J7 memory_find_paths) + capabilities = 18"
         );
     }
 
@@ -5401,9 +5460,9 @@ mod tests {
         assert_eq!(core_row["tool_count"], 6);
         let graph_row = families.iter().find(|r| r["name"] == "graph").unwrap();
         assert_eq!(graph_row["loaded"], false);
-        // v0.7 H4 — graph now ships 10 tools (8 baseline + memory_replay
-        // [I4] + memory_verify [H4]).
-        assert_eq!(graph_row["tool_count"], 10);
+        // v0.7 J7 — graph now ships 11 tools (8 baseline + memory_replay
+        // [I4] + memory_verify [H4] + memory_find_paths [J7]).
+        assert_eq!(graph_row["tool_count"], 11);
 
         let always_on = v["always_on"].as_array().unwrap();
         assert_eq!(always_on.len(), 1);
@@ -5417,13 +5476,14 @@ mod tests {
         assert_eq!(v["family"], "graph");
         assert_eq!(v["loaded_under_active_profile"], false);
         let tools = v["tools"].as_array().unwrap();
-        // v0.7 H4 — graph now lists 10 tools (8 baseline + memory_replay
-        // [I4] + memory_verify [H4]).
-        assert_eq!(tools.len(), 10);
+        // v0.7 J7 — graph now lists 11 tools (8 baseline + memory_replay
+        // [I4] + memory_verify [H4] + memory_find_paths [J7]).
+        assert_eq!(tools.len(), 11);
         // Spot-check known graph tool present.
         assert!(tools.iter().any(|t| t == "memory_kg_query"));
         assert!(tools.iter().any(|t| t == "memory_replay"));
         assert!(tools.iter().any(|t| t == "memory_verify"));
+        assert!(tools.iter().any(|t| t == "memory_find_paths"));
     }
 
     #[test]
@@ -5432,9 +5492,9 @@ mod tests {
         let v = handle_capabilities_family("graph", true, &p, None, None, None).unwrap();
         assert_eq!(v["family"], "graph");
         let tools = v["tools"].as_array().unwrap();
-        // v0.7 H4 — graph now ships 10 schemas (8 baseline + memory_replay
-        // [I4] + memory_verify [H4]).
-        assert_eq!(tools.len(), 10);
+        // v0.7 J7 — graph now ships 11 schemas (8 baseline + memory_replay
+        // [I4] + memory_verify [H4] + memory_find_paths [J7]).
+        assert_eq!(tools.len(), 11);
         // Each row must carry the full MCP tool definition shape.
         for tool in tools {
             assert!(tool.get("name").is_some(), "missing name");
@@ -5795,10 +5855,11 @@ mod tests {
             "missing err outcome in: {captured}"
         );
     }
-    /// Parametrized smoke matrix for all 48 MCP tools (Justice of MCP pathway).
+    /// Parametrized smoke matrix for all 49 MCP tools (Justice of MCP pathway).
     /// v0.6.3 baseline = 43; v0.7.0 I4 added memory_replay (44);
     /// v0.7 H4 added memory_verify (45); v0.7 B1 added memory_load_family (46);
-    /// v0.7 K7 added memory_subscription_replay + memory_subscription_dlq_list (48).
+    /// v0.7 K7 added memory_subscription_replay + memory_subscription_dlq_list (48);
+    /// v0.7 J7 added memory_find_paths (49).
     /// Tier 1: happy path with canonical valid args.
     /// Tier 2: required arg validation (missing required arg → error).
     #[test]
@@ -5874,6 +5935,17 @@ mod tests {
             ToolCase {
                 name: "memory_kg_query",
                 valid_args: json!({"source_id": "fake-id-for-test"}),
+                required_arg: Some("source_id"),
+            },
+            // v0.7 J7 — memory_find_paths: an unknown source/target
+            // returns an empty `paths` list, not an error, so the happy
+            // path works without pre-seeding the DB.
+            ToolCase {
+                name: "memory_find_paths",
+                valid_args: json!({
+                    "source_id": "fake-src-for-test",
+                    "target_id": "fake-dst-for-test",
+                }),
                 required_arg: Some("source_id"),
             },
             ToolCase {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -26,12 +26,12 @@
 //!
 //! - `core` — 6 tools, the new v0.6.4 default (v0.7 B1 added
 //!   `memory_load_family`). Always loaded.
-//! - `graph` — adds the 10 KG/entity/replay/verify tools. ~16 tools.
+//! - `graph` — adds the 11 KG/entity/replay/verify/find_paths tools. ~17 tools.
 //! - `admin` — adds lifecycle (5) + governance (8). ~19 tools.
 //! - `power` — adds the 8 LLM-augmented + operator tools (consolidate,
 //!   auto_tag, …, plus the v0.7 K7 subscription-reliability pair).
 //!   ~14 tools.
-//! - `full` — every family. 48 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 K7 `memory_subscription_replay` + `memory_subscription_dlq_list`).
+//! - `full` — every family. 49 tools (v0.6.3 baseline 43 + v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 K7 `memory_subscription_replay` + `memory_subscription_dlq_list` + v0.7 J7 `memory_find_paths`).
 //! - `custom` — comma-separated family list (`core,graph,archive` …).
 //!   `core` is implicitly added if missing — there's no profile that
 //!   ships *less than* the 5 core tools.
@@ -57,11 +57,12 @@
 use std::str::FromStr;
 
 /// A tool family. Source-anchored at `src/mcp.rs::tool_definitions()`
-/// 2026-05-05. Counts must sum to 48 (the v0.6.3.1 baseline of 43 +
+/// 2026-05-05. Counts must sum to 49 (the v0.6.3.1 baseline of 43 +
 /// v0.7.0 I4 `memory_replay` + v0.7 H4 `memory_verify` (both in
 /// `Family::Graph`) + v0.7 B1 `memory_load_family` in `Family::Core` +
 /// v0.7 K7 `memory_subscription_replay` and `memory_subscription_dlq_list`
-/// in `Family::Power`).
+/// in `Family::Power` +
+/// v0.7 J7 `memory_find_paths` in `Family::Graph`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Family {
     /// store, recall, list, get, search, load_family — 6
@@ -73,7 +74,7 @@ pub enum Family {
     Lifecycle,
     /// kg_query, kg_timeline, kg_invalidate, link, get_links,
     /// entity_register, entity_get_by_alias, get_taxonomy, replay,
-    /// verify — 10 (replay added in v0.7.0 I4 — joins to the I2
+    /// verify, find_paths — 11 (replay added in v0.7.0 I4 — joins to the I2
     /// transcript-link substrate to reconstruct a memory's source
     /// transcript chain; verify added in v0.7 H4 — re-checks the
     /// Ed25519 signature on a stored memory_links row.)
@@ -119,7 +120,8 @@ impl Family {
             // lifecycle (5)
             "memory_update" | "memory_delete" | "memory_forget" | "memory_gc"
             | "memory_promote" => Some(Self::Lifecycle),
-            // graph (10 — v0.7.0 I4 added memory_replay; v0.7 H4 added memory_verify)
+            // graph (11 — v0.7.0 I4 added memory_replay; v0.7 H4 added memory_verify;
+            // v0.7 J7 added memory_find_paths)
             "memory_kg_query"
             | "memory_kg_timeline"
             | "memory_kg_invalidate"
@@ -129,7 +131,8 @@ impl Family {
             | "memory_entity_get_by_alias"
             | "memory_get_taxonomy"
             | "memory_replay"
-            | "memory_verify" => Some(Self::Graph),
+            | "memory_verify"
+            | "memory_find_paths" => Some(Self::Graph),
             // governance (8)
             "memory_pending_list"
             | "memory_pending_approve"
@@ -206,8 +209,9 @@ impl Family {
             // Core: 5 baseline + memory_load_family (v0.7 B1) = 6.
             Self::Core => 6,
             Self::Lifecycle | Self::Meta => 5,
-            // Graph: 8 baseline + memory_replay (v0.7.0 I4) + memory_verify (v0.7 H4) = 10.
-            Self::Graph => 10,
+            // Graph: 8 baseline + memory_replay (v0.7.0 I4) + memory_verify (v0.7 H4) +
+            // memory_find_paths (v0.7 J7) = 11.
+            Self::Graph => 11,
             Self::Governance | Self::Power => 8,
             Self::Archive => 4,
             Self::Other => 2,
@@ -261,6 +265,9 @@ impl Family {
                 // v0.7 H4 — re-verifies a stored link's Ed25519
                 // signature on demand, returning attest_level.
                 "memory_verify",
+                // v0.7 J7 — enumerate up to N paths between two memories
+                // (BFS with cycle detection over memory_links).
+                "memory_find_paths",
             ],
             Self::Governance => &[
                 "memory_pending_list",
@@ -351,9 +358,9 @@ impl Profile {
         }
     }
 
-    /// `graph` — core + graph. 16 tools (v0.7.0 I4 added `memory_replay`;
+    /// `graph` — core + graph. 17 tools (v0.7.0 I4 added `memory_replay`;
     /// v0.7 H4 added `memory_verify`; v0.7 B1 added `memory_load_family`
-    /// to core).
+    /// to core; v0.7 J7 added `memory_find_paths`).
     #[must_use]
     pub fn graph() -> Self {
         Self {
@@ -380,10 +387,10 @@ impl Profile {
         }
     }
 
-    /// `full` — every family. 48 tools (v0.6.3 baseline 43 + v0.7.0 I4
+    /// `full` — every family. 49 tools (v0.6.3 baseline 43 + v0.7.0 I4
     /// `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1
     /// `memory_load_family` + v0.7 K7 `memory_subscription_replay`
-    /// + `memory_subscription_dlq_list`).
+    /// + `memory_subscription_dlq_list` + v0.7 J7 `memory_find_paths`).
     #[must_use]
     pub fn full() -> Self {
         Self {
@@ -562,14 +569,15 @@ mod tests {
     }
 
     #[test]
-    fn family_expected_tool_counts_sum_to_48() {
+    fn family_expected_tool_counts_sum_to_49() {
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 48,
+            total, 49,
             "v0.6.3.1 baseline (43) + v0.7.0 I4 `memory_replay` + v0.7 H4 \
              `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 K7 \
              `memory_subscription_replay` + `memory_subscription_dlq_list` \
-             = 48. If this drifts, update Family::expected_tool_count and \
+             + v0.7 J7 `memory_find_paths` \
+             = 49. If this drifts, update Family::expected_tool_count and \
              the family map docs together."
         );
     }
@@ -619,12 +627,12 @@ mod tests {
     }
 
     #[test]
-    fn profile_graph_has_sixteen_tools() {
+    fn profile_graph_has_seventeen_tools() {
         let p = Profile::graph();
-        // v0.7 H4 — Graph now ships 10 tools (8 baseline + memory_replay
-        // [I4] + memory_verify [H4]); v0.7 B1 added memory_load_family
-        // to core (6 instead of 5).
-        assert_eq!(p.expected_tool_count(), 6 + 10);
+        // v0.7 J7 — Graph now ships 11 tools (8 baseline + memory_replay
+        // [I4] + memory_verify [H4] + memory_find_paths [J7]); v0.7 B1
+        // added memory_load_family to core (6 instead of 5).
+        assert_eq!(p.expected_tool_count(), 6 + 11);
         assert!(p.includes(Family::Graph));
     }
 
@@ -647,13 +655,13 @@ mod tests {
     }
 
     #[test]
-    fn profile_full_has_forty_eight_tools() {
+    fn profile_full_has_forty_nine_tools() {
         let p = Profile::full();
-        // v0.7 K7 — full surface = 43 baseline + memory_replay (I4) +
+        // v0.7 J7 (post-K7) — full surface = 43 baseline + memory_replay (I4) +
         // memory_verify (H4) + memory_load_family (B1) +
-        // memory_subscription_replay (K7) + memory_subscription_dlq_list
-        // (K7) = 48.
-        assert_eq!(p.expected_tool_count(), 48);
+        // memory_subscription_replay (K7) + memory_subscription_dlq_list (K7) +
+        // memory_find_paths (J7) = 49.
+        assert_eq!(p.expected_tool_count(), 49);
 
         // The K7 additions live in Family::Power (operator/governance),
         // so the `power` profile picks them up too.
@@ -679,14 +687,14 @@ mod tests {
 
     #[test]
     fn parse_custom_comma_list_dedup() {
-        // `core,graph` → core (6, after v0.7 B1) + graph (10, after v0.7
-        // H4) = 16 tools. Meta is NOT included — `memory_capabilities`
+        // `core,graph` → core (6, after v0.7 B1) + graph (11, after v0.7
+        // J7) = 17 tools. Meta is NOT included — `memory_capabilities`
         // is always-on bootstrapped outside the family map (v0.6.4-002).
         let p = Profile::parse("core,graph").unwrap();
         assert!(p.includes(Family::Core));
         assert!(!p.includes(Family::Meta));
         assert!(p.includes(Family::Graph));
-        assert_eq!(p.expected_tool_count(), 16);
+        assert_eq!(p.expected_tool_count(), 17);
     }
 
     #[test]
@@ -798,6 +806,8 @@ mod tests {
             "memory_replay",
             // graph (v0.7 H4 addition)
             "memory_verify",
+            // graph (v0.7 J7 addition)
+            "memory_find_paths",
             // governance
             "memory_pending_list",
             "memory_pending_approve",
@@ -834,10 +844,11 @@ mod tests {
         ];
         assert_eq!(
             baseline.len(),
-            48,
+            49,
             "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) + \
              1 (v0.7 H4 memory_verify) + 1 (v0.7 B1 memory_load_family) + \
-             2 (v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list) = 48"
+             2 (v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list) + \
+             1 (v0.7 J7 memory_find_paths) = 49"
         );
         for name in baseline {
             assert!(

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -140,16 +140,17 @@ mod tests {
     /// `tool_definitions()` regressions that would silently hide other
     /// failures.
     #[test]
-    fn table_has_48_entries_matching_tool_definitions_count() {
+    fn table_has_49_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 48,
-            "expected exactly 48 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
+            n, 49,
+            "expected exactly 49 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
              `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 \
              `memory_load_family` + v0.7 K7 `memory_subscription_replay` \
-             + `memory_subscription_dlq_list`, source-anchored at \
-             src/mcp.rs::tool_definitions); got {n}. If the count changed, \
-             update the family map and this assertion together."
+             + `memory_subscription_dlq_list` + v0.7 J7 `memory_find_paths`, \
+             source-anchored at src/mcp.rs::tool_definitions); got {n}. \
+             If the count changed, update the family map and this \
+             assertion together."
         );
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1233,6 +1233,225 @@ impl PostgresStore {
         })
     }
 
+    /// v0.7 J7 — enumerate up to N paths between two memories.
+    ///
+    /// Routes on the [`KgBackend`] resolved at [`Self::connect`] time
+    /// (J1 substrate). When AGE is installed the enumeration runs as a
+    /// Cypher `MATCH p = (s)-[*..N]-(t) RETURN p LIMIT M` query through
+    /// the `memory_graph` projection; otherwise we fall back to a
+    /// recursive CTE over the `memory_links` table that mirrors the
+    /// SQLite shape in `db::find_paths`.
+    ///
+    /// Both branches return rows in the same `Vec<Vec<String>>` shape
+    /// so the upper-layer `memory_find_paths` handler stays
+    /// backend-blind.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::InvalidInput` for `max_depth == 0` or above
+    /// the supported ceiling, and `StoreError::BackendUnavailable` for
+    /// any underlying SQL or Cypher error.
+    pub async fn find_paths(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        max_depth: Option<usize>,
+        max_results: Option<usize>,
+    ) -> StoreResult<Vec<Vec<String>>> {
+        match self.kg_backend {
+            KgBackend::Age => {
+                self.find_paths_cypher(source_id, target_id, max_depth, max_results)
+                    .await
+            }
+            KgBackend::Cte => {
+                self.find_paths_cte(source_id, target_id, max_depth, max_results)
+                    .await
+            }
+        }
+    }
+
+    /// Recursive-CTE fallback for `find_paths` on Postgres.
+    ///
+    /// Mirrors the SQLite recursive-CTE in `db::find_paths` so vanilla
+    /// Postgres deployments (no AGE extension) get the same enumeration
+    /// semantics. The walk is undirected: edges are unioned with their
+    /// reverse so paths can traverse `memory_links` against the
+    /// declared direction. Cycle prevention uses a TEXT-array prefix
+    /// of visited ids.
+    ///
+    /// # Errors
+    ///
+    /// `StoreError::InvalidInput` for an out-of-range `max_depth`;
+    /// `StoreError::BackendUnavailable` for any sqlx error.
+    pub async fn find_paths_cte(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        max_depth: Option<usize>,
+        max_results: Option<usize>,
+    ) -> StoreResult<Vec<Vec<String>>> {
+        let depth = max_depth.unwrap_or(FIND_PATHS_DEFAULT_DEPTH_SAL);
+        validate_find_paths_depth(depth)?;
+        let cap = max_results
+            .unwrap_or(FIND_PATHS_DEFAULT_LIMIT_SAL)
+            .clamp(1, FIND_PATHS_MAX_LIMIT_SAL);
+
+        if source_id == target_id {
+            return Ok(vec![vec![source_id.to_string()]]);
+        }
+
+        let depth_i32 = i32::try_from(depth).unwrap_or(i32::MAX);
+        let cap_i64 = i64::try_from(cap).unwrap_or(i64::MAX);
+
+        // The CTE walks symmetric edges via a UNION over the original
+        // and reverse direction. The visited-id prefix is carried as
+        // TEXT[] so we can both check membership (= ANY) and append
+        // (array_append). Rows whose `current_id` matches the target
+        // and whose depth is at least 1 are reported as completed
+        // paths; ordering by depth then path keeps the shortest paths
+        // first so the LIMIT cap drops the longest tail.
+        let sql = "WITH RECURSIVE traversal(current_id, depth, path) AS (
+                SELECT $1::TEXT, 0, ARRAY[$1::TEXT]
+                UNION ALL
+                SELECT edges.next_id, t.depth + 1, t.path || edges.next_id
+                FROM traversal t
+                JOIN (
+                    SELECT source_id AS from_id, target_id AS next_id FROM memory_links
+                    UNION
+                    SELECT target_id AS from_id, source_id AS next_id FROM memory_links
+                ) edges ON edges.from_id = t.current_id
+                WHERE t.depth < $3
+                  AND NOT (edges.next_id = ANY(t.path))
+            )
+            SELECT path
+            FROM traversal
+            WHERE current_id = $2 AND depth >= 1
+            ORDER BY depth ASC, path ASC
+            LIMIT $4";
+
+        let rows = sqlx::query(sql)
+            .bind(source_id)
+            .bind(target_id)
+            .bind(depth_i32)
+            .bind(cap_i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| to_store_err("cte find_paths", e))?;
+
+        rows.iter()
+            .map(|r| {
+                let path: Vec<String> = r
+                    .try_get::<Vec<String>, _>("path")
+                    .map_err(|e| to_store_err("read path", e))?;
+                Ok(path)
+            })
+            .collect()
+    }
+
+    /// Cypher (Apache AGE) implementation of `find_paths`.
+    ///
+    /// Wraps a `MATCH p = (s)-[*..N]-(t) RETURN [n IN nodes(p) | n.id]`
+    /// traversal in the `cypher('memory_graph', ...)` set-returning
+    /// function, ordered by `length(p)` so shorter paths land first.
+    /// Source / target ids are bound through AGE's `$vars` JSON so
+    /// user input is never interpolated into the Cypher body. The
+    /// variable-length pattern's upper bound IS interpolated — Cypher
+    /// does not accept a parameter there — but `validate_find_paths_depth`
+    /// already clamps it to a small bounded integer with no injection
+    /// surface.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::InvalidInput` for an out-of-range
+    /// `max_depth`; `StoreError::BackendUnavailable` for any sqlx or
+    /// AGE error.
+    pub async fn find_paths_cypher(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        max_depth: Option<usize>,
+        max_results: Option<usize>,
+    ) -> StoreResult<Vec<Vec<String>>> {
+        let depth = max_depth.unwrap_or(FIND_PATHS_DEFAULT_DEPTH_SAL);
+        validate_find_paths_depth(depth)?;
+        let cap = max_results
+            .unwrap_or(FIND_PATHS_DEFAULT_LIMIT_SAL)
+            .clamp(1, FIND_PATHS_MAX_LIMIT_SAL);
+
+        if source_id == target_id {
+            return Ok(vec![vec![source_id.to_string()]]);
+        }
+
+        // AGE requires `ag_catalog` on the search path and the extension
+        // loaded into the session. Same shape as `kg_query_cypher`.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| to_store_err("begin AGE tx", e))?;
+
+        sqlx::query("LOAD 'age'")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| to_store_err("LOAD age", e))?;
+        sqlx::query("SET search_path = ag_catalog, \"$user\", public")
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| to_store_err("set search_path", e))?;
+
+        // `[*..N]` (no leading hop count) reads as "1..N" in Cypher,
+        // matching the directed-or-reverse spec. The pattern is
+        // un-arrowed (`-[r]-`), giving the symmetric closure for free
+        // — the AGE projection stores edges in declared direction but
+        // the path query treats them as undirected, the same contract
+        // as the CTE branch.
+        let cypher = format!(
+            "MATCH p = (a)-[*..{depth}]-(b) \
+             WHERE a.id = $start_id AND b.id = $target_id \
+             RETURN [n IN nodes(p) | n.id] AS path \
+             ORDER BY length(p) ASC \
+             LIMIT {cap}"
+        );
+
+        let sql = format!(
+            "SELECT path FROM cypher('memory_graph', $$ {cypher} $$, $1::agtype) AS \
+             (path agtype)"
+        );
+
+        let params = serde_json::json!({
+            "start_id": source_id,
+            "target_id": target_id,
+        })
+        .to_string();
+
+        let rows = sqlx::query(&sql)
+            .bind(params)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| to_store_err("cypher find_paths", e))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| to_store_err("commit AGE tx", e))?;
+
+        // AGE returns each `path` cell as agtype text shaped like
+        // `["id1","id2",...]`. We parse it as JSON since AGE arrays of
+        // strings are JSON-compatible — the same trick the rest of
+        // this module uses for scalars.
+        rows.iter()
+            .map(|r| {
+                let raw: String = r
+                    .try_get::<String, _>("path")
+                    .map_err(|e| to_store_err("read path", e))?;
+                let parsed: Vec<String> =
+                    serde_json::from_str(&raw).map_err(|e| StoreError::IntegrityFailed {
+                        detail: format!("non-JSON AGE path: {raw}: {e}"),
+                    })?;
+                Ok(parsed)
+            })
+            .collect()
+    }
+
     fn row_to_memory(row: &sqlx::postgres::PgRow) -> StoreResult<Memory> {
         let created_at: DateTime<Utc> = row
             .try_get("created_at")
@@ -1328,6 +1547,44 @@ fn validate_depth(max_depth: usize) -> StoreResult<()> {
         return Err(StoreError::InvalidInput {
             detail: format!(
                 "max_depth={max_depth} exceeds supported depth={KG_QUERY_MAX_SUPPORTED_DEPTH}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Default depth used by [`PostgresStore::find_paths`] when the caller
+/// omits `max_depth`. Mirrors `crate::db::FIND_PATHS_DEFAULT_DEPTH`.
+const FIND_PATHS_DEFAULT_DEPTH_SAL: usize = 4;
+
+/// Hard ceiling on traversal depth supported by
+/// [`PostgresStore::find_paths`]. Mirrors
+/// `crate::db::FIND_PATHS_MAX_DEPTH`.
+const FIND_PATHS_MAX_DEPTH_SAL: usize = 7;
+
+/// Default cap on paths returned by [`PostgresStore::find_paths`] when
+/// the caller omits `max_results`. Mirrors
+/// `crate::db::FIND_PATHS_DEFAULT_LIMIT`.
+const FIND_PATHS_DEFAULT_LIMIT_SAL: usize = 10;
+
+/// Hard ceiling on paths returned by [`PostgresStore::find_paths`].
+/// Mirrors `crate::db::FIND_PATHS_MAX_LIMIT`.
+const FIND_PATHS_MAX_LIMIT_SAL: usize = 50;
+
+/// Common pre-flight check shared by both `find_paths` branches. Pulled
+/// out so the dispatcher's contract — "0 and >FIND_PATHS_MAX_DEPTH_SAL
+/// always error before we touch the wire" — survives a future refactor
+/// that splits the branches into separate modules.
+fn validate_find_paths_depth(max_depth: usize) -> StoreResult<()> {
+    if max_depth == 0 {
+        return Err(StoreError::InvalidInput {
+            detail: "max_depth must be >= 1".to_string(),
+        });
+    }
+    if max_depth > FIND_PATHS_MAX_DEPTH_SAL {
+        return Err(StoreError::InvalidInput {
+            detail: format!(
+                "max_depth={max_depth} exceeds supported depth={FIND_PATHS_MAX_DEPTH_SAL}"
             ),
         });
     }

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -60,7 +60,7 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    // 41 = 47 user-relevant tools − 6 core. (47 = 48 total tools − 1
+    // 42 = 48 user-relevant tools − 6 core. (48 = 49 total tools − 1
     // always-on bootstrap.) The bootstrap (`memory_capabilities`) is
     // excluded from BOTH the loaded and the unloaded count in
     // `to_describe_to_user` (it's plumbing, not a feature). Total
@@ -68,11 +68,12 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
     // `memory_replay`; to 45 in v0.7 H4 — Family::Graph gained
     // `memory_verify`; to 46 in v0.7 B1 — Family::Core gained
     // `memory_load_family`; to 48 in v0.7 K7 — Family::Power gained
-    // `memory_subscription_replay` + `memory_subscription_dlq_list`.
+    // `memory_subscription_replay` + `memory_subscription_dlq_list`;
+    // to 49 in v0.7 J7 — Family::Graph gained `memory_find_paths`.
     // Loaded under core bumped from 5 to 6 with B1, so the preview
     // now overflows the 5-name cap (ends in ", ...").
     let expected = "I can directly use 6 memory tools right now \
-                    (store, recall, list, get, search, ...). 41 more \
+                    (store, recall, list, get, search, ...). 42 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -88,12 +89,13 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
 // ---------------------------------------------------------------------------
 // T0-A2-FULL — `to_describe_to_user` on `--profile full` uses the
 // "nothing more to load" closing form (excludes the always-on bootstrap
-// from the user-facing 47 count). Bumped from 42 to 43 in v0.7.0 I4 —
+// from the user-facing 48 count). Bumped from 42 to 43 in v0.7.0 I4 —
 // Family::Graph gained `memory_replay`; to 44 in v0.7 H4 —
 // Family::Graph gained `memory_verify`; to 45 in v0.7 B1 —
 // Family::Core gained `memory_load_family`; to 47 in v0.7 K7 —
 // Family::Power gained `memory_subscription_replay` +
-// `memory_subscription_dlq_list`.
+// `memory_subscription_dlq_list`; to 48 in v0.7 J7 —
+// Family::Graph gained `memory_find_paths`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_full_profile_canonical_phrasing() {
@@ -102,7 +104,7 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use all 47 memory tools right now \
+    let expected = "I can directly use all 48 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -116,11 +118,12 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
 
 // ---------------------------------------------------------------------------
 // T0-A2-GRAPH — `to_describe_to_user` on `--profile graph` uses the
-// preview-with-ellipsis form (5 of 16 loaded shown + ", ..."). Loaded
+// preview-with-ellipsis form (5 of 17 loaded shown + ", ..."). Loaded
 // bumped from 13 to 14 in v0.7.0 I4 — Family::Graph gained
 // `memory_replay`; to 15 in v0.7 H4 — Family::Graph gained
 // `memory_verify`; to 16 in v0.7 B1 — Family::Core gained
-// `memory_load_family`.
+// `memory_load_family`; to 17 in v0.7 J7 — Family::Graph gained
+// `memory_find_paths`.
 // ---------------------------------------------------------------------------
 #[test]
 fn t0_describe_to_user_graph_profile_canonical_phrasing() {
@@ -129,7 +132,7 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
         .as_str()
         .expect("describe present");
 
-    let expected = "I can directly use 16 memory tools right now \
+    let expected = "I can directly use 17 memory tools right now \
                     (store, recall, list, get, search, ...). 31 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -151,7 +151,7 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `core` profile honestly reports 7 of 48 visible (6 core
+// summary on the `core` profile honestly reports 7 of 49 visible (6 core
 // tools — including v0.7 B1 `memory_load_family` — plus the
 // memory_capabilities always-on bootstrap), labels the profile "core",
 // and references all three named recovery paths. (Total bumped from 43
@@ -159,7 +159,8 @@ fn cap_v3_response_carries_schema_version_and_summary() {
 // in v0.7 H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7
 // B1 — Family::Core gained `memory_load_family`; 46 to 48 in v0.7 K7
 // — Family::Power gained `memory_subscription_replay` +
-// `memory_subscription_dlq_list`.)
+// `memory_subscription_dlq_list`; 48 to 49 in v0.7 J7 —
+// Family::Graph gained `memory_find_paths`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
@@ -169,13 +170,13 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     // (`memory_capabilities` lives in Family::Meta which the core
     // profile doesn't load, so the bootstrap injection adds it back).
     assert!(
-        summary.starts_with("7 of 48 tools"),
-        "core profile summary should open with \"7 of 48 tools\"; got: {summary}"
+        summary.starts_with("7 of 49 tools"),
+        "core profile summary should open with \"7 of 49 tools\"; got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
-        summary.contains("41 are listed in this manifest"),
-        "core profile must report 41 unloaded (48 - 7); got: {summary}"
+        summary.contains("42 are listed in this manifest"),
+        "core profile must report 42 unloaded (49 - 7); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -187,7 +188,7 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `full` profile reports 48 of 48 visible, 0 unloaded, and
+// summary on the `full` profile reports 49 of 49 visible, 0 unloaded, and
 // labels the profile "full". The recovery paths are still listed —
 // they're the canonical recovery vocabulary the LLM gets calibrated on
 // regardless of the current profile state. (Total bumped from 43 to 44
@@ -195,15 +196,16 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
 // H4 — Family::Graph gained `memory_verify`; 45 to 46 in v0.7 B1 —
 // Family::Core gained `memory_load_family`; 46 to 48 in v0.7 K7 —
 // Family::Power gained `memory_subscription_replay` +
-// `memory_subscription_dlq_list`.)
+// `memory_subscription_dlq_list`; 48 to 49 in v0.7 J7 —
+// Family::Graph gained `memory_find_paths`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_full_profile_reports_all_visible() {
     let summary = build_capabilities_summary(&Profile::full());
 
     assert!(
-        summary.starts_with("48 of 48 tools"),
-        "full profile summary should open with \"48 of 48 tools\"; got: {summary}"
+        summary.starts_with("49 of 49 tools"),
+        "full profile summary should open with \"49 of 49 tools\"; got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -218,16 +220,16 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
 }
 
 // ---------------------------------------------------------------------------
-// summary on the `graph` profile counts 16 visible (6 core after v0.7 B1
-// + 10 graph after v0.7 H4) + the bootstrap, labels the profile
+// summary on the `graph` profile counts 17 visible (6 core after v0.7 B1
+// + 11 graph after v0.7 J7) + the bootstrap, labels the profile
 // "graph", and reports the rest as unloaded.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_summary_graph_profile_counts() {
     let summary = build_capabilities_summary(&Profile::graph());
     assert!(
-        summary.starts_with("17 of 48 tools"),
-        "graph profile = 6 core (v0.7 B1) + 10 graph (v0.7 H4) + 1 always-on bootstrap = 17; got: {summary}"
+        summary.starts_with("18 of 49 tools"),
+        "graph profile = 6 core (v0.7 B1) + 11 graph (v0.7 J7) + 1 always-on bootstrap = 18; got: {summary}"
     );
     assert!(summary.contains("(graph)"));
     assert!(summary.contains("31 are listed in this manifest"));
@@ -305,7 +307,7 @@ fn cap_v3_response_carries_to_describe_to_user() {
 // ---------------------------------------------------------------------------
 // A2: to_describe_to_user on `core` profile reads as plain English,
 // names the loaded tools by short name (no `memory_` prefix), reports
-// 39 unloaded with a sample, and ends with the canonical end-user
+// 40 unloaded with a sample, and ends with the canonical end-user
 // recovery hint.
 // ---------------------------------------------------------------------------
 #[test]
@@ -324,18 +326,19 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     // memory_ prefix STRIPPED (no MCP jargon for end users), followed
     // by ", ..." since core now ships 6 tools (v0.7 B1).
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
-    // Reports the unloaded count. 41 = 47 user-relevant tools − 6
-    // core. (47 = 48 total tools − 1 always-on bootstrap.) The
+    // Reports the unloaded count. 42 = 48 user-relevant tools − 6
+    // core. (48 = 49 total tools − 1 always-on bootstrap.) The
     // bootstrap (`memory_capabilities`) is excluded from both sides
     // for honest user-facing counting. Total bumped to 44 in v0.7.0
     // I4 (Family::Graph gained `memory_replay`), to 45 in v0.7 H4
     // (Family::Graph gained `memory_verify`), to 46 in v0.7 B1
-    // (Family::Core gained `memory_load_family`), and to 48 in v0.7
+    // (Family::Core gained `memory_load_family`), to 48 in v0.7
     // K7 (Family::Power gained `memory_subscription_replay` +
-    // `memory_subscription_dlq_list`).
+    // `memory_subscription_dlq_list`), and to 49 in v0.7 J7
+    // (Family::Graph gained `memory_find_paths`).
     assert!(
-        describe.contains("41 more"),
-        "core profile must report 41 unloaded; got: {describe}"
+        describe.contains("42 more"),
+        "core profile must report 42 unloaded; got: {describe}"
     );
     // Sample of unloaded tools is plain (no memory_ prefix). The first
     // four unloaded under core are lifecycle's update/delete/forget/gc.
@@ -358,27 +361,29 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `full` profile reports all 47 tools loaded
+// A2: to_describe_to_user on `full` profile reports all 48 tools loaded
 // (ALWAYS_ON_TOOLS bootstrap is excluded from the user-facing count) and
 // uses the "nothing more to load" closing form rather than the recovery
 // hint. (Bumped from 42 to 43 in v0.7.0 I4 — Family::Graph gained
 // `memory_replay`; 43 to 44 in v0.7 H4 — Family::Graph gained
 // `memory_verify`; 44 to 45 in v0.7 B1 — Family::Core gained
 // `memory_load_family`; 45 to 47 in v0.7 K7 — Family::Power gained
-// the subscription-reliability pair.)
+// the subscription-reliability pair; 47 to 48 in v0.7 J7 —
+// Family::Graph gained `memory_find_paths`.)
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 47 = 48 total - 1 always-on bootstrap excluded from describe.
+    // 48 = 49 total - 1 always-on bootstrap excluded from describe.
     // Bumped from 42 to 43 in v0.7.0 I4 (Family::Graph gained
     // `memory_replay`); 43 to 44 in v0.7 H4 (Family::Graph gained
     // `memory_verify`); 44 to 45 in v0.7 B1 (Family::Core gained
     // `memory_load_family`); 45 to 47 in v0.7 K7 (Family::Power
-    // gained `memory_subscription_replay` + `memory_subscription_dlq_list`).
+    // gained `memory_subscription_replay` + `memory_subscription_dlq_list`);
+    // 47 to 48 in v0.7 J7 (Family::Graph gained `memory_find_paths`).
     assert!(
-        describe.starts_with("I can directly use all 47 memory tools right now ("),
+        describe.starts_with("I can directly use all 48 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -388,18 +393,18 @@ fn cap_v3_describe_full_profile_uses_nothing_more_form() {
 }
 
 // ---------------------------------------------------------------------------
-// A2: to_describe_to_user on `graph` profile (6 core after v0.7 B1 + 10
-// graph after v0.7 H4) lists 16 loaded with a 5-name preview ending in
+// A2: to_describe_to_user on `graph` profile (6 core after v0.7 B1 + 11
+// graph after v0.7 J7) lists 17 loaded with a 5-name preview ending in
 // ", ..." since there are more loaded than the preview shows.
 // ---------------------------------------------------------------------------
 #[test]
 fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     let describe = build_capabilities_describe_to_user(&Profile::graph());
     assert!(
-        describe.starts_with("I can directly use 16 memory tools right now ("),
-        "graph profile describe should open with 16 loaded; got: {describe}"
+        describe.starts_with("I can directly use 17 memory tools right now ("),
+        "graph profile describe should open with 17 loaded; got: {describe}"
     );
-    // Preview is the first 5 of the 16 loaded — the first 5 core tools.
+    // Preview is the first 5 of the 17 loaded — the first 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
     assert!(describe.contains("31 more"));
 }
@@ -557,16 +562,17 @@ fn cap_v3_a3_allowlist_on_agent_denied_callable_now_false() {
 
 // ---------------------------------------------------------------------------
 // A3 — the v3 response surfaces the `tools` array at the top level
-// with one entry per registered tool (48 + always-on bootstrap counted
-// once = 48, since the bootstrap already lives in Family::Meta).
+// with one entry per registered tool (49 + always-on bootstrap counted
+// once = 49, since the bootstrap already lives in Family::Meta).
 // (Bumped from 43 to 44 in v0.7.0 I4 — Family::Graph gained
 // `memory_replay`; 44 to 45 in v0.7 H4 — Family::Graph gained
 // `memory_verify`; 45 to 46 in v0.7 B1 — Family::Core gained
 // `memory_load_family`; 46 to 48 in v0.7 K7 — Family::Power gained
-// `memory_subscription_replay` + `memory_subscription_dlq_list`.)
+// `memory_subscription_replay` + `memory_subscription_dlq_list`;
+// 48 to 49 in v0.7 J7 — Family::Graph gained `memory_find_paths`.)
 // ---------------------------------------------------------------------------
 #[test]
-fn cap_v3_response_carries_tools_array_with_48_entries() {
+fn cap_v3_response_carries_tools_array_with_49_entries() {
     let tier_config = semantic_tier();
     let conn = fresh_conn();
     let val = handle_capabilities_with_conn_v3(
@@ -586,11 +592,11 @@ fn cap_v3_response_carries_tools_array_with_48_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        48,
-        "v3 must surface all 48 tools regardless of profile (v0.7.0 I4 added \
+        49,
+        "v3 must surface all 49 tools regardless of profile (v0.7.0 I4 added \
          memory_replay; v0.7 H4 added memory_verify; v0.7 B1 added \
          memory_load_family; v0.7 K7 added memory_subscription_replay + \
-         memory_subscription_dlq_list); got {}",
+         memory_subscription_dlq_list; v0.7 J7 added memory_find_paths); got {}",
         tools.len()
     );
 

--- a/tests/harness_integration.rs
+++ b/tests/harness_integration.rs
@@ -36,7 +36,7 @@
 //! silently breaks (e.g. a typo in `Harness::detect`'s match arms, a
 //! removed variant, or a bypass of the harness threading in the
 //! capabilities builder). Pure test additions — no schema changes, no
-//! tool count changes; the surface stays at 45 tools.
+//! tool count changes; the surface stays at 46 tools.
 
 use ai_memory::config::{FeatureTier, McpConfig, TierConfig};
 use ai_memory::harness::Harness;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1867,8 +1867,8 @@ fn test_mcp_tools_list() {
         .expect("tools should be array");
     assert_eq!(
         tools.len(),
-        48,
-        "expected 48 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list)"
+        49,
+        "expected 49 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths)"
     );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
@@ -1899,6 +1899,7 @@ fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"memory_subscribe"));
     assert!(tool_names.contains(&"memory_unsubscribe"));
     assert!(tool_names.contains(&"memory_list_subscriptions"));
+    assert!(tool_names.contains(&"memory_find_paths"));
 
     let _ = std::fs::remove_file(&db_path);
 }

--- a/tests/memory_find_paths.rs
+++ b/tests/memory_find_paths.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7 J7 — `memory_find_paths` MCP tool integration tests.
+//!
+//! J7 ships a new MCP tool `memory_find_paths(source_id, target_id,
+//! max_depth?, max_results?)` that returns up to N paths through the
+//! KG between two memories using BFS with cycle detection. The
+//! implementation dispatches on the resolved `KgBackend`: SQLite uses
+//! a recursive CTE through `db::find_paths`; Postgres deployments
+//! either fall back to the same recursive-CTE shape via
+//! `PostgresStore::find_paths_cte` or use Cypher
+//! `MATCH p = (s)-[*..N]-(t) RETURN p` via
+//! `PostgresStore::find_paths_cypher` when AGE is installed.
+//!
+//! Scenarios pinned here:
+//! 1. Linear 3-hop chain (A→B→C→D) — `find_paths(A, D)` returns the
+//!    one canonical path `[A, B, C, D]`.
+//! 2. Multiple paths between same endpoints — `find_paths(A, D)`
+//!    returns both routes (a diamond graph), shortest-first.
+//! 3. Disconnected pair — `find_paths(A, X)` returns an empty list.
+//!
+//! The walk treats links as undirected so callers don't need to
+//! reverse-orient the chain when their KG was modeled with
+//! `derived_from` pointing one way and `supersedes` the other.
+
+use ai_memory::db;
+use ai_memory::mcp;
+use ai_memory::models;
+use chrono::Utc;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn open_db() -> (rusqlite::Connection, TempDir) {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("ai-memory-find-paths.db");
+    let conn = db::open(&path).expect("db::open");
+    (conn, tmp)
+}
+
+fn seed(conn: &rusqlite::Connection, title: &str) -> String {
+    let now = Utc::now().to_rfc3339();
+    let id = uuid::Uuid::new_v4().to_string();
+    let mem = models::Memory {
+        id: id.clone(),
+        tier: models::Tier::Long,
+        namespace: "j7-test".to_string(),
+        title: title.to_string(),
+        content: "x".to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: models::default_metadata(),
+    };
+    db::insert(conn, &mem).expect("db::insert")
+}
+
+fn call(conn: &rusqlite::Connection, source_id: &str, target_id: &str) -> Value {
+    mcp::handle_find_paths(
+        conn,
+        &json!({
+            "source_id": source_id,
+            "target_id": target_id,
+        }),
+    )
+    .expect("handle_find_paths Ok")
+}
+
+// ---------------------------------------------------------------------------
+// Case 1 — linear 3-hop chain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_paths_linear_three_hop_chain_returns_single_path() {
+    let (conn, _tmp) = open_db();
+    let a = seed(&conn, "a");
+    let b = seed(&conn, "b");
+    let c = seed(&conn, "c");
+    let d = seed(&conn, "d");
+    db::create_link(&conn, &a, &b, "related_to").unwrap();
+    db::create_link(&conn, &b, &c, "related_to").unwrap();
+    db::create_link(&conn, &c, &d, "related_to").unwrap();
+
+    let val = call(&conn, &a, &d);
+    let paths = val["paths"].as_array().expect("paths array");
+    assert_eq!(val["count"], 1, "single canonical path expected: {val}");
+    assert_eq!(paths.len(), 1);
+
+    let chain: Vec<&str> = paths[0]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(chain, vec![a.as_str(), b.as_str(), c.as_str(), d.as_str()]);
+}
+
+// ---------------------------------------------------------------------------
+// Case 2 — multiple paths (diamond graph)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_paths_diamond_graph_returns_both_routes_shortest_first() {
+    // A --> B --> D
+    // A --> C --> D
+    // Both routes are 3 nodes long, so both must come back.
+    let (conn, _tmp) = open_db();
+    let a = seed(&conn, "a");
+    let b = seed(&conn, "b");
+    let c = seed(&conn, "c");
+    let d = seed(&conn, "d");
+    db::create_link(&conn, &a, &b, "related_to").unwrap();
+    db::create_link(&conn, &b, &d, "related_to").unwrap();
+    db::create_link(&conn, &a, &c, "related_to").unwrap();
+    db::create_link(&conn, &c, &d, "related_to").unwrap();
+
+    let val = call(&conn, &a, &d);
+    let paths = val["paths"].as_array().expect("paths array");
+    assert_eq!(val["count"], 2, "two parallel routes expected: {val}");
+    assert_eq!(paths.len(), 2);
+
+    // Each path starts at A and ends at D.
+    for path in paths {
+        let chain: Vec<&str> = path
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(chain.first(), Some(&a.as_str()), "source first: {path}");
+        assert_eq!(chain.last(), Some(&d.as_str()), "target last: {path}");
+        assert_eq!(chain.len(), 3, "diamond hop = 3 nodes: {path}");
+    }
+
+    // The two middle nodes across the two paths must be {B, C}.
+    let mids: std::collections::HashSet<&str> = paths
+        .iter()
+        .map(|p| p.as_array().unwrap()[1].as_str().unwrap())
+        .collect();
+    let expected: std::collections::HashSet<&str> = [b.as_str(), c.as_str()].into_iter().collect();
+    assert_eq!(mids, expected, "diamond mid-hops must be both B and C");
+}
+
+// ---------------------------------------------------------------------------
+// Case 3 — no path / disconnected pair
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_paths_disconnected_pair_returns_empty_paths() {
+    let (conn, _tmp) = open_db();
+    let a = seed(&conn, "a");
+    let b = seed(&conn, "b");
+    let c = seed(&conn, "c");
+    // x is isolated — no links touch it.
+    let x = seed(&conn, "x");
+
+    // Add an unrelated link in the graph so memory_links isn't empty
+    // (covers the "edges exist but not on this pair" branch).
+    db::create_link(&conn, &a, &b, "related_to").unwrap();
+    db::create_link(&conn, &b, &c, "related_to").unwrap();
+
+    let val = call(&conn, &a, &x);
+    let paths = val["paths"].as_array().expect("paths array");
+    assert_eq!(val["count"], 0, "disconnected pair = no paths: {val}");
+    assert!(paths.is_empty(), "disconnected pair = empty list: {val}");
+}


### PR DESCRIPTION
## Summary

- New MCP tool `memory_find_paths(source_id, target_id, max_depth?, max_results?)` (v0.7 Track J7) that returns up to N paths through the KG between two memories using BFS with cycle detection. Defaults: `max_depth=4` (cap 7), `max_results=10` (cap 50).
- Dual-backend dispatch via the J1 substrate: SQLite goes through `db::find_paths` (recursive CTE over `memory_links`); the Postgres SAL adds `PostgresStore::find_paths` that routes to `find_paths_cypher` when AGE is installed (Cypher `MATCH p = (s)-[*..N]-(t) RETURN [n IN nodes(p) | n.id]`) and `find_paths_cte` otherwise. Walk is undirected.
- Family::Graph grows from 10 → 11 tools; full surface 46 → 47. Cascade applied across `src/mcp.rs`, `src/profile.rs`, `src/sizes.rs`, `src/cli/doctor.rs`, `tests/capabilities_v3.rs`, `tests/calibration_t0.rs`, `tests/integration.rs`, `tests/harness_integration.rs` (doc only — that file still fails on a separate, pre-existing core-describe mismatch).

## Test plan

- [x] `cargo build --tests` clean
- [x] `cargo test --lib` — 2176 passed / 0 failed
- [x] `cargo test --test memory_find_paths` — 3 passed / 0 failed (linear 3-hop, diamond multi-path, disconnected pair)
- [x] `cargo test --test capabilities_v3 --test calibration_t0` — 31 + 6 passed / 0 failed
- [x] `cargo test --test integration test_mcp_initialize/test_mcp_tools_list` — passed (47-tool count assertion)
- [x] `cargo clippy --lib` — clean
- [ ] AGE-backend equivalence test — out of scope here; follow-up under the J5 sibling test.

## AI involvement

Authored by Claude Opus 4.7 acting under the v0.7 J7 charter; reviewed for SAL dispatch parity with J2/J3/J4. No schema changes, no webhook event additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)