### PR TITLE
docs(drift): post-K8 + post-J7 stale-number fixes (#628)

### DIFF
--- a/docs/MIGRATION_v0.7.md
+++ b/docs/MIGRATION_v0.7.md
@@ -47,7 +47,7 @@ Most users on v0.6.4 see **no behavior change** unless they opt in. The exceptio
 
 | Field | Type | Purpose |
 |---|---|---|
-| `summary` | string | Top-level pre-computed description ("AI Memory MCP exposes a 5-tool core with N additional families available via runtime expansion.") |
+| `summary` | string | Top-level pre-computed description ("AI Memory MCP exposes a 7-tool core with N additional families available via runtime expansion.") |
 | `to_describe_to_user` | string | Human-shaped summary the agent can paraphrase verbatim — eliminates calibration drift |
 | `callable_now` | bool (per tool) | Whether this caller may invoke the tool right now (allowlist + profile aware) |
 | `agent_permitted_families` | array<string> | Families this caller is allowed to expand into via `memory_load_family` |
@@ -57,7 +57,7 @@ Most users on v0.6.4 see **no behavior change** unless they opt in. The exceptio
 ```json
 {
   "schema_version": 3,
-  "summary": "AI Memory MCP exposes a 5-tool core ...",
+  "summary": "AI Memory MCP exposes a 7-tool core ...",
   "to_describe_to_user": "I have access to a memory substrate ...",
   "agent_permitted_families": ["core", "graph"],
   "tools": [
@@ -266,7 +266,7 @@ Schema migration v20 → v22 (audit_log → signed_events → memory_transcripts
 
 ## What did **not** change
 
-- v0.6.4 default tool surface (`--profile core`) is **unchanged**. The five core tools stay the only advertised tools by default.
+- v0.6.4 default tool surface (`--profile core`) is **unchanged in spirit**. The seven core tools (the original 5 — `store`, `recall`, `list`, `get`, `search` — plus v0.7 B1's `memory_load_family` and v0.7 B2's `memory_smart_load`) stay the only advertised tools by default.
 - Existing v0.6.4 SDKs continue to work against a v0.7.0 server. Capabilities v3 fields are additive; v2 fields stay at their existing paths.
 - Memory data — no migration required for stored memories; embeddings, archives, links, governance policies all carry forward.
 - HTTP API endpoints — every v0.6.4 route stays at the same path with the same shape.

--- a/docs/v0.7/canonical-phrasings.md
+++ b/docs/v0.7/canonical-phrasings.md
@@ -32,10 +32,10 @@ Substitution variables:
 
 | Variable | Value | Example (`--profile core`) |
 |---|---|---|
-| `{visible}` | tools advertised in `tools/list` under the active profile (includes always-on bootstraps not already in profile) | `6` |
-| `{total}` | total tool count across all families | `43` |
+| `{visible}` | tools advertised in `tools/list` under the active profile (includes always-on bootstraps not already in profile) | `8` |
+| `{total}` | total tool count across all families | `51` |
 | `{label}` | profile name (`core`/`graph`/`admin`/`power`/`full`) or comma-joined family list for custom profiles | `core` |
-| `{unloaded}` | `total − visible` | `37` |
+| `{unloaded}` | `total − visible` | `43` |
 
 The four recovery paths (a–d) appear verbatim in the canonical phrasing **regardless of the active profile** — so an LLM exposed only to `--profile full` still learns the recovery vocabulary for environments where it isn't.
 
@@ -43,9 +43,9 @@ The four recovery paths (a–d) appear verbatim in the canonical phrasing **rega
 
 | Profile | Opening |
 |---|---|
-| `core` | `6 of 43 tools are advertised in tools/list under the current profile (core). The other 37 …` |
-| `graph` | `14 of 43 tools are advertised in tools/list under the current profile (graph). The other 29 …` |
-| `full` | `43 of 43 tools are advertised in tools/list under the current profile (full). The other 0 …` |
+| `core` | `8 of 51 tools are advertised in tools/list under the current profile (core). The other 43 …` |
+| `graph` | `19 of 51 tools are advertised in tools/list under the current profile (graph). The other 32 …` |
+| `full` | `51 of 51 tools are advertised in tools/list under the current profile (full). The other 0 …` |
 
 ---
 
@@ -69,10 +69,10 @@ Substitution variables:
 
 | Variable | Value | Notes |
 |---|---|---|
-| `{n_loaded}` | tools loaded by family membership, EXCLUDING the always-on bootstrap (`memory_capabilities`) | `core`: 5; `graph`: 13; `full`: 42 |
+| `{n_loaded}` | tools loaded by family membership, EXCLUDING the always-on bootstrap (`memory_capabilities`) | `core`: 7; `graph`: 18; `full`: 50 |
 | `{preview_loaded}` | comma-joined first 5 loaded tool names with the `memory_` prefix STRIPPED | `core`: `store, recall, list, get, search` |
-| `{ellipsis}` | `, ...` if `n_loaded > 5`, else empty | `graph` and larger get the ellipsis |
-| `{n_unloaded}` | `42 − n_loaded` — the 42 excludes the always-on bootstrap from BOTH sides for honest counting | `core`: 37; `graph`: 29; `full`: 0 |
+| `{ellipsis}` | `, ...` if `n_loaded > 5`, else empty | `core` (7 loaded) and larger get the ellipsis |
+| `{n_unloaded}` | `50 − n_loaded` — the 50 excludes the always-on bootstrap from BOTH sides for honest counting | `core`: 43; `graph`: 32; `full`: 0 |
 | `{preview_unloaded}` | comma-joined first 4 unloaded tool names, prefix-stripped | `core`: `update, delete, forget, gc` |
 | `{s}` | `s` if `n_loaded != 1`, else empty | always `s` in practice |
 
@@ -94,9 +94,9 @@ If a future increment adds MCP-internal vocabulary to this string, that test goe
 
 | Profile | `to_describe_to_user` |
 |---|---|
-| `core` | `I can directly use 5 memory tools right now (store, recall, list, get, search). 37 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
-| `graph` | `I can directly use 13 memory tools right now (store, recall, list, get, search, ...). 29 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
-| `full` | `I can directly use all 42 memory tools right now (store, recall, list, get, search, ...). Nothing more to load — the full memory surface is already active.` |
+| `core` | `I can directly use 7 memory tools right now (store, recall, list, get, search, ...). 43 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
+| `graph` | `I can directly use 18 memory tools right now (store, recall, list, get, search, ...). 32 more (update, delete, forget, gc, etc.) are available on demand — I can load them if you ask for something that needs them, or you can restart the server with a different profile.` |
+| `full` | `I can directly use all 50 memory tools right now (store, recall, list, get, search, ...). Nothing more to load — the full memory surface is already active.` |
 
 ---
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -416,7 +416,7 @@ fn snippet_body(target: Target) -> String {
          surface and a pre-computed `to_describe_to_user` summary. Trust \
          it over any cached belief.\n\
          2. Use `memory_load_family` to pre-load the context family you \
-         need (`core`, `recall`, `link`, `governance`). {harness_hint}\n\
+         need (`core`, `lifecycle`, `graph`, `governance`). {harness_hint}\n\
          3. Transcripts auto-extract via the R5 hook after each turn — \
          do not call `memory_store` for chat history; extract only \
          durable insights.\n\

--- a/tests/harness_integration.rs
+++ b/tests/harness_integration.rs
@@ -36,7 +36,8 @@
 //! silently breaks (e.g. a typo in `Harness::detect`'s match arms, a
 //! removed variant, or a bypass of the harness threading in the
 //! capabilities builder). Pure test additions — no schema changes, no
-//! tool count changes; the surface stays at 46 tools.
+//! tool count changes; the surface stays at the v0.7.0 tool count
+//! (51 tools — pinned in `src/profile.rs::Profile::full`).
 
 use ai_memory::config::{FeatureTier, McpConfig, TierConfig};
 use ai_memory::harness::Harness;


### PR DESCRIPTION
## Summary

Fix the four stale-number / stale-string drift blockers identified in the v0.7.0 review (#628). Every reference now matches the post-K8 + post-J7 surface truth: 51 total tools, 7 in `core`.

- **C3** — `docs/v0.7/canonical-phrasings.md` worked-example tables: summary table (visible/total/unloaded for `core` 8/51/43, `graph` 19/51/32, `full` 51/51/0); describe variables and per-profile sentences updated to match what `tests/calibration_t0.rs` already pins on the substrate. Ellipsis note bumped because `core` (7 loaded) now triggers the `, ...` marker.
- **C4** — `src/cli/install.rs` system-prompt snippet: replaced the bad family names (`recall`, `link`) with the actual `Family` enum names (`lifecycle`, `graph`). The snippet ships to every operator who runs `ai-memory install <harness>`; teaching agents bad family names would surface as `ProfileParseError::UnknownFamily` at runtime.
- **H1** — `docs/MIGRATION_v0.7.md` "5-tool core" stale references (3 occurrences): table example, JSON snippet, and the "What did NOT change" bullet now name the 7 tools and the v0.7 B1/B2 additions explicitly.
- **H2** — `tests/harness_integration.rs` doc-comment "46 tools" → "the v0.7.0 tool count (51 tools — pinned in `src/profile.rs::Profile::full`)" so this comment doesn't have to drift again.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib --tests` — 0 failed
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test calibration_t0 --test harness_integration --test capabilities_v3` — 0 failed
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --all-targets -- -D warnings -D clippy::pedantic` — clean
- [x] Verified canonical phrasings against substrate output (`src/mcp.rs::build_capabilities_summary` + `build_capabilities_describe_to_user`) and against the assertions in `tests/calibration_t0.rs`.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the AlphaOne human author. Mechanical drift fixes — no behavior change.

Closes #628 blockers 3, 4, 13, 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)