### PR TITLE
fix(test): clippy pedantic cleanups on Phase E + parity test files

### DIFF
--- a/tests/g_phase_e_1_links_validation.rs
+++ b/tests/g_phase_e_1_links_validation.rs
@@ -28,7 +28,7 @@ use serde_json::json;
 use tower::ServiceExt as _;
 
 /// Build the router from a fresh in-memory DB so each test starts
-/// clean and there's no inter-test leakage on the memory_links table.
+/// clean and there's no inter-test leakage on the `memory_links` table.
 fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
     let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
     let path = std::path::PathBuf::from(":memory:");

--- a/tests/g_phase_e_2_namespace_set_standard_governance_passthrough.rs
+++ b/tests/g_phase_e_2_namespace_set_standard_governance_passthrough.rs
@@ -7,7 +7,7 @@
 //! Pre-#707 regression: when the caller passed a `governance` payload
 //! to `memory_namespace_set_standard`, the handler round-tripped it
 //! through the typed `GovernancePolicy` struct (write / promote /
-//! delete / approver / inherit / max_reflection_depth). Any other key
+//! delete / approver / inherit / `max_reflection_depth`). Any other key
 //! — most notably `require_approval_above_depth`, which is read by the
 //! free function `storage::resolve_require_approval_above_depth` and
 //! never lives on the typed struct — was silently dropped during the
@@ -79,9 +79,9 @@ fn insert_with_metadata(
 /// stdio JSON-RPC.
 fn call_set_standard(
     conn: &Connection,
-    params: serde_json::Value,
+    params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    ai_memory::mcp::handle_namespace_set_standard(conn, &params)
+    ai_memory::mcp::handle_namespace_set_standard(conn, params)
 }
 
 /// Re-read a memory's metadata.governance blob.
@@ -117,7 +117,7 @@ fn existing_require_approval_above_depth_survives_set_standard() {
     // the pre-#707 caller shape that triggered the silent drop.
     let resp = call_set_standard(
         &conn,
-        json!({
+        &json!({
             "namespace": "phase-e-2",
             "id": id,
             "governance": {
@@ -156,7 +156,7 @@ fn incoming_require_approval_above_depth_lands_on_standard() {
     let id = insert_with_metadata(&conn, "phase-e-2-incoming", "standard", json!({}));
     let resp = call_set_standard(
         &conn,
-        json!({
+        &json!({
             "namespace": "phase-e-2-incoming",
             "id": id,
             "governance": {
@@ -199,7 +199,7 @@ fn extra_fields_on_existing_blob_survive_set_standard() {
     );
     let resp = call_set_standard(
         &conn,
-        json!({
+        &json!({
             "namespace": "phase-e-2-extras",
             "id": id,
             "governance": {
@@ -241,7 +241,7 @@ fn incoming_overrides_existing_for_overlapping_keys() {
     );
     let resp = call_set_standard(
         &conn,
-        json!({
+        &json!({
             "namespace": "phase-e-2-override",
             "id": id,
             "governance": {

--- a/tests/serve_postgres_handler_parity.rs
+++ b/tests/serve_postgres_handler_parity.rs
@@ -28,8 +28,8 @@
 //!   duplicate detection; per-agent quota counters.
 //! - **F — Link signing** (`bucket_f_*`): signed-link wire envelope
 //!   carries `attest_level=self_signed` and populates `observed_by`.
-//! - **G — pg schema_version test-side fix** (`bucket_g_*`): read the
-//!   live schema_version via the daemon and assert it matches
+//! - **G — pg `schema_version` test-side fix** (`bucket_g_*`): read the
+//!   live `schema_version` via the daemon and assert it matches
 //!   `current_schema_version()` (same constant the cert oracle should
 //!   pin against).
 //! - **State flake** (`state_flake_*`): `memory_promote` round-trip


### PR DESCRIPTION
## Summary

Three pedantic lint violations were masked from CI by earlier per-module coverage gate failures (which short-circuited the \`cargo test --tests\` build). With PR #713 (daemon_runtime coverage) landing, these surface and would gate the merge.

## Fixes

- \`tests/g_phase_e_1_links_validation.rs:31\` — wrap \`memory_links\` in backticks (doc_markdown)
- \`tests/g_phase_e_2_namespace_set_standard_governance_passthrough.rs:10\` — wrap \`max_reflection_depth\` in backticks (doc_markdown)
- \`tests/g_phase_e_2_namespace_set_standard_governance_passthrough.rs:82\` — pass \`&serde_json::Value\` (needless_pass_by_value); 4 call-site updates
- \`tests/serve_postgres_handler_parity.rs:31-32\` — wrap \`schema_version\` in backticks (doc_markdown)

## Verification

\`cargo clippy --features sal --tests -- -D warnings -D clippy::all -D clippy::pedantic\` — clean.

Per operator directive: fix every surfaced gap in v0.7.0. Refs #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)