### PR TITLE
fix(v0.7.0 cluster-H): docs accuracy sweep — tool counts, MIGRATION, README, release-notes, 6 new docs (issue #767)

### DIFF
--- a/.github/workflows/tool-count-drift.yml
+++ b/.github/workflows/tool-count-drift.yml
@@ -1,0 +1,76 @@
+# Tool-count drift gate (Cluster H, issue #767).
+#
+# Prevents the v0.6.4 → v0.7.0 tool-count drift bug from recurring.
+# The single source of truth is `Profile::full().expected_tool_count()`
+# in `src/profile.rs` (and the per-family `Family::expected_tool_count`
+# match arm at `src/profile.rs:279-318`). At v0.7.0 the canonical
+# answer is 71 tools at `--profile full` and 7 at `--profile core`.
+#
+# This workflow is a CI grep gate — fast, cheap, deterministic. It
+# catches the most common drift modes:
+#
+#   1. A new MCP tool lands in `src/mcp/registry.rs` but the
+#      `Family::expected_tool_count` arm isn't incremented to match.
+#   2. README / release-notes / MIGRATION text claims a stale count
+#      (60 / 63 / 43) without the v0.7.0 footnote.
+#   3. `src/daemon_runtime.rs` `--profile full` help text drifts away
+#      from `Profile::full().expected_tool_count()`.
+#
+# The authoritative test that pins the family-count sum lives in
+# `src/profile.rs::family_expected_tool_counts_sum_to_51`
+# (test name predates v0.7 expansion). This grep gate runs alongside,
+# not in place of, that unit test.
+
+name: tool-count-drift
+
+on:
+  push:
+    branches: [main, develop, "feat/**", "fix/**", "release/**"]
+  pull_request:
+    branches: [main, develop, "feat/**", "release/**"]
+
+jobs:
+  grep-gate:
+    name: tool-count grep gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'registry-vs-profile parity (71 unique memory_* literals)'
+        shell: bash
+        run: |
+          count=$(grep -oE '"memory_[a-z_]+"' src/mcp/registry.rs | sort -u | wc -l | tr -d ' ')
+          echo "registry has $count unique memory_* tool literals"
+          # 71 at v0.7.0 — bump in lockstep with Family::expected_tool_count.
+          if [ "$count" -lt 70 ] || [ "$count" -gt 72 ]; then
+            echo "::error::registry memory_* literal count ($count) drifted from 71±1"
+            echo "::error::either update Family::expected_tool_count in src/profile.rs"
+            echo "::error::and this CI gate, or remove the stray tool literal"
+            exit 1
+          fi
+
+      - name: 'daemon_runtime help text honesty (no stale 43-tool claim)'
+        shell: bash
+        run: |
+          if grep -nE 'profile full.*43 tools|43 tools.*profile full|surface 1:1 \(43 tools\)' src/daemon_runtime.rs; then
+            echo "::error::src/daemon_runtime.rs --profile full help text claims 43 tools"
+            echo "::error::v0.7.0 ceiling is Profile::full().expected_tool_count() == 71"
+            exit 1
+          fi
+
+      - name: 'README badge / narrative tool counts'
+        shell: bash
+        run: |
+          # The README badge MUST advertise the v0.7.0 default + full counts.
+          if ! grep -qE 'MCP-7_default.*71_full|MCP-7.*71' README.md; then
+            echo "::error::README MCP badge missing '7_default • 71_full' (v0.7.0)"
+            exit 1
+          fi
+
+      - name: 'release-notes 60 -> N includes 71 at v0.7.0'
+        shell: bash
+        run: |
+          if ! grep -qE '60.*(→|->).*71' docs/v0.7.0/release-notes.md; then
+            echo "::error::docs/v0.7.0/release-notes.md missing '60 → 71' tool count delta"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -15,34 +15,60 @@
 [![Test Hub](https://img.shields.io/badge/test--hub-live_results-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-test-hub/)
 [![Discovery Gate](https://img.shields.io/badge/discovery--gate-6%2F6_PASS_%E2%80%A2_GATE_GREEN-2ea043?logo=githubpages)](https://alphaonedev.github.io/ai-memory-discovery-gate/)
 [![v0.6.4 Cert](https://img.shields.io/badge/v0.6.4_cert-CERT_GREEN-2ea043?logo=githubpages)](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md)
-[![MCP](https://img.shields.io/badge/MCP-5_default_%E2%80%A2_63_full-blueviolet)]()
-[![Evidence](https://img.shields.io/badge/claims-frozen_v0.6.4-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![MCP](https://img.shields.io/badge/MCP-7_default_%E2%80%A2_71_full-blueviolet)]()
+[![Evidence v0.6.4](https://img.shields.io/badge/claims-frozen_v0.6.4-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![Evidence v0.7.0](https://img.shields.io/badge/claims-frozen_v0.7.0-7e57c2)](docs/v0.7.0/release-notes.md)
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)](https://crates.io/crates/ai-memory)
 [![npm](https://img.shields.io/npm/v/@alphaone/ai-memory?label=npm&logo=npm)](https://www.npmjs.com/package/@alphaone/ai-memory)
 [![PyPI](https://img.shields.io/pypi/v/ai-memory-mcp?label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/ai-memory-mcp/)
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
 
-**v0.7.0 (`attested-cortex`)** rolls together the cortex-fluent legibility work with the full v0.7 trust + A2A scope from ROADMAP2 §7.3, **plus** (per operator directive 2026-05-09) the originally-v0.7.1 postgres+AGE first-class work. The substrate becomes both **more articulate** (capabilities v3, named loader tools, compacted schemas) and **cryptographically trustworthy** (Ed25519 attestation, sidechain transcripts, programmable hook pipeline, enforced namespace inheritance). v0.7.0 also ships **postgres + Apache AGE as a first-class storage backend** — `ai-memory serve --store-url postgres://…` for live daemon use, schema parity v28 across both backends, the new `ai-memory schema-init` CLI verb, and 6-factor recall scoring parity (Wave 1-4 expanded scope). The v0.6.4 5-tool default surface is unchanged; the runtime ceiling moves from 43 to **63 tools** (20 net-new across recursive-learning Task 4/8, L1-5 Agent Skills × 5, L1-6 substrate-rules check × 2, L2-2 reflection origin, L2-3 dependents_of_invalidated, L2-6 promote_from_reflection, L2-7 compositional_context, plus the v0.6.4 / v0.7.0 Track B / J / K additions) and everything new is additive and (for the trust + postgres surfaces) opt-in. **Upgrading from v0.6.x?** Read [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) first — most v0.6.4 callers see no behavior change, but pre-v0.6.3.1 v0.6.x users hit the G1 namespace-inheritance fix. **Switching to postgres+AGE?** See [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md) and [`docs/migration-v0.7.0-postgres.md`](docs/migration-v0.7.0-postgres.md). **Full release notes:** [`docs/v0.7.0/release-notes.md`](docs/v0.7.0/release-notes.md).
+**v0.7.0 (`attested-cortex`)** rolls together the cortex-fluent legibility work with the full v0.7 trust + A2A scope from ROADMAP2 §7.3, **plus** (per operator directive 2026-05-09) the originally-v0.7.1 postgres+AGE first-class work, **plus** the post-grand-slam ship-readiness wave (Batman Forms 1-6 + 7th-form Option-B foundation + QW-1/2/3 + reconciliation security sweep). The substrate becomes both **more articulate** (capabilities v3, named loader tools, compacted schemas, Batman `MemoryKind` vocabulary, persona/atomisation/multistep-ingest primitives) and **cryptographically trustworthy** (Ed25519 attestation, sidechain transcripts, programmable 25-event hook pipeline, enforced namespace inheritance, V-4 cross-row signed-events hash chain). v0.7.0 also ships **postgres + Apache AGE as a first-class storage backend** — `ai-memory serve --store-url postgres://…` for live daemon use, schema parity across both backends (sqlite ladder ends at migration 0033, postgres at 0020), the new `ai-memory schema-init` CLI verb, and 6-factor recall scoring parity. **The v0.6.4 default surface grows by two always-on loaders to 7 tools** (`memory_load_family` + `memory_smart_load` join the original five); the runtime ceiling at `--profile full` is **71 tools** (verified against `Profile::full().expected_tool_count()` — see [`src/profile.rs`](src/profile.rs)). Everything new is additive and (for the trust + postgres surfaces) opt-in. **Upgrading from v0.6.x?** Read [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) first — most v0.6.4 callers see no behavior change, but pre-v0.6.3.1 v0.6.x users hit the G1 namespace-inheritance fix. **Switching to postgres+AGE?** See [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md) and [`docs/migration-v0.7.0-postgres.md`](docs/migration-v0.7.0-postgres.md). **Full release notes:** [`docs/v0.7.0/release-notes.md`](docs/v0.7.0/release-notes.md).
 
 **v0.6.4 (`quiet-tools`)** — the MCP server ships with a **5-tool default surface** (`memory_store`, `memory_recall`, `memory_list`, `memory_get`, `memory_search`) plus the always-on `memory_capabilities` bootstrap. The other 38 tools remain reachable via `--profile graph|admin|power|full` or runtime expansion through `memory_capabilities --include-schema family=<name>`. Eager-loading harnesses (Claude Desktop / Codex CLI / Grok CLI / Gemini CLI) drop ~4,700 input tokens of tool schemas per request — a **76.4% reduction** measured against `cl100k_base` BPE. To preserve v0.6.3 behavior 1:1, run `ai-memory mcp --profile full`. See `docs/MIGRATION_v0.6.4.md`.
 
 ## What's new in v0.7
 
-v0.7.0 ships **five interlocking substrates** under one release banner. Every surface stays default-off or default-equivalent for v0.6.4 callers — see the [v0.7 compatibility matrix](docs/v0.7/compatibility-matrix.html) for the breakdown.
+v0.7.0 closes the `attested-cortex` epic (69/69 across 11 tracks A–K), folds in the originally-v0.7.1 postgres+AGE first-class work, and absorbs the post-grand-slam ship-readiness wave (Batman Forms 1-6 + 7th-form Option-B foundation + QW-1/2/3 + security reconciliation). Canonical feature inventory: [`docs/internal/v070-feature-inventory.md`](docs/internal/v070-feature-inventory.md). Every surface stays default-off or default-equivalent for v0.6.4 callers — see the [v0.7 compatibility matrix](docs/v0.7/compatibility-matrix.html) for the breakdown.
+
+### Substrate-native write-time investment (Batman Forms 1-6 + 7th-form)
+
+- **Form 1 — online dedup-and-synthesis** (issue [#754](https://github.com/alphaonedev/ai-memory-mcp/issues/754)). Single-batch action-emitting LLM call replaces the v0.6.x per-pair classifier on the store path. Opt back into legacy yes/no via `legacy_per_pair_classifier = true` on the namespace standard.
+- **Form 2 — synchronous atomise-before-embed** (issue [#755](https://github.com/alphaonedev/ai-memory-mcp/issues/755)). New `memory_atomise` tool + `auto_atomise_mode = Synchronous|Deferred|Off` pre-store hook. Curator decomposes long writes into 2–10 atomic propositions before recall ever sees them. See [`docs/atomisation.md`](docs/atomisation.md).
+- **Form 3 — multi-step ingest orchestrator** (issue [#756](https://github.com/alphaonedev/ai-memory-mcp/issues/756)). `memory_ingest_multistep` threads deterministic Jaccard+FTS helpers through prompt-cache-stable LLM stages. See [`docs/multistep-ingest.md`](docs/multistep-ingest.md) + [`cookbook/multistep-ingest/01-two-phase.sh`](cookbook/multistep-ingest/01-two-phase.sh).
+- **Form 4 — fact provenance** (issue [#757](https://github.com/alphaonedev/ai-memory-mcp/issues/757)). Citations + source-URI + atom-grain spans ride on existing `memory_store` / `memory_atomise` payloads. See [`docs/provenance.md`](docs/provenance.md).
+- **Form 5 — auto-confidence + shadow calibration + freshness decay** (issue [#758](https://github.com/alphaonedev/ai-memory-mcp/issues/758)). `memory_calibrate_confidence` MCP tool + per-source baseline sweep. Env vars `AI_MEMORY_AUTO_CONFIDENCE`, `AI_MEMORY_CONFIDENCE_SHADOW`, `AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE`, `AI_MEMORY_CONFIDENCE_DECAY`. See [`docs/confidence-calibration.md`](docs/confidence-calibration.md).
+- **Form 6 — `MemoryKind` Batman vocabulary** (issue [#759](https://github.com/alphaonedev/ai-memory-mcp/issues/759)). 10-variant enum (`Observation` default + `Reflection` / `Persona` / `Concept` / `Entity` / `Claim` / `Relation` / `Event` / `Conversation` / `Decision`). Optional `auto_classify_kind` pre-store hook (off / regex_only / regex_then_llm). See [`docs/memory-kind-vocab.md`](docs/memory-kind-vocab.md).
+- **7th-form — agent-EXTERNAL Layer-4 wiring (Option-B foundation)** (issue [#760](https://github.com/alphaonedev/ai-memory-mcp/issues/760); v0.8.0 complete cover at [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697)). Operator-keypair-signed seed rules `R001..R004`, `memory_check_agent_action` + `memory_rule_list` MCP tools, substrate `storage::insert` pre-write hook. See [`docs/policy-engine.md`](docs/policy-engine.md) + [`docs/governance/agent-action-rules.md`](docs/governance/agent-action-rules.md).
+
+### Quick wins (Tencent QW-1/2/3)
+
+- **QW-1 — file-backed reflection chain export.** `memory_export_reflection` MCP tool + `auto_export_reflections_to_filesystem` namespace policy → `~/.ai-memory/reflections/<ns>/<id>.md`.
+- **QW-2 — persona-as-artifact.** `memory_persona` + `memory_persona_generate` tools, `MemoryKind::Persona` rows, `auto_persona_trigger_every_n_memories` namespace policy. See [`docs/persona.md`](docs/persona.md).
+- **QW-3 — context offload primitive.** `memory_offload` + `memory_deref` move large tool outputs out of the agent context window into addressable blob storage. See [`docs/context-offload.md`](docs/context-offload.md).
+
+### Attested cortex epic (Tracks A–K)
 
 - **Attested links (Ed25519).** The dead `signature` column shipped in v0.6.3 is now filled with real per-agent Ed25519 attestation, and `memory_verify(link_id)` returns `{signature_verified, attest_level, signed_by, signed_at}` on demand. Generate a keypair with `ai-memory identity generate`; opt-in via `attest_level = "self_signed"`. See the [`attested-cortex` RFC](docs/v0.7/rfc-attested-cortex.md#decision-1--why-ed25519-over-x25519--chacha20).
-- **Hook pipeline (25 lifecycle events).** A programmable extension surface fires on the 20 baseline `pre_/post_store|recall|search|delete|promote|link|consolidate|governance_decision|archive|transcript_store` + `on_index_eviction` events, plus 5 grand-slam additions (`pre_recall_expand` G10 + `pre_reflect`/`post_reflect` recursive-learning Task 6/8 + `pre_compaction`/`on_compaction_rollback` L1-7). Hooks return `Allow` / `Modify` / `Deny` / `AskUser`. Default off; opt in via `~/.config/ai-memory/hooks.toml`. See [MIGRATION § Hook pipeline](docs/MIGRATION_v0.7.md#hook-pipeline-opt-in).
-- **Transcripts + replay.** zstd-3 BLOB sidechain stores raw conversation/reasoning trails; `memory_replay(memory_id)` walks `memory_transcript_links` to reconstruct the chain. Opt-in per namespace via `[transcripts."team/*"]`. See [MIGRATION § Sidechain transcripts](docs/MIGRATION_v0.7.md#sidechain-transcripts-opt-in-per-namespace).
-- **Postgres + Apache AGE first-class backend.** v0.7.0 promotes postgres+AGE from "migration target" (v0.7-alpha) to a fully-supported live daemon backend: `ai-memory serve --store-url postgres://…`, schema parity v28, 6-factor recall scoring parity, link migration, KG features (`kg_query`, `kg_timeline`, `kg_invalidate`, `find_paths`) on AGE Cypher with recursive-CTE fallback when AGE is absent, plus a new `ai-memory schema-init` CLI verb. Bench-gated — AGE p95 must beat CTE p95 by ≥30% at depth=5. Operator how-to: [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md). Migration runbook: [`docs/migration-v0.7.0-postgres.md`](docs/migration-v0.7.0-postgres.md). See also [MIGRATION § Apache AGE acceleration](docs/MIGRATION_v0.7.md#apache-age-acceleration-opt-in).
-- **Capabilities v3 + smart loaders.** `memory_capabilities` v3 adds `summary`, `to_describe_to_user`, per-tool `callable_now`, and `agent_permitted_families`; the new always-on `memory_load_family(family)` and `memory_smart_load(intent)` tools replace the `memory_capabilities --include-schema` ergonomics. The pinned phrasings live in [`docs/v0.7/canonical-phrasings.md`](docs/v0.7/canonical-phrasings.md).
-- **Permissions + A2A approvals.** The v0.6.x governance subsystem is refactored into rules + modes + hooks → a single `Decision`, with namespace inheritance (G1) actually enforced. `memory_approval_pending` / `memory_approval_decide(remember=forever)` enable progressive trust; HMAC signing on the approval API is mandatory. Migrate with `ai-memory governance migrate-to-permissions --apply`. See [`What's new in v0.7`](docs/whats-new-v07.html) for the full walk-through.
+- **Signed events V-4 closeout (cross-row hash chain)** (issue [#698](https://github.com/alphaonedev/ai-memory-mcp/issues/698)). Each `signed_events` row carries `prev_hash` + `sequence`; first-row `prev_hash` is zero, subsequent rows chain the SHA-256 of the prior canonical-CBOR payload. `ai-memory verify-signed-events-chain` walks the chain end-to-end. See [`docs/signed-events-v4.md`](docs/signed-events-v4.md).
+- **Hook pipeline (25 lifecycle events).** A programmable extension surface fires on the 20 baseline `pre_/post_store|recall|search|delete|promote|link|consolidate|governance_decision|archive|transcript_store` + `on_index_eviction` events, plus 5 grand-slam additions (`pre_recall_expand` G10 + `pre_reflect`/`post_reflect` recursive-learning Task 6/8 + `pre_compaction`/`on_compaction_rollback` L1-7). Hooks return `Allow` / `Modify` / `Deny` / `AskUser`. Default off; opt in via `~/.config/ai-memory/hooks.toml`. See [`docs/hook-pipeline.md`](docs/hook-pipeline.md).
+- **Sidechain transcripts + replay.** zstd-3 BLOB sidechain stores raw conversation/reasoning trails; `memory_replay(memory_id)` walks `memory_transcript_links` to reconstruct the chain. Opt-in per namespace via `[transcripts."team/*"]`. See [`docs/sidechain-transcripts.md`](docs/sidechain-transcripts.md).
+- **Federation hardening.** mTLS + X-API-Key + SHA-256 cert fingerprint allowlist; env vars `AI_MEMORY_FED_PEER_ATTESTATION`, `AI_MEMORY_FED_SYNC_TRUST_PEER`, `AI_MEMORY_FED_TRUST_BODY_AGENT_ID`. See [`docs/federation.md`](docs/federation.md).
+- **K8 quota tool + K10 SSE approvals.** `memory_quota_status` + `/api/v1/quota/status` (K8). `/api/v1/approvals/stream` server-sent events with HMAC nonce, method+pending_id binding, lagged-event count strip (K10). See [`docs/k8-quotas.md`](docs/k8-quotas.md) + [`docs/k10-sse-approvals.md`](docs/k10-sse-approvals.md).
+- **Postgres + Apache AGE first-class backend.** `ai-memory serve --store-url postgres://…`, schema parity, 6-factor recall scoring parity, link migration, KG features (`kg_query`, `kg_timeline`, `kg_invalidate`, `find_paths`) on AGE Cypher with recursive-CTE fallback when AGE is absent, plus a new `ai-memory schema-init` CLI verb. Bench-gated — AGE p95 must beat CTE p95 by ≥30% at depth=5. Operator how-to: [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md). Migration runbook: [`docs/migration-v0.7.0-postgres.md`](docs/migration-v0.7.0-postgres.md).
+- **Capabilities v3 + smart loaders.** `memory_capabilities` v3 adds `summary`, `to_describe_to_user`, per-tool `callable_now`, `agent_permitted_families`, `schema_version="3"`; the new always-on `memory_load_family(family)` and `memory_smart_load(intent)` tools join the default `core` profile. The pinned phrasings live in [`docs/v0.7/canonical-phrasings.md`](docs/v0.7/canonical-phrasings.md).
+- **Permissions + A2A approvals.** The v0.6.x governance subsystem is refactored into rules + modes + hooks → a single `Decision`, with namespace inheritance (G1) actually enforced. `memory_pending_list` / `memory_pending_approve` / `memory_pending_reject(remember=forever)` enable progressive trust; HMAC signing on the approval API is mandatory. `permissions.mode` defaults to `enforce` (was `advisory` in v0.6.4). Migrate with `ai-memory governance migrate-to-permissions --apply`. See [`docs/governance.md`](docs/governance.md).
 
-> **Where to start:** [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) (upgrade procedure), [`docs/whats-new-v07.html`](docs/whats-new-v07.html) (visual summary), [`docs/v0.7/rfc-attested-cortex.md`](docs/v0.7/rfc-attested-cortex.md) (design rationale), [`docs/ADMIN_GUIDE.md`](docs/ADMIN_GUIDE.md) (operator playbook).
+### Recursive-learning + L1/L2 grand-slam wave
+
+`memory_reflect` substrate primitive with namespace-scoped `max_reflection_depth` cap (default 3, `Some(0)` is the kill-switch). L2-1 reflection-pass curator, L2-2 federation-aware reflection coordination (`memory_reflection_origin`), L2-3 invalidation propagation (`memory_dependents_of_invalidated`), L2-5 forensic bundle (`ai-memory export-forensic-bundle` + `verify-forensic-bundle`), L1-5 Agent Skills (`memory_skill_register|list|get|resource|export|promote_from_reflection|compositional_context`). Full primer: [`docs/RECURSIVE_LEARNING.md`](docs/RECURSIVE_LEARNING.md). Agent Skills primer: [`docs/agent-skills.md`](docs/agent-skills.md). Forensic-export primer: [`docs/forensic-export.md`](docs/forensic-export.md).
+
+> **Where to start:** [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) (upgrade procedure), [`docs/v0.7.0/release-notes.md`](docs/v0.7.0/release-notes.md) (full release notes), [`docs/whats-new-v07.html`](docs/whats-new-v07.html) (visual summary), [`docs/v0.7/rfc-attested-cortex.md`](docs/v0.7/rfc-attested-cortex.md) (design rationale), [`docs/ADMIN_GUIDE.md`](docs/ADMIN_GUIDE.md) (operator playbook), [`docs/internal/v070-feature-inventory.md`](docs/internal/v070-feature-inventory.md) (canonical feature truth).
 
 **One binary, four operational modes** (v0.6.4). The `ai-memory` Rust binary (tokio + axum) can run any of these in isolation or simultaneously, sharing a single SQLite database:
 
-1. **stdio MCP server** -- 63 native tools over JSON-RPC at full profile. Default `--profile core` advertises 5 + always-on `memory_capabilities`. `ai-memory mcp` / `ai-memory mcp --profile full`
+1. **stdio MCP server** -- 71 native tools over JSON-RPC at full profile (v0.7.0; verified against `Profile::full().expected_tool_count()`). Default `--profile core` advertises 7 (the original 5 + `memory_load_family` + `memory_smart_load`) plus the always-on `memory_capabilities` bootstrap. `ai-memory mcp` / `ai-memory mcp --profile full`
 2. **HTTP / mTLS daemon** -- 42 REST endpoints on `127.0.0.1:9077`, TLS + optional mTLS allowlist + API-key auth, background GC loop. `ai-memory serve`
 3. **Autonomous curator daemon** -- self-scheduling loop (default 1h cadence) that auto-tags, surfaces contradictions across namespace siblings, consolidates near-duplicates, and adjusts priority by access pattern. Every action goes to a rollback log; destructive ops can be gated behind a governance approval flow. `ai-memory curator --daemon`
 4. **Sync daemon** -- quorum-based peer federation across instances. W-of-N writes (default majority), vector-clock CRDT-lite merge, mTLS allowlist between peers. `ai-memory sync-daemon`
@@ -504,7 +530,7 @@ ai-memory recall "database"
 ai-memory stats
 ```
 
-**6. Use with your AI.** Restart your AI client. It now has **5 default memory tools** advertised on boot (43 total reachable via runtime expansion or `--profile full`) over MCP -- it can store and recall memories natively during conversations.
+**6. Use with your AI.** Restart your AI client. It now has **7 default memory tools** advertised on boot (71 total reachable via runtime expansion or `--profile full` at v0.7.0) over MCP -- it can store and recall memories natively during conversations.
 
 ---
 
@@ -554,7 +580,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (50 endpoints on port 90
 ## Features
 
 ### Core
-- **MCP tool server** -- 63 tools over stdio JSON-RPC (full profile), compatible with any MCP client
+- **MCP tool server** -- 71 tools over stdio JSON-RPC (full profile at v0.7.0), compatible with any MCP client
 - **Three-tier memory** -- short (6h TTL default), mid (7d TTL default), long (permanent) -- TTLs are configurable
 - **Full-text search** -- SQLite FTS5 with ranked retrieval
 - **Hybrid recall** -- FTS5 keyword + cosine similarity with fixed 0.6 semantic / 0.4 keyword (60/40) blend weights
@@ -580,7 +606,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (50 endpoints on port 90
 ### Interfaces
 - **42 HTTP endpoints** -- full REST API on 127.0.0.1:9077 (works with any AI or tool)
 - **26 CLI commands** -- complete CLI with identical capabilities
-- **63 MCP tools** at full profile (5 default) -- native integration for any MCP-compatible AI
+- **71 MCP tools** at full profile (7 default at v0.7.0; verified against `Profile::full().expected_tool_count()`) -- native integration for any MCP-compatible AI
 - **Interactive REPL shell** -- recall, search, list, get, stats, namespaces, delete with color output
 - **JSON output** -- `--json` flag on all CLI commands
 
@@ -719,9 +745,9 @@ ai-memory supports 4 feature tiers, selected at startup with `ai-memory mcp --ti
 | Tier | Recall Method | Extra Capabilities | Approx. Overhead |
 |------|---------------|-------------------|-----------------|
 | **keyword** | FTS5 only | Baseline 26 tools | 0 MB |
-| **semantic** | FTS5 + cosine similarity (hybrid) | MiniLM-L6-v2 embeddings (384-dim), HNSW index, semantic tier (subset of 63-tool surface) | ~256 MB |
-| **smart** | Hybrid + LLM query expansion | + nomic-embed-text (768-dim) + Gemma 4 E2B via Ollama: `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, full 63-tool surface | ~1 GB |
-| **autonomous** | Hybrid + LLM expansion + cross-encoder reranking | + Gemma 4 E4B via Ollama, neural cross-encoder (ms-marco-MiniLM), memory reflection, full 63-tool surface | ~4 GB |
+| **semantic** | FTS5 + cosine similarity (hybrid) | MiniLM-L6-v2 embeddings (384-dim), HNSW index, semantic tier (subset of 71-tool surface (v0.7.0)) | ~256 MB |
+| **smart** | Hybrid + LLM query expansion | + nomic-embed-text (768-dim) + Gemma 4 E2B via Ollama: `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, full 71-tool surface (v0.7.0) | ~1 GB |
+| **autonomous** | Hybrid + LLM expansion + cross-encoder reranking | + Gemma 4 E4B via Ollama, neural cross-encoder (ms-marco-MiniLM), memory reflection, full 71-tool surface (v0.7.0) | ~4 GB |
 
 ### Capability Matrix
 
@@ -753,7 +779,7 @@ Every capability mapped to its minimum tier. Each tier includes all capabilities
 
 **Semantic tier** (default) bundles the Candle ML framework and downloads the all-MiniLM-L6-v2 model on first run (~90 MB). **Smart** and **autonomous** tiers require [Ollama](https://ollama.com) running locally.
 
-**Tiers gate features, not models.** The `--tier` flag controls which tools are exposed. The LLM model is independently configurable via `llm_model` in `~/.config/ai-memory/config.toml`. For example, run autonomous tier (full 63-tool surface + reranker) with the faster e2b model:
+**Tiers gate features, not models.** The `--tier` flag controls which tools are exposed. The LLM model is independently configurable via `llm_model` in `~/.config/ai-memory/config.toml`. For example, run autonomous tier (full 71-tool surface (v0.7.0) + reranker) with the faster e2b model:
 
 ```toml
 # ~/.config/ai-memory/config.toml
@@ -783,7 +809,7 @@ The `memory_capabilities` tool reports the active tier, loaded models, and avail
 
 ## MCP Tools
 
-These 63 tools (full profile) are available to any MCP-compatible AI when configured as an MCP server (canonical count on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); the table below documents the core subset most clients use day-to-day):
+These 71 tools (full profile at v0.7.0; canonical count via `Profile::full().expected_tool_count()` in [`src/profile.rs`](src/profile.rs)) are available to any MCP-compatible AI when configured as an MCP server (the v0.6.4-frozen evidence page lists the 63-tool baseline; the table below documents the core subset most clients use day-to-day):
 
 | Tool | Description |
 |------|-------------|

--- a/RELEASE_NOTES_v0.7.0.md
+++ b/RELEASE_NOTES_v0.7.0.md
@@ -1,0 +1,66 @@
+# ai-memory v0.7.0 — `attested-cortex`
+
+**Tagged:** 2026-05-15 (post-grand-slam ship-readiness wave at HEAD `c9472c1`).
+**Theme:** attested cortex + Batman 7-form closeout + postgres+AGE first-class.
+**One-line summary:** v0.7.0 ships **71 MCP tools at `--profile full`** (was 43 at v0.6.3, 60 at the original `attested-cortex` cut), **7 always-on tools** at `--profile core` (the original 5 + `memory_load_family` + `memory_smart_load`), all 7 Batman write-time-investment forms IMPLEMENTED, postgres + Apache AGE as a first-class storage backend, and per-agent Ed25519 attestation with a V-4 cross-row signed-events hash chain.
+
+---
+
+This file is the top-level entrypoint by convention (matches
+[`RELEASE_NOTES_v0.6.4.md`](RELEASE_NOTES_v0.6.4.md)). The **full
+release notes** — including the post-grand-slam ship-readiness wave,
+the schema and tool-surface deltas, the upgrade path from v0.6.4 and
+v0.7-alpha, breaking changes, and the operator-references index —
+live at:
+
+  → [`docs/v0.7.0/release-notes.md`](docs/v0.7.0/release-notes.md)
+
+The **canonical feature inventory** (every net-new feature relative
+to v0.6.4, with code-path evidence) lives at:
+
+  → [`docs/internal/v070-feature-inventory.md`](docs/internal/v070-feature-inventory.md)
+
+The **v0.6.4 → v0.7.0 migration guide** lives at:
+
+  → [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md)
+
+---
+
+## Headline highlights
+
+- **71 MCP tools at `--profile full`** (verified against
+  `Profile::full().expected_tool_count()` in [`src/profile.rs`](src/profile.rs)).
+  **7 always-on at `--profile core`** (the original 5 + the v0.7 B1/B2
+  loader pair). Default tool surface is unchanged in spirit for v0.6.4
+  callers — the two new loaders are additive.
+- **Batman 6-form audit + Forms 1-6 + 7th-form (Option-B foundation)
+  closeout.** All 7 forms IMPLEMENTED at HEAD `c9472c1`. See
+  [`docs/internal/batman-framework-audit.md`](docs/internal/batman-framework-audit.md)
+  (prologue covers the post-audit Forms wave).
+- **QW-1/2/3 (Tencent quick-wins).** File-backed reflection export,
+  persona-as-artifact, context-offload primitive.
+- **Substrate trust.** Per-agent Ed25519 attestation, append-only
+  `signed_events` audit table, V-4 cross-row hash chain (`prev_hash`
+  + `sequence`) verified by `ai-memory verify-signed-events-chain`.
+- **Postgres + Apache AGE first-class backend.**
+  `ai-memory serve --store-url postgres://…`, schema parity, 6-factor
+  recall scoring parity, KG features on AGE Cypher with recursive-CTE
+  fallback. `ai-memory schema-init` CLI verb.
+- **25-event programmable hook pipeline** (`~/.config/ai-memory/hooks.toml`).
+- **K8 quota tool** (`memory_quota_status` + `/api/v1/quota/status`)
+  and **K10 SSE approvals** (`/api/v1/approvals/stream` with mandatory
+  HMAC signing).
+- **Reconciliation security sweep** (11 late-cycle commits, merged
+  into trunk at `64528b1`).
+
+## Upgrade path
+
+For most v0.6.4 callers, **no behavior change**. Run the schema
+migration once (auto on first start of a sqlite-backed daemon),
+optionally generate an Ed25519 keypair (`ai-memory identity generate`),
+optionally migrate the governance policy store to the new permissions
+shape (`ai-memory governance migrate-to-permissions --apply`).
+
+Full procedure: [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md).
+
+— AlphaOne LLC, 2026-05-15

--- a/cookbook/multistep-ingest/01-two-phase.sh
+++ b/cookbook/multistep-ingest/01-two-phase.sh
@@ -39,14 +39,14 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-scratch_root="${SCRATCH_ROOT:-/Users/fate/v07/v07-fixes/.local-runs}"
+scratch_root="${SCRATCH_ROOT:-${repo_root}/.local-runs}"
 ts="$(date -u +%Y%m%dT%H%M%SZ)"
 run_dir="${scratch_root}/cookbook-multistep-${ts}"
 mkdir -p "${run_dir}"
 
 export TMPDIR="${scratch_root}/tmp"
 mkdir -p "${TMPDIR}"
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/Users/fate/v07/v07-fixes/.cargo-shared-target}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${repo_root}/target}"
 
 echo "==> Form 3 multi-step ingest cookbook recipe"
 echo "    repo: ${repo_root}"

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -742,6 +742,45 @@ follow-up — they are NOT drift in the doc surface, just transport-level
 surface-area differences captured here so operators don't re-derive
 them.
 
+## v0.7.0 net-new endpoints
+
+The eight HTTP routes added since v0.6.4. All accept the same auth +
+agent-identity headers documented above. Wire-shape source of truth is
+`src/handlers/http.rs` (the route file enumeration in `src/lib.rs`).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/v1/quota/status` | K8 quota status — read the calling agent's daily quota row. Auto-inserts a default row on first call. See [`docs/k8-quotas.md`](k8-quotas.md). |
+| `GET`  | `/api/v1/approvals/stream` | K10 SSE approval channel — server-sent events for pending-approval state changes. HMAC body signature required on the partnered POST decide path. See [`docs/k10-sse-approvals.md`](k10-sse-approvals.md). |
+| `POST` | `/api/v1/auto_tag` | LLM auto-tag endpoint (v0.7 smart-tier surface). |
+| `POST` | `/api/v1/expand_query` | HTTP parity for the MCP `memory_expand_query` tool. |
+| `POST` | `/api/v1/kg/find_paths` | KG chain-walk over HTTP; Cypher on AGE / recursive-CTE on SQLite. |
+| `POST` | `/api/v1/links/verify` | Ed25519 link verification surface — wire shape: `{verified, attest_level, signature_present, observed_by, source_id, target_id, relation, findings}`. |
+| `POST` | `/api/v1/memory_load_family` | HTTP parity for the always-on `memory_load_family` MCP loader. |
+| `GET`  | `/api/v1/tools/list` | MCP `tools/list` mirror for harness ops — returns the live tool surface for the daemon's profile (71 at `full`, 7 at `core`). |
+
+> Total HTTP surface at v0.7.0: ~42 routes on the sqlite-backed daemon
+> (the v0.6.4 baseline of 34 + the 8 net-new above). Authoritative
+> count via the `.route(...)` grep in `src/lib.rs`.
+
+### v0.7.0 net-new MCP tools
+
+The 28 MCP tools added since v0.6.4 are documented inline in
+`src/mcp/registry.rs` and enumerated in
+[`docs/MIGRATION_v0.7.md` §"New MCP tools"](MIGRATION_v0.7.md#new-mcp-tools).
+Highlights for HTTP-equivalent surfaces:
+
+| MCP tool | HTTP equivalent | Notes |
+|---|---|---|
+| `memory_load_family` | `POST /api/v1/memory_load_family` | Always-on. |
+| `memory_quota_status` | `POST /api/v1/quota/status` | K8. |
+| `memory_find_paths` | `POST /api/v1/kg/find_paths` | J7. |
+| `memory_verify` | `POST /api/v1/links/verify` | H4. |
+| `memory_pending_list` / `memory_pending_approve` / `memory_pending_reject` | `GET /api/v1/pending`, `POST /api/v1/pending/{id}/approve`, `POST /api/v1/pending/{id}/reject` | K10. The MCP tool names changed from the v0.7-alpha drafts (`memory_approval_pending` / `memory_approval_decide`); the HTTP paths are stable. |
+
+For the canonical 71-tool full inventory: `grep -oE '"memory_[a-z_]+"'
+src/mcp/registry.rs | sort -u`.
+
 ## See also
 
 - `docs/USER_GUIDE.md` — MCP tool reference (parallel to this HTTP doc).

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -537,6 +537,85 @@ ai-memory migrate \
   --dry-run
 ```
 
+## v0.7.0 net-new CLI subcommands
+
+These subcommands joined the CLI surface between v0.6.4 and v0.7.0
+HEAD `c9472c1`. Source files in `src/cli/` (and `src/cli/commands/`
+for the WT-1/QW/Form additions).
+
+### `atomise` — Form 2 / WT-1-C decomposition
+
+Decomposes a long memory into 2-10 atomic propositions. Backs the
+`memory_atomise` MCP tool. See [`docs/atomisation.md`](atomisation.md).
+
+### `calibrate-confidence` — Form 5 sweep
+
+Per-source baseline calibration. Backs `memory_calibrate_confidence`.
+See [`docs/confidence-calibration.md`](confidence-calibration.md).
+
+### `export-reflections` — QW-1 file-backed export
+
+Walks the reflection-chain and writes Markdown to
+`~/.ai-memory/reflections/<ns>/<id>.md` by default. Pair with
+`auto_export_reflections_to_filesystem = true` for hands-off operation.
+
+### `persona` — QW-2 persona-as-artifact
+
+Build a persona from observation-kind memories for a given entity.
+Backs `memory_persona` / `memory_persona_generate`.
+
+### `offload` — QW-3 context offload
+
+Move a large blob out of the agent context window. Pairs with the
+background `offload_ttl_sweep` worker.
+
+### `identity` — Ed25519 keypair management (H-track)
+
+| Subcommand | Notes |
+|---|---|
+| `ai-memory identity generate --agent-id <id>` | Create a keypair under `~/.config/ai-memory/keys/<agent_id>.{pub,priv}`. |
+| `ai-memory identity list` | List enrolled keypairs. |
+| `ai-memory identity export-pub --agent-id <id>` | Print the public key. |
+| `ai-memory identity suggest-id` | Print the canonical `ai:<harness>@<host>:pid-<pid>` form. |
+
+### `verify-signed-events-chain` — V-4 closeout verifier
+
+Walks the `signed_events` cross-row hash chain end-to-end. Supports
+`--since N` (skip the first N rows) and `--format text|json`. See
+[`docs/signed-events-v4.md`](signed-events-v4.md).
+
+### `schema-init` — postgres + AGE bootstrap
+
+Idempotent schema bootstrap for a fresh postgres store, including the
+AGE projection. Supports `--skip-age` for the CTE fallback. See
+[`docs/postgres-age-guide.md`](postgres-age-guide.md).
+
+### `governance` subcommands
+
+| Subcommand | Notes |
+|---|---|
+| `ai-memory governance migrate-to-permissions` | Dry-run by default; `--apply` to commit the v0.6.x governance → v0.7 permissions migration. Idempotent. |
+| `ai-memory governance install-defaults` | Install the operator-signed seed rules `R001..R004`. |
+
+### `rules` subcommand (7th-form)
+
+| Subcommand | Notes |
+|---|---|
+| `ai-memory rules sign <rule.json>` | Sign a rule with the operator key for `attest_level = "signed"`. |
+| `ai-memory rules list` | List the active rule corpus (CLI equivalent of `memory_rule_list`). |
+
+### `export-forensic-bundle` / `verify-forensic-bundle` — L2-5
+
+Deterministic in-process POSIX-ustar tar with byte-identical mod
+timestamps. Operator-signed when an operator keypair is present. See
+[`docs/forensic-export.md`](forensic-export.md).
+
+### `install --enforce-policy` flag
+
+The `ai-memory install --harness <h>` command gains an
+`--enforce-policy` flag that wires the 7th-form policy file at install
+time.
+
 ## Shell, completions, man
 
 ```bash

--- a/docs/MIGRATION_v0.7.md
+++ b/docs/MIGRATION_v0.7.md
@@ -1,8 +1,8 @@
 # Migrating from v0.6.4 to v0.7.0
 
-**v0.7.0 — `attested-cortex`** rolls together the v0.6.5 cortex-fluent legibility work with ROADMAP2 §7.3's full v0.7 trust + A2A maturity scope. The substrate becomes both **more articulate** (capabilities v3, named loaders, compacted schemas) and **cryptographically trustworthy** (Ed25519 attestation, sidechain transcripts, programmable hook pipeline, enforced namespace inheritance).
+**v0.7.0 — `attested-cortex`** rolls together the v0.6.5 cortex-fluent legibility work with ROADMAP2 §7.3's full v0.7 trust + A2A maturity scope, **plus** (per operator directive 2026-05-09) the originally-v0.7.1 postgres+AGE first-class work, **plus** the post-grand-slam ship-readiness wave (Batman Forms 1-6 + 7th-form Option-B foundation + QW-1/2/3 + reconciliation security sweep). The substrate becomes both **more articulate** (capabilities v3, named loaders, compacted schemas, Batman `MemoryKind` vocabulary, persona/atomisation/multistep-ingest primitives) and **cryptographically trustworthy** (Ed25519 attestation, sidechain transcripts, programmable 25-event hook pipeline, enforced namespace inheritance, V-4 cross-row signed-events hash chain).
 
-> **Status:** Released 2026-05-06. v0.7.0 closes the `attested-cortex` epic at 69/69 tasks across 11 tracks (A/B/C/D/E/F/G/H/I/J/K). See [`CHANGELOG.md`](../CHANGELOG.md#070--2026-05-06--attested-cortex) for the full release entry. Any sections still marked TODO below are post-v0.7.0 follow-ups (e.g. v0.7.0.1 cross-platform Rust binaries — issue [#625](https://github.com/alphaonedev/ai-memory-mcp/issues/625)).
+> **Status:** Released 2026-05-15 at HEAD `c9472c1`. v0.7.0 closes the `attested-cortex` epic at 69/69 tasks across 11 tracks (A/B/C/D/E/F/G/H/I/J/K), plus the grand-slam recursive-learning + Agent Skills + L1-6 substrate-rules wave, plus the post-grand-slam Forms 1-6 + 7th-form + QW closeout (PRs [#761](https://github.com/alphaonedev/ai-memory-mcp/pull/761)-[#766](https://github.com/alphaonedev/ai-memory-mcp/pull/766)). See [`CHANGELOG.md`](../CHANGELOG.md) for the full release entry and [`docs/v0.7.0/release-notes.md`](v0.7.0/release-notes.md) for the per-area walk-through. The canonical post-grand-slam feature truth lives at [`docs/internal/v070-feature-inventory.md`](internal/v070-feature-inventory.md).
 
 ---
 
@@ -10,34 +10,53 @@
 
 | Area | What ships | Default behavior | Opt-in surface |
 |---|---|---|---|
-| Capabilities v3 | `summary`, `to_describe_to_user`, `callable_now`, `agent_permitted_families` | Returned alongside v2 fields | Read v3 fields if present; v2 unchanged |
-| Loader tools | `memory_load_family`, `memory_smart_load` | Always-on (replace `memory_capabilities --include-schema` ergonomics) | Call directly from agent loop |
-| Hook pipeline | 20 lifecycle events, exec + daemon modes | **No change** — no hooks fire | `~/.config/ai-memory/hooks.toml` |
+| Capabilities v3 | `summary`, `to_describe_to_user`, `callable_now`, `agent_permitted_families`, `schema_version="3"` | Returned alongside v2 fields | Read v3 fields if present; v2 unchanged |
+| Loader tools | `memory_load_family`, `memory_smart_load` join `core` | **Always-on under `--profile core`** (now 7 tools, was 5) | Replace `memory_capabilities --include-schema` ergonomics |
+| Hook pipeline | **25 lifecycle events**, exec + daemon modes | **No change** — no hooks fire | `~/.config/ai-memory/hooks.toml` ([doc](hook-pipeline.md)) |
 | Ed25519 attestation | Per-agent keypair, link signing, `attest_level` enum, `signed_events` audit table | `attest_level = "unsigned"` for legacy callers | `ai-memory identity generate` |
-| Sidechain transcripts | zstd-3 BLOB store, `memory_transcript_links`, `memory_replay` | Off | `[transcripts]` config per namespace |
+| Signed-events V-4 chain | Cross-row `prev_hash` + `sequence` SHA-256 chain | On for new daemons (backfilled by `migrate_v34_backfill_chain`) | `ai-memory verify-signed-events-chain` ([doc](signed-events-v4.md)) |
+| Sidechain transcripts | zstd-3 BLOB store, `memory_transcript_links`, `memory_replay` | Off | `[transcripts]` config per namespace ([doc](sidechain-transcripts.md)) |
 | Apache AGE acceleration | Cypher backend for KG ops, `memory_find_paths` | SQLite/CTE path unchanged | Install AGE Postgres extension |
+| Postgres-first SAL | `ai-memory serve --store-url postgres://…`, `ai-memory schema-init` | Sqlite default unchanged | Build with `--features sal-postgres` |
 | G1 inheritance enforcement | `resolve_governance_policy` walks the namespace chain | **Behavior change** for pre-v0.6.3.1 v0.6.x users | Per-policy `inherit: bool` (default `true`) |
-| Permission system | Refactored governance with rules + modes + hooks → decision | `mode = "advisory"` preserves v0.6.4 semantics on first boot | `ai-memory governance migrate-to-permissions` |
+| Permission system | Refactored governance with rules + modes + hooks → decision | `permissions.mode = "enforce"` (was `"advisory"` in v0.6.4) | `ai-memory governance migrate-to-permissions` ([doc](governance.md)) |
+| Federation hardening | mTLS + X-API-Key + fingerprint allowlist | Same as v0.6.4 if not configured | Three new `AI_MEMORY_FED_*` env vars ([doc](federation.md)) |
+| K8 quota tool | `memory_quota_status` + `/api/v1/quota/status` | Per-agent daily quota tracked, surfaced on demand | [doc](k8-quotas.md) |
+| K10 SSE approvals | `/api/v1/approvals/stream` with mandatory HMAC | Off when `permissions.mode = "off"` | [doc](k10-sse-approvals.md) |
+| Batman Form 1 (online dedup-and-synthesis) | Single-batch action-emitting LLM on store | Opt-IN via existing autonomy flag | `legacy_per_pair_classifier = true` to revert |
+| Batman Form 2 (synchronous atomise) | `memory_atomise` MCP tool + pre-store hook | `auto_atomise_mode = Off` default | `Synchronous | Deferred` ([doc](atomisation.md)) |
+| Batman Form 3 (multi-step ingest) | `memory_ingest_multistep` MCP tool | Caller-driven | [doc](multistep-ingest.md) |
+| Batman Form 4 (fact provenance) | Citations + source-URI + atom-grain spans | Caller-driven via `memory_store` payload | [doc](provenance.md) |
+| Batman Form 5 (auto-confidence) | `memory_calibrate_confidence` MCP tool | Shadow mode by default | Four `AI_MEMORY_CONFIDENCE_*` env vars ([doc](confidence-calibration.md)) |
+| Batman Form 6 (MemoryKind vocab) | 10-variant enum, optional auto-classify pre-store hook | `auto_classify_kind = off` default | `regex_only \| regex_then_llm` ([doc](memory-kind-vocab.md)) |
+| Batman 7th-form (Layer-4 wiring) | Operator-signed rules `R001..R004`, `memory_check_agent_action`, `memory_rule_list` | Substrate-INTERNAL writes gated; agent-EXTERNAL `callable_now` flag | v0.8.0 full cover per [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697) |
+| QW-1 file-backed reflection export | `memory_export_reflection` MCP tool | Opt-IN per namespace | `auto_export_reflections_to_filesystem = true` |
+| QW-2 persona-as-artifact | `memory_persona` + `memory_persona_generate` tools, `MemoryKind::Persona` | Opt-IN per namespace | `auto_persona_trigger_every_n_memories = N` ([doc](persona.md)) |
+| QW-3 context-offload primitive | `memory_offload` + `memory_deref` tools | Caller-driven | [doc](context-offload.md) |
 
 ---
 
 ## Why this matters
 
-v0.7.0 closes two long-standing gaps at once.
+v0.7.0 closes three long-standing gaps at once.
 
 **Legibility gap (cortex-fluent):** the 2026-05-05 NHI Discovery Gate verdict on v0.6.4 came back **6/6 PASS, GATE GREEN**, but reasoning-class LLMs (Grok 4.2 reasoning) didn't find the runtime loader because it lived inside an introspection tool's parameter set. v0.7.0 promotes loaders to first-class tools (`memory_load_family`, `memory_smart_load`) and pre-computes per-agent calibration in `memory_capabilities` v3.
 
-**Trust gap (attested):** v0.6.3 left an Ed25519 `signature` column in `memory_links` that nothing populated (the v0.6.3 audit's "dead column" finding). Hook events were advertised via subscriptions but lifecycle hooks weren't programmable. Permissions were advisory, not enforced. Namespace inheritance was display-only — a parent `Approve` rule didn't actually block a child write. v0.7.0 fills the column, ships the hook pipeline, enforces inheritance, and lands an append-only `signed_events` audit chain.
+**Trust gap (attested):** v0.6.3 left an Ed25519 `signature` column in `memory_links` that nothing populated (the v0.6.3 audit's "dead column" finding). Hook events were advertised via subscriptions but lifecycle hooks weren't programmable. Permissions were advisory, not enforced. Namespace inheritance was display-only — a parent `Approve` rule didn't actually block a child write. v0.7.0 fills the column, ships the hook pipeline, enforces inheritance, and lands an append-only `signed_events` audit chain with cross-row hash chaining (V-4 closeout #698).
+
+**Write-time-investment gap (Batman):** the v0.7.0 audit at commit `53b4d39` ([`docs/internal/batman-framework-audit.md`](internal/batman-framework-audit.md)) found 0 of Batman's 6 forms cleanly IMPLEMENTED. The post-grand-slam Forms 1-6 wave + the 7th-form Option-B foundation closed every gap; HEAD `c9472c1` ships all 7 forms IMPLEMENTED.
 
 ---
 
 ## Action required
 
-Most users on v0.6.4 see **no behavior change** unless they opt in. The exceptions:
+Most users on v0.6.4 see **two intentional behavior changes** + a few opt-in surfaces:
 
-1. **Pre-v0.6.3.1 v0.6.x users** — the G1 namespace inheritance fix (already shipped in v0.6.3.1) means parent `Approve` policies now block child writes. See [G1 inheritance fix](#g1-inheritance-fix-behavior-change) below.
-2. **Operators with custom governance policies** — run `ai-memory governance migrate-to-permissions --dry-run` before upgrading to preview the migration.
-3. **SDK consumers reading `memory_capabilities`** — v3 adds fields; v2 fields remain. No code changes required, but adopt v3 fields for richer per-agent calibration.
+1. **`permissions.mode` flips `advisory` → `enforce`** (F8 — Round-2 NHI sweep). Operators who relied on default-permissive behavior must opt back in via `[permissions] mode = "advisory"` in config.toml.
+2. **`ai-memory forget --pattern` / `--tier` without `--namespace` requires `--confirm-global`** (F11). Scoped forget is unchanged.
+3. **Pre-v0.6.3.1 v0.6.x users** — the G1 namespace inheritance fix (already shipped in v0.6.3.1) means parent `Approve` policies now block child writes. See [G1 inheritance fix](#g1-inheritance-fix-behavior-change) below.
+4. **Operators with custom governance policies** — run `ai-memory governance migrate-to-permissions --dry-run` before upgrading to preview the migration.
+5. **SDK consumers reading `memory_capabilities`** — v3 adds fields; v2 fields remain. No code changes required, but adopt v3 fields for richer per-agent calibration.
 
 ---
 
@@ -47,56 +66,153 @@ Most users on v0.6.4 see **no behavior change** unless they opt in. The exceptio
 
 | Field | Type | Purpose |
 |---|---|---|
+| `schema_version` | string (`"3"`) | Top-level version tag. |
 | `summary` | string | Top-level pre-computed description ("AI Memory MCP exposes a 7-tool core with N additional families available via runtime expansion.") |
-| `to_describe_to_user` | string | Human-shaped summary the agent can paraphrase verbatim — eliminates calibration drift |
-| `callable_now` | bool (per tool) | Whether this caller may invoke the tool right now (allowlist + profile aware) |
-| `agent_permitted_families` | array<string> | Families this caller is allowed to expand into via `memory_load_family` |
+| `to_describe_to_user` | string | Human-shaped summary the agent can paraphrase verbatim — eliminates calibration drift. |
+| `callable_now` | bool (per tool) | Whether this caller may invoke the tool right now (allowlist + profile aware). |
+| `agent_permitted_families` | array<string> | Families this caller is allowed to expand into via `memory_load_family`. |
+| `memory_kind_vocab` | object | Form-6 vocabulary + auto-classify modes (see [`docs/memory-kind-vocab.md`](memory-kind-vocab.md)). |
 
-**Wire shape (v2 → v3):** the response gains a top-level `schema_version: 3` field. Clients that pin `schema_version: 2` continue to receive the v2 shape — v2 stays supported through v0.7.x.
-
-```json
-{
-  "schema_version": 3,
-  "summary": "AI Memory MCP exposes a 7-tool core ...",
-  "to_describe_to_user": "I have access to a memory substrate ...",
-  "agent_permitted_families": ["core", "graph"],
-  "tools": [
-    {
-      "name": "memory_store",
-      "callable_now": true,
-      "...": "..."
-    }
-  ]
-}
-```
+Clients that pin `schema_version: 2` continue to receive the v2 shape — v2 stays supported through v0.7.x.
 
 Backward compat: v0.6.4 SDKs continue to work — they read v2 fields and ignore the new top-level keys.
 
-> **TODO** — track A (A1-A5) lands the v3 fields; track B (B5) updates `memory_capabilities` description to point at the new loaders. Status will be linked here once merged.
+To inspect the live v3 response (replace the legacy `doctor --capabilities=v3` recipe with):
+
+```bash
+ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq .memory_kind_vocab
+```
 
 ---
 
-## New tools
+## New MCP tools
 
-v0.7.0 adds the following MCP tools. Every tool is documented in `docs/API_REFERENCE.md` once the corresponding track merges.
+v0.7.0 adds the following tools relative to v0.6.4. Every tool ships
+in [`src/mcp/registry.rs`](../src/mcp/registry.rs) and is grouped into
+a `Family` (see [`src/profile.rs`](../src/profile.rs)). Full
+post-grand-slam inventory: [`docs/internal/v070-feature-inventory.md`](internal/v070-feature-inventory.md).
 
-| Tool | Track | One-line description |
-|---|---|---|
-| `memory_load_family(family)` | B1 | Always-on loader — registers the named family's tools without restarting the MCP server |
-| `memory_smart_load(intent)` | B2 | Embedding-matched loader — picks the family that best fits a natural-language intent string |
-| `memory_find_paths(source, target, max_depth=5)` | J7 (R2) | Returns paths through the knowledge graph; Cypher on AGE, recursive CTE on SQLite |
-| `memory_replay(memory_id)` | I4 | Reconstructs the transcript chain for a memory by traversing `memory_transcript_links` |
-| `memory_verify(link_id)` | H4 | Returns `{signature_verified, attest_level, signed_by, signed_at}` for a link |
-| `memory_approval_pending` | K10 | Lists pending approval requests |
-| `memory_approval_decide(id, decision, remember=forever?)` | K10 | Decides a pending approval; `remember=forever` enables progressive trust |
+| Tool | Family | Track / form | One-line description |
+|---|---|---|---|
+| `memory_load_family(family)` | Core | B1 | Always-on loader — registers the named family's tools without restarting the MCP server. |
+| `memory_smart_load(intent)` | Core | B2 | Embedding-matched loader — picks the family that best fits a natural-language intent string. |
+| `memory_find_paths(source, target, max_depth=5)` | Graph | J7 | Returns paths through the knowledge graph; Cypher on AGE, recursive CTE on SQLite. |
+| `memory_replay(memory_id, depth?)` | Graph | I4 / L2-4 | Reconstructs the transcript chain for a memory by traversing `memory_transcript_links`. |
+| `memory_verify(link_id)` | Graph | H4 | Returns `{signature_verified, attest_level, signed_by, signed_at}` for a link. |
+| `memory_pending_list` | Power | K10 | Lists pending approval requests. **Note:** the original v0.7-alpha drafts called this `memory_approval_pending`; the shipped name is `memory_pending_list`. |
+| `memory_pending_approve(id, …)` | Power | K10 | Approves a pending action. HMAC-signed body required. |
+| `memory_pending_reject(id, …, remember=forever?)` | Power | K10 | Rejects a pending action; `remember=forever` enables progressive trust. |
+| `memory_subscription_dlq_list` | Power | K7 | Lists dead-letter subscription deliveries. |
+| `memory_subscription_replay` | Power | K7 | Replays a DLQ entry. |
+| `memory_quota_status` | Power | K8 | Returns the caller's per-agent daily quota row. See [`docs/k8-quotas.md`](k8-quotas.md). |
+| `memory_reflect` | Power | Recursive-learning Task 4/8 | Substrate primitive that synthesises a reflection over a recall set; depth-capped per namespace. |
+| `memory_reflection_origin` | Power | L2-2 / #667 | Reads `reflection_origin` metadata that federation receivers stamp on import. |
+| `memory_dependents_of_invalidated` | Power | L2-3 / #668 | Notifies dependents when a Reflection→Reflection `supersedes` edge fires. |
+| `memory_check_agent_action` | Power | 7th-form / #691 | Dry-run check against the operator-signed rule corpus. |
+| `memory_rule_list` | Power | 7th-form / #691 | Read-only listing of the rule corpus. |
+| `memory_export_reflection` | Power | QW-1 | File-backed reflection-chain export. |
+| `memory_offload` | Power | QW-3 | Move a large blob out of the agent context window into addressable blob storage. |
+| `memory_deref` | Power | QW-3 | Read-side companion to `memory_offload`. |
+| `memory_atomise` | Power | WT-1-C / Form 2 | Curator decomposes a long memory into 2-10 atomic propositions. |
+| `memory_persona` | Power | QW-2 | Read/write a `MemoryKind::Persona` row. |
+| `memory_persona_generate` | Power | QW-2 | Synthesise a persona over the entity's observation set. |
+| `memory_ingest_multistep` | Power | Form 3 / #756 | Multi-step ingest orchestrator with deterministic helpers + prompt-cache reuse. |
+| `memory_calibrate_confidence` | Power | Form 5 / #758 | Per-source baseline calibration sweep (shadow mode by default). |
+| `memory_skill_register` | Other | L1-5 | Register a SKILL.md-format Agent Skill. |
+| `memory_skill_list` | Other | L1-5 | List skills. |
+| `memory_skill_get` | Other | L1-5 | Read a skill. |
+| `memory_skill_resource` | Other | L1-5 | Read a resource referenced by a skill. |
+| `memory_skill_export` | Other | L1-5 | Export a skill back to SKILL.md. |
+| `memory_skill_promote_from_reflection` | Other | L2-6 / #671 | Promote a Reflection (depth ≥ 1) to a SKILL.md-format Agent Skill. |
+| `memory_skill_compositional_context` | Other | L2-7 / #672 | Return a skill body + bounded reflection set ranked by recency + recall count. |
 
-> **TODO** — tools land per their respective tracks. Track G hook pipeline lands first; H/I/J/K tools follow.
+---
+
+## Per-form migration notes
+
+### Form 1 — online dedup-and-synthesis ([#754](https://github.com/alphaonedev/ai-memory-mcp/issues/754))
+
+The store path now issues a **single batch action-emitting LLM call** that emits `add | update | delete | no-op` per existing memory candidate, replacing the v0.6.x per-pair binary yes/no classifier. The new path is gated by the same `autonomous_hooks` toggle that gated the v0.6.x classifier; behavior is opt-in.
+
+To preserve the v0.6.x per-pair behavior on a specific namespace, set on the namespace standard:
+
+```jsonc
+{
+  "governance": {
+    "legacy_per_pair_classifier": true
+  }
+}
+```
+
+The shipped code path is `src/synthesis/mod.rs`. Tests:
+[`tests/form_1_synthesis.rs`](../tests/form_1_synthesis.rs).
+
+### Form 2 — synchronous atomise-before-embed ([#755](https://github.com/alphaonedev/ai-memory-mcp/issues/755))
+
+New `memory_atomise` MCP tool + `auto_atomise_mode` namespace-policy field with three settings:
+
+- **`Off`** (default) — caller-driven, no curator pass.
+- **`Deferred`** — curator runs out-of-band after the write commits.
+- **`Synchronous`** — curator runs inside the pre-store hook chain; the parent memory is archived once atoms commit.
+
+Token budget is governed by `auto_atomise_threshold_cl100k` (default 800) and `auto_atomise_max_atom_tokens` (default 200). Each atom is a first-class memory with an `atom_of` back-pointer and a signed `derives_from` edge.
+
+Operator doc: [`docs/atomisation.md`](atomisation.md). Cookbook: [`cookbook/atomisation/01-basic-flow.sh`](../cookbook/atomisation/01-basic-flow.sh).
+
+### Form 3 — multi-step ingest orchestrator ([#756](https://github.com/alphaonedev/ai-memory-mcp/issues/756))
+
+`memory_ingest_multistep` threads deterministic Jaccard+FTS helpers through prompt-cache-stable LLM stages. The two reference variants (two-phase Understand-Anything exemplar; four-step OpenKB exemplar) both produce reports with a single distinct cache key per run — provable by the cookbook recipe.
+
+Operator doc: [`docs/multistep-ingest.md`](multistep-ingest.md). Cookbook: [`cookbook/multistep-ingest/01-two-phase.sh`](../cookbook/multistep-ingest/01-two-phase.sh).
+
+### Form 4 — fact provenance ([#757](https://github.com/alphaonedev/ai-memory-mcp/issues/757))
+
+No new MCP tool; provenance rides on the existing `memory_store` / `memory_atomise` payloads. Schema migration `0032_v07_form4_provenance.sql` adds the columns. Federation wire shape stays backward-compatible — pre-v0.7.0 peers ignore the new fields.
+
+Operator doc: [`docs/provenance.md`](provenance.md).
+
+### Form 5 — auto-confidence + shadow-mode calibration + freshness decay ([#758](https://github.com/alphaonedev/ai-memory-mcp/issues/758))
+
+`memory_calibrate_confidence` MCP tool + four env vars:
+
+- `AI_MEMORY_AUTO_CONFIDENCE` — enable on-write confidence assignment.
+- `AI_MEMORY_CONFIDENCE_SHADOW` — calibrate in shadow mode (no live writes).
+- `AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE` — shadow-mode sample rate (default 0.1).
+- `AI_MEMORY_CONFIDENCE_DECAY` — enable per-memory freshness decay.
+
+Schema migration `0033_v07_form5_confidence_calibration.sql`. Capability registry entry: `CapabilityConfidenceCalibration` at `src/config.rs:1331`.
+
+Operator doc: [`docs/confidence-calibration.md`](confidence-calibration.md).
+
+### Form 6 — MemoryKind Batman vocabulary ([#759](https://github.com/alphaonedev/ai-memory-mcp/issues/759))
+
+10-variant `MemoryKind` enum: `Observation` (default) + `Reflection`, `Persona`, `Concept`, `Entity`, `Claim`, `Relation`, `Event`, `Conversation`, `Decision`. **No schema migration** — `memories.memory_kind TEXT NOT NULL DEFAULT 'observation'` has no CHECK constraint, so new variants land as new string values on the existing column.
+
+Optional `auto_classify_kind` pre-store hook on each namespace standard: `off | regex_only | regex_then_llm`. See [`docs/memory-kind-vocab.md`](memory-kind-vocab.md) for the per-variant matrix and recall-filter wire shapes.
+
+### 7th-form — agent-EXTERNAL Layer-4 wiring ([#760](https://github.com/alphaonedev/ai-memory-mcp/issues/760))
+
+**Status:** Option-B foundation SHIPPED in v0.7.0; full cover at v0.8.0 per [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697).
+
+What v0.7.0 ships:
+
+- Operator-keypair-signed seed rules `R001..R004` (`~/.config/ai-memory/operator.key`).
+- `memory_check_agent_action` MCP tool — dry-run check against the rule corpus.
+- `memory_rule_list` MCP tool — read-only listing.
+- Substrate `storage::insert` pre-write hook surfaces structured refusal via the `RuleRefused` error variant.
+- `ai-memory install --harness claude-code --enforce-policy` wires the policy at install time.
+
+What v0.7.0 does NOT ship (v0.8.0 cover):
+
+- Agent-EXTERNAL Bash / FilesystemWrite / NetworkRequest / ProcessSpawn enforcement is `callable_now=false` at the substrate boundary — the rule corpus is consulted on the substrate write path only.
+
+Audit-honest framing: see [`docs/RECURSIVE_LEARNING.md` §Substrate authority claim](RECURSIVE_LEARNING.md#substrate-authority-claim--v070-option-b-foundation). Operator doc: [`docs/policy-engine.md`](policy-engine.md) + [`docs/governance/agent-action-rules.md`](governance/agent-action-rules.md).
 
 ---
 
 ## Hook pipeline (opt-in)
 
-v0.7.0 adds 20 lifecycle hook events at every memory operation point — a programmable extension surface that R3 (auto-link inference) and R5 (auto-extraction) build on.
+v0.7.0 ships **25 lifecycle hook events** (20 baseline + 5 grand-slam additions) at every memory operation point — a programmable extension surface that R3 (auto-link inference) and R5 (auto-extraction) build on.
 
 Default: **no behavior change.** Hooks fire only when `~/.config/ai-memory/hooks.toml` exists and registers them.
 
@@ -111,13 +227,16 @@ enabled = true
 namespace = "team/*"
 ```
 
-**Event matrix (20 events):** `pre_store`, `post_store`, `pre_recall`, `post_recall`, `pre_search`, `post_search`, `pre_delete`, `post_delete`, `pre_promote`, `post_promote`, `pre_link`, `post_link`, `pre_consolidate`, `post_consolidate`, `pre_governance_decision`, `post_governance_decision`, `on_index_eviction`, `pre_archive`, `pre_transcript_store`, `post_transcript_store`.
+**Event matrix (25 events):**
+
+- 20 baseline: `pre_store`, `post_store`, `pre_recall`, `post_recall`, `pre_search`, `post_search`, `pre_delete`, `post_delete`, `pre_promote`, `post_promote`, `pre_link`, `post_link`, `pre_consolidate`, `post_consolidate`, `pre_governance_decision`, `post_governance_decision`, `on_index_eviction`, `pre_archive`, `pre_transcript_store`, `post_transcript_store`.
+- 5 grand-slam additions: `pre_recall_expand` (G10), `pre_reflect` + `post_reflect` (recursive-learning Task 6/8), `pre_compaction` + `on_compaction_rollback` (L1-7).
 
 **Decision contract:** hooks return one of `Allow`, `Modify(delta)` (pre- events only), `Deny{reason, code}`, or `AskUser{prompt, options, default}`. Chain ordering is priority-desc; first `Deny` short-circuits.
 
 **Hot-path constraint:** `post_recall` and `post_search` default to `daemon` mode, preserving the v0.6.3 50ms recall p95 budget. `mode = "exec"` requires explicit override.
 
-> **TODO** — track G (G1-G11) lands the pipeline. Per-task documentation will live under `docs/hooks/` once merged. See [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md#track-g--hook-pipeline-bucket-0) for the full task list.
+Operator doc: [`docs/hook-pipeline.md`](hook-pipeline.md).
 
 ---
 
@@ -135,11 +254,15 @@ Keys live at `~/.config/ai-memory/keys/<agent_id>.{pub,priv}` with mode 0600 / 0
 
 **`attest_level` enum:** `unsigned` (no keypair present — preserves v0.6.4 backward compat), `self_signed` (active agent has a keypair; outbound writes signed), `peer_attested` (federated link verified against the peer's known public key).
 
-**Append-only `signed_events` audit table** (schema v21) records every signed write — no UPDATE or DELETE through the application layer.
+**Append-only `signed_events` audit table** records every signed write — no UPDATE or DELETE through the application layer. The V-4 closeout ([#698](https://github.com/alphaonedev/ai-memory-mcp/issues/698)) added a cross-row hash chain (`prev_hash` BLOB + `sequence` INTEGER) so the chain itself is tamper-evident, not just each row. Verify with:
+
+```bash
+ai-memory verify-signed-events-chain --format json
+```
+
+Operator doc: [`docs/signed-events-v4.md`](signed-events-v4.md).
 
 > **Hardware-backed key storage** (TPM / HSM / Secure Enclave) is **out of OSS scope** per ROADMAP2; available in the AgenticMem commercial layer.
-
-> **TODO** — track H (H1-H6) lands attestation. See [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md#track-h--ed25519-attested-identity-bucket-1) for task detail.
 
 ---
 
@@ -156,11 +279,9 @@ ttl_days = 30
 archive_after_days = 7
 ```
 
-Schema migration v21 → v22 adds `memory_transcripts` and `memory_transcript_links`. Background sweeper archives transcripts whose memories are all expired, then prunes after a grace period.
+Background sweeper archives transcripts whose memories are all expired, then prunes after a grace period. `memory_replay(memory_id, depth?)` reconstructs the transcript chain; `depth=0` reproduces the pre-L2-4 shape.
 
-`memory_replay(memory_id)` reconstructs the transcript chain for a memory; returns the decompressed text plus span metadata.
-
-> **TODO** — track I (I1-I5) lands transcripts. See [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md#track-i--sidechain-transcripts-bucket-17) for task detail.
+Operator doc: [`docs/sidechain-transcripts.md`](sidechain-transcripts.md).
 
 ---
 
@@ -168,11 +289,21 @@ Schema migration v21 → v22 adds `memory_transcripts` and `memory_transcript_li
 
 v0.7.0 detects Apache AGE in Postgres at SAL initialization (`SELECT * FROM pg_extension WHERE extname='age'`). When present, KG operations route through Cypher; otherwise the recursive-CTE path used since v0.6.x stays in place.
 
-Install AGE in your Postgres instance, restart `ai-memory`, and confirm via `ai-memory doctor --kg-backend` (which prints `kg_backend = "age"` or `"cte"`).
+Install AGE in your Postgres instance and restart `ai-memory`. To confirm which backend is live, inspect the v3 capabilities response (which records `kg_backend`):
+
+```bash
+ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq '.kg_backend'
+```
+
+Or, from the HTTP surface:
+
+```bash
+curl -s http://127.0.0.1:9077/api/v1/capabilities | jq '.kg_backend'
+```
+
+Returns `"age"` when AGE is detected, `"cte"` when it falls through. (The v0.7-alpha drafts referenced a `ai-memory doctor --kg-backend` flag; that flag was not shipped — use the capabilities-response surface above.)
 
 **Acceptance gate:** AGE p95 must beat CTE p95 by ≥30% at depth=5 to ship — the bench gate (`feat/v0.7-j-8-age-bench-gate`) enforces it. If AGE isn't faster on your hardware, stay on the CTE path.
-
-> **TODO** — track J (J1-J8) lands AGE. See [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md#track-j--apache-age-acceleration-bucket-2) for task detail.
 
 ---
 
@@ -204,9 +335,9 @@ Audit log records which ancestor's policy fired on every gate decision.
 
 v0.7.0 refactors the existing `governance` system into:
 
-- **Rules** — declarative policies (the existing governance shape)
-- **Modes** — `enforce` / `advisory` / `off`
-- **Hooks** — programmable from Track G
+- **Rules** — declarative policies (the existing governance shape, now operator-keypair-signed under 7th-form).
+- **Modes** — `enforce` (v0.7.0 default) / `advisory` / `off`.
+- **Hooks** — programmable from Track G.
 
 → a single `Decision`. Default deny-first; ask-by-default for ambiguous cases.
 
@@ -221,12 +352,24 @@ The dry-run prints the proposed `permissions` rows alongside the source `governa
 
 Honest disclosures from v0.6.3.1 close out:
 
-- `permissions.mode = "advisory"` is now actually consulted by the gate (K3)
-- `default_timeout_seconds` on `pending_actions` is now enforced by a 60s sweeper (K2)
-- `approval.subscribers` events are now actually published through the subscription system (K4)
-- `rule_summary` is now populated with a real ordered list of active governance rules (K5)
+- `permissions.mode = "advisory"` is now actually consulted by the gate (K3).
+- `default_timeout_seconds` on `pending_actions` is now enforced by a 60s sweeper (K2).
+- `approval.subscribers` events are now actually published through the subscription system (K4).
+- `rule_summary` is now populated with a real ordered list of active governance rules (K5).
 
-> **TODO** — track K (K1-K11) lands the permission system. K1 (G1 inheritance) is the **mandatory cutline** — even if everything else slips, K1 ships.
+Operator docs: [`docs/governance.md`](governance.md), [`docs/policy-engine.md`](policy-engine.md), [`docs/k10-sse-approvals.md`](k10-sse-approvals.md).
+
+---
+
+## Federation hardening
+
+v0.7.0 hardens the v0.6.x federation surface with mTLS + X-API-Key + SHA-256 cert fingerprint allowlist + three new `AI_MEMORY_FED_*` env vars:
+
+- `AI_MEMORY_FED_PEER_ATTESTATION` — require peer Ed25519 attestation on inbound sync.
+- `AI_MEMORY_FED_SYNC_TRUST_PEER` — trust the peer's claim about origin agent on inbound sync (default deny).
+- `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` — trust the wire body's `agent_id` claim (default deny — use the authenticated peer cert).
+
+Operator doc: [`docs/federation.md`](federation.md).
 
 ---
 
@@ -257,19 +400,20 @@ ai-memory start
 
 # 8. Verify
 ai-memory doctor --tokens
-ai-memory doctor --kg-backend                             # cte | age
+ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq '.kg_backend'
+ai-memory verify-signed-events-chain --format json
 ```
 
-Schema migration v20 → v22 (audit_log → signed_events → memory_transcripts) runs automatically on first start. The migration is idempotent.
+Schema migrations (sqlite v20 → v34, postgres 0012 → 0020) run automatically on first start of a sqlite-backed daemon and are idempotent. Postgres schema bootstrap is via `ai-memory schema-init` per [`docs/migration-v0.7.0-postgres.md`](migration-v0.7.0-postgres.md).
 
 ---
 
 ## What did **not** change
 
-- v0.6.4 default tool surface (`--profile core`) is **unchanged in spirit**. The seven core tools (the original 5 — `store`, `recall`, `list`, `get`, `search` — plus v0.7 B1's `memory_load_family` and v0.7 B2's `memory_smart_load`) stay the only advertised tools by default.
+- The original v0.6.4 5-tool default surface is **preserved in spirit** — the v0.7 B1/B2 loaders (`memory_load_family`, `memory_smart_load`) joined the `core` family, bringing the default count to 7. No tool was removed from `core`.
 - Existing v0.6.4 SDKs continue to work against a v0.7.0 server. Capabilities v3 fields are additive; v2 fields stay at their existing paths.
 - Memory data — no migration required for stored memories; embeddings, archives, links, governance policies all carry forward.
-- HTTP API endpoints — every v0.6.4 route stays at the same path with the same shape.
+- HTTP API endpoints — every v0.6.4 route stays at the same path with the same shape. v0.7.0 adds 8 net-new routes (see [`docs/internal/v070-feature-inventory.md` §"8 new HTTP routes"](internal/v070-feature-inventory.md)).
 - The CLI surface (`ai-memory store`, `recall`, etc.) — every v0.6.4 subcommand continues to work unchanged.
 - Boot manifest cost — `ai-memory boot` output is independent of attestation, hooks, transcripts, AGE.
 - Hook pipeline — **default off.** A v0.7.0 install with no `hooks.toml` behaves identically to v0.6.4 at the lifecycle layer.
@@ -278,9 +422,11 @@ Schema migration v20 → v22 (audit_log → signed_events → memory_transcripts
 
 ## Related
 
-- [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md) — single-doc framework for the v0.7.0 sprint
-- [`docs/MIGRATION_v0.6.4.md`](MIGRATION_v0.6.4.md) — predecessor migration guide
-- [`docs/MIGRATION-v0.6.2-to-v0.6.3.md`](MIGRATION-v0.6.2-to-v0.6.3.md) — earlier migration
-- [`ROADMAP2.md §7.3`](../ROADMAP2.md) — original v0.7 spec
-- [`CHANGELOG.md`](../CHANGELOG.md) — full v0.7.0 entry (released 2026-05-06)
-- v0.7.0 cert campaign in [`alphaonedev/ai-memory-test-hub`](https://github.com/alphaonedev/ai-memory-test-hub) (TODO — `campaigns/v0.7.md` filed at release)
+- [`docs/v0.7.0/release-notes.md`](v0.7.0/release-notes.md) — full release notes (incl. post-grand-slam ship-readiness wave).
+- [`docs/internal/v070-feature-inventory.md`](internal/v070-feature-inventory.md) — canonical feature truth.
+- [`docs/v0.7/V0.7-EPIC.md`](v0.7/V0.7-EPIC.md) — single-doc framework for the v0.7.0 sprint.
+- [`docs/MIGRATION_v0.6.4.md`](MIGRATION_v0.6.4.md) — predecessor migration guide.
+- [`docs/MIGRATION-v0.6.2-to-v0.6.3.md`](MIGRATION-v0.6.2-to-v0.6.3.md) — earlier migration.
+- [`docs/migration-v0.7.0-postgres.md`](migration-v0.7.0-postgres.md) — sqlite → postgres migration runbook.
+- [`ROADMAP2.md §7.3`](../ROADMAP2.md) — original v0.7 spec.
+- [`CHANGELOG.md`](../CHANGELOG.md) — full v0.7.0 entry.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -1,0 +1,117 @@
+# Federation hardening (mTLS + X-API-Key + fingerprint allowlist)
+
+v0.7.0 hardens the v0.6.x federation surface with three concurrent
+authentication layers and three new `AI_MEMORY_FED_*` env vars. Peers
+that don't satisfy every configured layer cannot push or fan-out into
+the local store.
+
+- **Code paths:** [`src/federation/mod.rs`](../src/federation/mod.rs),
+  [`src/federation/peer.rs`](../src/federation/peer.rs),
+  [`src/federation/peer_attestation.rs`](../src/federation/peer_attestation.rs),
+  [`src/federation/quorum.rs`](../src/federation/quorum.rs),
+  [`src/federation/receive.rs`](../src/federation/receive.rs),
+  [`src/federation/sync.rs`](../src/federation/sync.rs),
+  [`src/federation/vector_clock.rs`](../src/federation/vector_clock.rs),
+  [`src/federation/reflection_bookkeeping.rs`](../src/federation/reflection_bookkeeping.rs).
+- **Issue trail:** [#238](https://github.com/alphaonedev/ai-memory-mcp/issues/238),
+  [#239](https://github.com/alphaonedev/ai-memory-mcp/issues/239),
+  [#318](https://github.com/alphaonedev/ai-memory-mcp/issues/318),
+  v0.7.0 security-hardening sweep.
+
+## The three auth layers
+
+### Layer 1 — mTLS allowlist
+
+```bash
+ai-memory serve --tls-cert /etc/ai-memory/server.crt \
+                --tls-key  /etc/ai-memory/server.key \
+                --mtls-allowlist /etc/ai-memory/peer-fingerprints.allow
+```
+
+The allowlist file is a newline-delimited set of SHA-256
+fingerprints in hex with optional `:` separators and `#` comments.
+Peers without a listed cert **cannot open the TCP connection** — the
+TLS handshake fails before any HTTP layer code runs.
+
+### Layer 2 — X-API-Key
+
+```bash
+ai-memory serve --api-key "$(cat /etc/ai-memory/api.key)"
+```
+
+When set, every endpoint except `/api/v1/health` requires either the
+`X-API-Key` header or the `?api_key=` query parameter. Required in
+combination with mTLS for federated peers.
+
+Pinned by [`tests/federation_x_api_key.rs`](../tests/federation_x_api_key.rs).
+
+### Layer 3 — Peer Ed25519 attestation
+
+```bash
+export AI_MEMORY_FED_PEER_ATTESTATION=1
+```
+
+When set, inbound federation writes (`POST /api/v1/sync/push`,
+`POST /api/v1/inbox`) MUST carry a per-batch Ed25519 signature in the
+`X-Peer-Signature` header that verifies against the peer's enrolled
+public key. Peers without an enrolled key are rejected at the
+authentication layer.
+
+Pinned by [`tests/federation_b2_hardening.rs`](../tests/federation_b2_hardening.rs),
+[`tests/g_issue_238_sender_attestation.rs`](../tests/g_issue_238_sender_attestation.rs).
+
+## Three new env vars
+
+| Var | Default | Effect |
+|---|---|---|
+| `AI_MEMORY_FED_PEER_ATTESTATION` | unset | When set, inbound peer writes must carry `X-Peer-Signature` and verify against the enrolled peer key. |
+| `AI_MEMORY_FED_SYNC_TRUST_PEER` | unset (deny) | When set, the substrate trusts the peer's claim about origin agent on inbound sync. Default behavior is to re-stamp inbound rows with `imported_from_agent_id = <peer.claim>` and `agent_id = <local.sync-id>`. |
+| `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` | unset (deny) | When set, the substrate trusts the wire body's `agent_id` claim instead of the authenticated peer cert. Default: the peer cert wins. |
+
+The default posture is **strict**: an inbound write from an authenticated
+peer is treated as the peer's write, not as the underlying agent's
+write, unless the operator explicitly opts in to the peer's claim via
+the two `TRUST_*` flags. See
+[`tests/g_issue_239_sync_scope.rs`](../tests/g_issue_239_sync_scope.rs)
+for the bypass-attempt fleet.
+
+## Quorum + vector clocks
+
+v0.6.x quorum semantics are unchanged: W-of-N writes (default majority),
+vector-clock CRDT-lite merge, mTLS allowlist between peers. v0.7.0
+adds reflection-aware bookkeeping
+([`src/federation/reflection_bookkeeping.rs`](../src/federation/reflection_bookkeeping.rs))
+so federated reflection writes carry origin metadata that prevents
+depth-cap laundering.
+
+## Operator checklist
+
+1. **Generate peer certs.** Use your CA of choice; export the
+   SHA-256 fingerprint via `openssl x509 -in peer.crt -noout -fingerprint -sha256`.
+2. **Populate `peer-fingerprints.allow`.** One fingerprint per line.
+3. **Generate per-peer Ed25519 keys** (`ai-memory identity generate`)
+   and exchange public keys out-of-band.
+4. **Set `AI_MEMORY_FED_PEER_ATTESTATION=1`** on the receiving daemon.
+5. **Leave the two `TRUST_*` flags unset** unless your peer mesh is
+   under operator-level control.
+6. **Verify** with `curl --cert peer.crt --key peer.key
+   https://memory.prod/api/v1/health` — a 200 with `{"status":"ok"}`
+   means TLS + mTLS + API key all aligned.
+7. **Watch** the daemon log for `peer_attestation_failed` /
+   `peer_fingerprint_unknown` lines — those are real rejections.
+
+## Hardening lineage
+
+- The v0.6.x default was "any TCP peer can push if they speak the
+  protocol". The v0.7.0 default is "authenticated peer cert OR
+  refusal". Three concurrent layers, all enforced.
+- The original Ed25519 `signature` column shipped in v0.6.3 was a
+  dead column — v0.7.0 fills it via the Ed25519 attestation
+  track (H1-H6). Inbound federation re-verifies link signatures via
+  `POST /api/v1/links/verify`; see
+  [`docs/signed-events-v4.md`](signed-events-v4.md) for the V-4
+  audit chain that records each verification outcome.
+
+See also: [`docs/MIGRATION_v0.7.md` §"Federation hardening"](MIGRATION_v0.7.md#federation-hardening),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: Federation hardening"](internal/v070-feature-inventory.md).

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,77 @@
+# Governance + permissions (operator index)
+
+v0.7.0 refactors the v0.6.x governance subsystem into **rules + modes
++ hooks** that resolve to a single `Decision`. This page is the
+operator-facing index — the deep docs live under
+[`docs/governance/`](governance/) and the linked design + migration
+docs below.
+
+> **Default change at v0.7.0:** `permissions.mode` flips from
+> `"advisory"` (v0.6.4) to `"enforce"` (v0.7.0). Operators who rely
+> on the old default-permissive behavior must opt back in via
+> `[permissions] mode = "advisory"` in `config.toml`.
+
+## Where to read what
+
+| Topic | Doc |
+|---|---|
+| Migration path v0.6.4 → v0.7.0 permissions | [`docs/MIGRATION_v0.7.md` §"Permissions migration"](MIGRATION_v0.7.md#permissions-migration) |
+| 7th-form policy engine (substrate-authoritative rules) | [`docs/policy-engine.md`](policy-engine.md) |
+| Agent-action rule catalogue | [`docs/governance/agent-action-rules.md`](governance/agent-action-rules.md) |
+| SSE approval channel + HMAC binding | [`docs/k10-sse-approvals.md`](k10-sse-approvals.md) |
+| Per-agent daily quotas (K8) | [`docs/k8-quotas.md`](k8-quotas.md) |
+| Audit-trail coverage map | [`docs/security/audit-trail-coverage.md`](security/audit-trail-coverage.md) |
+| Federation hardening (peer auth) | [`docs/federation.md`](federation.md) |
+| Signed-events V-4 chain (substrate audit) | [`docs/signed-events-v4.md`](signed-events-v4.md) |
+| Programmable lifecycle hooks | [`docs/hook-pipeline.md`](hook-pipeline.md) |
+
+## Three modes
+
+- **`enforce`** (v0.7.0 default) — every gated write is checked
+  against the active rules; refusal returns `Decision::Deny`.
+- **`advisory`** (v0.6.4 default) — gated writes are logged but not
+  refused.
+- **`off`** — pipeline disabled; substrate writes are accepted
+  without consulting the rule corpus.
+
+## Commands
+
+```bash
+# Preview the v0.6.x → v0.7 permissions migration (dry-run by default)
+ai-memory governance migrate-to-permissions
+
+# Apply
+ai-memory governance migrate-to-permissions --apply
+
+# Install the operator-signed seed rules R001..R004
+ai-memory governance install-defaults
+
+# Sign a rule with the operator key (7th-form `attest_level = "signed"`)
+ai-memory rules sign rule.json
+
+# List the active rule corpus (CLI equivalent of memory_rule_list)
+ai-memory rules list
+
+# Wire the policy file at install time on a harness
+ai-memory install --harness claude-code --enforce-policy
+```
+
+## Honest disclosures from v0.6.3.1 close out
+
+- `permissions.mode = "advisory"` is now actually consulted by the
+  gate (K3).
+- `default_timeout_seconds` on `pending_actions` is now enforced by a
+  60s sweeper (K2).
+- `approval.subscribers` events are now actually published through
+  the subscription system (K4).
+- `rule_summary` is now populated with a real ordered list of active
+  governance rules (K5).
+- The 7th-form agent-EXTERNAL Layer-4 surface (Bash /
+  FilesystemWrite / NetworkRequest / ProcessSpawn) is **Option-B
+  foundation** at v0.7.0 (substrate-INTERNAL writes gated; agent
+  contracts surface `callable_now=false`). Full cover lands in
+  v0.8.0 per [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697).
+
+See [`docs/internal/v070-feature-inventory.md` §"K1/G1
+namespace-inheritance"](internal/v070-feature-inventory.md) for the
+canonical track-K rollup.

--- a/docs/hook-pipeline.md
+++ b/docs/hook-pipeline.md
@@ -1,0 +1,130 @@
+# Hook pipeline (Track G — 25 lifecycle events)
+
+v0.7.0 ships a programmable extension surface that fires on every
+substrate lifecycle point. Hooks return one of `Allow`,
+`Modify(delta)`, `Deny{reason, code}`, or `AskUser{prompt, options, default}`.
+Default off — a v0.7.0 install with no `hooks.toml` behaves
+identically to v0.6.4 at the lifecycle layer.
+
+- **Code paths:** [`src/hooks/mod.rs`](../src/hooks/mod.rs),
+  [`src/hooks/chain.rs`](../src/hooks/chain.rs),
+  [`src/hooks/config.rs`](../src/hooks/config.rs),
+  [`src/hooks/decision.rs`](../src/hooks/decision.rs),
+  [`src/hooks/events.rs`](../src/hooks/events.rs),
+  [`src/hooks/executor.rs`](../src/hooks/executor.rs),
+  [`src/hooks/recall.rs`](../src/hooks/recall.rs),
+  [`src/hooks/timeouts.rs`](../src/hooks/timeouts.rs),
+  pre-store hook subtree under [`src/hooks/pre_store/`](../src/hooks/pre_store/),
+  post-reflect hook subtree under [`src/hooks/post_reflect/`](../src/hooks/post_reflect/).
+- **Helper binary:** [`tools/auto-link-detector/`](../tools/auto-link-detector/)
+  is the R3 reference `pre_link` hook (~775 LoC).
+- **Capability registry entry:** `CapabilityHooks` in
+  [`src/config.rs:703`](../src/config.rs).
+- **Config file:** `~/.config/ai-memory/hooks.toml` — hot-reloadable.
+
+## Configuration
+
+```toml
+[[hook]]
+event = "post_store"
+command = "/usr/local/bin/auto-link-detector"
+priority = 100
+timeout_ms = 5000
+mode = "daemon"          # daemon | exec
+enabled = true
+namespace = "team/*"     # glob match
+secret_redact = true     # opt-in to stderr redaction
+```
+
+Fields:
+
+- **`event`** — one of the 25 events below.
+- **`command`** — absolute path to the helper binary.
+- **`priority`** — higher fires first; first `Deny` short-circuits the chain.
+- **`timeout_ms`** — wall-clock budget per call; exceeded → `Deny{code: "hook_timeout"}`.
+- **`mode`** — `daemon` (long-lived subprocess, stdin JSON-RPC) or `exec` (one-shot fork+exec).
+- **`enabled`** — soft-disable without removing the row.
+- **`namespace`** — glob pattern; chain is filtered before invocation.
+- **`secret_redact`** — opt-in stderr scrubbing (see hardening note below).
+
+## 25-event matrix
+
+The 20 baseline events:
+
+| Event | Phase | Fires on |
+|---|---|---|
+| `pre_store` / `post_store` | write | `memory_store`, `memory_update` (when content changes) |
+| `pre_recall` / `post_recall` | read | `memory_recall`, family-loader recall |
+| `pre_recall_expand` | read | query-expansion path (G10) |
+| `pre_search` / `post_search` | read | `memory_search` |
+| `pre_delete` / `post_delete` | write | `memory_delete` |
+| `pre_promote` / `post_promote` | write | tier promotion (manual + auto) |
+| `pre_link` / `post_link` | write | `memory_link` |
+| `pre_consolidate` / `post_consolidate` | write | `memory_consolidate` |
+| `pre_governance_decision` / `post_governance_decision` | gate | governance pipeline |
+| `on_index_eviction` | maintenance | HNSW eviction |
+| `pre_archive` | write | archive-on-GC + manual archive |
+| `pre_transcript_store` / `post_transcript_store` | write | transcript sidechain writes |
+
+The 5 grand-slam additions:
+
+| Event | Track | Fires on |
+|---|---|---|
+| `pre_recall_expand` | G10 | query-expansion synthesise step |
+| `pre_reflect` / `post_reflect` | Recursive-learning Task 6/8 | `memory_reflect` |
+| `pre_compaction` / `on_compaction_rollback` | L1-7 | curator compaction pipeline |
+
+## Hot-path constraint
+
+`post_recall` and `post_search` default to `mode = "daemon"`. The
+v0.6.3 recall p95 budget is 50 ms; the daemon subprocess keeps the
+hook chain off the synchronous fork/exec path. `mode = "exec"` is
+permitted for these events but requires the explicit setting — the
+default is intentionally biased toward latency-preserving behavior.
+
+## Security hardening
+
+- **Stderr redaction** — the executor scrubs stderr through a
+  regex-based pass before forwarding to the daemon log when
+  `secret_redact = true`. Mitigates the v0.7.0 reconciliation finding
+  (commit `cbe934c`).
+- **Timeout enforcement** — hooks past their `timeout_ms` are killed
+  with `SIGKILL` after `SIGTERM` + 200 ms grace.
+- **Substrate authority** — hook decisions are advisory unless the
+  substrate explicitly elevates them (e.g., the 7th-form
+  `storage::insert` pre-write hook gates on the rule corpus, not on
+  arbitrary user hooks).
+
+## Tests
+
+Pinned by [`tests/hooks_executor_test.rs`](../tests/hooks_executor_test.rs),
+[`tests/hooks_hot_reload.rs`](../tests/hooks_hot_reload.rs),
+[`tests/hooks_pre_recall.rs`](../tests/hooks_pre_recall.rs),
+[`tests/hooks_timeout_budget.rs`](../tests/hooks_timeout_budget.rs),
+[`tests/g3_hooks_stderr_drain.rs`](../tests/g3_hooks_stderr_drain.rs),
+[`tests/g11_auto_link_detector.rs`](../tests/g11_auto_link_detector.rs).
+
+## Operator workflow
+
+1. **Author the helper binary.** Use the auto-link-detector as the
+   reference (`tools/auto-link-detector/src/main.rs`). Speak JSON-RPC
+   over stdin/stdout for `mode = "daemon"`; one-shot exec for
+   `mode = "exec"`.
+2. **Drop the binary on `PATH`** and `chmod +x`.
+3. **Edit `~/.config/ai-memory/hooks.toml`** with the row schema above.
+4. **Restart `ai-memory mcp`** (or wait for hot-reload — the config
+   file is watched).
+5. **Verify** with `ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq '.hooks'`
+   — the `enabled_events` field lists every event with at least one
+   registered hook.
+
+## Migration
+
+A v0.6.4 → v0.7.0 install with no `hooks.toml` is a no-op at the
+lifecycle layer. To opt in, follow the operator workflow above. To
+verify hooks are NOT firing on a write path, set `RUST_LOG=ai_memory::hooks=debug`
+and watch for the `chain_skipped: empty` log line.
+
+See also: [`docs/MIGRATION_v0.7.md` §"Hook pipeline (opt-in)"](MIGRATION_v0.7.md#hook-pipeline-opt-in),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: Hook pipeline (Track G, 25 events)"](internal/v070-feature-inventory.md).

--- a/docs/internal/batman-framework-audit.md
+++ b/docs/internal/batman-framework-audit.md
@@ -1,5 +1,34 @@
 # ai-memory vs Batman's 6-Form Write-Time-Investment Framework — Honest Audit
 
+> ## Post-audit status (2026-05-15, HEAD `c9472c1`)
+>
+> **This document reflects state at commit `53b4d39` (audit baseline).**
+> The 0-of-6-IMPLEMENTED + 4-partial + 2-absent findings (and the
+> PARTIAL grade for the 7th-form claim) **drove the Forms 1-6 + 7th-form
+> closeout wave** — PRs [#761](https://github.com/alphaonedev/ai-memory-mcp/pull/761),
+> [#762](https://github.com/alphaonedev/ai-memory-mcp/pull/762),
+> [#763](https://github.com/alphaonedev/ai-memory-mcp/pull/763),
+> [#764](https://github.com/alphaonedev/ai-memory-mcp/pull/764),
+> [#765](https://github.com/alphaonedev/ai-memory-mcp/pull/765),
+> [#766](https://github.com/alphaonedev/ai-memory-mcp/pull/766) — all
+> merged 2026-05-15.
+>
+> **Post-closeout state at HEAD `c9472c1`: all 7 forms IMPLEMENTED.**
+>
+> - Form 1 — `src/synthesis/mod.rs` + `tests/form_1_synthesis.rs` (issue [#754](https://github.com/alphaonedev/ai-memory-mcp/issues/754)).
+> - Form 2 — `src/atomisation/mod.rs` + `Synchronous` mode branch in `src/hooks/pre_store/auto_atomise.rs` + `tests/form_2_synchronous_atomise.rs` (issue [#755](https://github.com/alphaonedev/ai-memory-mcp/issues/755)).
+> - Form 3 — `src/multistep_ingest/{mod,executor,helpers,pipeline,cache}.rs` + `tests/form_3_multistep_ingest.rs` (issue [#756](https://github.com/alphaonedev/ai-memory-mcp/issues/756)).
+> - Form 4 — `migrations/sqlite/0032_v07_form4_provenance.sql` + `migrations/postgres/0019_v07_form4_provenance.sql` + `tests/form_4_provenance.rs` (issue [#757](https://github.com/alphaonedev/ai-memory-mcp/issues/757)).
+> - Form 5 — `src/confidence/{mod,calibrate,shadow,decay}.rs` + `tests/form_5_confidence_calibration.rs` (issue [#758](https://github.com/alphaonedev/ai-memory-mcp/issues/758)).
+> - Form 6 — `src/models/memory.rs:38-200` (10-variant `MemoryKind` enum) + `tests/form_6_memorykind_vocab.rs` (issue [#759](https://github.com/alphaonedev/ai-memory-mcp/issues/759)).
+> - 7th-form (Option-B foundation) — `src/governance/{mod,agent_action,deferred_audit,rules_store,wire_point}.rs` + `tests/form_7_agent_external_wiring.rs` (issue [#760](https://github.com/alphaonedev/ai-memory-mcp/issues/760)). The agent-EXTERNAL Layer-4 surface (Bash / FilesystemWrite / NetworkRequest / ProcessSpawn) is `callable_now=false` at the substrate boundary; v0.8.0 wires it 100% per [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697).
+>
+> The audit body below is preserved verbatim as the historical record
+> that drove the wave. For the canonical post-wave feature inventory,
+> see [`docs/internal/v070-feature-inventory.md`](v070-feature-inventory.md).
+
+---
+
 > Audit date: 2026-05-15
 > ai-memory commit hash audited: `53b4d399db7bf8c08700ba9ea860f784ef3d2baa`
 > Branches inspected: `audit/batman-6-form` (off `feat/v0.7.0-grand-slam` which subsumes `wt-1-integration` after the 2026-05-15 cascade); cross-referenced against `main`.

--- a/docs/internal/v070-feature-inventory.md
+++ b/docs/internal/v070-feature-inventory.md
@@ -1,0 +1,693 @@
+# v0.7.0 Feature Inventory — Net-New from v0.6.4
+
+> Baseline: **v0.6.4** (commit `6416539a370490977a25eeabded54393b08ac87c`, tag `v0.6.4`)
+> Target:   **v0.7.0** (commit `64528b15d484c68e4352ab6798f2c39c80296032`, branch `catalogue/v0.7.0-features` @ HEAD)
+> Compiled: 2026-05-15 by the AI NHI ship-readiness initiative
+> Methodology: `git diff v0.6.4..HEAD` (code & schema) + doc scan + commit-trailer issue cross-reference
+> Worktree:  `/Users/fate/v07/catalogue`
+> Scratch:   `/Users/fate/v07/v07-fixes/.local-runs/tmp/` (project no-`/tmp` HARD RULE honored)
+> Read-only review except for this deliverable.
+
+---
+
+## Summary (code-evidence totals)
+
+| Metric | Count | Evidence |
+|---|---|---|
+| Commits ahead of `v0.6.4` | **453** | `git log --oneline v0.6.4..HEAD \| wc -l` |
+| Files touched | **545** | `git diff --name-only v0.6.4..HEAD \| wc -l` |
+| Insertions / deletions | **+233,589 / −23,541** | `git diff --stat v0.6.4..HEAD` tail |
+| `src/*.rs` files touched | **207** | `git diff --name-only v0.6.4..HEAD -- src/ \| grep -c '\.rs$'` |
+| New top-level `src/<x>/mod.rs` modules | **23** | see §"New substrate modules" below |
+| New MCP tools (added since v0.6.4) | **28** | diff of `"memory_*"` literals between `v0.6.4:src/mcp.rs` and `HEAD:src/mcp/registry.rs` |
+| Total MCP tools at v0.7.0 full profile | **71** (registry literals — release notes head-line of **63** counts the canonical user-facing surface; the extra 8 are sub-tools / aliases / internals registered alongside) | `grep -oE '"memory_[a-z_]+"' src/mcp/registry.rs \| sort -u \| wc -l` |
+| New SQLite migrations (`0015..0033`) | **20** | `migrations/sqlite/0015_v07_pending_action_timeouts.sql … 0033_v07_form5_confidence_calibration.sql` |
+| New Postgres migrations (`0012..0020`) | **10** | `migrations/postgres/0012_v0700_metadata_object_check.sql … 0020_v07_form5_confidence_calibration.sql` |
+| New `AI_MEMORY_*` env vars | **17** (incl. probe artefact `AI_MEMORY_` — net 16 useful) | diff of `AI_MEMORY_[A-Z_]*` literals |
+| New HTTP routes | **8** | diff of `.route("..."` literals between v0.6.4 and HEAD |
+| New `GovernancePolicy` fields | **9** (`max_reflection_depth`, `auto_export_reflections_to_filesystem`, `auto_atomise`, `auto_atomise_threshold_cl100k`, `auto_atomise_max_atom_tokens`, `auto_persona_trigger_every_n_memories`, `auto_export_personas_to_filesystem`, `auto_atomise_mode`, `legacy_per_pair_classifier`, `auto_classify_kind`) | `src/models/namespace.rs:289-422` vs `v0.6.4:src/models.rs` |
+| New `MemoryKind` variants | **10 (whole enum is new)** — `Observation` (default), `Reflection`, `Persona`, `Concept`, `Entity`, `Claim`, `Relation`, `Event`, `Conversation`, `Decision` | `src/models/memory.rs:38-85` (did not exist in v0.6.4) |
+| New `Capability*` structs in `src/config.rs` | **7** (`CapabilityReflection`, `CapabilitySkills`, `CapabilityForensic`, `CapabilityGovernance`, `CapabilityAtomisation`, `CapabilityMemoryKindVocab`, `CapabilityConfidenceCalibration`) | `grep '^pub struct Capability' src/config.rs` vs v0.6.4 |
+| New integration tests | **163** (file count under `tests/`) | `git diff --name-status v0.6.4..HEAD -- tests/ \| awk '$1=="A"' \| wc -l` |
+| New benchmarks | **11** (5 in `benches/`, 6 in `benchmarks/`) | `git diff --name-status v0.6.4..HEAD -- benches/ benchmarks/` |
+| New documents in `docs/` | **42** | `git diff --name-status v0.6.4..HEAD -- docs/ \| awk '$1=="A"' \| wc -l` |
+| New cookbook directories | **8** | `cookbook/{agent-external-governance,atomisation,context-offload,file-backed-export,multistep-ingest,persona,production-deployment,recursive-learning}` |
+| New helper binaries | **4** | `tools/{auto-link-detector,post-ship-converge,t0-orchestrate,transcript-extractor}` |
+| Cargo version bump | `0.6.4` → `0.7.0` | `Cargo.toml` |
+
+### New substrate modules (23 new `mod.rs`)
+
+`src/{atomisation,background,cli,confidence,curator,federation,forensic,governance,handlers,hooks,identity,kg,mcp,models,multistep_ingest,notification,offload,parsing,persona,storage,store,synthesis,transcripts}/mod.rs`
+
+(`src/handlers.rs` → `src/handlers/mod.rs`, `src/mcp.rs` → `src/mcp/`, `src/models.rs` → `src/models/`: these are flat-to-tree refactors with substantial expansion.)
+
+### 28 new MCP tools (full list, alphabetical)
+
+```
+memory_atomise
+memory_calibrate_confidence
+memory_check_agent_action
+memory_dependents_of_invalidated
+memory_deref
+memory_export_reflection
+memory_find_paths
+memory_ingest_multistep
+memory_load_family
+memory_offload
+memory_persona
+memory_persona_generate
+memory_quota_status
+memory_reflect
+memory_reflection_origin
+memory_replay
+memory_rule_list
+memory_skill_compositional_context
+memory_skill_export
+memory_skill_get
+memory_skill_list
+memory_skill_promote_from_reflection
+memory_skill_register
+memory_skill_resource
+memory_smart_load
+memory_subscription_dlq_list
+memory_subscription_replay
+memory_verify
+```
+
+### 17 new `AI_MEMORY_*` env vars (1 probe artefact, 16 net)
+
+```
+AI_MEMORY_ALLOW_LOOPBACK_WEBHOOKS
+AI_MEMORY_AUTO_CONFIDENCE
+AI_MEMORY_CONFIDENCE_DECAY
+AI_MEMORY_CONFIDENCE_SHADOW
+AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE
+AI_MEMORY_DB_PATH
+AI_MEMORY_FED_PEER_ATTESTATION
+AI_MEMORY_FED_SYNC_TRUST_PEER
+AI_MEMORY_FED_TRUST_BODY_AGENT_ID
+AI_MEMORY_KEY_DIR
+AI_MEMORY_OPERATOR_PUBKEY
+AI_MEMORY_PERMISSIONS_MODE
+AI_MEMORY_PRECOMPUTE_FAMILY_EMBEDDINGS
+AI_MEMORY_SYSTEM_PROMPT_DIR
+AI_MEMORY_TEST_AGE_URL
+AI_MEMORY_TOOLS_VERBOSE
+```
+
+### 8 new HTTP routes
+
+```
+/api/v1/approvals/stream      (K10 SSE approval channel)
+/api/v1/auto_tag              (LLM auto-tag endpoint)
+/api/v1/expand_query          (HTTP parity for memory_expand_query)
+/api/v1/kg/find_paths         (KG chain-walk over HTTP)
+/api/v1/links/verify          (Ed25519 link verification surface)
+/api/v1/memory_load_family    (HTTP parity for memory_load_family)
+/api/v1/quota/status          (K8 quota status surface)
+/api/v1/tools/list            (MCP tools/list mirror for harness ops)
+```
+
+### Per-feature-category headline counts
+
+| Category | Sub-tasks / items | Status |
+|---|---|---|
+| WT-1 atomisation primitive | **7** sub-tasks (A-G) | SHIPPED |
+| QW Tencent quick wins | **4** (QW-1 file-backed export, QW-2 persona, QW-3 context-offload, QW-4 inferred from `RuleRefused`) | SHIPPED |
+| Batman 7-form closeout | **7** forms (1-6 + 7th-form agent-EXTERNAL Layer-4) | Forms 1-6 SHIPPED; 7th-form Option B foundation LANDED, full cover at v0.8.0 per `#697` |
+| Recursive-learning primitive | **8** tasks (issue `#655`) | Tasks 1-6 SHIPPED commits; Tasks 7-8 ship-gate landed on `feat/v0.7.0-recursive-learning` |
+| L1/L2 grand-slam wave | **8** L2 items + **3** L1 items (issues `#666`-`#673`, `#691`, `#693`) | SHIPPED |
+| Schema migration ladder | **20 sqlite + 10 postgres** | SHIPPED; v33 → v34 V-4 closeout pinned by `tests/signed_events_chain_v34.rs` |
+| Security-hardening sweep | **11** late-cycle commits | SHIPPED on `release/v0.7.0`, reconciled into trunk @ `64528b1` |
+| Round-2 fixes | **F1-F18** (18 findings) | SHIPPED |
+| Capability v3 system | **7** new Capability* structs + Track A 5 tasks | SHIPPED |
+| Signed events V-4 closeout | `prev_hash + sequence` cross-row hash chain | SHIPPED (sqlite v34 / postgres v33) |
+| Forensic bundle | L2-5 (issue `#670`) | SHIPPED |
+| Federation hardening | mTLS + X-API-Key + fingerprint allowlist | SHIPPED |
+| K8 quota status tool | `memory_quota_status` | SHIPPED |
+| Batman framework audit | `docs/internal/batman-framework-audit.md` (4,478 words) | SHIPPED |
+| 11-track v0.7.0 epic (A-K) | **69/69** tasks | SHIPPED per CHANGELOG headline |
+
+---
+
+## Per-feature matrix
+
+### Feature: WT-1 atomisation primitive (Form 2 substrate-native)
+
+- **Issue(s):** `#754` (Form 1 synthesis), part of v0.7.0 grand-slam wave; documented in `docs/atomisation.md`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES (whole module is new)
+- **Docs:** `docs/atomisation.md` (1,455 words)
+- **Cookbook:** `cookbook/atomisation/01-basic-flow.sh` (1 file)
+- **Code paths (absolute):**
+  - Substrate: `/Users/fate/v07/catalogue/src/atomisation/mod.rs` (29,533 bytes) + `/Users/fate/v07/catalogue/src/atomisation/curator.rs` (22,432 bytes)
+  - Curator integration: `/Users/fate/v07/catalogue/src/atomisation/curator.rs`
+  - Schema: `/Users/fate/v07/catalogue/migrations/sqlite/0030_v07_atomisation.sql`, `/Users/fate/v07/catalogue/migrations/sqlite/0031_v07_namespace_auto_atomise.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0017_v07_atomisation.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0018_v07_namespace_auto_atomise.sql`
+  - MCP tool: `/Users/fate/v07/catalogue/src/mcp/tools/atomise.rs`
+  - Pre-store hook: `/Users/fate/v07/catalogue/src/hooks/pre_store/auto_atomise.rs`
+  - CLI: `/Users/fate/v07/catalogue/src/cli/commands/atomise.rs`
+- **Tests (absolute):**
+  - Integration: `/Users/fate/v07/catalogue/tests/atomisation.rs`, `/Users/fate/v07/catalogue/tests/atomisation/core.rs`, `/Users/fate/v07/catalogue/tests/auto_atomise.rs`, `/Users/fate/v07/catalogue/tests/auto_atomise/core.rs`, `/Users/fate/v07/catalogue/tests/wt1c_mcp_atomise.rs`, `/Users/fate/v07/catalogue/tests/wt_1_a_schema_migration.rs`
+  - Form 2: `/Users/fate/v07/catalogue/tests/form_2_synchronous_atomise.rs`
+- **Env vars:** none new (governed via namespace policy)
+- **Namespace policy fields:** `auto_atomise`, `auto_atomise_threshold_cl100k`, `auto_atomise_max_atom_tokens`, `auto_atomise_mode` (`Off | Deferred | Synchronous`)
+- **Capability registry entry:** `CapabilityAtomisation` at `/Users/fate/v07/catalogue/src/config.rs:1164`
+- **Public API surface:** `memory_atomise` MCP tool; `ai-memory atomise` CLI; namespace standard JSON keys
+- **Known unknowns:** WT-1 sub-task A-G fan-out — release notes claim "A-G shipped" but per-letter mapping is implicit; reviewer should cross-check `wt1c_*` / `wt_1_a_*` test names against the original WT-1 spec.
+
+### Feature: Form 1 — online dedup-and-synthesis (single-batch action-emitting LLM)
+
+- **Issue(s):** `#754`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/synthesis/mod.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_1_synthesis.rs`
+- **Namespace policy fields:** `legacy_per_pair_classifier: Option<bool>` (opt-IN to legacy yes/no classifier; default routes to single-batch synth)
+- **Capability registry entry:** subsumed by `CapabilityAtomisation`
+- **Public API surface:** internal store-path call; no new MCP tool
+
+### Feature: Form 2 — synchronous atomise-before-embed
+
+- **Issue(s):** `#755`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/atomisation/mod.rs` + `auto_atomise_mode = Synchronous` branch in `/Users/fate/v07/catalogue/src/hooks/pre_store/auto_atomise.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_2_synchronous_atomise.rs`
+- **Namespace policy fields:** `auto_atomise_mode` (`Off | Deferred | Synchronous`) at `src/models/namespace.rs:395`
+
+### Feature: Form 3 — multi-step ingest orchestrator (prompt-cache reuse + explicit-trust helpers)
+
+- **Issue(s):** `#756`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/multistep-ingest.md` (1,079 words)
+- **Cookbook:** `cookbook/multistep-ingest/01-two-phase.sh`
+- **Code paths:** `/Users/fate/v07/catalogue/src/multistep_ingest/{mod.rs,executor.rs,helpers.rs,pipeline.rs,cache.rs}`
+- **MCP tool:** `/Users/fate/v07/catalogue/src/mcp/tools/ingest_multistep.rs` → `memory_ingest_multistep`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_3_multistep_ingest.rs`
+
+### Feature: Form 4 — fact-provenance (citations + source-URI + atom-grain span)
+
+- **Issue(s):** `#757`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/provenance.md` (983 words)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0032_v07_form4_provenance.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0019_v07_form4_provenance.sql`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_4_provenance.rs`
+- **Known unknowns:** no dedicated MCP tool — provenance rides on the existing `memory_store` / `memory_atomise` payloads. Reviewer should verify wire-shape backward-compat with pre-v0.7.0 federation peers.
+
+### Feature: Form 5 — auto-confidence + shadow-mode calibration + freshness decay
+
+- **Issue(s):** `#758`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/confidence-calibration.md` (913 words)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0033_v07_form5_confidence_calibration.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0020_v07_form5_confidence_calibration.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/confidence/{mod.rs,calibrate.rs,shadow.rs,decay.rs}`
+- **MCP tool:** `/Users/fate/v07/catalogue/src/mcp/tools/calibrate_confidence.rs` → `memory_calibrate_confidence`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/commands/calibrate_confidence.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_5_confidence_calibration.rs`, `/Users/fate/v07/catalogue/tests/calibration_t0.rs`
+- **Env vars:** `AI_MEMORY_AUTO_CONFIDENCE`, `AI_MEMORY_CONFIDENCE_SHADOW`, `AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE`, `AI_MEMORY_CONFIDENCE_DECAY`
+- **Capability registry entry:** `CapabilityConfidenceCalibration` at `src/config.rs:1331`
+
+### Feature: Form 6 — MemoryKind Batman vocabulary
+
+- **Issue(s):** `#759`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES (enum did not exist in v0.6.4)
+- **Docs:** `docs/memory-kind-vocab.md` (800 words)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0025_v07_memory_kind.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/models/memory.rs:38-200` (10-variant enum)
+- **Hooks:** `/Users/fate/v07/catalogue/src/hooks/pre_store/auto_classify_kind.rs`
+- **Namespace policy fields:** `auto_classify_kind: Option<MemoryKindAutoClassify>` (`Off | RegexOnly | RegexThenLlm`) at `src/models/namespace.rs:421`
+- **Capability registry entry:** `CapabilityMemoryKindVocab` at `src/config.rs:1260`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_6_memorykind_vocab.rs`, `/Users/fate/v07/catalogue/tests/l1_1_memory_kind.rs`
+
+### Feature: Form 7 (7th-form) — agent-EXTERNAL Layer-4 wiring
+
+- **Issue(s):** `#760`, parent meta `#693`, V08 closeout `#697`
+- **Status:** PARTIAL — Option B foundation (PE-1/PE-2/PE-3) SHIPPED; complete cover at v0.8.0 per CHANGELOG "Honest framing" callout
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/policy-engine.md` (3,597 words), `docs/security/audit-trail-coverage.md`, `docs/governance/agent-action-rules.md`
+- **Cookbook:** `cookbook/agent-external-governance/01-deny-bash.sh`
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0024_v07_governance_rules.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/governance/{mod.rs,agent_action.rs,deferred_audit.rs,rules_store.rs,wire_check.rs}`
+- **MCP tools:** `/Users/fate/v07/catalogue/src/mcp/tools/{check_agent_action.rs,rule_list.rs}` → `memory_check_agent_action`, `memory_rule_list`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/rules.rs`, `/Users/fate/v07/catalogue/src/cli/governance_install_defaults.rs`, `/Users/fate/v07/catalogue/src/cli/governance_migrate.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/form_7_agent_external_wiring.rs`, `/Users/fate/v07/catalogue/tests/governance_agent_action.rs`, `/Users/fate/v07/catalogue/tests/governance_a2a_rules.rs`, `/Users/fate/v07/catalogue/tests/governance_storage_insert_hook.rs`, `/Users/fate/v07/catalogue/tests/governance_l16_activation.rs`, `/Users/fate/v07/catalogue/tests/governance_wire_points.rs`, `/Users/fate/v07/catalogue/tests/policy_engine_hostile_prompts.rs`, `/Users/fate/v07/catalogue/tests/cli_install_pretool_hook.rs`, `/Users/fate/v07/catalogue/tests/governance_deferred_log_audit.rs`
+- **Capability registry entry:** `CapabilityGovernance` at `src/config.rs:1083`
+- **Public API surface:** `R001..R004` seed rules; `~/.config/ai-memory/operator.key`; `ai-memory install --harness claude-code --enforce-policy`
+- **Known unknowns:** the "complete cover" 5% gap (V08-PE-1 .. V08-PE-8) is explicitly out-of-scope per `#697`. Reviewer should sanity-check that the "PE-1 / PE-2 / PE-3 all landed" claim matches code (CHANGELOG asserts this — `governance_wire_points.rs` is the pin).
+
+### Feature: Recursive-learning primitive (Tasks 1-8, issue `#655`)
+
+- **Issue(s):** `#655` (parent), tasks 1-6 commits `f5d8a9e`, `630a6db`, `b51a3f3`, `3dc76f3`, `c61a05b`, `fbf093c`; Tasks 7-8 land on the grand-slam branch
+- **Status:** SHIPPED (Tasks 1-6 + 7-8 ship-gate + docs)
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/RECURSIVE_LEARNING.md` (3,782 words)
+- **Cookbook:** `cookbook/recursive-learning/*.sh` + `*.md` (5 scenarios + README, 11 files total)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/postgres/0013_v0700_reflection_depth.sql` (SQLite v29 via in-tree `storage/migrations.rs` ladder)
+- **Code paths:**
+  - Substrate: `/Users/fate/v07/catalogue/src/storage/reflect.rs`, `/Users/fate/v07/catalogue/src/storage/mod.rs` (reflect path + `GOVERNANCE_PRE_WRITE` OnceLock)
+  - MCP tool: `/Users/fate/v07/catalogue/src/mcp/tools/reflect.rs` → `memory_reflect`
+  - Origin tool: `/Users/fate/v07/catalogue/src/mcp/tools/reflection_origin.rs` → `memory_reflection_origin`
+  - Dependents-of-invalidated: `/Users/fate/v07/catalogue/src/mcp/tools/dependents_of_invalidated.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/recursive_learning_task{1..7}_*.rs` (8 files), `/Users/fate/v07/catalogue/tests/ship_gate/grand_slam_recursive_learning.rs`, `/Users/fate/v07/catalogue/tests/approval_reflect.rs`, `/Users/fate/v07/catalogue/tests/federation_reflection_replication.rs`, `/Users/fate/v07/catalogue/tests/reranker_reflection_test.rs`, `/Users/fate/v07/catalogue/tests/longmemeval_reflection_bench.rs`
+- **Namespace policy fields:** `max_reflection_depth: Option<u32>` (default 3, `Some(0)` is documented kill-switch)
+- **Capability registry entry:** `CapabilityReflection` at `src/config.rs:917`
+- **Public API surface:** `memory_reflect` (Family::Power); `pre_reflect` + `post_reflect` hook events (Track G grew 21 → 23)
+- **Reproducer script:** `scripts/reproduce-recursive-learning.sh` (CLAUDE.md documented)
+
+### Feature: L1-5 Agent Skills ingestion substrate
+
+- **Issue(s):** grand-slam wave (issues `#666`–`#673`, `#691`)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/agent-skills.md` (1,641 words)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0026_v07_agent_skills.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/models/skill.rs`, `/Users/fate/v07/catalogue/src/parsing/skill_md.rs`
+- **MCP tools (5):** `/Users/fate/v07/catalogue/src/mcp/tools/skill_{register,list,get,resource,export,promote,compositional_context}.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/skill_test.rs`, `/Users/fate/v07/catalogue/tests/skill_composition_test.rs`, `/Users/fate/v07/catalogue/tests/skill_promote_test.rs`, `/Users/fate/v07/catalogue/tests/ship_gate/grand_slam_skills.rs`
+- **Capability registry entry:** `CapabilitySkills` at `src/config.rs:975`
+
+### Feature: L1-6 substrate rules-enforcement engine (Option B foundation)
+
+- **Issue(s):** `#691`, Deliverable E commit `1b877ce`
+- **Status:** SHIPPED (foundation; complete cover at v0.8.0)
+- **See:** Feature "Form 7 — agent-EXTERNAL Layer-4 wiring" above (same body of code)
+- **Audit deliverables:** `/Users/fate/v07/catalogue/docs/v0.7.0/validation/rules-store-isolation-audit.md`, `/Users/fate/v07/catalogue/docs/v0.7.0/validation/wire-check-bypass-audit.md`
+
+### Feature: L1-7 compaction pipeline
+
+- **Issue(s):** grand-slam wave (merge commit `7451143`)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/curator/{compaction.rs,pipeline.rs,cluster.rs,reflection_pass.rs,candidates.rs,persist.rs}`
+- **Tests:** `/Users/fate/v07/catalogue/tests/curator/compaction_test.rs`, `/Users/fate/v07/catalogue/tests/curator/reflection_pass_test.rs`
+- **Capability registry entry:** `CapabilityCompaction` (extends v0.6.4)
+- **Hook events added:** `pre_compaction`, `on_compaction_rollback` (Track G additions)
+
+### Feature: L2-1 reflection-pass curator
+
+- **Issue(s):** `#666`, commit `c3f6e82`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/curator/reflection_pass.rs` (67,400 bytes)
+- **CLI:** `ai-memory curator --reflect` via `/Users/fate/v07/catalogue/src/cli/curator.rs` (modified)
+- **Runbook:** `/Users/fate/v07/catalogue/docs/RUNBOOK-curator-soak.md`
+- **Constants:** `MIN_CLUSTER_SIZE = 3`, `MAX_CLUSTER_SIZE = 12`, 7-day temporal window
+
+### Feature: L2-2 federation-aware reflection coordination
+
+- **Issue(s):** `#667`, commit `0b1c9cc`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/federation/reflection_bookkeeping.rs`, `/Users/fate/v07/catalogue/src/federation/receive.rs`
+- **MCP tool:** `memory_reflection_origin` → `/Users/fate/v07/catalogue/src/mcp/tools/reflection_origin.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/federation_reflection_replication.rs`
+
+### Feature: L2-3 reflection invalidation propagation (NOT cascade)
+
+- **Issue(s):** `#668`, commit `3f419be`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/notification/invalidation.rs`
+- **MCP tool:** `memory_dependents_of_invalidated` → `/Users/fate/v07/catalogue/src/mcp/tools/dependents_of_invalidated.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/notification/invalidation_test.rs`
+- **Notification namespace:** `<dependent.namespace>/_invalidations`
+
+### Feature: L2-4 transcript replay union
+
+- **Issue(s):** `#669`, commit `a50b34c`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES (extends v0.6.4 transcript surface)
+- **Code paths:** `/Users/fate/v07/catalogue/src/transcripts/{mod.rs,replay.rs,storage.rs}`
+- **MCP tool:** `memory_replay` → `/Users/fate/v07/catalogue/src/mcp/tools/replay.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/transcripts/replay_test.rs`, `/Users/fate/v07/catalogue/tests/i4_memory_replay_authz.rs`
+
+### Feature: L2-5 forensic bundle
+
+- **Issue(s):** `#670`, commit `bb870b3`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/forensic-export.md` (1,756 words)
+- **Cookbook:** `cookbook/recursive-learning/04-forensic-bundle.sh`
+- **Code paths:** `/Users/fate/v07/catalogue/src/forensic/{mod.rs,bundle.rs}`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/export.rs`, `/Users/fate/v07/catalogue/src/cli/verify.rs` — `ai-memory export-forensic-bundle`, `ai-memory verify-forensic-bundle`
+- **Tests:** `/Users/fate/v07/catalogue/tests/forensic.rs`, `/Users/fate/v07/catalogue/tests/forensic/bundle_test.rs`, `/Users/fate/v07/catalogue/tests/forensic/wt1e_chain_test.rs`
+- **Capability registry entry:** `CapabilityForensic` at `src/config.rs:1038`
+- **Reproducibility property:** deterministic in-process POSIX-ustar tar with byte-identical mod timestamps
+
+### Feature: L2-6 reflection-as-skill promote
+
+- **Issue(s):** `#671`, commit `505c538`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **MCP tool:** `memory_skill_promote_from_reflection` → `/Users/fate/v07/catalogue/src/mcp/tools/skill_promote.rs`
+- **Cookbook:** `cookbook/recursive-learning/03-reflection-to-skill-promote.sh`
+- **Tests:** `/Users/fate/v07/catalogue/tests/skill_promote_test.rs`
+- **Round-trip guarantee:** promote → export → re-register produces IDENTICAL SHA-256 digest
+
+### Feature: L2-7 skill ↔ reflection composition
+
+- **Issue(s):** `#672`, commit `0966b57`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **MCP tool:** `memory_skill_compositional_context` → `/Users/fate/v07/catalogue/src/mcp/tools/skill_compositional_context.rs`
+- **Cookbook:** `cookbook/recursive-learning/05-autoresearch-composition.sh`
+- **Tests:** `/Users/fate/v07/catalogue/tests/skill_composition_test.rs`, `/Users/fate/v07/catalogue/tests/ship_gate/grand_slam_composition.rs`
+- **Budget bounds:** `budget_tokens` default 4000, max 32000
+
+### Feature: L2-8 reflection-aware reranker boost
+
+- **Issue(s):** `#673`, commit `90291c0`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** EXTENDS_v0_6_4 (reranker existed; reflection-aware boost is new)
+- **Code paths:** modified `/Users/fate/v07/catalogue/src/reranker.rs` (defaults `boost=1.2`, `per_depth_increment=0.05`, `max_depth_cap=3`)
+- **Tests:** `/Users/fate/v07/catalogue/tests/reranker_reflection_test.rs`
+- **Kill-switch:** `boost=1.0`
+
+### Feature: QW-1 file-backed reflection chain export
+
+- **Issue(s):** v0.7.0 Tencent QW-1
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Cookbook:** `cookbook/file-backed-export/01-export-and-inspect.sh`
+- **MCP tool:** `memory_export_reflection` → `/Users/fate/v07/catalogue/src/mcp/tools/export_reflection.rs`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/commands/export_reflections.rs`
+- **Hook:** `/Users/fate/v07/catalogue/src/hooks/post_reflect/auto_export.rs`
+- **Namespace policy field:** `auto_export_reflections_to_filesystem: Option<bool>`
+- **Default destination:** `~/.ai-memory/reflections/<namespace>/<id>.md`
+- **Tests:** `/Users/fate/v07/catalogue/tests/cli/export_reflections.rs`
+
+### Feature: QW-2 persona-as-artifact
+
+- **Issue(s):** v0.7.0 Tencent QW-2
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/persona.md` (894 words)
+- **Cookbook:** `cookbook/persona/01-build-persona-from-observations.sh`
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0031_v07_persona.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0018_v07_persona.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/persona/mod.rs` (30,003 bytes)
+- **MCP tools:** `memory_persona`, `memory_persona_generate` → `/Users/fate/v07/catalogue/src/mcp/tools/persona.rs`
+- **Hook:** `/Users/fate/v07/catalogue/src/hooks/post_reflect/auto_persona.rs`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/commands/persona.rs`
+- **Namespace policy fields:** `auto_persona_trigger_every_n_memories: Option<u32>`, `auto_export_personas_to_filesystem: Option<bool>`
+- **Tests:** `/Users/fate/v07/catalogue/tests/persona.rs`, `/Users/fate/v07/catalogue/tests/persona/acceptance.rs`
+- **Memory kind:** `MemoryKind::Persona` (paired with `entity_id` + `persona_version` columns)
+- **Default destination:** `~/.ai-memory/personas/<namespace>/<entity_id>.md`
+
+### Feature: QW-3 context offload primitive
+
+- **Issue(s):** v0.7.0 Tencent QW-3
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/context-offload.md` (497 words)
+- **Cookbook:** `cookbook/context-offload/01-offload-large-tool-output.sh`
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0029_v07_offloaded_blobs.sql`, `/Users/fate/v07/catalogue/migrations/postgres/0016_v07_offloaded_blobs.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/offload/mod.rs` (27,017 bytes)
+- **MCP tools:** `memory_offload`, `memory_deref` → `/Users/fate/v07/catalogue/src/mcp/tools/offload.rs`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/offload.rs`
+- **Background sweep:** `/Users/fate/v07/catalogue/src/background/offload_ttl_sweep.rs`
+- **Tests:** `/Users/fate/v07/catalogue/tests/offload.rs`, `/Users/fate/v07/catalogue/tests/offload/acceptance.rs`, `/Users/fate/v07/catalogue/tests/offload/registration.rs`, `/Users/fate/v07/catalogue/tests/l07_3_chunk_d_http_surface.rs`
+
+### Feature: Sidechain transcripts (Track I — v0.6.4 → v0.7.0 hardening)
+
+- **Issue(s):** Track I (5 tasks, Bucket 1.7)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0016_v07_transcripts.sql`, `0018_v07_transcript_links.sql`, `0019_v07_transcript_lifecycle.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/transcripts/{mod.rs,replay.rs,storage.rs}`
+- **MCP tool:** `memory_replay`
+- **Helper binary:** `/Users/fate/v07/catalogue/tools/transcript-extractor/` (R5 reference hook, intentionally excluded from crates.io upload via parent `Cargo.toml` `include` allowlist)
+- **Tests:** `/Users/fate/v07/catalogue/tests/transcripts.rs`, `/Users/fate/v07/catalogue/tests/transcripts/replay_test.rs`, `/Users/fate/v07/catalogue/tests/transcript_extractor.rs`
+- **Capability registry entry:** `CapabilityTranscripts` (extends v0.6.4)
+- **Security hardening (release/v0.7.0):** I1 — `TranscriptsConfig.max_decompressed_bytes` config-driven (commit `26fab06`), default 16 MiB
+
+### Feature: Ed25519 attested identity (Track H — full closeout)
+
+- **Issue(s):** Track H (6 tasks, Bucket 1)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** EXTENDS_v0_6_4 (v0.6.4 had `memory_links.signature` "dead column"; v0.7.0 fills it)
+- **Code paths:** `/Users/fate/v07/catalogue/src/identity/{mod.rs,keypair.rs,sign.rs,verify.rs,replay.rs}`
+- **MCP tool:** `memory_verify` → `/Users/fate/v07/catalogue/src/mcp/tools/verify.rs`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/identity.rs` — `ai-memory identity generate`
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0017_v07_link_attest_level.sql`, `0020_v07_signed_events.sql`
+- **Env vars:** `AI_MEMORY_KEY_DIR`, `AI_MEMORY_OPERATOR_PUBKEY`
+- **Round-2 fix F12:** keypair auto-generated on `serve` startup if absent
+- **Tests:** `/Users/fate/v07/catalogue/tests/identity_e2e.rs`, `/Users/fate/v07/catalogue/tests/memory_verify.rs`, `/Users/fate/v07/catalogue/tests/round2_f12_keypair_autogen.rs`, `/Users/fate/v07/catalogue/tests/federation_inbound_verify.rs`
+
+### Feature: Signed events V-4 closeout (cross-row hash chain)
+
+- **Issue(s):** `#698`
+- **Status:** SHIPPED (flips V-4 YELLOW → GREEN)
+- **Net-new in v0.7.0:** YES
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0020_v07_signed_events.sql`, `0028_v07_signed_events_chain.sql` (v34 cross-row chain), `/Users/fate/v07/catalogue/migrations/postgres/0015_v07_signed_events_chain.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/signed_events.rs`, `/Users/fate/v07/catalogue/src/storage/migrations.rs` (backfill `migrate_v34_backfill_chain`)
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/verify_signed_events.rs` — `ai-memory verify-signed-events-chain [--since N] [--format text|json]`
+- **Tests:** `/Users/fate/v07/catalogue/tests/signed_events_chain_v34.rs` (7 tests pinning first-row zero `prev_hash`, multi-row chaining, payload tamper, sequence tamper, concurrent drainer inserts via PE-3, backfill idempotency, backfill correctness), `/Users/fate/v07/catalogue/tests/deferred_audit_soak.rs` (5K concurrent insert chain assertion), `/Users/fate/v07/catalogue/tests/cli_verify_chain.rs`
+
+### Feature: Apache AGE acceleration (Track J)
+
+- **Issue(s):** Track J (8 tasks, Bucket 2)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/postgres-age-guide.md` (4,479 words), `docs/kg-backend-fallback.md`
+- **Code paths:** `/Users/fate/v07/catalogue/src/kg/{mod.rs,cycle_check.rs}` + AGE detection in postgres storage adapter
+- **MCP tools:** `memory_find_paths`, `memory_kg_query`, `memory_kg_timeline`, `memory_kg_invalidate` (find_paths is new)
+- **Bench:** `/Users/fate/v07/catalogue/benches/age_vs_cte.rs`
+- **Env var:** `AI_MEMORY_TEST_AGE_URL` (test-side AGE pin)
+- **Tests:** `/Users/fate/v07/catalogue/tests/age_cte_equivalence.rs`, `/Users/fate/v07/catalogue/tests/kg_age_fallback.rs`, `/Users/fate/v07/catalogue/tests/kg/cycle_check_test.rs`, `/Users/fate/v07/catalogue/tests/g4_postgres_link_projects_into_age_graph.rs`, `/Users/fate/v07/catalogue/tests/g5_find_paths_cypher_no_syntax_error.rs`, `/Users/fate/v07/catalogue/tests/g2_postgres_find_paths_age_param_binding.rs`
+
+### Feature: K1/G1 namespace-inheritance enforcement + permissions pipeline (Track K, 11 tasks)
+
+- **Issue(s):** Track K
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/policy-engine.md` (3,597 words)
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0015_v07_pending_action_timeouts.sql`, `0021_v07_a2a_correlation.sql`, `0022_v07_agent_quotas.sql`
+- **Code paths:** `/Users/fate/v07/catalogue/src/approvals.rs`, `/Users/fate/v07/catalogue/src/quotas.rs`
+- **Env var:** `AI_MEMORY_PERMISSIONS_MODE`
+- **Round-2 fix F8:** default `permissions.mode = enforce` (was `advisory`)
+- **MCP tools:** `memory_quota_status`, `memory_subscription_dlq_list`, `memory_subscription_replay`, `memory_pending_*` (extends v0.6.4)
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/governance_migrate.rs` — `ai-memory governance migrate-to-permissions`
+- **Capability registry entry:** `CapabilityPermissions` (extends v0.6.4)
+- **Tests:** `/Users/fate/v07/catalogue/tests/k7_dlq_list_tool.rs`, `/Users/fate/v07/catalogue/tests/k7_hmac.rs`, `/Users/fate/v07/catalogue/tests/k7_replay_tool.rs`, `/Users/fate/v07/catalogue/tests/k8_quota_status_tool.rs`, `/Users/fate/v07/catalogue/tests/k8_quota_enforcement.rs`, `/Users/fate/v07/catalogue/tests/k8_daily_reset.rs`, `/Users/fate/v07/catalogue/tests/k9_permission_pipeline.rs`, `/Users/fate/v07/catalogue/tests/k10_approval_http.rs`, `/Users/fate/v07/catalogue/tests/k10_approval_sse.rs`, `/Users/fate/v07/catalogue/tests/k10_approval_security.rs`, `/Users/fate/v07/catalogue/tests/k10_remember_forever.rs`, `/Users/fate/v07/catalogue/tests/k11_migrate_dry_run.rs`, `/Users/fate/v07/catalogue/tests/k11_migrate_in_place.rs`, `/Users/fate/v07/catalogue/tests/k11_migrate_to_file.rs`, `/Users/fate/v07/catalogue/tests/permissions_mode_gate.rs`
+
+### Feature: Hook pipeline (Track G, 25 events)
+
+- **Issue(s):** Track G (11 tasks, Bucket 0)
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/hooks/{mod.rs,chain.rs,config.rs,decision.rs,events.rs,executor.rs,recall.rs,timeouts.rs}`, sub-trees `pre_store/`, `post_reflect/`
+- **Helper binary:** `/Users/fate/v07/catalogue/tools/auto-link-detector/` (R3 reference hook)
+- **Config:** `~/.config/ai-memory/hooks.toml`
+- **Capability registry entry:** `CapabilityHooks` at `src/config.rs:703` (extended)
+- **25 events:** 20 baseline + 5 grand-slam additions (`pre_recall_expand`, `pre_reflect`, `post_reflect`, `pre_compaction`, `on_compaction_rollback`)
+- **Tests:** `/Users/fate/v07/catalogue/tests/hooks_executor_test.rs`, `/Users/fate/v07/catalogue/tests/hooks_hot_reload.rs`, `/Users/fate/v07/catalogue/tests/hooks_pre_recall.rs`, `/Users/fate/v07/catalogue/tests/hooks_timeout_budget.rs`, `/Users/fate/v07/catalogue/tests/g3_hooks_stderr_drain.rs`, `/Users/fate/v07/catalogue/tests/g11_auto_link_detector.rs`
+
+### Feature: Capabilities v3 response shape (Track A, 5 tasks)
+
+- **Issue(s):** Track A
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** EXTENDS_v0_6_4 (v0.6.4 was v2)
+- **Code paths:** `/Users/fate/v07/catalogue/src/config.rs` (all `Capability*` structs), `/Users/fate/v07/catalogue/src/mcp/tools/capabilities.rs`
+- **Docs:** `docs/v0.7/canonical-phrasings.md`
+- **Tests:** `/Users/fate/v07/catalogue/tests/capabilities_v3.rs`, `/Users/fate/v07/catalogue/tests/capabilities_v3_l3_5.rs`, `/Users/fate/v07/catalogue/tests/round2_f13_capabilities.rs`, `/Users/fate/v07/catalogue/tests/s75_capabilities_db_schema_version.rs`
+- **Added fields:** `summary`, `to_describe_to_user`, `callable_now`, `agent_permitted_families`, `schema_version="3"`
+- **Round-2 fix F13:** `verbose` and `include_schema` flags fixed
+
+### Feature: Loader tools (Track B, 5 tasks)
+
+- **Issue(s):** Track B
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES (promoted from hidden parameter set to always-on tools)
+- **MCP tools:** `memory_load_family`, `memory_smart_load` → `/Users/fate/v07/catalogue/src/mcp/tools/load_family.rs`, `src/mcp/tools/skill_compositional_context.rs` (smart load is in registry)
+- **Env var:** `AI_MEMORY_PRECOMPUTE_FAMILY_EMBEDDINGS`
+- **Tests:** `/Users/fate/v07/catalogue/tests/memory_load_family.rs`, `/Users/fate/v07/catalogue/tests/memory_smart_load.rs`, `/Users/fate/v07/catalogue/tests/b3_precompute_doesnt_block_serve.rs`, `/Users/fate/v07/catalogue/tests/b4_config_cleanup.rs`, `/Users/fate/v07/catalogue/tests/round2_f14_smart_load.rs`
+
+### Feature: Schema compaction (Track C, 5 tasks) — 52% MCP tool-token reduction
+
+- **Issue(s):** Track C
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Audit:** `docs/v0.7/schema-compaction-audit.md`
+- **Tests:** `/Users/fate/v07/catalogue/tests/c2_tool_docs_field.rs`, `/Users/fate/v07/catalogue/tests/c3_no_inline_examples.rs`
+- **CI gate:** ≤ 3,500 input tokens for `--profile full` `tools/list`
+
+### Feature: Per-harness positioning + tests (Track D, 4 tasks)
+
+- **Issue(s):** Track D
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/v0.7/compatibility-matrix.html`, `docs/positioning.md`, `docs/integrations/networking.md`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/install.rs` (modified — emits install-time system-prompt snippet)
+- **Env var:** `AI_MEMORY_SYSTEM_PROMPT_DIR`
+- **Bench:** `/Users/fate/v07/catalogue/benches/harness_bench.rs`, `/Users/fate/v07/catalogue/benchmarks/competitive-benchmarks/`
+- **Tests:** `/Users/fate/v07/catalogue/tests/harness_integration.rs`
+
+### Feature: Discovery Gate + T0 calibration (Track E, 3 tasks)
+
+- **Issue(s):** Track E
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Docs:** `docs/v0.7/T0-ORCHESTRATION.md`, `docs/v0.7/POST-SHIP-CONVERGENCE.md`
+- **Helper binaries:** `/Users/fate/v07/catalogue/tools/t0-orchestrate/`, `/Users/fate/v07/catalogue/tools/post-ship-converge/`
+- **Tests:** `/Users/fate/v07/catalogue/tests/discovery_gate_t1_t3.rs`, `/Users/fate/v07/catalogue/tests/e1_orchestration_dry_run.rs`, `/Users/fate/v07/catalogue/tests/e2_post_ship_dry_run.rs`
+
+### Feature: Postgres + AGE first-class (Wave 1-4)
+
+- **Issue(s):** `#646` (Wave 1), per `05e0cb9a` v0.7.1-fold decision
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES (Storage Abstraction Layer is new; SqliteStore + PostgresStore both live)
+- **Docs:** `docs/postgres-age-guide.md` (4,479 words), `docs/migration-v0.7.0-postgres.md` (1,604 words)
+- **Code paths:** `/Users/fate/v07/catalogue/src/store/mod.rs`, `/Users/fate/v07/catalogue/src/storage/{connection.rs,migrations.rs,reflect.rs,mod.rs}`
+- **CLI:** `/Users/fate/v07/catalogue/src/cli/schema_init.rs` — `ai-memory schema-init`
+- **Cargo features:** `sal-postgres` (opt-in; default sqlite build is byte-for-byte unchanged)
+- **Postgres migrations:** 10 new files `0012..0020`
+- **Tests:** `/Users/fate/v07/catalogue/tests/postgres_schema_parity.rs`, `/Users/fate/v07/catalogue/tests/sal_v07_postgres_findings.rs`, `/Users/fate/v07/catalogue/tests/serve_postgres_*.rs` (5 files), `/Users/fate/v07/catalogue/tests/recall_scoring_parity.rs`, `/Users/fate/v07/catalogue/tests/cli_schema_init.rs`, `/Users/fate/v07/catalogue/tests/migrate_links_roundtrip.rs`, `/Users/fate/v07/catalogue/tests/federation_postgres_fanout.rs`, `/Users/fate/v07/catalogue/tests/g1_postgres_quota_increment_on_store.rs`, `/Users/fate/v07/catalogue/tests/governance_postgres_inheritance.rs`, `/Users/fate/v07/catalogue/tests/s79_postgres_recall_returns_results.rs`
+
+### Feature: Federation hardening (mTLS + X-API-Key + fingerprint allowlist)
+
+- **Issue(s):** `#238`, `#239`, `#318` (continued), security-hardening sweep
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** EXTENDS_v0_6_4
+- **Code paths:** `/Users/fate/v07/catalogue/src/federation/{mod.rs,peer.rs,peer_attestation.rs,quorum.rs,receive.rs,sync.rs,vector_clock.rs}`
+- **Env vars:** `AI_MEMORY_FED_PEER_ATTESTATION`, `AI_MEMORY_FED_SYNC_TRUST_PEER`, `AI_MEMORY_FED_TRUST_BODY_AGENT_ID`
+- **Tests:** `/Users/fate/v07/catalogue/tests/federation_b2_hardening.rs`, `/Users/fate/v07/catalogue/tests/federation_x_api_key.rs`, `/Users/fate/v07/catalogue/tests/federation_inbound_verify.rs`, `/Users/fate/v07/catalogue/tests/federation_reflection_replication.rs`, `/Users/fate/v07/catalogue/tests/g_issue_238_sender_attestation.rs`, `/Users/fate/v07/catalogue/tests/g_issue_239_sync_scope.rs`, `/Users/fate/v07/catalogue/tests/issue_318_mcp_federation_forward.rs`
+
+### Feature: Security-hardening sweep (release/v0.7.0 reconciled into trunk)
+
+- **Issue(s):** 11 late-cycle commits between initial release-cut and reconciled HEAD `64528b1`
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Per-commit map (CHANGELOG):**
+  - K9 governance gate on `handle_kg_invalidate` (`a41c08f`)
+  - K10 SSE `host:` prefix bypass (`7496a6e`)
+  - K10 HMAC method+pending_id binding (`99ffacc`)
+  - K10 HMAC nonce single-use 300s window (`a69325f`)
+  - K10 SSE lagged-event count strip (`d1f6c9f`)
+  - SSRF IPv4-mapped-IPv6 + NAT64 (`3ab72dc`, test `6b6b3c0`)
+  - `invalidate_link` BEGIN IMMEDIATE wrap (`2c77537`)
+  - Hooks executor secret-redaction (`cbe934c`)
+  - H8 rebound-namespace `Ask` walk (`69ad41c`)
+  - I1 zstd-decompression cap config-driven (`26fab06`)
+- **Tests:** `/Users/fate/v07/catalogue/tests/k10_approval_security.rs`, `/Users/fate/v07/catalogue/tests/i1_zstd_bomb.rs`, `/Users/fate/v07/catalogue/tests/h2_invalidate_link_signed.rs`
+
+### Feature: Round-2 NHI sweep (F1-F18)
+
+- **Issue(s):** `#644` (F1), `#645` (F2), `#646` (F6)
+- **Status:** SHIPPED (all 18 closed)
+- **Net-new in v0.7.0:** YES
+- **Per-finding:** see CHANGELOG `## [0.7.0]` "F-series fixes" section (lines 16-36 of CHANGELOG.md)
+- **Tests:** `/Users/fate/v07/catalogue/tests/round2_f{6,7,8,9,10,11,12,13,14,15,16,17,18}_*.rs` (13 files)
+
+### Feature: K8 quota status tool
+
+- **Issue(s):** Track K, K8 family
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **MCP tool:** `memory_quota_status` → `/Users/fate/v07/catalogue/src/mcp/tools/quota_status.rs`
+- **HTTP route:** `/api/v1/quota/status`
+- **Code paths:** `/Users/fate/v07/catalogue/src/quotas.rs`
+- **Schema:** `/Users/fate/v07/catalogue/migrations/sqlite/0022_v07_agent_quotas.sql`
+- **Tests:** `/Users/fate/v07/catalogue/tests/k8_quota_status_tool.rs`, `/Users/fate/v07/catalogue/tests/k8_daily_reset.rs`, `/Users/fate/v07/catalogue/tests/k8_quota_enforcement.rs`
+
+### Feature: Batman framework audit deliverable
+
+- **Status:** SHIPPED (audit document only)
+- **Net-new in v0.7.0:** YES
+- **Docs:** `/Users/fate/v07/catalogue/docs/internal/batman-framework-audit.md` (4,478 words)
+- **Code paths:** N/A — audit document
+- **Cross-reference:** anchors Forms 1-7 inventory above
+
+### Feature: Schema migration ladder v33 → v39 / postgres v17 → v38
+
+- **Status:** SHIPPED — final extant: sqlite up to `0033_v07_form5_confidence_calibration.sql`, postgres up to `0020_v07_form5_confidence_calibration.sql`
+- **Net-new in v0.7.0:** YES (all 20 sqlite + 10 postgres files added since v0.6.4)
+- **Per-migration evidence:** every `migrations/sqlite/0015..0033` and `migrations/postgres/0012..0020` is `git diff --name-status v0.6.4..HEAD` "A"-status
+- **Known unknowns:** the task prompt said "sqlite v33 → v39 / postgres v17 → v38" but in-tree highest migration files are sqlite 0033 / postgres 0020. The release-notes references to "v34" (V-4 closeout) and beyond are applied via the in-process ladder in `/Users/fate/v07/catalogue/src/storage/migrations.rs` rather than as additional SQL files. Reviewer should verify whether the "v34 → v39" range refers to in-process migrations or whether SQL files are still in flight.
+
+### Feature: Adapter selection refactor + `AppState.store: Arc<dyn MemoryStore>`
+
+- **Issue(s):** Wave 3
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Code paths:** `/Users/fate/v07/catalogue/src/store/mod.rs`, `/Users/fate/v07/catalogue/src/handlers/mod.rs`, `/Users/fate/v07/catalogue/src/handlers/{http.rs,transport.rs,federation_receive.rs,hook_subscribers.rs}`
+- **Public surface:** `ai-memory serve --store-url postgres://...`
+
+### Feature: Tests pinning ship gate
+
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Test files:** `/Users/fate/v07/catalogue/tests/ship_gate.rs`, `/Users/fate/v07/catalogue/tests/ship_gate/{grand_slam_recursive_learning.rs,grand_slam_skills.rs,grand_slam_composition.rs}`
+
+### Feature: Helper binaries (4 new under `tools/`)
+
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Bins:**
+  - `/Users/fate/v07/catalogue/tools/auto-link-detector/` — R3 reference `pre_link` hook (775 LoC `src/main.rs`)
+  - `/Users/fate/v07/catalogue/tools/transcript-extractor/` — R5 reference `pre_store` hook (Track I)
+  - `/Users/fate/v07/catalogue/tools/t0-orchestrate/` — Track E T0 calibration driver
+  - `/Users/fate/v07/catalogue/tools/post-ship-converge/` — post-ship convergence verifier
+- **Cargo note:** kept out of crates.io upload via the parent `Cargo.toml` `include` allowlist
+
+### Feature: Benchmarks (11 new)
+
+- **Status:** SHIPPED
+- **Net-new in v0.7.0:** YES
+- **Files:** `/Users/fate/v07/catalogue/benches/{age_vs_cte,harness_bench,longmemeval_reflection,reflect,reranker_throughput}.rs`; `/Users/fate/v07/catalogue/benchmarks/longmemeval_reflection/{dataset,runner}.rs` + `data/scenarios.jsonl`; `/Users/fate/v07/catalogue/benchmarks/competitive-benchmarks/{README.md,expected_output.md,harness.sh}`; existing `/Users/fate/v07/catalogue/benchmarks/v0.6.4-cross-harness.md`
+
+### Feature: 42 new docs
+
+- **Status:** SHIPPED
+- **See list above** (§ "docs added since v0.6.4"). Key per-feature anchors:
+  - `docs/MIGRATION_v0.7.md` (2,068 words) — v0.6.4 → v0.7.0 surface delta
+  - `docs/migration-v0.7.0-postgres.md` (1,604 words)
+  - `docs/v0.7/V0.7-EPIC.md` (7,331 words) — canonical scope
+  - `docs/v0.7/rfc-attested-cortex.md` (17,501 words) — design RFC
+  - `docs/v0.7.0/release-notes.md` (5,001 words)
+  - `docs/v0.7.0/roadmap-audit-report.md`
+  - `docs/v0.7.0/validation/{rules-store-isolation-audit,wire-check-bypass-audit,soak-test-results}.md`
+  - `docs/policy-engine.md` (3,597 words)
+  - `docs/RECURSIVE_LEARNING.md` (3,782 words)
+  - `docs/agent-skills.md` (1,641 words)
+  - `docs/internal/batman-framework-audit.md` (4,478 words)
+
+### Feature: 8 cookbook directories
+
+- **Status:** SHIPPED
+- See full file list in §"Inventory cookbook details" above. The `recursive-learning/` cookbook is the largest (5 scenarios with paired `.md` + `.sh` files, plus README).
+
+---
+
+## Known unknowns / open questions (for downstream reviewers)
+
+1. **Schema-ladder version names** — task prompt anchors at "sqlite v33 → v39 / postgres v17 → v38". On-disk: sqlite tops out at `0033_v07_form5_confidence_calibration.sql`, postgres at `0020_v07_form5_confidence_calibration.sql`. The "v34" / "v36" / etc. labels in CHANGELOG appear to refer to the `PRAGMA user_version` numbering applied by `src/storage/migrations.rs` rather than SQL filenames. Reviewer should verify the SQL-file vs in-process-ladder mapping.
+2. **MCP tool count drift** — release-notes headline says "63 MCP tools at full profile"; the registry literal grep at `src/mcp/registry.rs` yields **71 unique `memory_*` names**. The delta of 8 likely covers (a) sub-tools, (b) aliases, (c) internal-only registrations. Reviewer should reconcile against the published `--profile full` `tools/list` output.
+3. **Form 1 vs Form 2 ship-status** — CHANGELOG lists `#754` (Form 1) and `#755` (Form 2) as still OPEN on GitHub, but the code paths (`src/synthesis/`, `src/atomisation/mod.rs`), tests (`tests/form_1_synthesis.rs`, `tests/form_2_synchronous_atomise.rs`), and namespace-policy fields (`legacy_per_pair_classifier`, `auto_atomise_mode = Synchronous`) are present. Reviewer should clarify the "OPEN issue + SHIPPED code" reconciliation.
+4. **Form 7 closeout completeness** — release-notes explicitly mark V08-PE-1..V08-PE-8 as v0.8.0 work. Reviewer must verify what ship-readiness means in this context: foundation lands v0.7.0; full cover is v0.8.0.
+5. **Recursive-learning Tasks 7-8** — Tasks 1-6 each have a named commit; Tasks 7-8 (ship-gate test suite + docs/release-notes/capabilities honesty pass) are stated to "land on the same branch and roll up here". Pinned by `tests/recursive_learning_task7_*.rs` (2 files) and `tests/ship_gate/grand_slam_recursive_learning.rs`; no Task-8-named test file. Reviewer should verify Task 8 coverage.
+6. **CapabilityCuration / CapabilityFederation absence** — no `Capability*` struct for the curator pipeline or federation. The release notes treat both as first-class features. Reviewer should confirm whether the absence is intentional (rolled into `CapabilityCompaction` and federation-config respectively) or a capabilities-surface gap.
+7. **Persona `entity_id` + `persona_version` columns** — referenced in `MemoryKind::Persona` doc-comment as "populated only for this variant". No dedicated schema migration; columns must already exist or be added by `0031_v07_persona.sql`. Reviewer should verify column-level coverage.
+8. **`memory_deref` MCP tool** — added in v0.7.0 but not covered explicitly by any of the named feature categories (QW-3 context offload registers `memory_offload`, but `memory_deref` is its read-side companion). Reviewer should confirm `memory_deref` belongs under QW-3 / context-offload.
+9. **Tencent QW-4** — task prompt enumerates QW-1, QW-2, QW-3 (file-backed export, persona, context-offload). A fourth QW item is not surfaced explicitly in CHANGELOG or in `cookbook/`. If QW-4 was scoped, reviewer should locate its code path or confirm it didn't ship.
+10. **HTTP `/api/v1/auto_tag` and `/api/v1/expand_query` ownership** — both surfaces are added but neither is enumerated in CHANGELOG track summaries. Reviewer should map these to their owning track/feature.
+11. **`policy-engine/wire-points`, `policy-engine/harness-hook`, `policy-engine/deferred-audit-log` branch refs** — CHANGELOG references these as the source branches for PE-1/PE-2/PE-3. Verify all three are merged into HEAD `64528b1` (the CHANGELOG asserts this; reviewer should grep).
+
+---
+
+## Procurement-grade discipline notes
+
+- Every file path in this document was verified by either `git diff --name-only v0.6.4..HEAD` or direct `ls` against the worktree.
+- "Net-new" claims rest on `git diff --name-status v0.6.4..HEAD` `A`-status output.
+- "Extends v0.6.4" claims rest on `M`-status output plus a baseline grep against `git show v0.6.4:<file>`.
+- Word counts via `wc -w` on the on-disk file.
+- Tool names extracted via `grep -oE '"memory_[a-z_]+"'` against `src/mcp/registry.rs` (HEAD) and `src/mcp.rs` (v0.6.4), diffed with `comm`.
+- HTTP routes extracted via `grep -oE '\.route\("[^"]+"'` against all `*.rs` files at each ref, diffed with `comm`.
+- Env vars extracted via `grep -oE 'AI_MEMORY_[A-Z_]*'` against all `src/*.rs` files at each ref, diffed with `comm`.
+
+This document is the foundation for the 6-agent parallel ship-readiness review. Each row above is precise enough for a reviewer to navigate directly to the code.
+
+— Cold mountain.

--- a/docs/k10-sse-approvals.md
+++ b/docs/k10-sse-approvals.md
@@ -1,0 +1,114 @@
+# K10 SSE approvals — `/api/v1/approvals/stream`
+
+v0.7.0 ships a server-sent-events stream that surfaces pending-approval
+lifecycle changes to listening operators (CLI tools, dashboards, A2A
+governance peers). The stream pairs with the HMAC-signed `decide`
+HTTP path so a hostile network observer who sees the SSE event stream
+still cannot forge a decision.
+
+- **Code paths:** [`src/approvals.rs`](../src/approvals.rs),
+  [`src/handlers/transport.rs`](../src/handlers/transport.rs)
+  (the `/api/v1/approvals/stream` route handler at line 455).
+- **Schema:** [`migrations/sqlite/0015_v07_pending_action_timeouts.sql`](../migrations/sqlite/0015_v07_pending_action_timeouts.sql)
+  + [`migrations/sqlite/0021_v07_a2a_correlation.sql`](../migrations/sqlite/0021_v07_a2a_correlation.sql).
+- **Reconciliation security-sweep commits:**
+  - `7496a6e` — K10 SSE `host:` prefix bypass closure.
+  - `99ffacc` — K10 HMAC method+pending_id binding.
+  - `a69325f` — K10 HMAC nonce single-use 300s window.
+  - `d1f6c9f` — K10 SSE lagged-event count strip.
+
+## Stream contract
+
+```bash
+curl -N -H "X-API-Key: $API_KEY" \
+  http://127.0.0.1:9077/api/v1/approvals/stream
+```
+
+The stream emits one named event per state change. Frame names:
+
+| Event | Frame body | Fires on |
+|---|---|---|
+| `approval_pending`  | `{id, agent_id, namespace, requested_at, ttl_secs, summary}` | New row inserted in `pending_actions`. |
+| `approval_decided`  | `{id, decision, decided_by, decided_at}` | Operator or sweeper resolves a pending row. |
+| `approval_timeout`  | `{id, ttl_secs}` | The 60s `default_timeout_seconds` sweeper expires a row. |
+| `lagged`            | `{count}` (no per-event detail) | The subscriber dropped frames; reconnect to re-sync. |
+| `heartbeat`         | empty | 30s liveness ping. |
+
+The `lagged` event carries **only the count**, never the per-event
+detail — closing the K10 lagged-event-leak finding (commit `d1f6c9f`).
+Subscribers that see `lagged` must reconnect and re-fetch the pending
+list via `GET /api/v1/pending`.
+
+## HMAC binding on the decide path
+
+The companion decide path:
+
+```
+POST /api/v1/pending/{id}/approve
+POST /api/v1/pending/{id}/reject
+```
+
+requires three headers when `permissions.mode = "enforce"`:
+
+- `X-HMAC-Signature: <hex SHA-256>` — HMAC of the canonical request.
+- `X-HMAC-Nonce: <16+ char ascii>` — single-use within a 300s window.
+- `X-HMAC-Timestamp: <unix seconds>` — request freshness clock.
+
+The canonical request bound by the HMAC is:
+
+```
+<method>\n<pending_id>\n<nonce>\n<timestamp>\n<body sha256>
+```
+
+- **Method binding** (`99ffacc`) prevents a hostile observer from
+  replaying an `approve` HMAC against the `reject` endpoint or vice
+  versa.
+- **pending_id binding** (`99ffacc`) prevents replay across pending
+  actions.
+- **Nonce single-use 300s window** (`a69325f`) prevents replay attacks
+  even within the freshness window — a nonce is rejected on second
+  use regardless of timestamp.
+- **`host:` prefix bypass** (`7496a6e`) — the v0.7.0-alpha
+  implementation accepted nonce values prefixed with `host:` as a
+  free-pass. Closed in `7496a6e`.
+
+Pinned by [`tests/k10_approval_security.rs`](../tests/k10_approval_security.rs),
+[`tests/k10_approval_http.rs`](../tests/k10_approval_http.rs),
+[`tests/k10_approval_sse.rs`](../tests/k10_approval_sse.rs),
+[`tests/k10_remember_forever.rs`](../tests/k10_remember_forever.rs).
+
+## Pairing with the MCP surface
+
+The MCP tools `memory_pending_list` / `memory_pending_approve` /
+`memory_pending_reject` are the stdio-side equivalents. The v0.7-alpha
+drafts named these `memory_approval_pending` / `memory_approval_decide`;
+**the shipped names are `memory_pending_*`** (see
+[`src/mcp/registry.rs`](../src/mcp/registry.rs)). The MCP path uses
+the same HMAC binding as the HTTP path when the substrate is in
+`enforce` mode.
+
+## Operator workflow
+
+1. **Bring up the SSE consumer.** A tiny operator dashboard that
+   subscribes to `/api/v1/approvals/stream`, renders the pending row
+   with the substrate-supplied `summary` field, and prompts the human
+   for approve/reject. Reference implementation lives in the
+   `tools/post-ship-converge/` helper.
+2. **Sign the decide.** Compute the canonical-request string above,
+   HMAC with the operator secret, send the three `X-HMAC-*` headers.
+3. **Verify** the operator-side log records the SSE `approval_decided`
+   frame within one round-trip.
+
+## `remember=forever` progressive trust
+
+`POST /api/v1/pending/{id}/reject?remember=forever` (or
+`memory_pending_reject(remember=forever)`) writes a permanent
+deny-rule into the rule corpus, so the same action shape is auto-rejected
+without re-prompting. The reverse `remember=forever` on `approve`
+similarly writes a permanent allow. Use sparingly; pinned by
+[`tests/k10_remember_forever.rs`](../tests/k10_remember_forever.rs).
+
+See also: [`docs/governance.md`](governance.md) for the wider
+permissions pipeline, [`docs/MIGRATION_v0.7.md` §"K10 SSE approvals"](MIGRATION_v0.7.md),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: K1/G1 namespace-inheritance"](internal/v070-feature-inventory.md).

--- a/docs/k8-quotas.md
+++ b/docs/k8-quotas.md
@@ -1,0 +1,128 @@
+# Per-agent daily quotas (K8)
+
+v0.7.0 ships per-agent daily quotas plus a structured read surface
+(`memory_quota_status` MCP tool / `POST /api/v1/quota/status` HTTP
+route). Default is "track, surface on demand, do not deny" — operators
+opt in to enforcement via the `enforce` mode on the agent_quotas row.
+
+- **Code paths:** [`src/quotas.rs`](../src/quotas.rs),
+  [`src/handlers/http.rs`](../src/handlers/http.rs) `quota_status_handler`,
+  [`src/mcp/tools/quota_status.rs`](../src/mcp/tools/quota_status.rs).
+- **Schema:** [`migrations/sqlite/0022_v07_agent_quotas.sql`](../migrations/sqlite/0022_v07_agent_quotas.sql).
+- **HTTP route:** `POST /api/v1/quota/status` (see
+  [`docs/API_REFERENCE.md` §"v0.7.0 net-new endpoints"](API_REFERENCE.md#v070-net-new-endpoints)).
+- **MCP tool:** `memory_quota_status` in the Power family.
+
+## Row shape
+
+```
+CREATE TABLE agent_quotas (
+  agent_id       TEXT NOT NULL,
+  date_utc       TEXT NOT NULL,            -- YYYY-MM-DD
+  writes_count   INTEGER NOT NULL DEFAULT 0,
+  bytes_written  INTEGER NOT NULL DEFAULT 0,
+  writes_limit   INTEGER,                  -- NULL = unlimited
+  bytes_limit    INTEGER,                  -- NULL = unlimited
+  enforce        INTEGER NOT NULL DEFAULT 0,   -- 0 = advisory, 1 = enforce
+  PRIMARY KEY (agent_id, date_utc)
+);
+```
+
+A row is auto-inserted on first `memory_quota_status` call for an
+agent that has never been seen — `writes_limit = NULL` and
+`bytes_limit = NULL` mean "no cap" by default. Operators set caps via
+direct SQL (substrate-level write; not an MCP-mutable surface).
+
+## Daily reset
+
+A background task at midnight UTC rotates the date partition.
+Cumulative state for prior days is preserved (operator-side
+observability), but `writes_count` and `bytes_written` reset to 0 for
+the new `date_utc`. Pinned by
+[`tests/k8_daily_reset.rs`](../tests/k8_daily_reset.rs).
+
+## Enforcement semantics
+
+When `enforce = 1`:
+
+- A `memory_store` write that would push `writes_count + 1 > writes_limit`
+  is refused at the substrate boundary with `QuotaExceeded`.
+- A `memory_store` write whose serialized payload would push
+  `bytes_written + payload_size > bytes_limit` is refused with
+  `QuotaExceeded`.
+- Refusals carry the surfaced quota row so the caller can render
+  "you have used X/Y for today, reset at UTC midnight" without a
+  second round-trip.
+
+When `enforce = 0` (default), the substrate increments the counters
+but never refuses on quota. Pinned by
+[`tests/k8_quota_enforcement.rs`](../tests/k8_quota_enforcement.rs).
+
+## MCP tool wire shape
+
+Request:
+
+```jsonc
+{
+  "tool": "memory_quota_status",
+  "args": {
+    "agent_id": "ai:claude-opus@host:pid-12345"   // optional; defaults to caller
+  }
+}
+```
+
+Response:
+
+```jsonc
+{
+  "agent_id": "ai:claude-opus@host:pid-12345",
+  "date_utc": "2026-05-15",
+  "writes_count": 142,
+  "bytes_written": 487331,
+  "writes_limit": 1000,
+  "bytes_limit": 10485760,
+  "enforce": true,
+  "remaining_writes": 858,
+  "remaining_bytes": 9998429,
+  "resets_at": "2026-05-16T00:00:00Z"
+}
+```
+
+## HTTP wire shape
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-Agent-Id: ai:claude-opus@host:pid-12345" \
+  http://127.0.0.1:9077/api/v1/quota/status \
+  -d '{}'
+```
+
+Same response shape as the MCP tool.
+
+## Operator workflow
+
+1. **Observe.** Default install tracks counters but does not enforce.
+   Watch `memory_quota_status` for the agents with the heaviest write
+   volume.
+2. **Set caps.** When you decide on a per-agent budget, set
+   `writes_limit` / `bytes_limit` via SQL (the operator-only mutation
+   surface — there is no MCP write path on `agent_quotas` by design).
+3. **Flip enforcement.** `UPDATE agent_quotas SET enforce = 1 WHERE
+   agent_id = '…' AND date_utc = '…'`. Or set a default by adding the
+   row to your config bootstrap.
+4. **Watch refusals** at `RUST_LOG=ai_memory::quotas=debug` — every
+   refused write logs the row that caused the cap.
+
+## Test coverage
+
+- [`tests/k8_quota_status_tool.rs`](../tests/k8_quota_status_tool.rs)
+  — MCP tool wire shape + auto-insert behavior.
+- [`tests/k8_quota_enforcement.rs`](../tests/k8_quota_enforcement.rs)
+  — refusal semantics under `enforce = 1`.
+- [`tests/k8_daily_reset.rs`](../tests/k8_daily_reset.rs) — midnight
+  UTC partition rotation.
+
+See also: [`docs/MIGRATION_v0.7.md` §"K8 quota tool"](MIGRATION_v0.7.md),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: K8 quota status tool"](internal/v070-feature-inventory.md).

--- a/docs/memory-kind-vocab.md
+++ b/docs/memory-kind-vocab.md
@@ -131,8 +131,14 @@ under the `memory_kind_vocab` block of the v3 capabilities
 response. Operators can read the live state via:
 
 ```bash
-ai-memory doctor --capabilities=v3 | jq .memory_kind_vocab
+ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq .memory_kind_vocab
 ```
+
+(The v0.7-alpha drafts referenced `ai-memory doctor --capabilities=v3`;
+that flag was not shipped. The MCP `memory_capabilities` tool is the
+canonical inspection surface — it works against any running daemon
+regardless of profile because `memory_capabilities` is on the
+`ALWAYS_ON_TOOLS` allowlist.)
 
 ```jsonc
 {

--- a/docs/sidechain-transcripts.md
+++ b/docs/sidechain-transcripts.md
@@ -1,0 +1,130 @@
+# Sidechain transcripts (Track I)
+
+v0.7.0 ships raw conversation / reasoning trail storage in zstd-3
+compressed BLOBs, linked to derived memories via the
+`memory_transcript_links` table. The substrate underlies R5
+auto-extraction and the L2-4 `memory_replay` union — operators get
+full per-memory reconstruction without paying token costs on every
+recall.
+
+- **Code paths:** [`src/transcripts/mod.rs`](../src/transcripts/mod.rs),
+  [`src/transcripts/replay.rs`](../src/transcripts/replay.rs),
+  [`src/transcripts/storage.rs`](../src/transcripts/storage.rs).
+- **Schema:**
+  - [`migrations/sqlite/0016_v07_transcripts.sql`](../migrations/sqlite/0016_v07_transcripts.sql)
+    — base `memory_transcripts` table.
+  - [`migrations/sqlite/0018_v07_transcript_links.sql`](../migrations/sqlite/0018_v07_transcript_links.sql)
+    — link table from memory → transcript span.
+  - [`migrations/sqlite/0019_v07_transcript_lifecycle.sql`](../migrations/sqlite/0019_v07_transcript_lifecycle.sql)
+    — lifecycle columns (`archived_at`, `archive_reason`).
+- **Helper binary:** [`tools/transcript-extractor/`](../tools/transcript-extractor/)
+  is the R5 reference `pre_store` hook. (Excluded from the crates.io
+  upload via the parent `Cargo.toml` `include` allowlist.)
+- **Capability registry entry:** `CapabilityTranscripts` extends the
+  v0.6.4 entry with the lifecycle columns.
+- **MCP tool:** `memory_replay(memory_id, depth?)` in the Graph
+  family.
+
+## Opt-in shape
+
+```toml
+# ~/.config/ai-memory/config.toml
+[transcripts."team/*"]
+enabled = true
+ttl_days = 30
+archive_after_days = 7
+max_decompressed_bytes = 16777216   # 16 MiB cap (default; see hardening note)
+```
+
+Per-namespace glob match. A namespace with no matching block is
+**not** transcript-enabled — writes to it never land in
+`memory_transcripts`.
+
+## Wire shape
+
+```
+CREATE TABLE memory_transcripts (
+  id              TEXT PRIMARY KEY,           -- UUID
+  namespace       TEXT NOT NULL,
+  agent_id        TEXT NOT NULL,
+  source_kind     TEXT NOT NULL,              -- 'llm_turn' | 'tool_output' | 'session_log' | …
+  body_zstd       BLOB NOT NULL,              -- zstd-3 compressed
+  body_sha256     BLOB NOT NULL,              -- of decompressed body
+  created_at      TEXT NOT NULL,
+  archived_at     TEXT,
+  archive_reason  TEXT
+);
+
+CREATE TABLE memory_transcript_links (
+  memory_id       TEXT NOT NULL,
+  transcript_id   TEXT NOT NULL,
+  span_start      INTEGER,
+  span_end        INTEGER,
+  PRIMARY KEY (memory_id, transcript_id)
+);
+```
+
+`body_zstd` is the only token-bearing column; everything else is
+metadata. The compression ratio on representative LLM-turn payloads
+is ~4-6× — the substrate makes the trade explicit so operators can
+choose between TTL aggression and recall fidelity.
+
+## Lifecycle sweep
+
+A background worker runs every 60 minutes by default:
+
+1. **Archive pass.** Transcripts whose linked memories are all expired
+   or archived get `archived_at` stamped and `archive_reason` set to
+   `dependents_gone`.
+2. **Prune pass.** Transcripts archived more than
+   `archive_after_days` days ago are deleted; `body_zstd` is cleared
+   first to free disk before the row deletion.
+
+## `memory_replay` union (L2-4)
+
+`memory_replay(memory_id, depth=N)` returns the **union** of
+transcripts reachable by walking `reflects_on` edges from the target
+memory up to `depth` levels. `depth=0` reproduces the pre-L2-4 shape
+(direct link only). The walk respects the per-namespace
+`max_reflection_depth` cap — composition cannot bypass.
+
+## Security hardening (I1)
+
+The v0.7.0 release/v0.7.0 branch landed
+**`TranscriptsConfig.max_decompressed_bytes`** as a config-driven
+cap (commit `26fab06`) with a default of 16 MiB. Prior to I1, a
+malicious peer could push a 1 KiB zstd payload that decompressed to
+hundreds of MiB and exhaust the daemon's memory. The cap is checked
+on every read; payloads above the cap are refused with
+`TranscriptDecompressionExceedsCap`.
+
+Pinned by [`tests/i1_zstd_bomb.rs`](../tests/i1_zstd_bomb.rs).
+
+## Test coverage
+
+- [`tests/transcripts.rs`](../tests/transcripts.rs) — base
+  read/write round-trip.
+- [`tests/transcripts/replay_test.rs`](../tests/transcripts/replay_test.rs)
+  — `memory_replay` walk.
+- [`tests/transcript_extractor.rs`](../tests/transcript_extractor.rs)
+  — R5 reference hook end-to-end.
+- [`tests/i4_memory_replay_authz.rs`](../tests/i4_memory_replay_authz.rs)
+  — auth path for `memory_replay`.
+
+## Operator workflow
+
+1. **Pick a namespace** that benefits from transcript storage (high
+   information density per turn — engineering namespaces, postmortems,
+   RCA tickets).
+2. **Add the `[transcripts."<glob>"]` block** to config.toml.
+3. **Restart** the daemon.
+4. **Verify** with `ai-memory mcp call memory_capabilities
+   '{"schema_version":"3"}' | jq '.transcripts'` — the response
+   surfaces the enabled namespaces.
+5. **Audit disk usage** periodically — the `body_zstd` column is the
+   only large surface. `du -sh ~/.local/share/ai-memory/memory.db`
+   tells the story.
+
+See also: [`docs/MIGRATION_v0.7.md` §"Sidechain transcripts"](MIGRATION_v0.7.md),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: Sidechain transcripts"](internal/v070-feature-inventory.md).

--- a/docs/signed-events-v4.md
+++ b/docs/signed-events-v4.md
@@ -1,0 +1,132 @@
+# Signed events V-4 closeout — cross-row hash chain
+
+v0.7.0 flips the V-4 validation from YELLOW to GREEN by adding a
+cross-row hash chain to the `signed_events` audit table. Each row
+carries `prev_hash` + `sequence` so the chain itself is tamper-evident,
+not just each individual signed payload. Verify end-to-end with
+`ai-memory verify-signed-events-chain`.
+
+- **Issue trail:** [#698](https://github.com/alphaonedev/ai-memory-mcp/issues/698).
+- **Code paths:** [`src/signed_events.rs`](../src/signed_events.rs),
+  the `migrate_v34_backfill_chain` function in
+  [`src/storage/migrations.rs`](../src/storage/migrations.rs).
+- **Schema:**
+  - [`migrations/sqlite/0020_v07_signed_events.sql`](../migrations/sqlite/0020_v07_signed_events.sql)
+    — base `signed_events` table (v33).
+  - [`migrations/sqlite/0028_v07_signed_events_chain.sql`](../migrations/sqlite/0028_v07_signed_events_chain.sql)
+    — V-4 cross-row chain columns (v34).
+  - [`migrations/postgres/0015_v07_signed_events_chain.sql`](../migrations/postgres/0015_v07_signed_events_chain.sql)
+    — postgres mirror at v33 (postgres ladder ran one step behind).
+- **CLI verb:** [`src/cli/verify_signed_events.rs`](../src/cli/verify_signed_events.rs)
+  — `ai-memory verify-signed-events-chain [--since N] [--format text|json]`.
+
+## Row shape (v34)
+
+```
+CREATE TABLE signed_events (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  sequence      INTEGER NOT NULL,             -- monotonic per-DB
+  prev_hash     BLOB NOT NULL,                -- 32 bytes; zero for first row
+  event_type    TEXT NOT NULL,
+  payload_cbor  BLOB NOT NULL,                -- canonical CBOR
+  payload_sha256 BLOB NOT NULL,               -- SHA-256 of payload_cbor
+  signed_by     TEXT NOT NULL,                -- agent_id
+  signature     BLOB NOT NULL,                -- Ed25519 over the canonical preimage
+  created_at    TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX signed_events_sequence_uniq ON signed_events(sequence);
+```
+
+The canonical preimage that the Ed25519 signature covers is:
+
+```
+sequence || prev_hash || event_type || payload_sha256 || signed_by || created_at
+```
+
+`prev_hash` for row `N` is the SHA-256 of row `N-1`'s `payload_cbor`.
+For row 1, `prev_hash` is 32 zero bytes. Tampering with any prior
+row's `payload_cbor` invalidates every subsequent row's `prev_hash`.
+
+## Backfill (v33 → v34)
+
+A fresh v0.7.0 install starts at v34 and writes the chain from row 1.
+A v0.7-alpha install at v33 has rows without `prev_hash` /
+`sequence`; the `migrate_v34_backfill_chain` function in
+[`src/storage/migrations.rs`](../src/storage/migrations.rs) walks the
+existing rows in `id` order, assigns sequential `sequence` numbers,
+and computes `prev_hash` from the prior row's `payload_cbor`. The
+backfill is **idempotent** — re-running on an already-backfilled
+table is a no-op.
+
+Pinned by [`tests/signed_events_chain_v34.rs`](../tests/signed_events_chain_v34.rs):
+
+- First-row `prev_hash` is zero.
+- Multi-row chaining (each row's `prev_hash` = SHA-256 of prior payload).
+- Payload tamper (the signature still verifies in isolation, but the
+  chain walk catches it on the next row).
+- Sequence tamper (gaps fail the chain check).
+- Concurrent drainer inserts via PE-3 (the wire-point pre-write hook
+  guarantees the chain stays monotonic under concurrent writers).
+- Backfill idempotency.
+- Backfill correctness (re-walked chain matches a fresh-write chain).
+
+## CLI verifier
+
+```bash
+# Text output (operator readable)
+ai-memory verify-signed-events-chain
+
+# JSON output (operator scriptable)
+ai-memory verify-signed-events-chain --format json | jq
+
+# Skip the first N rows (incremental verification)
+ai-memory verify-signed-events-chain --since 100000
+```
+
+Exit codes:
+
+- `0` — chain valid from start (or `--since`) to current tail.
+- `1` — chain invalid; the JSON output identifies the first offending
+  row's `sequence` and reason (`prev_hash_mismatch` /
+  `signature_invalid` / `sequence_gap` / `payload_hash_mismatch`).
+
+Pinned by [`tests/cli_verify_chain.rs`](../tests/cli_verify_chain.rs).
+
+## Concurrent-writer guarantee (PE-3)
+
+`signed_events` writes happen on the substrate `storage::insert` path
+under a transactional wrap that the PE-3 wire-point hook elevates so
+the chain stays monotonic under concurrent writers. The
+[`tests/deferred_audit_soak.rs`](../tests/deferred_audit_soak.rs)
+soak fires 5,000 concurrent inserts and asserts the chain walk passes
+afterwards.
+
+## Operator workflow
+
+1. **Generate an operator keypair** (`ai-memory identity generate
+   --agent-id "$(ai-memory identity suggest-id)"`).
+2. **Restart the daemon.** The v34 schema migration runs
+   automatically on first start and backfills the chain from existing
+   `signed_events` rows.
+3. **Run the verifier daily** (cron / systemd timer). A non-zero exit
+   indicates either tampering or a v0.7.0-alpha row that didn't make
+   it through the backfill — investigate immediately.
+4. **Pair with the forensic bundle** (L2-5,
+   [`docs/forensic-export.md`](forensic-export.md)) — the signed
+   events table ships inside the bundle by default. Offline reviewers
+   can re-verify the chain without DB access.
+
+## Mapping to the V-4 audit
+
+- **V-4 (cross-row hash chain) PASS** — pinned by
+  `tests/signed_events_chain_v34.rs`.
+- **V-4 (per-row signature) PASS** — unchanged from v0.6.3.
+- **V-4 (append-only enforcement) PASS** — no UPDATE / DELETE path
+  through the application layer; the substrate validates against
+  `SignedEventsAppendOnlyViolation` on any write that would non-append.
+
+See also: [`docs/MIGRATION_v0.7.md` §"Ed25519 attestation"](MIGRATION_v0.7.md#ed25519-attestation-opt-in),
+[`docs/v0.7.0/release-notes.md` §"Signed events V-4 closeout"](v0.7.0/release-notes.md),
+the canonical inventory in
+[`docs/internal/v070-feature-inventory.md` §"Feature: Signed events V-4 closeout"](internal/v070-feature-inventory.md).

--- a/docs/v0.7.0/release-notes.md
+++ b/docs/v0.7.0/release-notes.md
@@ -424,7 +424,7 @@ handler. ([commit `fbf093c`](https://github.com/alphaonedev/ai-memory-mcp/commit
 > cross-row hash chain — `prev_hash BLOB` + `sequence INTEGER`) per the
 > v0.7.1-fold decision (`05e0cb9a`). Postgres parity is at v33 (the V-4
 > closeout maps to postgres v33 since the postgres ladder ran one step
-> behind). The MCP tool count moves from 60 → 63 over the L2 wave; the
+> behind). The MCP tool count moves from 60 → 71 over the L2 wave + Batman Forms 1-6 + 7th-form + QW-1/2/3 closeout (the +8 over the original 63 narrative cover Forms/QW/L2 additions enumerated below); the
 > full reflection narrative lives in
 > [`docs/RECURSIVE_LEARNING.md`](../RECURSIVE_LEARNING.md), the
 > Agent Skills surface in [`docs/agent-skills.md`](../agent-skills.md),
@@ -448,15 +448,26 @@ handler. ([commit `fbf093c`](https://github.com/alphaonedev/ai-memory-mcp/commit
   `CURRENT_SCHEMA_VERSION = 34`;
   [`src/store/postgres.rs`](../../src/store/postgres.rs)
   `CURRENT_SCHEMA_VERSION = 33`.)
-- **MCP tool count 60 → 63.** The L2 wave added three tools:
+- **MCP tool count 60 → 71** (post-grand-slam at HEAD `c9472c1`;
+  authoritative count from `Profile::full().expected_tool_count()` in
+  [`src/profile.rs`](../../src/profile.rs) and verified by
+  `grep -oE '"memory_[a-z_]+"' src/mcp/registry.rs | sort -u | wc -l`).
+  The L2 wave added three tools:
   `memory_dependents_of_invalidated` (L2-3 / #668),
   `memory_skill_promote_from_reflection` (L2-6 / #671), and
   `memory_skill_compositional_context` (L2-7 / #672). The L1-5
   Agent Skills substrate added 5 tools (`memory_skill_register`,
   `_list`, `_get`, `_resource`, `_export`) earlier in the grand-slam
   branch. The L2-2 federation-aware reflection coordination added
-  `memory_reflection_origin`. See [`docs/agent-skills.md`](../agent-skills.md)
-  for the per-tool wire surface.
+  `memory_reflection_origin`. The post-grand-slam Forms / QW wave
+  added a further 8: `memory_atomise` (WT-1 / Form 2), `memory_ingest_multistep`
+  (Form 3 / #756), `memory_calibrate_confidence` (Form 5 / #758),
+  `memory_check_agent_action` + `memory_rule_list` (7th-form / #691),
+  `memory_export_reflection` (QW-1), `memory_persona` +
+  `memory_persona_generate` (QW-2), `memory_offload` + `memory_deref`
+  (QW-3). See [`docs/agent-skills.md`](../agent-skills.md) for the
+  Skills per-tool wire surface; the canonical post-grand-slam
+  inventory lives in [`docs/internal/v070-feature-inventory.md`](../internal/v070-feature-inventory.md).
 
 #### L1-6 substrate rules engine (issues [#691](https://github.com/alphaonedev/ai-memory-mcp/issues/691), [#693](https://github.com/alphaonedev/ai-memory-mcp/issues/693))
 
@@ -572,6 +583,108 @@ procurement-grade evidence path. Full surface in
 - **A2A regression suite** — 76 scenarios consolidating ai2ai-gate
   v0.6.x baseline + v0.7.0 net-new + postgres+AGE substrate. Cert
   acceptance is two consecutive 100% GREEN rounds.
+
+## Post-grand-slam ship-readiness wave (2026-05-15)
+
+After the original `attested-cortex` epic landed at `fcdd2a5` (2026-05-06)
+and the Round-2 NHI sweep closed F1-F18, a final ship-readiness wave
+folded into the v0.7.0 tag rather than slipping to v0.7.1:
+
+- **Batman 6-form audit + Forms 1-6 + 7th-form closeout** (PRs
+  [#761](https://github.com/alphaonedev/ai-memory-mcp/pull/761)-
+  [#766](https://github.com/alphaonedev/ai-memory-mcp/pull/766),
+  merged 2026-05-15). The
+  [`docs/internal/batman-framework-audit.md`](../internal/batman-framework-audit.md)
+  audit at commit `53b4d39` found 0/6 forms cleanly IMPLEMENTED + 4
+  partial + 2 absent. The Forms wave closed every gap to **all 7 forms
+  IMPLEMENTED at HEAD `c9472c1`**:
+  - **Form 1 (online dedup-and-synthesis, issue [#754](https://github.com/alphaonedev/ai-memory-mcp/issues/754)).**
+    Single-batch action-emitting LLM call on `memory_store`.
+    `src/synthesis/mod.rs`. Opt back into the v0.6.x per-pair
+    classifier via `legacy_per_pair_classifier = true` on the
+    namespace standard.
+  - **Form 2 (synchronous atomise-before-embed, issue [#755](https://github.com/alphaonedev/ai-memory-mcp/issues/755)).**
+    `auto_atomise_mode = Synchronous` pre-store hook in
+    `src/hooks/pre_store/auto_atomise.rs`. New `memory_atomise` MCP
+    tool. Doc: [`docs/atomisation.md`](../atomisation.md).
+  - **Form 3 (multi-step ingest orchestrator, issue [#756](https://github.com/alphaonedev/ai-memory-mcp/issues/756)).**
+    `memory_ingest_multistep` threads deterministic helpers (Jaccard
+    overlap, FTS classifier) before prompt-cache-stable LLM stages.
+    `src/multistep_ingest/{mod,executor,helpers,pipeline,cache}.rs`.
+    Doc: [`docs/multistep-ingest.md`](../multistep-ingest.md). Cookbook:
+    [`cookbook/multistep-ingest/01-two-phase.sh`](../../cookbook/multistep-ingest/01-two-phase.sh).
+  - **Form 4 (fact provenance, issue [#757](https://github.com/alphaonedev/ai-memory-mcp/issues/757)).**
+    Citations + source-URI + atom-grain spans ride on existing
+    `memory_store` / `memory_atomise` payloads. Schema migration
+    `0032_v07_form4_provenance.sql`. Doc:
+    [`docs/provenance.md`](../provenance.md).
+  - **Form 5 (auto-confidence + shadow calibration + freshness decay,
+    issue [#758](https://github.com/alphaonedev/ai-memory-mcp/issues/758)).**
+    `memory_calibrate_confidence` MCP tool +
+    `src/confidence/{mod,calibrate,shadow,decay}.rs`. Env vars
+    `AI_MEMORY_AUTO_CONFIDENCE`, `AI_MEMORY_CONFIDENCE_SHADOW`,
+    `AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE`,
+    `AI_MEMORY_CONFIDENCE_DECAY`. Schema migration
+    `0033_v07_form5_confidence_calibration.sql`. Doc:
+    [`docs/confidence-calibration.md`](../confidence-calibration.md).
+  - **Form 6 (`MemoryKind` Batman vocabulary, issue [#759](https://github.com/alphaonedev/ai-memory-mcp/issues/759)).**
+    10-variant `MemoryKind` enum (`Observation` default + 9 specific
+    variants). Optional `auto_classify_kind` pre-store hook
+    (`off | regex_only | regex_then_llm`). No CHECK constraint on
+    `memories.memory_kind` — future variants land additively. Doc:
+    [`docs/memory-kind-vocab.md`](../memory-kind-vocab.md).
+  - **7th-form (agent-EXTERNAL Layer-4 wiring, issue [#760](https://github.com/alphaonedev/ai-memory-mcp/issues/760);
+    full cover at v0.8.0 per [#697](https://github.com/alphaonedev/ai-memory-mcp/issues/697)).**
+    Option-B foundation: operator-keypair-signed seed rules
+    `R001..R004`, `memory_check_agent_action` + `memory_rule_list`
+    MCP tools, substrate `storage::insert` pre-write hook. Doc:
+    [`docs/policy-engine.md`](../policy-engine.md) +
+    [`docs/governance/agent-action-rules.md`](../governance/agent-action-rules.md).
+- **QW (Tencent quick-wins).**
+  - **QW-1** file-backed reflection chain export — `memory_export_reflection`
+    + `auto_export_reflections_to_filesystem` namespace policy.
+    Default destination `~/.ai-memory/reflections/<ns>/<id>.md`.
+    Cookbook: `cookbook/file-backed-export/`.
+  - **QW-2** persona-as-artifact — `memory_persona` + `memory_persona_generate`,
+    `MemoryKind::Persona` rows, `auto_persona_trigger_every_n_memories`
+    + `auto_export_personas_to_filesystem` namespace policy. Doc:
+    [`docs/persona.md`](../persona.md). Cookbook: `cookbook/persona/`.
+  - **QW-3** context offload primitive — `memory_offload` + `memory_deref`
+    move large tool outputs out of the agent context window into an
+    addressable blob store with a background TTL sweep. Doc:
+    [`docs/context-offload.md`](../context-offload.md). Cookbook:
+    `cookbook/context-offload/`.
+- **Reconciliation security sweep (11 late-cycle commits, merged
+  into trunk at `64528b1`).** K9 governance gate on `handle_kg_invalidate`
+  (`a41c08f`), K10 SSE `host:` prefix bypass (`7496a6e`), K10 HMAC
+  method+pending_id binding (`99ffacc`), K10 HMAC nonce single-use 300s
+  window (`a69325f`), K10 SSE lagged-event count strip (`d1f6c9f`),
+  SSRF IPv4-mapped-IPv6 + NAT64 (`3ab72dc`), `invalidate_link` BEGIN
+  IMMEDIATE wrap (`2c77537`), hooks executor secret-redaction
+  (`cbe934c`), H8 rebound-namespace `Ask` walk (`69ad41c`), I1
+  zstd-decompression cap config-driven (`26fab06`). Pinned by
+  [`tests/k10_approval_security.rs`](../../tests/k10_approval_security.rs),
+  [`tests/i1_zstd_bomb.rs`](../../tests/i1_zstd_bomb.rs),
+  [`tests/h2_invalidate_link_signed.rs`](../../tests/h2_invalidate_link_signed.rs).
+- **Default tool surface.** The original v0.6.4 narrative said
+  "5 default tools". The actual v0.7.0 `--profile core` surface is
+  **7 tools** (`memory_store`, `memory_recall`, `memory_list`,
+  `memory_get`, `memory_search`, `memory_load_family`,
+  `memory_smart_load`) per `Family::Core.expected_tool_count()` in
+  [`src/profile.rs`](../../src/profile.rs). The `memory_capabilities`
+  bootstrap remains always-on regardless of profile.
+- **Six new operator-focused docs landed alongside this wave:**
+  [`docs/hook-pipeline.md`](../hook-pipeline.md),
+  [`docs/federation.md`](../federation.md),
+  [`docs/k8-quotas.md`](../k8-quotas.md),
+  [`docs/k10-sse-approvals.md`](../k10-sse-approvals.md),
+  [`docs/sidechain-transcripts.md`](../sidechain-transcripts.md),
+  [`docs/signed-events-v4.md`](../signed-events-v4.md).
+- **Canonical feature inventory.** The full post-grand-slam feature
+  truth lives at [`docs/internal/v070-feature-inventory.md`](../internal/v070-feature-inventory.md)
+  (453 commits ahead of v0.6.4, +233,589/−23,541 lines, 71 MCP tools,
+  28 net-new since v0.6.4, 17 net-new `AI_MEMORY_*` env vars, 8 new
+  HTTP routes, 20 sqlite + 10 postgres new migrations).
 
 ## Backward compatibility
 

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -177,8 +177,8 @@ pub enum Command {
         /// `power`, `full`, or a comma-separated custom list (e.g.,
         /// `core,graph,archive`). Default `core` (5 tools). Resolution
         /// order: this CLI flag > `AI_MEMORY_PROFILE` env > `[mcp].profile`
-        /// in config.toml > `core`. Set `--profile full` to reproduce
-        /// v0.6.3 surface 1:1 (43 tools).
+        /// in config.toml > `core`. Set `--profile full` to expose
+        /// every family (71 tools at v0.7.0 — `Profile::full().expected_tool_count()`).
         #[arg(long, env = "AI_MEMORY_PROFILE")]
         profile: Option<String>,
     },


### PR DESCRIPTION
## Summary

Closes ~20 findings from the v0.7.0 docs review (issue #767), Cluster H — docs accuracy sweep. **Docs-only with one single-line source touch** (`src/daemon_runtime.rs` help text only; all gates green).

- **Tool-count drift fix (DOC-4 + API-1 + API-7 + API-20 + DOC-18).**
  - README badge `5_default / 63_full` → `7_default / 71_full`; added v0.7.0 evidence companion badge alongside the v0.6.4 frozen-claims badge.
  - `docs/v0.7.0/release-notes.md` "60 → 63" → "60 → 71" with the explicit +8 breakdown (Forms 1-6 + 7th-form + QW additions).
  - `src/daemon_runtime.rs` `--profile full` help text → "71 tools at v0.7.0" (anchored on `Profile::full().expected_tool_count()`).
  - Added `.github/workflows/tool-count-drift.yml` CI grep gate that asserts registry literal count (70-72), no stale 43-tool help, README badge, and release-notes 60→71 delta.

- **Release notes update (DOC-2 + DOC-17).**
  - Appended a "Post-grand-slam ship-readiness wave (2026-05-15)" section to `docs/v0.7.0/release-notes.md` covering Forms 1-6 + 7th-form + QW-1/2/3 + reconciliation security sweep + per-form code-path + test pinning.
  - Created top-level `RELEASE_NOTES_v0.7.0.md` as a synopsis-plus-pointer (matching `RELEASE_NOTES_v0.6.4.md` shape).

- **README v0.7 rewrite (DOC-3 + DOC-5).**
  - Rewrote "What's new in v0.7" anchored on the feature inventory; links every new operator doc (atomisation, persona, memory-kind-vocab, confidence-calibration, provenance, multistep-ingest, governance, plus the six new ones below).
  - Added a v0.7.0 evidence companion badge alongside the frozen v0.6.4 badge.

- **MIGRATION_v0.7.md rewrite (DOC-6/7/8/9/10/11).**
  - Deleted every `TODO — track X lands` block (all 11 tracks shipped at HEAD c9472c1).
  - Renamed phantom MCP tool refs: `memory_approval_pending` → `memory_pending_list`; `memory_approval_decide` → `memory_pending_approve` / `memory_pending_reject`.
  - Fixed "20 lifecycle events" → "25" with the per-event matrix split.
  - Dropped `doctor --kg-backend` claim (non-existent flag) and documented the actual `ai-memory mcp call memory_capabilities` / `curl /api/v1/capabilities` recipe.
  - Added per-form sections (Form 1 / 2 / 3 / 4 / 5 / 6 / 7th-form) with issue links, code-path anchors, namespace-policy fields.

- **`docs/memory-kind-vocab.md` capability recipe (DOC-9).** Replaced the non-existent `ai-memory doctor --capabilities=v3` flag with `ai-memory mcp call memory_capabilities '{"schema_version":"3"}' | jq .memory_kind_vocab`.

- **Cookbook hardcoded-path fix (DOC-12).** `cookbook/multistep-ingest/01-two-phase.sh` `/Users/fate/v07/v07-fixes/...` defaults → `${repo_root}/.local-runs` and `${repo_root}/target`. `bash -n` syntax check passes.

- **Batman audit prologue (DOC-13).** Post-audit prologue on `docs/internal/batman-framework-audit.md`: audit at `53b4d39` drove Forms 1-6 + 7th-form closeout (PRs #761-#766, merged 2026-05-15); post-closeout state at `c9472c1`: all 7 forms IMPLEMENTED with per-form code-evidence anchors.

- **API_REFERENCE + CLI_REFERENCE v0.7 sections (DOC-14 + DOC-15).** Added §"v0.7.0 net-new endpoints" (8 HTTP routes) + §"v0.7.0 net-new MCP tools" to `docs/API_REFERENCE.md`; added §"v0.7.0 net-new CLI subcommands" to `docs/CLI_REFERENCE.md` covering atomise / calibrate-confidence / export-reflections / persona / offload / identity / verify-signed-events-chain / schema-init / governance / rules / export-forensic-bundle / install --enforce-policy.

- **Six new dedicated operator docs (DOC-16) — all 400-700 words, operator-focused with code-evidence references:**
  - `docs/hook-pipeline.md` (690 words) — 25 lifecycle events
  - `docs/federation.md` (588 words) — three-layer auth + 3 env vars
  - `docs/k8-quotas.md` (524 words) — per-agent daily quotas
  - `docs/k10-sse-approvals.md` (570 words) — SSE channel + HMAC binding
  - `docs/sidechain-transcripts.md` (561 words) — transcripts subsystem
  - `docs/signed-events-v4.md` (663 words) — V-4 cross-row hash chain
  - Plus `docs/governance.md` (392 words) — operator-facing permissions index that MIGRATION links to.

- **Canonical inventory imported.** `docs/internal/v070-feature-inventory.md` (the catalogue-worktree canonical feature truth) imported into this worktree so every cluster-H doc resolves its `feature inventory` references locally.

## Test plan

- [x] `cargo fmt --check` — green
- [x] `cargo check --features sal,sal-postgres --tests` — green (3m 38s)
- [x] `bash -n cookbook/multistep-ingest/01-two-phase.sh` — green; no remaining hardcoded `/Users/fate` paths in `cookbook/`
- [x] CI grep gate (`.github/workflows/tool-count-drift.yml`) runs locally:
    - registry literal count: 72 (memory_id is a JSON field; family-sum = 71) ✓
    - no stale "43 tools" claim in `src/daemon_runtime.rs` ✓
    - README badge advertises `7_default • 71_full` ✓
    - release-notes carries "60 → 71" delta ✓
- [x] Per-file relative-link resolver across all 15 touched/new docs — every `.md` reference resolves on disk
- [x] Tool-count parity confirmed against `Profile::full().expected_tool_count()` in `src/profile.rs:570-574` (sum of `Family::expected_tool_count` arms = 7+5+5+11+8+22+4+9 = 71)

## AI involvement

Authored by Claude Opus 4.7 (1M context). Per the v0.7.0 cluster-H prompt, the only source-code touch was the one help-text line in `src/daemon_runtime.rs`; everything else is docs/cookbook/README. Inventory file copied verbatim from the catalogue worktree (read-only deliverable). `CHANGELOG.md` not touched (already updated at bbeb1e8 per task constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)