### PR TITLE
test(coverage v0.7.0): bring cli/rules.rs back above 95% floor

### DIFF
--- a/tests/g_phase_e_3_rules_key_naming_compat.rs
+++ b/tests/g_phase_e_3_rules_key_naming_compat.rs
@@ -299,3 +299,182 @@ fn enable_rejects_mismatched_key_keypub_pair() {
         "mismatched pub must refuse; got: {msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Coverage-targeted tests for `load_operator_signing_key_from_dir`
+// uncovered error branches surfaced by the per-module coverage gate
+// (cli/rules.rs dropped to 94.35% after #708).
+// ---------------------------------------------------------------------------
+
+/// Layout 2 — `operator.key` present, but no `operator.key.pub` sidecar.
+/// The verify block is skipped and the seed-only load must still succeed.
+/// Covers the `if pub_keygen.exists()` FALSE branch (load_operator_signing_key_from_dir).
+#[test]
+fn enable_accepts_keygen_layout_without_pub_sidecar() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-keygen-priv-only");
+    fs::create_dir_all(&key_dir).unwrap();
+
+    // Write ONLY operator.key (raw 32B seed) — deliberately omit
+    // operator.key.pub. The function should still load + sign.
+    let mut csprng = rand_core::OsRng;
+    let signing = SigningKey::generate(&mut csprng);
+    let priv_path = key_dir.join("operator.key");
+    fs::write(&priv_path, signing.to_bytes()).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&priv_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    run_enable(&db_path, &key_dir, "R-PHASE-E-3")
+        .expect("enable must succeed when operator.key exists but operator.key.pub is absent");
+    let rule = read_rule(&db_path, "R-PHASE-E-3");
+    assert!(rule.enabled);
+    assert_eq!(rule.attest_level, "operator_signed");
+    assert!(rule.signature.is_some());
+}
+
+/// Layout 2 — `operator.key.pub` contains content that is NOT valid
+/// base64url. Covers the `.decode(...).with_context(...)?` error
+/// branch in `load_operator_signing_key_from_dir`.
+#[test]
+fn enable_rejects_keygen_layout_with_invalid_base64_pub() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-bad-b64");
+    fs::create_dir_all(&key_dir).unwrap();
+    let _signing = stage_layout_key_keypub(&key_dir);
+
+    // Overwrite the public sidecar with content that cannot be base64url
+    // decoded. `!!!` is not a valid base64url alphabet character.
+    fs::write(key_dir.join("operator.key.pub"), "!!!not_base64!!!").unwrap();
+
+    let err = run_enable(&db_path, &key_dir, "R-PHASE-E-3").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("decode base64url public key"),
+        "base64 decode failure must surface; got: {msg}"
+    );
+}
+
+/// Layout 2 — `operator.key.pub` decodes successfully but to a byte
+/// length other than 32 (`ED25519_PUBLIC_LEN`). Covers the
+/// `pub_bytes.len() != ED25519_PUBLIC_LEN` bail branch.
+#[test]
+fn enable_rejects_keygen_layout_with_wrong_pub_byte_length() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-wrong-len");
+    fs::create_dir_all(&key_dir).unwrap();
+    let _signing = stage_layout_key_keypub(&key_dir);
+
+    // Write a base64url-valid encoding of a 16-byte payload (not 32).
+    // Decoder accepts it but the length check refuses.
+    let short_bytes = [0u8; 16];
+    let short_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(short_bytes);
+    fs::write(key_dir.join("operator.key.pub"), short_b64).unwrap();
+
+    let err = run_enable(&db_path, &key_dir, "R-PHASE-E-3").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("decoded to 16 bytes") || msg.contains("expected 32"),
+        "wrong-length pub must surface byte counts; got: {msg}"
+    );
+}
+
+/// Layout 2 — `operator.key` is present but contains the wrong number
+/// of bytes (not 32). `load_operator_signing_key` will refuse, and the
+/// outer `with_context` wraps it under the `governance.no_operator_key:
+/// failed loading ...` prefix. Covers that wrapping branch.
+#[test]
+fn enable_rejects_keygen_layout_with_corrupt_seed() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-bad-seed");
+    fs::create_dir_all(&key_dir).unwrap();
+
+    // Write a too-short seed (must be 32B). No pub sidecar needed —
+    // load_operator_signing_key fails on length before we'd reach it.
+    let priv_path = key_dir.join("operator.key");
+    fs::write(&priv_path, b"too-short-seed").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&priv_path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let err = run_enable(&db_path, &key_dir, "R-PHASE-E-3").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("governance.no_operator_key: failed loading"),
+        "context wrapper must appear; got: {msg}"
+    );
+    assert!(
+        msg.contains("operator.key"),
+        "failing path must name the bad file; got: {msg}"
+    );
+}
+
+/// Layout 1 — `operator.priv` exists with the right shape but
+/// `operator.pub` is present yet corrupt (wrong length). The guard
+/// `priv_legacy.exists() && pub_legacy.exists()` is satisfied, so
+/// `kp::load` is invoked and fails. Covers the layout-1
+/// `with_context(...)` branch in `load_operator_signing_key_from_dir`.
+#[test]
+fn enable_rejects_legacy_layout_when_kp_load_fails() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-legacy-bad-pub");
+    fs::create_dir_all(&key_dir).unwrap();
+
+    // Stage a normal priv, then overwrite .pub with a too-short blob so
+    // `kp::load` fails its `pub_bytes.len() != PUBLIC_KEY_LEN` check.
+    let _signing = stage_layout_priv_pub(&key_dir);
+    fs::write(key_dir.join("operator.pub"), b"short").unwrap();
+
+    let err = run_enable(&db_path, &key_dir, "R-PHASE-E-3").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("governance.no_operator_key: failed loading operator.priv/operator.pub"),
+        "layout-1 context wrapper must appear; got: {msg}"
+    );
+}
+
+/// Layout 1 — only `operator.priv` exists (no `operator.pub`). The
+/// guard `priv_legacy.exists() && pub_legacy.exists()` is FALSE, so
+/// the function falls through to layout 2 detection; since
+/// `operator.key` is also absent, the unified `bail!` at the bottom
+/// fires. Pins the layout-1 short-circuit + the "neither" path
+/// together (no exists-check ordering surprises).
+#[test]
+fn enable_falls_through_when_only_operator_priv_exists() {
+    let tdir = tempfile::tempdir().unwrap();
+    let db_path = tdir.path().join("rules.db");
+    init_governance_db(&db_path);
+    let key_dir = tdir.path().join("keys-priv-only");
+    fs::create_dir_all(&key_dir).unwrap();
+
+    // Stage a normal pair, then DELETE the pub. The function should
+    // not load layout 1 (guard fails) and should not find layout 2
+    // (operator.key absent) — must surface the unified error.
+    let _signing = stage_layout_priv_pub(&key_dir);
+    fs::remove_file(key_dir.join("operator.pub")).unwrap();
+
+    let err = run_enable(&db_path, &key_dir, "R-PHASE-E-3").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("no operator key found"),
+        "must hit the unified neither-layout error; got: {msg}"
+    );
+    assert!(
+        msg.contains("operator.priv") && msg.contains("operator.key"),
+        "error must mention both layouts; got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

After #708 (G-PHASE-E-3) added the operator-key naming auto-detect branch in `load_operator_signing_key_from_dir`, **cli/rules.rs line coverage dropped from 95.57% to 94.35%** — below the 95% Tier-B floor recorded in `coverage/thresholds.toml`. The daemon_runtime coverage agent surfaced this regression in its PR #713 body (`cli/rules.rs: 94.35% < threshold 95%`).

Per the operator directive "we are not shipping gaps" and the per-module discipline (`coverage/policy.md` §8: thresholds rise across releases; NEVER fall), this PR closes that gap **without lowering the threshold**.

## What changed

`tests/g_phase_e_3_rules_key_naming_compat.rs` — added six coverage-targeted tests pinning the previously-uncovered error branches in the auto-detect function:

| Test | Branch pinned |
|------|----------------|
| `enable_accepts_keygen_layout_without_pub_sidecar` | `operator.key` exists, no `operator.key.pub` (verify block is skipped, seed load succeeds) |
| `enable_rejects_keygen_layout_with_invalid_base64_pub` | base64url `decode(...)?` error wrapper |
| `enable_rejects_keygen_layout_with_wrong_pub_byte_length` | decoded pub ≠ 32 bytes → length-mismatch `bail!` |
| `enable_rejects_keygen_layout_with_corrupt_seed` | layout-2 `load_operator_signing_key` failure wrapped under `governance.no_operator_key: failed loading …` |
| `enable_rejects_legacy_layout_when_kp_load_fails` | layout-1 `kp::load(...).with_context(...)?` wrapper (both `.priv` + `.pub` exist but `.pub` is wrong length) |
| `enable_falls_through_when_only_operator_priv_exists` | only `operator.priv` present → guards exists-check ordering, surfaces unified "neither layout" error |

Total: **11 tests** (5 existing + 6 new), all green.

## Measurement

Canonical llvm-cov gate command from `coverage/policy.md`:

```bash
CARGO_TARGET_DIR=/.../.cargo-shared-target \
AI_MEMORY_NO_CONFIG=1 \
cargo llvm-cov --features sal,sal-postgres --lib --tests --workspace \
  --json --output-path coverage/current.json -- --test-threads=2
bash coverage/check-thresholds.sh coverage/thresholds.toml coverage/current.json
```

- **Pre-fix:** `cli/rules.rs: 94.35% (1220/1293 lines)` — FAIL
- **Post-fix:** `cli/rules.rs: 95.82% (1239/1293 lines)` — PASS (+1.47pp, 19 lines newly covered)
- **PER-MODULE summary:** `150 pass, 1 fail, 0 warn` — the one fail is `daemon_runtime.rs (85.60% < 86%)`, which is the same regression PR #713 (the daemon_runtime coverage agent) is closing; not in this PR's scope.
- **GLOBAL:** `89.56% >= 88.00% PASS`.

## Honest disclosure of remaining uncovered lines

After the fix, 6 lines in `load_operator_signing_key_from_dir` remain uncovered. Both groups are structurally unreachable defensive arms:

- Lines 742–746: The `kp.private.ok_or_else(...)` branch — only reachable if `kp::load` returns a keypair with `private == None` while both `operator.priv` and `operator.pub` exist. Per `src/identity/keypair.rs:300-330`, that's impossible: `private` is only `None` when `fs::read(priv_path)` returns `NotFound`, which can't happen after our `priv_legacy.exists()` guard already passed.
- Lines 764–766: The `read_to_string(pub_keygen)?.with_context(...)` error path — only reachable if `pub_keygen.exists()` returns `true` (guard passed) but the subsequent `read_to_string` fails. That's a TOCTOU race we can't deterministically simulate hermetically.

I'm leaving both as defensive code rather than removing them; they cost ~0.4pp and keep the function robust to filesystem oddities.

## Test plan

- [x] `cargo test --features sal,sal-postgres --test g_phase_e_3_rules_key_naming_compat` — 11/11 green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --features sal,sal-postgres --tests --test g_phase_e_3_rules_key_naming_compat -- -D warnings` — clean
- [x] Full workspace `cargo llvm-cov` re-run + `coverage/check-thresholds.sh` — `cli/rules.rs >= 95%` PASS
- [x] Hermetic: no Ollama, no real keychain, no `/tmp` writes (`TMPDIR` redirected to project-local scratch)

## AI involvement

- Authored by: Claude Opus 4.7 (1M context)
- Reviewer: human operator (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)