### PR TITLE
fix(#797): move v36/v38/v39/v41/v42 partial indexes out of bootstrap SCHEMA

### DIFF
--- a/examples/atomise_roundtrip.rs
+++ b/examples/atomise_roundtrip.rs
@@ -177,6 +177,7 @@ fn observe_recall(
         None,
         None,
         /* include_archived = */ false,
+        /* source_uri_prefix = */ None,
     )
     .context("recall default")?;
     let recall_ids: Vec<&str> = rows.iter().map(|(m, _)| m.id.as_str()).collect();
@@ -200,6 +201,7 @@ fn observe_recall(
         None,
         None,
         /* include_archived = */ true,
+        /* source_uri_prefix = */ None,
     )
     .context("recall include_archived")?;
     let parent_visible_with_flag = rows_all.iter().any(|(m, _)| m.id == parent_id);

--- a/examples/offload_roundtrip.rs
+++ b/examples/offload_roundtrip.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     let result = off
         .offload(&content, "cookbook/offload", None, "ai:cookbook")
         .context("offload step")?;
-    let deref = off.deref(&result.ref_id).context("deref step")?;
+    let deref = off.deref(&result.ref_id, None).context("deref step")?;
     std::fs::write(&args.output, deref.content.as_bytes())
         .with_context(|| format!("write output {}", args.output.display()))?;
     let round_trip_ok = deref.content == content && deref.sha256 == result.content_sha256;
@@ -95,7 +95,7 @@ fn main() -> Result<()> {
         "UPDATE offloaded_blobs SET content_zstd = ?1 WHERE ref_id = ?2",
         params![tampered, result.ref_id],
     )?;
-    let tamper_refused = match off.deref(&result.ref_id) {
+    let tamper_refused = match off.deref(&result.ref_id, None) {
         Err(e) => e
             .downcast_ref::<OffloadError>()
             .map(|err| matches!(err, OffloadError::IntegrityFailed { .. }))

--- a/src/mcp/tools/skill_register.rs
+++ b/src/mcp/tools/skill_register.rs
@@ -338,11 +338,19 @@ fn collect_resources(
         if path.is_dir() {
             collect_resources(base, &path, out)?;
         } else {
+            // Always emit forward-slash-joined relative paths regardless of
+            // host OS. `to_string_lossy()` on Windows produces backslashes
+            // ("scripts\\run.sh") which then fail every downstream
+            // `WHERE resource_path = 'scripts/run.sh'` lookup — the wire
+            // format (and the `memory_skill_resource` MCP contract) is
+            // forward-slash-only. Issue #797 sibling fix.
             let rel = path
                 .strip_prefix(base)
                 .map_err(|_| "path prefix error".to_string())?
-                .to_string_lossy()
-                .into_owned();
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
             let content = std::fs::read(&path)
                 .map_err(|e| format!("read resource '{}': {e}", path.display()))?;
             // Determine kind from sub-directory name or file extension.
@@ -664,10 +672,27 @@ mod tests {
         let mut out: Vec<(String, String, Vec<u8>)> = Vec::new();
         collect_resources(&base, &base, &mut out).unwrap();
         assert_eq!(out.len(), 2);
-        // Paths are relative to base, with forward slashes (StringLossy).
+        // Resource paths MUST be forward-slash-joined on every platform —
+        // they are the wire-format key used by `memory_skill_resource`
+        // (`WHERE resource_path = ?2`). The previous `to_string_lossy`
+        // implementation emitted backslashes on Windows ("a\\f1.txt") and
+        // every peer lookup missed; the assertion below is the exact-string
+        // form so a future regression of the same shape fails the test on
+        // Unix even when CI is Linux-only.
         let paths: Vec<&str> = out.iter().map(|(p, _, _)| p.as_str()).collect();
-        assert!(paths.iter().any(|p| p.ends_with("f1.txt")));
-        assert!(paths.iter().any(|p| p.ends_with("f2.txt")));
+        assert!(
+            paths.iter().any(|p| *p == "a/f1.txt"),
+            "expected exact path 'a/f1.txt'; got {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|p| *p == "b/c/f2.txt"),
+            "expected exact path 'b/c/f2.txt'; got {paths:?}"
+        );
+        assert!(
+            paths.iter().all(|p| !p.contains('\\')),
+            "no resource path may contain a backslash (wire format is \
+             forward-slash-only); got {paths:?}"
+        );
     }
 
     #[test]

--- a/src/storage/connection.rs
+++ b/src/storage/connection.rs
@@ -236,6 +236,173 @@ mod tests {
         assert_eq!(fk, 1, "open() must enable foreign_keys");
     }
 
+    /// Helper: confirm a named index is registered in `sqlite_master`.
+    fn index_present(conn: &Connection, name: &str) -> bool {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                rusqlite::params![name],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        n == 1
+    }
+
+    /// Helper: column existence on a table.
+    fn column_present(conn: &Connection, table: &str, column: &str) -> bool {
+        let sql = format!("PRAGMA table_info({table})");
+        let mut stmt = match conn.prepare(&sql) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let mut rows = stmt.query([]).expect("PRAGMA query");
+        while let Some(row) = rows.next().expect("PRAGMA next") {
+            let name: String = row.get(1).expect("col name");
+            if name == column {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Regression for #797: a pre-v36 DB shape (no `atom_of` /
+    /// `atomised_into` / `source_uri` / `confidence_source` /
+    /// `mentioned_entity_id` columns on `memories`) must `open()`
+    /// cleanly. Before the fix, the bootstrap SCHEMA issued
+    /// `CREATE INDEX … ON memories(atom_of)` before `migrate` ran the
+    /// v36 ALTER, so SQLite refused with `no such column: atom_of`.
+    ///
+    /// We synthesise the legacy shape by opening a fresh v42 DB, then
+    /// stripping the v36+ columns and re-stamping `schema_version = 34`.
+    /// Re-opening must drive the migration ladder forward to
+    /// `CURRENT_SCHEMA_VERSION` and re-attach every partial index the
+    /// bootstrap used to crash on.
+    #[test]
+    fn open_succeeds_on_legacy_pre_v36_memories_shape() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        {
+            let conn = open(tmp.path()).expect("seed: fresh open");
+            for ix in [
+                "idx_memories_atom_of",
+                "idx_memories_atomised_into",
+                "idx_personas_by_entity",
+                "idx_memories_source_uri",
+                "idx_memories_confidence_source",
+                "idx_memories_mentioned_entity",
+            ] {
+                conn.execute(&format!("DROP INDEX IF EXISTS {ix}"), [])
+                    .expect("drop index");
+            }
+            for col in [
+                "mentioned_entity_id",
+                "confidence_decayed_at",
+                "confidence_signals",
+                "confidence_source",
+                "source_span",
+                "source_uri",
+                "citations",
+                "persona_version",
+                "entity_id",
+                "atom_of",
+                "atomised_into",
+            ] {
+                conn.execute(&format!("ALTER TABLE memories DROP COLUMN {col}"), [])
+                    .unwrap_or_else(|e| panic!("DROP COLUMN {col}: {e}"));
+            }
+            conn.execute("DROP TABLE IF EXISTS confidence_shadow_observations", [])
+                .expect("drop shadow table");
+            conn.execute("DROP TABLE IF EXISTS signed_events_dlq", [])
+                .expect("drop dlq");
+            conn.execute("DELETE FROM schema_version", [])
+                .expect("clear version");
+            conn.execute("INSERT INTO schema_version (version) VALUES (34)", [])
+                .expect("stamp v34");
+        }
+
+        let conn = open(tmp.path()).expect("legacy-upgrade open must succeed");
+
+        let v: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read schema_version");
+        assert!(
+            v >= 42,
+            "migrate ladder must reach CURRENT_SCHEMA_VERSION; got {v}"
+        );
+
+        for col in [
+            "atom_of",
+            "atomised_into",
+            "entity_id",
+            "persona_version",
+            "citations",
+            "source_uri",
+            "source_span",
+            "confidence_source",
+            "confidence_signals",
+            "confidence_decayed_at",
+            "mentioned_entity_id",
+        ] {
+            assert!(
+                column_present(&conn, "memories", col),
+                "memories.{col} must be ALTER-added by the migrate ladder"
+            );
+        }
+
+        for ix in [
+            "idx_memories_atom_of",
+            "idx_memories_atomised_into",
+            "idx_memories_source_uri",
+            "idx_memories_confidence_source",
+            "idx_memories_mentioned_entity",
+            "idx_shadow_obs_namespace_source_observed",
+        ] {
+            assert!(
+                index_present(&conn, ix),
+                "index {ix} must exist after legacy upgrade"
+            );
+        }
+    }
+
+    /// Regression for #797: a v39/v40-era shadow table (no `source`
+    /// column) must also `open()` cleanly. Before the fix, the
+    /// bootstrap created `idx_shadow_obs_namespace_source_observed`
+    /// against the missing column.
+    #[test]
+    fn open_succeeds_on_legacy_pre_v41_shadow_shape() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        {
+            let conn = open(tmp.path()).expect("seed: fresh open");
+            conn.execute(
+                "DROP INDEX IF EXISTS idx_shadow_obs_namespace_source_observed",
+                [],
+            )
+            .expect("drop compound shadow index");
+            conn.execute(
+                "ALTER TABLE confidence_shadow_observations DROP COLUMN source",
+                [],
+            )
+            .expect("drop shadow.source");
+            conn.execute("DELETE FROM schema_version", [])
+                .expect("clear version");
+            conn.execute("INSERT INTO schema_version (version) VALUES (40)", [])
+                .expect("stamp v40");
+        }
+
+        let conn = open(tmp.path()).expect("v40 legacy-upgrade open must succeed");
+        assert!(
+            column_present(&conn, "confidence_shadow_observations", "source"),
+            "v41 migrate arm must ALTER-add shadow.source"
+        );
+        assert!(
+            index_present(&conn, "idx_shadow_obs_namespace_source_observed"),
+            "v41 compound shadow index must be re-attached"
+        );
+    }
+
     #[test]
     fn check_trigger_rejects_bad_tier_insert() {
         // R1-M2 trigger contract: a write that violates the closed-set

--- a/src/storage/migrations.rs
+++ b/src/storage/migrations.rs
@@ -106,42 +106,29 @@ CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);
 CREATE INDEX IF NOT EXISTS idx_memories_priority ON memories(priority DESC);
 CREATE INDEX IF NOT EXISTS idx_memories_expires ON memories(expires_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_title_ns ON memories(title, namespace);
--- v36 partial indexes on the atomisation columns. Restricted predicates
--- keep legacy-DB index footprint at zero until WT-1-B starts minting
--- atoms.
-CREATE INDEX IF NOT EXISTS idx_memories_atom_of
-    ON memories(atom_of) WHERE atom_of IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_memories_atomised_into
-    ON memories(atomised_into) WHERE atomised_into > 0;
--- v37 (QW-2) partial index covering per-entity persona lookups lives
--- in `migrations/sqlite/0031_v07_persona.sql` and runs from the
--- migrate step's `if version < 37` arm — NOT in this bootstrap
--- SCHEMA, because `db::open` applies SCHEMA before `migrate`, and
--- the index references `entity_id` (a column only present after the
--- v37 ALTER fires on a legacy DB). Fresh installs land the column
--- via the CREATE TABLE above, then the migrate step's v37 arm
--- creates the index a few statements later.
--- v38 (Form 4) partial index covering the `--source-uri-prefix`
--- recall filter. Mirrors the persona pattern: legacy rows have NULL
--- `source_uri`, the partial predicate keeps the index footprint at
--- zero until callers start writing URIs.
-CREATE INDEX IF NOT EXISTS idx_memories_source_uri
-    ON memories(source_uri) WHERE source_uri IS NOT NULL;
--- v39 (Form 5) partial index covering rows whose `confidence_source`
--- is NOT the (overwhelming-majority) `caller_provided` bucket. The
--- calibration CLI scans this slice to enumerate derived / calibrated /
--- decayed rows; the partial predicate keeps the index footprint on
--- legacy DBs at zero until the auto-confidence engine starts writing.
-CREATE INDEX IF NOT EXISTS idx_memories_confidence_source
-    ON memories(confidence_source) WHERE confidence_source != 'caller_provided';
--- v39 (Form 5) — per-recall shadow-mode telemetry. Populated when
--- AI_MEMORY_CONFIDENCE_SHADOW=1 and sampled at
--- AI_MEMORY_CONFIDENCE_SHADOW_SAMPLE_RATE. The calibration CLI reads
--- this table to compute per-(namespace, source) baselines.
--- v40 (Cluster G) added the denormalised `source` column + compound
--- `(namespace, source, observed_at)` index so the calibration scan
--- streams a single-table SQL aggregation (was: full-window Vec materialise
--- + Rust grouping, PERF-12).
+-- Partial indexes referencing v36+ columns (`atom_of`, `atomised_into`,
+-- `source_uri`, `confidence_source`, `mentioned_entity_id`) and the v41
+-- compound shadow-observations index are NOT in this bootstrap SCHEMA
+-- (issue #797). They live exclusively in their migration .sql files
+-- (`migrations/sqlite/0030_v07_atomisation.sql`,
+-- `0032_v07_form4_provenance.sql`,
+-- `0033_v07_form5_confidence_calibration.sql`,
+-- `0035_v07_shadow_retention.sql`,
+-- `0036_v07_auto_persona_entity_id.sql`) and run from the matching
+-- `if version < N` arms of `migrate()` AFTER the ALTER TABLE that adds
+-- the column.
+--
+-- `db::open` applies SCHEMA before `migrate`, so any `CREATE INDEX` here
+-- that references a v36+ column crashes on a legacy DB whose pre-v36
+-- `memories` row leaves the `CREATE TABLE IF NOT EXISTS` as a no-op
+-- (the new columns never land). The maintainers caught this for the v37
+-- `entity_id` index from the start; v36/v38/v39/v41/v42 were brought
+-- under the same discipline in #797.
+--
+-- Fresh installs are unaffected: the `CREATE TABLE` above lands every
+-- v42-era column, then every `if version < N` arm runs its .sql file
+-- (idempotent `CREATE INDEX IF NOT EXISTS`) to attach the partial
+-- indexes.
 CREATE TABLE IF NOT EXISTS confidence_shadow_observations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     memory_id TEXT NOT NULL,
@@ -160,18 +147,9 @@ CREATE INDEX IF NOT EXISTS idx_shadow_obs_observed_at
     ON confidence_shadow_observations(observed_at);
 CREATE INDEX IF NOT EXISTS idx_shadow_obs_memory
     ON confidence_shadow_observations(memory_id);
-CREATE INDEX IF NOT EXISTS idx_shadow_obs_namespace_source_observed
-    ON confidence_shadow_observations(namespace, source, observed_at);
--- v42 (PERF-8 #781) — partial index covering the auto-persona matcher's
--- `WHERE memory_kind = 'reflection' AND mentioned_entity_id = ?
--- AND namespace = ?` lookup. The partial predicate matches the literal
--- `memory_kind = 'reflection'` constraint in the matcher SQL so the
--- SQLite planner reliably picks this index over a sequential scan
--- (the `mentioned_entity_id = ?` equality predicate prunes NULL rows
--- from the result set; the partial predicate just keeps the index
--- narrow). Non-reflection rows contribute zero index pages.
-CREATE INDEX IF NOT EXISTS idx_memories_mentioned_entity
-    ON memories(mentioned_entity_id, namespace) WHERE memory_kind = 'reflection';
+-- `idx_shadow_obs_namespace_source_observed` references the v41
+-- `confidence_shadow_observations.source` column and lives in
+-- `migrations/sqlite/0035_v07_shadow_retention.sql` (see comment above).
 
 CREATE TABLE IF NOT EXISTS memory_links (
     source_id    TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -198,42 +198,28 @@ CREATE INDEX IF NOT EXISTS idx_memories_embedding_dim
 CREATE INDEX IF NOT EXISTS idx_memories_ns_dim
     ON memories (namespace, embedding_dim)
     WHERE embedding_dim IS NOT NULL;
--- v0.7.0 WT-1-A — atomisation partial indexes. Restricted predicates
--- keep the index footprint on legacy databases at zero (every row has
--- NULL until WT-1-B starts minting atoms).
-CREATE INDEX IF NOT EXISTS idx_memories_atom_of
-    ON memories(atom_of) WHERE atom_of IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_memories_atomised_into
-    ON memories(atomised_into) WHERE atomised_into > 0;
--- v0.7.0 QW-2 (schema v36 postgres / v37 sqlite) — partial index covering
--- per-entity persona lookups. Persona rows are a small minority of the
--- table; the partial predicate keeps the index footprint minimal on
--- observation/reflection-dominant workloads.
-CREATE INDEX IF NOT EXISTS idx_personas_by_entity
-    ON memories(entity_id, namespace) WHERE memory_kind = 'persona';
--- v0.7.0 polish PERF-8 (schema v41 postgres / v42 sqlite, issue #781)
--- — partial index covering the auto-persona matcher's
--- `WHERE memory_kind = 'reflection' AND mentioned_entity_id = ? AND
--- namespace = ?` lookup. Partial predicate is the literal
--- `memory_kind = 'reflection'` so the planner picks the partial index
--- deterministically; non-reflection rows contribute zero index pages.
-CREATE INDEX IF NOT EXISTS idx_memories_mentioned_entity
-    ON memories(mentioned_entity_id, namespace) WHERE memory_kind = 'reflection';
--- v0.7.0 Form 4 (schema v37 postgres / v38 sqlite) — partial index
--- covering the `--source-uri-prefix` recall filter. Legacy rows
--- have NULL `source_uri` so the partial predicate keeps the index
--- footprint at zero on every pre-v37 database.
-CREATE INDEX IF NOT EXISTS idx_memories_source_uri
-    ON memories(source_uri) WHERE source_uri IS NOT NULL;
--- v0.7.0 Form 5 (schema v38 postgres / v39 sqlite) — partial index
--- covering rows whose `confidence_source` is NOT the (overwhelming-
--- majority) `caller_provided` bucket. The calibration CLI scans this
--- slice to enumerate derived / calibrated / decayed rows; the partial
--- predicate keeps the index footprint on legacy DBs at zero until the
--- auto-confidence engine starts writing.
-CREATE INDEX IF NOT EXISTS idx_memories_confidence_source
-    ON memories(confidence_source)
-    WHERE confidence_source != 'caller_provided';
+-- Partial indexes that reference columns ALTER-added by the migrate
+-- ladder (`atom_of` / `atomised_into` v35 postgres ↔ v36 sqlite;
+-- `entity_id` v36 ↔ v37; `source_uri` v37 ↔ v38; `confidence_source`
+-- v38 ↔ v39; `mentioned_entity_id` v41 ↔ v42) and the v40 compound
+-- shadow index referencing `confidence_shadow_observations.source` are
+-- NOT in this bootstrap (issue #797). They live exclusively in their
+-- migration .sql files (`migrations/postgres/0017_v07_atomisation.sql`,
+-- `0018_v07_persona.sql`, `0019_v07_form4_provenance.sql`,
+-- `0020_v07_form5_confidence_calibration.sql`,
+-- `0022_v07_shadow_retention.sql`,
+-- `0023_v07_auto_persona_entity_id.sql`) and run from the matching
+-- `migrate_vN` arms of `src/store/postgres.rs::migrate` AFTER the
+-- `ALTER TABLE memories ADD COLUMN IF NOT EXISTS` that adds the
+-- referenced column.
+--
+-- `PostgresStore::connect` applies this bootstrap before `migrate`, so
+-- any `CREATE INDEX` here referencing a v35+ column would crash on a
+-- legacy DB whose pre-existing `memories` table makes the `CREATE TABLE
+-- IF NOT EXISTS` above a no-op (the new columns never land). Fresh
+-- installs are unaffected: the `CREATE TABLE` above carries every
+-- v41-era column, then every `if current_version < N` arm runs its
+-- (idempotent) .sql file to attach the partial index.
 
 -- v0.7.0 Form 5 — per-recall shadow-mode telemetry. Populated when
 -- AI_MEMORY_CONFIDENCE_SHADOW=1 and sampled at
@@ -261,8 +247,10 @@ CREATE INDEX IF NOT EXISTS idx_shadow_obs_observed_at
     ON confidence_shadow_observations(observed_at);
 CREATE INDEX IF NOT EXISTS idx_shadow_obs_memory
     ON confidence_shadow_observations(memory_id);
-CREATE INDEX IF NOT EXISTS idx_shadow_obs_namespace_source_observed
-    ON confidence_shadow_observations(namespace, source, observed_at);
+-- `idx_shadow_obs_namespace_source_observed` references the v40
+-- `confidence_shadow_observations.source` column and lives in
+-- `migrations/postgres/0022_v07_shadow_retention.sql` (see #797
+-- comment block above).
 
 -- Full-text search. English stemming; matches the SQLite FTS5 setup.
 CREATE INDEX IF NOT EXISTS memories_content_fts ON memories

--- a/tests/postgres_schema_parity.rs
+++ b/tests/postgres_schema_parity.rs
@@ -41,26 +41,23 @@ use ai_memory::store::postgres::PostgresStore;
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 
-/// `SQLite` `CURRENT_SCHEMA_VERSION` as of v0.7.0.
-///
-/// Mirrors `src/db.rs::CURRENT_SCHEMA_VERSION`. We re-declare here
-/// rather than re-export because `crate::db` is gated on the `SQLite`
-/// feature surface and the parity test must run identically against
-/// either backend's `schema_version` stamp. A future bump on the
-/// `SQLite` side without the corresponding `Postgres` port will trip
-/// this test.
-const SQLITE_CURRENT_VERSION: i64 = 29;
-
 /// `Postgres` `CURRENT_SCHEMA_VERSION` — tracks
-/// `src/store/postgres.rs::CURRENT_SCHEMA_VERSION`. Diverges from the
-/// SQLite ladder for postgres-only steps:
-///   - v29: in-place `vector(N)` conversion (no SQLite analogue).
-///   - v30: `memories_metadata_is_object` CHECK (M15; SQLite metadata
-///     column has no `jsonb_typeof` equivalent).
-///   - v31: `memories.reflection_depth` column (v0.7.0 Task 1/8 —
-///     recursive learning). Mirrors SQLite v29; the offset by two is
-///     why the ladders diverge by 2 here.
-const POSTGRES_CURRENT_VERSION: i64 = 31;
+/// `src/store/postgres.rs::CURRENT_SCHEMA_VERSION`.
+///
+/// The two ladders (SQLite + Postgres) are independent integer
+/// namespaces. Early in v0.7 the Postgres ladder ran AHEAD of SQLite
+/// because of postgres-only steps (v29 in-place `vector(N)`
+/// conversion, v30 `metadata_is_object` CHECK). The SQLite ladder has
+/// since added more steps than Postgres (v40/v41/v42 PERF/Cluster
+/// work) and the integer relationship inverted — SQLite is now at 42
+/// while Postgres is at 41, and Postgres v41 is the functional mirror
+/// of SQLite v42 (PERF-8 auto-persona `mentioned_entity_id`). The
+/// functional mapping is documented inline in each `migrate_vN` arm
+/// of `src/store/postgres.rs`; the integer relationship here is just
+/// bookkeeping for this parity test. The previous cross-ladder `>=`
+/// floor assertion was retired in #797 once the namespaces inverted —
+/// see the docstring of `schema_versions_match_across_adapters`.
+const POSTGRES_CURRENT_VERSION: i64 = 41;
 
 /// Returns Some(url) when the live-PG fixture is configured, None otherwise.
 fn postgres_url() -> Option<String> {
@@ -139,26 +136,22 @@ async fn schema_versions_match_across_adapters() {
         .expect("read schema_version");
 
     let pg_version_i64 = i64::from(pg_version.expect("schema_version row must exist"));
-    // Postgres is allowed to land postgres-only ladder steps (v29
-    // in-place vector(N) conversion, v30 M15 metadata-CHECK) so the
-    // floor is the SQLite version, the ceiling is the Postgres
-    // version. Both bounds re-trip the assertion when either side
-    // drifts.
-    assert!(
-        pg_version_i64 >= SQLITE_CURRENT_VERSION,
-        "Postgres schema_version ({pg_version_i64}) must be at least the \
-         SQLite CURRENT_SCHEMA_VERSION ({SQLITE_CURRENT_VERSION}). \
-         If you bumped the SQLite ladder, port the corresponding \
-         migrate_vN function to src/store/postgres.rs."
-    );
+    // The two ladders are independent integer namespaces (see the
+    // POSTGRES_CURRENT_VERSION docstring); a direct `>=` cross-ladder
+    // comparison is no longer meaningful now that SQLite trails Postgres
+    // numerically while still leading functionally. The equality
+    // assertion below is the load-bearing parity check — if Postgres'
+    // `migrate()` did not reach its own CURRENT_SCHEMA_VERSION constant
+    // (because a `migrate_vN` arm panicked, was skipped, or the
+    // constant was bumped without the corresponding function), this
+    // test fails.
     assert_eq!(
         pg_version_i64, POSTGRES_CURRENT_VERSION,
         "Postgres schema_version ({pg_version_i64}) must match the \
          Postgres CURRENT_SCHEMA_VERSION ({POSTGRES_CURRENT_VERSION}). \
-         A drift here means a Postgres-only ladder step (e.g. v29 \
-         in-place vector(N), v30 M15 metadata CHECK) didn't run, \
-         or the constant was bumped without the corresponding \
-         migrate_vN function."
+         A drift here means a Postgres ladder step didn't run, or the \
+         constant was bumped without the corresponding migrate_vN \
+         function in src/store/postgres.rs."
     );
 }
 


### PR DESCRIPTION
## Summary

- `storage::connection::open` runs `execute_batch(SCHEMA)` before `migrate(&conn)`. The bootstrap `SCHEMA` carried `CREATE INDEX` statements referencing columns ALTER-added by the v36/v38/v39/v41/v42 migration arms — on any legacy DB whose existing `memories` table predates those ALTERs, the next `CREATE INDEX` crashed with `no such column: <colname>` and every entry point (CLI, MCP, HTTP) refused to start.
- Strips the offending `CREATE INDEX` lines from `SCHEMA` and replaces them with a single comment explaining the bootstrap-vs-legacy ordering invariant. The indexes already live in their migration .sql files and attach from the matching `if version < N` arm after the ALTER lands. Mirrors the v37 (`entity_id`) discipline the maintainers already applied.
- Applies the same fix to the Postgres bootstrap (`src/store/postgres_schema.sql`) — same RCA class, six analogous indexes. Unblocks the pre-existing `migrate_v36_restores_memory_kind_column_and_backfills_legacy_rows` regression pin (added by #773).
- Fixes a Windows-only path-separator bug in `src/mcp/tools/skill_register.rs::collect_resources` that was failing `tests/cov_17_skills_federation_roundtrip.rs::skill_export_import_roundtrip_resolves_resources_on_peer` on the Windows CI runner. Replaces `Path::to_string_lossy()` (OS-native separator) with `.components().join("/")` so resource_path keys are forward-slash on every platform.
- Unblocks two pre-existing example compile errors (`examples/offload_roundtrip.rs` + `examples/atomise_roundtrip.rs`) that local `cargo test` doesn't catch.
- Unrots `tests/postgres_schema_parity.rs::schema_versions_match_across_adapters` — the test held hardcoded SQLite/Postgres CURRENT_SCHEMA_VERSION constants from a baseline 13/10 ladder bumps ago.
- Adds two regression tests in `src/storage/connection.rs` exercising the legacy-upgrade `db::open` path (v34-shape and v40-shape) that fresh-install tests can't reach.

## AI involvement

- Agent: Claude Opus 4.7 (1M context)
- Authority class: Standard
- Human approver(s) for Sensitive items: n/a
- Memory entries created/updated: none

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 4019 lib + 5551 integration, 0 failures
- [x] `cargo build --features sal-postgres --lib` — compile clean
- [x] `cargo audit` — exit 0
- [x] `cargo build --release` — clean (catches examples)
- [x] End-to-end validation against the reporter's production-shape DB (`schema_version = 34`, 1197 memories): `ai-memory doctor` flips from `CRIT (failed to initialize schema)` to `INFO` with full storage/index/recall/governance dashboard populated; schema advances to v42 with every previously-missing partial index re-attached.

## Why fresh-install tests didn't catch the SQLite/Postgres bugs

`tests::migrate_brings_v0_to_current` exercises the migration ladder against a bare connection (no pre-existing `memories` table), so the bootstrap `CREATE TABLE` creates the columns and the indexes succeed. The bug only surfaces on the bootstrap-vs-pre-existing-table path. The new tests synthesise that exact shape by opening a fresh v42 DB, then stripping the v36+ columns / shadow table and re-stamping `schema_version` backward — re-opening then drives the migration ladder through the previously-broken arms.

## Linked issues

Closes #797