### PR TITLE
fix(governance): K9 namespace lock + K7 SSRF loopback + K8 TOCTOU (#628 H1/H3/H4)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1511,6 +1511,13 @@ pub struct AppConfig {
     /// When unset, only per-subscription secrets are used (legacy
     /// pre-K7 behaviour).
     pub hooks: Option<HooksConfig>,
+    /// v0.7.0 H11 (#628 blocker) — `[subscriptions]` block. Carries
+    /// the `allow_loopback_webhooks` opt-in that re-enables loopback
+    /// webhook URLs (`127.0.0.1`, `localhost`, `[::1]`). Default-OFF
+    /// closes an authenticated SSRF gadget against local services
+    /// (Postgres on 5432, the hooks daemon, etc.). Operators who need
+    /// loopback for testing must set this explicitly.
+    pub subscriptions: Option<SubscriptionsConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1550,6 +1557,30 @@ pub struct HooksSubscriptionConfig {
     pub hmac_secret: Option<String>,
 }
 
+/// v0.7.0 H11 (#628 blocker) — `[subscriptions]` block. Operator
+/// knobs for the outgoing-webhook surface that are NOT specific to
+/// HMAC signing (which lives under `[hooks.subscription]`).
+///
+/// Wire format:
+/// ```toml
+/// [subscriptions]
+/// allow_loopback_webhooks = true   # default false; opt-in for testing
+/// ```
+///
+/// When unset (or false), the SSRF guard rejects webhook URLs that
+/// resolve to loopback addresses (`127.0.0.0/8`, `localhost`, `::1`).
+/// Loopback hosts are reachable from the daemon process itself, so
+/// permitting them by default exposes any locally-bound service
+/// (database, internal admin sockets) to authenticated SSRF.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubscriptionsConfig {
+    /// Re-enable loopback webhook URLs. Default `false` (loopback
+    /// rejected). Operators who need to point a webhook at a local
+    /// listener (CI, dev) set this to `true` explicitly.
+    #[serde(default)]
+    pub allow_loopback_webhooks: bool,
+}
+
 impl AppConfig {
     /// v0.7.0 K7 — resolved server-wide webhook HMAC secret. `None`
     /// means no server-wide override (per-subscription secrets still
@@ -1560,6 +1591,41 @@ impl AppConfig {
             .as_ref()
             .and_then(|h| h.subscription.as_ref())
             .and_then(|s| s.hmac_secret.clone())
+    }
+
+    /// v0.7.0 H11 (#628 blocker) — resolved loopback-webhook opt-in
+    /// flag. Defaults to `false` (loopback rejected — closes the
+    /// authenticated SSRF gadget against local services). Operators
+    /// who need loopback for testing set
+    /// `[subscriptions] allow_loopback_webhooks = true`.
+    ///
+    /// Resolution order (mirrors `effective_permissions_mode`):
+    /// 1. `AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS` env var (`1` / `true` —
+    ///    case-insensitive). Lets the integration suite — which
+    ///    sets `AI_MEMORY_NO_CONFIG=1` and therefore cannot use
+    ///    `[subscriptions]` from `config.toml` — bind wiremock at
+    ///    `127.0.0.1:0` and drive webhooks through it without
+    ///    touching the production default.
+    /// 2. `[subscriptions].allow_loopback_webhooks` from `config.toml`.
+    /// 3. Compiled default (`false` — loopback rejected).
+    #[must_use]
+    pub fn effective_allow_loopback_webhooks(&self) -> bool {
+        if let Ok(raw) = std::env::var("AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS") {
+            match raw.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => return true,
+                "0" | "false" | "no" | "off" | "" => return false,
+                other => {
+                    eprintln!(
+                        "ai-memory: AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS={other:?} is not a valid \
+                         boolean (expected 1/true/yes/on or 0/false/no/off); falling back to \
+                         config.toml"
+                    );
+                }
+            }
+        }
+        self.subscriptions
+            .as_ref()
+            .is_some_and(|s| s.allow_loopback_webhooks)
     }
 }
 
@@ -1593,6 +1659,42 @@ pub fn set_active_hooks_hmac_secret(secret: Option<String>) {
 #[must_use]
 pub fn active_hooks_hmac_secret() -> Option<String> {
     ACTIVE_HOOKS_HMAC_SECRET.read().ok().and_then(|g| g.clone())
+}
+
+// ---------------------------------------------------------------------------
+// H11 — process-wide handle for the loopback-webhook opt-in
+// ---------------------------------------------------------------------------
+//
+// `validate_url` in `subscriptions.rs` consults this handle to decide
+// whether to accept loopback webhook destinations. Default-OFF closes
+// the SSRF gadget; the boot code in `main` / daemon reads
+// `[subscriptions] allow_loopback_webhooks` and sets the flag here.
+
+// Default-OFF in production builds so the SSRF guard rejects loopback
+// without explicit opt-in. Defaults to `true` under `cfg(test)` so
+// the existing test surface (which binds wiremock to `127.0.0.1:0`
+// and drives validate_url/validate_url_dns through real loopback
+// URLs) passes without 16-test fan-out modifications. The H11
+// default-OFF behaviour is independently asserted via the
+// `validate_url_with` / `validate_url_dns_check_addrs` inner helpers
+// in `subscriptions.rs`, so flipping the test-build default here
+// does NOT relax the H11 ship-gate test coverage.
+static ALLOW_LOOPBACK_WEBHOOKS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(cfg!(test));
+
+/// v0.7.0 H11 — set the process-wide loopback-webhook opt-in. Called
+/// from boot with the value of `[subscriptions] allow_loopback_webhooks`.
+/// Defaults to `false` (loopback rejected).
+pub fn set_allow_loopback_webhooks(allow: bool) {
+    ALLOW_LOOPBACK_WEBHOOKS.store(allow, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// v0.7.0 H11 — read the process-wide loopback-webhook opt-in.
+/// Returns `false` when unset (the safe default — loopback URLs are
+/// rejected by the SSRF guard).
+#[must_use]
+pub fn allow_loopback_webhooks() -> bool {
+    ALLOW_LOOPBACK_WEBHOOKS.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,12 @@ async fn main() -> Result<()> {
     // per-subscription secret when unset.
     config::set_active_hooks_hmac_secret(app_config.effective_hooks_hmac_secret());
 
+    // v0.7.0 H11 (#628 blocker) — pin the loopback-webhook opt-in. The
+    // SSRF guard in `validate_url` rejects loopback URLs by default;
+    // operators who need to point a webhook at a local listener (CI,
+    // dev) set `[subscriptions] allow_loopback_webhooks = true`.
+    config::set_allow_loopback_webhooks(app_config.effective_allow_loopback_webhooks());
+
     // v0.7.0 K9 — load `[[permissions.rules]]` into the process-wide
     // registry consulted by `Permissions::evaluate`. Empty by default
     // (pre-K9 behaviour: mode + hooks + governance gate decide

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1682,7 +1682,11 @@ fn handle_store(
                 .unwrap_or(0),
     )
     .unwrap_or(i64::MAX);
-    if let Err(e) = crate::quotas::check_quota(
+    // H12 (#628 blocker): combine the quota check + counter
+    // increment in a single atomic transaction so concurrent writers
+    // cannot each pass the check and then both bump the counter past
+    // the cap.
+    if let Err(e) = crate::quotas::check_and_record(
         conn,
         &agent_id,
         crate::quotas::QuotaOp::Memory {
@@ -1692,21 +1696,23 @@ fn handle_store(
         return Err(e.to_string());
     }
 
-    let actual_id = db::insert(conn, &mem).map_err(|e| e.to_string())?;
-
-    // v0.7 K8 — record the successful write against the agent's
-    // counters. Best-effort: a counter update failure is logged but
-    // does not roll back the insert (the inline-roll branch in
-    // check_quota would re-derive any missed delta on the next call).
-    if let Err(e) = crate::quotas::record_op(
-        conn,
-        &agent_id,
-        crate::quotas::QuotaOp::Memory {
-            bytes: payload_bytes,
-        },
-    ) {
-        tracing::warn!("quota record_op failed for agent {}: {}", &agent_id, e);
-    }
+    let actual_id = match db::insert(conn, &mem) {
+        Ok(id) => id,
+        Err(e) => {
+            // Insert failed AFTER we committed quota — refund so the
+            // counter reflects only successful stores.
+            if let Err(re) = crate::quotas::refund_op(
+                conn,
+                &agent_id,
+                crate::quotas::QuotaOp::Memory {
+                    bytes: payload_bytes,
+                },
+            ) {
+                tracing::warn!("quota refund_op failed for agent {}: {}", &agent_id, re);
+            }
+            return Err(e.to_string());
+        }
+    };
 
     // PR-5 (issue #487): security audit trail. No-op when disabled.
     crate::audit::emit(crate::audit::EventBuilder::new(
@@ -4207,8 +4213,12 @@ fn handle_link(
             .and_then(|v| v.as_str())
             .map(str::to_string)
     });
+    // H12 (#628 blocker): combine the link quota check + counter
+    // increment in a single atomic transaction. The check + record
+    // pair was previously a TOCTOU window; `check_and_record` closes
+    // it.
     if let Some(ref aid) = link_agent_id {
-        if let Err(e) = crate::quotas::check_quota(conn, aid, crate::quotas::QuotaOp::Link) {
+        if let Err(e) = crate::quotas::check_and_record(conn, aid, crate::quotas::QuotaOp::Link) {
             return Err(e.to_string());
         }
     }
@@ -4217,17 +4227,22 @@ fn handle_link(
     // to attest_level="unsigned" otherwise. The chosen attest_level is
     // surfaced in the wire response so callers can tell signed vs
     // unsigned without re-querying.
-    let attest_level = db::create_link_signed(conn, source_id, target_id, relation, active_keypair)
-        .map_err(|e| e.to_string())?;
-
-    // v0.7 K8 — record the successful link against the agent's
-    // counters (best-effort; does not roll back the link insert on
-    // counter-update failure).
-    if let Some(ref aid) = link_agent_id {
-        if let Err(e) = crate::quotas::record_op(conn, aid, crate::quotas::QuotaOp::Link) {
-            tracing::warn!("quota record_op failed for agent {}: {}", aid, e);
-        }
-    }
+    let attest_level =
+        match db::create_link_signed(conn, source_id, target_id, relation, active_keypair) {
+            Ok(v) => v,
+            Err(e) => {
+                // Refund the link counter we already committed: insert
+                // failed downstream of the quota commit.
+                if let Some(ref aid) = link_agent_id {
+                    if let Err(re) =
+                        crate::quotas::refund_op(conn, aid, crate::quotas::QuotaOp::Link)
+                    {
+                        tracing::warn!("quota refund_op failed for agent {}: {}", aid, re);
+                    }
+                }
+                return Err(e.to_string());
+            }
+        };
 
     // P5 (G9): fire `memory_link_created` webhook AFTER the link is
     // persisted. Resolve the source memory to populate `namespace` /

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -313,6 +313,18 @@ impl Permissions {
     /// mode as explicit parameters. Used by the K9 test matrix so
     /// scenarios can exercise specific rule-set / mode combinations
     /// without poking the process-wide registry.
+    ///
+    /// # H8 invariant — namespace cannot be elevated by `Modify`
+    ///
+    /// The pinned namespace for rule evaluation is taken from
+    /// `ctx.namespace` BEFORE any rule pass. If a hook returns
+    /// `Modify { namespace: <other_ns> }` the pipeline RE-EVALUATES
+    /// the entire rule set against the new namespace; if that
+    /// re-evaluation returns `Decision::Deny`, the modification is
+    /// rejected (the original `Deny` reason is surfaced — annotated
+    /// with the rejected escalation). This closes the v0.7.0 review
+    /// blocker H8 / #628 where a `Modify`-rewrite of `namespace`
+    /// could bypass a rule that targeted the destination namespace.
     #[must_use]
     pub fn evaluate_with(
         ctx: &PermissionContext,
@@ -325,6 +337,13 @@ impl Permissions {
         if mode == PermissionsMode::Off {
             return Decision::Allow;
         }
+
+        // H8 — pin the namespace at entry. The original namespace
+        // is the only one that may participate in this evaluation;
+        // any hook that proposes a different namespace must survive
+        // a re-evaluation against the rules pinned to the *new*
+        // namespace below.
+        let pinned_ns = ctx.namespace.clone();
 
         // Collect rule decisions matching this context.
         let matched = matched_rules(ctx, rules);
@@ -360,6 +379,34 @@ impl Permissions {
             }
         }
         if let Some(delta) = composed {
+            // H8 — if the composed delta rewrites `namespace` to a
+            // value other than the pinned one, RE-EVALUATE the rule
+            // pipeline against the new namespace. A Deny on the new
+            // namespace rejects the modification (the hook cannot
+            // launder a write into a denied namespace).
+            if let Some(new_ns) = delta.namespace.as_deref()
+                && new_ns != pinned_ns
+            {
+                let rebound_ctx = PermissionContext {
+                    op: ctx.op,
+                    namespace: new_ns.to_string(),
+                    agent_id: ctx.agent_id.clone(),
+                    payload: ctx.payload.clone(),
+                };
+                // Re-evaluate against rules ONLY (we already drained
+                // the hooks slice above; re-running them would either
+                // loop indefinitely or re-Modify the same delta).
+                // The hooks pass is empty here so the recursion
+                // terminates after a single rule pass.
+                let rebound = Self::evaluate_with(&rebound_ctx, &[], rules, mode);
+                if let Decision::Deny(reason) = rebound {
+                    return Decision::Deny(format!(
+                        "namespace escalation rejected: hook proposed Modify into \
+                         namespace {new_ns:?} (from pinned {pinned_ns:?}) which is denied: \
+                         {reason}"
+                    ));
+                }
+            }
             return Decision::Modify(delta);
         }
 

--- a/src/quotas.rs
+++ b/src/quotas.rs
@@ -285,9 +285,208 @@ impl std::fmt::Display for QuotaCheckError {
 
 impl std::error::Error for QuotaCheckError {}
 
+/// v0.7 K8 / H12 (#628 blocker) — atomic check + record. Combines the
+/// quota check with the counter increment under a single
+/// `BEGIN IMMEDIATE` SQLite transaction so concurrent writers cannot
+/// each pass the check and then both increment the counter past the
+/// cap. `BEGIN IMMEDIATE` acquires a `RESERVED` lock on the database
+/// at the start of the transaction; SQLite serialises every other
+/// would-be writer behind the lock until COMMIT/ROLLBACK, which is
+/// the SQLite analogue of `SELECT ... FOR UPDATE` against the single
+/// `agent_quotas` row.
+///
+/// On a clean check + increment, returns `Ok(())`. On a quota breach,
+/// returns `Err(QuotaError)` naming the limit that was hit and the
+/// counter / ceiling values at the moment of the check; the
+/// transaction is rolled back so no counter mutation persists.
+///
+/// Callers replace the previous two-step `check_quota(...)?;
+/// op(...)?; record_op(...)?` pattern with `check_and_record(...)?;
+/// op(...)?;` (then `refund_op(...)` on op-failure if needed) so the
+/// gap between check and record cannot be raced.
+///
+/// # Errors
+///
+/// - [`QuotaCheckError::Quota`] when one of the three limits would be
+///   exceeded by the pending op.
+/// - [`QuotaCheckError::Sql`] when the substrate read or write fails.
+pub fn check_and_record(
+    conn: &Connection,
+    agent_id: &str,
+    op: QuotaOp,
+) -> std::result::Result<(), QuotaCheckError> {
+    // Make sure the row exists OUTSIDE the immediate transaction;
+    // `INSERT OR IGNORE` itself is atomic and contention-free.
+    let _ = ensure_row(conn, agent_id).map_err(QuotaCheckError::Sql)?;
+
+    // BEGIN IMMEDIATE — acquires a RESERVED lock immediately. This is
+    // the SQLite shape of "SELECT ... FOR UPDATE": no other connection
+    // can begin a write transaction until we COMMIT or ROLLBACK. The
+    // window between SELECT and UPDATE inside the transaction is
+    // therefore safe from another writer's UPDATE racing past us.
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("BEGIN IMMEDIATE failed: {e}")))?;
+
+    let result: std::result::Result<(), QuotaCheckError> = (|| {
+        let row = load_row(conn, agent_id)
+            .map_err(QuotaCheckError::Sql)?
+            .ok_or_else(|| {
+                QuotaCheckError::Sql(anyhow::anyhow!(
+                    "quota row vanished mid-transaction for agent {agent_id}"
+                ))
+            })?;
+
+        // Inline daily-bucket roll: if the stored bucket isn't today,
+        // the daily counters are treated as zero for the check AND
+        // the UPDATE below resets them.
+        let now = chrono::Utc::now().to_rfc3339();
+        let today = day_bucket(&now);
+        let stored_day = day_bucket(&row.day_started_at);
+        let day_rolled = stored_day != today;
+        let (memories_today, links_today) = if day_rolled {
+            (0, 0)
+        } else {
+            (row.current_memories_today, row.current_links_today)
+        };
+
+        match op {
+            QuotaOp::Memory { bytes } => {
+                if memories_today + 1 > row.max_memories_per_day {
+                    return Err(QuotaCheckError::Quota(QuotaError {
+                        agent_id: agent_id.to_string(),
+                        limit: QuotaLimit::MemoriesPerDay,
+                        current: memories_today,
+                        max: row.max_memories_per_day,
+                    }));
+                }
+                if row.current_storage_bytes + bytes > row.max_storage_bytes {
+                    return Err(QuotaCheckError::Quota(QuotaError {
+                        agent_id: agent_id.to_string(),
+                        limit: QuotaLimit::StorageBytes,
+                        current: row.current_storage_bytes,
+                        max: row.max_storage_bytes,
+                    }));
+                }
+                if day_rolled {
+                    conn.execute(
+                        "UPDATE agent_quotas SET
+                           current_memories_today = 1,
+                           current_links_today = 0,
+                           current_storage_bytes = current_storage_bytes + ?1,
+                           day_started_at = ?2,
+                           updated_at = ?2
+                         WHERE agent_id = ?3",
+                        params![bytes, now, agent_id],
+                    )
+                    .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("update failed: {e}")))?;
+                } else {
+                    conn.execute(
+                        "UPDATE agent_quotas SET
+                           current_memories_today = current_memories_today + 1,
+                           current_storage_bytes = current_storage_bytes + ?1,
+                           updated_at = ?2
+                         WHERE agent_id = ?3",
+                        params![bytes, now, agent_id],
+                    )
+                    .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("update failed: {e}")))?;
+                }
+            }
+            QuotaOp::Link => {
+                if links_today + 1 > row.max_links_per_day {
+                    return Err(QuotaCheckError::Quota(QuotaError {
+                        agent_id: agent_id.to_string(),
+                        limit: QuotaLimit::LinksPerDay,
+                        current: links_today,
+                        max: row.max_links_per_day,
+                    }));
+                }
+                if day_rolled {
+                    conn.execute(
+                        "UPDATE agent_quotas SET
+                           current_memories_today = 0,
+                           current_links_today = 1,
+                           day_started_at = ?1,
+                           updated_at = ?1
+                         WHERE agent_id = ?2",
+                        params![now, agent_id],
+                    )
+                    .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("update failed: {e}")))?;
+                } else {
+                    conn.execute(
+                        "UPDATE agent_quotas SET
+                           current_links_today = current_links_today + 1,
+                           updated_at = ?1
+                         WHERE agent_id = ?2",
+                        params![now, agent_id],
+                    )
+                    .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("update failed: {e}")))?;
+                }
+            }
+        }
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => {
+            conn.execute_batch("COMMIT")
+                .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("quota commit failed: {e}")))?;
+            Ok(())
+        }
+        Err(e) => {
+            // Rollback is best-effort — even if it fails, the
+            // transaction is implicitly aborted on connection drop.
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(e)
+        }
+    }
+}
+
+/// v0.7 K8 / H12 — refund a previously-recorded op. Used by callers
+/// that have already incremented the counters via
+/// [`check_and_record`] but whose downstream insert failed AFTER the
+/// quota commit. Decrements the same counters [`check_and_record`]
+/// incremented; storage bytes is decremented for `QuotaOp::Memory`.
+///
+/// Counters never go below zero (saturating) so a buggy double-refund
+/// cannot poison the substrate.
+///
+/// # Errors
+///
+/// Wrapped SQL errors on update failure.
+pub fn refund_op(conn: &Connection, agent_id: &str, op: QuotaOp) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    match op {
+        QuotaOp::Memory { bytes } => {
+            conn.execute(
+                "UPDATE agent_quotas SET
+                   current_memories_today = MAX(current_memories_today - 1, 0),
+                   current_storage_bytes = MAX(current_storage_bytes - ?1, 0),
+                   updated_at = ?2
+                 WHERE agent_id = ?3",
+                params![bytes, now, agent_id],
+            )?;
+        }
+        QuotaOp::Link => {
+            conn.execute(
+                "UPDATE agent_quotas SET
+                   current_links_today = MAX(current_links_today - 1, 0),
+                   updated_at = ?1
+                 WHERE agent_id = ?2",
+                params![now, agent_id],
+            )?;
+        }
+    }
+    Ok(())
+}
+
 /// v0.7 K8 — record a successful write against the agent's quota
 /// counters. Called AFTER the underlying insert succeeds so a failed
 /// store does not consume quota.
+///
+/// **DEPRECATED for new code paths**: prefer [`check_and_record`]
+/// which combines the check + record into a single atomic transaction
+/// (closes H12 TOCTOU). `record_op` remains for callers (and tests)
+/// that bypass the check phase entirely.
 ///
 /// If the stored `day_started_at` rolled over since the row was last
 /// touched, the daily counters are reset before the new op posts —

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -912,6 +912,14 @@ fn hex_decode(s: &str) -> Option<Vec<u8>> {
 /// we let reqwest surface the error rather than fail closed, because
 /// transient DNS outages should not silently drop webhook delivery.
 pub fn validate_url_dns(url: &str) -> Result<()> {
+    validate_url_dns_with(url, crate::config::allow_loopback_webhooks())
+}
+
+/// H11 inner helper: takes `allow_loopback` explicitly so tests can
+/// assert both branches without poking the process-wide atomic
+/// (which would race with parallel tests). Production callers go
+/// through `validate_url_dns`.
+fn validate_url_dns_with(url: &str, allow_loopback: bool) -> Result<()> {
     let lower = url.to_ascii_lowercase();
     let (_scheme, rest) = lower
         .split_once("://")
@@ -952,6 +960,17 @@ pub fn validate_url_dns(url: &str) -> Result<()> {
                 "host resolves to private/link-local IP {ip}: {url}"
             ));
         }
+        // H11 (#628 blocker) — DNS-rebind protection for loopback.
+        // Default-OFF; operators with `[subscriptions]
+        // allow_loopback_webhooks = true` accept loopback-resolving
+        // hostnames.
+        if ip.is_loopback() && !allow_loopback {
+            return Err(anyhow!(
+                "host resolves to loopback IP {ip}: {url} — rejected by default \
+                 (SSRF guard); set `[subscriptions] allow_loopback_webhooks = true` \
+                 to opt in"
+            ));
+        }
     }
     Ok(())
 }
@@ -960,6 +979,14 @@ pub fn validate_url_dns(url: &str) -> Result<()> {
 /// to private-range addresses, link-local, loopback (except
 /// explicitly), or non-HTTPS remote hosts.
 pub fn validate_url(url: &str) -> Result<()> {
+    validate_url_with(url, crate::config::allow_loopback_webhooks())
+}
+
+/// H11 inner helper: takes `allow_loopback` explicitly so tests can
+/// assert both branches without poking the process-wide atomic
+/// (which would race with parallel tests). Production callers go
+/// through `validate_url`.
+fn validate_url_with(url: &str, allow_loopback: bool) -> Result<()> {
     // Cheap scheme check without pulling the `url` crate.
     let lower = url.to_ascii_lowercase();
     let (scheme, rest) = lower
@@ -986,12 +1013,27 @@ pub fn validate_url(url: &str) -> Result<()> {
             .map_or(host_port.to_string(), |(h, _)| h.to_string())
     };
     let host = host.as_str();
-    // Allow localhost for dev / CI.
+    // H11 (#628 blocker): loopback hostnames + IPs are rejected by
+    // default. Operators who need to point a webhook at a local
+    // listener (CI, dev) opt in via `[subscriptions]
+    // allow_loopback_webhooks = true`. Default-OFF closes an
+    // authenticated SSRF gadget against local services (Postgres on
+    // 5432, the hooks daemon, etc.).
     let is_loopback_hostname = matches!(host, "localhost" | "localhost.localdomain" | "");
-    if scheme == "http" && !is_loopback_hostname {
+    let parsed_ip = IpAddr::from_str(host).ok();
+    let is_loopback_ip = parsed_ip.is_some_and(|ip| ip.is_loopback());
+    let is_loopback = is_loopback_hostname || is_loopback_ip;
+    if is_loopback && !allow_loopback {
+        return Err(anyhow!(
+            "webhook URL targets loopback address {url} — rejected by default \
+             (SSRF guard); set `[subscriptions] allow_loopback_webhooks = true` \
+             to opt in (testing / dev only)"
+        ));
+    }
+    if scheme == "http" && !is_loopback {
         // Accept http only to parsed-loopback IPs; everything else
         // requires https.
-        if let Ok(ip) = IpAddr::from_str(host) {
+        if let Some(ip) = parsed_ip {
             if !ip.is_loopback() {
                 return Err(anyhow!(
                     "webhook URL must be https for non-loopback host: {url}"
@@ -1008,7 +1050,7 @@ pub fn validate_url(url: &str) -> Result<()> {
     // caught here — the dispatch thread will still be able to reach
     // them; operators who want to reach internal services should set
     // up reverse proxies or allow explicitly in config.
-    if let Ok(ip) = IpAddr::from_str(host)
+    if let Some(ip) = parsed_ip
         && is_private(ip)
         && !ip.is_loopback()
     {
@@ -1257,12 +1299,53 @@ mod tests {
 
     #[test]
     fn http_only_to_loopback() {
-        assert!(validate_url("http://localhost/hook").is_ok());
-        assert!(validate_url("http://127.0.0.1:8080/hook").is_ok());
+        // H11 inner helper — assert with allow_loopback=true so the
+        // test does not depend on the test-build default and does not
+        // race with parallel tests poking the global atomic.
+        assert!(validate_url_with("http://localhost/hook", true).is_ok());
+        assert!(validate_url_with("http://127.0.0.1:8080/hook", true).is_ok());
         // IPv6 in URLs must be bracketed per RFC 3986 §3.2.2.
-        assert!(validate_url("http://[::1]/hook").is_ok());
-        assert!(validate_url("http://example.com/hook").is_err());
-        assert!(validate_url("http://8.8.8.8/hook").is_err());
+        assert!(validate_url_with("http://[::1]/hook", true).is_ok());
+        assert!(validate_url_with("http://example.com/hook", true).is_err());
+        assert!(validate_url_with("http://8.8.8.8/hook", true).is_err());
+    }
+
+    #[test]
+    fn loopback_rejected_by_default_h11() {
+        // H11 (#628 blocker) — loopback URLs are rejected without an
+        // explicit opt-in. This closes an authenticated SSRF gadget
+        // against local services (Postgres on 5432, hooks daemon, …).
+        // Uses the inner helper so the assertion does not race with
+        // parallel tests that touch `crate::config` or use real
+        // loopback URLs through `validate_url`.
+        for url in [
+            "http://127.0.0.1:5432/hook",
+            "http://localhost/hook",
+            "http://[::1]/hook",
+            "https://127.0.0.1/hook",
+            "https://localhost/hook",
+        ] {
+            let res = validate_url_with(url, false);
+            assert!(
+                res.is_err(),
+                "loopback URL {url} must be rejected when allow_loopback=false (H11), got {res:?}"
+            );
+            let msg = res.unwrap_err().to_string();
+            assert!(
+                msg.contains("loopback") || msg.contains("SSRF"),
+                "rejection message should explain loopback policy, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn loopback_accepted_when_opted_in_h11() {
+        // H11 — operators who need loopback for CI/testing opt in via
+        // `[subscriptions] allow_loopback_webhooks = true`. Inner
+        // helper isolates this test from the global atomic.
+        assert!(validate_url_with("http://127.0.0.1:9999/hook", true).is_ok());
+        assert!(validate_url_with("http://localhost/hook", true).is_ok());
+        assert!(validate_url_with("http://[::1]/hook", true).is_ok());
     }
 
     #[test]
@@ -1446,34 +1529,49 @@ mod tests {
 
     #[test]
     fn test_validate_url_dns_accepts_loopback_v4() {
-        // DESIGN: loopback is allowed by `validate_url_dns` for dev/CI;
-        // the layered defence is `validate_url`, which forces https for
-        // non-loopback hosts. We document that current behaviour here
-        // so a regression that *tightens* loopback handling is visible.
+        // H11 inner helper — assert with allow_loopback=true so the
+        // test does not race with parallel tests poking the global
+        // atomic. Dev/CI workflows opt in via config to get this
+        // behaviour at runtime.
         assert!(
-            validate_url_dns("http://127.0.0.1/foo").is_ok(),
-            "127.0.0.1 should be accepted by validate_url_dns (dev/CI)"
+            validate_url_dns_with("http://127.0.0.1/foo", true).is_ok(),
+            "127.0.0.1 should be accepted by validate_url_dns when opted in"
         );
         assert!(
-            validate_url_dns("http://127.0.0.1:8080/").is_ok(),
-            "127.0.0.1:8080 should be accepted by validate_url_dns"
+            validate_url_dns_with("http://127.0.0.1:8080/", true).is_ok(),
+            "127.0.0.1:8080 should be accepted by validate_url_dns when opted in"
         );
         assert!(
-            validate_url_dns("http://localhost/").is_ok(),
-            "localhost should be accepted by validate_url_dns"
+            validate_url_dns_with("http://localhost/", true).is_ok(),
+            "localhost should be accepted by validate_url_dns when opted in"
         );
     }
 
     #[test]
     fn test_validate_url_dns_accepts_loopback_v6() {
-        // Same as v4: loopback is documented-allowed.
+        // Same as v4 — loopback opt-in via inner helper.
         assert!(
-            validate_url_dns("http://[::1]/").is_ok(),
-            "[::1] should be accepted by validate_url_dns"
+            validate_url_dns_with("http://[::1]/", true).is_ok(),
+            "[::1] should be accepted by validate_url_dns when opted in"
         );
         assert!(
-            validate_url_dns("http://[0:0:0:0:0:0:0:1]/").is_ok(),
-            "[::1] expanded form should be accepted"
+            validate_url_dns_with("http://[0:0:0:0:0:0:0:1]/", true).is_ok(),
+            "[::1] expanded form should be accepted when opted in"
+        );
+    }
+
+    #[test]
+    fn test_validate_url_dns_rejects_loopback_by_default_h11() {
+        // H11 — loopback DNS-resolves are rejected by default to
+        // close DNS-rebind SSRF against local services. Inner helper
+        // pins allow_loopback=false without touching the global.
+        assert!(
+            validate_url_dns_with("http://127.0.0.1/foo", false).is_err(),
+            "127.0.0.1 must be rejected by validate_url_dns when allow_loopback=false (H11)"
+        );
+        assert!(
+            validate_url_dns_with("http://[::1]/", false).is_err(),
+            "[::1] must be rejected by validate_url_dns when allow_loopback=false (H11)"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18,6 +18,13 @@ fn cmd(binary: &str) -> std::process::Command {
     // so opt these scenarios into Enforce explicitly. Per-test
     // overrides win because env-vars are shadowed at .env() call time.
     c.env("AI_MEMORY_PERMISSIONS_MODE", "enforce");
+    // v0.7.0 H11 (#628 blocker) — webhook subscriber tests bind
+    // wiremock to `127.0.0.1:0` and POST loopback URLs to
+    // `/api/v1/subscriptions`. The H11 SSRF guard rejects loopback
+    // by default; the integration suite opts in via env so it
+    // exercises the production happy path without permanently
+    // relaxing the production default.
+    c.env("AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS", "1");
     c
 }
 /// Spawn a command and collect its output, panicking with a descriptive
@@ -8754,6 +8761,14 @@ impl OneshotDaemon {
     /// against in-process mock peers (see `spawn_inproc_mock_peer`).
     #[allow(dead_code)]
     fn with_federation(federation: Option<ai_memory::federation::FederationConfig>) -> Self {
+        // v0.7.0 H11 (#628 blocker) — webhook-subscriber tests POST
+        // loopback URLs (`http://localhost/...`, `127.0.0.1:0`) into
+        // `/api/v1/subscriptions`. The H11 SSRF guard rejects loopback
+        // by default; the in-process integration suite opts in here
+        // (mirrors the env-var opt-in for subprocess-spawned daemon
+        // tests in `cmd()`) so the production happy path is exercised
+        // without permanently relaxing the production default.
+        ai_memory::config::set_allow_loopback_webhooks(true);
         let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
         let path = std::path::PathBuf::from(":memory:");
         let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((

--- a/tests/k7_hmac.rs
+++ b/tests/k7_hmac.rs
@@ -43,6 +43,9 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 static K7_HMAC_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
 
 fn fresh_db() -> (NamedTempFile, std::path::PathBuf) {
+    // H11 (#628 blocker): wiremock binds to 127.0.0.1; loopback
+    // webhook URLs are rejected by default, so opt in here.
+    ai_memory::config::set_allow_loopback_webhooks(true);
     let f = NamedTempFile::new().expect("tempfile");
     let p = f.path().to_path_buf();
     let _ = ai_memory::db::open(&p).expect("db::open");

--- a/tests/k8_quota_enforcement.rs
+++ b/tests/k8_quota_enforcement.rs
@@ -138,6 +138,122 @@ fn k8_link_at_links_per_day_limit_returns_quota_exceeded() {
     }
 }
 
+/// H12 (#628 blocker) — concurrent writers must not each pass the
+/// quota check and then both record_op past the cap. The
+/// `check_and_record` API combines both operations into a single
+/// `BEGIN IMMEDIATE` SQLite transaction so SQLite serialises every
+/// other would-be writer behind the row lock. Spawn 10 threads each
+/// trying to store one memory at a quota cap of 1; exactly 1 must
+/// succeed and 9 must see `QUOTA_EXCEEDED`.
+#[test]
+fn k8_check_and_record_serialises_concurrent_writers_h12() {
+    let (_keep, db_path) = fresh_db();
+
+    // Seed the row with the default caps, then tighten memories cap
+    // to 1. The first thread that wins the BEGIN IMMEDIATE lock will
+    // commit a count of 1; every other thread must see QUOTA_EXCEEDED.
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        ai_memory::quotas::check_and_record(&conn, "race-agent", QuotaOp::Memory { bytes: 1 })
+            .expect("seed insert");
+        // Reset the counter back to zero so the cap-1 race below can
+        // play out from a clean slate.
+        conn.execute(
+            "UPDATE agent_quotas SET
+               max_memories_per_day = 1,
+               current_memories_today = 0
+             WHERE agent_id = ?1",
+            params!["race-agent"],
+        )
+        .unwrap();
+    }
+
+    // Spawn 10 threads. Each opens its own connection to the shared
+    // on-disk database, then races to call `check_and_record`. SQLite
+    // WAL mode permits concurrent readers, but writers serialise on
+    // the RESERVED lock acquired by `BEGIN IMMEDIATE` — exactly the
+    // shape `check_and_record` relies on.
+    let path = std::sync::Arc::new(db_path.clone());
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let p = path.clone();
+        handles.push(std::thread::spawn(move || -> bool {
+            // Each thread retries on `SQLITE_BUSY` (the lock-waiter
+            // signal) so the race is decided by quota state, not by
+            // the OS scheduler dropping a busy retry. Cap retries to
+            // avoid an infinite loop if something unexpected fails.
+            let conn = {
+                let c = Connection::open(&*p).expect("open");
+                c.busy_timeout(std::time::Duration::from_secs(5))
+                    .expect("set busy timeout");
+                c
+            };
+            matches!(
+                ai_memory::quotas::check_and_record(
+                    &conn,
+                    "race-agent",
+                    QuotaOp::Memory { bytes: 1 },
+                ),
+                Ok(()),
+            )
+        }));
+    }
+
+    let mut successes = 0;
+    let mut failures = 0;
+    for h in handles {
+        if h.join().expect("thread join") {
+            successes += 1;
+        } else {
+            failures += 1;
+        }
+    }
+
+    assert_eq!(
+        successes, 1,
+        "exactly one thread must commit past the cap-1 quota; got {successes} successes / {failures} failures"
+    );
+    assert_eq!(
+        failures, 9,
+        "the other nine threads must see QUOTA_EXCEEDED; got {successes} successes / {failures} failures"
+    );
+
+    // The persisted counter must read exactly 1 — no double-increment
+    // could have slipped past the BEGIN IMMEDIATE lock.
+    let conn = Connection::open(&db_path).unwrap();
+    let s = ai_memory::quotas::get_status(&conn, "race-agent").unwrap();
+    assert_eq!(
+        s.current_memories_today, 1,
+        "counter should be exactly 1 after the race"
+    );
+}
+
+/// H12 — `refund_op` rolls back a successfully-recorded op when the
+/// downstream insert fails. Callers use this to keep the quota
+/// counter coherent with the actual successful-write count.
+#[test]
+fn k8_refund_op_decrements_counters_h12() {
+    let (_keep, db_path) = fresh_db();
+    let conn = Connection::open(&db_path).unwrap();
+
+    ai_memory::quotas::check_and_record(&conn, "refund-agent", QuotaOp::Memory { bytes: 100 })
+        .unwrap();
+    let pre = ai_memory::quotas::get_status(&conn, "refund-agent").unwrap();
+    assert_eq!(pre.current_memories_today, 1);
+    assert_eq!(pre.current_storage_bytes, 100);
+
+    ai_memory::quotas::refund_op(&conn, "refund-agent", QuotaOp::Memory { bytes: 100 }).unwrap();
+    let post = ai_memory::quotas::get_status(&conn, "refund-agent").unwrap();
+    assert_eq!(post.current_memories_today, 0);
+    assert_eq!(post.current_storage_bytes, 0);
+
+    // Saturating: extra refunds must not push counters below zero.
+    ai_memory::quotas::refund_op(&conn, "refund-agent", QuotaOp::Memory { bytes: 100 }).unwrap();
+    let saturated = ai_memory::quotas::get_status(&conn, "refund-agent").unwrap();
+    assert_eq!(saturated.current_memories_today, 0);
+    assert_eq!(saturated.current_storage_bytes, 0);
+}
+
 #[test]
 fn k8_record_op_after_check_increments_counters() {
     let (_keep, db_path) = fresh_db();

--- a/tests/k9_permission_pipeline.rs
+++ b/tests/k9_permission_pipeline.rs
@@ -280,6 +280,89 @@ fn k9_longest_pattern_wins_specificity() {
     }
 }
 
+/// H8 (#628 blocker) — a hook returning `Modify { namespace: <ns> }`
+/// where `<ns>` is denied by a rule must NOT be allowed to launder
+/// the write into the denied namespace. The pipeline pins the
+/// original namespace at entry, lets the rule pass evaluate against
+/// it, and then — if a Modify proposes a different namespace —
+/// re-evaluates the rules against the new namespace before accepting
+/// the modification. A deny on the destination escalates the result
+/// from `Modify` to `Deny`.
+#[test]
+fn k9_modify_cannot_escalate_into_denied_namespace() {
+    // Rules: deny stores into `secrets/*`, allow stores into
+    // `public/*`. The starting namespace is `public/blog` — the rule
+    // pass returns Allow. A hook proposes Modify { namespace:
+    // "secrets/x" } and the H8 fix must catch the escalation.
+    let rules = vec![
+        rule(
+            "secrets/*",
+            "memory_store",
+            "*",
+            RuleDecision::Deny,
+            Some("ai agents may not write to secrets"),
+        ),
+        rule("public/*", "memory_store", "*", RuleDecision::Allow, None),
+    ];
+    let hook = HookDecision::Modify(ModifyPayload {
+        delta: MemoryDelta {
+            namespace: Some("secrets/x".into()),
+            ..Default::default()
+        },
+    });
+    let d = Permissions::evaluate_with(
+        &ctx(Op::MemoryStore, "public/blog", "ai:claude"),
+        &[hook],
+        &rules,
+        PermissionsMode::Enforce,
+    );
+    match d {
+        Decision::Deny(reason) => {
+            assert!(
+                reason.contains("namespace escalation rejected"),
+                "expected H8 escalation marker in deny reason, got: {reason}"
+            );
+            assert!(
+                reason.contains("secrets/x"),
+                "deny reason should name the rejected destination namespace, got: {reason}"
+            );
+        }
+        other => panic!("expected Deny (escalation rejected), got {other:?}"),
+    }
+}
+
+/// H8 — a Modify proposing a namespace that is also allowed by the
+/// rule pipeline still surfaces as `Decision::Modify(delta)`. The
+/// fix only rejects on a Deny re-evaluation; legitimate
+/// namespace-rewrite hooks continue to work.
+#[test]
+fn k9_modify_into_allowed_namespace_still_succeeds() {
+    let rules = vec![
+        rule("public/*", "memory_store", "*", RuleDecision::Allow, None),
+        rule("staging/*", "memory_store", "*", RuleDecision::Allow, None),
+    ];
+    let hook = HookDecision::Modify(ModifyPayload {
+        delta: MemoryDelta {
+            namespace: Some("staging/x".into()),
+            tags: Some(vec!["rewritten".into()]),
+            ..Default::default()
+        },
+    });
+    let d = Permissions::evaluate_with(
+        &ctx(Op::MemoryStore, "public/blog", "ai:claude"),
+        &[hook],
+        &rules,
+        PermissionsMode::Enforce,
+    );
+    match d {
+        Decision::Modify(delta) => {
+            assert_eq!(delta.namespace.as_deref(), Some("staging/x"));
+            assert_eq!(delta.tags.as_deref(), Some(&["rewritten".to_string()][..]));
+        }
+        other => panic!("expected Modify, got {other:?}"),
+    }
+}
+
 /// Bonus: Off mode short-circuits the entire pipeline, even past a
 /// rule that would otherwise deny. This is the documented freeze-
 /// thaw escape hatch (mirrors K3 `Off` semantics — the gate is

--- a/tests/webhook_coverage.rs
+++ b/tests/webhook_coverage.rs
@@ -41,6 +41,10 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 /// Stand up a fresh on-disk `SQLite` at a tempfile path with the
 /// production schema applied (incl. P5 migration v17).
 fn fresh_db() -> (NamedTempFile, PathBuf) {
+    // H11 (#628 blocker): loopback webhook URLs are rejected by
+    // default. These tests use wiremock on 127.0.0.1, so opt in
+    // explicitly for the duration of the test process.
+    ai_memory::config::set_allow_loopback_webhooks(true);
     let f = NamedTempFile::new().expect("tempfile");
     let p = f.path().to_path_buf();
     let _ = ai_memory::db::open(&p).expect("db::open");

--- a/tests/webhook_http_parity.rs
+++ b/tests/webhook_http_parity.rs
@@ -135,6 +135,9 @@ impl HttpHarness {
 /// Insert a wildcard subscription pointing at the wiremock URL via a
 /// fresh DB connection (the dispatch thread will reopen anyway).
 fn subscribe_all(db_path: &Path, mock_url: &str) -> String {
+    // H11 (#628 blocker): wiremock binds to 127.0.0.1; loopback
+    // webhook URLs are rejected by default, so opt in here.
+    ai_memory::config::set_allow_loopback_webhooks(true);
     let conn = Connection::open(db_path).expect("open db");
     subscriptions::insert(
         &conn,


### PR DESCRIPTION
## Summary

Closes three v0.7.0 ship-readiness blockers from the [#628 K-track audit](https://github.com/alphaonedev/ai-memory-mcp/issues/628) (SHIP-WITH-FOLLOWUPS verdict). Required-fix queue items **H1**, **H3**, **H4** in the consolidated verdict.

| # | Track | Blocker |
|---|---|---|
| H1 | K9 + G3 cross-track | \`Decision::Modify\` path could rewrite \`namespace\` AFTER the deny-first rule eval — privilege escalation |
| H3 | K7 | SSRF guard **exempts loopback** — authenticated SSRF gadget against local services (Postgres, hooks daemon, etc.) |
| H4 | K8 | TOCTOU between \`check_quota\` and \`record_op\` — concurrent writers can each pass the check then both record, exceeding the quota |

## What changed

### H1 — K9 Modify-path namespace lock (\`src/permissions.rs\`)
- Pin original namespace at \`evaluate_with()\` entry
- If a hook returns \`Decision::Modify { namespace: <other_ns> }\`, **re-evaluate the rule pipeline** against the new namespace
- A \`Deny\` on the rebound rejects the modification with an explicit \`namespace escalation rejected\` reason
- Closes the path where a pre-store hook could launder a write into a denied namespace

### H3 — K7 SSRF loopback default-OFF (\`src/subscriptions.rs\`, \`src/config.rs\`, \`src/main.rs\`)
- \`validate_url\` and \`validate_url_dns\` now reject loopback (\`localhost\`, \`127.0.0.0/8\`, \`::1\`) **by default**
- New \`[subscriptions] allow_loopback_webhooks\` config knob (default \`false\`) re-enables loopback for CI/dev
- \`AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS\` env var override (mirrors the \`AI_MEMORY_PERMISSIONS_MODE\` pattern)
- Both validators refactored to take \`allow_loopback\` as an inner parameter — the H11 default-OFF tests assert via the inner helper without poking the process-wide atomic, eliminating a parallel-test race
- Production daemon pins the flag at boot from \`AppConfig::effective_allow_loopback_webhooks()\`

### H4 — K8 quota TOCTOU (\`src/quotas.rs\`, \`src/mcp.rs\`)
- New \`check_and_record()\` combines the quota check + counter increment under a single \`BEGIN IMMEDIATE\` SQLite transaction
- \`BEGIN IMMEDIATE\` acquires a \`RESERVED\` lock at tx start — the SQLite analogue of \`SELECT … FOR UPDATE\`. Concurrent writers can no longer each pass the check then both increment past the cap
- New \`refund_op()\` lets callers roll the counter back when the underlying op fails after the quota was committed
- \`handle_store\` and \`handle_link\` migrated from \`check_quota + op + record_op\` to \`check_and_record + op + refund_op-on-error\`

### Tests
- \`tests/k9_permission_pipeline.rs\` — pre-store hook proposes Modify into a denied namespace; assert Deny + escalation reason
- \`tests/k8_quota_enforcement.rs\` — N concurrent writers attempt to bump a tightened quota; assert exactly \`cap\` successes + \`(N - cap)\` quota errors
- \`tests/k7_hmac.rs\`, \`tests/webhook_coverage.rs\`, \`tests/webhook_http_parity.rs\`, \`tests/integration.rs\` — opt-in to loopback via env var / \`set_allow_loopback_webhooks(true)\` in \`OneshotDaemon::with_federation\` so pre-existing webhook tests still exercise the production happy path

## Test plan

- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` — clean
- [x] \`AI_MEMORY_NO_CONFIG=1 cargo test\` — 2232 unit + 211 integration + all feature-tests, 0 failed across all binaries
- [ ] CI passes (token-budget gate is failing on \`main\` — separate 15th blocker, tracked outside this PR)

## AI involvement

Authored by Claude Opus 4.7 (1M context) under operator direction. Human-approved before push. Reviewed against \`docs/AI_DEVELOPER_WORKFLOW.md\` Standard-class authority bar; no Sensitive/Restricted-class actions taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)