### PR TITLE
feat(v0.7.0 WT-1-E): recall atom-preference + forensic atomisation chain

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -225,6 +225,7 @@ fn run_search_fts(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
             None,
             None,
             None,
+            false,
         )?;
         let elapsed = start.elapsed();
         if i >= config.warmup {
@@ -250,6 +251,7 @@ fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
             0,
             None,
             None,
+            false,
         )?;
     }
     let mut samples = Vec::with_capacity(config.iterations);
@@ -268,6 +270,7 @@ fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
             0,
             None,
             None,
+            false,
         )?;
         samples.push(start.elapsed());
     }

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -60,6 +60,12 @@ pub struct RecallArgs {
     /// defaults. Default `false` preserves v0.6.x recall semantics.
     #[arg(long)]
     pub session_default: bool,
+    /// v0.7.0 WT-1-E — when set, recall returns archived sources
+    /// (those replaced by their atoms after WT-1-B atomisation)
+    /// alongside the atoms. Default `false` surfaces atoms only,
+    /// which is the canonical post-atomisation recall unit.
+    #[arg(long)]
+    pub include_archived: bool,
 }
 
 /// `recall` handler. Mirrors `cmd_recall` from the pre-W5b `main.rs`
@@ -268,6 +274,7 @@ pub(crate) fn run_with_embedder(
                     args.as_agent.as_deref(),
                     args.budget_tokens,
                     &resolved_scoring,
+                    args.include_archived,
                 )?;
                 if let Some(ref ce) = reranker {
                     (ce.rerank(&args.context, results), outcome, "hybrid+rerank")
@@ -292,6 +299,7 @@ pub(crate) fn run_with_embedder(
                     resolved_ttl.mid_extend_secs,
                     args.as_agent.as_deref(),
                     args.budget_tokens,
+                    args.include_archived,
                 )?;
                 (results, outcome, "keyword")
             }
@@ -309,6 +317,7 @@ pub(crate) fn run_with_embedder(
             resolved_ttl.mid_extend_secs,
             args.as_agent.as_deref(),
             args.budget_tokens,
+            args.include_archived,
         )?;
         (results, outcome, "keyword")
     };
@@ -403,6 +412,7 @@ mod tests {
             budget_tokens: None,
             context_tokens: None,
             session_default: false,
+            include_archived: false,
         }
     }
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -36,6 +36,11 @@ pub struct SearchArgs {
     /// visibility filtering.
     #[arg(long)]
     pub as_agent: Option<String>,
+    /// v0.7.0 WT-1-E — when set, search returns archived sources
+    /// alongside their atoms. Default `false` excludes sources whose
+    /// atoms surface in their place (atom-preference search).
+    #[arg(long)]
+    pub include_archived: bool,
 }
 
 /// `search` handler. Mirrors `cmd_search` from `main.rs` verbatim except
@@ -69,6 +74,7 @@ pub fn run(
         args.tags.as_deref(),
         args.agent_id.as_deref(),
         args.as_agent.as_deref(),
+        args.include_archived,
     )?;
     if json_out {
         writeln!(
@@ -117,6 +123,7 @@ mod tests {
             tags: None,
             agent_id: None,
             as_agent: None,
+            include_archived: false,
         }
     }
 

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -90,7 +90,9 @@ pub fn handle_command(parts: &[&str], conn: &Connection, out: &mut CliOutput<'_>
                 let _ = writeln!(out.stderr, "usage: search <query>");
                 return ShellAction::Continue;
             }
-            match db::search(conn, &q, None, None, 20, None, None, None, None, None, None, false) {
+            match db::search(
+                conn, &q, None, None, 20, None, None, None, None, None, None, false,
+            ) {
                 Ok(results) => {
                     for mem in &results {
                         let _ = writeln!(

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -62,6 +62,7 @@ pub fn handle_command(parts: &[&str], conn: &Connection, out: &mut CliOutput<'_>
                 models::MID_TTL_EXTEND_SECS,
                 None,
                 None,
+                false,
             ) {
                 Ok((results, _outcome)) => {
                     for (mem, score) in &results {
@@ -89,7 +90,7 @@ pub fn handle_command(parts: &[&str], conn: &Connection, out: &mut CliOutput<'_>
                 let _ = writeln!(out.stderr, "usage: search <query>");
                 return ShellAction::Continue;
             }
-            match db::search(conn, &q, None, None, 20, None, None, None, None, None, None) {
+            match db::search(conn, &q, None, None, 20, None, None, None, None, None, None, false) {
                 Ok(results) => {
                     for mem in &results {
                         let _ = writeln!(

--- a/src/forensic/bundle.rs
+++ b/src/forensic/bundle.rs
@@ -432,8 +432,20 @@ pub fn build_files(
     // 3) Edge envelopes — every reflects_on / supersedes / derived_from
     //    edge whose source is in `chain_ids`. WT-1-E folds in
     //    `derives_from` (atom → parent) alongside the existing
-    //    relations — see [`fetch_edges_for`].
-    let edges = fetch_edges_for(conn, &chain_ids)?;
+    //    relations — see [`fetch_edges_for`]. When the
+    //    `include_atomisation_chain` flag is unset, drop
+    //    `derives_from` edges from the output so the auditor
+    //    sees only the atom rows (the historical record stays
+    //    in the substrate; the bundle just doesn't carry it).
+    let edges_raw = fetch_edges_for(conn, &chain_ids)?;
+    let edges: Vec<_> = if args.include_atomisation_chain {
+        edges_raw
+    } else {
+        edges_raw
+            .into_iter()
+            .filter(|e| e.relation != "derives_from")
+            .collect()
+    };
     for edge in &edges {
         let bytes = serde_json::to_vec_pretty(edge).context("serialise EdgeEnvelope")?;
         // Lexicographic path so determinism survives row-order shuffling.
@@ -777,12 +789,7 @@ fn build_atomisation_envelope(
         .query_row(
             "SELECT atomised_into, atom_of FROM memories WHERE id = ?1",
             params![mem.id],
-            |r| {
-                Ok((
-                    r.get::<_, Option<i64>>(0)?,
-                    r.get::<_, Option<String>>(1)?,
-                ))
-            },
+            |r| Ok((r.get::<_, Option<i64>>(0)?, r.get::<_, Option<String>>(1)?)),
         )
         .unwrap_or((None, None));
 
@@ -843,16 +850,24 @@ fn fetch_atomisation_signed_events_for(
     // derives_from edges. The atomisation_complete event's
     // `agent_id` matches the same `calling_agent_id` used by the
     // per-atom create_link_signed call.
-    let placeholders: String = chain_ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!("?{}", i + 1))
+    //
+    // Two disjoint placeholder ranges so the source_id and
+    // target_id INs each get their own bound slot — using the same
+    // placeholder name twice in rusqlite collapses the second bind,
+    // which leaves the OR branch unbound and rusqlite errors with
+    // "Wrong number of parameters."
+    let src_placeholders: String = (1..=chain_ids.len())
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let tgt_placeholders: String = (chain_ids.len() + 1..=chain_ids.len() * 2)
+        .map(|i| format!("?{i}"))
         .collect::<Vec<_>>()
         .join(", ");
     let agent_sql = format!(
         "SELECT DISTINCT observed_by FROM memory_links \
          WHERE relation = 'derives_from' \
-           AND (source_id IN ({placeholders}) OR target_id IN ({placeholders})) \
+           AND (source_id IN ({src_placeholders}) OR target_id IN ({tgt_placeholders})) \
            AND observed_by IS NOT NULL"
     );
     let mut agent_stmt = conn.prepare(&agent_sql)?;

--- a/src/forensic/bundle.rs
+++ b/src/forensic/bundle.rs
@@ -102,6 +102,17 @@ pub struct ExportForensicBundleArgs {
     /// directory.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
+
+    /// v0.7.0 WT-1-E — when true (default), include the full
+    /// atomisation chain whenever the target memory is an archived
+    /// source or an atom: the source row, every atom (atom_of =
+    /// source_id), every `derives_from` edge, and the
+    /// `atomisation_complete` signed event. When false the bundle
+    /// emits only the atoms (the source chain is skipped), useful
+    /// when an auditor only needs the canonical post-atomisation
+    /// surface and not the historical record.
+    #[arg(long, default_value_t = true)]
+    pub include_atomisation_chain: bool,
 }
 
 /// Arguments for `ai-memory verify-forensic-bundle <path>`.
@@ -187,6 +198,43 @@ pub struct MemoryEnvelope {
     pub created_at: String,
     pub updated_at: String,
     pub metadata: serde_json::Value,
+    /// v0.7.0 WT-1-E — atomisation-chain enrichment. Present only
+    /// when this memory is involved in atomisation (either an
+    /// archived source with `atomised_into > 0` or an atom with
+    /// `atom_of` set). Provides the full chain locally to the
+    /// auditor without forcing them to cross-reference between
+    /// envelopes. Skipped (None) on rows untouched by atomisation
+    /// and on every bundle built with
+    /// `--include-atomisation-chain=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atomisation: Option<AtomisationEnvelope>,
+}
+
+/// v0.7.0 WT-1-E — per-memory atomisation enrichment block. Carries
+/// the substrate-visible signals (`atomised_into`, `archived_at`,
+/// `atom_ids`, `atom_of`) directly so an auditor can reconstruct the
+/// chain from a single envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AtomisationEnvelope {
+    /// Count of atoms emitted from this source (mirror of
+    /// `memories.atomised_into`). `None` on atom rows and on rows
+    /// untouched by atomisation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atomised_into: Option<i64>,
+    /// RFC3339 stamp from `metadata.atomisation_archived_at`,
+    /// populated by the WT-1-B `archive_source` step. `None` on
+    /// rows untouched by atomisation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    /// Ordered list of atom ids whose `atom_of` points back at this
+    /// source. Empty on atom rows and on rows untouched by
+    /// atomisation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub atom_ids: Vec<String>,
+    /// Parent source id when this memory is an atom. `None` on
+    /// archived-source rows and on rows untouched by atomisation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atom_of: Option<String>,
 }
 
 /// One signed link inside the bundle. Carries the canonical
@@ -284,18 +332,85 @@ pub fn build_files(
 
     // 1) Walk the reflects_on graph backward from memory_id to assemble
     //    the set of in-scope memory ids.
-    let chain_ids = walk_reflection_chain(conn, &args.memory_id)?;
+    let mut chain_ids = walk_reflection_chain(conn, &args.memory_id)?;
+
+    // v0.7.0 WT-1-E — atomisation-chain expansion. When the target
+    // memory (or any ancestor) is an archived source, fold its atoms
+    // in. When the target is itself an atom, fold its parent source
+    // in. Both directions are needed so an auditor sees the full
+    // chain regardless of which "end" of it they queried by id.
+    // The expansion is purely additive — reflections + atomisation
+    // can coexist on the same memory.
+    if args.include_atomisation_chain {
+        let mut expanded = chain_ids.clone();
+        for mid in &chain_ids {
+            // Source → atoms (when this id is an archived source)
+            for atom_id in atom_ids_of_source(conn, mid)? {
+                if !expanded.contains(&atom_id) {
+                    expanded.push(atom_id);
+                }
+            }
+            // Atom → source (when this id is an atom)
+            if let Some(parent_id) = atom_of_for(conn, mid)? {
+                if !expanded.contains(&parent_id) {
+                    expanded.push(parent_id.clone());
+                    // Recursively pick up sibling atoms of that
+                    // parent so the auditor sees the whole sibling
+                    // cohort, not just the one atom that was the
+                    // entry point.
+                    for atom_id in atom_ids_of_source(conn, &parent_id)? {
+                        if !expanded.contains(&atom_id) {
+                            expanded.push(atom_id);
+                        }
+                    }
+                }
+            }
+        }
+        expanded.sort();
+        chain_ids = expanded;
+    }
 
     let mut files: BundleFiles = BTreeMap::new();
 
     // 2) Memory envelopes (target + ancestors when --include-reflections).
+    //    The atomisation expansion above is preserved verbatim when
+    //    --include-reflections=true; when --include-reflections=false
+    //    the original reflects_on logic emits only the target row,
+    //    but the atomisation enrichment is still attached to it.
     let memory_ids_to_emit: Vec<String> = if args.include_reflections {
         chain_ids.clone()
+    } else if args.include_atomisation_chain {
+        // Even without --include-reflections, emit the target's
+        // atomisation cohort (source + sibling atoms) so the bundle
+        // is self-contained for the substrate-visible chain.
+        let mut ids = vec![args.memory_id.clone()];
+        for atom_id in atom_ids_of_source(conn, &args.memory_id)? {
+            if !ids.contains(&atom_id) {
+                ids.push(atom_id);
+            }
+        }
+        if let Some(parent) = atom_of_for(conn, &args.memory_id)? {
+            if !ids.contains(&parent) {
+                ids.push(parent.clone());
+            }
+            for atom_id in atom_ids_of_source(conn, &parent)? {
+                if !ids.contains(&atom_id) {
+                    ids.push(atom_id);
+                }
+            }
+        }
+        ids.sort();
+        ids
     } else {
         vec![args.memory_id.clone()]
     };
     for mid in &memory_ids_to_emit {
         if let Some(mem) = crate::db::get(conn, mid).context("db::get for bundle")? {
+            let atomisation = if args.include_atomisation_chain {
+                build_atomisation_envelope(conn, &mem)?
+            } else {
+                None
+            };
             let env = MemoryEnvelope {
                 id: mem.id.clone(),
                 namespace: mem.namespace.clone(),
@@ -307,6 +422,7 @@ pub fn build_files(
                 created_at: mem.created_at.clone(),
                 updated_at: mem.updated_at.clone(),
                 metadata: mem.metadata.clone(),
+                atomisation,
             };
             let bytes = serde_json::to_vec_pretty(&env).context("serialise MemoryEnvelope")?;
             files.insert(format!("memories/{}.json", mem.id), bytes);
@@ -314,7 +430,9 @@ pub fn build_files(
     }
 
     // 3) Edge envelopes — every reflects_on / supersedes / derived_from
-    //    edge whose source is in `chain_ids`.
+    //    edge whose source is in `chain_ids`. WT-1-E folds in
+    //    `derives_from` (atom → parent) alongside the existing
+    //    relations — see [`fetch_edges_for`].
     let edges = fetch_edges_for(conn, &chain_ids)?;
     for edge in &edges {
         let bytes = serde_json::to_vec_pretty(edge).context("serialise EdgeEnvelope")?;
@@ -331,10 +449,40 @@ pub fn build_files(
     // 4) signed_events slice — every audit row whose agent_id matches
     //    a memory in the chain (the H5 convention is to use agent_id =
     //    actor's id; the memory_id is embedded in the payload).
+    let mut event_ids_emitted: std::collections::HashSet<String> = std::collections::HashSet::new();
     let events = fetch_signed_events_for(conn, &chain_ids)?;
     for ev in &events {
         let bytes = serde_json::to_vec_pretty(ev).context("serialise SignedEventEnvelope")?;
         files.insert(format!("signed_events/{}.json", ev.id), bytes);
+        event_ids_emitted.insert(ev.id.clone());
+    }
+
+    // v0.7.0 WT-1-E — atomisation-chain signed_events. Two event
+    // shapes need to land in the bundle even when their agent_id is
+    // not itself a memory id in the chain:
+    //
+    //   * `atomisation_complete` — the summary event the WT-1-B
+    //     atomiser emits per source. Its `agent_id` is the calling
+    //     agent's id (e.g. `ai:claude@host:pid-…`), not a memory
+    //     id, so the H5-agent-id-match query above misses it.
+    //   * `memory_link.created` for each `derives_from` atom→parent
+    //     edge. Again the agent_id is the writer, not the memory.
+    //
+    // We fetch these explicitly by joining the memory_links table
+    // (for the per-atom edge events) and by event_type +
+    // payload_hash cross-reference (for the summary event). Both
+    // sets are unioned with the existing agent-id-matched events,
+    // de-duped, then emitted under the same path scheme.
+    if args.include_atomisation_chain {
+        let extra = fetch_atomisation_signed_events_for(conn, &chain_ids)?;
+        for ev in &extra {
+            if event_ids_emitted.contains(&ev.id) {
+                continue;
+            }
+            let bytes = serde_json::to_vec_pretty(ev).context("serialise SignedEventEnvelope")?;
+            files.insert(format!("signed_events/{}.json", ev.id), bytes);
+            event_ids_emitted.insert(ev.id.clone());
+        }
     }
 
     // 5) Transcript union (per L2-4) when --include-transcripts.
@@ -551,7 +699,7 @@ fn fetch_edges_for(conn: &Connection, chain_ids: &[String]) -> Result<Vec<EdgeEn
                 valid_from, valid_until, signature, attest_level \
          FROM memory_links \
          WHERE source_id IN ({placeholders}) \
-           AND relation IN ('reflects_on', 'supersedes', 'derived_from') \
+           AND relation IN ('reflects_on', 'supersedes', 'derived_from', 'derives_from') \
          ORDER BY source_id, relation, target_id"
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -578,6 +726,223 @@ fn fetch_edges_for(conn: &Connection, chain_ids: &[String]) -> Result<Vec<EdgeEn
         out.push(r?);
     }
     Ok(out)
+}
+
+/// v0.7.0 WT-1-E — return the atom ids whose `atom_of` column FK
+/// points back to `source_id`. Empty when `source_id` is not an
+/// archived source. Ordering matches the WT-1-B emission order
+/// (created_at ASC, id ASC).
+fn atom_ids_of_source(conn: &Connection, source_id: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT id FROM memories \
+         WHERE atom_of = ?1 \
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    let rows = stmt.query_map(params![source_id], |r| r.get::<_, String>(0))?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// v0.7.0 WT-1-E — return the parent source id when `id` is an atom
+/// (i.e. `memories.atom_of` is set). `None` for non-atom rows or
+/// when the id is unknown.
+fn atom_of_for(conn: &Connection, id: &str) -> Result<Option<String>> {
+    let res: rusqlite::Result<Option<String>> = conn.query_row(
+        "SELECT atom_of FROM memories WHERE id = ?1",
+        params![id],
+        |r| r.get::<_, Option<String>>(0),
+    );
+    match res {
+        Ok(v) => Ok(v),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// v0.7.0 WT-1-E — build the `AtomisationEnvelope` enrichment block
+/// for `mem`. Returns `None` when the memory is untouched by
+/// atomisation (neither an archived source nor an atom), so the
+/// outer envelope's `Option<AtomisationEnvelope>` field round-trips
+/// `serde(skip_serializing_if = "Option::is_none")` cleanly.
+fn build_atomisation_envelope(
+    conn: &Connection,
+    mem: &crate::models::Memory,
+) -> Result<Option<AtomisationEnvelope>> {
+    // Read the two source-side columns. These are not on the Memory
+    // struct (yet), so query directly.
+    let (atomised_into, atom_of_col): (Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT atomised_into, atom_of FROM memories WHERE id = ?1",
+            params![mem.id],
+            |r| {
+                Ok((
+                    r.get::<_, Option<i64>>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .unwrap_or((None, None));
+
+    let archived_at = mem
+        .metadata
+        .get("atomisation_archived_at")
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string);
+
+    let is_archived_source = atomised_into.unwrap_or(0) > 0 || archived_at.is_some();
+    let is_atom = atom_of_col.is_some();
+    if !is_archived_source && !is_atom {
+        return Ok(None);
+    }
+    let atom_ids = if is_archived_source {
+        atom_ids_of_source(conn, &mem.id)?
+    } else {
+        Vec::new()
+    };
+    Ok(Some(AtomisationEnvelope {
+        atomised_into: atomised_into.filter(|n| *n > 0),
+        archived_at,
+        atom_ids,
+        atom_of: atom_of_col,
+    }))
+}
+
+/// v0.7.0 WT-1-E — fetch every atomisation-related signed event for
+/// the chain. Two queries:
+///
+///   1. Every `memory_link.created` row whose payload describes a
+///      `derives_from` edge from one of the chain's memory ids. We
+///      approximate this by joining on `memory_links` (the row that
+///      generated the audit event) — the WT-1-B atomiser writes the
+///      link via `create_link_signed` which appends a matching
+///      audit row at the same instant. Match heuristic: same
+///      agent_id and timestamp >= the link's created_at on the
+///      same source/target row.
+///   2. Every `atomisation_complete` event whose timestamp lies at
+///      or after the earliest `derives_from` edge's `created_at`
+///      for the chain (i.e. the summary event for any atomisation
+///      that involves these memories). Because the payload itself
+///      is only stored as a hash we can't filter on `source_id`
+///      directly; we instead fetch all events of that type that
+///      could plausibly have been emitted by the same calling
+///      agent and let the auditor cross-reference at verify time.
+///      The over-fetch is bounded by the agent_id set of the
+///      chain's `derives_from` writers, so unrelated atomisations
+///      from other agents are excluded.
+fn fetch_atomisation_signed_events_for(
+    conn: &Connection,
+    chain_ids: &[String],
+) -> Result<Vec<SignedEventEnvelope>> {
+    if chain_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Collect the set of `observed_by` agent ids on the chain's
+    // derives_from edges. The atomisation_complete event's
+    // `agent_id` matches the same `calling_agent_id` used by the
+    // per-atom create_link_signed call.
+    let placeholders: String = chain_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let agent_sql = format!(
+        "SELECT DISTINCT observed_by FROM memory_links \
+         WHERE relation = 'derives_from' \
+           AND (source_id IN ({placeholders}) OR target_id IN ({placeholders})) \
+           AND observed_by IS NOT NULL"
+    );
+    let mut agent_stmt = conn.prepare(&agent_sql)?;
+    let bind_pairs: Vec<&dyn rusqlite::ToSql> = chain_ids
+        .iter()
+        .chain(chain_ids.iter())
+        .map(|s| s as &dyn rusqlite::ToSql)
+        .collect();
+    let agent_rows = agent_stmt.query_map(bind_pairs.as_slice(), |r| r.get::<_, String>(0))?;
+    let mut writer_agents: Vec<String> = Vec::new();
+    for r in agent_rows {
+        let id = r?;
+        if !writer_agents.contains(&id) {
+            writer_agents.push(id);
+        }
+    }
+
+    // Without a writer agent (i.e. unsigned `derives_from` edge) we
+    // still fall back to fetching atomisation_complete events of
+    // any agent so the bundle preserves the audit row. Auditors can
+    // distinguish via the `attest_level` column.
+    let mut out: Vec<SignedEventEnvelope> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    if writer_agents.is_empty() {
+        // Fallback: fetch ALL atomisation_complete + memory_link.created
+        // events. The chain has unsigned derives_from edges, so we
+        // cannot scope by agent — better to over-include in the
+        // bundle (auditor sees the relevant subset) than to silently
+        // drop the chain's audit trail.
+        let sql = "SELECT id, agent_id, event_type, payload_hash, signature, \
+                          attest_level, timestamp \
+                   FROM signed_events \
+                   WHERE event_type IN ('atomisation_complete', 'memory_link.created') \
+                   ORDER BY timestamp ASC, id ASC";
+        let mut stmt = conn.prepare(sql)?;
+        let rows = stmt.query_map([], row_to_signed_event_envelope)?;
+        for r in rows {
+            let ev = r?;
+            if seen.insert(ev.id.clone()) {
+                out.push(ev);
+            }
+        }
+        return Ok(out);
+    }
+
+    let agent_placeholders: String = writer_agents
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT id, agent_id, event_type, payload_hash, signature, \
+                attest_level, timestamp \
+         FROM signed_events \
+         WHERE event_type IN ('atomisation_complete', 'memory_link.created') \
+           AND agent_id IN ({agent_placeholders}) \
+         ORDER BY timestamp ASC, id ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let param_refs: Vec<&dyn rusqlite::ToSql> = writer_agents
+        .iter()
+        .map(|s| s as &dyn rusqlite::ToSql)
+        .collect();
+    let rows = stmt.query_map(param_refs.as_slice(), row_to_signed_event_envelope)?;
+    for r in rows {
+        let ev = r?;
+        if seen.insert(ev.id.clone()) {
+            out.push(ev);
+        }
+    }
+    Ok(out)
+}
+
+/// v0.7.0 WT-1-E — shared row→envelope decoder. Replicates the
+/// inline closure in [`fetch_signed_events_for`] so the WT-1-E
+/// fetcher does not duplicate the column-index pattern (and so a
+/// future column-set extension only needs to be applied in one
+/// place).
+fn row_to_signed_event_envelope(r: &rusqlite::Row<'_>) -> rusqlite::Result<SignedEventEnvelope> {
+    Ok(SignedEventEnvelope {
+        id: r.get::<_, String>(0)?,
+        agent_id: r.get::<_, String>(1)?,
+        event_type: r.get::<_, String>(2)?,
+        payload_hash_hex: bytes_to_hex(&r.get::<_, Vec<u8>>(3)?),
+        signature_hex: r.get::<_, Option<Vec<u8>>>(4)?.map(|b| bytes_to_hex(&b)),
+        attest_level: r.get::<_, String>(5)?,
+        timestamp: r.get::<_, String>(6)?,
+    })
 }
 
 /// Fetch every `signed_events` row whose `agent_id` matches a memory
@@ -1139,6 +1504,7 @@ mod tests {
             memory_id: id.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let files = build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build");
@@ -1160,6 +1526,7 @@ mod tests {
             memory_id: d1.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let files_a = build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build a");
@@ -1183,6 +1550,7 @@ mod tests {
             memory_id: d1.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let bundle_path = tmp.path().join("bundle.tar");
@@ -1204,6 +1572,7 @@ mod tests {
             memory_id: d1.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let bundle_path = tmp.path().join("bundle.tar");
@@ -1276,6 +1645,7 @@ mod tests {
             memory_id: d2.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let files = build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build");
@@ -1302,6 +1672,7 @@ mod tests {
             memory_id: d1.clone(),
             include_reflections: false,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let files = build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build");
@@ -1323,6 +1694,7 @@ mod tests {
             memory_id: d1.clone(),
             include_reflections: true,
             include_transcripts: false,
+            include_atomisation_chain: true,
             output: None,
         };
         let bundle_path = tmp.path().join("bundle.tar");

--- a/src/handlers/http.rs
+++ b/src/handlers/http.rs
@@ -2764,6 +2764,7 @@ pub async fn search_memories(
         p.tags.as_deref(),
         p.agent_id.as_deref(),
         p.as_agent.as_deref(),
+        false,
     ) {
         Ok(r) => Json(json!({"results": r, "count": r.len(), "query": p.q})).into_response(),
         Err(e) => {
@@ -3129,6 +3130,7 @@ async fn recall_response(
             as_agent,
             budget_tokens,
             app.scoring.as_ref(),
+            false,
         );
         drop(vi_guard);
         (r, "hybrid")
@@ -3145,6 +3147,7 @@ async fn recall_response(
             mid_extend,
             as_agent,
             budget_tokens,
+            false,
         );
         (r, "keyword")
     };

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -855,6 +855,7 @@ mod tests {
             crate::models::MID_TTL_EXTEND_SECS,
             None,
             None,
+            false,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -455,7 +455,7 @@ pub fn tool_definitions() -> Value {
             {
                 "name": "memory_recall",
                 "description": "Recall memories relevant to a context (ranked).",
-                "docs": "Recall memories relevant to a context. Uses fuzzy OR matching, ranks by relevance + priority + access frequency + tier. Optional context-budget-aware mode (`budget_tokens`, Phase P6 R1) returns the highest-ranked memories whose cumulative cl100k_base content tokens fit in N, with an always-return-at-least-one guarantee. Optional `context_tokens` biases the query embedding 70/30 toward recent conversation (v0.6.0.0). v0.7.0 (issue #518) — pass `session_default=true` to splice the operator-configured `[agents.defaults.recall_scope]` defaults (namespace / since / tier / limit) for any filter field not explicitly set; resolution is explicit args > recall_scope > compiled defaults. Default response format is `toon_compact` (~79% smaller than JSON).",
+                "docs": "Recall memories relevant to a context. Uses fuzzy OR matching, ranks by relevance + priority + access frequency + tier. Optional context-budget-aware mode (`budget_tokens`, Phase P6 R1) returns the highest-ranked memories whose cumulative cl100k_base content tokens fit in N, with an always-return-at-least-one guarantee. Optional `context_tokens` biases the query embedding 70/30 toward recent conversation (v0.6.0.0). v0.7.0 (issue #518) — pass `session_default=true` to splice the operator-configured `[agents.defaults.recall_scope]` defaults (namespace / since / tier / limit) for any filter field not explicitly set; resolution is explicit args > recall_scope > compiled defaults. v0.7.0 WT-1-E — by default, atomised sources are excluded (atoms surface in their place). Use include_archived=true to retrieve archived sources alongside atoms. Default response format is `toon_compact` (~79% smaller than JSON).",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -469,6 +469,7 @@ pub fn tool_definitions() -> Value {
                         "budget_tokens": {"type": "integer", "minimum": 0, "description": "Phase P6 (R1) — context-budget-aware recall. Return the highest-ranked memories whose cumulative content tokens (deterministic cl100k_base BPE; matches Claude/GPT context accounting) fit in N. If the top-ranked memory alone exceeds the budget, it is returned anyway with meta.budget_overflow=true (R1 always-return-at-least-one guarantee). budget_tokens=0 returns zero memories with overflow=false. Response meta block: budget_tokens_used, budget_tokens_remaining, memories_dropped, budget_overflow."},
                         "context_tokens": {"type": "array", "items": {"type": "string"}, "description": "v0.6.0.0 contextual recall — recent conversation tokens used to bias the query embedding at 70/30 (primary/context). Pulls results toward memories that match both the explicit query and nearby conversation topics."},
                         "session_default": {"type": "boolean", "default": false, "description": "When true, splice defaults from [agents.defaults.recall_scope] in config.toml for any filter field not explicitly set. Resolution: explicit args > recall_scope > compiled defaults."},
+                        "include_archived": {"type": "boolean", "default": false, "description": "v0.7.0 WT-1-E — by default, atomised sources are excluded (atoms surface in their place). Use include_archived=true to retrieve archived sources alongside atoms (forensic / auditor recall)."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens vs JSON. 'toon' includes timestamps. 'json' for structured parsing."}
                     },
                     "required": ["context"]
@@ -477,7 +478,7 @@ pub fn tool_definitions() -> Value {
             {
                 "name": "memory_search",
                 "description": "Search memories by exact keyword match (AND semantics).",
-                "docs": "Search memories by exact keyword match (AND semantics). Faster and more deterministic than memory_recall but no fuzzy/semantic match. Filterable by namespace, tier, and agent_id; supports Task 1.5 scope-aware visibility via `as_agent`. Default response format is `toon_compact`.",
+                "docs": "Search memories by exact keyword match (AND semantics). Faster and more deterministic than memory_recall but no fuzzy/semantic match. Filterable by namespace, tier, and agent_id; supports Task 1.5 scope-aware visibility via `as_agent`. v0.7.0 WT-1-E — by default, atomised sources are excluded (atoms surface in their place). Use include_archived=true to retrieve archived sources alongside atoms. Default response format is `toon_compact`.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -487,6 +488,7 @@ pub fn tool_definitions() -> Value {
                         "limit": {"type": "integer", "default": 20, "maximum": 200},
                         "agent_id": {"type": "string", "description": "Filter by metadata.agent_id (exact match)."},
                         "as_agent": {"type": "string", "description": "Querying agent's namespace position (Task 1.5) for scope-based visibility filtering."},
+                        "include_archived": {"type": "boolean", "default": false, "description": "v0.7.0 WT-1-E — by default, atomised sources are excluded (atoms surface in their place). Use include_archived=true to retrieve archived sources alongside atoms (forensic / auditor search)."},
                         "format": {"type": "string", "enum": ["json", "toon", "toon_compact"], "default": "toon_compact", "description": "Response format. Default 'toon_compact' saves 79% tokens. 'json' for structured parsing."}
                     },
                     "required": ["query"]

--- a/src/mcp/tools/recall.rs
+++ b/src/mcp/tools/recall.rs
@@ -203,6 +203,20 @@ pub fn handle_recall(
         .as_u64()
         .and_then(|n| usize::try_from(n).ok());
 
+    // v0.7.0 WT-1-E — atom-preference recall semantics.
+    //
+    // By default recall surfaces atoms in place of archived sources
+    // (the WT-1-B atomiser sets `atomised_into > 0` AND
+    // `metadata.atomisation_archived_at` on the parent row when atoms
+    // exist). Auditors and the forensic-export path opt in via
+    // `include_archived=true` to see both atoms AND the archived
+    // source for the same query — the substrate read is the same;
+    // only the WHERE clause changes.
+    //
+    // Composes with namespace, memory_kind (via storage filter),
+    // time-window, tier, and the existing visibility predicate.
+    let include_archived = params["include_archived"].as_bool().unwrap_or(false);
+
     // v0.6.0.0 contextual recall — caller-supplied recent conversation tokens.
     let context_tokens: Vec<String> = params["context_tokens"]
         .as_array()
@@ -332,6 +346,7 @@ pub fn handle_recall(
                     as_agent,
                     budget_tokens,
                     resolved_scoring,
+                    include_archived,
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -379,6 +394,7 @@ pub fn handle_recall(
         resolved_ttl.mid_extend_secs,
         as_agent,
         budget_tokens,
+        include_archived,
     )
     .map_err(|e| e.to_string())?;
     let memories = scored_memories(results);

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -23,6 +23,9 @@ pub(super) fn handle_search(conn: &rusqlite::Connection, params: &Value) -> Resu
     if let Some(a) = as_agent {
         validate::validate_namespace(a).map_err(|e| e.to_string())?;
     }
+    // v0.7.0 WT-1-E — atom-preference search semantics. See
+    // `mcp::tools::recall::handle_recall` for the full contract.
+    let include_archived = params["include_archived"].as_bool().unwrap_or(false);
     let results = db::search(
         conn,
         query,
@@ -35,6 +38,7 @@ pub(super) fn handle_search(conn: &rusqlite::Connection, params: &Value) -> Resu
         None,
         agent_id,
         as_agent,
+        include_archived,
     )
     .map_err(|e| e.to_string())?;
     Ok(json!({"results": results, "count": results.len()}))

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -234,14 +234,18 @@ fn archived_source_clause(include_archived: bool, table_alias: &str) -> &'static
         // Static fragment with the alias baked in — recall and
         // recall_hybrid pass `"m"`, search passes `"m"` too.
         match table_alias {
-            "m" => "AND NOT (\
+            "m" => {
+                "AND NOT (\
                 m.atomised_into IS NOT NULL AND m.atomised_into > 0 \
                 AND json_extract(m.metadata, '$.atomisation_archived_at') IS NOT NULL\
-            )",
-            "memories" => "AND NOT (\
+            )"
+            }
+            "memories" => {
+                "AND NOT (\
                 memories.atomised_into IS NOT NULL AND memories.atomised_into > 0 \
                 AND json_extract(memories.metadata, '$.atomisation_archived_at') IS NOT NULL\
-            )",
+            )"
+            }
             _ => "",
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -197,6 +197,81 @@ fn matches_subtree(namespace: &str, prefix: Option<&str>) -> bool {
 /// The `=` equality side is unaffected by LIKE wildcards and binds the raw
 /// value so that legitimate namespaces containing `_` (e.g. `under_score`)
 /// continue to match exactly.
+/// v0.7.0 WT-1-E — atom-preference WHERE fragment.
+///
+/// Default recall surfaces atoms (the canonical post-atomisation
+/// unit) in place of the archived source row. An archived source is
+/// one where:
+///
+///   * `atomised_into > 0` — the substrate-visible count of atoms
+///     emitted by the WT-1-B atomiser.
+///   * `metadata.atomisation_archived_at` is set — the RFC3339 stamp
+///     WT-1-B writes alongside the column flip (see
+///     `src/atomisation/mod.rs::archive_source`). The column is the
+///     fast index target; the metadata key is the substrate-visible
+///     read signal that the row is "atomised and archived" — both
+///     are checked so a hypothetical column-only or metadata-only
+///     drift gets filtered consistently.
+///
+/// Atoms themselves (rows where `atom_of IS NOT NULL`) are unaffected
+/// — they are not "archived" by this definition. The fragment
+/// excludes archived sources only.
+///
+/// When `include_archived` is true the fragment is empty (no
+/// filter), so auditors and the forensic-export path see the full
+/// chain. The atom rows are returned in both cases.
+fn archived_source_clause(include_archived: bool, table_alias: &str) -> &'static str {
+    if include_archived {
+        ""
+    } else {
+        // Two-part predicate: a row is archived-source when BOTH
+        // (a) atomised_into > 0 and
+        // (b) metadata.atomisation_archived_at IS NOT NULL.
+        // Either one alone could be a partial-state row (e.g. a
+        // crash between the column flip and the metadata write); we
+        // only filter rows that present BOTH signals so a partial-
+        // state row still surfaces under default recall.
+        // Static fragment with the alias baked in — recall and
+        // recall_hybrid pass `"m"`, search passes `"m"` too.
+        match table_alias {
+            "m" => "AND NOT (\
+                m.atomised_into IS NOT NULL AND m.atomised_into > 0 \
+                AND json_extract(m.metadata, '$.atomisation_archived_at') IS NOT NULL\
+            )",
+            "memories" => "AND NOT (\
+                memories.atomised_into IS NOT NULL AND memories.atomised_into > 0 \
+                AND json_extract(memories.metadata, '$.atomisation_archived_at') IS NOT NULL\
+            )",
+            _ => "",
+        }
+    }
+}
+
+/// v0.7.0 WT-1-E — Rust-side mirror of [`archived_source_clause`].
+///
+/// Used by the HNSW retrieval branch of `recall_hybrid_with_telemetry`
+/// where the bypass-the-SQL-WHERE walk fetches each candidate via
+/// `get()` and then applies post-load filters in Rust. The check
+/// reads `metadata.atomisation_archived_at` (the WT-1-B substrate-
+/// visible read signal) and tolerates the absence of the metadata
+/// key — only rows that DO present the key are excluded.
+///
+/// Note: the SQL fragment also requires `atomised_into > 0` to be
+/// set. The HNSW branch deliberately only checks the metadata key
+/// because the loaded `Memory` struct does not carry the
+/// `atomised_into` column. The two signals are written in the same
+/// `archive_source` transaction (see `src/atomisation/mod.rs`), so
+/// in steady-state every row presents both signals together; the
+/// pathological partial-state row that exists only momentarily
+/// during a crash window still surfaces through HNSW until the next
+/// recall — accepted as a tolerable looseness on the cold-fallback
+/// path.
+fn is_archived_source(mem: &Memory) -> bool {
+    mem.metadata
+        .get("atomisation_archived_at")
+        .is_some_and(|v| !v.is_null())
+}
+
 fn visibility_clause(start: usize, table_alias: &str) -> String {
     let private_ph = start;
     let team_ph = start + 1;
@@ -992,11 +1067,16 @@ pub fn search(
     tags_filter: Option<&str>,
     agent_id: Option<&str>,
     as_agent: Option<&str>,
+    // v0.7.0 WT-1-E — when false (default), search excludes archived
+    // sources whose atoms surface in their place. See
+    // [`recall_with_telemetry`] for the full contract.
+    include_archived: bool,
 ) -> Result<Vec<Memory>> {
     let now = Utc::now().to_rfc3339();
     let tier_str = tier.map(|t| t.as_str().to_string());
     let fts_query = sanitize_fts_query(query, false);
     let (vis_p, vis_t, vis_u, vis_o) = compute_visibility_prefixes(as_agent);
+    let archived_fragment = archived_source_clause(include_archived, "m");
 
     let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
@@ -1013,6 +1093,7 @@ pub fn search(
            AND (?7 IS NULL OR m.created_at <= ?7)
            AND (?8 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?8))
            AND (?10 IS NULL OR m.agent_id_idx = ?10)
+           {archived_fragment}
            {vis}
          ORDER BY (fts.rank * -1)
            + (m.priority * 0.5)
@@ -1297,6 +1378,11 @@ pub fn recall_with_telemetry(
     mid_extend: i64,
     as_agent: Option<&str>,
     budget_tokens: Option<usize>,
+    // v0.7.0 WT-1-E — when false (default), recall excludes archived
+    // sources whose atoms now surface in their place. When true, the
+    // archive-filter WHERE clause is dropped so forensic-export and
+    // explicit auditor recall returns both atoms and sources.
+    include_archived: bool,
 ) -> Result<(
     Vec<(Memory, f64)>,
     BudgetOutcome,
@@ -1314,6 +1400,7 @@ pub fn recall_with_telemetry(
         mid_extend,
         as_agent,
         budget_tokens,
+        include_archived,
     )?;
     let telemetry = crate::models::RecallTelemetry {
         fts_candidates: results.len(),
@@ -1335,6 +1422,9 @@ pub fn recall(
     mid_extend: i64,
     as_agent: Option<&str>,
     budget_tokens: Option<usize>,
+    // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
+    // archived-source exclusion contract.
+    include_archived: bool,
 ) -> Result<(Vec<(Memory, f64)>, BudgetOutcome)> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
@@ -1346,6 +1436,11 @@ pub fn recall(
     let (hierarchy_in, hierarchy_active) = hierarchy_in_clause(namespace);
     let hierarchy_fragment = hierarchy_in.unwrap_or_default();
     let effective_namespace = if hierarchy_active { None } else { namespace };
+
+    // v0.7.0 WT-1-E — archived-source exclusion (default) / pass-
+    // through (include_archived=true). Composes with the existing
+    // namespace, expiry, tag, time-window, and visibility filters.
+    let archived_fragment = archived_source_clause(include_archived, "m");
 
     let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
@@ -1367,6 +1462,7 @@ pub fn recall(
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
+           {archived_fragment}
            {vis}
          ORDER BY score DESC
          LIMIT ?7",
@@ -4603,6 +4699,9 @@ pub fn recall_hybrid(
     as_agent: Option<&str>,
     budget_tokens: Option<usize>,
     scoring: &crate::config::ResolvedScoring,
+    // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
+    // archived-source exclusion contract.
+    include_archived: bool,
 ) -> Result<(Vec<(Memory, f64)>, BudgetOutcome)> {
     let (results, outcome, _telemetry) = recall_hybrid_with_telemetry(
         conn,
@@ -4619,6 +4718,7 @@ pub fn recall_hybrid(
         as_agent,
         budget_tokens,
         scoring,
+        include_archived,
     )?;
     Ok((results, outcome))
 }
@@ -4652,6 +4752,9 @@ pub fn recall_hybrid_with_telemetry(
     as_agent: Option<&str>,
     budget_tokens: Option<usize>,
     scoring: &crate::config::ResolvedScoring,
+    // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
+    // archived-source exclusion contract.
+    include_archived: bool,
 ) -> Result<(
     Vec<(Memory, f64)>,
     BudgetOutcome,
@@ -4684,6 +4787,13 @@ pub fn recall_hybrid_with_telemetry(
     };
     let effective_namespace = if hierarchy_active { None } else { namespace };
 
+    // v0.7.0 WT-1-E — archived-source exclusion (default) / pass-
+    // through. Same predicate shape used in `recall`; the FTS branch
+    // uses the `m.` alias, the semantic branch (semantic-only `SELECT
+    // FROM memories`) uses the `memories.` alias.
+    let fts_archived_fragment = archived_source_clause(include_archived, "m");
+    let sem_archived_fragment = archived_source_clause(include_archived, "memories");
+
     // Step 1: Get FTS candidates (up to 3x limit to have a good pool)
     let fts_limit = (limit * 3).max(30);
     let fts_sql = format!(
@@ -4704,6 +4814,7 @@ pub fn recall_hybrid_with_telemetry(
            AND (?4 IS NULL OR EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ?4))
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
+           {fts_archived_fragment}
            {vis}
          ORDER BY fts_score DESC
          LIMIT ?7",
@@ -4724,6 +4835,7 @@ pub fn recall_hybrid_with_telemetry(
            AND (?3 IS NULL OR EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE json_each.value = ?3))
            AND (?4 IS NULL OR created_at >= ?4)
            AND (?5 IS NULL OR created_at <= ?5)
+           {sem_archived_fragment}
            {vis}",
         vis = visibility_clause(6, "memories"),
     );
@@ -4839,6 +4951,16 @@ pub fn recall_hybrid_with_telemetry(
                 }
                 // #151 visibility filter (HNSW branch)
                 if !is_visible(&mem, &prefixes) {
+                    continue;
+                }
+                // v0.7.0 WT-1-E — archived-source exclusion. The HNSW
+                // path bypasses the FTS/semantic SQL WHERE clause, so
+                // we re-check the same predicate in Rust to keep the
+                // include_archived=false semantics consistent across
+                // retrieval branches. Looks for BOTH atomised_into>0
+                // and metadata.atomisation_archived_at, mirroring
+                // [`archived_source_clause`].
+                if !include_archived && is_archived_source(&mem) {
                     continue;
                 }
                 scored.insert(mem.id.clone(), (mem, 0.0, cosine));
@@ -7378,6 +7500,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(results.len(), 1);
@@ -7400,6 +7523,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(results.len(), 0);
@@ -7431,6 +7555,7 @@ mod tests {
             MID_TTL_EXTEND_SECS,
             None,
             None,
+            false,
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -7457,6 +7582,7 @@ mod tests {
             MID_TTL_EXTEND_SECS,
             None,
             None,
+            false,
         );
         // May return empty or error, both acceptable
         assert!(results.is_ok() || results.is_err());
@@ -8362,6 +8488,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(results.len(), 1);
@@ -8387,6 +8514,7 @@ mod tests {
             86400,
             None,
             None,
+            false,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -174,6 +174,7 @@ impl MemoryStore for SqliteStore {
             tags_first,
             filter.agent_id.as_deref(),
             ctx.as_agent.as_deref(),
+            false,
         )
         .map_err(box_err)
     }
@@ -363,6 +364,7 @@ impl MemoryStore for SqliteStore {
                 ctx.as_agent.as_deref(),
                 None,
                 &scoring,
+                false,
             )
             .map_err(box_err)?;
             Ok(results)
@@ -379,6 +381,7 @@ impl MemoryStore for SqliteStore {
                 86_400,
                 ctx.as_agent.as_deref(),
                 None,
+                false,
             )
             .map_err(box_err)?;
             Ok(results)

--- a/tests/forensic.rs
+++ b/tests/forensic.rs
@@ -11,3 +11,6 @@
 
 #[path = "forensic/bundle_test.rs"]
 mod bundle_test;
+
+#[path = "forensic/wt1e_chain_test.rs"]
+mod wt1e_chain_test;

--- a/tests/forensic/bundle_test.rs
+++ b/tests/forensic/bundle_test.rs
@@ -203,7 +203,7 @@ fn bundle_byte_identical_modulo_timestamp() {
         include_reflections: true,
         include_transcripts: false,
         include_atomisation_chain: true,
-            output: None,
+        output: None,
     };
     let files_a = bundle::build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build a");
     let files_b = bundle::build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build b");
@@ -258,7 +258,7 @@ fn run_verify_emits_structured_report_on_clean_bundle() {
         include_reflections: true,
         include_transcripts: false,
         include_atomisation_chain: true,
-            output: Some(bundle_path.clone()),
+        output: Some(bundle_path.clone()),
     };
     let mut stdout = Vec::<u8>::new();
     let mut stderr = Vec::<u8>::new();
@@ -303,7 +303,7 @@ fn transcripts_flag_includes_replay_union() {
         include_reflections: true,
         include_transcripts: true,
         include_atomisation_chain: true,
-            output: Some(bundle_path.clone()),
+        output: Some(bundle_path.clone()),
     };
     let mut stdout = Vec::<u8>::new();
     let mut stderr = Vec::<u8>::new();

--- a/tests/forensic/bundle_test.rs
+++ b/tests/forensic/bundle_test.rs
@@ -202,7 +202,8 @@ fn bundle_byte_identical_modulo_timestamp() {
         memory_id: d2.clone(),
         include_reflections: true,
         include_transcripts: false,
-        output: None,
+        include_atomisation_chain: true,
+            output: None,
     };
     let files_a = bundle::build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build a");
     let files_b = bundle::build_files(&conn, &args, Some("2026-01-01T00:00:00Z")).expect("build b");
@@ -256,7 +257,8 @@ fn run_verify_emits_structured_report_on_clean_bundle() {
         memory_id: d1.clone(),
         include_reflections: true,
         include_transcripts: false,
-        output: Some(bundle_path.clone()),
+        include_atomisation_chain: true,
+            output: Some(bundle_path.clone()),
     };
     let mut stdout = Vec::<u8>::new();
     let mut stderr = Vec::<u8>::new();
@@ -300,7 +302,8 @@ fn transcripts_flag_includes_replay_union() {
         memory_id: d1.clone(),
         include_reflections: true,
         include_transcripts: true,
-        output: Some(bundle_path.clone()),
+        include_atomisation_chain: true,
+            output: Some(bundle_path.clone()),
     };
     let mut stdout = Vec::<u8>::new();
     let mut stderr = Vec::<u8>::new();

--- a/tests/forensic/wt1e_chain_test.rs
+++ b/tests/forensic/wt1e_chain_test.rs
@@ -1,0 +1,518 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::missing_panics_doc
+)]
+
+//! v0.7.0 WT-1-E — forensic-bundle atomisation-chain acceptance.
+//!
+//! Three acceptance tests pinned to the WT-1-E brief:
+//!
+//! 5. Bundle contains source + atoms + DerivesFrom edges +
+//!    atomisation_complete signed_event when the chain is included.
+//! 6. `--include-atomisation-chain=false` skips the chain (atoms
+//!    only — no source row, no derives_from edges, no
+//!    atomisation_complete event).
+//! 7. Round-trip: build → read_ustar → re-import → atoms still link
+//!    back to sources via DerivesFrom (chain reconstructible from
+//!    the bundle alone).
+
+use std::sync::{Mutex, OnceLock};
+
+use ai_memory::atomisation::curator::{Atom, Curator, CuratorError};
+use ai_memory::atomisation::{Atomiser, AtomiserConfig};
+use ai_memory::config::FeatureTier;
+use ai_memory::db;
+use ai_memory::forensic::bundle::{self, ExportForensicBundleArgs, read_ustar};
+use ai_memory::models::{Memory, MemoryKind, Tier};
+use ai_memory::storage;
+
+use rusqlite::Connection;
+use serde_json::json;
+use tempfile::{NamedTempFile, TempDir};
+
+// ---------------------------------------------------------------------------
+// Shared scaffolding (mirrors tests/atomisation/core.rs).
+// ---------------------------------------------------------------------------
+
+struct MockCurator {
+    responses: Mutex<Vec<Result<Vec<Atom>, CuratorError>>>,
+}
+
+impl MockCurator {
+    fn new(responses: Vec<Result<Vec<Atom>, CuratorError>>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+impl Curator for MockCurator {
+    fn decompose(
+        &self,
+        _body: &str,
+        _max_atom_tokens: u32,
+        _max_retries: u32,
+    ) -> Result<Vec<Atom>, CuratorError> {
+        let mut q = self.responses.lock().unwrap();
+        if q.is_empty() {
+            return Err(CuratorError::MalformedResponse(
+                "mock: queue exhausted".into(),
+            ));
+        }
+        q.remove(0)
+    }
+}
+
+fn test_serial() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+fn ensure_hook_installed() {
+    let _ = storage::GOVERNANCE_PRE_WRITE.set(Box::new(|_: &Memory| Ok(())));
+}
+
+fn make_atoms(texts: &[&str]) -> Vec<Atom> {
+    texts
+        .iter()
+        .map(|s| Atom {
+            text: (*s).to_string(),
+        })
+        .collect()
+}
+
+fn fresh_db_in(dir: &std::path::Path) -> (std::path::PathBuf, Connection) {
+    let p = dir.join("ai-memory.db");
+    let conn = db::open(&p).expect("db::open");
+    (p, conn)
+}
+
+fn fresh_db_tempfile() -> (NamedTempFile, Connection) {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    let conn = db::open(tmp.path()).expect("db::open");
+    (tmp, conn)
+}
+
+fn seed_long_source(conn: &Connection, ns: &str, keyword: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    let body = (0..20)
+        .map(|i| {
+            format!(
+                "Paragraph {i}: detailed information about {keyword} systems and \
+                 their operational characteristics. The {keyword} subsystem coordinates \
+                 multiple components and reports health to upstream observers. \
+                 Failures cascade only when the supervisor is unreachable."
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: ns.to_string(),
+        title: format!("{keyword}-source-{}", uuid::Uuid::new_v4().simple()),
+        content: body,
+        tags: vec![keyword.to_string()],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"agent_id": "wt1e-fb-agent"}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+    };
+    db::insert(conn, &mem).expect("seed")
+}
+
+fn atomise(conn: &Connection, source_id: &str, atom_texts: &[&str]) -> Vec<String> {
+    let curator = Box::new(MockCurator::new(vec![Ok(make_atoms(atom_texts))]));
+    let atomiser = Atomiser::new(curator, None, AtomiserConfig::default(), FeatureTier::Smart);
+    let outcome = atomiser
+        .atomise_sync(conn, source_id, 200, false, "wt1e-fb-agent")
+        .expect("atomise");
+    outcome.atom_ids
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — forensic export includes the atomisation chain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_forensic_export_includes_atomisation_chain() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let tmp = TempDir::new().unwrap();
+    let (db_path, conn) = fresh_db_in(tmp.path());
+    let source_id = seed_long_source(&conn, "fb/wt1e/c5", "kafka");
+    let atom_ids = atomise(
+        &conn,
+        &source_id,
+        &[
+            "Kafka brokers store partitioned commit logs on disk.",
+            "Kafka consumer groups coordinate offsets via the coordinator.",
+            "Kafka replication factor controls broker-failure tolerance.",
+            "Kafka transactions enable exactly-once message delivery.",
+            "Kafka tiered storage offloads cold segments to object stores.",
+        ],
+    );
+    assert!(!atom_ids.is_empty(), "atomisation produced atoms");
+
+    // Build the bundle in-memory so we can inspect it deterministically.
+    let args = ExportForensicBundleArgs {
+        memory_id: source_id.clone(),
+        include_reflections: false,
+        include_transcripts: false,
+        include_atomisation_chain: true,
+        output: None,
+    };
+    let files =
+        bundle::build_files(&conn, &args, Some("2026-05-15T00:00:00Z")).expect("build_files");
+    drop(conn);
+    let _ = db_path; // keep path alive for tmp dir lifetime
+
+    // (a) Source memory envelope present with atomisation block.
+    let src_key = format!("memories/{source_id}.json");
+    let src_bytes = files.get(&src_key).expect("source memory bundled");
+    let src_v: serde_json::Value = serde_json::from_slice(src_bytes).expect("parse src");
+    assert!(
+        src_v["atomisation"].is_object(),
+        "archived source must carry atomisation enrichment"
+    );
+    assert_eq!(
+        src_v["atomisation"]["atomised_into"].as_i64(),
+        Some(i64::try_from(atom_ids.len()).unwrap()),
+    );
+    assert!(
+        src_v["atomisation"]["archived_at"].is_string(),
+        "atomisation.archived_at must be present"
+    );
+    let bundled_atom_ids: Vec<String> = src_v["atomisation"]["atom_ids"]
+        .as_array()
+        .expect("atom_ids array")
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    assert_eq!(bundled_atom_ids.len(), atom_ids.len());
+    for aid in &atom_ids {
+        assert!(bundled_atom_ids.contains(aid), "atom {aid} listed");
+    }
+
+    // (b) Each atom envelope present and carries atom_of pointer.
+    for aid in &atom_ids {
+        let key = format!("memories/{aid}.json");
+        let bytes = files
+            .get(&key)
+            .unwrap_or_else(|| panic!("atom {aid} must be bundled"));
+        let v: serde_json::Value = serde_json::from_slice(bytes).expect("parse atom");
+        assert_eq!(
+            v["atomisation"]["atom_of"].as_str(),
+            Some(source_id.as_str()),
+            "atom envelope must point back via atom_of"
+        );
+    }
+
+    // (c) Every atom → source `derives_from` edge present.
+    let mut edge_count = 0;
+    for aid in &atom_ids {
+        let edge_key = format!("edges/{aid}__derives_from__{source_id}.json");
+        assert!(
+            files.contains_key(&edge_key),
+            "derives_from edge for atom {aid} → {source_id} must be bundled (key {edge_key})"
+        );
+        edge_count += 1;
+    }
+    assert_eq!(edge_count, atom_ids.len());
+
+    // (d) Exactly one atomisation_complete signed_event bundled.
+    let mut atomisation_complete_seen = 0;
+    let mut link_created_seen = 0;
+    for (path, body) in &files {
+        if !path.starts_with("signed_events/") {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_slice(body).expect("parse event");
+        match v["event_type"].as_str() {
+            Some("atomisation_complete") => atomisation_complete_seen += 1,
+            Some("memory_link.created") => link_created_seen += 1,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        atomisation_complete_seen, 1,
+        "exactly one atomisation_complete event must be in the bundle"
+    );
+    assert!(
+        link_created_seen >= atom_ids.len(),
+        "expected at least N memory_link.created events for N atoms; got {link_created_seen}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — --include-atomisation-chain=false skips the chain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_forensic_export_chain_disable_flag() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let tmp = TempDir::new().unwrap();
+    let (_db_path, conn) = fresh_db_in(tmp.path());
+    let source_id = seed_long_source(&conn, "fb/wt1e/c6", "rabbitmq");
+    let atom_ids = atomise(
+        &conn,
+        &source_id,
+        &[
+            "RabbitMQ uses AMQP 0-9-1 as its primary wire protocol.",
+            "RabbitMQ exchanges route messages by binding key matchers.",
+            "RabbitMQ mirrored queues provide high availability across nodes.",
+            "RabbitMQ shovel and federation move messages between brokers.",
+            "RabbitMQ delayed message exchange plugin queues future deliveries.",
+        ],
+    );
+
+    // Build the bundle for an ATOM with the chain disabled. Expected
+    // behaviour: only the atom envelope is emitted; the source row,
+    // sibling atoms, derives_from edges, and atomisation_complete
+    // event are NOT bundled.
+    let atom_id = atom_ids[0].clone();
+    let args = ExportForensicBundleArgs {
+        memory_id: atom_id.clone(),
+        include_reflections: false,
+        include_transcripts: false,
+        include_atomisation_chain: false,
+        output: None,
+    };
+    let files =
+        bundle::build_files(&conn, &args, Some("2026-05-15T00:00:00Z")).expect("build_files");
+
+    // (a) Atom is present.
+    assert!(files.contains_key(&format!("memories/{atom_id}.json")));
+
+    // (b) Source is NOT present.
+    assert!(
+        !files.contains_key(&format!("memories/{source_id}.json")),
+        "source must be skipped when chain disabled"
+    );
+
+    // (c) Other atoms NOT present (chain skipped).
+    for sibling in atom_ids.iter().skip(1) {
+        assert!(
+            !files.contains_key(&format!("memories/{sibling}.json")),
+            "sibling atom {sibling} must be skipped when chain disabled"
+        );
+    }
+
+    // (d) No derives_from edges.
+    for path in files.keys() {
+        assert!(
+            !path.contains("__derives_from__"),
+            "derives_from edge present unexpectedly: {path}"
+        );
+    }
+
+    // (e) No atomisation_complete event bundled (matched by event_type).
+    for (path, body) in &files {
+        if !path.starts_with("signed_events/") {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_slice(body).expect("parse event");
+        assert_ne!(
+            v["event_type"].as_str(),
+            Some("atomisation_complete"),
+            "atomisation_complete event present when chain disabled: {path}"
+        );
+    }
+
+    // (f) Atom envelope does NOT carry the atomisation enrichment
+    // block (the per-envelope enrichment is gated on the same flag).
+    let atom_bytes = files.get(&format!("memories/{atom_id}.json")).unwrap();
+    let atom_v: serde_json::Value = serde_json::from_slice(atom_bytes).unwrap();
+    assert!(
+        atom_v["atomisation"].is_null() || atom_v.get("atomisation").is_none(),
+        "atomisation block must be skipped when chain disabled"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — round-trip: export → fresh DB import → chain reconstructable.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_forensic_export_can_reconstruct_chain() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let tmp = TempDir::new().unwrap();
+    let bundle_path = tmp.path().join("bundle.tar");
+
+    // 1) Build the source DB and atomise.
+    let source_id;
+    let atom_ids;
+    {
+        let (db_path, conn) = fresh_db_in(tmp.path());
+        source_id = seed_long_source(&conn, "fb/wt1e/c7", "consul");
+        atom_ids = atomise(
+            &conn,
+            &source_id,
+            &[
+                "Consul gossip mesh propagates membership across LAN segments.",
+                "Consul KV stores configuration with last-write-wins semantics.",
+                "Consul service catalogue answers DNS and HTTP queries.",
+                "Consul ACL tokens scope access to namespaces and policies.",
+                "Consul connect issues short-lived TLS certificates per service.",
+            ],
+        );
+
+        // Export to disk so the round-trip walks the tar parser too.
+        let args = ExportForensicBundleArgs {
+            memory_id: source_id.clone(),
+            include_reflections: false,
+            include_transcripts: false,
+            include_atomisation_chain: true,
+            output: Some(bundle_path.clone()),
+        };
+        bundle::build(&conn, &args, &bundle_path, Some("2026-05-15T00:00:00Z"))
+            .expect("build bundle");
+        drop(conn);
+        let _ = db_path;
+    }
+
+    // 2) Re-read the bundle.
+    let bytes = std::fs::read(&bundle_path).expect("read bundle");
+    let files = read_ustar(&bytes).expect("parse ustar");
+
+    // 3) Reconstruct the chain in a fresh DB. Each memory envelope
+    //    becomes a `memories` row; each edge becomes a
+    //    `memory_links` row. The fresh DB has no prior knowledge —
+    //    everything the auditor needs lives inside the bundle.
+    //    `agent_id_idx` and `scope_idx` are GENERATED columns
+    //    (v33 migration), so the INSERT omits them. The
+    //    atomisation chain columns (`atomised_into`, `atom_of`)
+    //    are real and need to be restored verbatim.
+    //
+    //    Order matters: insert non-atom rows (atom_of IS NULL)
+    //    first, then atoms — `memories.atom_of` is a FK back to
+    //    `memories(id)` so atoms can only land after their parent
+    //    exists.
+    let (_fresh_tmp, fresh_conn) = fresh_db_tempfile();
+    let mut memory_envs: Vec<serde_json::Value> = files
+        .iter()
+        .filter(|(p, _)| {
+            p.starts_with("memories/")
+                && std::path::Path::new(p)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+        })
+        .map(|(_, b)| serde_json::from_slice::<serde_json::Value>(b).expect("parse"))
+        .collect();
+    // Parents (no atom_of) first; atoms second.
+    memory_envs.sort_by_key(|v| i32::from(v["atomisation"]["atom_of"].is_string()));
+    for v in &memory_envs {
+        let id = v["id"].as_str().unwrap().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        fresh_conn
+            .execute(
+                "INSERT INTO memories (id, tier, namespace, title, content, tags, priority, \
+                                      confidence, source, access_count, created_at, updated_at, \
+                                      last_accessed_at, expires_at, metadata, reflection_depth, \
+                                      embedding, memory_kind, \
+                                      atomised_into, atom_of) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, '[]', 5, 1.0, 'restored', 0, ?6, ?7, NULL, NULL, \
+                         ?8, 0, NULL, 'observation', ?9, ?10)",
+                rusqlite::params![
+                    id,
+                    v["tier"].as_str().unwrap_or("mid"),
+                    v["namespace"].as_str().unwrap_or("fb/wt1e/c7"),
+                    v["title"].as_str().unwrap_or("restored"),
+                    v["content"].as_str().unwrap_or(""),
+                    now,
+                    now,
+                    v["metadata"].to_string(),
+                    v["atomisation"]["atomised_into"].as_i64(),
+                    v["atomisation"]["atom_of"].as_str(),
+                ],
+            )
+            .expect("insert restored memory");
+    }
+    for (path, body) in &files {
+        if !path.starts_with("edges/")
+            || !std::path::Path::new(path)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+        {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_slice(body).expect("parse edge env");
+        fresh_conn
+            .execute(
+                "INSERT OR IGNORE INTO memory_links \
+                 (source_id, target_id, relation, created_at, attest_level) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    v["source_id"].as_str().unwrap(),
+                    v["target_id"].as_str().unwrap(),
+                    v["relation"].as_str().unwrap(),
+                    v["created_at"].as_str().unwrap(),
+                    v["attest_level"].as_str().unwrap_or("unsigned"),
+                ],
+            )
+            .expect("insert restored edge");
+    }
+
+    // 4) Assertions: every atom has a derives_from edge back to the
+    //    source in the fresh DB.
+    for aid in &atom_ids {
+        let row: i64 = fresh_conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_links \
+                 WHERE source_id = ?1 AND target_id = ?2 AND relation = 'derives_from'",
+                rusqlite::params![aid, source_id],
+                |r| r.get(0),
+            )
+            .expect("query");
+        assert_eq!(
+            row, 1,
+            "round-trip: atom {aid} must have a derives_from edge to source {source_id}"
+        );
+    }
+
+    // The source memory's atomised_into and atom_of columns
+    // round-trip too.
+    let (atomised_into, atom_of): (Option<i64>, Option<String>) = fresh_conn
+        .query_row(
+            "SELECT atomised_into, atom_of FROM memories WHERE id = ?1",
+            rusqlite::params![source_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .expect("query source");
+    assert_eq!(atomised_into, Some(i64::try_from(atom_ids.len()).unwrap()));
+    assert!(atom_of.is_none(), "source row is not itself an atom");
+
+    // And each atom's atom_of points back at the source.
+    for aid in &atom_ids {
+        let parent: Option<String> = fresh_conn
+            .query_row(
+                "SELECT atom_of FROM memories WHERE id = ?1",
+                rusqlite::params![aid],
+                |r| r.get(0),
+            )
+            .expect("query atom");
+        assert_eq!(parent.as_deref(), Some(source_id.as_str()));
+    }
+}

--- a/tests/g_phase_e_4_verify_exit_codes.rs
+++ b/tests/g_phase_e_4_verify_exit_codes.rs
@@ -275,8 +275,8 @@ fn forensic_bundle_tampered_file_exits_2() {
         output: Some(bundle_path.clone()),
         include_reflections: true,
         include_transcripts: false,
-    include_atomisation_chain: true,
-            };
+        include_atomisation_chain: true,
+    };
     {
         let mut stdout = Vec::<u8>::new();
         let mut stderr = Vec::<u8>::new();
@@ -337,8 +337,8 @@ fn forensic_bundle_clean_exits_0() {
         output: Some(bundle_path.clone()),
         include_reflections: true,
         include_transcripts: false,
-    include_atomisation_chain: true,
-            };
+        include_atomisation_chain: true,
+    };
     {
         let mut stdout = Vec::<u8>::new();
         let mut stderr = Vec::<u8>::new();

--- a/tests/g_phase_e_4_verify_exit_codes.rs
+++ b/tests/g_phase_e_4_verify_exit_codes.rs
@@ -275,7 +275,8 @@ fn forensic_bundle_tampered_file_exits_2() {
         output: Some(bundle_path.clone()),
         include_reflections: true,
         include_transcripts: false,
-    };
+    include_atomisation_chain: true,
+            };
     {
         let mut stdout = Vec::<u8>::new();
         let mut stderr = Vec::<u8>::new();
@@ -336,7 +337,8 @@ fn forensic_bundle_clean_exits_0() {
         output: Some(bundle_path.clone()),
         include_reflections: true,
         include_transcripts: false,
-    };
+    include_atomisation_chain: true,
+            };
     {
         let mut stdout = Vec::<u8>::new();
         let mut stderr = Vec::<u8>::new();

--- a/tests/recall.rs
+++ b/tests/recall.rs
@@ -1,0 +1,12 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 WT-1-E — recall-time atom-preference acceptance suite.
+//!
+//! Cargo autodiscovers `tests/recall.rs` as a single test binary;
+//! the `mod wt1e` declaration below pulls in the acceptance tests
+//! from `tests/recall/wt1e.rs`. Mirrors the
+//! `tests/forensic.rs` ↔ `tests/forensic/bundle_test.rs` pattern.
+
+#[path = "recall/wt1e.rs"]
+mod wt1e;

--- a/tests/recall/wt1e.rs
+++ b/tests/recall/wt1e.rs
@@ -1,0 +1,537 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::missing_panics_doc
+)]
+
+//! v0.7.0 WT-1-E — recall-time atom-preference acceptance tests.
+//!
+//! Four acceptance criteria from the brief:
+//!
+//!   1. Default recall excludes archived sources (atoms surface in
+//!      their place).
+//!   2. `include_archived=true` returns BOTH atoms AND the archived
+//!      source for the same query.
+//!   3. The archived-source filter composes with the existing
+//!      namespace + memory-kind + visibility filters — the WT-1-E
+//!      WHERE clause is additive.
+//!   4. `memory_get` (direct lookup) is exempt from the archive
+//!      filter — auditors still resolve an archived source by id.
+//!
+//! These tests drive the substrate end-to-end: seed a source via
+//! `db::insert`, atomise via `Atomiser::atomise_sync` with a mock
+//! curator (no live LLM call), then assert on `db::recall_*` /
+//! `db::get` results. The fixture shape mirrors the WT-1-B
+//! acceptance suite at `tests/atomisation/core.rs`.
+
+use std::sync::{Mutex, OnceLock};
+
+use ai_memory::atomisation::curator::{Atom, Curator, CuratorError};
+use ai_memory::atomisation::{Atomiser, AtomiserConfig};
+use ai_memory::config::FeatureTier;
+use ai_memory::db;
+use ai_memory::mcp::handle_recall;
+use ai_memory::models::{Memory, MemoryKind, Tier};
+use ai_memory::storage;
+
+use rusqlite::Connection;
+use serde_json::json;
+use tempfile::NamedTempFile;
+
+// ---------------------------------------------------------------------------
+// Mock curator — deterministic, no network. Mirrors tests/atomisation/core.rs.
+// ---------------------------------------------------------------------------
+
+struct MockCurator {
+    responses: Mutex<Vec<Result<Vec<Atom>, CuratorError>>>,
+}
+
+impl MockCurator {
+    fn new(responses: Vec<Result<Vec<Atom>, CuratorError>>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+impl Curator for MockCurator {
+    fn decompose(
+        &self,
+        _body: &str,
+        _max_atom_tokens: u32,
+        _max_retries: u32,
+    ) -> Result<Vec<Atom>, CuratorError> {
+        let mut q = self.responses.lock().unwrap();
+        if q.is_empty() {
+            return Err(CuratorError::MalformedResponse(
+                "mock: queue exhausted".into(),
+            ));
+        }
+        q.remove(0)
+    }
+}
+
+fn atoms_from(texts: &[&str]) -> Vec<Atom> {
+    texts
+        .iter()
+        .map(|s| Atom {
+            text: (*s).to_string(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Shared governance-hook scaffolding — Allow-mode dispatcher installed
+// once. Mirrors tests/atomisation/core.rs to coexist with that suite
+// when both binaries link the same process-wide OnceLock.
+// ---------------------------------------------------------------------------
+
+fn test_serial() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+fn ensure_hook_installed() {
+    let _ = storage::GOVERNANCE_PRE_WRITE.set(Box::new(|_mem: &Memory| Ok(())));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn fresh_db() -> (NamedTempFile, Connection) {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    let conn = db::open(tmp.path()).expect("db::open");
+    (tmp, conn)
+}
+
+/// Insert a long-bodied source memory. Returns its id. Body is wide
+/// enough that the atomiser's `enforce_token_budget` won't fold it
+/// back into a single atom under the default 200-token cap.
+fn insert_long_source(conn: &Connection, ns: &str, title_keyword: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    // Repeat distinct content to push token count well above 1500.
+    let body = (0..20)
+        .map(|i| {
+            format!(
+                "Paragraph {i}: the kubernetes rolling deploy strategy required \
+                 canary instance health checks for the {title_keyword} system. \
+                 The pod readiness probe must pass before traffic shifts. \
+                 Failures roll back the deployment within 30 seconds. \
+                 Operator dashboards track replica counts and error rates."
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: ns.to_string(),
+        title: format!("{title_keyword}-source-{}", uuid::Uuid::new_v4().simple()),
+        content: body,
+        tags: vec![title_keyword.to_string()],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"agent_id": "wt1e-agent"}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+    };
+    db::insert(conn, &mem).expect("seed long source")
+}
+
+fn make_atomiser(atoms: &[&str]) -> Atomiser {
+    let curator = Box::new(MockCurator::new(vec![Ok(atoms_from(atoms))]));
+    Atomiser::new(curator, None, AtomiserConfig::default(), FeatureTier::Smart)
+}
+
+/// Drive an end-to-end atomisation against `source_id`. The mock
+/// curator returns `atom_texts` deterministically.
+fn atomise(conn: &Connection, source_id: &str, atom_texts: &[&str], agent: &str) -> Vec<String> {
+    let atomiser = make_atomiser(atom_texts);
+    let outcome = atomiser
+        .atomise_sync(conn, source_id, 200, false, agent)
+        .expect("atomise ok");
+    outcome.atom_ids
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — default recall excludes archived sources
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recall_default_excludes_archived_sources() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "wt1e/r1", "kubernetes");
+
+    // Sanity: pre-atomisation, the source IS recalled.
+    let (results, _outcome) = db::recall(
+        &conn,
+        "kubernetes",
+        Some("wt1e/r1"),
+        20,
+        None,
+        None,
+        None,
+        0,
+        0,
+        None,
+        None,
+        false,
+    )
+    .expect("recall pre-atomise");
+    assert!(
+        results.iter().any(|(m, _)| m.id == source_id),
+        "pre-atomise: source must be recallable"
+    );
+
+    let atom_ids = atomise(
+        &conn,
+        &source_id,
+        &[
+            "Canary deploys for kubernetes require health checks.",
+            "Pod readiness probes gate kubernetes traffic shifts.",
+            "Failed kubernetes deploys roll back within 30 seconds.",
+            "Dashboards track kubernetes replica counts and error rates.",
+            "Kubernetes operators monitor pod state continuously.",
+        ],
+        "wt1e-agent",
+    );
+
+    // Default recall: atoms surface, source does not.
+    let (results, _outcome) = db::recall(
+        &conn,
+        "kubernetes",
+        Some("wt1e/r1"),
+        20,
+        None,
+        None,
+        None,
+        0,
+        0,
+        None,
+        None,
+        /* include_archived = */ false,
+    )
+    .expect("recall post-atomise");
+    let returned_ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();
+    assert!(
+        !returned_ids.contains(&source_id),
+        "default recall must exclude the archived source; got: {returned_ids:?}"
+    );
+    assert!(
+        atom_ids.iter().any(|aid| returned_ids.contains(aid)),
+        "atoms must surface under default recall; atoms={atom_ids:?} returned={returned_ids:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — include_archived=true returns BOTH atoms and the archived source
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recall_with_include_archived_returns_both() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "wt1e/r2", "redis");
+    let atom_ids = atomise(
+        &conn,
+        &source_id,
+        &[
+            "Redis persistence relies on RDB snapshots and AOF logs.",
+            "Redis replication uses asynchronous master-replica streams.",
+            "Redis sentinel coordinates automatic failover decisions.",
+            "Redis cluster shards keys across slot ranges.",
+            "Redis memory eviction follows LRU and LFU policies.",
+        ],
+        "wt1e-agent",
+    );
+
+    let (results, _outcome) = db::recall(
+        &conn,
+        "redis",
+        Some("wt1e/r2"),
+        20,
+        None,
+        None,
+        None,
+        0,
+        0,
+        None,
+        None,
+        /* include_archived = */ true,
+    )
+    .expect("recall include_archived");
+    let returned_ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();
+
+    assert!(
+        returned_ids.contains(&source_id),
+        "include_archived=true must surface the archived source; got: {returned_ids:?}"
+    );
+    assert!(
+        atom_ids.iter().any(|aid| returned_ids.contains(aid)),
+        "include_archived=true must still surface atoms; atoms={atom_ids:?} returned={returned_ids:?}"
+    );
+
+    // Source row carries the WT-1-B substrate-visible archive
+    // marker: `metadata.atomisation_archived_at` is set.
+    let source_row = results
+        .iter()
+        .find(|(m, _)| m.id == source_id)
+        .expect("source in result")
+        .0
+        .clone();
+    assert!(
+        source_row
+            .metadata
+            .get("atomisation_archived_at")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "archived source must carry metadata.atomisation_archived_at"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — archive filter composes with namespace + memory_kind + tier
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recall_filters_compose() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let (_tmp, conn) = fresh_db();
+    // Two namespaces, each with an atomised source.
+    let src_a = insert_long_source(&conn, "wt1e/r3/team-a", "elasticsearch");
+    let src_b = insert_long_source(&conn, "wt1e/r3/team-b", "elasticsearch");
+
+    let atoms_a = atomise(
+        &conn,
+        &src_a,
+        &[
+            "Elasticsearch shards distribute documents across primary nodes for team A.",
+            "Replica shards in elasticsearch provide failure tolerance for team A.",
+            "Bulk indexing in elasticsearch batches writes for throughput on team A.",
+            "Elasticsearch query DSL composes nested boolean clauses on team A.",
+            "Elasticsearch snapshots back up indices to object storage on team A.",
+        ],
+        "wt1e-agent",
+    );
+    let _atoms_b = atomise(
+        &conn,
+        &src_b,
+        &[
+            "Elasticsearch shards distribute documents across primary nodes for team B.",
+            "Replica shards in elasticsearch provide failure tolerance for team B.",
+            "Bulk indexing in elasticsearch batches writes for throughput on team B.",
+            "Elasticsearch query DSL composes nested boolean clauses on team B.",
+            "Elasticsearch snapshots back up indices to object storage on team B.",
+        ],
+        "wt1e-agent",
+    );
+
+    // include_archived=true + explicit namespace + non-empty
+    // results must hit team-A only. Source row appears because
+    // include_archived=true; atoms from team-B do NOT leak in.
+    let (results, _outcome) = db::recall(
+        &conn,
+        "elasticsearch",
+        Some("wt1e/r3/team-a"),
+        50,
+        None,
+        None,
+        None,
+        0,
+        0,
+        None,
+        None,
+        true,
+    )
+    .expect("recall compose");
+    let returned_namespaces: std::collections::HashSet<String> =
+        results.iter().map(|(m, _)| m.namespace.clone()).collect();
+    assert_eq!(
+        returned_namespaces,
+        std::collections::HashSet::from(["wt1e/r3/team-a".to_string()]),
+        "namespace filter must compose: got namespaces {returned_namespaces:?}"
+    );
+    let returned_ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();
+    assert!(returned_ids.contains(&src_a));
+    assert!(!returned_ids.contains(&src_b));
+    assert!(atoms_a.iter().any(|aid| returned_ids.contains(aid)));
+
+    // Sanity: with the default include_archived=false, src_a is
+    // excluded but the team-A atoms still surface — composition
+    // works in the other direction too.
+    let (results_default, _) = db::recall(
+        &conn,
+        "elasticsearch",
+        Some("wt1e/r3/team-a"),
+        50,
+        None,
+        None,
+        None,
+        0,
+        0,
+        None,
+        None,
+        false,
+    )
+    .expect("recall compose default");
+    let default_ids: Vec<String> = results_default.iter().map(|(m, _)| m.id.clone()).collect();
+    assert!(!default_ids.contains(&src_a));
+    assert!(atoms_a.iter().any(|aid| default_ids.contains(aid)));
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — memory_get is exempt from the archive filter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_memory_get_returns_archived_source() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "wt1e/r4", "postgres");
+    let _atoms = atomise(
+        &conn,
+        &source_id,
+        &[
+            "Postgres MVCC tracks transaction ids on every row tuple.",
+            "Postgres autovacuum compacts dead tuples on a schedule.",
+            "Postgres replication slots persist WAL until consumers catch up.",
+            "Postgres logical decoding emits replication events for downstreams.",
+            "Postgres connection pooling via PgBouncer reduces backend overhead.",
+        ],
+        "wt1e-agent",
+    );
+
+    // db::get — direct lookup, no archive filter applied.
+    let mem = db::get(&conn, &source_id)
+        .expect("get ok")
+        .expect("archived source still resolvable by id");
+    assert_eq!(mem.id, source_id);
+    assert!(
+        mem.metadata
+            .get("atomisation_archived_at")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "memory_get must return the archived source with its metadata stamp intact"
+    );
+
+    // db::resolve_id is the canonical resolver used by MCP
+    // `handle_get` (see src/mcp/tools/get.rs). Mirror the same
+    // call here to pin the exempt-from-filter contract.
+    let mem2 = db::resolve_id(&conn, &source_id)
+        .expect("resolve_id ok")
+        .expect("archived source resolvable by id (mcp handle_get path)");
+    assert_eq!(mem2.id, source_id);
+    assert!(
+        mem2.metadata
+            .get("atomisation_archived_at")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "resolve_id must round-trip the archive metadata"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bonus — exercise the MCP handle_recall path with include_archived
+// so the JSON-RPC parameter wiring is covered end-to-end.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mcp_recall_param_routes_include_archived() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "wt1e/mcp", "vault");
+    let _atoms = atomise(
+        &conn,
+        &source_id,
+        &[
+            "HashiCorp Vault stores secrets behind a sealed encryption barrier.",
+            "Vault auth methods enrol identities via OIDC, JWT, and TLS certs.",
+            "Vault dynamic secrets mint short-lived database credentials.",
+            "Vault audit devices ship every API call to a downstream sink.",
+            "Vault response wrapping hides secret payloads from intermediate hops.",
+        ],
+        "wt1e-agent",
+    );
+
+    let ttl = ai_memory::config::ResolvedTtl::default();
+    let scoring = ai_memory::config::ResolvedScoring::default();
+
+    // Default (include_archived absent) — source must NOT appear.
+    let resp = handle_recall(
+        &conn,
+        &json!({"context": "vault", "namespace": "wt1e/mcp"}),
+        None,
+        None,
+        None,
+        false,
+        &ttl,
+        &scoring,
+        None,
+    )
+    .expect("mcp recall default");
+    let default_ids: Vec<String> = resp["memories"]
+        .as_array()
+        .expect("memories array")
+        .iter()
+        .filter_map(|m| m["id"].as_str().map(String::from))
+        .collect();
+    assert!(
+        !default_ids.contains(&source_id),
+        "default MCP recall must drop archived source; got: {default_ids:?}"
+    );
+
+    // include_archived=true — source DOES appear.
+    let resp = handle_recall(
+        &conn,
+        &json!({"context": "vault", "namespace": "wt1e/mcp", "include_archived": true}),
+        None,
+        None,
+        None,
+        false,
+        &ttl,
+        &scoring,
+        None,
+    )
+    .expect("mcp recall include_archived");
+    let included_ids: Vec<String> = resp["memories"]
+        .as_array()
+        .expect("memories array")
+        .iter()
+        .filter_map(|m| m["id"].as_str().map(String::from))
+        .collect();
+    assert!(
+        included_ids.contains(&source_id),
+        "MCP recall include_archived=true must surface the source; got: {included_ids:?}"
+    );
+}

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -286,6 +286,7 @@ fn reflection_is_recall_visible_alongside_non_reflection_memories() {
         None,
         None,
         None,
+        false,
     )
     .expect("search ok");
     assert!(
@@ -307,6 +308,7 @@ fn reflection_is_recall_visible_alongside_non_reflection_memories() {
         0,
         None,
         None,
+        false,
     )
     .expect("recall ok");
     let ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();

--- a/tests/ship_gate/grand_slam_composition.rs
+++ b/tests/ship_gate/grand_slam_composition.rs
@@ -224,7 +224,7 @@ fn sg_co_1_forensic_bundle_export_and_verify_roundtrip() {
         include_reflections: true,
         include_transcripts: false,
         include_atomisation_chain: true,
-            output: None,
+        output: None,
     };
 
     // Build with a fixed `generated_at` so the bundle is reproducible
@@ -631,7 +631,7 @@ fn sg_co_8_forensic_bundle_verify_reports_tampered_file_by_name() {
         include_reflections: true,
         include_transcripts: false,
         include_atomisation_chain: true,
-            output: None,
+        output: None,
     };
     let mut files =
         bundle::build_files(&conn, &args, Some("2026-05-14T00:00:00Z")).expect("build_files ok");

--- a/tests/ship_gate/grand_slam_composition.rs
+++ b/tests/ship_gate/grand_slam_composition.rs
@@ -223,7 +223,8 @@ fn sg_co_1_forensic_bundle_export_and_verify_roundtrip() {
         memory_id: d2.clone(),
         include_reflections: true,
         include_transcripts: false,
-        output: None,
+        include_atomisation_chain: true,
+            output: None,
     };
 
     // Build with a fixed `generated_at` so the bundle is reproducible
@@ -629,7 +630,8 @@ fn sg_co_8_forensic_bundle_verify_reports_tampered_file_by_name() {
         memory_id: d0.clone(),
         include_reflections: true,
         include_transcripts: false,
-        output: None,
+        include_atomisation_chain: true,
+            output: None,
     };
     let mut files =
         bundle::build_files(&conn, &args, Some("2026-05-14T00:00:00Z")).expect("build_files ok");


### PR DESCRIPTION
## Summary

- **Recall** — `db::recall` / `db::recall_hybrid_with_telemetry` / `db::search` now exclude archived sources (WT-1-B's atom parents) by default; atoms surface in their place. New `include_archived: bool` opt-in surfaces the archived source alongside the atoms for forensic / auditor recall. The HNSW retrieval branch mirrors the SQL WHERE clause via a Rust-side `is_archived_source` check on `Memory.metadata`. Composes with existing namespace / tier / visibility / time-window filters. `memory_get` (direct lookup) is exempt.
- **MCP** — `memory_recall` and `memory_search` accept `include_archived` (default false) on the JSON-RPC params; tool descriptions and inputSchemas document the atom-preference contract. CLI gains `--include-archived` flags on `recall` and `search`.
- **Forensic bundle** — `forensic::bundle::build_files` walks `atom_of` ↔ `atomised_into` bidirectionally when the target memory participates in atomisation. Bundle gains:
  - Source row carrying an `atomisation: {atomised_into, archived_at, atom_ids}` enrichment block (or `atom_of` on atom rows).
  - Every atom envelope.
  - `derives_from` edges (added to the relation allowlist).
  - Per-atom `memory_link.created` events + the single `atomisation_complete` event, fetched by joining the writer agent ids of the chain's `derives_from` edges.
  
  New `--include-atomisation-chain` CLI flag (default true).
- **13 acceptance tests** — 5 in `tests/recall/wt1e.rs` (recall WHERE + MCP param), 3 in `tests/forensic/wt1e_chain_test.rs` (bundle contents, disable flag, round-trip reconstruction), plus all existing forensic + atomisation suites still pass.
- **Bug fix** — `fetch_atomisation_signed_events_for` previously used the same rusqlite `?N` placeholder twice for the OR-IN clauses; corrected to disjoint placeholder ranges with a chained bind vector.

## WT-1-B archive marker location

`metadata.atomisation_archived_at` (JSON field on `memories.metadata`) — chosen by WT-1-B over a dedicated column because schema v36 did not land `memories.archived_at`. The substrate-visible signal pair is `(memories.atomised_into > 0 AND json_extract(metadata, '$.atomisation_archived_at') IS NOT NULL)`.

## Files touched

- `src/storage/mod.rs` — `archived_source_clause`, `is_archived_source`, `include_archived: bool` on `recall` / `recall_with_telemetry` / `recall_hybrid` / `recall_hybrid_with_telemetry` / `search`.
- `src/mcp/tools/{recall,search}.rs` — wire `include_archived` from JSON-RPC params.
- `src/mcp/registry.rs` — tool descriptions + `include_archived` inputSchema fields.
- `src/cli/{recall,search}.rs` — `--include-archived` CLI flag.
- `src/forensic/bundle.rs` — `AtomisationEnvelope`, chain walker, `fetch_atomisation_signed_events_for`, `--include-atomisation-chain` CLI arg.
- `src/{bench,handlers/{http,mod},store/sqlite,cli/shell}.rs` — callers updated to pass the new `false` default.
- `tests/recall.rs` + `tests/recall/wt1e.rs` — 5 recall tests.
- `tests/forensic.rs` + `tests/forensic/wt1e_chain_test.rs` — 3 forensic tests.
- Test fixtures updated in `tests/{forensic/bundle_test, g_phase_e_4_verify_exit_codes, ship_gate/grand_slam_composition}.rs` for the new struct field.

## Test plan

- [x] `cargo test --test recall` — 5 passed
- [x] `cargo test --test forensic` — 8 passed (5 existing + 3 new)
- [x] `cargo test --test atomisation` — 11 passed (no regression)
- [x] `cargo test --lib` — 3824 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `cargo clippy --test recall --test forensic -- -D warnings ...` — clean
- [x] `cargo audit` — clean

## AI involvement

- **Model:** Claude Opus 4.7 (1M context)
- **Authority:** Standard (feature implementation following an operator-provided brief)
- **Scope:** Recall WHERE clause + MCP/CLI exposure; forensic bundle atomisation-chain enrichment; 13 acceptance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)