### PR TITLE
fix(v0.7-polish #780): auto_export detached-thread failure counter + capability surface

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -722,6 +722,22 @@ pub struct CapabilityHooks {
     /// the 22nd + 23rd; L1-7 adds the 24th + 25th → total **25**.
     #[serde(default = "default_hook_events_count")]
     pub hook_events_count: usize,
+    /// v0.7-polish SEC-15 / COR-11 (issue #780): mirror of the
+    /// process-wide
+    /// `crate::metrics::auto_export_spawn_failed_total` counter.
+    /// Non-zero means at least one `post_reflect.auto_export` detached
+    /// worker panicked or returned `Err` since process start — the
+    /// reflection is committed in the DB but its on-disk markdown/json
+    /// artefact did NOT land. Operators alert on a non-zero value
+    /// without scraping `/metrics` directly.
+    ///
+    /// `skip_serializing_if = is_zero_u64` keeps healthy daemons'
+    /// capabilities responses byte-identical to pre-#780 — only
+    /// daemons that have actually hit the failure path see the field
+    /// on the wire. The MCP/HTTP capabilities builder overlays the
+    /// live value at response time.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub auto_export_spawn_failed_total: u64,
 }
 
 /// Compile-time count of `HookEvent` variants.  Updated here when new
@@ -739,6 +755,7 @@ impl Default for CapabilityHooks {
             registered_count: 0,
             webhook_events: default_webhook_events(),
             hook_events_count: HOOK_EVENTS_COUNT,
+            auto_export_spawn_failed_total: 0,
         }
     }
 }

--- a/src/hooks/post_reflect/auto_export.rs
+++ b/src/hooks/post_reflect/auto_export.rs
@@ -20,18 +20,40 @@
 //!    NEVER propagated back to the caller. The reflection is already
 //!    committed; making the operator chase a transient disk error is
 //!    worse than a missed file.
+//!    *v0.7-polish SEC-15 / COR-11 (issue #780):* failure is also
+//!    counted via [`crate::metrics::record_auto_export_spawn_failed`]
+//!    and mirrored onto the capabilities-v3
+//!    `hooks.auto_export_spawn_failed_total` field so operators can
+//!    alert on the otherwise-silent disk-write loss without scraping
+//!    `/metrics` directly. The detached worker closure is wrapped in
+//!    `catch_unwind` so a panic inside the closure (e.g., a poisoned
+//!    DB handle or a corrupt JSON column) is converted to the same
+//!    counter+warn path rather than being swallowed by the runtime's
+//!    detached-thread default.
 //! 3. **Capability isolation.** This code runs inside the substrate
 //!    process (CLI, MCP, HTTP daemon). It is gated by the namespace
 //!    policy — an operator who has not explicitly opted in to
 //!    `auto_export_reflections_to_filesystem` will see no disk writes
 //!    from this module ever.
 
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::cli::commands::export_reflections::{self, ExportFormat};
 use crate::db;
 use crate::storage::reflect::{ReflectHooks, ReflectOutcome};
+
+/// v0.7-polish SEC-15 / COR-11 (issue #780) — test-only panic-injection
+/// env-var. When set to `1` (any case), the next worker spawn panics
+/// inside its closure body so the panic-recovery path
+/// (`catch_unwind` → counter increment → `tracing::warn!`) can be
+/// exercised by an in-process integration test without an unsafe
+/// runtime hack. Production binaries never read this env-var
+/// (`debug_assertions`-gated read-site below), so the hot path stays
+/// uninstrumented in release builds.
+#[cfg(any(test, debug_assertions))]
+const AUTO_EXPORT_INJECT_PANIC_ENV: &str = "AI_MEMORY_AUTO_EXPORT_INJECT_PANIC";
 
 /// Static configuration for the auto-export hook.
 ///
@@ -92,15 +114,66 @@ pub fn build_post_reflect_hook(
         let namespace = outcome.namespace.clone();
         // Detached worker thread. Notify-class: any failure stays
         // inside this thread, never reaches the caller.
+        //
+        // v0.7-polish SEC-15 / COR-11 (issue #780): the closure body
+        // is wrapped in `catch_unwind` so a panic inside
+        // `run_auto_export` (poisoned DB handle, corrupt JSON column,
+        // an `unwrap` deep in the export-rendering chain, etc.) is
+        // caught and converted to the same counter+warn path that an
+        // `Err` return takes. Without this, a panic would silently
+        // unwind the detached thread — the reflection would be
+        // committed in the DB but no on-disk artefact would land and
+        // no operator-visible signal would fire.
         std::thread::spawn(move || {
-            if let Err(e) = run_auto_export(&dbp, &outcome_id, &namespace, &cfg) {
-                tracing::warn!(
-                    target: "post_reflect.auto_export",
-                    "auto-export of reflection {} (ns={}) failed: {}",
-                    outcome_id,
-                    namespace,
-                    e,
-                );
+            let outcome_id_for_log = outcome_id.clone();
+            let namespace_for_log = namespace.clone();
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                // v0.7-polish #780 — debug-only panic injection so the
+                // catch_unwind path is reachable from an in-process
+                // integration test. Release builds never read the
+                // env-var (cfg-gated below).
+                #[cfg(any(test, debug_assertions))]
+                {
+                    if std::env::var(AUTO_EXPORT_INJECT_PANIC_ENV)
+                        .ok()
+                        .is_some_and(|v| v == "1")
+                    {
+                        panic!("auto_export panic injected via {AUTO_EXPORT_INJECT_PANIC_ENV}=1");
+                    }
+                }
+                run_auto_export(&dbp, &outcome_id, &namespace, &cfg)
+            }));
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    crate::metrics::record_auto_export_spawn_failed();
+                    tracing::warn!(
+                        target: "post_reflect.auto_export",
+                        "auto-export of reflection {} (ns={}) failed: {}",
+                        outcome_id_for_log,
+                        namespace_for_log,
+                        e,
+                    );
+                }
+                Err(panic_payload) => {
+                    crate::metrics::record_auto_export_spawn_failed();
+                    let panic_msg = panic_payload
+                        .downcast_ref::<String>()
+                        .cloned()
+                        .or_else(|| {
+                            panic_payload
+                                .downcast_ref::<&'static str>()
+                                .map(|s| (*s).to_string())
+                        })
+                        .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                    tracing::warn!(
+                        target: "post_reflect.auto_export",
+                        "auto-export of reflection {} (ns={}) panicked: {}",
+                        outcome_id_for_log,
+                        namespace_for_log,
+                        panic_msg,
+                    );
+                }
             }
         });
     });
@@ -410,6 +483,85 @@ mod tests {
         // could still be running. We don't assert here; the file
         // existence is exercised by `run_auto_export_writes_md_when_policy_enabled`.
         let _ = outcome.id;
+    }
+
+    /// v0.7-polish SEC-15 / COR-11 (issue #780) — when the detached
+    /// `auto_export` worker panics, the `catch_unwind` wrapper must
+    /// (a) keep the panic from unwinding the runtime, (b) increment
+    /// `crate::metrics::auto_export_spawn_failed_total` so operators
+    /// see the loss, and (c) leave the reflect path itself unaffected
+    /// (it had already returned). The test induces the panic via the
+    /// debug-only `AI_MEMORY_AUTO_EXPORT_INJECT_PANIC=1` env-var hook
+    /// in the spawn closure, then polls the counter for the increment.
+    ///
+    /// Serialised via a process-wide mutex because the env-var is
+    /// process-global — if two tests in this module raced on it the
+    /// "off" test would see the injection. The mutex scope brackets
+    /// the env-var lifetime + the counter-advance wait so unrelated
+    /// tests (which never set the env-var) are not held up.
+    #[test]
+    fn auto_export_worker_panic_increments_spawn_failed_counter() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        // PoisonError is fine — we only care about exclusive access.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let (conn, dir, db_path) = fresh_db();
+        enable_auto_export_on_namespace(&conn, "panic-ns");
+        let src = seed_observation(&conn, "panic-ns");
+        let hooks = build_post_reflect_hook(
+            db_path.clone(),
+            AutoExportConfig {
+                out_dir: dir.path().join("out"),
+                format: ExportFormat::Markdown,
+            },
+        );
+        let input = crate::storage::reflect::ReflectInput {
+            source_ids: vec![src.clone()],
+            title: "rfl".into(),
+            content: "rfl body".into(),
+            namespace: Some("panic-ns".into()),
+            tier: Tier::Mid,
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "cli".into(),
+            agent_id: "ai:test".into(),
+            metadata: serde_json::json!({}),
+        };
+
+        let before = crate::metrics::auto_export_spawn_failed_count();
+        // SAFETY: env-var mutation is process-global; the ENV_LOCK
+        // mutex above serialises against any other test in this
+        // module that touches the same key. No other module sets it.
+        // SAFETY justification documented above; unsafe is required
+        // because `set_var` is `unsafe` on edition-2024.
+        unsafe {
+            std::env::set_var(AUTO_EXPORT_INJECT_PANIC_ENV, "1");
+        }
+        let _outcome = crate::storage::reflect::reflect_with_hooks(&conn, &input, &hooks).unwrap();
+
+        // Poll for the counter to advance. The worker is detached;
+        // its thread may not have run by the time reflect_with_hooks
+        // returns. Bound the wait at 5s — generous for any host.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut after = before;
+        while std::time::Instant::now() < deadline {
+            after = crate::metrics::auto_export_spawn_failed_count();
+            if after > before {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        // SAFETY: same as set_var above — protected by ENV_LOCK.
+        unsafe {
+            std::env::remove_var(AUTO_EXPORT_INJECT_PANIC_ENV);
+        }
+        assert!(
+            after > before,
+            "auto_export_spawn_failed_total did not advance after panic injection \
+             (before={before}, after={after})"
+        );
     }
 
     #[test]

--- a/src/mcp/tools/capabilities.rs
+++ b/src/mcp/tools/capabilities.rs
@@ -212,6 +212,12 @@ fn build_capabilities_overlay(
     caps.hnsw.evictions_total = crate::hnsw::index_evictions_total();
     caps.hnsw.evicted_recently = crate::hnsw::evicted_recently(60);
 
+    // v0.7-polish SEC-15 / COR-11 (issue #780) — mirror the
+    // process-wide auto-export spawn-failure counter onto the
+    // capabilities surface so operators see otherwise-silent
+    // detached-worker failures without scraping /metrics directly.
+    caps.hooks.auto_export_spawn_failed_total = crate::metrics::auto_export_spawn_failed_count();
+
     // --- Live DB-count overlays ---
     if let Some(c) = conn {
         if let Ok(n) = db::count_active_governance_rules(c) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -67,6 +67,16 @@ pub struct Metrics {
     /// column name (`citations` | `source_span` | `confidence_signals`
     /// | `metadata`).
     pub corrupt_provenance_rows_total: IntCounterVec,
+    /// v0.7-polish SEC-15 / COR-11 (issue #780): count of
+    /// `post_reflect.auto_export` detached worker invocations whose
+    /// outcome was a panic or a returned `Err`. Non-zero means an
+    /// operator-opted-in namespace had a reflection that did NOT
+    /// land on the filesystem and the failure would otherwise be
+    /// silent (the worker thread is detached; the reflection itself
+    /// already committed). The capabilities-v3 surface mirrors this
+    /// counter so operator dashboards can alert without scraping
+    /// `/metrics` directly.
+    pub auto_export_spawn_failed_total: IntCounter,
 }
 
 /// Lazily-built process-global metrics handle.
@@ -255,6 +265,18 @@ impl Metrics {
         )?;
         registry.register(Box::new(corrupt_provenance_rows_total.clone()))?;
 
+        // v0.7-polish SEC-15 / COR-11 (issue #780) — auto-export
+        // detached-worker failure observability.
+        let auto_export_spawn_failed_total = IntCounter::new(
+            "ai_memory_auto_export_spawn_failed_total",
+            "Detached post_reflect.auto_export worker invocations whose \
+             outcome was a panic or returned Err. Non-zero means at \
+             least one reflection was committed to the DB but its \
+             on-disk markdown/json artefact did not land — operators \
+             use this to alert on otherwise-silent disk-write failures.",
+        )?;
+        registry.register(Box::new(auto_export_spawn_failed_total.clone()))?;
+
         Ok(Self {
             registry,
             store_total,
@@ -274,6 +296,7 @@ impl Metrics {
             federation_fanout_retry_total,
             federation_partial_quorum_total,
             corrupt_provenance_rows_total,
+            auto_export_spawn_failed_total,
         })
     }
 }
@@ -288,6 +311,27 @@ pub fn record_corrupt_provenance(column: &str) {
         .corrupt_provenance_rows_total
         .with_label_values(&[column])
         .inc();
+}
+
+/// v0.7-polish SEC-15 / COR-11 (issue #780) — record one detached
+/// `auto_export` worker failure (panic OR returned `Err`). Pairs with
+/// a `tracing::warn!` at the call site so operators see the
+/// reflection id + failure mode. The counter is also mirrored onto the
+/// capabilities-v3 `hooks.auto_export_spawn_failed_total` field so
+/// dashboards that consume `memory_capabilities` (vs `/metrics`) see
+/// the same signal.
+pub fn record_auto_export_spawn_failed() {
+    registry().auto_export_spawn_failed_total.inc();
+}
+
+/// v0.7-polish SEC-15 / COR-11 (issue #780) — read the current value
+/// of the auto-export spawn-failure counter. Used by the
+/// capabilities-v3 builder to mirror the metric onto the
+/// `hooks.auto_export_spawn_failed_total` field without scraping
+/// `/metrics`.
+#[must_use]
+pub fn auto_export_spawn_failed_count() -> u64 {
+    registry().auto_export_spawn_failed_total.get()
 }
 
 /// Render the current registry state to the Prometheus text exposition
@@ -575,6 +619,7 @@ mod tests {
             .with_label_values(&["ok"])
             .inc();
         m.federation_partial_quorum_total.inc();
+        m.auto_export_spawn_failed_total.inc();
     }
 
     #[test]
@@ -593,6 +638,29 @@ mod tests {
         enc.encode(&b.registry.gather(), &mut buf_b).unwrap();
         assert!(String::from_utf8_lossy(&buf_a).contains("ai_memory_store_total"));
         assert!(String::from_utf8_lossy(&buf_b).contains("ai_memory_store_total"));
+    }
+
+    #[test]
+    fn record_auto_export_spawn_failed_increments_singleton() {
+        // v0.7-polish #780 — record_auto_export_spawn_failed() must
+        // monotonically advance the process-wide counter that the
+        // capabilities-v3 builder mirrors onto
+        // `hooks.auto_export_spawn_failed_total`.
+        let before = auto_export_spawn_failed_count();
+        record_auto_export_spawn_failed();
+        let after = auto_export_spawn_failed_count();
+        assert!(
+            after >= before + 1,
+            "auto_export_spawn_failed_total did not advance \
+             (before={before}, after={after})"
+        );
+        // The render text must mention the metric name so /metrics
+        // scrapers see it.
+        let text = render();
+        assert!(
+            text.contains("ai_memory_auto_export_spawn_failed_total"),
+            "/metrics output missing auto_export counter\n\n{text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #780 (SEC-15 / COR-11): the `post_reflect.auto_export` detached worker thread silently swallowed panics and only emitted an unaggregated `tracing::warn!` on `Err`. Operators had no signal when an opt-in disk-write failed mid-process. This change wraps the worker in `catch_unwind`, adds a process-wide `IntCounter` `ai_memory_auto_export_spawn_failed_total`, and mirrors it onto the capabilities-v3 `hooks.auto_export_spawn_failed_total` field (default-omitted when zero).
- Adds a debug-only `AI_MEMORY_AUTO_EXPORT_INJECT_PANIC=1` env-var hook (cfg-gated to `test|debug_assertions`) so the panic-recovery path is exercisable from an in-process integration test without unsafe runtime hacks. Release binaries never read the env-var.
- New regression test `auto_export_worker_panic_increments_spawn_failed_counter` induces the panic, polls the counter for the advance (5s ceiling), and asserts monotonic increase. Module-local `Mutex` serialises the process-global env-var write so concurrent tests in this module are not affected.

## Files touched

- `src/metrics.rs` — new `IntCounter` family + `record_auto_export_spawn_failed()` / `auto_export_spawn_failed_count()` helpers, plus tickle in the existing `try_new_builds_a_fresh_metrics_handle` test and a new `record_auto_export_spawn_failed_increments_singleton` test pinning the `/metrics` render contract.
- `src/hooks/post_reflect/auto_export.rs` — `catch_unwind`-wrapped spawn body, `Ok(Ok(_))` / `Ok(Err(_))` / `Err(panic_payload)` triage, panic-payload downcast for the warn message, and the test-only env-var injection point.
- `src/config.rs` — new `CapabilityHooks.auto_export_spawn_failed_total: u64` field with `#[serde(default, skip_serializing_if = "is_zero_u64")]` so healthy daemons' wire shape stays byte-identical.
- `src/mcp/tools/capabilities.rs` — single-line overlay populating the field from `crate::metrics::auto_export_spawn_failed_count()` inside `build_capabilities_overlay`.

## Gates (all green on this branch)

- `cargo fmt --check`
- `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic`
- `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --lib` — **4216 passed, 0 failed, 1 ignored**
- `cargo audit`

## Compat

Tool count + schema-version baselines unchanged. The new `CapabilityHooks.auto_export_spawn_failed_total` field is additive with `serde(default)` + `skip_serializing_if = is_zero_u64`, so v1 / v2 consumers and pre-#780 v3 consumers round-trip cleanly. The new `IntCounter` family registers on a fresh metric name (`ai_memory_auto_export_spawn_failed_total`), no collision with existing series.

## Test plan

- [x] `cargo test --lib hooks::post_reflect::auto_export` — 8 tests (7 existing + 1 new), all pass.
- [x] `cargo test --lib metrics::tests` — new counter test + every existing test still passes.
- [x] Manual review of `catch_unwind` triage: `Ok(Ok(()))` no-ops, `Ok(Err(e))` counter+warn, `Err(payload)` counter+warn with downcast to `String` then `&'static str` then `<non-string panic payload>` fallback.
- [x] Manual review of capability surface: zero state omitted from wire; non-zero present.
- [ ] Operator-side smoke (post-merge): trigger a real panic via the env-var on a dev daemon, scrape `/metrics` and `memory_capabilities` (v3), confirm both surface the increment.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the v0.7-polish #780 mission directive. All four gates run locally before commit; PR opened on operator instruction.