### PR TITLE
fix(test): gate s75_capabilities_db_schema_version behind sal feature

### DIFF
--- a/tests/s75_capabilities_db_schema_version.rs
+++ b/tests/s75_capabilities_db_schema_version.rs
@@ -1,6 +1,15 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.0 SHIP CAMPAIGN — this test routes through the SAL `MemoryStore`
+// trait + `SqliteStore` adapter (both in `ai_memory::store::*`, which
+// is gated behind the `sal` feature). Under the default feature set
+// the module is configured out, so the unconditional `use` lines below
+// would fail to resolve and the workspace `cargo test` (default-feature)
+// build would break. Gate the entire file behind `sal` to match the
+// shape of the code under test. Surfaced by the fold-a2a1.7 polish
+// closeout per operator directive: no v0.8.0 deferral.
+#![cfg(feature = "sal")]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown)]
 //! v0.7.0.1 S75 — `/api/v1/capabilities` must surface a runtime


### PR DESCRIPTION
## Summary

\`tests/s75_capabilities_db_schema_version.rs\` imports \`ai_memory::store::MemoryStore\` and \`ai_memory::store::sqlite::SqliteStore\` unconditionally. The \`store\` module is \`#[cfg(feature = \"sal\")]\`. Under default features the imports fail to resolve and workspace \`cargo test\` build breaks with E0432/E0433.

## Fix

\`#![cfg(feature = \"sal\")]\` at the top of the file — configures the entire test out under default features, keeps it as-is under \`--features sal\` and \`--features sal-postgres\`.

## Verification

- \`cargo test --test s75_capabilities_db_schema_version --no-run\` (default features): builds clean (test is configured out)
- \`cargo test --test s75_capabilities_db_schema_version --no-run --features sal\` (where it's load-bearing): unchanged, builds and runs

Surfaced by the fold-a2a1.7 agent during the Phase E polish closeout. Pre-existing — not introduced by fold-a2a1.7. Per operator directive, fixing in v0.7.0 (no v0.8.0 deferral).

Refs #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)