### PR TITLE
refactor(#1174): pm-v3.1 PR1 — extract 73 MCP tool names to tool_names const module

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -905,10 +905,13 @@ fn remove_claude_code(obj: &mut Map<String, Value>) {
 //   intentionally scope the hook to a subset of tools; clobbering that
 //   would silently change their policy.
 
-/// Reference name for the MCP tool the PreToolUse hook invokes. Pinned
-/// here so changing the tool name in one place updates the installer +
-/// docs together. Matches the wire name registered in `src/mcp/mod.rs`.
-const PRETOOL_HOOK_TOOL_NAME: &str = "memory_check_agent_action";
+/// Reference name for the MCP tool the PreToolUse hook invokes.
+///
+/// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): routes
+/// through the canonical [`crate::mcp::registry::tool_names`] const,
+/// so renaming a tool is one edit (the const value) and the installer
+/// follows automatically.
+const PRETOOL_HOOK_TOOL_NAME: &str = crate::mcp::registry::tool_names::MEMORY_CHECK_AGENT_ACTION;
 
 /// Build the PreToolUse entry the installer writes. Uses the
 /// type=`mcp_tool` form (vs `type=command`) so Claude Code dispatches

--- a/src/config.rs
+++ b/src/config.rs
@@ -910,10 +910,15 @@ impl Default for CapabilityHooks {
 /// here closes the v0.6.3.1 honest-disclosure that the
 /// `approval.subscribers` field was advertised but unwired.
 fn default_webhook_events() -> Vec<String> {
+    // v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): the
+    // three entries that ARE MCP tool names route through the
+    // canonical `tool_names` consts; the remaining four are
+    // subscription-event types (different namespace) and stay raw.
+    use crate::mcp::registry::tool_names as tn;
     vec![
-        "memory_store".to_string(),
-        "memory_promote".to_string(),
-        "memory_delete".to_string(),
+        tn::MEMORY_STORE.to_string(),
+        tn::MEMORY_PROMOTE.to_string(),
+        tn::MEMORY_DELETE.to_string(),
         "memory_link_created".to_string(),
         "memory_link_invalidated".to_string(),
         "memory_consolidated".to_string(),
@@ -1158,14 +1163,20 @@ pub struct CapabilitySkills {
 /// the regression test
 /// `cap_v3_l3_5_skill_tools_match_registered_mcp_dispatch` ensures the
 /// two stay in sync.
+// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep) — each
+// entry routes through the canonical `tool_names` const so this
+// capability surface cannot drift from the dispatch table in name
+// spelling. The `cap_v3_l3_5_skill_tools_match_registered_mcp_dispatch`
+// regression test continues to enforce membership equality between
+// this slice and the registered set.
 pub const SKILL_TOOL_NAMES: &[&str] = &[
-    "memory_skill_register",
-    "memory_skill_list",
-    "memory_skill_get",
-    "memory_skill_resource",
-    "memory_skill_export",
-    "memory_skill_promote_from_reflection",
-    "memory_skill_compositional_context",
+    crate::mcp::registry::tool_names::MEMORY_SKILL_REGISTER,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_LIST,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_GET,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_RESOURCE,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_EXPORT,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_PROMOTE_FROM_REFLECTION,
+    crate::mcp::registry::tool_names::MEMORY_SKILL_COMPOSITIONAL_CONTEXT,
 ];
 
 impl CapabilitySkills {

--- a/src/governance/mod.rs
+++ b/src/governance/mod.rs
@@ -143,28 +143,39 @@ pub enum Op {
 impl Op {
     /// Wire name used in `[permissions.rules].op`. Stable across
     /// versions.
+    ///
+    /// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): the
+    /// five variants whose wire string ALSO appears as an MCP tool
+    /// name reference the canonical `tool_names` const so the
+    /// governance-op spelling cannot drift from the dispatch table.
+    /// `MemoryArchive` is the lone exception: its wire string
+    /// `"memory_archive"` is a governance op identifier covering the
+    /// 4-tool archive family (list/purge/restore/stats); it is NOT
+    /// itself an MCP tool name and therefore stays as a raw literal.
     #[must_use]
     pub fn as_str(self) -> &'static str {
+        use crate::mcp::registry::tool_names as tn;
         match self {
-            Op::MemoryStore => "memory_store",
-            Op::MemoryLink => "memory_link",
-            Op::MemoryDelete => "memory_delete",
+            Op::MemoryStore => tn::MEMORY_STORE,
+            Op::MemoryLink => tn::MEMORY_LINK,
+            Op::MemoryDelete => tn::MEMORY_DELETE,
             Op::MemoryArchive => "memory_archive",
-            Op::MemoryConsolidate => "memory_consolidate",
-            Op::MemoryReplay => "memory_replay",
+            Op::MemoryConsolidate => tn::MEMORY_CONSOLIDATE,
+            Op::MemoryReplay => tn::MEMORY_REPLAY,
         }
     }
 
     /// Parse from the wire name. Used by rule loaders.
     #[must_use]
     pub fn from_str(s: &str) -> Option<Op> {
+        use crate::mcp::registry::tool_names as tn;
         match s {
-            "memory_store" => Some(Op::MemoryStore),
-            "memory_link" => Some(Op::MemoryLink),
-            "memory_delete" => Some(Op::MemoryDelete),
+            tn::MEMORY_STORE => Some(Op::MemoryStore),
+            tn::MEMORY_LINK => Some(Op::MemoryLink),
+            tn::MEMORY_DELETE => Some(Op::MemoryDelete),
             "memory_archive" => Some(Op::MemoryArchive),
-            "memory_consolidate" => Some(Op::MemoryConsolidate),
-            "memory_replay" => Some(Op::MemoryReplay),
+            tn::MEMORY_CONSOLIDATE => Some(Op::MemoryConsolidate),
+            tn::MEMORY_REPLAY => Some(Op::MemoryReplay),
             _ => None,
         }
     }

--- a/src/handlers/create.rs
+++ b/src/handlers/create.rs
@@ -629,7 +629,7 @@ async fn fanout_and_assemble_create_response(
         let lock = app.db.lock().await;
         crate::subscriptions::dispatch_event(
             &lock.0,
-            "memory_store",
+            crate::mcp::registry::tool_names::MEMORY_STORE,
             actual_id,
             &mem.namespace,
             resolved_agent_id.as_deref(),
@@ -812,7 +812,7 @@ async fn create_memory_postgres(
             let agent_for_dispatch = agent_id.to_string();
             super::dispatch_event_postgres(
                 app,
-                "memory_store",
+                crate::mcp::registry::tool_names::MEMORY_STORE,
                 &id_for_dispatch,
                 &ns_for_dispatch,
                 Some(&agent_for_dispatch),

--- a/src/handlers/memories.rs
+++ b/src/handlers/memories.rs
@@ -250,7 +250,7 @@ pub async fn update_memory(
                         let ns_for_dispatch = mem.namespace.clone();
                         super::dispatch_event_postgres(
                             &app,
-                            "memory_update",
+                            crate::mcp::registry::tool_names::MEMORY_UPDATE,
                             &id,
                             &ns_for_dispatch,
                             agent_for_dispatch.as_deref(),
@@ -504,7 +504,7 @@ pub async fn delete_memory(
     crate::governance::audit::record_decision(
         &caller_for_forensic,
         "allow",
-        "memory_delete",
+        crate::mcp::registry::tool_names::MEMORY_DELETE,
         "",
         json!({ "id": &id }),
     );
@@ -617,7 +617,7 @@ pub async fn delete_memory(
                         .map(str::to_string);
                     super::dispatch_event_postgres(
                         &app,
-                        "memory_delete",
+                        crate::mcp::registry::tool_names::MEMORY_DELETE,
                         &id,
                         &mem.namespace,
                         mem_owner.as_deref(),
@@ -791,7 +791,7 @@ pub async fn delete_memory(
             .map(str::to_string);
         crate::subscriptions::dispatch_event_with_details(
             &lock.0,
-            "memory_delete",
+            crate::mcp::registry::tool_names::MEMORY_DELETE,
             &target.id,
             &target.namespace,
             owner_aid.as_deref(),
@@ -1008,7 +1008,7 @@ pub async fn promote_memory(
                     .map(str::to_string);
                 super::dispatch_event_postgres(
                     &app,
-                    "memory_promote",
+                    crate::mcp::registry::tool_names::MEMORY_PROMOTE,
                     &target.id,
                     &target.namespace,
                     mem_owner.as_deref(),
@@ -1213,7 +1213,7 @@ pub async fn promote_memory(
             .ok();
             crate::subscriptions::dispatch_event_with_details(
                 &lock.0,
-                "memory_promote",
+                crate::mcp::registry::tool_names::MEMORY_PROMOTE,
                 &resolved_id,
                 &target.namespace,
                 owner_aid.as_deref(),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -135,21 +135,22 @@ fn audit_emit_for_mcp_dispatch(
     if !crate::audit::is_enabled() {
         return;
     }
+    use crate::mcp::registry::tool_names;
     let action = match tool_name {
         // Skipped — emitted from inside the handler with full target context.
-        "memory_store" | "memory_delete" => return,
-        "memory_recall"
-        | "memory_search"
-        | "memory_get"
-        | "memory_list"
-        | "memory_session_start" => crate::audit::AuditAction::Recall,
-        "memory_update" => crate::audit::AuditAction::Update,
-        "memory_promote" => crate::audit::AuditAction::Promote,
-        "memory_forget" => crate::audit::AuditAction::Forget,
-        "memory_link" => crate::audit::AuditAction::Link,
-        "memory_consolidate" => crate::audit::AuditAction::Consolidate,
-        "memory_pending_approve" => crate::audit::AuditAction::Approve,
-        "memory_pending_reject" => crate::audit::AuditAction::Reject,
+        tool_names::MEMORY_STORE | tool_names::MEMORY_DELETE => return,
+        tool_names::MEMORY_RECALL
+        | tool_names::MEMORY_SEARCH
+        | tool_names::MEMORY_GET
+        | tool_names::MEMORY_LIST
+        | tool_names::MEMORY_SESSION_START => crate::audit::AuditAction::Recall,
+        tool_names::MEMORY_UPDATE => crate::audit::AuditAction::Update,
+        tool_names::MEMORY_PROMOTE => crate::audit::AuditAction::Promote,
+        tool_names::MEMORY_FORGET => crate::audit::AuditAction::Forget,
+        tool_names::MEMORY_LINK => crate::audit::AuditAction::Link,
+        tool_names::MEMORY_CONSOLIDATE => crate::audit::AuditAction::Consolidate,
+        tool_names::MEMORY_PENDING_APPROVE => crate::audit::AuditAction::Approve,
+        tool_names::MEMORY_PENDING_REJECT => crate::audit::AuditAction::Reject,
         // Read-only / metadata tools — no audit event.
         _ => return,
     };
@@ -931,16 +932,23 @@ pub(crate) struct ToolDispatchCtx<'a> {
 pub(crate) type DispatchFn = fn(&ToolDispatchCtx<'_>) -> Result<Value, String>;
 
 /// Registry-registration macro. Today this expands to a plain
-/// `(literal, fn)` tuple suitable for the `TOOL_DISPATCH_TABLE` array
+/// `(name, fn)` tuple suitable for the `TOOL_DISPATCH_TABLE` array
 /// literal, but the indirection lets future refactors swap to
 /// `inventory::submit!` (cross-module collect) without touching every
 /// call site.
 ///
+/// `$name` accepts any `&'static str` expression: a string literal
+/// OR a `pub const NAME: &str` from
+/// [`crate::mcp::registry::tool_names`] (issue #1174 PR1 — pm-v3.1
+/// MCP tool name sweep). Per-tool registrations should reference the
+/// `tool_names` const so the dispatch table stays in sync with the
+/// canonical tool-name table.
+///
 /// ```text
-/// register_mcp_tool!("memory_search", dispatch_memory_search)
+/// register_mcp_tool!(tool_names::MEMORY_SEARCH, dispatch_memory_search)
 /// ```
 macro_rules! register_mcp_tool {
-    ($name:literal, $f:path) => {
+    ($name:expr, $f:path) => {
         ($name, $f as DispatchFn)
     };
 }
@@ -1454,129 +1462,200 @@ fn dispatch_memory_deref(ctx: &ToolDispatchCtx<'_>) -> Result<Value, String> {
 ///
 /// New tools land by adding a `dispatch_<tool>` wrapper above and an
 /// entry here via [`register_mcp_tool!`].
-pub(crate) static TOOL_DISPATCH_TABLE: &[(&str, DispatchFn)] = &[
-    register_mcp_tool!("memory_store", dispatch_memory_store),
-    register_mcp_tool!("memory_recall", dispatch_memory_recall),
-    register_mcp_tool!(
-        "memory_recall_observations",
-        dispatch_memory_recall_observations
-    ),
-    register_mcp_tool!("memory_search", dispatch_memory_search),
-    register_mcp_tool!("memory_list", dispatch_memory_list),
-    register_mcp_tool!("memory_load_family", dispatch_memory_load_family),
-    register_mcp_tool!("memory_smart_load", dispatch_memory_smart_load),
-    register_mcp_tool!("memory_get_taxonomy", dispatch_memory_get_taxonomy),
-    register_mcp_tool!("memory_check_duplicate", dispatch_memory_check_duplicate),
-    register_mcp_tool!("memory_entity_register", dispatch_memory_entity_register),
-    register_mcp_tool!(
-        "memory_entity_get_by_alias",
-        dispatch_memory_entity_get_by_alias
-    ),
-    register_mcp_tool!("memory_kg_timeline", dispatch_memory_kg_timeline),
-    register_mcp_tool!("memory_kg_invalidate", dispatch_memory_kg_invalidate),
-    register_mcp_tool!("memory_kg_query", dispatch_memory_kg_query),
-    register_mcp_tool!("memory_find_paths", dispatch_memory_find_paths),
-    register_mcp_tool!("memory_delete", dispatch_memory_delete),
-    register_mcp_tool!("memory_promote", dispatch_memory_promote),
-    register_mcp_tool!("memory_pending_list", dispatch_memory_pending_list),
-    register_mcp_tool!("memory_pending_approve", dispatch_memory_pending_approve),
-    register_mcp_tool!("memory_pending_reject", dispatch_memory_pending_reject),
-    register_mcp_tool!("memory_forget", dispatch_memory_forget),
-    register_mcp_tool!("memory_stats", dispatch_memory_stats),
-    register_mcp_tool!("memory_update", dispatch_memory_update),
-    register_mcp_tool!("memory_get", dispatch_memory_get),
-    register_mcp_tool!("memory_link", dispatch_memory_link),
-    register_mcp_tool!("memory_get_links", dispatch_memory_get_links),
-    register_mcp_tool!("memory_verify", dispatch_memory_verify),
-    register_mcp_tool!("memory_replay", dispatch_memory_replay),
-    register_mcp_tool!("memory_consolidate", dispatch_memory_consolidate),
-    register_mcp_tool!("memory_atomise", dispatch_memory_atomise),
-    register_mcp_tool!("memory_ingest_multistep", dispatch_memory_ingest_multistep),
-    register_mcp_tool!("memory_reflect", dispatch_memory_reflect),
-    register_mcp_tool!("memory_capabilities", dispatch_memory_capabilities),
-    register_mcp_tool!("memory_expand_query", dispatch_memory_expand_query),
-    register_mcp_tool!("memory_auto_tag", dispatch_memory_auto_tag),
-    register_mcp_tool!(
-        "memory_detect_contradiction",
-        dispatch_memory_detect_contradiction
-    ),
-    register_mcp_tool!("memory_archive_list", dispatch_memory_archive_list),
-    register_mcp_tool!("memory_archive_restore", dispatch_memory_archive_restore),
-    register_mcp_tool!("memory_archive_purge", dispatch_memory_archive_purge),
-    register_mcp_tool!("memory_archive_stats", dispatch_memory_archive_stats),
-    register_mcp_tool!("memory_gc", dispatch_memory_gc),
-    register_mcp_tool!("memory_session_start", dispatch_memory_session_start),
-    register_mcp_tool!(
-        "memory_namespace_set_standard",
-        dispatch_memory_namespace_set_standard
-    ),
-    register_mcp_tool!(
-        "memory_namespace_get_standard",
-        dispatch_memory_namespace_get_standard
-    ),
-    register_mcp_tool!(
-        "memory_namespace_clear_standard",
-        dispatch_memory_namespace_clear_standard
-    ),
-    register_mcp_tool!("memory_agent_register", dispatch_memory_agent_register),
-    register_mcp_tool!("memory_agent_list", dispatch_memory_agent_list),
-    register_mcp_tool!("memory_notify", dispatch_memory_notify),
-    register_mcp_tool!("memory_share", dispatch_memory_share),
-    register_mcp_tool!("memory_inbox", dispatch_memory_inbox),
-    register_mcp_tool!("memory_subscribe", dispatch_memory_subscribe),
-    register_mcp_tool!("memory_unsubscribe", dispatch_memory_unsubscribe),
-    register_mcp_tool!(
-        "memory_list_subscriptions",
-        dispatch_memory_list_subscriptions
-    ),
-    register_mcp_tool!(
-        "memory_subscription_replay",
-        dispatch_memory_subscription_replay
-    ),
-    register_mcp_tool!(
-        "memory_subscription_dlq_list",
-        dispatch_memory_subscription_dlq_list
-    ),
-    register_mcp_tool!("memory_quota_status", dispatch_memory_quota_status),
-    register_mcp_tool!(
-        "memory_check_agent_action",
-        dispatch_memory_check_agent_action
-    ),
-    register_mcp_tool!("memory_rule_list", dispatch_memory_rule_list),
-    register_mcp_tool!(
-        "memory_reflection_origin",
-        dispatch_memory_reflection_origin
-    ),
-    register_mcp_tool!(
-        "memory_export_reflection",
-        dispatch_memory_export_reflection
-    ),
-    register_mcp_tool!("memory_persona", dispatch_memory_persona),
-    register_mcp_tool!("memory_persona_generate", dispatch_memory_persona_generate),
-    register_mcp_tool!(
-        "memory_calibrate_confidence",
-        dispatch_memory_calibrate_confidence
-    ),
-    register_mcp_tool!(
-        "memory_dependents_of_invalidated",
-        dispatch_memory_dependents_of_invalidated
-    ),
-    register_mcp_tool!("memory_skill_register", dispatch_memory_skill_register),
-    register_mcp_tool!("memory_skill_list", dispatch_memory_skill_list),
-    register_mcp_tool!("memory_skill_get", dispatch_memory_skill_get),
-    register_mcp_tool!("memory_skill_resource", dispatch_memory_skill_resource),
-    register_mcp_tool!("memory_skill_export", dispatch_memory_skill_export),
-    register_mcp_tool!(
-        "memory_skill_promote_from_reflection",
-        dispatch_memory_skill_promote_from_reflection
-    ),
-    register_mcp_tool!(
-        "memory_skill_compositional_context",
-        dispatch_memory_skill_compositional_context
-    ),
-    register_mcp_tool!("memory_offload", dispatch_memory_offload),
-    register_mcp_tool!("memory_deref", dispatch_memory_deref),
-];
+///
+/// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): every
+/// dispatch arm references a const from
+/// [`crate::mcp::registry::tool_names`]. Renaming a tool is now a
+/// one-line edit (the const value) rather than a per-call-site sweep.
+pub(crate) static TOOL_DISPATCH_TABLE: &[(&str, DispatchFn)] = {
+    use crate::mcp::registry::tool_names;
+    &[
+        register_mcp_tool!(tool_names::MEMORY_STORE, dispatch_memory_store),
+        register_mcp_tool!(tool_names::MEMORY_RECALL, dispatch_memory_recall),
+        register_mcp_tool!(
+            tool_names::MEMORY_RECALL_OBSERVATIONS,
+            dispatch_memory_recall_observations
+        ),
+        register_mcp_tool!(tool_names::MEMORY_SEARCH, dispatch_memory_search),
+        register_mcp_tool!(tool_names::MEMORY_LIST, dispatch_memory_list),
+        register_mcp_tool!(tool_names::MEMORY_LOAD_FAMILY, dispatch_memory_load_family),
+        register_mcp_tool!(tool_names::MEMORY_SMART_LOAD, dispatch_memory_smart_load),
+        register_mcp_tool!(
+            tool_names::MEMORY_GET_TAXONOMY,
+            dispatch_memory_get_taxonomy
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_CHECK_DUPLICATE,
+            dispatch_memory_check_duplicate
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ENTITY_REGISTER,
+            dispatch_memory_entity_register
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ENTITY_GET_BY_ALIAS,
+            dispatch_memory_entity_get_by_alias
+        ),
+        register_mcp_tool!(tool_names::MEMORY_KG_TIMELINE, dispatch_memory_kg_timeline),
+        register_mcp_tool!(
+            tool_names::MEMORY_KG_INVALIDATE,
+            dispatch_memory_kg_invalidate
+        ),
+        register_mcp_tool!(tool_names::MEMORY_KG_QUERY, dispatch_memory_kg_query),
+        register_mcp_tool!(tool_names::MEMORY_FIND_PATHS, dispatch_memory_find_paths),
+        register_mcp_tool!(tool_names::MEMORY_DELETE, dispatch_memory_delete),
+        register_mcp_tool!(tool_names::MEMORY_PROMOTE, dispatch_memory_promote),
+        register_mcp_tool!(
+            tool_names::MEMORY_PENDING_LIST,
+            dispatch_memory_pending_list
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_PENDING_APPROVE,
+            dispatch_memory_pending_approve
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_PENDING_REJECT,
+            dispatch_memory_pending_reject
+        ),
+        register_mcp_tool!(tool_names::MEMORY_FORGET, dispatch_memory_forget),
+        register_mcp_tool!(tool_names::MEMORY_STATS, dispatch_memory_stats),
+        register_mcp_tool!(tool_names::MEMORY_UPDATE, dispatch_memory_update),
+        register_mcp_tool!(tool_names::MEMORY_GET, dispatch_memory_get),
+        register_mcp_tool!(tool_names::MEMORY_LINK, dispatch_memory_link),
+        register_mcp_tool!(tool_names::MEMORY_GET_LINKS, dispatch_memory_get_links),
+        register_mcp_tool!(tool_names::MEMORY_VERIFY, dispatch_memory_verify),
+        register_mcp_tool!(tool_names::MEMORY_REPLAY, dispatch_memory_replay),
+        register_mcp_tool!(tool_names::MEMORY_CONSOLIDATE, dispatch_memory_consolidate),
+        register_mcp_tool!(tool_names::MEMORY_ATOMISE, dispatch_memory_atomise),
+        register_mcp_tool!(
+            tool_names::MEMORY_INGEST_MULTISTEP,
+            dispatch_memory_ingest_multistep
+        ),
+        register_mcp_tool!(tool_names::MEMORY_REFLECT, dispatch_memory_reflect),
+        register_mcp_tool!(
+            tool_names::MEMORY_CAPABILITIES,
+            dispatch_memory_capabilities
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_EXPAND_QUERY,
+            dispatch_memory_expand_query
+        ),
+        register_mcp_tool!(tool_names::MEMORY_AUTO_TAG, dispatch_memory_auto_tag),
+        register_mcp_tool!(
+            tool_names::MEMORY_DETECT_CONTRADICTION,
+            dispatch_memory_detect_contradiction
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ARCHIVE_LIST,
+            dispatch_memory_archive_list
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ARCHIVE_RESTORE,
+            dispatch_memory_archive_restore
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ARCHIVE_PURGE,
+            dispatch_memory_archive_purge
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_ARCHIVE_STATS,
+            dispatch_memory_archive_stats
+        ),
+        register_mcp_tool!(tool_names::MEMORY_GC, dispatch_memory_gc),
+        register_mcp_tool!(
+            tool_names::MEMORY_SESSION_START,
+            dispatch_memory_session_start
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_NAMESPACE_SET_STANDARD,
+            dispatch_memory_namespace_set_standard
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_NAMESPACE_GET_STANDARD,
+            dispatch_memory_namespace_get_standard
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_NAMESPACE_CLEAR_STANDARD,
+            dispatch_memory_namespace_clear_standard
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_AGENT_REGISTER,
+            dispatch_memory_agent_register
+        ),
+        register_mcp_tool!(tool_names::MEMORY_AGENT_LIST, dispatch_memory_agent_list),
+        register_mcp_tool!(tool_names::MEMORY_NOTIFY, dispatch_memory_notify),
+        register_mcp_tool!(tool_names::MEMORY_SHARE, dispatch_memory_share),
+        register_mcp_tool!(tool_names::MEMORY_INBOX, dispatch_memory_inbox),
+        register_mcp_tool!(tool_names::MEMORY_SUBSCRIBE, dispatch_memory_subscribe),
+        register_mcp_tool!(tool_names::MEMORY_UNSUBSCRIBE, dispatch_memory_unsubscribe),
+        register_mcp_tool!(
+            tool_names::MEMORY_LIST_SUBSCRIPTIONS,
+            dispatch_memory_list_subscriptions
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SUBSCRIPTION_REPLAY,
+            dispatch_memory_subscription_replay
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SUBSCRIPTION_DLQ_LIST,
+            dispatch_memory_subscription_dlq_list
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_QUOTA_STATUS,
+            dispatch_memory_quota_status
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_CHECK_AGENT_ACTION,
+            dispatch_memory_check_agent_action
+        ),
+        register_mcp_tool!(tool_names::MEMORY_RULE_LIST, dispatch_memory_rule_list),
+        register_mcp_tool!(
+            tool_names::MEMORY_REFLECTION_ORIGIN,
+            dispatch_memory_reflection_origin
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_EXPORT_REFLECTION,
+            dispatch_memory_export_reflection
+        ),
+        register_mcp_tool!(tool_names::MEMORY_PERSONA, dispatch_memory_persona),
+        register_mcp_tool!(
+            tool_names::MEMORY_PERSONA_GENERATE,
+            dispatch_memory_persona_generate
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_CALIBRATE_CONFIDENCE,
+            dispatch_memory_calibrate_confidence
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_DEPENDENTS_OF_INVALIDATED,
+            dispatch_memory_dependents_of_invalidated
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SKILL_REGISTER,
+            dispatch_memory_skill_register
+        ),
+        register_mcp_tool!(tool_names::MEMORY_SKILL_LIST, dispatch_memory_skill_list),
+        register_mcp_tool!(tool_names::MEMORY_SKILL_GET, dispatch_memory_skill_get),
+        register_mcp_tool!(
+            tool_names::MEMORY_SKILL_RESOURCE,
+            dispatch_memory_skill_resource
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SKILL_EXPORT,
+            dispatch_memory_skill_export
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SKILL_PROMOTE_FROM_REFLECTION,
+            dispatch_memory_skill_promote_from_reflection
+        ),
+        register_mcp_tool!(
+            tool_names::MEMORY_SKILL_COMPOSITIONAL_CONTEXT,
+            dispatch_memory_skill_compositional_context
+        ),
+        register_mcp_tool!(tool_names::MEMORY_OFFLOAD, dispatch_memory_offload),
+        register_mcp_tool!(tool_names::MEMORY_DEREF, dispatch_memory_deref),
+    ]
+};
 
 /// v0.7.0 #1105 — O(1) HashMap-based lookup against
 /// [`TOOL_DISPATCH_TABLE`]. Pre-#1105 this was a linear scan over the
@@ -1833,11 +1912,12 @@ fn handle_request(
                         .get("format")
                         .and_then(|v| v.as_str())
                         .unwrap_or("toon_compact");
+                    use crate::mcp::registry::tool_names as tn;
                     let text = match format_str {
                         "toon"
                             if matches!(
                                 tool_name,
-                                "memory_recall" | "memory_list" | "memory_session_start"
+                                tn::MEMORY_RECALL | tn::MEMORY_LIST | tn::MEMORY_SESSION_START
                             ) =>
                         {
                             crate::toon::memories_to_toon(&val, false)
@@ -1845,15 +1925,15 @@ fn handle_request(
                         "toon_compact"
                             if matches!(
                                 tool_name,
-                                "memory_recall" | "memory_list" | "memory_session_start"
+                                tn::MEMORY_RECALL | tn::MEMORY_LIST | tn::MEMORY_SESSION_START
                             ) =>
                         {
                             crate::toon::memories_to_toon(&val, true)
                         }
-                        "toon" if tool_name == "memory_search" => {
+                        "toon" if tool_name == tn::MEMORY_SEARCH => {
                             crate::toon::search_to_toon(&val, false)
                         }
-                        "toon_compact" if tool_name == "memory_search" => {
+                        "toon_compact" if tool_name == tn::MEMORY_SEARCH => {
                             crate::toon::search_to_toon(&val, true)
                         }
                         _ => serde_json::to_string_pretty(&val).unwrap_or_default(),

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -5,6 +5,384 @@
 
 use serde_json::{Value, json};
 
+// --- v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep) — tool_names module ---
+
+/// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep) — canonical
+/// constants for every MCP tool name. Replaces ~150 inline string
+/// literals across the codebase. Adding a tool name in one place
+/// instead of N places makes renaming a one-line edit and prevents
+/// silent drift between dispatch-arm tables and audit/governance
+/// allowlists.
+///
+/// **Invariants pinned by the registry-level pin tests below
+/// (`tool_names::pin_tests`):**
+///
+/// - Every const's value is byte-equal to the historical wire string
+///   it replaces; the wire layer still emits `"memory_store"` as the
+///   JSON-RPC method name, exact byte-for-byte.
+/// - Every tool registered in [`registered_tools`] has a matching
+///   `pub const` here and the const value equals the tool's
+///   `McpTool::name()` return.
+/// - The count of consts equals
+///   [`crate::profile::Profile::full().expected_tool_count`].
+///
+/// **Adding a new tool**: append the const here AND the
+/// `RegisteredTool::of::<…>()` line in [`registered_tools`]. The pin
+/// tests will fail if either side is missed.
+///
+/// Naming convention: `MEMORY_<UPPER_SNAKE>` matches the wire string
+/// `memory_<lower_snake>` so the call site reads naturally
+/// (`tool_names::MEMORY_STORE => …` ⇒ `"memory_store" => …`).
+pub mod tool_names {
+    pub const MEMORY_AGENT_LIST: &str = "memory_agent_list";
+    pub const MEMORY_AGENT_REGISTER: &str = "memory_agent_register";
+    pub const MEMORY_ARCHIVE_LIST: &str = "memory_archive_list";
+    pub const MEMORY_ARCHIVE_PURGE: &str = "memory_archive_purge";
+    pub const MEMORY_ARCHIVE_RESTORE: &str = "memory_archive_restore";
+    pub const MEMORY_ARCHIVE_STATS: &str = "memory_archive_stats";
+    pub const MEMORY_ATOMISE: &str = "memory_atomise";
+    pub const MEMORY_AUTO_TAG: &str = "memory_auto_tag";
+    pub const MEMORY_CALIBRATE_CONFIDENCE: &str = "memory_calibrate_confidence";
+    pub const MEMORY_CAPABILITIES: &str = "memory_capabilities";
+    pub const MEMORY_CHECK_AGENT_ACTION: &str = "memory_check_agent_action";
+    pub const MEMORY_CHECK_DUPLICATE: &str = "memory_check_duplicate";
+    pub const MEMORY_CONSOLIDATE: &str = "memory_consolidate";
+    pub const MEMORY_DELETE: &str = "memory_delete";
+    pub const MEMORY_DEPENDENTS_OF_INVALIDATED: &str = "memory_dependents_of_invalidated";
+    pub const MEMORY_DEREF: &str = "memory_deref";
+    pub const MEMORY_DETECT_CONTRADICTION: &str = "memory_detect_contradiction";
+    pub const MEMORY_ENTITY_GET_BY_ALIAS: &str = "memory_entity_get_by_alias";
+    pub const MEMORY_ENTITY_REGISTER: &str = "memory_entity_register";
+    pub const MEMORY_EXPAND_QUERY: &str = "memory_expand_query";
+    pub const MEMORY_EXPORT_REFLECTION: &str = "memory_export_reflection";
+    pub const MEMORY_FIND_PATHS: &str = "memory_find_paths";
+    pub const MEMORY_FORGET: &str = "memory_forget";
+    pub const MEMORY_GC: &str = "memory_gc";
+    pub const MEMORY_GET: &str = "memory_get";
+    pub const MEMORY_GET_LINKS: &str = "memory_get_links";
+    pub const MEMORY_GET_TAXONOMY: &str = "memory_get_taxonomy";
+    pub const MEMORY_INBOX: &str = "memory_inbox";
+    pub const MEMORY_INGEST_MULTISTEP: &str = "memory_ingest_multistep";
+    pub const MEMORY_KG_INVALIDATE: &str = "memory_kg_invalidate";
+    pub const MEMORY_KG_QUERY: &str = "memory_kg_query";
+    pub const MEMORY_KG_TIMELINE: &str = "memory_kg_timeline";
+    pub const MEMORY_LINK: &str = "memory_link";
+    pub const MEMORY_LIST: &str = "memory_list";
+    pub const MEMORY_LIST_SUBSCRIPTIONS: &str = "memory_list_subscriptions";
+    pub const MEMORY_LOAD_FAMILY: &str = "memory_load_family";
+    pub const MEMORY_NAMESPACE_CLEAR_STANDARD: &str = "memory_namespace_clear_standard";
+    pub const MEMORY_NAMESPACE_GET_STANDARD: &str = "memory_namespace_get_standard";
+    pub const MEMORY_NAMESPACE_SET_STANDARD: &str = "memory_namespace_set_standard";
+    pub const MEMORY_NOTIFY: &str = "memory_notify";
+    pub const MEMORY_OFFLOAD: &str = "memory_offload";
+    pub const MEMORY_PENDING_APPROVE: &str = "memory_pending_approve";
+    pub const MEMORY_PENDING_LIST: &str = "memory_pending_list";
+    pub const MEMORY_PENDING_REJECT: &str = "memory_pending_reject";
+    pub const MEMORY_PERSONA: &str = "memory_persona";
+    pub const MEMORY_PERSONA_GENERATE: &str = "memory_persona_generate";
+    pub const MEMORY_PROMOTE: &str = "memory_promote";
+    pub const MEMORY_QUOTA_STATUS: &str = "memory_quota_status";
+    pub const MEMORY_RECALL: &str = "memory_recall";
+    pub const MEMORY_RECALL_OBSERVATIONS: &str = "memory_recall_observations";
+    pub const MEMORY_REFLECT: &str = "memory_reflect";
+    pub const MEMORY_REFLECTION_ORIGIN: &str = "memory_reflection_origin";
+    pub const MEMORY_REPLAY: &str = "memory_replay";
+    pub const MEMORY_RULE_LIST: &str = "memory_rule_list";
+    pub const MEMORY_SEARCH: &str = "memory_search";
+    pub const MEMORY_SESSION_START: &str = "memory_session_start";
+    pub const MEMORY_SHARE: &str = "memory_share";
+    pub const MEMORY_SKILL_COMPOSITIONAL_CONTEXT: &str = "memory_skill_compositional_context";
+    pub const MEMORY_SKILL_EXPORT: &str = "memory_skill_export";
+    pub const MEMORY_SKILL_GET: &str = "memory_skill_get";
+    pub const MEMORY_SKILL_LIST: &str = "memory_skill_list";
+    pub const MEMORY_SKILL_PROMOTE_FROM_REFLECTION: &str = "memory_skill_promote_from_reflection";
+    pub const MEMORY_SKILL_REGISTER: &str = "memory_skill_register";
+    pub const MEMORY_SKILL_RESOURCE: &str = "memory_skill_resource";
+    pub const MEMORY_SMART_LOAD: &str = "memory_smart_load";
+    pub const MEMORY_STATS: &str = "memory_stats";
+    pub const MEMORY_STORE: &str = "memory_store";
+    pub const MEMORY_SUBSCRIBE: &str = "memory_subscribe";
+    pub const MEMORY_SUBSCRIPTION_DLQ_LIST: &str = "memory_subscription_dlq_list";
+    pub const MEMORY_SUBSCRIPTION_REPLAY: &str = "memory_subscription_replay";
+    pub const MEMORY_UNSUBSCRIBE: &str = "memory_unsubscribe";
+    pub const MEMORY_UPDATE: &str = "memory_update";
+    pub const MEMORY_VERIFY: &str = "memory_verify";
+
+    /// The full canonical set of every MCP tool name. Useful for
+    /// iterating in tests + the audit-tool-call dispatcher's
+    /// "known names" guard. Order is alphabetical by const name so
+    /// adding a new entry has a stable diff position. The slice
+    /// length is pinned to `73` by [`pin_tests::const_count_is_73`].
+    ///
+    /// `dead_code` is allowed because the only consumer today is the
+    /// `pin_tests` module below; making it `pub` keeps the API
+    /// available to external test crates (e.g. integration tests
+    /// under `tests/`) that may want to iterate the canonical set
+    /// without re-typing it.
+    #[allow(dead_code)]
+    pub const ALL: &[&str] = &[
+        MEMORY_AGENT_LIST,
+        MEMORY_AGENT_REGISTER,
+        MEMORY_ARCHIVE_LIST,
+        MEMORY_ARCHIVE_PURGE,
+        MEMORY_ARCHIVE_RESTORE,
+        MEMORY_ARCHIVE_STATS,
+        MEMORY_ATOMISE,
+        MEMORY_AUTO_TAG,
+        MEMORY_CALIBRATE_CONFIDENCE,
+        MEMORY_CAPABILITIES,
+        MEMORY_CHECK_AGENT_ACTION,
+        MEMORY_CHECK_DUPLICATE,
+        MEMORY_CONSOLIDATE,
+        MEMORY_DELETE,
+        MEMORY_DEPENDENTS_OF_INVALIDATED,
+        MEMORY_DEREF,
+        MEMORY_DETECT_CONTRADICTION,
+        MEMORY_ENTITY_GET_BY_ALIAS,
+        MEMORY_ENTITY_REGISTER,
+        MEMORY_EXPAND_QUERY,
+        MEMORY_EXPORT_REFLECTION,
+        MEMORY_FIND_PATHS,
+        MEMORY_FORGET,
+        MEMORY_GC,
+        MEMORY_GET,
+        MEMORY_GET_LINKS,
+        MEMORY_GET_TAXONOMY,
+        MEMORY_INBOX,
+        MEMORY_INGEST_MULTISTEP,
+        MEMORY_KG_INVALIDATE,
+        MEMORY_KG_QUERY,
+        MEMORY_KG_TIMELINE,
+        MEMORY_LINK,
+        MEMORY_LIST,
+        MEMORY_LIST_SUBSCRIPTIONS,
+        MEMORY_LOAD_FAMILY,
+        MEMORY_NAMESPACE_CLEAR_STANDARD,
+        MEMORY_NAMESPACE_GET_STANDARD,
+        MEMORY_NAMESPACE_SET_STANDARD,
+        MEMORY_NOTIFY,
+        MEMORY_OFFLOAD,
+        MEMORY_PENDING_APPROVE,
+        MEMORY_PENDING_LIST,
+        MEMORY_PENDING_REJECT,
+        MEMORY_PERSONA,
+        MEMORY_PERSONA_GENERATE,
+        MEMORY_PROMOTE,
+        MEMORY_QUOTA_STATUS,
+        MEMORY_RECALL,
+        MEMORY_RECALL_OBSERVATIONS,
+        MEMORY_REFLECT,
+        MEMORY_REFLECTION_ORIGIN,
+        MEMORY_REPLAY,
+        MEMORY_RULE_LIST,
+        MEMORY_SEARCH,
+        MEMORY_SESSION_START,
+        MEMORY_SHARE,
+        MEMORY_SKILL_COMPOSITIONAL_CONTEXT,
+        MEMORY_SKILL_EXPORT,
+        MEMORY_SKILL_GET,
+        MEMORY_SKILL_LIST,
+        MEMORY_SKILL_PROMOTE_FROM_REFLECTION,
+        MEMORY_SKILL_REGISTER,
+        MEMORY_SKILL_RESOURCE,
+        MEMORY_SMART_LOAD,
+        MEMORY_STATS,
+        MEMORY_STORE,
+        MEMORY_SUBSCRIBE,
+        MEMORY_SUBSCRIPTION_DLQ_LIST,
+        MEMORY_SUBSCRIPTION_REPLAY,
+        MEMORY_UNSUBSCRIBE,
+        MEMORY_UPDATE,
+        MEMORY_VERIFY,
+    ];
+
+    #[cfg(test)]
+    mod pin_tests {
+        //! v0.7.x (issue #1174 PR1) — pin tests for every const VALUE
+        //! is byte-equal to the historical wire string it replaces.
+        //! If any of these fail, the refactor introduced wire drift —
+        //! revert the offending const or the dispatch site, NOT this
+        //! test.
+        use super::*;
+
+        #[test]
+        fn const_count_is_73() {
+            // The v0.7.0 surface advertises 73 MCP tools at
+            // `--profile full` (72 callable + the always-on
+            // `memory_capabilities` bootstrap; both are in `ALL`).
+            // If you added a new tool: bump this to N+1 AND add the
+            // const above AND the slice entry AND a per-name byte-
+            // equal test below AND a `RegisteredTool::of::<…>()`
+            // line in `registered_tools()`. The
+            // `consts_match_registered_tools` test below mechanically
+            // verifies the registry side.
+            assert_eq!(
+                ALL.len(),
+                73,
+                "tool_names::ALL must hold exactly the 73 v0.7.0 MCP tool names"
+            );
+        }
+
+        #[test]
+        fn const_set_is_deduplicated() {
+            // Defence-in-depth: forbids accidental copy-paste
+            // duplication when adding a new const. A duplicate entry
+            // in `ALL` would silently mask the missing tool.
+            use std::collections::BTreeSet;
+            let unique: BTreeSet<&&str> = ALL.iter().collect();
+            assert_eq!(
+                unique.len(),
+                ALL.len(),
+                "tool_names::ALL has duplicate entries"
+            );
+        }
+
+        #[test]
+        fn const_values_lowercase_memory_prefix() {
+            // Wire-shape invariant: every tool name starts with
+            // `"memory_"` and is otherwise `[a-z_]+`. Catches the
+            // failure mode where someone writes
+            // `pub const MEMORY_Foo: &str = "memory_Foo";` and the
+            // const compiles but the wire side rejects the casing.
+            for name in ALL {
+                assert!(
+                    name.starts_with("memory_"),
+                    "tool name {name:?} does not start with 'memory_'"
+                );
+                assert!(
+                    name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                    "tool name {name:?} contains non-[a-z_] character"
+                );
+            }
+        }
+
+        /// Per-name byte-equal pin tests. Each `assert_eq!(CONST, "literal")`
+        /// is the load-bearing assertion: if anyone "tidies" the const
+        /// value (e.g. `"memory_Store"` for camel-case "consistency"
+        /// with a renamed module), the wire layer breaks and this
+        /// test surfaces the regression at `cargo test` time, not at
+        /// `Claude Desktop reload` time.
+        #[test]
+        fn const_values_byte_equal_to_historical_wire_strings() {
+            assert_eq!(MEMORY_AGENT_LIST, "memory_agent_list");
+            assert_eq!(MEMORY_AGENT_REGISTER, "memory_agent_register");
+            assert_eq!(MEMORY_ARCHIVE_LIST, "memory_archive_list");
+            assert_eq!(MEMORY_ARCHIVE_PURGE, "memory_archive_purge");
+            assert_eq!(MEMORY_ARCHIVE_RESTORE, "memory_archive_restore");
+            assert_eq!(MEMORY_ARCHIVE_STATS, "memory_archive_stats");
+            assert_eq!(MEMORY_ATOMISE, "memory_atomise");
+            assert_eq!(MEMORY_AUTO_TAG, "memory_auto_tag");
+            assert_eq!(MEMORY_CALIBRATE_CONFIDENCE, "memory_calibrate_confidence");
+            assert_eq!(MEMORY_CAPABILITIES, "memory_capabilities");
+            assert_eq!(MEMORY_CHECK_AGENT_ACTION, "memory_check_agent_action");
+            assert_eq!(MEMORY_CHECK_DUPLICATE, "memory_check_duplicate");
+            assert_eq!(MEMORY_CONSOLIDATE, "memory_consolidate");
+            assert_eq!(MEMORY_DELETE, "memory_delete");
+            assert_eq!(
+                MEMORY_DEPENDENTS_OF_INVALIDATED,
+                "memory_dependents_of_invalidated"
+            );
+            assert_eq!(MEMORY_DEREF, "memory_deref");
+            assert_eq!(MEMORY_DETECT_CONTRADICTION, "memory_detect_contradiction");
+            assert_eq!(MEMORY_ENTITY_GET_BY_ALIAS, "memory_entity_get_by_alias");
+            assert_eq!(MEMORY_ENTITY_REGISTER, "memory_entity_register");
+            assert_eq!(MEMORY_EXPAND_QUERY, "memory_expand_query");
+            assert_eq!(MEMORY_EXPORT_REFLECTION, "memory_export_reflection");
+            assert_eq!(MEMORY_FIND_PATHS, "memory_find_paths");
+            assert_eq!(MEMORY_FORGET, "memory_forget");
+            assert_eq!(MEMORY_GC, "memory_gc");
+            assert_eq!(MEMORY_GET, "memory_get");
+            assert_eq!(MEMORY_GET_LINKS, "memory_get_links");
+            assert_eq!(MEMORY_GET_TAXONOMY, "memory_get_taxonomy");
+            assert_eq!(MEMORY_INBOX, "memory_inbox");
+            assert_eq!(MEMORY_INGEST_MULTISTEP, "memory_ingest_multistep");
+            assert_eq!(MEMORY_KG_INVALIDATE, "memory_kg_invalidate");
+            assert_eq!(MEMORY_KG_QUERY, "memory_kg_query");
+            assert_eq!(MEMORY_KG_TIMELINE, "memory_kg_timeline");
+            assert_eq!(MEMORY_LINK, "memory_link");
+            assert_eq!(MEMORY_LIST, "memory_list");
+            assert_eq!(MEMORY_LIST_SUBSCRIPTIONS, "memory_list_subscriptions");
+            assert_eq!(MEMORY_LOAD_FAMILY, "memory_load_family");
+            assert_eq!(
+                MEMORY_NAMESPACE_CLEAR_STANDARD,
+                "memory_namespace_clear_standard"
+            );
+            assert_eq!(
+                MEMORY_NAMESPACE_GET_STANDARD,
+                "memory_namespace_get_standard"
+            );
+            assert_eq!(
+                MEMORY_NAMESPACE_SET_STANDARD,
+                "memory_namespace_set_standard"
+            );
+            assert_eq!(MEMORY_NOTIFY, "memory_notify");
+            assert_eq!(MEMORY_OFFLOAD, "memory_offload");
+            assert_eq!(MEMORY_PENDING_APPROVE, "memory_pending_approve");
+            assert_eq!(MEMORY_PENDING_LIST, "memory_pending_list");
+            assert_eq!(MEMORY_PENDING_REJECT, "memory_pending_reject");
+            assert_eq!(MEMORY_PERSONA, "memory_persona");
+            assert_eq!(MEMORY_PERSONA_GENERATE, "memory_persona_generate");
+            assert_eq!(MEMORY_PROMOTE, "memory_promote");
+            assert_eq!(MEMORY_QUOTA_STATUS, "memory_quota_status");
+            assert_eq!(MEMORY_RECALL, "memory_recall");
+            assert_eq!(MEMORY_RECALL_OBSERVATIONS, "memory_recall_observations");
+            assert_eq!(MEMORY_REFLECT, "memory_reflect");
+            assert_eq!(MEMORY_REFLECTION_ORIGIN, "memory_reflection_origin");
+            assert_eq!(MEMORY_REPLAY, "memory_replay");
+            assert_eq!(MEMORY_RULE_LIST, "memory_rule_list");
+            assert_eq!(MEMORY_SEARCH, "memory_search");
+            assert_eq!(MEMORY_SESSION_START, "memory_session_start");
+            assert_eq!(MEMORY_SHARE, "memory_share");
+            assert_eq!(
+                MEMORY_SKILL_COMPOSITIONAL_CONTEXT,
+                "memory_skill_compositional_context"
+            );
+            assert_eq!(MEMORY_SKILL_EXPORT, "memory_skill_export");
+            assert_eq!(MEMORY_SKILL_GET, "memory_skill_get");
+            assert_eq!(MEMORY_SKILL_LIST, "memory_skill_list");
+            assert_eq!(
+                MEMORY_SKILL_PROMOTE_FROM_REFLECTION,
+                "memory_skill_promote_from_reflection"
+            );
+            assert_eq!(MEMORY_SKILL_REGISTER, "memory_skill_register");
+            assert_eq!(MEMORY_SKILL_RESOURCE, "memory_skill_resource");
+            assert_eq!(MEMORY_SMART_LOAD, "memory_smart_load");
+            assert_eq!(MEMORY_STATS, "memory_stats");
+            assert_eq!(MEMORY_STORE, "memory_store");
+            assert_eq!(MEMORY_SUBSCRIBE, "memory_subscribe");
+            assert_eq!(MEMORY_SUBSCRIPTION_DLQ_LIST, "memory_subscription_dlq_list");
+            assert_eq!(MEMORY_SUBSCRIPTION_REPLAY, "memory_subscription_replay");
+            assert_eq!(MEMORY_UNSUBSCRIBE, "memory_unsubscribe");
+            assert_eq!(MEMORY_UPDATE, "memory_update");
+            assert_eq!(MEMORY_VERIFY, "memory_verify");
+        }
+
+        #[test]
+        fn consts_match_registered_tools() {
+            // The `tool_names::ALL` slice and the
+            // `registered_tools()` iterator are two halves of the
+            // same contract: they enumerate the same set of names.
+            // This test enforces that every const value also appears
+            // as some registered tool's `name()` return, and vice
+            // versa. Drift in either direction is a refactor bug.
+            use std::collections::BTreeSet;
+            let from_consts: BTreeSet<&str> = ALL.iter().copied().collect();
+            let from_registry: BTreeSet<&str> = crate::mcp::registry::registered_tools()
+                .iter()
+                .map(|r| r.name)
+                .collect();
+            let only_in_consts: Vec<&&str> = from_consts.difference(&from_registry).collect();
+            let only_in_registry: Vec<&&str> = from_registry.difference(&from_consts).collect();
+            assert!(
+                only_in_consts.is_empty() && only_in_registry.is_empty(),
+                "tool_names::ALL and registered_tools() drifted; \
+                 only_in_consts = {only_in_consts:?}, \
+                 only_in_registry = {only_in_registry:?}"
+            );
+        }
+    }
+}
+
 // --- McpTool trait (v0.7.0 #972 D1.1, issue #982) ---
 
 /// Per-tool descriptor surface introduced by v0.7.0 #972 split D1.1.

--- a/src/mcp/tools/agent.rs
+++ b/src/mcp/tools/agent.rs
@@ -103,7 +103,7 @@ pub struct AgentRegisterTool;
 
 impl McpTool for AgentRegisterTool {
     fn name() -> &'static str {
-        "memory_agent_register"
+        crate::mcp::registry::tool_names::MEMORY_AGENT_REGISTER
     }
     fn description() -> &'static str {
         "Register an agent in the reserved _agents namespace."
@@ -132,7 +132,7 @@ pub struct AgentListTool;
 
 impl McpTool for AgentListTool {
     fn name() -> &'static str {
-        "memory_agent_list"
+        crate::mcp::registry::tool_names::MEMORY_AGENT_LIST
     }
     fn description() -> &'static str {
         "List every registered agent."

--- a/src/mcp/tools/archive.rs
+++ b/src/mcp/tools/archive.rs
@@ -170,7 +170,7 @@ pub struct ArchiveListTool;
 
 impl McpTool for ArchiveListTool {
     fn name() -> &'static str {
-        "memory_archive_list"
+        crate::mcp::registry::tool_names::MEMORY_ARCHIVE_LIST
     }
     fn description() -> &'static str {
         "List archived (expired) memories."
@@ -202,7 +202,7 @@ pub struct ArchivePurgeTool;
 
 impl McpTool for ArchivePurgeTool {
     fn name() -> &'static str {
-        "memory_archive_purge"
+        crate::mcp::registry::tool_names::MEMORY_ARCHIVE_PURGE
     }
     fn description() -> &'static str {
         "Permanently delete archived memories."
@@ -233,7 +233,7 @@ pub struct ArchiveRestoreTool;
 
 impl McpTool for ArchiveRestoreTool {
     fn name() -> &'static str {
-        "memory_archive_restore"
+        crate::mcp::registry::tool_names::MEMORY_ARCHIVE_RESTORE
     }
     fn description() -> &'static str {
         "Restore an archived memory back to the active store."
@@ -271,7 +271,7 @@ pub struct GcTool;
 
 impl McpTool for GcTool {
     fn name() -> &'static str {
-        "memory_gc"
+        crate::mcp::registry::tool_names::MEMORY_GC
     }
     fn description() -> &'static str {
         "Trigger garbage collection on expired memories (archives first)."
@@ -294,7 +294,7 @@ pub struct ArchiveStatsTool;
 
 impl McpTool for ArchiveStatsTool {
     fn name() -> &'static str {
-        "memory_archive_stats"
+        crate::mcp::registry::tool_names::MEMORY_ARCHIVE_STATS
     }
     fn description() -> &'static str {
         "Show archive statistics (total count and per-namespace breakdown)."

--- a/src/mcp/tools/atomise.rs
+++ b/src/mcp/tools/atomise.rs
@@ -262,7 +262,7 @@ pub struct AtomiseTool;
 
 impl McpTool for AtomiseTool {
     fn name() -> &'static str {
-        "memory_atomise"
+        crate::mcp::registry::tool_names::MEMORY_ATOMISE
     }
     fn description() -> &'static str {
         "Decompose a memory into 2-10 atomic propositions; source archived. Smart+ tier."

--- a/src/mcp/tools/auto_tag.rs
+++ b/src/mcp/tools/auto_tag.rs
@@ -79,7 +79,7 @@ pub struct AutoTagTool;
 
 impl McpTool for AutoTagTool {
     fn name() -> &'static str {
-        "memory_auto_tag"
+        crate::mcp::registry::tool_names::MEMORY_AUTO_TAG
     }
     fn description() -> &'static str {
         "LLM-generate tags for a memory (smart/autonomous tier)."

--- a/src/mcp/tools/calibrate_confidence.rs
+++ b/src/mcp/tools/calibrate_confidence.rs
@@ -77,7 +77,7 @@ pub struct CalibrateConfidenceTool;
 
 impl McpTool for CalibrateConfidenceTool {
     fn name() -> &'static str {
-        "memory_calibrate_confidence"
+        crate::mcp::registry::tool_names::MEMORY_CALIBRATE_CONFIDENCE
     }
     fn description() -> &'static str {
         "Scan confidence_shadow_observations and emit per-source baselines (Form 5)."

--- a/src/mcp/tools/capabilities.rs
+++ b/src/mcp/tools/capabilities.rs
@@ -65,7 +65,7 @@ pub struct CapabilitiesTool;
 
 impl McpTool for CapabilitiesTool {
     fn name() -> &'static str {
-        "memory_capabilities"
+        crate::mcp::registry::tool_names::MEMORY_CAPABILITIES
     }
 
     fn description() -> &'static str {
@@ -677,6 +677,7 @@ pub fn build_capabilities_tools(
 #[must_use]
 pub fn tool_examples(name: &str) -> Vec<crate::config::ToolExample> {
     use crate::config::ToolExample;
+    use crate::mcp::registry::tool_names as tn;
     use crate::models::Tier;
     use serde_json::json;
     let ex = |call: serde_json::Value, desc: &str| ToolExample {
@@ -684,27 +685,27 @@ pub fn tool_examples(name: &str) -> Vec<crate::config::ToolExample> {
         description: desc.to_string(),
     };
     match name {
-        "memory_store" => vec![ex(
+        tn::MEMORY_STORE => vec![ex(
             json!({"title": "design", "content": "wt-1 atomisation", "tier": Tier::Long.as_str(), "namespace": "ai-memory"}),
             "Persists a long-tier memory; returns {id, status}.",
         )],
-        "memory_recall" => vec![ex(
+        tn::MEMORY_RECALL => vec![ex(
             json!({"query": "atomisation gates", "namespace": "ai-memory", "limit": 5}),
             "Hybrid FTS+semantic recall; returns top-K ranked memories.",
         )],
-        "memory_search" => vec![ex(
+        tn::MEMORY_SEARCH => vec![ex(
             json!({"query": "L1-6 governance", "limit": 10}),
             "FTS5 keyword search across namespaces.",
         )],
-        "memory_link" => vec![ex(
+        tn::MEMORY_LINK => vec![ex(
             json!({"from_id": "<uuid-a>", "to_id": "<uuid-b>", "relation": "derives_from"}),
             "Signed directional edge; returns {link_id, attest_level}.",
         )],
-        "memory_reflect" => vec![ex(
+        tn::MEMORY_REFLECT => vec![ex(
             json!({"memory_ids": ["<uuid-1>", "<uuid-2>"], "depth": 1}),
             "Curator synthesises a Reflection; returns {reflection_id}.",
         )],
-        "memory_persona_generate" => vec![
+        tn::MEMORY_PERSONA_GENERATE => vec![
             ex(
                 json!({"entity_id": "alice", "namespace": "team/alpha"}),
                 "Single-namespace scope.",
@@ -714,43 +715,43 @@ pub fn tool_examples(name: &str) -> Vec<crate::config::ToolExample> {
                 "#848 cross-namespace; persona lands in 'global'.",
             ),
         ],
-        "memory_consolidate" => vec![ex(
+        tn::MEMORY_CONSOLIDATE => vec![ex(
             json!({"namespace": "raw/notes", "into_namespace": "team/alpha", "limit": 20}),
             "Curator distils notes into one consolidated memory.",
         )],
-        "memory_atomise" => vec![ex(
+        tn::MEMORY_ATOMISE => vec![ex(
             json!({"memory_id": "<long-uuid>", "max_atom_tokens": 200}),
             "WT-1 decomposition; archives parent.",
         )],
-        "memory_find_paths" => vec![ex(
+        tn::MEMORY_FIND_PATHS => vec![ex(
             json!({"from_id": "<uuid-a>", "to_id": "<uuid-b>", "max_depth": 4}),
             "BFS over KG; returns path arrays of memory ids.",
         )],
-        "memory_kg_query" => vec![ex(
+        tn::MEMORY_KG_QUERY => vec![ex(
             json!({"start_id": "<uuid>", "relation": "derives_from", "direction": "out", "depth": 2}),
             "Typed KG walk; returns nodes+edges.",
         )],
-        "memory_export_reflection" => vec![ex(
+        tn::MEMORY_EXPORT_REFLECTION => vec![ex(
             json!({"memory_id": "<reflection-uuid>", "format": "md"}),
             "QW-1 export; returns {content, suggested_filename}.",
         )],
-        "memory_smart_load" => vec![ex(
+        tn::MEMORY_SMART_LOAD => vec![ex(
             json!({"intent": "inspect the knowledge graph", "include_schema": true}),
             "B2 intent routing.",
         )],
-        "memory_load_family" => vec![ex(
+        tn::MEMORY_LOAD_FAMILY => vec![ex(
             json!({"family": "graph", "include_schema": true}),
             "B1 explicit family load.",
         )],
-        "memory_session_start" => vec![ex(
+        tn::MEMORY_SESSION_START => vec![ex(
             json!({"topic": "v0.7.0 ship"}),
             "SessionStart bootstrap; returns memories+persona+rules.",
         )],
-        "memory_verify" => vec![ex(
+        tn::MEMORY_VERIFY => vec![ex(
             json!({"memory_id": "<uuid>"}),
             "H4 signature replay; returns {verified, attest_level}.",
         )],
-        "memory_notify" => vec![ex(
+        tn::MEMORY_NOTIFY => vec![ex(
             json!({"event_type": "deploy.completed", "payload": {"env": "prod"}, "ttl_seconds": crate::SECS_PER_HOUR}),
             "Fan-out to active subscribers.",
         )],

--- a/src/mcp/tools/check_agent_action.rs
+++ b/src/mcp/tools/check_agent_action.rs
@@ -270,7 +270,7 @@ pub struct CheckAgentActionTool;
 
 impl McpTool for CheckAgentActionTool {
     fn name() -> &'static str {
-        "memory_check_agent_action"
+        crate::mcp::registry::tool_names::MEMORY_CHECK_AGENT_ACTION
     }
     fn description() -> &'static str {
         "Check action vs governance_rules (#691); Allow/Refuse/Warn."

--- a/src/mcp/tools/check_duplicate.rs
+++ b/src/mcp/tools/check_duplicate.rs
@@ -99,7 +99,7 @@ pub struct CheckDuplicateTool;
 
 impl McpTool for CheckDuplicateTool {
     fn name() -> &'static str {
-        "memory_check_duplicate"
+        crate::mcp::registry::tool_names::MEMORY_CHECK_DUPLICATE
     }
     fn description() -> &'static str {
         "Pre-write near-duplicate check via cosine over stored embeddings."

--- a/src/mcp/tools/consolidate.rs
+++ b/src/mcp/tools/consolidate.rs
@@ -231,7 +231,7 @@ pub struct ConsolidateTool;
 
 impl McpTool for ConsolidateTool {
     fn name() -> &'static str {
-        "memory_consolidate"
+        crate::mcp::registry::tool_names::MEMORY_CONSOLIDATE
     }
     fn description() -> &'static str {
         "Consolidate multiple memories into one long-term summary."

--- a/src/mcp/tools/delete.rs
+++ b/src/mcp/tools/delete.rs
@@ -26,7 +26,7 @@ pub struct DeleteTool;
 
 impl McpTool for DeleteTool {
     fn name() -> &'static str {
-        "memory_delete"
+        crate::mcp::registry::tool_names::MEMORY_DELETE
     }
     fn description() -> &'static str {
         "Delete a memory by ID."
@@ -89,7 +89,7 @@ pub(super) fn handle_delete(
     crate::governance::audit::record_decision(
         &caller_for_forensic,
         "allow",
-        "memory_delete",
+        crate::mcp::registry::tool_names::MEMORY_DELETE,
         "",
         json!({ "id": id }),
     );
@@ -224,7 +224,7 @@ pub(super) fn handle_delete(
         .ok();
         crate::subscriptions::dispatch_event_with_details(
             conn,
-            "memory_delete",
+            crate::mcp::registry::tool_names::MEMORY_DELETE,
             &target.id,
             &snapshot_namespace,
             snapshot_owner.as_deref(),

--- a/src/mcp/tools/dependents_of_invalidated.rs
+++ b/src/mcp/tools/dependents_of_invalidated.rs
@@ -86,7 +86,7 @@ pub struct DependentsOfInvalidatedTool;
 
 impl McpTool for DependentsOfInvalidatedTool {
     fn name() -> &'static str {
-        "memory_dependents_of_invalidated"
+        crate::mcp::registry::tool_names::MEMORY_DEPENDENTS_OF_INVALIDATED
     }
     fn description() -> &'static str {
         "List dependents flagged by the L2-3 invalidation walker."

--- a/src/mcp/tools/detect_contradiction.rs
+++ b/src/mcp/tools/detect_contradiction.rs
@@ -70,7 +70,7 @@ pub struct DetectContradictionTool;
 
 impl McpTool for DetectContradictionTool {
     fn name() -> &'static str {
-        "memory_detect_contradiction"
+        crate::mcp::registry::tool_names::MEMORY_DETECT_CONTRADICTION
     }
     fn description() -> &'static str {
         "LLM-check whether two memories contradict each other (smart/autonomous tier)."

--- a/src/mcp/tools/entity_get_by_alias.rs
+++ b/src/mcp/tools/entity_get_by_alias.rs
@@ -29,7 +29,7 @@ pub struct EntityGetByAliasTool;
 
 impl McpTool for EntityGetByAliasTool {
     fn name() -> &'static str {
-        "memory_entity_get_by_alias"
+        crate::mcp::registry::tool_names::MEMORY_ENTITY_GET_BY_ALIAS
     }
     fn description() -> &'static str {
         "Resolve an alias to its registered entity."

--- a/src/mcp/tools/entity_register.rs
+++ b/src/mcp/tools/entity_register.rs
@@ -40,7 +40,7 @@ pub struct EntityRegisterTool;
 
 impl McpTool for EntityRegisterTool {
     fn name() -> &'static str {
-        "memory_entity_register"
+        crate::mcp::registry::tool_names::MEMORY_ENTITY_REGISTER
     }
     fn description() -> &'static str {
         "Register an entity (canonical name + aliases) under a namespace."

--- a/src/mcp/tools/expand_query.rs
+++ b/src/mcp/tools/expand_query.rs
@@ -49,7 +49,7 @@ pub struct ExpandQueryTool;
 
 impl McpTool for ExpandQueryTool {
     fn name() -> &'static str {
-        "memory_expand_query"
+        crate::mcp::registry::tool_names::MEMORY_EXPAND_QUERY
     }
     fn description() -> &'static str {
         "LLM-expand a search query into related terms (smart/autonomous tier)."

--- a/src/mcp/tools/export_reflection.rs
+++ b/src/mcp/tools/export_reflection.rs
@@ -148,7 +148,7 @@ pub struct ExportReflectionTool;
 
 impl McpTool for ExportReflectionTool {
     fn name() -> &'static str {
-        "memory_export_reflection"
+        crate::mcp::registry::tool_names::MEMORY_EXPORT_REFLECTION
     }
     fn description() -> &'static str {
         "Render a single reflection memory as markdown or JSON (no filesystem write)."

--- a/src/mcp/tools/find_paths.rs
+++ b/src/mcp/tools/find_paths.rs
@@ -40,7 +40,7 @@ pub struct FindPathsTool;
 
 impl McpTool for FindPathsTool {
     fn name() -> &'static str {
-        "memory_find_paths"
+        crate::mcp::registry::tool_names::MEMORY_FIND_PATHS
     }
     fn description() -> &'static str {
         "Enumerate up to N paths through the KG between two memories (BFS, max_depth<=7)."

--- a/src/mcp/tools/forget.rs
+++ b/src/mcp/tools/forget.rs
@@ -68,7 +68,7 @@ pub struct ForgetTool;
 
 impl McpTool for ForgetTool {
     fn name() -> &'static str {
-        "memory_forget"
+        crate::mcp::registry::tool_names::MEMORY_FORGET
     }
     fn description() -> &'static str {
         "Bulk delete memories matching a pattern, namespace, or tier (archives first)."
@@ -97,7 +97,7 @@ pub struct StatsTool;
 
 impl McpTool for StatsTool {
     fn name() -> &'static str {
-        "memory_stats"
+        crate::mcp::registry::tool_names::MEMORY_STATS
     }
     fn description() -> &'static str {
         "Get memory store statistics (counts, tier breakdown, sizes)."

--- a/src/mcp/tools/get.rs
+++ b/src/mcp/tools/get.rs
@@ -25,7 +25,7 @@ pub struct GetTool;
 
 impl McpTool for GetTool {
     fn name() -> &'static str {
-        "memory_get"
+        crate::mcp::registry::tool_names::MEMORY_GET
     }
     fn description() -> &'static str {
         "Get a specific memory by ID, including its links."

--- a/src/mcp/tools/get_taxonomy.rs
+++ b/src/mcp/tools/get_taxonomy.rs
@@ -34,7 +34,7 @@ pub struct GetTaxonomyTool;
 
 impl McpTool for GetTaxonomyTool {
     fn name() -> &'static str {
-        "memory_get_taxonomy"
+        crate::mcp::registry::tool_names::MEMORY_GET_TAXONOMY
     }
     fn description() -> &'static str {
         "Return a hierarchical tree of namespaces with memory counts."

--- a/src/mcp/tools/ingest_multistep.rs
+++ b/src/mcp/tools/ingest_multistep.rs
@@ -217,7 +217,7 @@ pub struct IngestMultistepTool;
 
 impl McpTool for IngestMultistepTool {
     fn name() -> &'static str {
-        "memory_ingest_multistep"
+        crate::mcp::registry::tool_names::MEMORY_INGEST_MULTISTEP
     }
     fn description() -> &'static str {
         "Form 3 multi-step ingest: deterministic helpers + LLM stages."

--- a/src/mcp/tools/kg_invalidate.rs
+++ b/src/mcp/tools/kg_invalidate.rs
@@ -36,7 +36,7 @@ pub struct KgInvalidateTool;
 
 impl McpTool for KgInvalidateTool {
     fn name() -> &'static str {
-        "memory_kg_invalidate"
+        crate::mcp::registry::tool_names::MEMORY_KG_INVALIDATE
     }
     fn description() -> &'static str {
         "Mark a KG link as superseded by setting its valid_until column."

--- a/src/mcp/tools/kg_query.rs
+++ b/src/mcp/tools/kg_query.rs
@@ -53,7 +53,7 @@ pub struct KgQueryTool;
 
 impl McpTool for KgQueryTool {
     fn name() -> &'static str {
-        "memory_kg_query"
+        crate::mcp::registry::tool_names::MEMORY_KG_QUERY
     }
     fn description() -> &'static str {
         "Outbound KG traversal from a source memory (<=5 hops)."

--- a/src/mcp/tools/kg_timeline.rs
+++ b/src/mcp/tools/kg_timeline.rs
@@ -37,7 +37,7 @@ pub struct KgTimelineTool;
 
 impl McpTool for KgTimelineTool {
     fn name() -> &'static str {
-        "memory_kg_timeline"
+        crate::mcp::registry::tool_names::MEMORY_KG_TIMELINE
     }
     fn description() -> &'static str {
         "Ordered fact timeline for an entity (outbound KG links by valid_from)."

--- a/src/mcp/tools/link.rs
+++ b/src/mcp/tools/link.rs
@@ -33,7 +33,7 @@ pub struct LinkTool;
 
 impl McpTool for LinkTool {
     fn name() -> &'static str {
-        "memory_link"
+        crate::mcp::registry::tool_names::MEMORY_LINK
     }
     fn description() -> &'static str {
         "Create a typed link between two memories."
@@ -64,7 +64,7 @@ pub struct GetLinksTool;
 
 impl McpTool for GetLinksTool {
     fn name() -> &'static str {
-        "memory_get_links"
+        crate::mcp::registry::tool_names::MEMORY_GET_LINKS
     }
     fn description() -> &'static str {
         "Get all links for a memory (both directions)."

--- a/src/mcp/tools/list.rs
+++ b/src/mcp/tools/list.rs
@@ -40,7 +40,7 @@ pub struct ListTool;
 
 impl McpTool for ListTool {
     fn name() -> &'static str {
-        "memory_list"
+        crate::mcp::registry::tool_names::MEMORY_LIST
     }
     fn description() -> &'static str {
         "List memories, optionally filtered by namespace or tier."

--- a/src/mcp/tools/load_family.rs
+++ b/src/mcp/tools/load_family.rs
@@ -38,7 +38,7 @@ pub struct LoadFamilyTool;
 
 impl McpTool for LoadFamilyTool {
     fn name() -> &'static str {
-        "memory_load_family"
+        crate::mcp::registry::tool_names::MEMORY_LOAD_FAMILY
     }
     fn description() -> &'static str {
         "Load top-k recent + high-priority memories from a Family."
@@ -80,7 +80,7 @@ pub struct SmartLoadTool;
 
 impl McpTool for SmartLoadTool {
     fn name() -> &'static str {
-        "memory_smart_load"
+        crate::mcp::registry::tool_names::MEMORY_SMART_LOAD
     }
     fn description() -> &'static str {
         "Intent-routed loader: free-text intent picks the best Family."

--- a/src/mcp/tools/namespace.rs
+++ b/src/mcp/tools/namespace.rs
@@ -38,7 +38,7 @@ pub struct NamespaceSetStandardTool;
 
 impl McpTool for NamespaceSetStandardTool {
     fn name() -> &'static str {
-        "memory_namespace_set_standard"
+        crate::mcp::registry::tool_names::MEMORY_NAMESPACE_SET_STANDARD
     }
     fn description() -> &'static str {
         "Set a memory as the standard/policy for a namespace."
@@ -73,7 +73,7 @@ pub struct NamespaceGetStandardTool;
 
 impl McpTool for NamespaceGetStandardTool {
     fn name() -> &'static str {
-        "memory_namespace_get_standard"
+        crate::mcp::registry::tool_names::MEMORY_NAMESPACE_GET_STANDARD
     }
     fn description() -> &'static str {
         "Get the standard/policy memory for a namespace."
@@ -104,7 +104,7 @@ pub struct NamespaceClearStandardTool;
 
 impl McpTool for NamespaceClearStandardTool {
     fn name() -> &'static str {
-        "memory_namespace_clear_standard"
+        crate::mcp::registry::tool_names::MEMORY_NAMESPACE_CLEAR_STANDARD
     }
     fn description() -> &'static str {
         "Clear the standard/policy for a namespace."

--- a/src/mcp/tools/notify.rs
+++ b/src/mcp/tools/notify.rs
@@ -182,7 +182,7 @@ pub struct NotifyTool;
 
 impl McpTool for NotifyTool {
     fn name() -> &'static str {
-        "memory_notify"
+        crate::mcp::registry::tool_names::MEMORY_NOTIFY
     }
     fn description() -> &'static str {
         "Send a message from the caller to another agent's inbox."
@@ -222,7 +222,7 @@ pub struct InboxTool;
 
 impl McpTool for InboxTool {
     fn name() -> &'static str {
-        "memory_inbox"
+        crate::mcp::registry::tool_names::MEMORY_INBOX
     }
     fn description() -> &'static str {
         "List messages sent to an agent via memory_notify."

--- a/src/mcp/tools/offload.rs
+++ b/src/mcp/tools/offload.rs
@@ -122,7 +122,7 @@ pub struct OffloadTool;
 
 impl McpTool for OffloadTool {
     fn name() -> &'static str {
-        "memory_offload"
+        crate::mcp::registry::tool_names::MEMORY_OFFLOAD
     }
     fn description() -> &'static str {
         "Offload verbatim content; returns ref_id (Family::Power)."
@@ -153,7 +153,7 @@ pub struct DerefTool;
 
 impl McpTool for DerefTool {
     fn name() -> &'static str {
-        "memory_deref"
+        crate::mcp::registry::tool_names::MEMORY_DEREF
     }
     fn description() -> &'static str {
         "Dereference a memory_offload ref_id (Family::Power)."

--- a/src/mcp/tools/pending.rs
+++ b/src/mcp/tools/pending.rs
@@ -30,7 +30,7 @@ pub struct PendingListTool;
 
 impl McpTool for PendingListTool {
     fn name() -> &'static str {
-        "memory_pending_list"
+        crate::mcp::registry::tool_names::MEMORY_PENDING_LIST
     }
     fn description() -> &'static str {
         "List pending governance-queued actions."
@@ -65,7 +65,7 @@ pub struct PendingApproveTool;
 
 impl McpTool for PendingApproveTool {
     fn name() -> &'static str {
-        "memory_pending_approve"
+        crate::mcp::registry::tool_names::MEMORY_PENDING_APPROVE
     }
     fn description() -> &'static str {
         "Approve a pending action; `remember` auto-decides next time."
@@ -100,7 +100,7 @@ pub struct PendingRejectTool;
 
 impl McpTool for PendingRejectTool {
     fn name() -> &'static str {
-        "memory_pending_reject"
+        crate::mcp::registry::tool_names::MEMORY_PENDING_REJECT
     }
     fn description() -> &'static str {
         "Reject a pending action; `remember` auto-decides next time."
@@ -375,7 +375,7 @@ pub struct SubscriptionDlqListTool;
 
 impl McpTool for SubscriptionDlqListTool {
     fn name() -> &'static str {
-        "memory_subscription_dlq_list"
+        crate::mcp::registry::tool_names::MEMORY_SUBSCRIPTION_DLQ_LIST
     }
     fn description() -> &'static str {
         "List subscription_dlq rows (exhausted retry ladder)."

--- a/src/mcp/tools/persona.rs
+++ b/src/mcp/tools/persona.rs
@@ -192,7 +192,7 @@ pub struct PersonaTool;
 
 impl McpTool for PersonaTool {
     fn name() -> &'static str {
-        "memory_persona"
+        crate::mcp::registry::tool_names::MEMORY_PERSONA
     }
     fn description() -> &'static str {
         "Fetch the latest Persona artefact for an entity (read-only)."
@@ -230,7 +230,7 @@ pub struct PersonaGenerateTool;
 
 impl McpTool for PersonaGenerateTool {
     fn name() -> &'static str {
-        "memory_persona_generate"
+        crate::mcp::registry::tool_names::MEMORY_PERSONA_GENERATE
     }
     fn description() -> &'static str {
         "Generate/regen a Persona artefact for an entity."

--- a/src/mcp/tools/promote.rs
+++ b/src/mcp/tools/promote.rs
@@ -36,7 +36,7 @@ pub struct PromoteTool;
 
 impl McpTool for PromoteTool {
     fn name() -> &'static str {
-        "memory_promote"
+        crate::mcp::registry::tool_names::MEMORY_PROMOTE
     }
     fn description() -> &'static str {
         "Promote a memory to long (or chosen tier) / ancestor namespace."
@@ -168,7 +168,7 @@ pub(super) fn handle_promote(
         .ok();
         crate::subscriptions::dispatch_event_with_details(
             conn,
-            "memory_promote",
+            crate::mcp::registry::tool_names::MEMORY_PROMOTE,
             &resolved_id,
             &snapshot_namespace,
             snapshot_owner.as_deref(),

--- a/src/mcp/tools/quota_status.rs
+++ b/src/mcp/tools/quota_status.rs
@@ -101,7 +101,7 @@ pub struct QuotaStatusTool;
 
 impl McpTool for QuotaStatusTool {
     fn name() -> &'static str {
-        "memory_quota_status"
+        crate::mcp::registry::tool_names::MEMORY_QUOTA_STATUS
     }
     fn description() -> &'static str {
         "Report per-agent + per-namespace quota usage. Operator-facing."

--- a/src/mcp/tools/recall.rs
+++ b/src/mcp/tools/recall.rs
@@ -34,7 +34,7 @@ pub struct RecallTool;
 
 impl McpTool for RecallTool {
     fn name() -> &'static str {
-        "memory_recall"
+        crate::mcp::registry::tool_names::MEMORY_RECALL
     }
     fn description() -> &'static str {
         "Recall memories relevant to a context (ranked)."

--- a/src/mcp/tools/recall_observations.rs
+++ b/src/mcp/tools/recall_observations.rs
@@ -85,7 +85,7 @@ pub struct RecallObservationsTool;
 
 impl McpTool for RecallObservationsTool {
     fn name() -> &'static str {
-        "memory_recall_observations"
+        crate::mcp::registry::tool_names::MEMORY_RECALL_OBSERVATIONS
     }
     fn description() -> &'static str {
         "List recall_observations (#886)."

--- a/src/mcp/tools/reflect.rs
+++ b/src/mcp/tools/reflect.rs
@@ -381,7 +381,7 @@ pub struct ReflectTool;
 
 impl McpTool for ReflectTool {
     fn name() -> &'static str {
-        "memory_reflect"
+        crate::mcp::registry::tool_names::MEMORY_REFLECT
     }
     fn description() -> &'static str {
         "Persist a reflection memory plus reflects_on provenance links to each source."

--- a/src/mcp/tools/reflection_origin.rs
+++ b/src/mcp/tools/reflection_origin.rs
@@ -78,7 +78,7 @@ pub struct ReflectionOriginTool;
 
 impl McpTool for ReflectionOriginTool {
     fn name() -> &'static str {
-        "memory_reflection_origin"
+        crate::mcp::registry::tool_names::MEMORY_REFLECTION_ORIGIN
     }
     fn description() -> &'static str {
         "Inspect the cross-peer provenance of a reflection memory."

--- a/src/mcp/tools/replay.rs
+++ b/src/mcp/tools/replay.rs
@@ -38,7 +38,7 @@ pub struct ReplayTool;
 
 impl McpTool for ReplayTool {
     fn name() -> &'static str {
-        "memory_replay"
+        crate::mcp::registry::tool_names::MEMORY_REPLAY
     }
     fn description() -> &'static str {
         "Reconstruct the conversation transcript chain that produced a memory."

--- a/src/mcp/tools/rule_list.rs
+++ b/src/mcp/tools/rule_list.rs
@@ -139,7 +139,7 @@ pub struct RuleListTool;
 
 impl McpTool for RuleListTool {
     fn name() -> &'static str {
-        "memory_rule_list"
+        crate::mcp::registry::tool_names::MEMORY_RULE_LIST
     }
     fn description() -> &'static str {
         "List substrate-level agent-action rules. Read-only (#691)."

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -50,7 +50,7 @@ pub struct SearchTool;
 
 impl McpTool for SearchTool {
     fn name() -> &'static str {
-        "memory_search"
+        crate::mcp::registry::tool_names::MEMORY_SEARCH
     }
     fn description() -> &'static str {
         "Search memories by exact keyword match (AND semantics)."

--- a/src/mcp/tools/session_start.rs
+++ b/src/mcp/tools/session_start.rs
@@ -112,7 +112,7 @@ pub struct SessionStartTool;
 
 impl McpTool for SessionStartTool {
     fn name() -> &'static str {
-        "memory_session_start"
+        crate::mcp::registry::tool_names::MEMORY_SESSION_START
     }
     fn description() -> &'static str {
         "Auto-recall recent memories on session start."

--- a/src/mcp/tools/share.rs
+++ b/src/mcp/tools/share.rs
@@ -160,7 +160,7 @@ pub struct ShareTool;
 
 impl McpTool for ShareTool {
     fn name() -> &'static str {
-        "memory_share"
+        crate::mcp::registry::tool_names::MEMORY_SHARE
     }
     fn description() -> &'static str {
         "Share a memory with another agent (copy into _shared/<from>→<to>/)."

--- a/src/mcp/tools/skill_compositional_context.rs
+++ b/src/mcp/tools/skill_compositional_context.rs
@@ -359,7 +359,7 @@ pub struct SkillCompositionalContextTool;
 
 impl McpTool for SkillCompositionalContextTool {
     fn name() -> &'static str {
-        "memory_skill_compositional_context"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_COMPOSITIONAL_CONTEXT
     }
     fn description() -> &'static str {
         "Skill body + composes_with_reflections (bounded by max_reflection_depth)."

--- a/src/mcp/tools/skill_export.rs
+++ b/src/mcp/tools/skill_export.rs
@@ -302,7 +302,7 @@ pub struct SkillExportTool;
 
 impl McpTool for SkillExportTool {
     fn name() -> &'static str {
-        "memory_skill_export"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_EXPORT
     }
     fn description() -> &'static str {
         "Export a skill to a folder; re-register produces identical digest."

--- a/src/mcp/tools/skill_get.rs
+++ b/src/mcp/tools/skill_get.rs
@@ -172,7 +172,7 @@ pub struct SkillGetTool;
 
 impl McpTool for SkillGetTool {
     fn name() -> &'static str {
-        "memory_skill_get"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_GET
     }
     fn description() -> &'static str {
         "Get full skill activation payload (metadata + body)."

--- a/src/mcp/tools/skill_list.rs
+++ b/src/mcp/tools/skill_list.rs
@@ -141,7 +141,7 @@ pub struct SkillListTool;
 
 impl McpTool for SkillListTool {
     fn name() -> &'static str {
-        "memory_skill_list"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_LIST
     }
     fn description() -> &'static str {
         "List current (non-superseded) skills; body not returned."

--- a/src/mcp/tools/skill_promote.rs
+++ b/src/mcp/tools/skill_promote.rs
@@ -369,7 +369,7 @@ pub struct SkillPromoteFromReflectionTool;
 
 impl McpTool for SkillPromoteFromReflectionTool {
     fn name() -> &'static str {
-        "memory_skill_promote_from_reflection"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_PROMOTE_FROM_REFLECTION
     }
     fn description() -> &'static str {
         "Promote a Reflection into a reusable Agent Skill."

--- a/src/mcp/tools/skill_register.rs
+++ b/src/mcp/tools/skill_register.rs
@@ -426,7 +426,7 @@ pub struct SkillRegisterTool;
 
 impl McpTool for SkillRegisterTool {
     fn name() -> &'static str {
-        "memory_skill_register"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_REGISTER
     }
     fn description() -> &'static str {
         "Register an agentskills.io SKILL.md from a folder or inline text."

--- a/src/mcp/tools/skill_resource.rs
+++ b/src/mcp/tools/skill_resource.rs
@@ -124,7 +124,7 @@ pub struct SkillResourceTool;
 
 impl McpTool for SkillResourceTool {
     fn name() -> &'static str {
-        "memory_skill_resource"
+        crate::mcp::registry::tool_names::MEMORY_SKILL_RESOURCE
     }
     fn description() -> &'static str {
         "Fetch + digest-verify a skill resource."

--- a/src/mcp/tools/store/mod.rs
+++ b/src/mcp/tools/store/mod.rs
@@ -117,7 +117,7 @@ pub struct StoreTool;
 
 impl McpTool for StoreTool {
     fn name() -> &'static str {
-        "memory_store"
+        crate::mcp::registry::tool_names::MEMORY_STORE
     }
     fn description() -> &'static str {
         "Store a memory; deduplicates by title+namespace."
@@ -673,7 +673,7 @@ pub(crate) fn handle_store(
     // response here does not wait on any webhook dispatch.
     crate::subscriptions::dispatch_event(
         conn,
-        "memory_store",
+        crate::mcp::registry::tool_names::MEMORY_STORE,
         &actual_id,
         &mem.namespace,
         Some(&agent_id),

--- a/src/mcp/tools/subscribe.rs
+++ b/src/mcp/tools/subscribe.rs
@@ -45,7 +45,7 @@ pub struct SubscribeTool;
 
 impl McpTool for SubscribeTool {
     fn name() -> &'static str {
-        "memory_subscribe"
+        crate::mcp::registry::tool_names::MEMORY_SUBSCRIBE
     }
     fn description() -> &'static str {
         "Register a webhook subscription for memory events."
@@ -75,7 +75,7 @@ pub struct UnsubscribeTool;
 
 impl McpTool for UnsubscribeTool {
     fn name() -> &'static str {
-        "memory_unsubscribe"
+        crate::mcp::registry::tool_names::MEMORY_UNSUBSCRIBE
     }
     fn description() -> &'static str {
         "Delete a subscription by id."
@@ -275,7 +275,7 @@ pub struct ListSubscriptionsTool;
 
 impl McpTool for ListSubscriptionsTool {
     fn name() -> &'static str {
-        "memory_list_subscriptions"
+        crate::mcp::registry::tool_names::MEMORY_LIST_SUBSCRIPTIONS
     }
     fn description() -> &'static str {
         "List active webhook subscriptions."
@@ -309,7 +309,7 @@ pub struct SubscriptionReplayTool;
 
 impl McpTool for SubscriptionReplayTool {
     fn name() -> &'static str {
-        "memory_subscription_replay"
+        crate::mcp::registry::tool_names::MEMORY_SUBSCRIPTION_REPLAY
     }
     fn description() -> &'static str {
         "Replay subscription_events since an RFC3339 timestamp."

--- a/src/mcp/tools/update.rs
+++ b/src/mcp/tools/update.rs
@@ -75,7 +75,7 @@ pub struct UpdateTool;
 
 impl McpTool for UpdateTool {
     fn name() -> &'static str {
-        "memory_update"
+        crate::mcp::registry::tool_names::MEMORY_UPDATE
     }
     fn description() -> &'static str {
         "Update an existing memory by ID (only provided fields change)."

--- a/src/mcp/tools/verify.rs
+++ b/src/mcp/tools/verify.rs
@@ -38,7 +38,7 @@ pub struct VerifyTool;
 
 impl McpTool for VerifyTool {
     fn name() -> &'static str {
-        "memory_verify"
+        crate::mcp::registry::tool_names::MEMORY_VERIFY
     }
     fn description() -> &'static str {
         "Re-verify a stored memory_links row's Ed25519 signature on demand."

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -112,7 +112,11 @@ pub enum Family {
 /// always-on bootstrap so the runtime-discovery dance works out of the
 /// box on `--profile core`. Per RFC S27 and the v0.6.4-002 acceptance
 /// criteria.
-pub const ALWAYS_ON_TOOLS: &[&str] = &["memory_capabilities"];
+///
+/// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): the
+/// literal references the canonical const so this slice cannot drift
+/// from the dispatch table.
+pub const ALWAYS_ON_TOOLS: &[&str] = &[crate::mcp::registry::tool_names::MEMORY_CAPABILITIES];
 
 impl Family {
     /// Lookup the family that owns a given tool name. Source-anchored
@@ -123,132 +127,139 @@ impl Family {
     /// reconciliation).
     #[must_use]
     pub fn for_tool(name: &str) -> Option<Self> {
+        // v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep) — every
+        // match arm references a const from
+        // [`crate::mcp::registry::tool_names`] so the family routing
+        // table and the dispatch table cannot drift in name spelling.
+        use crate::mcp::registry::tool_names as tn;
         match name {
             // core (7 — v0.7 B1 added memory_load_family as the always-on
             // alternative to memory_recall when the agent already knows
             // which family taxonomy it wants; v0.7 B2 added
             // memory_smart_load as the intent-routed front door that
             // picks the best family for the caller).
-            "memory_store" | "memory_recall" | "memory_list" | "memory_get" | "memory_search"
-            | "memory_load_family" | "memory_smart_load" => Some(Self::Core),
+            tn::MEMORY_STORE | tn::MEMORY_RECALL | tn::MEMORY_LIST | tn::MEMORY_GET
+            | tn::MEMORY_SEARCH | tn::MEMORY_LOAD_FAMILY | tn::MEMORY_SMART_LOAD => {
+                Some(Self::Core)
+            }
             // lifecycle (5)
-            "memory_update" | "memory_delete" | "memory_forget" | "memory_gc"
-            | "memory_promote" => Some(Self::Lifecycle),
+            tn::MEMORY_UPDATE | tn::MEMORY_DELETE | tn::MEMORY_FORGET | tn::MEMORY_GC
+            | tn::MEMORY_PROMOTE => Some(Self::Lifecycle),
             // graph (11 — v0.7.0 I4 added memory_replay; v0.7 H4 added memory_verify;
             // v0.7 J7 added memory_find_paths)
-            "memory_kg_query"
-            | "memory_kg_timeline"
-            | "memory_kg_invalidate"
-            | "memory_link"
-            | "memory_get_links"
-            | "memory_entity_register"
-            | "memory_entity_get_by_alias"
-            | "memory_get_taxonomy"
-            | "memory_replay"
-            | "memory_verify"
-            | "memory_find_paths" => Some(Self::Graph),
+            tn::MEMORY_KG_QUERY
+            | tn::MEMORY_KG_TIMELINE
+            | tn::MEMORY_KG_INVALIDATE
+            | tn::MEMORY_LINK
+            | tn::MEMORY_GET_LINKS
+            | tn::MEMORY_ENTITY_REGISTER
+            | tn::MEMORY_ENTITY_GET_BY_ALIAS
+            | tn::MEMORY_GET_TAXONOMY
+            | tn::MEMORY_REPLAY
+            | tn::MEMORY_VERIFY
+            | tn::MEMORY_FIND_PATHS => Some(Self::Graph),
             // governance (8)
-            "memory_pending_list"
-            | "memory_pending_approve"
-            | "memory_pending_reject"
-            | "memory_namespace_set_standard"
-            | "memory_namespace_get_standard"
-            | "memory_namespace_clear_standard"
-            | "memory_subscribe"
-            | "memory_unsubscribe" => Some(Self::Governance),
+            tn::MEMORY_PENDING_LIST
+            | tn::MEMORY_PENDING_APPROVE
+            | tn::MEMORY_PENDING_REJECT
+            | tn::MEMORY_NAMESPACE_SET_STANDARD
+            | tn::MEMORY_NAMESPACE_GET_STANDARD
+            | tn::MEMORY_NAMESPACE_CLEAR_STANDARD
+            | tn::MEMORY_SUBSCRIBE
+            | tn::MEMORY_UNSUBSCRIBE => Some(Self::Governance),
             // power (10 — v0.7 K7 added the subscription-reliability pair:
             // `memory_subscription_replay` + `memory_subscription_dlq_list`;
             // v0.7 K8 added `memory_quota_status` for the per-agent quota
             // substrate; v0.7.0 Task 4/8 added `memory_reflect` — the
             // substrate-native recursive-learning primitive. All
             // operator/governance, not data-plane.)
-            "memory_consolidate"
-            | "memory_detect_contradiction"
-            | "memory_check_duplicate"
-            | "memory_auto_tag"
-            | "memory_expand_query"
-            | "memory_inbox"
-            | "memory_subscription_replay"
-            | "memory_subscription_dlq_list"
-            | "memory_quota_status"
-            | "memory_reflect"
-            | "memory_reflection_origin"
+            tn::MEMORY_CONSOLIDATE
+            | tn::MEMORY_DETECT_CONTRADICTION
+            | tn::MEMORY_CHECK_DUPLICATE
+            | tn::MEMORY_AUTO_TAG
+            | tn::MEMORY_EXPAND_QUERY
+            | tn::MEMORY_INBOX
+            | tn::MEMORY_SUBSCRIPTION_REPLAY
+            | tn::MEMORY_SUBSCRIPTION_DLQ_LIST
+            | tn::MEMORY_QUOTA_STATUS
+            | tn::MEMORY_REFLECT
+            | tn::MEMORY_REFLECTION_ORIGIN
             // v0.7.0 QW-1 — file-backed reflection chain export.
             // Operator-facing; substrate returns rendered content,
             // agent harness owns the disk write.
-            | "memory_export_reflection"
+            | tn::MEMORY_EXPORT_REFLECTION
             // v0.7.0 QW-2 — Persona-as-artifact. The read-only
             // `memory_persona` lookup and the write-side
             // `memory_persona_generate` regeneration both sit under
             // Power. Tier-gating in the MCP dispatcher refuses the
             // write-side surface unless smart+autonomous is enabled.
-            | "memory_persona"
-            | "memory_persona_generate"
+            | tn::MEMORY_PERSONA
+            | tn::MEMORY_PERSONA_GENERATE
             // v0.7.0 Form 5 (issue #758) — calibration sweep over the
             // shadow-mode observation table. Operator-callable
             // equivalent of `ai-memory calibrate confidence
             // --from-shadow`. Lives in Power alongside the other
             // operator-facing observability tools.
-            | "memory_calibrate_confidence"
+            | tn::MEMORY_CALIBRATE_CONFIDENCE
             // v0.7.0 L2-3 (issue #668) — read-side surface for the
             // reflection invalidation propagation walker. Operator-
             // facing inspector for the per-reflection dependent set
             // that gets notified on Reflection→Reflection supersedes.
-            | "memory_dependents_of_invalidated"
+            | tn::MEMORY_DEPENDENTS_OF_INVALIDATED
             // v0.7.0 (issue #691) — substrate-level agent-action rules
             // engine. Both tools live in Family::Power (governance /
             // operator-facing, not data-plane). Mutation tools are
             // explicitly NOT registered over MCP per design revision
             // 2026-05-13 — operator uses CLI / HTTP with signed key.
-            | "memory_check_agent_action"
-            | "memory_rule_list"
+            | tn::MEMORY_CHECK_AGENT_ACTION
+            | tn::MEMORY_RULE_LIST
             // v0.7.0 QW-3 follow-up — context-offload substrate primitive.
             // The pair lives in Family::Power so the `power` (and `full`)
             // profile surfaces them while keeping the keyword-tier
             // `core` surface unchanged (semantic-tier+ exposure per the
             // QW-3 brief).
-            | "memory_offload"
-            | "memory_deref"
+            | tn::MEMORY_OFFLOAD
+            | tn::MEMORY_DEREF
             // v0.7.0 WT-1-C — curator-pass atomisation tool. Lives in
             // the same family/profile group as memory_consolidate and
             // memory_reflect (semantic+ tier; the keyword tier short-
             // circuits with a tier-locked advisory envelope).
-            | "memory_atomise"
+            | tn::MEMORY_ATOMISE
             // v0.7.0 Form 3 (issue #756) — multi-step ingest
             // orchestrator. Lives at Family::Power alongside the other
             // LLM-driven write-side tools; tier-gated to smart+ with
             // the standard tier-locked advisory on keyword.
-            | "memory_ingest_multistep"
+            | tn::MEMORY_INGEST_MULTISTEP
             // v0.7.0 (issues #224 + #311) — Phase 3 Memory Sharing &
             // Sync RFC pulled forward per operator directive
             // `28860423-d12c-4959-bc8b-8fa9a94a33d9`. Substrate-level
             // point-to-point copy into `_shared/<from>→<to>/`.
-            | "memory_share" => Some(Self::Power),
+            | tn::MEMORY_SHARE => Some(Self::Power),
             // meta (6 — 5 baseline + v0.7.0 Gap 3 (#886)
             // memory_recall_observations).
-            "memory_capabilities"
-            | "memory_agent_register"
-            | "memory_agent_list"
-            | "memory_session_start"
-            | "memory_stats"
-            | "memory_recall_observations" => Some(Self::Meta),
+            tn::MEMORY_CAPABILITIES
+            | tn::MEMORY_AGENT_REGISTER
+            | tn::MEMORY_AGENT_LIST
+            | tn::MEMORY_SESSION_START
+            | tn::MEMORY_STATS
+            | tn::MEMORY_RECALL_OBSERVATIONS => Some(Self::Meta),
             // archive (4)
-            "memory_archive_list"
-            | "memory_archive_purge"
-            | "memory_archive_restore"
-            | "memory_archive_stats" => Some(Self::Archive),
+            tn::MEMORY_ARCHIVE_LIST
+            | tn::MEMORY_ARCHIVE_PURGE
+            | tn::MEMORY_ARCHIVE_RESTORE
+            | tn::MEMORY_ARCHIVE_STATS => Some(Self::Archive),
             // other (9 — 2 baseline + v0.7.0 L1-5 5 skill tools +
             // v0.7.0 L2-6 memory_skill_promote_from_reflection (#671) +
             // v0.7.0 L2-7 memory_skill_compositional_context (#672))
-            "memory_list_subscriptions"
-            | "memory_notify"
-            | "memory_skill_register"
-            | "memory_skill_list"
-            | "memory_skill_get"
-            | "memory_skill_resource"
-            | "memory_skill_export"
-            | "memory_skill_promote_from_reflection"
-            | "memory_skill_compositional_context" => Some(Self::Other),
+            tn::MEMORY_LIST_SUBSCRIPTIONS
+            | tn::MEMORY_NOTIFY
+            | tn::MEMORY_SKILL_REGISTER
+            | tn::MEMORY_SKILL_LIST
+            | tn::MEMORY_SKILL_GET
+            | tn::MEMORY_SKILL_RESOURCE
+            | tn::MEMORY_SKILL_EXPORT
+            | tn::MEMORY_SKILL_PROMOTE_FROM_REFLECTION
+            | tn::MEMORY_SKILL_COMPOSITIONAL_CONTEXT => Some(Self::Other),
             _ => None,
         }
     }
@@ -348,158 +359,164 @@ impl Family {
     /// sync.
     #[must_use]
     pub const fn tool_names(self) -> &'static [&'static str] {
+        // v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep) — every
+        // entry references a `pub const` from
+        // [`crate::mcp::registry::tool_names`] so the per-family lists,
+        // the dispatch table, and the registry iterator cannot drift
+        // in name spelling.
+        use crate::mcp::registry::tool_names as tn;
         match self {
             Self::Core => &[
-                "memory_store",
-                "memory_recall",
-                "memory_list",
-                "memory_get",
-                "memory_search",
+                tn::MEMORY_STORE,
+                tn::MEMORY_RECALL,
+                tn::MEMORY_LIST,
+                tn::MEMORY_GET,
+                tn::MEMORY_SEARCH,
                 // v0.7 B1 — always-on alternative to memory_recall when
                 // the agent already knows the Family taxonomy it wants.
-                "memory_load_family",
+                tn::MEMORY_LOAD_FAMILY,
                 // v0.7 B2 — intent-routed front door. Caller passes a
                 // free-text intent; the handler picks the best family
                 // from the cached descriptors and forwards to
                 // `memory_load_family`.
-                "memory_smart_load",
+                tn::MEMORY_SMART_LOAD,
             ],
             Self::Lifecycle => &[
-                "memory_update",
-                "memory_delete",
-                "memory_forget",
-                "memory_gc",
-                "memory_promote",
+                tn::MEMORY_UPDATE,
+                tn::MEMORY_DELETE,
+                tn::MEMORY_FORGET,
+                tn::MEMORY_GC,
+                tn::MEMORY_PROMOTE,
             ],
             Self::Graph => &[
-                "memory_kg_query",
-                "memory_kg_timeline",
-                "memory_kg_invalidate",
-                "memory_link",
-                "memory_get_links",
-                "memory_entity_register",
-                "memory_entity_get_by_alias",
-                "memory_get_taxonomy",
+                tn::MEMORY_KG_QUERY,
+                tn::MEMORY_KG_TIMELINE,
+                tn::MEMORY_KG_INVALIDATE,
+                tn::MEMORY_LINK,
+                tn::MEMORY_GET_LINKS,
+                tn::MEMORY_ENTITY_REGISTER,
+                tn::MEMORY_ENTITY_GET_BY_ALIAS,
+                tn::MEMORY_GET_TAXONOMY,
                 // v0.7.0 I4 — traverses memory_transcript_links (I2) to
                 // reconstruct the source-transcript chain for a memory.
-                "memory_replay",
+                tn::MEMORY_REPLAY,
                 // v0.7 H4 — re-verifies a stored link's Ed25519
                 // signature on demand, returning attest_level.
-                "memory_verify",
+                tn::MEMORY_VERIFY,
                 // v0.7 J7 — enumerate up to N paths between two memories
                 // (BFS with cycle detection over memory_links).
-                "memory_find_paths",
+                tn::MEMORY_FIND_PATHS,
             ],
             Self::Governance => &[
-                "memory_pending_list",
-                "memory_pending_approve",
-                "memory_pending_reject",
-                "memory_namespace_set_standard",
-                "memory_namespace_get_standard",
-                "memory_namespace_clear_standard",
-                "memory_subscribe",
-                "memory_unsubscribe",
+                tn::MEMORY_PENDING_LIST,
+                tn::MEMORY_PENDING_APPROVE,
+                tn::MEMORY_PENDING_REJECT,
+                tn::MEMORY_NAMESPACE_SET_STANDARD,
+                tn::MEMORY_NAMESPACE_GET_STANDARD,
+                tn::MEMORY_NAMESPACE_CLEAR_STANDARD,
+                tn::MEMORY_SUBSCRIBE,
+                tn::MEMORY_UNSUBSCRIBE,
             ],
             Self::Power => &[
-                "memory_consolidate",
-                "memory_detect_contradiction",
-                "memory_check_duplicate",
-                "memory_auto_tag",
-                "memory_expand_query",
-                "memory_inbox",
+                tn::MEMORY_CONSOLIDATE,
+                tn::MEMORY_DETECT_CONTRADICTION,
+                tn::MEMORY_CHECK_DUPLICATE,
+                tn::MEMORY_AUTO_TAG,
+                tn::MEMORY_EXPAND_QUERY,
+                tn::MEMORY_INBOX,
                 // v0.7 K7 — operator/governance subscription-reliability
                 // tools. Replay reads back the audit row series for one
                 // subscription since an RFC3339 cursor; dlq_list inspects
                 // payloads that exhausted the [200ms, 1s, 5s] retry ladder.
-                "memory_subscription_replay",
-                "memory_subscription_dlq_list",
+                tn::MEMORY_SUBSCRIPTION_REPLAY,
+                tn::MEMORY_SUBSCRIPTION_DLQ_LIST,
                 // v0.7 K8 — per-agent quota status (memories/day, storage
                 // bytes, links/day). Operator-facing inspector for the K8
                 // rate-limit substrate.
-                "memory_quota_status",
+                tn::MEMORY_QUOTA_STATUS,
                 // v0.7.0 Task 4/8 (recursive learning, issue #655) —
                 // substrate-native reflection primitive. Inserts a
                 // reflection memory plus N `reflects_on` provenance
                 // links in a single atomic transaction.
-                "memory_reflect",
+                tn::MEMORY_REFLECT,
                 // v0.7.0 L2-2 (S6-M1) — cross-peer reflection origin
                 // inspector. Returns peer_origin / signing_agent /
                 // original_depth / local_depth_at_arrival for a row.
-                "memory_reflection_origin",
+                tn::MEMORY_REFLECTION_ORIGIN,
                 // v0.7.0 L2-3 (issue #668) — invalidation propagation
                 // read-side inspector. Lists dependents flagged by
                 // the walker on Reflection→Reflection supersedes.
-                "memory_dependents_of_invalidated",
+                tn::MEMORY_DEPENDENTS_OF_INVALIDATED,
                 // v0.7.0 (issue #691) — substrate-level agent-action
                 // rules engine. Read-side surface; mutation tools are
                 // NOT registered over MCP (operator uses CLI / HTTP).
-                "memory_check_agent_action",
-                "memory_rule_list",
+                tn::MEMORY_CHECK_AGENT_ACTION,
+                tn::MEMORY_RULE_LIST,
                 // v0.7.0 QW-1 — file-backed reflection chain export
                 // companion. Renders the markdown / JSON envelope;
                 // does NOT write to disk (agent harness owns disk I/O).
-                "memory_export_reflection",
+                tn::MEMORY_EXPORT_REFLECTION,
                 // v0.7.0 QW-3 follow-up — context-offload substrate
                 // primitive (offload + deref). Power-family registration
                 // gives semantic-tier+ exposure per the QW-3 brief; the
                 // handlers themselves live at src/mcp/tools/offload.rs.
-                "memory_offload",
-                "memory_deref",
+                tn::MEMORY_OFFLOAD,
+                tn::MEMORY_DEREF,
                 // v0.7.0 WT-1-C — curator-pass atomisation tool.
                 // Decomposes a coarse memory into 2-10 atomic
                 // propositions; archives the source. Lives in Power
                 // alongside memory_consolidate / memory_reflect.
-                "memory_atomise",
+                tn::MEMORY_ATOMISE,
                 // v0.7.0 QW-2 — Persona-as-artifact. Read-only lookup
                 // + smart+ regeneration. Substrate writes the SQL row
                 // (and optionally the filesystem export via namespace
                 // policy); the agent never holds the keypair.
-                "memory_persona",
-                "memory_persona_generate",
+                tn::MEMORY_PERSONA,
+                tn::MEMORY_PERSONA_GENERATE,
                 // v0.7.0 Form 3 (issue #756) — multi-step ingest
                 // orchestrator. Deterministic helpers + LLM stages
                 // with explicit-trust slots and prompt-cache reuse.
-                "memory_ingest_multistep",
+                tn::MEMORY_INGEST_MULTISTEP,
                 // v0.7.0 Form 5 (issue #758) — calibration sweep over
                 // the shadow-mode observation table. Operator surface
                 // for tuning per-(namespace, source) confidence
                 // baselines.
-                "memory_calibrate_confidence",
+                tn::MEMORY_CALIBRATE_CONFIDENCE,
                 // v0.7.0 (issues #224 + #311) — Phase 3 Memory Sharing &
                 // Sync RFC pulled forward per operator directive
                 // `28860423-d12c-4959-bc8b-8fa9a94a33d9`. Substrate-
                 // level point-to-point copy into `_shared/<from>→<to>/`.
-                "memory_share",
+                tn::MEMORY_SHARE,
             ],
             Self::Meta => &[
-                "memory_capabilities",
-                "memory_agent_register",
-                "memory_agent_list",
-                "memory_session_start",
-                "memory_stats",
+                tn::MEMORY_CAPABILITIES,
+                tn::MEMORY_AGENT_REGISTER,
+                tn::MEMORY_AGENT_LIST,
+                tn::MEMORY_SESSION_START,
+                tn::MEMORY_STATS,
                 // v0.7.0 Gap 3 (#886) — read-side surface for the
                 // `recall_observations` ledger.
-                "memory_recall_observations",
+                tn::MEMORY_RECALL_OBSERVATIONS,
             ],
             Self::Archive => &[
-                "memory_archive_list",
-                "memory_archive_purge",
-                "memory_archive_restore",
-                "memory_archive_stats",
+                tn::MEMORY_ARCHIVE_LIST,
+                tn::MEMORY_ARCHIVE_PURGE,
+                tn::MEMORY_ARCHIVE_RESTORE,
+                tn::MEMORY_ARCHIVE_STATS,
             ],
             Self::Other => &[
-                "memory_list_subscriptions",
-                "memory_notify",
+                tn::MEMORY_LIST_SUBSCRIPTIONS,
+                tn::MEMORY_NOTIFY,
                 // v0.7.0 L1-5 — Agent Skills ingestion substrate (Pillar 1.5).
-                "memory_skill_register",
-                "memory_skill_list",
-                "memory_skill_get",
-                "memory_skill_resource",
-                "memory_skill_export",
+                tn::MEMORY_SKILL_REGISTER,
+                tn::MEMORY_SKILL_LIST,
+                tn::MEMORY_SKILL_GET,
+                tn::MEMORY_SKILL_RESOURCE,
+                tn::MEMORY_SKILL_EXPORT,
                 // v0.7.0 L2-6 (issue #671) — closing the recursive-learning loop.
-                "memory_skill_promote_from_reflection",
+                tn::MEMORY_SKILL_PROMOTE_FROM_REFLECTION,
                 // v0.7.0 L2-7 (issue #672) — reflection-skill composition.
-                "memory_skill_compositional_context",
+                tn::MEMORY_SKILL_COMPOSITIONAL_CONTEXT,
             ],
         }
     }

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -83,10 +83,18 @@ pub struct NewSubscription<'a> {
 /// `memory_kg_invalidate` fires this event after the link's
 /// `valid_until` is set, regardless of which KG backend handled the
 /// SET).
+// v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep): the three
+// entries that ARE MCP tool names (`memory_store`, `memory_promote`,
+// `memory_delete`) reference the canonical `tool_names` consts. The
+// remaining four entries (`memory_link_created`,
+// `memory_link_invalidated`, `memory_consolidated`,
+// `approval_requested`) are subscription-event types, NOT MCP tool
+// names — they stay as raw literals because they live in a different
+// namespace (webhook events vs. JSON-RPC method names).
 pub const WEBHOOK_EVENT_TYPES: &[&str] = &[
-    "memory_store",
-    "memory_promote",
-    "memory_delete",
+    crate::mcp::registry::tool_names::MEMORY_STORE,
+    crate::mcp::registry::tool_names::MEMORY_PROMOTE,
+    crate::mcp::registry::tool_names::MEMORY_DELETE,
     "memory_link_created",
     "memory_link_invalidated",
     "memory_consolidated",


### PR DESCRIPTION
## Summary

v0.7.x (issue #1174 PR1 — pm-v3.1 MCP tool name sweep). Closes
Class B MUST item 1 of the pm-v3.1 audit inventory at
`.local-runs/refactor-pmv31-audit-20260524-120814/INVENTORY.md`.

Adds a canonical `tool_names` constants module to
`src/mcp/registry.rs` carrying one `pub const MEMORY_<NAME>: &str`
per MCP tool (73 in total) plus an `ALL: &[&str]` slice. Every prod
call site that historically used a raw `"memory_xxx"` literal now
references the const. Renaming a tool is a one-line edit at the
const definition; the dispatch table, family routing,
audit-tool-call arms, webhook event types, governance op aliases,
capabilities examples, and per-tool `McpTool::name()` impls all
follow automatically.

- **Base SHA:** `84ec159c1c88c9840b7a97af966f77ef6d35eb20`
- **Commit:** `351007dcd`
- **Site count:** 200+ production call sites swept across 63 files;
  92 raw literals collapsed via `register_mcp_tool!` macro + 73
  per-tool `name()` impls + 73 `Family::tool_names()` entries + 73
  `Family::for_tool()` match arms + 6 handler dispatch sites + 7
  governance op arms + 7 skill tool-name entries + 16 capabilities
  example arms + assorted others.
- **Const count:** 73 + 1 ALL slice.

## Per-file site count

| File | Consts referenced | Notes |
|---|---|---|
| `src/profile.rs` | 138 aliased `tn::MEMORY_*` | `Family::for_tool` + `Family::tool_names` + `ALWAYS_ON_TOOLS` |
| `src/mcp/mod.rs` | 81 (TOOL_DISPATCH_TABLE + audit_tool_call + TOON dispatch) | macro signature widened from `:literal` to `:expr` |
| `src/config.rs` | 10 (default_webhook_events + SKILL_TOOL_NAMES) | webhook table mix |
| `src/handlers/memories.rs` | 6 (dispatch_event + record_decision) | postgres + sqlite paths |
| `src/mcp/tools/archive.rs` | 5 (`name()` impls) | list/purge/restore/stats/gc |
| `src/mcp/tools/subscribe.rs` | 4 (`name()` impls) | subscribe/unsubscribe/list/replay |
| `src/mcp/tools/pending.rs` | 4 (`name()` impls) | list/approve/reject/dlq_list |
| `src/mcp/tools/namespace.rs` | 3 (`name()` impls) | set/get/clear standard |
| `src/mcp/tools/delete.rs` | 3 (`name()` + dispatch + audit) | |
| `src/mcp/tools/capabilities.rs` | 17 (tool_examples match) | |
| `src/governance/mod.rs` | 10 (Op::as_str + Op::from_str) | `memory_archive` stays raw (gov op id) |
| `src/subscriptions.rs` | 3 (WEBHOOK_EVENT_TYPES) | 4 webhook-only types stay raw |
| `src/cli/install.rs` | 1 (PRETOOL_HOOK_TOOL_NAME const) | |
| `src/handlers/create.rs` | 2 (dispatch_event x2) | |
| Other per-tool `src/mcp/tools/*.rs` | 1 each (`name()` impl) | 56 files |

## Const definitions added

Module `crate::mcp::registry::tool_names` (in `src/mcp/registry.rs`):

```rust
pub const MEMORY_AGENT_LIST: &str = "memory_agent_list";
pub const MEMORY_AGENT_REGISTER: &str = "memory_agent_register";
pub const MEMORY_ARCHIVE_LIST: &str = "memory_archive_list";
pub const MEMORY_ARCHIVE_PURGE: &str = "memory_archive_purge";
pub const MEMORY_ARCHIVE_RESTORE: &str = "memory_archive_restore";
pub const MEMORY_ARCHIVE_STATS: &str = "memory_archive_stats";
pub const MEMORY_ATOMISE: &str = "memory_atomise";
pub const MEMORY_AUTO_TAG: &str = "memory_auto_tag";
pub const MEMORY_CALIBRATE_CONFIDENCE: &str = "memory_calibrate_confidence";
pub const MEMORY_CAPABILITIES: &str = "memory_capabilities";
pub const MEMORY_CHECK_AGENT_ACTION: &str = "memory_check_agent_action";
pub const MEMORY_CHECK_DUPLICATE: &str = "memory_check_duplicate";
pub const MEMORY_CONSOLIDATE: &str = "memory_consolidate";
pub const MEMORY_DELETE: &str = "memory_delete";
pub const MEMORY_DEPENDENTS_OF_INVALIDATED: &str = "memory_dependents_of_invalidated";
pub const MEMORY_DEREF: &str = "memory_deref";
pub const MEMORY_DETECT_CONTRADICTION: &str = "memory_detect_contradiction";
pub const MEMORY_ENTITY_GET_BY_ALIAS: &str = "memory_entity_get_by_alias";
pub const MEMORY_ENTITY_REGISTER: &str = "memory_entity_register";
pub const MEMORY_EXPAND_QUERY: &str = "memory_expand_query";
pub const MEMORY_EXPORT_REFLECTION: &str = "memory_export_reflection";
pub const MEMORY_FIND_PATHS: &str = "memory_find_paths";
pub const MEMORY_FORGET: &str = "memory_forget";
pub const MEMORY_GC: &str = "memory_gc";
pub const MEMORY_GET: &str = "memory_get";
pub const MEMORY_GET_LINKS: &str = "memory_get_links";
pub const MEMORY_GET_TAXONOMY: &str = "memory_get_taxonomy";
pub const MEMORY_INBOX: &str = "memory_inbox";
pub const MEMORY_INGEST_MULTISTEP: &str = "memory_ingest_multistep";
pub const MEMORY_KG_INVALIDATE: &str = "memory_kg_invalidate";
pub const MEMORY_KG_QUERY: &str = "memory_kg_query";
pub const MEMORY_KG_TIMELINE: &str = "memory_kg_timeline";
pub const MEMORY_LINK: &str = "memory_link";
pub const MEMORY_LIST: &str = "memory_list";
pub const MEMORY_LIST_SUBSCRIPTIONS: &str = "memory_list_subscriptions";
pub const MEMORY_LOAD_FAMILY: &str = "memory_load_family";
pub const MEMORY_NAMESPACE_CLEAR_STANDARD: &str = "memory_namespace_clear_standard";
pub const MEMORY_NAMESPACE_GET_STANDARD: &str = "memory_namespace_get_standard";
pub const MEMORY_NAMESPACE_SET_STANDARD: &str = "memory_namespace_set_standard";
pub const MEMORY_NOTIFY: &str = "memory_notify";
pub const MEMORY_OFFLOAD: &str = "memory_offload";
pub const MEMORY_PENDING_APPROVE: &str = "memory_pending_approve";
pub const MEMORY_PENDING_LIST: &str = "memory_pending_list";
pub const MEMORY_PENDING_REJECT: &str = "memory_pending_reject";
pub const MEMORY_PERSONA: &str = "memory_persona";
pub const MEMORY_PERSONA_GENERATE: &str = "memory_persona_generate";
pub const MEMORY_PROMOTE: &str = "memory_promote";
pub const MEMORY_QUOTA_STATUS: &str = "memory_quota_status";
pub const MEMORY_RECALL: &str = "memory_recall";
pub const MEMORY_RECALL_OBSERVATIONS: &str = "memory_recall_observations";
pub const MEMORY_REFLECT: &str = "memory_reflect";
pub const MEMORY_REFLECTION_ORIGIN: &str = "memory_reflection_origin";
pub const MEMORY_REPLAY: &str = "memory_replay";
pub const MEMORY_RULE_LIST: &str = "memory_rule_list";
pub const MEMORY_SEARCH: &str = "memory_search";
pub const MEMORY_SESSION_START: &str = "memory_session_start";
pub const MEMORY_SHARE: &str = "memory_share";
pub const MEMORY_SKILL_COMPOSITIONAL_CONTEXT: &str = "memory_skill_compositional_context";
pub const MEMORY_SKILL_EXPORT: &str = "memory_skill_export";
pub const MEMORY_SKILL_GET: &str = "memory_skill_get";
pub const MEMORY_SKILL_LIST: &str = "memory_skill_list";
pub const MEMORY_SKILL_PROMOTE_FROM_REFLECTION: &str =
    "memory_skill_promote_from_reflection";
pub const MEMORY_SKILL_REGISTER: &str = "memory_skill_register";
pub const MEMORY_SKILL_RESOURCE: &str = "memory_skill_resource";
pub const MEMORY_SMART_LOAD: &str = "memory_smart_load";
pub const MEMORY_STATS: &str = "memory_stats";
pub const MEMORY_STORE: &str = "memory_store";
pub const MEMORY_SUBSCRIBE: &str = "memory_subscribe";
pub const MEMORY_SUBSCRIPTION_DLQ_LIST: &str = "memory_subscription_dlq_list";
pub const MEMORY_SUBSCRIPTION_REPLAY: &str = "memory_subscription_replay";
pub const MEMORY_UNSUBSCRIBE: &str = "memory_unsubscribe";
pub const MEMORY_UPDATE: &str = "memory_update";
pub const MEMORY_VERIFY: &str = "memory_verify";

pub const ALL: &[&str] = &[ /* 73 entries in alphabetical order */ ];
```

## Cases handled with care

- **Match-arm dispatch tables** (`audit_tool_call`,
  `Family::for_tool`, `Op::from_str`, `tool_examples`) accept const
  refs in Rust; patterns are now `tool_names::MEMORY_STORE => …`
  instead of `"memory_store" => …`.
- **Webhook event tables** list a mix of MCP tool names (3) and
  webhook-only event types (4); only the MCP-tool-name entries
  route through the consts. Doc comments alongside each table call
  out the split explicitly. The webhook-only event types
  (`memory_link_created`, `memory_link_invalidated`,
  `memory_consolidated`, `approval_requested`) stay as raw literals
  because they are NOT MCP tool names — they live in the webhook-
  event namespace.
- **The `register_mcp_tool!` macro** was widened from `:literal` to
  `:expr` so the dispatch table can accept const refs. The macro
  doc-comment was updated to call out the new contract.
- **Doc-comment prose** mentioning tool names ("`memory_store`
  is …") stays as text — it is documentation, not runtime code.
- **`tracing::info!(target: "memory_store", ...)`** and similar
  tracing macro `target:` arguments stay literal because the
  `tracing` macros require a string literal at expansion time. The
  tracing target is conceptually a separate namespace from the MCP
  dispatch identifier; the byte-equality is preserved by inspection.
- **The `memory_archive` Op variant** in `src/governance/mod.rs`
  stays as a raw literal because it is a governance op identifier
  covering the 4-tool archive family (list/purge/restore/stats) —
  not itself an MCP tool name.
- **Test fixtures and snapshot data** stay as raw literals — they
  are explicit assertion targets that pin the wire shape, and
  must be visually obvious as wire-string assertions.

## Gates

| Gate | Status |
|---|---|
| `cargo fmt --check` | clean |
| `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | clean |
| `AI_MEMORY_NO_CONFIG=1 cargo test --lib` | 4745 / 4745 pass |
| `AI_MEMORY_NO_CONFIG=1 cargo test --tests --no-fail-fast` | 145+ groups green, 0 failures (suite still finishing at PR-open; live tail in `.local-runs/pr1174-tests.log`) |
| `cargo audit` | Cargo.lock unchanged from base SHA `84ec159c1`; audit result inherits from base |

## Test plan

- [x] **`tool_names` pin tests** (in
  `src/mcp/registry::tool_names::pin_tests`):
  - `const_count_is_73` — `ALL.len() == 73`
  - `const_set_is_deduplicated` — `ALL` has no duplicates
  - `const_values_lowercase_memory_prefix` — every const starts
    with `"memory_"` and is `[a-z_]+`
  - `const_values_byte_equal_to_historical_wire_strings` —
    `assert_eq!(MEMORY_<NAME>, "memory_<name>")` for every const
    (load-bearing byte-equality guard)
  - `consts_match_registered_tools` — `tool_names::ALL` and
    `registered_tools()` return identical sets
- [x] **Pre-existing D1.6 byte-shape compat tests** in
  `mcp::registry::d1_6_987_tests::tool_definitions_byte_shape_v0_7_0_compat_987_*`
  continue to verify that the wire JSON catalog is identical to the
  pre-D1.6 snapshot — proves the const refactor preserves the wire
  bytes
- [x] **Existing `handle_capabilities_family_lists_tool_names`**
  passes against the refactored `Family::tool_names()` and
  `Family::for_tool()` paths
- [x] **Full library test suite** (4745 unit tests across the lib
  crate) passes with no regressions
- [ ] Reviewer: verify a representative `tools/list` MCP probe
  against the refactored binary returns byte-identical JSON to the
  pre-refactor binary (the D1.6 snapshot test is the mechanical
  guarantee; the manual probe is the human-visible signal)

## AI involvement

This PR was authored by Claude Opus 4.7 (1M context) under the
pm-v3.1 / pm-v3.2 NO FAIL MISSION discipline, dispatched as Wave
1 PR1 of GitHub issue #1174. Per-tool sweep, dispatch-table
rewrite, family-table rewrite, pin tests, and PR composition are
the assistant's work; the operator-approved scope is the
inventory's Class B MUST item 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)