### PR TITLE
refactor(#1174): pm-v3.1 PR5 — extract DEFAULT_NAMESPACE / disambiguate from quotas::GLOBAL_NAMESPACE

### DIFF
--- a/src/cli/boot.rs
+++ b/src/cli/boot.rs
@@ -596,7 +596,11 @@ pub fn run(
         return Ok(());
     }
 
-    let displayed_ns = if fell_back { "global" } else { &namespace };
+    let displayed_ns = if fell_back {
+        crate::DEFAULT_NAMESPACE
+    } else {
+        &namespace
+    };
     let status = if fell_back {
         BootStatus::InfoFallback
     } else {

--- a/src/cli/commands/persona.rs
+++ b/src/cli/commands/persona.rs
@@ -35,7 +35,7 @@ pub struct PersonaArgs {
     pub entity_id: String,
 
     /// Namespace the persona lives under. Defaults to `global`.
-    #[arg(long, value_name = "NS", default_value = "global")]
+    #[arg(long, value_name = "NS", default_value = crate::DEFAULT_NAMESPACE)]
     pub namespace: String,
 
     /// When set, force a fresh curator synthesis and persist a new

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -59,7 +59,7 @@ pub fn auto_namespace() -> String {
     std::env::current_dir()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
-        .unwrap_or_else(|| "global".to_string())
+        .unwrap_or_else(|| crate::DEFAULT_NAMESPACE.to_string())
 }
 
 /// Format an RFC3339 timestamp as a short relative age ("just now", "5m ago",

--- a/src/config.rs
+++ b/src/config.rs
@@ -5549,7 +5549,7 @@ impl AppConfig {
                     .clone()
                     .filter(|s| !s.trim().is_empty())
             })
-            .unwrap_or_else(|| "global".to_string());
+            .unwrap_or_else(|| crate::DEFAULT_NAMESPACE.to_string());
 
         let archive_on_gc = cfg
             .and_then(|s| s.archive_on_gc)

--- a/src/handlers/links.rs
+++ b/src/handlers/links.rs
@@ -525,7 +525,7 @@ pub async fn create_link(
     // the MCP contract.
     if create_result.is_ok() {
         let (link_namespace, link_owner) = db::get(&lock.0, &source_id).ok().flatten().map_or_else(
-            || ("global".to_string(), None),
+            || (crate::DEFAULT_NAMESPACE.to_string(), None),
             |m| {
                 let owner = m
                     .metadata

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -69,7 +69,7 @@ pub struct ConsolidateBody {
 }
 
 fn default_ns() -> String {
-    "global".to_string()
+    crate::DEFAULT_NAMESPACE.to_string()
 }
 
 /// v0.7.0 L7 — resolve the consolidation `summary` field when the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,42 @@ pub const SECS_PER_WEEK: i64 = 604_800;
 pub const HEADER_CONTENT_TYPE: &str = "content-type";
 pub const MIME_JSON: &str = "application/json";
 
+// ---------------------------------------------------------------------------
+// v0.7.x (issue #1174 PR5 — pm-v3.1 namespace-sentinel sweep) — the
+// default namespace for AI-NHI memory writes when the caller omits
+// the `namespace` parameter. Bare value: `"global"`.
+//
+// Distinguished from [`GLOBAL_NAMESPACE`] (underscored `"_global"`),
+// which is the system-reserved namespace for substrate-internal
+// rows (governance, quotas, audit). NEVER conflate these — they
+// are different namespaces with different semantics. The
+// underscore prefix is the reserved-namespace convention.
+//
+// Replaces ~25 inline literal `"global"` sites across config,
+// storage, handlers, MCP tools, and models. The wire value is
+// preserved byte-for-byte (`"global"` stays `"global"` on every
+// JSON-RPC and HTTP response); only the literal's source location
+// changes.
+// ---------------------------------------------------------------------------
+
+/// v0.7.x (issue #1174 PR5 — pm-v3.1 namespace-sentinel sweep) — the
+/// default namespace for AI-NHI memory writes when the caller omits
+/// the `namespace` parameter. Bare value: `"global"`.
+///
+/// Distinguished from [`GLOBAL_NAMESPACE`] (underscored `"_global"`),
+/// which is the system-reserved namespace for substrate-internal
+/// rows (governance, quotas, audit). NEVER conflate these — they
+/// are different namespaces with different semantics. The
+/// underscore prefix is the reserved-namespace convention.
+pub const DEFAULT_NAMESPACE: &str = "global";
+
+/// v0.7.x (issue #1174 PR5) — re-export of the system-reserved
+/// namespace constant defined originally at `src/quotas.rs:70`.
+/// Centralised here so other modules don't independently re-define
+/// the literal. SEPARATE from [`DEFAULT_NAMESPACE`] — see that
+/// doc-comment for the disambiguation.
+pub use crate::quotas::GLOBAL_NAMESPACE;
+
 pub mod approvals;
 // v0.7.0 WT-1-B — substrate-level atomisation engine. Decomposes
 // long-form memories into atomic propositions with full provenance

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -166,7 +166,7 @@ fn audit_emit_for_mcp_dispatch(
     let namespace = arguments
         .get("namespace")
         .and_then(Value::as_str)
-        .unwrap_or("global")
+        .unwrap_or(crate::DEFAULT_NAMESPACE)
         .to_string();
     let memory_id = arguments
         .get("id")
@@ -10587,7 +10587,7 @@ mod tests {
     fn chunkc_archive_purge_denied_by_permission_rule() {
         let _gate = chunkc_lock_perms();
         crate::permissions::set_active_permission_rules(vec![crate::permissions::PermissionRule {
-            namespace_pattern: "global".to_string(),
+            namespace_pattern: crate::DEFAULT_NAMESPACE.to_string(),
             op: "memory_archive".to_string(),
             // Unique agent_pattern so other tests' implicit calls don't
             // match this rule.
@@ -10620,7 +10620,7 @@ mod tests {
             crate::config::PermissionsMode::Advisory,
         );
         crate::permissions::set_active_permission_rules(vec![crate::permissions::PermissionRule {
-            namespace_pattern: "global".to_string(),
+            namespace_pattern: crate::DEFAULT_NAMESPACE.to_string(),
             op: "memory_archive".to_string(),
             agent_pattern: "chunkc-archask-*".to_string(),
             decision: crate::permissions::RuleDecision::Ask,

--- a/src/mcp/tools/archive.rs
+++ b/src/mcp/tools/archive.rs
@@ -78,7 +78,7 @@ pub(super) fn handle_archive_purge(
             .map_err(|e| e.to_string())?;
         let ctx = PermissionContext {
             op: Op::MemoryArchive,
-            namespace: "global".to_string(),
+            namespace: crate::DEFAULT_NAMESPACE.to_string(),
             agent_id,
             payload: json!({
                 "older_than_days": older_than_days,

--- a/src/mcp/tools/consolidate.rs
+++ b/src/mcp/tools/consolidate.rs
@@ -33,7 +33,9 @@ pub(super) fn handle_consolidate(
         }
     }
     let title = params["title"].as_str().ok_or("title is required")?;
-    let namespace = params["namespace"].as_str().unwrap_or("global");
+    let namespace = params["namespace"]
+        .as_str()
+        .unwrap_or(crate::DEFAULT_NAMESPACE);
 
     // Auto-generate summary via LLM if not provided
     let summary: String = if let Some(s) = params["summary"].as_str() {

--- a/src/mcp/tools/ingest_multistep.rs
+++ b/src/mcp/tools/ingest_multistep.rs
@@ -114,7 +114,7 @@ pub fn handle_ingest_multistep(
     let namespace = params
         .get("namespace")
         .and_then(Value::as_str)
-        .unwrap_or("global");
+        .unwrap_or(crate::DEFAULT_NAMESPACE);
 
     // ── Tier gate ───────────────────────────────────────────────────
     if tier == FeatureTier::Keyword || handler.is_none() {

--- a/src/mcp/tools/kg_invalidate.rs
+++ b/src/mcp/tools/kg_invalidate.rs
@@ -91,7 +91,7 @@ pub fn handle_kg_invalidate(
         use crate::permissions::{Op, PermissionContext, Permissions};
         let link_ns = match db::get(conn, source_id) {
             Ok(Some(m)) => m.namespace,
-            _ => "global".to_string(),
+            _ => crate::DEFAULT_NAMESPACE.to_string(),
         };
         let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), None)
             .map_err(|e| e.to_string())?;
@@ -150,7 +150,7 @@ pub fn handle_kg_invalidate(
                         .map(str::to_string);
                     (mem.namespace, owner)
                 }
-                _ => ("global".to_string(), None),
+                _ => (crate::DEFAULT_NAMESPACE.to_string(), None),
             };
             let details = serde_json::to_value(crate::subscriptions::LinkInvalidatedEventDetails {
                 target_id: target_id.to_string(),

--- a/src/mcp/tools/link.rs
+++ b/src/mcp/tools/link.rs
@@ -126,7 +126,7 @@ pub(super) fn handle_link(
         use crate::permissions::{Op, PermissionContext, Permissions};
         let link_ns = match db::get(conn, source_id) {
             Ok(Some(m)) => m.namespace,
-            _ => "global".to_string(),
+            _ => crate::DEFAULT_NAMESPACE.to_string(),
         };
         let agent_id = crate::identity::resolve_agent_id(params["agent_id"].as_str(), None)
             .map_err(|e| e.to_string())?;
@@ -169,7 +169,7 @@ pub(super) fn handle_link(
 
         let source_ns = match db::get(conn, source_id) {
             Ok(Some(m)) => m.namespace,
-            _ => "global".to_string(),
+            _ => crate::DEFAULT_NAMESPACE.to_string(),
         };
         let policy = db::resolve_governance_policy(conn, &source_ns)
             .unwrap_or_else(GovernancePolicy::default);
@@ -297,7 +297,7 @@ pub(super) fn handle_link(
                 .map(str::to_string);
             (mem.namespace, owner)
         }
-        _ => ("global".to_string(), None),
+        _ => (crate::DEFAULT_NAMESPACE.to_string(), None),
     };
     let details = serde_json::to_value(crate::subscriptions::LinkCreatedEventDetails {
         target_id: target_id.to_string(),

--- a/src/mcp/tools/persona.rs
+++ b/src/mcp/tools/persona.rs
@@ -59,7 +59,9 @@ pub(super) fn handle_persona(conn: &rusqlite::Connection, params: &Value) -> Res
     if entity_id.is_empty() {
         return Err("entity_id cannot be empty".to_string());
     }
-    let namespace = params["namespace"].as_str().unwrap_or("global");
+    let namespace = params["namespace"]
+        .as_str()
+        .unwrap_or(crate::DEFAULT_NAMESPACE);
 
     let persona = get_latest_persona(conn, entity_id, namespace)
         .map_err(|e| format!("memory_persona substrate error: {e}"))?;
@@ -151,7 +153,7 @@ pub fn handle_persona_generate(
         ),
         None => (
             generator
-                .generate_cross_namespace(entity_id, "global")
+                .generate_cross_namespace(entity_id, crate::DEFAULT_NAMESPACE)
                 .map_err(persona_error_to_string)?,
             "cross_namespace".to_string(),
         ),

--- a/src/mcp/tools/store/validation.rs
+++ b/src/mcp/tools/store/validation.rs
@@ -98,7 +98,10 @@ pub(super) fn parse_and_build_memory(
     let content = params["content"].as_str().ok_or("content is required")?;
     let tier_str = params["tier"].as_str().unwrap_or(Tier::Mid.as_str());
     let tier = Tier::from_str(tier_str).ok_or(format!("invalid tier: {tier_str}"))?;
-    let namespace = params["namespace"].as_str().unwrap_or("global").to_string();
+    let namespace = params["namespace"]
+        .as_str()
+        .unwrap_or(crate::DEFAULT_NAMESPACE)
+        .to_string();
     // v0.7.x (issue #1175): vendor-neutral substrate default. The
     // pre-#1175 hardcode of `"claude"` was a heterogeneous-NHI monoculture
     // defect — `memory_store` from a non-Anthropic NHI silently stamped

--- a/src/models/memory.rs
+++ b/src/models/memory.rs
@@ -765,7 +765,7 @@ impl Default for Memory {
         Self {
             id: String::new(),
             tier: Tier::Mid,
-            namespace: "global".to_string(),
+            namespace: crate::DEFAULT_NAMESPACE.to_string(),
             title: String::new(),
             content: String::new(),
             tags: Vec::new(),
@@ -871,7 +871,7 @@ fn default_tier() -> Tier {
     Tier::Mid
 }
 fn default_namespace() -> String {
-    "global".to_string()
+    crate::DEFAULT_NAMESPACE.to_string()
 }
 fn default_priority() -> i32 {
     5

--- a/src/multistep_ingest/helpers.rs
+++ b/src/multistep_ingest/helpers.rs
@@ -350,7 +350,7 @@ pub fn fts_classifier_with(params: &HelperParams, ctx: &HelperContext<'_>) -> He
         .namespace
         .as_deref()
         .or(ctx.namespace)
-        .unwrap_or("global");
+        .unwrap_or(crate::DEFAULT_NAMESPACE);
 
     let body_lower = content.to_lowercase();
     let kind = if body_lower.contains("step ")

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2897,7 +2897,7 @@ pub fn validate_link_pre_create(
         // the missing-memory error after this returns.
         let link_ns = match get(conn, source_id) {
             Ok(Some(m)) => m.namespace,
-            _ => "global".to_string(),
+            _ => crate::DEFAULT_NAMESPACE.to_string(),
         };
         let ctx = PermissionContext {
             op: Op::MemoryLink,


### PR DESCRIPTION
## Summary

PR5 of the #1174 codegraph-driven pm-v3.1 global refactor sweep ([NO FAIL MISSION](https://github.com/alphaonedev/ai-memory-mcp/issues/1174), pm-v3.2 governance — ai-memory memory `2cb15d34-2399-4611-a020-df6ef91683fe`).

Extracts ~25 inline `"global"` namespace-sentinel literals behind a single named constant in `src/lib.rs`, AND disambiguates explicitly from the system-reserved `"_global"` namespace defined in `src/quotas.rs:70` per the audit inventory § 6 collision-hazard risk register.

## Hazard handled: `"global"` vs `"_global"` disambiguation

Per the inventory's risk register, these are DIFFERENT namespaces:

| Const | Value | Semantics |
|---|---|---|
| `DEFAULT_NAMESPACE` (NEW) | `"global"` | Default for AI-NHI memory writes when caller omits `namespace` |
| `GLOBAL_NAMESPACE` (existing at `src/quotas.rs:70`, re-exported) | `"_global"` | System-reserved for substrate-internal rows (governance, quotas, audit) |

The underscore prefix is the reserved-namespace convention. **NEVER conflate these** — doc-comments on both consts make the distinction queryable.

## Constants added (`src/lib.rs`)

```rust
pub const DEFAULT_NAMESPACE: &str = "global";
pub use crate::quotas::GLOBAL_NAMESPACE;  // re-export the "_global" const
```

## Files swept (18)

`src/cli/boot.rs`, `src/cli/commands/persona.rs`, `src/cli/helpers.rs`, `src/config.rs`, `src/handlers/links.rs`, `src/handlers/power_consolidation.rs`, `src/lib.rs` (const definitions), `src/mcp/mod.rs`, `src/mcp/tools/{archive, consolidate, ingest_multistep, kg_invalidate, link, persona, store/validation}.rs`, `src/models/memory.rs`, `src/multistep_ingest/helpers.rs`, `src/storage/mod.rs`.

Net: **71 insertions / 24 deletions**.

## Out of scope (preserved)

- Test fixtures using `"global"` as tag/title/value (NOT a namespace) — preserved.
- SQL string literals like `namespace LIKE 'global/%'` — preserved (cannot reference Rust consts inside SQL strings).
- Doc-comment prose mentioning `"global"` — preserved (it's prose, not runtime code).

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | clean |
| `cargo test --lib` | local gate hit exit 144 (memory pressure from 4 concurrent worktree cargo builds); CI runs gates from clean environment |

Changes are pure literal substitution with byte-equal wire preservation; CI's clean-environment gate run will confirm tests green.

## Provenance

Drafted by general-purpose worktree-isolated subagent (agent `a0902ecf44fd7c78c`, 95 tool calls, ~33 min). The agent stopped at "wait for monitor notification" without completing commit/push/PR; parent orchestrator (Claude Opus 4.7) verified the diff was semantically correct (pm-v3 verify-before-claiming), pushed, and opened this PR.

Wave 2 sibling PRs:
- PR2 (#1188) — http-const, CI in flight
- PR9 (#1189) — tests-vendor-deflake, CI in flight (1 postgres-gate flake)
- PR7 (`refactor/1174-pmv31-static-state-config`) — sub-agent still working
- PR8 (`refactor/1174-pmv31-static-state-rest`) — re-dispatched after stale-base abort

Per pm-v3.2 NO FAIL MISSION closure gate: this PR is one of 9 train PRs whose collective state must pass 3 independent codegraph-driven QC audits before #1174 can close.

## AI involvement

Drafted by general-purpose subagent + verified/completed by Claude Opus 4.7 (1M context).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
