### PR TITLE
feat(v0.7.0 QW-3 follow-up): register memory_offload + memory_deref in MCP tool registry

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2490,8 +2490,8 @@ mod tests {
             "default profile should be core; got: {stdout}"
         );
         assert!(
-            stdout.contains("Full   (64 tools loaded)"),
-            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5×skill tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection = 64)"
+            stdout.contains("Full   (66 tools loaded)"),
+            "report should include full-profile baseline (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5×skill tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection + v0.7.0 QW-3 follow-up memory_offload + memory_deref = 66)"
         );
         assert!(
             stdout.contains("Tokenizer: cl100k_base"),
@@ -2523,7 +2523,7 @@ mod tests {
         // verbose token total past 10K. Updated upper bound to 12K.
         let total = v["full_profile_total_tokens"].as_u64().unwrap();
         assert!(
-            (5_000..=13_000).contains(&total),
+            (5_000..=14_000).contains(&total),
             "full_profile_total_tokens out of honest range: {total}"
         );
         assert!(v["active_total_tokens"].as_u64().unwrap() > 0);
@@ -2551,8 +2551,8 @@ mod tests {
         let tools = v["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            64,
-            "raw_table must include all 64 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5×skill tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection = 64)"
+            66,
+            "raw_table must include all 66 baseline tools (43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5×skill tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection + v0.7.0 QW-3 follow-up memory_offload + memory_deref = 66)"
         );
         // memory_store is in core and must be loaded under the default
         // (core) profile.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -305,6 +305,11 @@ mod load_family;
 mod namespace;
 #[path = "tools/notify.rs"]
 mod notify;
+// v0.7.0 QW-3 follow-up — context-offload substrate primitive
+// (memory_offload + memory_deref). Family::Power registration; handlers
+// live at src/mcp/tools/offload.rs.
+#[path = "tools/offload.rs"]
+mod offload;
 #[path = "tools/pending.rs"]
 mod pending;
 #[path = "tools/promote.rs"]
@@ -1038,6 +1043,29 @@ fn handle_request(
                 "memory_skill_compositional_context" => {
                     handle_skill_compositional_context(conn, arguments)
                 }
+                // v0.7.0 QW-3 follow-up — context-offload substrate
+                // primitive. `memory_offload` accepts verbatim content
+                // and returns a ref_id; `memory_deref` round-trips the
+                // body. agent_id is resolved through the same NHI
+                // precedence chain memory_store uses
+                // (explicit > metadata > mcp_client > host fallback)
+                // so the substrate row is correctly attributed.
+                "memory_offload" => {
+                    let explicit_agent_id = arguments
+                        .get("agent_id")
+                        .and_then(Value::as_str)
+                        .or_else(|| {
+                            arguments
+                                .get("metadata")
+                                .and_then(|m| m.get("agent_id"))
+                                .and_then(Value::as_str)
+                        });
+                    match crate::identity::resolve_agent_id(explicit_agent_id, mcp_client) {
+                        Ok(agent_id) => offload::handle_offload(conn, arguments, &agent_id),
+                        Err(e) => Err(e.to_string()),
+                    }
+                }
+                "memory_deref" => offload::handle_deref(conn, arguments),
                 // Ultrareview #349: unknown tool is a JSON-RPC 2.0
                 // "method not found" condition — return -32601, not
                 // an ok_response with `isError: true`. Clients that
@@ -1529,9 +1557,12 @@ mod tests {
         // v0.7.0 QW-1 adds memory_export_reflection (Family::Power) → 64 —
         // file-backed reflection chain export companion to the
         // `ai-memory export-reflections` CLI subcommand.
+        // v0.7.0 QW-3 follow-up adds memory_offload + memory_deref
+        // (Family::Power) → 66 — context-offload substrate primitive
+        // surfaced at the semantic-tier+ Power profile.
         let defs = tool_definitions();
         let tools = defs["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 64);
+        assert_eq!(tools.len(), 66);
     }
 
     /// v0.6.4-002 acceptance gate (RFC §S25/S26): `--profile core`
@@ -1586,7 +1617,7 @@ mod tests {
         let tools = defs["tools"].as_array().unwrap();
         assert_eq!(
             tools.len(),
-            64,
+            66,
             "full profile = v0.6.3 surface (43) + v0.7.0 I4 memory_replay (1) + \
              v0.7 H4 memory_verify (1) + v0.7 B1 memory_load_family (1) + \
              v0.7 B2 memory_smart_load (1) + \
@@ -1599,7 +1630,8 @@ mod tests {
              v0.7.0 L1-5 5×memory_skill_* (5) + \
              v0.7.0 L2-6 memory_skill_promote_from_reflection (1) + \
              v0.7.0 L2-7 memory_skill_compositional_context (1) + \
-             v0.7.0 QW-1 memory_export_reflection (1) = 64"
+             v0.7.0 QW-1 memory_export_reflection (1) + \
+             v0.7.0 QW-3 follow-up memory_offload + memory_deref (2) = 66"
         );
     }
 

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -1358,6 +1358,32 @@ pub fn tool_definitions() -> Value {
                     },
                     "required": ["skill_id"]
                 }
+            },
+            {
+                "name": "memory_offload",
+                "description": "Offload verbatim content into the context-offload substrate; returns a ref_id to keep in-window (Family::Power).",
+                "docs": "v0.7.0 QW-3 follow-up — context-offload substrate primitive. Stores `content` verbatim in the `offloaded_blobs` substrate table under the caller's namespace (defaults to `auto`) with an optional `ttl_seconds` retention hint, and returns a `ref_id` plus the row's `content_sha256` + `stored_at` timestamp. The caller keeps the short `ref_id` in their working window; the body is dereferenced on demand via `memory_deref`. Semantic-tier+ surface (registered under Family::Power) so the keyword-tier `core` profile stays at its 7-tool minimum. Substrate-only at v0.7.0; the v0.8.0 short-term-context-compression patch wires the pair into the auto-compaction loop.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "content": {"type": "string", "description": "Verbatim content to offload. The substrate stores it as a single row; recall is exact-byte via memory_deref."},
+                        "namespace": {"type": "string", "description": "Namespace bucket for the offloaded row. Defaults to `auto` so a tier-gated MCP caller that omits this field still produces a non-empty, audit-friendly bucket rather than a NULL violation."},
+                        "ttl_seconds": {"type": "integer", "minimum": 0, "description": "Optional retention hint in seconds. The QW-3 substrate's TTL sweep picks this up; absence means substrate-default retention."}
+                    },
+                    "required": ["content"]
+                }
+            },
+            {
+                "name": "memory_deref",
+                "description": "Dereference a memory_offload ref_id and return the verbatim content (Family::Power).",
+                "docs": "v0.7.0 QW-3 follow-up — companion to `memory_offload`. Looks up the `ref_id` in the `offloaded_blobs` substrate, verifies the row has not been tampered with (sha256 check), and returns `{ref_id, content, stored_at, sha256}`. Refuses tampered rows. Semantic-tier+ surface (registered under Family::Power).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "ref_id": {"type": "string", "description": "The opaque reference returned by a prior memory_offload call."}
+                    },
+                    "required": ["ref_id"]
+                }
             }
         ]
     })

--- a/src/mcp/tools/offload.rs
+++ b/src/mcp/tools/offload.rs
@@ -51,9 +51,7 @@ pub fn handle_offload(
         .and_then(Value::as_str)
         .ok_or("content is required")?;
     let namespace = resolve_namespace(params);
-    let ttl_seconds = params
-        .get("ttl_seconds")
-        .and_then(Value::as_u64);
+    let ttl_seconds = params.get("ttl_seconds").and_then(Value::as_u64);
 
     let off = ContextOffloader::new(conn, None, OffloadConfig::default());
     let result = off
@@ -68,10 +66,7 @@ pub fn handle_offload(
 }
 
 /// `memory_deref(ref_id)`.
-pub fn handle_deref(
-    conn: &rusqlite::Connection,
-    params: &Value,
-) -> Result<Value, String> {
+pub fn handle_deref(conn: &rusqlite::Connection, params: &Value) -> Result<Value, String> {
     let ref_id = params
         .get("ref_id")
         .and_then(Value::as_str)

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -184,7 +184,14 @@ impl Family {
             // explicitly NOT registered over MCP per design revision
             // 2026-05-13 — operator uses CLI / HTTP with signed key.
             | "memory_check_agent_action"
-            | "memory_rule_list" => Some(Self::Power),
+            | "memory_rule_list"
+            // v0.7.0 QW-3 follow-up — context-offload substrate primitive.
+            // The pair lives in Family::Power so the `power` (and `full`)
+            // profile surfaces them while keeping the keyword-tier
+            // `core` surface unchanged (semantic-tier+ exposure per the
+            // QW-3 brief).
+            | "memory_offload"
+            | "memory_deref" => Some(Self::Power),
             // meta (5)
             "memory_capabilities"
             | "memory_agent_register"
@@ -263,8 +270,11 @@ impl Family {
             // 2 (v0.7.0 issue #691 — memory_check_agent_action +
             // memory_rule_list, substrate-level agent-action rules) +
             // 1 (v0.7.0 QW-1 — memory_export_reflection, file-backed
-            // reflection chain export) = 15.
-            Self::Power => 15,
+            // reflection chain export) +
+            // 2 (v0.7.0 QW-3 follow-up — memory_offload + memory_deref,
+            // context-offload substrate primitive surfaced at the
+            // semantic-tier+ Power family) = 17.
+            Self::Power => 17,
             Self::Archive => 4,
             // v0.7.0 L1-5 — 5 skill tools added to the Other family.
             // v0.7.0 L2-6 (issue #671) — memory_skill_promote_from_reflection
@@ -380,6 +390,12 @@ impl Family {
                 // companion. Renders the markdown / JSON envelope;
                 // does NOT write to disk (agent harness owns disk I/O).
                 "memory_export_reflection",
+                // v0.7.0 QW-3 follow-up — context-offload substrate
+                // primitive (offload + deref). Power-family registration
+                // gives semantic-tier+ exposure per the QW-3 brief; the
+                // handlers themselves live at src/mcp/tools/offload.rs.
+                "memory_offload",
+                "memory_deref",
             ],
             Self::Meta => &[
                 "memory_capabilities",
@@ -679,7 +695,7 @@ mod tests {
     fn family_expected_tool_counts_sum_to_51() {
         let total: usize = Family::all().iter().map(|f| f.expected_tool_count()).sum();
         assert_eq!(
-            total, 64,
+            total, 66,
             "v0.6.3.1 baseline (43) + v0.7.0 I4 `memory_replay` + v0.7 H4 \
              `memory_verify` + v0.7 B1 `memory_load_family` + v0.7 B2 \
              `memory_smart_load` + v0.7 K7 `memory_subscription_replay` \
@@ -691,7 +707,8 @@ mod tests {
              `memory_rule_list` + v0.7.0 L1-5 5×skill tools + \
              v0.7.0 L2-6 `memory_skill_promote_from_reflection` + \
              v0.7.0 L2-7 `memory_skill_compositional_context` + \
-             v0.7.0 QW-1 `memory_export_reflection` = 64. \
+             v0.7.0 QW-1 `memory_export_reflection` + \
+             v0.7.0 QW-3 follow-up `memory_offload` + `memory_deref` = 66. \
              If this drifts, update Family::expected_tool_count and the \
              family map docs together."
         );
@@ -776,7 +793,9 @@ mod tests {
         // v0.7.0 issue #691 — Power got memory_check_agent_action +
         // memory_rule_list (+2 → 14).
         // v0.7.0 QW-1 — Power got memory_export_reflection (+1 → 15).
-        assert_eq!(p.expected_tool_count(), 7 + 15);
+        // v0.7.0 QW-3 follow-up — Power got memory_offload + memory_deref
+        // (context-offload substrate primitive, +2 → 17).
+        assert_eq!(p.expected_tool_count(), 7 + 17);
     }
 
     #[test]
@@ -791,13 +810,14 @@ mod tests {
         // (L2-3) + memory_check_agent_action + memory_rule_list (#691) +
         // 5×memory_skill_* (L1-5) + memory_skill_promote_from_reflection
         // (L2-6, #671) + memory_skill_compositional_context (L2-7, #672) +
-        // memory_export_reflection (QW-1) = 64.
-        assert_eq!(p.expected_tool_count(), 64);
+        // memory_export_reflection (QW-1) +
+        // memory_offload + memory_deref (QW-3 follow-up, Family::Power) = 66.
+        assert_eq!(p.expected_tool_count(), 66);
 
-        // The K7+K8 + Task 4/8 + L2-2 + L2-3 + #691 + QW-1 additions live
-        // in Family::Power (operator/governance), so the `power` profile
-        // picks them up too.
-        assert_eq!(Profile::power().expected_tool_count(), 7 + 15);
+        // The K7+K8 + Task 4/8 + L2-2 + L2-3 + #691 + QW-1 + QW-3 follow-up
+        // additions live in Family::Power (operator/governance), so the
+        // `power` profile picks them up too.
+        assert_eq!(Profile::power().expected_tool_count(), 7 + 17);
     }
 
     // ---------- Profile::parse ----------
@@ -990,10 +1010,15 @@ mod tests {
             "memory_skill_promote_from_reflection",
             // v0.7.0 L2-7 (issue #672) — reflection-skill composition.
             "memory_skill_compositional_context",
+            // v0.7.0 QW-1 — file-backed reflection chain export (Family::Power).
+            "memory_export_reflection",
+            // v0.7.0 QW-3 follow-up — context-offload substrate (Family::Power).
+            "memory_offload",
+            "memory_deref",
         ];
         assert_eq!(
             baseline.len(),
-            59,
+            62,
             "baseline list = 43 (v0.6.3.1) + 1 (v0.7.0 I4 memory_replay) + \
              1 (v0.7 H4 memory_verify) + 1 (v0.7 B1 memory_load_family) + \
              1 (v0.7 B2 memory_smart_load) + \
@@ -1002,7 +1027,9 @@ mod tests {
              1 (v0.7.0 Task 4/8 memory_reflect) + \
              5 (v0.7.0 L1-5 skill tools) + \
              1 (v0.7.0 L2-6 memory_skill_promote_from_reflection) + \
-             1 (v0.7.0 L2-7 memory_skill_compositional_context) = 59"
+             1 (v0.7.0 L2-7 memory_skill_compositional_context) + \
+             1 (v0.7.0 QW-1 memory_export_reflection) + \
+             2 (v0.7.0 QW-3 follow-up memory_offload + memory_deref) = 62"
         );
         for name in baseline {
             assert!(

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -190,8 +190,8 @@ mod tests {
     fn table_has_51_entries_matching_tool_definitions_count() {
         let n = tool_sizes().len();
         assert_eq!(
-            n, 64,
-            "expected exactly 64 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
+            n, 66,
+            "expected exactly 66 tools (v0.6.3.1 baseline 43 + v0.7.0 I4 \
              `memory_replay` + v0.7 H4 `memory_verify` + v0.7 B1 \
              `memory_load_family` + v0.7 B2 `memory_smart_load` + v0.7 K7 \
              `memory_subscription_replay` + `memory_subscription_dlq_list` \
@@ -205,7 +205,8 @@ mod tests {
              `memory_skill_export` + v0.7.0 L2-6 \
              `memory_skill_promote_from_reflection` + v0.7.0 L2-7 \
              `memory_skill_compositional_context` + v0.7.0 QW-1 \
-             `memory_export_reflection`, source-anchored at \
+             `memory_export_reflection` + v0.7.0 QW-3 follow-up \
+             `memory_offload` + `memory_deref`, source-anchored at \
              src/mcp.rs::tool_definitions); got {n}. If the count changed, \
              update the family map and this assertion together."
         );
@@ -250,14 +251,19 @@ mod tests {
         // v0.7.0 L1-5 adds 5 skill tools with docs strings, bumping the
         // verbose total past 10K. Updated bound to 12K to accommodate the
         // new surface without invalidating the honest-range contract.
+        // v0.7.0 QW-1 + QW-3 follow-up add 3 more docs-bearing tools
+        // (`memory_export_reflection` + `memory_offload` + `memory_deref`),
+        // pushing the verbose source-of-truth total past 13K. Upper bound
+        // widened to 14K.
         assert!(
-            (5_000..=13_000).contains(&total),
+            (5_000..=14_000).contains(&total),
             "full-profile total {total} tokens is outside the measured \
-             cl100k_base range (5K–13K, source-of-truth incl. v0.7 C2 \
+             cl100k_base range (5K–14K, source-of-truth incl. v0.7 C2 \
              `docs` fields + v0.7.0 L2-2 memory_reflection_origin + \
-             v0.7.0 issue #691 2 rule tools + v0.7.0 L1-5 5 skill tools). \
-             If the schema grew, update the public claim in RFC/README/\
-             roadmap and adjust this bound."
+             v0.7.0 issue #691 2 rule tools + v0.7.0 L1-5 5 skill tools + \
+             v0.7.0 QW-1 memory_export_reflection + v0.7.0 QW-3 follow-up \
+             memory_offload + memory_deref). If the schema grew, update \
+             the public claim in RFC/README/roadmap and adjust this bound."
         );
     }
 

--- a/tests/atomisation/core.rs
+++ b/tests/atomisation/core.rs
@@ -643,6 +643,7 @@ fn test_atomiser_records_signed_events() {
 // surface (matching the brief's "use a mock curator" guidance).
 
 #[test]
+#[allow(clippy::items_after_statements)]
 fn test_atomiser_curator_malformed_json_retries() {
     let _g = test_serial()
         .lock()

--- a/tests/calibration_t0.rs
+++ b/tests/calibration_t0.rs
@@ -100,8 +100,11 @@ fn t0_describe_to_user_core_profile_canonical_phrasing() {
     // so the "more" count grows from 54 to 55.
     // v0.7.0 QW-1 — Family::Power gained `memory_export_reflection`
     // (not loaded under core), so the "more" count grows 55 → 56.
+    // v0.7.0 QW-3 follow-up — Family::Power gained `memory_offload` +
+    // `memory_deref` (not loaded under core), so the "more" count grows
+    // from 56 to 58.
     let expected = "I can directly use 7 memory tools right now \
-                    (store, recall, list, get, search, ...). 56 more \
+                    (store, recall, list, get, search, ...). 58 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";
@@ -154,12 +157,13 @@ fn t0_describe_to_user_full_profile_canonical_phrasing() {
     // v0.7.0 L2-6 (issue #671) — Family::Other gained
     // `memory_skill_promote_from_reflection` → 61 visible.
     // v0.7.0 L2-7 (issue #672) — Family::Other gained
-    // `memory_skill_compositional_context` → 62 visible (the "all 62"
-    // form excludes the always-on `memory_capabilities` bootstrap
-    // from the 63-tool total).
+    // `memory_skill_compositional_context` → 62 visible.
     // v0.7.0 QW-1 — Family::Power gained `memory_export_reflection`
-    // → 63 visible under full (out of the 64-tool total).
-    let expected = "I can directly use all 63 memory tools right now \
+    // → 63 visible under full.
+    // v0.7.0 QW-3 follow-up — Family::Power gained `memory_offload` +
+    // `memory_deref` → 65 visible (the "all 65" form excludes the
+    // always-on `memory_capabilities` bootstrap from the 66-tool total).
+    let expected = "I can directly use all 65 memory tools right now \
                     (store, recall, list, get, search, ...). Nothing more to load — \
                     the full memory surface is already active.";
 
@@ -213,8 +217,11 @@ fn t0_describe_to_user_graph_profile_canonical_phrasing() {
     // so the "more" count grows from 43 to 44.
     // v0.7.0 QW-1 — Family::Power gained `memory_export_reflection`
     // (not loaded under graph), so the "more" count grows 44 → 45.
+    // v0.7.0 QW-3 follow-up — Family::Power gained `memory_offload` +
+    // `memory_deref` (not loaded under graph), so the "more" count grows
+    // from 45 to 47.
     let expected = "I can directly use 18 memory tools right now \
-                    (store, recall, list, get, search, ...). 45 more \
+                    (store, recall, list, get, search, ...). 47 more \
                     (update, delete, forget, gc, etc.) are available on demand — \
                     I can load them if you ask for something that needs them, \
                     or you can restart the server with a different profile.";

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -179,19 +179,21 @@ fn cap_v3_summary_core_profile_counts_and_names_recovery_paths() {
     // bumped via v0.7.0 L1-5 5×memory_skill_* + v0.7.0 L2-7
     // memory_skill_compositional_context).
     assert!(
-        summary.starts_with("7 of 63 memory tools"),
-        "core profile summary should open with \"7 of 63 memory tools\" (Round-2 F13; \
+        summary.starts_with("7 of 65 memory tools"),
+        "core profile summary should open with \"7 of 65 memory tools\" (Round-2 F13; \
          v0.7.0 issue #691 added memory_check_agent_action + memory_rule_list, \
          v0.7.0 L1-5 added 5 memory_skill_* tools to Family::Other, v0.7.0 L2-3 \
          added memory_dependents_of_invalidated to Family::Power, v0.7.0 L2-6 \
-         added memory_skill_promote_from_reflection to Family::Other, and v0.7.0 \
-         L2-7 added memory_skill_compositional_context to Family::Other — bumping \
-         the substantive total from 52 to 62); got: {summary}"
+         added memory_skill_promote_from_reflection to Family::Other, v0.7.0 \
+         L2-7 added memory_skill_compositional_context to Family::Other, v0.7.0 \
+         QW-1 added memory_export_reflection to Family::Power, and v0.7.0 QW-3 \
+         follow-up added memory_offload + memory_deref to Family::Power — \
+         bumping the substantive total from 52 to 65); got: {summary}"
     );
     assert!(summary.contains("(core)"), "must label the profile as core");
     assert!(
-        summary.contains("56 are listed in this manifest"),
-        "core profile must report 56 unloaded (63 - 7); got: {summary}"
+        summary.contains("58 are listed in this manifest"),
+        "core profile must report 58 unloaded (65 - 7); got: {summary}"
     );
 
     // Three named recovery paths must all appear (verbatim names — these
@@ -228,13 +230,15 @@ fn cap_v3_summary_full_profile_reports_all_visible() {
     // 5 memory_skill_* tools to Family::Other, bumping the substantive
     // total from 51 to 56.
     assert!(
-        summary.starts_with("63 of 63 memory tools"),
-        "full profile summary should open with \"63 of 63 memory tools\" (Round-2 F13; \
+        summary.starts_with("65 of 65 memory tools"),
+        "full profile summary should open with \"65 of 65 memory tools\" (Round-2 F13; \
          v0.7.0 issue #691 added memory_check_agent_action + memory_rule_list, \
          v0.7.0 L1-5 added 5 memory_skill_* tools, v0.7.0 L2-3 added \
          memory_dependents_of_invalidated, v0.7.0 L2-6 added \
-         memory_skill_promote_from_reflection, and v0.7.0 L2-7 added \
-         memory_skill_compositional_context); got: {summary}"
+         memory_skill_promote_from_reflection, v0.7.0 L2-7 added \
+         memory_skill_compositional_context, v0.7.0 QW-1 added \
+         memory_export_reflection, and v0.7.0 QW-3 follow-up added \
+         memory_offload + memory_deref); got: {summary}"
     );
     assert!(summary.contains("(full)"));
     assert!(
@@ -261,17 +265,19 @@ fn cap_v3_summary_graph_profile_counts() {
     // memory tools. Total = 55 (56 - bootstrap; v0.7.0 L1-5 added 5
     // memory_skill_* tools to Family::Other, bumping total from 51 to 56).
     assert!(
-        summary.starts_with("18 of 63 memory tools"),
+        summary.starts_with("18 of 65 memory tools"),
         "graph profile = 7 core (v0.7 B1+B2) + 11 graph (v0.7 J7) = 18 memory tools \
          (Round-2 F13: bootstrap excluded; v0.7.0 issue #691 added two power tools, \
          v0.7.0 L1-5 added 5 memory_skill_* tools to Family::Other, v0.7.0 L2-3 \
          added memory_dependents_of_invalidated, v0.7.0 L2-6 added \
-         memory_skill_promote_from_reflection, and v0.7.0 L2-7 added \
-         memory_skill_compositional_context, bumping the substantive total from \
-         52 to 62); got: {summary}"
+         memory_skill_promote_from_reflection, v0.7.0 L2-7 added \
+         memory_skill_compositional_context, v0.7.0 QW-1 added \
+         memory_export_reflection, and v0.7.0 QW-3 follow-up added \
+         memory_offload + memory_deref to Family::Power, bumping the substantive \
+         total from 52 to 65); got: {summary}"
     );
     assert!(summary.contains("(graph)"));
-    assert!(summary.contains("45 are listed in this manifest"));
+    assert!(summary.contains("47 are listed in this manifest"));
 }
 
 // ---------------------------------------------------------------------------
@@ -371,13 +377,15 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
     // for honest user-facing counting. Total bumped to 56 in v0.7.0
     // L1-5 (Family::Other gained 5 memory_skill_* tools).
     assert!(
-        describe.contains("56 more"),
-        "core profile must report 56 unloaded (63 - 7); v0.7.0 issue #691 \
+        describe.contains("58 more"),
+        "core profile must report 58 unloaded (65 - 7); v0.7.0 issue #691 \
          added memory_check_agent_action + memory_rule_list, v0.7.0 L1-5 added \
          5 memory_skill_* tools, v0.7.0 L2-3 added \
          memory_dependents_of_invalidated, v0.7.0 L2-6 added \
-         memory_skill_promote_from_reflection, and v0.7.0 L2-7 added \
-         memory_skill_compositional_context, bumping the substantive total to 62; \
+         memory_skill_promote_from_reflection, v0.7.0 L2-7 added \
+         memory_skill_compositional_context, v0.7.0 QW-1 added \
+         memory_export_reflection, and v0.7.0 QW-3 follow-up added \
+         memory_offload + memory_deref, bumping the substantive total to 65; \
          got: {describe}"
     );
     // Sample of unloaded tools is plain (no memory_ prefix). The first
@@ -417,13 +425,15 @@ fn cap_v3_describe_core_profile_is_plain_english_with_loaded_names() {
 fn cap_v3_describe_full_profile_uses_nothing_more_form() {
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // 62 = 63 total - 1 always-on bootstrap excluded from describe.
+    // 65 = 66 total - 1 always-on bootstrap excluded from describe.
     // Bumped from 51 to 56 in v0.7.0 L1-5 (Family::Other gained
     // 5 memory_skill_* tools); to 60 with L2-3 (memory_dependents_of_invalidated);
     // to 61 with L2-6 (memory_skill_promote_from_reflection);
-    // to 62 with L2-7 (memory_skill_compositional_context).
+    // to 62 with L2-7 (memory_skill_compositional_context); to 63 with QW-1
+    // (memory_export_reflection, Family::Power); to 65 with QW-3 follow-up
+    // (memory_offload + memory_deref, Family::Power).
     assert!(
-        describe.starts_with("I can directly use all 63 memory tools right now ("),
+        describe.starts_with("I can directly use all 65 memory tools right now ("),
         "full profile describe must open with all-loaded form; got: {describe}"
     );
     assert!(describe.contains("Nothing more to load"));
@@ -446,9 +456,11 @@ fn cap_v3_describe_graph_profile_uses_preview_ellipsis() {
     );
     // Preview is the first 5 of the 18 loaded — the first 5 core tools.
     assert!(describe.contains("(store, recall, list, get, search, ...)"));
-    // 44 more = 62 substantive - 18 loaded (L2-3 + L2-6 + L2-7 each
-    // added one tool not loaded under graph, so 42 → 43 → 44).
-    assert!(describe.contains("45 more"));
+    // 47 more = 65 substantive - 18 loaded. L2-3 + L2-6 + L2-7 each
+    // added one tool not loaded under graph (42 → 43 → 44); QW-1 added
+    // memory_export_reflection to Family::Power (44 → 45); QW-3 follow-up
+    // added memory_offload + memory_deref to Family::Power (45 → 47).
+    assert!(describe.contains("47 more"));
 }
 
 // ---------------------------------------------------------------------------
@@ -632,8 +644,8 @@ fn cap_v3_response_carries_tools_array_with_51_entries() {
         .expect("top-level tools must be present and an array under v3");
     assert_eq!(
         tools.len(),
-        64,
-        "v3 must surface all 64 tools regardless of profile (v0.7.0 I4 added \
+        66,
+        "v3 must surface all 66 tools regardless of profile (v0.7.0 I4 added \
          memory_replay; v0.7 H4 added memory_verify; v0.7 B1 added \
          memory_load_family; v0.7 B2 added memory_smart_load; v0.7 K7 added \
          memory_subscription_replay + memory_subscription_dlq_list; v0.7 J7 \
@@ -644,7 +656,8 @@ fn cap_v3_response_carries_tools_array_with_51_entries() {
          v0.7.0 L1-5 added 5 memory_skill_* tools; v0.7.0 L2-6 added \
          memory_skill_promote_from_reflection; v0.7.0 L2-7 added \
          memory_skill_compositional_context; v0.7.0 QW-1 added \
-         memory_export_reflection); got {}",
+         memory_export_reflection; v0.7.0 QW-3 follow-up added \
+         memory_offload + memory_deref); got {}",
         tools.len()
     );
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1873,8 +1873,8 @@ fn test_mcp_tools_list() {
         .expect("tools should be array");
     assert_eq!(
         tools.len(),
-        64,
-        "expected 64 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5 memory_skill_* tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection)"
+        66,
+        "expected 66 MCP tools (v0.6.3 baseline 43 + v0.7.0 I4 memory_replay + v0.7 H4 memory_verify + v0.7 B1 memory_load_family + v0.7 B2 memory_smart_load + v0.7 K7 memory_subscription_replay + memory_subscription_dlq_list + v0.7 J7 memory_find_paths + v0.7 K8 memory_quota_status + v0.7.0 Task 4/8 memory_reflect + v0.7.0 L2-2 memory_reflection_origin + v0.7.0 L2-3 memory_dependents_of_invalidated + v0.7.0 issue #691 memory_check_agent_action + memory_rule_list + v0.7.0 L1-5 5 memory_skill_* tools + v0.7.0 L2-6 memory_skill_promote_from_reflection + v0.7.0 L2-7 memory_skill_compositional_context + v0.7.0 QW-1 memory_export_reflection + v0.7.0 QW-3 follow-up memory_offload + memory_deref)"
     );
 
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();

--- a/tests/k8_quota_status_tool.rs
+++ b/tests/k8_quota_status_tool.rs
@@ -59,14 +59,15 @@ fn k8_quota_status_loaded_under_full_profile() {
     );
     assert_eq!(
         Profile::full().expected_tool_count(),
-        64,
-        "tool count cascade must advance to 64 with v0.7.0 QW-1 \
-         memory_export_reflection on top of L2-3 \
+        66,
+        "tool count cascade must advance to 66 with v0.7.0 L2-3 \
          memory_dependents_of_invalidated, v0.7.0 L2-6 \
-         memory_skill_promote_from_reflection, and v0.7.0 L2-7 \
+         memory_skill_promote_from_reflection, v0.7.0 L2-7 \
          memory_skill_compositional_context on top of v0.7.0 issue #691 \
-         memory_check_agent_action + memory_rule_list (post-L2-2) and \
-         v0.7.0 L1-5 5 memory_skill_* tools"
+         memory_check_agent_action + memory_rule_list (post-L2-2), \
+         v0.7.0 L1-5 5 memory_skill_* tools, v0.7.0 QW-1 \
+         memory_export_reflection, and v0.7.0 QW-3 follow-up \
+         memory_offload + memory_deref"
     );
 }
 

--- a/tests/offload.rs
+++ b/tests/offload.rs
@@ -10,3 +10,9 @@
 
 #[path = "offload/acceptance.rs"]
 mod acceptance;
+// v0.7.0 QW-3 follow-up — MCP-tool registration cascade. The substrate
+// behaviour lives in `acceptance.rs`; the Family-mapping +
+// per-profile loads() + pair-together invariants live here so a
+// future profile-count regression cannot mask one half of the pair.
+#[path = "offload/registration.rs"]
+mod registration;

--- a/tests/offload/acceptance.rs
+++ b/tests/offload/acceptance.rs
@@ -89,8 +89,7 @@ fn test_offload_signature_verification_on_deref() {
 
     let err = off
         .deref(&r.ref_id)
-        .err()
-        .expect("deref must refuse tampered blob");
+        .expect_err("deref must refuse tampered blob");
     let downcast = err
         .downcast_ref::<OffloadError>()
         .expect("substrate domain error");
@@ -119,8 +118,7 @@ fn test_offload_size_limit_enforced() {
     let oversize = "y".repeat(128);
     let err = off
         .offload(&oversize, "tenant-a", None, "ai:alice")
-        .err()
-        .expect("oversize must refuse");
+        .expect_err("oversize must refuse");
     let downcast = err.downcast_ref::<OffloadError>().expect("OffloadError");
     assert!(matches!(
         downcast,

--- a/tests/offload/registration.rs
+++ b/tests/offload/registration.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 QW-3 follow-up — MCP-tool registration tests for the
+//! context-offload substrate primitive.
+//!
+//! The QW-3 substrate (PR #741) merged with `handle_offload` /
+//! `handle_deref` ready but NOT registered in
+//! `tool_definitions_for_profile`. This follow-up wires both tools
+//! into the `Family::Power` registration so `--profile power` (and
+//! `--profile full`) surface them via `tools/list`, while the
+//! keyword-tier `--profile core` minimum stays at its 7-tool surface.
+//!
+//! The substrate-level behaviour (round-trip, tampered-row refusal,
+//! size limit) is pinned by `tests/offload/acceptance.rs`. This file
+//! pins ONLY the registration cascade — Family mapping, per-profile
+//! `loads(name)` truth table, and the pair-appears-together
+//! invariant that future profile-count regressions would otherwise
+//! mask.
+
+use ai_memory::profile::{Family, Profile};
+
+// ---------------------------------------------------------------------------
+// 1. memory_offload registered at the semantic-tier+ Power family —
+//    visible under `--profile power` and `--profile full` but NOT under
+//    the keyword-tier `--profile core` minimum.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_memory_offload_registered_at_semantic_tier() {
+    assert_eq!(
+        Family::for_tool("memory_offload"),
+        Some(Family::Power),
+        "memory_offload must live in Family::Power (semantic-tier+ surface)"
+    );
+
+    // Power + full + admin-with-power custom profiles load it.
+    assert!(
+        Profile::power().loads("memory_offload"),
+        "--profile power must surface memory_offload"
+    );
+    assert!(
+        Profile::full().loads("memory_offload"),
+        "--profile full must surface memory_offload"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Keyword-tier `core` profile does NOT surface memory_offload — the
+//    7-tool keyword-tier minimum stays at its original surface so an
+//    eager-loading harness that picks `--profile core` to minimise
+//    schema tokens still pays the same prefix cost it paid pre-QW-3.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_memory_offload_absent_at_keyword_tier() {
+    let core = Profile::core();
+    assert!(
+        !core.loads("memory_offload"),
+        "--profile core must NOT surface memory_offload (QW-3 brief: \
+         semantic-tier+ exposure only)"
+    );
+    assert!(
+        !core.loads("memory_deref"),
+        "--profile core must NOT surface memory_deref (paired with offload)"
+    );
+
+    // Graph / admin profiles (also keyword-tier-style minimums without
+    // the power family) likewise omit the pair.
+    let graph = Profile::graph();
+    assert!(!graph.loads("memory_offload"));
+    assert!(!graph.loads("memory_deref"));
+    let admin = Profile::admin();
+    assert!(!admin.loads("memory_offload"));
+    assert!(!admin.loads("memory_deref"));
+}
+
+// ---------------------------------------------------------------------------
+// 3. The offload + deref pair is registered together — never one without
+//    the other. A regression that registered just one half would leave
+//    callers with a substrate primitive they cannot round-trip
+//    (`offload` returns a `ref_id` whose only consumer is `deref`, and
+//    vice versa).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_memory_deref_pair_registered() {
+    // Both tools resolve to the same family.
+    assert_eq!(Family::for_tool("memory_offload"), Some(Family::Power));
+    assert_eq!(Family::for_tool("memory_deref"), Some(Family::Power));
+
+    // Across every profile that loads one, the other loads too.
+    for profile in &[
+        Profile::core(),
+        Profile::graph(),
+        Profile::admin(),
+        Profile::power(),
+        Profile::full(),
+    ] {
+        let offload = profile.loads("memory_offload");
+        let deref = profile.loads("memory_deref");
+        assert_eq!(
+            offload, deref,
+            "profile={profile:?}: memory_offload and memory_deref must be \
+             registered together (loads(offload)={offload}, loads(deref)={deref})"
+        );
+    }
+
+    // Both must appear in the Power family's canonical tool_names list
+    // so the family map + family preview surfaces stay aligned.
+    let power_names = Family::Power.tool_names();
+    assert!(
+        power_names.contains(&"memory_offload"),
+        "Family::Power.tool_names() must contain memory_offload; got: {power_names:?}"
+    );
+    assert!(
+        power_names.contains(&"memory_deref"),
+        "Family::Power.tool_names() must contain memory_deref; got: {power_names:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. (Bonus, complements the three required tests above.) The pair's
+//    expected_tool_count contribution to Family::Power matches the
+//    advertised family size. Catches a half-baked cherry-pick that adds
+//    the names to `for_tool` / `tool_names` but forgets to bump the
+//    `expected_tool_count` counter (or vice versa) — exactly the
+//    failure mode the family_tool_names_match_expected_count unit test
+//    in src/profile.rs pins per-family. Mirrored here at the
+//    integration boundary so a future profile-count audit can run
+//    against the integration crate alone.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_offload_pair_in_family_power_expected_count() {
+    let power_names = Family::Power.tool_names();
+    assert_eq!(
+        power_names.len(),
+        Family::Power.expected_tool_count(),
+        "Family::Power tool_names length must match expected_tool_count; \
+         got names.len()={n}, expected_tool_count()={c}",
+        n = power_names.len(),
+        c = Family::Power.expected_tool_count()
+    );
+}

--- a/tests/round2_f13_capabilities.rs
+++ b/tests/round2_f13_capabilities.rs
@@ -77,21 +77,23 @@ fn f13_summary_and_describe_to_user_agree_on_count_full_profile() {
     let summary = build_capabilities_summary(&Profile::full());
     let describe = build_capabilities_describe_to_user(&Profile::full());
 
-    // Both must report "62" for the full profile (substantive memory
+    // Both must report "65" for the full profile (substantive memory
     // tools, excluding the always-on `memory_capabilities` bootstrap).
     // v0.7.0 issue #691 added memory_check_agent_action + memory_rule_list,
     // v0.7.0 L1-5 added 5 memory_skill_* tools, v0.7.0 L2-3 added
     // memory_dependents_of_invalidated to Family::Power, v0.7.0 L2-6 added
-    // memory_skill_promote_from_reflection, and v0.7.0 L2-7 added
-    // memory_skill_compositional_context — bumping the substantive total
-    // from 52 to 62.
+    // memory_skill_promote_from_reflection, v0.7.0 L2-7 added
+    // memory_skill_compositional_context, v0.7.0 QW-1 added
+    // memory_export_reflection, and v0.7.0 QW-3 follow-up added
+    // memory_offload + memory_deref to Family::Power — bumping the
+    // substantive total from 52 to 65.
     assert!(
-        summary.contains("63 of 63 memory tools"),
-        "summary must report 63 of 63 memory tools; got: {summary}"
+        summary.contains("65 of 65 memory tools"),
+        "summary must report 65 of 65 memory tools; got: {summary}"
     );
     assert!(
-        describe.contains("all 63 memory tools"),
-        "describe_to_user must report all 63 memory tools; got: {describe}"
+        describe.contains("all 65 memory tools"),
+        "describe_to_user must report all 65 memory tools; got: {describe}"
     );
 }
 
@@ -101,16 +103,18 @@ fn f13_summary_and_describe_to_user_agree_on_count_core_profile() {
     let describe = build_capabilities_describe_to_user(&Profile::core());
 
     // Core profile loads `Family::Core` (7 tools). Bootstrap excluded.
-    // Total memory tools = 62 (63 - bootstrap). v0.7.0 issue #691 added
+    // Total memory tools = 65 (66 - bootstrap). v0.7.0 issue #691 added
     // memory_check_agent_action + memory_rule_list, v0.7.0 L1-5 added
     // 5 memory_skill_* tools, v0.7.0 L2-3 added
     // memory_dependents_of_invalidated, v0.7.0 L2-6 added
-    // memory_skill_promote_from_reflection, and v0.7.0 L2-7 added
-    // memory_skill_compositional_context — bumping the substantive
-    // total from 52 to 62.
+    // memory_skill_promote_from_reflection, v0.7.0 L2-7 added
+    // memory_skill_compositional_context, v0.7.0 QW-1 added
+    // memory_export_reflection, and v0.7.0 QW-3 follow-up added
+    // memory_offload + memory_deref to Family::Power — bumping the
+    // substantive total from 52 to 65.
     assert!(
-        summary.contains("7 of 63 memory tools"),
-        "summary must report 7 of 63 memory tools; got: {summary}"
+        summary.contains("7 of 65 memory tools"),
+        "summary must report 7 of 65 memory tools; got: {summary}"
     );
     assert!(
         describe.contains("7 memory tools"),


### PR DESCRIPTION
## Summary

- QW-3 substrate (PR #741) merged with handlers ready but **not** registered in `tool_definitions_for_profile`. This completes the registration per operator directive "no v0.8.0 deferral".
- Both `memory_offload` and `memory_deref` map to `Family::Power` (semantic-tier+ surface — visible at `--profile power` and `--profile full`, never at the keyword-tier `core/graph/admin/archive` minimums).
- Power family count cascades 15 → 17; full profile count cascades 64 → 66. Every profile-count assertion across the test fleet is updated in lockstep.

## What lands

- `src/profile.rs` — both names join `Family::Power`'s `for_tool` map, `tool_names` slice, and `expected_tool_count`. Counts updated; baseline list in the family-map regression test extended by 3 entries (the QW-1 `memory_export_reflection` was also missing from that list, so it's added too).
- `src/mcp/registry.rs` — JSON schema definitions for both tools following the neighbouring `memory_consolidate` shape (input schema, short description, long-form `docs`).
- `src/mcp/mod.rs` — `#[path = "tools/offload.rs"] mod offload;` + dispatch arms. `memory_offload` resolves `agent_id` through the same NHI precedence chain (`explicit > metadata > mcp_client > host fallback`) `memory_store` / `memory_reflect` use, so the substrate row's attribution is consistent. `memory_deref` is a thin pass-through.
- `src/mcp/tools/offload.rs` — two mechanical rustfmt fixes that shipped red with the QW-3 merge.
- 9 test files: per-profile count assertions bumped (+2 for each loaded profile, total stays at +2 across the substantive count).

## New tests (4)

`tests/offload/registration.rs`, registered via `tests/offload.rs`:

- `test_memory_offload_registered_at_semantic_tier` — Family::Power mapping; loads under power + full.
- `test_memory_offload_absent_at_keyword_tier` — does NOT load under core / graph / admin.
- `test_memory_deref_pair_registered` — offload + deref appear together in every profile's loads() map and both list in `Family::Power.tool_names()`.
- `test_offload_pair_in_family_power_expected_count` — bonus check pinning the family_tool_names_match_expected_count invariant at the integration boundary.

## Out-of-scope cleanups (necessary for the four-gate matrix)

- `tests/offload/acceptance.rs` — `.err().expect(_)` → `.expect_err(_)` (two sites, pre-existing clippy `err_expect` lint).
- `tests/atomisation/core.rs` — `#[allow(clippy::items_after_statements)]` on `test_atomiser_curator_malformed_json_retries` (the WT-1-B `RetryMock` struct is declared inside the test fn after stmt; newer clippy version landed with WT-1-B surfaces it as -D pedantic error).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo test --features sal,sal-postgres` — 4031 lib tests pass + every targeted integration binary green (`offload`, `capabilities_v3`, `round2_f13_capabilities`, `calibration_t0`, `k8_quota_status_tool`, `integration` w/ `--test-threads=1`, `atomisation`, `boot_lifecycle`). Two pre-existing test-binary flakes (`boot_lifecycle`, certain `integration::http_*`) race when run in parallel with sibling binaries sharing the `ai-memory` test bin; both pass when run alone or with `--test-threads=1`. Pre-existing infrastructure flakiness, not introduced by this PR.
- [x] `cargo audit` — 530 crates scanned, 0 vulnerabilities.
- [x] End-to-end MCP `tools/list` returns 66 tools including `memory_offload` + `memory_deref` (pinned by `integration::test_mcp_tools_list`).

## AI involvement

Authored by Claude Opus 4.7 (1M context) under operator-driving session. Brief delivered by operator ("QW-3 follow-up — register `memory_offload` + `memory_deref` MCP tools in the profile registry"). Mechanical fanout + 4 gates green; PR opens against `wt-1-integration` per operator instruction "Don't merge".

🤖 Generated with [Claude Code](https://claude.com/claude-code)