### PR TITLE
feat: v0.7-k10 — approval API (HTTP + SSE + MCP, HMAC, remember=forever)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,8 +53,10 @@ dependencies = [
  "criterion",
  "dirs",
  "ed25519-dalek",
+ "futures-core",
  "gethostname",
  "hf-hub",
+ "http-body-util",
  "instant-distance",
  "libc",
  "pgvector",
@@ -75,6 +77,7 @@ dependencies = [
  "tiktoken-rs",
  "tokenizers",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower",
  "tower-http",
@@ -4317,6 +4320,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,13 @@ rusqlite = { version = "0.32" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+# v0.7 K10 — Approval API SSE endpoint adapts a `tokio::sync::broadcast`
+# Receiver into the `futures_core::Stream` axum's `Sse` requires.
+# `tokio-stream`'s `BroadcastStream` wrapper does that bridging, and
+# `futures-core` exposes the `Stream` trait the wrapper implements.
+# Pure Rust, dep-light, both are in the tokio family.
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures-core = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 # v0.6.3.1 (PR-5 / issue #487) — rolling file appender for the
@@ -203,6 +210,12 @@ predicates = "3"
 # reqwest calls can be exercised end-to-end without any network or daemon.
 # Used only by tests; never linked into the release binary.
 wiremock = "0.6"
+# v0.7 K10 — SSE integration tests need to pull individual body frames
+# off an `http_body::Body` to assert event boundaries, which is exactly
+# what `http_body_util::BodyExt::frame` exposes. Already in the
+# transitive tree via axum/hyper; declared explicitly so the test
+# imports compile without leaking the dep into the production crate.
+http-body-util = "0.1"
 # v0.7 J5 — direct sqlx access from `tests/age_cte_equivalence.rs` so
 # the dual-path harness can seed `memory_links` rows and the AGE
 # `memory_graph` projection without going through the SAL surface

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -1,0 +1,282 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K10 — Approval API (HTTP + SSE + MCP).
+//!
+//! When the governance gate returns `Pending`, an operator must
+//! eventually decide. v0.7.0 surfaces three transports for that
+//! decision:
+//!
+//! 1. **HTTP** — `POST /api/v1/approvals/{pending_id}` with the body
+//!    `{"decision":"approve|deny","remember":"once|session|forever"}`.
+//!    Gated behind the K7 `[hooks.subscription] hmac_secret` server-wide
+//!    HMAC: requests without a valid `X-AI-Memory-Signature: sha256=…`
+//!    header are rejected `401`.
+//! 2. **SSE** — `GET /api/v1/approvals/stream` server-sent events.
+//!    Subscribers receive `approval_requested` (one per new
+//!    `pending_actions` row) and `approval_decided` (one per
+//!    approve/deny outcome) frames, fanned out through a process-wide
+//!    `tokio::sync::broadcast` channel so multiple watchers can attach
+//!    concurrently without contention on the DB lock.
+//! 3. **MCP** — the existing `memory_pending_approve` /
+//!    `memory_pending_reject` tools gain an optional `remember`
+//!    property. The K10 contract preserves the pre-K10 schema (no new
+//!    tools, no removed properties) — so existing callers keep working
+//!    unchanged and only opt into `remember` when they want
+//!    forever-persisted permission rules.
+//!
+//! When `remember = "forever"`, K10 stamps a synthetic
+//! [`SyntheticPermissionRule`] into the process-wide registry so the
+//! same `(action, namespace, agent_id)` tuple auto-decides next time.
+//! K9 (the unified permission pipeline) will consult the registry from
+//! its rule-evaluation path; until K9 lands on this branch, the
+//! registry exists as an isolated K10-internal store that the K10 test
+//! suite can introspect to pin the contract.
+
+use std::sync::OnceLock;
+use std::sync::RwLock;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Capacity of the process-wide approval broadcast channel.
+///
+/// Sized to absorb a brief spike of `approval_requested` /
+/// `approval_decided` events without forcing a slow SSE subscriber to
+/// drop frames. SSE consumers see [`broadcast::error::RecvError::Lagged`]
+/// when this is exceeded; the [`approvals_sse`](crate::handlers::approvals_sse)
+/// handler turns that into a `lagged` SSE event so clients can re-sync
+/// via `GET /api/v1/pending`.
+pub const APPROVAL_BROADCAST_CAPACITY: usize = 1024;
+
+/// Decision an operator submits via the K10 transports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Decision {
+    Approve,
+    Deny,
+}
+
+/// How long a `remember` choice persists.
+///
+/// - `Once` — just this decision; no rule recorded.
+/// - `Session` — recorded in-memory; cleared on restart.
+/// - `Forever` — recorded in-memory AND queued for persistence to the
+///   live `config.toml` `[[permissions.rules]]` table on the next
+///   config write. (The actual disk write is owned by the K9 rule
+///   loader; K10's contract is to populate the registry that K9
+///   consults.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Remember {
+    Once,
+    Session,
+    Forever,
+}
+
+/// One row in the K10 synthetic-permission-rule registry.
+///
+/// Mirrors the shape K9's `[[permissions.rules]]` table will use
+/// once K9 lands on the same branch — that way K9's loader can
+/// promote these in-memory rows into config-file rows without a
+/// schema translation step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyntheticPermissionRule {
+    /// `pending_actions.action_type` — `"store"`, `"delete"`, or `"promote"`.
+    pub action_type: String,
+    /// `pending_actions.namespace` — the namespace the original gated
+    /// action targeted.
+    pub namespace: String,
+    /// `pending_actions.requested_by` — the agent the rule auto-decides
+    /// for. `None` means "any agent in this namespace" (rare, but the
+    /// K10 contract reserves the slot for fleet-wide rules).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// `"approve"` or `"deny"` — the auto-decision the gate should
+    /// return next time it sees a matching tuple.
+    pub decision: String,
+    /// RFC3339 timestamp the rule was recorded. Surfaced in audit
+    /// trails and (eventually) in K9's rule-summary doctor surface.
+    pub recorded_at: String,
+}
+
+/// Process-wide registry of `remember=forever` rules. Populated by
+/// the K10 transports; read by K9's rule resolver (when K9 lands).
+static SYNTHETIC_RULES: RwLock<Vec<SyntheticPermissionRule>> = RwLock::new(Vec::new());
+
+/// Append a synthetic rule to the registry.
+///
+/// Idempotent on the `(action_type, namespace, agent_id, decision)`
+/// tuple — calling twice with the same tuple is a no-op (the recorded
+/// timestamp from the first insert wins). Lock poisoning is treated as
+/// fatal-but-recoverable: we drop the poisoned guard and proceed
+/// against the inner data, mirroring the K3 `lock_permissions_mode_for_test`
+/// posture.
+pub fn record_synthetic_rule(rule: SyntheticPermissionRule) {
+    let mut guard = SYNTHETIC_RULES
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let already = guard.iter().any(|r| {
+        r.action_type == rule.action_type
+            && r.namespace == rule.namespace
+            && r.agent_id == rule.agent_id
+            && r.decision == rule.decision
+    });
+    if !already {
+        guard.push(rule);
+    }
+}
+
+/// Snapshot the registry. Returns a clone so callers can release the
+/// read lock immediately.
+#[must_use]
+pub fn list_synthetic_rules() -> Vec<SyntheticPermissionRule> {
+    SYNTHETIC_RULES
+        .read()
+        .map(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// Test-only: clear the registry. Production code never resets the
+/// registry mid-process; tests use this to assert against a clean slate.
+#[doc(hidden)]
+pub fn clear_synthetic_rules_for_test() {
+    if let Ok(mut g) = SYNTHETIC_RULES.write() {
+        g.clear();
+    }
+}
+
+/// One frame on the SSE stream.
+///
+/// Two variants today:
+///   - `ApprovalRequested` — fired when a `pending_actions` row is
+///     inserted (governance gate returned `Pending`).
+///   - `ApprovalDecided` — fired when an approve/reject decision is
+///     finalised (any of the three K10 transports).
+///
+/// Both carry the pending-action id so subscribers can round-trip back
+/// through `GET /api/v1/pending/{id}` for the full row payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ApprovalEvent {
+    ApprovalRequested {
+        pending_id: String,
+        action_type: String,
+        namespace: String,
+        requested_by: String,
+        requested_at: String,
+    },
+    ApprovalDecided {
+        pending_id: String,
+        decision: String,
+        decided_by: String,
+        remember: String,
+    },
+}
+
+/// Process-wide broadcast channel for [`ApprovalEvent`]. Lazily
+/// initialised on first subscribe / publish — the server's HTTP layer
+/// touches it from `handlers::approvals_sse` and the publish side fires
+/// from `handlers::approve_via_approval_api`,
+/// `subscriptions::dispatch_approval_requested`, and the MCP
+/// approve/reject handlers.
+static APPROVAL_BUS: OnceLock<broadcast::Sender<ApprovalEvent>> = OnceLock::new();
+
+fn bus() -> &'static broadcast::Sender<ApprovalEvent> {
+    APPROVAL_BUS.get_or_init(|| {
+        let (tx, _rx) = broadcast::channel(APPROVAL_BROADCAST_CAPACITY);
+        tx
+    })
+}
+
+/// Publish an [`ApprovalEvent`] to all SSE subscribers.
+///
+/// No subscribers → swallowed silently (the `broadcast::Sender::send`
+/// `Err(SendError(_))` branch is the documented "no receivers" outcome
+/// and is never an error in this codebase: SSE is best-effort and we
+/// must not fail the underlying approve/reject path on a missing
+/// subscriber).
+pub fn publish(event: ApprovalEvent) {
+    let _ = bus().send(event);
+}
+
+/// Subscribe to the process-wide approval bus. Returns a fresh
+/// [`broadcast::Receiver`] that will see every event published AFTER
+/// this call (broadcast channels do not replay history — that's what
+/// `GET /api/v1/pending` is for).
+#[must_use]
+pub fn subscribe() -> broadcast::Receiver<ApprovalEvent> {
+    bus().subscribe()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialise the unit tests that mutate the global registry —
+    /// `cargo test` runs tests in parallel by default and the
+    /// `SYNTHETIC_RULES` static is shared across them.
+    fn registry_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn record_and_list_round_trip() {
+        let _g = registry_lock();
+        clear_synthetic_rules_for_test();
+        let rule = SyntheticPermissionRule {
+            action_type: "store".into(),
+            namespace: "scratch".into(),
+            agent_id: Some("alice".into()),
+            decision: "approve".into(),
+            recorded_at: "2026-05-05T00:00:00Z".into(),
+        };
+        record_synthetic_rule(rule.clone());
+        let snap = list_synthetic_rules();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0], rule);
+    }
+
+    #[test]
+    fn record_synthetic_rule_is_idempotent() {
+        let _g = registry_lock();
+        clear_synthetic_rules_for_test();
+        let rule = SyntheticPermissionRule {
+            action_type: "delete".into(),
+            namespace: "ns".into(),
+            agent_id: Some("bob".into()),
+            decision: "deny".into(),
+            recorded_at: "2026-05-05T00:00:00Z".into(),
+        };
+        record_synthetic_rule(rule.clone());
+        // Second call with a later timestamp must not double the row.
+        let mut later = rule.clone();
+        later.recorded_at = "2099-01-01T00:00:00Z".into();
+        record_synthetic_rule(later);
+        let snap = list_synthetic_rules();
+        assert_eq!(snap.len(), 1);
+        // First-writer-wins on the timestamp.
+        assert_eq!(snap[0].recorded_at, "2026-05-05T00:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn publish_and_subscribe_round_trip() {
+        let mut rx = subscribe();
+        let evt = ApprovalEvent::ApprovalRequested {
+            pending_id: "pa-1".into(),
+            action_type: "store".into(),
+            namespace: "scratch".into(),
+            requested_by: "alice".into(),
+            requested_at: "2026-05-05T00:00:00Z".into(),
+        };
+        publish(evt.clone());
+        let received = rx.recv().await.expect("recv");
+        match received {
+            ApprovalEvent::ApprovalRequested { pending_id, .. } => assert_eq!(pending_id, "pa-1"),
+            _ => panic!("wrong variant"),
+        }
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -5296,6 +5296,312 @@ pub async fn session_start(
     }
 }
 
+// ---------------------------------------------------------------------------
+// v0.7.0 K10 — Approval API (HTTP + SSE)
+// ---------------------------------------------------------------------------
+//
+// `POST /api/v1/approvals/{pending_id}` — approve / deny a pending row.
+// Body: `{"decision":"approve|deny","remember":"once|session|forever"}`.
+// Gated behind the K7 server-wide HMAC: caller MUST present
+// `X-AI-Memory-Signature: sha256=<hex>` keyed on
+// `SHA256([hooks.subscription].hmac_secret)` over the canonical
+// `<timestamp>.<body>` string. Missing or invalid signature → 401.
+//
+// `GET /api/v1/approvals/stream` — long-lived SSE stream that fans out
+// every `approval_requested` and `approval_decided` event from the
+// process-wide [`crate::approvals`] broadcast bus to every attached
+// subscriber.
+//
+// The SSE endpoint is intentionally unauthenticated beyond the
+// existing `api_key_auth` middleware: SSE re-key handshakes are clunky
+// and the K7 HMAC is a *write*-side gate. Read-side gating piggybacks
+// on the api-key middleware that wraps every other route.
+
+/// Body of `POST /api/v1/approvals/{pending_id}`.
+#[derive(Debug, Deserialize)]
+pub struct ApprovalRequestBody {
+    /// `"approve"` or `"deny"`.
+    pub decision: crate::approvals::Decision,
+    /// `"once"` (default), `"session"`, or `"forever"`.
+    #[serde(default = "default_remember")]
+    pub remember: crate::approvals::Remember,
+}
+
+fn default_remember() -> crate::approvals::Remember {
+    crate::approvals::Remember::Once
+}
+
+/// HMAC-verify an inbound approval request.
+///
+/// Mirrors the K7 outbound construction: signature value is
+/// `sha256=<hex>` where `<hex>` = `HMAC-SHA256(SHA256(secret),
+/// "<timestamp>.<body>")`. Returns `Ok(())` on a valid signature;
+/// `Err(StatusCode)` (always 401) on any failure mode (missing
+/// header, missing timestamp, bad encoding, mismatch).
+///
+/// The caller MUST send the body verbatim — even a single
+/// reformatted byte invalidates the signature, which is the whole
+/// point of HMAC. We compare in constant time via `constant_time_eq`
+/// to avoid timing oracles on the hex digest.
+fn verify_approval_hmac(headers: &HeaderMap, body: &[u8]) -> Result<(), StatusCode> {
+    let secret = match crate::config::active_hooks_hmac_secret() {
+        Some(s) => s,
+        None => {
+            // No server-wide HMAC configured → the K10 contract is
+            // strict by default: reject every inbound approval. This
+            // is the safe posture (better to refuse a write than to
+            // accept an unauthenticated one) and matches the spec
+            // header "HMAC signing per K7's pattern".
+            tracing::warn!("K10 approval rejected: no [hooks.subscription].hmac_secret configured");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+    let sig_header = headers
+        .get("x-ai-memory-signature")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    let sig_hex = sig_header
+        .strip_prefix("sha256=")
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    let timestamp = headers
+        .get("x-ai-memory-timestamp")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    let body_str = std::str::from_utf8(body).map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let canonical = format!("{timestamp}.{body_str}");
+    let key_hash = crate::subscriptions::sha256_hex(&secret);
+    let expected = crate::subscriptions::hmac_sha256_hex(&key_hash, &canonical);
+    if constant_time_eq(expected.as_bytes(), sig_hex.as_bytes()) {
+        Ok(())
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+/// `POST /api/v1/approvals/{pending_id}` — K10's HMAC-gated approval
+/// endpoint. See module-level comment above for the full contract.
+#[allow(clippy::too_many_lines)]
+pub async fn approval_decide(
+    State(app): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    body_bytes: axum::body::Bytes,
+) -> impl IntoResponse {
+    if let Err(status) = verify_approval_hmac(&headers, &body_bytes) {
+        return (
+            status,
+            Json(json!({"error": "invalid or missing X-AI-Memory-Signature"})),
+        )
+            .into_response();
+    }
+    let body: ApprovalRequestBody = match serde_json::from_slice(&body_bytes) {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid body: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    if let Err(e) = validate::validate_id(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+    let agent_id = match crate::identity::resolve_http_agent_id(None, header_agent_id) {
+        Ok(a) => a,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid agent_id: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    let lock = app.db.lock().await;
+    // Snapshot the pending row before deciding so we can synthesise a
+    // permission rule even after the row transitions.
+    let pending_snapshot = db::get_pending_action(&lock.0, &id).ok().flatten();
+    let outcome = match body.decision {
+        crate::approvals::Decision::Approve => {
+            match db::approve_with_approver_type(&lock.0, &id, &agent_id) {
+                Ok(crate::db::ApproveOutcome::Approved) => {
+                    let executed = db::execute_pending_action(&lock.0, &id);
+                    match executed {
+                        Ok(memory_id) => json!({
+                            "approved": true,
+                            "id": id,
+                            "decided_by": agent_id,
+                            "executed": true,
+                            "memory_id": memory_id,
+                            "remember": format!("{:?}", body.remember).to_lowercase(),
+                        }),
+                        Err(e) => {
+                            tracing::error!("execute pending error: {e}");
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                Json(json!({"error": "approved but execution failed"})),
+                            )
+                                .into_response();
+                        }
+                    }
+                }
+                Ok(crate::db::ApproveOutcome::Pending { votes, quorum }) => json!({
+                    "approved": false,
+                    "status": "pending",
+                    "id": id,
+                    "votes": votes,
+                    "quorum": quorum,
+                    "remember": format!("{:?}", body.remember).to_lowercase(),
+                }),
+                Ok(crate::db::ApproveOutcome::Rejected(reason)) => {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(json!({"error": format!("approve rejected: {reason}")})),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    tracing::error!("handler error: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        crate::approvals::Decision::Deny => {
+            match db::decide_pending_action(&lock.0, &id, false, &agent_id) {
+                Ok(true) => json!({
+                    "rejected": true,
+                    "id": id,
+                    "decided_by": agent_id,
+                    "remember": format!("{:?}", body.remember).to_lowercase(),
+                }),
+                Ok(false) => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(json!({"error": "pending action not found or already decided"})),
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    tracing::error!("handler error: {e}");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "internal server error"})),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    };
+    drop(lock);
+
+    // Fan out the decision on the broadcast bus and (for forever)
+    // record the synthetic rule.
+    let decision_label = match body.decision {
+        crate::approvals::Decision::Approve => "approve",
+        crate::approvals::Decision::Deny => "deny",
+    };
+    let remember_label = match body.remember {
+        crate::approvals::Remember::Once => "once",
+        crate::approvals::Remember::Session => "session",
+        crate::approvals::Remember::Forever => "forever",
+    };
+    crate::approvals::publish(crate::approvals::ApprovalEvent::ApprovalDecided {
+        pending_id: id.clone(),
+        decision: decision_label.to_string(),
+        decided_by: agent_id.clone(),
+        remember: remember_label.to_string(),
+    });
+    if matches!(
+        body.remember,
+        crate::approvals::Remember::Forever | crate::approvals::Remember::Session
+    ) && let Some(snap) = pending_snapshot
+    {
+        crate::approvals::record_synthetic_rule(crate::approvals::SyntheticPermissionRule {
+            action_type: snap.action_type,
+            namespace: snap.namespace,
+            agent_id: Some(snap.requested_by),
+            decision: decision_label.to_string(),
+            recorded_at: Utc::now().to_rfc3339(),
+        });
+    }
+    Json(outcome).into_response()
+}
+
+/// `GET /api/v1/approvals/stream` — SSE endpoint streaming
+/// `approval_requested` and `approval_decided` events from the
+/// process-wide broadcast bus.
+///
+/// Returns the axum SSE response. Each event is a JSON-encoded
+/// [`crate::approvals::ApprovalEvent`] payload tagged with `event:
+/// approval_requested` (or `_decided`) per the SSE spec. A keepalive
+/// comment line fires every 15 s to prevent intermediary timeouts.
+pub async fn approvals_sse(
+    State(_app): State<AppState>,
+) -> axum::response::Sse<
+    impl futures_core::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>,
+> {
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures_core::Stream;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration as StdDuration;
+    use tokio_stream::wrappers::BroadcastStream;
+    use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+
+    /// Bridges a `BroadcastStream<ApprovalEvent>` into the
+    /// `Stream<Item = Result<Event, Infallible>>` axum's `Sse` requires.
+    /// We swallow `Lagged` by emitting a synthetic `lagged` SSE event
+    /// so subscribers can re-sync via `GET /api/v1/pending` instead of
+    /// silently missing frames; channel `Closed` ends the stream.
+    struct ApprovalSseStream {
+        inner: BroadcastStream<crate::approvals::ApprovalEvent>,
+    }
+
+    impl Stream for ApprovalSseStream {
+        type Item = Result<Event, std::convert::Infallible>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Ready(Some(Ok(evt))) => {
+                    let (event_name, json_value) = match &evt {
+                        crate::approvals::ApprovalEvent::ApprovalRequested { .. } => (
+                            "approval_requested",
+                            serde_json::to_value(&evt).unwrap_or_default(),
+                        ),
+                        crate::approvals::ApprovalEvent::ApprovalDecided { .. } => (
+                            "approval_decided",
+                            serde_json::to_value(&evt).unwrap_or_default(),
+                        ),
+                    };
+                    let data = serde_json::to_string(&json_value).unwrap_or_else(|_| "{}".into());
+                    Poll::Ready(Some(Ok(Event::default().event(event_name).data(data))))
+                }
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
+                    let body = serde_json::json!({"lagged": n}).to_string();
+                    Poll::Ready(Some(Ok(Event::default().event("lagged").data(body))))
+                }
+            }
+        }
+    }
+
+    let rx = crate::approvals::subscribe();
+    let stream = ApprovalSseStream {
+        inner: BroadcastStream::new(rx),
+    };
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(StdDuration::from_secs(15)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 // Library interface for ai-memory. Exposes public modules for testing and external use.
 
+pub mod approvals;
 pub mod audit;
 pub mod autonomy;
 pub mod bench;
@@ -194,6 +195,13 @@ pub fn build_router(
             "/api/v1/pending/{id}/reject",
             post(handlers::reject_pending),
         )
+        // v0.7.0 K10 — Approval API. POST is HMAC-gated; SSE rides on
+        // top of the existing api_key_auth middleware (no extra gate).
+        .route(
+            "/api/v1/approvals/{pending_id}",
+            post(handlers::approval_decide),
+        )
+        .route("/api/v1/approvals/stream", get(handlers::approvals_sse))
         // Phase 3 foundation (issue #224) — peer-to-peer sync endpoints.
         .route("/api/v1/sync/push", post(handlers::sync_push))
         .route("/api/v1/sync/since", get(handlers::sync_since))

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -857,22 +857,34 @@ pub(crate) fn tool_definitions() -> Value {
             },
             {
                 "name": "memory_pending_approve",
-                "description": "Approve a pending action by id (Task 1.9). Caller identity is stamped as decided_by.",
+                "description": "Approve a pending action by id (Task 1.9). Caller identity is stamped as decided_by. v0.7 K10 — optional `remember` (\"once\"|\"session\"|\"forever\") records a synthetic permission rule so the same context auto-decides next time.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "id": {"type": "string", "description": "Pending action id"}
+                        "id": {"type": "string", "description": "Pending action id"},
+                        "remember": {
+                            "type": "string",
+                            "enum": ["once", "session", "forever"],
+                            "default": "once",
+                            "description": "v0.7 K10 — persistence horizon for the decision"
+                        }
                     },
                     "required": ["id"]
                 }
             },
             {
                 "name": "memory_pending_reject",
-                "description": "Reject a pending action by id (Task 1.9). Caller identity is stamped as decided_by.",
+                "description": "Reject a pending action by id (Task 1.9). Caller identity is stamped as decided_by. v0.7 K10 — optional `remember` (\"once\"|\"session\"|\"forever\") records a synthetic deny rule so the same context auto-rejects next time.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "id": {"type": "string", "description": "Pending action id"}
+                        "id": {"type": "string", "description": "Pending action id"},
+                        "remember": {
+                            "type": "string",
+                            "enum": ["once", "session", "forever"],
+                            "default": "once",
+                            "description": "v0.7 K10 — persistence horizon for the decision"
+                        }
                     },
                     "required": ["id"]
                 }
@@ -4964,7 +4976,68 @@ fn handle_pending_list(conn: &rusqlite::Connection, params: &Value) -> Result<Va
     Ok(json!({"count": items.len(), "pending": items}))
 }
 
-fn handle_pending_approve(
+/// v0.7 K10 — parse the optional `remember` MCP param.
+///
+/// Defaults to `Once` when absent or invalid (the K10 contract is
+/// best-effort: a typoed `remember` value MUST NOT block the underlying
+/// approve/reject path). Validation drift is logged at WARN so
+/// operators can see the regression without it surfacing as a
+/// caller-facing error.
+fn parse_remember_param(params: &Value) -> crate::approvals::Remember {
+    match params["remember"].as_str() {
+        Some("session") => crate::approvals::Remember::Session,
+        Some("forever") => crate::approvals::Remember::Forever,
+        Some("once") | None => crate::approvals::Remember::Once,
+        Some(other) => {
+            tracing::warn!(
+                "memory_pending_*: unknown remember value {other:?}, defaulting to once"
+            );
+            crate::approvals::Remember::Once
+        }
+    }
+}
+
+/// v0.7 K10 — record a synthetic rule + publish on the approval bus
+/// for an MCP-side approve/reject. Mirrors the HTTP-side hook in
+/// `handlers::approval_decide` so the three transports stay
+/// behaviourally identical.
+fn record_mcp_decision(
+    conn: &rusqlite::Connection,
+    pending_id: &str,
+    decided_by: &str,
+    decision_label: &str,
+    remember: crate::approvals::Remember,
+) {
+    let pa = crate::db::get_pending_action(conn, pending_id)
+        .ok()
+        .flatten();
+    let remember_label = match remember {
+        crate::approvals::Remember::Once => "once",
+        crate::approvals::Remember::Session => "session",
+        crate::approvals::Remember::Forever => "forever",
+    };
+    crate::approvals::publish(crate::approvals::ApprovalEvent::ApprovalDecided {
+        pending_id: pending_id.to_string(),
+        decision: decision_label.to_string(),
+        decided_by: decided_by.to_string(),
+        remember: remember_label.to_string(),
+    });
+    if matches!(
+        remember,
+        crate::approvals::Remember::Forever | crate::approvals::Remember::Session
+    ) && let Some(snap) = pa
+    {
+        crate::approvals::record_synthetic_rule(crate::approvals::SyntheticPermissionRule {
+            action_type: snap.action_type,
+            namespace: snap.namespace,
+            agent_id: Some(snap.requested_by),
+            decision: decision_label.to_string(),
+            recorded_at: chrono::Utc::now().to_rfc3339(),
+        });
+    }
+}
+
+pub fn handle_pending_approve(
     conn: &rusqlite::Connection,
     params: &Value,
     mcp_client: Option<&str>,
@@ -4974,16 +5047,23 @@ fn handle_pending_approve(
     validate::validate_id(id).map_err(|e| e.to_string())?;
     let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
         .map_err(|e| e.to_string())?;
+    let remember = parse_remember_param(params);
     match db::approve_with_approver_type(conn, id, &agent_id).map_err(|e| e.to_string())? {
         ApproveOutcome::Approved => {
             // Task 1.10: auto-execute the queued action on final approval.
             let executed = db::execute_pending_action(conn, id).map_err(|e| e.to_string())?;
+            record_mcp_decision(conn, id, &agent_id, "approve", remember);
             Ok(json!({
                 "approved": true,
                 "id": id,
                 "decided_by": agent_id,
                 "executed": true,
                 "memory_id": executed,
+                "remember": match remember {
+                    crate::approvals::Remember::Once => "once",
+                    crate::approvals::Remember::Session => "session",
+                    crate::approvals::Remember::Forever => "forever",
+                },
             }))
         }
         ApproveOutcome::Pending { votes, quorum } => Ok(json!({
@@ -4998,7 +5078,7 @@ fn handle_pending_approve(
     }
 }
 
-fn handle_pending_reject(
+pub fn handle_pending_reject(
     conn: &rusqlite::Connection,
     params: &Value,
     mcp_client: Option<&str>,
@@ -5007,12 +5087,23 @@ fn handle_pending_reject(
     validate::validate_id(id).map_err(|e| e.to_string())?;
     let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), mcp_client)
         .map_err(|e| e.to_string())?;
+    let remember = parse_remember_param(params);
     let transitioned =
         db::decide_pending_action(conn, id, false, &agent_id).map_err(|e| e.to_string())?;
     if !transitioned {
         return Err(format!("pending action not found or already decided: {id}"));
     }
-    Ok(json!({"rejected": true, "id": id, "decided_by": agent_id}))
+    record_mcp_decision(conn, id, &agent_id, "deny", remember);
+    Ok(json!({
+        "rejected": true,
+        "id": id,
+        "decided_by": agent_id,
+        "remember": match remember {
+            crate::approvals::Remember::Once => "once",
+            crate::approvals::Remember::Session => "session",
+            crate::approvals::Remember::Forever => "forever",
+        },
+    }))
 }
 
 fn handle_archive_list(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -679,6 +679,16 @@ pub fn dispatch_approval_requested(conn: &Connection, pending_id: &str, db_path:
             None
         }
     };
+    // v0.7.0 K10 — publish on the in-process approval bus so HTTP SSE
+    // subscribers see the new pending row in real time. Best-effort
+    // (no receivers → swallowed); never blocks the gate path.
+    crate::approvals::publish(crate::approvals::ApprovalEvent::ApprovalRequested {
+        pending_id: pa.id.clone(),
+        action_type: pa.action_type.clone(),
+        namespace: pa.namespace.clone(),
+        requested_by: pa.requested_by.clone(),
+        requested_at: pa.requested_at.clone(),
+    });
     dispatch_event_with_details(
         conn,
         "approval_requested",
@@ -843,7 +853,7 @@ fn send(
 }
 
 /// Hash a plaintext secret (SHA-256 hex).
-fn sha256_hex(s: &str) -> String {
+pub(crate) fn sha256_hex(s: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(s.as_bytes());
     format!("{:x}", hasher.finalize())
@@ -853,7 +863,7 @@ fn sha256_hex(s: &str) -> String {
 /// construction manually using the hashed secret as key material.
 /// Matches the RFC-2104 HMAC construction with SHA-256 as the
 /// primitive.
-fn hmac_sha256_hex(key_hex: &str, body: &str) -> String {
+pub(crate) fn hmac_sha256_hex(key_hex: &str, body: &str) -> String {
     const BLOCK: usize = 64;
     // Decode key — if invalid hex, fall back to the raw bytes (which
     // keeps the signature stable for operators who set bad secrets;

--- a/tests/k10_approval_http.rs
+++ b/tests/k10_approval_http.rs
@@ -49,6 +49,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
         mcp_config: std::sync::Arc::new(None),
         active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
     let router = ai_memory::build_router(api_key_state, app_state);

--- a/tests/k10_approval_http.rs
+++ b/tests/k10_approval_http.rs
@@ -1,0 +1,262 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K10 — `POST /api/v1/approvals/{pending_id}` HMAC gate.
+//!
+//! Pins:
+//!   - With a valid `X-AI-Memory-Signature` (and a server-wide
+//!     `[hooks.subscription].hmac_secret` configured) the endpoint
+//!     accepts the body and approves the pending row → 200.
+//!   - Without the signature header, the endpoint rejects with 401
+//!     even when the body would otherwise be valid.
+//!   - Without ANY server-wide HMAC secret configured, the endpoint
+//!     fails closed (rejects every inbound request → 401), matching
+//!     the K10 spec contract that the K7 secret is the only
+//!     authentication mode for write-side approval traffic.
+
+// `await_holding_lock` lints fire on `std::sync::Mutex` — the lock
+// here is purely a test-serialisation primitive (the global HMAC
+// secret state is itself thread-safe). Allow at the file level.
+#![allow(clippy::await_holding_lock)]
+
+use ai_memory::config::set_active_hooks_hmac_secret;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use std::sync::Mutex;
+use tower::ServiceExt as _;
+
+static K10_HTTP_LOCK: Mutex<()> = Mutex::new(());
+
+/// Build the router from a shared `Db` so the test body can both
+/// hit HTTP routes AND seed `pending_actions` rows directly.
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
+    let router = ai_memory::build_router(api_key_state, app_state);
+    (router, db)
+}
+
+async fn seed_pending_row_via_db(
+    db: &ai_memory::handlers::Db,
+    namespace: &str,
+    requested_by: &str,
+) -> String {
+    // Seed a real memory and queue a delete-pending row that targets
+    // it. The delete branch of `db::execute_pending_action` only needs
+    // a valid `memory_id`, so the test doesn't have to forge a full
+    // store payload.
+    let lock = db.lock().await;
+    let mem = ai_memory::models::Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: ai_memory::models::Tier::Long,
+        namespace: namespace.to_string(),
+        title: "k10-test".into(),
+        content: "from K10 HTTP test".into(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".into(),
+        access_count: 0,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({}),
+    };
+    let mem_id = ai_memory::db::insert(&lock.0, &mem).expect("insert memory");
+    let payload = json!({"reason": "k10-test"});
+    ai_memory::db::queue_pending_action(
+        &lock.0,
+        ai_memory::models::GovernedAction::Delete,
+        namespace,
+        Some(&mem_id),
+        requested_by,
+        &payload,
+    )
+    .expect("queue_pending_action")
+}
+
+/// Compute the K7-style HMAC signature header value for a request body.
+fn sign(secret: &str, timestamp: &str, body: &str) -> String {
+    use sha2::Digest;
+    use sha2::Sha256;
+    fn sha256_hex(s: &str) -> String {
+        let mut h = Sha256::new();
+        h.update(s.as_bytes());
+        format!("{:x}", h.finalize())
+    }
+    fn hmac_sha256_hex(key_hex: &str, body: &str) -> String {
+        const BLOCK: usize = 64;
+        let key_bytes = hex_decode(key_hex).unwrap_or_else(|| key_hex.as_bytes().to_vec());
+        let mut key = key_bytes;
+        if key.len() > BLOCK {
+            let mut h = Sha256::new();
+            h.update(&key);
+            key = h.finalize().to_vec();
+        }
+        key.resize(BLOCK, 0);
+        let mut opad = [0x5cu8; BLOCK];
+        let mut ipad = [0x36u8; BLOCK];
+        for i in 0..BLOCK {
+            opad[i] ^= key[i];
+            ipad[i] ^= key[i];
+        }
+        let mut inner = Sha256::new();
+        inner.update(ipad);
+        inner.update(body.as_bytes());
+        let inner_digest = inner.finalize();
+        let mut outer = Sha256::new();
+        outer.update(opad);
+        outer.update(inner_digest);
+        format!("{:x}", outer.finalize())
+    }
+    fn hex_decode(s: &str) -> Option<Vec<u8>> {
+        if !s.len().is_multiple_of(2) {
+            return None;
+        }
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+            .collect()
+    }
+    let key_hash = sha256_hex(secret);
+    let canonical = format!("{timestamp}.{body}");
+    let sig = hmac_sha256_hex(&key_hash, &canonical);
+    format!("sha256={sig}")
+}
+
+#[tokio::test]
+async fn http_approve_with_valid_hmac_returns_200() {
+    let _g = K10_HTTP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    set_active_hooks_hmac_secret(Some("k10-test-secret".to_string()));
+    let (router, db) = build_router_with_db();
+    let pending_id = seed_pending_row_via_db(&db, "scratch", "alice").await;
+
+    let body = json!({"decision": "approve", "remember": "once"}).to_string();
+    let timestamp = chrono::Utc::now().timestamp().to_string();
+    let sig = sign("k10-test-secret", &timestamp, &body);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/approvals/{pending_id}"))
+        .header("content-type", "application/json")
+        .header("x-ai-memory-timestamp", &timestamp)
+        .header("x-ai-memory-signature", sig)
+        .header("x-agent-id", "operator-1")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "expected 200 with valid HMAC; got {status} body={json}"
+    );
+    assert_eq!(json["approved"], json!(true));
+    assert_eq!(json["remember"], json!("once"));
+    set_active_hooks_hmac_secret(None);
+}
+
+#[tokio::test]
+async fn http_approve_without_hmac_returns_401() {
+    let _g = K10_HTTP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    set_active_hooks_hmac_secret(Some("k10-test-secret".to_string()));
+    let (router, db) = build_router_with_db();
+    let pending_id = seed_pending_row_via_db(&db, "scratch", "alice").await;
+
+    let body = json!({"decision": "approve", "remember": "once"}).to_string();
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/approvals/{pending_id}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "expected 401 without signature header"
+    );
+    set_active_hooks_hmac_secret(None);
+}
+
+#[tokio::test]
+async fn http_approve_without_server_secret_returns_401() {
+    let _g = K10_HTTP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    // Explicitly clear the server-wide secret. Without it the endpoint
+    // MUST refuse all inbound approvals — fail-closed posture.
+    set_active_hooks_hmac_secret(None);
+    let (router, db) = build_router_with_db();
+    let pending_id = seed_pending_row_via_db(&db, "scratch", "alice").await;
+
+    // Even with a "looks-valid" signature, no server secret → 401.
+    let body = json!({"decision": "approve", "remember": "once"}).to_string();
+    let timestamp = chrono::Utc::now().timestamp().to_string();
+    let sig = sign("anything-since-no-server-secret", &timestamp, &body);
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/approvals/{pending_id}"))
+        .header("content-type", "application/json")
+        .header("x-ai-memory-timestamp", &timestamp)
+        .header("x-ai-memory-signature", sig)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "expected 401 when server has no HMAC secret configured"
+    );
+}
+
+#[tokio::test]
+async fn http_approve_with_wrong_signature_returns_401() {
+    let _g = K10_HTTP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    set_active_hooks_hmac_secret(Some("real-secret".to_string()));
+    let (router, db) = build_router_with_db();
+    let pending_id = seed_pending_row_via_db(&db, "scratch", "alice").await;
+
+    let body = json!({"decision": "approve", "remember": "once"}).to_string();
+    let timestamp = chrono::Utc::now().timestamp().to_string();
+    // Sign with the wrong key — must be rejected even though header
+    // is well-formed.
+    let sig = sign("wrong-secret", &timestamp, &body);
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/approvals/{pending_id}"))
+        .header("content-type", "application/json")
+        .header("x-ai-memory-timestamp", &timestamp)
+        .header("x-ai-memory-signature", sig)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "expected 401 when signature does not match the configured secret"
+    );
+    set_active_hooks_hmac_secret(None);
+}

--- a/tests/k10_approval_sse.rs
+++ b/tests/k10_approval_sse.rs
@@ -121,6 +121,7 @@ async fn http_sse_endpoint_emits_event_to_attached_client() {
         profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
         mcp_config: std::sync::Arc::new(None),
         active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
     let router = ai_memory::build_router(api_key_state, app_state);

--- a/tests/k10_approval_sse.rs
+++ b/tests/k10_approval_sse.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K10 — `GET /api/v1/approvals/stream` SSE endpoint.
+//!
+//! The endpoint subscribes to the process-wide approval bus
+//! (`approvals::subscribe`) and emits SSE frames for every
+//! `approval_requested` and `approval_decided` event published. We
+//! exercise that contract two ways:
+//!
+//!   1. **In-process bus** — subscribe directly via
+//!      `approvals::subscribe`, fire `approvals::publish`, assert the
+//!      event arrives. This pins the load-bearing fan-out without
+//!      depending on the SSE response-stream wiring (which is best
+//!      tested via integration tests against a real bound socket).
+//!   2. **Dispatcher hook** — call
+//!      `subscriptions::dispatch_approval_requested` against a freshly
+//!      seeded `pending_actions` row and assert an `ApprovalRequested`
+//!      frame fires on a subscriber attached BEFORE the dispatch
+//!      (broadcast channels do not replay history, so the subscribe
+//!      ordering matters).
+
+use ai_memory::approvals::{ApprovalEvent, publish, subscribe};
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::test]
+async fn subscribe_then_publish_round_trip() {
+    let mut rx = subscribe();
+    let evt = ApprovalEvent::ApprovalRequested {
+        pending_id: "pa-sse-1".into(),
+        action_type: "store".into(),
+        namespace: "scratch".into(),
+        requested_by: "alice".into(),
+        requested_at: "2026-05-05T00:00:00Z".into(),
+    };
+    publish(evt.clone());
+    let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("recv timeout")
+        .expect("recv channel closed");
+    match received {
+        ApprovalEvent::ApprovalRequested { pending_id, .. } => {
+            assert_eq!(pending_id, "pa-sse-1");
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_approval_requested_fans_out_on_bus() {
+    // Set up a fresh in-memory DB and seed a pending row so
+    // dispatch_approval_requested can read it back.
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let payload = json!({"title": "k10-sse", "content": "x", "namespace": "ns-sse"});
+    let pending_id = ai_memory::db::queue_pending_action(
+        &conn,
+        ai_memory::models::GovernedAction::Store,
+        "ns-sse",
+        None,
+        "alice",
+        &payload,
+    )
+    .expect("queue_pending_action");
+
+    // Subscribe BEFORE firing — broadcast channels never replay.
+    let mut rx = subscribe();
+
+    // Fire the dispatcher; it publishes on the K10 approval bus AND
+    // attempts the legacy webhook fan-out (which is a no-op here
+    // because no subscriptions are registered).
+    ai_memory::subscriptions::dispatch_approval_requested(
+        &conn,
+        &pending_id,
+        std::path::Path::new(":memory:"),
+    );
+
+    let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("recv timeout")
+        .expect("recv channel closed");
+    match received {
+        ApprovalEvent::ApprovalRequested {
+            pending_id: pid,
+            namespace,
+            requested_by,
+            action_type,
+            ..
+        } => {
+            assert_eq!(pid, pending_id);
+            assert_eq!(namespace, "ns-sse");
+            assert_eq!(requested_by, "alice");
+            assert_eq!(action_type, "store");
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn http_sse_endpoint_emits_event_to_attached_client() {
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt as _;
+    use tower::ServiceExt as _;
+
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState { key: None };
+    let router = ai_memory::build_router(api_key_state, app_state);
+
+    // Initiate the SSE request. axum returns immediately with the
+    // streaming body; we hold the response body and pull a single
+    // chunk after publishing an event.
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/v1/approvals/stream")
+        .header("accept", "text/event-stream")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let mut body = resp.into_body();
+
+    // Spawn a task that fires the dispatcher slightly after we begin
+    // polling the body (so the subscriber inside the handler is
+    // attached before the broadcast).
+    let conn_for_publish = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let payload = json!({"title": "x", "content": "y", "namespace": "ns-sse-http"});
+    let pending_id = ai_memory::db::queue_pending_action(
+        &conn_for_publish,
+        ai_memory::models::GovernedAction::Store,
+        "ns-sse-http",
+        None,
+        "operator",
+        &payload,
+    )
+    .expect("queue_pending_action");
+    tokio::spawn(async move {
+        // Small delay so the SSE handler attaches its subscriber
+        // before the publish fires. 100ms is generous on CI hardware.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        ai_memory::subscriptions::dispatch_approval_requested(
+            &conn_for_publish,
+            &pending_id,
+            std::path::Path::new(":memory:"),
+        );
+    });
+
+    // Read until we get a non-empty data frame OR timeout.
+    let mut buf = Vec::new();
+    let read = async {
+        loop {
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    if let Some(bytes) = frame.data_ref() {
+                        buf.extend_from_slice(bytes);
+                        let s = String::from_utf8_lossy(&buf);
+                        if s.contains("approval_requested") {
+                            return Ok::<(), String>(());
+                        }
+                    }
+                }
+                Some(Err(e)) => return Err(format!("body error: {e}")),
+                None => return Err("body ended before event".into()),
+            }
+        }
+    };
+    let result = tokio::time::timeout(Duration::from_secs(5), read)
+        .await
+        .expect("SSE timeout — no approval_requested event in 5s");
+    result.expect("SSE read failed");
+    let text = String::from_utf8_lossy(&buf);
+    assert!(
+        text.contains("event: approval_requested"),
+        "expected SSE `event: approval_requested` line; got: {text}"
+    );
+}

--- a/tests/k10_remember_forever.rs
+++ b/tests/k10_remember_forever.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 K10 — `remember=forever` writes a synthetic permission rule.
+//!
+//! The K10 contract: any of the three transports (HTTP, SSE-driven,
+//! MCP) accepting `remember=forever` MUST register a
+//! [`SyntheticPermissionRule`] in the process-wide registry so K9's
+//! permission resolver auto-decides the same `(action_type,
+//! namespace, agent_id)` tuple next time without re-asking.
+//!
+//! Until K9's resolver lands on the same branch, the registry's
+//! consumer-facing surface is `approvals::list_synthetic_rules` —
+//! we assert against that.
+
+// `await_holding_lock` lints fire on `std::sync::Mutex` — but the
+// lock is purely a test-serialisation primitive (the registry
+// mutation that follows is itself thread-safe), so the lint is a
+// false positive in this context. We allow it at the file level
+// instead of at every test fn.
+#![allow(clippy::await_holding_lock)]
+
+use ai_memory::approvals::{
+    Decision, Remember, SyntheticPermissionRule, clear_synthetic_rules_for_test,
+    list_synthetic_rules, record_synthetic_rule,
+};
+use serde_json::json;
+use std::sync::Mutex;
+
+static REMEMBER_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn forever_rule_round_trips_through_registry() {
+    let _g = REMEMBER_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    clear_synthetic_rules_for_test();
+    let rule = SyntheticPermissionRule {
+        action_type: "store".into(),
+        namespace: "scratch".into(),
+        agent_id: Some("alice".into()),
+        decision: "approve".into(),
+        recorded_at: "2026-05-05T00:00:00Z".into(),
+    };
+    record_synthetic_rule(rule.clone());
+    let snap = list_synthetic_rules();
+    assert!(snap.contains(&rule), "rule absent: {snap:?}");
+}
+
+#[tokio::test]
+async fn mcp_pending_approve_with_forever_records_rule() {
+    let _g = REMEMBER_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    clear_synthetic_rules_for_test();
+
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    // Seed a real memory + delete-pending row so `execute_pending_action`
+    // takes the delete branch (which only needs `memory_id`, no full
+    // Memory payload to forge).
+    let mem = ai_memory::models::Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: ai_memory::models::Tier::Long,
+        namespace: "ns-forever".into(),
+        title: "k10-forever".into(),
+        content: "x".into(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".into(),
+        access_count: 0,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({}),
+    };
+    let mem_id = ai_memory::db::insert(&conn, &mem).expect("insert memory");
+    let payload = json!({"reason": "k10-forever"});
+    let pending_id = ai_memory::db::queue_pending_action(
+        &conn,
+        ai_memory::models::GovernedAction::Delete,
+        "ns-forever",
+        Some(&mem_id),
+        "alice",
+        &payload,
+    )
+    .expect("queue_pending_action");
+
+    let args = json!({
+        "id": pending_id,
+        "agent_id": "operator-1",
+        "remember": "forever",
+    });
+    let resp = ai_memory::mcp::handle_pending_approve(&conn, &args, None)
+        .expect("memory_pending_approve handler");
+    assert_eq!(resp["approved"], json!(true), "approve failed: {resp}");
+    assert_eq!(resp["remember"], json!("forever"));
+
+    let snap = list_synthetic_rules();
+    let found = snap.iter().any(|r| {
+        r.action_type == "delete"
+            && r.namespace == "ns-forever"
+            && r.agent_id.as_deref() == Some("alice")
+            && r.decision == "approve"
+    });
+    assert!(
+        found,
+        "forever rule not recorded after MCP approve; snap={snap:?}"
+    );
+}
+
+#[tokio::test]
+async fn mcp_pending_reject_with_forever_records_deny_rule() {
+    let _g = REMEMBER_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    clear_synthetic_rules_for_test();
+
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let payload = json!({"title": "k10-deny", "content": "x", "namespace": "ns-deny"});
+    let pending_id = ai_memory::db::queue_pending_action(
+        &conn,
+        ai_memory::models::GovernedAction::Delete,
+        "ns-deny",
+        None,
+        "bob",
+        &payload,
+    )
+    .expect("queue_pending_action");
+
+    let args = json!({
+        "id": pending_id,
+        "agent_id": "operator-1",
+        "remember": "forever",
+    });
+    let resp = ai_memory::mcp::handle_pending_reject(&conn, &args, None)
+        .expect("memory_pending_reject handler");
+    assert_eq!(resp["rejected"], json!(true), "reject failed: {resp}");
+    assert_eq!(resp["remember"], json!("forever"));
+
+    let snap = list_synthetic_rules();
+    let found = snap.iter().any(|r| {
+        r.action_type == "delete"
+            && r.namespace == "ns-deny"
+            && r.agent_id.as_deref() == Some("bob")
+            && r.decision == "deny"
+    });
+    assert!(found, "deny rule not recorded; snap={snap:?}");
+}
+
+#[test]
+fn remember_once_does_not_record_a_rule() {
+    let _g = REMEMBER_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    clear_synthetic_rules_for_test();
+
+    // Sanity: just constructing decisions doesn't alter the registry.
+    let _ = (Decision::Approve, Remember::Once);
+    let snap = list_synthetic_rules();
+    assert!(snap.is_empty(), "registry should start empty: {snap:?}");
+}


### PR DESCRIPTION
## Summary

Closes the v0.7 K10 epic item: when the governance gate returns
`Pending`, an operator can decide via three transports backed by a
single in-process broadcast bus + synthetic-rule registry.

- **HTTP** — `POST /api/v1/approvals/{pending_id}` with body
  `{\"decision\":\"approve|deny\",\"remember\":\"once|session|forever\"}`,
  HMAC-gated via the K7 `[hooks.subscription].hmac_secret` server-wide
  override (`X-AI-Memory-Signature: sha256=<hex>` + `X-AI-Memory-Timestamp`).
  Missing or invalid signature → 401; no server secret configured → 401
  (fail-closed posture).
- **SSE** — `GET /api/v1/approvals/stream` exposes the in-process
  `tokio::sync::broadcast` bus as a server-sent-events stream.
  `approval_requested` frames fire whenever
  `subscriptions::dispatch_approval_requested` runs; `approval_decided`
  frames fire from each of the three transports. Slow subscribers see
  a `lagged` event instead of silent drops.
- **MCP** — `memory_pending_approve` / `memory_pending_reject` gain an
  optional `remember` property (no new tools, no removed properties);
  tool count unchanged at 49.

`remember=forever` (and `session`) records a `SyntheticPermissionRule`
in a process-wide registry exposed via `approvals::list_synthetic_rules`
so K9's permission resolver can promote them into config-file rules
without a schema translation step. `once` records nothing.

## Scope guarantees

- Schema version unchanged at 27.
- MCP tool count unchanged at 49 (modified existing tools' input schema).
- No new HookEvent variants.
- No new webhook event types.

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --lib --test k10_approval_http --test k10_approval_sse --test k10_remember_forever -- -D warnings` clean.
- [x] `cargo test --lib` — 2184 / 2184 pass.
- [x] `cargo test --test k10_approval_http --test k10_approval_sse --test k10_remember_forever` — 11 / 11 pass.
- [ ] Reviewer: spot-check that `verify_approval_hmac` rejects on a
      replayed timestamp (current K10 ships per-request HMAC; replay
      window matching K7's 5-minute window is a follow-up).

## AI involvement

Drafted by Claude Opus 4.7 (1M context). Implementation, tests, and
PR body all generated against the spec from `docs/v0.7/V0.7-EPIC.md`
K10. Workspace `/Users/fate/v07/v07-k10/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)