### PR TITLE
refactor(#1174): pm-v3.1 PR9 — deflake test fixtures from vendor-specific "claude" literals

### DIFF
--- a/tests/approval_reflect.rs
+++ b/tests/approval_reflect.rs
@@ -37,6 +37,14 @@ use ai_memory::models::ConfidenceSource;
 use ai_memory::models::{GovernanceLevel, GovernancePolicy, GovernedAction, Memory, Tier};
 use chrono::Utc;
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). Pre-deflake the
+/// literal `"claude"` was used here, which silently coupled this test
+/// to a single vendor identity and weakened the heterogeneous-NHI
+/// invariant pinned by `tests/issue_809_*` + `tests/capabilities_v3_*`.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers
 // ─────────────────────────────────────────────────────────────────────
@@ -84,7 +92,7 @@ fn reflect_input(source_ids: Vec<String>, namespace: Option<&str>, title: &str) 
         tags: vec!["l1-8".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-l1-8".to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/federation_reflection_replication.rs
+++ b/tests/federation_reflection_replication.rs
@@ -80,6 +80,14 @@ use chrono::Utc;
 use rusqlite::Connection;
 use tempfile::TempDir;
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this federation-replication
+/// test to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ---------------------------------------------------------------------------
 // Topology helpers
 // ---------------------------------------------------------------------------
@@ -206,7 +214,7 @@ fn reflect_input(
         tags: vec!["l2-2".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: agent_id.to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/form_4_provenance.rs
+++ b/tests/form_4_provenance.rs
@@ -144,13 +144,20 @@ fn source_uri_accepts_typed_schemes_rejects_bare_strings() {
             "expected accepted: {ok}"
         );
     }
-    // Rejected: empty, no scheme, unrecognised scheme, empty payload
+    // Rejected: empty, no scheme, unrecognised scheme, empty payload.
+    //
+    // Note (#1174 PR9): the bare-word reject sample was previously
+    // `"claude"` (a vendor name), which gave the wrong optical
+    // impression that the validator special-cases vendor identifiers.
+    // It does not — any bare word without a recognised URI scheme is
+    // rejected. Using `"bare-word"` here removes the vendor-name
+    // association while exercising the exact same rejection branch.
     for bad in [
         "",
         "   ",
         "https://example.test",
         "user",
-        "claude",
+        "bare-word",
         "ftp:foo",
         "uri:",
         "doc:",

--- a/tests/form_5_confidence_calibration.rs
+++ b/tests/form_5_confidence_calibration.rs
@@ -47,6 +47,16 @@ use rusqlite::Connection;
 mod common;
 use common::fresh_db_tempfile_conn as fresh_db;
 
+/// Vendor-neutral non-"user" fixture source for this test file's
+/// per-source baseline aggregation tests, per PR #1175
+/// (`validate::DEFAULT_NHI_SOURCE = "nhi"`) + PR #1174 PR9
+/// (vendor-deflake test fixtures). The form-5 calibration tests just
+/// need a contrast source value (anything != `"user"`) to demonstrate
+/// per-source grouping — pre-deflake the literal `"claude"` was used,
+/// which silently coupled the calibration coverage to a single vendor
+/// identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ---------------------------------------------------------------------------
 // Fixture helpers
 // ---------------------------------------------------------------------------
@@ -230,7 +240,7 @@ fn calibration_produces_per_source_baselines_from_shadow() {
     let m1 = fixture_memory("ns", "u-1");
     let m2 = fixture_memory("ns", "u-2");
     let mut m3 = fixture_memory("ns", "c-1");
-    m3.source = "claude".to_string();
+    m3.source = FIXTURE_SOURCE.to_string();
     db::insert(&conn, &m1).expect("ins");
     db::insert(&conn, &m2).expect("ins");
     db::insert(&conn, &m3).expect("ins");
@@ -238,7 +248,7 @@ fn calibration_produces_per_source_baselines_from_shadow() {
     let s = ConfidenceSignals::default();
     observe(&conn, &m1.id, "ns", "user", 0.95, 0.55, &s, None).unwrap();
     observe(&conn, &m2.id, "ns", "user", 0.95, 0.65, &s, None).unwrap();
-    observe(&conn, &m3.id, "ns", "claude", 0.95, 0.30, &s, None).unwrap();
+    observe(&conn, &m3.id, "ns", FIXTURE_SOURCE, 0.95, 0.30, &s, None).unwrap();
 
     let report = calibrate_from_shadow(&conn, 30, Utc::now()).expect("calibrate");
     assert_eq!(report.total_observations, 3);
@@ -251,12 +261,12 @@ fn calibration_produces_per_source_baselines_from_shadow() {
     assert_eq!(user.namespace, "ns");
     assert_eq!(user.count, 2);
     assert!((user.median - 0.6).abs() < 1e-6);
-    let claude = report
+    let non_user = report
         .baselines
         .iter()
-        .find(|b| b.source == "claude")
-        .expect("claude baseline");
-    assert!((claude.median - 0.3).abs() < 1e-6);
+        .find(|b| b.source == FIXTURE_SOURCE)
+        .expect("non-user baseline");
+    assert!((non_user.median - 0.3).abs() < 1e-6);
 }
 
 // ---------------------------------------------------------------------------
@@ -467,7 +477,7 @@ fn mcp_handler_calibrate_confidence_returns_baselines_envelope() {
     let m1 = fixture_memory("ns_a", "u-1");
     let m2 = fixture_memory("ns_a", "u-2");
     let mut m3 = fixture_memory("ns_a", "c-1");
-    m3.source = "claude".to_string();
+    m3.source = FIXTURE_SOURCE.to_string();
     db::insert(&conn, &m1).expect("insert m1");
     db::insert(&conn, &m2).expect("insert m2");
     db::insert(&conn, &m3).expect("insert m3");
@@ -475,7 +485,7 @@ fn mcp_handler_calibrate_confidence_returns_baselines_envelope() {
     let s = ConfidenceSignals::default();
     observe(&conn, &m1.id, "ns_a", "user", 0.9, 0.55, &s, None).unwrap();
     observe(&conn, &m2.id, "ns_a", "user", 0.9, 0.65, &s, None).unwrap();
-    observe(&conn, &m3.id, "ns_a", "claude", 0.9, 0.30, &s, None).unwrap();
+    observe(&conn, &m3.id, "ns_a", FIXTURE_SOURCE, 0.9, 0.30, &s, None).unwrap();
 
     // The MCP handler lives at
     // `src/mcp/tools/calibrate_confidence.rs::handle_calibrate_confidence`.
@@ -509,13 +519,13 @@ fn mcp_handler_calibrate_confidence_returns_baselines_envelope() {
     assert_eq!(user.count, 2);
     assert!((user.median - 0.6).abs() < 1e-6);
 
-    let claude = report
+    let non_user = report
         .baselines
         .iter()
-        .find(|b| b.source == "claude")
-        .expect("claude");
-    assert_eq!(claude.count, 1);
-    assert!((claude.median - 0.3).abs() < 1e-6);
+        .find(|b| b.source == FIXTURE_SOURCE)
+        .expect("non-user baseline");
+    assert_eq!(non_user.count, 1);
+    assert!((non_user.median - 0.3).abs() < 1e-6);
 
     // The same call serialised to JSON matches the documented wire
     // envelope (the MCP handler wraps it in `{ "report": ... }`).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3962,6 +3962,12 @@ fn test_mine_stamps_caller_agent_id() {
     });
     std::fs::write(&conv_path, format!("{conv}\n")).unwrap();
 
+    // NOTE (#1174 PR9): `--format claude` is the canonical CLI selector
+    // for the `Format::Claude` mine-conversation parser variant, which
+    // exists specifically to ingest Anthropic's Claude `conversations.json`
+    // export format. This is legitimately vendor-named integration code
+    // (not vendor-monoculture substrate) per the PR #1184 reasoning, so
+    // the literal is preserved here.
     let out = cmd(binary)
         .args([
             "--db",

--- a/tests/l1_1_memory_kind.rs
+++ b/tests/l1_1_memory_kind.rs
@@ -28,6 +28,14 @@ use ai_memory::models::{Memory, MemoryKind, Tier};
 use chrono::Utc;
 use rusqlite::Connection;
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this test to a single
+/// vendor identity and weaken the heterogeneous-NHI invariant.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
 // ─────────────────────────────────────────────────────────────────────────────
@@ -79,7 +87,7 @@ fn reflect_input(source_ids: Vec<String>, namespace: &str, title: &str) -> Refle
         tags: vec!["l1-1-reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-l1-1".to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/recursive_learning_task4_memory_reflect.rs
+++ b/tests/recursive_learning_task4_memory_reflect.rs
@@ -73,6 +73,14 @@ mod common;
 #[cfg(feature = "sal-postgres")]
 use common::postgres_url;
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this test to a single
+/// vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers.
 // ─────────────────────────────────────────────────────────────────────
@@ -120,7 +128,7 @@ fn reflect_input(source_ids: Vec<String>, namespace: Option<&str>, title: &str) 
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-task4".to_string(),
         metadata: serde_json::json!({}),
     }
@@ -623,7 +631,7 @@ async fn postgres_reflect_roundtrips_memory_and_reflects_on_edge() {
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-task4-pg".to_string(),
         metadata: serde_json::json!({}),
     };

--- a/tests/recursive_learning_task5_audit_record.rs
+++ b/tests/recursive_learning_task5_audit_record.rs
@@ -62,6 +62,14 @@ use ai_memory::signed_events::{SignedEvent, list_signed_events, payload_hash};
 use chrono::Utc;
 use rusqlite::Connection;
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple the audit-record test
+/// to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers — mirror tests/recursive_learning_task4_memory_reflect.rs.
 // ─────────────────────────────────────────────────────────────────────
@@ -114,7 +122,7 @@ fn reflect_input(
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: agent_id.to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/recursive_learning_task6_reflect_hooks.rs
+++ b/tests/recursive_learning_task6_reflect_hooks.rs
@@ -74,6 +74,14 @@ use rusqlite::Connection;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+/// Vendor-neutral fixture source for this test file's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple the reflect-hooks test
+/// to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers — mirror tests/recursive_learning_task4*+task5*.rs.
 // ─────────────────────────────────────────────────────────────────────
@@ -121,7 +129,7 @@ fn reflect_input(source_ids: Vec<String>, namespace: Option<&str>, title: &str) 
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-task6".to_string(),
         metadata: serde_json::json!({}),
     }
@@ -713,7 +721,7 @@ fn reflect_each_validation_failure_surfaces_validation_error() {
         tags: vec!["t".to_string()],
         priority: 5,
         confidence: 0.5,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-validation".to_string(),
         metadata: serde_json::json!({}),
     };
@@ -791,7 +799,7 @@ fn reflect_refuses_when_title_namespace_collides_with_existing() {
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: "test-agent-task6c".to_string(),
         metadata: serde_json::json!({}),
     };

--- a/tests/recursive_learning_task7_shipgate_chaos_migration.rs
+++ b/tests/recursive_learning_task7_shipgate_chaos_migration.rs
@@ -73,6 +73,14 @@ mod common;
 #[cfg(feature = "sal-postgres")]
 use common::postgres_url;
 
+/// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this chaos / migration
+/// ship-gate scenario to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers — mirror tests/recursive_learning_task{4,5,6}_*.rs.
 // ─────────────────────────────────────────────────────────────────────
@@ -125,7 +133,7 @@ fn reflect_input(
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: agent_id.to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -50,6 +50,14 @@ use rusqlite::Connection;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+/// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this functional ship-gate
+/// scenario to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers — mirror tests/recursive_learning_task{4,5,6}_*.rs.
 // ─────────────────────────────────────────────────────────────────────
@@ -102,7 +110,7 @@ fn reflect_input(
         tags: vec!["reflection".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: agent_id.to_string(),
         metadata: serde_json::json!({}),
     }

--- a/tests/ship_gate/grand_slam_recursive_learning.rs
+++ b/tests/ship_gate/grand_slam_recursive_learning.rs
@@ -73,6 +73,14 @@ use std::path::Path;
 use std::sync::Mutex;
 use tempfile::TempDir;
 
+/// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
+/// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
+/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// stamps `source = "nhi"` by default for any AI NHI; pinning a
+/// vendor literal here would silently couple this ship-gate scenario
+/// to a single vendor identity.
+const FIXTURE_SOURCE: &str = "nhi";
+
 // ─────────────────────────────────────────────────────────────────────
 // Fixture helpers — match the style of recursive_learning_task7_*.rs.
 // ─────────────────────────────────────────────────────────────────────
@@ -240,7 +248,7 @@ fn reflect_input(
         tags: vec!["l3-3".to_string()],
         priority: 5,
         confidence: 1.0,
-        source: "claude".to_string(),
+        source: FIXTURE_SOURCE.to_string(),
         agent_id: agent_id.to_string(),
         metadata: serde_json::json!({}),
     }


### PR DESCRIPTION
## Summary

PR9 of the #1174 codegraph-driven pm-v3.1 global refactor sweep ([NO FAIL MISSION](https://github.com/alphaonedev/ai-memory-mcp/issues/1174), pm-v3.2 governance — ai-memory memory `2cb15d34-2399-4611-a020-df6ef91683fe`).

Replaces hardcoded `"claude"` test-fixture literals with vendor-neutral `FIXTURE_SOURCE = "nhi"` per-file constants (or `validate::DEFAULT_NHI_SOURCE` from PR #1175). **Net: 22 vendor-literal sites flipped across 11 files, 122 insertions / 27 deletions.**

## Files updated (11)

Per-file `FIXTURE_SOURCE` const + literal flip in:
- `tests/approval_reflect.rs`
- `tests/federation_reflection_replication.rs`
- `tests/form_5_confidence_calibration.rs` (also flipped matching `observe(..., "claude", ...)` shadow-mode calls + `find(|b| b.source == "claude")` baseline lookups so per-source aggregation still demonstrates with a non-`"user"` contrast)
- `tests/l1_1_memory_kind.rs`
- `tests/recursive_learning_task4_memory_reflect.rs`
- `tests/recursive_learning_task5_audit_record.rs`
- `tests/recursive_learning_task6_reflect_hooks.rs`
- `tests/recursive_learning_task7_shipgate_functional.rs`
- `tests/recursive_learning_task7_shipgate_chaos_migration.rs`
- `tests/ship_gate/grand_slam_recursive_learning.rs`

Different-pattern edits:
- `tests/form_4_provenance.rs` — `"claude"` in REJECT list of `validate_source_uri` test → replaced with `"bare-word"` + doc comment clarifying the validator does not special-case vendor identifiers.
- `tests/integration.rs` — `--format claude` CLI arg KEPT (it's the canonical selector for `Format::Claude` mine-conversation parser variant, legitimately vendor-named per PR #1184 reasoning); added clarifying doc comment.

## Preserved (NOT TOUCHED) — heterogeneity invariant tests

- **`tests/issue_809_nhi_self_persona_any_agent.rs`** — vendor blocklist test (KEEP per inventory § 3 carve-out).
- **`tests/capabilities_v3_provenance_layer.rs`** — iterates `["anthropic", "openai", "google", "deepmind", "meta"]` (KEEP).
- **`tests/e1_orchestration_dry_run.rs`** — iterates `["claude", "gpt5", "gemini", "grok"]` (KEEP).
- **`tests/issue_1168_capabilities_resolver_drift.rs`** — uses `model = "claude-opus-4.7"` + `assert_eq!(v2["llm"], "anthropic:claude-opus-4.7")` as a deliberate heterogeneity test pinning that capabilities wire reports operator-configured Anthropic vendor+model. The Phase 1 inventory's line-number references (147/176/187/212/...) for this file were **stale** and actually pointed at `backend = "xai"` / `backend = "ollama"` / `backend = "anthropic"` TOML fixtures, not at `"claude"` literals.

Inventory-vs-actual discrepancy: inventory claimed 35 sites across 18 files; actual unique vendor-literal sites in scope after deflake review = 22 (across 11 files + 1 KEPT-with-doc in integration.rs + 1 KEPT-with-doc in form_4_provenance.rs). The 13-site gap = stale `issue_1168` line-numbers (intentional heterogeneity tests, all preserved) + duplicate counting of multi-site files.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | clean |
| `cargo test` per touched file | 77 tests + 7 ship_gate + 1 integration filter, all green |
| `cargo audit --no-fetch` | clean |

## Provenance

Drafted by general-purpose worktree-isolated subagent (agent `a671b6253f0e1cd2b`, 95 tool calls, ~21 min). Per CLAUDE.md multi-agent worktree discipline §856, the sub-agent committed to its worktree branch (commit `131e5cf98894de12798533d15ade8b7e740957a7`) and deferred push + cherry-pick decisions to the parent. Parent orchestrator (Claude Opus 4.7) pushed + opened this PR.

Wave 2 sibling PRs:
- PR2 (#1188) — http-const, opened in parallel
- PR5 (`refactor/1174-pmv31-namespace-sentinels`) — sub-agent still working
- PR7 (`refactor/1174-pmv31-static-state-config`) — sub-agent still working
- PR8 (`refactor/1174-pmv31-static-state-rest`) — re-dispatched after stale-base abort

## AI involvement

Drafted by general-purpose subagent (correctly followed #856 worktree discipline) + push/PR by Claude Opus 4.7 (1M context).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
