### PR TITLE
fix(tests): serialise env-var mutations in snippet + keypair tests

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -2104,6 +2104,15 @@ mod tests {
     fn snippet_every_target_emits_under_budget() {
         // The full per-target sweep — every harness gets its own
         // snippet file, each within budget and carrying every anchor.
+        //
+        // Hold `snippet_env_lock` across the entire iteration. Without
+        // it, the per-target tests below (snippet_claude_code_*,
+        // snippet_cursor_*, etc.) can grab the lock between iterations
+        // and clobber `AI_MEMORY_SYSTEM_PROMPT_DIR`, racing with the
+        // emit + readback this loop performs. Observed as flaky
+        // assertion at `assert!(body.contains(harness))` under
+        // `cargo test` default `--test-threads=N` on Linux + macOS CI.
+        let _g = snippet_env_lock().lock().unwrap_or_else(|e| e.into_inner());
         for target in [
             Target::ClaudeCode,
             Target::Openclaw,
@@ -2116,9 +2125,21 @@ mod tests {
             Target::GrokCli,
             Target::GeminiCli,
         ] {
-            let (path, body) = emit_snippet_isolated(target);
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let tmp_path = tmp.path().to_path_buf();
+            // SAFETY: env mutation serialised by the outer
+            // `snippet_env_lock` guard for the full iteration.
+            unsafe {
+                std::env::set_var("AI_MEMORY_SYSTEM_PROMPT_DIR", &tmp_path);
+            }
+            let snippet_path = write_system_prompt_snippet(target).expect("snippet write");
+            let body = fs::read_to_string(&snippet_path).expect("read snippet");
+            unsafe {
+                std::env::remove_var("AI_MEMORY_SYSTEM_PROMPT_DIR");
+            }
+            std::mem::forget(tmp);
             assert!(
-                path.exists(),
+                snippet_path.exists(),
                 "snippet file for {} not created",
                 target.name(),
             );

--- a/src/identity/keypair.rs
+++ b/src/identity/keypair.rs
@@ -587,13 +587,25 @@ mod tests {
         assert!(s.ends_with("ai-memory/keys") || s.ends_with("ai-memory\\keys"));
     }
 
+    /// Process-wide guard for tests that mutate `AI_MEMORY_KEY_DIR`.
+    /// Without this any other test that reads the env var concurrently
+    /// can observe a half-written value, surfacing as
+    /// `assert_eq!(p, "/tmp/h4-override-test")` failing because another
+    /// thread cleared the var between set + read.
+    fn key_dir_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
     #[test]
     fn default_key_dir_honours_env_override() {
         // v0.7 H4 — the override exists so `memory_verify` integration
         // tests can populate a hermetic key dir per test process. Pin
         // the contract here so a future refactor doesn't quietly drop
         // the override.
-        // SAFETY: single-threaded test block; no concurrent env writes.
+        let _g = key_dir_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: env mutation serialised by `key_dir_env_lock` for
+        // the duration of this test.
         unsafe {
             std::env::set_var("AI_MEMORY_KEY_DIR", "/tmp/h4-override-test");
         }


### PR DESCRIPTION
## Summary

Two flaky tests were the actual blocker for B3, K8, K11, J8, K10, K11, and clippy-fix PRs in the v0.7 epic. Real fix instead of repeated re-runs.

- Hold \`snippet_env_lock\` across the entire sweep in \`snippet_every_target_emits_under_budget\` (was releasing between iterations).
- Introduce \`key_dir_env_lock\` for \`default_key_dir_honours_env_override\` (was unguarded).

## Test plan
- [x] Local: 7 + 2 = 9/9 pass
- [ ] CI: 3/3 platform pass
- [ ] After merge: re-run B3, K8, K11, J8, K10, K11, clippy-fix CIs to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)