### PR TITLE
fix(#815): sign reflects_on edges from storage::reflect via threaded keypair

### DIFF
--- a/src/curator/reflection_pass.rs
+++ b/src/curator/reflection_pass.rs
@@ -419,11 +419,18 @@ impl<'a> CompactionPass for ReflectionPass<'a> {
             metadata: summary.metadata.clone(),
         };
 
-        match reflect_with_hooks(
-            self.conn,
-            &input,
-            &crate::storage::reflect::ReflectHooks::empty(),
-        ) {
+        // Issue #815 — thread the curator's signing keypair into the
+        // hook bundle so the substrate's `create_link_signed` path
+        // sees it and produces `attest_level='self_signed'` rows for
+        // every `reflects_on` edge this pass writes. Pre-#815 the
+        // call site passed `ReflectHooks::empty()`, dropping
+        // `self.keypair` on the floor and writing unsigned edges
+        // despite the comment at `verify()` claiming otherwise.
+        let hooks = crate::storage::reflect::ReflectHooks {
+            active_keypair: self.keypair,
+            ..crate::storage::reflect::ReflectHooks::empty()
+        };
+        match reflect_with_hooks(self.conn, &input, &hooks) {
             Ok(_outcome) => Ok(()),
             Err(ReflectError::DepthExceeded {
                 attempted,

--- a/src/hooks/post_reflect/auto_export.rs
+++ b/src/hooks/post_reflect/auto_export.rs
@@ -180,6 +180,13 @@ pub fn build_post_reflect_hook(
     ReflectHooks {
         pre_reflect: None,
         post_reflect: Some(cb),
+        // Issue #815 — auto-export does not need a signing keypair;
+        // signing is owned by the reflect handler that built this hook
+        // bundle. The handler-side construction in
+        // `mcp::tools::reflect::handle_reflect` overrides this field
+        // when an active keypair is available, so the field is left
+        // None here and re-assigned by the caller.
+        active_keypair: None,
     }
 }
 

--- a/src/hooks/post_reflect/auto_persona.rs
+++ b/src/hooks/post_reflect/auto_persona.rs
@@ -115,6 +115,15 @@ where
     ReflectHooks {
         pre_reflect: None,
         post_reflect: Some(cb),
+        // Issue #815 — the auto-persona hook signs the persona
+        // artifact via its own keypair forwarded to
+        // `PersonaGenerator::new`, but it does NOT sign the
+        // reflection's `reflects_on` edges (that's the storage layer's
+        // concern, signaled via this field). The handler that
+        // installed this hook overrides `active_keypair` to its own
+        // active keypair so the upstream `create_link_signed` path
+        // inside `storage::reflect_with_hooks` sees the keypair too.
+        active_keypair: None,
     }
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -931,9 +931,15 @@ fn handle_request(
                 // v0.7.0 Task 4/8 (recursive learning, issue #655) —
                 // substrate-native reflection primitive. See
                 // `handle_reflect` for the contract.
-                "memory_reflect" => {
-                    handle_reflect(conn, db_path, arguments, embedder, vector_index, mcp_client)
-                }
+                "memory_reflect" => handle_reflect(
+                    conn,
+                    db_path,
+                    arguments,
+                    embedder,
+                    vector_index,
+                    mcp_client,
+                    active_keypair,
+                ),
                 "memory_capabilities" => {
                     // v0.6.4-006 — runtime expansion via family enumeration.
                     // When `family` is set, route to the family-listing path
@@ -3408,6 +3414,152 @@ mod tests {
             .unwrap();
         let sig_bytes = sig.expect("signed link must persist a signature blob");
         assert_eq!(sig_bytes.len(), 64);
+    }
+
+    // Issue #815 — when an active keypair is plumbed through to the
+    // memory_reflect MCP handler, every reflects_on edge written
+    // inside the reflect transaction lands as attest_level =
+    // 'self_signed' with a 64-byte Ed25519 signature. Mirrors the
+    // `handle_link_with_active_keypair_returns_self_signed` shape
+    // above so the substrate's two write-paths-that-create-links
+    // (memory_link, memory_reflect) are pinned by parallel
+    // regression tests.
+    //
+    // Pre-#815 every reflects_on edge from memory_reflect landed
+    // as 'unsigned' because storage::reflect_with_hooks called
+    // `create_link` (the unsigned helper) regardless of whether
+    // the caller had loaded a daemon keypair. The fix routes
+    // through `create_link_signed` with the keypair threaded via
+    // ReflectHooks::active_keypair; this test pins that contract.
+    #[test]
+    fn handle_reflect_with_active_keypair_returns_signed_reflects_on_edges() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        // Three source observations the reflection will fan out to.
+        // Three is the minimum interesting count: it pins that every
+        // link in the loop gets signed, not just the first.
+        let mut source_ids = Vec::new();
+        for tag in ["src-a", "src-b", "src-c"] {
+            let mem = Memory {
+                id: uuid::Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: "issue-815-reflect".into(),
+                title: tag.into(),
+                content: format!("body for {tag}"),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "test".into(),
+                access_count: 0,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: json!({}),
+                reflection_depth: 0,
+                memory_kind: crate::models::MemoryKind::Observation,
+                entity_id: None,
+                persona_version: None,
+                citations: Vec::new(),
+                source_uri: None,
+                source_span: None,
+                confidence_source: crate::models::ConfidenceSource::CallerProvided,
+                confidence_signals: None,
+                confidence_decayed_at: None,
+            };
+            source_ids.push(db::insert(&conn, &mem).unwrap());
+        }
+        let req = make_tools_call(
+            "memory_reflect",
+            json!({
+                "source_ids": source_ids,
+                "title": "issue-815 reflect signing pin",
+                "content": "reflects_on edges must come back self_signed",
+                "namespace": "issue-815-reflect",
+            }),
+        );
+
+        let kp = crate::identity::keypair::generate("alice").unwrap();
+        let tier_config = FeatureTier::Keyword.config();
+        let resolved_ttl = crate::config::ResolvedTtl::default();
+        let resolved_scoring = crate::config::ResolvedScoring::default();
+        let resp = handle_request(
+            &conn,
+            std::path::Path::new(":memory:"),
+            &req,
+            None,
+            None,
+            None,
+            &tier_config,
+            None,
+            &resolved_ttl,
+            &resolved_scoring,
+            true,
+            false,
+            None,
+            &crate::profile::Profile::full(),
+            None,
+            Some(&kp),
+            None,
+            None, // federation_forward_url (#318)
+            None, // recall_scope (#518)
+            None, // atomise_handler (WT-1-C)
+            None, // ingest_multistep_handler (Form 3 / #756)
+        );
+        assert!(resp.error.is_none(), "MCP error: {:?}", resp.error);
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let val: Value = serde_json::from_str(&text).unwrap();
+        let reflection_id = val["id"]
+            .as_str()
+            .expect("reflect response must carry the new memory id")
+            .to_string();
+
+        // Every reflects_on edge from this reflection must be signed
+        // with a 64-byte Ed25519 signature, and the row's attest_level
+        // must read 'self_signed'. We check all three edges so a
+        // partial-fix regression (signs the first edge only) cannot
+        // pass.
+        let mut stmt = conn
+            .prepare(
+                "SELECT target_id, attest_level, signature \
+                 FROM memory_links \
+                 WHERE source_id = ?1 AND relation = 'reflects_on' \
+                 ORDER BY created_at",
+            )
+            .unwrap();
+        let rows: Vec<(String, String, Option<Vec<u8>>)> = stmt
+            .query_map(rusqlite::params![&reflection_id], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<Vec<u8>>>(2)?,
+                ))
+            })
+            .unwrap()
+            .map(std::result::Result::unwrap)
+            .collect();
+        assert_eq!(
+            rows.len(),
+            source_ids.len(),
+            "expected one reflects_on edge per source; got {rows:?}"
+        );
+        for (target_id, attest_level, signature) in &rows {
+            assert_eq!(
+                attest_level, "self_signed",
+                "reflects_on edge to {target_id} must surface self_signed (got {attest_level})"
+            );
+            let sig_bytes = signature.as_ref().unwrap_or_else(|| {
+                panic!("reflects_on edge to {target_id} must persist a signature blob")
+            });
+            assert_eq!(
+                sig_bytes.len(),
+                64,
+                "reflects_on edge to {target_id} signature must be 64 bytes (got {})",
+                sig_bytes.len()
+            );
+        }
     }
 
     #[test]

--- a/src/mcp/tools/reflect.rs
+++ b/src/mcp/tools/reflect.rs
@@ -31,6 +31,15 @@ pub(super) fn handle_reflect(
     embedder: Option<&dyn Embed>,
     vector_index: Option<&VectorIndex>,
     mcp_client: Option<&str>,
+    // Issue #815 — when `Some`, every `reflects_on` edge written by
+    // this reflect call is signed with this keypair. When `None`
+    // (operator hasn't generated a daemon keypair, or the caller is
+    // a test harness without one) the edges land unsigned, matching
+    // the pre-#815 behaviour. Same signature shape as `handle_link`
+    // and `handle_persona_generate` use for the H2 link-signing
+    // surface so the dispatcher in `mcp::mod` can pass through the
+    // shared `active_keypair` argument verbatim.
+    active_keypair: Option<&crate::identity::keypair::AgentKeypair>,
 ) -> Result<Value, String> {
     // ─── Argument parsing ───────────────────────────────────────────
     let source_ids_arr = params["source_ids"]
@@ -200,14 +209,21 @@ pub(super) fn handle_reflect(
             .and_then(|ns| db::resolve_governance_policy(conn, ns))
             .map(|p| p.effective_auto_export_reflections_to_filesystem())
             .unwrap_or(false);
-        if auto_export {
+        let mut h = if auto_export {
             crate::hooks::post_reflect::build_post_reflect_hook(
                 db_path.to_path_buf(),
                 crate::hooks::post_reflect::AutoExportConfig::default_for_home(),
             )
         } else {
             db::ReflectHooks::empty()
-        }
+        };
+        // Issue #815 — `build_post_reflect_hook` leaves `active_keypair`
+        // None because signing is the handler's concern, not the
+        // auto-export hook's. Plug the dispatcher-supplied keypair in
+        // so the `create_link_signed` call inside
+        // `storage::reflect_with_hooks` reaches the signed path.
+        h.active_keypair = active_keypair;
+        h
     };
     let outcome = match db::reflect_with_hooks(conn, &input, &hooks) {
         Ok(o) => o,
@@ -357,6 +373,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("source_ids"), "got: {err}");
@@ -373,6 +390,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("empty"), "got: {err}");
@@ -389,6 +407,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("must be a string"), "got: {err}");
@@ -405,6 +424,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("title"), "got: {err}");
@@ -421,6 +441,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("content"), "got: {err}");
@@ -437,6 +458,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("invalid tier"), "got: {err}");
@@ -457,6 +479,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .unwrap_err();
         assert!(err.contains("source memory not found"), "got: {err}");
@@ -478,6 +501,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .expect("ok");
         assert!(resp["id"].is_string());
@@ -502,6 +526,7 @@ mod tests {
             Some(&emb),
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .expect("ok");
         let new_id = resp["id"].as_str().unwrap();
@@ -551,6 +576,7 @@ mod tests {
             None,
             None,
             None,
+            None, // active_keypair — #815 regression coverage uses the dedicated mcp/mod.rs test
         )
         .expect("ok");
         // Approval gate fires before substrate write.

--- a/src/storage/reflect.rs
+++ b/src/storage/reflect.rs
@@ -9,6 +9,7 @@
 //! and `emit_reflection_depth_exceeded_audit` out of `src/db.rs` into
 //! this sub-module. Pure refactor — semantics unchanged.
 
+use crate::identity::keypair::AgentKeypair;
 use crate::models::ConfidenceSource;
 use anyhow::Context;
 use chrono::Utc;
@@ -16,7 +17,9 @@ use rusqlite::Connection;
 
 use crate::models::{GovernancePolicy, Memory, MemoryKind, Tier};
 
-use super::{ConflictMode, create_link, get, insert_with_conflict, resolve_governance_policy};
+use super::{
+    ConflictMode, create_link_signed, get, insert_with_conflict, resolve_governance_policy,
+};
 
 /// Typed substrate-level error surface for [`reflect`]. Kept distinct
 /// from [`crate::errors::MemoryError`] so the SQLite substrate layer
@@ -143,17 +146,28 @@ pub struct ReflectHooks<'a> {
     /// (mirrors [`crate::hooks::events::ReflectResult`]). Notify-class
     /// — return value is ignored; the reflect already landed.
     pub post_reflect: Option<Box<dyn Fn(&ReflectOutcome) + Send + Sync + 'a>>,
+    /// Issue #815 — signing keypair for the `reflects_on` edges
+    /// written inside the reflect transaction. When `Some`, each
+    /// edge is persisted via [`create_link_signed`] with this
+    /// keypair, producing `attest_level='self_signed'` rows with a
+    /// 64-byte Ed25519 signature. When `None`, edges land as
+    /// `attest_level='unsigned'` — the v0.6.x behaviour and the
+    /// state of the world before #815 fixed the storage::reflect
+    /// gap that #814 left behind.
+    pub active_keypair: Option<&'a AgentKeypair>,
 }
 
 impl<'a> ReflectHooks<'a> {
-    /// Empty bundle — both callbacks `None`. The default used by
-    /// callers that don't want to register hooks (today: the MCP
-    /// handler at `mcp::handle_reflect`).
+    /// Empty bundle — both callbacks `None`, no signing keypair.
+    /// The default used by callers that don't want to register
+    /// hooks AND don't have a keypair to sign with (test harnesses,
+    /// the thin [`reflect`] shim that preserves pre-#815 behaviour).
     #[must_use]
     pub fn empty() -> Self {
         Self {
             pre_reflect: None,
             post_reflect: None,
+            active_keypair: None,
         }
     }
 }
@@ -169,6 +183,10 @@ impl<'a> std::fmt::Debug for ReflectHooks<'a> {
         f.debug_struct("ReflectHooks")
             .field("pre_reflect", &self.pre_reflect.as_ref().map(|_| "<fn>"))
             .field("post_reflect", &self.post_reflect.as_ref().map(|_| "<fn>"))
+            .field(
+                "active_keypair",
+                &self.active_keypair.map(|k| k.agent_id.as_str()),
+            )
             .finish()
     }
 }
@@ -528,8 +546,29 @@ pub fn reflect_with_hooks(
         for src_id in &input.source_ids {
             validate::validate_link(&actual_id, src_id, "reflects_on")
                 .map_err(|e| ReflectError::Validation(e.to_string()))?;
-            create_link(conn, &actual_id, src_id, "reflects_on")
-                .map_err(|e| ReflectError::Database(e.to_string()))?;
+            // Issue #815 — the pre-#815 path called `create_link` here,
+            // which always produced `attest_level='unsigned'` rows for
+            // every reflects_on edge regardless of whether the caller
+            // had loaded a daemon keypair. Route through the signed
+            // helper instead so the keypair threaded through the
+            // hook bundle (MCP-tier handler, curator daemon) reaches
+            // the link insert and the edges land as `self_signed`
+            // with a 64-byte Ed25519 signature. Callers that pass
+            // `active_keypair: None` (the `reflect()` shim, the
+            // auto-export hook constructor's no-keypair test paths)
+            // get the previous unsigned behaviour — `create_link_signed`
+            // matches `create_link`'s output when the keypair is
+            // absent (verified by the existing
+            // `create_link_signed_without_keypair_is_unsigned` test in
+            // `src/storage/mod.rs`).
+            create_link_signed(
+                conn,
+                &actual_id,
+                src_id,
+                "reflects_on",
+                hooks.active_keypair,
+            )
+            .map_err(|e| ReflectError::Database(e.to_string()))?;
         }
         Ok(actual_id)
     })();

--- a/tests/recursive_learning_task6_reflect_hooks.rs
+++ b/tests/recursive_learning_task6_reflect_hooks.rs
@@ -208,6 +208,7 @@ fn pre_reflect_fires_before_cap_check_on_refusal_path() {
             ReflectHookDecision::Allow
         })),
         post_reflect: None,
+        active_keypair: None,
     };
 
     let err = db::reflect_with_hooks(&conn, &input, &hooks)
@@ -255,6 +256,7 @@ fn pre_reflect_deny_veto_refuses_reflection_and_writes_nothing() {
             }
         })),
         post_reflect: None,
+        active_keypair: None,
     };
 
     let err =
@@ -317,6 +319,7 @@ fn post_reflect_fires_after_commit_so_new_row_is_visible() {
             #[allow(clippy::cast_sign_loss)]
             captured_depth_clone.store(outcome.reflection_depth as usize, Ordering::SeqCst);
         })),
+        active_keypair: None,
     };
     let outcome = db::reflect_with_hooks(&conn, &input, &hooks).expect("must succeed");
     let saw = captured_id.lock().unwrap().clone();
@@ -361,6 +364,7 @@ fn post_reflect_cannot_veto_reflect_persists_regardless() {
         post_reflect: Some(Box::new(move |_o: &ReflectOutcome| {
             post_ran_clone.fetch_add(1, Ordering::SeqCst);
         })),
+        active_keypair: None,
     };
     let outcome = db::reflect_with_hooks(&conn, &input, &hooks).expect("must succeed");
     assert_eq!(post_ran.load(Ordering::SeqCst), 1, "post must fire once");
@@ -396,6 +400,7 @@ fn pre_reflect_veto_emits_no_depth_cap_audit_row() {
             code: 451,
         })),
         post_reflect: None,
+        active_keypair: None,
     };
     let err = db::reflect_with_hooks(&conn, &input, &hooks).expect_err("veto must refuse");
     assert!(matches!(err, ReflectError::HookVeto { .. }));
@@ -451,6 +456,7 @@ fn both_pre_and_post_reflect_fire_when_reflect_succeeds() {
                 Ordering::SeqCst,
             );
         })),
+        active_keypair: None,
     };
     let _ = db::reflect_with_hooks(&conn, &input, &hooks).expect("reflect must succeed");
 
@@ -631,6 +637,7 @@ fn reflect_hooks_debug_renders_fn_placeholder() {
     let hooks = ReflectHooks {
         pre_reflect: Some(Box::new(|_| ReflectHookDecision::Allow)),
         post_reflect: Some(Box::new(|_| {})),
+        active_keypair: None,
     };
     let rendered = format!("{hooks:?}");
     // Both fields surface as `<fn>` in the Debug output.

--- a/tests/recursive_learning_task7_shipgate_chaos_migration.rs
+++ b/tests/recursive_learning_task7_shipgate_chaos_migration.rs
@@ -473,6 +473,7 @@ fn mid_tx_target_deletion_rolls_back_reflection_atomically() {
             ReflectHookDecision::Allow
         })),
         post_reflect: None,
+        active_keypair: None,
     };
 
     let input = reflect_input(
@@ -565,6 +566,7 @@ fn post_reflect_panic_leaves_reflection_committed_documented_gap() {
                 *outcome_capture.lock().unwrap() = Some(o.id.clone());
                 panic!("intentional panic in post_reflect handler");
             })),
+            active_keypair: None,
         };
         db::reflect_with_hooks(&conn, &input, &hooks)
     }));

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -489,6 +489,7 @@ fn hook_veto_refuses_reflection_without_depth_cap_audit() {
             code: 451,
         })),
         post_reflect: None,
+        active_keypair: None,
     };
     let err = db::reflect_with_hooks(&conn, &input, &hooks).expect_err("veto refuses");
     match err {
@@ -541,6 +542,7 @@ fn post_reflect_fires_after_commit_observable_on_same_connection() {
         post_reflect: Some(Box::new(move |o: &ReflectOutcome| {
             *captured_id_clone.lock().unwrap() = Some(o.id.clone());
         })),
+        active_keypair: None,
     };
     let outcome = db::reflect_with_hooks(&conn, &input, &hooks).expect("reflect ok");
     let captured = captured_id.lock().unwrap().clone();
@@ -593,6 +595,7 @@ fn both_pre_and_post_reflect_fire_on_successful_reflect() {
                 Ordering::SeqCst,
             );
         })),
+        active_keypair: None,
     };
     let _ = db::reflect_with_hooks(&conn, &input, &hooks).expect("reflect ok");
 


### PR DESCRIPTION
## Summary

- Closes #815 — the post-PR-#814 substrate was still bleeding new unsigned `reflects_on` rows on every `memory_reflect` call because `storage::reflect_with_hooks` unconditionally used `create_link` (unsigned) at the link-insert step.
- One-line fix at the substrate (`create_link` → `create_link_signed`) plus a new `active_keypair` field on `ReflectHooks` so MCP and curator callers can opt in to signing without breaking the back-compat path.
- Regression test pins the contract: a fresh `memory_reflect` with an active keypair produces N `reflects_on` edges, all `attest_level='self_signed'` with 64-byte Ed25519 signatures.

## Why now / urgency

Pre-fix, every reflection produced 1–N unsigned `reflects_on` rows. The 160-row legacy-unsigned-links count cited in the cold-boot smoke is misleading — a meaningful chunk is post-#814 bleed, not pre-fix data. Once this lands, the count stabilises and any future legacy-row hardening conversation becomes meaningful.

The fix is surgical:
- `src/storage/reflect.rs` — extend `ReflectHooks` with `active_keypair`, route the link-insert call through `create_link_signed` with the threaded keypair. Pre-#815 behaviour preserved when keypair is None (the thin `reflect()` shim + auto-export hook tests + every existing `ReflectHooks::empty()` call site stay None).
- `src/mcp/tools/reflect.rs` — `handle_reflect` accepts `active_keypair` and plugs it onto the hooks bundle.
- `src/mcp/mod.rs` — dispatcher threads `active_keypair` into `memory_reflect`, matching the existing pattern for `memory_link` and `memory_persona_generate`.
- `src/curator/reflection_pass.rs::persist` — constructs hooks with `self.keypair` baked in. The pass already held the keypair for `metadata.agent_id` stamping but dropped it at the substrate call.
- `src/hooks/post_reflect/auto_export.rs` + `src/hooks/post_reflect/auto_persona.rs` — struct literals add `active_keypair: None` (signing is the handler's concern, not the hook's).
- 12 `ReflectHooks { ... }` struct literals across 3 test files extended with `active_keypair: None,` via a script (mechanical, reviewed manually).

## Test plan

- [x] `cargo build --tests` — green.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4166 passed, 0 failed (includes new `handle_reflect_with_active_keypair_returns_signed_reflects_on_edges`).
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` — clean.
- [x] `cargo audit` — 0 vulnerabilities, 0 warnings.
- [x] New regression test mirrors `handle_link_with_active_keypair_returns_self_signed`: drives the full MCP envelope, asserts every `reflects_on` edge is signed.

## Pre-existing test environment caveat (not caused by this PR)

When the test host carries `~/Library/Application Support/ai-memory/operator.key.pub`, three tests fall through the L1-6 enforcement arm and fail because their fixtures rely on the no-operator-pubkey arm (`cli_install_pretool_hook::installed_hook_smoke_test_invokes_check_action` + 2 in `tests/governance_a2a_rules.rs`). Confirmed identical behaviour on bare release/v0.7.0 via git stash run — not caused by this PR. Recommend filing as a separate test-hygiene issue (mock `resolve_operator_pubkey()` or use a temp config dir in the affected tests). Pre-existing clippy errors in `tests/issue_800_batman_mode.rs` + `tests/handler_postgres_branches_fake_pg.rs` are also pre-existing on release/v0.7.0.

## AI involvement

This PR was authored by Claude Opus 4.7 (1M context) under Authority Class **Standard** per `docs/AI_DEVELOPER_GOVERNANCE.md`. The cold-boot smoke that surfaced this regression was operator-directed; the fix design, implementation, regression test, and gate verification were autonomous. Branch was rebased from `docs/batman-active-mode-issue-800` (PR #814's branch) onto `release/v0.7.0` after confirming the fix doesn't depend on #814's commits and that the bug exists identically on release/v0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)