### PR TITLE
fix(test): C5 budget gate measures the trimmed wire form (#628 15th-blocker)

### DIFF
--- a/.github/workflows/token-budget.yml
+++ b/.github/workflows/token-budget.yml
@@ -71,9 +71,13 @@ jobs:
       # Belt-and-braces: also drive the assertion through the operator-
       # facing `doctor --tokens --json` reporter so a regression in the
       # JSON shape (renamed field, dropped key) trips the gate too. We
-      # parse the documented `full_profile_total_tokens` field and fail
-      # with a pointer to the C2-C4 audit if the value exceeds 3500.
-      - name: doctor --tokens --json reports total <= 3500 (v0.7 C5)
+      # parse the documented `trimmed_full_profile_total_tokens` field
+      # — the bare `tools/list` wire payload after C2/C3/C4 trims —
+      # and fail with a pointer to the C2-C4 audit if it exceeds 3500.
+      # The verbose sibling `full_profile_total_tokens` is only reachable
+      # via the opt-in `memory_capabilities { verbose: true, … }` path
+      # and is not gated here (see tests/budget_tokens.rs rationale).
+      - name: doctor --tokens --json reports trimmed total <= 3500 (v0.7 C5)
         env:
           AI_MEMORY_NO_CONFIG: "1"
         run: |
@@ -81,11 +85,11 @@ jobs:
           cargo build --release --bin ai-memory
           PAYLOAD="$(./target/release/ai-memory doctor --tokens --json)"
           TOTAL="$(printf '%s' "$PAYLOAD" \
-            | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["full_profile_total_tokens"])')"
-          echo "doctor --tokens --json: full_profile_total_tokens=$TOTAL (ceiling 3500)"
+            | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trimmed_full_profile_total_tokens"])')"
+          echo "doctor --tokens --json: trimmed_full_profile_total_tokens=$TOTAL (ceiling 3500)"
           if [ "$TOTAL" -gt 3500 ]; then
-            echo "::error::v0.7 C5 CI gate FAILED: full-profile tools/list payload is $TOTAL cl100k_base tokens (ceiling: 3500)."
-            echo "::error::C2 (split docs field), C3 (collapse schema boilerplate) and C4 (hide rare optional params) drove this from ~7.4K to ~3.49K tokens; this gate locks in that win."
-            echo "::error::Inspect 'cargo run --release -- doctor --tokens --raw-table' to find the offending tool. See docs/v0.7/schema-compaction-audit.md."
+            echo "::error::v0.7 C5 CI gate FAILED: trimmed full-profile tools/list payload is $TOTAL cl100k_base tokens (ceiling: 3500)."
+            echo "::error::C2 (split docs field), C3 (collapse schema boilerplate) and C4 (hide rare optional params) drove the wire form from ~7.4K to ~2.3K tokens; this gate locks in that win."
+            echo "::error::Inspect 'cargo run --release -- doctor --tokens --raw-table' to find the offending tool (the per-tool 'tokens' column already reflects the trim). See docs/v0.7/schema-compaction-audit.md."
             exit 1
           fi

--- a/tests/budget_tokens.rs
+++ b/tests/budget_tokens.rs
@@ -20,19 +20,37 @@
 
 use ai_memory::db::{BudgetOutcome, apply_token_budget, count_tokens_cl100k};
 use ai_memory::models::{Memory, Tier};
-use ai_memory::sizes::full_profile_total_tokens;
+use ai_memory::sizes::trimmed_full_profile_total_tokens;
 use serde_json::json;
 
 /// v0.7 C5 — hard CI ceiling on the full-profile MCP `tools/list` payload.
 ///
 /// C2 (split tool description from `docs` field), C3 (collapse repeated
 /// schema boilerplate), and C4 (hide rarely-used optional params) together
-/// drive the full-profile `cl100k_base` cost from the v0.6.4 baseline (~7.4K
-/// tokens) down to ~3.49K. C5 locks in that win so a future PR cannot
-/// silently grow the surface back toward the old baseline. The 3500-token
-/// ceiling has ~8 tokens of headroom over the C2-shipped 3492 figure;
-/// future PRs that add tools or expand descriptions must claw back budget
-/// elsewhere (or move the tool out of the default `core` family).
+/// drive the full-profile `cl100k_base` cost (the trimmed wire form) from
+/// the v0.6.4 baseline (~7.4K tokens) down to ~2.3K post-trim. C5 locks
+/// in that win so a future PR cannot silently grow the surface back toward
+/// the old baseline. The 3500-token ceiling has ~1.2K of headroom over the
+/// post-trim figure; future PRs that add tools or expand descriptions must
+/// claw back budget elsewhere (or move the tool out of the default `core`
+/// family).
+///
+/// **What this measures**: the cost of the bare `tools/list` MCP payload
+/// — i.e. [`trimmed_full_profile_total_tokens`], which mirrors what
+/// [`mcp::tool_definitions_for_profile`] actually serialises onto the wire
+/// (per-tool `docs` field stripped, per-property `description` prose
+/// stripped, optional params hidden — all C2/C3/C4 trims applied). This is
+/// the always-on payload every MCP client pays per session.
+///
+/// The verbose form (with full `docs` + per-property `description` prose +
+/// optional params) is reachable only via the opt-in
+/// `memory_capabilities { verbose: true, family: …, include_schema: true }`
+/// path; its growth is tracked separately via
+/// [`ai_memory::sizes::full_profile_total_tokens`] (no CI gate — the
+/// verbose path is rarely materialised and is bounded by the C2/C3/C4
+/// invariants on the base table). Mismeasuring against the verbose total
+/// here was the root cause of the v0.7.0 #628 15th-blocker token-budget
+/// regression — see PR ref in CHANGELOG.
 ///
 /// **Why `#[ignore]` by default?** This test is the load-bearing assertion
 /// for the v0.7 schema-compaction track. Running it from a plain
@@ -247,16 +265,18 @@ fn cl100k_tokenizer_is_deterministic() {
             `.github/workflows/token-budget.yml` C5 step. Depends on C2-C4 \
             having landed on the branch."]
 fn full_profile_tools_list_under_3500_tokens() {
-    let total = full_profile_total_tokens();
+    let total = trimmed_full_profile_total_tokens();
     assert!(
         total <= FULL_PROFILE_TOKEN_CEILING,
         "v0.7 C5 CI gate: full-profile tools/list payload is {total} cl100k_base \
          tokens (ceiling: {FULL_PROFILE_TOKEN_CEILING}). C2 (split docs field), \
          C3 (collapse schema boilerplate), and C4 (hide rare optional params) \
-         together drove this from ~7.4K to ~3.49K; this assertion locks in the \
-         win. Inspect `cargo run --release -- doctor --tokens --raw-table` to \
-         find the tool whose schema grew, and either trim it back or claw back \
-         budget elsewhere."
+         together drove the bare wire payload from ~7.4K to ~2.3K post-trim; \
+         this assertion locks in the win. Inspect \
+         `cargo run --release -- doctor --tokens --raw-table` to find the \
+         tool whose trimmed schema grew (look at the per-tool `tokens` column \
+         which already reflects the trim), and either trim it back or claw \
+         back budget elsewhere."
     );
 }
 


### PR DESCRIPTION
## Summary

The v0.7 C5 CI gate has been **failing on every push to \`main\` since #619 landed** because the test was wired to the wrong sizes function. This is a 1-line fix that closes the 15th \`#628\` blocker (discovered post-audit while running the merge sweep for the original 14).

## Root cause

\`tests/budget_tokens.rs::full_profile_tools_list_under_3500_tokens\` calls \`full_profile_total_tokens()\` — the **verbose** schema total (every \`docs\` blob, every per-property \`description\`, every optional param). But:

- C2 (#618), C3, and C4 (#620) trim all of those off the **wire payload** via \`tool_definitions_for_profile\` / \`strip_docs_from_tools\` / \`trim_optional_params\`
- The bare \`tools/list\` payload is therefore measured by \`trimmed_full_profile_total_tokens()\`, **not** the verbose form
- The test name says "tools/list payload" — i.e. the wire form

Since #619 landed, **B1 / B2 / I4 / H4 / J7 / K7 / K8 / K11** (8 new tools across May 5-6) grew the verbose total to **9008 tokens** while the actual wire payload sits at **2316 tokens** — well under the 3500-token C5 ceiling.

The sister test \`tests/c2_tool_docs_field.rs::c2_tools_list_token_budget_is_under_3500\` already correctly measures the wire form (\`tool_definitions_for_profile(&Profile::full())\` → serialize → \`count_tokens_cl100k\`) and has been passing throughout — proves the wire payload is healthy, just the C5 gate's import was wrong.

## Fix

```rust
// before
use ai_memory::sizes::full_profile_total_tokens;
let total = full_profile_total_tokens();

// after
use ai_memory::sizes::trimmed_full_profile_total_tokens;
let total = trimmed_full_profile_total_tokens();
```

Plus updated doc comment to (a) clarify the test measures the bare wire payload, (b) note the verbose form is opt-in via \`memory_capabilities { verbose: true, include_schema: true }\` and is not gated, (c) record this regression as the #628 15th-blocker root-cause for posterity.

## Test plan

- [x] \`AI_MEMORY_NO_CONFIG=1 cargo test --test budget_tokens -- --include-ignored\` — 7 passed (incl. C5 gate)
- [x] Sister test \`c2_tools_list_token_budget_is_under_3500\` still passes (same wire form, unchanged)
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic\` — clean
- [x] \`AI_MEMORY_NO_CONFIG=1 cargo test\` — full suite passes (0 failed across all binaries)
- [ ] CI \`token-budget gates\` job goes green for the first time since #619

## Why this matters

F5 release-cut #626 cannot merge until \`token-budget gates\` passes (branch protection). The 4 fix-PRs (#630, #631, #632, #633) addressing the audit's original 14 blockers also can't ride to green CI without this. **This PR unblocks the v0.7.0 ship sequence.**

## AI involvement

Authored by Claude Opus 4.7 (1M context) under operator direction. Human-approved before push. Reviewed against \`docs/AI_DEVELOPER_WORKFLOW.md\` Standard-class authority bar; no Sensitive/Restricted-class actions taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)