### PR TITLE
feat(config) #1146: enterprise configuration standard — sectioned schema + canonical resolver + migration + doctor probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.7.x doc follow-ups + Wave-2 refactor (post-tag)
 
+### feat(config, #1146) — enterprise configuration standard (2026-05-22)
+
+Closes [#1146](https://github.com/alphaonedev/ai-memory-mcp/issues/1146)
+(subsumes [#1143](https://github.com/alphaonedev/ai-memory-mcp/issues/1143)).
+Consolidates the previously-fragmented configuration surface
+(legacy flat fields, `~/.claude.json` `mcpServers.*.env` block,
+SessionStart hook env, compiled tier presets, process env) into a
+single canonical sectioned schema with one resolver every surface
+consumes.
+
+- **Schema v2** — `[llm]` / `[llm.auto_tag]` / `[embeddings]` /
+  `[reranker]` / `[storage]` sections in `~/.config/ai-memory/config.toml`,
+  plus an explicit `schema_version = 2` field. Legacy v0.6.x flat
+  fields continue to parse (deprecation WARN on first load) and will
+  be removed in v0.8.0.
+- **Canonical resolvers** — `AppConfig::resolve_llm` /
+  `resolve_llm_auto_tag` / `resolve_embeddings` / `resolve_reranker` /
+  `resolve_storage`. Uniform precedence: CLI > AI_MEMORY_LLM_* env >
+  section > legacy fields > compiled default. Resolved shapes carry
+  provenance tags (`ConfigSource`, `KeySource`) surfaced by the boot
+  banner and `ai-memory doctor`.
+- **Single-entry LLM constructor** — `OllamaClient::build_from_resolved`
+  replaces every inline env-vs-tier-preset match across 6 LLM-init
+  sites (MCP stdio, HTTP daemon, curator-primitives entrypoint,
+  atomise CLI, curator CLI, boot banner).
+- **Inline-key rejection at parse time** — `[llm].api_key = "<literal>"`,
+  `api_key_env + api_key_file` mutex, and the same mutex on
+  `[llm.auto_tag]` are all refused. Loader falls back to
+  `AppConfig::default()` on rejection so the daemon still boots.
+- **`api_key_file` mode 0400 enforcement** — reuses #1055 escape hatch
+  (`AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1`).
+- **New CLI**: `ai-memory config migrate [--dry-run]
+  [--also-clean-claude-json]` — rewrites a legacy v1 config to v2
+  shape with a timestamped `.bak`. Idempotent.
+- **`ai-memory doctor` LLM reachability probe** — new section
+  `LLM Reachability (#1146)` resolves the canonical LLM config and
+  probes the endpoint with the resolved Bearer key. 7-bucket severity
+  partition: INFO (200), WARN (401/403/429/5xx), CRIT (4xx other /
+  network / DNS / TLS).
+- **Boot banner upgrade** — reports `llm=<backend>:<model>` (e.g.
+  `llm=xai:grok-4.3`) when backend is non-Ollama; the historic
+  `llm=<model>` shape is preserved for Ollama backends so existing
+  scrapers continue to match. Closes the operator-visible defect that
+  triggered the campaign (boot banner reporting compiled tier preset
+  `gemma4:e4b` while the MCP server was actually routing to
+  `xai/grok-4.3`).
+- **`ResolvedLlm::Debug` redacts api_key** to `<redacted>`.
+- **19 unit tests** pin resolver precedence, inline-key rejection,
+  mutex enforcement, alias-fallback API-key resolution, `api_key_env`
+  and `api_key_file` paths (incl. 0400 perms check), legacy alias
+  canonicalisation, backfill-batch env override, reranker bool→table
+  fold, Debug redaction, and v1→v2 migration shape.
+
+Migration: existing v0.6.x deployments boot unchanged with a one-line
+WARN nudging them to run `ai-memory config migrate`. Operators who
+previously inlined `AI_MEMORY_LLM_API_KEY` in `~/.claude.json`
+`mcpServers.memory.env` can migrate the key to `config.toml`
+`[llm].api_key_env = "XAI_API_KEY"` (referencing a shell-injected env
+var) or `[llm].api_key_file = "/path/to/key"` (mode 0400 file).
+
 ### feat(llm, #1067) — provider-agnostic LLM substrate (2026-05-21)
 
 Closes [#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,112 @@ are pinned by `tests/config_precedence.rs`:
 If you add a new env var, update the table above AND extend
 `tests/config_precedence.rs` so the invariant is mechanically enforced.
 
+### Config schema v0.7.x (#1146) — sectioned `[llm]` / `[embeddings]` / `[reranker]` / `[storage]`
+
+**Canonical shape.** As of v0.7.x (#1146), `~/.config/ai-memory/config.toml`
+uses a schema-versioned, sectioned shape:
+
+```toml
+schema_version = 2
+
+tier = "autonomous"
+db = "/Users/fate/.claude/ai-memory.db"
+
+[llm]
+backend     = "xai"          # ollama | openai | xai | anthropic | gemini |
+                             # deepseek | kimi | qwen | mistral | groq |
+                             # together | cerebras | openrouter |
+                             # fireworks | lmstudio | openai-compatible
+model       = "grok-4.3"     # vendor-specific
+base_url    = "https://api.x.ai/v1"   # optional; vendor-default if unset
+api_key_env = "XAI_API_KEY"            # env-var name reference (mutually
+                                       # exclusive with api_key_file)
+# api_key_file = "/etc/ai-memory/keys/xai.key"   # alt — mode 0400 enforced
+
+[llm.auto_tag]
+# Fast structured-output sibling of [llm] (auto_tag, query expansion,
+# contradiction detection). Field-by-field fallback to parent [llm];
+# operators commonly override only `model` to point at a fast local
+# Ollama variant.
+backend = "ollama"
+model   = "gemma3:4b"
+
+[embeddings]
+backend        = "ollama"
+url            = "http://localhost:11434"
+model          = "nomic-embed-text-v1.5"
+backfill_batch = 100
+
+[reranker]
+enabled = true
+model   = "ms-marco-MiniLM-L-6-v2"
+
+[storage]
+default_namespace = "alphaone"
+archive_on_gc     = true
+
+[mcp]
+profile = "full"
+```
+
+**Canonical resolver.** Every LLM-init surface (MCP stdio, HTTP daemon,
+`ai-memory atomise`, `ai-memory curator`, the boot banner, the
+`ai-memory doctor` reachability probe) consumes the `ResolvedLlm`
+shape produced by `AppConfig::resolve_llm(cli_backend, cli_model,
+cli_base_url)`. The resolver applies the uniform precedence ladder:
+
+```
+CLI flag  >  AI_MEMORY_LLM_* env  >  [llm] section  >  legacy flat fields  >  compiled default
+```
+
+Sister resolvers `resolve_llm_auto_tag`, `resolve_embeddings`,
+`resolve_reranker`, and `resolve_storage` follow the same ladder for
+their respective concerns. The `ResolvedLlm` struct's `Debug` impl
+redacts the resolved `api_key` to `<redacted>` so accidental `{:?}`
+prints never leak credentials.
+
+**Inline-key rejection.** `[llm].api_key = "<literal>"` is rejected at
+parse time with a clear stderr error and the daemon falls back to
+`AppConfig::default()` so it still boots. Operators must use either
+`[llm].api_key_env = "<ENV_VAR_NAME>"` (process env reference) or
+`[llm].api_key_file = "/path/to/key"` (file; mode 0400 enforced via
+`AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS` escape hatch from #1055).
+
+**Legacy v0.6.x flat fields** (`llm_model`, `ollama_url`, `embed_url`,
+`embedding_model`, `cross_encoder`, `default_namespace`,
+`archive_on_gc`, `archive_max_days`, `max_memory_mb`, `auto_tag_model`)
+continue to parse and feed the resolver's `Legacy` arm. Loading a
+legacy config emits a `Once`-gated stderr WARN pointing at
+`ai-memory config migrate`. Legacy fields will be removed in v0.8.0.
+
+**Migration tool.**
+
+```bash
+ai-memory config migrate              # write <file>.bak.<ts> + rewrite in v2 shape
+ai-memory config migrate --dry-run    # print diff to stderr, no writes
+ai-memory config migrate \
+    --also-clean-claude-json          # additionally remove
+                                      # mcpServers.<*>.env from
+                                      # ~/.claude.json after the
+                                      # operator has verified the
+                                      # new config works
+```
+
+Idempotent — running against a v2 file is a no-op INFO log.
+
+**Reachability probe.** `ai-memory doctor` emits a section
+`LLM Reachability (#1146)` that probes `<base_url>/api/tags` (Ollama)
+or `<base_url>/models` (OpenAI-compatible) with the resolved Bearer
+key and reports PASS / WARN (401/403/429/5xx) / CRIT (4xx other,
+network, DNS, TLS) plus the resolved provenance facts so operators
+can see WHICH precedence layer won.
+
+**Test pins.** Resolver precedence + secret-handling discipline are
+pinned by 19 tests under `src/config::tests::*1146*` and
+`src/cli/commands/config::tests::migrate_*`. Adding a new resolver
+field requires updating both the resolver function and the precedence
+test for that resolver (CLI > env > config > legacy > default).
+
 ### Agent Identity (NHI) — `metadata.agent_id`
 
 Every stored memory carries `metadata.agent_id` — a best-effort Non-Human Identity

--- a/README.md
+++ b/README.md
@@ -839,10 +839,10 @@ Every capability mapped to its minimum tier. Each tier includes all capabilities
 
 **Semantic tier** (default) bundles the Candle ML framework and downloads the all-MiniLM-L6-v2 model on first run (~90 MB). **Smart** and **autonomous** tiers require an LLM backend — post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0) that can be local ([Ollama](https://ollama.com), LMStudio, vLLM, llama.cpp server) or any OpenAI-compatible remote endpoint (xAI, OpenAI, Anthropic via OpenAI shim, Google Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks). Selection is by `AI_MEMORY_LLM_BACKEND` env var; per-vendor API keys via `XAI_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `DEEPSEEK_API_KEY` / `MOONSHOT_API_KEY` / `DASHSCOPE_API_KEY` / etc. or the canonical `AI_MEMORY_LLM_API_KEY`.
 
-**Tiers gate features, not models — and post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0), tiers gate features, not vendors either.** The `--tier` flag controls which tools are exposed. The LLM backend + model are independently configurable via `AI_MEMORY_LLM_BACKEND` + `AI_MEMORY_LLM_MODEL` env vars (or the `llm_model` field in `~/.config/ai-memory/config.toml` for legacy Ollama setups). For example, run autonomous tier (full 73-tool surface (v0.7.0) + reranker) against xAI Grok 4 via the OpenAI-compatible alias:
+**Tiers gate features, not models — and post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) (v0.7.0), tiers gate features, not vendors either.** The `--tier` flag controls which tools are exposed. The LLM backend + model are independently configurable via `AI_MEMORY_LLM_BACKEND` + `AI_MEMORY_LLM_MODEL` env vars (or via the canonical `[llm]` section in `~/.config/ai-memory/config.toml` — see [docs/CONFIG_SCHEMA.md](docs/CONFIG_SCHEMA.md) for the v0.7.x enterprise schema and the migration tool). For example, run autonomous tier (full 73-tool surface (v0.7.0) + reranker) against xAI Grok 4 via the OpenAI-compatible alias:
 
 ```bash
-# Remote LLM via env (post-#1067)
+# Quick path: env vars
 export AI_MEMORY_LLM_BACKEND=xai
 export AI_MEMORY_LLM_MODEL=grok-4
 export XAI_API_KEY=xai-…   # or AI_MEMORY_LLM_API_KEY
@@ -850,8 +850,22 @@ ai-memory mcp --tier autonomous
 ```
 
 ```toml
-# ~/.config/ai-memory/config.toml — legacy local Ollama
-tier = "autonomous"        # all features enabled
+# Enterprise path: ~/.config/ai-memory/config.toml (v0.7.x schema v2, #1146)
+schema_version = 2
+tier = "autonomous"
+
+[llm]
+backend     = "xai"
+model       = "grok-4.3"
+base_url    = "https://api.x.ai/v1"
+api_key_env = "XAI_API_KEY"          # mutually exclusive with api_key_file;
+                                     # inline `api_key = "..."` is REJECTED.
+```
+
+```toml
+# Legacy v0.6.x shape — still works, deprecation WARN at load; run
+# `ai-memory config migrate` to upgrade in place.
+tier = "autonomous"
 llm_model = "gemma4:e2b"   # faster model (46 tok/s vs 26 tok/s for e4b)
 ```
 

--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -1,0 +1,257 @@
+# `ai-memory` configuration schema reference
+
+This is the canonical reference for the v0.7.x schema-versioned
+sectioned configuration format introduced in
+[#1146](https://github.com/alphaonedev/ai-memory-mcp/issues/1146).
+Every deployment of `ai-memory` (MCP server, HTTP daemon, CLI) reads
+configuration from a single file at `~/.config/ai-memory/config.toml`.
+
+## Quick reference
+
+```toml
+schema_version = 2
+
+# Top-level operational settings.
+tier = "autonomous"
+db   = "/Users/fate/.claude/ai-memory.db"
+
+# ---------------------------------------------------------------------
+# [llm] — chat-completion LLM configuration.
+# ---------------------------------------------------------------------
+[llm]
+backend     = "xai"           # ollama | openai | xai | anthropic | gemini |
+                              # deepseek | kimi | qwen | mistral | groq |
+                              # together | cerebras | openrouter |
+                              # fireworks | lmstudio | openai-compatible
+model       = "grok-4.3"      # vendor-specific identifier
+base_url    = "https://api.x.ai/v1"   # optional; vendor-default if unset
+
+# Exactly one of api_key_env / api_key_file (or neither — falls back to
+# the per-vendor env-var chain). Inline `api_key = "<literal>"` is
+# REJECTED at parse time.
+api_key_env = "XAI_API_KEY"
+# api_key_file = "/etc/ai-memory/keys/xai.key"   # mode 0400 enforced
+
+# Fast structured-output sibling (auto_tag, query expansion,
+# contradiction detection). Field-by-field fallback to parent [llm];
+# commonly only `model` is overridden.
+[llm.auto_tag]
+backend = "ollama"
+model   = "gemma3:4b"
+
+# ---------------------------------------------------------------------
+# [embeddings] — embedding-model configuration.
+# ---------------------------------------------------------------------
+[embeddings]
+backend        = "ollama"
+url            = "http://localhost:11434"
+model          = "nomic-embed-text-v1.5"
+backfill_batch = 100            # env override: AI_MEMORY_EMBED_BACKFILL_BATCH
+
+# ---------------------------------------------------------------------
+# [reranker] — cross-encoder rerank configuration.
+# ---------------------------------------------------------------------
+[reranker]
+enabled = true
+model   = "ms-marco-MiniLM-L-6-v2"
+
+# ---------------------------------------------------------------------
+# [storage] — storage configuration.
+# ---------------------------------------------------------------------
+[storage]
+default_namespace = "alphaone"
+archive_on_gc     = true
+archive_max_days  = 90
+max_memory_mb     = 4096
+
+# ---------------------------------------------------------------------
+# Existing sections at v0.7.x — see env-var table in CLAUDE.md.
+# ---------------------------------------------------------------------
+[mcp]
+profile = "full"
+
+[permissions]
+mode = "enforce"
+```
+
+## Canonical resolver
+
+Every LLM / embedder / reranker / storage decision in the binary
+consumes the corresponding `Resolved*` struct produced by these
+methods:
+
+- `AppConfig::resolve_llm(cli_backend, cli_model, cli_base_url)`
+- `AppConfig::resolve_llm_auto_tag()`
+- `AppConfig::resolve_embeddings()`
+- `AppConfig::resolve_reranker()`
+- `AppConfig::resolve_storage()`
+
+**Uniform precedence ladder** (CLI > env > config > legacy > compiled):
+
+```
+CLI flag  >  AI_MEMORY_LLM_* env  >  [llm] section  >  legacy flat fields  >  compiled default
+```
+
+Resolvers are pure (no network I/O). File reads for `api_key_file`
+happen at resolve time; permission-bit enforcement is non-fatal and
+surfaces via `KeySource::Error(reason)` so the daemon can boot and
+report the problem through `ai-memory doctor` rather than failing
+at load time.
+
+The `Resolved*` structs carry provenance tags:
+
+- `ConfigSource` — which layer of the precedence ladder won
+  (`Cli` / `Env` / `Config` / `Legacy` / `CompiledDefault`).
+- `KeySource` — where the resolved API key came from
+  (`ProcessEnv` / `AliasFallback(name)` / `ConfigEnvVar(name)` /
+  `ConfigFile(path)` / `None` / `Error(reason)`).
+
+The `ResolvedLlm::Debug` impl redacts the resolved `api_key` to
+`<redacted>` so accidental `{:?}` prints never leak credentials.
+
+## Secret handling discipline
+
+`[llm].api_key = "<literal>"` is **REJECTED at parse time** with a
+clear stderr error. The daemon falls back to `AppConfig::default()`
+on rejection so it still boots, and the operator sees:
+
+```
+ai-memory: config rejected (~/.config/ai-memory/config.toml): inline
+`api_key = "<literal>"` in [llm] is forbidden — use
+`api_key_env = "<ENV_VAR_NAME>"` to reference a process env var, or
+`api_key_file = "/path/to/key"` to reference a file (mode 0400
+enforced). Inline secrets in config.toml (typically world-readable)
+are a credential leak.
+```
+
+`[llm].api_key_env` and `[llm].api_key_file` are mutually exclusive
+— the daemon refuses to load a config that sets both. Same mutex
+applies to `[llm.auto_tag]`.
+
+`[llm].api_key_file` requires `mode 0400` (or stricter). The check
+is skipped on non-Unix platforms. To opt out (operator-advisory,
+NOT recommended for production):
+
+```bash
+export AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1
+```
+
+This is the same escape hatch [#1055](https://github.com/alphaonedev/ai-memory-mcp/issues/1055)
+introduced for `AI_MEMORY_DB_PASSPHRASE_FILE`.
+
+## Migration from v0.6.x (legacy flat fields)
+
+The v0.6.x flat-field shape (`llm_model`, `ollama_url`, `embed_url`,
+`embedding_model`, `cross_encoder`, `default_namespace`,
+`archive_on_gc`, `archive_max_days`, `max_memory_mb`,
+`auto_tag_model`) continues to parse in v0.7.x and feeds the
+resolver's `Legacy` arm. Loading a legacy config emits a one-shot
+stderr WARN pointing operators at the migration tool. **Legacy
+fields will be removed in v0.8.0.**
+
+To migrate in place:
+
+```bash
+ai-memory config migrate              # write <file>.bak.<ts> + rewrite
+ai-memory config migrate --dry-run    # print diff, write nothing
+ai-memory config migrate \
+    --also-clean-claude-json          # additionally remove
+                                      # mcpServers.<*>.env from
+                                      # ~/.claude.json
+```
+
+The migrator is **idempotent** — running against an already-v2 file
+is a no-op INFO log.
+
+## Reachability probe
+
+`ai-memory doctor` emits a section `LLM Reachability (#1146)` that
+resolves the canonical LLM config and probes the endpoint with the
+resolved Bearer key:
+
+- `ollama` → `GET <base_url>/api/tags` (no auth)
+- any OpenAI-compatible → `GET <base_url>/models` (Bearer auth)
+
+Severity partition:
+
+| Severity | HTTP outcomes                                    |
+|----------|--------------------------------------------------|
+| INFO     | 200 (vendor reachable + auth OK)                 |
+| WARN     | 401 / 403 (auth issue; URL reachable)            |
+| WARN     | 429 (rate-limited; reachable)                    |
+| WARN     | 5xx (vendor outage; reachable)                   |
+| CRIT     | 4xx other (likely wrong base_url / endpoint)     |
+| CRIT     | network / DNS / connect-refused / TLS error      |
+
+Surfaces the resolved provenance facts (`backend`, `model`,
+`base_url`, `config_source`, `key_source`) so the operator can see
+WHICH precedence layer won.
+
+## API-key resolution chain
+
+For non-Ollama backends, the resolver consults these layers in
+order:
+
+1. `AI_MEMORY_LLM_API_KEY` (process env) — universal escape hatch.
+2. Per-vendor process env-var fallback:
+   - `xai` → `XAI_API_KEY`
+   - `openai` → `OPENAI_API_KEY`
+   - `anthropic` → `ANTHROPIC_API_KEY`
+   - `gemini` → `GEMINI_API_KEY` (or `GOOGLE_API_KEY`)
+   - `deepseek` → `DEEPSEEK_API_KEY`
+   - `kimi` / `moonshot` → `MOONSHOT_API_KEY` (or `KIMI_API_KEY`)
+   - `qwen` / `dashscope` → `DASHSCOPE_API_KEY` (or `QWEN_API_KEY`)
+   - `mistral` → `MISTRAL_API_KEY`
+   - `groq` → `GROQ_API_KEY`
+   - `together` → `TOGETHER_API_KEY`
+   - `cerebras` → `CEREBRAS_API_KEY`
+   - `openrouter` → `OPENROUTER_API_KEY`
+   - `fireworks` → `FIREWORKS_API_KEY`
+3. `[llm].api_key_env = "<NAME>"` — config-pointed env var.
+4. `[llm].api_key_file = "/path"` — file (mode 0400 enforced).
+
+If all four return empty, the resolver returns `KeySource::None`
+(correct for `backend = "ollama"`; a misconfiguration for any
+OpenAI-compatible backend — `ai-memory doctor` surfaces this).
+
+## Backend defaults
+
+For each backend, the resolver applies these defaults when the
+operator does not override:
+
+| Backend          | Default base URL                                  | Default model                                   |
+|------------------|---------------------------------------------------|-------------------------------------------------|
+| `ollama`         | `http://localhost:11434`                          | `gemma3:4b`                                     |
+| `openai`         | `https://api.openai.com/v1`                       | `gpt-5`                                         |
+| `xai`            | `https://api.x.ai/v1`                             | `grok-4.3`                                      |
+| `anthropic`      | `https://api.anthropic.com/v1`                    | `claude-opus-4.7`                               |
+| `gemini`         | `https://generativelanguage.googleapis.com/v1beta/openai` | `gemini-2.0-flash`                      |
+| `deepseek`       | `https://api.deepseek.com/v1`                     | `deepseek-chat`                                 |
+| `kimi`/`moonshot`| `https://api.moonshot.cn/v1`                      | `moonshot-v1-8k`                                |
+| `qwen`/`dashscope`| `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max`                                |
+| `mistral`        | `https://api.mistral.ai/v1`                       | `mistral-large-latest`                          |
+| `groq`           | `https://api.groq.com/openai/v1`                  | `llama-3.3-70b-versatile`                       |
+| `together`       | `https://api.together.xyz/v1`                     | `meta-llama/Llama-3.3-70B-Instruct-Turbo`       |
+| `cerebras`       | `https://api.cerebras.ai/v1`                      | `llama-3.3-70b`                                 |
+| `openrouter`     | `https://openrouter.ai/api/v1`                    | `openai/gpt-5`                                  |
+| `fireworks`      | `https://api.fireworks.ai/inference/v1`           | `accounts/fireworks/models/llama-v3p3-70b-instruct` |
+| `lmstudio`       | `http://localhost:1234/v1`                        | `local-model`                                   |
+| `openai-compatible` | _(no default — operator must set `base_url`)_ | `gpt-5`                                         |
+
+The model defaults are intentionally aggressive — operators MUST
+verify the chosen model exists on their account before relying on it.
+
+## Related
+
+- [#1146](https://github.com/alphaonedev/ai-memory-mcp/issues/1146) —
+  umbrella issue for this schema (QC-amended 2026-05-22).
+- [#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067) —
+  the underlying provider-agnostic LLM substrate this schema configures.
+- [#1143](https://github.com/alphaonedev/ai-memory-mcp/issues/1143) —
+  the sibling-site cleanup this schema subsumed.
+- [#1055](https://github.com/alphaonedev/ai-memory-mcp/issues/1055) —
+  the `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS` escape hatch
+  reused by `api_key_file`.
+- CLAUDE.md `### Environment Variables` — full env-var table with
+  precedence ladder and classification (`secret` / `config` /
+  `test-only`).

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -164,6 +164,7 @@ recipe's snippets and `ai-memory wrap <agent>` (PR-6).
 | [`networking.md`](networking.md) | macOS + Tailscale / VPN per-app intercept gotchas (#704) and tailnet-IP workarounds | n/a | n/a | reference |
 | [`global-claude-md-template.md`](global-claude-md-template.md) | `~/.claude/CLAUDE.md` belt-and-suspenders snippet | 1 fallback | n/a | reference |
 | [`v0.6.4-system-prompt-snippet.md`](v0.6.4-system-prompt-snippet.md) | v0.6.4 discovery-aware NHI bootstrap (drop-in for any harness) | n/a | n/a | reference |
+| [`llm-backends.md`](llm-backends.md) | Per-backend MCP `env:` block recipes (Ollama, LMStudio, xAI, OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, Mistral, Groq, Together, Cerebras, OpenRouter, Fireworks, vLLM, llama.cpp). Closes #1144 (operator paper-cut: shell env doesn't reach MCP subprocesses). | n/a | n/a | reference |
 
 ## Failure modes (any recipe)
 

--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -381,19 +381,46 @@ impl BootManifest {
         latency_ms: u128,
         schema_supported: bool,
     ) -> Self {
-        // Resolve the *configured* tier. Boot doesn't materialize the
-        // embedder / LLM / reranker handles, so these reflect what would
-        // load — not what actually loaded.
+        // v0.7.x (#1146) — Boot reports the SAME resolved configuration
+        // that the live MCP / HTTP / CLI surfaces will use, instead of
+        // the compiled tier preset. The resolver folds CLI flags (none
+        // at boot time), AI_MEMORY_LLM_* env vars, the `[llm]` /
+        // `[embeddings]` / `[reranker]` config sections, the legacy
+        // flat fields, and the compiled fallback through the uniform
+        // precedence ladder. The banner emits `backend:model` so the
+        // operator can verify wiring at a glance (`llm=xai:grok-4.3`
+        // vs `llm=ollama:gemma3:4b` vs `llm=ollama:none`).
         let feature_tier = app_config.effective_tier(None);
-        let tier_config = feature_tier.config();
-        let embedder = tier_config
-            .embedding_model
-            .map_or_else(|| "none".to_string(), |m| m.hf_model_id().to_string());
-        let llm = tier_config
-            .llm_model
-            .map_or_else(|| "none".to_string(), |m| m.ollama_model_id().to_string());
-        let reranker = if tier_config.cross_encoder {
-            "ms-marco-MiniLM-L-6-v2".to_string()
+        let resolved_llm = app_config.resolve_llm(None, None, None);
+        let resolved_emb = app_config.resolve_embeddings();
+        let resolved_rer = app_config.resolve_reranker();
+
+        // Embedder: report the resolver's view UNLESS the tier preset
+        // disables embeddings entirely (keyword tier), in which case
+        // we keep the historical "none" string so existing scrapers
+        // continue to recognise a tier-disabled embedder posture.
+        let embedder = if feature_tier.config().embedding_model.is_none() {
+            "none".to_string()
+        } else {
+            resolved_emb.model.clone()
+        };
+
+        // LLM: `backend:model` provenance. When backend == "ollama" we
+        // emit just the model (legacy banner shape) so existing
+        // grep'ing tools that match `llm=gemma3:4b` continue to work;
+        // when backend != "ollama" the full `xai:grok-4.3` shape is
+        // emitted so the operator-facing disambiguation is loud.
+        let llm = if resolved_llm.backend == "ollama" {
+            resolved_llm.model.clone()
+        } else {
+            resolved_llm.display_label()
+        };
+
+        // Reranker: respect the resolver (which folds `[reranker]` +
+        // legacy `cross_encoder`); fall back to tier preset only when
+        // neither configured the field.
+        let reranker = if resolved_rer.enabled || feature_tier.config().cross_encoder {
+            resolved_rer.model.clone()
         } else {
             "none".to_string()
         };

--- a/src/cli/commands/atomise.rs
+++ b/src/cli/commands/atomise.rs
@@ -329,28 +329,30 @@ pub fn run_with_curator(
 /// LLM configured (only `Keyword`, which the caller has already
 /// gated), or when the underlying client construction fails.
 fn build_llm_curator(tier: FeatureTier) -> std::result::Result<Box<dyn Curator>, String> {
-    let backend_env = std::env::var("AI_MEMORY_LLM_BACKEND")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    if let Some(backend) = backend_env {
-        return match OllamaClient::from_env() {
-            Ok(Some(client)) => Ok(Box::new(LlmCurator::new(client))),
-            Ok(None) => Err(format!(
-                "AI_MEMORY_LLM_BACKEND={backend} resolved to no LLM client — \
-                 atomise requires a curator LLM"
-            )),
-            Err(e) => Err(format!("AI_MEMORY_LLM_BACKEND={backend} init failed: {e}")),
-        };
+    // v0.7.x (#1146) — route through the canonical resolver. The
+    // resolver folds CLI flags (none here), AI_MEMORY_LLM_* env vars,
+    // the [llm] config section, the legacy `llm_model`/`ollama_url`
+    // fields, and the compiled tier preset through the uniform
+    // precedence ladder. Atomise's tier gate already refused
+    // `Keyword`; for the other three tiers the resolver always
+    // produces a usable backend/model pair.
+    let _ = tier;
+    let app_config = AppConfig::load();
+    let resolved = app_config.resolve_llm(None, None, None);
+    match OllamaClient::build_from_resolved(&resolved) {
+        Ok(Some(client)) => Ok(Box::new(LlmCurator::new(client))),
+        Ok(None) => Err(format!(
+            "atomise: LLM resolver returned no client \
+             (backend={}, source={}); atomise requires a curator LLM",
+            resolved.backend,
+            resolved.source.as_str()
+        )),
+        Err(e) => Err(format!(
+            "atomise: LLM init failed (backend={}, source={}): {e}",
+            resolved.backend,
+            resolved.source.as_str()
+        )),
     }
-    let llm_model = tier
-        .config()
-        .llm_model
-        .ok_or_else(|| format!("tier '{tier}' has no curator LLM configured"))?;
-    let model_id = llm_model.ollama_model_id().to_string();
-    let client =
-        OllamaClient::new(&model_id).map_err(|e| format!("OllamaClient::new({model_id}): {e}"))?;
-    Ok(Box::new(LlmCurator::new(client)))
 }
 
 /// Best-effort keypair load — returns `None` if no key exists or the

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -1,0 +1,604 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.x (#1146) — `ai-memory config <subcommand>` CLI surface.
+//!
+//! Today exposes a single action: `migrate`. Rewrites a legacy v1
+//! (flat-field) `config.toml` to the canonical v2 sectioned shape
+//! (`[llm]`, `[embeddings]`, `[reranker]`, `[storage]`) defined in
+//! issue #1146.
+//!
+//! ## Wire shape
+//!
+//! ```bash
+//! ai-memory config migrate              # write <file>.bak.<ts> + rewrite
+//! ai-memory config migrate --dry-run    # print diff, write nothing
+//! ai-memory config migrate \
+//!     --also-clean-claude-json          # additionally remove the
+//!                                       # mcpServers.<*>.env block from
+//!                                       # ~/.claude.json after verifying
+//!                                       # the new config.toml works
+//! ```
+//!
+//! ## Exit codes
+//!
+//! | Code | Meaning                                                  |
+//! |-----:|----------------------------------------------------------|
+//! |   0  | success — file migrated or already v2 (no-op INFO)       |
+//! |   1  | informational — dry-run mode, no writes performed        |
+//! |   2  | file not found (no `~/.config/ai-memory/config.toml`)    |
+//! |   3  | parse error — file is not valid TOML                     |
+//! |   4  | write error — could not write `.bak` or new file         |
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+use crate::cli::CliOutput;
+
+/// Args for `ai-memory config <subcommand>`.
+#[derive(Args, Debug, Clone)]
+pub struct ConfigCliArgs {
+    #[command(subcommand)]
+    pub action: ConfigAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigAction {
+    /// Rewrite a legacy v1 (flat-field) `config.toml` to the v2
+    /// sectioned shape (`[llm]`, `[embeddings]`, `[reranker]`,
+    /// `[storage]`).
+    ///
+    /// Default behaviour: write `<config.toml>.bak.<timestamp>` then
+    /// rewrite the live file. Idempotent — running against a v2 file
+    /// is a no-op `INFO` log.
+    Migrate {
+        /// Print the diff to stderr without writing anything. Exits
+        /// with code 1 (informational).
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Additionally remove every `mcpServers.<*>.env` block whose
+        /// command resolves to `ai-memory` from `~/.claude.json`. A
+        /// timestamped `.bak` is written alongside. Default OFF — the
+        /// operator must opt in after verifying the new
+        /// `config.toml` works.
+        #[arg(long)]
+        also_clean_claude_json: bool,
+    },
+}
+
+/// Entry point dispatched by `daemon_runtime::run`.
+///
+/// # Errors
+///
+/// Returns the underlying I/O / parse error if the migration fails.
+pub fn run(_db: &Path, args: ConfigCliArgs, out: &mut CliOutput) -> Result<i32> {
+    match args.action {
+        ConfigAction::Migrate {
+            dry_run,
+            also_clean_claude_json,
+        } => migrate(dry_run, also_clean_claude_json, out),
+    }
+}
+
+fn migrate(dry_run: bool, also_clean_claude_json: bool, out: &mut CliOutput) -> Result<i32> {
+    use crate::config::AppConfig;
+
+    let Some(path) = AppConfig::config_path() else {
+        let _ = writeln!(
+            out.stderr,
+            "ERROR: $HOME is not set; cannot resolve config path."
+        );
+        return Ok(2);
+    };
+
+    if !path.exists() {
+        let _ = writeln!(
+            out.stderr,
+            "ERROR: no config file at {} — nothing to migrate.",
+            path.display()
+        );
+        return Ok(2);
+    }
+
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = writeln!(
+                out.stderr,
+                "ERROR: could not read {}: {}",
+                path.display(),
+                e
+            );
+            return Ok(4);
+        }
+    };
+
+    let original_value: toml::Value = match toml::from_str(&contents) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(
+                out.stderr,
+                "ERROR: {} is not valid TOML: {}",
+                path.display(),
+                e
+            );
+            return Ok(3);
+        }
+    };
+
+    let original_table = match original_value.as_table() {
+        Some(t) => t.clone(),
+        None => {
+            let _ = writeln!(
+                out.stderr,
+                "ERROR: {} is valid TOML but not a top-level table.",
+                path.display()
+            );
+            return Ok(3);
+        }
+    };
+
+    // Detect idempotent no-op: schema_version >= 2 AND no legacy
+    // fields present.
+    let v2_already = original_table
+        .get("schema_version")
+        .and_then(toml::Value::as_integer)
+        .is_some_and(|v| v >= 2);
+    let has_legacy = LEGACY_FIELDS
+        .iter()
+        .any(|k| original_table.contains_key(*k));
+
+    if v2_already && !has_legacy {
+        let _ = writeln!(
+            out.stderr,
+            "INFO: {} is already schema_version >= 2 with no legacy fields; no migration needed.",
+            path.display()
+        );
+        return Ok(0);
+    }
+
+    let migrated_table = build_migrated_table(&original_table);
+    let migrated_value = toml::Value::Table(migrated_table);
+    let migrated_text = toml::to_string_pretty(&migrated_value).unwrap_or_else(|_| String::new());
+
+    if dry_run {
+        let _ = writeln!(
+            out.stderr,
+            "--- DRY RUN — {} would be rewritten as: ---",
+            path.display()
+        );
+        let _ = writeln!(out.stderr, "{migrated_text}");
+        let _ = writeln!(out.stderr, "--- end dry run ---");
+        if also_clean_claude_json {
+            let _ = writeln!(
+                out.stderr,
+                "(--also-clean-claude-json also skipped in dry-run.)"
+            );
+        }
+        return Ok(1);
+    }
+
+    // Write backup.
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let backup_path = path.with_extension(format!("toml.bak.{timestamp}"));
+    if let Err(e) = std::fs::write(&backup_path, &contents) {
+        let _ = writeln!(
+            out.stderr,
+            "ERROR: could not write backup {}: {}",
+            backup_path.display(),
+            e
+        );
+        return Ok(4);
+    }
+
+    // Write migrated file.
+    if let Err(e) = std::fs::write(&path, &migrated_text) {
+        let _ = writeln!(
+            out.stderr,
+            "ERROR: could not write {}: {}",
+            path.display(),
+            e
+        );
+        return Ok(4);
+    }
+
+    let _ = writeln!(
+        out.stderr,
+        "OK: migrated {} (backup: {})",
+        path.display(),
+        backup_path.display()
+    );
+
+    if also_clean_claude_json {
+        match clean_claude_json(&timestamp) {
+            Ok(Some(claude_path)) => {
+                let _ = writeln!(
+                    out.stderr,
+                    "OK: cleaned ~/.claude.json (backup: {claude_path})"
+                );
+            }
+            Ok(None) => {
+                let _ = writeln!(
+                    out.stderr,
+                    "INFO: ~/.claude.json had no mcpServers env block referencing ai-memory; no changes."
+                );
+            }
+            Err(e) => {
+                let _ = writeln!(out.stderr, "WARN: ~/.claude.json clean failed: {e}");
+            }
+        }
+    } else {
+        let _ = writeln!(
+            out.stderr,
+            "INFO: your ~/.claude.json may still carry an mcpServers env block. \
+             Re-run with `--also-clean-claude-json` to remove it after verifying \
+             the new config.toml works."
+        );
+    }
+
+    Ok(0)
+}
+
+/// Legacy v1 flat-field names that the migrator folds into v2 sections.
+const LEGACY_FIELDS: &[&str] = &[
+    "llm_model",
+    "ollama_url",
+    "embed_url",
+    "embedding_model",
+    "cross_encoder",
+    "default_namespace",
+    "archive_on_gc",
+    "archive_max_days",
+    "max_memory_mb",
+    "auto_tag_model",
+];
+
+/// Construct the v2 migrated table from a parsed v1 table. Pure (no
+/// I/O) so the dry-run path and the apply path share one implementation.
+fn build_migrated_table(
+    original: &toml::map::Map<String, toml::Value>,
+) -> toml::map::Map<String, toml::Value> {
+    let mut migrated = original.clone();
+
+    // Remove legacy fields from the top-level.
+    let mut llm_model: Option<toml::Value> = None;
+    let mut ollama_url: Option<toml::Value> = None;
+    let mut embed_url: Option<toml::Value> = None;
+    let mut embedding_model: Option<toml::Value> = None;
+    let mut cross_encoder: Option<toml::Value> = None;
+    let mut default_namespace: Option<toml::Value> = None;
+    let mut archive_on_gc: Option<toml::Value> = None;
+    let mut archive_max_days: Option<toml::Value> = None;
+    let mut max_memory_mb: Option<toml::Value> = None;
+    let mut auto_tag_model: Option<toml::Value> = None;
+
+    macro_rules! take {
+        ($name:literal, $target:ident) => {
+            if let Some(v) = migrated.remove($name) {
+                $target = Some(v);
+            }
+        };
+    }
+
+    take!("llm_model", llm_model);
+    take!("ollama_url", ollama_url);
+    take!("embed_url", embed_url);
+    take!("embedding_model", embedding_model);
+    take!("cross_encoder", cross_encoder);
+    take!("default_namespace", default_namespace);
+    take!("archive_on_gc", archive_on_gc);
+    take!("archive_max_days", archive_max_days);
+    take!("max_memory_mb", max_memory_mb);
+    take!("auto_tag_model", auto_tag_model);
+
+    // schema_version = 2 (highest priority on insert).
+    migrated.insert("schema_version".to_string(), toml::Value::Integer(2));
+
+    // [llm] section — synthesise only if a legacy LLM field was present
+    // OR the existing [llm] section is missing. (When the existing
+    // [llm] section is present, the v1 legacy llm_model/ollama_url
+    // were either redundant or operator drift; drop them.)
+    if !migrated.contains_key("llm") && llm_model.is_some() {
+        let mut llm = toml::map::Map::new();
+        // Legacy implied Ollama.
+        llm.insert(
+            "backend".to_string(),
+            toml::Value::String("ollama".to_string()),
+        );
+        if let Some(v) = llm_model {
+            llm.insert("model".to_string(), v);
+        }
+        if let Some(v) = ollama_url {
+            llm.insert("base_url".to_string(), v);
+        }
+        // [llm.auto_tag] if legacy `auto_tag_model` was set.
+        if let Some(v) = auto_tag_model {
+            let mut sub = toml::map::Map::new();
+            sub.insert("model".to_string(), v);
+            llm.insert("auto_tag".to_string(), toml::Value::Table(sub));
+        }
+        migrated.insert("llm".to_string(), toml::Value::Table(llm));
+    }
+
+    // [embeddings] section.
+    if !migrated.contains_key("embeddings") && (embed_url.is_some() || embedding_model.is_some()) {
+        let mut emb = toml::map::Map::new();
+        emb.insert(
+            "backend".to_string(),
+            toml::Value::String("ollama".to_string()),
+        );
+        if let Some(v) = embed_url {
+            emb.insert("url".to_string(), v);
+        }
+        if let Some(v) = embedding_model {
+            emb.insert("model".to_string(), v);
+        }
+        migrated.insert("embeddings".to_string(), toml::Value::Table(emb));
+    }
+
+    // [reranker] section.
+    if !migrated.contains_key("reranker") && cross_encoder.is_some() {
+        let mut rerank = toml::map::Map::new();
+        if let Some(v) = cross_encoder.clone() {
+            rerank.insert("enabled".to_string(), v);
+        }
+        rerank.insert(
+            "model".to_string(),
+            toml::Value::String("ms-marco-MiniLM-L-6-v2".to_string()),
+        );
+        migrated.insert("reranker".to_string(), toml::Value::Table(rerank));
+    }
+
+    // [storage] section.
+    if !migrated.contains_key("storage")
+        && (default_namespace.is_some()
+            || archive_on_gc.is_some()
+            || archive_max_days.is_some()
+            || max_memory_mb.is_some())
+    {
+        let mut storage = toml::map::Map::new();
+        if let Some(v) = default_namespace {
+            storage.insert("default_namespace".to_string(), v);
+        }
+        if let Some(v) = archive_on_gc {
+            storage.insert("archive_on_gc".to_string(), v);
+        }
+        if let Some(v) = archive_max_days {
+            storage.insert("archive_max_days".to_string(), v);
+        }
+        if let Some(v) = max_memory_mb {
+            storage.insert("max_memory_mb".to_string(), v);
+        }
+        migrated.insert("storage".to_string(), toml::Value::Table(storage));
+    }
+
+    migrated
+}
+
+/// Remove `mcpServers.<*>.env` blocks (the entire `env` key) from any
+/// `mcpServers` entry whose `command` resolves to an `ai-memory`
+/// binary. Returns the backup path on change; `None` when no change
+/// was needed.
+fn clean_claude_json(timestamp: &str) -> Result<Option<String>> {
+    let home = std::env::var("HOME").map_err(|_| anyhow::anyhow!("$HOME not set"))?;
+    let path = PathBuf::from(&home).join(".claude.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = std::fs::read_to_string(&path)?;
+    let mut value: serde_json::Value = serde_json::from_str(&contents)?;
+
+    let mut changed = false;
+    if let Some(servers) = value
+        .get_mut("mcpServers")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        for (_name, entry) in servers.iter_mut() {
+            let is_ai_memory = entry
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .map(|c| c.ends_with("/ai-memory") || c == "ai-memory")
+                .unwrap_or(false);
+            if !is_ai_memory {
+                continue;
+            }
+            if let Some(obj) = entry.as_object_mut() {
+                if obj.remove("env").is_some() {
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    if !changed {
+        return Ok(None);
+    }
+
+    let backup_path = format!("{}.bak.{}", path.display(), timestamp);
+    std::fs::write(&backup_path, &contents)?;
+    std::fs::write(&path, serde_json::to_string_pretty(&value)?)?;
+
+    Ok(Some(backup_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_v1_legacy_fields_to_sections() {
+        let toml_text = r#"
+tier = "autonomous"
+db = "/tmp/test.db"
+llm_model = "gemma4:e4b"
+ollama_url = "http://localhost:11434"
+embed_url = "http://localhost:11434"
+embedding_model = "nomic_embed_v15"
+cross_encoder = true
+default_namespace = "alphaone"
+archive_on_gc = true
+"#;
+        let value: toml::Value = toml::from_str(toml_text).unwrap();
+        let original = value.as_table().unwrap().clone();
+
+        let migrated = build_migrated_table(&original);
+
+        assert_eq!(
+            migrated
+                .get("schema_version")
+                .and_then(toml::Value::as_integer),
+            Some(2),
+            "schema_version must land at 2"
+        );
+
+        // Legacy fields stripped from top-level.
+        for k in LEGACY_FIELDS {
+            assert!(
+                !migrated.contains_key(*k),
+                "legacy field {k} should have been removed"
+            );
+        }
+
+        // [llm] section populated.
+        let llm = migrated.get("llm").and_then(toml::Value::as_table).unwrap();
+        assert_eq!(
+            llm.get("backend").and_then(toml::Value::as_str),
+            Some("ollama")
+        );
+        assert_eq!(
+            llm.get("model").and_then(toml::Value::as_str),
+            Some("gemma4:e4b")
+        );
+        assert_eq!(
+            llm.get("base_url").and_then(toml::Value::as_str),
+            Some("http://localhost:11434")
+        );
+
+        // [embeddings] section populated.
+        let emb = migrated
+            .get("embeddings")
+            .and_then(toml::Value::as_table)
+            .unwrap();
+        assert_eq!(
+            emb.get("model").and_then(toml::Value::as_str),
+            Some("nomic_embed_v15")
+        );
+
+        // [reranker] section populated.
+        let rerank = migrated
+            .get("reranker")
+            .and_then(toml::Value::as_table)
+            .unwrap();
+        assert_eq!(
+            rerank.get("enabled").and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            rerank.get("model").and_then(toml::Value::as_str),
+            Some("ms-marco-MiniLM-L-6-v2")
+        );
+
+        // [storage] section populated.
+        let storage = migrated
+            .get("storage")
+            .and_then(toml::Value::as_table)
+            .unwrap();
+        assert_eq!(
+            storage
+                .get("default_namespace")
+                .and_then(toml::Value::as_str),
+            Some("alphaone")
+        );
+        assert_eq!(
+            storage.get("archive_on_gc").and_then(toml::Value::as_bool),
+            Some(true)
+        );
+
+        // Top-level non-legacy fields preserved.
+        assert_eq!(
+            migrated.get("tier").and_then(toml::Value::as_str),
+            Some("autonomous")
+        );
+        assert_eq!(
+            migrated.get("db").and_then(toml::Value::as_str),
+            Some("/tmp/test.db")
+        );
+    }
+
+    #[test]
+    fn migrate_idempotent_on_already_v2() {
+        let toml_text = r#"
+schema_version = 2
+tier = "autonomous"
+
+[llm]
+backend = "xai"
+model = "grok-4.3"
+api_key_env = "XAI_API_KEY"
+
+[storage]
+default_namespace = "alphaone"
+"#;
+        let value: toml::Value = toml::from_str(toml_text).unwrap();
+        let original = value.as_table().unwrap().clone();
+
+        let migrated = build_migrated_table(&original);
+
+        // schema_version stays 2.
+        assert_eq!(
+            migrated
+                .get("schema_version")
+                .and_then(toml::Value::as_integer),
+            Some(2)
+        );
+
+        // Existing [llm] preserved verbatim.
+        let llm = migrated.get("llm").and_then(toml::Value::as_table).unwrap();
+        assert_eq!(
+            llm.get("backend").and_then(toml::Value::as_str),
+            Some("xai")
+        );
+        assert_eq!(
+            llm.get("model").and_then(toml::Value::as_str),
+            Some("grok-4.3")
+        );
+    }
+
+    #[test]
+    fn migrate_does_not_overwrite_existing_sections() {
+        // Pathological: operator left both legacy AND v2 fields. The
+        // migrator should preserve the existing [llm] section and drop
+        // the legacy field rather than clobbering.
+        let toml_text = r#"
+llm_model = "legacy-model"
+ollama_url = "http://stale:9999"
+
+[llm]
+backend = "xai"
+model = "grok-4.3"
+"#;
+        let value: toml::Value = toml::from_str(toml_text).unwrap();
+        let original = value.as_table().unwrap().clone();
+
+        let migrated = build_migrated_table(&original);
+
+        // Legacy fields stripped.
+        assert!(!migrated.contains_key("llm_model"));
+        assert!(!migrated.contains_key("ollama_url"));
+
+        // [llm] section preserved verbatim.
+        let llm = migrated.get("llm").and_then(toml::Value::as_table).unwrap();
+        assert_eq!(
+            llm.get("backend").and_then(toml::Value::as_str),
+            Some("xai")
+        );
+        assert_eq!(
+            llm.get("model").and_then(toml::Value::as_str),
+            Some("grok-4.3")
+        );
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -11,6 +11,8 @@
 
 /// v0.7.0 WT-1-F — `ai-memory atomise` CLI subcommand.
 pub mod atomise;
+/// v0.7.x (#1146) — `ai-memory config <subcommand>` CLI surface.
+pub mod config;
 pub mod export_reflections;
 // v0.7.0 QW-2 — Persona-as-artifact CLI surface. `ai-memory persona
 // <entity_id> [--namespace NS] [--regenerate] [--json]`.

--- a/src/cli/curator.rs
+++ b/src/cli/curator.rs
@@ -83,16 +83,18 @@ pub struct CuratorArgs {
 /// failure — the curator falls through to keyword-only behavior so
 /// the daemon never hard-fails on an unreachable provider.
 fn build_curator_llm(tier: config::FeatureTier) -> Option<llm::OllamaClient> {
-    let backend_env = std::env::var("AI_MEMORY_LLM_BACKEND")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    if backend_env.is_some() {
-        return llm::OllamaClient::from_env().ok().flatten();
+    // v0.7.x (#1146) — route through the canonical resolver. Keyword
+    // tier intentionally returns None (no curator LLM); for the other
+    // three tiers the resolver folds CLI/env/config/legacy/compiled
+    // through the uniform precedence ladder.
+    if matches!(tier, config::FeatureTier::Keyword) {
+        return None;
     }
-    let llm_model = tier.config().llm_model?;
-    let model = llm_model.ollama_model_id().to_string();
-    llm::OllamaClient::new(&model).ok()
+    let app_config = config::AppConfig::load();
+    let resolved = app_config.resolve_llm(None, None, None);
+    llm::OllamaClient::build_from_resolved(&resolved)
+        .ok()
+        .flatten()
 }
 
 fn print_curator_report(r: &curator::CuratorReport, out: &mut CliOutput<'_>) -> Result<()> {

--- a/src/cli/curator.rs
+++ b/src/cli/curator.rs
@@ -83,15 +83,24 @@ pub struct CuratorArgs {
 /// failure — the curator falls through to keyword-only behavior so
 /// the daemon never hard-fails on an unreachable provider.
 fn build_curator_llm(tier: config::FeatureTier) -> Option<llm::OllamaClient> {
-    // v0.7.x (#1146) — route through the canonical resolver. Keyword
-    // tier intentionally returns None (no curator LLM); for the other
-    // three tiers the resolver folds CLI/env/config/legacy/compiled
-    // through the uniform precedence ladder.
-    if matches!(tier, config::FeatureTier::Keyword) {
-        return None;
-    }
+    // v0.7.x (#1146) — route through the canonical resolver. Two
+    // short-circuits preserve pre-#1146 semantics:
+    //   1. Tiers with no `llm_model` preset (Keyword, Semantic) AND
+    //      no operator intent (env / config / legacy field absent —
+    //      resolver `source == CompiledDefault`) return None without
+    //      attempting client construction. Avoids paying a blocking
+    //      reqwest call to a (likely-absent) Ollama under tokio test
+    //      contexts and matches pre-#1146 v0.6.x behaviour.
+    //   2. With operator intent, the resolver folds CLI / env /
+    //      config / legacy / compiled through the uniform precedence
+    //      ladder.
     let app_config = config::AppConfig::load();
     let resolved = app_config.resolve_llm(None, None, None);
+    if matches!(resolved.source, config::ConfigSource::CompiledDefault)
+        && tier.config().llm_model.is_none()
+    {
+        return None;
+    }
     llm::OllamaClient::build_from_resolved(&resolved)
         .ok()
         .flatten()

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -526,6 +526,7 @@ fn run_local(db_path: &Path) -> Report {
     sections.push(section_webhook(&conn));
     sections.push(section_capabilities_local());
     sections.push(section_reflection_health(&conn));
+    sections.push(section_llm_reachability_1146());
 
     Report {
         mode: "local".into(),
@@ -833,6 +834,179 @@ fn section_capabilities_local() -> ReportSection {
             "use --remote <url> to query the live capabilities endpoint".into(),
         )],
         note: None,
+    }
+}
+
+/// v0.7.x (#1146) — LLM reachability probe.
+///
+/// Resolves the canonical LLM configuration via
+/// [`crate::config::AppConfig::resolve_llm`] (the same path used by
+/// MCP, HTTP daemon, atomise, curator, and the boot banner) and
+/// fires a lightweight HTTP probe at the resolved `base_url`. Maps
+/// the response to a Severity per the #1146 spec:
+///
+/// | Status   | HTTP outcomes                          |
+/// |----------|----------------------------------------|
+/// | INFO     | 200 (vendor reachable + auth OK)       |
+/// | WARN     | 401 / 403 (auth issue; URL reachable)  |
+/// | WARN     | 429 (rate-limited; reachable)          |
+/// | WARN     | 5xx (vendor outage; reachable)         |
+/// | CRIT     | 4xx other (likely wrong base_url)      |
+/// | CRIT     | network/DNS/connect-refused/TLS error  |
+///
+/// Probe endpoint per backend:
+/// - `ollama` → `GET <base_url>/api/tags` (no auth)
+/// - any OpenAI-compatible → `GET <base_url>/models` (Bearer auth)
+///
+/// The section's `facts` carry the resolver's full provenance
+/// (`backend`, `model`, `base_url`, `config_source`, `key_source`)
+/// plus the HTTP status code + observed latency, so operators can
+/// see WHERE the wiring came from and WHY the probe lands where it
+/// does.
+fn section_llm_reachability_1146() -> ReportSection {
+    use crate::config::{AppConfig, ConfigSource, KeySource};
+
+    let app_config = AppConfig::load();
+    let resolved = app_config.resolve_llm(None, None, None);
+
+    let mut facts = vec![
+        ("backend".into(), resolved.backend.clone()),
+        ("model".into(), resolved.model.clone()),
+        ("base_url".into(), resolved.base_url.clone()),
+        ("config_source".into(), resolved.source.as_str().to_string()),
+        (
+            "key_source".into(),
+            resolved.api_key_source.as_str().to_string(),
+        ),
+    ];
+
+    // If the key resolution surfaced an error during resolve (file
+    // perms / missing env / etc.), call it out — but still try the
+    // probe so the operator sees if the URL is at least reachable.
+    if let KeySource::Error(reason) = &resolved.api_key_source {
+        facts.push(("key_error".into(), reason.clone()));
+    }
+
+    // Compiled-default warning — operator has no LLM configuration
+    // anywhere; the resolver's last-resort fallback won.
+    if matches!(resolved.source, ConfigSource::CompiledDefault) {
+        return ReportSection {
+            name: "LLM Reachability (#1146)".into(),
+            severity: Severity::Warning,
+            facts,
+            note: Some(
+                "no operator LLM configuration found (CLI / env / [llm] section / \
+                 legacy flat fields all absent); resolver fell through to the \
+                 compiled default. Set AI_MEMORY_LLM_BACKEND or write a [llm] \
+                 section in config.toml to enable LLM-powered features."
+                    .into(),
+            ),
+        };
+    }
+
+    // Build the probe URL.
+    let (probe_url, bearer) = if resolved.is_ollama_native() {
+        (format!("{}/api/tags", resolved.base_url), None)
+    } else {
+        (
+            format!("{}/models", resolved.base_url),
+            resolved.api_key().map(str::to_string),
+        )
+    };
+    facts.push(("probe_url".into(), probe_url.clone()));
+
+    let started = std::time::Instant::now();
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            facts.push(("error".into(), format!("http client build failed: {e}")));
+            return ReportSection {
+                name: "LLM Reachability (#1146)".into(),
+                severity: Severity::Critical,
+                facts,
+                note: Some("could not build HTTP client for probe".into()),
+            };
+        }
+    };
+
+    let mut req = client.get(&probe_url);
+    if let Some(k) = bearer {
+        req = req.bearer_auth(k);
+    }
+
+    let (severity, note) = match req.send() {
+        Ok(resp) => {
+            let status = resp.status();
+            let elapsed_ms = started.elapsed().as_millis();
+            facts.push(("http_status".into(), status.as_u16().to_string()));
+            facts.push(("latency_ms".into(), elapsed_ms.to_string()));
+
+            if status.is_success() {
+                (Severity::Info, None)
+            } else if status.as_u16() == 401 || status.as_u16() == 403 {
+                (
+                    Severity::Warning,
+                    Some(format!(
+                        "auth failed (status {}); URL is reachable but the \
+                         resolved API key was rejected — check api_key_env / \
+                         api_key_file / process env",
+                        status.as_u16()
+                    )),
+                )
+            } else if status.as_u16() == 429 {
+                (
+                    Severity::Warning,
+                    Some("rate-limited (status 429); vendor reachable but throttling".into()),
+                )
+            } else if status.is_server_error() {
+                (
+                    Severity::Warning,
+                    Some(format!(
+                        "vendor 5xx (status {}); reachable but currently degraded",
+                        status.as_u16()
+                    )),
+                )
+            } else {
+                (
+                    Severity::Critical,
+                    Some(format!(
+                        "unexpected status {} from {} — verify base_url + endpoint shape",
+                        status.as_u16(),
+                        probe_url
+                    )),
+                )
+            }
+        }
+        Err(e) => {
+            let elapsed_ms = started.elapsed().as_millis();
+            facts.push(("latency_ms".into(), elapsed_ms.to_string()));
+            facts.push(("error".into(), e.to_string()));
+            let kind = if e.is_timeout() {
+                "timeout"
+            } else if e.is_connect() {
+                "connect"
+            } else {
+                "transport"
+            };
+            (
+                Severity::Critical,
+                Some(format!(
+                    "network/{kind} error contacting {probe_url} — verify \
+                     base_url and connectivity"
+                )),
+            )
+        }
+    };
+
+    ReportSection {
+        name: "LLM Reachability (#1146)".into(),
+        severity,
+        facts,
+        note,
     }
 }
 
@@ -1358,12 +1532,13 @@ mod tests {
     }
 
     #[test]
-    fn local_run_on_empty_db_produces_eight_sections() {
+    fn local_run_on_empty_db_produces_nine_sections() {
         let env = TestEnv::fresh();
         let report = run_local_collect(&env.db_path);
         assert_eq!(report.mode, "local");
-        // L1-4 adds "Reflection Health" — total is now 8.
-        assert_eq!(report.sections.len(), 8);
+        // L1-4 added "Reflection Health"; #1146 added
+        // "LLM Reachability (#1146)" — total is now 9.
+        assert_eq!(report.sections.len(), 9);
         let names: Vec<&str> = report.sections.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(
             names,
@@ -1376,6 +1551,7 @@ mod tests {
                 "Webhook",
                 "Capabilities",
                 "Reflection Health",
+                "LLM Reachability (#1146)",
             ]
         );
     }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -887,18 +887,23 @@ fn section_llm_reachability_1146() -> ReportSection {
         facts.push(("key_error".into(), reason.clone()));
     }
 
-    // Compiled-default warning — operator has no LLM configuration
-    // anywhere; the resolver's last-resort fallback won.
+    // Compiled-default — operator has no LLM configuration anywhere
+    // (a fresh install or a keyword-tier-only deployment). This is a
+    // legitimate state, not a misconfiguration: emit INFO with a
+    // pointer at how to enable LLM features rather than WARN (which
+    // would break the "fresh-DB doctor report = all INFO" invariant
+    // pinned by `tests/doctor_cli.rs::doctor_reports_clean_on_fresh_db`).
     if matches!(resolved.source, ConfigSource::CompiledDefault) {
         return ReportSection {
             name: "LLM Reachability (#1146)".into(),
-            severity: Severity::Warning,
+            severity: Severity::Info,
             facts,
             note: Some(
                 "no operator LLM configuration found (CLI / env / [llm] section / \
-                 legacy flat fields all absent); resolver fell through to the \
-                 compiled default. Set AI_MEMORY_LLM_BACKEND or write a [llm] \
-                 section in config.toml to enable LLM-powered features."
+                 legacy flat fields all absent); LLM-powered features will be \
+                 inactive. To enable, set AI_MEMORY_LLM_BACKEND in the process \
+                 env or write a [llm] section in config.toml. See \
+                 docs/CONFIG_SCHEMA.md for the canonical schema."
                     .into(),
             ),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -2956,6 +2956,220 @@ pub struct StorageSection {
     pub max_memory_mb: Option<usize>,
 }
 
+// ---------------------------------------------------------------------------
+// Resolved-config shapes (#1146)
+//
+// Every surface that needs LLM / embedder / reranker / storage config
+// consumes one of the `Resolved*` shapes below. The resolver methods on
+// `AppConfig` (`resolve_llm` / `resolve_embeddings` / `resolve_reranker`
+// / `resolve_storage`) produce them by applying the uniform precedence
+// ladder:
+//
+//   CLI flag  >  AI_MEMORY_* env var  >  config.toml section
+//             >  legacy flat fields (with deprecation WARN once)
+//             >  compiled default (CompiledDefault arm, WARN once)
+//
+// Resolvers are PURE (no network I/O). File reads for `api_key_file`
+// happen at resolve time and surface errors via the `KeySource::Error`
+// variant rather than panicking, so the daemon can boot and report the
+// problem via the doctor reachability probe rather than failing at
+// load time.
+// ---------------------------------------------------------------------------
+
+/// Provenance tag for a resolved `Resolved*` field's value, surfaced by
+/// the boot banner and `ai-memory doctor` so operators can see WHICH
+/// source won the precedence ladder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// CLI flag (highest precedence).
+    Cli,
+    /// `AI_MEMORY_*` process environment variable.
+    Env,
+    /// `[llm]` / `[embeddings]` / `[reranker]` / `[storage]` section
+    /// in `~/.config/ai-memory/config.toml`.
+    Config,
+    /// Legacy flat field in `~/.config/ai-memory/config.toml` (e.g.
+    /// `llm_model = "gemma4:e4b"`). Triggers a one-shot deprecation
+    /// WARN on `Config::load`.
+    Legacy,
+    /// Compiled-in default (no operator configuration). Triggers a
+    /// one-shot WARN at resolve time so silent misconfigurations are
+    /// loud.
+    CompiledDefault,
+}
+
+impl ConfigSource {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Env => "env",
+            Self::Config => "config",
+            Self::Legacy => "legacy",
+            Self::CompiledDefault => "compiled-default",
+        }
+    }
+}
+
+/// Provenance tag for a resolved API-key value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeySource {
+    /// `AI_MEMORY_LLM_API_KEY` process env var (highest precedence).
+    ProcessEnv,
+    /// Per-vendor process env-var fallback (`XAI_API_KEY`,
+    /// `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.). The string field
+    /// carries the name of the var that won (for observability).
+    AliasFallback(String),
+    /// `[llm].api_key_env` config-pointed env var. The string field
+    /// carries the resolved env-var name.
+    ConfigEnvVar(String),
+    /// `[llm].api_key_file` config-pointed file path. The string field
+    /// carries the resolved (tilde-expanded) path.
+    ConfigFile(String),
+    /// No API key resolved. Correct for `backend = "ollama"`
+    /// (no auth); a misconfiguration for OpenAI-compatible vendors.
+    None,
+    /// Error reading the resolved key source. The string carries the
+    /// human-readable error for the doctor probe to surface.
+    Error(String),
+}
+
+impl KeySource {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ProcessEnv => "process-env",
+            Self::AliasFallback(_) => "alias-fallback",
+            Self::ConfigEnvVar(_) => "config-env-var",
+            Self::ConfigFile(_) => "config-file",
+            Self::None => "none",
+            Self::Error(_) => "error",
+        }
+    }
+
+    /// True when the key was resolved from any source.
+    #[must_use]
+    pub fn is_present(&self) -> bool {
+        !matches!(self, Self::None | Self::Error(_))
+    }
+}
+
+/// Canonical resolved-LLM configuration. Produced by
+/// [`AppConfig::resolve_llm`]. Every LLM-init surface (MCP stdio,
+/// HTTP daemon, `ai-memory atomise`, `ai-memory curator`,
+/// embed-client fallback, boot banner) consumes this struct rather
+/// than reading raw config / env / tier presets.
+///
+/// **Secret handling.** The `api_key` field is private; access via
+/// `api_key()`. The `Debug` impl redacts the value (`<redacted>`).
+#[derive(Clone, PartialEq, Eq)]
+pub struct ResolvedLlm {
+    /// Backend alias / wire-shape selector (e.g. `"ollama"`, `"xai"`,
+    /// `"openai-compatible"`).
+    pub backend: String,
+    /// Model identifier passed verbatim to the chat endpoint.
+    pub model: String,
+    /// Base URL of the chat endpoint (vendor-default or operator
+    /// override).
+    pub base_url: String,
+    /// Resolved API key. `None` for `backend = "ollama"` and for
+    /// misconfigured backends; `Some` otherwise. Private — access via
+    /// [`Self::api_key`] to keep accidental `{:?}` prints from
+    /// leaking the value.
+    api_key: Option<String>,
+    /// Provenance of the resolved API key for boot-banner /
+    /// doctor-probe display.
+    pub api_key_source: KeySource,
+    /// Provenance of the resolved configuration (CLI / env / config /
+    /// legacy / compiled-default).
+    pub source: ConfigSource,
+}
+
+impl ResolvedLlm {
+    /// Access the resolved API key. Use this only when constructing
+    /// the LLM client; do NOT log or `{:?}` the result.
+    #[must_use]
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    /// True when the resolved backend uses the Ollama-native wire
+    /// shape (`/api/chat`, `/api/embed`, no auth). False for any
+    /// OpenAI-compatible vendor.
+    #[must_use]
+    pub fn is_ollama_native(&self) -> bool {
+        self.backend == "ollama"
+    }
+
+    /// Display string for the boot banner: `<backend>:<model>`.
+    #[must_use]
+    pub fn display_label(&self) -> String {
+        format!("{}:{}", self.backend, self.model)
+    }
+}
+
+impl std::fmt::Debug for ResolvedLlm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedLlm")
+            .field("backend", &self.backend)
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("api_key_source", &self.api_key_source)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+/// Canonical resolved-embedder configuration. Produced by
+/// [`AppConfig::resolve_embeddings`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedEmbeddings {
+    /// Embedding backend selector. At v0.7.0 only `"ollama"` is
+    /// produced (the substrate's nomic-embed + minilm models both
+    /// speak Ollama's `/api/embed` wire shape).
+    pub backend: String,
+    /// Embedding endpoint URL.
+    pub url: String,
+    /// Embedding model identifier (canonicalised — legacy aliases
+    /// `nomic_embed_v15` / `mini_lm_l6_v2` are mapped to the
+    /// `EmbeddingModel` enum's canonical HF id at resolve time).
+    pub model: String,
+    /// Backfill batch size. Bounded `1..=10000`; out-of-range values
+    /// fall back to 100 with a WARN.
+    pub backfill_batch: u32,
+    /// Provenance of the resolved configuration.
+    pub source: ConfigSource,
+}
+
+/// Canonical resolved-reranker configuration. Produced by
+/// [`AppConfig::resolve_reranker`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedReranker {
+    /// Whether the cross-encoder rerank stage runs.
+    pub enabled: bool,
+    /// Cross-encoder model identifier.
+    pub model: String,
+    /// Provenance of the resolved configuration.
+    pub source: ConfigSource,
+}
+
+/// Canonical resolved-storage configuration. Produced by
+/// [`AppConfig::resolve_storage`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedStorage {
+    /// Default namespace for new memories when the caller omits one.
+    pub default_namespace: String,
+    /// Whether to archive memories before GC deletion.
+    pub archive_on_gc: bool,
+    /// Archive retention ceiling in days (`None` = disabled).
+    pub archive_max_days: Option<i64>,
+    /// Memory budget in MB for the auto tier selector.
+    pub max_memory_mb: Option<usize>,
+    /// Provenance of the resolved configuration.
+    pub source: ConfigSource,
+}
+
 /// v0.7.0 (issue #518) — `[agents]` top-level block. Today only carries
 /// the `defaults` sub-block (`[agents.defaults.recall_scope]`); future
 /// agent-scoped knobs (per-agent quota overrides, per-agent autonomy
@@ -3970,6 +4184,181 @@ pub fn parse_duration_string(s: &str) -> Option<chrono::Duration> {
 /// unset (no-home environments like some CI containers), the tilde is left
 /// untouched so the existing failure mode (path not found) is preserved
 /// rather than silently rewriting to an empty prefix.
+// ---------------------------------------------------------------------------
+// Resolver helpers (#1146)
+// ---------------------------------------------------------------------------
+
+/// Backend-specific default model identifier. Used by
+/// [`AppConfig::resolve_llm`] when no model is configured at any
+/// precedence layer.
+fn backend_default_model(backend: &str) -> &'static str {
+    match backend {
+        "xai" => "grok-4.3",
+        "openai" => "gpt-5",
+        "anthropic" => "claude-opus-4.7",
+        "gemini" => "gemini-2.0-flash",
+        "deepseek" => "deepseek-chat",
+        "kimi" | "moonshot" => "moonshot-v1-8k",
+        "qwen" | "dashscope" => "qwen-max",
+        "mistral" => "mistral-large-latest",
+        "groq" => "llama-3.3-70b-versatile",
+        "together" => "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "cerebras" => "llama-3.3-70b",
+        "openrouter" => "openai/gpt-5",
+        "fireworks" => "accounts/fireworks/models/llama-v3p3-70b-instruct",
+        "lmstudio" => "local-model",
+        // ollama / openai-compatible / any unknown alias → legacy default.
+        _ => "gemma3:4b",
+    }
+}
+
+/// Backend-specific default base URL. Used by
+/// [`AppConfig::resolve_llm`] when no base_url is configured at any
+/// precedence layer. `openai-compatible` returns the empty string (the
+/// resolver does not validate this — surface plumbing surfaces the
+/// misconfiguration via the reachability probe in `ai-memory doctor`).
+fn backend_default_base_url(backend: &str) -> &'static str {
+    match backend {
+        "openai" => "https://api.openai.com/v1",
+        "xai" => "https://api.x.ai/v1",
+        "anthropic" => "https://api.anthropic.com/v1",
+        "gemini" => "https://generativelanguage.googleapis.com/v1beta/openai",
+        "deepseek" => "https://api.deepseek.com/v1",
+        "kimi" | "moonshot" => "https://api.moonshot.cn/v1",
+        "qwen" | "dashscope" => "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "mistral" => "https://api.mistral.ai/v1",
+        "groq" => "https://api.groq.com/openai/v1",
+        "together" => "https://api.together.xyz/v1",
+        "cerebras" => "https://api.cerebras.ai/v1",
+        "openrouter" => "https://openrouter.ai/api/v1",
+        "fireworks" => "https://api.fireworks.ai/inference/v1",
+        "lmstudio" => "http://localhost:1234/v1",
+        // ollama / openai-compatible / unknown → localhost ollama.
+        _ => "http://localhost:11434",
+    }
+}
+
+/// Per-alias environment variable fallback chain for the API key.
+/// Mirrors `crate::llm::alias_api_key_env_vars` (kept duplicated to
+/// avoid a circular dependency between the resolver and the LLM
+/// client; both lists must stay in sync — pinned by a test in
+/// commit 12/13).
+fn alias_api_key_env_vars_for_resolver(alias: &str) -> &'static [&'static str] {
+    match alias {
+        "openai" => &["OPENAI_API_KEY"],
+        "xai" => &["XAI_API_KEY"],
+        "anthropic" => &["ANTHROPIC_API_KEY"],
+        "gemini" => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        "deepseek" => &["DEEPSEEK_API_KEY"],
+        "kimi" | "moonshot" => &["MOONSHOT_API_KEY", "KIMI_API_KEY"],
+        "qwen" | "dashscope" => &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
+        "mistral" => &["MISTRAL_API_KEY"],
+        "groq" => &["GROQ_API_KEY"],
+        "together" => &["TOGETHER_API_KEY"],
+        "cerebras" => &["CEREBRAS_API_KEY"],
+        "openrouter" => &["OPENROUTER_API_KEY"],
+        "fireworks" => &["FIREWORKS_API_KEY"],
+        _ => &[],
+    }
+}
+
+/// Canonicalise legacy embedding-model aliases to the HF-id form. Lets
+/// existing config.toml files with `embedding_model = "nomic_embed_v15"`
+/// continue to work while the resolver returns the canonical id used
+/// throughout the substrate.
+fn canonicalise_embedding_model(raw: String) -> String {
+    match raw.trim() {
+        "nomic_embed_v15" => "nomic-embed-text-v1.5".to_string(),
+        "mini_lm_l6_v2" => "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+        _ => raw,
+    }
+}
+
+/// Resolve the API key + provenance tag for the configured backend.
+///
+/// Precedence:
+///   1. `AI_MEMORY_LLM_API_KEY` process env → `KeySource::ProcessEnv`
+///   2. Per-vendor process env-var fallback (e.g. `XAI_API_KEY`)
+///      → `KeySource::AliasFallback(name)`
+///   3. `[llm].api_key_env` → `KeySource::ConfigEnvVar(name)`
+///   4. `[llm].api_key_file` → `KeySource::ConfigFile(path)`
+///   5. None resolved → `KeySource::None` (correct for `backend =
+///      "ollama"`; a misconfiguration for OpenAI-compatible vendors —
+///      surfaced by the reachability probe).
+///
+/// File reads do NOT enforce permission bits at this commit; the 0400
+/// enforcement lands in a follow-up commit and surfaces errors via
+/// `KeySource::Error(reason)` so the daemon can boot and report the
+/// problem through `ai-memory doctor` rather than failing at config load.
+fn resolve_api_key(backend: &str, llm: Option<&LlmSection>) -> (Option<String>, KeySource) {
+    // 1. Process env (highest).
+    if let Some(k) = std::env::var("AI_MEMORY_LLM_API_KEY")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    {
+        return (Some(k), KeySource::ProcessEnv);
+    }
+
+    // 2. Per-vendor alias fallback.
+    for name in alias_api_key_env_vars_for_resolver(backend) {
+        if let Some(k) = std::env::var(name).ok().filter(|s| !s.trim().is_empty()) {
+            return (Some(k), KeySource::AliasFallback((*name).to_string()));
+        }
+    }
+
+    // 3. config-pointed env var.
+    if let Some(name) = llm
+        .and_then(|l| l.api_key_env.as_ref())
+        .filter(|s| !s.trim().is_empty())
+    {
+        return match std::env::var(name) {
+            Ok(v) if !v.trim().is_empty() => (Some(v), KeySource::ConfigEnvVar(name.clone())),
+            Ok(_) => (
+                None,
+                KeySource::Error(format!(
+                    "[llm].api_key_env = {name:?} resolves to an empty env var"
+                )),
+            ),
+            Err(_) => (
+                None,
+                KeySource::Error(format!(
+                    "[llm].api_key_env = {name:?} is not set in the process env"
+                )),
+            ),
+        };
+    }
+
+    // 4. config-pointed file.
+    if let Some(raw_path) = llm
+        .and_then(|l| l.api_key_file.as_ref())
+        .filter(|s| !s.trim().is_empty())
+    {
+        let path = expand_tilde(raw_path);
+        let path_display = path.display().to_string();
+        return match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                let key = contents.lines().next().unwrap_or("").trim().to_string();
+                if key.is_empty() {
+                    (
+                        None,
+                        KeySource::Error(format!("[llm].api_key_file = {path_display:?} is empty")),
+                    )
+                } else {
+                    (Some(key), KeySource::ConfigFile(path_display))
+                }
+            }
+            Err(e) => (
+                None,
+                KeySource::Error(format!(
+                    "[llm].api_key_file = {path_display:?} could not be read: {e}"
+                )),
+            ),
+        };
+    }
+
+    (None, KeySource::None)
+}
+
 fn expand_tilde(s: &str) -> PathBuf {
     if s == "~" {
         return std::env::var("HOME").map_or_else(|_| PathBuf::from(s), PathBuf::from);
@@ -4323,6 +4712,325 @@ impl AppConfig {
             .as_deref()
             .or(self.ollama_url.as_deref())
             .unwrap_or("http://localhost:11434")
+    }
+
+    // ------------------------------------------------------------------
+    // Canonical resolvers (#1146). Every LLM / embedder / reranker /
+    // storage surface MUST consume the corresponding `Resolved*` shape
+    // produced by these methods rather than reading raw config / env
+    // / tier presets.
+    //
+    // Precedence (uniform across all four):
+    //   CLI flag > AI_MEMORY_* env > config.toml section
+    //            > legacy flat fields (Legacy source) > compiled default
+    //
+    // Resolvers are PURE (no network I/O). `resolve_llm` reads the
+    // `api_key_file` content at call time if configured; perm checks
+    // land in a follow-up commit and surface via `KeySource::Error`
+    // without panicking.
+    // ------------------------------------------------------------------
+
+    /// v0.7.x (#1146) — resolve the canonical LLM configuration.
+    ///
+    /// `cli_backend` / `cli_model` / `cli_base_url` carry CLI-flag
+    /// overrides (pass `None` for `ai-memory mcp` / `ai-memory serve`
+    /// which currently expose no CLI override; the CLI plumbing lands
+    /// in a follow-up commit).
+    #[must_use]
+    pub fn resolve_llm(
+        &self,
+        cli_backend: Option<&str>,
+        cli_model: Option<&str>,
+        cli_base_url: Option<&str>,
+    ) -> ResolvedLlm {
+        // ------- 1. backend selection ----------------------------------
+        let env_backend = std::env::var("AI_MEMORY_LLM_BACKEND")
+            .ok()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty());
+        let cfg_backend = self
+            .llm
+            .as_ref()
+            .and_then(|l| l.backend.as_ref())
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty());
+
+        let (backend, source) = if let Some(b) = cli_backend.map(str::to_ascii_lowercase) {
+            (b, ConfigSource::Cli)
+        } else if let Some(b) = env_backend.clone() {
+            (b, ConfigSource::Env)
+        } else if let Some(b) = cfg_backend {
+            (b, ConfigSource::Config)
+        } else if self.llm_model.is_some() || self.ollama_url.is_some() {
+            // Legacy flat fields imply Ollama.
+            ("ollama".to_string(), ConfigSource::Legacy)
+        } else {
+            // Compiled default = tier preset (Ollama-native).
+            ("ollama".to_string(), ConfigSource::CompiledDefault)
+        };
+
+        // ------- 2. model selection ------------------------------------
+        let model = cli_model
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                std::env::var("AI_MEMORY_LLM_MODEL")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .or_else(|| {
+                self.llm
+                    .as_ref()
+                    .and_then(|l| l.model.clone())
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .or_else(|| self.llm_model.clone().filter(|s| !s.trim().is_empty()))
+            .unwrap_or_else(|| backend_default_model(&backend).to_string());
+
+        // ------- 3. base_url selection ---------------------------------
+        let base_url = cli_base_url
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                std::env::var("AI_MEMORY_LLM_BASE_URL")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .or_else(|| {
+                self.llm
+                    .as_ref()
+                    .and_then(|l| l.base_url.clone())
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .or_else(|| {
+                if backend == "ollama" {
+                    self.ollama_url.clone()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| backend_default_base_url(&backend).to_string());
+
+        // ------- 4. api_key selection ----------------------------------
+        let (api_key, api_key_source) = resolve_api_key(&backend, self.llm.as_ref());
+
+        ResolvedLlm {
+            backend,
+            model,
+            base_url,
+            api_key,
+            api_key_source,
+            source,
+        }
+    }
+
+    /// v0.7.x (#1146) — resolve the `[llm.auto_tag]` fast-structured-
+    /// output sibling. Fields fall back to [`Self::resolve_llm`] field-
+    /// by-field; commonly only `model` is overridden (defaults to
+    /// `gemma3:4b` per the L15 fast-structured-output policy).
+    #[must_use]
+    pub fn resolve_llm_auto_tag(&self) -> ResolvedLlm {
+        let parent = self.resolve_llm(None, None, None);
+        let sub = self.llm.as_ref().and_then(|l| l.auto_tag.as_ref());
+
+        let backend = sub
+            .and_then(|s| s.backend.clone())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| parent.backend.clone());
+
+        let model = sub
+            .and_then(|s| s.model.clone())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.auto_tag_model.clone().filter(|s| !s.trim().is_empty()))
+            .unwrap_or_else(|| {
+                // L15 default: gemma3:4b for fast structured output,
+                // regardless of parent backend.
+                if backend == "ollama" {
+                    "gemma3:4b".to_string()
+                } else {
+                    // For non-Ollama backends, use the parent model
+                    // (no sane way to pick a "fast" model across vendors).
+                    parent.model.clone()
+                }
+            });
+
+        let base_url = sub
+            .and_then(|s| s.base_url.clone())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| {
+                if backend == parent.backend {
+                    parent.base_url.clone()
+                } else {
+                    backend_default_base_url(&backend).to_string()
+                }
+            });
+
+        // api_key: inherit from parent if backend matches, else fresh resolve.
+        let (api_key, api_key_source) = if backend == parent.backend {
+            (parent.api_key.clone(), parent.api_key_source.clone())
+        } else {
+            // Synthesise a transient LlmSection-like view from the sub-table
+            // for fresh API-key resolution.
+            let synthetic = sub.map(|s| LlmSection {
+                backend: Some(backend.clone()),
+                model: None,
+                base_url: None,
+                api_key_env: s.api_key_env.clone(),
+                api_key_file: s.api_key_file.clone(),
+                api_key: None,
+                auto_tag: None,
+            });
+            resolve_api_key(&backend, synthetic.as_ref())
+        };
+
+        ResolvedLlm {
+            backend,
+            model,
+            base_url,
+            api_key,
+            api_key_source,
+            source: parent.source,
+        }
+    }
+
+    /// v0.7.x (#1146) — resolve the canonical embedder configuration.
+    #[must_use]
+    pub fn resolve_embeddings(&self) -> ResolvedEmbeddings {
+        let cfg = self.embeddings.as_ref();
+
+        let backend = cfg
+            .and_then(|e| e.backend.clone())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "ollama".to_string());
+
+        let url = cfg
+            .and_then(|e| e.url.clone())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.embed_url.clone().filter(|s| !s.trim().is_empty()))
+            .or_else(|| self.ollama_url.clone().filter(|s| !s.trim().is_empty()))
+            .unwrap_or_else(|| "http://localhost:11434".to_string());
+
+        let model = cfg
+            .and_then(|e| e.model.clone())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                self.embedding_model
+                    .clone()
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .map(canonicalise_embedding_model)
+            .unwrap_or_else(|| "nomic-embed-text-v1.5".to_string());
+
+        let backfill_batch_env = std::env::var("AI_MEMORY_EMBED_BACKFILL_BATCH")
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok());
+        let backfill_batch_cfg = cfg.and_then(|e| e.backfill_batch);
+        let backfill_batch_raw = backfill_batch_env.or(backfill_batch_cfg);
+        let backfill_batch = match backfill_batch_raw {
+            Some(n) if (1..=10000).contains(&n) => n,
+            Some(_) | None => 100,
+        };
+
+        let source = if cfg.is_some() {
+            ConfigSource::Config
+        } else if self.embed_url.is_some()
+            || self.embedding_model.is_some()
+            || self.ollama_url.is_some()
+        {
+            ConfigSource::Legacy
+        } else {
+            ConfigSource::CompiledDefault
+        };
+
+        ResolvedEmbeddings {
+            backend,
+            url,
+            model,
+            backfill_batch,
+            source,
+        }
+    }
+
+    /// v0.7.x (#1146) — resolve the canonical reranker configuration.
+    /// Folds the legacy `cross_encoder: Option<bool>` flag into the
+    /// `enabled` field; `model` defaults to `ms-marco-MiniLM-L-6-v2`.
+    #[must_use]
+    pub fn resolve_reranker(&self) -> ResolvedReranker {
+        let cfg = self.reranker.as_ref();
+
+        let enabled = cfg
+            .and_then(|r| r.enabled)
+            .or(self.cross_encoder)
+            // Default reranker-on for the autonomous tier; off otherwise.
+            // Boot wires the actual tier-default at the resolver call
+            // site (it's already keyed off `tier_config.cross_encoder`).
+            .unwrap_or(false);
+
+        let model = cfg
+            .and_then(|r| r.model.clone())
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "ms-marco-MiniLM-L-6-v2".to_string());
+
+        let source = if cfg.is_some() {
+            ConfigSource::Config
+        } else if self.cross_encoder.is_some() {
+            ConfigSource::Legacy
+        } else {
+            ConfigSource::CompiledDefault
+        };
+
+        ResolvedReranker {
+            enabled,
+            model,
+            source,
+        }
+    }
+
+    /// v0.7.x (#1146) — resolve the canonical storage configuration.
+    #[must_use]
+    pub fn resolve_storage(&self) -> ResolvedStorage {
+        let cfg = self.storage.as_ref();
+
+        let default_namespace = cfg
+            .and_then(|s| s.default_namespace.clone())
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                self.default_namespace
+                    .clone()
+                    .filter(|s| !s.trim().is_empty())
+            })
+            .unwrap_or_else(|| "global".to_string());
+
+        let archive_on_gc = cfg
+            .and_then(|s| s.archive_on_gc)
+            .or(self.archive_on_gc)
+            .unwrap_or(true);
+
+        let archive_max_days = cfg
+            .and_then(|s| s.archive_max_days)
+            .or(self.archive_max_days);
+
+        let max_memory_mb = cfg.and_then(|s| s.max_memory_mb).or(self.max_memory_mb);
+
+        let source = if cfg.is_some() {
+            ConfigSource::Config
+        } else if self.default_namespace.is_some()
+            || self.archive_on_gc.is_some()
+            || self.archive_max_days.is_some()
+            || self.max_memory_mb.is_some()
+        {
+            ConfigSource::Legacy
+        } else {
+            ConfigSource::CompiledDefault
+        };
+
+        ResolvedStorage {
+            default_namespace,
+            archive_on_gc,
+            archive_max_days,
+            max_memory_mb,
+            source,
+        }
     }
 
     /// Write a default config file if one doesn't exist yet.

--- a/src/config.rs
+++ b/src/config.rs
@@ -4405,11 +4405,24 @@ impl AppConfig {
                 // (`[memory]`, `[autonomous]`, `[governance]`, `[federation]`)
                 // can no longer silently neutralise an operator's intent.
                 Self::warn_unknown_top_level_keys(path, &contents);
-                match toml::from_str(&contents) {
-                    Ok(cfg) => {
-                        eprintln!("ai-memory: loaded config from {}", path.display());
-                        cfg
-                    }
+                match toml::from_str::<Self>(&contents) {
+                    Ok(cfg) => match cfg.validate_secret_handling() {
+                        Ok(()) => {
+                            eprintln!("ai-memory: loaded config from {}", path.display());
+                            cfg
+                        }
+                        Err(reason) => {
+                            eprintln!(
+                                "ai-memory: config rejected ({}): {}\n\
+                                 ai-memory: falling back to default config — \
+                                 fix the issue and restart. \
+                                 See https://github.com/alphaonedev/ai-memory-mcp/issues/1146",
+                                path.display(),
+                                reason
+                            );
+                            Self::default()
+                        }
+                    },
                     Err(e) => {
                         eprintln!("ai-memory: config parse error ({}): {}", path.display(), e);
                         Self::default()
@@ -4418,6 +4431,59 @@ impl AppConfig {
             }
             Err(_) => Self::default(),
         }
+    }
+
+    /// v0.7.x (#1146) — validate secret-handling discipline in the
+    /// `[llm]` (and `[llm.auto_tag]`) sections after parse. Three
+    /// rejections fire at load time so misconfigurations are loud
+    /// rather than silent:
+    ///
+    /// 1. Inline `api_key = "<literal>"` in `[llm]`. Operators MUST
+    ///    use `api_key_env = "<ENV_VAR_NAME>"` or `api_key_file =
+    ///    "/path/to/key"` instead. Closes the v0.6.x posture where
+    ///    inline secrets in `~/.config/ai-memory/config.toml` were
+    ///    silently accepted even though the file is typically
+    ///    world-readable.
+    ///
+    /// 2. Both `api_key_env` and `api_key_file` set on `[llm]`.
+    ///    Mutually exclusive — operator must pick one.
+    ///
+    /// 3. Both `api_key_env` and `api_key_file` set on
+    ///    `[llm.auto_tag]`. Same mutex.
+    ///
+    /// On any rejection, [`Self::load_from`] surfaces the message to
+    /// stderr and falls back to [`Self::default`] so the daemon boots
+    /// without the misconfigured secret rather than refusing to start
+    /// entirely.
+    fn validate_secret_handling(&self) -> Result<(), String> {
+        if let Some(llm) = &self.llm {
+            // Rejection 1 — inline api_key literal.
+            if llm.api_key.is_some() {
+                return Err("inline `api_key = \"<literal>\"` in [llm] is forbidden — \
+                     use `api_key_env = \"<ENV_VAR_NAME>\"` to reference a \
+                     process env var, or `api_key_file = \"/path/to/key\"` to \
+                     reference a file (mode 0400 enforced). Inline secrets in \
+                     config.toml (typically world-readable) are a credential \
+                     leak."
+                    .to_string());
+            }
+            // Rejection 2 — env vs file mutex.
+            if llm.api_key_env.is_some() && llm.api_key_file.is_some() {
+                return Err("[llm].api_key_env and [llm].api_key_file are mutually \
+                     exclusive — set exactly one (or neither, to fall back \
+                     to the per-vendor env-var chain)."
+                    .to_string());
+            }
+            // Rejection 3 — auto_tag env vs file mutex.
+            if let Some(auto_tag) = &llm.auto_tag {
+                if auto_tag.api_key_env.is_some() && auto_tag.api_key_file.is_some() {
+                    return Err("[llm.auto_tag].api_key_env and \
+                         [llm.auto_tag].api_key_file are mutually exclusive."
+                        .to_string());
+                }
+            }
+        }
+        Ok(())
     }
 
     /// L1 fix (v0.7.0): enumerate top-level keys in `contents` and emit a

--- a/src/config.rs
+++ b/src/config.rs
@@ -6995,4 +6995,340 @@ legacy_scoring = false
         assert!((surface.tier_thresholds.likely - 0.7).abs() < f64::EPSILON);
         assert!((surface.tier_thresholds.ambiguous - 0.0).abs() < f64::EPSILON);
     }
+
+    // ---------------------------------------------------------------------
+    // v0.7.x enterprise-config tests (#1146)
+    //
+    // Pin: precedence ladder per resolver (CLI > env > config > legacy >
+    // compiled), inline-key rejection at parse time, api_key_env /
+    // api_key_file resolution, Once-gated legacy-drift WARN.
+    // ---------------------------------------------------------------------
+
+    fn empty_app_config() -> AppConfig {
+        AppConfig {
+            schema_version: Some(2),
+            ..AppConfig::default()
+        }
+    }
+
+    fn scrub_llm_env() {
+        for k in [
+            "AI_MEMORY_LLM_BACKEND",
+            "AI_MEMORY_LLM_MODEL",
+            "AI_MEMORY_LLM_BASE_URL",
+            "AI_MEMORY_LLM_API_KEY",
+            "XAI_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "AI_MEMORY_EMBED_BACKFILL_BATCH",
+            "AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS",
+        ] {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_llm_1146_compiled_default_when_nothing_configured() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        let cfg = empty_app_config();
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.backend, "ollama");
+        assert_eq!(resolved.model, "gemma3:4b");
+        assert_eq!(resolved.base_url, "http://localhost:11434");
+        assert_eq!(resolved.source, ConfigSource::CompiledDefault);
+        assert_eq!(resolved.api_key_source, KeySource::None);
+        assert!(resolved.api_key().is_none());
+    }
+
+    #[test]
+    fn resolve_llm_1146_env_overrides_config_section() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        unsafe {
+            std::env::set_var("AI_MEMORY_LLM_BACKEND", "xai");
+            std::env::set_var("AI_MEMORY_LLM_MODEL", "grok-99");
+            std::env::set_var("AI_MEMORY_LLM_API_KEY", "env-key");
+        }
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("openai".into()),
+            model: Some("gpt-4".into()),
+            ..LlmSection::default()
+        });
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.backend, "xai", "env must beat config");
+        assert_eq!(resolved.model, "grok-99");
+        assert_eq!(resolved.source, ConfigSource::Env);
+        assert_eq!(resolved.api_key_source, KeySource::ProcessEnv);
+        assert_eq!(resolved.api_key(), Some("env-key"));
+        scrub_llm_env();
+    }
+
+    #[test]
+    fn resolve_llm_1146_cli_overrides_env() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        unsafe {
+            std::env::set_var("AI_MEMORY_LLM_BACKEND", "ollama");
+            std::env::set_var("AI_MEMORY_LLM_MODEL", "ollama-model");
+        }
+        let cfg = empty_app_config();
+        let resolved = cfg.resolve_llm(Some("xai"), Some("grok-4.3"), Some("https://x"));
+        assert_eq!(resolved.backend, "xai", "CLI flag must beat env");
+        assert_eq!(resolved.model, "grok-4.3");
+        assert_eq!(resolved.base_url, "https://x");
+        assert_eq!(resolved.source, ConfigSource::Cli);
+        scrub_llm_env();
+    }
+
+    #[test]
+    fn resolve_llm_1146_config_section_when_no_env() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            model: Some("grok-4.3".into()),
+            ..LlmSection::default()
+        });
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.backend, "xai");
+        assert_eq!(resolved.model, "grok-4.3");
+        assert_eq!(
+            resolved.base_url, "https://api.x.ai/v1",
+            "vendor-default base_url applied"
+        );
+        assert_eq!(resolved.source, ConfigSource::Config);
+    }
+
+    #[test]
+    fn resolve_llm_1146_alias_fallback_key_for_xai() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        unsafe {
+            std::env::set_var("AI_MEMORY_LLM_BACKEND", "xai");
+            std::env::set_var("XAI_API_KEY", "alias-fallback-key");
+        }
+        let cfg = empty_app_config();
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.backend, "xai");
+        assert_eq!(resolved.api_key(), Some("alias-fallback-key"));
+        match &resolved.api_key_source {
+            KeySource::AliasFallback(name) => assert_eq!(name, "XAI_API_KEY"),
+            other => panic!("expected AliasFallback(XAI_API_KEY), got {other:?}"),
+        }
+        scrub_llm_env();
+    }
+
+    #[test]
+    fn resolve_llm_1146_legacy_llm_model_feeds_resolver() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        let mut cfg = AppConfig::default();
+        cfg.llm_model = Some("gemma4:e4b".into());
+        cfg.ollama_url = Some("http://localhost:11434".into());
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.backend, "ollama");
+        assert_eq!(resolved.model, "gemma4:e4b");
+        assert_eq!(resolved.source, ConfigSource::Legacy);
+    }
+
+    #[test]
+    fn validate_secret_handling_1146_rejects_inline_api_key() {
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            api_key: Some("xai-INLINE-SECRET".into()),
+            ..LlmSection::default()
+        });
+        let err = cfg
+            .validate_secret_handling()
+            .expect_err("inline api_key must be rejected");
+        assert!(
+            err.contains("api_key") && err.contains("forbidden"),
+            "error must name the field and the policy: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_secret_handling_1146_rejects_env_and_file_both_set() {
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            api_key_env: Some("XAI_API_KEY".into()),
+            api_key_file: Some("/etc/key".into()),
+            ..LlmSection::default()
+        });
+        let err = cfg
+            .validate_secret_handling()
+            .expect_err("env+file mutex must be enforced");
+        assert!(
+            err.contains("api_key_env") && err.contains("api_key_file"),
+            "error must call out the mutex: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_llm_1146_api_key_env_reads_named_env_var() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        unsafe {
+            std::env::set_var("MY_CUSTOM_LLM_KEY", "via-config-env-var");
+        }
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            model: Some("grok-4.3".into()),
+            api_key_env: Some("MY_CUSTOM_LLM_KEY".into()),
+            ..LlmSection::default()
+        });
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(resolved.api_key(), Some("via-config-env-var"));
+        match &resolved.api_key_source {
+            KeySource::ConfigEnvVar(name) => assert_eq!(name, "MY_CUSTOM_LLM_KEY"),
+            other => panic!("expected ConfigEnvVar(MY_CUSTOM_LLM_KEY), got {other:?}"),
+        }
+        unsafe {
+            std::env::remove_var("MY_CUSTOM_LLM_KEY");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_llm_1146_api_key_file_rejects_lax_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let _g = env_var_lock();
+        scrub_llm_env();
+        // Tempdir under .local-runs (project HARD rule: no /tmp).
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(".local-runs")
+            .join(format!("test-1146-perms-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        let key_path = base.join("xai.key");
+        std::fs::write(&key_path, "shhh").unwrap();
+        // World-readable mode 0644 — must be rejected.
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            api_key_file: Some(key_path.display().to_string()),
+            ..LlmSection::default()
+        });
+        let resolved = cfg.resolve_llm(None, None, None);
+        match &resolved.api_key_source {
+            KeySource::Error(reason) => {
+                assert!(
+                    reason.contains("lax permissions") && reason.contains("0400"),
+                    "error must name the perm policy: {reason}"
+                );
+            }
+            other => panic!("expected KeySource::Error(lax perms), got {other:?}"),
+        }
+        // Cleanup.
+        let _ = std::fs::remove_file(&key_path);
+        let _ = std::fs::remove_dir(&base);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_llm_1146_api_key_file_accepts_0400() {
+        use std::os::unix::fs::PermissionsExt;
+        let _g = env_var_lock();
+        scrub_llm_env();
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(".local-runs")
+            .join(format!("test-1146-perms-ok-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        let key_path = base.join("xai.key");
+        std::fs::write(&key_path, "the-actual-key\n").unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+        let mut cfg = empty_app_config();
+        cfg.llm = Some(LlmSection {
+            backend: Some("xai".into()),
+            api_key_file: Some(key_path.display().to_string()),
+            ..LlmSection::default()
+        });
+        let resolved = cfg.resolve_llm(None, None, None);
+        assert_eq!(
+            resolved.api_key(),
+            Some("the-actual-key"),
+            "first line is the key"
+        );
+        assert!(matches!(resolved.api_key_source, KeySource::ConfigFile(_)));
+
+        let _ = std::fs::remove_file(&key_path);
+        let _ = std::fs::remove_dir(&base);
+    }
+
+    #[test]
+    fn resolve_embeddings_1146_legacy_alias_canonicalised() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        let mut cfg = AppConfig::default();
+        cfg.embedding_model = Some("nomic_embed_v15".into());
+        let resolved = cfg.resolve_embeddings();
+        assert_eq!(
+            resolved.model, "nomic-embed-text-v1.5",
+            "legacy alias must be canonicalised"
+        );
+        assert_eq!(resolved.source, ConfigSource::Legacy);
+        assert_eq!(resolved.backfill_batch, 100, "compiled default applied");
+    }
+
+    #[test]
+    fn resolve_embeddings_1146_backfill_batch_env_overrides_config() {
+        let _g = env_var_lock();
+        scrub_llm_env();
+        unsafe {
+            std::env::set_var("AI_MEMORY_EMBED_BACKFILL_BATCH", "500");
+        }
+        let mut cfg = empty_app_config();
+        cfg.embeddings = Some(EmbeddingsSection {
+            backfill_batch: Some(50),
+            ..EmbeddingsSection::default()
+        });
+        let resolved = cfg.resolve_embeddings();
+        assert_eq!(resolved.backfill_batch, 500, "env must beat config");
+        scrub_llm_env();
+    }
+
+    #[test]
+    fn resolve_reranker_1146_folds_legacy_cross_encoder() {
+        let _g = env_var_lock();
+        let mut cfg = AppConfig::default();
+        cfg.cross_encoder = Some(true);
+        let resolved = cfg.resolve_reranker();
+        assert!(resolved.enabled);
+        assert_eq!(resolved.model, "ms-marco-MiniLM-L-6-v2");
+        assert_eq!(resolved.source, ConfigSource::Legacy);
+    }
+
+    #[test]
+    fn resolved_llm_1146_debug_redacts_api_key() {
+        let resolved = ResolvedLlm {
+            backend: "xai".into(),
+            model: "grok-4.3".into(),
+            base_url: "https://api.x.ai/v1".into(),
+            api_key: Some("SUPER-SECRET-DONT-LEAK".into()),
+            api_key_source: KeySource::ProcessEnv,
+            source: ConfigSource::Env,
+        };
+        let dbg = format!("{resolved:?}");
+        assert!(
+            !dbg.contains("SUPER-SECRET-DONT-LEAK"),
+            "Debug impl must redact the api_key: {dbg}"
+        );
+        assert!(
+            dbg.contains("<redacted>"),
+            "Debug impl must show <redacted> placeholder: {dbg}"
+        );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4474,6 +4474,7 @@ impl AppConfig {
                     Ok(cfg) => match cfg.validate_secret_handling() {
                         Ok(()) => {
                             eprintln!("ai-memory: loaded config from {}", path.display());
+                            cfg.warn_legacy_schema_drift(path);
                             cfg
                         }
                         Err(reason) => {
@@ -4496,6 +4497,76 @@ impl AppConfig {
             }
             Err(_) => Self::default(),
         }
+    }
+
+    /// v0.7.x (#1146) — emit a one-shot deprecation WARN to stderr
+    /// when the loaded config carries legacy v1 flat fields that have
+    /// been superseded by the sectioned v2 schema.
+    ///
+    /// Two posture WARNs:
+    ///
+    /// - **Legacy-only** (no `schema_version` OR `schema_version = 1`,
+    ///   AND any of `llm_model`, `ollama_url`, `embed_url`,
+    ///   `embedding_model`, `cross_encoder`, `default_namespace`,
+    ///   `archive_on_gc`, `archive_max_days`, `max_memory_mb`,
+    ///   `auto_tag_model` set): operator running pre-#1146 config
+    ///   shape — point them at `ai-memory config migrate`.
+    ///
+    /// - **Drift** (`schema_version >= 2` AND any legacy field set):
+    ///   operator has migrated but left legacy fields in place —
+    ///   legacy fields are ignored under v2, point them at
+    ///   `ai-memory config migrate` to clean up the dead weight.
+    ///
+    /// The WARN is gated by [`std::sync::Once`] so re-loading the
+    /// config in the same process (e.g. tests that call
+    /// [`AppConfig::load_from`] in a loop) does not spam stderr.
+    fn warn_legacy_schema_drift(&self, path: &Path) {
+        use std::sync::Once;
+        static WARN_ONCE: Once = Once::new();
+
+        let has_legacy = self.llm_model.is_some()
+            || self.ollama_url.is_some()
+            || self.embed_url.is_some()
+            || self.embedding_model.is_some()
+            || self.cross_encoder.is_some()
+            || self.default_namespace.is_some()
+            || self.archive_on_gc.is_some()
+            || self.archive_max_days.is_some()
+            || self.max_memory_mb.is_some()
+            || self.auto_tag_model.is_some();
+
+        if !has_legacy {
+            return;
+        }
+
+        let v2 = matches!(self.schema_version, Some(v) if v >= 2);
+
+        WARN_ONCE.call_once(|| {
+            if v2 {
+                eprintln!(
+                    "ai-memory: WARN — schema_version = {:?} but legacy v1 fields \
+                     are still present in {} (llm_model / ollama_url / embed_url / \
+                     embedding_model / cross_encoder / default_namespace / \
+                     archive_on_gc / archive_max_days / max_memory_mb / \
+                     auto_tag_model). Under v2 the legacy fields are IGNORED in \
+                     favor of [llm] / [embeddings] / [reranker] / [storage] \
+                     sections. Run `ai-memory config migrate` to remove them.",
+                    self.schema_version,
+                    path.display(),
+                );
+            } else {
+                eprintln!(
+                    "ai-memory: WARN — legacy v1 flat-field configuration shape \
+                     detected in {}. The [llm] / [embeddings] / [reranker] / \
+                     [storage] sectioned schema (v2) is the canonical shape; \
+                     legacy fields continue to work in v0.7.x but will be \
+                     removed in v0.8.0. Run `ai-memory config migrate` to \
+                     upgrade in place (a timestamped .bak is written). See \
+                     https://github.com/alphaonedev/ai-memory-mcp/issues/1146",
+                    path.display(),
+                );
+            }
+        });
     }
 
     /// v0.7.x (#1146) — validate secret-handling discipline in the

--- a/src/config.rs
+++ b/src/config.rs
@@ -4335,6 +4335,12 @@ fn resolve_api_key(backend: &str, llm: Option<&LlmSection>) -> (Option<String>, 
     {
         let path = expand_tilde(raw_path);
         let path_display = path.display().to_string();
+
+        // Mode 0400 enforcement (#1055-style escape hatch).
+        if let Err(reason) = enforce_api_key_file_perms(&path) {
+            return (None, KeySource::Error(reason));
+        }
+
         return match std::fs::read_to_string(&path) {
             Ok(contents) => {
                 let key = contents.lines().next().unwrap_or("").trim().to_string();
@@ -4357,6 +4363,65 @@ fn resolve_api_key(backend: &str, llm: Option<&LlmSection>) -> (Option<String>, 
     }
 
     (None, KeySource::None)
+}
+
+/// v0.7.x (#1146) — enforce mode 0400 (or stricter) on the file
+/// referenced by `[llm].api_key_file`. The check mirrors the existing
+/// `AI_MEMORY_DB_PASSPHRASE_FILE` enforcement (issue #1055): any bits
+/// set in `mode & 0o077` (group / world readable / executable) cause
+/// the daemon to refuse the file, unless the operator opts out via
+/// `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1`.
+///
+/// On non-Unix platforms (the `staticlib` mobile target, future
+/// Windows builds) the check is a no-op — the perm bits are not
+/// expressible on those platforms.
+fn enforce_api_key_file_perms(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = std::fs::metadata(path).map_err(|e| {
+            format!(
+                "[llm].api_key_file = {:?} could not be stat'd for perms check: {}",
+                path.display(),
+                e
+            )
+        })?;
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            // Allow lax perms only when the operator explicitly opts in
+            // (mirroring #1055 for AI_MEMORY_DB_PASSPHRASE_FILE).
+            let opt_in = std::env::var("AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS")
+                .ok()
+                .is_some_and(|s| {
+                    let t = s.trim().to_ascii_lowercase();
+                    matches!(t.as_str(), "1" | "true" | "yes" | "on")
+                });
+            if !opt_in {
+                return Err(format!(
+                    "[llm].api_key_file = {:?} has lax permissions \
+                     (mode = {:o}; expected 0400 or stricter). Run \
+                     `chmod 0400 {}` to fix, or set \
+                     `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1` to \
+                     bypass (NOT recommended for production).",
+                    path.display(),
+                    mode & 0o777,
+                    path.display()
+                ));
+            }
+            tracing::warn!(
+                "[llm].api_key_file = {:?} has lax permissions (mode = {:o}); \
+                 accepted because AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1",
+                path.display(),
+                mode & 0o777
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Permission bits do not apply on non-Unix platforms.
+        let _ = path;
+    }
+    Ok(())
 }
 
 fn expand_tilde(s: &str) -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2570,6 +2570,66 @@ pub struct AppConfig {
     /// non-admin callers — the safe-by-default posture per CLAUDE.md
     /// `pm-v3`. See [`AdminConfig`] for the full role-gate semantics.
     pub admin: Option<AdminConfig>,
+
+    // ------------------------------------------------------------------
+    // v0.7.x enterprise configuration sections (issue #1146).
+    //
+    // These four sectioned blocks (`[llm]` / `[embeddings]` /
+    // `[reranker]` / `[storage]`) consolidate the previously-flat
+    // LLM / embedder / reranker / storage knobs into named tables with
+    // a uniform canonical resolver. Legacy flat fields above
+    // (`llm_model`, `ollama_url`, `embed_url`, `embedding_model`,
+    // `cross_encoder`, `default_namespace`, `archive_on_gc`,
+    // `archive_max_days`, `max_memory_mb`) continue to parse and feed
+    // the resolver's legacy arm with a one-shot deprecation WARN until
+    // v0.8.0 removes them.
+    //
+    // The `schema_version` field carries the explicit shape version.
+    // Absent / `1` selects the legacy parse path; `>= 2` selects the
+    // sectioned parse path and warns when legacy fields are also
+    // present (so an operator who hand-edited the file knows the
+    // legacy fields are dead weight).
+    // ------------------------------------------------------------------
+    /// v0.7.x (#1146) — explicit configuration schema version. `None`
+    /// or `1` selects the v0.6.x flat-field parse path; `2` selects
+    /// the sectioned parse path (`[llm]`, `[embeddings]`, `[reranker]`,
+    /// `[storage]`) and emits a WARN if any legacy flat field is also
+    /// present. Future bumps (`3`, `4`, …) introduce additional schema
+    /// transitions and are gated through `ai-memory config migrate`.
+    pub schema_version: Option<u32>,
+
+    /// v0.7.x (#1146) — `[llm]` sectioned LLM configuration. Carries
+    /// the canonical backend / model / base_url / api_key references
+    /// consumed by every LLM-init surface (MCP stdio, HTTP daemon,
+    /// `ai-memory atomise`, `ai-memory curator`, embed-client
+    /// disambiguator, the boot banner). Resolved via
+    /// [`AppConfig::resolve_llm`]; the resolver applies the uniform
+    /// precedence ladder (CLI flag > `AI_MEMORY_LLM_*` env > `[llm]`
+    /// section > legacy flat fields > compiled default).
+    ///
+    /// Includes an optional `[llm.auto_tag]` sub-table for the fast
+    /// structured-output sibling that handles `auto_tag`, query
+    /// expansion, and contradiction detection — see [`LlmSection`].
+    pub llm: Option<LlmSection>,
+
+    /// v0.7.x (#1146) — `[embeddings]` sectioned embedding-model
+    /// configuration. Consumed by the embedder bootstrap in
+    /// `daemon_runtime` and the MCP embed-client fallback path.
+    /// Resolved via [`AppConfig::resolve_embeddings`].
+    pub embeddings: Option<EmbeddingsSection>,
+
+    /// v0.7.x (#1146) — `[reranker]` sectioned cross-encoder
+    /// configuration. Folds the legacy `cross_encoder = bool` knob
+    /// into a `{ enabled, model }` table with explicit model
+    /// selection. Resolved via [`AppConfig::resolve_reranker`].
+    pub reranker: Option<RerankerSection>,
+
+    /// v0.7.x (#1146) — `[storage]` sectioned storage configuration.
+    /// Carries `default_namespace`, `archive_on_gc`, `archive_max_days`,
+    /// `max_memory_mb` (folded from the previously-flat top-level
+    /// fields). The `db` path stays top-level per the I4 carve-out in
+    /// #1146 (path expansion semantics pinned by #507).
+    pub storage: Option<StorageSection>,
 }
 
 /// v0.7.0 SEC-2 (Cluster D, issue #767) — `[governance]` top-level
@@ -2672,6 +2732,228 @@ impl AdminConfig {
         }
         out
     }
+}
+
+// ---------------------------------------------------------------------------
+// v0.7.x enterprise configuration sections (issue #1146)
+//
+// `[llm]` / `[embeddings]` / `[reranker]` / `[storage]` consolidate
+// previously-flat LLM / embedder / reranker / storage knobs into a
+// uniform sectioned shape consumed by the canonical resolvers in
+// `impl AppConfig`. See the issue for the full design rationale,
+// migration plan, and acceptance criteria.
+// ---------------------------------------------------------------------------
+
+/// v0.7.x (#1146) — `[llm]` sectioned LLM configuration.
+///
+/// Wire format:
+/// ```toml
+/// [llm]
+/// backend     = "xai"          # ollama | openai | xai | anthropic | gemini | …
+/// model       = "grok-4.3"     # vendor-specific identifier
+/// base_url    = "https://api.x.ai/v1"   # optional; vendor-default if unset
+/// api_key_env = "XAI_API_KEY"           # env var name (mutually exclusive
+///                                        # with api_key_file)
+/// # api_key_file = "/etc/ai-memory/keys/xai.key"   # mode 0400 enforced
+///
+/// [llm.auto_tag]
+/// # Fast structured-output sibling (auto_tag, query expansion,
+/// # contradiction detection). Fields fall back to parent [llm]
+/// # field-by-field when unset; commonly only `model` is overridden.
+/// model = "gemma3:4b"
+/// ```
+///
+/// **Secret handling discipline.** Inline `api_key = "<literal>"` is
+/// REJECTED at parse time — operators MUST use either
+/// `api_key_env = "<ENV_VAR_NAME>"` (resolved at runtime) or
+/// `api_key_file = "/path/to/key"` (mode 0400 enforced, override via
+/// `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1`). Both unset selects
+/// the per-vendor-alias env-var fallback chain (see `src/llm.rs`
+/// `alias_api_key_env_vars`).
+///
+/// **Precedence.** Resolved via [`AppConfig::resolve_llm`] through the
+/// uniform precedence ladder: CLI flag > `AI_MEMORY_LLM_*` env vars >
+/// `[llm]` section > legacy flat fields (`llm_model`, `ollama_url`) >
+/// compiled default (warn-logged once on the resolver's `CompiledDefault`
+/// arm).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmSection {
+    /// Backend selector. One of: `ollama` (native `/api/chat` +
+    /// `/api/embed`, no auth), `openai-compatible` (generic; requires
+    /// explicit `base_url`), or an alias that pre-fills `base_url`
+    /// (`openai`, `xai`, `anthropic`, `gemini`, `deepseek`, `kimi`,
+    /// `qwen`, `mistral`, `groq`, `together`, `cerebras`, `openrouter`,
+    /// `fireworks`, `lmstudio`). Unset = inherit legacy resolution
+    /// (treated as `ollama`).
+    pub backend: Option<String>,
+
+    /// Model identifier passed verbatim to the chat endpoint.
+    /// Vendor-specific (e.g., `grok-4.3`, `gpt-5`, `claude-opus-4.7`).
+    /// Unset = backend-specific default (see `OllamaClient::from_env`).
+    pub model: Option<String>,
+
+    /// Optional base-URL override. Required when `backend =
+    /// "openai-compatible"`; ignored otherwise (vendor-default
+    /// applies). For `backend = "ollama"`, defaults to
+    /// `http://localhost:11434`.
+    pub base_url: Option<String>,
+
+    /// Name of the environment variable to read at runtime for the
+    /// API-key Bearer auth secret. Mutually exclusive with
+    /// `api_key_file`. Example: `api_key_env = "XAI_API_KEY"`. The
+    /// `AI_MEMORY_LLM_API_KEY` process-env override (and the
+    /// per-vendor fallback chain at `src/llm.rs`
+    /// `alias_api_key_env_vars`) take precedence over this field per
+    /// the uniform precedence ladder.
+    pub api_key_env: Option<String>,
+
+    /// Path to a file whose first line is the API-key Bearer secret.
+    /// Mutually exclusive with `api_key_env`. File must be `mode 0400`
+    /// or stricter (overridable via
+    /// `AI_MEMORY_PASSPHRASE_FILE_ALLOW_LAX_PERMS=1` per #1055). Tilde
+    /// expansion applies.
+    pub api_key_file: Option<String>,
+
+    /// **REJECTED AT PARSE TIME.** Accepting the field name here lets
+    /// the validator emit a clear "use api_key_env or api_key_file"
+    /// error instead of serde's generic "unknown field". Operators
+    /// inlining secrets in the config file see the security-rationale
+    /// message at load time.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// `[llm.auto_tag]` sub-table for the fast structured-output
+    /// sibling (`auto_tag`, query expansion, contradiction detection).
+    /// Unset = inherit every field from the parent [`LlmSection`].
+    /// When set, only the explicitly-provided fields override; unset
+    /// fields fall back to the parent.
+    #[serde(default)]
+    pub auto_tag: Option<LlmAutoTagSection>,
+}
+
+/// v0.7.x (#1146) — `[llm.auto_tag]` sub-table. Fast structured-output
+/// sibling of [`LlmSection`]. Fields fall back to the parent `[llm]`
+/// section field-by-field when unset; commonly only `model` is
+/// overridden to point at a faster model (default `gemma3:4b`,
+/// ~0.7s p50 vs ~15s p50 for thinking-mode Gemma 4 per L15 patch).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmAutoTagSection {
+    /// Backend override. Unset = inherit `[llm].backend`.
+    pub backend: Option<String>,
+    /// Model override. Unset = inherit `[llm].model`. Compiled default
+    /// at the resolver level is `gemma3:4b` (L15 fast-structured-output
+    /// model selection).
+    pub model: Option<String>,
+    /// Base-URL override. Unset = inherit `[llm].base_url`.
+    pub base_url: Option<String>,
+    /// Env-var-name override for the API key. Unset = inherit
+    /// `[llm].api_key_env` (or `[llm].api_key_file`).
+    pub api_key_env: Option<String>,
+    /// File-path override for the API key. Unset = inherit
+    /// `[llm].api_key_file` (or `[llm].api_key_env`).
+    pub api_key_file: Option<String>,
+}
+
+/// v0.7.x (#1146) — `[embeddings]` sectioned embedding-model
+/// configuration.
+///
+/// Wire format:
+/// ```toml
+/// [embeddings]
+/// backend        = "ollama"                    # only backend at v0.7.0
+/// url            = "http://localhost:11434"
+/// model          = "nomic-embed-text-v1.5"
+/// backfill_batch = 100                         # 1-10000 (env override:
+///                                              # AI_MEMORY_EMBED_BACKFILL_BATCH)
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmbeddingsSection {
+    /// Embedding backend. At v0.7.0 only `ollama` is supported (the
+    /// `nomic-embed-text-v1.5` and `all-MiniLM-L6-v2` models both
+    /// speak Ollama's `/api/embed` wire shape). Field is present for
+    /// forward compatibility with future OpenAI-compatible embedding
+    /// vendors.
+    pub backend: Option<String>,
+
+    /// Embedding endpoint URL. Defaults to `http://localhost:11434`
+    /// when unset.
+    pub url: Option<String>,
+
+    /// Embedding model identifier. Legacy values `nomic_embed_v15`
+    /// (alias for `nomic-embed-text-v1.5`) and `mini_lm_l6_v2` (alias
+    /// for `sentence-transformers/all-MiniLM-L6-v2`) are honored at
+    /// parse time.
+    pub model: Option<String>,
+
+    /// Backfill batch size. Bounded `1..=10000`; out-of-range values
+    /// fall back to the compiled default (100) with a WARN. Env
+    /// override: `AI_MEMORY_EMBED_BACKFILL_BATCH` (#38).
+    pub backfill_batch: Option<u32>,
+}
+
+/// v0.7.x (#1146) — `[reranker]` sectioned cross-encoder
+/// configuration.
+///
+/// Wire format:
+/// ```toml
+/// [reranker]
+/// enabled = true
+/// model   = "ms-marco-MiniLM-L-6-v2"   # v0.7.0 has one variant;
+///                                       # field reserved for future
+///                                       # bake-offs.
+/// ```
+///
+/// Folds the legacy `cross_encoder = bool` top-level flag. Migration
+/// (via `ai-memory config migrate`) writes the explicit `enabled` +
+/// `model` fold; the legacy field continues to be honored at parse
+/// time until v0.8.0.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RerankerSection {
+    /// Whether the cross-encoder rerank stage runs in the recall
+    /// pipeline. Folded from `cross_encoder: Option<bool>` at the
+    /// resolver layer.
+    pub enabled: Option<bool>,
+
+    /// Cross-encoder model identifier. Defaults to
+    /// `ms-marco-MiniLM-L-6-v2` when unset. Field reserved for future
+    /// model bake-offs (e.g., `bge-reranker-v2-m3`,
+    /// `mxbai-rerank-large-v2`).
+    pub model: Option<String>,
+}
+
+/// v0.7.x (#1146) — `[storage]` sectioned storage configuration.
+///
+/// Wire format:
+/// ```toml
+/// [storage]
+/// default_namespace = "alphaone"
+/// archive_on_gc     = true
+/// archive_max_days  = 90
+/// max_memory_mb     = 4096
+/// ```
+///
+/// Carries the previously-flat top-level fields `default_namespace`,
+/// `archive_on_gc`, `archive_max_days`, `max_memory_mb`. The `db`
+/// path stays top-level per the #1146 I4 carve-out (path expansion
+/// semantics pinned by #507).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageSection {
+    /// Default namespace for new memories when the caller's request
+    /// omits one. Folded from the previously-flat top-level
+    /// `default_namespace` field.
+    pub default_namespace: Option<String>,
+
+    /// Whether to archive memories before GC deletion. Folded from
+    /// `archive_on_gc`. Default `true`.
+    pub archive_on_gc: Option<bool>,
+
+    /// Archive retention ceiling in days. `None` (default) disables
+    /// the automatic purge. Folded from `archive_max_days`.
+    pub archive_max_days: Option<i64>,
+
+    /// Memory budget in MB for the auto tier selector. Folded from
+    /// `max_memory_mb`.
+    pub max_memory_mb: Option<usize>,
 }
 
 /// v0.7.0 (issue #518) — `[agents]` top-level block. Today only carries
@@ -3793,6 +4075,12 @@ impl AppConfig {
             "governance",
             "confidence",
             "admin",
+            // v0.7.x (#1146) — enterprise configuration sections.
+            "schema_version",
+            "llm",
+            "embeddings",
+            "reranker",
+            "storage",
         ];
 
         let value: toml::Value = match toml::from_str(contents) {
@@ -5310,6 +5598,12 @@ legacy_scoring = false
             governance: Some(GovernanceConfig::default()),
             confidence: Some(ConfidenceConfig::default()),
             admin: Some(AdminConfig::default()),
+            // v0.7.x (#1146) — enterprise configuration sections.
+            schema_version: Some(2),
+            llm: Some(LlmSection::default()),
+            embeddings: Some(EmbeddingsSection::default()),
+            reranker: Some(RerankerSection::default()),
+            storage: Some(StorageSection::default()),
         };
 
         let serialised = toml::to_string(&cfg).expect("serialise AppConfig to TOML");
@@ -5355,6 +5649,12 @@ legacy_scoring = false
             "governance",
             "confidence",
             "admin",
+            // v0.7.x (#1146) — enterprise configuration sections.
+            "schema_version",
+            "llm",
+            "embeddings",
+            "reranker",
+            "storage",
         ];
 
         for key in table.keys() {

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1765,113 +1765,81 @@ pub async fn build_llm_client(
     feature_tier: FeatureTier,
     app_config: &AppConfig,
 ) -> Option<llm::OllamaClient> {
-    // #1067 (2026-05-21) — LLM availability is no longer gated on
-    // `tier_config.llm_model`. Per operator directive every tier
-    // (keyword, semantic, smart, autonomous) can communicate with an
-    // LLM whenever the operator sets the `AI_MEMORY_LLM_*` env vars.
-    // Tier still determines *which features* run (embedder, reranker,
-    // autonomous curator), but the chat-completion path is tier-
-    // independent.
-    //
-    // Resolution order:
-    // 1. `AI_MEMORY_LLM_BACKEND` + companion env vars (handled by
-    //    `OllamaClient::from_env`). This is the universal escape hatch
-    //    — picks Ollama (default), any per-vendor alias, or the
-    //    generic `openai-compatible` for custom URLs.
-    // 2. Legacy fallback: if no env declares a backend AND the tier
-    //    has a default `llm_model`, build the Ollama client against
-    //    the tier-default URL + model. Preserves backward compat for
-    //    operators who don't set any LLM env.
-    // 3. Else: return None (LLM features are no-ops, but the daemon
-    //    boots fine).
-    let backend_env = std::env::var("AI_MEMORY_LLM_BACKEND").ok();
-    if backend_env
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .is_some()
-    {
-        // Operator explicitly chose a backend — route via `from_env`.
-        let backend = backend_env.unwrap_or_default();
-        let build = match tokio::task::spawn_blocking(llm::OllamaClient::from_env).await {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!("L5: build_llm_client from_env join failed: {e}");
-                return None;
-            }
-        };
-        return match build {
-            Ok(Some(client)) => {
-                tracing::info!(
-                    "L5: llm client ready — tier={} backend={backend} — \
-                     auto_tag/expand_query/contradiction-detection/reflection \
-                     hooks armed",
-                    feature_tier.as_str(),
-                );
-                Some(client)
-            }
-            Ok(None) => {
-                tracing::warn!(
-                    "L5: llm client disabled — AI_MEMORY_LLM_BACKEND={backend} \
-                     resolved to None (no client built); LLM-powered hooks are \
-                     no-ops"
-                );
-                None
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "L5: llm client init failed (backend={backend}, tier={}); \
-                     LLM-powered hooks are no-ops: {e}",
-                    feature_tier.as_str()
-                );
-                None
-            }
-        };
-    }
+    // v0.7.x (#1146) — single canonical entry through the resolver.
+    // The resolver folds CLI flags (none here — `ai-memory serve`
+    // exposes no CLI LLM override), AI_MEMORY_LLM_* env vars, the
+    // [llm] config section, the legacy llm_model/ollama_url flat
+    // fields, and the compiled tier preset. The provenance fields
+    // surface via the tracing log line so RUST_LOG=ai_memory=debug
+    // shows which precedence layer won.
+    let resolved = app_config.resolve_llm(None, None, None);
 
-    // Legacy fallback: no AI_MEMORY_LLM_BACKEND set.
-    let tier_config = feature_tier.config();
-    let Some(llm_model) = tier_config.llm_model else {
+    // Keyword tier short-circuit: when there is no explicit operator
+    // intent (no CLI flag, no env var, no [llm] section, no legacy
+    // flat fields — i.e. source == CompiledDefault), the resolver's
+    // Ollama-default-fallback should NOT pull a client into existence
+    // for a keyword-tier daemon. Operators who explicitly want LLM
+    // on keyword tier set AI_MEMORY_LLM_BACKEND (or write a [llm]
+    // section), which moves `source` off the CompiledDefault arm.
+    if matches!(feature_tier, FeatureTier::Keyword)
+        && matches!(
+            resolved.source,
+            crate::config::ConfigSource::CompiledDefault
+        )
+    {
         tracing::debug!(
-            "llm client disabled — no AI_MEMORY_LLM_BACKEND env AND tier={} has \
-             no default llm_model; auto_tag hook will be a no-op (set \
-             AI_MEMORY_LLM_BACKEND=ollama / xai / openai / deepseek / kimi / qwen \
-             / etc. to enable)",
-            feature_tier.as_str()
+            "L5: llm client disabled — keyword tier with no operator LLM config; \
+             set AI_MEMORY_LLM_BACKEND or [llm] section to enable"
         );
         return None;
-    };
-    let model_id = app_config
-        .llm_model
-        .clone()
-        .unwrap_or_else(|| llm_model.ollama_model_id().to_string());
-    let ollama_url = app_config.effective_ollama_url().to_string();
+    }
+
+    let backend = resolved.backend.clone();
+    let model = resolved.model.clone();
+    let source = resolved.source.as_str().to_string();
+    let key_source = resolved.api_key_source.as_str().to_string();
+    let tier_str = feature_tier.as_str().to_string();
+
+    // The resolver pin is sync, but the actual client construction
+    // (which spins reqwest::blocking inside the http builder chain)
+    // must still run in `spawn_blocking` to avoid panicking the
+    // tokio executor.
     let build = match tokio::task::spawn_blocking(move || {
-        llm::OllamaClient::new_with_url(&ollama_url, &model_id)
+        llm::OllamaClient::build_from_resolved(&resolved)
     })
     .await
     {
         Ok(b) => b,
         Err(e) => {
-            tracing::warn!("L5: build_llm_client spawn_blocking join failed: {e}");
+            tracing::warn!(
+                "L5: build_llm_client spawn_blocking join failed (tier={tier_str}): {e}"
+            );
             return None;
         }
     };
+
     match build {
-        Ok(client) => {
+        Ok(Some(client)) => {
             tracing::info!(
-                "L5: llm client ready — tier={} model={} (legacy ollama fallback; \
-                 set AI_MEMORY_LLM_BACKEND for provider-agnostic access) — \
-                 auto_tag hook armed for HTTP create_memory",
-                feature_tier.as_str(),
-                llm_model.ollama_model_id(),
+                "L5: llm client ready — tier={tier_str} backend={backend} \
+                 model={model} source={source} key_source={key_source} \
+                 — auto_tag/expand_query/contradiction-detection/reflection \
+                 hooks armed (#1146 resolver path)"
             );
             Some(client)
         }
+        Ok(None) => {
+            tracing::warn!(
+                "L5: llm client disabled — resolver returned no client \
+                 (tier={tier_str} backend={backend} source={source}); \
+                 LLM-powered hooks are no-ops"
+            );
+            None
+        }
         Err(e) => {
             tracing::warn!(
-                "L5: llm client init failed (tier={}); auto_tag hook will be a no-op: {e}",
-                feature_tier.as_str()
+                "L5: llm client init failed (tier={tier_str} backend={backend} \
+                 source={source}); LLM-powered hooks are no-ops: {e}"
             );
             None
         }
@@ -3973,23 +3941,18 @@ pub async fn run_curator_daemon_with_primitives(
         exclude_namespaces,
         compaction: crate::curator::CompactionConfig::default(),
     };
-    // #1143: honor AI_MEMORY_LLM_BACKEND env even on the legacy
-    // primitive-args entrypoint (used by some CLI shims and tests).
-    // The explicit `ollama_model` arg still wins when env is unset, so
-    // older callers that hardcoded a model retain their behavior.
+    // v0.7.x (#1146) — route through the canonical resolver.
+    // `ollama_model` retained as a CLI/test override for the model
+    // field only; backend / base_url / api_key still flow through the
+    // resolver. If the caller passed an explicit `ollama_model`, the
+    // resolver honors it via the CLI-flag arm of the precedence ladder.
     let llm: Option<Arc<crate::llm::OllamaClient>> = {
-        let backend_env = std::env::var("AI_MEMORY_LLM_BACKEND")
+        let app_config = AppConfig::load();
+        let resolved = app_config.resolve_llm(None, ollama_model.as_deref(), None);
+        crate::llm::OllamaClient::build_from_resolved(&resolved)
             .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-        if backend_env.is_some() {
-            crate::llm::OllamaClient::from_env()
-                .ok()
-                .flatten()
-                .map(Arc::new)
-        } else {
-            ollama_model.and_then(|m| crate::llm::OllamaClient::new(&m).ok().map(Arc::new))
-        }
+            .flatten()
+            .map(Arc::new)
     };
 
     let shutdown_flag = Arc::new(AtomicBool::new(false));

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -3950,13 +3950,31 @@ pub async fn run_curator_daemon_with_primitives(
     // field only; backend / base_url / api_key still flow through the
     // resolver. If the caller passed an explicit `ollama_model`, the
     // resolver honors it via the CLI-flag arm of the precedence ladder.
+    //
+    // No-construct short-circuit (mirrors `build_curator_llm` +
+    // `build_llm_client`): when the caller didn't supply
+    // `ollama_model` AND the resolver's source lands on
+    // `CompiledDefault` (no env, no [llm] section, no legacy field
+    // anywhere), don't pull a client into existence. Avoids paying a
+    // blocking reqwest call to a (likely-absent) Ollama under tokio
+    // test contexts and matches pre-#1146 v0.6.x behaviour where the
+    // ollama_model-None caller path produced no client.
     let llm: Option<Arc<crate::llm::OllamaClient>> = {
         let app_config = AppConfig::load();
         let resolved = app_config.resolve_llm(None, ollama_model.as_deref(), None);
-        crate::llm::OllamaClient::build_from_resolved(&resolved)
-            .ok()
-            .flatten()
-            .map(Arc::new)
+        if ollama_model.is_none()
+            && matches!(
+                resolved.source,
+                crate::config::ConfigSource::CompiledDefault
+            )
+        {
+            None
+        } else {
+            crate::llm::OllamaClient::build_from_resolved(&resolved)
+                .ok()
+                .flatten()
+                .map(Arc::new)
+        }
     };
 
     let shutdown_flag = Arc::new(AtomicBool::new(false));

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -222,6 +222,15 @@ pub enum Command {
     /// Batman Forms 2 + 6 dormant on most installs by replacing the
     /// MCP-stdio JSON-RPC dance with first-class CLI surface.
     Namespace(crate::cli::namespace::NamespaceArgs),
+    /// v0.7.x (#1146) — enterprise configuration tooling.
+    /// `ai-memory config migrate` rewrites a legacy v1 (flat-field)
+    /// `config.toml` to the v2 sectioned shape (`[llm]`, `[embeddings]`,
+    /// `[reranker]`, `[storage]`) with a timestamped `.bak` backup.
+    /// `--dry-run` prints the diff without writing.
+    /// `--also-clean-claude-json` additionally removes the
+    /// `mcpServers.<*>.env` block from `~/.claude.json` after the
+    /// operator has verified the new config.
+    Config(crate::cli::commands::config::ConfigCliArgs),
     /// Export all memories as JSON
     Export,
     /// Import memories from JSON (stdin)
@@ -922,6 +931,20 @@ pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
             let mut se = stderr.lock();
             let mut out = cli::CliOutput::from_std(&mut so, &mut se);
             cli::namespace::run(&db_path, a, j, &mut out)
+        }
+        Command::Config(a) => {
+            // v0.7.x (#1146) — enterprise configuration tooling.
+            // `ai-memory config migrate` rewrites a legacy v1
+            // (flat-field) `config.toml` to the v2 sectioned shape.
+            let stdout = std::io::stdout();
+            let stderr = std::io::stderr();
+            let mut so = stdout.lock();
+            let mut se = stderr.lock();
+            let mut out = cli::CliOutput::from_std(&mut so, &mut se);
+            match cli::commands::config::run(&db_path, a, &mut out)? {
+                0 => Ok(()),
+                code => std::process::exit(code),
+            }
         }
         Command::Export => {
             let stdout = std::io::stdout();

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1774,22 +1774,26 @@ pub async fn build_llm_client(
     // shows which precedence layer won.
     let resolved = app_config.resolve_llm(None, None, None);
 
-    // Keyword tier short-circuit: when there is no explicit operator
-    // intent (no CLI flag, no env var, no [llm] section, no legacy
-    // flat fields — i.e. source == CompiledDefault), the resolver's
-    // Ollama-default-fallback should NOT pull a client into existence
-    // for a keyword-tier daemon. Operators who explicitly want LLM
-    // on keyword tier set AI_MEMORY_LLM_BACKEND (or write a [llm]
-    // section), which moves `source` off the CompiledDefault arm.
-    if matches!(feature_tier, FeatureTier::Keyword)
+    // No-preset-tier short-circuit: when the tier has no compiled
+    // `llm_model` preset (Keyword + Semantic at v0.7.0) AND there is
+    // no explicit operator intent (resolver `source == CompiledDefault`),
+    // the resolver's Ollama-default-fallback should NOT pull a client
+    // into existence. This matches pre-#1146 v0.6.x behaviour and
+    // avoids paying a blocking reqwest call to a (likely-absent)
+    // Ollama under tokio test contexts. Operators who explicitly
+    // want an LLM on Keyword/Semantic set AI_MEMORY_LLM_BACKEND or
+    // write a [llm] section, which moves `source` off the
+    // CompiledDefault arm.
+    if feature_tier.config().llm_model.is_none()
         && matches!(
             resolved.source,
             crate::config::ConfigSource::CompiledDefault
         )
     {
         tracing::debug!(
-            "L5: llm client disabled — keyword tier with no operator LLM config; \
-             set AI_MEMORY_LLM_BACKEND or [llm] section to enable"
+            "L5: llm client disabled — tier={} has no llm_model preset AND no \
+             operator LLM config; set AI_MEMORY_LLM_BACKEND or [llm] section to enable",
+            feature_tier.as_str()
         );
         return None;
     }

--- a/src/handlers/kg.rs
+++ b/src/handlers/kg.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 
 use crate::db;
 #[cfg(feature = "sal")]
-use crate::models::{Memory, Tier};
+use crate::models::Tier;
 use crate::validate;
 
 use super::AppState;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -388,6 +388,66 @@ impl OllamaClient {
         Self::new_with_url(legacy_url, legacy_model).map(Some)
     }
 
+    /// v0.7.x (#1146) — Construct an `OllamaClient` from a fully-resolved
+    /// LLM configuration produced by [`crate::config::AppConfig::resolve_llm`].
+    /// This is the enterprise-class single-entry-point that replaces
+    /// every call to [`Self::build_for_init`] /
+    /// [`Self::new_with_url`] / [`Self::from_env`] /
+    /// [`Self::new_openai_compatible`] in the surface plumbing.
+    ///
+    /// The resolver has already done all precedence + provenance work
+    /// (CLI flag > env > [llm] config section > legacy fields >
+    /// compiled default) and produced a [`ResolvedLlm`] carrying the
+    /// authoritative `(backend, model, base_url, api_key)` quad. This
+    /// constructor just maps it onto the appropriate wire-shape
+    /// client.
+    ///
+    /// Returns `Ok(None)` when the resolved `api_key_source` is
+    /// `KeySource::Error(_)` and the backend is non-Ollama (so we
+    /// can't even attempt to construct an OpenAI-compatible client).
+    /// The error surfaces through the `ai-memory doctor` LLM
+    /// reachability probe rather than panicking at construct time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client itself fails to build, or
+    /// if the Ollama-backend reachability check fails the same way
+    /// [`Self::new_with_url`] already fails.
+    pub fn build_from_resolved(resolved: &crate::config::ResolvedLlm) -> Result<Option<Self>> {
+        // Surface the resolved provenance for operator-facing debugging
+        // (RUST_LOG=ai_memory=debug ai-memory <cmd>).
+        tracing::debug!(
+            "LLM client construction via #1146 resolver — backend={}, model={}, base_url={}, key_source={}, source={}",
+            resolved.backend,
+            resolved.model,
+            resolved.base_url,
+            resolved.api_key_source.as_str(),
+            resolved.source.as_str(),
+        );
+
+        if resolved.backend == "ollama" {
+            return Self::new_with_url(&resolved.base_url, &resolved.model).map(Some);
+        }
+
+        // Non-Ollama backends require an API key. If the resolver
+        // could not produce one, surface the error via a returned
+        // `Err` (consistent with the pre-#1143 `from_env` posture).
+        let Some(api_key) = resolved.api_key() else {
+            return Err(anyhow!(
+                "LLM backend `{}` requires an API key but the resolver \
+                 produced none. KeySource = {}. Configure either \
+                 AI_MEMORY_LLM_API_KEY, a per-vendor env var (e.g. \
+                 XAI_API_KEY), [llm].api_key_env, or [llm].api_key_file \
+                 in config.toml. See \
+                 https://github.com/alphaonedev/ai-memory-mcp/issues/1146",
+                resolved.backend,
+                resolved.api_key_source.as_str(),
+            ));
+        };
+
+        Self::new_openai_compatible(&resolved.base_url, &resolved.model, api_key).map(Some)
+    }
+
     /// #1143 — Wire-shape introspection for embed-client fallback.
     /// Embed endpoints differ from chat endpoints across vendors: only
     /// Ollama (and a couple of OpenAI-compatible vendors) expose a

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2145,58 +2145,62 @@ pub fn run_mcp_server(
     // CLI `curator`) shares one resolution rule. Behavioural parity
     // with the daemon's async wrapper is pinned by tests in
     // `src/llm.rs::tests::build_for_init_*`.
-    let backend_env = std::env::var("AI_MEMORY_LLM_BACKEND")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-    let llm: Option<Arc<OllamaClient>> = if let Some(backend) = backend_env {
-        match OllamaClient::from_env() {
+    // v0.7.x (#1146) — single canonical entry through the resolver.
+    // The resolver folds CLI flags (none at MCP boot), AI_MEMORY_LLM_*
+    // env vars, the [llm] config section, the legacy
+    // `llm_model`/`ollama_url` flat fields, and the compiled tier
+    // preset. The provenance fields on `ResolvedLlm` (`source`,
+    // `api_key_source`) surface in the startup banner so the operator
+    // can see WHICH layer won.
+    let resolved_llm = app_config.resolve_llm(None, None, None);
+    let llm: Option<Arc<OllamaClient>> = if tier_config.llm_model.is_none()
+        && resolved_llm.source == crate::config::ConfigSource::CompiledDefault
+    {
+        // Keyword tier with no operator config: LLM intentionally disabled.
+        None
+    } else {
+        match OllamaClient::build_from_resolved(&resolved_llm) {
             Ok(Some(client)) => {
-                let model_env = std::env::var("AI_MEMORY_LLM_MODEL")
-                    .ok()
-                    .unwrap_or_else(|| "<default-for-backend>".to_string());
-                eprintln!("ai-memory: LLM ready (backend={backend}, model={model_env})");
-                Some(Arc::new(client))
-            }
-            Ok(None) => {
                 eprintln!(
-                    "ai-memory: LLM disabled — AI_MEMORY_LLM_BACKEND={backend} resolved to None"
+                    "ai-memory: LLM ready (backend={}, model={}, source={}, key_source={})",
+                    resolved_llm.backend,
+                    resolved_llm.model,
+                    resolved_llm.source.as_str(),
+                    resolved_llm.api_key_source.as_str(),
                 );
-                None
-            }
-            Err(e) => {
-                eprintln!(
-                    "ai-memory: LLM init failed (backend={backend}): {e} (LLM features disabled)"
-                );
-                None
-            }
-        }
-    } else if let Some(ref llm_model) = tier_config.llm_model {
-        let model_id = llm_model.ollama_model_id();
-        eprintln!(
-            "ai-memory: connecting to Ollama for {} (legacy tier-default; set \
-             AI_MEMORY_LLM_BACKEND for provider-agnostic access) ...",
-            llm_model.display_name()
-        );
-        let ollama_url = app_config.effective_ollama_url();
-        match OllamaClient::new_with_url(ollama_url, model_id) {
-            Ok(client) => {
-                eprintln!("ai-memory: Ollama connected, ensuring model {model_id} is available...");
-                if let Err(e) = client.ensure_model() {
-                    eprintln!("ai-memory: model pull failed: {e} (LLM features disabled)");
-                    None
+                // For ollama backends, exercise the legacy ensure_model
+                // pull step so first-run UX (model not on disk) still
+                // emits the pull-progress hint.
+                if resolved_llm.backend == "ollama" {
+                    if let Err(e) = client.ensure_model() {
+                        eprintln!("ai-memory: model pull failed: {e} (LLM features disabled)");
+                        None
+                    } else {
+                        Some(Arc::new(client))
+                    }
                 } else {
-                    eprintln!("ai-memory: LLM ready ({})", llm_model.display_name());
                     Some(Arc::new(client))
                 }
             }
+            Ok(None) => {
+                eprintln!(
+                    "ai-memory: LLM disabled — resolver returned no client \
+                     (backend={}, source={})",
+                    resolved_llm.backend,
+                    resolved_llm.source.as_str(),
+                );
+                None
+            }
             Err(e) => {
-                eprintln!("ai-memory: Ollama not available: {e} (LLM features disabled)");
+                eprintln!(
+                    "ai-memory: LLM init failed (backend={}, source={}): {e} \
+                     (LLM features disabled)",
+                    resolved_llm.backend,
+                    resolved_llm.source.as_str(),
+                );
                 None
             }
         }
-    } else {
-        None
     };
 
     // --- Initialize embedder (semantic tier and above) ---

--- a/tests/sr3_perf_regressions.rs
+++ b/tests/sr3_perf_regressions.rs
@@ -34,6 +34,16 @@
 
 #![allow(clippy::doc_markdown)]
 
+/// v0.7.x (#1146 PR #1147 cycle 5) — normalise CRLF → LF on Windows
+/// checkouts so the source-pattern matchers below (which use `\n`
+/// literals) match regardless of platform line-ending posture. The
+/// gates pre-#1146 were Linux-only via the matrix; the rebased PR
+/// surfaced the gap. Pure transform — no behaviour change on Linux
+/// / macOS where `\r\n` does not appear.
+fn lf(source: &str) -> String {
+    source.replace("\r\n", "\n")
+}
+
 // -----------------------------------------------------------------
 // #1077 — tool_definitions() memoization (source-level pin)
 // -----------------------------------------------------------------
@@ -47,7 +57,7 @@
 
 #[test]
 fn sr3_1077_tool_definitions_has_oncelock_cache() {
-    let source = include_str!("../src/mcp/registry.rs");
+    let source = lf(include_str!("../src/mcp/registry.rs"));
     // The bare `tool_definitions()` function must memoize the catalog.
     assert!(
         source.contains("static CACHE: std::sync::OnceLock<Value> = std::sync::OnceLock::new();"),
@@ -88,7 +98,7 @@ fn sr3_1093_eviction_ring_is_vecdeque_not_vec() {
     // Source-level pin via the static declaration. A regression
     // that switches back to `Vec<u64>` would change the declared
     // type and break this grep-flavored read.
-    let source = include_str!("../src/hnsw.rs");
+    let source = lf(include_str!("../src/hnsw.rs"));
     assert!(
         source.contains("Mutex<std::collections::VecDeque<u64>>"),
         "EVICTION_RATE_RING must be Mutex<VecDeque<u64>> post-#1093"
@@ -111,7 +121,7 @@ fn sr3_1093_eviction_ring_is_vecdeque_not_vec() {
 
 #[test]
 fn sr3_1105_mcp_dispatch_is_hashmap_lookup() {
-    let source = include_str!("../src/mcp/mod.rs");
+    let source = lf(include_str!("../src/mcp/mod.rs"));
     // The post-#1105 implementation builds a `HashMap` via
     // `OnceLock` and looks up via `map.get(tool_name).copied()`.
     assert!(
@@ -144,7 +154,7 @@ fn sr3_1105_mcp_dispatch_is_hashmap_lookup() {
 
 #[test]
 fn sr3_1072_subscription_dispatch_reuses_worker_conn() {
-    let source = include_str!("../src/subscriptions.rs");
+    let source = lf(include_str!("../src/subscriptions.rs"));
     // The post-#1072 worker thread opens ONE Connection at entry and
     // routes all four sqlite writes (record_subscription_event,
     // update_event_status, record_dispatch, record_dlq) through the
@@ -193,7 +203,7 @@ fn sr3_1073_dispatch_http_client_scaffolding_exists() {
     // SSRF correctness gate wins over the per-attempt builder cost;
     // this pin documents that the accessor exists and the OnceLock
     // shape is correct for the future swap-in.
-    let source = include_str!("../src/subscriptions.rs");
+    let source = lf(include_str!("../src/subscriptions.rs"));
     assert!(
         source.contains("fn dispatch_http_client() -> Option<&'static reqwest::blocking::Client>"),
         "dispatch_http_client() scaffolding must exist post-#1073"
@@ -210,7 +220,7 @@ fn sr3_1073_dispatch_http_client_scaffolding_exists() {
 
 #[test]
 fn sr3_1097_dispatch_uses_list_by_event() {
-    let source = include_str!("../src/subscriptions.rs");
+    let source = lf(include_str!("../src/subscriptions.rs"));
     let dispatch_fn = source
         .split("pub fn dispatch_event_with_details(")
         .nth(1)
@@ -246,7 +256,7 @@ fn sr3_1097_dispatch_uses_list_by_event() {
 
 #[test]
 fn sr3_1079_touch_after_recall_uses_touch_many() {
-    let source = include_str!("../src/store/sqlite.rs");
+    let source = lf(include_str!("../src/store/sqlite.rs"));
     let fn_body = source
         .split("async fn touch_after_recall(")
         .nth(1)
@@ -271,7 +281,7 @@ fn sr3_1079_touch_after_recall_uses_touch_many() {
 
 #[test]
 fn sr3_1084_embedder_local_no_mutex() {
-    let source = include_str!("../src/embeddings.rs");
+    let source = lf(include_str!("../src/embeddings.rs"));
     let local_variant = source
         .split("    Local {")
         .nth(1)
@@ -290,7 +300,7 @@ fn sr3_1084_embedder_local_no_mutex() {
 
 #[test]
 fn sr3_1084_crossencoder_neural_no_mutex() {
-    let source = include_str!("../src/reranker.rs");
+    let source = lf(include_str!("../src/reranker.rs"));
     let neural_variant = source
         .split("    Neural {\n        model:")
         .nth(1)
@@ -315,7 +325,7 @@ fn sr3_1084_crossencoder_neural_no_mutex() {
 
 #[test]
 fn sr3_1087_hnsw_search_caches_valid_ids() {
-    let source = include_str!("../src/hnsw.rs");
+    let source = lf(include_str!("../src/hnsw.rs"));
     assert!(
         source.contains("valid_ids_cache: Option<std::collections::HashSet<String>>"),
         "IndexState must carry a cached valid_ids set post-#1087"
@@ -360,7 +370,7 @@ fn sr3_1087_hnsw_search_caches_valid_ids() {
 
 #[test]
 fn sr3_1091_session_recency_uses_callback_membership() {
-    let source = include_str!("../src/reranker.rs");
+    let source = lf(include_str!("../src/reranker.rs"));
     assert!(
         source.contains("pub fn with_recent_ids<R>("),
         "with_recent_ids callback API must exist post-#1091"


### PR DESCRIPTION
## Summary

Closes [#1146](https://github.com/alphaonedev/ai-memory-mcp/issues/1146) (subsumes #1143). 12-commit campaign consolidating ai-memory's fragmented configuration surface into a sectioned v2 schema with one canonical resolver every surface consumes (`AppConfig::resolve_llm` etc.). Triggered by an operator-visible defect where the boot banner reported `llm=gemma4:e4b` (compiled tier preset) while the live MCP server was actually routing to `xai/grok-4.3`.

Commit log: `git log 8d511185f..HEAD --oneline` on this branch.

## What changed (operator-facing)

- **Schema v2** in `~/.config/ai-memory/config.toml`: `[llm]` / `[llm.auto_tag]` / `[embeddings]` / `[reranker]` / `[storage]` sections + explicit `schema_version = 2`.
- **Canonical resolver** consumed by 7 surfaces (MCP, HTTP daemon, atomise, curator, daemon-primitives, boot banner, doctor). Uniform precedence ladder: CLI > AI_MEMORY_LLM_* env > section > legacy fields > compiled default.
- **Secret-handling discipline**: inline `[llm].api_key = "<literal>"` rejected at parse time. `api_key_env` / `api_key_file` (mode 0400, #1055 escape hatch reused) are the only sanctioned sources. `ResolvedLlm::Debug` redacts.
- **New `ai-memory config migrate [--dry-run] [--also-clean-claude-json]`** — idempotent; timestamped `.bak`.
- **New `ai-memory doctor` section `LLM Reachability (#1146)`** with 7-bucket severity partition (INFO/WARN/CRIT).
- **Boot banner upgrade**: `llm=<backend>:<model>` (e.g. `llm=xai:grok-4.3`) when backend is non-Ollama.

## Test plan

- [x] `cargo fmt --check`: GREEN at every commit
- [x] `cargo clippy --release --lib -- -D warnings -D clippy::all -D clippy::pedantic`: GREEN at every commit
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --release --lib`: GREEN at every commit (4700 passed at HEAD; 4681 baseline + 19 new `*1146*` tests)
- [x] Live smoke: `ai-memory boot --quiet` reports `llm=xai:grok-4.3` under env, `llm=gemma4:e4b` under legacy config
- [x] Live smoke: `ai-memory config migrate --dry-run` produces clean v2 sectioned output from operator's actual v1 config

## QC

Pre-implementation QC surfaced 9 spec defects, all addressed via amendment posted at https://github.com/alphaonedev/ai-memory-mcp/issues/1146#issuecomment-4523600642 BEFORE any code landed.

## Docs (per operator "100% all documentation" mandate)

- CLAUDE.md `### Config schema v0.7.x (#1146)` subsection added
- New `docs/CONFIG_SCHEMA.md` canonical reference (precedence, secret discipline, migration, reachability probe, API-key chain, backend defaults table)
- README.md config example updated to v2 shape
- CHANGELOG.md `[Unreleased]` entry

Migration impact: existing v0.6.x deployments boot unchanged with a single-line WARN. Legacy fields removed in v0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)