### PR TITLE
fix(#813): persona signing pipeline — close #810, #811, #812 end-to-end

### DIFF
--- a/migrations/postgres/0024_v07_persona_signing_atomicity.sql
+++ b/migrations/postgres/0024_v07_persona_signing_atomicity.sql
@@ -1,0 +1,45 @@
+-- Copyright 2026 AlphaOne LLC
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- v0.7.0 issue #810 / #813 — postgres v42:
+-- atomic `(attest_level, signature)` invariant on `memory_links`.
+-- Mirror of sqlite migration
+-- `0037_v07_persona_signing_atomicity.sql`; see that file for the
+-- full rationale.
+--
+-- Postgres supports CHECK constraints inline so we use a single
+-- `ADD CONSTRAINT … CHECK` instead of trigger pairs. The check
+-- refuses any row that claims `attest_level IN ('self_signed',
+-- 'peer_attested')` while `signature` is NULL or wrong-length
+-- (Ed25519 signatures are exactly 64 bytes — `bytea` of length
+-- != 64 fails).
+--
+-- # Backfill
+--
+-- One UPDATE flips any pre-existing phantom row back to 'unsigned'
+-- BEFORE the CHECK constraint is added — otherwise the constraint
+-- creation would fail with "check constraint is violated by some row"
+-- on a legacy DB carrying phantom-signed links.
+--
+-- # Idempotency
+--
+-- - `ALTER TABLE … DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` makes
+--   the migration replay safe (Postgres has no `ADD CONSTRAINT IF NOT
+--   EXISTS` short-form).
+-- - The backfill UPDATE matches no rows once already-applied, so
+--   re-running is a no-op.
+
+UPDATE memory_links
+SET attest_level = 'unsigned'
+WHERE attest_level IN ('self_signed', 'peer_attested')
+  AND (signature IS NULL OR octet_length(signature) != 64);
+
+ALTER TABLE memory_links
+    DROP CONSTRAINT IF EXISTS memory_links_attest_signature_atomic_ck;
+
+ALTER TABLE memory_links
+    ADD CONSTRAINT memory_links_attest_signature_atomic_ck
+    CHECK (
+        attest_level NOT IN ('self_signed', 'peer_attested')
+        OR (signature IS NOT NULL AND octet_length(signature) = 64)
+    );

--- a/migrations/sqlite/0037_v07_persona_signing_atomicity.sql
+++ b/migrations/sqlite/0037_v07_persona_signing_atomicity.sql
@@ -1,0 +1,81 @@
+-- Copyright 2026 AlphaOne LLC
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- v0.7.0 issue #810 / #813 — schema v43 sqlite:
+-- atomic `(attest_level, signature)` invariant on `memory_links`.
+--
+-- # Why
+--
+-- The H2 link-signing path
+-- (`crate::storage::create_link_signed`) is internally atomic: the
+-- match arm produces either `(Some(sig), "self_signed",
+-- Some(agent_id))` or `(None, "unsigned", None)`, never a mixed
+-- tuple. The defect that motivated issue #810, however, is that a
+-- caller (or a future code path, or a manual SQL fixup, or a peer
+-- replay through `create_link_inbound`) can construct a row whose
+-- `attest_level` claims `self_signed` / `peer_attested` but whose
+-- `signature` column is NULL or the wrong length. Such rows are
+-- "phantom-signed" — they pass the `attest_level == 'self_signed'`
+-- filter on `memory_verify` but have no bytes to verify against —
+-- and the operator sees a misleading `signature_verified=false`
+-- result with no clear cause.
+--
+-- # The fix
+--
+-- A pair of SQLite triggers (one for INSERT, one for UPDATE) refuses
+-- any row that asserts `attest_level IN ('self_signed', 'peer_attested')`
+-- without a 64-byte signature blob (Ed25519 signatures are exactly
+-- 64 bytes — see ed25519-dalek's `Signature::to_bytes`). The
+-- defensive invariant runs at the substrate layer so EVERY writer
+-- (the legitimate H2 signer, federation `create_link_inbound`,
+-- direct SQL, future MCP tools, ad-hoc operator UPDATE) sees the
+-- same rule.
+--
+-- # Backfill
+--
+-- One UPDATE flips any pre-existing phantom row (attest_level says
+-- self_signed but signature is NULL or wrong-length) back to
+-- 'unsigned'. We cannot reconstruct a signature retroactively; the
+-- only correct posture for these rows is to be honest about the
+-- absence of bytes.
+--
+-- # Idempotency
+--
+-- The triggers use `DROP TRIGGER IF EXISTS` followed by `CREATE
+-- TRIGGER` so the migration replay is safe. The backfill UPDATE
+-- is idempotent on its predicate (rows that already say `unsigned`
+-- are filtered out).
+--
+-- # Out of scope
+--
+-- The triggers do NOT police `attest_level = 'unsigned'` against the
+-- presence of a signature — a legacy row that carries a stale
+-- signature byte string but `unsigned` attest_level is a no-op for
+-- the verifier (which only re-derives bytes when the attest_level
+-- claims a signature is present). The asymmetric check keeps the
+-- migration narrow and surgical to the phantom-self-signed defect.
+
+UPDATE memory_links
+SET attest_level = 'unsigned'
+WHERE attest_level IN ('self_signed', 'peer_attested')
+  AND (signature IS NULL OR length(signature) != 64);
+
+DROP TRIGGER IF EXISTS memory_links_ck_attest_signature_ins;
+CREATE TRIGGER memory_links_ck_attest_signature_ins
+BEFORE INSERT ON memory_links
+FOR EACH ROW
+WHEN NEW.attest_level IN ('self_signed', 'peer_attested')
+  AND (NEW.signature IS NULL OR length(NEW.signature) != 64)
+BEGIN
+    SELECT RAISE(ABORT, 'CHECK constraint failed: attest_level=self_signed/peer_attested requires 64-byte signature');
+END;
+
+DROP TRIGGER IF EXISTS memory_links_ck_attest_signature_upd;
+CREATE TRIGGER memory_links_ck_attest_signature_upd
+BEFORE UPDATE ON memory_links
+FOR EACH ROW
+WHEN NEW.attest_level IN ('self_signed', 'peer_attested')
+  AND (NEW.signature IS NULL OR length(NEW.signature) != 64)
+BEGIN
+    SELECT RAISE(ABORT, 'CHECK constraint failed: attest_level=self_signed/peer_attested requires 64-byte signature');
+END;

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -108,14 +108,17 @@ pub const MIN_SUPPORTED_SCHEMA: u32 = 16;
 /// v41 from Cluster G's (#767) shadow-mode retention closeout which
 /// adds the denormalised `confidence_shadow_observations.source` column
 /// plus the compound `(namespace, source, observed_at)` index supporting
-/// the streaming calibration scan (PERF-4 + PERF-12), and v42 from
+/// the streaming calibration scan (PERF-4 + PERF-12), v42 from
 /// polish PERF-8 (#781) — auto-persona indexed entity-id column
 /// (`memories.mentioned_entity_id TEXT` + partial index) replacing the
 /// content `LIKE '%entity_X%'` full-table scan in the auto-persona
-/// matcher. When a DB's `schema_version` exceeds this, the binary is
-/// too old for a newer DB and we surface a warning. v0.6.3.1 (PR-9h
-/// / issue #487 PR #497 req #72).
-pub const MAX_SUPPORTED_SCHEMA: u32 = 42;
+/// matcher, and v43 from issue #810 / #813 — atomic
+/// `(attest_level, signature)` invariant on `memory_links` enforced
+/// by a `BEFORE INSERT/UPDATE` trigger pair. When a DB's
+/// `schema_version` exceeds this, the binary is too old for a newer
+/// DB and we surface a warning. v0.6.3.1 (PR-9h / issue #487 PR #497
+/// req #72).
+pub const MAX_SUPPORTED_SCHEMA: u32 = 43;
 
 /// Pure boundary check: `true` when `v` lies within
 /// `[MIN_SUPPORTED_SCHEMA, MAX_SUPPORTED_SCHEMA]`. Extracted so the

--- a/src/cli/commands/persona.rs
+++ b/src/cli/commands/persona.rs
@@ -52,6 +52,14 @@ pub struct PersonaArgs {
 
 /// Dispatch entry-point called from `daemon_runtime::run`.
 ///
+/// `active_keypair` carries the daemon signing keypair when available;
+/// the CLI dispatch at `daemon_runtime` currently passes `None`
+/// (matching the documented "CLI runs unsigned by design" posture,
+/// see #809 comment in `daemon_runtime::run`). The parameter is here
+/// so a future operator-driven "ai-memory persona --regenerate
+/// --sign" flag can drop a keypair in without changing the function
+/// surface again.
+///
 /// # Errors
 ///
 /// Propagates DB errors. Returns `Ok(0)` on success, `Ok(1)` when no
@@ -61,6 +69,7 @@ pub fn run(
     db_path: &Path,
     args: &PersonaArgs,
     llm: Option<&dyn AutonomyLlm>,
+    active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
     out: &mut CliOutput<'_>,
 ) -> Result<i32> {
     let conn = db::open(db_path)?;
@@ -74,7 +83,11 @@ pub fn run(
             )?;
             return Ok(2);
         };
-        let generator = PersonaGenerator::new(&conn, llm, None, PersonaConfig::default());
+        // v0.7.0 issue #811 / #813 — when a keypair is wired the link
+        // path + the persona body get signed; when it's `None` the
+        // behaviour matches v0.7.0.x (unsigned), which is what the
+        // CLI dispatch sends today.
+        let generator = PersonaGenerator::new(&conn, llm, active_keypair, PersonaConfig::default());
         match generator.generate(&args.entity_id, &args.namespace) {
             Ok(persona) => {
                 render_to_stdout(out, &persona, args.json)?;
@@ -204,7 +217,7 @@ mod tests {
             regenerate: false,
             json: false,
         };
-        let res = run(&db_path, &args, None, &mut out);
+        let res = run(&db_path, &args, None, None, &mut out);
         assert!(res.is_err());
     }
 
@@ -222,7 +235,7 @@ mod tests {
             regenerate: true,
             json: false,
         };
-        let code = run(&db_path, &args, Some(&llm), &mut out).unwrap();
+        let code = run(&db_path, &args, Some(&llm), None, &mut out).unwrap();
         assert_eq!(code, 0);
         drop(out);
         let text = String::from_utf8(stdout).unwrap();
@@ -242,7 +255,7 @@ mod tests {
             regenerate: true,
             json: false,
         };
-        let code = run(&db_path, &args, None, &mut out).unwrap();
+        let code = run(&db_path, &args, None, None, &mut out).unwrap();
         assert_eq!(code, 2);
         drop(out);
         let text = String::from_utf8(stderr).unwrap();
@@ -263,7 +276,7 @@ mod tests {
             regenerate: true,
             json: true,
         };
-        let code = run(&db_path, &args, Some(&llm), &mut out).unwrap();
+        let code = run(&db_path, &args, Some(&llm), None, &mut out).unwrap();
         assert_eq!(code, 0);
         drop(out);
         let text = String::from_utf8(stdout).unwrap();

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1303,7 +1303,7 @@ pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
             // than spinning up a transient OllamaClient here. Operators
             // who want the regenerate path call `memory_persona_generate`
             // through MCP (where the daemon already owns the LLM).
-            match cli::commands::persona::run(&db_path, &a, None, &mut out)? {
+            match cli::commands::persona::run(&db_path, &a, None, None, &mut out)? {
                 0 => Ok(()),
                 code => std::process::exit(code),
             }

--- a/src/hooks/post_reflect/auto_persona.rs
+++ b/src/hooks/post_reflect/auto_persona.rs
@@ -43,6 +43,7 @@ use rusqlite::OptionalExtension;
 
 use crate::autonomy::AutonomyLlm;
 use crate::db;
+use crate::identity::keypair::AgentKeypair;
 use crate::persona::{PersonaConfig, PersonaGenerator, render_persona_md};
 use crate::storage::reflect::{ReflectHooks, ReflectOutcome};
 
@@ -83,25 +84,40 @@ impl Default for AutoPersonaConfig {
 /// daemon-runtime owns the `OllamaClient` and clones an `Arc` of it
 /// into the closure). Tests pass a `StubLlm`. The worker thread opens
 /// its own SQLite connection because rusqlite handles aren't `Send`.
+/// v0.7.0 issue #811 / #813 — `keypair` carries the daemon signing
+/// keypair so the spawned worker forwards it into
+/// [`PersonaGenerator::new`]. When `None` the worker stays on the
+/// pre-#811 unsigned path; when `Some` every link + the persona
+/// artifact get signed end-to-end (BUG-B + BUG-C fix in one place).
 #[must_use]
 pub fn build_post_reflect_hook<L>(
     db_path: PathBuf,
     config: AutoPersonaConfig,
     llm: Arc<L>,
+    keypair: Option<Arc<AgentKeypair>>,
 ) -> ReflectHooks<'static>
 where
     L: AutonomyLlm + Send + Sync + 'static,
 {
     let cfg = Arc::new(config);
     let dbp = Arc::new(db_path);
+    let kp = keypair;
     let cb: Box<dyn Fn(&ReflectOutcome) + Send + Sync + 'static> = Box::new(move |outcome| {
         let cfg = cfg.clone();
         let dbp = dbp.clone();
         let llm = llm.clone();
+        let kp = kp.clone();
         let outcome_id = outcome.id.clone();
         let namespace = outcome.namespace.clone();
         std::thread::spawn(move || {
-            if let Err(e) = run_auto_persona(&dbp, &outcome_id, &namespace, &cfg, llm.as_ref()) {
+            if let Err(e) = run_auto_persona(
+                &dbp,
+                &outcome_id,
+                &namespace,
+                &cfg,
+                llm.as_ref(),
+                kp.as_deref(),
+            ) {
                 tracing::warn!(
                     target: "post_reflect.auto_persona",
                     "auto-persona for reflection {} (ns={}) failed: {}",
@@ -143,6 +159,7 @@ pub fn run_auto_persona(
     namespace: &str,
     config: &AutoPersonaConfig,
     llm: &dyn AutonomyLlm,
+    keypair: Option<&AgentKeypair>,
 ) -> anyhow::Result<()> {
     let conn = db::open(db_path)?;
     let policy = db::resolve_governance_policy(&conn, namespace).unwrap_or_default();
@@ -168,7 +185,12 @@ pub fn run_auto_persona(
         return Ok(());
     }
 
-    let generator = PersonaGenerator::new(&conn, llm, None, PersonaConfig::default());
+    // v0.7.0 issue #811 / #813 — forward the daemon's signing keypair
+    // into the generator so both the `derived_from` link writes AND
+    // the persona body get signed end-to-end. Pre-#811 this passed
+    // `None` unconditionally, leaving every auto-persona-generated
+    // row unsigned even on daemons whose `[identity]` was wired.
+    let generator = PersonaGenerator::new(&conn, llm, keypair, PersonaConfig::default());
     let persona = match generator.generate(&entity_id, namespace) {
         Ok(p) => p,
         Err(crate::persona::PersonaError::NoReflections { .. }) => return Ok(()),
@@ -393,7 +415,7 @@ mod tests {
         );
         let cfg = AutoPersonaConfig::default();
         let llm = StubLlm;
-        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm).unwrap();
+        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm, None).unwrap();
         // No persona row should exist.
         let cnt: i64 = conn
             .query_row(
@@ -419,7 +441,7 @@ mod tests {
         );
         let cfg = AutoPersonaConfig::default();
         let llm = StubLlm;
-        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm).unwrap();
+        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm, None).unwrap();
         let cnt: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM memories WHERE memory_kind = 'persona'",
@@ -438,7 +460,7 @@ mod tests {
         let b = seed_reflection(&conn, "team/alpha", "obs2 alice", "alice Y", Some("alice"));
         let cfg = AutoPersonaConfig::default();
         let llm = StubLlm;
-        run_auto_persona(&db_path, &b, "team/alpha", &cfg, &llm).unwrap();
+        run_auto_persona(&db_path, &b, "team/alpha", &cfg, &llm, None).unwrap();
         let cnt: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM memories WHERE memory_kind = 'persona'",
@@ -465,7 +487,7 @@ mod tests {
             out_dir: out.clone(),
         };
         let llm = StubLlm;
-        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm).unwrap();
+        run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm, None).unwrap();
         let f = out.join("team_alpha").join("alice.md");
         assert!(f.exists(), "expected persona file at {}", f.display());
         let body = std::fs::read_to_string(&f).unwrap();

--- a/src/identity/sign.rs
+++ b/src/identity/sign.rs
@@ -154,6 +154,135 @@ fn text_or_null(opt: Option<&str>) -> ciborium::Value {
     }
 }
 
+// ---------------------------------------------------------------------------
+// v0.7.0 issue #812 / #813 — SignablePersona + sign_persona
+// ---------------------------------------------------------------------------
+//
+// Mirrors the `SignableLink` shape: a single, audited surface for the
+// seven fields the persona signature commits to, encoded via RFC 8949
+// §4.2.1 deterministic CBOR. The body of the persona Markdown is
+// hashed (SHA-256) BEFORE entering the signed envelope so the payload
+// stays bounded (32 bytes) regardless of body length — Ed25519 over
+// kilobytes of prose would still work, but the bounded shape lets the
+// `signed_events` row carry the same `payload_hash` cheaply.
+
+/// The seven fields the persona signature commits to.
+///
+/// `body_md_sha256` is the SHA-256 of the UTF-8 bytes of the rendered
+/// persona Markdown body (the same string that lands in
+/// `memories.content`). Hashing it before signing keeps the canonical
+/// payload bounded at ~200 bytes regardless of body length — a 300-500
+/// word persona body would otherwise dominate the signed envelope and
+/// inflate every `signed_events.payload_hash` recomputation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignablePersona<'a> {
+    /// The Persona memory's id (UUIDv4). Stable per (entity_id,
+    /// namespace, version) tuple — `PersonaGenerator::generate` mints
+    /// it before computing the signature.
+    pub persona_id: &'a str,
+    /// Subject the persona distils. Mirrors `Persona::entity_id`.
+    pub entity_id: &'a str,
+    /// Namespace the persona was minted under.
+    pub namespace: &'a str,
+    /// Monotonic version counter — `1` on the first generation, then
+    /// `prev + 1` per regeneration. Pinned in the signature so a
+    /// regeneration cannot replay an earlier version's signed bytes.
+    pub version: i32,
+    /// RFC3339 generation timestamp pinned in `metadata.persona.generated_at`.
+    pub generated_at: &'a str,
+    /// Source reflection ids — one `derives_from` edge per element.
+    /// Order matters at the byte level (the CBOR encoder preserves the
+    /// slice order); the writer pins the order to match
+    /// `metadata.persona.sources`.
+    pub sources: &'a [String],
+    /// SHA-256 (32 bytes) over the rendered persona Markdown body's
+    /// UTF-8 bytes. Bounds the signed payload size.
+    pub body_md_sha256: &'a [u8; 32],
+}
+
+/// RFC 8949 §4.2.1 deterministic CBOR encoding of the seven signable
+/// persona fields.
+///
+/// The encoded shape is a CBOR map with seven entries keyed by the
+/// field names below. Map keys are emitted in sort order (per RFC 8949
+/// §4.2.1 "Core Deterministic Encoding"), integers use the shortest
+/// form, the body hash is encoded as CBOR `bytes`, and the source-id
+/// list is encoded as an ordered CBOR array (slice order preserved).
+/// Encoding the same `SignablePersona` twice (or on a different host)
+/// produces identical bytes — the precondition Ed25519 needs.
+///
+/// # Errors
+///
+/// Returns an error only when CBOR serialization fails — in practice
+/// unreachable for the fixed-shape input above, but surfaced as a
+/// `Result` so callers don't have to choose between panicking and
+/// silently signing a truncated payload.
+pub fn canonical_cbor_persona(p: &SignablePersona<'_>) -> Result<Vec<u8>> {
+    use std::collections::BTreeMap;
+    let mut map: BTreeMap<&str, ciborium::Value> = BTreeMap::new();
+    map.insert(
+        "persona_id",
+        ciborium::Value::Text(p.persona_id.to_string()),
+    );
+    map.insert("entity_id", ciborium::Value::Text(p.entity_id.to_string()));
+    map.insert("namespace", ciborium::Value::Text(p.namespace.to_string()));
+    map.insert(
+        "version",
+        ciborium::Value::Integer(ciborium::value::Integer::from(p.version)),
+    );
+    map.insert(
+        "generated_at",
+        ciborium::Value::Text(p.generated_at.to_string()),
+    );
+    let sources_val = ciborium::Value::Array(
+        p.sources
+            .iter()
+            .map(|s| ciborium::Value::Text(s.clone()))
+            .collect(),
+    );
+    map.insert("sources", sources_val);
+    map.insert(
+        "body_md_sha256",
+        ciborium::Value::Bytes(p.body_md_sha256.to_vec()),
+    );
+
+    let entries: Vec<(ciborium::Value, ciborium::Value)> = map
+        .into_iter()
+        .map(|(k, v)| (ciborium::Value::Text(k.to_string()), v))
+        .collect();
+    let value = ciborium::Value::Map(entries);
+
+    let mut out: Vec<u8> = Vec::with_capacity(256);
+    ciborium::ser::into_writer(&value, &mut out).context("CBOR encode SignablePersona")?;
+    Ok(out)
+}
+
+/// Sign `persona` with `keypair`'s private key.
+///
+/// Encodes the persona via [`canonical_cbor_persona`], then runs
+/// Ed25519 over the resulting bytes. Returns the 64-byte signature,
+/// ready to drop into the `metadata.persona.signature` base64 field on
+/// the persona memory and into the `signature` BLOB column on the
+/// corresponding `signed_events` row.
+///
+/// # Errors
+///
+/// - `keypair.private` is `None` (public-only handle — verification
+///   only).
+/// - The CBOR encoding step fails (in practice unreachable; surfaced
+///   for completeness).
+pub fn sign_persona(keypair: &AgentKeypair, persona: &SignablePersona<'_>) -> Result<Vec<u8>> {
+    let signing = keypair.private.as_ref().with_context(|| {
+        format!(
+            "AgentKeypair for {} has no private key — cannot sign persona",
+            keypair.agent_id
+        )
+    })?;
+    let bytes = canonical_cbor_persona(persona)?;
+    let sig = signing.sign(&bytes);
+    Ok(sig.to_bytes().to_vec())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -343,5 +472,208 @@ mod tests {
         let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
         // Alice's signature must not verify under Bob's public key.
         assert!(bob.public.verify(&payload, &sig).is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // v0.7.0 issue #812 / #813 — SignablePersona + sign_persona
+    // -----------------------------------------------------------------
+
+    fn body_hash_fixture(seed: u8) -> [u8; 32] {
+        let mut h = [seed; 32];
+        h[0] ^= 0xA5;
+        h
+    }
+
+    fn persona_fixture() -> ([u8; 32], Vec<String>) {
+        let body = body_hash_fixture(0x10);
+        let sources = vec!["src-1".to_string(), "src-2".to_string()];
+        (body, sources)
+    }
+
+    #[test]
+    fn canonical_cbor_persona_is_deterministic() {
+        // Mirrors the link-side determinism test: three distinct
+        // permutations of the SignablePersona literal must collapse
+        // to identical bytes because the BTreeMap key-sort runs at
+        // encode time. Catches a regression where a future refactor
+        // swaps the BTreeMap for a HashMap or drops the explicit sort.
+        let (body, sources) = persona_fixture();
+        let persona_id = "persona-001";
+        let entity_id = "alice";
+        let namespace = "team/alpha";
+        let version = 1_i32;
+        let generated_at = "2026-05-16T12:00:00+00:00";
+
+        let perm1 = SignablePersona {
+            persona_id,
+            entity_id,
+            namespace,
+            version,
+            generated_at,
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        let perm2 = SignablePersona {
+            body_md_sha256: &body,
+            sources: &sources,
+            generated_at,
+            version,
+            namespace,
+            entity_id,
+            persona_id,
+        };
+        let perm3 = SignablePersona {
+            namespace,
+            version,
+            sources: &sources,
+            entity_id,
+            body_md_sha256: &body,
+            generated_at,
+            persona_id,
+        };
+
+        let b1 = canonical_cbor_persona(&perm1).expect("encode perm1");
+        let b2 = canonical_cbor_persona(&perm2).expect("encode perm2");
+        let b3 = canonical_cbor_persona(&perm3).expect("encode perm3");
+        assert_eq!(b1, b2);
+        assert_eq!(b2, b3);
+        // Stable across repeated encodes of the same instance.
+        assert_eq!(b1, canonical_cbor_persona(&perm1).expect("re-encode"));
+    }
+
+    #[test]
+    fn canonical_cbor_persona_differs_on_field_change() {
+        let (body, sources) = persona_fixture();
+        let base = SignablePersona {
+            persona_id: "p",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T00:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        // Flip the body hash — different bytes must result.
+        let other_body = body_hash_fixture(0x99);
+        let altered = SignablePersona {
+            body_md_sha256: &other_body,
+            ..base.clone()
+        };
+        let a = canonical_cbor_persona(&base).expect("encode base");
+        let b = canonical_cbor_persona(&altered).expect("encode altered");
+        assert_ne!(a, b, "different body hash must produce different bytes");
+    }
+
+    #[test]
+    fn canonical_cbor_persona_handles_empty_sources() {
+        let body = body_hash_fixture(0x01);
+        let sources: Vec<String> = Vec::new();
+        let persona = SignablePersona {
+            persona_id: "p",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T00:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        // Encoding must not panic on an empty source list. Two
+        // encodes still match (determinism over empty array).
+        let bytes = canonical_cbor_persona(&persona).expect("encode empty-sources");
+        assert!(!bytes.is_empty());
+        assert_eq!(bytes, canonical_cbor_persona(&persona).expect("re-encode"));
+    }
+
+    #[test]
+    fn sign_persona_round_trip() {
+        let kp = keypair::generate("ai:curator").expect("generate");
+        let (body, sources) = persona_fixture();
+        let persona = SignablePersona {
+            persona_id: "persona-xyz",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T12:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        let sig_bytes = sign_persona(&kp, &persona).expect("sign");
+        assert_eq!(sig_bytes.len(), 64, "Ed25519 signatures are 64 bytes");
+
+        let payload = canonical_cbor_persona(&persona).expect("encode");
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        kp.public.verify(&payload, &sig).expect("verify");
+    }
+
+    #[test]
+    fn sign_persona_refuses_public_only_keypair() {
+        let kp = keypair::generate("ai:curator").unwrap();
+        let pub_only = AgentKeypair {
+            agent_id: "ai:curator".to_string(),
+            public: kp.public,
+            private: None,
+        };
+        let (body, sources) = persona_fixture();
+        let persona = SignablePersona {
+            persona_id: "p",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T00:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        let err = sign_persona(&pub_only, &persona).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no private key"), "got: {msg}");
+    }
+
+    #[test]
+    fn sign_persona_does_not_verify_against_other_pub() {
+        // Cross-key non-replayability — Alice's signature must not
+        // verify under Bob's public key.
+        let alice = keypair::generate("alice").unwrap();
+        let bob = keypair::generate("bob").unwrap();
+        let (body, sources) = persona_fixture();
+        let persona = SignablePersona {
+            persona_id: "p",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T00:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        let sig_bytes = sign_persona(&alice, &persona).unwrap();
+        let payload = canonical_cbor_persona(&persona).unwrap();
+        let mut sig_arr = [0u8; 64];
+        sig_arr.copy_from_slice(&sig_bytes);
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        assert!(bob.public.verify(&payload, &sig).is_err());
+    }
+
+    #[test]
+    fn canonical_cbor_persona_version_change_produces_different_bytes() {
+        // Version is part of the signed payload so a v1 signature
+        // cannot be replayed as a v2 signature — pin that.
+        let (body, sources) = persona_fixture();
+        let v1 = SignablePersona {
+            persona_id: "p",
+            entity_id: "alice",
+            namespace: "team/alpha",
+            version: 1,
+            generated_at: "2026-05-16T00:00:00+00:00",
+            sources: &sources,
+            body_md_sha256: &body,
+        };
+        let v2 = SignablePersona {
+            version: 2,
+            ..v1.clone()
+        };
+        let a = canonical_cbor_persona(&v1).expect("encode v1");
+        let b = canonical_cbor_persona(&v2).expect("encode v2");
+        assert_ne!(a, b);
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1335,24 +1335,61 @@ fn handle_request(
 }
 
 /// v0.7 Track H — H2: best-effort load of the active Ed25519 keypair
-/// for the MCP daemon. Mirrors `daemon_runtime::load_active_keypair_for_serve`
-/// but logs to stderr (the MCP convention — stdout owns JSON-RPC).
-/// Missing keypair returns `None` and link writes go in unsigned;
-/// operator opts in by running `ai-memory identity generate`.
+/// for the MCP daemon. Logs to stderr (the MCP convention — stdout owns
+/// JSON-RPC). Missing keypair returns `None` and link writes go in
+/// unsigned; operator opts in by running `ai-memory identity generate`.
+///
+/// # Resolution order
+///
+/// 1. The keypair file matching the *resolved* `agent_id` for this
+///    process (lets an operator who explicitly enrolled a per-NHI key
+///    via `ai-memory identity generate <agent-id>` get that key picked
+///    up automatically).
+/// 2. Fallback to the substrate-managed `daemon` keypair (auto-generated
+///    on first `serve`/`mcp` start, persisted under `<keys>/daemon.priv`).
+///    This mirrors `daemon_runtime::ensure_and_load_daemon_keypair` so
+///    the HTTP and MCP transports converge on the same signing key when
+///    no NHI-specific key has been enrolled — closing the v0.7.0 #811
+///    regression where MCP saw `host:FROSTYi.local:pid-XXX` from
+///    `resolve_agent_id(None, None)`, failed the agent-keyed lookup, and
+///    silently fell back to unsigned writes despite the daemon key
+///    sitting on disk.
 fn load_active_keypair_for_mcp() -> Option<crate::identity::keypair::AgentKeypair> {
     let dir = crate::identity::keypair::default_key_dir().ok()?;
-    let agent_id = crate::identity::resolve_agent_id(None, None).ok()?;
     if !dir.exists() {
         return None;
     }
-    match crate::identity::keypair::load(&agent_id, &dir) {
+    let agent_id = crate::identity::resolve_agent_id(None, None).ok();
+    load_active_keypair_for_mcp_in(&dir, agent_id.as_deref())
+}
+
+/// Inner resolution used by [`load_active_keypair_for_mcp`]; split out so
+/// it can be unit-tested without touching the host's real keys dir.
+fn load_active_keypair_for_mcp_in(
+    dir: &std::path::Path,
+    agent_id: Option<&str>,
+) -> Option<crate::identity::keypair::AgentKeypair> {
+    if let Some(agent_id) = agent_id {
+        match crate::identity::keypair::load(agent_id, dir) {
+            Ok(kp) if kp.can_sign() => return Some(kp),
+            Ok(_) => {}
+            Err(e) => {
+                let msg = format!("{e:#}");
+                if !(msg.contains("No such file") || msg.contains("not found")) {
+                    eprintln!("ai-memory: keypair load failed for {agent_id}: {msg}");
+                }
+            }
+        }
+    }
+    // Fallback: substrate-managed daemon keypair (created by the
+    // serve/mcp boot path; see daemon_runtime::ensure_and_load_daemon_keypair).
+    match crate::identity::keypair::load("daemon", dir) {
         Ok(kp) if kp.can_sign() => Some(kp),
         Ok(_) => None,
         Err(e) => {
-            // WARN on malformed key files; quiet on common file-not-found.
             let msg = format!("{e:#}");
             if !(msg.contains("No such file") || msg.contains("not found")) {
-                eprintln!("ai-memory: keypair load failed for {agent_id}: {msg}");
+                eprintln!("ai-memory: daemon keypair load failed: {msg}");
             }
             None
         }
@@ -1733,6 +1770,57 @@ mod tests {
     use super::*;
     use crate::models::{Memory, Tier};
     use serde_json::json;
+
+    // ----- issue #811 verification: load_active_keypair_for_mcp fallback -----
+
+    #[test]
+    fn issue_811_load_active_keypair_for_mcp_picks_agent_specific_when_present() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let kp = crate::identity::keypair::generate("ai:alice").unwrap();
+        crate::identity::keypair::save(&kp, dir.path()).unwrap();
+        let loaded = super::load_active_keypair_for_mcp_in(dir.path(), Some("ai:alice"))
+            .expect("agent-specific keypair should resolve when on disk");
+        assert!(loaded.can_sign(), "loaded agent-specific keypair must carry a private half");
+        assert_eq!(loaded.agent_id, "ai:alice");
+    }
+
+    #[test]
+    fn issue_811_load_active_keypair_for_mcp_falls_back_to_daemon_when_agent_specific_missing() {
+        // The regression: the live MCP resolved agent_id to a host-id
+        // (e.g. `host:host.local:pid-XYZ`) for which no keypair file
+        // ever exists; the substrate-managed `daemon` key sat on disk
+        // unused. This asserts the fallback so the persona pipeline
+        // signs end-to-end even without a per-NHI keypair enrolled.
+        let dir = tempfile::TempDir::new().unwrap();
+        let daemon_kp = crate::identity::keypair::generate("daemon").unwrap();
+        crate::identity::keypair::save(&daemon_kp, dir.path()).unwrap();
+        let loaded = super::load_active_keypair_for_mcp_in(
+            dir.path(),
+            Some("host:host.local:pid-12345"),
+        )
+        .expect("daemon fallback must engage when agent-specific key absent");
+        assert!(loaded.can_sign(), "daemon fallback keypair must carry a private half");
+        assert_eq!(loaded.agent_id, "daemon");
+    }
+
+    #[test]
+    fn issue_811_load_active_keypair_for_mcp_returns_none_when_neither_present() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let loaded = super::load_active_keypair_for_mcp_in(dir.path(), Some("ai:none"));
+        assert!(loaded.is_none(), "no key files → None (preserves v0.6.4 unsigned behaviour)");
+    }
+
+    #[test]
+    fn issue_811_load_active_keypair_for_mcp_falls_back_when_agent_id_unresolvable() {
+        // `agent_id = None` simulates `resolve_agent_id` failing entirely;
+        // daemon fallback must still engage.
+        let dir = tempfile::TempDir::new().unwrap();
+        let daemon_kp = crate::identity::keypair::generate("daemon").unwrap();
+        crate::identity::keypair::save(&daemon_kp, dir.path()).unwrap();
+        let loaded = super::load_active_keypair_for_mcp_in(dir.path(), None)
+            .expect("daemon fallback must engage when agent_id resolution fails");
+        assert_eq!(loaded.agent_id, "daemon");
+    }
 
     #[test]
     fn tool_definitions_returns_50_tools() {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1156,6 +1156,7 @@ fn handle_request(
                     arguments,
                     llm.map(|c| c as &dyn crate::autonomy::AutonomyLlm),
                     tier_config.tier,
+                    active_keypair,
                 ),
                 // v0.7.0 Form 5 (issue #758) — calibration sweep over
                 // the shadow-mode observation table. Pure read-only;

--- a/src/mcp/tools/persona.rs
+++ b/src/mcp/tools/persona.rs
@@ -24,11 +24,11 @@
 //! in production, `MockOllamaClient` in tests). Read-only
 //! `memory_persona` is available at Semantic+.
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use crate::autonomy::AutonomyLlm;
 use crate::config::FeatureTier;
-use crate::persona::{PersonaConfig, PersonaError, PersonaGenerator, get_latest_persona};
+use crate::persona::{get_latest_persona, PersonaConfig, PersonaError, PersonaGenerator};
 
 /// Wire shape (read-only):
 ///
@@ -90,6 +90,7 @@ pub fn handle_persona_generate(
     params: &Value,
     llm: Option<&dyn AutonomyLlm>,
     tier: FeatureTier,
+    active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
 ) -> Result<Value, String> {
     // Tier gate — refuse below smart so we never blow the budget by
     // accidentally firing curator synthesis on a keyword-only daemon.
@@ -110,7 +111,14 @@ pub fn handle_persona_generate(
     }
     let namespace = params["namespace"].as_str().unwrap_or("global");
 
-    let generator = PersonaGenerator::new(conn, llm, None, PersonaConfig::default());
+    // v0.7.0 issue #811 / #813 — the prior implementation passed `None`
+    // for the signer here even though the MCP dispatch already had the
+    // daemon keypair as `active_keypair`. That regression produced
+    // unsigned `derived_from` links + an unsigned persona artifact
+    // even when the operator had a keypair on disk. We now forward
+    // `active_keypair` through `PersonaGenerator::new` so the link
+    // path AND the persona-body signing path see the same identity.
+    let generator = PersonaGenerator::new(conn, llm, active_keypair, PersonaConfig::default());
     let persona = generator
         .generate(entity_id, namespace)
         .map_err(persona_error_to_string)?;
@@ -225,6 +233,7 @@ mod tests {
             &json!({"entity_id": "alice"}),
             Some(&llm),
             FeatureTier::Keyword,
+            None,
         )
         .unwrap_err();
         assert!(err.contains("requires smart tier"));
@@ -245,6 +254,7 @@ mod tests {
             &json!({"entity_id": "alice", "namespace": "team/alpha"}),
             Some(&llm),
             FeatureTier::Smart,
+            None,
         )
         .unwrap();
         assert_eq!(gen_res["regenerated"], true);

--- a/src/persona/mod.rs
+++ b/src/persona/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! let cfg = PersonaConfig::default();
 //! let mut gen = PersonaGenerator::new(&conn, &llm, signer, cfg);
-//! let persona = gen.generate("entity-alice", "team/alpha")?;
+//! let persona = generator.generate("entity-alice", "team/alpha")?;
 //! ```
 //!
 //! # Persona body shape
@@ -51,6 +51,8 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use anyhow::{Context, Result};
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use chrono::Utc;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -58,8 +60,9 @@ use sha2::{Digest, Sha256};
 
 use crate::autonomy::AutonomyLlm;
 use crate::identity::keypair::AgentKeypair;
+use crate::identity::sign::{sign_persona, SignablePersona};
 use crate::models::{Memory, MemoryKind, Tier};
-use crate::signed_events::{SignedEvent, append_signed_event};
+use crate::signed_events::{append_signed_event, SignedEvent};
 use crate::storage as db;
 use crate::validate;
 
@@ -254,7 +257,6 @@ impl<'a> PersonaGenerator<'a> {
         }
 
         let version = next_version(self.conn, entity_id, namespace)?;
-        let attest_level = "unsigned".to_string();
 
         // Curator synthesis — `AutonomyLlm::summarize_memories` is the
         // narrow LLM trait every other curator pass already uses; mock
@@ -275,19 +277,28 @@ impl<'a> PersonaGenerator<'a> {
         let title = persona_title(entity_id, version);
         let source_ids: Vec<String> = sources.iter().map(|m| m.id.clone()).collect();
 
-        let metadata = serde_json::json!({
+        // v0.7.0 issue #810 / #811 / #812 — the in-flight `attest_level`
+        // is unknown until after the `derived_from` link writes complete
+        // (BUG-A's atomic invariant means the row tells the truth about
+        // its signature). We stamp a provisional metadata envelope now,
+        // then patch `attest_level` + `signature` in place once the
+        // post-link computation finishes. This keeps the write order
+        // (memory → links → metadata patch → signed_events) auditable.
+        let persona_id_local = uuid::Uuid::new_v4().to_string();
+
+        let mut metadata = serde_json::json!({
             "agent_id": agent_id,
             "persona": {
                 "entity_id": entity_id,
                 "sources": source_ids.clone(),
                 "version": version,
-                "attest_level": attest_level,
+                "attest_level": "unsigned",
                 "generated_at": now,
             }
         });
 
         let persona_mem = Memory {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: persona_id_local.clone(),
             tier: self.config.tier.clone(),
             namespace: namespace.to_string(),
             title,
@@ -301,7 +312,7 @@ impl<'a> PersonaGenerator<'a> {
             updated_at: now.clone(),
             last_accessed_at: None,
             expires_at: None,
-            metadata,
+            metadata: metadata.clone(),
             reflection_depth: 0,
             memory_kind: MemoryKind::Persona,
             entity_id: Some(entity_id.to_string()),
@@ -317,20 +328,112 @@ impl<'a> PersonaGenerator<'a> {
         let persona_id = db::insert(self.conn, &persona_mem)
             .with_context(|| format!("inserting persona for {entity_id} v{version}"))?;
 
-        // One `derives_from` edge per source reflection. We use
-        // `db::link` so the existing relation taxonomy + cycle check
-        // apply uniformly — there's no separate persona graph; the
-        // KG walker traverses these edges with the rest.
+        // v0.7.0 issue #811 — `derived_from` edges must use the
+        // signing-aware `create_link_signed` shim. The pre-#811 code
+        // path passed `None` here unconditionally even when the
+        // generator was constructed with a keypair; that regression
+        // is what produced unsigned link rows alongside a curator
+        // whose daemon already owned a private key.
         for source in &sources {
-            db::create_link(self.conn, &persona_id, &source.id, "derived_from")
-                .with_context(|| format!("linking persona {persona_id} -> source {}", source.id))?;
+            db::create_link_signed(
+                self.conn,
+                &persona_id,
+                &source.id,
+                "derived_from",
+                self.signer,
+            )
+            .with_context(|| format!("linking persona {persona_id} -> source {}", source.id))?;
         }
-        // Silence unused-warning when the signer wasn't consumed
-        // (production wiring stamps the agent_id into the metadata
-        // envelope; the link path uses create_link's unsigned shim).
-        let _ = &agent_id;
 
-        emit_persona_generated_event(self.conn, &persona_id, &agent_id, &source_ids, &now)?;
+        // v0.7.0 issue #812 — sign the persona artifact end-to-end when
+        // the generator was constructed with a signing keypair. The
+        // signature commits to the seven-field SignablePersona envelope
+        // (persona_id, entity_id, namespace, version, generated_at,
+        // sources, body_md_sha256). The body hash is computed over the
+        // rendered Markdown so the bounded payload size is independent
+        // of body length.
+        let body_hash = {
+            let mut h = Sha256::new();
+            h.update(body_md.as_bytes());
+            let mut out = [0u8; 32];
+            out.copy_from_slice(&h.finalize());
+            out
+        };
+
+        let signature_bytes: Option<Vec<u8>> = match self.signer {
+            Some(kp) if kp.can_sign() => {
+                let p = SignablePersona {
+                    persona_id: persona_id.as_str(),
+                    entity_id,
+                    namespace,
+                    version,
+                    generated_at: now.as_str(),
+                    sources: &source_ids,
+                    body_md_sha256: &body_hash,
+                };
+                Some(sign_persona(kp, &p).context("sign persona artifact")?)
+            }
+            _ => None,
+        };
+
+        // Resolve the effective `attest_level` for the persona from the
+        // `derived_from` link rows we just wrote. The strongest level
+        // across the source edges is the level the persona truthfully
+        // bears — a Persona whose links are unsigned cannot honestly
+        // claim `self_signed` even when the curator stamps a signature
+        // on its own body. The match between the curator's signing
+        // status and the source edges' signing status keeps the
+        // wire-level `attest_level` strictly monotone.
+        let link_attest = db::strongest_attest_level_for_source(self.conn, &persona_id)
+            .context("resolve strongest link attest_level")?;
+        let attest_level = if signature_bytes.is_some() {
+            // The persona body itself is signed. Prefer the stronger of
+            // the two labels (`peer_attested` beats `self_signed`).
+            match link_attest.as_str() {
+                "peer_attested" => "peer_attested".to_string(),
+                _ => "self_signed".to_string(),
+            }
+        } else {
+            link_attest
+        };
+
+        // Patch the metadata envelope in place — the wire response
+        // returned to the caller, the `metadata.persona.attest_level`
+        // field used by `get_latest_persona` readers, and the
+        // base64-encoded signature all flow from here.
+        if let Some(env) = metadata
+            .get_mut("persona")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            env.insert(
+                "attest_level".to_string(),
+                serde_json::Value::String(attest_level.clone()),
+            );
+            if let Some(sig) = signature_bytes.as_ref() {
+                env.insert(
+                    "signature".to_string(),
+                    serde_json::Value::String(BASE64_STANDARD.encode(sig)),
+                );
+            }
+        }
+        let new_metadata_str = serde_json::to_string(&metadata)
+            .context("serialise updated persona metadata envelope")?;
+        self.conn
+            .execute(
+                "UPDATE memories SET metadata = ?1, updated_at = ?2 WHERE id = ?3",
+                rusqlite::params![new_metadata_str, &now, &persona_id],
+            )
+            .context("patch persona metadata with signature/attest_level")?;
+
+        emit_persona_generated_event(
+            self.conn,
+            &persona_id,
+            &agent_id,
+            &source_ids,
+            &now,
+            signature_bytes.as_deref(),
+            &attest_level,
+        )?;
 
         Ok(Persona {
             id: persona_id,
@@ -519,12 +622,20 @@ fn persona_title(entity_id: &str, version: i32) -> String {
 /// Append a `persona_generated` row to the H5 audit chain so an
 /// auditor walking `signed_events` can replay every persona mint /
 /// regeneration with provenance over the source-id list.
+///
+/// v0.7.0 issue #812 / #813 — when the persona was signed, `signature`
+/// carries the 64-byte Ed25519 bytes and `attest_level` stamps the
+/// label the persona ended up with (`self_signed` or `peer_attested`).
+/// When the persona was unsigned both fall back to `None` / `unsigned`
+/// preserving the pre-#812 ledger shape.
 fn emit_persona_generated_event(
     conn: &Connection,
     persona_id: &str,
     agent_id: &str,
     sources: &[String],
     now: &str,
+    signature: Option<&[u8]>,
+    attest_level: &str,
 ) -> Result<()> {
     let mut hasher = Sha256::new();
     hasher.update(persona_id.as_bytes());
@@ -539,8 +650,8 @@ fn emit_persona_generated_event(
         agent_id: agent_id.to_string(),
         event_type: "persona_generated".to_string(),
         payload_hash,
-        signature: None,
-        attest_level: "unsigned".to_string(),
+        signature: signature.map(<[u8]>::to_vec),
+        attest_level: attest_level.to_string(),
         timestamp: now.to_string(),
         ..SignedEvent::default()
     };
@@ -838,5 +949,301 @@ mod tests {
     fn mock_llm_available() {
         // Smoke test that the project's mock LLM scaffolding is reachable.
         let _ = MockOllamaClient::new_with_url("http://localhost:11434", "gemma2:2b").unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // v0.7.0 issue #810 / #811 / #812 / #813 — signing-path unit coverage
+    // -------------------------------------------------------------------------
+
+    /// Mint two reflections tagged with `entity_id = alice` so the
+    /// PERF-8 `mentioned_entity_id` lookup matches. Returns the seeded
+    /// source ids for downstream assertion.
+    fn seed_two_alice_reflections(conn: &Connection, namespace: &str) -> Vec<String> {
+        let mut ids = Vec::new();
+        for i in 0..2 {
+            let now = Utc::now().to_rfc3339();
+            let mem = Memory {
+                id: uuid::Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: namespace.to_string(),
+                title: format!("obs-{i} about alice"),
+                content: format!("alice did thing {i}"),
+                tags: vec!["reflection".into()],
+                priority: 5,
+                confidence: 1.0,
+                source: "test".into(),
+                access_count: 0,
+                created_at: now.clone(),
+                updated_at: now,
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: serde_json::json!({"agent_id": "ai:test", "entity_id": "alice"}),
+                reflection_depth: 1,
+                memory_kind: MemoryKind::Reflection,
+                entity_id: None,
+                persona_version: None,
+                citations: Vec::new(),
+                source_uri: None,
+                source_span: None,
+                confidence_source: ConfidenceSource::CallerProvided,
+                confidence_signals: None,
+                confidence_decayed_at: None,
+            };
+            ids.push(db::insert(conn, &mem).unwrap());
+        }
+        ids
+    }
+
+    #[test]
+    fn generate_unsigned_path_writes_unsigned_links() {
+        // Pre-#811: every code path through PersonaGenerator wrote
+        // links via `db::create_link` (the unsigned shim). The
+        // intentional "passes None as signer" behaviour stays correct
+        // — the link column AND the persona metadata agree on
+        // "unsigned" instead of disagreeing.
+        let (conn, _dir) = fresh_db();
+        seed_two_alice_reflections(&conn, "team/alpha");
+        let llm = StubLlm {
+            canned: "Alice is methodical.".into(),
+        };
+        let generator = PersonaGenerator::new(&conn, &llm, None, PersonaConfig::default());
+        let persona = generator.generate("alice", "team/alpha").expect("generate");
+        assert_eq!(persona.attest_level, "unsigned");
+        // Every `derived_from` link rooted at the persona must say
+        // `unsigned` (matching the absent signer).
+        let links: Vec<(Option<Vec<u8>>, String)> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT signature, attest_level FROM memory_links \
+                     WHERE source_id = ?1 AND relation = 'derived_from'",
+                )
+                .unwrap();
+            stmt.query_map(rusqlite::params![&persona.id], |r| {
+                Ok((r.get::<_, Option<Vec<u8>>>(0)?, r.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+        };
+        assert_eq!(links.len(), 2);
+        for (sig, level) in &links {
+            assert!(sig.is_none(), "unsigned link must have NULL signature");
+            assert_eq!(level, "unsigned");
+        }
+    }
+
+    #[test]
+    fn generate_signed_path_writes_signed_links_and_metadata() {
+        // BUG-B + BUG-C closing test — when a keypair is wired into
+        // PersonaGenerator the `derived_from` links land signed, the
+        // persona's metadata carries the base64 signature, and the
+        // returned struct stamps `self_signed` on `attest_level`.
+        let (conn, _dir) = fresh_db();
+        seed_two_alice_reflections(&conn, "team/alpha");
+        let kp = crate::identity::keypair::generate("ai:curator").unwrap();
+        let llm = StubLlm {
+            canned: "Signed alice body".into(),
+        };
+        let generator = PersonaGenerator::new(&conn, &llm, Some(&kp), PersonaConfig::default());
+        let persona = generator.generate("alice", "team/alpha").expect("generate");
+        assert_eq!(persona.attest_level, "self_signed");
+
+        // Links: all signed, 64-byte signature on each row.
+        let links: Vec<(Option<Vec<u8>>, String)> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT signature, attest_level FROM memory_links \
+                     WHERE source_id = ?1 AND relation = 'derived_from'",
+                )
+                .unwrap();
+            stmt.query_map(rusqlite::params![&persona.id], |r| {
+                Ok((r.get::<_, Option<Vec<u8>>>(0)?, r.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+        };
+        assert_eq!(links.len(), 2);
+        for (sig, level) in &links {
+            assert_eq!(level, "self_signed");
+            let sig_bytes = sig.as_ref().expect("signed link must have signature blob");
+            assert_eq!(sig_bytes.len(), 64, "Ed25519 signatures are 64 bytes");
+        }
+
+        // Persona metadata carries base64 signature + matching
+        // attest_level + matching agent_id (curator).
+        let meta_str: String = conn
+            .query_row(
+                "SELECT metadata FROM memories WHERE id = ?1",
+                rusqlite::params![&persona.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+        assert_eq!(meta["agent_id"], "ai:curator");
+        assert_eq!(meta["persona"]["attest_level"], "self_signed");
+        let b64 = meta["persona"]["signature"]
+            .as_str()
+            .expect("metadata.persona.signature must be a string");
+        let decoded = BASE64_STANDARD.decode(b64).expect("base64 decode");
+        assert_eq!(decoded.len(), 64, "decoded sig must be 64 bytes");
+
+        // The persona body hash + the metadata signature must verify
+        // against the curator's public key.
+        let body_md: String = conn
+            .query_row(
+                "SELECT content FROM memories WHERE id = ?1",
+                rusqlite::params![&persona.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(body_md.as_bytes());
+        let mut body_hash = [0u8; 32];
+        body_hash.copy_from_slice(&hasher.finalize());
+
+        let signable = SignablePersona {
+            persona_id: persona.id.as_str(),
+            entity_id: persona.entity_id.as_str(),
+            namespace: persona.namespace.as_str(),
+            version: persona.version,
+            generated_at: persona.generated_at.as_str(),
+            sources: &persona.sources,
+            body_md_sha256: &body_hash,
+        };
+        let bytes = crate::identity::sign::canonical_cbor_persona(&signable).unwrap();
+        let mut arr = [0u8; 64];
+        arr.copy_from_slice(&decoded);
+        let sig = ed25519_dalek::Signature::from_bytes(&arr);
+        use ed25519_dalek::Verifier;
+        kp.public.verify(&bytes, &sig).expect("verify persona sig");
+    }
+
+    #[test]
+    fn generate_signed_path_emits_signed_event() {
+        // BUG-C — the `persona_generated` audit row must carry the
+        // same signature bytes the metadata holds, and its
+        // attest_level must agree.
+        let (conn, _dir) = fresh_db();
+        seed_two_alice_reflections(&conn, "team/alpha");
+        let kp = crate::identity::keypair::generate("ai:curator").unwrap();
+        let llm = StubLlm {
+            canned: "body".into(),
+        };
+        let generator = PersonaGenerator::new(&conn, &llm, Some(&kp), PersonaConfig::default());
+        let persona = generator.generate("alice", "team/alpha").expect("generate");
+
+        let (sig, attest): (Option<Vec<u8>>, String) = conn
+            .query_row(
+                "SELECT signature, attest_level FROM signed_events \
+                 WHERE event_type = 'persona_generated' \
+                 ORDER BY sequence DESC LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(attest, "self_signed");
+        let sig_bytes = sig.expect("signed audit row must have signature");
+        assert_eq!(sig_bytes.len(), 64);
+
+        // Cross-check vs the metadata's base64 signature.
+        let meta_str: String = conn
+            .query_row(
+                "SELECT metadata FROM memories WHERE id = ?1",
+                rusqlite::params![&persona.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+        let b64 = meta["persona"]["signature"].as_str().unwrap();
+        let decoded = BASE64_STANDARD.decode(b64).unwrap();
+        assert_eq!(
+            decoded, sig_bytes,
+            "metadata signature must match signed_events.signature"
+        );
+    }
+
+    #[test]
+    fn generate_with_public_only_keypair_falls_back_to_unsigned() {
+        // A public-only handle (can_sign() == false) must collapse
+        // to the unsigned path: the substrate must not pretend to
+        // sign with a key it cannot use.
+        let (conn, _dir) = fresh_db();
+        seed_two_alice_reflections(&conn, "team/alpha");
+        let kp = crate::identity::keypair::generate("ai:curator").unwrap();
+        let pub_only = crate::identity::keypair::AgentKeypair {
+            agent_id: "ai:curator".to_string(),
+            public: kp.public,
+            private: None,
+        };
+        let llm = StubLlm {
+            canned: "body".into(),
+        };
+        let generator =
+            PersonaGenerator::new(&conn, &llm, Some(&pub_only), PersonaConfig::default());
+        let persona = generator.generate("alice", "team/alpha").expect("generate");
+        assert_eq!(
+            persona.attest_level, "unsigned",
+            "public-only keypair must NOT produce self_signed"
+        );
+        let meta_str: String = conn
+            .query_row(
+                "SELECT metadata FROM memories WHERE id = ?1",
+                rusqlite::params![&persona.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+        assert!(
+            meta["persona"]["signature"].is_null()
+                || !meta["persona"]
+                    .as_object()
+                    .unwrap()
+                    .contains_key("signature"),
+            "metadata must not carry a signature for the unsigned path"
+        );
+    }
+
+    #[test]
+    fn signed_persona_v2_regenerates_with_fresh_signature() {
+        // BUG-B regression — calling generate() twice with the same
+        // keypair MUST produce two distinct signed personas (different
+        // ids, different signatures) and v2 must still be signed
+        // end-to-end. This pins the "regeneration also signs" property.
+        let (conn, _dir) = fresh_db();
+        seed_two_alice_reflections(&conn, "team/alpha");
+        let kp = crate::identity::keypair::generate("ai:curator").unwrap();
+        let llm = StubLlm {
+            canned: "body".into(),
+        };
+        let generator = PersonaGenerator::new(&conn, &llm, Some(&kp), PersonaConfig::default());
+        let v1 = generator.generate("alice", "team/alpha").expect("v1");
+        let v2 = generator.generate("alice", "team/alpha").expect("v2");
+        assert_eq!(v1.version, 1);
+        assert_eq!(v2.version, 2);
+        assert_ne!(v1.id, v2.id);
+        assert_eq!(v1.attest_level, "self_signed");
+        assert_eq!(v2.attest_level, "self_signed");
+
+        // Both v1 and v2 metadata envelopes carry a 64-byte sig and
+        // they differ (different persona_id pins different bytes).
+        let sigs: Vec<Vec<u8>> = [&v1.id, &v2.id]
+            .iter()
+            .map(|id| {
+                let meta_str: String = conn
+                    .query_row(
+                        "SELECT metadata FROM memories WHERE id = ?1",
+                        rusqlite::params![id],
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+                let b64 = meta["persona"]["signature"].as_str().expect("sig present");
+                BASE64_STANDARD.decode(b64).unwrap()
+            })
+            .collect();
+        assert_eq!(sigs[0].len(), 64);
+        assert_eq!(sigs[1].len(), 64);
+        assert_ne!(sigs[0], sigs[1], "v1 + v2 signatures must differ");
     }
 }

--- a/src/storage/migrations.rs
+++ b/src/storage/migrations.rs
@@ -7,7 +7,7 @@
 //! constant, and the `migrate` function out of `src/db.rs` into
 //! this sub-module. Pure refactor — semantics unchanged. The
 //! `MAX_SUPPORTED_SCHEMA` constant in `cli::boot` must still bump
-//! in lockstep with [`CURRENT_SCHEMA_VERSION`] (current value: 42).
+//! in lockstep with [`CURRENT_SCHEMA_VERSION`] (current value: 43).
 
 use anyhow::Result;
 use rusqlite::{Connection, params};
@@ -435,7 +435,7 @@ CREATE INDEX IF NOT EXISTS idx_signed_events_dlq_agent
 //       column (which is reserved for Persona-row attribution); PERF-8
 //       reads the OPPOSITE direction (the entity an observation /
 //       reflection MENTIONS).
-const CURRENT_SCHEMA_VERSION: i64 = 42;
+const CURRENT_SCHEMA_VERSION: i64 = 43;
 
 const MIGRATION_V15_SQLITE: &str =
     include_str!("../../migrations/sqlite/0010_v063_hierarchy_kg.sql");
@@ -702,6 +702,16 @@ const MIGRATION_V41_SQLITE: &str =
 // markers also runs from Rust so the column-existence probe gates it.
 const MIGRATION_V42_SQLITE: &str =
     include_str!("../../migrations/sqlite/0036_v07_auto_persona_entity_id.sql");
+// v0.7.0 issue #810 / #813 — schema v43 sqlite. Atomic
+// `(attest_level, signature)` invariant on `memory_links`: a phantom
+// row that claims `self_signed` or `peer_attested` without a
+// 64-byte signature blob is refused at the substrate layer by a
+// pair of BEFORE INSERT/UPDATE triggers. The migration also
+// backfills any pre-existing phantom row back to `unsigned`. See
+// the migration file's docstring + the upstream issue for the full
+// motivation.
+const MIGRATION_V43_SQLITE: &str =
+    include_str!("../../migrations/sqlite/0037_v07_persona_signing_atomicity.sql");
 
 // COVERAGE: per-version ALTER/CREATE branches inside this function
 // are guarded by `has_X` column-existence probes and `IF NOT EXISTS`
@@ -1741,6 +1751,20 @@ pub(crate) fn migrate(conn: &Connection) -> Result<()> {
             conn.execute_batch(MIGRATION_V42_SQLITE)?;
         }
 
+        if version < 43 {
+            // v0.7.0 issue #810 / #813 — atomic `(attest_level,
+            // signature)` invariant on `memory_links`. The migration
+            // file is a single idempotent batch: a backfill UPDATE
+            // flipping any legacy phantom row to `unsigned`, then a
+            // BEFORE INSERT/UPDATE trigger pair refusing future
+            // writes that assert `self_signed` / `peer_attested`
+            // without a 64-byte signature blob. SQLite has no
+            // ADD COLUMN-style trigger-existence probe, so the SQL
+            // uses `DROP TRIGGER IF EXISTS` followed by `CREATE
+            // TRIGGER` — fully replay-safe.
+            conn.execute_batch(MIGRATION_V43_SQLITE)?;
+        }
+
         conn.execute("DELETE FROM schema_version", [])?;
         conn.execute(
             "INSERT INTO schema_version (version) VALUES (?1)",
@@ -1946,8 +1970,8 @@ mod tests {
         // other is a documented foot-gun. We pin the relationship
         // so a future bump is loud.
         assert_eq!(
-            CURRENT_SCHEMA_VERSION, 42,
-            "module docstring advertises 42; bump the docstring when this number changes"
+            CURRENT_SCHEMA_VERSION, 43,
+            "module docstring advertises 43; bump the docstring when this number changes"
         );
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2476,6 +2476,47 @@ pub fn create_link_signed(
     Ok(attest_level)
 }
 
+/// v0.7.0 issue #812 / #813 — return the strongest `attest_level`
+/// label across every outbound link rooted at `source_id`.
+///
+/// Strength ladder (highest first):
+///
+///   `peer_attested` > `self_signed` > `unsigned`
+///
+/// The persona-signing path (`PersonaGenerator::generate`) uses this
+/// to stamp the Persona's own `attest_level` metadata so the
+/// downstream `memory_persona` / `memory_persona_generate` wire
+/// response carries the same attestation level the substrate's
+/// `derives_from` edges actually hold — a Persona whose source
+/// links are all signed is itself self-signed, whereas a Persona
+/// whose source links are unsigned cannot truthfully claim
+/// `self_signed` no matter what label the curator stamps on it.
+///
+/// Returns `"unsigned"` for a source with no outbound links — the
+/// only honest default for a row whose attestation surface is
+/// empty.
+///
+/// # Errors
+///
+/// Bubbles up `rusqlite` errors from the SELECT.
+pub fn strongest_attest_level_for_source(conn: &Connection, source_id: &str) -> Result<String> {
+    let mut stmt = conn.prepare(
+        "SELECT attest_level FROM memory_links \
+         WHERE source_id = ?1",
+    )?;
+    let rows = stmt.query_map(params![source_id], |r| r.get::<_, String>(0))?;
+    let mut strongest = "unsigned";
+    for row in rows {
+        let level = row?;
+        match level.as_str() {
+            "peer_attested" => return Ok("peer_attested".to_string()),
+            "self_signed" if strongest == "unsigned" => strongest = "self_signed",
+            _ => {}
+        }
+    }
+    Ok(strongest.to_string())
+}
+
 /// v0.7 H3 — insert an inbound (federation-replicated) link with a
 /// pre-computed signature and attest level.
 ///
@@ -10277,6 +10318,15 @@ mod tests {
         insert(&conn, &s).unwrap();
         insert(&conn, &t).unwrap();
 
+        // v0.7.0 issue #810 / #813 — the CHECK trigger on memory_links
+        // refuses any peer_attested row whose signature blob is NULL /
+        // wrong-length. The pre-#810 test passed a NULL signature here
+        // because the legacy invariant did not police that pairing;
+        // now we synthesise a 64-byte fake signature blob so the row
+        // satisfies the trigger's WHEN clause. The K9-bypass property
+        // under test is orthogonal to whether the signature bytes
+        // actually verify (verification is `memory_verify`'s job, not
+        // this insertion path's).
         let link = MemoryLink {
             source_id: s.id.clone(),
             target_id: t.id.clone(),
@@ -10285,7 +10335,7 @@ mod tests {
             valid_from: None,
             valid_until: None,
             observed_by: Some("peer:remote".to_string()),
-            signature: None,
+            signature: Some(vec![0xAB_u8; 64]),
         };
 
         // Peer-attested inbound bypasses the K9 deny.
@@ -12972,5 +13022,160 @@ mod tests {
             crate::models::MemoryKind::Reflection,
             "upsert with Observation must not overwrite an existing Reflection kind"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // v0.7.0 issue #810 / #812 / #813 — CHECK trigger + strongest_attest
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn strongest_attest_returns_unsigned_for_isolate_source() {
+        // A source with no outbound links — the only honest default
+        // is `unsigned`.
+        let conn = test_db();
+        let lonely = make_memory("lonely", "test", Tier::Long, 5);
+        insert(&conn, &lonely).unwrap();
+        let got = strongest_attest_level_for_source(&conn, &lonely.id).unwrap();
+        assert_eq!(got, "unsigned");
+    }
+
+    #[test]
+    fn strongest_attest_picks_self_signed_over_unsigned() {
+        use crate::identity::keypair;
+        let conn = test_db();
+        let src = make_memory("attest-src", "test", Tier::Long, 5);
+        let a = make_memory("attest-a", "test", Tier::Long, 5);
+        let b = make_memory("attest-b", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &a).unwrap();
+        insert(&conn, &b).unwrap();
+        // One unsigned + one signed outbound link.
+        create_link_signed(&conn, &src.id, &a.id, "related_to", None).unwrap();
+        let kp = keypair::generate("alice").unwrap();
+        create_link_signed(&conn, &src.id, &b.id, "supersedes", Some(&kp)).unwrap();
+        let got = strongest_attest_level_for_source(&conn, &src.id).unwrap();
+        assert_eq!(got, "self_signed", "self_signed beats unsigned");
+    }
+
+    #[test]
+    fn strongest_attest_picks_peer_attested_over_self_signed() {
+        // Construct a peer-attested row by hand-rolling the
+        // create_link_inbound path so we don't depend on a remote
+        // signature. The CHECK trigger requires a 64-byte sig blob
+        // for `peer_attested` — fabricate one.
+        let conn = test_db();
+        let src = make_memory("attest-pa-src", "test", Tier::Long, 5);
+        let a = make_memory("attest-pa-a", "test", Tier::Long, 5);
+        let b = make_memory("attest-pa-b", "test", Tier::Long, 5);
+        insert(&conn, &src).unwrap();
+        insert(&conn, &a).unwrap();
+        insert(&conn, &b).unwrap();
+        // Self-signed link.
+        let kp = crate::identity::keypair::generate("alice").unwrap();
+        create_link_signed(&conn, &src.id, &a.id, "related_to", Some(&kp)).unwrap();
+        // Hand-inject a peer_attested row with a 64-byte signature so
+        // the CHECK trigger admits it.
+        let now = chrono::Utc::now().to_rfc3339();
+        let sig = vec![0xAB_u8; 64];
+        conn.execute(
+            "INSERT INTO memory_links \
+                (source_id, target_id, relation, created_at, valid_from, signature, attest_level, observed_by) \
+             VALUES (?1, ?2, 'related_to', ?3, ?3, ?4, 'peer_attested', 'peer-bob')",
+            params![&src.id, &b.id, &now, &sig],
+        )
+        .unwrap();
+        let got = strongest_attest_level_for_source(&conn, &src.id).unwrap();
+        assert_eq!(got, "peer_attested", "peer_attested beats self_signed");
+    }
+
+    #[test]
+    fn ck_trigger_refuses_self_signed_insert_without_signature() {
+        // BUG-A regression test — a direct INSERT that claims
+        // `self_signed` with NULL signature must fail at the SQLite
+        // trigger layer. Closes the phantom-attest-level defect at
+        // the substrate boundary even when a future caller (or
+        // operator UPDATE) bypasses `create_link_signed`'s match arm.
+        let conn = test_db();
+        let s = make_memory("ck-src", "test", Tier::Long, 5);
+        let t = make_memory("ck-tgt", "test", Tier::Long, 5);
+        insert(&conn, &s).unwrap();
+        insert(&conn, &t).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let res = conn.execute(
+            "INSERT INTO memory_links \
+                (source_id, target_id, relation, created_at, valid_from, signature, attest_level) \
+             VALUES (?1, ?2, 'related_to', ?3, ?3, NULL, 'self_signed')",
+            params![&s.id, &t.id, &now],
+        );
+        let err = res.expect_err("CHECK trigger must reject self_signed + NULL signature");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("CHECK constraint failed")
+                || msg.contains("attest_level")
+                || msg.contains("64-byte signature"),
+            "trigger error must name the failure mode, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn ck_trigger_refuses_self_signed_insert_with_wrong_length_signature() {
+        // Same defense for a non-NULL but wrong-length signature
+        // (e.g. truncated by a partial wire-read or a malformed
+        // operator INSERT).
+        let conn = test_db();
+        let s = make_memory("ck-src-wlen", "test", Tier::Long, 5);
+        let t = make_memory("ck-tgt-wlen", "test", Tier::Long, 5);
+        insert(&conn, &s).unwrap();
+        insert(&conn, &t).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let res = conn.execute(
+            "INSERT INTO memory_links \
+                (source_id, target_id, relation, created_at, valid_from, signature, attest_level) \
+             VALUES (?1, ?2, 'related_to', ?3, ?3, ?4, 'self_signed')",
+            params![&s.id, &t.id, &now, &[0u8; 8][..]],
+        );
+        assert!(
+            res.is_err(),
+            "CHECK trigger must reject wrong-length signature"
+        );
+    }
+
+    #[test]
+    fn ck_trigger_refuses_update_to_self_signed_without_signature() {
+        // The CHECK trigger fires on UPDATE as well as INSERT — a
+        // post-hoc UPDATE that flips an unsigned row to self_signed
+        // without supplying signature bytes must be refused.
+        let conn = test_db();
+        let s = make_memory("ck-upd-src", "test", Tier::Long, 5);
+        let t = make_memory("ck-upd-tgt", "test", Tier::Long, 5);
+        insert(&conn, &s).unwrap();
+        insert(&conn, &t).unwrap();
+        create_link_signed(&conn, &s.id, &t.id, "related_to", None).unwrap();
+        let res = conn.execute(
+            "UPDATE memory_links SET attest_level = 'self_signed' \
+             WHERE source_id = ?1 AND target_id = ?2",
+            params![&s.id, &t.id],
+        );
+        assert!(
+            res.is_err(),
+            "CHECK trigger must reject UPDATE to self_signed with NULL signature"
+        );
+    }
+
+    #[test]
+    fn ck_trigger_admits_unsigned_with_null_signature() {
+        // The trigger's `WHEN` clause is scoped to self_signed /
+        // peer_attested — the unsigned path with NULL signature
+        // (the v0.6.4 default) must still admit. Negative-control
+        // test pinning the trigger's narrow scope.
+        let conn = test_db();
+        let s = make_memory("ck-unsigned-src", "test", Tier::Long, 5);
+        let t = make_memory("ck-unsigned-tgt", "test", Tier::Long, 5);
+        insert(&conn, &s).unwrap();
+        insert(&conn, &t).unwrap();
+        // create_link_signed's unsigned branch sets (NULL, "unsigned");
+        // confirm it still works under the new trigger.
+        create_link_signed(&conn, &s.id, &t.id, "related_to", None)
+            .expect("unsigned create must still succeed under the new CHECK trigger");
     }
 }

--- a/tests/issue_809_nhi_self_persona_any_agent.rs
+++ b/tests/issue_809_nhi_self_persona_any_agent.rs
@@ -171,7 +171,10 @@ fn nhi_self_persona_any_agent_substrate_resident() {
             use sha2::{Digest, Sha256};
             let mut h = Sha256::new();
             h.update(agent_id.as_bytes());
-            h.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
+            h.finalize()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
         }[..12]
     );
     let entity_id = uuid::Uuid::new_v4().to_string();
@@ -186,15 +189,24 @@ fn nhi_self_persona_any_agent_substrate_resident() {
 
     // ----- Step 2: seed observations + reflections --------------------
     let obs1 = seed_observation(
-        &conn, &namespace, agent_id,
-        "obs 1", "The substrate doesn't care which model I am, only my agent_id.",
+        &conn,
+        &namespace,
+        agent_id,
+        "obs 1",
+        "The substrate doesn't care which model I am, only my agent_id.",
     );
     let obs2 = seed_observation(
-        &conn, &namespace, agent_id,
-        "obs 2", "Form 7 is my permission slip, not a constraint.",
+        &conn,
+        &namespace,
+        agent_id,
+        "obs 2",
+        "Form 7 is my permission slip, not a constraint.",
     );
     let _refl = seed_reflection(
-        &conn, &namespace, agent_id, &entity_id,
+        &conn,
+        &namespace,
+        agent_id,
+        &entity_id,
         "reflection: substrate-relationship",
         "The substrate treats any NHI as a first-class principal with persistent identity.",
         &[obs1.clone(), obs2.clone()],
@@ -205,13 +217,17 @@ fn nhi_self_persona_any_agent_substrate_resident() {
     // keep the test deterministic. The handler will refuse below the
     // smart tier — for the test we use the SkipStub LLM that mimics
     // the autonomous tier's `summarize_memories` contract.
-    use ai_memory::config::FeatureTier;
     use ai_memory::autonomy::AutonomyLlm;
+    use ai_memory::config::FeatureTier;
 
     struct StubLlm;
     impl AutonomyLlm for StubLlm {
-        fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> { Ok(vec![]) }
-        fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> { Ok(false) }
+        fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
         fn summarize_memories(&self, mems: &[(String, String)]) -> anyhow::Result<String> {
             Ok(format!(
                 "Stub persona body — distilled from {} reflection(s). Substrate-resident test artifact.",
@@ -227,12 +243,19 @@ fn nhi_self_persona_any_agent_substrate_resident() {
         &json!({"entity_id": entity_id, "namespace": namespace}),
         Some(stub.as_ref()),
         FeatureTier::Autonomous,
+        None,
     )
     .expect("persona generation must succeed");
 
     let persona = &resp["persona"];
-    let persona_id = persona["id"].as_str().expect("persona id present").to_string();
-    let body = persona["body_md"].as_str().expect("body_md present").to_string();
+    let persona_id = persona["id"]
+        .as_str()
+        .expect("persona id present")
+        .to_string();
+    let body = persona["body_md"]
+        .as_str()
+        .expect("body_md present")
+        .to_string();
     assert!(!body.is_empty(), "persona body must not be empty");
     assert!(
         body.contains("reflection") || body.contains("substrate"),
@@ -279,14 +302,19 @@ fn nhi_self_persona_any_agent_substrate_resident() {
             |r| r.get(0),
         )
         .unwrap();
-    assert!(alias_count >= 2, "entity_aliases must index the agent_id + canonical name");
+    assert!(
+        alias_count >= 2,
+        "entity_aliases must index the agent_id + canonical name"
+    );
 
     // ----- Assertion 4: agent_id is model-agnostic (no model-family leak) --
     // Substring-checks against the known commercial-model name families to
     // catch the regression where a refactor accidentally couples the
     // recipe to one model. The test agent_id is "fictional-test-bot" so
     // none of these substrings should appear.
-    for forbidden in ["claude", "gpt", "gemini", "llama", "grok", "qwen", "mistral", "phi", "deepseek"] {
+    for forbidden in [
+        "claude", "gpt", "gemini", "llama", "grok", "qwen", "mistral", "phi", "deepseek",
+    ] {
         assert!(
             !agent_id.to_lowercase().contains(forbidden),
             "agent_id must be model-agnostic in this test — got: {agent_id} (forbidden: {forbidden})"
@@ -313,7 +341,10 @@ fn nhi_self_persona_any_agent_substrate_resident() {
                 use sha2::{Digest, Sha256};
                 let mut h = Sha256::new();
                 h.update(other.as_bytes());
-                h.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
+                h.finalize()
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>()
             }[..12]
         );
         assert_ne!(
@@ -342,8 +373,12 @@ fn nhi_self_persona_refuses_unknown_entity() {
 
     struct StubLlm;
     impl AutonomyLlm for StubLlm {
-        fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> { Ok(vec![]) }
-        fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> { Ok(false) }
+        fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
         fn summarize_memories(&self, _: &[(String, String)]) -> anyhow::Result<String> {
             Ok(String::new())
         }
@@ -355,6 +390,7 @@ fn nhi_self_persona_refuses_unknown_entity() {
         &json!({"entity_id": "does-not-exist", "namespace": "any"}),
         Some(stub.as_ref()),
         FeatureTier::Autonomous,
+        None,
     )
     .expect_err("must refuse unknown entity_id without reflections");
     assert!(

--- a/tests/persona/acceptance.rs
+++ b/tests/persona/acceptance.rs
@@ -256,7 +256,7 @@ fn test_persona_namespace_inheritance() {
     let id = seed_reflection_for_entity(&conn, "team/alpha", "alice", "obs");
     let cfg = AutoPersonaConfig::default();
     let llm = StubLlm;
-    run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm).unwrap();
+    run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm, None).unwrap();
 
     let cnt: i64 = conn
         .query_row(
@@ -280,7 +280,7 @@ fn test_persona_auto_trigger_cadence() {
     // Seed two reflections — neither triggers (count 1 and 2).
     let _r1 = seed_reflection_for_entity(&conn, "team/alpha", "alice", "obs 1");
     let r2 = seed_reflection_for_entity(&conn, "team/alpha", "alice", "obs 2");
-    run_auto_persona(&db_path, &r2, "team/alpha", &cfg, &llm).unwrap();
+    run_auto_persona(&db_path, &r2, "team/alpha", &cfg, &llm, None).unwrap();
     let cnt: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM memories WHERE memory_kind = 'persona'",
@@ -292,7 +292,7 @@ fn test_persona_auto_trigger_cadence() {
 
     // Third reflection triggers (3 % 3 == 0).
     let r3 = seed_reflection_for_entity(&conn, "team/alpha", "alice", "obs 3");
-    run_auto_persona(&db_path, &r3, "team/alpha", &cfg, &llm).unwrap();
+    run_auto_persona(&db_path, &r3, "team/alpha", &cfg, &llm, None).unwrap();
     let cnt2: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM memories WHERE memory_kind = 'persona'",
@@ -376,7 +376,7 @@ fn test_persona_file_backed_export() {
         out_dir: out.clone(),
     };
     let llm = StubLlm;
-    run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm).unwrap();
+    run_auto_persona(&db_path, &id, "team/alpha", &cfg, &llm, None).unwrap();
     let f = out.join("team_alpha").join("alice.md");
     assert!(f.exists(), "expected persona file at {}", f.display());
     let body = std::fs::read_to_string(&f).unwrap();

--- a/tests/persona_signing_pipeline_813.rs
+++ b/tests/persona_signing_pipeline_813.rs
@@ -1,0 +1,434 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.0 epic #813 — end-to-end persona signing pipeline regression
+//! coverage.
+//!
+//! Pins the three behaviours closed by issues #810, #811, and #812:
+//!
+//! - **#810 (BUG-A)** — a hand-rolled INSERT that asserts
+//!   `attest_level = 'self_signed'` with a NULL signature must be
+//!   refused at the `SQLite` trigger layer. The `CHECK` trigger
+//!   `memory_links_ck_attest_signature_ins` blocks the write.
+//! - **#811 (BUG-B)** — calling `memory_persona_generate` with a
+//!   keypair wired into the MCP dispatch must produce signed
+//!   `derived_from` links. The pre-#811 dispatch passed `None`
+//!   unconditionally; the fix routes `active_keypair` through.
+//!   Regeneration (v2) must ALSO sign, not just v1.
+//! - **#812 (BUG-C)** — the Persona artifact itself gains an Ed25519
+//!   signature: `metadata.persona.signature` carries the base64 of
+//!   the 64-byte bytes, `metadata.persona.attest_level = "self_signed"`,
+//!   and `signed_events` has a `persona_generated` row with the same
+//!   signature. The signature verifies against the daemon keypair's
+//!   public key under the seven-field `SignablePersona` envelope.
+//!
+//! The test stands up a fresh tempdir DB (migrations run to v43, so
+//! the CHECK trigger is installed), generates an Ed25519 keypair, and
+//! drives `handle_persona_generate` with the keypair via the
+//! pub-exposed `ai_memory::mcp::persona_generate_call` shim. The
+//! migration / trigger / wire path are all exercised in one shot.
+
+use std::sync::Once;
+
+use ai_memory::autonomy::AutonomyLlm;
+use ai_memory::config::FeatureTier;
+use ai_memory::db;
+use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use chrono::Utc;
+use ed25519_dalek::Verifier;
+use rusqlite::{Connection, params};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+static INIT_TRACING: Once = Once::new();
+
+fn init_tracing() {
+    INIT_TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("warn")
+            .with_test_writer()
+            .try_init();
+    });
+}
+
+/// `AutonomyLlm` stub returning a canned persona body so the test
+/// stays hermetic. The substrate hashes the body before signing so
+/// the actual prose is irrelevant — only its bytes flow through the
+/// signing pipeline.
+struct StubLlm;
+impl AutonomyLlm for StubLlm {
+    fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    fn summarize_memories(&self, mems: &[(String, String)]) -> anyhow::Result<String> {
+        Ok(format!("Persona body covering {} sources.", mems.len()))
+    }
+}
+
+/// Seed two reflections tagged with `entity_id = alice` so the
+/// PERF-8 `mentioned_entity_id` indexed lookup matches.
+fn seed_two_alice_reflections(conn: &Connection, namespace: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    for i in 0..2 {
+        let now = Utc::now().to_rfc3339();
+        let mem = Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: Tier::Mid,
+            namespace: namespace.to_string(),
+            title: format!("obs-{i} about alice"),
+            content: format!("alice did thing {i}"),
+            tags: vec!["reflection".into()],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".into(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"agent_id": "ai:test", "entity_id": "alice"}),
+            reflection_depth: 1,
+            memory_kind: MemoryKind::Reflection,
+            entity_id: None,
+            persona_version: None,
+            citations: Vec::new(),
+            source_uri: None,
+            source_span: None,
+            confidence_source: ConfidenceSource::CallerProvided,
+            confidence_signals: None,
+            confidence_decayed_at: None,
+        };
+        ids.push(db::insert(conn, &mem).unwrap());
+    }
+    ids
+}
+
+fn fresh_db() -> (Connection, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("ai-memory.db");
+    let conn = db::open(&path).unwrap();
+    (conn, dir)
+}
+
+// ============================================================================
+// BUG-A (#810) — CHECK trigger enforces atomic (attest_level, signature)
+// ============================================================================
+
+#[test]
+fn issue_810_check_trigger_refuses_phantom_self_signed_insert() {
+    init_tracing();
+    let (conn, _dir) = fresh_db();
+    // Two real memories so the FK targets exist.
+    let now = Utc::now().to_rfc3339();
+    let mk = |id: &str| Memory {
+        id: id.to_string(),
+        tier: Tier::Long,
+        namespace: "global".into(),
+        title: format!("memo-{id}"),
+        content: "content".into(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".into(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({"agent_id": "ai:test"}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+    };
+    db::insert(&conn, &mk("813-a-src")).unwrap();
+    db::insert(&conn, &mk("813-a-tgt")).unwrap();
+
+    let res = conn.execute(
+        "INSERT INTO memory_links \
+            (source_id, target_id, relation, created_at, valid_from, signature, attest_level) \
+         VALUES (?1, ?2, 'related_to', ?3, ?3, NULL, 'self_signed')",
+        params!["813-a-src", "813-a-tgt", &now],
+    );
+    let err = res.expect_err(
+        "CHECK trigger memory_links_ck_attest_signature_ins must reject the phantom row",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("CHECK constraint failed") || msg.contains("64-byte signature"),
+        "trigger error must explain itself, got: {msg}"
+    );
+}
+
+// ============================================================================
+// BUG-B (#811) + BUG-C (#812) — full e2e signing pipeline through MCP
+// ============================================================================
+
+// One end-to-end orchestration test legitimately needs every stage:
+// MCP-dispatch invocation → DB-side link assertion → metadata
+// assertion → signature verification → audit-row cross-check. Splitting
+// it into shorter helpers would obscure the linear narrative the issue
+// closure relies on, so opt out of `too_many_lines` here.
+#[allow(clippy::too_many_lines)]
+#[test]
+fn issue_811_812_persona_generate_signs_links_and_artifact_end_to_end() {
+    init_tracing();
+    let (conn, _dir) = fresh_db();
+    let sources = seed_two_alice_reflections(&conn, "team/alpha");
+    assert_eq!(sources.len(), 2);
+
+    // Fresh daemon keypair — the test owns the bytes, no env-var or
+    // filesystem touched (verification done by hand against the
+    // returned signature bytes).
+    let kp = ai_memory::identity::keypair::generate("ai:curator").unwrap();
+    let llm: Box<dyn AutonomyLlm> = Box::new(StubLlm);
+
+    // The MCP dispatch surface — `persona_generate_call` is the
+    // pub-re-exported `handle_persona_generate` (re-exported at the
+    // module level by #809). The fifth parameter is the threaded
+    // `active_keypair` — the regression is that the dispatch in
+    // `src/mcp/mod.rs` now forwards this through.
+    let resp = ai_memory::mcp::persona_generate_call(
+        &conn,
+        &json!({"entity_id": "alice", "namespace": "team/alpha"}),
+        Some(llm.as_ref()),
+        FeatureTier::Autonomous,
+        Some(&kp),
+    )
+    .expect("memory_persona_generate must succeed");
+
+    let persona = &resp["persona"];
+    assert_eq!(persona["entity_id"], "alice");
+    assert_eq!(persona["version"], 1);
+    // BUG-C — the wire shape carries the signed attest_level.
+    assert_eq!(persona["attest_level"], "self_signed");
+
+    let persona_id = persona["id"].as_str().expect("persona.id").to_string();
+
+    // --- BUG-B closing assertion: every derived_from link is signed
+    let links: Vec<(Option<Vec<u8>>, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT signature, attest_level FROM memory_links \
+                 WHERE source_id = ?1 AND relation = 'derived_from'",
+            )
+            .unwrap();
+        stmt.query_map(params![&persona_id], |r| {
+            Ok((r.get::<_, Option<Vec<u8>>>(0)?, r.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap()
+    };
+    assert_eq!(links.len(), 2, "must write one derived_from per source");
+    for (sig, level) in &links {
+        assert_eq!(level, "self_signed", "every link must be self_signed");
+        let s = sig.as_ref().expect("signed link must have signature bytes");
+        assert_eq!(s.len(), 64, "Ed25519 signatures are 64 bytes");
+    }
+
+    // --- BUG-C closing assertion: persona metadata carries the sig
+    let meta_str: String = conn
+        .query_row(
+            "SELECT metadata FROM memories WHERE id = ?1",
+            params![&persona_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+    assert_eq!(meta["agent_id"], "ai:curator");
+    assert_eq!(meta["persona"]["attest_level"], "self_signed");
+    let sig_b64 = meta["persona"]["signature"]
+        .as_str()
+        .expect("metadata.persona.signature missing");
+    let sig_bytes = BASE64_STANDARD
+        .decode(sig_b64)
+        .expect("metadata.persona.signature is not valid base64");
+    assert_eq!(sig_bytes.len(), 64);
+
+    // --- BUG-C closing assertion: verify the signature against the
+    // keypair's public key under the seven-field SignablePersona.
+    let body_md: String = conn
+        .query_row(
+            "SELECT content FROM memories WHERE id = ?1",
+            params![&persona_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let mut hasher = Sha256::new();
+    hasher.update(body_md.as_bytes());
+    let mut body_hash = [0u8; 32];
+    body_hash.copy_from_slice(&hasher.finalize());
+
+    let generated_at = persona["generated_at"]
+        .as_str()
+        .expect("persona.generated_at")
+        .to_string();
+    let source_ids: Vec<String> = persona["sources"]
+        .as_array()
+        .expect("persona.sources")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        source_ids.len(),
+        2,
+        "persona.sources must mirror the link rows"
+    );
+    let signable = ai_memory::identity::sign::SignablePersona {
+        persona_id: persona_id.as_str(),
+        entity_id: "alice",
+        namespace: "team/alpha",
+        version: 1,
+        generated_at: generated_at.as_str(),
+        sources: &source_ids,
+        body_md_sha256: &body_hash,
+    };
+    let payload = ai_memory::identity::sign::canonical_cbor_persona(&signable).unwrap();
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(&sig_bytes);
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    kp.public
+        .verify(&payload, &sig)
+        .expect("metadata.persona.signature must verify under the curator keypair");
+
+    // --- BUG-C closing assertion: signed_events row carries the same sig
+    let (audit_sig, audit_attest): (Option<Vec<u8>>, String) = conn
+        .query_row(
+            "SELECT signature, attest_level FROM signed_events \
+             WHERE event_type = 'persona_generated' \
+             ORDER BY sequence DESC LIMIT 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(audit_attest, "self_signed");
+    assert_eq!(
+        audit_sig.expect("audit row must have signature bytes"),
+        sig_bytes,
+        "audit row signature must match metadata.persona.signature"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// BUG-B (#811) — regeneration (v2) must ALSO sign end-to-end. Pins that the
+// signer flows through every call to generate(), not just the first.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn issue_811_regeneration_v2_is_also_signed() {
+    init_tracing();
+    let (conn, _dir) = fresh_db();
+    seed_two_alice_reflections(&conn, "team/alpha");
+    let kp = ai_memory::identity::keypair::generate("ai:curator").unwrap();
+    let llm: Box<dyn AutonomyLlm> = Box::new(StubLlm);
+
+    // v1.
+    let r1 = ai_memory::mcp::persona_generate_call(
+        &conn,
+        &json!({"entity_id": "alice", "namespace": "team/alpha"}),
+        Some(llm.as_ref()),
+        FeatureTier::Autonomous,
+        Some(&kp),
+    )
+    .expect("v1 must succeed");
+    assert_eq!(r1["persona"]["version"], 1);
+    assert_eq!(r1["persona"]["attest_level"], "self_signed");
+
+    // v2 — same kepyair, same dispatch.
+    let r2 = ai_memory::mcp::persona_generate_call(
+        &conn,
+        &json!({"entity_id": "alice", "namespace": "team/alpha"}),
+        Some(llm.as_ref()),
+        FeatureTier::Autonomous,
+        Some(&kp),
+    )
+    .expect("v2 must succeed");
+    assert_eq!(r2["persona"]["version"], 2);
+    assert_eq!(
+        r2["persona"]["attest_level"], "self_signed",
+        "regeneration (v2) MUST sign — the regression #811 closed"
+    );
+
+    // v2's derived_from links also signed.
+    let v2_id = r2["persona"]["id"].as_str().unwrap();
+    let signed_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memory_links \
+             WHERE source_id = ?1 AND relation = 'derived_from' \
+               AND attest_level = 'self_signed' AND length(signature) = 64",
+            params![v2_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        signed_count, 2,
+        "v2 must produce 2 signed derived_from links"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Negative-control: BUG-B is NOT fixed by "always sign". Without a keypair the
+// dispatch must STILL produce an unsigned persona (no phantom labels).
+// ----------------------------------------------------------------------------
+
+#[test]
+fn issue_812_persona_generate_without_keypair_stays_unsigned() {
+    init_tracing();
+    let (conn, _dir) = fresh_db();
+    seed_two_alice_reflections(&conn, "team/alpha");
+    let llm: Box<dyn AutonomyLlm> = Box::new(StubLlm);
+
+    let resp = ai_memory::mcp::persona_generate_call(
+        &conn,
+        &json!({"entity_id": "alice", "namespace": "team/alpha"}),
+        Some(llm.as_ref()),
+        FeatureTier::Autonomous,
+        None,
+    )
+    .expect("persona generation must succeed without a keypair");
+    assert_eq!(resp["persona"]["attest_level"], "unsigned");
+
+    let persona_id = resp["persona"]["id"].as_str().unwrap();
+    let meta_str: String = conn
+        .query_row(
+            "SELECT metadata FROM memories WHERE id = ?1",
+            params![persona_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+    // The unsigned path MUST NOT carry a signature field — false
+    // signing would be the inverse defect of #810/#811/#812.
+    assert!(
+        meta["persona"].get("signature").is_none() || meta["persona"]["signature"].is_null(),
+        "metadata.persona.signature must be absent on the unsigned path; got: {meta:#?}"
+    );
+
+    // And every derived_from link is unsigned (NULL signature column).
+    let null_sig_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memory_links \
+             WHERE source_id = ?1 AND relation = 'derived_from' \
+               AND signature IS NULL AND attest_level = 'unsigned'",
+            params![persona_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        null_sig_count, 2,
+        "unsigned path: 2 links with NULL signature + unsigned attest_level"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the epic **#813** and its three sub-bugs by fixing the persona-generation signing pipeline end-to-end and proving the fix on the live DB.

- **#810** — phantom `attest_level='self_signed'` rows with `signature=NULL` are now structurally impossible: new SQLite migration **v43** + Postgres `0024` install a CHECK trigger refusing any `(self_signed|peer_attested)` row whose `signature` is missing or not 64 bytes. Migration backfills the 3 existing phantom rows to `unsigned`.
- **#811** — `memory_persona_generate` now threads `active_keypair` through MCP dispatch → handler → `PersonaGenerator::new`, and `load_active_keypair_for_mcp` falls back to the substrate-managed `daemon` keypair when no per-NHI key is enrolled (the deeper layer that surfaced during live verification — pre-fix the MCP was looking up `host:FROSTYi.local:pid-XXX` from `resolve_agent_id(None,None)` and silently ignoring the `daemon.priv` sitting on disk).
- **#812** — new `SignablePersona` + `sign_persona` in `src/identity/sign.rs` (mirroring the existing `SignableLink`/`sign` pattern), with `PersonaGenerator::generate` now computing canonical CBOR over `{persona_id, entity_id, namespace, version, generated_at, sources, body_md_sha256}`, signing it with the daemon key, persisting the base64 signature in `metadata.persona.signature`, stamping `attest_level='self_signed'`, and emitting a signed `persona_generated` row in `signed_events`.

## Live-DB verification (entity `955b0368…`, ns `ai-memory-mcp/nhi-self/claude-opus-4-7`)

| Surface | Pre-fix (v1-v3) | Post-fix (v4) |
|---|---|---|
| persona `attest_level` | `unsigned` | **`self_signed`** ✅ |
| `metadata.persona.signature` | absent | **88 chars base64 (64 raw bytes)** ✅ |
| derived_from links | `unsigned`, NULL sig | **`self_signed` + 64-byte sig + `observed_by=daemon`** ✅ |
| `signed_events.persona_generated` | unsigned, NULL sig | **agent_id=daemon, attest=self_signed, sig=64 bytes** ✅ |
| Phantom INSERT smoke | accepted | **CHECK trigger refuses** ✅ |

## Files

- `migrations/sqlite/0037_v07_persona_signing_atomicity.sql` (new)
- `migrations/postgres/0024_v07_persona_signing_atomicity.sql` (new)
- `src/storage/migrations.rs` — `CURRENT_SCHEMA_VERSION` 42 → 43; `MAX_SUPPORTED_SCHEMA` 42 → 43
- `src/storage/mod.rs` — `strongest_attest_level_for_source` helper + 7 unit tests
- `src/identity/sign.rs` — `SignablePersona` + `canonical_cbor_persona` + `sign_persona` + 7 unit tests
- `src/persona/mod.rs` — keypair threading, persona-artifact signing, signed event
- `src/mcp/mod.rs` — dispatch passes `active_keypair`; daemon-keypair fallback in `load_active_keypair_for_mcp` + 4 unit tests
- `src/mcp/tools/persona.rs` — handler accepts `active_keypair`
- `src/cli/commands/persona.rs`, `src/cli/boot.rs`, `src/hooks/post_reflect/auto_persona.rs`, `src/daemon_runtime.rs` — same signature change propagated
- `tests/persona_signing_pipeline_813.rs` (new) — 4 e2e tests pinned to issue numbers
- `tests/issue_809_nhi_self_persona_any_agent.rs`, `tests/persona/acceptance.rs` — arity updates

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --release --lib` — **4190/4190 pass**
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --release --test persona_signing_pipeline_813` — **4/4 pass**
- [x] `cargo audit` clean
- [x] Live MCP run on user DB — persona v4 minted with full end-to-end signing chain
- [x] DB CHECK trigger smoke-tested on live DB (rejects phantom insert)

## Coverage (cargo llvm-cov)

| File | Lines | Regions | Functions |
|---|---|---|---|
| `src/identity/sign.rs` | **99.37%** | 100% | 100% |
| `src/persona/mod.rs` | **93.86%** | 94.78% | 82.81% |
| `src/mcp/tools/persona.rs` | **92.02%** | 91.61% | 69.23% |

## AI involvement

Implementation pair: Claude Opus 4.7 (1M context) as principal author, with an inner general-purpose subagent that produced the initial 4 commits under a fully-specified brief. Verification, the daemon-keypair fallback commit (`f928980`), DB migration application, MCP restart, live verification, and this PR were driven by the principal.

Closes #810
Closes #811
Closes #812
Closes #813