### PR TITLE
fix(v0.7.0 cluster-A): Form 4 fact-provenance correctness + atomisation idempotency (issue #767)

### DIFF
--- a/src/atomisation/mod.rs
+++ b/src/atomisation/mod.rs
@@ -404,17 +404,30 @@ impl Atomiser {
 // ---------------------------------------------------------------------------
 
 /// Read the `atomised_into` column for a memory. Returns `Ok(None)`
-/// when the column is NULL (memory has not been atomised), `Ok(Some(n))`
-/// when set, error on rusqlite failures.
+/// when the column is NULL (memory has not been atomised) OR the row
+/// does not exist, `Ok(Some(n))` when set, error on rusqlite failures
+/// other than `QueryReturnedNoRows`.
+///
+/// # Cluster-A COR-2 fix
+///
+/// Pre-fix, the body swallowed every rusqlite error via
+/// `.unwrap_or(None)`. A real failure (lock-timeout, IO error, schema
+/// drift) was indistinguishable from "row not present" — the
+/// idempotency check would fall through and the caller would proceed
+/// to re-atomise an already-atomised source. Now only the
+/// `QueryReturnedNoRows` variant maps to `Ok(None)`; every other
+/// rusqlite error propagates via `?` and surfaces as
+/// `AtomiseError::DbError`.
 fn read_atomised_into(conn: &Connection, id: &str) -> anyhow::Result<Option<i64>> {
-    let v: Option<i64> = conn
-        .query_row(
-            "SELECT atomised_into FROM memories WHERE id = ?1",
-            params![id],
-            |r| r.get(0),
-        )
-        .unwrap_or(None);
-    Ok(v)
+    match conn.query_row(
+        "SELECT atomised_into FROM memories WHERE id = ?1",
+        params![id],
+        |r| r.get::<_, Option<i64>>(0),
+    ) {
+        Ok(v) => Ok(v),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Return the ordered list of atom ids whose `atom_of` column points
@@ -662,32 +675,79 @@ fn emit_atomisation_complete_event(
 ///
 /// Strategy:
 /// 1. Search verbatim for `atom_text` in `source[cursor..]`. When
-///    found, advance the cursor to one past the start of the hit so
-///    a subsequent atom that quotes the same prefix doesn't latch
-///    onto the same offset.
+///    found, advance the cursor past the hit so a subsequent atom
+///    that quotes the same prefix doesn't latch onto the same offset.
 /// 2. When the verbatim search misses (curator paraphrased, or
-///    whitespace differs), fall back to a trimmed prefix-search
-///    (first 32 chars of the atom). Trimming whitespace + lowercasing
-///    is intentionally NOT performed — we want exact byte-offsets
-///    into the unmodified source.
-/// 3. Return `None` when both searches miss. The substrate still
+///    whitespace differs), return `None`. The substrate still
 ///    stamps `source_uri` so the lineage edge survives without the
 ///    span. This is the documented fallback contract for
 ///    curator-paraphrase atoms.
+///
+/// # UTF-8 safety
+///
+/// `cursor` is treated as a byte offset into `source_body`. The
+/// cursor MUST point at a char boundary on entry; the function
+/// advances it to the next char boundary AFTER the hit start so
+/// repeated invocations on the same body cannot land mid-codepoint.
+/// The returned span's `start` and `end` are both guaranteed to fall
+/// on char boundaries because `str::find` itself only returns
+/// codepoint-aligned offsets (a property of `str` slicing).
+///
+/// # Cluster-A COR-1 / COR-7 fix
+///
+/// Pre-fix, the cursor advanced via `start.saturating_add(1)` which
+/// could leave the cursor mid-codepoint on multi-byte text — a
+/// subsequent `source_body[*cursor..]` slice would panic at the byte
+/// boundary check. The fix walks to the next `char_indices()` entry
+/// past the hit so every advance lands on a valid boundary, and
+/// clamps `end` to `source_body.len()` defensively (verbatim
+/// `str::find` already guarantees this — the clamp is belt-and-braces
+/// against a future refactor that might pre-pad `needle`).
 fn compute_atom_span(source_body: &str, atom_text: &str, cursor: &mut usize) -> Option<SourceSpan> {
     let needle = atom_text.trim();
     if needle.is_empty() {
         return None;
     }
-    let start = if *cursor < source_body.len() {
-        source_body[*cursor..].find(needle).map(|off| *cursor + off)
+    // If the cursor has drifted mid-codepoint (shouldn't happen with the
+    // boundary-aware advance below, but defend against pathological
+    // callers passing in a stale cursor), realign DOWN to the previous
+    // boundary before slicing. `floor_char_boundary` is nightly-only;
+    // hand-roll the equivalent by walking back at most 3 bytes (UTF-8
+    // codepoints are ≤4 bytes).
+    let cursor_aligned = floor_char_boundary(source_body, *cursor);
+    let start = if cursor_aligned < source_body.len() {
+        source_body[cursor_aligned..]
+            .find(needle)
+            .map(|off| cursor_aligned + off)
     } else {
         None
     };
     let start = start.or_else(|| source_body.find(needle))?;
-    let end = start + needle.len();
-    *cursor = start.saturating_add(1);
+    let end = (start + needle.len()).min(source_body.len());
+    // Advance the cursor to the next char boundary AFTER `start` — using
+    // `char_indices()` to find the first index strictly greater than
+    // `start`. This ensures the cursor never lands mid-codepoint on
+    // multi-byte text (Café / 中文 / 🦀 etc.).
+    *cursor = source_body[start..]
+        .char_indices()
+        .nth(1)
+        .map_or(source_body.len(), |(off, _)| start + off);
     Some(SourceSpan { start, end })
+}
+
+/// Hand-rolled `str::floor_char_boundary` (the std fn is nightly-only as
+/// of 1.83). Returns the largest index `≤ index` that lies on a UTF-8
+/// char boundary in `s`. When `index >= s.len()`, returns `s.len()`
+/// (which is itself a valid boundary).
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }
 
 // ---------------------------------------------------------------------------
@@ -728,5 +788,110 @@ mod tests {
             let s = format!("{e}");
             assert!(!s.is_empty());
         }
+    }
+
+    // ---- Cluster-A COR-1 / COR-7 / COV-3 — compute_atom_span tests.
+
+    #[test]
+    fn compute_atom_span_paraphrase_fallback_returns_none() {
+        // Atom text that the curator paraphrased — does not appear
+        // verbatim in the parent body. Pre-fix the fallback was a
+        // 32-char prefix search; the new contract returns `None`
+        // gracefully so the substrate stamps `source_uri` without a
+        // span. Critical: NO panic, even when the cursor was advanced
+        // by a prior successful hit on the same body.
+        let body = "The deployment manifest pins the image digest explicitly.";
+        let mut cursor = 0_usize;
+        let got = compute_atom_span(
+            body,
+            "Curator paraphrased this sentence entirely.",
+            &mut cursor,
+        );
+        assert!(
+            got.is_none(),
+            "paraphrase miss must return None, got {got:?}"
+        );
+        // Cursor unchanged on miss.
+        assert_eq!(cursor, 0);
+    }
+
+    #[test]
+    fn compute_atom_span_multibyte_utf8_stays_on_char_boundary() {
+        // Multi-byte body covering Latin-with-diacritic (Café), CJK
+        // (中文), and a 4-byte emoji (🦀). Pre-fix the cursor advance
+        // (`start.saturating_add(1)`) split codepoints and the next
+        // `source_body[*cursor..]` slice would panic. Post-fix the
+        // cursor always lands on a valid char boundary.
+        let body = "Café 中文 🦀 statement that follows the emoji.";
+        let mut cursor = 0_usize;
+
+        // First hit — the CJK substring.
+        let span = compute_atom_span(body, "中文", &mut cursor)
+            .expect("multi-byte needle should be found verbatim");
+        // Span lies on char boundaries (Rust's str::find guarantees
+        // this for verbatim matches; we re-assert as a regression pin).
+        assert!(body.is_char_boundary(span.start));
+        assert!(body.is_char_boundary(span.end));
+        assert_eq!(&body[span.start..span.end], "中文");
+
+        // Cursor must have advanced PAST `start` to the next char
+        // boundary — never mid-codepoint.
+        assert!(cursor > span.start);
+        assert!(
+            body.is_char_boundary(cursor),
+            "cursor={cursor} mid-codepoint"
+        );
+
+        // Second hit — the emoji. Critical: this slice would have
+        // panicked pre-fix because the cursor would have been
+        // mid-codepoint at byte-offset start+1 of the CJK char.
+        let span2 = compute_atom_span(body, "🦀", &mut cursor)
+            .expect("emoji needle should be found after CJK");
+        assert!(body.is_char_boundary(span2.start));
+        assert!(body.is_char_boundary(span2.end));
+        assert_eq!(&body[span2.start..span2.end], "🦀");
+
+        // Third hit — verify a verbatim ASCII sentence still works in
+        // the same pass.
+        let span3 = compute_atom_span(body, "statement that follows the emoji.", &mut cursor)
+            .expect("ascii needle should still be found");
+        assert_eq!(
+            &body[span3.start..span3.end],
+            "statement that follows the emoji."
+        );
+    }
+
+    #[test]
+    fn compute_atom_span_cursor_clamps_to_body_length() {
+        // Cursor sitting past EOL should NOT panic. The function falls
+        // through to the whole-body search.
+        let body = "short body";
+        let mut cursor = 1_000_usize;
+        let span = compute_atom_span(body, "body", &mut cursor).expect("fallback whole-body");
+        assert_eq!(&body[span.start..span.end], "body");
+    }
+
+    #[test]
+    fn compute_atom_span_stale_cursor_realigns_to_boundary() {
+        // A pathological caller passing a cursor mid-codepoint should
+        // not panic; the function realigns DOWN to the prior boundary
+        // before slicing. Regression pin for `floor_char_boundary`.
+        let body = "Café statement";
+        // The 'é' is the bytes `0xC3 0xA9` — byte offset 4 is the
+        // start of `0xA9`, mid-codepoint.
+        let mut cursor = 4_usize;
+        // Should not panic.
+        let _ = compute_atom_span(body, "statement", &mut cursor);
+    }
+
+    #[test]
+    fn floor_char_boundary_walks_back_to_codepoint_start() {
+        let s = "Café 中文";
+        // Boundary already valid.
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        // Mid-codepoint (`é` starts at 3, occupies bytes 3..5).
+        assert_eq!(floor_char_boundary(s, 4), 3);
+        // Past EOL clamps to len.
+        assert_eq!(floor_char_boundary(s, 9999), s.len());
     }
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -253,6 +253,7 @@ fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
             None,
             None,
             false,
+            None,
         )?;
     }
     let mut samples = Vec::with_capacity(config.iterations);
@@ -272,6 +273,7 @@ fn run_recall_hot(conn: &Connection, config: &BenchConfig) -> Result<OperationRe
             None,
             None,
             false,
+            None,
         )?;
         samples.push(start.elapsed());
     }

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -341,6 +341,7 @@ pub(crate) fn run_with_embedder(
                     args.budget_tokens,
                     &resolved_scoring,
                     args.include_archived,
+                    args.source_uri_prefix.as_deref(),
                 )?;
                 if let Some(ref ce) = reranker {
                     (ce.rerank(&args.context, results), outcome, "hybrid+rerank")
@@ -366,6 +367,7 @@ pub(crate) fn run_with_embedder(
                     args.as_agent.as_deref(),
                     args.budget_tokens,
                     args.include_archived,
+                    args.source_uri_prefix.as_deref(),
                 )?;
                 (results, outcome, "keyword")
             }
@@ -384,6 +386,7 @@ pub(crate) fn run_with_embedder(
             args.as_agent.as_deref(),
             args.budget_tokens,
             args.include_archived,
+            args.source_uri_prefix.as_deref(),
         )?;
         (results, outcome, "keyword")
     };

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -63,6 +63,7 @@ pub fn handle_command(parts: &[&str], conn: &Connection, out: &mut CliOutput<'_>
                 None,
                 None,
                 false,
+                None,
             ) {
                 Ok((results, _outcome)) => {
                     for (mem, score) in &results {

--- a/src/handlers/http.rs
+++ b/src/handlers/http.rs
@@ -3186,6 +3186,12 @@ async fn recall_response(
             budget_tokens,
             app.scoring.as_ref(),
             false,
+            // v0.7.0 Cluster-A PERF-3 — push the prefix into SQL on
+            // both FTS and semantic branches so the partial
+            // idx_memories_source_uri index covers the lookup; the
+            // post-fetch apply_form4_recall_filters below remains for
+            // the `has_citations` axis.
+            source_uri_prefix,
         );
         drop(vi_guard);
         (r, "hybrid")
@@ -3203,6 +3209,8 @@ async fn recall_response(
             as_agent,
             budget_tokens,
             false,
+            // v0.7.0 Cluster-A PERF-3 — see hybrid branch above.
+            source_uri_prefix,
         );
         (r, "keyword")
     };

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -963,6 +963,7 @@ mod tests {
             None,
             None,
             false,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/mcp/tools/recall.rs
+++ b/src/mcp/tools/recall.rs
@@ -415,6 +415,13 @@ pub fn handle_recall(
                     budget_tokens,
                     resolved_scoring,
                     include_archived,
+                    // v0.7.0 Cluster-A PERF-3 — push source-URI prefix
+                    // into SQL WHERE so the partial
+                    // `idx_memories_source_uri` index covers the lookup.
+                    // The post-filter call below is a no-op when the
+                    // SQL push-down already constrained the set; we
+                    // keep it for the `has_citations` axis only.
+                    source_uri_prefix.as_deref(),
                 )
                 .map_err(|e| e.to_string())?;
                 let results = crate::cli::recall::apply_form4_recall_filters(
@@ -470,6 +477,8 @@ pub fn handle_recall(
         as_agent,
         budget_tokens,
         include_archived,
+        // v0.7.0 Cluster-A PERF-3 — see hybrid branch above.
+        source_uri_prefix.as_deref(),
     )
     .map_err(|e| e.to_string())?;
     let results = crate::cli::recall::apply_form4_recall_filters(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -58,6 +58,15 @@ pub struct Metrics {
     /// non-zero rate to detect mesh-divergence drift early — before a
     /// follow-up catchup sync surfaces the gap.
     pub federation_partial_quorum_total: IntCounter,
+    /// Cluster-A COR-3 (v0.7.0): count of memory rows whose Form 4
+    /// fact-provenance JSON columns (`citations`, `source_span`,
+    /// `confidence_signals`, or pre-Form-4 `metadata`) failed to parse
+    /// and were silently defaulted by `row_to_memory`. Non-zero
+    /// indicates schema drift, writer-side corruption, or a
+    /// migration that left malformed JSON in the column. Labeled by
+    /// column name (`citations` | `source_span` | `confidence_signals`
+    /// | `metadata`).
+    pub corrupt_provenance_rows_total: IntCounterVec,
 }
 
 /// Lazily-built process-global metrics handle.
@@ -233,6 +242,19 @@ impl Metrics {
         )?;
         registry.register(Box::new(federation_partial_quorum_total.clone()))?;
 
+        // Cluster-A COR-3 (v0.7.0) — corrupt-provenance observability.
+        let corrupt_provenance_rows_total = IntCounterVec::new(
+            prometheus::Opts::new(
+                "ai_memory_corrupt_provenance_rows_total",
+                "Memory rows whose Form 4 fact-provenance JSON columns \
+                 failed to deserialise and were silently defaulted. \
+                 Non-zero indicates schema drift, writer-side corruption, \
+                 or a migration leaving malformed JSON.",
+            ),
+            &["column"],
+        )?;
+        registry.register(Box::new(corrupt_provenance_rows_total.clone()))?;
+
         Ok(Self {
             registry,
             store_total,
@@ -251,8 +273,21 @@ impl Metrics {
             federation_fanout_dropped_total,
             federation_fanout_retry_total,
             federation_partial_quorum_total,
+            corrupt_provenance_rows_total,
         })
     }
+}
+
+/// Cluster-A COR-3 (v0.7.0) — record a single corrupt-provenance row
+/// observation. `column` is the offending JSON column name
+/// (`citations` / `source_span` / `confidence_signals` / `metadata`).
+/// Pairs with a `tracing::warn!` at the call site so operators see the
+/// row id + parse error.
+pub fn record_corrupt_provenance(column: &str) {
+    registry()
+        .corrupt_provenance_rows_total
+        .with_label_values(&[column])
+        .inc();
 }
 
 /// Render the current registry state to the Prometheus text exposition

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -29,7 +29,7 @@ use crate::models::{
     AGENTS_NAMESPACE, AgentRegistration, Approval, ApproverType, ConfidenceSource, DuplicateCheck,
     DuplicateMatch, GovernanceDecision, GovernanceLevel, GovernancePolicy, GovernedAction,
     MAX_NAMESPACE_DEPTH, Memory, MemoryLink, NamespaceCount, PROMOTION_THRESHOLD, PendingAction,
-    Stats, Taxonomy, TaxonomyNode, Tier, TierCount, namespace_ancestors,
+    SourceSpan, Stats, Taxonomy, TaxonomyNode, Tier, TierCount, namespace_ancestors,
 };
 
 // ---------------------------------------------------------------------------
@@ -294,6 +294,26 @@ fn visibility_clause(start: usize, table_alias: &str) -> String {
     )
 }
 
+/// v0.7.0 Form 4 / Cluster-A PERF-3 — escape SQL `LIKE` metacharacters
+/// (`%`, `_`, `\`) in a user-supplied substring so the substring matches
+/// literally when paired with `LIKE ... ESCAPE '\\'`. Used by the
+/// `source_uri LIKE 'prefix%'` filter in [`recall`] and
+/// [`recall_hybrid_with_telemetry`] to push the `--source-uri-prefix`
+/// filter into SQL.
+fn escape_like_pattern(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 // v0.7.0 L0.5-3 — flat `src/db.rs` decomposed into `src/storage/`.
 // Sub-modules stay private to this module per the L0.5-1 pattern;
 // only the re-exports below form the public surface. The
@@ -327,6 +347,7 @@ pub use reflect::{
 pub(crate) use reflect::emit_reflection_depth_exceeded_audit;
 
 pub(crate) fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
+    let row_id: String = row.get("id")?;
     let tags_json: String = row.get("tags")?;
     let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
     let tier_str: String = row.get("tier")?;
@@ -335,11 +356,73 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         .get::<_, String>("metadata")
         .unwrap_or_else(|_| "{}".to_string());
     let metadata: serde_json::Value = serde_json::from_str(&metadata_str).unwrap_or_else(|e| {
-        tracing::warn!("corrupt metadata in DB row, defaulting to {{}}: {e}");
+        tracing::warn!(
+            row_id = %row_id,
+            column = "metadata",
+            error = %e,
+            "corrupt metadata in DB row, defaulting to {{}}"
+        );
+        crate::metrics::record_corrupt_provenance("metadata");
         serde_json::json!({})
     });
+    // v0.7.0 Form 4 / Cluster-A COR-3 — citations JSON. Pre-fix used a
+    // bare `.ok()` chain that silently turned corrupt JSON into an empty
+    // vec with no operator signal. Now: log via `tracing::warn!` with the
+    // row id + column + parse error, bump the
+    // `corrupt_provenance_rows_total{column=...}` counter, then return
+    // the safe default.
+    let citations = match row.get::<_, String>("citations").ok() {
+        Some(s) => match serde_json::from_str::<Vec<crate::models::Citation>>(&s) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    row_id = %row_id,
+                    column = "citations",
+                    error = %e,
+                    "corrupt citations JSON in DB row, defaulting to []"
+                );
+                crate::metrics::record_corrupt_provenance("citations");
+                Vec::new()
+            }
+        },
+        None => Vec::new(),
+    };
+    let source_span: Option<SourceSpan> = row
+        .get::<_, Option<String>>("source_span")
+        .unwrap_or(None)
+        .and_then(|s| match serde_json::from_str::<SourceSpan>(&s) {
+            Ok(span) => Some(span),
+            Err(e) => {
+                tracing::warn!(
+                    row_id = %row_id,
+                    column = "source_span",
+                    error = %e,
+                    "corrupt source_span JSON in DB row, defaulting to None"
+                );
+                crate::metrics::record_corrupt_provenance("source_span");
+                None
+            }
+        });
+    let confidence_signals = row
+        .get::<_, Option<String>>("confidence_signals")
+        .unwrap_or(None)
+        .and_then(
+            |s| match serde_json::from_str::<crate::models::ConfidenceSignals>(&s) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    tracing::warn!(
+                        row_id = %row_id,
+                        column = "confidence_signals",
+                        error = %e,
+                        "corrupt confidence_signals JSON in DB row, defaulting to None"
+                    );
+                    crate::metrics::record_corrupt_provenance("confidence_signals");
+                    None
+                }
+            },
+        );
     Ok(Memory {
-        id: row.get("id")?,
+        id: row_id,
         tier,
         namespace: row.get("namespace")?,
         title: row.get("title")?,
@@ -374,21 +457,13 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         entity_id: row.get::<_, Option<String>>("entity_id").unwrap_or(None),
         persona_version: row.get::<_, Option<i32>>("persona_version").unwrap_or(None),
         // v0.7.0 Form 4 — schema v38 fact-provenance columns. `citations`
-        // is JSON-encoded with SQL DEFAULT '[]', so legacy rows resolve
-        // to an empty vec; the `.ok()` fallthrough yields the same
-        // default on a pre-v38 row that lacks the column entirely.
-        // `source_uri` is a plain TEXT column (NULL on legacy rows);
-        // `source_span` is JSON `{start,end}` (NULL on legacy rows).
-        citations: row
-            .get::<_, String>("citations")
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default(),
+        // / `source_span` corruption now logs WARN + bumps the
+        // `corrupt_provenance_rows_total` counter above so silent JSON
+        // drops surface in operator observability (Cluster-A COR-3 fix).
+        // `source_uri` is a plain TEXT column (NULL on legacy rows).
+        citations,
         source_uri: row.get::<_, Option<String>>("source_uri").unwrap_or(None),
-        source_span: row
-            .get::<_, Option<String>>("source_span")
-            .unwrap_or(None)
-            .and_then(|s| serde_json::from_str(&s).ok()),
+        source_span,
         // v0.7.0 Form 5 — schema v39 columns. Legacy rows resolve
         // to `CallerProvided` (SQL DEFAULT), NULL signals, NULL
         // decayed_at. `.ok()` fallthrough keeps the reader tolerant
@@ -399,10 +474,7 @@ pub(crate) fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
             .ok()
             .and_then(|s| crate::models::ConfidenceSource::from_str(&s))
             .unwrap_or_default(),
-        confidence_signals: row
-            .get::<_, Option<String>>("confidence_signals")
-            .unwrap_or(None)
-            .and_then(|s| serde_json::from_str(&s).ok()),
+        confidence_signals,
         confidence_decayed_at: row
             .get::<_, Option<String>>("confidence_decayed_at")
             .unwrap_or(None),
@@ -1502,6 +1574,11 @@ pub fn recall_with_telemetry(
     // archive-filter WHERE clause is dropped so forensic-export and
     // explicit auditor recall returns both atoms and sources.
     include_archived: bool,
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — push `--source-uri-prefix`
+    // into the SQL WHERE so the partial `idx_memories_source_uri`
+    // index covers the lookup and excluded rows never enter the
+    // top-K. See [`recall`] for the contract.
+    source_uri_prefix: Option<&str>,
 ) -> Result<(
     Vec<(Memory, f64)>,
     BudgetOutcome,
@@ -1520,6 +1597,7 @@ pub fn recall_with_telemetry(
         as_agent,
         budget_tokens,
         include_archived,
+        source_uri_prefix,
     )?;
     let telemetry = crate::models::RecallTelemetry {
         fts_candidates: results.len(),
@@ -1544,6 +1622,16 @@ pub fn recall(
     // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
     // archived-source exclusion contract.
     include_archived: bool,
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — when `Some(prefix)`, restrict
+    // results to memories whose `source_uri` starts with `prefix`. The
+    // predicate is `source_uri LIKE 'prefix%'` so the partial
+    // `idx_memories_source_uri` index (defined in migration
+    // `0032_v07_form4_provenance.sql`) covers the scan. Pre-fix this
+    // filter ran in Rust AFTER the SQL returned, which excluded valid
+    // matches from the top-K when the substrate returned `limit` rows
+    // that subsequently filtered to fewer. `None` preserves the legacy
+    // no-filter behaviour for callers that filter post-hoc.
+    source_uri_prefix: Option<&str>,
 ) -> Result<(Vec<(Memory, f64)>, BudgetOutcome)> {
     let now = Utc::now().to_rfc3339();
     let fts_query = sanitize_fts_query(context, true);
@@ -1560,6 +1648,22 @@ pub fn recall(
     // through (include_archived=true). Composes with the existing
     // namespace, expiry, tag, time-window, and visibility filters.
     let archived_fragment = archived_source_clause(include_archived, "m");
+
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — push the source-URI prefix
+    // predicate into SQL. We escape SQL LIKE metacharacters (`%`, `_`,
+    // `\`) in the supplied prefix so a caller passing e.g. `doc:abc_`
+    // matches only that literal value (not `doc:abcX`). The LIKE
+    // pattern is constructed with the bound parameter holding the
+    // already-escaped prefix + `%`; combined with the partial index
+    // on `source_uri WHERE source_uri IS NOT NULL`, SQLite picks the
+    // index for the lookup. See [`escape_like_pattern`].
+    let (source_uri_fragment, source_uri_param): (&str, Option<String>) = match source_uri_prefix {
+        Some(prefix) if !prefix.is_empty() => (
+            "AND m.source_uri LIKE ?12 ESCAPE '\\'",
+            Some(format!("{}%", escape_like_pattern(prefix))),
+        ),
+        _ => ("", None),
+    };
 
     let sql = format!(
         "SELECT m.id, m.tier, m.namespace, m.title, m.content, m.tags, m.priority,
@@ -1585,39 +1689,64 @@ pub fn recall(
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
            {archived_fragment}
+           {source_uri_fragment}
            {vis}
          ORDER BY score DESC
          LIMIT ?7",
         vis = visibility_clause(8, "m"),
     );
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(
-        params![
-            fts_query,
-            effective_namespace,
-            now,
-            tags_filter,
-            since,
-            until,
-            limit,
-            vis_p,
-            vis_t,
-            vis_u,
-            vis_o
-        ],
-        |row| {
-            let mem = row_to_memory(row)?;
-            // v0.7.0 Form 4 / v0.7.x Form 6 — name-based read for the
-            // trailing score column. Switched from positional `row.get`
-            // after schema v38 (citations, source_uri, source_span) and
-            // Form 6's `memory_kind`/`entity_id`/`persona_version`
-            // shifted the trailing column's index; name-based reads
-            // survive future column additions without further churn.
-            let score: f64 = row.get("score")?;
-            Ok((mem, score))
-        },
-    )?;
-    let results: Vec<(Memory, f64)> = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    // Bind ?12 only when the source-URI fragment is active; SQLite
+    // errors on parameter-count mismatch.
+    let row_handler = |row: &rusqlite::Row<'_>| -> rusqlite::Result<(Memory, f64)> {
+        let mem = row_to_memory(row)?;
+        // v0.7.0 Form 4 / v0.7.x Form 6 — name-based read for the
+        // trailing score column. Switched from positional `row.get`
+        // after schema v38 (citations, source_uri, source_span) and
+        // Form 6's `memory_kind`/`entity_id`/`persona_version`
+        // shifted the trailing column's index; name-based reads
+        // survive future column additions without further churn.
+        let score: f64 = row.get("score")?;
+        Ok((mem, score))
+    };
+    let results: Vec<(Memory, f64)> = if let Some(ref uri_param) = source_uri_param {
+        let rows = stmt.query_map(
+            params![
+                fts_query,
+                effective_namespace,
+                now,
+                tags_filter,
+                since,
+                until,
+                limit,
+                vis_p,
+                vis_t,
+                vis_u,
+                vis_o,
+                uri_param,
+            ],
+            row_handler,
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        let rows = stmt.query_map(
+            params![
+                fts_query,
+                effective_namespace,
+                now,
+                tags_filter,
+                since,
+                until,
+                limit,
+                vis_p,
+                vis_t,
+                vis_u,
+                vis_o,
+            ],
+            row_handler,
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
 
     // Task 1.12: proximity boost when hierarchy expansion is active.
     let boosted = if let (true, Some(anchor)) = (hierarchy_active, namespace) {
@@ -4942,6 +5071,11 @@ pub fn recall_hybrid(
     // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
     // archived-source exclusion contract.
     include_archived: bool,
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — push `--source-uri-prefix`
+    // into the SQL WHERE on both the FTS and semantic branches so the
+    // partial `idx_memories_source_uri` index covers the lookup. See
+    // [`recall`] for the contract.
+    source_uri_prefix: Option<&str>,
 ) -> Result<(Vec<(Memory, f64)>, BudgetOutcome)> {
     let (results, outcome, _telemetry) = recall_hybrid_with_telemetry(
         conn,
@@ -4959,6 +5093,7 @@ pub fn recall_hybrid(
         budget_tokens,
         scoring,
         include_archived,
+        source_uri_prefix,
     )?;
     Ok((results, outcome))
 }
@@ -4995,6 +5130,11 @@ pub fn recall_hybrid_with_telemetry(
     // v0.7.0 WT-1-E — see [`recall_with_telemetry`] for the
     // archived-source exclusion contract.
     include_archived: bool,
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — see [`recall`] for the
+    // contract. Pushed into both the FTS and semantic branch SQL so
+    // both pools are constrained by the partial
+    // `idx_memories_source_uri` index, not the post-fetch Rust filter.
+    source_uri_prefix: Option<&str>,
 ) -> Result<(
     Vec<(Memory, f64)>,
     BudgetOutcome,
@@ -5034,6 +5174,24 @@ pub fn recall_hybrid_with_telemetry(
     let fts_archived_fragment = archived_source_clause(include_archived, "m");
     let sem_archived_fragment = archived_source_clause(include_archived, "memories");
 
+    // v0.7.0 Form 4 / Cluster-A PERF-3 — push `source_uri_prefix` into
+    // both branches. FTS branch binds at ?12 (visibility uses ?8–?11);
+    // semantic branch binds at ?10 (visibility uses ?6–?9).
+    let source_uri_like_param: Option<String> = match source_uri_prefix {
+        Some(prefix) if !prefix.is_empty() => Some(format!("{}%", escape_like_pattern(prefix))),
+        _ => None,
+    };
+    let fts_source_uri_fragment = if source_uri_like_param.is_some() {
+        "AND m.source_uri LIKE ?12 ESCAPE '\\'"
+    } else {
+        ""
+    };
+    let sem_source_uri_fragment = if source_uri_like_param.is_some() {
+        "AND memories.source_uri LIKE ?10 ESCAPE '\\'"
+    } else {
+        ""
+    };
+
     // Step 1: Get FTS candidates (up to 3x limit to have a good pool)
     let fts_limit = (limit * 3).max(30);
     let fts_sql = format!(
@@ -5058,6 +5216,7 @@ pub fn recall_hybrid_with_telemetry(
            AND (?5 IS NULL OR m.created_at >= ?5)
            AND (?6 IS NULL OR m.created_at <= ?6)
            {fts_archived_fragment}
+           {fts_source_uri_fragment}
            {vis}
          ORDER BY fts_score DESC
          LIMIT ?7",
@@ -5079,6 +5238,7 @@ pub fn recall_hybrid_with_telemetry(
            AND (?4 IS NULL OR created_at >= ?4)
            AND (?5 IS NULL OR created_at <= ?5)
            {sem_archived_fragment}
+           {sem_source_uri_fragment}
            {vis}",
         vis = visibility_clause(6, "memories"),
     );
@@ -5087,31 +5247,51 @@ pub fn recall_hybrid_with_telemetry(
     // Collect FTS results with scores
     let mut scored: HashMap<String, (Memory, f64, f64)> = HashMap::new(); // id -> (memory, fts_score, cosine_score)
 
-    let fts_rows = fts_stmt.query_map(
-        params![
-            fts_query,
-            effective_namespace,
-            now,
-            tags_filter,
-            since,
-            until,
-            fts_limit,
-            vis_p,
-            vis_t,
-            vis_u,
-            vis_o,
-        ],
-        |row| {
-            let mem = row_to_memory(row)?;
-            // v0.7.0 Form 4 / v0.7.x Form 6 — name-based read for the
-            // trailing fts_score column. Same rationale as the other
-            // recall SELECT — schema v38 columns shifted the trailing
-            // computed column's index. Named reads survive future
-            // additive column drops.
-            let fts_score: f64 = row.get("fts_score")?;
-            Ok((mem, fts_score))
-        },
-    )?;
+    // Conditional binding: SQLite errors on parameter-count mismatch,
+    // so when source_uri_prefix is None we must NOT bind ?12.
+    let fts_row_handler = |row: &rusqlite::Row<'_>| -> rusqlite::Result<(Memory, f64)> {
+        let mem = row_to_memory(row)?;
+        let fts_score: f64 = row.get("fts_score")?;
+        Ok((mem, fts_score))
+    };
+    let fts_results: Vec<(Memory, f64)> = if let Some(ref uri_param) = source_uri_like_param {
+        let rows = fts_stmt.query_map(
+            params![
+                fts_query,
+                effective_namespace,
+                now,
+                tags_filter,
+                since,
+                until,
+                fts_limit,
+                vis_p,
+                vis_t,
+                vis_u,
+                vis_o,
+                uri_param,
+            ],
+            fts_row_handler,
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        let rows = fts_stmt.query_map(
+            params![
+                fts_query,
+                effective_namespace,
+                now,
+                tags_filter,
+                since,
+                until,
+                fts_limit,
+                vis_p,
+                vis_t,
+                vis_u,
+                vis_o,
+            ],
+            fts_row_handler,
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
 
     // v0.6.3.1 (P3): pre-fusion candidate-pool counters surfaced to the
     // MCP `meta` block. Counted here at retrieval time, not after fusion,
@@ -5121,8 +5301,8 @@ pub fn recall_hybrid_with_telemetry(
     let mut hnsw_candidates_count: usize = 0;
 
     let mut max_fts_score: f64 = 1.0;
-    for row in fts_rows {
-        let (mem, fts_score) = row?;
+    for row in fts_results {
+        let (mem, fts_score) = (row.0, row.1);
         if fts_score > max_fts_score {
             max_fts_score = fts_score;
         }
@@ -5208,36 +5388,75 @@ pub fn recall_hybrid_with_telemetry(
                 if !include_archived && is_archived_source(&mem) {
                     continue;
                 }
+                // v0.7.0 Form 4 / Cluster-A PERF-3 — apply
+                // source-URI-prefix filter on the HNSW branch in Rust
+                // (the HNSW index returns vector neighbours, not a
+                // SQL query — so the WHERE-clause push-down in the
+                // FTS/semantic branches doesn't reach here).
+                if let Some(prefix) = source_uri_prefix
+                    && !prefix.is_empty()
+                    && !mem
+                        .source_uri
+                        .as_deref()
+                        .is_some_and(|u| u.starts_with(prefix))
+                {
+                    continue;
+                }
                 scored.insert(mem.id.clone(), (mem, 0.0, cosine));
                 hnsw_candidates_count += 1;
             }
         }
     } else {
-        // Fallback: linear scan over all embeddings
-        let sem_rows = sem_stmt.query_map(
-            params![
-                effective_namespace,
-                now,
-                tags_filter,
-                since,
-                until,
-                vis_p,
-                vis_t,
-                vis_u,
-                vis_o
-            ],
-            |row| {
+        // Fallback: linear scan over all embeddings. Conditional
+        // binding mirrors the FTS branch — when source_uri_prefix is
+        // None we must not bind ?10.
+        let sem_row_handler =
+            |row: &rusqlite::Row<'_>| -> rusqlite::Result<(Memory, Option<Vec<u8>>)> {
                 let mem = row_to_memory(row)?;
                 // v0.7.x Form 6: bumped from 15 to 16 when `memory_kind`
                 // was inserted between `reflection_depth` and `embedding`
                 // in the SELECT list above.
                 let emb_bytes: Option<Vec<u8>> = row.get(16)?;
                 Ok((mem, emb_bytes))
-            },
-        )?;
+            };
+        let sem_results: Vec<(Memory, Option<Vec<u8>>)> =
+            if let Some(ref uri_param) = source_uri_like_param {
+                let rows = sem_stmt.query_map(
+                    params![
+                        effective_namespace,
+                        now,
+                        tags_filter,
+                        since,
+                        until,
+                        vis_p,
+                        vis_t,
+                        vis_u,
+                        vis_o,
+                        uri_param,
+                    ],
+                    sem_row_handler,
+                )?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()?
+            } else {
+                let rows = sem_stmt.query_map(
+                    params![
+                        effective_namespace,
+                        now,
+                        tags_filter,
+                        since,
+                        until,
+                        vis_p,
+                        vis_t,
+                        vis_u,
+                        vis_o,
+                    ],
+                    sem_row_handler,
+                )?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()?
+            };
 
-        for row in sem_rows {
-            let (mem, emb_bytes) = row?;
+        for row in sem_results {
+            let (mem, emb_bytes) = (row.0, row.1);
             if scored.contains_key(&mem.id) {
                 continue;
             }
@@ -7812,6 +8031,7 @@ mod tests {
             None,
             None,
             false,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());
@@ -7839,6 +8059,7 @@ mod tests {
             None,
             None,
             false,
+            None,
         );
         // May return empty or error, both acceptable
         assert!(results.is_ok() || results.is_err());
@@ -8771,6 +8992,7 @@ mod tests {
             None,
             None,
             false,
+            None,
         )
         .unwrap();
         assert!(!results.is_empty());

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -366,6 +366,12 @@ impl MemoryStore for SqliteStore {
                 None,
                 &scoring,
                 false,
+                // v0.7.0 Cluster-A PERF-3 — Filter has no source-URI
+                // axis on the SAL surface today; pass `None` so the
+                // SQL push-down is inactive. The HTTP/MCP path applies
+                // the URI prefix via the dedicated argument on the
+                // direct db::recall call.
+                None,
             )
             .map_err(box_err)?;
             Ok(results)
@@ -383,6 +389,7 @@ impl MemoryStore for SqliteStore {
                 ctx.as_agent.as_deref(),
                 None,
                 false,
+                None,
             )
             .map_err(box_err)?;
             Ok(results)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -617,6 +617,51 @@ pub fn validate_source_span(span: &SourceSpan) -> Result<()> {
     Ok(())
 }
 
+/// v0.7.0 Form 4 / Cluster-A — body-aware [`SourceSpan`] validation.
+///
+/// Stricter superset of [`validate_source_span`]: in addition to the
+/// `start < end` invariant, this also requires:
+///
+/// 1. `span.end <= body.len()` — the half-open interval `[start, end)`
+///    must lie entirely within the body, so `body[span.start..span.end]`
+///    cannot panic on out-of-bounds.
+/// 2. Both `span.start` and `span.end` fall on UTF-8 char boundaries
+///    in `body`. Slicing on a non-boundary panics, which would break
+///    every downstream consumer (forensic export, CLI display, etc.).
+///
+/// Call this from validators that have the source body in hand (e.g.
+/// the atomisation writer, the citation validator on a known parent).
+/// Validators that only have the span (the bare-bones
+/// `validate_source_span` above) keep their lighter contract.
+///
+/// # Errors
+///
+/// Returns when `start >= end`, when `end > body.len()`, or when either
+/// endpoint lands mid-codepoint.
+pub fn validate_source_span_for_body(span: &SourceSpan, body: &str) -> Result<()> {
+    validate_source_span(span)?;
+    if span.end > body.len() {
+        bail!(
+            "source_span end={} exceeds body length {}",
+            span.end,
+            body.len()
+        );
+    }
+    if !body.is_char_boundary(span.start) {
+        bail!(
+            "source_span start={} is not a UTF-8 char boundary in body",
+            span.start
+        );
+    }
+    if !body.is_char_boundary(span.end) {
+        bail!(
+            "source_span end={} is not a UTF-8 char boundary in body",
+            span.end
+        );
+    }
+    Ok(())
+}
+
 /// Validate a full `CreateMemory` before insert.
 pub fn validate_create(mem: &CreateMemory) -> Result<()> {
     validate_title(&mem.title)?;

--- a/tests/form_4_provenance.rs
+++ b/tests/form_4_provenance.rs
@@ -343,6 +343,7 @@ fn has_citations_recall_filter_excludes_empty_provenance() {
         None,
         None,
         false,
+        None,
     )
     .expect("recall");
     // Substrate returns both; the post-filter restricts.
@@ -389,6 +390,7 @@ fn source_uri_prefix_recall_filter_restricts_to_matching_uri() {
         None,
         None,
         false,
+        None,
     )
     .expect("recall");
     assert_eq!(results.len(), 3, "substrate returns all three rows");
@@ -497,4 +499,196 @@ fn schema_v38_columns_present_and_migration_is_idempotent() {
         )
         .ok();
     assert!(idx_exists.is_some(), "source_uri partial index present");
+}
+
+// ---------------------------------------------------------------------------
+// 7. Cluster-A PERF-3 — source_uri_prefix push-down hits the partial index
+// ---------------------------------------------------------------------------
+
+/// Cluster-A PERF-3 regression pin. Pre-fix the `--source-uri-prefix`
+/// filter ran in Rust AFTER the substrate returned top-K rows, so
+/// `idx_memories_source_uri` was dead code and valid matches outside
+/// the substrate's top-K were silently excluded. This test:
+///
+/// 1. Inserts a mix of rows whose `source_uri` matches the prefix and
+///    rows that don't, with the matching rows competing for slots
+///    against many non-matching rows.
+/// 2. Runs `db::recall(... source_uri_prefix=Some("uri:https://"))`
+///    and asserts that only matching rows are returned.
+/// 3. Runs `EXPLAIN QUERY PLAN` on the same SQL shape and asserts the
+///    plan mentions `idx_memories_source_uri` — pinning the SQL
+///    push-down so a future refactor that drops the WHERE-clause
+///    re-introduces the dead-index regression.
+#[test]
+fn recall_with_source_uri_prefix_uses_index() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (_tmp, conn) = fresh_db();
+
+    let ns = "form4-perf3-prefix-index";
+    // 6 matching rows (uri:https://...) — chosen large enough that the
+    // pre-fix bug would surface if the substrate returned the top-K by
+    // FTS rank alone and then the post-filter trimmed matches out.
+    for i in 0..6 {
+        let mut m = mem_with_citations(
+            ns,
+            &format!("matching note {i}"),
+            "deployment manifest example payload",
+            Vec::new(),
+        );
+        m.source_uri = Some(format!("uri:https://example.test/path/{i}"));
+        storage::insert(&conn, &m).expect("insert matching");
+    }
+    // 12 non-matching rows (doc:... and bare).
+    for i in 0..6 {
+        let mut m = mem_with_citations(
+            ns,
+            &format!("doc note {i}"),
+            "deployment manifest example payload",
+            Vec::new(),
+        );
+        m.source_uri = Some(format!("doc:parent-{i:03}"));
+        storage::insert(&conn, &m).expect("insert doc");
+    }
+    for i in 0..6 {
+        let m = mem_with_citations(
+            ns,
+            &format!("bare note {i}"),
+            "deployment manifest example payload",
+            Vec::new(),
+        );
+        storage::insert(&conn, &m).expect("insert bare");
+    }
+
+    let resolved_ttl = ai_memory::config::ResolvedTtl::default();
+    let (results, _outcome) = db::recall(
+        &conn,
+        "deployment",
+        Some(ns),
+        50,
+        None,
+        None,
+        None,
+        resolved_ttl.short_extend_secs,
+        resolved_ttl.mid_extend_secs,
+        None,
+        None,
+        false,
+        Some("uri:https://"),
+    )
+    .expect("recall with prefix");
+    // Every returned row must carry a source_uri starting with the
+    // prefix — Rust-side post-filter is no longer load-bearing.
+    assert_eq!(
+        results.len(),
+        6,
+        "all 6 matching rows must surface; got {} rows",
+        results.len()
+    );
+    for (m, _) in &results {
+        let uri = m
+            .source_uri
+            .as_deref()
+            .expect("matching row has source_uri");
+        assert!(
+            uri.starts_with("uri:https://"),
+            "row {} leaked: source_uri={uri}",
+            m.id
+        );
+    }
+
+    // EXPLAIN QUERY PLAN — prove SQLite picks the partial index. The
+    // exact recall SQL uses interpolated fragments + bind parameters,
+    // but the prefix-filter shape we care about is invariant: a LIKE
+    // predicate on `m.source_uri` against a partial index whose
+    // predicate is `source_uri IS NOT NULL`. Smoke-test with a
+    // minimal SELECT that mirrors the recall's WHERE — if SQLite picks
+    // the index here, the recall path (which has more selective
+    // predicates) will too.
+    let plan: String = {
+        let mut stmt = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN SELECT id FROM memories WHERE source_uri LIKE ?1 ESCAPE '\\'",
+            )
+            .expect("prepare explain");
+        let rows = stmt
+            .query_map(["uri:https://%"], |r| r.get::<_, String>(3))
+            .expect("explain rows");
+        rows.collect::<rusqlite::Result<Vec<String>>>()
+            .expect("collect plan")
+            .join("\n")
+    };
+    assert!(
+        plan.contains("idx_memories_source_uri"),
+        "EXPLAIN QUERY PLAN must use idx_memories_source_uri; got:\n{plan}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Cluster-A COR-3 — row_to_memory logs + counts on corrupt JSON
+// ---------------------------------------------------------------------------
+
+/// Cluster-A COR-3 regression pin. Pre-fix `row_to_memory` silently
+/// defaulted corrupt provenance JSON. The fix logs a `tracing::warn!`
+/// AND bumps `corrupt_provenance_rows_total{column=...}` so operators
+/// see the corruption. This test:
+///
+/// 1. Inserts a memory with valid citations.
+/// 2. Surgically corrupts the `citations` column via raw UPDATE
+///    (mimicking schema drift / external corruption).
+/// 3. Re-reads via `storage::get` — asserts the corrupt-counter
+///    advanced AND the row came back with `citations: vec![]`.
+#[test]
+fn row_to_memory_corrupt_citations_logs_and_defaults() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (_tmp, conn) = fresh_db();
+
+    let mem = mem_with_citations(
+        "form4-cor3-corrupt",
+        "row-to-memory regression",
+        "body content",
+        vec![Citation {
+            uri: "uri:https://example.test/cite".into(),
+            accessed_at: now(),
+            hash: None,
+            span: None,
+        }],
+    );
+    let id = storage::insert(&conn, &mem).expect("insert");
+
+    // Surgical corruption — bypass validators by writing raw bytes.
+    conn.execute(
+        "UPDATE memories SET citations = ?1 WHERE id = ?2",
+        rusqlite::params!["{not valid json", &id],
+    )
+    .expect("corrupt write");
+
+    // Snapshot the counter before the corrupt read so we can detect a
+    // +1 increment irrespective of other tests' contributions.
+    let before = ai_memory::metrics::registry()
+        .corrupt_provenance_rows_total
+        .with_label_values(&["citations"])
+        .get();
+
+    let read = storage::get(&conn, &id)
+        .expect("get tolerant of corruption")
+        .expect("row present");
+    assert!(
+        read.citations.is_empty(),
+        "corrupt JSON must default to empty vec; got {:?}",
+        read.citations
+    );
+
+    let after = ai_memory::metrics::registry()
+        .corrupt_provenance_rows_total
+        .with_label_values(&["citations"])
+        .get();
+    assert_eq!(
+        after,
+        before + 1,
+        "corrupt_provenance_rows_total{{column=citations}} did not advance (before={before}, after={after})"
+    );
 }

--- a/tests/recall/wt1e.rs
+++ b/tests/recall/wt1e.rs
@@ -200,6 +200,7 @@ fn test_recall_default_excludes_archived_sources() {
         None,
         None,
         false,
+        None,
     )
     .expect("recall pre-atomise");
     assert!(
@@ -234,6 +235,7 @@ fn test_recall_default_excludes_archived_sources() {
         None,
         None,
         /* include_archived = */ false,
+        None,
     )
     .expect("recall post-atomise");
     let returned_ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();
@@ -286,6 +288,7 @@ fn test_recall_with_include_archived_returns_both() {
         None,
         None,
         /* include_archived = */ true,
+        None,
     )
     .expect("recall include_archived");
     let returned_ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();
@@ -374,6 +377,7 @@ fn test_recall_filters_compose() {
         None,
         None,
         true,
+        None,
     )
     .expect("recall compose");
     let returned_namespaces: std::collections::HashSet<String> =
@@ -404,6 +408,7 @@ fn test_recall_filters_compose() {
         None,
         None,
         false,
+        None,
     )
     .expect("recall compose default");
     let default_ids: Vec<String> = results_default.iter().map(|(m, _)| m.id.clone()).collect();

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -326,6 +326,7 @@ fn reflection_is_recall_visible_alongside_non_reflection_memories() {
         None,
         None,
         false,
+        None,
     )
     .expect("recall ok");
     let ids: Vec<String> = results.iter().map(|(m, _)| m.id.clone()).collect();

--- a/tests/v070_a1_authn.rs
+++ b/tests/v070_a1_authn.rs
@@ -36,7 +36,7 @@ use tower::ServiceExt as _;
 /// `tests/k10_approval_http.rs::K10_HTTP_LOCK`.
 static A1_HMAC_LOCK: Mutex<()> = Mutex::new(());
 
-/// Synthesise a K10 approval signature binding method + pending_id per
+/// Synthesise a K10 approval signature binding method + `pending_id` per
 /// release/v0.7.0 commit 99ffacc. Canonical: `<ts>.<METHOD>.<pending_id>.<body>`.
 fn sign(secret: &str, timestamp: &str, method: &str, pending_id: &str, body: &str) -> String {
     use sha2::Digest;


### PR DESCRIPTION
## Summary

Cluster A of the v0.7.0 6-reviewer audit (issue #767) — Form 4
fact-provenance correctness + atomisation idempotency. Closes 6
findings dedupe'd from correctness / performance / coverage reviews.

- **COR-1 CRITICAL** UTF-8 panic in `compute_atom_span` — multi-byte
  bodies (Café / 中文 / 🦀) panicked when the cursor advanced via
  `start.saturating_add(1)` mid-codepoint. Fix: codepoint-aware
  advance via `char_indices().nth(1)`, plus `floor_char_boundary`
  realignment defending against stale cursors.
- **COR-2 HIGH** `read_atomised_into` error swallow — every rusqlite
  error mapped to "not yet atomised", so lock-timeout double-atomised
  the source. Fix: distinguish `QueryReturnedNoRows` from real errors
  via match arm; real errors propagate as `AtomiseError::DbError`.
- **COR-3 HIGH** `row_to_memory` silent JSON drop — corrupt
  `citations` / `source_span` / `confidence_signals` columns
  defaulted with no operator signal. Fix: `tracing::warn!` per
  corrupt column with row id + parse error, plus a new
  `corrupt_provenance_rows_total{column=...}` Prometheus counter.
- **COR-7 MED** atom-span out-of-bounds — defensive clamp of `end` to
  `source_body.len()` (verbatim `str::find` already guarantees this;
  the clamp is belt-and-braces against future refactors).
- **PERF-3 HIGH** `idx_memories_source_uri` dead code — pre-fix the
  `--source-uri-prefix` filter ran in Rust AFTER recall returned top-K,
  so valid matches outside top-K were silently dropped. Fix: thread
  `source_uri_prefix: Option<&str>` through `db::recall` /
  `db::recall_hybrid` (+ `_with_telemetry` variants), push into FTS
  and semantic SQL WHERE as ``source_uri LIKE 'prefix%' ESCAPE '\\\\'``.
  HNSW branch applies prefix in Rust (no SQL there). `EXPLAIN QUERY
  PLAN` regression pin asserts SQLite picks the index.
- **COV-3 HIGH** `compute_atom_span` test gaps — 5 new unit tests
  cover paraphrase fallback, multibyte UTF-8 boundaries (CJK + emoji),
  stale cursor realignment, cursor-past-EOL, and the
  `floor_char_boundary` helper.

Plus tightened `validate_source_span_for_body`: new body-aware
variant that enforces `end <= body.len()` and char-boundary
endpoints. Bare `validate_source_span` (used where the body is not
in hand) keeps its lighter contract.

Collateral: `tests/v070_a1_authn.rs` doc-markdown backtick — a
pre-existing clippy pedantic fail unrelated to this cluster that
blocked gate 2; fixed in-place to keep the gate green.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --lib` — 4197 passed; 0 failed; 1 ignored
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --test form_4_provenance --test atomisation` — 22 passed; 0 failed (11 form_4 + 11 atomisation, 1 ignored live-Ollama)
- [x] `cargo audit` — clean (530 deps, 0 vulnerabilities)

## AI involvement

- **Author:** Claude (Opus 4.7, 1M context)
- **Reviewer:** Pending operator review
- **Files in scope:**
  - `src/atomisation/mod.rs` — `compute_atom_span`, `read_atomised_into`, `floor_char_boundary`, +5 unit tests
  - `src/storage/mod.rs` — `row_to_memory` corrupt-JSON logging, `escape_like_pattern`, `source_uri_prefix` parameter threaded through `recall` + `recall_hybrid` + `_with_telemetry` variants with conditional SQL binding
  - `src/validate.rs` — `validate_source_span_for_body`
  - `src/metrics.rs` — `corrupt_provenance_rows_total{column}` IntCounterVec + `record_corrupt_provenance` helper
  - `src/cli/recall.rs`, `src/cli/shell.rs`, `src/bench.rs`, `src/handlers/http.rs`, `src/handlers/mod.rs`, `src/mcp/tools/recall.rs`, `src/store/sqlite.rs` — call-site updates for the new `source_uri_prefix` parameter
  - `tests/form_4_provenance.rs` — +2 acceptance tests (`recall_with_source_uri_prefix_uses_index`, `row_to_memory_corrupt_citations_logs_and_defaults`)
  - `tests/recall/wt1e.rs`, `tests/recursive_learning_task7_shipgate_functional.rs` — test-fixture updates for new parameter
  - `tests/v070_a1_authn.rs` — collateral doc-markdown fix

- **Tool count baseline:** Untouched (71/70/Power 22).
- **Schema baseline:** Untouched (sqlite v39 / postgres v38).
- **No new dependencies.**

Issue: #767