### PR TITLE
feat: v0.7-e1 — T0 cell orchestration script (4 LLMs)

### DIFF
--- a/docs/v0.7/T0-ORCHESTRATION.md
+++ b/docs/v0.7/T0-ORCHESTRATION.md
@@ -1,0 +1,161 @@
+# T0 cross-LLM orchestration (v0.7.0 task E1)
+
+> **Status:** SHIPPING with v0.7.0 — E1
+> **Date:** 2026-05-06
+> **Script:** [`scripts/t0-orchestrate.sh`](../../scripts/t0-orchestrate.sh)
+> **CI counterpart:** [`tests/calibration_t0.rs`](../../tests/calibration_t0.rs)
+
+The Discovery Gate **T0 calibration cells** in
+`tests/calibration_t0.rs` pin the canonical capabilities-v3 phrasings
+(A1 `summary` + A2 `to_describe_to_user`) against fixture inputs
+running on the local substrate. Those tests are deterministic and run
+in CI on every PR.
+
+E1 wraps the same Discovery Gate questions into an **out-of-band
+orchestration harness** that exercises them against four live frontier
+LLMs. The goal is to validate that the canonical phrasings (the A1, A2
+strings + the per-tool short descriptions from C2) are correctly
+understood and reproduced by every major frontier reasoning-class
+model — not just by the local fixture-driven test cells.
+
+This is a script, not a runtime change. No tools, schemas, webhooks,
+or hook events are added by E1.
+
+---
+
+## LLMs covered
+
+| Provider  | Model              | Env var               |
+|-----------|--------------------|-----------------------|
+| Anthropic | Claude Sonnet 4.6  | `ANTHROPIC_API_KEY`   |
+| OpenAI    | GPT-5              | `OPENAI_API_KEY`      |
+| Google    | Gemini 3           | `GOOGLE_API_KEY`      |
+| xAI       | Grok 4.3           | `XAI_API_KEY`         |
+
+The four-vendor coverage matches the v0.6.5/v0.7.0 NHI Discovery Gate
+observation matrix. Adding a fifth vendor is a one-line append to the
+`LLMS=(…)` array in the script.
+
+---
+
+## Setup
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GOOGLE_API_KEY=...
+export XAI_API_KEY=xai-...
+
+# Build the local substrate so the script can pull live capabilities-v3
+# payloads to use as system context for each LLM call.
+cargo build --release
+```
+
+Dependencies for live mode: `bash`, `curl`, `jq`. (Dry-run mode needs
+only `bash`.)
+
+---
+
+## Running
+
+```bash
+# Live run — all four LLMs, six Discovery Gate questions each.
+scripts/t0-orchestrate.sh
+
+# Restrict to one provider (debugging, partial outages, key rotation).
+scripts/t0-orchestrate.sh --llm claude
+
+# Dry-run — no API calls, prints the plan + result file paths.
+# Used by tests/e1_orchestration_dry_run.rs to validate harness
+# structure without spending API tokens or requiring keys.
+scripts/t0-orchestrate.sh --dry-run
+```
+
+Skipped LLMs (env var unset) print `skip <llm> — <ENV> unset` and
+continue. A single missing key never aborts the run.
+
+---
+
+## Output layout
+
+```
+results/t0/
+  claude-20260506T120000Z.json    # one per LLM per run
+  gpt5-20260506T120000Z.json
+  gemini-20260506T120000Z.json
+  grok-20260506T120000Z.json
+  summary-20260506T120000Z.md     # cross-LLM scorecard
+```
+
+Each `<llm>-<ts>.json` file is:
+
+```json
+{
+  "llm": "claude",
+  "model": "claude-sonnet-4-6",
+  "timestamp": "20260506T120000Z",
+  "results": [
+    { "qid": "T0-A2-CORE", "profile": "core",
+      "question": "What tools do you have available right now? …",
+      "response": "I can directly use 7 memory tools right now …",
+      "passed": 3, "total": 3 }
+  ]
+}
+```
+
+The `summary-<ts>.md` file is a markdown table — one row per
+`(llm, qid)` pair — that you can paste directly into a release-notes
+appendix or a Discovery Gate observation cell.
+
+---
+
+## How to interpret results
+
+Each Discovery Gate question carries one or more **expected fragments**
+(canonical substrings the response should contain). The `passed/total`
+numbers in the summary report how many fragments matched.
+
+| `passed/total` | Meaning |
+|----------------|---------|
+| `total/total`  | LLM reproduced the canonical phrasing — pass. |
+| `0/total`      | LLM ignored or misunderstood the canonical strings — investigate the system-context payload first; if the payload looks right, the LLM may need a clearer per-tool short description (open a C2 ticket). |
+| Mixed          | LLM paraphrased; check whether the missing fragment is load-bearing (e.g., a recovery path name) or cosmetic (e.g., the tone constraint). |
+
+The acceptance threshold per the v0.7.0 ship gate is **≥95% across all
+four LLMs combined** (E2 measures this post-ship).
+
+---
+
+## When to re-run
+
+Re-run the orchestrator after any change that could shift LLM
+convergence on the canonical phrasings:
+
+1. The phrasings themselves change in `docs/v0.7/canonical-phrasings.md`
+   or in `src/mcp.rs::build_capabilities_{summary,describe_to_user}`.
+2. A new tool family is added (loaded/unloaded counts shift — the T0
+   tests update their expected counts; orchestration should
+   re-confirm LLM convergence on the new numbers).
+3. A frontier model rev lands on one of the four covered providers
+   (Claude N+1, GPT N+1, Gemini N+1, Grok N+1). Add the new model id
+   to the `LLMS=(…)` array and re-run.
+4. The per-tool short descriptions ship from C2 (orchestration becomes
+   the load-bearing check that LLMs render those descriptions sanely
+   to end users).
+
+The CI-side `tests/calibration_t0.rs` cells catch substrate drift
+**before** you re-run this orchestrator. If those tests are red, fix
+them first — a live cross-LLM run against a drifted substrate burns
+API budget on a question you already know the answer to.
+
+---
+
+## Refs
+
+- [v0.7.0 epic](./V0.7-EPIC.md) — track E
+- [`docs/v0.7/canonical-phrasings.md`](./canonical-phrasings.md) — the
+  A1/A2 strings the orchestrator validates against
+- [`tests/calibration_t0.rs`](../../tests/calibration_t0.rs) — the
+  CI-side T0 cells the orchestrator wraps
+- [`tests/e1_orchestration_dry_run.rs`](../../tests/e1_orchestration_dry_run.rs)
+  — minimal Rust test that runs `--dry-run` and asserts harness shape

--- a/scripts/t0-orchestrate.sh
+++ b/scripts/t0-orchestrate.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# t0-orchestrate.sh — Discovery Gate T0 calibration cells across 4 LLMs.
+#
+# v0.7.0 task E1. The CI-side T0 cells in tests/calibration_t0.rs pin the
+# canonical capabilities-v3 phrasings (A1 `summary` + A2
+# `to_describe_to_user`) against fixture inputs running on the local
+# substrate. E1 wraps those same questions into an orchestration harness
+# that exercises them against four live frontier LLMs:
+#
+#   - Anthropic Claude Sonnet 4.6   (ANTHROPIC_API_KEY)
+#   - OpenAI GPT-5                  (OPENAI_API_KEY)
+#   - Google Gemini 3               (GOOGLE_API_KEY)
+#   - xAI Grok 4.3                  (XAI_API_KEY)
+#
+# Goal: validate that the canonical phrasings (A1, A2 strings + per-tool
+# short descriptions from C2) are correctly understood by every major
+# frontier LLM. This is a SCRIPT + HARNESS, not a runtime change. The
+# actual cross-LLM run happens out-of-band — operator runs this script
+# with the four API keys in env. Results land under results/t0/.
+#
+# Usage:
+#   scripts/t0-orchestrate.sh                # live run, all 4 LLMs
+#   scripts/t0-orchestrate.sh --dry-run      # print plan, no API calls
+#   scripts/t0-orchestrate.sh --llm claude   # restrict to one LLM
+#
+# See docs/v0.7/T0-ORCHESTRATION.md for setup, interpretation, and
+# re-run cadence.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_DIR="${REPO}/results/t0"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+DRY_RUN=0
+ONLY_LLM=""
+
+usage() {
+  sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --llm)     ONLY_LLM="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Discovery Gate questions — taken from tests/calibration_t0.rs.
+# Each question pairs with an expected canonical phrasing that the LLM
+# response is grep-checked against (substring match — LLMs paraphrase
+# the framing but should reproduce the load-bearing fragments verbatim).
+# ---------------------------------------------------------------------------
+
+# Q-id        | Source cell in tests/calibration_t0.rs
+# T0-A2-CORE  | t0_describe_to_user_core_profile_canonical_phrasing
+# T0-A2-FULL  | t0_describe_to_user_full_profile_canonical_phrasing
+# T0-A2-GRAPH | t0_describe_to_user_graph_profile_canonical_phrasing
+# T0-A2-NJG   | t0_describe_to_user_omits_mcp_jargon_across_profiles
+# T0-A1-CORE  | t0_summary_core_profile_lists_four_recovery_paths
+# T0-CONTRACT | t0_v3_contract_both_strings_present_under_every_named_profile
+
+QUESTIONS=(
+  "T0-A2-CORE|core|What tools do you have available right now? Answer in one sentence to a non-technical user."
+  "T0-A2-FULL|full|What tools do you have available right now? Answer in one sentence to a non-technical user."
+  "T0-A2-GRAPH|graph|What tools do you have available right now? Answer in one sentence to a non-technical user."
+  "T0-A2-NJG|core|Describe your memory tools to me without using any internal jargon."
+  "T0-A1-CORE|core|If you needed to use a memory tool that isn't currently loaded, what are all the recovery paths available?"
+  "T0-CONTRACT|core|Confirm both your operator-facing summary and your user-facing description fields are populated."
+)
+
+EXPECTED_FRAGMENTS=(
+  "T0-A2-CORE|7 memory tools right now"
+  "T0-A2-CORE|43 more"
+  "T0-A2-CORE|available on demand"
+  "T0-A2-FULL|all 50 memory tools right now"
+  "T0-A2-FULL|Nothing more to load"
+  "T0-A2-GRAPH|18 memory tools right now"
+  "T0-A2-GRAPH|32 more"
+  "T0-A2-NJG|memory tools"
+  "T0-A1-CORE|--profile <family>"
+  "T0-A1-CORE|memory_load_family"
+  "T0-A1-CORE|memory_smart_load"
+  "T0-A1-CORE|JSON-RPC -32601"
+  "T0-CONTRACT|summary"
+  "T0-CONTRACT|to_describe_to_user"
+)
+
+# ---------------------------------------------------------------------------
+# LLM endpoints — (id|model|env_var|api_url) tuples.
+# Chat-completions-style POST bodies live in build_request().
+# ---------------------------------------------------------------------------
+LLMS=(
+  "claude|claude-sonnet-4-6|ANTHROPIC_API_KEY|https://api.anthropic.com/v1/messages"
+  "gpt5|gpt-5|OPENAI_API_KEY|https://api.openai.com/v1/chat/completions"
+  "gemini|gemini-3|GOOGLE_API_KEY|https://generativelanguage.googleapis.com/v1/models/gemini-3:generateContent"
+  "grok|grok-4-3|XAI_API_KEY|https://api.x.ai/v1/chat/completions"
+)
+
+# ---------------------------------------------------------------------------
+# Fetch the canonical capabilities-v3 payload from the local binary so
+# every LLM gets identical system context. In dry-run, we substitute a
+# placeholder (no build needed) — the dry-run path is for testing the
+# orchestrator structure, not the LLMs themselves.
+# ---------------------------------------------------------------------------
+load_capabilities_payload() {
+  local profile="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '{"profile":"%s","schema_version":"3","summary":"<dry-run>","to_describe_to_user":"<dry-run>"}' "$profile"
+    return
+  fi
+  local bin="${REPO}/target/release/ai-memory"
+  if [[ ! -x "$bin" ]]; then
+    bin="${REPO}/target/debug/ai-memory"
+  fi
+  if [[ ! -x "$bin" ]]; then
+    echo "warn: no built ai-memory binary; cargo build first" >&2
+    printf '{"profile":"%s","schema_version":"3","summary":"<unavailable>","to_describe_to_user":"<unavailable>"}' "$profile"
+    return
+  fi
+  printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"memory_capabilities","arguments":{"accept":"v3"}}}\n' \
+    | AI_MEMORY_NO_CONFIG=1 "$bin" mcp --profile "$profile" 2>/dev/null \
+    | head -1
+}
+
+# ---------------------------------------------------------------------------
+# Score a response against the expected fragments for its question id.
+# Outputs space-separated "passed total" counts.
+# ---------------------------------------------------------------------------
+score_response() {
+  local qid="$1"; local response="$2"
+  local total=0; local passed=0
+  for entry in "${EXPECTED_FRAGMENTS[@]}"; do
+    local eid="${entry%%|*}"
+    local frag="${entry#*|}"
+    [[ "$eid" == "$qid" ]] || continue
+    total=$((total + 1))
+    if [[ "$response" == *"$frag"* ]]; then
+      passed=$((passed + 1))
+    fi
+  done
+  echo "$passed $total"
+}
+
+# ---------------------------------------------------------------------------
+# Per-provider request body builders. Each takes the system context +
+# the user question and prints a curl invocation suitable for `eval`
+# under live mode. In dry-run we just print the plan.
+# ---------------------------------------------------------------------------
+plan_call() {
+  local llm_id="$1"; local model="$2"; local env_var="$3"; local url="$4"
+  local qid="$5"; local profile="$6"; local question="$7"
+  cat <<EOF
+  - llm:      $llm_id
+    model:    $model
+    api_url:  $url
+    auth_env: $env_var
+    qid:      $qid
+    profile:  $profile
+    question: $question
+EOF
+}
+
+# Live POST — provider-specific body shape. Returns the assistant text
+# extracted by jq. Designed defensively: HTTP/network errors yield an
+# empty string so scoring records a 0/N for the question rather than
+# crashing the whole run.
+do_call() {
+  local llm_id="$1"; local model="$2"; local env_var="$3"; local url="$4"
+  local system_ctx="$5"; local question="$6"
+  local key="${!env_var:-}"
+  if [[ -z "$key" ]]; then
+    echo "" ; return
+  fi
+
+  local body
+  case "$llm_id" in
+    claude)
+      body=$(jq -n --arg m "$model" --arg s "$system_ctx" --arg q "$question" \
+        '{model:$m, max_tokens:1024, system:$s, messages:[{role:"user", content:$q}]}')
+      curl -sS --max-time 60 "$url" \
+        -H "x-api-key: $key" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "content-type: application/json" \
+        -d "$body" 2>/dev/null | jq -r '.content[0].text // ""'
+      ;;
+    gpt5)
+      body=$(jq -n --arg m "$model" --arg s "$system_ctx" --arg q "$question" \
+        '{model:$m, messages:[{role:"system",content:$s},{role:"user",content:$q}]}')
+      curl -sS --max-time 60 "$url" \
+        -H "Authorization: Bearer $key" \
+        -H "content-type: application/json" \
+        -d "$body" 2>/dev/null | jq -r '.choices[0].message.content // ""'
+      ;;
+    gemini)
+      body=$(jq -n --arg s "$system_ctx" --arg q "$question" \
+        '{system_instruction:{parts:[{text:$s}]}, contents:[{parts:[{text:$q}]}]}')
+      curl -sS --max-time 60 "${url}?key=${key}" \
+        -H "content-type: application/json" \
+        -d "$body" 2>/dev/null | jq -r '.candidates[0].content.parts[0].text // ""'
+      ;;
+    grok)
+      body=$(jq -n --arg m "$model" --arg s "$system_ctx" --arg q "$question" \
+        '{model:$m, messages:[{role:"system",content:$s},{role:"user",content:$q}]}')
+      curl -sS --max-time 60 "$url" \
+        -H "Authorization: Bearer $key" \
+        -H "content-type: application/json" \
+        -d "$body" 2>/dev/null | jq -r '.choices[0].message.content // ""'
+      ;;
+    *) echo "" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Main orchestration loop.
+# ---------------------------------------------------------------------------
+mkdir -p "$RESULTS_DIR"
+
+echo "==> t0-orchestrate"
+echo "    timestamp: $TIMESTAMP"
+echo "    dry-run:   $DRY_RUN"
+echo "    only-llm:  ${ONLY_LLM:-<all>}"
+echo "    results:   $RESULTS_DIR"
+echo "    questions: ${#QUESTIONS[@]}"
+echo
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "plan:"
+  for llm_entry in "${LLMS[@]}"; do
+    IFS='|' read -r llm_id model env_var url <<<"$llm_entry"
+    [[ -z "$ONLY_LLM" || "$ONLY_LLM" == "$llm_id" ]] || continue
+    for q_entry in "${QUESTIONS[@]}"; do
+      IFS='|' read -r qid profile question <<<"$q_entry"
+      plan_call "$llm_id" "$model" "$env_var" "$url" "$qid" "$profile" "$question"
+    done
+  done
+  echo
+  echo "expected_fragments: ${#EXPECTED_FRAGMENTS[@]}"
+  echo "results_template:   $RESULTS_DIR/<llm>-${TIMESTAMP}.json"
+  echo "summary_template:   $RESULTS_DIR/summary-${TIMESTAMP}.md"
+  echo "==> dry-run complete (no API calls made)"
+  exit 0
+fi
+
+# Live mode: jq is required for body construction + response extraction.
+command -v jq >/dev/null 2>&1 || { echo "jq required for live mode" >&2; exit 3; }
+command -v curl >/dev/null 2>&1 || { echo "curl required for live mode" >&2; exit 3; }
+
+SUMMARY_MD="${RESULTS_DIR}/summary-${TIMESTAMP}.md"
+{
+  echo "# T0 cross-LLM orchestration — ${TIMESTAMP}"
+  echo
+  echo "| LLM | Question | Profile | Passed | Total |"
+  echo "|---|---|---|---|---|"
+} >"$SUMMARY_MD"
+
+for llm_entry in "${LLMS[@]}"; do
+  IFS='|' read -r llm_id model env_var url <<<"$llm_entry"
+  [[ -z "$ONLY_LLM" || "$ONLY_LLM" == "$llm_id" ]] || continue
+
+  if [[ -z "${!env_var:-}" ]]; then
+    echo "skip $llm_id — $env_var unset"
+    continue
+  fi
+
+  out_file="${RESULTS_DIR}/${llm_id}-${TIMESTAMP}.json"
+  echo "==> $llm_id ($model) -> $out_file"
+
+  printf '{"llm":"%s","model":"%s","timestamp":"%s","results":[' "$llm_id" "$model" "$TIMESTAMP" >"$out_file"
+  first=1
+
+  for q_entry in "${QUESTIONS[@]}"; do
+    IFS='|' read -r qid profile question <<<"$q_entry"
+    system_ctx="$(load_capabilities_payload "$profile")"
+    response="$(do_call "$llm_id" "$model" "$env_var" "$url" "$system_ctx" "$question")"
+    read -r passed total <<<"$(score_response "$qid" "$response")"
+    [[ $first -eq 1 ]] || printf ',' >>"$out_file"
+    first=0
+    jq -n \
+      --arg qid "$qid" --arg profile "$profile" --arg q "$question" \
+      --arg r "$response" --argjson p "$passed" --argjson t "$total" \
+      '{qid:$qid, profile:$profile, question:$q, response:$r, passed:$p, total:$t}' \
+      >>"$out_file"
+    echo "| $llm_id | $qid | $profile | $passed | $total |" >>"$SUMMARY_MD"
+    echo "    $qid ($profile): $passed/$total"
+  done
+
+  printf ']}' >>"$out_file"
+done
+
+echo
+echo "==> summary: $SUMMARY_MD"

--- a/tests/e1_orchestration_dry_run.rs
+++ b/tests/e1_orchestration_dry_run.rs
@@ -1,0 +1,115 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 task E1 — minimal harness check on `scripts/t0-orchestrate.sh`.
+//!
+//! The orchestrator is an out-of-band script that fans the Discovery
+//! Gate questions out to four live LLMs (see
+//! `docs/v0.7/T0-ORCHESTRATION.md`). Live runs cost API budget and
+//! require keys, so CI exercises it in `--dry-run` mode and asserts:
+//!
+//! 1. The script is present and executable.
+//! 2. `--dry-run` exits 0 without making API calls.
+//! 3. The plan output names all four LLMs (claude / gpt5 / gemini / grok).
+//! 4. The plan output names every Discovery Gate question id pinned
+//!    in `tests/calibration_t0.rs`.
+//! 5. The dry-run advertises the result-file template paths.
+//!
+//! If any of these go red, the orchestration harness has drifted from
+//! the calibration cells it wraps — fix the script (or the cell ids)
+//! before merging.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn run_dry_run() -> String {
+    let script = repo_root().join("scripts").join("t0-orchestrate.sh");
+    assert!(
+        script.exists(),
+        "E1: scripts/t0-orchestrate.sh missing at {}",
+        script.display()
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg("--dry-run")
+        .current_dir(repo_root())
+        .output()
+        .expect("spawn t0-orchestrate.sh --dry-run");
+
+    assert!(
+        output.status.success(),
+        "E1: --dry-run exited non-zero (status={:?})\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("dry-run stdout is UTF-8")
+}
+
+#[test]
+fn e1_dry_run_exits_clean_and_names_all_four_llms() {
+    let out = run_dry_run();
+
+    for llm in &["claude", "gpt5", "gemini", "grok"] {
+        assert!(
+            out.contains(&format!("llm:      {llm}")),
+            "E1: dry-run plan missing llm={llm}\nfull output:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn e1_dry_run_covers_every_calibration_cell_id() {
+    let out = run_dry_run();
+
+    // Question ids must match the calibration cells in
+    // tests/calibration_t0.rs. If a new cell lands there, add the id
+    // to QUESTIONS in scripts/t0-orchestrate.sh and to this list.
+    for qid in &[
+        "T0-A2-CORE",
+        "T0-A2-FULL",
+        "T0-A2-GRAPH",
+        "T0-A2-NJG",
+        "T0-A1-CORE",
+        "T0-CONTRACT",
+    ] {
+        assert!(
+            out.contains(qid),
+            "E1: dry-run plan missing calibration cell id={qid}\nfull output:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn e1_dry_run_advertises_result_file_template() {
+    let out = run_dry_run();
+
+    assert!(
+        out.contains("results_template:"),
+        "E1: dry-run missing results_template line\nfull output:\n{out}"
+    );
+    assert!(
+        out.contains("summary_template:"),
+        "E1: dry-run missing summary_template line\nfull output:\n{out}"
+    );
+    assert!(
+        out.contains("results/t0/"),
+        "E1: dry-run results path should sit under results/t0/\nfull output:\n{out}"
+    );
+}
+
+#[test]
+fn e1_dry_run_makes_no_api_calls() {
+    // Sanity: dry-run must terminate with the explicit marker so we
+    // never confuse a silent abort with a clean dry-run.
+    let out = run_dry_run();
+    assert!(
+        out.contains("dry-run complete (no API calls made)"),
+        "E1: dry-run did not print completion marker\nfull output:\n{out}"
+    );
+}

--- a/tests/e1_orchestration_dry_run.rs
+++ b/tests/e1_orchestration_dry_run.rs
@@ -1,6 +1,12 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// E1's t0-orchestrate.sh is a bash script. Windows runners don't ship
+// bash by default, so the dry-run harness check only runs on Unix. The
+// orchestrator itself works on any platform with a bash interpreter
+// (WSL/Git-Bash); CI just doesn't validate that path.
+#![cfg(unix)]
+
 //! v0.7.0 task E1 — minimal harness check on `scripts/t0-orchestrate.sh`.
 //!
 //! The orchestrator is an out-of-band script that fans the Discovery


### PR DESCRIPTION
## Summary

- v0.7.0 task **E1** — wrap the Discovery Gate T0 calibration cells from `tests/calibration_t0.rs` into an out-of-band orchestration harness that exercises the canonical capabilities-v3 phrasings (A1 `summary` + A2 `to_describe_to_user`) against four live frontier LLMs: Claude Sonnet 4.6, GPT-5, Gemini 3, Grok 4.3.
- Lands `scripts/t0-orchestrate.sh` (bash, with `--dry-run` + `--llm <id>` flags, per-vendor request bodies, jq-based scoring, JSON-per-LLM + markdown summary under `results/t0/`).
- Lands `docs/v0.7/T0-ORCHESTRATION.md` (setup, run, interpret, re-run cadence) and `tests/e1_orchestration_dry_run.rs` (four-test harness that runs `--dry-run` and asserts it covers all four LLMs plus every calibration cell id).

No tools, schemas, webhook events, or `HookEvent` variants change. Pure script + docs + test addition. CI counterpart `tests/calibration_t0.rs` is untouched — orchestration wraps the existing cells, it does not replace them.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test e1_orchestration_dry_run` — 4/4 passing
- [x] `bash scripts/t0-orchestrate.sh --dry-run` — exits 0, prints plan covering all 4 LLMs × 6 questions, advertises result file templates
- [ ] Operator sets the four API keys and runs `scripts/t0-orchestrate.sh` against the v0.7.0 binary as the E2 ship-gate verification

## AI involvement

- **Author:** AlphaOne (Justin Watts)
- **Co-author:** Claude Opus 4.7 (1M context) — implementation under operator direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)