### PR TITLE
refactor(#1174): pm-v3.1 PR6 — sweep raw tier strings to Tier::<X>.as_str()

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -976,6 +976,7 @@ fn mark_append_only(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::Tier;
 
     fn sample_event(seq: u64, prev: &str) -> AuditEvent {
         let mut ev = AuditEvent {
@@ -988,7 +989,7 @@ mod tests {
                 format!("mem-{seq}"),
                 "ns-x",
                 Some("title".to_string()),
-                Some("mid".to_string()),
+                Some(Tier::Mid.as_str().to_string()),
                 None,
             ),
             outcome: AuditOutcome::Allow,
@@ -1767,10 +1768,10 @@ mod tests {
             "mem-1",
             "ns-x",
             Some("title".to_string()),
-            Some("long".to_string()),
+            Some(Tier::Long.as_str().to_string()),
             Some("team".to_string()),
         );
-        assert_eq!(t.tier.as_deref(), Some("long"));
+        assert_eq!(t.tier.as_deref(), Some(Tier::Long.as_str()));
         assert_eq!(t.scope.as_deref(), Some("team"));
     }
 

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -481,6 +481,7 @@ mod tests {
         AuditAction as AAct, AuditOutcome, CHAIN_HEAD_PREV_HASH, EventBuilder, actor, target_memory,
     };
     use crate::config::AuditConfig;
+    use crate::models::Tier;
 
     fn write_chained_log(dir: &Path) -> std::path::PathBuf {
         // Build a 3-line chain by hand using the public API; we use
@@ -512,7 +513,7 @@ mod tests {
                 format!("mem-{seq}"),
                 "ns-x",
                 Some("title".to_string()),
-                Some("mid".to_string()),
+                Some(Tier::Mid.as_str().to_string()),
                 None,
             ),
             outcome: AuditOutcome::Allow,

--- a/src/cli/crud.rs
+++ b/src/cli/crud.rs
@@ -415,7 +415,7 @@ mod tests {
         }
         let cfg = config::AppConfig::default();
         let mut args = list_args();
-        args.tier = Some("long".to_string());
+        args.tier = Some(Tier::Long.as_str().to_string());
         {
             let mut out = env.output();
             cmd_list(&db, &args, true, &cfg, &mut out).unwrap();
@@ -423,7 +423,7 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
         let mems = v["memories"].as_array().unwrap();
         assert_eq!(mems.len(), 1);
-        assert_eq!(mems[0]["tier"].as_str().unwrap(), "long");
+        assert_eq!(mems[0]["tier"].as_str().unwrap(), Tier::Long.as_str());
     }
 
     #[test]

--- a/src/cli/forget.rs
+++ b/src/cli/forget.rs
@@ -189,7 +189,7 @@ mod tests {
             .unwrap();
         }
         let mut a = args();
-        a.tier = Some("long".to_string());
+        a.tier = Some(Tier::Long.as_str().to_string());
         // Round-2 F11 — `forget --tier` without `--namespace` requires
         // the global confirmation flag.
         a.confirm_global = true;
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     fn requires_global_confirmation_tier_no_namespace() {
         let mut a = args();
-        a.tier = Some("long".into());
+        a.tier = Some(Tier::Long.as_str().into());
         assert!(requires_global_confirmation(&a));
     }
 

--- a/src/cli/io.rs
+++ b/src/cli/io.rs
@@ -31,6 +31,12 @@ pub struct MineArgs {
     #[arg(long, short)]
     pub namespace: Option<String>,
     /// Memory tier for imported memories
+    ///
+    /// `default_value` must be a literal at attribute-parse time, so
+    /// the wire string is kept here verbatim; it is byte-equal to
+    /// `crate::models::Tier::Mid.as_str()` (pm-v3.1 PR6 #1174 sweep —
+    /// raw tier literals are confined to the deserializer + clap
+    /// `default_value` attrs that cannot accept const expressions).
     #[arg(long, short, default_value = "mid")]
     pub tier: String,
     /// Minimum message count to import a conversation
@@ -533,7 +539,7 @@ mod tests {
             "memories": [
                 {
                     "id": "11111111-1111-1111-1111-111111111111",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "",  // invalid: empty title
                     "content": "c",
@@ -550,7 +556,7 @@ mod tests {
                 },
                 {
                     "id": "22222222-2222-2222-2222-222222222222",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "valid-row",
                     "content": "c",
@@ -674,7 +680,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("mined-ns".to_string()),
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };
@@ -705,7 +711,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("mined-ns".to_string()),
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };
@@ -732,7 +738,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("mined-real".to_string()),
-            tier: "long".to_string(),
+            tier: Tier::Long.as_str().to_string(),
             min_messages: 3,
             dry_run: false,
         };
@@ -774,7 +780,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("mined-json".to_string()),
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: false,
         };
@@ -784,7 +790,7 @@ mod tests {
         }
         let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
         assert_eq!(v["namespace"].as_str().unwrap(), "mined-json");
-        assert_eq!(v["tier"].as_str().unwrap(), "mid");
+        assert_eq!(v["tier"].as_str().unwrap(), Tier::Mid.as_str());
         assert!(v["imported"].as_u64().unwrap() >= 1);
     }
 
@@ -800,7 +806,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: None,
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };
@@ -824,7 +830,7 @@ mod tests {
             path: p,
             format: "myspace".to_string(), // not claude/chatgpt/slack
             namespace: None,
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };
@@ -871,7 +877,7 @@ mod tests {
             "memories": [
                 {
                     "id": "33333333-3333-3333-3333-333333333333",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "tt",
                     "content": "cc",
@@ -912,7 +918,7 @@ mod tests {
             "memories": [
                 {
                     "id": "44444444-4444-4444-4444-444444444444",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "",  // empty title fails validate
                     "content": "c",
@@ -988,7 +994,7 @@ mod tests {
             "memories": [
                 {
                     "id": "55555555-5555-5555-5555-555555555555",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "tt",
                     "content": "cc",
@@ -1031,7 +1037,7 @@ mod tests {
             "memories": [
                 {
                     "id": "66666666-6666-6666-6666-666666666666",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "ns",
                     "title": "tt",
                     "content": "cc",
@@ -1113,7 +1119,7 @@ mod tests {
             path,
             format: "chatgpt".to_string(),
             namespace: None,
-            tier: "short".to_string(),
+            tier: Tier::Short.as_str().to_string(),
             min_messages: 3,
             dry_run: false,
         };
@@ -1140,7 +1146,7 @@ mod tests {
             path: tmp.path().to_path_buf(),
             format: "slack".to_string(),
             namespace: None,
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };
@@ -1166,7 +1172,7 @@ mod tests {
             path,
             format: "chatgpt".to_string(),
             namespace: None,
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             min_messages: 1,
             dry_run: true,
         };
@@ -1190,7 +1196,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("text-mine".to_string()),
-            tier: "long".to_string(),
+            tier: Tier::Long.as_str().to_string(),
             min_messages: 3,
             dry_run: false,
         };
@@ -1215,7 +1221,7 @@ mod tests {
             path: claude_path,
             format: "claude".to_string(),
             namespace: Some("dry-text".to_string()),
-            tier: "short".to_string(),
+            tier: Tier::Short.as_str().to_string(),
             min_messages: 3,
             dry_run: true,
         };

--- a/src/cli/promote.rs
+++ b/src/cli/promote.rs
@@ -134,7 +134,7 @@ pub fn cmd_promote(
         writeln!(
             out.stdout,
             "{}",
-            serde_json::json!({"promoted": true, "id": resolved_id, "tier": "long"})
+            serde_json::json!({"promoted": true, "id": resolved_id, "tier": Tier::Long.as_str()})
         )?;
     } else {
         writeln!(out.stdout, "promoted to long-term: {resolved_id}")?;
@@ -242,7 +242,7 @@ mod tests {
         }
         let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
         assert_eq!(v["promoted"].as_bool().unwrap(), true);
-        assert_eq!(v["tier"].as_str().unwrap(), "long");
+        assert_eq!(v["tier"].as_str().unwrap(), Tier::Long.as_str());
         let conn = db::open(&db).unwrap();
         let mem = db::get(&conn, &id).unwrap().unwrap();
         assert_eq!(mem.tier, Tier::Long);

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -201,7 +201,7 @@ mod tests {
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "content");
         let mut args = default_args();
-        args.tier = Some("long".to_string());
+        args.tier = Some(Tier::Long.as_str().to_string());
         {
             let mut out = env.output();
             run(&db, &args, true, &mut out).unwrap();

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -19,6 +19,11 @@ use std::path::Path;
 /// from main.rs verbatim in W5a — fields and attrs unchanged.
 #[derive(Args)]
 pub struct StoreArgs {
+    /// Memory tier. `default_value` must be a literal at attribute-parse
+    /// time, so the wire string is kept here verbatim; it is byte-equal
+    /// to `crate::models::Tier::Mid.as_str()` (pm-v3.1 PR6 #1174 sweep
+    /// — raw tier literals are confined to the deserializer + clap
+    /// `default_value` attrs that cannot accept const expressions).
     #[arg(long, short, default_value = "mid")]
     pub tier: String,
     #[arg(long, short)]
@@ -249,7 +254,7 @@ mod tests {
 
     fn default_args() -> StoreArgs {
         StoreArgs {
-            tier: "mid".to_string(),
+            tier: Tier::Mid.as_str().to_string(),
             namespace: Some("test-ns".to_string()),
             title: "test title".to_string(),
             content: "test content".to_string(),
@@ -305,7 +310,7 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
         assert!(v["id"].is_string());
         assert_eq!(v["title"].as_str().unwrap(), "test title");
-        assert_eq!(v["tier"].as_str().unwrap(), "mid");
+        assert_eq!(v["tier"].as_str().unwrap(), Tier::Mid.as_str());
         assert_eq!(v["namespace"].as_str().unwrap(), "test-ns");
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -46,6 +46,17 @@ pub fn cyan(text: &str) -> String {
     wrap("96", text)
 }
 
+/// Colorize `text` according to the caller-supplied tier wire string.
+///
+/// The string literals in the match arms below are the **canonical
+/// deserializer** for the `Tier` enum's wire form — they pair with
+/// `crate::models::Tier::as_str` (Short → "short" / Mid → "mid" /
+/// Long → "long"). They MUST stay as raw literals here because this
+/// is the boundary where a caller-supplied `&str` (config, CLI flag,
+/// JSON value) gets dispatched; the enum has nothing to plug in at
+/// this point. Anywhere else that constructs a tier wire value should
+/// route through `Tier::<X>.as_str()`. See pm-v3.1 PR6 (#1174) for the
+/// sweep that pinned this invariant.
 pub fn tier_color(tier: &str, text: &str) -> String {
     match tier {
         "short" => short(text),
@@ -106,10 +117,11 @@ mod tests {
 
     #[test]
     fn tier_color_dispatch() {
+        use crate::models::Tier;
         with_color_off(|| {
-            assert_eq!(tier_color("short", "x"), "x");
-            assert_eq!(tier_color("mid", "x"), "x");
-            assert_eq!(tier_color("long", "x"), "x");
+            assert_eq!(tier_color(Tier::Short.as_str(), "x"), "x");
+            assert_eq!(tier_color(Tier::Mid.as_str(), "x"), "x");
+            assert_eq!(tier_color(Tier::Long.as_str(), "x"), "x");
             assert_eq!(tier_color("unknown", "x"), "x");
         });
     }

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -479,13 +479,19 @@ pub async fn get_stats(
                     }
                     *by_namespace.entry(m.namespace.clone()).or_insert(0) += 1;
                 }
+                // by_tier wire shape: { <tier-wire-string>: <count> }.
+                // Keys are routed through `Tier::<X>.as_str()` so the
+                // wire-string mapping stays single-sourced (pm-v3.1 PR6,
+                // #1174). `json!` requires literal keys, so we build
+                // the inner map with `serde_json::Map` to interpolate
+                // the enum-derived keys.
+                let mut by_tier_map = serde_json::Map::new();
+                by_tier_map.insert(Tier::Short.as_str().to_string(), json!(short));
+                by_tier_map.insert(Tier::Mid.as_str().to_string(), json!(mid));
+                by_tier_map.insert(Tier::Long.as_str().to_string(), json!(long));
                 Json(json!({
                     "total_memories": total,
-                    "by_tier": {
-                        "short": short,
-                        "mid": mid,
-                        "long": long,
-                    },
+                    "by_tier": by_tier_map,
                     "by_namespace": by_namespace,
                     "storage_backend": "postgres",
                 }))

--- a/src/handlers/memories.rs
+++ b/src/handlers/memories.rs
@@ -1018,7 +1018,7 @@ pub async fn promote_memory(
                 Json(json!({
                     "promoted": true,
                     "id": target.id,
-                    "tier": "long",
+                    "tier": Tier::Long.as_str(),
                     "storage_backend": "postgres",
                 }))
                 .into_response()
@@ -1206,7 +1206,7 @@ pub async fn promote_memory(
                 .map(str::to_string);
             let details = serde_json::to_value(crate::subscriptions::PromoteEventDetails {
                 mode: "tier".to_string(),
-                tier: Some("long".to_string()),
+                tier: Some(Tier::Long.as_str().to_string()),
                 to_namespace: None,
                 clone_id: None,
             })
@@ -1229,7 +1229,8 @@ pub async fn promote_memory(
                 let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
                 return super::quorum_not_met_response(&payload);
             }
-            Json(json!({"promoted": true, "id": resolved_id, "tier": "long"})).into_response()
+            Json(json!({"promoted": true, "id": resolved_id, "tier": Tier::Long.as_str()}))
+                .into_response()
         }
         Ok((false, _)) => {
             (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()

--- a/src/handlers/subscriptions.rs
+++ b/src/handlers/subscriptions.rs
@@ -98,6 +98,12 @@ pub async fn notify(
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
         let priority_i32 = body.priority.and_then(|p| i32::try_from(p).ok());
+        // Canonical wire deserializer for the HTTP `tier` field — the
+        // raw string literals here pair byte-for-byte with
+        // `Tier::as_str` outputs and are intentionally kept in this
+        // form per pm-v3.1 PR6 (#1174) because the input is a caller-
+        // supplied wire string. Construction sites elsewhere route
+        // through `Tier::<X>.as_str()`.
         let resolved_tier = match body.tier.as_deref() {
             Some("short") => Some(Tier::Short),
             Some("mid") => Some(Tier::Mid),

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -409,7 +409,7 @@ async fn http_create_memory_uses_appstate_and_persists() {
         .with_state(test_app_state(state.clone()));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "http-embed-test",
         "title": "Semantic-ready via HTTP",
         "content": "HTTP-authored memories must now participate in semantic recall.",
@@ -471,7 +471,7 @@ async fn http_create_memory_succeeds_when_llm_is_absent_l5() {
         .with_state(test_app_state(state.clone()));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "l5-no-llm",
         "title": "L5 soft-hook absence",
         "content": "Auto-tag must remain a soft hook when no LLM is wired; \
@@ -649,7 +649,7 @@ async fn http_sync_push_applies_and_advances_clock() {
         "sender_clock": {"entries": {}},
         "memories": [{
             "id": Uuid::new_v4().to_string(),
-            "tier": "long",
+            "tier": Tier::Long.as_str(),
             "namespace": "sync-smoke",
             "title": "From peer",
             "content": "Pushed via HTTP sync endpoint.",
@@ -944,7 +944,7 @@ async fn http_bulk_create_uses_appstate_and_persists() {
     let bodies: Vec<serde_json::Value> = (0..5)
         .map(|i| {
             serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "bulk-appstate",
                 "title": format!("bulk-{i}"),
                 "content": format!("body-{i}"),
@@ -1089,7 +1089,7 @@ async fn http_bulk_create_fans_out_with_federation() {
     let bodies: Vec<serde_json::Value> = (0..n)
         .map(|i| {
             serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "bulk-fanout",
                 "title": format!("bulk-fanout-{i}"),
                 "content": "c",
@@ -1153,7 +1153,7 @@ async fn http_sync_push_rejects_oversized_batch_redteam_242() {
         .map(|i| {
             serde_json::json!({
                 "id": Uuid::new_v4().to_string(),
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "oversize",
                 "title": format!("m{i}"),
                 "content": "x",
@@ -1204,7 +1204,7 @@ async fn http_sync_push_dry_run_applies_nothing() {
         "sender_clock": {"entries": {}},
         "memories": [{
             "id": Uuid::new_v4().to_string(),
-            "tier": "long",
+            "tier": Tier::Long.as_str(),
             "namespace": "sync-dryrun",
             "title": "Must not land",
             "content": "Preview only.",
@@ -2170,7 +2170,7 @@ async fn create_memory_rejects_missing_required_fields() {
 
     // Missing title
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "content": "body text",
         "tags": [],
@@ -2218,7 +2218,7 @@ async fn create_memory_rejects_empty_title() {
         .with_state(test_app_state(state));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "",
         "content": "body text",
@@ -2257,7 +2257,7 @@ async fn create_memory_rejects_oversized_content() {
     // 65KB + 1 — exceeds MAX_CONTENT_SIZE (65536)
     let oversized = "x".repeat(65537);
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "Test",
         "content": oversized,
@@ -2322,7 +2322,7 @@ async fn create_memory_rejects_invalid_priority() {
         .with_state(test_app_state(state));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "Test",
         "content": "body",
@@ -2354,7 +2354,7 @@ async fn create_memory_rejects_invalid_confidence() {
         .with_state(test_app_state(state));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "Test",
         "content": "body",
@@ -2386,7 +2386,7 @@ async fn create_memory_rejects_invalid_source() {
         .with_state(test_app_state(state));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "Test",
         "content": "body",
@@ -2992,7 +2992,7 @@ async fn create_memory_handles_missing_content_type() {
         .with_state(test_app_state(state));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "Test",
         "content": "body",
@@ -3547,7 +3547,7 @@ async fn http_bulk_create_oversized_batch_rejected() {
     let bodies: Vec<serde_json::Value> = (0..=MAX_BULK_SIZE)
         .map(|i| {
             serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "bulk-overflow",
                 "title": format!("t-{i}"),
                 "content": "c",
@@ -3584,7 +3584,7 @@ async fn http_bulk_create_partial_success_collects_errors() {
         .with_state(test_app_state(state.clone()));
     let bodies = serde_json::json!([
         {
-            "tier": "long",
+            "tier": Tier::Long.as_str(),
             "namespace": "bulk-mixed",
             "title": "good row",
             "content": "ok",
@@ -3595,7 +3595,7 @@ async fn http_bulk_create_partial_success_collects_errors() {
             "metadata": {}
         },
         {
-            "tier": "long",
+            "tier": Tier::Long.as_str(),
             "namespace": "bulk-mixed",
             "title": "",
             "content": "bad: empty title",
@@ -5549,7 +5549,7 @@ async fn http_import_memories_oversized_batch_rejected() {
         .map(|i| {
             serde_json::json!({
                 "id": format!("11111111-1111-4111-8111-{:012}", i),
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "imp",
                 "title": format!("t-{i}"),
                 "content": "x",
@@ -5594,7 +5594,7 @@ async fn http_import_memories_skips_invalid_rows() {
         .with_state(test_app_state_with_admin(state, "ops:admin"));
     let valid = serde_json::json!({
         "id": Uuid::new_v4().to_string(),
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "imp",
         "title": "ok-row",
         "content": "valid content",
@@ -5612,7 +5612,7 @@ async fn http_import_memories_skips_invalid_rows() {
     // Empty title is rejected by validate_memory.
     let invalid = serde_json::json!({
         "id": Uuid::new_v4().to_string(),
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "imp",
         "title": "",
         "content": "x",
@@ -6623,7 +6623,7 @@ async fn http_forget_memories_by_tier_only_targets_tier() {
     let app = Router::new()
         .route("/api/v1/forget", axum_post(forget_memories))
         .with_state(test_app_state(state));
-    let body = serde_json::json!({"tier": "short"});
+    let body = serde_json::json!({"tier": Tier::Short.as_str()});
     let resp = app
         .oneshot(
             axum::http::Request::builder()
@@ -8553,7 +8553,7 @@ async fn http_approve_pending_happy_path_executes_store() {
             "alice",
             &serde_json::json!({
                 "id": Uuid::new_v4().to_string(),
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "approve-ns",
                 "title": "approved-store",
                 "content": "executed via approval",
@@ -8658,7 +8658,7 @@ async fn http_approve_pending_already_approved_is_rejected() {
             None,
             "alice",
             &serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "double-approve",
                 "title": "store",
                 "content": "x",
@@ -8724,7 +8724,7 @@ async fn http_approve_pending_executor_records_decided_by() {
             "requester-bob",
             &serde_json::json!({
                 "id": Uuid::new_v4().to_string(),
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "executor-ns",
                 "title": "e",
                 "content": "y",
@@ -8781,7 +8781,7 @@ async fn http_approve_pending_returns_memory_id_for_store_payload() {
             "alice",
             &serde_json::json!({
                 "id": Uuid::new_v4().to_string(),
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "executed-write",
                 "title": "executed-mem",
                 "content": "this exists after approval",
@@ -8853,7 +8853,7 @@ async fn http_reject_pending_happy_path_marks_rejected_no_execution() {
             None,
             "alice",
             &serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "reject-ns",
                 "title": "blocked",
                 "content": "must not be created",
@@ -8932,7 +8932,7 @@ async fn http_reject_pending_already_rejected_returns_404() {
             None,
             "alice",
             &serde_json::json!({
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "double-reject",
                 "title": "x",
                 "content": "x",
@@ -9046,7 +9046,7 @@ async fn http_consolidate_two_into_one_happy_path() {
         "title": "merged-result",
         "summary": "a merge of two drafts",
         "namespace": "merge-ns",
-        "tier": "long"
+        "tier": Tier::Long.as_str()
     });
     let resp = app
         .oneshot(
@@ -11573,7 +11573,7 @@ async fn http_import_memories_inserts_valid_rows() {
     let now = Utc::now().to_rfc3339();
     let mem = serde_json::json!({
         "id": Uuid::new_v4().to_string(),
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "imported",
         "title": "imported-row",
         "content": "imported content",
@@ -12797,7 +12797,7 @@ async fn http_create_memory_invalid_x_agent_id_header_returns_400() {
         .route("/api/v1/memories", axum_post(create_memory))
         .with_state(test_app_state(state));
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "t",
         "content": "c",
@@ -12852,7 +12852,7 @@ async fn l11_create_memory_rejects_metadata_agent_id_mismatch_post_907() {
         .with_state(test_app_state(state.clone()));
 
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "l11-agentid",
         "title": "L11 agent_id from metadata",
         "content": "Caller stamped agent_id only inside metadata.",
@@ -12892,7 +12892,7 @@ async fn http_create_memory_invalid_scope_returns_400() {
     // scope must be one of the recognised tokens; gibberish fails
     // validate_scope.
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "test",
         "title": "t",
         "content": "c",
@@ -13081,7 +13081,7 @@ async fn http_create_memory_governance_pending_returns_202() {
         .route("/api/v1/memories", axum_post(create_memory))
         .with_state(test_app_state(state));
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "gov-create",
         "title": "queued",
         "content": "should be queued, not stored",
@@ -13128,7 +13128,7 @@ async fn http_create_memory_governance_deny_returns_403() {
         .route("/api/v1/memories", axum_post(create_memory))
         .with_state(test_app_state(state));
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "gov-deny",
         "title": "rejected",
         "content": "rejected content",
@@ -13286,7 +13286,7 @@ async fn http_create_memory_with_top_level_scope_succeeds() {
         .route("/api/v1/memories", axum_post(create_memory))
         .with_state(test_app_state(state));
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "scoped",
         "title": "with scope",
         "content": "scoped content",
@@ -13322,7 +13322,7 @@ async fn http_create_memory_clamps_extreme_priority_to_range() {
     // priority=15 is an attempted overflow but validate_create
     // rejects out-of-range so we use 10 (max) which clamps to 10.
     let body = serde_json::json!({
-        "tier": "long",
+        "tier": Tier::Long.as_str(),
         "namespace": "clamp",
         "title": "clamp",
         "content": "c",

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2639,7 +2639,7 @@ mod tests {
                     "arguments": {
                         "title": format!("issue-965-stress-{i}"),
                         "content": format!("audit stress probe iteration {i}"),
-                        "tier": "short",
+                        "tier": Tier::Short.as_str(),
                         "namespace": "issue-965-audit",
                     },
                 }),
@@ -4183,7 +4183,7 @@ mod tests {
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
         let req = make_tools_call(
             "memory_store",
-            json!({"title": "t", "content": "c", "namespace": "m9-store", "tier": "short"}),
+            json!({"title": "t", "content": "c", "namespace": "m9-store", "tier": Tier::Short.as_str()}),
         );
         let resp = invoke_handle_request(&conn, &req);
         assert!(resp.error.is_none());
@@ -4193,7 +4193,7 @@ mod tests {
             .to_string();
         let val: Value = serde_json::from_str(&text).unwrap();
         assert!(val["id"].is_string());
-        assert_eq!(val["tier"], "short");
+        assert_eq!(val["tier"], Tier::Short.as_str());
     }
 
     #[test]
@@ -5921,7 +5921,7 @@ mod tests {
                 "target_agent_id": "alice",
                 "title": "hello",
                 "payload": "world",
-                "tier": "mid",
+                "tier": Tier::Mid.as_str(),
                 "priority": 5,
             }),
         );
@@ -6256,7 +6256,7 @@ mod tests {
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
         let req = make_tools_call(
             "memory_forget",
-            json!({"namespace": "w12-forget", "tier": "short", "dry_run": true}),
+            json!({"namespace": "w12-forget", "tier": Tier::Short.as_str(), "dry_run": true}),
         );
         let resp = invoke_handle_request(&conn, &req);
         assert!(resp.error.is_none());
@@ -7130,7 +7130,7 @@ mod tests {
         let val: Value = serde_json::from_str(&text).unwrap();
         assert_eq!(val["promoted"], true);
         assert_eq!(val["mode"], "tier");
-        assert_eq!(val["tier"], "long");
+        assert_eq!(val["tier"], Tier::Long.as_str());
     }
 
     #[test]
@@ -7144,7 +7144,7 @@ mod tests {
                 "title": "dup-title",
                 "content": "first",
                 "namespace": "w12-dedup",
-                "tier": "mid",
+                "tier": Tier::Mid.as_str(),
             }),
         );
         let resp1 = invoke_handle_request(&conn, &req1);
@@ -7162,7 +7162,7 @@ mod tests {
                 "title": "dup-title",
                 "content": "second-update",
                 "namespace": "w12-dedup",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
             }),
         );
         let resp2 = invoke_handle_request(&conn, &req2);
@@ -7806,7 +7806,7 @@ mod tests {
             json!({
                 "query": "test query",
                 "namespace": "w12-search",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "limit": 10,
                 "agent_id": "ai:bot",
                 "format": "json",
@@ -7911,7 +7911,7 @@ mod tests {
             "memory_list",
             json!({
                 "namespace": "w12-list-tier",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "agent_id": "ai:bot",
                 "limit": 25,
                 "format": "json",
@@ -8035,7 +8035,7 @@ mod tests {
                 "target_agent_id": "alice-w12",
                 "title": "ping",
                 "payload": "are you there?",
-                "tier": "short",
+                "tier": Tier::Short.as_str(),
             }),
         );
         let _ = invoke_handle_request(&conn, &notify);
@@ -8203,7 +8203,7 @@ mod tests {
                 "tags": ["a", "b"],
                 "title": "new-title",
                 "content": "new-content",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "priority": 8_i64,
                 "confidence": 0.9_f64,
             }),
@@ -8718,7 +8718,7 @@ mod tests {
                 "title": "pattern: alpha",
                 "content": "synthesised reflection content",
                 "namespace": "team/reflect-a",
-                "tier": "mid",
+                "tier": Tier::Mid.as_str(),
                 "priority": 7,
                 "confidence": 0.9,
                 "tags": ["reflection", "alpha"],
@@ -10609,7 +10609,7 @@ mod tests {
             json!({
                 "namespace": "chunkc-mix",
                 "pattern": "a-",
-                "tier": "short",
+                "tier": Tier::Short.as_str(),
                 "dry_run": true,
             }),
         );
@@ -10634,7 +10634,7 @@ mod tests {
             json!({
                 "query": "needle",
                 "namespace": "chunkc-search-ns",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "limit": 5,
                 "agent_id": "test-agent-chunkc",
                 "format": "json",

--- a/src/mcp/tools/capabilities.rs
+++ b/src/mcp/tools/capabilities.rs
@@ -677,6 +677,7 @@ pub fn build_capabilities_tools(
 #[must_use]
 pub fn tool_examples(name: &str) -> Vec<crate::config::ToolExample> {
     use crate::config::ToolExample;
+    use crate::models::Tier;
     use serde_json::json;
     let ex = |call: serde_json::Value, desc: &str| ToolExample {
         call,
@@ -684,7 +685,7 @@ pub fn tool_examples(name: &str) -> Vec<crate::config::ToolExample> {
     };
     match name {
         "memory_store" => vec![ex(
-            json!({"title": "design", "content": "wt-1 atomisation", "tier": "long", "namespace": "ai-memory"}),
+            json!({"title": "design", "content": "wt-1 atomisation", "tier": Tier::Long.as_str(), "namespace": "ai-memory"}),
             "Persists a long-tier memory; returns {id, status}.",
         )],
         "memory_recall" => vec![ex(

--- a/src/mcp/tools/forget.rs
+++ b/src/mcp/tools/forget.rs
@@ -263,7 +263,7 @@ mod tests {
         let _ = insert_one(&conn, "tier-ns", "m", Tier::Mid);
         let resp = handle_forget(
             &conn,
-            &json!({"namespace": "tier-ns", "tier": "short"}),
+            &json!({"namespace": "tier-ns", "tier": Tier::Short.as_str()}),
             false,
         )
         .expect("ok");

--- a/src/mcp/tools/list.rs
+++ b/src/mcp/tools/list.rs
@@ -167,7 +167,7 @@ mod tests {
         let conn = fresh_conn();
         db::insert(&conn, &make_mem("a", "ns", MTier::Short, "ai:a")).expect("ins");
         db::insert(&conn, &make_mem("b", "ns", MTier::Long, "ai:b")).expect("ins");
-        let out = handle_list(&conn, &json!({"tier": "long"})).expect("ok");
+        let out = handle_list(&conn, &json!({"tier": MTier::Long.as_str()})).expect("ok");
         assert_eq!(out["count"].as_u64(), Some(1));
         // invalid tier silently falls through (and_then None) — listed all.
         let out_bad = handle_list(&conn, &json!({"tier": "nonsense"})).expect("ok");

--- a/src/mcp/tools/notify.rs
+++ b/src/mcp/tools/notify.rs
@@ -25,7 +25,7 @@ pub(crate) fn handle_notify(
     let priority = i32::try_from(params["priority"].as_i64().unwrap_or(5))
         .unwrap_or(i32::MAX)
         .clamp(1, 10);
-    let tier_str = params["tier"].as_str().unwrap_or("mid");
+    let tier_str = params["tier"].as_str().unwrap_or(Tier::Mid.as_str());
     let tier = Tier::from_str(tier_str).ok_or(format!("invalid tier: {tier_str}"))?;
 
     validate::validate_agent_id(target).map_err(|e| e.to_string())?;

--- a/src/mcp/tools/pending.rs
+++ b/src/mcp/tools/pending.rs
@@ -428,6 +428,7 @@ mod tests {
     //! distinct payloads; tests do not assert on cross-test ordering.
 
     use super::*;
+    use crate::models::Tier;
     use crate::storage as db;
     use serde_json::json;
 
@@ -460,7 +461,7 @@ mod tests {
             "pa-ns",
             Some("11111111-2222-3333-4444-555555555555"),
             requester,
-            &json!({"target_tier": "long"}),
+            &json!({"target_tier": Tier::Long.as_str()}),
         )
         .expect("queue")
     }

--- a/src/mcp/tools/promote.rs
+++ b/src/mcp/tools/promote.rs
@@ -191,6 +191,14 @@ pub(super) fn handle_promote(
     // highest-reachable-tier behaviour (short→long / mid→long in a
     // single call), which the v0.7.0 CLAUDE.md docs pin under
     // "Data Model" + "Recall Pipeline → Touch operations".
+    //
+    // The string literals in the match arms below are the canonical
+    // wire deserializer for `target_tier`; they pair byte-for-byte with
+    // `Tier::as_str` outputs (see `src/models/memory.rs`). Per pm-v3.1
+    // PR6 (#1174), this site is intentionally kept as raw literals
+    // because it consumes caller-supplied wire input — anywhere else
+    // that *constructs* a tier wire value routes through
+    // `Tier::<X>.as_str()`.
     let target_tier = match params["target_tier"].as_str() {
         None => Tier::Long,
         Some("long") => Tier::Long,

--- a/src/mcp/tools/reflect.rs
+++ b/src/mcp/tools/reflect.rs
@@ -63,7 +63,7 @@ pub fn handle_reflect(
         .as_str()
         .ok_or("content is required")?
         .to_string();
-    let tier_str = params["tier"].as_str().unwrap_or("mid");
+    let tier_str = params["tier"].as_str().unwrap_or(Tier::Mid.as_str());
     let tier = Tier::from_str(tier_str).ok_or(format!("invalid tier: {tier_str}"))?;
     let namespace = params["namespace"].as_str().map(str::to_string);
     let priority = i32::try_from(params["priority"].as_i64().unwrap_or(5)).unwrap_or(5);

--- a/src/mcp/tools/store/tests.rs
+++ b/src/mcp/tools/store/tests.rs
@@ -15,7 +15,7 @@ use super::*;
 use crate::config::ResolvedTtl;
 use crate::embeddings::test_support::MockEmbedder;
 use crate::hnsw::VectorIndex;
-use crate::models::ConfidenceSource;
+use crate::models::{ConfidenceSource, Tier};
 use crate::storage as db;
 
 fn fresh_conn() -> rusqlite::Connection {
@@ -31,7 +31,7 @@ fn base_params(title: &str) -> Value {
         "title": title,
         "content": format!("This is the body of {title}, long enough to be meaningful prose."),
         "namespace": "test-ns",
-        "tier": "mid",
+        "tier": Tier::Mid.as_str(),
         "tags": ["tag1"],
         "priority": 5,
         "confidence": 0.9,
@@ -832,10 +832,9 @@ async fn federation_forward_url_happy_returns_body() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/api/v1/memories"))
-        .respond_with(
-            ResponseTemplate::new(201)
-                .set_body_json(json!({"id": "ok-id", "tier": "mid", "title": "fwd-happy"})),
-        )
+        .respond_with(ResponseTemplate::new(201).set_body_json(
+            json!({"id": "ok-id", "tier": Tier::Mid.as_str(), "title": "fwd-happy"}),
+        ))
         .mount(&server)
         .await;
 

--- a/src/mcp/tools/store/validation.rs
+++ b/src/mcp/tools/store/validation.rs
@@ -96,7 +96,7 @@ pub(super) fn parse_and_build_memory(
 
     let title = params["title"].as_str().ok_or("title is required")?;
     let content = params["content"].as_str().ok_or("content is required")?;
-    let tier_str = params["tier"].as_str().unwrap_or("mid");
+    let tier_str = params["tier"].as_str().unwrap_or(Tier::Mid.as_str());
     let tier = Tier::from_str(tier_str).ok_or(format!("invalid tier: {tier_str}"))?;
     let namespace = params["namespace"].as_str().unwrap_or("global").to_string();
     // v0.7.x (issue #1175): vendor-neutral substrate default. The

--- a/src/mcp/tools/update.rs
+++ b/src/mcp/tools/update.rs
@@ -380,7 +380,7 @@ mod tests {
                 "id": id,
                 "title": "new title",
                 "content": "new body content here",
-                "tier": "long",
+                "tier": MTier::Long.as_str(),
                 "namespace": "ns2",
                 "tags": ["x", "y"],
                 "priority": 7,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -451,6 +451,7 @@ pub fn curator_cycle_completed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::Tier;
 
     #[test]
     fn registry_is_singleton() {
@@ -463,7 +464,7 @@ mod tests {
     #[test]
     fn render_includes_registered_names() {
         // Tickle every series so each one has ≥1 sample.
-        record_store("short", true);
+        record_store(Tier::Short.as_str(), true);
         record_recall("hybrid", 0.042);
         record_autonomy_hook("auto_tag", true);
         registry().contradiction_detected_total.inc();
@@ -494,7 +495,7 @@ mod tests {
 
     #[test]
     fn record_store_labels_tier() {
-        record_store("long", true);
+        record_store(Tier::Long.as_str(), true);
         let text = render();
         assert!(text.contains("ai_memory_store_total{result=\"ok\",tier=\"long\"}"));
     }
@@ -557,7 +558,7 @@ mod tests {
 
     #[test]
     fn record_store_err_path() {
-        record_store("short", false);
+        record_store(Tier::Short.as_str(), false);
         let text = render();
         assert!(text.contains("ai_memory_store_total{result=\"err\",tier=\"short\""));
     }
@@ -582,7 +583,7 @@ mod tests {
     #[test]
     fn render_emits_help_and_type_lines() {
         // Tickle one series, then render and assert prom-format HELP/TYPE lines.
-        record_store("mid", true);
+        record_store(Tier::Mid.as_str(), true);
         let text = render();
         assert!(text.contains("# HELP ai_memory_store_total"));
         assert!(text.contains("# TYPE ai_memory_store_total counter"));
@@ -640,7 +641,9 @@ mod tests {
         let m = super::Metrics::try_new().expect("fresh registry must succeed");
         // The handle must expose every metric family — touch each to
         // exercise the assignment side of the struct literal.
-        m.store_total.with_label_values(&["short", "ok"]).inc();
+        m.store_total
+            .with_label_values(&[Tier::Short.as_str(), "ok"])
+            .inc();
         m.recall_total.with_label_values(&["hybrid"]).inc();
         m.recall_latency_seconds
             .with_label_values(&["hybrid"])
@@ -676,8 +679,12 @@ mod tests {
         let a = super::Metrics::try_new().expect("first");
         let b = super::Metrics::try_new().expect("second");
         // Tickle a counter on each so the family surfaces in gather().
-        a.store_total.with_label_values(&["short", "ok"]).inc();
-        b.store_total.with_label_values(&["short", "ok"]).inc();
+        a.store_total
+            .with_label_values(&[Tier::Short.as_str(), "ok"])
+            .inc();
+        b.store_total
+            .with_label_values(&[Tier::Short.as_str(), "ok"])
+            .inc();
         let mut buf_a = Vec::new();
         let mut buf_b = Vec::new();
         let enc = TextEncoder::new();

--- a/src/models/memory.rs
+++ b/src/models/memory.rs
@@ -363,6 +363,20 @@ impl Tier {
         }
     }
 
+    /// Parse a tier wire string into the typed enum.
+    ///
+    /// The string literals in the match arms below are the **canonical
+    /// deserializer** for the `Tier` wire form. They are the one place
+    /// in the codebase where raw `"short"` / `"mid"` / `"long"` literals
+    /// legitimately appear, because this is the boundary where a
+    /// caller-supplied `&str` (HTTP body field, MCP JSON param, CLI
+    /// flag value, TOML config field) gets dispatched into the typed
+    /// enum. They are intentionally byte-equal to
+    /// [`Tier::as_str`]'s outputs so the round-trip is identity.
+    /// Anywhere else that *constructs* a tier wire value MUST route
+    /// through `Tier::<X>.as_str()` instead of restamping a fresh
+    /// literal. See pm-v3.1 PR6 (#1174) for the sweep that pinned this
+    /// invariant.
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "short" => Some(Self::Short),
@@ -1406,7 +1420,7 @@ mod tests {
         // default must populate it as 0.
         let json = serde_json::json!({
             "id": "old-mem",
-            "tier": "mid",
+            "tier": Tier::Mid.as_str(),
             "namespace": "ns",
             "title": "t",
             "content": "c",
@@ -1775,7 +1789,7 @@ mod tests {
         // serde defaults must populate them.
         let json = serde_json::json!({
             "id": "old-mem",
-            "tier": "long",
+            "tier": Tier::Long.as_str(),
             "namespace": "ns",
             "title": "t",
             "content": "c",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10037,7 +10037,7 @@ mod tests {
         assert_eq!(got.title, "Restorable");
         assert_eq!(
             got.tier.as_str(),
-            "short",
+            Tier::Short.as_str(),
             "G5: restore must preserve the original tier"
         );
         assert_eq!(
@@ -13890,7 +13890,7 @@ mod tests {
             "title": "reflective synthesis",
             "content": "deep observation across sources",
             "namespace": "ns/reflect",
-            "tier": "mid",
+            "tier": Tier::Mid.as_str(),
             "tags": ["reflective"],
             "priority": 6,
             "confidence": 0.9,

--- a/src/toon.rs
+++ b/src/toon.rs
@@ -195,6 +195,7 @@ fn escape_toon(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::Tier;
     use serde_json::json;
 
     #[test]
@@ -215,7 +216,7 @@ mod tests {
             "memories": [{
                 "id": "abc-123",
                 "title": "PostgreSQL config",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "infra",
                 "priority": 9,
                 "confidence": 1.0,
@@ -244,7 +245,7 @@ mod tests {
     #[test]
     fn compact_mode_fewer_fields() {
         let resp = json!({
-            "memories": [{"id": "x", "title": "Test", "tier": "mid", "namespace": "test", "priority": 5, "score": 0.5, "tags": []}],
+            "memories": [{"id": "x", "title": "Test", "tier": Tier::Mid.as_str(), "namespace": "test", "priority": 5, "score": 0.5, "tags": []}],
             "count": 1
         });
         let toon = memories_to_toon(&resp, true);
@@ -260,7 +261,7 @@ mod tests {
             "memories": [{
                 "id": "x",
                 "title": "Test",
-                "tier": "mid",
+                "tier": Tier::Mid.as_str(),
                 "namespace": "test",
                 "priority": 5,
                 "score": 0.5,
@@ -279,7 +280,7 @@ mod tests {
 
     #[test]
     fn pipe_in_title_escaped() {
-        let resp = json!({"memories": [{"id": "x", "title": "A|B", "tier": "mid"}], "count": 1});
+        let resp = json!({"memories": [{"id": "x", "title": "A|B", "tier": Tier::Mid.as_str()}], "count": 1});
         let toon = memories_to_toon(&resp, true);
         assert!(toon.contains("A\\|B"));
     }
@@ -289,9 +290,9 @@ mod tests {
         // Demonstrate: 3 memories, field names appear only once
         let resp = json!({
             "memories": [
-                {"id": "a", "title": "Memory 1", "tier": "long", "namespace": "test", "priority": 9, "score": 0.9, "tags": ["t1"]},
-                {"id": "b", "title": "Memory 2", "tier": "mid", "namespace": "test", "priority": 7, "score": 0.7, "tags": ["t2"]},
-                {"id": "c", "title": "Memory 3", "tier": "short", "namespace": "test", "priority": 5, "score": 0.5, "tags": ["t3"]}
+                {"id": "a", "title": "Memory 1", "tier": Tier::Long.as_str(), "namespace": "test", "priority": 9, "score": 0.9, "tags": ["t1"]},
+                {"id": "b", "title": "Memory 2", "tier": Tier::Mid.as_str(), "namespace": "test", "priority": 7, "score": 0.7, "tags": ["t2"]},
+                {"id": "c", "title": "Memory 3", "tier": Tier::Short.as_str(), "namespace": "test", "priority": 5, "score": 0.5, "tags": ["t3"]}
             ],
             "count": 3,
             "mode": "hybrid"
@@ -309,7 +310,7 @@ mod tests {
 
     #[test]
     fn search_results_key() {
-        let resp = json!({"results": [{"id": "x", "title": "Found", "tier": "mid"}], "count": 1});
+        let resp = json!({"results": [{"id": "x", "title": "Found", "tier": Tier::Mid.as_str()}], "count": 1});
         let toon = search_to_toon(&resp, true);
         assert!(toon.contains("memories["));
         assert!(toon.contains("Found"));
@@ -326,7 +327,7 @@ mod tests {
                 {
                     "id": "01",
                     "title": "PostgreSQL config",
-                    "tier": "long",
+                    "tier": Tier::Long.as_str(),
                     "namespace": "infra",
                     "priority": 9,
                     "confidence": 1.0,
@@ -341,7 +342,7 @@ mod tests {
                 {
                     "id": "02",
                     "title": "Redis cache strategy",
-                    "tier": "long",
+                    "tier": Tier::Long.as_str(),
                     "namespace": "infra",
                     "priority": 8,
                     "confidence": 0.95,
@@ -356,7 +357,7 @@ mod tests {
                 {
                     "id": "03",
                     "title": "BIND9 custom build",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "infra/dns",
                     "priority": 7,
                     "confidence": 0.9,
@@ -371,7 +372,7 @@ mod tests {
                 {
                     "id": "04",
                     "title": "Kubernetes pod recovery",
-                    "tier": "mid",
+                    "tier": Tier::Mid.as_str(),
                     "namespace": "platform/k8s",
                     "priority": 6,
                     "confidence": 0.85,
@@ -386,7 +387,7 @@ mod tests {
                 {
                     "id": "05",
                     "title": "Vault secrets rotation",
-                    "tier": "short",
+                    "tier": Tier::Short.as_str(),
                     "namespace": "security",
                     "priority": 5,
                     "confidence": 0.8,
@@ -518,7 +519,7 @@ mod tests {
         // Empty metadata object → empty string in TOON output.
         let resp = json!({
             "memories": [{
-                "id": "x", "title": "t", "tier": "long", "namespace": "n",
+                "id": "x", "title": "t", "tier": Tier::Long.as_str(), "namespace": "n",
                 "priority": 1, "confidence": 1.0, "score": 0.5, "access_count": 0,
                 "tags": [], "source": "", "created_at": "", "updated_at": "",
                 "metadata": {}
@@ -535,7 +536,7 @@ mod tests {
     fn format_value_object_non_empty_serialized_json() {
         let resp = json!({
             "memories": [{
-                "id": "x", "title": "t", "tier": "long", "namespace": "n",
+                "id": "x", "title": "t", "tier": Tier::Long.as_str(), "namespace": "n",
                 "priority": 1, "confidence": 1.0, "score": 0.5, "access_count": 0,
                 "tags": [], "source": "", "created_at": "", "updated_at": "",
                 "metadata": {"k": "v"}
@@ -613,7 +614,7 @@ mod tests {
             "memories": [{
                 "id": "abc-xyz",
                 "title": "Round-trip test",
-                "tier": "long",
+                "tier": Tier::Long.as_str(),
                 "namespace": "test",
                 "priority": 9,
                 "confidence": 1.0,


### PR DESCRIPTION
## Summary

Wave 1 PR6 of the pm-v3.1 global refactor sweep (issue #1174). Sweeps **125 construction sites** in `src/` that stamped raw `"short"` / `"mid"` / `"long"` tier wire literals; they now route through `crate::models::Tier::<Variant>::as_str()`. The wire shape is preserved byte-for-byte — `Tier::as_str()` already returns those exact bytes — so this is a source-location refactor with zero behavioural change.

**Base SHA:** `84ec159c1c88c9840b7a97af966f77ef6d35eb20`
**Commit SHA:** `7916867eb9d30ca1d1ab2d9078cec956475ee679`

### Why

The `Tier` enum existed (`src/models/memory.rs:351`) but was invisible to refactors — call sites silently coupled the wire-string spelling to the variant spelling. Centralising construction through `Tier::as_str()` means a future spelling change is one variant edit instead of a 125-site grep.

## Sites updated per file (125 total)

| File | Sites |
|---|---:|
| `src/toon.rs` | 16 |
| `src/handlers/tests.rs` | 38 |
| `src/cli/io.rs` | 17 |
| `src/mcp/mod.rs` | 15 |
| `src/metrics.rs` | 7 |
| `src/handlers/admin.rs` | 3 |
| `src/handlers/memories.rs` | 3 |
| `src/storage/mod.rs` | 2 |
| `src/models/memory.rs` | 2 |
| `src/mcp/tools/store/tests.rs` | 2 |
| `src/mcp/tools/update.rs` | 1 |
| `src/mcp/tools/forget.rs` | 1 |
| `src/mcp/tools/list.rs` | 1 |
| `src/mcp/tools/notify.rs` | 1 |
| `src/mcp/tools/reflect.rs` | 1 |
| `src/mcp/tools/store/validation.rs` | 1 |
| `src/mcp/tools/capabilities.rs` | 1 |
| `src/mcp/tools/pending.rs` | 1 |
| `src/cli/audit.rs` | 1 |
| `src/cli/crud.rs` | 2 |
| `src/cli/forget.rs` | 2 |
| `src/cli/store.rs` | 2 |
| `src/cli/promote.rs` | 2 |
| `src/cli/search.rs` | 1 |
| `src/audit.rs` | 2 |
| `src/color.rs` | 3 |
| **Total** | **125** |

## Cases handled with care (raw literals preserved on purpose)

Per the audit's "Tricky cases" guidance, the following sites are NOT swept — each is documented inline with a doc-comment pinning the invariant per pm-v3.1 PR6:

1. **Canonical wire deserializers** — the one place raw literals legitimately appear because they consume caller-supplied wire input:
   - `src/models/memory.rs::Tier::from_str` (3 match arms — added doc comment naming the invariant)
   - `src/handlers/subscriptions.rs::subscribe` postgres branch (3 arms — doc comment added)
   - `src/mcp/tools/promote.rs::handle_promote` `target_tier` match (3 arms — doc comment added)
   - `src/color.rs::tier_color` (3 arms — doc comment added; the test inputs now exercise the deserializer via `Tier::<X>.as_str()` so the round-trip is enum-driven)

2. **Contract validation tests** — these literal strings ARE the contract; replacing them would make `assert!(Tier::Short.as_str() == "short")` circular and lose its teeth:
   - `src/models/memory.rs::tests::tier_round_trips_strings` / `tier_serializes_to_snake_case`
   - `src/models/mod.rs::tests::tier_from_str_valid` / `tier_display`

3. **clap `#[arg(default_value = "...")]` attrs** — clap's `default_value` requires a literal at attribute-parse time; const expressions are not accepted by the macro:
   - `src/cli/io.rs` `MineArgs.tier` — doc comment recording `default_value = "mid"` is byte-equal to `Tier::Mid.as_str()`
   - `src/cli/store.rs` `StoreArgs.tier` — same doc comment

4. **Invalid-input test fixtures** — the test asserts the deserializer rejects these; replacing them would defeat the test:
   - `"ULTRAMID"` / `"bogus-tier"` / `"ephemeral"` / `"nonsense"` / `"not-a-tier"` / `"permanent"` in `mcp/mod.rs`, `mcp/tools/store/tests.rs`, `cli/io.rs`

5. **Non-tier "short"/"mid"/"long" word uses** — the string is content / title / argument label / file fixture bytes, NOT a Tier reference:
   - `src/handlers/http.rs:482` `maybe_detect_conflicts(&app, "t", "short", "ns", ...)` — `"short"` is **content** (the function checks content length, not tier)
   - `src/handlers/tests.rs:559` same shape
   - `src/curator/mod.rs` `content: "short".to_string()`
   - `src/identity/keypair.rs` `fs::write(..., b"short")` — file-content bytes
   - `src/transcripts/replay.rs:369` `store(&conn, "team/eng", "mid", None)` — 3rd arg is **content**, not tier
   - `src/handlers/tests.rs:1894` `("mid", mid_ts)` — first element is the **title label** in a tuple
   - `src/storage/mod.rs:13060` `make_memory("mid", "ns", Tier::Long, 5)` — first arg is the **title**

6. **Doc-string examples + comments** — `src/subscriptions.rs::PromoteEventDetails` doc says `tier` is set to `"long"` after promotion (accurate prose description of the wire shape), `src/config.rs` TOML config example, `src/storage/mod.rs:8596` JSON example in docstring.

**Total: 125 sites swept, ~14 raw-literal call sites intentionally preserved.**

Also worth noting: `src/handlers/admin.rs` `by_tier` JSON map keys (3 keys: `"short"`, `"mid"`, `"long"`) **were** swept — they're now built via `serde_json::Map::insert(Tier::<X>.as_str().to_string(), ...)` so the `json!` macro's literal-key restriction doesn't block enum-driven construction. The wire shape is identical.

## Audit of the Tier enum's `as_str()` impl

`Tier::as_str` at `src/models/memory.rs:357-364` returns:
- `Self::Short => "short"`
- `Self::Mid => "mid"`
- `Self::Long => "long"`

Byte-equal to the literals it replaces. No enum change needed.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | PASS |
| `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `AI_MEMORY_NO_CONFIG=1 cargo test` | PASS (*) |
| `cargo audit` | PASS |

**(*) Test-suite caveat:** one test, `tests/g3_hooks_stderr_drain.rs::daemon_mode_timeout_still_trips_with_drain_task_running`, failed with a 500 ms timeout on the first daemon-warm fire. Reproduced on the unmodified base SHA `84ec159c1` with the same `Timeout { ms: 500 }` symptom — this is a pre-existing host-load-sensitive timing test, NOT a regression from this refactor. Filing a separate tracking issue for the flaky test is out of scope for this PR (the surrounding pm-v3.1 sweep stays scoped to its inventory entry); the next CI run on a non-loaded runner is expected to flip it green.

## Test plan

- [x] All four cargo gates pass locally (excluding the one pre-existing flaky test confirmed to fail identically on base SHA).
- [x] `cargo test` ran 4745+ tests in the lib + ~1100 in integration tests; only the documented pre-existing flake failed.
- [x] Spot-checked that `cargo fmt` is a no-op post-changes.
- [x] Verified the wire shape: every `Tier::<X>.as_str()` substitution returns the same `"short"` / `"mid"` / `"long"` bytes; the JSON / Prometheus-label / CLI-arg / struct-field outputs are byte-identical to the pre-refactor wire shape.
- [x] Confirmed the canonical-deserializer + clap-default + invalid-input + non-tier-word sites stay as raw literals (with doc comments on the deserializers + clap defaults so the invariant is greppable).
- [ ] CI on the PR branch should also report the four gates green (modulo the pre-existing g3 flake).

## AI involvement

Authored by Claude Opus 4.7 (1M context) as Wave 1 PR6 of the pm-v3.1 codegraph-driven refactor sweep dispatched by issue #1174, under the pm-v3.2 no-fail-mission discipline pinned by ai-memory `global/policies` memory `2cb15d34-2399-4611-a020-df6ef91683fe`. Reviewed by the parent agent before merge.