### PR TITLE
refactor(#1174): pm-v3.1 PR8 — extract Class A SHOULD statics into AppState / metrics registry

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -2,18 +2,58 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! ANSI color output for CLI — zero dependencies.
+//!
+//! pm-v3.1 PR8 (issue #1174) — color enablement is determined ONCE at
+//! process boot from `std::io::stdout().is_terminal()` and frozen for
+//! the lifetime of the process via `OnceLock<bool>`. The pre-PR8
+//! shape used a mutable `AtomicBool` which gave production callers no
+//! protection against accidental late mutation. Tests that need to
+//! force colour off route through a thread-local override consulted
+//! by `enabled()` (compiled out of non-test builds).
 
 use std::io::IsTerminal;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
-static COLOR_ENABLED: AtomicBool = AtomicBool::new(true);
+/// One-shot snapshot of the boot-time `stdout` is-a-terminal probe.
+/// Set exactly once by [`init`]; subsequent calls are no-ops thanks
+/// to `OnceLock::set` semantics (first-writer-wins). Production code
+/// SHOULD call [`init`] exactly once at process start (see
+/// `src/main.rs`).
+static COLOR_ENABLED: OnceLock<bool> = OnceLock::new();
 
 pub fn init() {
-    COLOR_ENABLED.store(std::io::stdout().is_terminal(), Ordering::Relaxed);
+    // `OnceLock::set` returns `Err` if already initialised; benign
+    // for double-init paths (tests, repeat embedder bootstrap), so
+    // the return value is intentionally discarded.
+    let _ = COLOR_ENABLED.set(std::io::stdout().is_terminal());
 }
 
 fn enabled() -> bool {
-    COLOR_ENABLED.load(Ordering::Relaxed)
+    #[cfg(test)]
+    if let Some(forced) = test_override::get() {
+        return forced;
+    }
+    // Default true matches the pre-PR8 `AtomicBool::new(true)` posture
+    // — if production code reads colour state before `init` runs the
+    // colourised path stays on (the prior behaviour).
+    *COLOR_ENABLED.get().unwrap_or(&true)
+}
+
+#[cfg(test)]
+mod test_override {
+    use std::cell::Cell;
+
+    thread_local! {
+        static OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    pub(super) fn get() -> Option<bool> {
+        OVERRIDE.with(Cell::get)
+    }
+
+    pub(super) fn set(value: Option<bool>) {
+        OVERRIDE.with(|cell| cell.set(value));
+    }
 }
 
 fn wrap(code: &str, text: &str) -> String {
@@ -87,14 +127,15 @@ pub fn priority_bar(p: i32) -> String {
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
-
+    /// pm-v3.1 PR8 (issue #1174) — thread-local override removes the
+    /// need for a process-wide `Mutex<()>` to serialise tests. Each
+    /// `cargo test` worker gets its own override slot, so the
+    /// previously-required `--test-threads=1` style of serialisation
+    /// is gone.
     fn with_color_off<F: FnOnce()>(f: F) {
-        let _guard = TEST_LOCK.lock().unwrap();
-        COLOR_ENABLED.store(false, Ordering::Relaxed);
+        test_override::set(Some(false));
         f();
-        COLOR_ENABLED.store(true, Ordering::Relaxed);
+        test_override::set(None);
     }
 
     #[test]
@@ -148,11 +189,11 @@ mod tests {
 
     #[test]
     fn wrap_with_color_enabled() {
-        let _guard = TEST_LOCK.lock().unwrap();
-        COLOR_ENABLED.store(true, Ordering::Relaxed);
+        test_override::set(Some(true));
         let result = wrap("91", "red");
         assert!(result.contains("\x1b[91m"));
         assert!(result.contains("\x1b[0m"));
         assert!(result.contains("red"));
+        test_override::set(None);
     }
 }

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -20,7 +20,7 @@ use instant_distance::{Builder, HnswMap, Search};
 use instant_distance::Point;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::thread::JoinHandle;
 
@@ -57,19 +57,26 @@ const MAX_ENTRIES: usize = 100_000;
 // invisibly. The two counters below + the structured `hnsw.eviction`
 // tracing event close that gap:
 //
-//   - `INDEX_EVICTIONS_TOTAL` — cumulative count surfaced via
-//     `db::stats().index_evictions_total` (and capabilities).
-//   - `LAST_EVICTION_AT_NANOS` — wall-clock UNIX nanoseconds of the most
-//     recent eviction; capabilities derive `hnsw.evicted_recently` from
-//     this with a 60 s rolling window.
+//   - eviction count — cumulative count surfaced via
+//     `db::stats().index_evictions_total` (and capabilities) AND at
+//     `/metrics` as `ai_memory_hnsw_evictions_total`.
+//   - last-eviction wall clock — UNIX nanoseconds of the most recent
+//     eviction; capabilities derive `hnsw.evicted_recently` from this
+//     with a 60 s rolling window.
+//
+// **pm-v3.1 PR8 (issue #1174).** Pre-PR8 the counters were two free
+// `static AtomicU64`s at the top of this file. PR8 sank both into the
+// metrics registry (`src/metrics.rs::HNSW_EVICTIONS_TOTAL` +
+// `HNSW_LAST_EVICTION_AT_NANOS`, plus matching Prometheus
+// `IntCounter` / `IntGauge` handles on `Metrics`) so the eviction
+// signal is `/metrics`-scrape-visible without a separate observer
+// thread. The accessor signatures here are preserved verbatim for
+// call-site backward compat.
 //
 // Process-local. The counters reset on restart because the index itself
 // resets on restart. Both atomics are touched only on the eviction edge
 // (rare: requires >100k vectors), so there is no measurable hot-path cost.
 // ---------------------------------------------------------------------------
-
-static INDEX_EVICTIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
-static LAST_EVICTION_AT_NANOS: AtomicU64 = AtomicU64::new(0);
 
 /// Cumulative HNSW oldest-eviction count since process start.
 ///
@@ -77,9 +84,11 @@ static LAST_EVICTION_AT_NANOS: AtomicU64 = AtomicU64::new(0);
 /// index has hit `MAX_ENTRIES` and dropped older embeddings; recall
 /// quality may have degraded for evicted ids until they are re-inserted
 /// (e.g. on next access via `recall` touch path).
+///
+/// pm-v3.1 PR8: thin shim over `crate::metrics::hnsw_evictions_total()`.
 #[must_use]
 pub fn index_evictions_total() -> u64 {
-    INDEX_EVICTIONS_TOTAL.load(Ordering::Relaxed)
+    crate::metrics::hnsw_evictions_total()
 }
 
 // ---------------------------------------------------------------------------
@@ -124,7 +133,7 @@ static EVICTION_RATE_RING: Mutex<std::collections::VecDeque<u64>> =
 /// Returns `false` when no evictions have ever happened in this process.
 #[must_use]
 pub fn evicted_recently(window_secs: u64) -> bool {
-    let last = LAST_EVICTION_AT_NANOS.load(Ordering::Relaxed);
+    let last = crate::metrics::hnsw_last_eviction_at_nanos();
     if last == 0 {
         return false;
     }
@@ -142,10 +151,12 @@ pub fn evicted_recently(window_secs: u64) -> bool {
 /// `pub(crate)`) so the integration-test crate at `tests/` can drive it
 /// alongside the public `index_evictions_total()` accessor; renaming
 /// keeps the intent obvious at every call site.
+///
+/// pm-v3.1 PR8: thin shim over
+/// `crate::metrics::reset_hnsw_eviction_counters_for_test()`.
 #[doc(hidden)]
 pub fn reset_eviction_counters_for_test() {
-    INDEX_EVICTIONS_TOTAL.store(0, Ordering::Relaxed);
-    LAST_EVICTION_AT_NANOS.store(0, Ordering::Relaxed);
+    crate::metrics::reset_hnsw_eviction_counters_for_test();
     if let Ok(mut g) = EVICTION_RATE_RING.lock() {
         g.clear();
     }
@@ -579,7 +590,11 @@ impl VectorIndex {
             drop(sink_guard);
             #[allow(clippy::cast_possible_truncation)]
             let evicted = excess as u64;
-            INDEX_EVICTIONS_TOTAL.fetch_add(evicted, Ordering::Relaxed);
+            // pm-v3.1 PR8 (issue #1174): counter sink moved to the
+            // metrics registry. We defer the actual `record_hnsw_eviction`
+            // call until `now_nanos_u64` is computed below so the
+            // counter and last-eviction timestamp move in lockstep.
+            let evicted_count_to_record = evicted;
 
             state.all_entries.drain(..excess);
             // v0.7.0 #1087 — invalidate cached valid_ids set after the
@@ -647,7 +662,12 @@ impl VectorIndex {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
             let now_nanos_u64 = u64::try_from(now_nanos).unwrap_or(u64::MAX);
-            LAST_EVICTION_AT_NANOS.store(now_nanos_u64, Ordering::Relaxed);
+            // pm-v3.1 PR8 (issue #1174): single sink call covers both
+            // the cumulative counter and the last-eviction timestamp,
+            // mirroring both onto the Prometheus handles so `/metrics`
+            // scrapes see the eviction event without polling
+            // `memory_stats`.
+            crate::metrics::record_hnsw_eviction(evicted_count_to_record, now_nanos_u64);
 
             // M8 (v0.7.0 round-2) — rolling-hour rate observer. Push
             // a stamp on this eviction, then count stamps in the

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,11 +10,91 @@
 //! metrics-backend swap stays internal.
 
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Registry,
     TextEncoder,
 };
+
+// =====================================================================
+// pm-v3.1 PR8 (issue #1174) — HNSW eviction observability.
+//
+// Pre-PR8 lived as two free `static AtomicU64`s at the top of
+// `src/hnsw.rs`. Class A "SHOULD" extraction: the counters are
+// metrics-bound (surfaced in `/metrics`, `memory_capabilities`,
+// `memory_stats`) so the metrics registry is the natural owner.
+//
+// The Prometheus handles (`hnsw_evictions_total` IntCounter +
+// `hnsw_last_eviction_at_nanos` IntGauge in `Metrics`) carry the
+// scrape-side wiring. The atomics below carry the read-side logic
+// (`evicted_recently` 60s window) AND the test-only reset path that
+// prometheus's monotonic-counter discipline does not support. Both
+// kept-in-lockstep by the `record_hnsw_eviction` sink and the
+// `reset_hnsw_eviction_counters_for_test` resetter.
+//
+// Process-local. The counters reset on restart because the index
+// itself resets on restart. Both atomics are touched only on the
+// eviction edge (rare: requires >100k vectors), so there is no
+// measurable hot-path cost.
+// =====================================================================
+
+static HNSW_EVICTIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static HNSW_LAST_EVICTION_AT_NANOS: AtomicU64 = AtomicU64::new(0);
+
+/// Record one HNSW eviction event. Bumps the process-local cumulative
+/// counter by `count`, sets the last-eviction wall-clock nanos to
+/// `now_nanos`, and mirrors both onto the Prometheus registry handles
+/// so `/metrics` scrapes see the same signal without a separate
+/// observer thread.
+pub fn record_hnsw_eviction(count: u64, now_nanos: u64) {
+    HNSW_EVICTIONS_TOTAL.fetch_add(count, Ordering::Relaxed);
+    HNSW_LAST_EVICTION_AT_NANOS.store(now_nanos, Ordering::Relaxed);
+    let r = registry();
+    r.hnsw_evictions_total.inc_by(count);
+    // IntGauge value is i64; nanos can exceed i64::MAX in ~292 years
+    // past the UNIX epoch — saturating clamp keeps the gauge in range
+    // for any plausible operator timeline.
+    #[allow(clippy::cast_possible_wrap)]
+    let nanos_i64 = i64::try_from(now_nanos).unwrap_or(i64::MAX);
+    r.hnsw_last_eviction_at_nanos.set(nanos_i64);
+}
+
+/// Cumulative HNSW oldest-eviction count since process start. Reads
+/// from the process-local atomic; the same value is scrape-visible at
+/// `/metrics` as `ai_memory_hnsw_evictions_total`.
+#[must_use]
+pub fn hnsw_evictions_total() -> u64 {
+    HNSW_EVICTIONS_TOTAL.load(Ordering::Relaxed)
+}
+
+/// Wall-clock UNIX nanoseconds of the most recent HNSW eviction (0 if
+/// none have occurred this process). Reads from the process-local
+/// atomic; the same value is scrape-visible at `/metrics` as
+/// `ai_memory_hnsw_last_eviction_at_nanos`.
+#[must_use]
+pub fn hnsw_last_eviction_at_nanos() -> u64 {
+    HNSW_LAST_EVICTION_AT_NANOS.load(Ordering::Relaxed)
+}
+
+/// Reset the HNSW eviction counters. Test-only: production callers
+/// must never reach into the counter directly. The Prometheus
+/// monotonic-counter discipline does NOT permit decrement, so the
+/// scrape-side `ai_memory_hnsw_evictions_total` retains its
+/// cumulative value across the reset — only the process-local
+/// atomics (used by `hnsw_evictions_total()`, `evicted_recently`,
+/// and `memory_stats`) drop back to zero. This asymmetry is
+/// deliberate: `/metrics` scrapes are time-series consumers that
+/// expect monotonic counters; the in-process reset is a unit-test
+/// affordance.
+#[doc(hidden)]
+pub fn reset_hnsw_eviction_counters_for_test() {
+    HNSW_EVICTIONS_TOTAL.store(0, Ordering::Relaxed);
+    HNSW_LAST_EVICTION_AT_NANOS.store(0, Ordering::Relaxed);
+    // Mirror the gauge reset so scrape-side `last_eviction_at_nanos`
+    // also flips back to 0 (gauges, unlike counters, may decrement).
+    registry().hnsw_last_eviction_at_nanos.set(0);
+}
 
 /// Handles to the registered metric families. Built once on first access
 /// via `registry()`.
@@ -95,6 +175,25 @@ pub struct Metrics {
     /// alert on non-zero increment rate — a healthy mesh should have
     /// zero rows reaching the quarantine threshold.
     pub federation_push_dlq_quarantined: IntCounter,
+
+    /// pm-v3.1 PR8 (issue #1174) — cumulative HNSW oldest-eviction
+    /// count since process start. Replaces the prior process-global
+    /// `AtomicU64` `INDEX_EVICTIONS_TOTAL` in `src/hnsw.rs`.
+    /// Non-zero means the in-memory vector index has hit
+    /// `MAX_ENTRIES` and dropped older embeddings; recall quality
+    /// may have degraded for evicted ids until they are re-inserted
+    /// (e.g. on next access via the `recall` touch path). Surfaces in
+    /// `memory_capabilities` (`hnsw.evictions_total`), `/metrics`
+    /// (`ai_memory_hnsw_evictions_total`), and `memory_stats`.
+    pub hnsw_evictions_total: IntCounter,
+
+    /// pm-v3.1 PR8 (issue #1174) — wall-clock UNIX nanoseconds of the
+    /// most recent HNSW eviction (0 if none have occurred). Replaces
+    /// the prior process-global `AtomicU64` `LAST_EVICTION_AT_NANOS`
+    /// in `src/hnsw.rs`. Capabilities derives `hnsw.evicted_recently`
+    /// from this with a 60s rolling window. Surfaced as an `IntGauge`
+    /// so the value is also readable via Prometheus scraping.
+    pub hnsw_last_eviction_at_nanos: IntGauge,
 }
 
 /// Lazily-built process-global metrics handle.
@@ -329,6 +428,31 @@ impl Metrics {
         )?;
         registry.register(Box::new(federation_push_dlq_quarantined.clone()))?;
 
+        // pm-v3.1 PR8 (issue #1174) — HNSW eviction observability moved
+        // from process-global atomics in `src/hnsw.rs` into the metrics
+        // registry. The counter mirrors `INDEX_EVICTIONS_TOTAL`; the
+        // gauge mirrors `LAST_EVICTION_AT_NANOS` as a UNIX-nanosecond
+        // wall-clock timestamp (0 if no eviction has occurred). Both
+        // are surfaced at `/metrics` so the eviction signal is
+        // scrape-visible without going through `memory_stats`.
+        let hnsw_evictions_total = IntCounter::new(
+            "ai_memory_hnsw_evictions_total",
+            "Cumulative HNSW oldest-eviction count since process start. \
+             Non-zero indicates the in-memory vector index has hit \
+             MAX_ENTRIES and dropped older embeddings; recall quality \
+             may have degraded for evicted ids until they are \
+             re-inserted on next access.",
+        )?;
+        registry.register(Box::new(hnsw_evictions_total.clone()))?;
+
+        let hnsw_last_eviction_at_nanos = IntGauge::new(
+            "ai_memory_hnsw_last_eviction_at_nanos",
+            "Wall-clock UNIX nanoseconds of the most recent HNSW \
+             eviction (0 if none). Capabilities derives \
+             hnsw.evicted_recently from this with a 60s rolling window.",
+        )?;
+        registry.register(Box::new(hnsw_last_eviction_at_nanos.clone()))?;
+
         Ok(Self {
             registry,
             store_total,
@@ -351,6 +475,8 @@ impl Metrics {
             auto_export_spawn_failed_total,
             federation_push_dlq_depth,
             federation_push_dlq_quarantined,
+            hnsw_evictions_total,
+            hnsw_last_eviction_at_nanos,
         })
     }
 }

--- a/src/sizes.rs
+++ b/src/sizes.rs
@@ -49,6 +49,17 @@ pub struct ToolSize {
     pub total_tokens: usize,
 }
 
+/// pm-v3.1 PR8 (issue #1174) — shared one-shot cache for the verbose
+/// table. Replaces the prior pair of function-local `static TABLE`
+/// declarations (one in `tool_sizes`, one in `trimmed_tool_sizes`)
+/// with a single module-level slot per shape. The cache is computed
+/// lazily on first use and reused forever after.
+static VERBOSE_TABLE: OnceLock<Vec<ToolSize>> = OnceLock::new();
+
+/// pm-v3.1 PR8 (issue #1174) — shared cache for the trimmed (wire-
+/// form) table, matching `VERBOSE_TABLE` above.
+static TRIMMED_TABLE: OnceLock<Vec<ToolSize>> = OnceLock::new();
+
 /// Runtime-computed table of every tool's tokenized schema cost
 /// **at the verbose ceiling** — every optional param, every default,
 /// every per-property description. This is the upper bound a host
@@ -59,8 +70,9 @@ pub struct ToolSize {
 /// Returns a static slice on every call after the first invocation
 /// (which performs the one-time BPE pass).
 pub fn tool_sizes() -> &'static [ToolSize] {
-    static TABLE: OnceLock<Vec<ToolSize>> = OnceLock::new();
-    TABLE.get_or_init(|| compute_table(false)).as_slice()
+    VERBOSE_TABLE
+        .get_or_init(|| compute_table(false))
+        .as_slice()
 }
 
 /// v0.7 C4 + #859 — runtime-computed table of every tool's tokenized
@@ -79,8 +91,7 @@ pub fn tool_sizes() -> &'static [ToolSize] {
 /// pins the sum at ≤ 5000 cl100k tokens (post-#859 floor; was 3500
 /// pre-#859 when the trim hid optional property keys entirely).
 pub fn trimmed_tool_sizes() -> &'static [ToolSize] {
-    static TABLE: OnceLock<Vec<ToolSize>> = OnceLock::new();
-    TABLE.get_or_init(|| compute_table(true)).as_slice()
+    TRIMMED_TABLE.get_or_init(|| compute_table(true)).as_slice()
 }
 
 /// Highest-cost tool in the verbose table. Used by the CI gate.


### PR DESCRIPTION
## Summary

Wave 2 of the pm-v3.1 codegraph-driven global refactor sweep (issue #1174). Extracts Class A "SHOULD" statics — process-globals whose owners should be a typed registry/state — into the metrics registry or a tighter shape that matches their lifecycle.

Base SHA: `04e28c4a21dec4f2ec1fb4acc6703d06fc62864d` (release/v0.7.0 at dispatch time).

## Statics extracted

### `src/sizes.rs` — two function-local `OnceLock` → two module-level slots
The pair of `static TABLE: OnceLock<Vec<ToolSize>>` declarations (one in `tool_sizes()`, one in `trimmed_tool_sizes()`) is now two module-level statics (`VERBOSE_TABLE`, `TRIMMED_TABLE`). Cache shape is now source-of-truth visible at the module level rather than scattered inside two function bodies.

### `src/color.rs` — `AtomicBool` → `OnceLock<bool>` + thread-local test override
Pre-PR8 `COLOR_ENABLED: AtomicBool` was mutable at runtime — production init wrote once at boot, but the contract was "anyone may toggle" rather than "boot fixes the value". PR8 freezes the production state via `OnceLock<bool>` and routes test overrides through a thread-local slot (`test_override::set(Some(false))`). Removes the prior `Mutex<()>` test serialiser — each cargo-test worker now owns its own override slot so default parallelism is preserved.

### `src/hnsw.rs` — two metrics-bound atomics → metrics registry sink
`INDEX_EVICTIONS_TOTAL` and `LAST_EVICTION_AT_NANOS` moved into `crate::metrics` as the canonical sink. The metrics module exposes:

- `record_hnsw_eviction(count, now_nanos)` — single-call sink that bumps both the process-local atomic counter AND the Prometheus `IntCounter` + `IntGauge` handles on the `Metrics` registry so `/metrics` scrapes see the eviction signal without polling `memory_stats`.
- `hnsw_evictions_total()` / `hnsw_last_eviction_at_nanos()` — read accessors used by the 60 s `evicted_recently` window check.
- `reset_hnsw_eviction_counters_for_test()` — test-only resetter. The Prometheus `IntCounter` is monotonic by discipline so the scrape-side cumulative value is retained across reset; only the process-local atomics + the gauge drop back to 0.

Public accessors `crate::hnsw::index_evictions_total()`, `crate::hnsw::evicted_recently()`, and `crate::hnsw::reset_eviction_counters_for_test()` preserved verbatim as thin shims so every call site (capabilities, memory_stats, doctor, tests) keeps working unchanged.

## Statics deferred (split per dispatch clause)

The dispatch authorised splitting if extracting all in one PR would be too invasive.

### `src/llm.rs::ENV_GUARD_1143` — already test-gated, no work needed
The static at `src/llm.rs:2692` is INSIDE `#[cfg(test)] mod wiremock_tests` (lines 2079–2868). The dispatch claim that it "leaks into non-test build" is incorrect — the enclosing module is already test-gated. No change required.

### `src/subscriptions.rs::CLIENT` — kept as scaffolding per #1073/#1082
`dispatch_http_client()` is `#[allow(dead_code)]` scaffolding documenting an intended future refactor (per-call DNS `resolve()` pins on `send()` prevent process-wide client reuse today). The shape is pinned by `tests/sr3_perf_regressions.rs::sr3_1073_dispatch_http_client_scaffolding_exists` which asserts both the function signature AND the literal `static CLIENT: std::sync::OnceLock<Option<reqwest::blocking::Client>>` text. Moving the static into AppState would break the regression test and contradicts the scaffolding-documents-intent contract. Blocked on the per-call DNS-resolve trait-object swap (see `src/subscriptions.rs:398-413` docstring).

### `src/reranker.rs::TRACKER` + `src/encryption/mod.rs::CACHE` — most invasive, deferred
Both require threading a per-process state slot through MCP, HTTP, and CLI call sites that don't currently share an `AppState`. HTTP has `AppState` (`src/handlers/transport.rs:22`) but MCP uses a plain `rusqlite::Connection` and CLI opens a fresh connection per invocation — so the migration is non-trivial. Both are functionally correct as process-globals today (per-test cross-talk hasn't surfaced because tests construct local `SessionRecallTracker::new()` / unique-agent-id keypair entries directly).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` — 6,903 passed / 0 failed across 277 test suites (default parallelism, no `--test-threads=1`)
- [x] `cargo audit` — clean (no vulnerabilities in 529 deps)
- [x] `crate::hnsw::reset_eviction_counters_for_test()` round-trip pinned by `tests/recall_observability.rs:227-273`
- [x] sizes.rs cache pinned by lib tests `no_tool_exceeds_1500_tokens`, `table_has_51_entries_matching_tool_definitions_count`, `every_tool_has_nonzero_cost`, `full_profile_total_in_honest_measured_range`, `tool_size_resolves_memory_store`, `trimmed_full_profile_total_under_post_859_ceiling`, `trimmed_table_strictly_smaller_per_tool_where_optionals_existed`
- [x] color.rs override pinned by lib tests `tier_colors_no_ansi`, `semantic_colors_no_ansi`, `tier_color_dispatch`, `priority_bar_length`, `priority_bar_clamps`, `wrap_with_color_enabled`

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) under the pm-v3.1 no-fail discipline. Codegraph used for caller analysis (`codegraph_callers` on `init`, `global_session_recall_tracker`, etc.) and impact verification. Disjoint from PR7 (`src/config.rs:3652-3955` + `src/audit.rs:206-208`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)