### PR TITLE
fix(test): normalise CRLF->LF in snapshot_matches_generator + .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Cross-platform line-ending policy.
+#
+# Default: auto-detect text, leave binary as-is.
+* text=auto
+
+# JSON/JSONL snapshots used by the test suite must use LF on every
+# checkout — Windows otherwise rewrites them as CRLF and the byte-for-byte
+# snapshot tests (e.g. tests/longmemeval_reflection_bench.rs::snapshot_matches_generator)
+# fail with a phantom drift.
+*.jsonl text eol=lf
+*.json  text eol=lf
+
+# Shell scripts always LF (POSIX-only consumers).
+*.sh    text eol=lf
+
+# Rust + TOML + Markdown — let git auto-detect but never normalise binaries.
+*.rs    text
+*.toml  text
+*.md    text
+
+# Migrations are SQL — LF always (deterministic hashing inputs).
+*.sql   text eol=lf
+
+# Test fixture binaries + model weights — never touch.
+*.bin   binary
+*.gz    binary
+*.zst   binary
+*.tar   binary
+*.png   binary
+*.jpg   binary
+*.parquet binary

--- a/tests/longmemeval_reflection_bench.rs
+++ b/tests/longmemeval_reflection_bench.rs
@@ -133,9 +133,15 @@ fn snapshot_matches_generator() {
             e
         )
     });
+    // Normalise CRLF -> LF: Windows git checkouts (no .gitattributes
+    // pinning eol=lf for this file) convert the snapshot's LF line
+    // endings to CRLF on disk. The in-memory generator always emits
+    // LF. Without normalisation the comparison fails on Windows even
+    // though the logical content is identical.
+    let on_disk_lf = on_disk.replace("\r\n", "\n");
     let in_memory = serialise_jsonl(&generate_scenarios());
     assert_eq!(
-        on_disk, in_memory,
+        on_disk_lf, in_memory,
         "scenarios.jsonl drift — regenerate via `cargo bench --bench longmemeval_reflection -- --regenerate`"
     );
 }


### PR DESCRIPTION
Closes Windows Check failure from v0.7.0 retag CI 25901669957. Defense-in-depth: test-side CRLF normalization + .gitattributes pinning text-fixture files eol=lf. Refs #700.