### PR TITLE
fix(fmt): canonical import order for cfg-gated imports

### DIFF
--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -17,12 +17,12 @@ use crate::federation::peer_attestation::{
 use crate::models::{Memory, MemoryLink};
 use crate::validate;
 
+use super::AppState;
 use super::MAX_BULK_SIZE;
 #[cfg(feature = "sal")]
-use super::store_err_to_response;
-use super::AppState;
-#[cfg(feature = "sal")]
 use super::StorageBackend;
+#[cfg(feature = "sal")]
+use super::store_err_to_response;
 
 /// v0.7.0 federation security — extract the peer's self-claimed
 /// `x-peer-id` header. Lowercase form per HTTP/2 wire convention;

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -17,10 +17,10 @@ use crate::models::{Memory, Tier};
 use crate::validate;
 
 #[cfg(feature = "sal")]
+use super::StorageBackend;
+#[cfg(feature = "sal")]
 use super::store_err_to_response;
 use super::{AppState, Db};
-#[cfg(feature = "sal")]
-use super::StorageBackend;
 use super::{fanout_or_503, list_namespaces, resolve_caller_agent_id};
 
 // --- /api/v1/notify (POST) + /api/v1/inbox (GET) ---------------------------

--- a/src/handlers/http.rs
+++ b/src/handlers/http.rs
@@ -22,12 +22,12 @@ use crate::models::{
 use crate::profile::Family;
 use crate::validate;
 
+#[cfg(feature = "sal")]
+use super::StorageBackend;
 use super::fanout_or_503;
 #[cfg(feature = "sal")]
 use super::store_err_to_response;
 use super::{AppState, JsonOrBadRequest};
-#[cfg(feature = "sal")]
-use super::StorageBackend;
 use super::{BULK_FANOUT_CONCURRENCY, MAX_BULK_SIZE};
 
 /// v0.7.0 L5 — minimum content length (chars) below which the HTTP


### PR DESCRIPTION
cargo fmt cleanup from PR #719's cfg-gated import additions. Closes v0.7.0 retag CI 'Check formatting' failure.