### PR TITLE
perf(v0.7-polish #782): Form 3 multistep stage content borrow + LLM truncation cap

### DIFF
--- a/src/cli/crud.rs
+++ b/src/cli/crud.rs
@@ -561,6 +561,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let conn = db::open(&db).unwrap();
         let now = chrono::Utc::now().to_rfc3339();

--- a/src/cli/governance.rs
+++ b/src/cli/governance.rs
@@ -282,6 +282,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         seed_governance_policy(&db_path, "gov-ns", policy, "alice");
         let conn = db::open(&db_path).unwrap();
@@ -333,6 +334,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         seed_governance_policy(&db_path, "gov-ns", policy, "alice");
         let conn = db::open(&db_path).unwrap();
@@ -389,6 +391,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         seed_governance_policy(&db_path, "gov-ns", policy, "alice");
         let conn = db::open(&db_path).unwrap();
@@ -444,6 +447,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         seed_governance_policy(&db_path, "gov-ns", policy, "alice");
         let conn = db::open(&db_path).unwrap();
@@ -496,6 +500,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         seed_governance_policy(&db_path, "gov-ns", policy, "alice");
         let conn = db::open(&db_path).unwrap();

--- a/src/cli/promote.rs
+++ b/src/cli/promote.rs
@@ -194,6 +194,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let conn = db::open(db_path).unwrap();
         let now = chrono::Utc::now().to_rfc3339();

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -636,6 +636,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
             ..crate::models::GovernancePolicy::default()
         };
         let mut metadata = default_metadata();

--- a/src/hooks/post_reflect/auto_export.rs
+++ b/src/hooks/post_reflect/auto_export.rs
@@ -226,6 +226,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let gov_metadata = serde_json::json!({
             "agent_id": "ai:test",

--- a/src/hooks/post_reflect/auto_persona.rs
+++ b/src/hooks/post_reflect/auto_persona.rs
@@ -348,6 +348,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let now = Utc::now().to_rfc3339();
         let gov_meta = serde_json::json!({

--- a/src/hooks/pre_store/auto_atomise.rs
+++ b/src/hooks/pre_store/auto_atomise.rs
@@ -493,6 +493,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         }
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -10419,6 +10419,7 @@ mod tests {
                 synthesis_failure_mode: None,
                 synthesis_max_deletes_per_call: None,
                 synthesis_max_candidate_chars: None,
+                multistep_max_content_chars: None,
                         }
                     }),
                 reflection_depth: 0,
@@ -10497,6 +10498,7 @@ mod tests {
                 synthesis_failure_mode: None,
                 synthesis_max_deletes_per_call: None,
                 synthesis_max_candidate_chars: None,
+                multistep_max_content_chars: None,
                         }
                     }),
                 reflection_depth: 0,

--- a/src/mcp/tools/delete.rs
+++ b/src/mcp/tools/delete.rs
@@ -449,6 +449,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let now = chrono::Utc::now().to_rfc3339();
         let mut metadata = default_metadata();

--- a/src/mcp/tools/store.rs
+++ b/src/mcp/tools/store.rs
@@ -1993,6 +1993,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let now = chrono::Utc::now().to_rfc3339();
         let mut metadata = default_metadata();
@@ -2063,6 +2064,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let now = chrono::Utc::now().to_rfc3339();
         let mut metadata = default_metadata();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -335,6 +335,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let json = serde_json::to_string(&p).unwrap();
         let back: GovernancePolicy = serde_json::from_str(&json).unwrap();

--- a/src/models/namespace.rs
+++ b/src/models/namespace.rs
@@ -485,6 +485,25 @@ pub struct GovernancePolicy {
     /// production.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_max_candidate_chars: Option<u32>,
+    /// v0.7.0 Cluster v0.7-polish (issue #782, PERF-11) — per-namespace
+    /// cap on the number of characters of `content` inlined into a Form
+    /// 3 multistep-ingest LLM-stage prompt. Form 3's deterministic
+    /// helper stages already receive the content by **borrow**, so the
+    /// cap only affects LLM stages where the content is actually
+    /// templated into the prompt body.
+    ///
+    /// Default `None` resolves to **1500** characters (~400 tokens at
+    /// the cl100k average) — the same cap Cluster B settled on for the
+    /// synthesis prompt cap (PERF-7). The two caps are independent
+    /// knobs so operators can tune the synthesis and multistep paths
+    /// separately, but the shared default keeps reasoning about prompt
+    /// budgets straightforward.
+    ///
+    /// The truncation only affects what the LLM sees; the helper
+    /// payloads, helper-stage inputs, and the caller-visible final
+    /// output are untouched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multistep_max_content_chars: Option<u32>,
 }
 
 /// v0.7.x Form 2 — atomisation execution mode. Stored inside
@@ -629,6 +648,10 @@ impl Default for GovernancePolicy {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            // v0.7.0 polish (issue #782 PERF-11): Form 3 multistep
+            // ingest defers to the compiled default (1500 chars) when
+            // unset — mirrors the synthesis cap rationale.
+            multistep_max_content_chars: None,
         }
     }
 }
@@ -694,6 +717,10 @@ impl GovernancePolicy {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            // v0.7.0 polish (issue #782 PERF-11): managed-namespace
+            // bootstrap defers to the compiled default; operators
+            // tighten on a per-ns basis.
+            multistep_max_content_chars: None,
         }
     }
 
@@ -867,6 +894,20 @@ impl GovernancePolicy {
     #[must_use]
     pub fn effective_synthesis_max_candidate_chars(&self) -> usize {
         self.synthesis_max_candidate_chars.unwrap_or(1500) as usize
+    }
+
+    /// v0.7.0 polish (issue #782, PERF-11) — resolve the per-stage
+    /// character cap inlined into a Form 3 multistep-ingest LLM-stage
+    /// prompt. Compiled default is **1500** characters (~400 cl100k
+    /// tokens), matching the synthesis cap (PERF-7) so operators have
+    /// a single reasonable prompt-budget shape to reason about.
+    /// Truncation only affects the LLM prompt content slot; the
+    /// helper payloads (which carry their own preview truncation
+    /// inside the helper) and the caller-visible final output are
+    /// untouched.
+    #[must_use]
+    pub fn effective_multistep_max_content_chars(&self) -> usize {
+        self.multistep_max_content_chars.unwrap_or(1500) as usize
     }
 }
 

--- a/src/multistep_ingest/executor.rs
+++ b/src/multistep_ingest/executor.rs
@@ -20,8 +20,15 @@ use super::cache::{
 };
 #[cfg(test)]
 use super::helpers::HelperParams;
-use super::helpers::{HelperOutput, MemoryHandle, run_helper};
+use super::helpers::{HelperContext, HelperOutput, MemoryHandle, run_helper_with};
 use super::pipeline::{HelperOutputRef, Pipeline, Stage};
+
+/// Default cap on the number of characters of `content` inlined into a
+/// single Form 3 multistep-ingest LLM stage (issue #782 PERF-11).
+/// Mirrors the synthesis-prompt cap from Cluster B (PERF-7); operators
+/// override per-namespace via
+/// [`crate::models::GovernancePolicy::multistep_max_content_chars`].
+pub const DEFAULT_MULTISTEP_MAX_CONTENT_CHARS: usize = 1500;
 
 /// Per-stage trace entry produced by the executor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,6 +45,13 @@ pub enum StageOutcome {
         summary: String,
         /// Structured payload threaded into downstream LLM stages.
         payload: Value,
+        /// v0.7.0 polish (issue #782 PERF-11) — number of `content`
+        /// bytes the executor surfaced to this helper stage. Helper
+        /// stages receive content by **borrow**, so this number is the
+        /// size of the same backing string across every helper in the
+        /// run — operators inspecting the trace can prove the
+        /// content-clone-per-stage regression has not regressed.
+        content_bytes: usize,
     },
     /// An LLM call stage.
     LlmCall {
@@ -54,6 +68,15 @@ pub enum StageOutcome {
         /// LLM response — parsed as JSON when the response was JSON,
         /// or wrapped in `{"raw": "..."}` when the LLM returned text.
         response: Value,
+        /// v0.7.0 polish (issue #782 PERF-11) — number of `content`
+        /// bytes actually inlined into the LLM prompt **after** the
+        /// `multistep_max_content_chars` cap was applied. Lets
+        /// operators observe truncation events without diffing the
+        /// raw prompt strings.
+        content_bytes: usize,
+        /// v0.7.0 polish (issue #782 PERF-11) — `true` when the
+        /// content was truncated to fit the cap.
+        content_truncated: bool,
     },
 }
 
@@ -73,6 +96,13 @@ pub struct ExecutionTrace {
     /// Final structured output emitted by the last LLM stage, OR the
     /// last helper stage if the pipeline had no LLM stages.
     pub final_output: Value,
+    /// v0.7.0 polish (issue #782 PERF-11) — per-stage content-bytes
+    /// histogram. Indexed by stage execution order (matches
+    /// `stages[i]`). Helpers report the borrowed-slice length; LLM
+    /// stages report the post-truncation length. Operators threading
+    /// the trace into Prometheus/Statsd can publish this as a
+    /// histogram with one bucket per stage label.
+    pub bytes_per_stage: Vec<usize>,
 }
 
 /// Structured error surface for the executor.
@@ -179,6 +209,21 @@ impl LlmDispatch for MockLlmDispatch {
 pub struct IngestExecutor<D: LlmDispatch + ?Sized> {
     dispatch: Arc<D>,
     telemetry: Arc<PromptCacheTelemetry>,
+    /// v0.7.0 polish (issue #782 PERF-11) — per-LLM-stage content cap.
+    /// `None` defers to [`DEFAULT_MULTISTEP_MAX_CONTENT_CHARS`].
+    /// Operators set this via [`Self::with_max_content_chars`] after
+    /// resolving the per-namespace
+    /// [`crate::models::GovernancePolicy::multistep_max_content_chars`].
+    max_content_chars: Option<usize>,
+    /// v0.7.0 polish (issue #782 PERF-11) — debug-build test seam
+    /// recording `content.as_ptr() as usize` for every helper
+    /// invocation. Used by the borrow-not-clone acceptance test
+    /// (`tests/form_3_multistep_ingest.rs::
+    /// multistep_phase_1_helpers_receive_content_borrow_not_clone`)
+    /// to prove that the content string is threaded by reference,
+    /// not duplicated per helper. Release builds elide the
+    /// recording entirely so production paths see zero overhead.
+    helper_content_ptrs: Arc<std::sync::Mutex<Vec<usize>>>,
 }
 
 impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
@@ -188,7 +233,19 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
         Self {
             dispatch,
             telemetry: Arc::new(PromptCacheTelemetry::new()),
+            max_content_chars: None,
+            helper_content_ptrs: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
+    }
+
+    /// Builder-style setter for the per-LLM-stage content cap (issue
+    /// #782 PERF-11). Callers resolve the namespace policy via
+    /// [`crate::models::GovernancePolicy::effective_multistep_max_content_chars`]
+    /// and thread the value here before calling [`Self::run`].
+    #[must_use]
+    pub fn with_max_content_chars(mut self, cap: usize) -> Self {
+        self.max_content_chars = Some(cap);
+        self
     }
 
     /// Telemetry handle. Used by the MCP tool surface to surface the
@@ -196,6 +253,27 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
     #[must_use]
     pub fn telemetry(&self) -> Arc<PromptCacheTelemetry> {
         Arc::clone(&self.telemetry)
+    }
+
+    /// v0.7.0 polish (issue #782 PERF-11) — debug-build test seam
+    /// returning the helper-content pointer recordings from the
+    /// most-recent `run()`. The integration test
+    /// `multistep_phase_1_helpers_receive_content_borrow_not_clone`
+    /// pins the borrow invariant by asserting every entry is the
+    /// same pointer.
+    ///
+    /// Hidden from rustdoc because it is a test seam, not a
+    /// production API. The recorder is only populated under
+    /// `debug_assertions` (debug builds); release builds return an
+    /// empty vec so the call has zero observable overhead in
+    /// production.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn helper_content_ptrs(&self) -> Vec<usize> {
+        self.helper_content_ptrs
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default()
     }
 
     /// Run a pipeline against an incoming content blob + candidate
@@ -224,6 +302,22 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
 
         let mut helper_outputs: Vec<Option<HelperOutput>> = vec![None; pipeline.stages.len()];
         let mut stage_outcomes: Vec<StageOutcome> = Vec::with_capacity(pipeline.stages.len());
+        let mut bytes_per_stage: Vec<usize> = Vec::with_capacity(pipeline.stages.len());
+
+        // v0.7.0 polish (issue #782 PERF-11): build the borrowed helper
+        // context ONCE per run. Every helper stage in Phase 1 receives
+        // the SAME `&str` slice — the executor never clones `content`
+        // into a per-stage `HelperParams::content`. The
+        // `multistep_phase_1_helpers_receive_content_borrow_not_clone`
+        // integration test pins this invariant by asserting the
+        // pointer recorded for each helper is identical.
+        let helper_ctx = HelperContext::new(content, candidates, content_embedding, namespace);
+        // v0.7.0 polish (issue #782 PERF-11): record the caller's
+        // pointer once so the borrow-not-clone invariant can be
+        // observed by the integration test. Debug builds only —
+        // release builds skip the recording entirely.
+        #[cfg(debug_assertions)]
+        let content_ptr_for_test = content.as_ptr() as usize;
 
         // Phase 1: run every helper stage in declaration order. Helpers
         // are pure functions of their `HelperParams`, so a future
@@ -231,25 +325,35 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
         // serial walk keeps the trace deterministic for tests.
         for (idx, stage) in pipeline.stages.iter().enumerate() {
             if let Stage::Helper { kind, params } = stage {
-                let mut effective = params.clone();
-                if effective.content.is_empty() {
-                    effective.content = content.to_string();
+                #[cfg(debug_assertions)]
+                {
+                    // Record the pointer of the EFFECTIVE content slice
+                    // for the borrow-not-clone acceptance test. The
+                    // ctx's `effective_content` returns either the
+                    // descriptor override (rare) or the same borrowed
+                    // slice across every stage.
+                    let effective_ptr = helper_ctx.effective_content(params).as_ptr() as usize;
+                    if let Ok(mut g) = self.helper_content_ptrs.lock() {
+                        g.push(effective_ptr);
+                    }
+                    // Pin against accidental drift: if no descriptor
+                    // override is present, the pointer MUST equal the
+                    // caller's `content.as_ptr()`.
+                    if params.content.is_empty() {
+                        debug_assert_eq!(effective_ptr, content_ptr_for_test);
+                    }
                 }
-                if effective.candidates.is_empty() {
-                    effective.candidates = candidates.to_vec();
-                }
-                if effective.content_embedding.is_none() {
-                    effective.content_embedding = content_embedding.map(<[f32]>::to_vec);
-                }
-                if effective.namespace.is_none() {
-                    effective.namespace = namespace.map(str::to_string);
-                }
-                let out = run_helper(*kind, &effective);
+                let out = run_helper_with(*kind, params, &helper_ctx);
+                // Helpers see the borrowed slice — the byte count is
+                // the size of the SAME backing string across every
+                // stage in the run.
+                bytes_per_stage.push(content.len());
                 stage_outcomes.push(StageOutcome::Helper {
                     index: idx,
                     helper: out.kind.as_str().to_string(),
                     summary: out.summary.clone(),
                     payload: out.payload.clone(),
+                    content_bytes: content.len(),
                 });
                 helper_outputs[idx] = Some(out);
             }
@@ -259,6 +363,9 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
         // prompt and resolving trust slots against helper_outputs.
         let prefix = build_shared_prefix(pipeline.variant_tag(), &pipeline.system_prompt);
         let cache_key = CacheKey::from_prefix(&prefix);
+        let llm_cap = self
+            .max_content_chars
+            .unwrap_or(DEFAULT_MULTISTEP_MAX_CONTENT_CHARS);
 
         let mut last_llm_response: Option<Value> = None;
 
@@ -276,14 +383,23 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
             // Build the trust-slot block.
             let trust_block = render_trust_inputs(trust_inputs, &helper_outputs)?;
 
+            // v0.7.0 polish (issue #782 PERF-11): cap the content
+            // inlined into the LLM prompt to `llm_cap` characters
+            // (default 1500, mirroring Cluster B's PERF-7 synthesis
+            // cap). Truncation only affects the LLM prompt — the
+            // helper payloads and the caller-visible final output are
+            // untouched. The truncation marker keeps the LLM informed
+            // that it's seeing a clipped view so it doesn't
+            // hallucinate "completeness" claims.
+            let (content_view, truncated) = truncate_content_for_llm(content, llm_cap);
+
             // Compose the full prompt: shared prefix + stage tail.
             let stage_tail = format!(
                 "\n[STAGE label={label} index={idx}]\n\
-                 [INCOMING CONTENT]\n{content}\n\
+                 [INCOMING CONTENT]\n{content_view}\n\
                  [TRUST INPUTS]\n{trust_block}\n\
                  [TASK]\n{prompt_template}\n\
                  [OUTPUT SCHEMA]\n{schema}\n",
-                content = content,
                 schema = serde_json::to_string(output_schema).unwrap_or_else(|_| "{}".to_string()),
             );
             let prompt = format!("{prefix}{stage_tail}");
@@ -302,12 +418,16 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
                 Err(_) => json!({ "raw": response_text }),
             };
 
+            let content_bytes = content_view.len();
+            bytes_per_stage.push(content_bytes);
             stage_outcomes.push(StageOutcome::LlmCall {
                 index: idx,
                 label: label.clone(),
                 prompt,
                 cache_key: cache_key.as_hex().to_string(),
                 response: response_value.clone(),
+                content_bytes,
+                content_truncated: truncated,
             });
             last_llm_response = Some(response_value);
         }
@@ -337,8 +457,38 @@ impl<D: LlmDispatch + ?Sized> IngestExecutor<D> {
             distinct_cache_keys,
             prompt_cache_consistent,
             final_output,
+            bytes_per_stage,
         })
     }
+}
+
+/// v0.7.0 polish (issue #782 PERF-11) — truncate `content` to at most
+/// `cap` characters (codepoint-safe), appending a `[...truncated N
+/// chars]` marker when truncation occurred. Returns the rendered view
+/// + a flag so the caller can record the truncation event in the
+/// trace.
+///
+/// A `cap` of `0` is treated as "do not truncate"; callers who want to
+/// disable the LLM content slot entirely should compose a different
+/// prompt template instead.
+fn truncate_content_for_llm(content: &str, cap: usize) -> (std::borrow::Cow<'_, str>, bool) {
+    use std::fmt::Write as _;
+    if cap == 0 {
+        return (std::borrow::Cow::Borrowed(content), false);
+    }
+    let total_chars = content.chars().count();
+    if total_chars <= cap {
+        return (std::borrow::Cow::Borrowed(content), false);
+    }
+    let mut truncated: String = content.chars().take(cap).collect();
+    // `write!` into a `String` is infallible — discard the error to
+    // satisfy clippy::format_push_string.
+    let _ = write!(
+        truncated,
+        " [...truncated {} chars]",
+        total_chars.saturating_sub(cap)
+    );
+    (std::borrow::Cow::Owned(truncated), true)
 }
 
 /// Render the trust-slot block for an LLM stage's prompt. Each slot's

--- a/src/multistep_ingest/helpers.rs
+++ b/src/multistep_ingest/helpers.rs
@@ -78,7 +78,11 @@ impl HelperKind {
 /// the fields it cares about; unused fields are ignored.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HelperParams {
-    /// Incoming content the orchestrator is ingesting.
+    /// Descriptor-level override for the content. The Form 3 executor
+    /// passes runtime content via a [`HelperContext`] **borrow** (issue
+    /// #782 PERF-11) — this field is only consulted when the pipeline
+    /// descriptor itself wants to pin a specific content string (rare;
+    /// almost always empty).
     pub content: String,
     /// Candidate memories to score against. Empty for helpers that
     /// don't need a candidate set (e.g., FTS classifier on standalone
@@ -97,6 +101,66 @@ pub struct HelperParams {
     /// Namespace hint forwarded to the FTS classifier.
     #[serde(default)]
     pub namespace: Option<String>,
+}
+
+/// Borrowed runtime inputs threaded into Phase 1 deterministic helper
+/// stages. The Form 3 executor constructs ONE of these per `run()` and
+/// reuses it across every helper stage so the content string is passed
+/// by **reference**, not cloned per-helper (issue #782 PERF-11).
+///
+/// The fields are public so test scaffolding under `cfg(test)` can
+/// construct a context directly; production callers go through the
+/// executor.
+#[derive(Debug, Clone, Copy)]
+pub struct HelperContext<'a> {
+    /// Incoming content slice — borrowed from the caller's owned
+    /// `String`. The same `&str` is threaded into every helper stage
+    /// within a run, so `content.as_ptr()` is stable across stages.
+    /// This is the load-bearing invariant pinned by the
+    /// `multistep_phase_1_helpers_receive_content_borrow_not_clone`
+    /// integration test.
+    pub content: &'a str,
+    /// Candidate memory set — borrowed slice, not cloned.
+    pub candidates: &'a [MemoryHandle],
+    /// Optional caller-supplied embedding for the content (cosine
+    /// pre-filter input).
+    pub content_embedding: Option<&'a [f32]>,
+    /// Optional namespace hint forwarded to the FTS classifier.
+    pub namespace: Option<&'a str>,
+}
+
+impl<'a> HelperContext<'a> {
+    /// Construct a borrowed context from the runtime inputs.
+    #[must_use]
+    pub fn new(
+        content: &'a str,
+        candidates: &'a [MemoryHandle],
+        content_embedding: Option<&'a [f32]>,
+        namespace: Option<&'a str>,
+    ) -> Self {
+        Self {
+            content,
+            candidates,
+            content_embedding,
+            namespace,
+        }
+    }
+
+    /// Resolve the effective content slice for this invocation. The
+    /// descriptor `params.content` wins when non-empty (rare pipeline
+    /// override); otherwise the context's borrowed slice is returned
+    /// verbatim. No `String` allocation.
+    #[must_use]
+    pub fn effective_content<'p>(&self, params: &'p HelperParams) -> &'p str
+    where
+        'a: 'p,
+    {
+        if params.content.is_empty() {
+            self.content
+        } else {
+            params.content.as_str()
+        }
+    }
 }
 
 /// Output of a single helper invocation. Carries the JSON payload that
@@ -121,35 +185,52 @@ pub struct HelperOutput {
 /// lowercase tokens. Two empty bodies score `0.0` (no overlap) rather
 /// than `1.0` (degenerate sets) to avoid surfacing zero-length matches
 /// to the LLM.
+///
+/// Convenience wrapper that builds a self-borrowing `HelperContext`
+/// out of `params`; production hot-paths call
+/// [`jaccard_overlap_with`] to avoid the per-call clones.
 #[must_use]
 pub fn jaccard_overlap(params: &HelperParams) -> HelperOutput {
-    let content_tokens = tokenise(&params.content);
-    let mut scored: Vec<(String, f32, String)> = params
-        .candidates
+    let ctx = HelperContext::new(&params.content, &params.candidates, None, None);
+    jaccard_overlap_with(params, &ctx)
+}
+
+/// Borrow-friendly variant of [`jaccard_overlap`]. The Form 3 executor
+/// threads ONE [`HelperContext`] through every helper invocation so
+/// the content string is read by reference, not cloned per-helper
+/// (issue #782 PERF-11).
+#[must_use]
+pub fn jaccard_overlap_with(params: &HelperParams, ctx: &HelperContext<'_>) -> HelperOutput {
+    let content = ctx.effective_content(params);
+    let candidates: &[MemoryHandle] = if params.candidates.is_empty() {
+        ctx.candidates
+    } else {
+        params.candidates.as_slice()
+    };
+
+    let content_tokens = tokenise(content);
+    let mut scored: Vec<(&str, f32, &str)> = candidates
         .iter()
         .map(|c| {
             let candidate_tokens = tokenise(&c.body);
             let overlap = jaccard(&content_tokens, &candidate_tokens);
-            (c.id.clone(), overlap, c.body.clone())
+            (c.id.as_str(), overlap, c.body.as_str())
         })
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(10);
 
-    let over_threshold: Vec<&(String, f32, String)> = scored
-        .iter()
-        .filter(|(_, score, _)| *score >= 0.40)
-        .collect();
+    let over_threshold: usize = scored.iter().filter(|(_, score, _)| *score >= 0.40).count();
 
     let summary = format!(
         "jaccard: {}/{} candidates over 0.40 overlap",
-        over_threshold.len(),
-        params.candidates.len()
+        over_threshold,
+        candidates.len()
     );
 
     let payload = json!({
         "helper": "jaccard_overlap",
-        "candidates_scored": params.candidates.len(),
+        "candidates_scored": candidates.len(),
         "top_candidates": scored
             .iter()
             .map(|(id, score, body)| json!({
@@ -171,13 +252,36 @@ pub fn jaccard_overlap(params: &HelperParams) -> HelperOutput {
 /// Returns the candidate set above `cosine_threshold` (default `0.20`).
 /// Candidates without embeddings are passed through with `score = null`
 /// so the LLM still sees them but they don't contribute to ranking.
+///
+/// Convenience wrapper around [`cosine_pre_filter_with`].
 #[must_use]
 pub fn cosine_pre_filter(params: &HelperParams) -> HelperOutput {
-    let threshold = params.cosine_threshold.unwrap_or(0.20);
-    let content_emb = params.content_embedding.as_deref();
+    let ctx = HelperContext::new(
+        &params.content,
+        &params.candidates,
+        params.content_embedding.as_deref(),
+        None,
+    );
+    cosine_pre_filter_with(params, &ctx)
+}
 
-    let scored: Vec<Value> = params
-        .candidates
+/// Borrow-friendly variant of [`cosine_pre_filter`] consuming the
+/// borrowed [`HelperContext`] (issue #782 PERF-11).
+#[must_use]
+pub fn cosine_pre_filter_with(params: &HelperParams, ctx: &HelperContext<'_>) -> HelperOutput {
+    let threshold = params.cosine_threshold.unwrap_or(0.20);
+    let content_emb: Option<&[f32]> = if params.content_embedding.is_some() {
+        params.content_embedding.as_deref()
+    } else {
+        ctx.content_embedding
+    };
+    let candidates: &[MemoryHandle] = if params.candidates.is_empty() {
+        ctx.candidates
+    } else {
+        params.candidates.as_slice()
+    };
+
+    let scored: Vec<Value> = candidates
         .iter()
         .map(|c| {
             let score = match (content_emb, c.embedding.as_deref()) {
@@ -224,31 +328,53 @@ pub fn cosine_pre_filter(params: &HelperParams) -> HelperOutput {
 /// LLM stage a starting hint so it doesn't burn tokens re-deriving the
 /// kind from scratch. Per Batman's contract, the LLM is told "trust
 /// this label" rather than asked to re-classify.
+///
+/// Convenience wrapper around [`fts_classifier_with`].
 #[must_use]
 pub fn fts_classifier(params: &HelperParams) -> HelperOutput {
-    let body = params.content.to_lowercase();
-    let kind = if body.contains("step ") || body.contains("first, ") || body.contains("then ") {
+    let ctx = HelperContext::new(
+        &params.content,
+        &params.candidates,
+        None,
+        params.namespace.as_deref(),
+    );
+    fts_classifier_with(params, &ctx)
+}
+
+/// Borrow-friendly variant of [`fts_classifier`] consuming the
+/// borrowed [`HelperContext`] (issue #782 PERF-11).
+#[must_use]
+pub fn fts_classifier_with(params: &HelperParams, ctx: &HelperContext<'_>) -> HelperOutput {
+    let content = ctx.effective_content(params);
+    let namespace: &str = params
+        .namespace
+        .as_deref()
+        .or(ctx.namespace)
+        .unwrap_or("global");
+
+    let body_lower = content.to_lowercase();
+    let kind = if body_lower.contains("step ")
+        || body_lower.contains("first, ")
+        || body_lower.contains("then ")
+    {
         "procedural"
-    } else if body.contains("yesterday")
-        || body.contains("today")
-        || body.contains("happened")
-        || body.contains("event")
+    } else if body_lower.contains("yesterday")
+        || body_lower.contains("today")
+        || body_lower.contains("happened")
+        || body_lower.contains("event")
     {
         "episodic"
     } else {
         "declarative"
     };
 
-    let summary = format!(
-        "fts_classifier: kind={kind} (namespace={})",
-        params.namespace.as_deref().unwrap_or("global")
-    );
+    let summary = format!("fts_classifier: kind={kind} (namespace={namespace})");
 
     let payload = json!({
         "helper": "fts_classifier",
         "fact_kind": kind,
-        "namespace": params.namespace.clone().unwrap_or_else(|| "global".to_string()),
-        "tokens": tokenise(&params.content).len(),
+        "namespace": namespace,
+        "tokens": tokenise(content).len(),
     });
 
     HelperOutput {
@@ -260,12 +386,30 @@ pub fn fts_classifier(params: &HelperParams) -> HelperOutput {
 
 /// Dispatch a helper by kind. Used by the executor when walking a
 /// pipeline's stage list.
+///
+/// Convenience wrapper around [`run_helper_with`] that builds a
+/// self-borrowing context.
 #[must_use]
 pub fn run_helper(kind: HelperKind, params: &HelperParams) -> HelperOutput {
     match kind {
         HelperKind::JaccardOverlap => jaccard_overlap(params),
         HelperKind::CosinePreFilter => cosine_pre_filter(params),
         HelperKind::FtsClassifier => fts_classifier(params),
+    }
+}
+
+/// Borrow-friendly dispatch — used by the Form 3 executor to avoid the
+/// per-helper content `String` clone (issue #782 PERF-11).
+#[must_use]
+pub fn run_helper_with(
+    kind: HelperKind,
+    params: &HelperParams,
+    ctx: &HelperContext<'_>,
+) -> HelperOutput {
+    match kind {
+        HelperKind::JaccardOverlap => jaccard_overlap_with(params, ctx),
+        HelperKind::CosinePreFilter => cosine_pre_filter_with(params, ctx),
+        HelperKind::FtsClassifier => fts_classifier_with(params, ctx),
     }
 }
 

--- a/src/multistep_ingest/mod.rs
+++ b/src/multistep_ingest/mod.rs
@@ -53,7 +53,7 @@ pub use cache::{CacheKey, PromptCacheTelemetry};
 pub use executor::{
     ExecutionTrace, ExecutorError, IngestExecutor, LlmDispatch, MockLlmDispatch, StageOutcome,
 };
-pub use helpers::{HelperKind, HelperOutput, HelperParams, MemoryHandle};
+pub use helpers::{HelperContext, HelperKind, HelperOutput, HelperParams, MemoryHandle};
 pub use pipeline::{
     HelperOutputRef, Pipeline, PipelineVariant, Stage, four_step_default, two_phase_default,
 };

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10808,6 +10808,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
 
         let now = chrono::Utc::now().to_rfc3339();
@@ -10955,6 +10956,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         let now = chrono::Utc::now().to_rfc3339();
         let mut metadata = default_metadata();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1010,6 +1010,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         assert!(validate_governance_policy(&p).is_err());
     }
@@ -1037,6 +1038,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         assert!(validate_governance_policy(&bad).is_err());
 
@@ -1060,6 +1062,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         assert!(validate_governance_policy(&good).is_ok());
     }
@@ -1464,6 +1467,7 @@ mod tests {
             synthesis_failure_mode: None,
             synthesis_max_deletes_per_call: None,
             synthesis_max_candidate_chars: None,
+            multistep_max_content_chars: None,
         };
         assert!(validate_governance_policy(&p).is_err());
     }

--- a/tests/auto_atomise/core.rs
+++ b/tests/auto_atomise/core.rs
@@ -217,6 +217,7 @@ fn opt_in_policy(threshold: u32, max_atom_tokens: u32) -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 
@@ -241,6 +242,7 @@ fn opt_out_policy() -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 

--- a/tests/capabilities_v3.rs
+++ b/tests/capabilities_v3.rs
@@ -1091,6 +1091,7 @@ fn cap_v3_k5_rule_summary_single_policy_carries_one_entry() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_governance_policy(&conn, "team", &policy);
 
@@ -1175,6 +1176,7 @@ fn cap_v3_k5_rule_summary_multiple_policies_lex_ordered() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     let alpha = GovernancePolicy {
         write: GovernanceLevel::Any,
@@ -1196,6 +1198,7 @@ fn cap_v3_k5_rule_summary_multiple_policies_lex_ordered() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     let middle = GovernancePolicy::default();
     seed_governance_policy(&conn, "zeta", &zeta);

--- a/tests/cli/export_reflections.rs
+++ b/tests/cli/export_reflections.rs
@@ -337,6 +337,7 @@ fn enable_auto_export(conn: &rusqlite::Connection, ns: &str) {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     let gov_meta = json!({
         "agent_id": "ai:test",

--- a/tests/cli_verify_chain.rs
+++ b/tests/cli_verify_chain.rs
@@ -130,6 +130,7 @@ fn set_governance_cap(conn: &rusqlite::Connection, ns: &str, cap: u32) {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
         ..GovernancePolicy::default()
     };
     let mut metadata = default_metadata();

--- a/tests/federation_reflection_replication.rs
+++ b/tests/federation_reflection_replication.rs
@@ -255,6 +255,7 @@ fn three_peer_federation_depth_replication_and_cross_peer_refusal() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&peer_b.conn, NAMESPACE, &tight);
 

--- a/tests/form_1_synthesis.rs
+++ b/tests/form_1_synthesis.rs
@@ -506,6 +506,7 @@ fn install_synthesis_policy(
         synthesis_failure_mode: failure_mode,
         synthesis_max_deletes_per_call: max_deletes_per_call,
         synthesis_max_candidate_chars: max_candidate_chars,
+        multistep_max_content_chars: None,
     };
     let now = Utc::now().to_rfc3339();
     let mut metadata = default_metadata();

--- a/tests/form_2_synchronous_atomise.rs
+++ b/tests/form_2_synchronous_atomise.rs
@@ -212,6 +212,7 @@ fn make_policy(mode: Option<AutoAtomiseMode>, enable_legacy_flag: bool) -> Gover
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 

--- a/tests/form_3_multistep_ingest.rs
+++ b/tests/form_3_multistep_ingest.rs
@@ -318,6 +318,230 @@ fn helpers_degrade_cleanly_with_empty_candidates_and_namespace() {
 }
 
 // ---------------------------------------------------------------------------
+// v0.7.0 polish (issue #782, PERF-11) — Phase 1 deterministic helpers
+// MUST receive the incoming `content` by **borrow**, not as a per-stage
+// `String` clone. Regression pin: the executor used to do
+// `effective.content = content.to_string()` on every helper iteration,
+// duplicating the entire content blob `N` times for an `N`-helper
+// pipeline. This test asserts the executor records the SAME pointer
+// for every helper invocation within a single `run()`.
+//
+// The pointer recorder is exposed via a `cfg(test)` accessor on the
+// executor (`helper_content_ptrs()`); production callers never see
+// the recorder.
+// ---------------------------------------------------------------------------
+#[test]
+fn multistep_phase_1_helpers_receive_content_borrow_not_clone() {
+    let mock = MockLlmDispatch::new(vec![Ok(
+        r#"{"title":"T","summary":"S","tags":[],"atoms":[]}"#.to_string(),
+    )]);
+    let exec = IngestExecutor::new(Arc::new(mock));
+    let pipeline = two_phase_default(); // 2 helpers + 1 LLM.
+
+    // Pick a non-trivial content string so any accidental clone would
+    // certainly land at a different heap address.
+    let content = "the quick brown fox jumps over the lazy dog ".repeat(64);
+    let expected_ptr = content.as_str().as_ptr() as usize;
+
+    let trace = exec
+        .run(
+            &pipeline,
+            content.as_str(),
+            &[
+                handle("c1", "a quick brown fox runs"),
+                handle("c2", "lazy dog naps under tree"),
+            ],
+            None,
+            Some("global"),
+        )
+        .expect("two-phase pipeline runs");
+
+    // The executor recorded one pointer per helper stage.
+    let ptrs = exec.helper_content_ptrs();
+    assert_eq!(
+        ptrs.len(),
+        2,
+        "two-phase default has 2 helper stages; got {} pointer recordings",
+        ptrs.len()
+    );
+
+    // CRITICAL: every recorded pointer is the SAME address as the
+    // caller's `content` slice. A clone would land at a different
+    // address; a borrow keeps the address stable.
+    for (idx, ptr) in ptrs.iter().enumerate() {
+        assert_eq!(
+            *ptr, expected_ptr,
+            "helper stage {idx}: content was cloned (ptr {ptr:#x} != caller {expected_ptr:#x}). \
+             Form 3 PERF-11 invariant violated — helpers must borrow, not clone."
+        );
+    }
+
+    // Cross-check: the per-stage `content_bytes` telemetry on every
+    // helper stage equals `content.len()` — proves the helpers saw the
+    // full backing slice (no implicit truncation).
+    for stage in &trace.stages {
+        if let ai_memory::multistep_ingest::executor::StageOutcome::Helper {
+            content_bytes, ..
+        } = stage
+        {
+            assert_eq!(
+                *content_bytes,
+                content.len(),
+                "helper stage content_bytes must match the caller's content.len()"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// v0.7.0 polish (issue #782, PERF-11) — Phase 2 LLM stages MUST
+// truncate the content slot at the `multistep_max_content_chars` cap
+// before inlining it into the prompt. Mirror of Cluster B's PERF-7
+// synthesis cap. Default cap is 1500 characters; the executor exposes
+// a builder setter so operators can thread the per-namespace policy
+// override.
+// ---------------------------------------------------------------------------
+#[test]
+fn multistep_llm_stage_truncates_content_at_cap() {
+    use ai_memory::multistep_ingest::executor::{
+        DEFAULT_MULTISTEP_MAX_CONTENT_CHARS, StageOutcome,
+    };
+
+    // Build a content blob WAY larger than the default cap so a
+    // truncation event is unambiguous.
+    let huge = "a".repeat(10_000);
+    assert!(huge.chars().count() > DEFAULT_MULTISTEP_MAX_CONTENT_CHARS);
+
+    // Default-cap path: confirm the executor truncates without an
+    // explicit override.
+    {
+        let mock = MockLlmDispatch::new(vec![Ok(
+            r#"{"title":"T","summary":"S","tags":[],"atoms":[]}"#.to_string(),
+        )]);
+        let exec = IngestExecutor::new(Arc::new(mock));
+        let pipeline = two_phase_default();
+        let trace = exec
+            .run(&pipeline, huge.as_str(), &[], None, Some("global"))
+            .expect("ok");
+
+        let llm_stage = trace
+            .stages
+            .iter()
+            .find(|s| matches!(s, StageOutcome::LlmCall { .. }))
+            .expect("two-phase has an LLM stage");
+        let (prompt, content_bytes, content_truncated) = match llm_stage {
+            StageOutcome::LlmCall {
+                prompt,
+                content_bytes,
+                content_truncated,
+                ..
+            } => (prompt, *content_bytes, *content_truncated),
+            StageOutcome::Helper { .. } => unreachable!("filtered above"),
+        };
+
+        assert!(
+            content_truncated,
+            "LLM stage MUST flag content_truncated when content exceeds the cap"
+        );
+        // post-truncation byte count is bounded by the default cap +
+        // the truncation marker tail (~32 chars).
+        assert!(
+            content_bytes <= DEFAULT_MULTISTEP_MAX_CONTENT_CHARS + 64,
+            "post-truncation content_bytes {content_bytes} must be <= cap ({DEFAULT_MULTISTEP_MAX_CONTENT_CHARS}) + marker tail"
+        );
+        assert!(
+            prompt.contains("[...truncated"),
+            "truncation marker must appear in the LLM prompt"
+        );
+        // The full 10k 'a' run cannot appear verbatim — the prompt
+        // would have to contain a 10k 'a' run, but the cap stops it.
+        assert!(
+            !prompt.contains(&"a".repeat(2000)),
+            "prompt must not carry the full content past the cap"
+        );
+
+        // Helper stages still get the FULL borrowed slice (no LLM cap
+        // applies to them — they're substrate-side).
+        let helper_content_bytes: Vec<usize> = trace
+            .stages
+            .iter()
+            .filter_map(|s| match s {
+                StageOutcome::Helper { content_bytes, .. } => Some(*content_bytes),
+                StageOutcome::LlmCall { .. } => None,
+            })
+            .collect();
+        for cb in &helper_content_bytes {
+            assert_eq!(
+                *cb,
+                huge.len(),
+                "helper stages MUST see the full caller content (no LLM cap on helpers)"
+            );
+        }
+    }
+
+    // Builder-override path: confirm an operator-supplied cap takes
+    // effect end-to-end.
+    {
+        let mock = MockLlmDispatch::new(vec![Ok(
+            r#"{"title":"T","summary":"S","tags":[],"atoms":[]}"#.to_string(),
+        )]);
+        let cap: usize = 250;
+        let exec = IngestExecutor::new(Arc::new(mock)).with_max_content_chars(cap);
+        let pipeline = two_phase_default();
+        let trace = exec
+            .run(&pipeline, huge.as_str(), &[], None, Some("global"))
+            .expect("ok");
+
+        let llm = trace
+            .stages
+            .iter()
+            .find_map(|s| match s {
+                StageOutcome::LlmCall {
+                    content_bytes,
+                    content_truncated,
+                    ..
+                } => Some((*content_bytes, *content_truncated)),
+                StageOutcome::Helper { .. } => None,
+            })
+            .expect("LLM stage present");
+        assert!(llm.1, "tighter cap must still flag truncated");
+        assert!(
+            llm.0 <= cap + 64,
+            "post-truncation content_bytes {} must be <= override cap ({cap}) + marker tail",
+            llm.0
+        );
+    }
+
+    // No-truncation path: content well within the cap goes through
+    // verbatim, no marker, `content_truncated == false`.
+    {
+        let mock = MockLlmDispatch::new(vec![Ok(
+            r#"{"title":"T","summary":"S","tags":[],"atoms":[]}"#.to_string(),
+        )]);
+        let exec = IngestExecutor::new(Arc::new(mock));
+        let pipeline = two_phase_default();
+        let tiny = "short content";
+        let trace = exec
+            .run(&pipeline, tiny, &[], None, Some("global"))
+            .expect("ok");
+        let llm_truncated = trace
+            .stages
+            .iter()
+            .find_map(|s| match s {
+                StageOutcome::LlmCall {
+                    content_truncated, ..
+                } => Some(*content_truncated),
+                StageOutcome::Helper { .. } => None,
+            })
+            .expect("LLM stage present");
+        assert!(
+            !llm_truncated,
+            "short content must not be flagged truncated"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Cross-cut: helper kinds round-trip through the public surface.
 // Sanity that `HelperKind::as_str()` is in sync with the trace's
 // `helper` field.

--- a/tests/g_phase_e_4_verify_exit_codes.rs
+++ b/tests/g_phase_e_4_verify_exit_codes.rs
@@ -142,6 +142,7 @@ fn set_cap(conn: &rusqlite::Connection, ns: &str, cap: u32) {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
         ..ai_memory::models::GovernancePolicy::default()
     };
     let metadata = serde_json::json!({

--- a/tests/governance_inheritance.rs
+++ b/tests/governance_inheritance.rs
@@ -93,6 +93,7 @@ fn approve_policy() -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 

--- a/tests/permissions_mode_gate.rs
+++ b/tests/permissions_mode_gate.rs
@@ -107,6 +107,7 @@ fn approve_write_policy() -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 

--- a/tests/persona/acceptance.rs
+++ b/tests/persona/acceptance.rs
@@ -133,6 +133,7 @@ fn install_namespace_policy(
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     let now = Utc::now().to_rfc3339();
     let metadata = serde_json::json!({

--- a/tests/recursive_learning_task2_max_reflection_depth.rs
+++ b/tests/recursive_learning_task2_max_reflection_depth.rs
@@ -108,6 +108,7 @@ fn effective_max_reflection_depth_explicit_override_returns_value() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     assert_eq!(p.effective_max_reflection_depth(), 7);
 }
@@ -141,6 +142,7 @@ fn effective_max_reflection_depth_some_zero_disables_reflection() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     assert_eq!(
         p.effective_max_reflection_depth(),
@@ -170,6 +172,7 @@ fn effective_max_reflection_depth_some_one_returns_one() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
         ..GovernancePolicy::default()
     };
     assert_eq!(p.effective_max_reflection_depth(), 1);
@@ -197,6 +200,7 @@ fn effective_max_reflection_depth_high_override_returns_value() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
         ..GovernancePolicy::default()
     };
     assert_eq!(p.effective_max_reflection_depth(), 255);
@@ -323,6 +327,7 @@ fn serialize_policy_with_explicit_field_writes_key_on_the_wire() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
         ..GovernancePolicy::default()
     };
     let json = serde_json::to_value(&p).expect("serialize");
@@ -359,6 +364,7 @@ fn full_roundtrip_with_explicit_field() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     let json = serde_json::to_string(&p).expect("serialize");
     let back: GovernancePolicy = serde_json::from_str(&json).expect("deserialize");

--- a/tests/recursive_learning_task4_memory_reflect.rs
+++ b/tests/recursive_learning_task4_memory_reflect.rs
@@ -303,6 +303,7 @@ fn explicit_cap_one_refuses_depth_two_reflection() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&conn, "task4-cap-one", &policy);
 
@@ -357,6 +358,7 @@ fn cap_zero_disables_every_reflection() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&conn, "task4-cap-zero", &policy);
 

--- a/tests/recursive_learning_task5_audit_record.rs
+++ b/tests/recursive_learning_task5_audit_record.rs
@@ -442,6 +442,7 @@ fn cap_zero_disable_path_still_emits_audit_row() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&conn, "task5-cap-zero", &policy);
     let src = make_memory("task5-cap-zero", "src-d0", 0);

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -440,6 +440,7 @@ fn cap_zero_disables_every_reflection_with_audit_row() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&conn, "task7-disabled", &policy);
     let src = make_memory("task7-disabled", "depth0-src", 0);

--- a/tests/ship_gate/grand_slam_recursive_learning.rs
+++ b/tests/ship_gate/grand_slam_recursive_learning.rs
@@ -400,6 +400,7 @@ fn sg_rl_3_federation_reflection_replication_with_cross_peer_refusal() {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     };
     seed_policy(&conn_b, ns, &tight);
 

--- a/tests/ship_gate_governance_inheritance.rs
+++ b/tests/ship_gate_governance_inheritance.rs
@@ -115,6 +115,7 @@ fn approve_write_policy() -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 
@@ -139,6 +140,7 @@ fn any_policy_no_inherit() -> GovernancePolicy {
         synthesis_failure_mode: None,
         synthesis_max_deletes_per_call: None,
         synthesis_max_candidate_chars: None,
+        multistep_max_content_chars: None,
     }
 }
 


### PR DESCRIPTION
## Summary

PERF-11 closeout — Form 3 multi-step ingest used to clone the FULL `content` blob once per Phase 1 deterministic helper stage and inline the full content (uncapped) into every Phase 2 LLM-stage prompt. This PR completes the Cluster B PERF-7 sibling fix.

* **Phase 1 helpers now borrow.** New `HelperContext<'a>` + `run_helper_with` thread the same `&str` through every helper invocation; debug-build pointer recorder + integration test pin the invariant.
* **Phase 2 LLM stages truncate.** Content inlined into the LLM prompt is capped at `multistep_max_content_chars` (default 1500; mirrors Cluster B's PERF-7 cap), with a `[...truncated N chars]` marker so the LLM knows it's seeing a clipped view.
* **New namespace policy field** — `GovernancePolicy::multistep_max_content_chars: Option<u32>` + `effective_multistep_max_content_chars() -> usize`. Default `None` resolves to 1500.
* **Per-stage telemetry** — `StageOutcome::Helper.content_bytes`, `StageOutcome::LlmCall.{content_bytes, content_truncated}`, `ExecutionTrace.bytes_per_stage` histogram.
* **GovernancePolicy struct cascade** — 49 struct-literal sites across 30 files updated via the same one-shot script pattern used in prior cluster reports (+ 1 hand-fixup in `form_1_synthesis.rs` where the field used a non-None binding).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --features sal,sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --lib` — **4214 passed, 0 failed**
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --features sal,sal-postgres --test form_3_multistep_ingest` — **10 passed** (8 existing + 2 new)
- [x] `cargo audit` — clean
- [x] New regression test: `multistep_phase_1_helpers_receive_content_borrow_not_clone` — asserts every helper stage in a `run()` sees the SAME `content.as_ptr()` (no clones).
- [x] New regression test: `multistep_llm_stage_truncates_content_at_cap` — covers default-cap, builder-override, and no-truncation paths; also confirms helpers still see the full uncapped slice.

## Hard constraints honoured

- Touched only `src/multistep_ingest/`, `src/models/namespace.rs` (one field), `tests/form_3_multistep_ingest.rs` for new functionality. The GovernancePolicy struct-literal cascade is the explicitly-mandated carve-out.
- Tool count + schema baselines preserved (no new MCP tools, no schema migration).
- Existing helper public API (`jaccard_overlap` / `cosine_pre_filter` / `fts_classifier` / `run_helper`) retained as backward-compatible self-borrowing convenience shims.

## AI involvement

Implemented end-to-end by **Claude Opus 4.7 (1M context)** under the operator's polish-782 worktree. Co-author trailer present on the commit.

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)