### PR TITLE
test(v0.7-polish #783): opportunistic coverage matrix expansion — COV-15..18

### DIFF
--- a/tests/cov_17_skills_federation_roundtrip.rs
+++ b/tests/cov_17_skills_federation_roundtrip.rs
@@ -1,0 +1,331 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7-polish #783 — COV-17: skills federation round-trip.
+//!
+//! End-to-end: register a skill (with resources) on a local node →
+//! export it to a folder (the skill wire format on disk) → import the
+//! folder into a fresh "peer" database → assert that the peer can
+//! resolve the skill's body and every attached resource with the
+//! digest verified.
+//!
+//! ## Why this isn't run against the federation/* substrate
+//!
+//! As of `polish/v0.7-783` HEAD `d856df2`, the federation receive
+//! pipeline (`src/federation/receive.rs`) ferries `memories` and
+//! `memory_links` between peers — it does NOT yet carry the `skills`
+//! / `skill_resources` tables. There is therefore no wire-level
+//! "import-into-peer" handler to test directly.
+//!
+//! The substrate-side primitive that DOES exist is the export folder
+//! shape: every skill round-trips through `target_folder/SKILL.md +
+//! target_folder/resources/...` with the digest preserved (see
+//! `tests/skill_test.rs::export_roundtrip_identical_digest`). The
+//! folder is the on-the-wire shape an operator (or a future
+//! federation skill-fanout) ships between peers — typically via
+//! `tar | curl | tar -x` or a future `memory_skill_publish` tool.
+//!
+//! This test exercises that folder as the wire format: writer-side
+//! `handle_skill_export` produces it from node A's DB; reader-side
+//! `handle_skill_register` consumes it into node B's DB; resource
+//! resolution on node B succeeds with the digest matching.
+//!
+//! If a future PR widens federation/* to fan skills out across peers,
+//! this test stays valid: it pins the substrate guarantee (folder is
+//! the canonical interchange shape) that the federation surface will
+//! ride on top of.
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::missing_panics_doc,
+    clippy::too_many_lines,
+    clippy::map_unwrap_or
+)]
+
+use std::path::PathBuf;
+
+use ai_memory::db;
+use ai_memory::mcp::{handle_skill_export, handle_skill_register, handle_skill_resource};
+use serde_json::{Value, json};
+
+fn local_runs_root() -> PathBuf {
+    std::env::var("TMPDIR")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".local-runs")
+                .join("tmp")
+        })
+}
+
+/// Fresh DB at a unique path under TMPDIR. We use real files (not
+/// `:memory:`) so two distinct peers don't accidentally share an
+/// in-memory connection cache.
+fn fresh_db_at(label: &str) -> (rusqlite::Connection, PathBuf) {
+    let root = local_runs_root();
+    std::fs::create_dir_all(&root).ok();
+    let path = root.join(format!("cov17-{}-{}.db", label, uuid::Uuid::new_v4()));
+    let conn = db::open(&path).expect("db::open");
+    (conn, path)
+}
+
+const SKILL_BODY: &str = "# Round-trip Skill\n\n\
+This is the body of the skill that the peer must end up with byte-\
+identical after the export → import round-trip.\n\n\
+## How it's used\n\n\
+The peer reads this body via `memory_skill_get` after import.\n";
+
+const RESOURCE_SCRIPT: &str = "#!/bin/bash\nset -euo pipefail\necho 'hello from peer'\n";
+const RESOURCE_REFERENCE: &str = "# Reference notes\n\nDetails the peer needs.\n";
+
+/// Build a SKILL.md folder layout under `root` with one script + one
+/// reference resource. This is the input shape `handle_skill_register`
+/// consumes (`folder_path`).
+fn write_authored_skill_folder(root: &std::path::Path) {
+    std::fs::create_dir_all(root).expect("mkdir root");
+    std::fs::write(
+        root.join("SKILL.md"),
+        format!(
+            "---\nnamespace: cov17\nname: round-trip-skill\n\
+             description: A skill exercised through the export-import wire format.\n\
+             ---\n\n{SKILL_BODY}"
+        )
+        .as_bytes(),
+    )
+    .expect("write SKILL.md");
+    let scripts = root.join("resources").join("scripts");
+    std::fs::create_dir_all(&scripts).expect("mkdir scripts");
+    std::fs::write(scripts.join("run.sh"), RESOURCE_SCRIPT.as_bytes()).expect("write run.sh");
+    let refer = root.join("resources").join("reference");
+    std::fs::create_dir_all(&refer).expect("mkdir reference");
+    std::fs::write(refer.join("notes.md"), RESOURCE_REFERENCE.as_bytes()).expect("write notes.md");
+}
+
+/// Full round-trip test: register a skill with resources on node A,
+/// export to a folder, import on node B, assert resources resolve.
+#[test]
+fn skill_export_import_roundtrip_resolves_resources_on_peer() {
+    // -----------------------------------------------------------------
+    // 1. Build authored skill folder (the operator's source artifact).
+    // -----------------------------------------------------------------
+    let workspace = local_runs_root().join(format!("cov17-ws-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let authored = workspace.join("authored-skill");
+    write_authored_skill_folder(&authored);
+
+    // -----------------------------------------------------------------
+    // 2. Node A — local peer registers the skill from the folder.
+    // -----------------------------------------------------------------
+    let (conn_a, _path_a) = fresh_db_at("node-a");
+    let registered_a: Value = handle_skill_register(
+        &conn_a,
+        &json!({"folder_path": authored.to_str().unwrap()}),
+        None,
+    )
+    .expect("node A: register");
+    assert_eq!(registered_a["registered"], json!(true));
+    assert_eq!(registered_a["namespace"], json!("cov17"));
+    assert_eq!(registered_a["name"], json!("round-trip-skill"));
+    let skill_id_a = registered_a["id"]
+        .as_str()
+        .expect("skill id on node A")
+        .to_string();
+    let digest_a = registered_a["digest"]
+        .as_str()
+        .expect("digest on node A")
+        .to_string();
+    assert_eq!(digest_a.len(), 64, "digest must be 64-char hex");
+
+    // -----------------------------------------------------------------
+    // 3. Node A — export to a peer-transport folder (the wire format).
+    // -----------------------------------------------------------------
+    let exported = workspace.join("exported");
+    let exported_resp = handle_skill_export(
+        &conn_a,
+        &json!({
+            "skill_id": skill_id_a,
+            "target_folder": exported.to_str().unwrap(),
+        }),
+        None,
+    )
+    .expect("node A: export");
+    assert_eq!(exported_resp["exported"], json!(true));
+    assert_eq!(
+        exported_resp["digest"].as_str().unwrap_or(""),
+        digest_a,
+        "exported digest must match the registered digest",
+    );
+    // Exported folder must contain SKILL.md and the two resource files.
+    assert!(
+        exported.join("SKILL.md").is_file(),
+        "wire format must include SKILL.md",
+    );
+    assert!(
+        exported
+            .join("resources")
+            .join("scripts")
+            .join("run.sh")
+            .is_file(),
+        "wire format must include scripts/run.sh",
+    );
+    assert!(
+        exported
+            .join("resources")
+            .join("reference")
+            .join("notes.md")
+            .is_file(),
+        "wire format must include reference/notes.md",
+    );
+
+    // -----------------------------------------------------------------
+    // 4. Node B (the "peer") — fresh DB; no prior knowledge of node A.
+    //    Import the exported folder. This is the substrate-side stand-
+    //    in for the future federation receive handler.
+    // -----------------------------------------------------------------
+    let (conn_b, _path_b) = fresh_db_at("node-b");
+    // Peer starts empty.
+    let pre_count: i64 = conn_b
+        .query_row("SELECT COUNT(*) FROM skills", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(pre_count, 0, "peer DB starts with zero skills");
+
+    let registered_b: Value = handle_skill_register(
+        &conn_b,
+        &json!({"folder_path": exported.to_str().unwrap()}),
+        None,
+    )
+    .expect("node B: register from peer transport");
+    assert_eq!(registered_b["registered"], json!(true));
+    let skill_id_b = registered_b["id"]
+        .as_str()
+        .expect("skill id on node B")
+        .to_string();
+    let digest_b = registered_b["digest"]
+        .as_str()
+        .expect("digest on node B")
+        .to_string();
+
+    // -----------------------------------------------------------------
+    // 5. Wire-format invariant: digest is identical across peers. This
+    //    is the load-bearing guarantee — the same skill on two peers
+    //    is identifiable by the same content-address.
+    // -----------------------------------------------------------------
+    assert_eq!(
+        digest_a, digest_b,
+        "round-trip across peer transport must preserve digest exactly",
+    );
+
+    // -----------------------------------------------------------------
+    // 6. Resource resolution on the peer — both attached resources
+    //    must decompress + digest-verify successfully on node B,
+    //    proving the substrate's resource interchange shape works
+    //    when the importer was not the original author.
+    // -----------------------------------------------------------------
+    let script_resp = handle_skill_resource(
+        &conn_b,
+        &json!({
+            "skill_id": skill_id_b,
+            "resource_path": "scripts/run.sh",
+        }),
+    )
+    .expect("peer: resolve script resource");
+    assert_eq!(script_resp["digest_verified"], json!(true));
+    assert_eq!(script_resp["encoding"], json!("utf-8"));
+    assert_eq!(
+        script_resp["content"].as_str().unwrap_or(""),
+        RESOURCE_SCRIPT,
+        "script content must be byte-identical on the peer",
+    );
+    assert_eq!(script_resp["resource_kind"], json!("script"));
+
+    let reference_resp = handle_skill_resource(
+        &conn_b,
+        &json!({
+            "skill_id": skill_id_b,
+            "resource_path": "reference/notes.md",
+        }),
+    )
+    .expect("peer: resolve reference resource");
+    assert_eq!(reference_resp["digest_verified"], json!(true));
+    assert_eq!(
+        reference_resp["content"].as_str().unwrap_or(""),
+        RESOURCE_REFERENCE,
+        "reference content must be byte-identical on the peer",
+    );
+    assert_eq!(reference_resp["resource_kind"], json!("reference"));
+
+    // -----------------------------------------------------------------
+    // 7. Skill body round-trips. The peer's decompressed body must
+    //    match the originally-authored body byte-for-byte.
+    // -----------------------------------------------------------------
+    let body_blob_b: Vec<u8> = conn_b
+        .query_row(
+            "SELECT body_blob FROM skills WHERE id = ?1",
+            [&skill_id_b],
+            |r| r.get(0),
+        )
+        .expect("read body blob on peer");
+    let body_b = zstd::decode_all(body_blob_b.as_slice()).expect("decompress body on peer");
+    assert_eq!(
+        String::from_utf8_lossy(&body_b).into_owned(),
+        SKILL_BODY,
+        "peer-side body must be byte-identical to author-side body",
+    );
+
+    // Cleanup test scratch.
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// Sanity guard — the exported folder must register on the peer even
+/// when the peer's DB was opened independently (no shared connection,
+/// no shared in-memory state). Mirrors the network-transit shape: the
+/// only thing carried between peers is the folder bytes.
+#[test]
+fn skill_export_folder_is_self_contained_for_peer_import() {
+    let workspace = local_runs_root().join(format!("cov17-sc-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let authored = workspace.join("authored");
+    write_authored_skill_folder(&authored);
+
+    let (conn_a, _) = fresh_db_at("self-contained-a");
+    let resp_a = handle_skill_register(
+        &conn_a,
+        &json!({"folder_path": authored.to_str().unwrap()}),
+        None,
+    )
+    .expect("register on a");
+    let id_a = resp_a["id"].as_str().unwrap().to_string();
+
+    let exported = workspace.join("exported");
+    handle_skill_export(
+        &conn_a,
+        &json!({
+            "skill_id": id_a,
+            "target_folder": exported.to_str().unwrap(),
+        }),
+        None,
+    )
+    .expect("export from a");
+
+    // Drop node A entirely before opening node B — proves the folder
+    // alone carries the wire-format payload.
+    drop(conn_a);
+
+    let (conn_b, _) = fresh_db_at("self-contained-b");
+    let resp_b = handle_skill_register(
+        &conn_b,
+        &json!({"folder_path": exported.to_str().unwrap()}),
+        None,
+    )
+    .expect("register on b from exported folder alone");
+    assert_eq!(resp_b["registered"], json!(true));
+    assert_eq!(
+        resp_b["digest"].as_str().unwrap_or(""),
+        resp_a["digest"].as_str().unwrap_or("ZZZ"),
+        "peer-import digest must match author-side digest",
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}

--- a/tests/cov_18_offload_ttl_postgres.rs
+++ b/tests/cov_18_offload_ttl_postgres.rs
@@ -1,0 +1,290 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7-polish #783 — COV-18: offload TTL sweep against postgres.
+//!
+//! The sqlite path is exercised by `tests/offload/acceptance.rs::
+//! test_offload_ttl_expiry` and the in-module unit test
+//! `src/offload/mod.rs::sweep_purges_expired_rows`. The postgres-backed
+//! schema landed in v34 (`MIGRATION_V34_OFFLOADED_BLOBS` →
+//! `migrations/postgres/0016_v07_offloaded_blobs.sql`) but no
+//! postgres-side TTL-sweep coverage exists.
+//!
+//! This test:
+//!   1. Connects to the test postgres URL (self-skip when unset).
+//!   2. Drives `PostgresStore::connect` so the v34 migration ladders.
+//!   3. Inserts N=10 blobs with backdated `stored_at` + TTLs, plus 5
+//!      fresh-stamped rows and 3 permanent (`ttl_seconds IS NULL`)
+//!      rows under a per-test unique namespace.
+//!   4. Runs the equivalent TTL-sweep predicate against postgres:
+//!      `DELETE FROM offloaded_blobs WHERE ttl_seconds IS NOT NULL
+//!      AND (stored_at + ttl_seconds) < $1`.
+//!   5. Asserts the backdated rows are gone, the fresh + permanent
+//!      rows survive, the namespace-isolation invariant holds for
+//!      unrelated namespaces, and the schema indexes the predicate
+//!      we're relying on.
+//!
+//! ## Why the sweep is replayed in-test
+//!
+//! `crate::offload::sweep_expired` takes a `&rusqlite::Connection` —
+//! the postgres adapter has no equivalent sweeper today. The brief's
+//! intent is to pin the PG schema's ability to honour the TTL sweep
+//! semantics so the future portable sweeper (or a daemon-side cron
+//! against pg) lands on a verified storage contract. Re-issuing the
+//! sqlite predicate in pg dialect is the load-bearing assertion here.
+
+#![cfg(feature = "sal-postgres")]
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::too_many_lines,
+    clippy::doc_markdown
+)]
+
+use ai_memory::store::postgres::PostgresStore;
+use sqlx::Row;
+
+fn postgres_url() -> Option<String> {
+    std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
+}
+
+/// Open a sqlx pool against the same URL. The `PostgresStore::connect`
+/// call ensures the v34 schema is in place; the pool is then used to
+/// drive direct SQL — there's no public adapter method for either the
+/// raw insert or the sweep on the postgres side as of `polish/v0.7-783`.
+async fn pool(url: &str) -> sqlx::Pool<sqlx::Postgres> {
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(4)
+        .acquire_timeout(std::time::Duration::from_secs(5))
+        .connect(url)
+        .await
+        .expect("connect sqlx pool")
+}
+
+async fn insert_blob(
+    pool: &sqlx::Pool<sqlx::Postgres>,
+    ref_id: &str,
+    namespace: &str,
+    stored_at: i64,
+    ttl_seconds: Option<i64>,
+) {
+    // Minimal blob; tests are about row lifecycle, not zstd integrity.
+    let dummy_zstd: Vec<u8> = vec![0x28, 0xb5, 0x2f, 0xfd, 0x00];
+    let sha = format!("{:064x}", 0_u128);
+    sqlx::query(
+        "INSERT INTO offloaded_blobs \
+         (ref_id, namespace, content_zstd, content_sha256, stored_at, ttl_seconds, agent_id, signature_b64) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(ref_id)
+    .bind(namespace)
+    .bind(&dummy_zstd)
+    .bind(sha)
+    .bind(stored_at)
+    .bind(ttl_seconds)
+    .bind("ai:cov18")
+    .bind("")
+    .execute(pool)
+    .await
+    .expect("insert offloaded_blob row");
+}
+
+async fn count_in_ns(pool: &sqlx::Pool<sqlx::Postgres>, namespace: &str) -> i64 {
+    sqlx::query("SELECT COUNT(*) FROM offloaded_blobs WHERE namespace = $1")
+        .bind(namespace)
+        .fetch_one(pool)
+        .await
+        .expect("count rows")
+        .try_get::<i64, _>(0)
+        .expect("read count")
+}
+
+async fn count_ttl_in_ns(pool: &sqlx::Pool<sqlx::Postgres>, namespace: &str, has_ttl: bool) -> i64 {
+    let sql = if has_ttl {
+        "SELECT COUNT(*) FROM offloaded_blobs \
+         WHERE namespace = $1 AND ttl_seconds IS NOT NULL"
+    } else {
+        "SELECT COUNT(*) FROM offloaded_blobs \
+         WHERE namespace = $1 AND ttl_seconds IS NULL"
+    };
+    sqlx::query(sql)
+        .bind(namespace)
+        .fetch_one(pool)
+        .await
+        .expect("count by ttl")
+        .try_get::<i64, _>(0)
+        .expect("read count")
+}
+
+/// Mirror of `sweep_expired` (sqlite) for the postgres dialect. Returns
+/// the rowcount deleted.
+async fn sweep_expired_pg(pool: &sqlx::Pool<sqlx::Postgres>, now_unix: i64) -> u64 {
+    sqlx::query(
+        "DELETE FROM offloaded_blobs \
+         WHERE ttl_seconds IS NOT NULL \
+           AND (stored_at + ttl_seconds) < $1",
+    )
+    .bind(now_unix)
+    .execute(pool)
+    .await
+    .expect("execute sweep delete")
+    .rows_affected()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cov18_offload_ttl_sweep_against_postgres() {
+    let Some(url) = postgres_url() else {
+        eprintln!(
+            "skipping cov18_offload_ttl_sweep_against_postgres: \
+             AI_MEMORY_TEST_POSTGRES_URL not set"
+        );
+        return;
+    };
+
+    // Drive PostgresStore::connect so the v34 offloaded_blobs migration
+    // is guaranteed to have landed. Drop the store before using sqlx
+    // directly — they share the underlying postgres tables but maintain
+    // independent connection pools.
+    let _store = PostgresStore::connect(&url)
+        .await
+        .expect("connect postgres adapter");
+
+    let pool = pool(&url).await;
+
+    // Per-test unique namespace so concurrent runs against the shared
+    // scratch DB don't fight each other.
+    let suffix = uuid::Uuid::new_v4();
+    let ns = format!("cov18-{suffix}");
+    let ns_other = format!("cov18-other-{suffix}");
+
+    // -----------------------------------------------------------------
+    // Seed N=10 backdated rows in `ns`. Each has stored_at ~ 1 hour
+    // ago and ttl_seconds = 60 (so `stored_at + ttl < now`).
+    // -----------------------------------------------------------------
+    let now: i64 = chrono::Utc::now().timestamp();
+    let one_hour_ago = now - 3600;
+    for i in 0..10 {
+        insert_blob(
+            &pool,
+            &format!("ofl_cov18_old_{suffix}_{i}"),
+            &ns,
+            one_hour_ago,
+            Some(60),
+        )
+        .await;
+    }
+    // 5 fresh rows: stored_at == now, ttl 1 day (stays well in the
+    // future).
+    for i in 0..5 {
+        insert_blob(
+            &pool,
+            &format!("ofl_cov18_fresh_{suffix}_{i}"),
+            &ns,
+            now,
+            Some(86_400),
+        )
+        .await;
+    }
+    // 3 permanent rows (ttl_seconds IS NULL).
+    for i in 0..3 {
+        insert_blob(
+            &pool,
+            &format!("ofl_cov18_perm_{suffix}_{i}"),
+            &ns,
+            now - 7200,
+            None,
+        )
+        .await;
+    }
+    // 2 backdated rows in an UNRELATED namespace — must NOT be touched
+    // by the sweep (it's predicate-only, not namespace-scoped).
+    for i in 0..2 {
+        insert_blob(
+            &pool,
+            &format!("ofl_cov18_other_{suffix}_{i}"),
+            &ns_other,
+            one_hour_ago,
+            Some(60),
+        )
+        .await;
+    }
+
+    let pre_total = count_in_ns(&pool, &ns).await;
+    assert_eq!(pre_total, 18, "pre-sweep total in ns: 10 + 5 + 3 = 18");
+    let pre_other = count_in_ns(&pool, &ns_other).await;
+    assert_eq!(pre_other, 2);
+
+    // -----------------------------------------------------------------
+    // Run the equivalent TTL-sweep predicate against postgres.
+    //
+    // The sweep predicate is unscoped by namespace (matches the sqlite
+    // sweeper's contract) — so the other namespace's expired row is
+    // also dropped. We assert that boundary explicitly.
+    // -----------------------------------------------------------------
+    let deleted = sweep_expired_pg(&pool, now).await;
+    assert_eq!(
+        deleted, 12,
+        "sweep removes 10 (ns) + 2 (ns_other) = 12 expired rows",
+    );
+
+    // -----------------------------------------------------------------
+    // Post-sweep invariants.
+    // -----------------------------------------------------------------
+    let post_total = count_in_ns(&pool, &ns).await;
+    assert_eq!(
+        post_total, 8,
+        "ns: 5 fresh + 3 permanent rows survive the sweep",
+    );
+    let post_ttl = count_ttl_in_ns(&pool, &ns, true).await;
+    assert_eq!(post_ttl, 5, "ns: only fresh ttl'd rows remain");
+    let post_perm = count_ttl_in_ns(&pool, &ns, false).await;
+    assert_eq!(post_perm, 3, "ns: all permanent rows survive");
+
+    let post_other = count_in_ns(&pool, &ns_other).await;
+    assert_eq!(
+        post_other, 0,
+        "unrelated namespace's expired row was also dropped \
+         (sweep predicate is namespace-agnostic; matches sqlite contract)",
+    );
+
+    // -----------------------------------------------------------------
+    // Idempotency — re-running the sweep at the same `now` deletes
+    // zero rows. Pins the row-bounded contract: a stable substrate
+    // doesn't keep DELETE-ing on every tick.
+    // -----------------------------------------------------------------
+    let again = sweep_expired_pg(&pool, now).await;
+    assert_eq!(again, 0, "second sweep at same now must be a no-op");
+
+    // -----------------------------------------------------------------
+    // Schema invariant — the partial index that makes the sweep cheap
+    // is in place. (`idx_offloaded_blobs_ttl WHERE ttl_seconds IS NOT
+    // NULL`, from the v34 migration.)
+    // -----------------------------------------------------------------
+    let idx_present: bool = sqlx::query(
+        "SELECT EXISTS ( \
+             SELECT 1 FROM pg_indexes \
+             WHERE schemaname = 'public' \
+               AND tablename = 'offloaded_blobs' \
+               AND indexname = 'idx_offloaded_blobs_ttl' \
+         )",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("query pg_indexes")
+    .try_get::<bool, _>(0)
+    .expect("read bool");
+    assert!(
+        idx_present,
+        "v34 migration must install the ttl partial index that the sweep relies on",
+    );
+
+    // -----------------------------------------------------------------
+    // Cleanup — surviving rows from this test go away. Other tests
+    // sharing the scratch DB rely on this no-leak discipline.
+    // -----------------------------------------------------------------
+    sqlx::query("DELETE FROM offloaded_blobs WHERE namespace = $1 OR namespace = $2")
+        .bind(&ns)
+        .bind(&ns_other)
+        .execute(&pool)
+        .await
+        .expect("cleanup test rows");
+}

--- a/tests/form_1_synthesis_verdict_matrix.rs
+++ b/tests/form_1_synthesis_verdict_matrix.rs
@@ -1,0 +1,575 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7-polish #783 — COV-15: synthesis verdict diff matrix.
+//!
+//! The four baseline tests in `form_1_synthesis.rs` cover one verb
+//! against a single seeded candidate. This matrix extends coverage
+//! combinatorially: 4 verb classes × 5 candidate counts (1, 2, 3, 4, 5)
+//! = 20 test cases, each asserting the substrate honours the verdict
+//! exactly for every candidate in the batch.
+//!
+//! ## Candidate-count selection (1, 2, 3, 4, 5)
+//!
+//! The brief proposed 1, 2, 3, 5, 10. The pre-filter the substrate
+//! actually uses — `storage::find_contradictions` — is hard-capped at
+//! `LIMIT 5` (see src/storage/mod.rs:1995). Verdicts that reference
+//! candidates beyond that pre-filter window are silently dropped by
+//! design because the synthesiser never sees them. Picking n=10 would
+//! test the pre-filter's cap, not the verdict-honouring contract, so
+//! the matrix walks the actually-exercisable 1..=5 range instead. The
+//! cap itself is a documented substrate property and not a bug; this
+//! comment exists so a future widening of the LIMIT can grow the
+//! matrix in lockstep.
+//!
+//! Tests against the already-shipped substrate; no source changes.
+
+#![allow(
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::missing_panics_doc,
+    clippy::needless_pass_by_value,
+    clippy::similar_names,
+    clippy::items_after_statements,
+    clippy::let_and_return,
+    clippy::wildcard_imports,
+    clippy::needless_range_loop,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::map_unwrap_or,
+    clippy::ptr_arg
+)]
+
+use std::path::PathBuf;
+
+use ai_memory::config::ResolvedTtl;
+use ai_memory::llm::OllamaClient;
+use ai_memory::models::Memory;
+use ai_memory::storage as db;
+
+use chrono::Utc;
+use rusqlite::Connection;
+use serde_json::{Value, json};
+use std::sync::OnceLock;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirrors form_1_synthesis.rs)
+// ---------------------------------------------------------------------------
+
+fn local_runs_root() -> PathBuf {
+    std::env::var("TMPDIR")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".local-runs")
+                .join("tmp")
+        })
+}
+
+fn fresh_db_path() -> PathBuf {
+    let root = local_runs_root();
+    std::fs::create_dir_all(&root).ok();
+    root.join(format!("form-1-matrix-{}.db", uuid::Uuid::new_v4()))
+}
+
+fn open_db() -> (Connection, PathBuf) {
+    let p = fresh_db_path();
+    let conn = db::open(&p).expect("open db");
+    (conn, p)
+}
+
+fn seed_existing(conn: &Connection, title: &str, content: &str, namespace: &str) -> String {
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: ai_memory::models::Tier::Mid,
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        content: content.to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"agent_id": "ai:seed"}),
+        reflection_depth: 0,
+        memory_kind: ai_memory::models::MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ai_memory::models::ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+    };
+    db::insert(conn, &mem).expect("seed insert")
+}
+
+fn run_store(
+    conn: &Connection,
+    db_path: &PathBuf,
+    llm: &OllamaClient,
+    params: Value,
+) -> Result<Value, String> {
+    let ttl = ResolvedTtl::default();
+    ai_memory::mcp::tools::handle_store_for_tests(
+        conn,
+        db_path,
+        &params,
+        None,
+        Some(llm),
+        None,
+        &ttl,
+        true,
+        None,
+        None,
+    )
+}
+
+fn mock_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime builds")
+    })
+}
+
+fn shared_mock_for_synthesis(verdicts_json: Value) -> MockServer {
+    let rt = mock_runtime();
+    rt.block_on(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/tags"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"models": []})))
+            .mount(&server)
+            .await;
+        let body_str = serde_json::to_string(&verdicts_json).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/api/chat"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"message": {"content": body_str}, "done": true})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"response": ""})))
+            .mount(&server)
+            .await;
+        server
+    })
+}
+
+const BASE_CONTENT: &str = "This is a substantial body so the AUTONOMY_MIN_CONTENT_LEN gate fires \
+                            and the synthesis hook becomes eligible during the store call.";
+
+/// Install a permissive synthesis-policy standard so the per-call delete
+/// cap (default 1) does not block batches with N > 1 deletes. The other
+/// substrate gates are left at their defaults.
+fn install_permissive_synthesis_policy(conn: &Connection, ns: &str) {
+    use ai_memory::models::{
+        ApproverType, GovernanceLevel, GovernancePolicy, Memory, MemoryKind, Tier, default_metadata,
+    };
+    let policy = GovernancePolicy {
+        write: GovernanceLevel::Any,
+        promote: GovernanceLevel::Any,
+        delete: GovernanceLevel::Any,
+        approver: ApproverType::Human,
+        inherit: true,
+        max_reflection_depth: None,
+        auto_export_reflections_to_filesystem: None,
+        auto_atomise: None,
+        auto_atomise_threshold_cl100k: None,
+        auto_atomise_max_atom_tokens: None,
+        auto_atomise_max_retries: None,
+        auto_persona_trigger_every_n_memories: None,
+        auto_export_personas_to_filesystem: None,
+        auto_atomise_mode: None,
+        legacy_per_pair_classifier: None,
+        auto_classify_kind: None,
+        synthesis_failure_mode: None,
+        synthesis_max_deletes_per_call: Some(64),
+        synthesis_max_candidate_chars: None,
+    };
+    let now = Utc::now().to_rfc3339();
+    let mut metadata = default_metadata();
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert("agent_id".to_string(), json!("ai:test"));
+        obj.insert(
+            "governance".to_string(),
+            serde_json::to_value(&policy).unwrap(),
+        );
+    }
+    let standard = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: format!("_standards-{ns}"),
+        title: format!("cov-15-std-{ns}"),
+        content: "policy".to_string(),
+        tags: vec![],
+        priority: 9,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata,
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ai_memory::models::ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+    };
+    let sid = db::insert(conn, &standard).expect("insert std");
+    db::set_namespace_standard(conn, ns, &sid, None).expect("set std");
+}
+
+/// Seed `n` candidates sharing a common token so the FTS pre-filter
+/// surfaces all of them as synthesis candidates.
+fn seed_n_candidates(conn: &Connection, n: usize, ns: &str) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            seed_existing(
+                conn,
+                &format!("kubernetes deployment notes v{i}"),
+                &format!("body for candidate {i}"),
+                ns,
+            )
+        })
+        .collect()
+}
+
+fn ns_count(conn: &Connection, ns: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM memories WHERE namespace = ?1",
+        [ns],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+fn row_exists(conn: &Connection, id: &str) -> bool {
+    conn.query_row("SELECT 1 FROM memories WHERE id = ?1", [id], |_| Ok(true))
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Matrix driver — one verb per fan-out.
+// ---------------------------------------------------------------------------
+
+/// Drive `add` against `n` candidates: substrate keeps all N candidates
+/// and inserts the new row → total = N + 1.
+fn matrix_add(n: usize) {
+    let (conn, db_path) = open_db();
+    let ns = format!("ns-matrix-add-{n}");
+    install_permissive_synthesis_policy(&conn, &ns);
+    let ids = seed_n_candidates(&conn, n, &ns);
+
+    let verdicts: Vec<Value> = ids
+        .iter()
+        .map(|id| json!({"candidate_id": id, "verb": "add"}))
+        .collect();
+    let server = shared_mock_for_synthesis(json!({"verdicts": verdicts}));
+    let llm = OllamaClient::new_with_url(&server.uri(), "test-model").expect("client");
+
+    let resp = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect("store ok");
+
+    assert!(resp["id"].is_string(), "add path returns id");
+    let want = i64::try_from(n).unwrap() + 1;
+    assert_eq!(
+        ns_count(&conn, &ns),
+        want,
+        "add matrix n={n}: all N candidates kept + new row inserted",
+    );
+    for id in &ids {
+        assert!(row_exists(&conn, id), "add: candidate {id} must survive");
+    }
+    assert_eq!(
+        resp["synthesis_decisions"]["add"].as_u64(),
+        Some(n as u64),
+        "add: every verdict counted",
+    );
+}
+
+/// Drive `update` against `n` candidates: substrate rewrites all N
+/// candidates' content; SKIPs the new-row insert. Total = N.
+fn matrix_update(n: usize) {
+    let (conn, db_path) = open_db();
+    let ns = format!("ns-matrix-update-{n}");
+    install_permissive_synthesis_policy(&conn, &ns);
+    let ids = seed_n_candidates(&conn, n, &ns);
+
+    let verdicts: Vec<Value> = ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            json!({
+                "candidate_id": id,
+                "verb": "update",
+                "merged_content": format!("merged-content-{i}"),
+            })
+        })
+        .collect();
+    let server = shared_mock_for_synthesis(json!({"verdicts": verdicts}));
+    let llm = OllamaClient::new_with_url(&server.uri(), "test-model").expect("client");
+
+    let resp = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect("store ok");
+
+    // The response surfaces the PRIMARY (first) update's id.
+    assert_eq!(
+        resp["id"].as_str(),
+        Some(ids[0].as_str()),
+        "update: primary id is the first updated candidate",
+    );
+    assert_eq!(
+        resp["duplicate"].as_bool(),
+        Some(true),
+        "update: dedup flag"
+    );
+    assert_eq!(
+        ns_count(&conn, &ns),
+        i64::try_from(n).unwrap(),
+        "update matrix n={n}: SKIPs new-row insert; total stays at N",
+    );
+    // Every candidate's body must reflect its merged_content.
+    for (i, id) in ids.iter().enumerate() {
+        let body: String = conn
+            .query_row("SELECT content FROM memories WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            body,
+            format!("merged-content-{i}"),
+            "update: candidate #{i} body must reflect merged_content",
+        );
+    }
+    assert_eq!(
+        resp["synthesis_decisions"]["update"].as_u64(),
+        Some(n as u64),
+    );
+}
+
+/// Drive `delete` against `n` candidates: substrate removes all N
+/// candidates and inserts the new row. Total = 1.
+fn matrix_delete(n: usize) {
+    let (conn, db_path) = open_db();
+    let ns = format!("ns-matrix-delete-{n}");
+    install_permissive_synthesis_policy(&conn, &ns);
+    let ids = seed_n_candidates(&conn, n, &ns);
+
+    let verdicts: Vec<Value> = ids
+        .iter()
+        .map(|id| json!({"candidate_id": id, "verb": "delete"}))
+        .collect();
+    let server = shared_mock_for_synthesis(json!({"verdicts": verdicts}));
+    let llm = OllamaClient::new_with_url(&server.uri(), "test-model").expect("client");
+
+    let resp = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect("store ok");
+
+    assert_eq!(
+        ns_count(&conn, &ns),
+        1,
+        "delete matrix n={n}: all N candidates removed + 1 new row",
+    );
+    for id in &ids {
+        assert!(
+            !row_exists(&conn, id),
+            "delete: candidate {id} must be gone",
+        );
+    }
+    let new_id = resp["id"].as_str().expect("new id");
+    assert!(row_exists(&conn, new_id), "delete: new row exists");
+    assert_eq!(
+        resp["synthesis_decisions"]["delete"].as_u64(),
+        Some(n as u64),
+    );
+}
+
+/// Drive `no_op` against `n` candidates: substrate keeps all N candidates
+/// AND inserts the new row. Total = N + 1.
+fn matrix_no_op(n: usize) {
+    let (conn, db_path) = open_db();
+    let ns = format!("ns-matrix-noop-{n}");
+    install_permissive_synthesis_policy(&conn, &ns);
+    let ids = seed_n_candidates(&conn, n, &ns);
+
+    let verdicts: Vec<Value> = ids
+        .iter()
+        .map(|id| json!({"candidate_id": id, "verb": "no_op"}))
+        .collect();
+    let server = shared_mock_for_synthesis(json!({"verdicts": verdicts}));
+    let llm = OllamaClient::new_with_url(&server.uri(), "test-model").expect("client");
+
+    let resp = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect("store ok");
+
+    assert!(resp["id"].is_string());
+    let want = i64::try_from(n).unwrap() + 1;
+    assert_eq!(
+        ns_count(&conn, &ns),
+        want,
+        "no_op matrix n={n}: candidates kept + new row",
+    );
+    for id in &ids {
+        assert!(row_exists(&conn, id), "no_op: candidate {id} kept");
+    }
+    assert_eq!(
+        resp["synthesis_decisions"]["no_op"].as_u64(),
+        Some(n as u64),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4 verbs × 5 candidate counts (1, 2, 3, 4, 5) = 20 #[test] functions.
+//
+// One `#[test]` per cell so a failure pinpoints the exact (verb, n)
+// pair. (`rstest` is not in the workspace's dependency set, so we
+// fan out the matrix manually rather than pull in a new dep.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cov15_add_n1() {
+    matrix_add(1);
+}
+#[test]
+fn cov15_add_n2() {
+    matrix_add(2);
+}
+#[test]
+fn cov15_add_n3() {
+    matrix_add(3);
+}
+#[test]
+fn cov15_add_n4() {
+    matrix_add(4);
+}
+#[test]
+fn cov15_add_n5() {
+    matrix_add(5);
+}
+
+#[test]
+fn cov15_update_n1() {
+    matrix_update(1);
+}
+#[test]
+fn cov15_update_n2() {
+    matrix_update(2);
+}
+#[test]
+fn cov15_update_n3() {
+    matrix_update(3);
+}
+#[test]
+fn cov15_update_n4() {
+    matrix_update(4);
+}
+#[test]
+fn cov15_update_n5() {
+    matrix_update(5);
+}
+
+#[test]
+fn cov15_delete_n1() {
+    matrix_delete(1);
+}
+#[test]
+fn cov15_delete_n2() {
+    matrix_delete(2);
+}
+#[test]
+fn cov15_delete_n3() {
+    matrix_delete(3);
+}
+#[test]
+fn cov15_delete_n4() {
+    matrix_delete(4);
+}
+#[test]
+fn cov15_delete_n5() {
+    matrix_delete(5);
+}
+
+#[test]
+fn cov15_no_op_n1() {
+    matrix_no_op(1);
+}
+#[test]
+fn cov15_no_op_n2() {
+    matrix_no_op(2);
+}
+#[test]
+fn cov15_no_op_n3() {
+    matrix_no_op(3);
+}
+#[test]
+fn cov15_no_op_n4() {
+    matrix_no_op(4);
+}
+#[test]
+fn cov15_no_op_n5() {
+    matrix_no_op(5);
+}

--- a/tests/form_5_confidence_calibration.rs
+++ b/tests/form_5_confidence_calibration.rs
@@ -676,6 +676,140 @@ fn shadow_observations_gc_sweeper_drops_old_rows() {
 // 14. Cluster G PERF-9 — shadow_observe uses cached config (no per-call env).
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// v0.7-polish #783 — COV-16: calibration window edge cases.
+//
+// Pins `calibrate_from_shadow`'s behaviour at the boundary values the
+// public CLI / MCP surface accepts: days=1 (smallest useful window),
+// days=3650 (10-year, the loose upper bound the API documents), and
+// days=0 (degenerate / opt-out). The substrate as shipped does NOT
+// clamp the `days` parameter; these tests document and pin that
+// observed behaviour so a future clamp lands as a deliberate change
+// (and a test diff) rather than a silent regression.
+// ---------------------------------------------------------------------------
+
+/// COV-16a — `days=1` returns a window containing only the most recent
+/// 24h of observations. Observations stamped 25h ago must NOT contribute.
+#[test]
+fn calibrate_with_days_1_returns_single_day_window() {
+    let (_tmp, conn) = fresh_db();
+    let m_fresh = fixture_memory("ns-cov16-1d", "fresh");
+    let m_stale = fixture_memory("ns-cov16-1d", "stale");
+    db::insert(&conn, &m_fresh).expect("ins fresh");
+    db::insert(&conn, &m_stale).expect("ins stale");
+
+    let s = ConfidenceSignals::default();
+    // Fresh observation (default observed_at = now via `observe`).
+    observe(
+        &conn,
+        &m_fresh.id,
+        "ns-cov16-1d",
+        "user",
+        0.9,
+        0.5,
+        &s,
+        None,
+    )
+    .expect("observe fresh");
+    // Stale observation: backdate observed_at to 25 hours ago.
+    let stale_at = (Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+    conn.execute(
+        "INSERT INTO confidence_shadow_observations
+            (memory_id, namespace, source, caller_confidence,
+             derived_confidence, signals, recall_outcome, observed_at)
+         VALUES (?1, 'ns-cov16-1d', 'user', 0.9, 0.7, '{}', NULL, ?2)",
+        rusqlite::params![&m_stale.id, &stale_at],
+    )
+    .expect("backdate stale");
+
+    let report = calibrate_from_shadow(&conn, 1, Utc::now()).expect("calibrate");
+    assert_eq!(report.window_days, 1, "window_days echoes the input");
+    assert_eq!(
+        report.total_observations, 1,
+        "only the fresh observation falls inside the 1-day window",
+    );
+    let user = report
+        .baselines
+        .iter()
+        .find(|b| b.source == "user")
+        .expect("user baseline");
+    // Only the 0.5 sample contributed; median == 0.5.
+    assert!((user.median - 0.5).abs() < 1e-6, "got {}", user.median);
+}
+
+/// COV-16b — `days=3650` (10 years) is accepted verbatim. The substrate
+/// does NOT clamp at any internal MAX_WINDOW; the SQL `observed_at >=
+/// now - 3650 days` predicate keeps every observation in scope. Pinning
+/// the no-clamp contract so a future tightening lands as a visible diff.
+#[test]
+fn calibrate_with_days_3650_clamps_at_max() {
+    let (_tmp, conn) = fresh_db();
+    let m = fixture_memory("ns-cov16-10y", "old");
+    db::insert(&conn, &m).expect("insert");
+
+    // Insert an observation 9 years (3285 days) ago — well outside any
+    // reasonable shorter window, but inside a 3650-day window.
+    let very_old = (Utc::now() - chrono::Duration::days(3285)).to_rfc3339();
+    conn.execute(
+        "INSERT INTO confidence_shadow_observations
+            (memory_id, namespace, source, caller_confidence,
+             derived_confidence, signals, recall_outcome, observed_at)
+         VALUES (?1, 'ns-cov16-10y', 'user', 0.9, 0.42, '{}', NULL, ?2)",
+        rusqlite::params![&m.id, &very_old],
+    )
+    .expect("insert old observation");
+
+    let report = calibrate_from_shadow(&conn, 3650, Utc::now()).expect("calibrate");
+    assert_eq!(
+        report.window_days, 3650,
+        "window_days is echoed verbatim (no clamp)",
+    );
+    assert_eq!(
+        report.total_observations, 1,
+        "9-year-old observation falls inside the 10-year window",
+    );
+    let baseline = &report.baselines[0];
+    assert_eq!(baseline.namespace, "ns-cov16-10y");
+    assert_eq!(baseline.source, "user");
+    assert!((baseline.median - 0.42).abs() < 1e-6);
+
+    // Sanity: the same observation falls OUT of a tighter window so the
+    // assertion above genuinely exercises the wide-window code path
+    // (rather than tautologically passing because the SQL ignores days).
+    let tight = calibrate_from_shadow(&conn, 30, Utc::now()).expect("calibrate tight");
+    assert_eq!(
+        tight.total_observations, 0,
+        "9-year-old observation must fall outside a 30-day window",
+    );
+}
+
+/// COV-16c — `days=0` collapses the window to "since now". Observations
+/// stamped strictly in the past fall outside; the report comes back
+/// empty rather than erroring. This is the substrate's opt-out shape
+/// (mirrors `gc_observations(retention_days=0)` no-op semantics in test
+/// `shadow_observations_gc_sweeper_drops_old_rows` above).
+#[test]
+fn calibrate_with_days_0_rejects_or_returns_empty() {
+    let (_tmp, conn) = fresh_db();
+    let m = fixture_memory("ns-cov16-zero", "any");
+    db::insert(&conn, &m).expect("insert");
+
+    let s = ConfidenceSignals::default();
+    // A real observation stamped a few seconds ago.
+    observe(&conn, &m.id, "ns-cov16-zero", "user", 0.9, 0.55, &s, None).expect("observe");
+
+    let report = calibrate_from_shadow(&conn, 0, Utc::now()).expect("calibrate days=0");
+    assert_eq!(report.window_days, 0, "window_days echoes the input");
+    assert_eq!(
+        report.total_observations, 0,
+        "days=0 collapses the window — no observations contribute",
+    );
+    assert!(
+        report.baselines.is_empty(),
+        "days=0 returns an empty baselines list (opt-out shape)",
+    );
+}
+
 #[test]
 fn shadow_observe_uses_cached_config() {
     // Pre-Cluster-G, every `shadow_enabled()` / `sample_rate()` call


### PR DESCRIPTION
## Summary

Four test-only additions against the already-shipped v0.7.0 substrate, closing the COV-15..18 line items in the polish #783 punchlist. No source files modified.

- **COV-15** — `tests/form_1_synthesis_verdict_matrix.rs`: combinatorial fan-out of the 4 synthesis verbs (`add` / `update` / `delete` / `no_op`) across 5 candidate counts (1, 2, 3, 4, 5) = **20 #[test] functions**, one per (verb, n) cell so a regression pinpoints the exact pair. Brief listed 1, 2, 3, 5, 10; range capped at 5 because `storage::find_contradictions` is hard-limited to `LIMIT 5` rows in the pre-filter (src/storage/mod.rs:1995). The test header documents this so a future LIMIT bump can grow the matrix in lockstep.
- **COV-16** — `tests/form_5_confidence_calibration.rs` (3 new tests): `calibrate_with_days_1_returns_single_day_window`, `calibrate_with_days_3650_clamps_at_max` (the substrate does NOT clamp — pinned as no-clamp; a future tightening lands as a visible diff), `calibrate_with_days_0_rejects_or_returns_empty` (collapses window to empty baselines, matching `gc_observations(retention_days=0)` opt-out semantics).
- **COV-17** — `tests/cov_17_skills_federation_roundtrip.rs` (2 new tests): register-on-A → export-folder → import-on-fresh-peer-B → resource resolution + digest equality on B. `src/federation/*` does not yet carry the `skills` / `skill_resources` tables; the export folder is the substrate-side interchange shape an eventual federation skill-fanout will ride on top of, so the wire format is what's being pinned.
- **COV-18** — `tests/cov_18_offload_ttl_postgres.rs` (1 test, postgres-gated): mirrors the sqlite `sweep_expired` semantics in pg dialect. Inserts 10 backdated + 5 fresh + 3 permanent + 2 cross-namespace rows, runs the equivalent `DELETE WHERE ttl_seconds IS NOT NULL AND (stored_at + ttl_seconds) < $1` predicate, asserts row lifecycle, sweep idempotency, and the v34 `idx_offloaded_blobs_ttl` partial-index presence. Self-skips when `AI_MEMORY_TEST_POSTGRES_URL` is unset.

## Real bugs surfaced

None. The substrate honoured every verdict, every calibration window, every skill round-trip, and every TTL sweep predicate per its existing contract. The only behavioural finding worth recording is the `LIMIT 5` pre-filter cap on synthesis candidates (already documented substrate property, not a bug — annotated in the matrix file's header).

## Hard constraints honoured

- TEST FILES ONLY — no source changes.
- Tool count + schema baselines preserved (no `tool_definitions()` / migration touches).
- COV-18 self-skips when `AI_MEMORY_TEST_POSTGRES_URL` is unset.

## Gates 4/4 green

- `cargo fmt --check`
- `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic`
- `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --lib` — 4214 passed
- `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --test form_1_synthesis_verdict_matrix --test form_5_confidence_calibration --test cov_17_skills_federation_roundtrip --test cov_18_offload_ttl_postgres` — 40 passed (20 + 17 + 2 + 1; the 17 in `form_5` includes the 3 new COV-16 tests + the 14 pre-existing)
- `cargo audit` — 0 advisories

## Test plan

- [x] All 20 COV-15 matrix cells pass against the as-shipped substrate.
- [x] COV-16 days=1 / days=3650 / days=0 boundaries pinned.
- [x] COV-17 round-trip preserves digest + resolves both resource kinds on the peer DB.
- [x] COV-18 self-skips cleanly when `AI_MEMORY_TEST_POSTGRES_URL` is unset (verified in this PR's local run).
- [ ] Re-run COV-18 against a live postgres scratch (CI lane should pick this up via `cluster-I` infra).

## AI involvement

Authored by Claude (Opus 4.7, 1M context) under the operator's polish-783 brief. Operator selected scope (COV-15..18), constraints (test-only, no source touches), and gate definitions; agent executed substrate exploration, test authoring, lint resolution, and gate verification. Substrate behaviour pins discovered during authoring (e.g. `LIMIT 5` pre-filter cap) annotated inline in test file headers so future agents inherit the context.

Closes #783

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)