### PR TITLE
docs(#1144): MCP env-block LLM-backend wiring across install / integration / GH Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
 
+---
+
+### Choose your installation path
+
+| You are… | Your deployment is… | Start here |
+|---|---|---|
+| **A single developer** trying ai-memory | One AI client on a laptop | [`docs/install-quickstart.md`](docs/install-quickstart.md) — 5-min super-simple install + LLM-backend wired in one block |
+| **An engineer / architect** | Single-node production, or multiple agents on one node | [`docs/INSTALL.md`](docs/INSTALL.md) → [`docs/production-deployment.md`](docs/production-deployment.md) |
+| **An engineer / architect** | Multi-server / multi-rack / multi-DC / swarm / hive / federation | [`docs/enterprise-deployment.md`](docs/enterprise-deployment.md) — 8 topologies, singleton → multi-region |
+| **An engineer / architect** | PostgreSQL + Apache AGE storage (multi-writer, 10M+ memories, KG-heavy) | [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md) — first-class postgres operator guide |
+| **A decision-maker** evaluating adoption | — | [`docs/audience/decision-maker.html`](https://alphaonedev.github.io/ai-memory-mcp/audience/decision-maker.html) |
+
+> Configuring the LLM backend (xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, llama.cpp server, or local Ollama)? See [`docs/integrations/llm-backends.md`](docs/integrations/llm-backends.md) — the MCP env-block recipe is the same regardless of installation path.
+
+---
+
 **v0.7.0 (`attested-cortex`)** rolls together the cortex-fluent legibility work with the full v0.7 trust + A2A scope from ROADMAP §7.3, **plus** (per operator directive 2026-05-09) the originally-v0.7.1 postgres+AGE first-class work, **plus** the post-grand-slam ship-readiness wave (Batman Forms 1-6 + 7th-form Option-B foundation + QW-1/2/3 + reconciliation security sweep). The substrate becomes both **more articulate** (capabilities v3, named loader tools, compacted schemas, Batman `MemoryKind` vocabulary, persona/atomisation/multistep-ingest primitives) and **cryptographically trustworthy** (Ed25519 attestation, sidechain transcripts, programmable 25-event hook pipeline, enforced namespace inheritance, V-4 cross-row signed-events hash chain). v0.7.0 also ships **postgres + Apache AGE as a first-class storage backend** — `ai-memory serve --store-url postgres://…` for live daemon use, schema parity across both backends (sqlite + postgres converge on logical schema **v49** — `CURRENT_SCHEMA_VERSION = 49` (canonical anchors: [`src/storage/migrations.rs`](src/storage/migrations.rs) for sqlite + [`src/store/postgres.rs`](src/store/postgres.rs) for postgres); on-disk migration files end at `migrations/sqlite/0041_v07_federation_push_dlq.sql` and `migrations/postgres/0030_v07_federation_push_dlq.sql` (file-name counters lag the logical schema version because both ladders apply post-v34 deltas via in-process arms — see [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) §schema-ladder for the v35-v49 narrative; v48 [#933](https://github.com/alphaonedev/ai-memory-mcp/issues/933) added the federation-push DLQ table; v49 [#1025](https://github.com/alphaonedev/ai-memory-mcp/issues/1025) added 14 nullable columns to `archived_memories` so archive → restore is lossless for the full v0.7.0 Memory shape)), the new `ai-memory schema-init` CLI verb, and 6-factor recall scoring parity. **The v0.6.4 default surface grows by two always-on loaders to 7 tools** (`memory_load_family` + `memory_smart_load` join the original five); the runtime ceiling at `--profile full` is **73 tools** (verified against `Profile::full().expected_tool_count()` — see [`src/profile.rs`](src/profile.rs)). Everything new is additive and (for the trust + postgres surfaces) opt-in. **Upgrading from v0.6.x?** Read [`docs/MIGRATION_v0.7.md`](docs/MIGRATION_v0.7.md) first — most v0.6.4 callers see no behavior change, but pre-v0.6.3.1 v0.6.x users hit the G1 namespace-inheritance fix. **Switching to postgres+AGE?** See [`docs/postgres-age-guide.md`](docs/postgres-age-guide.md) and [`docs/migration-v0.7.0-postgres.md`](docs/migration-v0.7.0-postgres.md). **Full release notes:** [`docs/v0.7.0/release-notes.md`](docs/v0.7.0/release-notes.md).
 
 **v0.6.4 (`quiet-tools`)** — the MCP server ships with a **5-tool default surface** (`memory_store`, `memory_recall`, `memory_list`, `memory_get`, `memory_search`) plus the always-on `memory_capabilities` bootstrap. The other 38 tools remain reachable via `--profile graph|admin|power|full` or runtime expansion through `memory_capabilities --include-schema family=<name>`. Eager-loading harnesses (Claude Desktop / Codex CLI / Grok CLI / Gemini CLI) drop ~4,700 input tokens of tool schemas per request — a **76.4% reduction** measured against `cl100k_base` BPE. To preserve v0.6.3 behavior 1:1, run `ai-memory mcp --profile full`. See `docs/MIGRATION_v0.6.4.md`.
@@ -228,6 +244,26 @@ Create `.mcp.json` in your project root:
   }
 }
 ```
+
+**`smart` / `autonomous` tier with a cloud LLM** — add an `env` block with your provider keys:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "xai",
+        "AI_MEMORY_LLM_API_KEY": "xai-...",
+        "AI_MEMORY_LLM_MODEL": "grok-4.3"
+      }
+    }
+  }
+}
+```
+
+> **Important — MCP clients do not inherit your interactive shell.** Setting `export AI_MEMORY_LLM_BACKEND=xai` in `.zshrc` / `.bashrc` is sufficient for the standalone `ai-memory` CLI but **not** for Claude Code / Cursor / Codex / etc., which spawn the MCP server as a fresh subprocess with only the `env:` keys from the MCP config. For MCP usage, replicate the LLM env vars inside the `env` block. Full per-backend recipes (Ollama, LMStudio, xAI, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, vLLM, llama.cpp server) live in [`docs/integrations/llm-backends.md`](docs/integrations/llm-backends.md). This was the operator paper-cut behind [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144).
 
 > **Windows paths:** Use forward slashes or escaped backslashes in `--db`. Example: `"--db", "C:/Users/YourName/.claude/ai-memory.db"`.
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -171,6 +171,16 @@ ai-memory serve --host 127.0.0.1 --port 9077
 
 The `smart` and `autonomous` tiers require an LLM backend. **Post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0)** the backend is provider-agnostic — pick from local Ollama OR any OpenAI-compatible vendor (xAI Grok, OpenAI, Anthropic via OpenAI shim, Google Gemini, DeepSeek, Kimi/Moonshot, Qwen/Dashscope, Mistral, Groq, Together AI, Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, llama.cpp server).
 
+> **Important — MCP clients do NOT inherit your interactive shell** ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). The shell-level `export AI_MEMORY_LLM_BACKEND=…` setup documented below is sufficient for:
+>
+> - the standalone `ai-memory` CLI (`ai-memory store / recall / search / list / …`)
+> - the standalone HTTP daemon (`ai-memory serve …`)
+> - any process you launch yourself from an interactive shell that inherits the exports
+>
+> It is **NOT sufficient** for MCP usage — Claude Code, Claude Desktop, Cursor, Codex CLI, Cline, Continue, Zed, Windsurf, Goose, Roo Code, etc. spawn the MCP server as a **fresh subprocess** with only the `env:` keys explicitly declared in the MCP server config. Shell exports from your `.zshrc` / `.bashrc` / `.profile` are invisible to that subprocess.
+>
+> For MCP usage, the same `AI_MEMORY_LLM_BACKEND` / `AI_MEMORY_LLM_API_KEY` / `AI_MEMORY_LLM_MODEL` variables MUST also live inside the MCP server config's `env:` block. Copy-pasteable per-backend recipes (Ollama, LMStudio, vLLM, llama.cpp server, xAI, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): see [`integrations/llm-backends.md`](integrations/llm-backends.md).
+
 **Selection by env var.** Set `AI_MEMORY_LLM_BACKEND` to one of: `ollama` (default), `openai-compatible` (generic; requires `AI_MEMORY_LLM_BASE_URL`), or a pre-filled vendor alias (`openai`, `xai`, `anthropic`, `gemini`, `deepseek`, `kimi`/`moonshot`, `qwen`/`dashscope`, `mistral`, `groq`, `together`, `cerebras`, `openrouter`, `fireworks`, `lmstudio`).
 
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,17 @@
 # Installation Guide
 
+> **Choose your path before you start — installation differs by audience and deployment scale.**
+>
+> | I am… | My deployment is… | Start here |
+> |---|---|---|
+> | **A single developer** | One AI client (Claude Code / Cursor / ChatGPT / etc.) on one laptop | [`install-quickstart.md`](install-quickstart.md) — 5-minute super-simple install + LLM-backend wired in one config block. Skip the rest of this file. |
+> | **An engineer / architect** | Multi-agent on one node, or any single-node production deployment | This file (full singleton reference) → [`production-deployment.md`](production-deployment.md) — 10-min hardening checklist. |
+> | **An engineer / architect** | Multi-server, multi-rack, multi-DC, multi-region, swarm, or hive | [`enterprise-deployment.md`](enterprise-deployment.md) — 60–90 min planning artefact covering 8 topologies, federation, identity material at fleet scale, disaster recovery. |
+> | **An engineer / architect** | PostgreSQL + Apache AGE storage backend (multi-tenant, multi-writer, 10M+ memories, KG-heavy workloads) | [`postgres-age-guide.md`](postgres-age-guide.md) — first-class postgres operator guide. |
+> | **A decision-maker** | Evaluating ai-memory for adoption | [`audience/decision-maker.html`](audience/decision-maker.html) — security posture, threat model, deployment cost envelope. |
+>
+> This file (`INSTALL.md`) is the **SME singleton + single-node reference.** Path-A non-technical readers should use [`install-quickstart.md`](install-quickstart.md) instead — it covers configuration end-to-end without exposing every flag.
+
 > **BLUF (Bottom Line Up Front):** `ai-memory` is an AI-agnostic memory management system that works with **any MCP-compatible AI client** -- including Claude AI, OpenAI ChatGPT, xAI Grok, META Llama, OpenClaw, and others. Install the binary, configure your AI client's MCP settings, and you get **7 MCP memory tools at the default `--profile core`** (or 73 advertised entries at `--profile full` — 72 callable memory tools + the always-on `memory_capabilities` bootstrap) at v0.7.0. The default `semantic` tier includes embedding-based hybrid recall out of the box. Total time: ~60 seconds (pre-built binary + fast internet; first semantic-tier run also downloads a ~100MB embedding model).
 
 ## Install in 60 Seconds (pre-built binary + fast internet)
@@ -95,7 +107,7 @@
 
 2. **Configure MCP in your AI client.** The example below is for **Claude Code** — add the `mcpServers` key to `~/.claude.json` (user scope, applies to all projects):
 
-   **macOS / Linux:**
+   **macOS / Linux — semantic tier (default; no LLM backend needed):**
    ```json
    {
      "mcpServers": {
@@ -119,12 +131,34 @@
    }
    ```
 
+   **`smart` / `autonomous` tier with a cloud LLM backend** (xAI Grok shown; same shape for OpenAI / Anthropic / Gemini / DeepSeek / Kimi / Qwen / Mistral / Groq / Together / Cerebras / OpenRouter / Fireworks / LMStudio / vLLM / llama.cpp server):
+
+   ```json
+   {
+     "mcpServers": {
+       "memory": {
+         "command": "ai-memory",
+         "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+         "env": {
+           "AI_MEMORY_LLM_BACKEND": "xai",
+           "AI_MEMORY_LLM_API_KEY": "xai-...",
+           "AI_MEMORY_LLM_MODEL": "grok-4.3"
+         }
+       }
+     }
+   }
+   ```
+
+   > **Important — MCP clients do NOT inherit your interactive shell.** Setting `export AI_MEMORY_LLM_BACKEND=xai` in `.zshrc` / `.bashrc` is sufficient for the standalone `ai-memory` CLI and the HTTP daemon, but is **NOT** sufficient for Claude Code / Cursor / Codex / Cline / Continue / Zed / Windsurf / etc. — they spawn the MCP server as a fresh subprocess with only the `env:` keys from the MCP config. For MCP usage, replicate the LLM env vars inside the `env` block as shown above. This was the operator paper-cut behind [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144). Full per-backend recipes (every supported provider with copy-pasteable snippets): [`integrations/llm-backends.md`](integrations/llm-backends.md).
+
    > **Note:** `~/.claude.json` likely already exists with other settings. Merge the `mcpServers` key into the existing JSON — do not overwrite the file. See [Claude Code MCP Scopes](#claude-code-mcp-configuration-scopes) below for project-level and team-shared alternatives.
 
-   > The `--tier` flag selects the feature tier: `keyword`, `semantic` (default), `smart`, or `autonomous`. **Important:** The `--tier` flag must be passed in the MCP args — the `config.toml` `tier` setting is not used when the server is launched by an AI client. Smart and autonomous tiers require an LLM backend — post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0), any of: local [Ollama](https://ollama.com), LMStudio, vLLM, llama.cpp server, OR any OpenAI-compatible vendor (xAI Grok, OpenAI, Anthropic, Google Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks). Selected via `AI_MEMORY_LLM_BACKEND` env var. See [`ADMIN_GUIDE.md` § "LLM Backend Setup"](ADMIN_GUIDE.md#llm-backend-setup-smart--autonomous-tiers) for the full matrix.
+   > The `--tier` flag selects the feature tier: `keyword`, `semantic` (default), `smart`, or `autonomous`. **Important:** The `--tier` flag must be passed in the MCP args — the `config.toml` `tier` setting is not used when the server is launched by an AI client. Smart and autonomous tiers require an LLM backend — post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0), any of: local [Ollama](https://ollama.com), LMStudio, vLLM, llama.cpp server, OR any OpenAI-compatible vendor (xAI Grok, OpenAI, Anthropic, Google Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks). Selected via `AI_MEMORY_LLM_BACKEND` env var. Full env-var matrix in [`ADMIN_GUIDE.md` § "LLM Backend Setup"](ADMIN_GUIDE.md#llm-backend-setup-smart--autonomous-tiers); MCP-config recipes in [`integrations/llm-backends.md`](integrations/llm-backends.md).
    > **Other AI platforms** (OpenAI ChatGPT, xAI Grok, META Llama, etc.) have their own MCP configuration locations. Consult your platform's documentation for where to add MCP server entries. The server command and args are the same — only the config file location differs.
 
 3. **Restart your AI client.**
+
+   > **Verify the LLM backend wired through (smart/autonomous tier only).** After restart, check the ai-memory boot banner that prints on first MCP session-start (or the AI client's MCP server stderr log). You should see `LLM ready (backend=<vendor>, model=<name>)` matching what you put in the `env:` block, plus an `(#1143)` embed-client banner line when using a non-Ollama backend. If you see `llm=gemma4:e4b` or another local Ollama tag when you intended a cloud backend, the `env:` block didn't land — re-check the MCP config path you edited matches the AI client's actual scope. Full troubleshooting: [`TROUBLESHOOTING.md` § LLM backend silently fell back](TROUBLESHOOTING.md#llm-backend-silently-fell-back-to-ollama).
 
 4. **Verify** — at the default `--profile core` (v0.7.0) you should see **7 new tools** registered plus the always-on `memory_capabilities` bootstrap (8 total): `memory_store`, `memory_recall`, `memory_search`, `memory_list`, `memory_get`, `memory_load_family`, `memory_smart_load`. To eagerly load the full v0.7.0 surface (73 advertised entries — 72 callable memory tools + the always-on `memory_capabilities` bootstrap), launch with `ai-memory mcp --profile full`. The full-profile surface includes (highlights): `memory_update`, `memory_delete`, `memory_promote`, `memory_forget`, `memory_stats`, `memory_link`, `memory_get_links`, `memory_consolidate`, `memory_expand_query`, `memory_auto_tag`, `memory_detect_contradiction`, the 4 archive tools, `memory_check_duplicate`, the 2 entity tools, the 3 KG tools (`memory_kg_query`/`memory_kg_timeline`/`memory_kg_invalidate`), `memory_get_taxonomy`, the 3 namespace-standard tools, the 3 pending-action tools, the 2 agent tools, `memory_notify`/`memory_inbox`, the 3 subscription tools, `memory_session_start`, `memory_gc`, and the v0.7 additions: `memory_reflect`, `memory_atomise`, `memory_ingest_multistep`, `memory_persona`, `memory_persona_generate`, `memory_offload`, `memory_deref`, `memory_calibrate_confidence`, the 7 L1-5 Agent Skills tools, `memory_check_agent_action`, `memory_rule_list`, `memory_export_reflection`, `memory_reflection_origin`, `memory_dependents_of_invalidated`, `memory_find_paths`, `memory_verify`, `memory_quota_status`, the archive-list metadata helpers (#860), and more. Full per-tool reference: [API_REFERENCE.md](API_REFERENCE.md). Run `memory_capabilities` from the agent loop to get the live family list.
 
@@ -297,6 +331,8 @@ File: `%USERPROFILE%\.claude.json`
 </table>
 
 > **Note:** `~/.claude.json` likely already exists with other Claude Code settings (tips, projects, etc.). Add the `mcpServers` key at the top level of the existing JSON object — do not overwrite the file.
+
+> **Adding an LLM backend (smart/autonomous tiers).** Extend the `memory` server block with an `env` map containing `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment (see [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider live in [`integrations/llm-backends.md`](integrations/llm-backends.md).
 
 **Project scope (shared with your team via git):**
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,6 +4,16 @@ This guide gets you from zero to a working ai-memory install and your
 first stored + recalled memory. Choose one of three paths depending
 on how you want to use it.
 
+> **Looking for a friendlier walkthrough?** This page is the
+> single-developer / single-laptop CLI + MCP + HTTP comparison. For a
+> super-simple, copy-paste install + config walkthrough with zero
+> jargon, see [`install-quickstart.md`](install-quickstart.md).
+>
+> **Standing up a fleet / multi-DC / postgres+AGE deployment?** This
+> page is the wrong starting point — see
+> [`production-deployment.md`](production-deployment.md) and
+> [`enterprise-deployment.md`](enterprise-deployment.md).
+
 ## Install
 
 ```bash
@@ -48,7 +58,7 @@ That's it. Memories live in `~/ai-memory.db` (override with `--db` or
 ai-memory is an MCP server. Wire it into your AI IDE and every
 conversation gets persistent memory across sessions.
 
-**Claude Code** — add to `~/.claude/mcp_servers.json`:
+**Claude Code** — add to `~/.claude.json` (user scope):
 
 ```json
 {
@@ -77,6 +87,35 @@ conversation gets persistent memory across sessions.
 Command: ai-memory
 Args: mcp --tier semantic
 ```
+
+**Smart / autonomous tier with a cloud LLM** (any of xAI Grok, OpenAI,
+Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together,
+Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, llama.cpp server) —
+add an `env` block to the MCP server entry. Example for xAI Grok:
+
+```json
+{
+  "mcpServers": {
+    "ai-memory": {
+      "command": "ai-memory",
+      "args": ["mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "xai",
+        "AI_MEMORY_LLM_API_KEY": "xai-...",
+        "AI_MEMORY_LLM_MODEL": "grok-4.3"
+      }
+    }
+  }
+}
+```
+
+> **MCP clients do not inherit your shell.** Setting `export
+> AI_MEMORY_LLM_BACKEND=xai` in `.zshrc` works for the standalone CLI
+> but **not** for MCP usage — Claude Code / Cursor / Codex spawn the
+> MCP server as a fresh subprocess. Put the LLM env vars inside the
+> MCP config's `env:` block. Full per-backend recipes:
+> [`integrations/llm-backends.md`](integrations/llm-backends.md)
+> (issue [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
 
 Restart the IDE. You'll now see 23 `memory_*` tools in the tool list.
 Ask the assistant "remember that my preferred deploy target is

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -2048,7 +2048,7 @@ footer.site-foot a { color: var(--text-muted); }
         <div class="card p1" style="height:100%;display:flex;flex-direction:column">
           <div class="card-eyebrow" style="color:var(--pillar-1)">▸ PROVIDER-AGNOSTIC LLM (#1067)</div>
           <div class="card-title">Autonomous</div>
-          <p class="card-body">Auto-tag, consolidate, expand-query, contradiction detection, memory reflection, session-start. Backed by any LLM via <code>AI_MEMORY_LLM_BACKEND</code> &mdash; Ollama (default; Gemma local) or xAI Grok / OpenAI / Anthropic / Gemini / DeepSeek / Kimi / Qwen / Mistral / Groq / Together / Cerebras / OpenRouter / Fireworks / LMStudio / vLLM / llama.cpp-server. Local-first by default, cloud-flexible by config.</p>
+          <p class="card-body">Auto-tag, consolidate, expand-query, contradiction detection, memory reflection, session-start. Backed by any LLM via <code>AI_MEMORY_LLM_BACKEND</code> &mdash; Ollama (default; Gemma local) or xAI Grok / OpenAI / Anthropic / Gemini / DeepSeek / Kimi / Qwen / Mistral / Groq / Together / Cerebras / OpenRouter / Fireworks / LMStudio / vLLM / llama.cpp-server. Local-first by default, cloud-flexible by config. <strong>MCP env-block recipes for every supported provider:</strong> <a href="integrations/llm-backends.md">integrations/llm-backends.md</a> (per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/1144">#1144</a>).</p>
           <div style="margin-top:.85rem;font-family:var(--font-mono);font-size:.78rem;color:var(--pillar-1)">autonomous.html →</div>
         </div>
       </a>

--- a/docs/autonomous.html
+++ b/docs/autonomous.html
@@ -177,7 +177,7 @@ footer a{color:var(--text-muted)}
 
 <section class="hero">
   <h1>Autonomous-tier intelligence.</h1>
-  <p class="tagline">Auto-tagging. Auto-consolidation. Query expansion. Contradiction detection. Memory reflection. Six features that turn ai-memory from a store into an agent &mdash; <strong>local-first by default</strong> (Gemma via Ollama) and, as of v0.7.0 (#1067), <strong>provider-agnostic by config</strong>: route any of these through xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, or any other OpenAI-compatible endpoint via <code>AI_MEMORY_LLM_BACKEND</code>. Local stays the default for the privacy story below; cloud unlocks the CPU-only and cellphone postures.</p>
+  <p class="tagline">Auto-tagging. Auto-consolidation. Query expansion. Contradiction detection. Memory reflection. Six features that turn ai-memory from a store into an agent &mdash; <strong>local-first by default</strong> (Gemma via Ollama) and, as of v0.7.0 (#1067), <strong>provider-agnostic by config</strong>: route any of these through xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, or any other OpenAI-compatible endpoint via <code>AI_MEMORY_LLM_BACKEND</code>. Local stays the default for the privacy story below; cloud unlocks the CPU-only and cellphone postures. <strong>MCP env-block recipes (every supported provider, copy-pasteable):</strong> <a href="integrations/llm-backends.md">integrations/llm-backends.md</a>.</p>
   <div class="pills">
     <span class="pill">Ollama local (default)</span>
     <span class="pill">15+ cloud vendors via #1067</span>

--- a/docs/enterprise-deployment.md
+++ b/docs/enterprise-deployment.md
@@ -23,6 +23,12 @@ Signed-events V-4 cross-row hash chain from
 [`signed-events-v4.md`](signed-events-v4.md). Threat model + disclosure
 policy from [`../SECURITY.md`](../SECURITY.md). v0.7.0 feature inventory
 from [`internal/v070-feature-inventory.md`](internal/v070-feature-inventory.md).
+**LLM backend wiring for smart / autonomous tiers — including the
+MCP env-block vs. shell-export distinction, per-vendor recipes, and
+fleet / multi-agent / multi-DC considerations** — from
+[`integrations/llm-backends.md`](integrations/llm-backends.md). The
+multi-agent / fleet / multi-DC section of that doc is the canonical
+cross-reference for "how do I wire the LLM at T2+ topologies."
 
 **Hard-rule reminders that hold across every topology in this guide:**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -419,6 +419,30 @@ cd ai-memory-mcp &amp;&amp; cargo build --release</code></pre>
       &nbsp;
       <a class="cta ghost" href="QUICKSTART.md">3-minute engineer quickstart</a>
     </div>
+
+    <div style="margin-top:3rem; padding-top:1.5rem; border-top:1px solid var(--border)">
+      <span class="eyebrow">Configure the LLM backend</span>
+      <h3 style="margin-top:0.5rem">Plug ai-memory's <code>smart</code> / <code>autonomous</code> tier into any LLM.</h3>
+      <p class="lede" style="margin-top:0.5rem">
+        v0.7.0 ships a provider-agnostic LLM client. Any of 16+ backends &mdash; local
+        <a href="https://ollama.com">Ollama</a>, LMStudio, vLLM, llama.cpp server,
+        <strong>xAI Grok</strong>, OpenAI, Anthropic, Google Gemini, DeepSeek, Kimi (Moonshot), Qwen
+        (DashScope), Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks
+        &mdash; selected by the <code>AI_MEMORY_LLM_BACKEND</code> env var.
+      </p>
+      <p>
+        <strong>Critical for MCP usage:</strong> shell exports do NOT reach the MCP-spawned subprocess.
+        The LLM env vars MUST live inside your AI client's MCP server-config <code>env:</code> block.
+        Copy-pasteable per-backend recipes (Claude Code <code>~/.claude.json</code>, Cursor
+        <code>~/.cursor/mcp.json</code>, Codex <code>~/.codex/config.toml</code>, etc.) live in the
+        canonical recipe page:
+      </p>
+      <div style="margin-top:1rem">
+        <a class="cta primary" href="integrations/llm-backends.md">LLM-backend MCP recipes &rarr;</a>
+        &nbsp;
+        <a class="cta ghost" href="ADMIN_GUIDE.md#llm-backend-setup-smart--autonomous-tiers">Standalone CLI / HTTP daemon setup</a>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/docs/install-quickstart.md
+++ b/docs/install-quickstart.md
@@ -1,13 +1,21 @@
-# ai-memory v0.7.0 — install quickstart
+# ai-memory v0.7.0 — install quickstart (Path A: super simple)
 
 A friendly, no-jargon install guide. If you can use a terminal, you can
 get ai-memory running in under five minutes. No software engineering
 background required.
 
+> **This is Path A — the singleton, single-laptop case.** One AI
+> client, one user, defaults work. If you're standing up a production
+> deployment (multi-agent on one node, multi-server, multi-DC, swarm,
+> hive, postgres + Apache AGE storage), this is the wrong page —
+> jump to [Path B: production / fleet deployment](#path-b--need-to-go-deeper-fleet-postgres-tuning)
+> at the bottom of this file, or directly to
+> [`production-deployment.md`](production-deployment.md).
+
 For the wire-it-up-to-an-AI step, see
 [`docs/integration-guide.md`](integration-guide.md).
 
-For the full reference (every flag, every package channel, every
+For the full SME reference (every flag, every package channel, every
 production knob) see [`docs/INSTALL.md`](INSTALL.md).
 
 ## 1. What is ai-memory, in one paragraph
@@ -156,7 +164,7 @@ might want to set once and forget:
 |---|---|---|
 | Database path | `export AI_MEMORY_DB=/path/to/db` | Move the SQLite file anywhere on disk. |
 | Default agent ID | `export AI_MEMORY_AGENT_ID=alice` | Stamps every memory `alice` wrote with that ID (instead of the leaky `host:<hostname>:pid-<pid>-<uuid>` fallback). Recommended on shared machines. |
-| LLM backend | `export AI_MEMORY_LLM_BACKEND=ollama` | Picks which LLM the `smart` and `autonomous` tiers talk to. Aliases for `openai`, `xai`, `anthropic`, `gemini`, `deepseek`, `kimi`, `qwen`, `mistral`, `groq`, `together`, `cerebras`, `openrouter`, `fireworks`, `lmstudio` are recognized. Pair with `AI_MEMORY_LLM_API_KEY` for hosted providers; `ollama` and `lmstudio` need no key. |
+| LLM backend | `export AI_MEMORY_LLM_BACKEND=ollama` | Picks which LLM the `smart` and `autonomous` tiers talk to. Aliases for `openai`, `xai`, `anthropic`, `gemini`, `deepseek`, `kimi`, `qwen`, `mistral`, `groq`, `together`, `cerebras`, `openrouter`, `fireworks`, `lmstudio` are recognized. Pair with `AI_MEMORY_LLM_API_KEY` for hosted providers; `ollama` and `lmstudio` need no key. **For MCP usage (Claude Code / Cursor / Codex / etc.) these shell exports are NOT visible to the MCP-spawned subprocess — the same vars MUST also live inside the MCP config's `env:` block.** See [`integrations/llm-backends.md`](integrations/llm-backends.md) for per-backend MCP env-block recipes, and [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144) for the operator paper-cut history. |
 | Permissions mode | `export AI_MEMORY_PERMISSIONS_MODE=advisory` | Loosens v0.7.0's enforced governance gate to the v0.6.x permissive posture. Default is `enforce` and you should leave it on unless you're debugging. |
 | Encrypted DB | `export AI_MEMORY_ENCRYPT_AT_REST=1` | Requires a sqlcipher build + `--db-passphrase-file`. See [`docs/INSTALL.md`](INSTALL.md) § encrypted-at-rest. |
 
@@ -188,6 +196,21 @@ This writes the right config into `~/.claude.json`, registers the
 SessionStart hook so every new conversation boots memory-aware, and
 backs up your existing settings to a timestamped file first. Restart
 Claude Code and you're done.
+
+> **Using `smart` or `autonomous` tier with a non-Ollama LLM?** The
+> installer writes a default MCP block without LLM-backend env vars
+> (so the default Ollama path keeps working out of the box). To wire
+> xAI Grok / OpenAI / Anthropic / Gemini / DeepSeek / Kimi / Qwen /
+> Mistral / Groq / Together / Cerebras / OpenRouter / Fireworks /
+> LMStudio / vLLM / llama.cpp server, after `--apply`, hand-edit
+> `~/.claude.json`'s `memory` server block and add an `env` map with
+> `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and
+> `AI_MEMORY_LLM_MODEL`. **Do NOT** rely on shell exports — MCP-spawned
+> subprocesses don't see your interactive shell's env. Copy-pasteable
+> per-backend recipes: [`integrations/llm-backends.md`](integrations/llm-backends.md).
+> Issue [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)
+> tracks operator-side ergonomics so future installer revisions wire
+> this for you on first run.
 
 ## 9. Uninstall
 
@@ -250,6 +273,62 @@ the full output.
 | `Error: governance refused` on a write | Permissions mode defaults to `enforce` at v0.7.0. Either approve the pending action (`ai-memory pending list` then `ai-memory pending approve <id>`) or temporarily set `AI_MEMORY_PERMISSIONS_MODE=advisory` while you debug. |
 | `Error: no MCP tools advertised` in the AI client | The AI client started ai-memory with the wrong `--profile` or no `--tier` flag. Confirm the args in the client's MCP config match the snippets in [`docs/integration-guide.md`](integration-guide.md). |
 | Memories from one session don't appear in another | The two clients are pointing at different DB files. Set `AI_MEMORY_DB` to the same path in every client's MCP config, or use `--db <shared-path>` consistently. |
+
+## Path B — Need to go deeper? (fleet, postgres, tuning)
+
+If Path A above met your needs, you're done. Use ai-memory as documented
+above; nothing else in this section applies.
+
+Read on **only if** any of these is true:
+
+- You're running **more than one AI agent on one machine** (Batman /
+  swarm / hive on a single node).
+- You're standing up ai-memory on a **server** with multiple agents
+  connecting over the network, or behind a service mesh.
+- You're deploying across **multiple servers, racks, data centers, or
+  regions**.
+- You need **PostgreSQL + Apache AGE** as the storage backend (multi-
+  tenant, multi-writer, >10M memories, or graph-heavy workloads).
+- You want every **tuning knob** exposed (TTL per tier, governance
+  modes, federation auth layers, hook pipeline, sidechain transcripts,
+  signed-events V-4 chain, …).
+
+The Path-B doc set, in reading order:
+
+1. **[`INSTALL.md`](INSTALL.md)** — full SME install reference. Every
+   package channel, every flag, every Windows / Docker / Kubernetes
+   variant.
+2. **[`production-deployment.md`](production-deployment.md)** — 10-min
+   hardening checklist: keypair provisioning, mTLS allowlist, backup
+   discipline, schema migrations, observability, topology (single-
+   instance / hub-spoke / W-of-N).
+3. **[`ADMIN_GUIDE.md`](ADMIN_GUIDE.md)** — every env var, every
+   `config.toml` field, the full LLM-backend matrix, the embedder /
+   reranker tuning surface.
+4. **[`enterprise-deployment.md`](enterprise-deployment.md)** — 60–90
+   min planning artefact. 8 deployment topologies from singleton on a
+   laptop to multi-region federated fleet; capacity envelope and
+   graduation triggers for each.
+5. **[`postgres-age-guide.md`](postgres-age-guide.md)** — PostgreSQL +
+   Apache AGE first-class storage backend. When to switch off sqlite,
+   how to provision pgvector + AGE, the `ai-memory schema-init` CLI,
+   migration runbook, AGE Cypher KG.
+6. **[`federation.md`](federation.md)** — mTLS, peer attestation,
+   `X-API-Key`, per-message Ed25519 signing + nonce freshness, signed-
+   events V-4 cross-row hash chain.
+7. **[`integrations/llm-backends.md`](integrations/llm-backends.md)** —
+   MCP env-block recipes for every supported LLM provider (Ollama /
+   LMStudio / vLLM / llama.cpp server / xAI / OpenAI / Anthropic /
+   Gemini / DeepSeek / Kimi / Qwen / Mistral / Groq / Together /
+   Cerebras / OpenRouter / Fireworks). Includes a fleet / multi-agent
+   / multi-DC considerations section.
+8. **[`batman-active-mode.md`](batman-active-mode.md)** — multi-agent
+   coordination on one node (Batman A2A); operator how-to for turning
+   Forms 1–6 + 7th from capable → active.
+9. **[`a2a-harness-integration.md`](a2a-harness-integration.md)** —
+   agent-to-agent across nodes (full A2A wire shape).
+10. **[`mobile-iot-deployment.md`](mobile-iot-deployment.md)** — iOS,
+    Android, edge / IoT, resource-constrained deployment.
 
 ## See also
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -73,6 +73,8 @@ memory on every conversation start), see
 > documented in
 > [`docs/CLI_REFERENCE.md`](CLI_REFERENCE.md) § `mcp`.
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`integrations/llm-backends.md`](integrations/llm-backends.md).
+
 ## 3. Cursor
 
 ```bash
@@ -105,7 +107,9 @@ Restart Cursor. Verify under Settings → Tools & MCP — a green dot
 next to `ai-memory` means it's live. Full recipe (including the
 project-rules `.cursorrules` directive that nudges Cursor to recall
 on session start):
-[`docs/integrations/cursor.md`](integrations/cursor.md).
+[`docs/integrations/cursor.md`](integrations/cursor.md). LLM-backend
+env-block recipe for smart / autonomous tiers:
+[`integrations/llm-backends.md`](integrations/llm-backends.md).
 
 > **Cursor has a ~40 tool cap across all MCP servers.** Stick to
 > `--profile core` (the default — 7 tools) unless you really need

--- a/docs/integrations/aider.md
+++ b/docs/integrations/aider.md
@@ -13,6 +13,8 @@ file to `aider --message-file`. The Rust-native cross-platform
 equivalent is `ai-memory wrap aider` (PR-6 of issue #487) — same
 semantics, no shell required.
 
+> **Note on ai-memory's own LLM backend.** This doc covers Aider AS the AI client (reading ai-memory boot output). If you also want ai-memory's smart/autonomous-tier features (query expansion, auto-tag, contradiction detection — which call out to an LLM internally), the `ai-memory boot` invocation is a CLI subprocess that inherits your shell's env, so `export AI_MEMORY_LLM_BACKEND=...` in your `.zshrc` works here. For the MCP-server posture (where shell exports do NOT reach the spawned subprocess), see [`llm-backends.md`](llm-backends.md).
+
 ## Wrapper script
 
 Save as `~/.local/bin/aider-with-memory` and make it executable:

--- a/docs/integrations/claude-agent-sdk.md
+++ b/docs/integrations/claude-agent-sdk.md
@@ -6,6 +6,8 @@ The Claude Agent SDK is programmatic by design — the developer constructs
 the messages array. Prepend `ai-memory boot` output to the system message
 on session/conversation start.
 
+> **Note on ai-memory's own LLM backend.** This doc covers the Claude Agent SDK reading ai-memory boot output (SDK as the client). For wiring ai-memory's smart/autonomous tier — which calls out to an LLM internally — see [`llm-backends.md`](llm-backends.md). The SDK invokes `ai-memory boot` as a subprocess in its own process tree, so the env it inherits depends on how the SDK process itself was started: an interactive-shell launch inherits exports; a systemd / Docker / Kubernetes launch needs the env vars declared in the unit / image / pod spec ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
+
 ## Or for the simple wrapper case — `ai-memory wrap`
 
 If your integration is just "spawn a CLI that calls Claude", PR-6 of

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -58,6 +58,8 @@ existing `SessionStart` array.
 That's it. Restart Claude Code. The next session will see your most-recent
 memory context as part of its system prompt.
 
+> **Running ai-memory's `--tier smart` or `--tier autonomous` with a non-default LLM backend?** The MCP server entry in `~/.claude.json` (separate from this SessionStart hook) needs an `env` block declaring `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Shell exports do not reach Claude Code's MCP-spawned subprocess** ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). See [`llm-backends.md`](llm-backends.md) for copy-pasteable recipes covering xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, LMStudio, vLLM, llama.cpp server, and Ollama.
+
 ## Why these flags
 
 - `--quiet`: a DB-unavailable failure becomes silent on stderr (so it

--- a/docs/integrations/cline.md
+++ b/docs/integrations/cline.md
@@ -39,6 +39,8 @@ instructions) is still manual.
 `autoApprove` lets the model call read-only memory tools without prompting
 for permission on every call — required for a smooth boot path.
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 ## Part 2 — Custom Instructions (best-effort)
 
 Settings → Cline → Custom Instructions:

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -7,6 +7,8 @@ mechanism. The integration is at the application boundary: prepend
 `ai-memory boot` output to the system message before each new
 conversation.
 
+> **Codex DOES launch ai-memory as an MCP server when configured in `~/.codex/config.toml` (`mcp_servers.memory`).** If you're using that path AND running `--tier smart` or `--tier autonomous` with a non-default LLM backend, see [`llm-backends.md` § Codex CLI TOML shape](llm-backends.md#codex-cli-toml-shape) for the TOML env-block recipe. Shell exports do NOT reach the MCP-spawned subprocess ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
+
 ## Use `ai-memory wrap` (recommended — pure Rust, cross-platform)
 
 PR-6 of issue #487 ships a built-in subcommand that does the wrapping

--- a/docs/integrations/cody.md
+++ b/docs/integrations/cody.md
@@ -2,6 +2,8 @@
 
 **Category 3 (programmatic).** 100% reliable when implemented.
 
+> **Cross-reference — using Cody as the AI client vs. running ai-memory's smart/autonomous tier behind Cody.** This doc covers Cody reading ai-memory boot output (Cody as client). For wiring an LLM backend to ai-memory's own smart/autonomous tier (which calls out to an LLM internally for query expansion, auto-tag, etc.), see [`llm-backends.md`](llm-backends.md) — the MCP-config env-block recipe applies to any MCP-host AI client; shell exports do NOT reach MCP-spawned subprocesses ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
+
 [Cody](https://sourcegraph.com/cody) is Sourcegraph's AI coding
 assistant. It ships as VS Code / JetBrains extensions and a CLI
 (`cody`), and exposes a programmatic chat API for Sourcegraph

--- a/docs/integrations/continue.md
+++ b/docs/integrations/continue.md
@@ -25,13 +25,18 @@ In `~/.continue/config.json`:
         "transport": {
           "type": "stdio",
           "command": "ai-memory",
-          "args": ["mcp"]
+          "args": ["mcp"],
+          "env": {
+            "AI_MEMORY_DB": "${HOME}/.claude/ai-memory.db"
+          }
         }
       }
     ]
   }
 }
 ```
+
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the inner `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
 
 ## Part 2 — systemMessage (best-effort)
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -36,6 +36,8 @@ Cursor's MCP config (Settings → Features → MCP, or `~/.cursor/mcp.json`):
 }
 ```
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 Restart Cursor.
 
 ## Part 2 — `.cursorrules` directive (best-effort)

--- a/docs/integrations/gemini.md
+++ b/docs/integrations/gemini.md
@@ -10,6 +10,8 @@ integration is at the application boundary: shell out to `ai-memory boot`
 and prepend the result to the system instruction (or the first message
 of the conversation when no system slot exists).
 
+> **Cross-reference — using Gemini as ai-memory's own LLM backend?** That's the inverse direction (ai-memory's smart/autonomous tiers calling out to Gemini for query expansion / auto-tag / contradiction detection). MCP-config recipe for that case: [`llm-backends.md` § Google Gemini](llm-backends.md#google-gemini). The shell-out pattern below uses Gemini as the AI client; that's a separate concern.
+
 The canonical Rust-native cross-platform replacement for the wrapper
 script below is `ai-memory wrap gemini` (PR-6 of issue #487) — same
 semantics, no shell required, works on Windows / Docker / Kubernetes.

--- a/docs/integrations/goose.md
+++ b/docs/integrations/goose.md
@@ -65,6 +65,8 @@ Notes:
 - Restart Goose after editing the config so the MCP server is picked
   up. `goose info` should list `ai-memory` under available extensions.
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `envs:` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — Goose's MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 ## Part 2 — system-instructions directive (best-effort fallback)
 
 Goose supports per-agent system instructions via its profile / preset

--- a/docs/integrations/grok-and-xai.md
+++ b/docs/integrations/grok-and-xai.md
@@ -1,10 +1,87 @@
-# xAI Grok — programmatic prepend or via Cursor
+# xAI Grok — programmatic prepend, via Cursor, or as ai-memory's LLM backend
 
-**Category 3 (programmatic) for raw API; category 2 if used via Cursor.**
+**Category 3 (programmatic) for raw API; category 2 if used via Cursor; ALSO usable as ai-memory's own LLM backend (see below).**
 
 xAI's Grok models are accessible via the xAI API (raw HTTP / OpenAI-compat
 SDK), via Cursor (where Grok is one of several model choices), and via the
 xAI consumer apps. The integration depends on the surface.
+
+## Three directions Grok intersects ai-memory
+
+1. **Grok-as-AI-client.** Grok reads ai-memory's boot context at session
+   start (this is what most of this doc covers — Category 3 programmatic
+   integration via the xAI SDK).
+2. **Grok via Cursor.** Cursor's Grok model picker plus the standard
+   Cursor MCP integration — see [`cursor.md`](cursor.md).
+3. **Grok-as-ai-memory's-LLM-backend.** ai-memory's smart / autonomous
+   tiers call out to an LLM for query expansion, auto-tagging,
+   contradiction detection, atomisation, reflection. As of v0.7.0
+   ([#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) /
+   [#1142](https://github.com/alphaonedev/ai-memory-mcp/issues/1142) /
+   [#1143](https://github.com/alphaonedev/ai-memory-mcp/issues/1143)),
+   that LLM can be Grok via xAI. **This is the inverse direction** —
+   ai-memory's own internals talking to Grok, rather than Grok reading
+   from ai-memory. See the dedicated section below.
+
+## Use Grok as ai-memory's LLM backend
+
+ai-memory's `smart` and `autonomous` tiers need an LLM. xAI Grok is one
+of 16+ supported backends (see [`llm-backends.md`](llm-backends.md) for
+the full vendor matrix — OpenAI, Anthropic, Gemini, DeepSeek, Kimi,
+Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks,
+LMStudio, vLLM, llama.cpp server, local Ollama all work identically).
+
+**MCP env-block recipe for Grok:**
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "xai",
+        "AI_MEMORY_LLM_API_KEY": "xai-...",
+        "AI_MEMORY_LLM_MODEL": "grok-4.3"
+      }
+    }
+  }
+}
+```
+
+Place this block in your AI client's MCP config file (Claude Code:
+`~/.claude.json`; Claude Desktop: `~/Library/Application Support/Claude/claude_desktop_config.json`
+on macOS; Cursor: `~/.cursor/mcp.json`; Codex: `~/.codex/config.toml`
+in TOML shape — see [`llm-backends.md` § Codex CLI TOML shape](llm-backends.md#codex-cli-toml-shape)).
+
+**Critical — MCP clients do not inherit your interactive shell.**
+Setting `export AI_MEMORY_LLM_BACKEND=xai` in `.zshrc` works for the
+standalone `ai-memory` CLI but **NOT** for MCP usage — Claude Code /
+Cursor / Codex / etc. spawn the MCP server as a fresh subprocess. Put
+the env vars inside the MCP config's `env:` block as shown above.
+This was the operator paper-cut behind
+[#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144).
+
+**Verification.** Restart your AI client and check the ai-memory boot
+banner — you should see:
+
+```text
+ai-memory: LLM ready (backend=xai, model=grok-4.3)
+ai-memory: LLM client is OpenAI-compatible (non-Ollama wire shape);
+           building dedicated Ollama embed client at http://localhost:11434 (#1143)
+```
+
+If you see `llm=gemma4:e4b` (the legacy Ollama default), the env
+block didn't land — re-check the MCP config path your AI client
+reads.
+
+**Common Grok model tags:** `grok-4.3`, `grok-4-latest`,
+`grok-code-fast-1`. xAI's API-key fallback env var (`XAI_API_KEY`) is
+honoured if `AI_MEMORY_LLM_API_KEY` is unset.
+
+**Going further:** for the full per-backend matrix, multi-agent / fleet
+considerations, and storage-vs-LLM-backend independence, see
+[`llm-backends.md`](llm-backends.md).
 
 ## Or for the simple wrapper case — `ai-memory wrap`
 

--- a/docs/integrations/llm-backends.md
+++ b/docs/integrations/llm-backends.md
@@ -1,0 +1,709 @@
+# LLM backends — MCP env-block recipes for every supported provider
+
+**Audience:** operators wiring ai-memory's `smart` / `autonomous` tiers to a specific LLM provider via an MCP-capable AI client (Claude Code, Claude Desktop, Cursor, Codex CLI, Cline, Continue, Zed, Windsurf, Goose, Roo Code, Aider, Cody, Gemini CLI, OpenClaw, …).
+
+**Why this page exists.** ai-memory v0.7.0 (#1067 / #1142 / #1143) ships a provider-agnostic LLM client. Any of 16+ backends can power the smart/autonomous tiers — local Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Google Gemini, DeepSeek, Kimi/Moonshot, Qwen/Dashscope, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, plus the generic `openai-compatible` escape hatch for anything else that speaks the OpenAI wire shape.
+
+The selector is the `AI_MEMORY_LLM_BACKEND` environment variable, paired with `AI_MEMORY_LLM_API_KEY` (or a per-vendor fallback like `XAI_API_KEY`) and `AI_MEMORY_LLM_MODEL`. **Setting those vars in `.zshrc` / `.bashrc` / `.profile` is sufficient for the standalone `ai-memory` CLI and the HTTP daemon — but it is NOT sufficient for MCP usage.**
+
+## Critical — MCP clients do not inherit your interactive shell
+
+When Claude Code, Claude Desktop, Cursor, Codex, Cline, Continue, Zed, Windsurf, Goose, Roo Code, etc. launch `ai-memory mcp` as an MCP server, they spawn it as a **fresh subprocess** with only the environment variables explicitly declared in the MCP server config's `env:` block (plus a minimal inherited set the client controls). Shell-exported variables from your interactive terminal session are **NOT visible** to that subprocess.
+
+So this in your `.zshrc`:
+
+```bash
+export AI_MEMORY_LLM_BACKEND=xai
+export XAI_API_KEY=xai-...
+export AI_MEMORY_LLM_MODEL=grok-4.3
+```
+
+…will let `ai-memory mcp --tier autonomous` produce `LLM ready (backend=xai, model=grok-4.3)` when you run it manually from that shell. It will silently fall back to the legacy Ollama default (`gemma4:e4b`) when Claude Code / Cursor / etc. spawn the same binary.
+
+The fix: **the LLM env vars MUST live inside the MCP server config's `env:` block.** Recipes below show this for every supported backend.
+
+### How to know it took effect
+
+Restart your AI client. Inspect the ai-memory boot banner that prints on first MCP session-start (or run `ai-memory boot` directly with the same env vars). You should see:
+
+```text
+ai-memory: LLM ready (backend=<vendor>, model=<name>)
+ai-memory: LLM client is OpenAI-compatible (non-Ollama wire shape);
+           building dedicated Ollama embed client at http://localhost:11434 (#1143)
+```
+
+The second line appears only when `backend` is non-Ollama and confirms the embed-client wire-shape disambiguation from #1143 is taking effect (semantic recall still uses Ollama-native embed at `localhost:11434` while chat goes to the cloud vendor). If you see `llm=gemma4:e4b` or another local Ollama tag when you intended a cloud backend, the `env:` block didn't land — re-check the path of the MCP config file your AI client actually reads.
+
+## The canonical recipe shape
+
+Every example below is the **`memory` MCP server entry** in your AI client's config file. The file path differs per client (Claude Code: `~/.claude.json`; Claude Desktop: `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows; Cursor: `~/.cursor/mcp.json`; Codex: `~/.codex/config.toml`; etc. — see [`platforms.md`](platforms.md) for the full path table). The **server block shape** is identical across clients (Codex uses TOML, every other client uses JSON — Codex shape shown at the end of this page).
+
+> **Replace the API key** in every example below with your own — do not paste examples verbatim into your config file.
+
+## Index
+
+- [Ollama (local default — no key required)](#ollama-local-default)
+- [LMStudio (local — no key required)](#lmstudio-local)
+- [vLLM, llama.cpp server, generic OpenAI-compatible (self-hosted)](#generic-openai-compatible-self-hosted)
+- [xAI Grok](#xai-grok)
+- [OpenAI](#openai)
+- [Anthropic (via OpenAI shim)](#anthropic)
+- [Google Gemini](#google-gemini)
+- [DeepSeek](#deepseek)
+- [Kimi (Moonshot)](#kimi-moonshot)
+- [Qwen (DashScope)](#qwen-dashscope)
+- [Mistral](#mistral)
+- [Groq](#groq)
+- [Together AI](#together-ai)
+- [Cerebras](#cerebras)
+- [OpenRouter](#openrouter)
+- [Fireworks](#fireworks)
+- [Codex CLI TOML shape](#codex-cli-toml-shape)
+
+---
+
+## Ollama (local default)
+
+No env block is required — Ollama at `http://localhost:11434` is the default. This recipe is shown only for explicitness or for pointing the backend at a non-default host/port.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "ollama",
+        "AI_MEMORY_LLM_MODEL": "gemma4:e4b",
+        "AI_MEMORY_LLM_BASE_URL": "http://localhost:11434"
+      }
+    }
+  }
+}
+```
+
+| Knob | Default | Notes |
+|---|---|---|
+| `AI_MEMORY_LLM_BACKEND` | `ollama` | Implied when unset. |
+| `AI_MEMORY_LLM_MODEL` | `gemma4:e2b` (smart) / `gemma4:e4b` (autonomous) | Any locally-pulled Ollama tag. `ollama pull <tag>` first. |
+| `AI_MEMORY_LLM_BASE_URL` | `http://localhost:11434` | Override for remote Ollama on the LAN. Legacy `OLLAMA_BASE_URL` is still honoured. |
+
+Pull the model once before first MCP session:
+
+```bash
+ollama pull gemma4:e4b   # ~2.3 GB Q4 — autonomous default
+```
+
+## LMStudio (local)
+
+LMStudio exposes an OpenAI-compatible endpoint at `http://localhost:1234/v1` by default. No API key required.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "lmstudio",
+        "AI_MEMORY_LLM_MODEL": "lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF",
+        "AI_MEMORY_LLM_BASE_URL": "http://localhost:1234/v1"
+      }
+    }
+  }
+}
+```
+
+`AI_MEMORY_LLM_BASE_URL` is optional — `lmstudio` alias pre-fills `http://localhost:1234/v1`. Override only if you've changed LMStudio's local server port.
+
+## Generic OpenAI-compatible (self-hosted)
+
+Use this for **vLLM**, **llama.cpp server**, **TGI**, **TabbyAPI**, or any other self-hosted endpoint that speaks the OpenAI wire shape. `AI_MEMORY_LLM_BASE_URL` is **required** — there is no default URL for the generic alias.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "openai-compatible",
+        "AI_MEMORY_LLM_BASE_URL": "http://your-host:8000/v1",
+        "AI_MEMORY_LLM_MODEL": "your-model-tag",
+        "AI_MEMORY_LLM_API_KEY": "your-bearer-token-or-blank"
+      }
+    }
+  }
+}
+```
+
+If your endpoint doesn't require auth (vLLM with `--api-key` unset, local llama.cpp server, etc.), leave `AI_MEMORY_LLM_API_KEY` set to any non-empty placeholder (e.g. `"none"`) — the field is non-optional in OpenAI-shape clients but the value is ignored by no-auth servers.
+
+## xAI Grok
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "xai",
+        "AI_MEMORY_LLM_API_KEY": "xai-...",
+        "AI_MEMORY_LLM_MODEL": "grok-4.3"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `XAI_API_KEY` is honoured if `AI_MEMORY_LLM_API_KEY` is unset. Common model tags: `grok-4.3`, `grok-4-latest`, `grok-code-fast-1`. See xAI's model catalog for the current list.
+
+## OpenAI
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "openai",
+        "AI_MEMORY_LLM_API_KEY": "sk-...",
+        "AI_MEMORY_LLM_MODEL": "gpt-4o"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `OPENAI_API_KEY`. Common tags: `gpt-4o`, `gpt-4o-mini`, `o1-mini`.
+
+## Anthropic
+
+ai-memory talks to Anthropic via the OpenAI-compatible shim at `https://api.anthropic.com/v1` (the alias pre-fills this).
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "anthropic",
+        "AI_MEMORY_LLM_API_KEY": "sk-ant-...",
+        "AI_MEMORY_LLM_MODEL": "claude-sonnet-4-6"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `ANTHROPIC_API_KEY`. Common tags: `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`.
+
+## Google Gemini
+
+Gemini exposes an OpenAI-compatible endpoint at `https://generativelanguage.googleapis.com/v1beta/openai`.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "gemini",
+        "AI_MEMORY_LLM_API_KEY": "AIza...",
+        "AI_MEMORY_LLM_MODEL": "gemini-2.5-pro"
+      }
+    }
+  }
+}
+```
+
+Fallback env vars: `GEMINI_API_KEY`, `GOOGLE_API_KEY`. Common tags: `gemini-2.5-pro`, `gemini-2.5-flash`.
+
+## DeepSeek
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "deepseek",
+        "AI_MEMORY_LLM_API_KEY": "sk-...",
+        "AI_MEMORY_LLM_MODEL": "deepseek-chat"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `DEEPSEEK_API_KEY`. Common tags: `deepseek-chat`, `deepseek-reasoner`.
+
+## Kimi (Moonshot)
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "kimi",
+        "AI_MEMORY_LLM_API_KEY": "sk-...",
+        "AI_MEMORY_LLM_MODEL": "moonshot-v1-128k"
+      }
+    }
+  }
+}
+```
+
+The `moonshot` alias is identical to `kimi`. Fallback env vars: `MOONSHOT_API_KEY`, `KIMI_API_KEY`.
+
+## Qwen (DashScope)
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "qwen",
+        "AI_MEMORY_LLM_API_KEY": "sk-...",
+        "AI_MEMORY_LLM_MODEL": "qwen-max"
+      }
+    }
+  }
+}
+```
+
+The `dashscope` alias is identical to `qwen`. Fallback env vars: `DASHSCOPE_API_KEY`, `QWEN_API_KEY`. Common tags: `qwen-max`, `qwen-plus`, `qwen-turbo`.
+
+## Mistral
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "mistral",
+        "AI_MEMORY_LLM_API_KEY": "...",
+        "AI_MEMORY_LLM_MODEL": "mistral-large-latest"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `MISTRAL_API_KEY`. Common tags: `mistral-large-latest`, `mistral-small-latest`, `codestral-latest`.
+
+## Groq
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "groq",
+        "AI_MEMORY_LLM_API_KEY": "gsk_...",
+        "AI_MEMORY_LLM_MODEL": "llama-3.3-70b-versatile"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `GROQ_API_KEY`. Common tags: `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`, `gemma2-9b-it`.
+
+## Together AI
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "together",
+        "AI_MEMORY_LLM_API_KEY": "...",
+        "AI_MEMORY_LLM_MODEL": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `TOGETHER_API_KEY`. See Together's model catalog for the full tag list.
+
+## Cerebras
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "cerebras",
+        "AI_MEMORY_LLM_API_KEY": "csk-...",
+        "AI_MEMORY_LLM_MODEL": "llama-3.3-70b"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `CEREBRAS_API_KEY`.
+
+## OpenRouter
+
+OpenRouter is a unified gateway — use `<vendor>/<model>` slugs.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "openrouter",
+        "AI_MEMORY_LLM_API_KEY": "sk-or-...",
+        "AI_MEMORY_LLM_MODEL": "anthropic/claude-sonnet-4-6"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `OPENROUTER_API_KEY`.
+
+## Fireworks
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "ai-memory",
+      "args": ["--db", "~/.claude/ai-memory.db", "mcp", "--tier", "autonomous"],
+      "env": {
+        "AI_MEMORY_LLM_BACKEND": "fireworks",
+        "AI_MEMORY_LLM_API_KEY": "fw_...",
+        "AI_MEMORY_LLM_MODEL": "accounts/fireworks/models/llama-v3p3-70b-instruct"
+      }
+    }
+  }
+}
+```
+
+Fallback env var: `FIREWORKS_API_KEY`.
+
+## Codex CLI TOML shape
+
+Codex CLI's config (`~/.codex/config.toml`) uses TOML rather than JSON, but the env-block contract is identical. Example shown for xAI Grok — swap the three values for any backend above.
+
+```toml
+[mcp_servers.memory]
+command = "ai-memory"
+args = ["--db", "~/.local/share/ai-memory/memories.db", "mcp", "--tier", "autonomous"]
+enabled = true
+
+[mcp_servers.memory.env]
+AI_MEMORY_LLM_BACKEND = "xai"
+AI_MEMORY_LLM_API_KEY = "xai-..."
+AI_MEMORY_LLM_MODEL = "grok-4.3"
+```
+
+Or use the `env_vars` form to forward shell variables (only works if the shell that launched the Codex client itself had the var exported — same MCP-vs-shell caveat applies):
+
+```toml
+[mcp_servers.memory]
+command = "ai-memory"
+args = ["--db", "~/.local/share/ai-memory/memories.db", "mcp", "--tier", "autonomous"]
+env_vars = ["AI_MEMORY_LLM_BACKEND", "AI_MEMORY_LLM_API_KEY", "AI_MEMORY_LLM_MODEL"]
+enabled = true
+```
+
+## Tier semantics — when does any of this matter?
+
+| Tier | LLM backend used? |
+|---|---|
+| `keyword` (FTS5 only) | **No.** The env block is ignored. |
+| `semantic` (default — embeddings only) | **No.** The env block is ignored. |
+| `smart` (+ LLM-backed query expansion, auto-tagging, contradiction detection) | **Yes.** |
+| `autonomous` (smart + cross-encoder reranking + reflection + atomisation) | **Yes.** |
+
+Keyword and semantic tiers don't call the LLM at all. The env block above is for `smart` and `autonomous` tiers only. Setting it on keyword/semantic is harmless — the env vars are unused — but adds no value either.
+
+## API-key precedence ladder
+
+For every backend except `ollama` and `lmstudio` (which don't need a key), the API key resolves through this ladder (first match wins):
+
+1. `AI_MEMORY_LLM_API_KEY` — canonical, backend-agnostic.
+2. Per-vendor fallback env var (from this table):
+
+| Backend | Fallback env vars (in resolution order) |
+|---|---|
+| `openai` | `OPENAI_API_KEY` |
+| `xai` | `XAI_API_KEY` |
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `gemini` | `GEMINI_API_KEY`, then `GOOGLE_API_KEY` |
+| `deepseek` | `DEEPSEEK_API_KEY` |
+| `kimi` / `moonshot` | `MOONSHOT_API_KEY`, then `KIMI_API_KEY` |
+| `qwen` / `dashscope` | `DASHSCOPE_API_KEY`, then `QWEN_API_KEY` |
+| `mistral` | `MISTRAL_API_KEY` |
+| `groq` | `GROQ_API_KEY` |
+| `together` | `TOGETHER_API_KEY` |
+| `cerebras` | `CEREBRAS_API_KEY` |
+| `openrouter` | `OPENROUTER_API_KEY` |
+| `fireworks` | `FIREWORKS_API_KEY` |
+
+3. **Error** — backend rejects the request at the first chat/embed call.
+
+The same precedence applies whether the var lives in your shell or in the MCP `env:` block. The recommended pattern is to put the canonical `AI_MEMORY_LLM_API_KEY` in the MCP env block — it's unambiguous and doesn't depend on the per-vendor fallback chain.
+
+## Embedding wire shape (#1143)
+
+ai-memory's embedder is Ollama-native (`/api/embed`). When the LLM backend is non-Ollama (e.g. xAI, OpenAI), the MCP server detects the wire-shape mismatch and builds a **dedicated Ollama embed client** at `http://localhost:11434` (configurable via `AI_MEMORY_EMBED_URL`) while chat goes to the cloud vendor. You'll see the `(#1143)` banner line on first MCP start confirming this disambiguation took effect.
+
+If you don't have a local Ollama running and you've selected a non-Ollama LLM backend, semantic recall will fall back to keyword-only. To run fully cloud-side, either:
+- Install Ollama locally just for the embedder (`brew install ollama && ollama serve &` — no models need to be pulled; the embed endpoint accepts any embedding model tag the daemon knows about).
+- OR drop to `semantic` tier with Ollama unset and accept the limited recall surface.
+
+A native OpenAI-compatible embedder path is tracked for v0.7.x — once shipped, the disambiguation line will go away and the embedder will use whatever the LLM backend exposes at `/v1/embeddings`.
+
+## Verification — quick smoke test
+
+After editing your MCP config, restart your AI client and ask it a question that exercises the smart/autonomous tier (e.g. "what do you remember about X?"). Then check the ai-memory boot banner — it appears in the AI client's MCP server log (Claude Code: `~/Library/Logs/Claude/mcp*.log` on macOS; Cursor: Settings → Tools & MCP → server detail panel; etc.).
+
+Expected output:
+
+```text
+ai-memory: requested tier = autonomous
+ai-memory: profile = 8 families (...); expected tool count = 73
+ai-memory: LLM ready (backend=<your-backend>, model=<your-model>)
+ai-memory: LLM client is OpenAI-compatible (non-Ollama wire shape);
+           building dedicated Ollama embed client at http://localhost:11434 (#1143)
+ai-memory: embedder loaded (nomic-embed-text-v1.5 (768-dim, Ollama))
+ai-memory: atomisation engine ready (curator=LlmCurator)
+ai-memory MCP server started (stdio, tier=autonomous)
+```
+
+If you see `llm=gemma4:e4b` or `llm=gemma4:e2b` when you intended a non-Ollama backend, the `env:` block isn't being picked up — re-check the path of the config file your AI client actually reads (see [`platforms.md`](platforms.md) for the per-client path table).
+
+## Multi-agent / fleet / multi-DC considerations
+
+The recipes above assume the **singleton** case — one operator, one
+machine, one AI client. Fleet and multi-DC deployments add concerns
+the singleton case can ignore. None of them change the env-block
+shape; they change which **values** you put in the env block and how
+those values flow across nodes.
+
+### Storage backend is orthogonal to LLM backend
+
+ai-memory's storage backend (SQLite-WAL vs. PostgreSQL + Apache AGE,
+selected via `--store-url postgres://…` or the default sqlite path)
+is **independent** of the LLM backend (selected via
+`AI_MEMORY_LLM_BACKEND`). Any combination is supported:
+
+| Storage backend | LLM backend | Works? |
+|---|---|---|
+| SQLite (default) | Ollama (default) | Yes — the default zero-decision case. |
+| SQLite | xAI Grok / OpenAI / Anthropic / any cloud | Yes. |
+| PostgreSQL + AGE | Ollama (default) | Yes. |
+| PostgreSQL + AGE | xAI Grok / OpenAI / Anthropic / any cloud | Yes. |
+
+Switching storage backends does **not** require touching the LLM env
+block, and vice versa. The cross-product is fully supported.
+Storage-side setup: [`postgres-age-guide.md`](../postgres-age-guide.md).
+
+### Multiple agents on one node — shared vs. per-agent backend
+
+Two patterns, both valid:
+
+**Pattern 1 — single shared LLM backend across all agents on the node.**
+
+Every agent's MCP config points at the same `AI_MEMORY_LLM_BACKEND` +
+`AI_MEMORY_LLM_API_KEY` + `AI_MEMORY_LLM_MODEL`. Cost is shared,
+rate-limit budget is shared, key rotation is one place to touch. The
+attribution story is muddier: the cloud vendor sees all of your
+agents under one API-key identity.
+
+```json
+// Same env block in every agent's MCP server config:
+{
+  "env": {
+    "AI_MEMORY_LLM_BACKEND": "xai",
+    "AI_MEMORY_LLM_API_KEY": "xai-shared-org-key",
+    "AI_MEMORY_LLM_MODEL": "grok-4.3"
+  }
+}
+```
+
+**Pattern 2 — per-agent backend (different keys / different models).**
+
+Each agent's MCP config carries a distinct API key (or distinct
+backend). Cost / rate-limit / attribution are per-agent; key rotation
+is N-touches. Useful when different agents have different
+trust / capability tiers (e.g. cheap-and-fast for routine recall, a
+premium model for the reflection / curator daemon).
+
+```json
+// Agent A — autonomous tier, premium model:
+{
+  "env": {
+    "AI_MEMORY_LLM_BACKEND": "xai",
+    "AI_MEMORY_LLM_API_KEY": "xai-agent-a-key",
+    "AI_MEMORY_LLM_MODEL": "grok-4.3"
+  }
+}
+```
+
+```json
+// Agent B — smart tier, cheap-and-fast model:
+{
+  "env": {
+    "AI_MEMORY_LLM_BACKEND": "groq",
+    "AI_MEMORY_LLM_API_KEY": "gsk-agent-b-key",
+    "AI_MEMORY_LLM_MODEL": "llama-3.3-70b-versatile"
+  }
+}
+```
+
+For the multi-agent coordination layer itself (A2A wire shape, ranges
+of memory each agent can see, identity attestation across agents on
+one node), see [`batman-active-mode.md`](../batman-active-mode.md).
+
+### Multi-server in one DC — env-block strategy
+
+On a fleet of nodes each running one or more ai-memory MCP servers,
+the env block lives **per-node** (in each node's MCP config files).
+Three rollout patterns:
+
+1. **Config-management tool (Ansible / Chef / Puppet / Salt / Nix).**
+   Render the MCP config files from a template. Operator commits the
+   template; secret material (API keys) comes from a vault. Re-running
+   the playbook against every node reconciles drift in one pass.
+2. **Container image baked.** The MCP config is baked into a custom
+   image alongside the `ai-memory` binary. Operator rolls a new image
+   on key rotation. Works well with Kubernetes / Plan-C deployments
+   (see [`plan-c-deployment.md`](../plan-c-deployment.md)).
+3. **Secret-manager sidecar.** A secrets-fetch sidecar (Vault Agent,
+   AWS Secrets Manager CSI driver, etc.) writes the MCP config to a
+   local file on container start, pulling secrets from the secret
+   store at boot. Avoids baking secrets into images.
+
+The env-block contract is the same in all three patterns — they
+differ only in **how the file gets there**, not in **what it
+contains**.
+
+### Multi-DC / multi-region — regional cloud endpoints
+
+For latency-sensitive workloads, pick a cloud LLM provider with
+regional endpoints. xAI, OpenAI, Anthropic, Gemini, etc. publish
+regional URLs in their model-catalog docs. Override the per-alias
+default base URL with `AI_MEMORY_LLM_BASE_URL`:
+
+```json
+// Asia-Pacific deployment pointed at a regional OpenAI endpoint:
+{
+  "env": {
+    "AI_MEMORY_LLM_BACKEND": "openai",
+    "AI_MEMORY_LLM_BASE_URL": "https://your-azure-openai-resource.openai.azure.com/v1",
+    "AI_MEMORY_LLM_API_KEY": "...",
+    "AI_MEMORY_LLM_MODEL": "gpt-4o"
+  }
+}
+```
+
+For self-hosted vLLM / llama.cpp endpoints inside your own DC, point
+`AI_MEMORY_LLM_BASE_URL` at the regional inference cluster. The
+ai-memory MCP server doesn't care where the endpoint lives — it just
+speaks the OpenAI wire shape.
+
+### Federation / A2A interaction
+
+ai-memory's federation layer (`/sync/push`, mTLS allowlist,
+`X-Memory-Sig` + nonce freshness, signed-events V-4 chain — see
+[`federation.md`](../federation.md)) is **independent** of the LLM
+backend choice. Federated peers can each use a different LLM backend;
+the memory rows that cross the wire are LLM-agnostic.
+
+That said, if you rely on LLM-backed features that travel with the
+data (auto-tag, contradiction detection, atomisation, reflection),
+peers running different LLM backends will produce slightly different
+artefacts for the same input. For deterministic-equivalent
+deployments across a federation, pin every peer to the same LLM
+backend + model + version.
+
+### Key management at fleet scale
+
+For >5 nodes, do NOT bake API keys into the MCP config files
+checked into version control. Use one of:
+
+- **A secret manager (HashiCorp Vault / AWS Secrets Manager / GCP
+  Secret Manager / Azure Key Vault / 1Password Connect / sops).**
+  Render the MCP config from a template; pull the secret at deploy
+  time. Rotation is one secret update + a rolling restart.
+- **Per-host file with strict perms** (`chmod 0400` on `.env`-shape
+  files, sourced into the MCP-launcher's startup). Audit failure mode
+  if the perms slip — `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS`-style
+  guards do not apply to the LLM API-key file; that's an operator
+  policy concern.
+- **Per-agent identity-bound keys.** Each agent's
+  `AI_MEMORY_AGENT_ID` is provisioned alongside its own LLM API key
+  during agent enrolment; rotation is per-agent. Works well with the
+  Ed25519 identity-keypair-per-agent pattern from
+  [`production-deployment.md`](../production-deployment.md) §2.
+
+### Postgres + Apache AGE deployments — same env block, different daemon launch
+
+Postgres-backed deployments launch the daemon with `--store-url
+postgres://…`. The MCP `env:` block for LLM-backend selection is
+identical to the sqlite case — neither the storage nor the LLM care
+about each other's choice. The full storage-side setup:
+[`postgres-age-guide.md`](../postgres-age-guide.md).
+
+For multi-writer postgres deployments, the LLM backend is typically
+**not** per-agent at the env-block level. Instead, every agent's MCP
+server uses a shared backend identity (Pattern 1 above), and
+per-agent attribution lands on the postgres side via
+`metadata.agent_id` columns + per-agent governance rules. The LLM
+backend in that posture is operating as infrastructure — a fungible
+inference engine — rather than as part of the agent's identity.
+
+### Swarm / hive — coordination layer is above this
+
+For swarm / hive deployments, the LLM-backend selection is the *unit
+configuration* — every agent in the swarm needs one. The
+coordination layer (which agent talks to which, when to fan-out,
+when to converge) lives above: see
+[`batman-active-mode.md`](../batman-active-mode.md) and
+[`enterprise-deployment.md`](../enterprise-deployment.md) topologies
+6–8. Choice of LLM backend per agent is a swarm-design decision (do
+you want premium models on the critical-path agents and cheap-and-
+fast on the perimeter? do you want every agent identical for
+behavioural reproducibility?) — see
+[`enterprise-deployment.md`](../enterprise-deployment.md) §6 for the
+LLM-cost / behaviour tradeoffs at fleet scale.
+
+## Related
+
+- [`ADMIN_GUIDE.md` § LLM Backend Setup](../ADMIN_GUIDE.md#llm-backend-setup-smart--autonomous-tiers) — the standalone-CLI / HTTP-daemon flavour of the same setup (shell-side `export`).
+- [`INSTALL.md`](../INSTALL.md) — the broader install path, including the MCP config base examples this page extends.
+- [`install-quickstart.md`](../install-quickstart.md) — Path-A super-simple singleton install.
+- [`production-deployment.md`](../production-deployment.md) — single-node hardening, hub-spoke, W-of-N topologies.
+- [`enterprise-deployment.md`](../enterprise-deployment.md) — 8-topology continuum: singleton → multi-region swarm.
+- [`postgres-age-guide.md`](../postgres-age-guide.md) — PostgreSQL + Apache AGE storage backend.
+- [`batman-active-mode.md`](../batman-active-mode.md) — multi-agent on one node (A2A coordination).
+- [`federation.md`](../federation.md) — peer-federation wire shape, mTLS, signing.
+- [`grok-and-xai.md`](grok-and-xai.md) — using ai-memory to feed memory INTO Grok (the inverse direction). Cross-links back here for the Grok-as-backend case.
+- [`platforms.md`](platforms.md) — per-AI-client MCP config-file path table.
+- Issues [#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067), [#1142](https://github.com/alphaonedev/ai-memory-mcp/issues/1142), [#1143](https://github.com/alphaonedev/ai-memory-mcp/issues/1143), [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144) — the backend-resolver and docs-gap history that produced this page.

--- a/docs/integrations/local-models.md
+++ b/docs/integrations/local-models.md
@@ -9,6 +9,8 @@ boundary. The pattern is the same regardless of runtime: the front-end app
 or wrapper script prepends `ai-memory boot` output to the system message
 before the first request.
 
+> **Cross-reference — using a local model as ai-memory's own LLM backend.** This doc covers local models as the AI client (reading ai-memory boot output). For the inverse direction — ai-memory's smart / autonomous tier calling out to a local LMStudio / vLLM / llama.cpp server / Ollama endpoint for query expansion, auto-tag, etc. — see [`llm-backends.md`](llm-backends.md) §§ Ollama / LMStudio / Generic OpenAI-compatible (self-hosted). MCP env-block recipes cover the full matrix; shell exports do NOT reach MCP-spawned subprocesses ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
+
 ## Or for the simple wrapper case — `ai-memory wrap`
 
 PR-6 of issue #487 ships a built-in cross-platform Rust subcommand

--- a/docs/integrations/openai-apps-sdk.md
+++ b/docs/integrations/openai-apps-sdk.md
@@ -6,6 +6,8 @@ OpenAI's Assistants API, Responses API, and Apps SDK all expose system
 messages / instructions as the integration point. Prepend `ai-memory boot`
 output before creating the assistant or before the first request.
 
+> **Cross-reference — using OpenAI as ai-memory's own LLM backend.** This doc covers OpenAI-family endpoints as the AI client. For the inverse direction (ai-memory's smart / autonomous tier calling OpenAI internally for query expansion, auto-tag, contradiction detection), see [`llm-backends.md` § OpenAI](llm-backends.md#openai). The MCP env-block recipe shown there is the supported posture; shell exports don't reach MCP-spawned subprocesses ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)).
+
 ## Or for the simple wrapper case — `ai-memory wrap`
 
 For callers that just want to spawn an OpenAI-compatible CLI with

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -47,6 +47,8 @@ Edit your OpenClaw config file (the canonical location is documented at
 }
 ```
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the inner `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 Notes:
 
 - `command: "ai-memory"` requires the binary to be on OpenClaw's `$PATH`.

--- a/docs/integrations/roo-code.md
+++ b/docs/integrations/roo-code.md
@@ -49,6 +49,8 @@ identical to Cline's:
 prompting for permission on every call — required for a smooth boot
 path.
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 ## Part 2 — Custom Instructions (best-effort)
 
 Roo Code's custom-instructions surface is reachable via Settings →

--- a/docs/integrations/windsurf.md
+++ b/docs/integrations/windsurf.md
@@ -28,6 +28,8 @@ is project-scoped and still manual.
 }
 ```
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 ## Part 2 — `.windsurfrules` (best-effort)
 
 At the project root:

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -39,6 +39,8 @@ Add to `~/.config/zed/settings.json`:
 }
 ```
 
+> **Using `--tier smart` or `--tier autonomous` with a non-default LLM backend?** Extend the inner `env` block above with `AI_MEMORY_LLM_BACKEND`, `AI_MEMORY_LLM_API_KEY`, and `AI_MEMORY_LLM_MODEL`. **Do not** rely on shell exports — Zed's MCP-spawned subprocesses don't see your interactive shell's environment ([#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144)). Copy-pasteable recipes for every supported provider (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks): [`llm-backends.md`](llm-backends.md).
+
 Notes:
 
 - `path: "ai-memory"` requires the binary to be on Zed's `$PATH` at

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -130,6 +130,62 @@ Sizing guide (Apple M2, 16 GB, SQLite reference):
 
 ---
 
+## 7b. LLM backend wiring (smart / autonomous tier)
+
+If your deployment uses `--tier smart` or `--tier autonomous`, the
+substrate needs an LLM backend. Two wire shapes apply, with **different
+discoverability stories** for the env vars:
+
+- **HTTP daemon (`ai-memory serve`).** The daemon inherits the env of
+  the user / systemd unit / Docker container that launched it. Setting
+  `AI_MEMORY_LLM_BACKEND` / `AI_MEMORY_LLM_API_KEY` / `AI_MEMORY_LLM_MODEL`
+  in the unit file's `Environment=` / `EnvironmentFile=` directives (or
+  in the container's `ENV` / `--env-file`) is the canonical pattern.
+  Shell exports work for interactive launch but not for systemd /
+  Docker / Kubernetes — those have their own env contracts.
+- **MCP servers (`ai-memory mcp`).** Spawned by AI clients (Claude
+  Code, Claude Desktop, Cursor, Codex CLI, Cline, Continue, Zed,
+  Windsurf, Goose, Roo Code, etc.) as a **fresh subprocess** with only
+  the `env:` keys declared in the MCP server config. Shell exports
+  from `.zshrc` / `.bashrc` / `.profile` are NOT visible. This was the
+  operator paper-cut behind [#1144](https://github.com/alphaonedev/ai-memory-mcp/issues/1144).
+
+For MCP usage, the LLM env vars MUST live inside the MCP server
+config's `env:` block. Copy-pasteable per-backend recipes (Ollama,
+LMStudio, vLLM, llama.cpp server, xAI, OpenAI, Anthropic, Gemini,
+DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter,
+Fireworks) + multi-agent / multi-DC / fleet considerations:
+[`integrations/llm-backends.md`](integrations/llm-backends.md).
+
+Fleet rollout pattern (systemd):
+
+```
+# /etc/systemd/system/ai-memory.service
+[Service]
+EnvironmentFile=/etc/ai-memory/llm.env
+ExecStart=/usr/local/bin/ai-memory serve --tier autonomous --store-url postgres://...
+User=ai-memory
+Group=ai-memory
+```
+
+```
+# /etc/ai-memory/llm.env  (chmod 0640, owned by root:ai-memory)
+AI_MEMORY_LLM_BACKEND=xai
+AI_MEMORY_LLM_API_KEY=xai-...
+AI_MEMORY_LLM_MODEL=grok-4.3
+```
+
+For fleet deployments managed via Ansible / Chef / Puppet / Salt / Nix,
+render `/etc/ai-memory/llm.env` from a template and pull the secret
+from your vault. Rotation = vault rotate + `systemctl restart
+ai-memory`.
+
+For multi-DC deployments with regional cloud LLM endpoints, override
+the per-alias default URL with `AI_MEMORY_LLM_BASE_URL`. See
+[`integrations/llm-backends.md` § Multi-DC / multi-region](integrations/llm-backends.md#multi-dc--multi-region--regional-cloud-endpoints).
+
+---
+
 ## 8. Upgrades
 
 The canonical upgrade sequence:


### PR DESCRIPTION
## Summary

Closes the docs side of the #1144 paper-cut: every `mcpServers` JSON / Codex TOML example in install + integration docs was silent on operator-side LLM-backend wiring, so post-#1067 the resolver code was correct but operators still hit `llm=gemma4:e4b` in the boot banner because shell exports don't reach MCP-spawned subprocesses.

This PR:

- **NEW** `docs/integrations/llm-backends.md` — canonical per-backend MCP env-block recipe page covering all 16+ supported backends (Ollama, LMStudio, vLLM, llama.cpp server, xAI Grok, OpenAI, Anthropic, Gemini, DeepSeek, Kimi/Moonshot, Qwen/DashScope, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks) plus the Codex CLI TOML shape, plus a multi-agent / fleet / multi-DC / postgres+AGE section.
- Path-A / Path-B audience selector at the top of README + INSTALL + install-quickstart + QUICKSTART. Non-technical users routed to install-quickstart.md (5-min super-simple including config); SMEs routed through INSTALL → production-deployment → ADMIN_GUIDE → enterprise-deployment → postgres-age-guide → federation.
- Inline env-block recipe + shell-vs-MCP callout in every MCP-config example across README, INSTALL, QUICKSTART, install-quickstart, integration-guide, and 16 per-platform integration docs.
- ADMIN_GUIDE.md § LLM Backend Setup gets the load-bearing admonition explaining when shell `export` is sufficient (standalone CLI / HTTP daemon) vs. when it is NOT (MCP).
- docs/integrations/grok-and-xai.md gets a new "Use Grok as ai-memory's LLM backend" section (the inverse direction — Grok-AS-backend, not Grok-as-client) with cross-link to the canonical recipe page for the full vendor matrix.
- docs/production-deployment.md gets a new §7b covering HTTP daemon (systemd EnvironmentFile) vs. MCP env-block patterns, plus the Ansible/Chef/Puppet/Salt/Nix + vault fleet rollout pattern.
- docs/enterprise-deployment.md gets a top-of-doc cross-link adding llm-backends.md to "what this guide assumes you have absorbed."
- GitHub Pages site (docs/index.html, docs/at-a-glance.html, docs/autonomous.html) get cross-links to the new recipe page; docs/index.html gains a "Configure the LLM backend" sub-section under the existing #install anchor.

## Test plan

Docs-only PR — no source changes, no test regressions, no behavior shifts.

- [ ] Spot-check the new `docs/integrations/llm-backends.md` renders correctly on GitHub.
- [ ] Spot-check the Path-A/Path-B selector tables render in README, INSTALL.md, install-quickstart.md.
- [ ] Spot-check internal cross-links resolve (none broken).
- [ ] Confirm the xAI smoke-banner block in llm-backends.md matches #1143 in-issue evidence (`LLM ready (backend=xai, model=grok-4.3)` + `(#1143)` line).
- [ ] Verify the env-block JSON example shape matches `OllamaClient::build_for_init` in `src/llm.rs` (#1143 implementation).

## Files changed

29 files: 28 modified + 1 new (`docs/integrations/llm-backends.md`). 1,123 insertions, 12 deletions. Explicit per-file stage list per CLAUDE.md commit-discipline.

## Refs

- #1067 — vendor-agnostic LLM backend resolver
- #1142 — MCP-LLM init env-aware port
- #1143 — sibling bypass closures + embed-client wire-shape fix
- #1144 — this docs-gap issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)