### PR TITLE
refactor(#1174): pm-v3.1 PR4 — substrate "ollama" backend literal sweep

### DIFF
--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -412,12 +412,15 @@ impl BootManifest {
             resolved_emb.model.clone()
         };
 
-        // LLM: `backend:model` provenance. When backend == "ollama" we
-        // emit just the model (legacy banner shape) so existing
-        // grep'ing tools that match `llm=gemma3:4b` continue to work;
-        // when backend != "ollama" the full `xai:grok-4.3` shape is
-        // emitted so the operator-facing disambiguation is loud.
-        let llm = if resolved_llm.backend == "ollama" {
+        // LLM: `backend:model` provenance. On the Ollama-native wire
+        // shape we emit just the model (legacy banner shape) so
+        // existing grep'ing tools that match `llm=gemma3:4b` continue
+        // to work; on any OpenAI-compatible vendor the full
+        // `xai:grok-4.3` shape is emitted so the operator-facing
+        // disambiguation is loud. The vendor-literal check lives on
+        // `ResolvedLlm` (issue #1174 PR4 — substrate-vendor cleanup)
+        // so the banner code never re-names the backend.
+        let llm = if resolved_llm.is_ollama_native() {
             resolved_llm.model.clone()
         } else {
             resolved_llm.display_label()

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -303,10 +303,14 @@ fn build_migrated_table(
     // were either redundant or operator drift; drop them.)
     if !migrated.contains_key("llm") && llm_model.is_some() {
         let mut llm = toml::map::Map::new();
-        // Legacy implied Ollama.
+        // Legacy v1 configs implied the Ollama-native backend
+        // (`llm_model` + `ollama_url` were the only LLM knobs).
+        // Reference the canonical backend-name const in `llm.rs`
+        // (issue #1174 PR4 — substrate-vendor cleanup) so the
+        // migrator never re-names the vendor.
         llm.insert(
             "backend".to_string(),
-            toml::Value::String("ollama".to_string()),
+            toml::Value::String(crate::llm::BACKEND_OLLAMA.to_string()),
         );
         if let Some(v) = llm_model {
             llm.insert("model".to_string(), v);
@@ -326,9 +330,11 @@ fn build_migrated_table(
     // [embeddings] section.
     if !migrated.contains_key("embeddings") && (embed_url.is_some() || embedding_model.is_some()) {
         let mut emb = toml::map::Map::new();
+        // Same legacy implication for embeddings — pre-v0.7.x configs
+        // only spoke to Ollama for embedding generation.
         emb.insert(
             "backend".to_string(),
-            toml::Value::String("ollama".to_string()),
+            toml::Value::String(crate::llm::BACKEND_OLLAMA.to_string()),
         );
         if let Some(v) = embed_url {
             emb.insert("url".to_string(), v);

--- a/src/config.rs
+++ b/src/config.rs
@@ -3189,9 +3189,15 @@ impl ResolvedLlm {
     /// True when the resolved backend uses the Ollama-native wire
     /// shape (`/api/chat`, `/api/embed`, no auth). False for any
     /// OpenAI-compatible vendor.
+    ///
+    /// Compares `self.backend` against the canonical
+    /// [`crate::llm::BACKEND_OLLAMA`] selector (#1174 PR4 substrate
+    /// cleanup) so the literal lives in `llm.rs` alongside the rest
+    /// of the vendor-alias tables instead of being re-named at each
+    /// substrate site.
     #[must_use]
     pub fn is_ollama_native(&self) -> bool {
-        self.backend == "ollama"
+        self.backend == crate::llm::BACKEND_OLLAMA
     }
 
     /// Display string for the boot banner: `<backend>:<model>`.

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -40,6 +40,23 @@ use std::time::{Duration, Instant};
 
 const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 
+/// v0.7.x (#1174 PR4-remainder) — canonical name of the Ollama-native
+/// backend selector.
+///
+/// Used in `AI_MEMORY_LLM_BACKEND`, the `[llm].backend` config field,
+/// and the `ResolvedLlm::backend` runtime view. Every substrate site
+/// that needs to ask "is this the native-Ollama wire shape?" must
+/// either reference this const (for string compares against the wire
+/// value) or call [`crate::config::ResolvedLlm::is_ollama_native`]
+/// (the typed accessor that wraps the comparison).
+///
+/// Centralising the literal here keeps the heterogeneous-NHI substrate
+/// (#1067) from re-naming a single vendor across `cli/`, `mcp/`,
+/// `handlers/`, etc. Per PR #1175 + this PR, vendor names belong in
+/// `llm.rs` aliases / `config.rs` alias tables, not scattered across
+/// the codebase.
+pub const BACKEND_OLLAMA: &str = "ollama";
+
 /// Per-vendor default base URLs for the OpenAI-compatible alias
 /// backends. Operator-provided `AI_MEMORY_LLM_BASE_URL` overrides
 /// these. Verified against vendor documentation as of 2026-Q2.


### PR DESCRIPTION
## Summary

PR4 of the #1174 codegraph-driven pm-v3.1 global refactor sweep ([NO FAIL MISSION](https://github.com/alphaonedev/ai-memory-mcp/issues/1174), pm-v3.2 governance — ai-memory memory `2cb15d34-2399-4611-a020-df6ef91683fe`).

Sweeps the genuinely-substrate-coupled `"ollama"` backend literals across `src/cli/` and `src/config.rs` behind a single `pub const BACKEND_OLLAMA` in `src/llm.rs`. Four substrate sites collapse behind one canonical const; wire shape preserved byte-for-byte.

## Changes

| File | Change |
|---|---|
| `src/llm.rs` | New `pub const BACKEND_OLLAMA: &str = "ollama"` with thorough doc explaining the single-source-of-truth contract. |
| `src/config.rs` | `ResolvedLlm::is_ollama_native()` now compares against `crate::llm::BACKEND_OLLAMA` instead of the inline literal. |
| `src/cli/boot.rs` | Banner LLM display formatting now calls `resolved_llm.is_ollama_native()` (typed accessor) instead of `resolved_llm.backend == "ollama"` string compare. |
| `src/cli/commands/config.rs` | v1 → v2 config migrator references `crate::llm::BACKEND_OLLAMA` when scaffolding default `[llm].backend` / `[embeddings].backend` strings. |

## Inventory false-positives documented (deliberately NOT touched)

The pm-v3.1 audit inventory at `.local-runs/refactor-pmv31-audit-20260524-120814/INVENTORY.md` flagged a broader scope; inspection confirmed several sites are legitimately per-vendor by design:

- **`src/cli/io.rs` (8 sites of `format: "claude"`)**: test fixture data for `MineArgs.format`, referring to the documented `Format::Claude` mine-conversation parser variant. The literal IS the canonical Claude-export format identifier.
- **`src/cli/wrap.rs` (7 sites of per-vendor `WrapStrategy`)**: per-vendor CLI integration table. Each vendor's CLI has a different system-prompt mechanism (`gemini --system` vs `ollama OLLAMA_SYSTEM`); the table IS the source of truth for which mechanism each vendor accepts. Per-vendor by necessity, not by monoculture.
- **`src/harness.rs:264` doc comment**: prose documentation. Comments aren't code; the historical context being Claude-first is correct.

Documented here for the Phase 2 triage subagent so they don't get re-flagged.

## Engineering discipline (per pm-v3.1)

- `BACKEND_OLLAMA` is a single `pub const` — one source of truth.
- The typed accessor `ResolvedLlm::is_ollama_native()` already existed; this PR routes inline comparisons through it so the literal lives in `llm.rs` alongside the rest of the vendor-alias surface.
- Wire-shape preserved: operators using `[llm].backend = "ollama"` continue to land at the correct dispatch branch.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | clean |
| `cargo test --lib` | 4740/4740 pass |

## Provenance

Drafted by general-purpose worktree-isolated subagent (agent `ac83e82edf594a726`). The agent stopped at "wait for test monitor notification" without completing the commit/push/PR workflow; parent orchestrator (Claude Opus 4.7) verified the partial work was semantically correct (per pm-v3 verify-before-claiming), ran the four gates locally, committed, and opened this PR.

Wave 1 sibling PRs in flight in parallel:
- PR1 (`refactor/1174-pmv31-mcp-tool-name-consts`) — 73 MCP tool name consts (~150 sites)
- PR3 (`refactor/1174-pmv31-time-secs-const`) — `SECS_PER_HOUR/_DAY/_WEEK` (~50 sites)
- PR6 (`refactor/1174-pmv31-tier-enum-as-str`) — Tier enum sweep (~125 sites)

Per pm-v3.2 NO FAIL MISSION closure gate: this PR is one of 9 train PRs whose collective state must pass 3 independent codegraph-driven QC audits before #1174 can close.

## AI involvement

Drafted by general-purpose subagent + verified/completed by Claude Opus 4.7 (1M context).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
