### PR TITLE
fix(subscriptions): K4 dispatch_count race in approval_requested test

### DIFF
--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -2534,15 +2534,26 @@ mod tests {
 
         // Sanity: the dispatch_count was bumped on the subscription
         // row (proves we went through record_dispatch on success).
+        // Poll up to 2s — dispatch_count is written back AFTER the HTTP
+        // POST is acked, so seeing the wiremock request above does not
+        // imply the row update has landed yet (race observed on Linux
+        // and Windows runners under load).
         let conn = Connection::open(&db_path).unwrap();
-        let dc: i64 = conn
-            .query_row(
-                "SELECT dispatch_count FROM subscriptions WHERE id = ?1",
-                params![sub_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(dc, 1);
+        let mut dc: i64 = 0;
+        for _ in 0..40 {
+            dc = conn
+                .query_row(
+                    "SELECT dispatch_count FROM subscriptions WHERE id = ?1",
+                    params![sub_id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            if dc == 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert_eq!(dc, 1, "dispatch_count must be 1 after successful dispatch");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures on \`subscriptions::tests::approval_requested_dispatches_to_opt_in_subscriber\` (Linux + Windows under load).

Root cause: the test observed the wiremock POST landing, then immediately read \`dispatch_count\` from the subscription row. But the dispatcher writes \`dispatch_count++\` AFTER the HTTP ack returns, so seeing the request did not guarantee the writeback had completed. Race window: ~5-50ms under CI load.

Fix: poll the row up to 2s with 50ms intervals.

## Test plan
- [x] Local: 1/1 PASS
- [ ] CI: 3/3 platform pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)