### PR TITLE
fix(lint): gate default-features unused imports/symbols introduced in #716

### DIFF
--- a/src/federation/receive.rs
+++ b/src/federation/receive.rs
@@ -4,6 +4,7 @@
 //! Post-partition catchup poller: spawn_catchup_loop, catchup_once,
 //! urlencoding_encode.
 
+#[cfg(feature = "sal")]
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -20,7 +20,9 @@ use crate::validate;
 use super::MAX_BULK_SIZE;
 #[cfg(feature = "sal")]
 use super::store_err_to_response;
-use super::{AppState, StorageBackend};
+use super::AppState;
+#[cfg(feature = "sal")]
+use super::StorageBackend;
 
 /// v0.7.0 federation security — extract the peer's self-claimed
 /// `x-peer-id` header. Lowercase form per HTTP/2 wire convention;

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -18,7 +18,9 @@ use crate::validate;
 
 #[cfg(feature = "sal")]
 use super::store_err_to_response;
-use super::{AppState, Db, StorageBackend};
+use super::{AppState, Db};
+#[cfg(feature = "sal")]
+use super::StorageBackend;
 use super::{fanout_or_503, list_namespaces, resolve_caller_agent_id};
 
 // --- /api/v1/notify (POST) + /api/v1/inbox (GET) ---------------------------
@@ -398,7 +400,13 @@ pub async fn subscribe(
         // wire shape. We mark it so the SSRF guard can skip the
         // loopback rejection — H11's allow_loopback_webhooks knob
         // gates real callers, not internally-synthesized stubs.
-        url_was_synthesized = true;
+        // The assignment is unused under default features (the reader
+        // is `#[cfg(feature = "sal")]`-gated); allow the unused-assignment
+        // warning specifically.
+        #[allow(unused_assignments)]
+        {
+            url_was_synthesized = true;
+        }
         let synthetic = format!("http://localhost/_ns/{caller}/{ns}");
         (
             synthetic,
@@ -942,6 +950,11 @@ fn namespace_standard_params(ns: &str, body: &NamespaceStandardBody) -> serde_js
 /// `mcp::tools::namespace`. Incoming keys override existing ones; keys
 /// present only on the existing blob (e.g. an operator-set
 /// `require_approval_above_depth`) survive untouched.
+///
+/// Only consumed on the SAL/postgres branch at line ~1064; gate the
+/// definition to match so default-features builds don't emit a
+/// dead-code warning.
+#[cfg(feature = "sal")]
 fn merge_governance_fields_http(
     existing: Option<&serde_json::Value>,
     incoming: &serde_json::Value,

--- a/src/handlers/http.rs
+++ b/src/handlers/http.rs
@@ -25,7 +25,9 @@ use crate::validate;
 use super::fanout_or_503;
 #[cfg(feature = "sal")]
 use super::store_err_to_response;
-use super::{AppState, JsonOrBadRequest, StorageBackend};
+use super::{AppState, JsonOrBadRequest};
+#[cfg(feature = "sal")]
+use super::StorageBackend;
 use super::{BULK_FANOUT_CONCURRENCY, MAX_BULK_SIZE};
 
 /// v0.7.0 L5 — minimum content length (chars) below which the HTTP
@@ -2978,6 +2980,12 @@ async fn recall_response(
     // tier filter parameter.
     recall_scope_tier: Option<&str>,
 ) -> axum::response::Response {
+    // `recall_scope_tier` is consumed only on the postgres SAL branch
+    // (line 3026). Suppress the unused-variable lint when the sal
+    // feature is off — same idiom as `url_was_synthesized` in
+    // hook_subscribers.rs.
+    #[cfg(not(feature = "sal"))]
+    let _ = recall_scope_tier;
     // v0.7.0 Wave-3 Continuation 2 (Phase 10) — postgres-backed
     // hybrid recall via the SAL trait. Embeds the query AND dispatches
     // through `app.store.recall_hybrid` so the postgres adapter applies


### PR DESCRIPTION
Closes the 7 lint failures on v0.7.0 tag CI. Verified clean across all 3 feature combos (default / --features sal / --features sal,sal-postgres). Refs #700.