### PR TITLE
fix(test): autonomy_hook tests must not depend on live Ollama daemon

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -103,6 +103,25 @@ impl OllamaClient {
         Self::new_with_url(DEFAULT_OLLAMA_URL, model)
     }
 
+    /// Test-only constructor that skips the Ollama reachability check.
+    /// Use this in unit tests that only need a `Some(&OllamaClient)` value
+    /// to exercise non-LLM code paths (e.g. the `autonomy_hook_skipped`
+    /// skip-reason waterfall short-circuits before any RPC fires when the
+    /// reason is `content_too_short` or `internal_namespace`).
+    #[cfg(test)]
+    pub fn new_for_testing(model: &str) -> Self {
+        Self {
+            base_url: DEFAULT_OLLAMA_URL.trim_end_matches('/').to_string(),
+            model: model.to_string(),
+            client: reqwest::blocking::Client::builder()
+                .timeout(GENERATE_TIMEOUT)
+                .connect_timeout(CONNECT_TIMEOUT)
+                .build()
+                .expect("test reqwest client builds"),
+            breaker: Mutex::new(BreakerState::new()),
+        }
+    }
+
     /// Creates a new `OllamaClient` with a custom base URL.
     /// Checks that Ollama is reachable before returning.
     ///

--- a/src/mcp/tools/store.rs
+++ b/src/mcp/tools/store.rs
@@ -1124,8 +1124,11 @@ mod tests {
         let conn = fresh_conn();
         let db_path = db_path();
         let ttl = ResolvedTtl::default();
-        // Stub LLM via OllamaClient::new (constructor doesn't need server).
-        let llm = crate::llm::OllamaClient::new("dummy-model").ok();
+        // Stub LLM via `new_for_testing` (no Ollama liveness check, so the
+        // test runs in CI without an Ollama daemon). The skip-reason
+        // waterfall returns `content_too_short` BEFORE any RPC fires, so
+        // the client itself never touches the network.
+        let llm = Some(crate::llm::OllamaClient::new_for_testing("dummy-model"));
         let resp = handle_store(
             &conn,
             &db_path,
@@ -1155,7 +1158,7 @@ mod tests {
         let conn = fresh_conn();
         let db_path = db_path();
         let ttl = ResolvedTtl::default();
-        let llm = crate::llm::OllamaClient::new("dummy-model").ok();
+        let llm = Some(crate::llm::OllamaClient::new_for_testing("dummy-model"));
         let resp = handle_store(
             &conn,
             &db_path,


### PR DESCRIPTION
## Summary

Two unit tests in `src/mcp/tools/store.rs` (`autonomy_hook_skipped_content_too_short` and `autonomy_hook_skipped_internal_namespace`) have been failing on every grand-slam push since the V-4 closeout (#698):

\`\`\`
assertion left == right failed
  left: Some(\"no_llm\")
 right: Some(\"content_too_short\")
\`\`\`

Pre-existing across multiple commits (run 25891550911, also 25877414563, 25873848031, 25864040330, 25849109573). L4 13-gate didn't catch it because the maintainer's Mac has Ollama running locally — environment divergence with CI masked the bug.

## Root cause

\`OllamaClient::new(\"dummy-model\").ok()\` runs an Ollama liveness check; in CI it returns Err → \`.ok()\` → \`None\` → the waterfall returns \`no_llm\` BEFORE reaching the \`content_too_short\` / \`internal_namespace\` branches.

## Fix

Adds \`OllamaClient::new_for_testing\` — a \`#[cfg(test)]\` constructor that builds the struct without the liveness check. The reqwest client is real but the network is never touched because the skip-reason waterfall short-circuits at the reason check.

## Test plan

- [x] Locally: \`cargo test --features sal,sal-postgres --lib autonomy_hook_skipped\` → 4/4 pass
- [ ] CI: Per-Module Coverage Thresholds gate lands green on this PR

Operator directive: every gap that surfaces gets fixed in v0.7.0. This closes a long-running CI regression masked by environment divergence.

Refs #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)