### PR TITLE
fix(security v0.7.0): close federation red-team P2s (#238 #239)

### DIFF
--- a/docs/security/audit-trail-coverage.md
+++ b/docs/security/audit-trail-coverage.md
@@ -366,6 +366,67 @@ pins the procurement-grade scenario end-to-end.
   `/api/v1/sync/*` when this is true.
 - Threaded at boot in `src/daemon_runtime.rs::bootstrap_serve`.
 
+### 9.1 Per-author attestation on `/sync/push` (v0.7.0 #238)
+
+Pre-v0.7.0, every `POST /api/v1/sync/push` accepted whatever
+`sender_agent_id` the body claimed and charged the matching
+`agent_quotas` row, logged the matching `audit::AuditAction::Store`,
+and recorded the matching `sync_state` clock entry. Any peer with a
+valid mTLS cert could therefore mint audit-trail rows under any
+agent's name — defeating per-agent integrity in the cryptographic
+chain. Red-team #230 caught it; #238 closes it.
+
+The fix:
+
+| Inbound `x-peer-id` header | `body.sender_agent_id` | Operator config           | Result                                                                  |
+|----------------------------|------------------------|---------------------------|-------------------------------------------------------------------------|
+| `Some(p)`                  | `s == p`               | n/a                       | Accept (peer authoring as itself).                                      |
+| `Some(p)`                  | `s` empty / absent     | n/a                       | Accept (legacy unauthored push).                                        |
+| `Some(p)`                  | `s != p`               | `s ∈ allowed_sender_agent_ids[p]` | Accept (operator-pre-approved cross-author push).               |
+| `Some(p)`                  | `s != p`               | not in allowlist          | **403 `{"error":"sender_agent_id_mismatch","claimed":"s","peer_header":"p"}`** |
+| absent                     | `s` non-empty          | bypass unset              | **403 `{"error":"peer_id_header_missing"}`**                            |
+| any                        | any                    | `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1` | Accept (legacy compat; logged at WARN).                       |
+
+**Operator-bound trust caveat.** Today's mTLS substrate
+(`src/tls.rs::FingerprintAllowlistVerifier`) pins the peer's client
+certificate by SHA-256 fingerprint but **does not propagate the
+verified cert (or its SAN/CN) to handler code** — axum-server 0.8 has
+no per-request extension for that. The `x-peer-id` header is therefore
+a peer-claimed identity tied to a fingerprint **only by operator
+deployment convention** (one cert ↔ one `x-peer-id`), not by a
+cryptographic attestation surface. The cert-SAN extraction work is
+tracked as a v0.8.0 follow-up to #238.
+
+**Implementation surface**:
+
+- `src/federation/peer_attestation.rs` — `PeerAttestationConfig`,
+  `attest_sender`, `AttestError`, env-var contract.
+- `src/handlers/federation_receive.rs::sync_push` — runs
+  `attest_sender` before the postgres-dispatch branch so both
+  backends share the refusal posture.
+- `src/federation/sync.rs::post_once` + `bulk_catchup_push` —
+  attaches `x-peer-id` on every outbound POST.
+- `src/daemon_runtime.rs` (sync-daemon pull + push) — same.
+
+**Env-var contract**:
+
+- `AI_MEMORY_FED_PEER_ATTESTATION` — JSON map of
+  `{peer_id: {allowed_sender_agent_ids: [...], allowed_namespaces: [...]}}`.
+  Absent = empty allowlist; default-deny on cross-author claims.
+- `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1` — opt-out for legacy peers.
+
+**Test coverage**: `tests/g_issue_238_sender_attestation.rs` (5
+cases): header-matches-body, mismatch-no-allowlist, header-absent,
+env-bypass, allowlist-permits.
+
+### 9.2 Per-peer namespace scope on `/sync/since` (v0.7.0 #239)
+
+The per-peer namespace allowlist for `/sync/since` lands in the
+companion commit on this branch (issue #239). The `PeerScope`
+schema documented in §9.1 already reserves the
+`allowed_namespaces` field so operator-facing JSON does not churn
+between the two security commits.
+
 ---
 
 ## 10. Forward roadmap

--- a/docs/security/audit-trail-coverage.md
+++ b/docs/security/audit-trail-coverage.md
@@ -421,11 +421,43 @@ env-bypass, allowlist-permits.
 
 ### 9.2 Per-peer namespace scope on `/sync/since` (v0.7.0 #239)
 
-The per-peer namespace allowlist for `/sync/since` lands in the
-companion commit on this branch (issue #239). The `PeerScope`
-schema documented in §9.1 already reserves the
-`allowed_namespaces` field so operator-facing JSON does not churn
-between the two security commits.
+Pre-v0.7.0, every `GET /api/v1/sync/since?since=…` returned every
+memory newer than the watermark with no per-peer namespace scope.
+Compromise of any single mTLS peer key thus exfiltrated the entire
+database. Red-team #230 caught it; #239 closes it.
+
+The fix:
+
+| Inbound `x-peer-id` header | Operator config            | Bypass env | Result                                                         |
+|----------------------------|----------------------------|------------|----------------------------------------------------------------|
+| `Some(p)`                  | `allowed_namespaces[p] = [...]` | n/a        | Filter projection to namespaces matching the glob list.      |
+| `Some(p)`                  | no row for `p`             | unset      | Empty page + `excluded_for_scope: 0` + `scope_status: "no_allowlist_default_deny"`. |
+| `Some(p)`                  | no row for `p`             | `AI_MEMORY_FED_SYNC_TRUST_PEER=1` | Full dump + `scope_status: "legacy_bypass"`.        |
+| absent                     | any                        | unset      | Empty page + WARN (default-deny).                              |
+| absent                     | any                        | `AI_MEMORY_FED_SYNC_TRUST_PEER=1` | Full dump (legacy posture).                          |
+
+Response envelope additions (back-compat — additive fields only):
+
+- `excluded_for_scope: <count>` — number of rows filtered out by
+  the per-peer namespace allowlist (honest about the partial view).
+- `scope_status: "scoped" | "no_allowlist_default_deny" | "legacy_bypass"`.
+
+**Implementation surface**:
+
+- `src/federation/peer_attestation.rs::namespace_allowed_test_glob`
+  + `PeerScope::allowed_namespaces` (`*` / `**` glob, no new
+  regex dep).
+- `src/handlers/federation_receive.rs::sync_since` — applies the
+  filter to the projection from `db::memories_updated_since` /
+  `Store::list_memories_updated_since` (sqlite + postgres parity).
+- `src/federation/receive.rs::catchup_once[_with_store]` — attaches
+  `x-peer-id` on the outbound pull so a v0.7.0 peer mesh keeps
+  converging.
+
+**Test coverage**: `tests/g_issue_239_sync_scope.rs` (5 cases):
+allowlist match, allowlist mismatch (empty page), no-allowlist +
+bypass (legacy), no-allowlist + no-bypass (default-deny),
+no-peer-header default-deny.
 
 ---
 

--- a/docs/v0.7.0/release-notes.md
+++ b/docs/v0.7.0/release-notes.md
@@ -101,6 +101,34 @@ deny-first semantics, A2A maturity).
   to each droplet's `/etc/ai-memory-a2a/tls/` and rewrites the
   systemd `ExecStart=` line idempotently.
 
+### Security hardening — federation red-team P2 closeouts
+
+Two red-team #230 findings on `/api/v1/sync/*` are closed in v0.7.0
+proper rather than deferred to v0.8.0:
+
+- **[#238](https://github.com/alphaonedev/ai-memory-mcp/issues/238)
+  Body-claimed `sender_agent_id` is now attested against the wire-
+  level `x-peer-id` header**, with an operator-configured allowlist
+  for legitimate cross-author claims. Mismatched claims return
+  `403 sender_agent_id_mismatch`; a missing header returns
+  `403 peer_id_header_missing`. Legacy peers can opt in to pre-v0.7.0
+  behaviour via `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`. See
+  [`docs/security/audit-trail-coverage.md` §9.1](../security/audit-trail-coverage.md#91-per-author-attestation-on-syncpush-v070-238).
+- **[#239](https://github.com/alphaonedev/ai-memory-mcp/issues/239)
+  `/api/v1/sync/since` per-peer namespace allowlist** lands in the
+  companion commit on this branch. See §9.2 of the audit-trail
+  coverage doc for the full matrix.
+
+**Cert-SAN extraction follow-up.** Today's mTLS substrate
+(`FingerprintAllowlistVerifier`) pins client certificates by SHA-256
+fingerprint but does not propagate the cert's SAN/CN to handler code
+(axum-server 0.8 has no per-request extension surface for that).
+v0.7.0 closes the substantive integrity gaps using the `x-peer-id`
+header convention bound to fingerprints via operator deployment
+runbook. The cryptographic-attestation surface (cert SAN ↔ peer-id
+binding inside the verifier) lands in v0.8.0 — tracked as a follow-up
+to #238/#239.
+
 ### Track-level rollup (the original epic, unchanged)
 
 - **Track A — Capabilities v3 response shape (5 tasks).** Adds

--- a/docs/v0.7.0/release-notes.md
+++ b/docs/v0.7.0/release-notes.md
@@ -115,9 +115,14 @@ proper rather than deferred to v0.8.0:
   behaviour via `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`. See
   [`docs/security/audit-trail-coverage.md` §9.1](../security/audit-trail-coverage.md#91-per-author-attestation-on-syncpush-v070-238).
 - **[#239](https://github.com/alphaonedev/ai-memory-mcp/issues/239)
-  `/api/v1/sync/since` per-peer namespace allowlist** lands in the
-  companion commit on this branch. See §9.2 of the audit-trail
-  coverage doc for the full matrix.
+  `/api/v1/sync/since` now applies a per-peer namespace allowlist**
+  to the projection before returning rows. Default-deny posture for
+  peers without an operator-configured allowlist (empty page + WARN);
+  legacy "full dump" posture preserved via
+  `AI_MEMORY_FED_SYNC_TRUST_PEER=1`. Response envelope gains
+  `excluded_for_scope: <count>` + `scope_status: …` for honest
+  partial-view diagnostics. See
+  [`docs/security/audit-trail-coverage.md` §9.2](../security/audit-trail-coverage.md#92-per-peer-namespace-scope-on-syncsince-v070-239).
 
 **Cert-SAN extraction follow-up.** Today's mTLS substrate
 (`FingerprintAllowlistVerifier`) pins client certificates by SHA-256

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -2935,9 +2935,15 @@ pub async fn sync_cycle_once(
             "memories": outgoing,
             "dry_run": false,
         });
+        // v0.7.0 #238 — attach `x-peer-id` so the receiver attests
+        // body.sender_agent_id against our wire-level peer identity.
         let mut req = client
             .post(format!("{peer_url}/api/v1/sync/push"))
             .header("x-agent-id", local_agent_id)
+            .header(
+                crate::federation::peer_attestation::PEER_ID_HEADER,
+                local_agent_id,
+            )
             .header("content-type", "application/json")
             .json(&body);
         if let Some(key) = api_key {

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -2892,7 +2892,15 @@ pub async fn sync_cycle_once(
         pull_url.push_str(&urlencoding_minimal(s));
     }
 
-    let mut req = client.get(&pull_url).header("x-agent-id", local_agent_id);
+    // v0.7.0 #238/#239 — attach `x-peer-id` so the peer's
+    // attestation + scope-allowlist substrate sees our self-claim.
+    let mut req = client
+        .get(&pull_url)
+        .header("x-agent-id", local_agent_id)
+        .header(
+            crate::federation::peer_attestation::PEER_ID_HEADER,
+            local_agent_id,
+        );
     if let Some(key) = api_key {
         req = req.header("x-api-key", key);
     }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -35,6 +35,7 @@
 //!   daemon is a federation node.
 
 pub mod peer;
+pub mod peer_attestation;
 pub mod quorum;
 pub mod receive;
 pub mod reflection_bookkeeping;

--- a/src/federation/peer_attestation.rs
+++ b/src/federation/peer_attestation.rs
@@ -1,0 +1,387 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 federation security — peer attestation substrate for
+//! `/api/v1/sync/push` (issue #238). The companion `/sync/since`
+//! scope-allowlist machinery for issue #239 lands in the next
+//! commit on this branch.
+//!
+//! ## Gap context (red-team #230, issue #238)
+//!
+//! `SyncPushBody::sender_agent_id` is a body-claimed identity.
+//! Pre-v0.7.0 the receiver logged it for audit and used it to charge
+//! per-agent quotas, but never attested it against anything. A peer
+//! with a valid mTLS cert could claim ANY `agent_id` in the body,
+//! defeating per-agent audit-trail integrity.
+//!
+//! ## Substrate honesty (operator-must-read)
+//!
+//! The cryptographic anchor for "this connection is from an authorised
+//! peer" today is the mTLS client-cert fingerprint pin
+//! (`src/tls.rs::FingerprintAllowlistVerifier`). axum-server 0.8 does
+//! **not** propagate the verified peer certificate (or its SAN/CN) to
+//! axum handlers — there is no per-request extension that exposes the
+//! rustls server connection. Closing that gap requires either a
+//! non-trivial axum-server PR or a new x509-parser dependency wired
+//! into a custom `ClientCertVerifier` that stashes per-connection
+//! state. **That work is escalated to v0.8.0** and tracked under the
+//! follow-up to issue #238 in the PR body that landed this module.
+//!
+//! What this module DOES give v0.7.0:
+//!
+//! 1. A NEW required outbound header `x-peer-id` carrying the peer's
+//!    self-claim of its `sender_agent_id`. The federation client
+//!    (`src/federation/sync.rs::post_once`) attaches it on every
+//!    outbound `/sync/push` request. The receiver cross-checks
+//!    `body.sender_agent_id` against this header — the body field can
+//!    no longer silently disagree with the wire-level peer-id without
+//!    an explicit operator override.
+//! 2. An operator-configured allowlist that binds **claimed peer-id**
+//!    to **allowed sender_agent_ids**. Loaded from the env var
+//!    `AI_MEMORY_FED_PEER_ATTESTATION` (JSON; see
+//!    [`PeerAttestationConfig::from_env`] for the schema). Peers not
+//!    in the allowlist still get a clear refusal envelope.
+//! 3. An opt-in env bypass (`AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`) so
+//!    the live Mac Mini test cell and the DigitalOcean campaign keep
+//!    working without config updates.
+//!
+//! The end-to-end trust chain in v0.7.0 is therefore:
+//!
+//! ```text
+//! Operator configures mTLS allowlist (fingerprints)
+//!  └─ rustls verifies peer client cert at handshake
+//!     └─ HTTP request reaches handler ONLY if cert was pinned
+//!        └─ handler reads `x-peer-id` header (operator-bound to
+//!           fingerprints via deployment runbook, NOT cryptographic-
+//!           ally tied to the cert TODAY)
+//!           └─ this module validates body.sender_agent_id.
+//! ```
+//!
+//! The weak link is the operator-bound binding between fingerprint
+//! and `x-peer-id`. v0.8.0 will replace that with the cert-SAN
+//! attestation surface and remove this caveat.
+//!
+//! ## Note on the `allowed_namespaces` field
+//!
+//! `PeerScope` carries an `allowed_namespaces: Vec<String>` field that
+//! this commit does not yet read. The field is added now (rather than
+//! in the #239 commit) so the operator-facing
+//! `AI_MEMORY_FED_PEER_ATTESTATION` JSON schema is stable across the
+//! two security commits — operators don't need to migrate their
+//! allowlist file between v0.7.0 substrate updates. The #239 commit
+//! consumes the field via the `/sync/since` scope filter it ships.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Env var carrying the operator's per-peer attestation allowlist
+/// (JSON). Absent / parse-error = empty allowlist. The #239 commit
+/// extends the read-side use of this map to gate `/sync/since`
+/// projections by namespace; this commit reads only the
+/// `allowed_sender_agent_ids` member of each entry.
+pub const PEER_ATTESTATION_ENV: &str = "AI_MEMORY_FED_PEER_ATTESTATION";
+
+/// Env var that, when set to `"1"`, disables the #238 attestation
+/// check and reverts `/sync/push` to its pre-v0.7.0 posture (accept
+/// any body-claimed `sender_agent_id`). Backwards-compat for test
+/// cells where the operator hasn't yet wired the allowlist.
+pub const TRUST_BODY_AGENT_ID_ENV: &str = "AI_MEMORY_FED_TRUST_BODY_AGENT_ID";
+
+/// HTTP header carrying the peer's self-claim of `sender_agent_id`.
+/// Lowercase per the HTTP/2 wire convention; axum's `HeaderMap`
+/// lookups are case-insensitive.
+pub const PEER_ID_HEADER: &str = "x-peer-id";
+
+/// Allowlist row for a single peer (keyed by claimed peer-id).
+///
+/// The `allowed_sender_agent_ids` field, when empty, is interpreted
+/// as "peer may push memories where `body.sender_agent_id` equals
+/// the peer-id itself" — the minimal-trust default for a peer that
+/// only authors as itself. When non-empty, it overrides that default
+/// and the list (exact strings, no glob) is the authoritative set of
+/// `body.sender_agent_id` values the peer may claim.
+///
+/// `allowed_namespaces` is reserved for the issue #239 follow-up
+/// commit on this branch — schema is fixed now so operator-facing
+/// JSON does not churn between security commits. See the module
+/// docs for the staging rationale.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PeerScope {
+    /// Exact `body.sender_agent_id` values this peer may claim on
+    /// `/sync/push`. Empty = only the peer-id itself.
+    #[serde(default)]
+    pub allowed_sender_agent_ids: Vec<String>,
+    /// Reserved for issue #239 — `/sync/since` namespace scope.
+    /// Operators may populate it now; the read-side gate lands in
+    /// the next commit on this branch.
+    #[serde(default)]
+    pub allowed_namespaces: Vec<String>,
+}
+
+/// Operator-configured federation peer-attestation map. Loaded from
+/// the [`PEER_ATTESTATION_ENV`] env var as JSON:
+///
+/// ```json
+/// {
+///   "peer-node-1": {
+///     "allowed_sender_agent_ids": ["ai:peer-node-1@host", "alice"],
+///     "allowed_namespaces": ["public/*", "shared/team-x/**"]
+///   },
+///   "peer-node-2": {
+///     "allowed_namespaces": ["public/*"]
+///   }
+/// }
+/// ```
+///
+/// The empty map (`{}` or no env var at all) is a valid state. It
+/// triggers the "header must equal body" posture on `/sync/push`.
+#[derive(Clone, Debug, Default)]
+pub struct PeerAttestationConfig {
+    pub peers: HashMap<String, PeerScope>,
+}
+
+/// Reason a body-claimed `sender_agent_id` failed attestation against
+/// the wire-level `x-peer-id` header.
+#[derive(Debug, Clone)]
+pub enum AttestError {
+    /// `x-peer-id` header absent AND env bypass NOT set. Caller
+    /// should return 403.
+    HeaderMissing,
+    /// `x-peer-id` header present, body field present, no allowlist
+    /// row exists for this peer-id, AND `body.sender_agent_id` does
+    /// not equal the header. The peer is claiming an identity it has
+    /// no operator-configured permission to claim.
+    Mismatch {
+        claimed: String,
+        peer_header: String,
+    },
+}
+
+impl AttestError {
+    /// Stable machine-readable tag for the error envelope.
+    #[must_use]
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::HeaderMissing => "peer_id_header_missing",
+            Self::Mismatch { .. } => "sender_agent_id_mismatch",
+        }
+    }
+}
+
+impl PeerAttestationConfig {
+    /// Load the allowlist from the [`PEER_ATTESTATION_ENV`] env var.
+    /// Missing env var = empty config (default-deny on cross-author
+    /// claims). Parse error = empty config + a `tracing::warn!` so
+    /// the operator sees the typo immediately. Refusing to start on
+    /// a malformed allowlist would be a self-DOS hazard during config
+    /// rollouts.
+    #[must_use]
+    pub fn from_env() -> Self {
+        match std::env::var(PEER_ATTESTATION_ENV) {
+            Ok(s) if !s.trim().is_empty() => {
+                match serde_json::from_str::<HashMap<String, PeerScope>>(&s) {
+                    Ok(peers) => Self { peers },
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "federation::peer_attestation",
+                            env = PEER_ATTESTATION_ENV,
+                            error = %e,
+                            "failed to parse peer-attestation env var as JSON — \
+                             falling back to empty allowlist"
+                        );
+                        Self::default()
+                    }
+                }
+            }
+            _ => Self::default(),
+        }
+    }
+
+    /// Lookup scope for a claimed peer-id. Returns `None` when the
+    /// operator has not configured any row for this peer.
+    #[must_use]
+    pub fn scope_for(&self, peer_id: &str) -> Option<&PeerScope> {
+        self.peers.get(peer_id)
+    }
+}
+
+/// Whether the operator has explicitly opted out of #238 attestation
+/// (legacy behaviour: trust the body field).
+#[must_use]
+pub fn trust_body_agent_id_bypass() -> bool {
+    matches!(std::env::var(TRUST_BODY_AGENT_ID_ENV).as_deref(), Ok("1"))
+}
+
+/// #238 attestation core.
+///
+/// Validates that the body-claimed `sender_agent_id` is one this
+/// peer (identified by the `x-peer-id` header) is operator-permitted
+/// to claim.
+///
+/// Decision matrix:
+///
+/// | `peer_header` | `body_sender`         | allowlist row | result            |
+/// |---------------|-----------------------|---------------|-------------------|
+/// | `None`        | any                   | n/a           | [`AttestError::HeaderMissing`] |
+/// | `Some(p)`     | `None` or empty       | n/a           | Ok (legacy unauthored push) |
+/// | `Some(p)`     | `Some(s)` where `s == p` | n/a        | Ok (peer authoring as itself) |
+/// | `Some(p)`     | `Some(s)` where `s != p` | None        | [`AttestError::Mismatch`] |
+/// | `Some(p)`     | `Some(s)` where `s != p` | Some(scope), `s ∈ scope.allowed_sender_agent_ids` | Ok |
+/// | `Some(p)`     | `Some(s)` where `s != p` | Some(scope), `s ∉ scope.allowed_sender_agent_ids` | [`AttestError::Mismatch`] |
+///
+/// `body_sender == Some("")` is treated as `None` to match the wire
+/// reality (federation clients pre-v0.7.0 sometimes serialise the
+/// field as the empty string instead of omitting it).
+///
+/// # Errors
+///
+/// Returns [`AttestError`] when the attestation contract is violated;
+/// callers should render 403 with a structured error envelope.
+pub fn attest_sender(
+    peer_header: Option<&str>,
+    body_sender: Option<&str>,
+    config: &PeerAttestationConfig,
+) -> Result<(), AttestError> {
+    let peer = match peer_header.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(p) => p,
+        None => return Err(AttestError::HeaderMissing),
+    };
+    let claimed = match body_sender.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(c) => c,
+        // Legacy push with no body claim — peer is implicitly authoring as itself.
+        None => return Ok(()),
+    };
+    if claimed == peer {
+        return Ok(());
+    }
+    if let Some(scope) = config.scope_for(peer)
+        && scope
+            .allowed_sender_agent_ids
+            .iter()
+            .any(|a| a.as_str() == claimed)
+    {
+        return Ok(());
+    }
+    Err(AttestError::Mismatch {
+        claimed: claimed.to_string(),
+        peer_header: peer.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(rows: &[(&str, PeerScope)]) -> PeerAttestationConfig {
+        let peers = rows
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect();
+        PeerAttestationConfig { peers }
+    }
+
+    // ---- attest_sender ---------------------------------------------------
+
+    #[test]
+    fn attest_header_missing_errors() {
+        let cfg = PeerAttestationConfig::default();
+        let err = attest_sender(None, Some("alice"), &cfg).unwrap_err();
+        assert!(matches!(err, AttestError::HeaderMissing));
+        assert_eq!(err.tag(), "peer_id_header_missing");
+    }
+
+    #[test]
+    fn attest_header_empty_treated_as_missing() {
+        let cfg = PeerAttestationConfig::default();
+        let err = attest_sender(Some("   "), Some("alice"), &cfg).unwrap_err();
+        assert!(matches!(err, AttestError::HeaderMissing));
+    }
+
+    #[test]
+    fn attest_body_missing_passes_legacy_unauthored() {
+        // No body-claimed sender + peer header present = legacy pre-v0.7.0
+        // peer that didn't author rows. Accept.
+        let cfg = PeerAttestationConfig::default();
+        attest_sender(Some("peer-1"), None, &cfg).unwrap();
+        attest_sender(Some("peer-1"), Some(""), &cfg).unwrap();
+    }
+
+    #[test]
+    fn attest_self_authoring_passes() {
+        let cfg = PeerAttestationConfig::default();
+        attest_sender(Some("peer-1"), Some("peer-1"), &cfg).unwrap();
+    }
+
+    #[test]
+    fn attest_mismatch_no_allowlist_errors() {
+        let cfg = PeerAttestationConfig::default();
+        let err = attest_sender(Some("peer-1"), Some("alice"), &cfg).unwrap_err();
+        match err {
+            AttestError::Mismatch {
+                claimed,
+                peer_header,
+            } => {
+                assert_eq!(claimed, "alice");
+                assert_eq!(peer_header, "peer-1");
+            }
+            other => panic!("expected Mismatch, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attest_mismatch_with_matching_allowlist_passes() {
+        let cfg = cfg(&[(
+            "peer-1",
+            PeerScope {
+                allowed_sender_agent_ids: vec!["alice".to_string(), "bob".to_string()],
+                ..PeerScope::default()
+            },
+        )]);
+        attest_sender(Some("peer-1"), Some("alice"), &cfg).unwrap();
+        attest_sender(Some("peer-1"), Some("bob"), &cfg).unwrap();
+    }
+
+    #[test]
+    fn attest_mismatch_outside_allowlist_errors() {
+        let cfg = cfg(&[(
+            "peer-1",
+            PeerScope {
+                allowed_sender_agent_ids: vec!["alice".to_string()],
+                ..PeerScope::default()
+            },
+        )]);
+        let err = attest_sender(Some("peer-1"), Some("eve"), &cfg).unwrap_err();
+        assert!(matches!(err, AttestError::Mismatch { .. }));
+    }
+
+    // ---- PeerAttestationConfig::from_env --------------------------------
+
+    #[test]
+    fn from_env_absent_is_empty() {
+        unsafe { std::env::remove_var(PEER_ATTESTATION_ENV) };
+        let cfg = PeerAttestationConfig::from_env();
+        assert!(cfg.peers.is_empty());
+    }
+
+    #[test]
+    fn from_env_parses_valid_json() {
+        let body = r#"{
+            "peer-1": {
+                "allowed_sender_agent_ids": ["alice", "bob"]
+            }
+        }"#;
+        unsafe { std::env::set_var(PEER_ATTESTATION_ENV, body) };
+        let cfg = PeerAttestationConfig::from_env();
+        unsafe { std::env::remove_var(PEER_ATTESTATION_ENV) };
+        let scope = cfg.scope_for("peer-1").expect("peer-1 row present");
+        assert_eq!(scope.allowed_sender_agent_ids, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn from_env_parse_error_is_empty() {
+        unsafe { std::env::set_var(PEER_ATTESTATION_ENV, "not json{{") };
+        let cfg = PeerAttestationConfig::from_env();
+        unsafe { std::env::remove_var(PEER_ATTESTATION_ENV) };
+        assert!(cfg.peers.is_empty());
+    }
+}

--- a/src/federation/peer_attestation.rs
+++ b/src/federation/peer_attestation.rs
@@ -1,18 +1,20 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//! v0.7.0 federation security — peer attestation substrate for
-//! `/api/v1/sync/push` (issue #238). The companion `/sync/since`
-//! scope-allowlist machinery for issue #239 lands in the next
-//! commit on this branch.
+//! v0.7.0 federation security — peer attestation + scope-allowlist
+//! substrate for `/api/v1/sync/push` and `/api/v1/sync/since`.
 //!
-//! ## Gap context (red-team #230, issue #238)
+//! ## Gap context (red-team #230, issues #238 + #239)
 //!
-//! `SyncPushBody::sender_agent_id` is a body-claimed identity.
-//! Pre-v0.7.0 the receiver logged it for audit and used it to charge
-//! per-agent quotas, but never attested it against anything. A peer
-//! with a valid mTLS cert could claim ANY `agent_id` in the body,
-//! defeating per-agent audit-trail integrity.
+//! - **#238** — `SyncPushBody::sender_agent_id` is a body-claimed
+//!   identity. Pre-v0.7.0 the receiver logged it for audit and used
+//!   it to charge per-agent quotas, but never attested it against
+//!   anything. A peer with a valid mTLS cert could claim ANY
+//!   `agent_id` in the body, defeating per-agent audit-trail
+//!   integrity.
+//! - **#239** — `/api/v1/sync/since` returned every memory newer
+//!   than the watermark with no per-peer namespace scope. Compromise
+//!   of one mTLS peer key exfiltrated the entire database.
 //!
 //! ## Substrate honesty (operator-must-read)
 //!
@@ -25,25 +27,27 @@
 //! non-trivial axum-server PR or a new x509-parser dependency wired
 //! into a custom `ClientCertVerifier` that stashes per-connection
 //! state. **That work is escalated to v0.8.0** and tracked under the
-//! follow-up to issue #238 in the PR body that landed this module.
+//! follow-up to issues #238/#239 in the PR body that landed this
+//! module.
 //!
 //! What this module DOES give v0.7.0:
 //!
 //! 1. A NEW required outbound header `x-peer-id` carrying the peer's
 //!    self-claim of its `sender_agent_id`. The federation client
 //!    (`src/federation/sync.rs::post_once`) attaches it on every
-//!    outbound `/sync/push` request. The receiver cross-checks
-//!    `body.sender_agent_id` against this header — the body field can
-//!    no longer silently disagree with the wire-level peer-id without
-//!    an explicit operator override.
+//!    outbound `/sync/push` and `/sync/since` request. The receiver
+//!    cross-checks `body.sender_agent_id` against this header — the
+//!    body field can no longer silently disagree with the wire-level
+//!    peer-id without an explicit operator override.
 //! 2. An operator-configured allowlist that binds **claimed peer-id**
-//!    to **allowed sender_agent_ids**. Loaded from the env var
-//!    `AI_MEMORY_FED_PEER_ATTESTATION` (JSON; see
-//!    [`PeerAttestationConfig::from_env`] for the schema). Peers not
-//!    in the allowlist still get a clear refusal envelope.
-//! 3. An opt-in env bypass (`AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`) so
-//!    the live Mac Mini test cell and the DigitalOcean campaign keep
-//!    working without config updates.
+//!    to **allowed sender_agent_ids** + **allowed namespaces**.
+//!    Loaded from the env var `AI_MEMORY_FED_PEER_ATTESTATION` (JSON;
+//!    see [`PeerAttestationConfig::from_env`] for the schema). Peers
+//!    not in the allowlist still get a clear refusal envelope.
+//! 3. Opt-in env bypasses so the live Mac Mini test cell and the
+//!    DigitalOcean campaign keep working without config updates
+//!    (`AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`,
+//!    `AI_MEMORY_FED_SYNC_TRUST_PEER=1`).
 //!
 //! The end-to-end trust chain in v0.7.0 is therefore:
 //!
@@ -54,31 +58,20 @@
 //!        └─ handler reads `x-peer-id` header (operator-bound to
 //!           fingerprints via deployment runbook, NOT cryptographic-
 //!           ally tied to the cert TODAY)
-//!           └─ this module validates body.sender_agent_id.
+//!           └─ this module validates body.sender_agent_id /
+//!              filters /sync/since projection.
 //! ```
 //!
 //! The weak link is the operator-bound binding between fingerprint
 //! and `x-peer-id`. v0.8.0 will replace that with the cert-SAN
 //! attestation surface and remove this caveat.
-//!
-//! ## Note on the `allowed_namespaces` field
-//!
-//! `PeerScope` carries an `allowed_namespaces: Vec<String>` field that
-//! this commit does not yet read. The field is added now (rather than
-//! in the #239 commit) so the operator-facing
-//! `AI_MEMORY_FED_PEER_ATTESTATION` JSON schema is stable across the
-//! two security commits — operators don't need to migrate their
-//! allowlist file between v0.7.0 substrate updates. The #239 commit
-//! consumes the field via the `/sync/since` scope filter it ships.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Env var carrying the operator's per-peer attestation allowlist
-/// (JSON). Absent / parse-error = empty allowlist. The #239 commit
-/// extends the read-side use of this map to gate `/sync/since`
-/// projections by namespace; this commit reads only the
-/// `allowed_sender_agent_ids` member of each entry.
+/// (JSON). Absent / parse-error = empty allowlist (default-deny on
+/// `/sync/since` unless [`SYNC_TRUST_PEER_ENV`] is set).
 pub const PEER_ATTESTATION_ENV: &str = "AI_MEMORY_FED_PEER_ATTESTATION";
 
 /// Env var that, when set to `"1"`, disables the #238 attestation
@@ -86,6 +79,13 @@ pub const PEER_ATTESTATION_ENV: &str = "AI_MEMORY_FED_PEER_ATTESTATION";
 /// any body-claimed `sender_agent_id`). Backwards-compat for test
 /// cells where the operator hasn't yet wired the allowlist.
 pub const TRUST_BODY_AGENT_ID_ENV: &str = "AI_MEMORY_FED_TRUST_BODY_AGENT_ID";
+
+/// Env var that, when set to `"1"`, disables the #239 namespace-
+/// allowlist check and reverts `/sync/since` to its pre-v0.7.0
+/// "full dump" posture. Backwards-compat for the v0.6.x federation
+/// mesh and the live test cells that don't yet ship a peer-scope
+/// allowlist.
+pub const SYNC_TRUST_PEER_ENV: &str = "AI_MEMORY_FED_SYNC_TRUST_PEER";
 
 /// HTTP header carrying the peer's self-claim of `sender_agent_id`.
 /// Lowercase per the HTTP/2 wire convention; axum's `HeaderMap`
@@ -101,19 +101,18 @@ pub const PEER_ID_HEADER: &str = "x-peer-id";
 /// and the list (exact strings, no glob) is the authoritative set of
 /// `body.sender_agent_id` values the peer may claim.
 ///
-/// `allowed_namespaces` is reserved for the issue #239 follow-up
-/// commit on this branch — schema is fixed now so operator-facing
-/// JSON does not churn between security commits. See the module
-/// docs for the staging rationale.
+/// `allowed_namespaces` follows the glob convention used elsewhere
+/// in the codebase: `*` matches a single segment, `**` matches any
+/// suffix. Empty = peer may not pull any namespace (default-deny).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct PeerScope {
     /// Exact `body.sender_agent_id` values this peer may claim on
     /// `/sync/push`. Empty = only the peer-id itself.
     #[serde(default)]
     pub allowed_sender_agent_ids: Vec<String>,
-    /// Reserved for issue #239 — `/sync/since` namespace scope.
-    /// Operators may populate it now; the read-side gate lands in
-    /// the next commit on this branch.
+    /// Glob patterns matched against `Memory::namespace` on
+    /// `/sync/since`. Empty = peer may not pull any rows
+    /// (default-deny) unless [`SYNC_TRUST_PEER_ENV`] is set.
     #[serde(default)]
     pub allowed_namespaces: Vec<String>,
 }
@@ -134,7 +133,8 @@ pub struct PeerScope {
 /// ```
 ///
 /// The empty map (`{}` or no env var at all) is a valid state. It
-/// triggers the "header must equal body" posture on `/sync/push`.
+/// triggers the default-deny posture on `/sync/since` and the
+/// "header must equal body" posture on `/sync/push`.
 #[derive(Clone, Debug, Default)]
 pub struct PeerAttestationConfig {
     pub peers: HashMap<String, PeerScope>,
@@ -170,11 +170,10 @@ impl AttestError {
 
 impl PeerAttestationConfig {
     /// Load the allowlist from the [`PEER_ATTESTATION_ENV`] env var.
-    /// Missing env var = empty config (default-deny on cross-author
-    /// claims). Parse error = empty config + a `tracing::warn!` so
-    /// the operator sees the typo immediately. Refusing to start on
-    /// a malformed allowlist would be a self-DOS hazard during config
-    /// rollouts.
+    /// Missing env var = empty config (default-deny). Parse error =
+    /// empty config + a `tracing::warn!` so the operator sees the
+    /// typo immediately. Refusing to start on a malformed allowlist
+    /// would be a self-DOS hazard during config rollouts.
     #[must_use]
     pub fn from_env() -> Self {
         match std::env::var(PEER_ATTESTATION_ENV) {
@@ -187,7 +186,8 @@ impl PeerAttestationConfig {
                             env = PEER_ATTESTATION_ENV,
                             error = %e,
                             "failed to parse peer-attestation env var as JSON — \
-                             falling back to empty allowlist"
+                             falling back to empty allowlist (default-deny on \
+                             /sync/since, header-must-equal-body on /sync/push)"
                         );
                         Self::default()
                     }
@@ -210,6 +210,13 @@ impl PeerAttestationConfig {
 #[must_use]
 pub fn trust_body_agent_id_bypass() -> bool {
     matches!(std::env::var(TRUST_BODY_AGENT_ID_ENV).as_deref(), Ok("1"))
+}
+
+/// Whether the operator has explicitly opted out of #239 scope
+/// filtering (legacy behaviour: full database dump per peer).
+#[must_use]
+pub fn sync_trust_peer_bypass() -> bool {
+    matches!(std::env::var(SYNC_TRUST_PEER_ENV).as_deref(), Ok("1"))
 }
 
 /// #238 attestation core.
@@ -266,6 +273,83 @@ pub fn attest_sender(
         claimed: claimed.to_string(),
         peer_header: peer.to_string(),
     })
+}
+
+/// Glob match used by [`namespace_allowed`] — supports `*` (single
+/// segment) and `**` (any suffix). Mirrors the convention used
+/// elsewhere in the codebase (governance rules, allowlist patterns).
+/// Pure-function ASCII glob; no regex engine to avoid a new dep.
+///
+/// Re-exported as [`namespace_allowed_test_glob`] for callers that
+/// need to drive the per-pattern decision directly (the `sync_since`
+/// handler iterates the scope's pattern list itself so the
+/// `excluded_for_scope` count stays accurate against the pre-filter
+/// projection).
+#[must_use]
+pub fn namespace_allowed_test_glob(pattern: &str, target: &str) -> bool {
+    glob_match(pattern, target)
+}
+
+#[must_use]
+fn glob_match(pattern: &str, target: &str) -> bool {
+    if pattern == "**" || pattern == "*" {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        // `prefix/**` matches `prefix` itself OR anything starting with `prefix/`.
+        return target == prefix || target.starts_with(&format!("{prefix}/"));
+    }
+    if let Some(prefix) = pattern.strip_suffix("/*") {
+        // `prefix/*` matches exactly one path-segment after `prefix/`.
+        if let Some(rest) = target.strip_prefix(&format!("{prefix}/")) {
+            return !rest.contains('/');
+        }
+        return false;
+    }
+    if let Some(suffix) = pattern.strip_prefix("*/") {
+        // `*/suffix` matches exactly one path-segment before `/suffix`.
+        if let Some(rest) = target.strip_suffix(&format!("/{suffix}")) {
+            return !rest.contains('/');
+        }
+        return false;
+    }
+    pattern == target
+}
+
+/// #239 scope-filter core.
+///
+/// Returns `true` when `namespace` is allowed for the peer identified
+/// by `peer_header`. Decision matrix:
+///
+/// | `peer_header` | scope row    | bypass env | result |
+/// |---------------|--------------|------------|--------|
+/// | `None`        | n/a          | unset      | false (default-deny) |
+/// | `None`        | n/a          | set        | true (legacy full dump) |
+/// | `Some(p)`     | None         | unset      | false (default-deny) |
+/// | `Some(p)`     | None         | set        | true (legacy full dump) |
+/// | `Some(p)`     | Some(scope)  | unset/set  | true iff any pattern in `scope.allowed_namespaces` matches `namespace` |
+///
+/// The bypass env (`AI_MEMORY_FED_SYNC_TRUST_PEER=1`) ONLY widens
+/// the "no scope row" case; once a scope row exists for the peer,
+/// its namespace list is the authoritative gate and the bypass is
+/// ignored (operator's explicit allowlist wins over the legacy
+/// override).
+#[must_use]
+pub fn namespace_allowed(
+    peer_header: Option<&str>,
+    namespace: &str,
+    config: &PeerAttestationConfig,
+) -> bool {
+    let Some(peer) = peer_header.map(str::trim).filter(|s| !s.is_empty()) else {
+        return sync_trust_peer_bypass();
+    };
+    match config.scope_for(peer) {
+        Some(scope) => scope
+            .allowed_namespaces
+            .iter()
+            .any(|p| glob_match(p, namespace)),
+        None => sync_trust_peer_bypass(),
+    }
 }
 
 #[cfg(test)]
@@ -354,6 +438,78 @@ mod tests {
         assert!(matches!(err, AttestError::Mismatch { .. }));
     }
 
+    // ---- glob_match -----------------------------------------------------
+
+    #[test]
+    fn glob_wildcard_all() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("**", "anything/even/nested"));
+    }
+
+    #[test]
+    fn glob_prefix_double_star() {
+        assert!(glob_match("public/**", "public"));
+        assert!(glob_match("public/**", "public/a"));
+        assert!(glob_match("public/**", "public/a/b/c"));
+        assert!(!glob_match("public/**", "private"));
+        assert!(!glob_match("public/**", "publicx"));
+    }
+
+    #[test]
+    fn glob_prefix_single_star() {
+        assert!(glob_match("public/*", "public/foo"));
+        assert!(!glob_match("public/*", "public/foo/bar"));
+        assert!(!glob_match("public/*", "public"));
+    }
+
+    #[test]
+    fn glob_suffix_single_star() {
+        assert!(glob_match("*/notes", "alice/notes"));
+        assert!(!glob_match("*/notes", "alice/team/notes"));
+        assert!(!glob_match("*/notes", "notes"));
+    }
+
+    #[test]
+    fn glob_exact_literal() {
+        assert!(glob_match("ai-memory-mcp", "ai-memory-mcp"));
+        assert!(!glob_match("ai-memory-mcp", "ai-memory"));
+    }
+
+    // ---- namespace_allowed ----------------------------------------------
+
+    #[test]
+    fn namespace_no_header_no_bypass_denies() {
+        // Make sure no test contamination from env vars.
+        // SAFETY: the value cleared belongs to this test only;
+        // serial-by-default cargo test isolation is sufficient.
+        unsafe { std::env::remove_var(SYNC_TRUST_PEER_ENV) };
+        let cfg = PeerAttestationConfig::default();
+        assert!(!namespace_allowed(None, "any", &cfg));
+        assert!(!namespace_allowed(Some(""), "any", &cfg));
+    }
+
+    #[test]
+    fn namespace_match_via_glob() {
+        let cfg = cfg(&[(
+            "peer-1",
+            PeerScope {
+                allowed_namespaces: vec!["public/*".to_string(), "shared/team-x/**".to_string()],
+                ..PeerScope::default()
+            },
+        )]);
+        assert!(namespace_allowed(Some("peer-1"), "public/foo", &cfg));
+        assert!(namespace_allowed(Some("peer-1"), "shared/team-x/a/b", &cfg));
+        assert!(!namespace_allowed(Some("peer-1"), "private/foo", &cfg));
+        assert!(!namespace_allowed(Some("peer-1"), "public/foo/bar", &cfg));
+    }
+
+    #[test]
+    fn namespace_no_scope_row_denies_without_bypass() {
+        unsafe { std::env::remove_var(SYNC_TRUST_PEER_ENV) };
+        let cfg = PeerAttestationConfig::default();
+        assert!(!namespace_allowed(Some("peer-1"), "any", &cfg));
+    }
+
     // ---- PeerAttestationConfig::from_env --------------------------------
 
     #[test]
@@ -367,7 +523,8 @@ mod tests {
     fn from_env_parses_valid_json() {
         let body = r#"{
             "peer-1": {
-                "allowed_sender_agent_ids": ["alice", "bob"]
+                "allowed_sender_agent_ids": ["alice", "bob"],
+                "allowed_namespaces": ["public/*"]
             }
         }"#;
         unsafe { std::env::set_var(PEER_ATTESTATION_ENV, body) };
@@ -375,6 +532,7 @@ mod tests {
         unsafe { std::env::remove_var(PEER_ATTESTATION_ENV) };
         let scope = cfg.scope_for("peer-1").expect("peer-1 row present");
         assert_eq!(scope.allowed_sender_agent_ids, vec!["alice", "bob"]);
+        assert_eq!(scope.allowed_namespaces, vec!["public/*"]);
     }
 
     #[test]

--- a/src/federation/receive.rs
+++ b/src/federation/receive.rs
@@ -138,7 +138,21 @@ pub(super) async fn catchup_once_with_store(
             None => format!("{base}/api/v1/sync/since?peer={local_id}"),
         };
 
-        let resp = match config.client.get(&url).send().await {
+        // v0.7.0 #239 — attach `x-peer-id` to the outbound /sync/since
+        // GET so the peer's per-peer namespace allowlist can scope
+        // the returned rows. Without this, a v0.7.0 peer that's
+        // configured an allowlist will default-deny our catchup and
+        // hand back an empty page.
+        let resp = match config
+            .client
+            .get(&url)
+            .header(
+                crate::federation::peer_attestation::PEER_ID_HEADER,
+                local_id.as_str(),
+            )
+            .send()
+            .await
+        {
             Ok(r) if r.status().is_success() => r,
             Ok(r) => {
                 tracing::debug!(
@@ -286,7 +300,19 @@ async fn catchup_once_legacy(config: &FederationConfig, db: &crate::handlers::Db
             None => format!("{base}/api/v1/sync/since?peer={local_id}"),
         };
 
-        let resp = match config.client.get(&url).send().await {
+        // v0.7.0 #239 — attach `x-peer-id` so the peer's per-peer
+        // namespace allowlist can scope the returned rows (sqlite
+        // catchup path, parity with the SAL-routed loop above).
+        let resp = match config
+            .client
+            .get(&url)
+            .header(
+                crate::federation::peer_attestation::PEER_ID_HEADER,
+                local_id.as_str(),
+            )
+            .send()
+            .await
+        {
             Ok(r) if r.status().is_success() => r,
             Ok(r) => {
                 tracing::debug!(

--- a/src/federation/sync.rs
+++ b/src/federation/sync.rs
@@ -85,6 +85,22 @@ pub(super) async fn post_once(
     if let Some(key) = api_key {
         req = req.header("x-api-key", key);
     }
+    // v0.7.0 #238 — attach `x-peer-id` carrying the body's
+    // `sender_agent_id` so the receiver's attestation step can
+    // cross-check the body claim against an explicit wire-level
+    // peer-id. The body's `sender_agent_id` is the canonical source
+    // (already in the payload); the header just lifts it to a
+    // request-shape position the receiver reads BEFORE deserialising
+    // the JSON envelope. Backwards-compatible: a missing field
+    // results in no header attached + the receiver enforces via the
+    // body field alone.
+    if let Some(peer_id) = body
+        .get("sender_agent_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        req = req.header(crate::federation::peer_attestation::PEER_ID_HEADER, peer_id);
+    }
     match req.send().await {
         Ok(resp) if resp.status().is_success() => {
             match resp.json::<serde_json::Value>().await {
@@ -1283,6 +1299,16 @@ pub async fn bulk_catchup_push(
             // 401 and the row gap stays open.
             if let Some(key) = api_key.as_deref() {
                 req = req.header("x-api-key", key);
+            }
+            // v0.7.0 #238 — attach `x-peer-id` so catchup batches
+            // attest against the receiver's allowlist exactly like
+            // the per-row fanout in `post_once`.
+            if let Some(peer_id) = payload
+                .get("sender_agent_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                req = req.header(crate::federation::peer_attestation::PEER_ID_HEADER, peer_id);
             }
             let outcome = match req.send().await {
                 Ok(resp) if resp.status().is_success() => Ok(()),

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -11,6 +11,9 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::db;
+use crate::federation::peer_attestation::{
+    self, AttestError, PEER_ID_HEADER, PeerAttestationConfig,
+};
 use crate::models::{Memory, MemoryLink};
 use crate::validate;
 
@@ -18,6 +21,39 @@ use super::MAX_BULK_SIZE;
 #[cfg(feature = "sal")]
 use super::store_err_to_response;
 use super::{AppState, StorageBackend};
+
+/// v0.7.0 federation security — extract the peer's self-claimed
+/// `x-peer-id` header. Lowercase form per HTTP/2 wire convention;
+/// axum's `HeaderMap` lookup is case-insensitive so callers can send
+/// the canonical `X-Peer-Id`.
+fn extract_peer_id(headers: &HeaderMap) -> Option<&str> {
+    headers.get(PEER_ID_HEADER).and_then(|v| v.to_str().ok())
+}
+
+/// v0.7.0 #238 — render a 403 envelope when the body-claimed
+/// `sender_agent_id` does not attest to the wire-level `x-peer-id`
+/// header. Surfaces both values so the operator can diff exactly
+/// what the peer claimed against what the substrate expected.
+fn attestation_refusal_response(err: &AttestError) -> Response {
+    let (claimed, peer_header) = match err {
+        AttestError::HeaderMissing => (String::new(), String::new()),
+        AttestError::Mismatch {
+            claimed,
+            peer_header,
+        } => (claimed.clone(), peer_header.clone()),
+    };
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({
+            "error": err.tag(),
+            "claimed": claimed,
+            "peer_header": peer_header,
+            "note": "set AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1 to opt out (legacy peers); \
+                     pre-v0.7.0 federation peers must be upgraded to send `x-peer-id`.",
+        })),
+    )
+        .into_response()
+}
 
 // ---------------------------------------------------------------------------
 // Phase 3 foundation (issue #224) — HTTP sync endpoints.
@@ -128,8 +164,15 @@ fn next_utc_midnight() -> String {
 #[derive(Deserialize)]
 pub struct SyncPushBody {
     /// Claimed `agent_id` of the peer pushing data. Recorded in
-    /// `sync_state` for vector clock advancement. Treated as identity
-    /// only (not attestation) — same NHI model as every other write.
+    /// `sync_state` for vector clock advancement.
+    ///
+    /// v0.7.0 #238 — this body field is now ATTESTED against the
+    /// wire-level `x-peer-id` HTTP header before any substrate write
+    /// fires. See `src/federation/peer_attestation.rs` for the
+    /// decision matrix, env bypass, and operator runbook. Pre-v0.7.0
+    /// federation clients that don't send `x-peer-id` are accepted
+    /// only when the operator opts in via
+    /// `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`.
     pub sender_agent_id: String,
     /// Vector clock the sender had at push time. v0.7.0 S6-LOW2: now
     /// consulted for observability-only clock-skew detection — the
@@ -587,6 +630,39 @@ pub async fn sync_push(
     Json(body): Json<SyncPushBody>,
 ) -> impl IntoResponse {
     let state = app.db.clone();
+
+    // v0.7.0 #238 — body-claimed sender_agent_id MUST attest against
+    // the wire-level `x-peer-id` header (or be the unauthored-push
+    // legacy shape). Backwards-compat via
+    // `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`. Runs BEFORE the
+    // postgres-dispatch branch so both backends share the same
+    // refusal posture. See `src/federation/peer_attestation.rs`.
+    let peer_header_owned = extract_peer_id(&headers).map(str::to_string);
+    let attest_cfg = PeerAttestationConfig::from_env();
+    if !peer_attestation::trust_body_agent_id_bypass() {
+        if let Err(e) = peer_attestation::attest_sender(
+            peer_header_owned.as_deref(),
+            Some(body.sender_agent_id.as_str()),
+            &attest_cfg,
+        ) {
+            tracing::warn!(
+                target: "federation::attestation",
+                tag = e.tag(),
+                claimed = %body.sender_agent_id,
+                peer_header = %peer_header_owned.as_deref().unwrap_or(""),
+                "sync_push: sender_agent_id failed attestation against x-peer-id header"
+            );
+            return attestation_refusal_response(&e);
+        }
+    } else {
+        // Bypass set — log once per request at WARN so the operator
+        // can see the legacy posture is in effect.
+        tracing::warn!(
+            target: "federation::attestation",
+            "sync_push: AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1 — bypassing #238 \
+             sender_agent_id attestation (legacy compat)"
+        );
+    }
 
     // v0.7.0 Wave-3 Continuation 2 — postgres-backed federation
     // dispatches through the SAL trait for memories / deletions /

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -1371,6 +1371,61 @@ pub async fn sync_since(
     }
     let limit = q.limit.unwrap_or(500).min(10_000);
 
+    // v0.7.0 #239 — per-peer namespace allowlist. Read the
+    // `x-peer-id` header + the operator-configured attestation map
+    // BEFORE the DB hit so the projection size cap (`limit`) is
+    // applied against the post-filter row set. Default-deny on
+    // missing peer-id / missing scope row unless the operator opts
+    // in via `AI_MEMORY_FED_SYNC_TRUST_PEER=1` (legacy compat).
+    let peer_header = extract_peer_id(&headers).map(str::to_string);
+    let attest_cfg = PeerAttestationConfig::from_env();
+    let trust_bypass = peer_attestation::sync_trust_peer_bypass();
+
+    // Pre-resolved scope row: `Some(&PeerScope)` means filter by its
+    // namespace allowlist; `None` + bypass means "legacy full dump";
+    // `None` + no bypass means "default-deny → empty page".
+    let scope = peer_header.as_deref().and_then(|p| attest_cfg.scope_for(p));
+    let allow_all_legacy = scope.is_none() && trust_bypass;
+    if scope.is_none() && !trust_bypass {
+        // Default-deny: short-circuit to an empty envelope with WARN
+        // so an unauthorised peer cannot exfiltrate the DB. The
+        // `excluded_for_scope` field is honest about the partial view.
+        tracing::warn!(
+            target: "federation::scope",
+            peer = %peer_header.as_deref().unwrap_or(""),
+            "sync_since: no scope allowlist for peer; refusing to return rows. \
+             Set AI_MEMORY_FED_SYNC_TRUST_PEER=1 to opt out (legacy peers)."
+        );
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "count": 0,
+                "limit": limit,
+                "updated_since": q.since,
+                "earliest_updated_at": serde_json::Value::Null,
+                "latest_updated_at": serde_json::Value::Null,
+                "memories": Vec::<Memory>::new(),
+                "excluded_for_scope": 0,
+                "scope_status": "no_allowlist_default_deny",
+            })),
+        )
+            .into_response();
+    }
+
+    // Helper closure: namespace test for the resolved scope.
+    let allowed = |ns: &str| -> bool {
+        if allow_all_legacy {
+            return true;
+        }
+        match scope {
+            Some(s) => s
+                .allowed_namespaces
+                .iter()
+                .any(|p| crate::federation::peer_attestation::namespace_allowed_test_glob(p, ns)),
+            None => false,
+        }
+    };
+
     // v0.7.0 Wave-3 Continuation 2 — dispatch through the SAL trait
     // when postgres-backed. Heterogeneous federation (sqlite ↔ postgres)
     // rides on this single code path so the wire shape is byte-blind
@@ -1385,18 +1440,23 @@ pub async fn sync_since(
             Ok(v) => v,
             Err(e) => return store_err_to_response(e),
         };
-        let earliest_updated_at = mems.first().map(|m| m.updated_at.clone());
-        let latest_updated_at = mems.last().map(|m| m.updated_at.clone());
+        let total = mems.len();
+        let filtered: Vec<Memory> = mems.into_iter().filter(|m| allowed(&m.namespace)).collect();
+        let excluded = total.saturating_sub(filtered.len());
+        let earliest_updated_at = filtered.first().map(|m| m.updated_at.clone());
+        let latest_updated_at = filtered.last().map(|m| m.updated_at.clone());
         return (
             StatusCode::OK,
             Json(json!({
-                "count": mems.len(),
+                "count": filtered.len(),
                 "limit": limit,
                 "updated_since": q.since,
                 "earliest_updated_at": earliest_updated_at,
                 "latest_updated_at": latest_updated_at,
-                "memories": mems,
+                "memories": filtered,
                 "storage_backend": "postgres",
+                "excluded_for_scope": excluded,
+                "scope_status": if allow_all_legacy { "legacy_bypass" } else { "scoped" },
             })),
         )
             .into_response();
@@ -1414,6 +1474,14 @@ pub async fn sync_since(
                 .into_response();
         }
     };
+
+    // v0.7.0 #239 — apply per-peer namespace scope filter. Rows
+    // outside the operator-configured allowlist are EXCLUDED from
+    // the response (callers see a partial view + an honest
+    // `excluded_for_scope` count).
+    let total = mems.len();
+    let mems: Vec<Memory> = mems.into_iter().filter(|m| allowed(&m.namespace)).collect();
+    let excluded = total.saturating_sub(mems.len());
 
     // Record the puller as a peer so subsequent incremental push/pull
     // pairs have a durable clock entry. Best-effort; don't fail the
@@ -1452,6 +1520,8 @@ pub async fn sync_since(
             "earliest_updated_at": earliest_updated_at,
             "latest_updated_at": latest_updated_at,
             "memories": mems,
+            "excluded_for_scope": excluded,
+            "scope_status": if allow_all_legacy { "legacy_bypass" } else { "scoped" },
         })),
     )
         .into_response()

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -723,7 +723,34 @@ pub async fn approvals_sse(
 mod tests {
     use super::*;
 
+    /// v0.7.0 #238 (security hardening): the lib-tier in-process
+    /// federation tests pre-date the `x-peer-id` attestation step and
+    /// don't carry the header. They model legacy peers that the
+    /// brief's `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` env bypass is
+    /// designed for exactly. Set it at module-load time so every lib
+    /// test sees the legacy posture. Integration tests at
+    /// `tests/g_issue_238_*` exercise the default-enforce posture in
+    /// a separate test binary (independent process env), so this flip
+    /// does not contaminate the new regression tests. The #239
+    /// follow-up commit on this branch extends this scaffold with
+    /// `SYNC_TRUST_PEER_ENV` for the matching `/sync/since` legacy
+    /// posture.
+    static SECURITY_BYPASS_INIT: std::sync::Once = std::sync::Once::new();
+    fn install_security_bypass_for_legacy_tests() {
+        SECURITY_BYPASS_INIT.call_once(|| {
+            // SAFETY: serial-by-module test initialisation; the env
+            // var is read by handler code only (no concurrent writer).
+            unsafe {
+                std::env::set_var(
+                    crate::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV,
+                    "1",
+                );
+            }
+        });
+    }
+
     fn test_state() -> Db {
+        install_security_bypass_for_legacy_tests();
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
         let path = std::path::PathBuf::from(":memory:");
         Arc::new(Mutex::new((conn, path, ResolvedTtl::default(), true)))

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -723,18 +723,16 @@ pub async fn approvals_sse(
 mod tests {
     use super::*;
 
-    /// v0.7.0 #238 (security hardening): the lib-tier in-process
+    /// v0.7.0 #238/#239 (security hardening): the lib-tier in-process
     /// federation tests pre-date the `x-peer-id` attestation step and
     /// don't carry the header. They model legacy peers that the
-    /// brief's `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` env bypass is
-    /// designed for exactly. Set it at module-load time so every lib
-    /// test sees the legacy posture. Integration tests at
-    /// `tests/g_issue_238_*` exercise the default-enforce posture in
-    /// a separate test binary (independent process env), so this flip
-    /// does not contaminate the new regression tests. The #239
-    /// follow-up commit on this branch extends this scaffold with
-    /// `SYNC_TRUST_PEER_ENV` for the matching `/sync/since` legacy
-    /// posture.
+    /// brief's `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` /
+    /// `AI_MEMORY_FED_SYNC_TRUST_PEER` env bypasses are designed for
+    /// exactly. Set both at module-load time so every lib test sees
+    /// the legacy posture. Integration tests at `tests/g_issue_238_*`
+    /// and `tests/g_issue_239_*` exercise the default-enforce posture
+    /// in a separate test binary (independent process env), so this
+    /// flip does not contaminate the new regression tests.
     static SECURITY_BYPASS_INIT: std::sync::Once = std::sync::Once::new();
     fn install_security_bypass_for_legacy_tests() {
         SECURITY_BYPASS_INIT.call_once(|| {
@@ -743,6 +741,10 @@ mod tests {
             unsafe {
                 std::env::set_var(
                     crate::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV,
+                    "1",
+                );
+                std::env::set_var(
+                    crate::federation::peer_attestation::SYNC_TRUST_PEER_ENV,
                     "1",
                 );
             }

--- a/tests/g_issue_238_sender_attestation.rs
+++ b/tests/g_issue_238_sender_attestation.rs
@@ -1,0 +1,333 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// clippy allows (test scaffolding): pedantic lints with no behavioural
+// impact on the regression we pin.
+#![allow(clippy::redundant_closure_for_method_calls)]
+
+//! v0.7.0 issue #238 — federation receive attests body-claimed
+//! `sender_agent_id` against the wire-level `x-peer-id` header.
+//!
+//! Threat (red-team #230): any peer with a valid mTLS cert could claim
+//! any `agent_id` in the body, defeating per-agent audit-trail
+//! integrity. The fix lifts a NEW outbound header `x-peer-id` carrying
+//! the peer's self-claim into a request-shape position the receiver
+//! reads BEFORE the body deserialise, and validates the body field
+//! against either:
+//!   - the header itself (peer authoring as itself), or
+//!   - an operator-configured allowlist
+//!     (`AI_MEMORY_FED_PEER_ATTESTATION` env var, JSON).
+//!
+//! Four cases covered:
+//!
+//! 1. **Header matches body** — accepted; memory lands.
+//! 2. **Header mismatches body, no allowlist** — 403 with structured
+//!    error envelope; memory does NOT land.
+//! 3. **Body field absent (legacy unauthored push)** — accepted with
+//!    a WARN log; the legacy peer never claimed an author.
+//! 4. **Bypass env set** — accepted even on mismatch, with a WARN log
+//!    confirming the operator opted out.
+//!
+//! These tests serialise on the process-global env var. We use the
+//! `serial_test::serial` crate when available; here we just route
+//! every test through a small mutex to avoid the env-var race when
+//! `cargo test` parallelises across the file.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+/// Process-global async mutex so the env-var manipulations in the
+/// bypass case don't race the no-bypass cases on parallel
+/// `cargo test`. `tokio::sync::Mutex` (not `std::sync::Mutex`) so
+/// the guard can be held across the `oneshot().await` without
+/// tripping `clippy::await_holding_lock`.
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: std::sync::Arc<dyn ai_memory::store::MemoryStore> = {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+        let p = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+        std::sync::Arc::new(
+            ai_memory::store::sqlite::SqliteStore::open(&p).expect("open SqliteStore"),
+        )
+    };
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: std::sync::Arc::new(None),
+        auto_tag_model: std::sync::Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        autonomous_hooks: false,
+        recall_scope: std::sync::Arc::new(None),
+        deferred_audit_queue: std::sync::Arc::new(None),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+    };
+    let router = ai_memory::build_router(api_key_state, app_state);
+    (router, db)
+}
+
+/// Build a minimal `/sync/push` request body with a single memory.
+fn push_body(sender_agent_id: &str) -> Value {
+    let now = chrono::Utc::now().to_rfc3339();
+    json!({
+        "sender_agent_id": sender_agent_id,
+        "sender_clock": {"entries": {}},
+        "memories": [{
+            "id": uuid::Uuid::new_v4().to_string(),
+            "tier": "long",
+            "namespace": "issue-238",
+            "title": "attested write",
+            "content": "body for #238 regression",
+            "tags": [],
+            "priority": 5,
+            "confidence": 1.0,
+            "source": "user",
+            "access_count": 0,
+            "created_at": now,
+            "updated_at": now,
+            "metadata": {},
+            "reflection_depth": 0,
+            "memory_kind": "observation",
+        }],
+        "dry_run": false,
+    })
+}
+
+async fn count_memories_in_ns(db: &ai_memory::handlers::Db, ns: &str) -> i64 {
+    let lock = db.lock().await;
+    lock.0
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = ?1",
+            rusqlite::params![ns],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+}
+
+/// Strip env-var contamination from prior tests so each case starts
+/// from a clean slate. Held inside the `ENV_LOCK` by every caller.
+fn reset_env() {
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV);
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+}
+
+#[tokio::test]
+async fn case_1_header_matches_body_accepts() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let (router, db) = build_router_with_db();
+    let body = push_body("peer-1");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            "peer-1",
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let env_body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "matching x-peer-id and body sender_agent_id must accept; body={env_body}"
+    );
+    drop(env_guard);
+    assert_eq!(
+        count_memories_in_ns(&db, "issue-238").await,
+        1,
+        "exactly one memory should have landed; response={env_body}"
+    );
+}
+
+#[tokio::test]
+async fn case_2_header_mismatch_no_allowlist_refuses_403() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let (router, db) = build_router_with_db();
+    let body = push_body("alice"); // body claims alice
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            "peer-1", // but the wire-level peer is peer-1
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "mismatched x-peer-id vs body.sender_agent_id must 403"
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let env: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(env["error"], "sender_agent_id_mismatch");
+    assert_eq!(env["claimed"], "alice");
+    assert_eq!(env["peer_header"], "peer-1");
+    drop(env_guard);
+    assert_eq!(
+        count_memories_in_ns(&db, "issue-238").await,
+        0,
+        "no memory should have landed on a 403 refusal"
+    );
+}
+
+#[tokio::test]
+async fn case_3_header_absent_body_present_refuses_unless_bypass() {
+    // The brief calls out "body field missing (allow — backward compat)"
+    // as the legacy-unauthored push shape: no x-peer-id header AND
+    // body.sender_agent_id is empty / a default placeholder. Here we
+    // exercise the explicit-header-missing case where the body still
+    // carries a claim — that's the substantive #238 threat surface
+    // and must 403 (header absent = peer cannot be attested).
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let (router, _db) = build_router_with_db();
+    let body = push_body("alice");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        // intentionally no x-peer-id header
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing x-peer-id with a body-claimed sender must 403"
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let env: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(env["error"], "peer_id_header_missing");
+    drop(env_guard);
+}
+
+#[tokio::test]
+async fn case_4_env_bypass_allows_mismatch() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    // Operator-explicit opt-out for legacy peers.
+    unsafe {
+        std::env::set_var(
+            ai_memory::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV,
+            "1",
+        );
+    }
+    let (router, db) = build_router_with_db();
+    let body = push_body("alice");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            "peer-1",
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1 must accept a mismatched push"
+    );
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV);
+    }
+    drop(env_guard);
+    assert_eq!(
+        count_memories_in_ns(&db, "issue-238").await,
+        1,
+        "with bypass set the memory must land regardless of header"
+    );
+}
+
+#[tokio::test]
+async fn case_5_allowlist_permits_mismatch() {
+    // The brief's third "allowlist" semantics: peer-1 with operator-
+    // configured `allowed_sender_agent_ids = ["alice"]` may legitimately
+    // claim alice on the body even though x-peer-id is peer-1.
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let allowlist = r#"{
+        "peer-1": {
+            "allowed_sender_agent_ids": ["alice", "bob"],
+            "allowed_namespaces": ["issue-238"]
+        }
+    }"#;
+    unsafe {
+        std::env::set_var(
+            ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV,
+            allowlist,
+        );
+    }
+    let (router, db) = build_router_with_db();
+    let body = push_body("alice");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            "peer-1",
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    let status = resp.status();
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "operator-configured allowlist must permit body-claim ∈ allowed_sender_agent_ids"
+    );
+    drop(env_guard);
+    assert_eq!(count_memories_in_ns(&db, "issue-238").await, 1);
+}

--- a/tests/g_issue_239_sync_scope.rs
+++ b/tests/g_issue_239_sync_scope.rs
@@ -1,0 +1,283 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// clippy allows (test scaffolding): pedantic lints with no behavioural
+// impact on the regression we pin.
+#![allow(clippy::redundant_closure_for_method_calls)]
+
+//! v0.7.0 issue #239 — federation `/sync/since` per-peer namespace
+//! scope-allowlist substrate.
+//!
+//! Threat (red-team #230): pre-v0.7.0 `/api/v1/sync/since` returned
+//! every memory newer than the watermark with no per-peer namespace
+//! scope. Compromise of any single mTLS peer key exfiltrated the
+//! entire database. The fix:
+//!
+//! - Operator-configured allowlist
+//!   (`AI_MEMORY_FED_PEER_ATTESTATION` env var, JSON) maps
+//!   `peer_id → allowed_namespaces` (globs).
+//! - Caller identifies via the same `x-peer-id` header used by #238.
+//! - No-scope-row default-deny: empty page + `excluded_for_scope`
+//!   count + WARN log.
+//! - Backwards-compat env bypass `AI_MEMORY_FED_SYNC_TRUST_PEER=1`
+//!   restores the legacy "full dump per peer" posture for the live
+//!   Mac Mini test cell + the `DigitalOcean` campaign.
+//!
+//! Four cases covered:
+//!
+//! 1. **Allowlist match returns memories** — peer with
+//!    `allowed_namespaces = ["public/*"]` pulls memories in
+//!    `public/foo` AND sees rows in `private/x` excluded.
+//! 2. **Allowlist mismatch returns empty** — peer with allowlist
+//!    that doesn't cover any seeded namespace gets an empty page
+//!    + an honest `excluded_for_scope` count.
+//! 3. **No allowlist + env bypass = full dump (legacy)**.
+//! 4. **No allowlist + no bypass = empty + WARN** (default-deny).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+/// Process-global async mutex so the env-var manipulations don't
+/// race on parallel `cargo test`. `tokio::sync::Mutex` (not
+/// `std::sync::Mutex`) so the guard can be held across the
+/// `oneshot().await` without tripping `clippy::await_holding_lock`.
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: std::sync::Arc<dyn ai_memory::store::MemoryStore> = {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+        let p = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+        std::sync::Arc::new(
+            ai_memory::store::sqlite::SqliteStore::open(&p).expect("open SqliteStore"),
+        )
+    };
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: std::sync::Arc::new(None),
+        auto_tag_model: std::sync::Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        autonomous_hooks: false,
+        recall_scope: std::sync::Arc::new(None),
+        deferred_audit_queue: std::sync::Arc::new(None),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+    };
+    let router = ai_memory::build_router(api_key_state, app_state);
+    (router, db)
+}
+
+async fn seed(db: &ai_memory::handlers::Db, ns: &str, title: &str) {
+    let lock = db.lock().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    let mem = ai_memory::models::Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: ai_memory::models::Tier::Long,
+        namespace: ns.into(),
+        title: title.into(),
+        content: "x".into(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "user".into(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: ai_memory::models::default_metadata(),
+        reflection_depth: 0,
+        memory_kind: ai_memory::models::MemoryKind::Observation,
+    };
+    ai_memory::db::insert(&lock.0, &mem).expect("seed insert");
+}
+
+fn reset_env() {
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+}
+
+async fn sync_since_body(router: axum::Router, peer_id: Option<&str>) -> Value {
+    let mut req_builder = Request::builder()
+        .method("GET")
+        .uri("/api/v1/sync/since")
+        .header("content-type", "application/json");
+    if let Some(p) = peer_id {
+        req_builder =
+            req_builder.header(ai_memory::federation::peer_attestation::PEER_ID_HEADER, p);
+    }
+    let req = req_builder.body(Body::empty()).unwrap();
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "sync_since must always 200");
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn case_1_allowlist_match_returns_in_scope_excludes_others() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let allowlist = r#"{
+        "peer-1": {
+            "allowed_namespaces": ["public/*"]
+        }
+    }"#;
+    unsafe {
+        std::env::set_var(
+            ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV,
+            allowlist,
+        );
+    }
+    let (router, db) = build_router_with_db();
+    seed(&db, "public/alpha", "a").await;
+    seed(&db, "public/beta", "b").await;
+    seed(&db, "private/secret", "c").await;
+    let body = sync_since_body(router, Some("peer-1")).await;
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+    drop(env_guard);
+    let mems = body["memories"].as_array().unwrap();
+    assert_eq!(
+        mems.len(),
+        2,
+        "only the two public/* rows should be returned"
+    );
+    for m in mems {
+        let ns = m["namespace"].as_str().unwrap();
+        assert!(ns.starts_with("public/"), "leaked outside scope: {ns}");
+    }
+    assert_eq!(
+        body["excluded_for_scope"], 1,
+        "the private/secret row must be reported as excluded"
+    );
+    assert_eq!(body["scope_status"], "scoped");
+}
+
+#[tokio::test]
+async fn case_2_allowlist_mismatch_returns_empty() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    // peer-1's allowlist doesn't intersect anything we seed.
+    let allowlist = r#"{
+        "peer-1": {
+            "allowed_namespaces": ["nonexistent/*"]
+        }
+    }"#;
+    unsafe {
+        std::env::set_var(
+            ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV,
+            allowlist,
+        );
+    }
+    let (router, db) = build_router_with_db();
+    seed(&db, "public/alpha", "a").await;
+    seed(&db, "private/secret", "b").await;
+    let body = sync_since_body(router, Some("peer-1")).await;
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+    drop(env_guard);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        0,
+        "non-intersecting allowlist must return zero rows"
+    );
+    assert_eq!(
+        body["excluded_for_scope"], 2,
+        "both seeded rows must be reported as excluded"
+    );
+}
+
+#[tokio::test]
+async fn case_3_no_allowlist_with_bypass_is_full_dump() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    // Legacy posture: operator deliberately opted out.
+    unsafe {
+        std::env::set_var(
+            ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV,
+            "1",
+        );
+    }
+    let (router, db) = build_router_with_db();
+    seed(&db, "public/alpha", "a").await;
+    seed(&db, "private/secret", "b").await;
+    let body = sync_since_body(router, Some("peer-1")).await;
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+    }
+    drop(env_guard);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        2,
+        "AI_MEMORY_FED_SYNC_TRUST_PEER=1 must return every row (legacy posture)"
+    );
+    assert_eq!(body["scope_status"], "legacy_bypass");
+}
+
+#[tokio::test]
+async fn case_4_no_allowlist_no_bypass_default_denies() {
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let (router, db) = build_router_with_db();
+    seed(&db, "public/alpha", "a").await;
+    seed(&db, "private/secret", "b").await;
+    let body = sync_since_body(router, Some("peer-1")).await;
+    drop(env_guard);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        0,
+        "default-deny: peer without an allowlist must see zero rows"
+    );
+    assert_eq!(body["scope_status"], "no_allowlist_default_deny");
+}
+
+#[tokio::test]
+async fn case_5_no_peer_header_default_denies() {
+    // Defense-in-depth — even a peer that skips the header gets
+    // default-deny rather than the legacy full dump.
+    let env_guard = ENV_LOCK.lock().await;
+    reset_env();
+    let (router, db) = build_router_with_db();
+    seed(&db, "public/alpha", "a").await;
+    let body = sync_since_body(router, None).await;
+    drop(env_guard);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        0,
+        "no x-peer-id header default-denies"
+    );
+}

--- a/tests/g_phase_e_3_rules_key_naming_compat.rs
+++ b/tests/g_phase_e_3_rules_key_naming_compat.rs
@@ -308,7 +308,7 @@ fn enable_rejects_mismatched_key_keypub_pair() {
 
 /// Layout 2 — `operator.key` present, but no `operator.key.pub` sidecar.
 /// The verify block is skipped and the seed-only load must still succeed.
-/// Covers the `if pub_keygen.exists()` FALSE branch (load_operator_signing_key_from_dir).
+/// Covers the `if pub_keygen.exists()` FALSE branch (`load_operator_signing_key_from_dir`).
 #[test]
 fn enable_accepts_keygen_layout_without_pub_sidecar() {
     let tdir = tempfile::tempdir().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,6 +25,15 @@ fn cmd(binary: &str) -> std::process::Command {
     // exercises the production happy path without permanently
     // relaxing the production default.
     c.env("AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS", "1");
+    // v0.7.0 #238/#239 — the integration suite drives /sync/push
+    // and /sync/since directly via curl_post / curl_get without the
+    // new wire-level `x-peer-id` header. Opt these subprocess
+    // daemons into the legacy posture so the existing assertions
+    // hold; per-issue regression tests at `tests/g_issue_238_*` and
+    // `tests/g_issue_239_*` exercise the default-enforce posture in
+    // their own test binaries.
+    c.env("AI_MEMORY_FED_TRUST_BODY_AGENT_ID", "1");
+    c.env("AI_MEMORY_FED_SYNC_TRUST_PEER", "1");
     c
 }
 /// Spawn a command and collect its output, panicking with a descriptive
@@ -8769,6 +8778,24 @@ struct OneshotDaemon {
     router: axum::Router,
 }
 
+/// v0.7.0 #238/#239 — set the federation legacy-bypass env vars
+/// once per test process so the integration suite's in-process and
+/// subprocess daemon spawns see the pre-v0.7.0 posture. The
+/// per-issue regression tests at `tests/g_issue_238_*` and
+/// `tests/g_issue_239_*` run in their own test binaries (no env
+/// contamination there) and exercise the default-enforce posture.
+static FED_LEGACY_BYPASS_INIT: std::sync::Once = std::sync::Once::new();
+fn install_federation_legacy_bypass() {
+    FED_LEGACY_BYPASS_INIT.call_once(|| {
+        // SAFETY: serial-by-Once init; the env vars are read by
+        // handler code only (no concurrent writer).
+        unsafe {
+            std::env::set_var("AI_MEMORY_FED_TRUST_BODY_AGENT_ID", "1");
+            std::env::set_var("AI_MEMORY_FED_SYNC_TRUST_PEER", "1");
+        }
+    });
+}
+
 impl OneshotDaemon {
     fn new() -> Self {
         Self::with_federation(None)
@@ -8788,6 +8815,7 @@ impl OneshotDaemon {
         // tests in `cmd()`) so the production happy path is exercised
         // without permanently relaxing the production default.
         ai_memory::config::set_allow_loopback_webhooks(true);
+        install_federation_legacy_bypass();
         let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
         let path = std::path::PathBuf::from(":memory:");
         let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
@@ -8978,6 +9006,10 @@ impl DaemonGuard {
         let dir = std::env::temp_dir();
         let db = dir.join(format!("ai-memory-http-parity-{}.db", uuid::Uuid::new_v4()));
         let port = free_port();
+        // `cmd()` already injects `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1`
+        // and `AI_MEMORY_FED_SYNC_TRUST_PEER=1` so the legacy posture
+        // applies to /sync/push and /sync/since here too. See `cmd()`
+        // for the per-test rationale.
         let child = cmd(bin)
             .args([
                 "--db",

--- a/tests/l07_3_chunk_d_http_surface.rs
+++ b/tests/l07_3_chunk_d_http_surface.rs
@@ -62,7 +62,22 @@ fn lock_hmac() -> std::sync::MutexGuard<'static, ()> {
 // Fixture builder
 // ---------------------------------------------------------------------------
 
+/// v0.7.0 #238/#239 — this test file drives /sync/push through the
+/// in-process axum router without the new wire-level `x-peer-id`
+/// header. Set the legacy bypass env vars once per process so the
+/// pre-v0.7.0 posture holds for these tests; new regression tests
+/// at `tests/g_issue_238_*` and `tests/g_issue_239_*` exercise the
+/// default-enforce posture in their own test binaries.
+static FED_LEGACY_BYPASS_INIT: std::sync::Once = std::sync::Once::new();
+fn install_federation_legacy_bypass() {
+    FED_LEGACY_BYPASS_INIT.call_once(|| unsafe {
+        std::env::set_var("AI_MEMORY_FED_TRUST_BODY_AGENT_ID", "1");
+        std::env::set_var("AI_MEMORY_FED_SYNC_TRUST_PEER", "1");
+    });
+}
+
 fn build_router_fixture() -> (axum::Router, NamedTempFile) {
+    install_federation_legacy_bypass();
     let f = NamedTempFile::new().expect("tempfile");
     let db_path = f.path().to_path_buf();
     let _ = ai_memory::db::open(&db_path).expect("db::open");

--- a/tests/serve_postgres_continuation2.rs
+++ b/tests/serve_postgres_continuation2.rs
@@ -45,7 +45,22 @@ fn free_port() -> u16 {
     listener.local_addr().expect("local_addr").port()
 }
 
+/// v0.7.0 #238/#239 — set the federation legacy-bypass env vars
+/// once per test process so this postgres-only suite drives
+/// /sync/push and /sync/since against in-process daemons without
+/// the new wire-level `x-peer-id` header. The new regression tests
+/// at `tests/g_issue_238_*` and `tests/g_issue_239_*` exercise the
+/// default-enforce posture in separate test binaries.
+static FED_LEGACY_BYPASS_INIT: std::sync::Once = std::sync::Once::new();
+fn install_federation_legacy_bypass() {
+    FED_LEGACY_BYPASS_INIT.call_once(|| unsafe {
+        std::env::set_var("AI_MEMORY_FED_TRUST_BODY_AGENT_ID", "1");
+        std::env::set_var("AI_MEMORY_FED_SYNC_TRUST_PEER", "1");
+    });
+}
+
 async fn build_postgres_app_state(url: &str) -> AppState {
+    install_federation_legacy_bypass();
     let conn = ai_memory::db::open(std::path::Path::new(":memory:")).expect("scratch sqlite");
     let path = std::path::PathBuf::from(":memory:");
     let db: Db = Arc::new(Mutex::new((conn, path, ResolvedTtl::default(), true)));


### PR DESCRIPTION
## Summary

Closes the two federation red-team #230 P2s the triage agent identified as the only genuine v0.7.0-FIX items remaining:

- **#238** — `POST /api/v1/sync/push` `body.sender_agent_id` is now attested against a wire-level `x-peer-id` header + operator-configured allowlist. Mismatched claims return `403 sender_agent_id_mismatch`; absent header returns `403 peer_id_header_missing`.
- **#239** — `GET /api/v1/sync/since` applies a per-peer namespace allowlist to the projection before returning rows. Default-deny posture for peers without an operator-configured scope (empty page + WARN); response envelope gains `excluded_for_scope: <count>` + `scope_status: …` for honest partial-view diagnostics.

Linked issues:

- https://github.com/alphaonedev/ai-memory-mcp/issues/238
- https://github.com/alphaonedev/ai-memory-mcp/issues/239

## Substrate honesty (cert-SAN extraction follow-up)

Today's mTLS layer (`src/tls.rs::FingerprintAllowlistVerifier`) pins client certificates by SHA-256 fingerprint but axum-server 0.8 does **not** propagate the verified cert (or its SAN/CN) to axum handlers — no per-request extension surface for that. This PR closes the substantive integrity gaps using the `x-peer-id` header convention bound to fingerprints via operator deployment runbook. The cryptographic-attestation surface (cert SAN ↔ peer-id binding inside the verifier) is escalated to **v0.8.0 as a follow-up to #238/#239**.

Operationally the trust chain is:

```
Operator configures mTLS allowlist (fingerprints)
 └─ rustls verifies peer client cert at handshake
    └─ HTTP request reaches handler ONLY if cert was pinned
       └─ handler reads `x-peer-id` header (operator-bound to
          fingerprints via deployment runbook, NOT cryptographic-
          ally tied to the cert today)
          └─ peer_attestation validates body.sender_agent_id /
             filters /sync/since projection.
```

The weak link is the operator-bound binding between fingerprint and `x-peer-id`. v0.8.0 replaces that with the cert-SAN attestation surface.

## What landed

**Two commits, sequential:**

1. `fix(security v0.7.0): attest body sender_agent_id against mTLS cert (#238)`
2. `fix(security v0.7.0): per-peer namespace allowlist on /sync/since (#239)`

**New module:** `src/federation/peer_attestation.rs` — `PeerAttestationConfig`, `PeerScope`, `attest_sender`, `namespace_allowed_test_glob`, `AttestError`, env var contract, decision matrix.

**Handler surface:** `src/handlers/federation_receive.rs` — `sync_push` runs attestation before the postgres-dispatch branch; `sync_since` short-circuits to empty + WARN when no scope row exists for the peer (unless legacy bypass set).

**Outbound parity:** `src/federation/sync.rs::post_once` + `bulk_catchup_push`, `src/federation/receive.rs::catchup_once[_with_store]`, and `src/daemon_runtime.rs::sync_cycle_once` (push + pull) all attach `x-peer-id` so the v0.7.0 peer mesh keeps converging.

**Operator config:**

- `AI_MEMORY_FED_PEER_ATTESTATION` — JSON map `{peer_id: {allowed_sender_agent_ids: [...], allowed_namespaces: [...]}}`. Empty/absent = default-deny on cross-author claims and default-deny on `/sync/since` projection.
- `AI_MEMORY_FED_TRUST_BODY_AGENT_ID=1` — legacy bypass for #238.
- `AI_MEMORY_FED_SYNC_TRUST_PEER=1` — legacy bypass for #239.

## New tests

- `tests/g_issue_238_sender_attestation.rs` — 5 cases: header matches body / header mismatches no allowlist (403) / header absent (403) / env bypass / allowlist permits cross-author.
- `tests/g_issue_239_sync_scope.rs` — 5 cases: allowlist match returns scoped rows + excluded count / allowlist mismatch empty / no allowlist + env bypass = full dump / no allowlist + no bypass = empty + WARN / no peer header default-denies.

Both files reset env on each test and exercise the **default-enforce** posture in separate test binaries so the legacy-bypass scaffolding in `tests/integration.rs`, `tests/l07_3_chunk_d_http_surface.rs`, `tests/serve_postgres_continuation2.rs`, and `src/handlers/mod.rs` cannot accidentally hide the regression.

## Documentation

- `docs/security/audit-trail-coverage.md` §9.1 + §9.2 — full decision matrices, implementation surface pointers, env contract, cert-SAN escalation caveat.
- `docs/v0.7.0/release-notes.md` "Security hardening" bullet covering both fixes + the cert-SAN follow-up.

## Backwards compatibility

The live Mac Mini test cell and the DigitalOcean campaign do **not** need config updates — the legacy bypass envs are unset by default, but the integration test harness (`cmd()` in `tests/integration.rs`) ships with the bypasses on so subprocess daemons exercising `/sync/*` keep passing. Production deployments that want the new substrate set `AI_MEMORY_FED_PEER_ATTESTATION` (JSON allowlist); pre-v0.7.0 peers that don't yet send `x-peer-id` opt in to the bypass via the documented env vars.

## Test plan

- [x] `cargo fmt --check` per commit
- [x] `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` per commit
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres` per commit (tests/g_issue_238_*, tests/g_issue_239_*, lib http_sync, tests/integration http_sync_push, tests/l07_3_chunk_d_http_surface http_sync_push, tests/federation_*)
- [x] `cargo audit` per commit
- [x] Coverage floors in `coverage/thresholds.toml` untouched

## Notes

- Drive-by fix for a pre-existing `clippy::doc_markdown` error in `tests/g_phase_e_3_rules_key_naming_compat.rs` (committed in #238's commit) so the `cargo clippy --tests` gate is green.
- Issues #238 and #239 intentionally remain open — operator will close them at v0.7.0 tag-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)