### PR TITLE
refactor(#1183): move WrapStrategy per-CLI-binary table to sibling module src/llm_cli_wrap.rs

### DIFF
--- a/src/cli/wrap.rs
+++ b/src/cli/wrap.rs
@@ -39,15 +39,26 @@
 //!
 //! ## Lookup table
 //!
-//! `default_strategy(agent)` resolves the unflagged form `ai-memory
-//! wrap <agent> -- <args>` to the right delivery mechanism for the
-//! agents we can identify by name today. Unknown agents fall through to
-//! `--system <msg>` because that's the most common contract across
-//! OpenAI-compatible CLIs. Future PRs (notably PR-7) can extend the
-//! table by adding match arms.
+//! [`crate::llm_cli_wrap::default_strategy`] resolves the unflagged
+//! form `ai-memory wrap <agent> -- <args>` to the right delivery
+//! mechanism for the agents we can identify by name today. Unknown
+//! agents fall through to `--system <msg>` because that's the most
+//! common contract across OpenAI-compatible CLIs. Future PRs (notably
+//! PR-7) can extend the table by adding match arms.
+//!
+//! ## Substrate split (#1183)
+//!
+//! The per-CLI-binary `WrapStrategy` enum + the per-vendor table live
+//! in [`crate::llm_cli_wrap`], adjacent to [`crate::llm`]'s alias
+//! tables, so the per-vendor substrate has one home per concern (HTTP
+//! wire shape in `llm.rs`, CLI ABI in `llm_cli_wrap.rs`). The
+//! CLI-binary-name detection logic that PICKS a `WrapStrategy` stays
+//! HERE because it's CLI-specific (clap `WrapArgs` overrides → table
+//! fallback).
 
 use crate::cli::CliOutput;
 use crate::cli::boot::{self, BootArgs};
+use crate::llm_cli_wrap::{WrapStrategy, default_strategy};
 use anyhow::{Context, Result};
 use clap::Args;
 use std::ffi::OsStr;
@@ -70,91 +81,14 @@ const DEFAULT_WRAP_LIMIT: usize = 10;
 const WRAP_PREAMBLE: &str = "You have access to ai-memory, a persistent memory system. \
 The recent context loaded for you appears below. Reference it when relevant to the user's request.";
 
-/// Strategy for delivering the assembled system message to the wrapped
-/// agent. Each variant maps to a distinct CLI ABI an agent might
-/// expose.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WrapStrategy {
-    /// Pass the system message as the value of a CLI flag, e.g.
-    /// `codex --system "<msg>" <args...>`.
-    SystemFlag {
-        /// The flag name including any leading dashes — e.g. `--system`,
-        /// `--system-prompt`, `-s`.
-        flag: String,
-    },
-    /// Set the system message as an environment variable for the child
-    /// process. e.g. `OLLAMA_SYSTEM=<msg> ollama run hermes3:8b`.
-    SystemEnv {
-        /// The env var name, e.g. `OLLAMA_SYSTEM`.
-        name: String,
-    },
-    /// Write the system message to a tempfile and pass the path via a
-    /// CLI flag. e.g. `aider --message-file <path> <args...>`. Used by
-    /// agents whose system-message length exceeds shell argv limits or
-    /// whose CLI explicitly takes a file path.
-    MessageFile {
-        /// The flag that takes the file path, e.g. `--message-file`.
-        flag: String,
-    },
-    /// Resolve the strategy at runtime from `default_strategy(agent)`.
-    /// This is the natural mode when the user hasn't passed any of the
-    /// strategy override flags.
-    Auto,
-}
-
-/// Built-in agent → strategy lookup. The list is small by design — we
-/// only encode strategies for agents we've actually verified. Anything
-/// not in the table falls through to `--system <msg>` because that's
-/// the most common contract across OpenAI-compatible CLIs.
-///
-/// PR-7 may extend this map; the matrix is intentionally tabular so
-/// adding a row is a one-line change.
-#[must_use]
-pub fn default_strategy(agent: &str) -> WrapStrategy {
-    match agent {
-        // OpenAI Codex CLI. The flag name varies between Codex variants
-        // (`--system`, `--system-prompt`, `OPENAI_CLI_SYSTEM`) but
-        // `--system` is the documented form on the upstream codex-cli
-        // crate (PR-1 recipe + Codex CLI README). Users running a
-        // variant that exposes a different flag can override with
-        // `--system-flag <flag>`.
-        "codex" | "codex-cli" => WrapStrategy::SystemFlag {
-            flag: "--system".into(),
-        },
-        // Aider takes its system / instructions input from a file via
-        // `--message-file`. Aider's CLI explicitly recommends this for
-        // anything longer than a one-liner because it doesn't shell-quote
-        // the arg-form for newlines reliably.
-        "aider" => WrapStrategy::MessageFile {
-            flag: "--message-file".into(),
-        },
-        // Google Gemini CLI. `--system` is the documented prepend form.
-        "gemini" => WrapStrategy::SystemFlag {
-            flag: "--system".into(),
-        },
-        // Ollama uses an env var because `ollama run <model>` doesn't
-        // expose a `--system` flag at the CLI level — it expects the
-        // system prompt either inside the prompt body or via the
-        // `OLLAMA_SYSTEM` env var (also the form `ollama serve` reads).
-        "ollama" => WrapStrategy::SystemEnv {
-            name: "OLLAMA_SYSTEM".into(),
-        },
-        // Default: most OpenAI-compatible CLIs accept `--system <msg>`.
-        // If that's wrong, users override with `--system-flag` /
-        // `--system-env` / `--message-file-flag`.
-        _ => WrapStrategy::SystemFlag {
-            flag: "--system".into(),
-        },
-    }
-}
-
 /// Args for `ai-memory wrap`. Designed so the simplest form
 /// (`ai-memory wrap codex -- "hello"`) just works — every flag has a
 /// defaulted value or the lookup table fills it in.
 #[derive(Args, Debug)]
 pub struct WrapArgs {
     /// Name of the agent CLI to wrap, e.g. `codex`, `aider`, `gemini`,
-    /// `ollama`. Resolved against `default_strategy` to pick the
+    /// `ollama`. Resolved against
+    /// [`crate::llm_cli_wrap::default_strategy`] to pick the
     /// system-message delivery mechanism unless the user overrides
     /// with one of the strategy flags below. The agent name is also
     /// the executable looked up on `$PATH`.
@@ -213,7 +147,9 @@ pub struct WrapArgs {
 /// 1. `--system-env <name>` → `SystemEnv`
 /// 2. `--message-file-flag <flag>` → `MessageFile`
 /// 3. `--system-flag <flag>` → `SystemFlag`
-/// 4. fall through to `default_strategy(agent)` (the lookup table)
+/// 4. fall through to
+///    [`crate::llm_cli_wrap::default_strategy`]`(agent)` (the
+///    per-CLI-binary lookup table)
 fn resolve_strategy(args: &WrapArgs) -> WrapStrategy {
     if let Some(name) = args.system_env.as_deref() {
         return WrapStrategy::SystemEnv { name: name.into() };
@@ -437,46 +373,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn wrap_resolves_default_strategy_per_known_agent() {
-        assert_eq!(
-            default_strategy("codex"),
-            WrapStrategy::SystemFlag {
-                flag: "--system".into()
-            }
-        );
-        assert_eq!(
-            default_strategy("codex-cli"),
-            WrapStrategy::SystemFlag {
-                flag: "--system".into()
-            }
-        );
-        assert_eq!(
-            default_strategy("aider"),
-            WrapStrategy::MessageFile {
-                flag: "--message-file".into()
-            }
-        );
-        assert_eq!(
-            default_strategy("gemini"),
-            WrapStrategy::SystemFlag {
-                flag: "--system".into()
-            }
-        );
-        assert_eq!(
-            default_strategy("ollama"),
-            WrapStrategy::SystemEnv {
-                name: "OLLAMA_SYSTEM".into()
-            }
-        );
-        // Unknown agent → fall through to --system.
-        assert_eq!(
-            default_strategy("some-future-cli"),
-            WrapStrategy::SystemFlag {
-                flag: "--system".into()
-            }
-        );
-    }
+    // NOTE: The canonical per-agent table pin moved to
+    // `crate::llm_cli_wrap::tests::default_strategy_per_known_agent_pins_1183`
+    // alongside the table itself in #1183. The tests below exercise the
+    // wrap-side dispatch (override precedence + command-build shape) and
+    // reach the moved table via the re-imported `default_strategy`
+    // symbol.
 
     #[test]
     fn resolve_strategy_explicit_overrides_lookup_table() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,12 @@ pub mod kg;
 // so a future GPU/MTP backend (v0.8 Phase 1) drops in transparently.
 pub mod inference;
 pub mod llm;
+// v0.7.x (#1183, split out of #1174 PR4) — per-CLI-binary WrapStrategy
+// table for `ai-memory wrap <agent>`. Sibling to `llm.rs` so the
+// per-vendor substrate has one home per concern (HTTP wire shape in
+// `llm.rs`, CLI ABI in `llm_cli_wrap.rs`). The CLI-binary-name
+// detection logic that PICKS a WrapStrategy stays in `cli/wrap.rs`.
+pub mod llm_cli_wrap;
 pub mod log_paths;
 pub mod logging;
 pub mod mcp;

--- a/src/llm_cli_wrap.rs
+++ b/src/llm_cli_wrap.rs
@@ -1,0 +1,174 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-CLI-binary `WrapStrategy` table for the `ai-memory wrap <agent>`
+//! subcommand.
+//!
+//! # Why this module exists (#1183, split out of #1174 PR4)
+//!
+//! The `ai-memory wrap` subcommand spawns *external CLI binaries* (the
+//! `codex`, `aider`, `gemini`, `ollama`, … executables on `$PATH`) and
+//! prepends a system-message envelope onto each invocation. Each
+//! downstream CLI has its own ABI for accepting that envelope —
+//! `--system "<msg>"` vs. `OLLAMA_SYSTEM=<msg>` vs. `--message-file
+//! <path>` — and the table that maps "agent binary name" → "delivery
+//! strategy" is the canonical knowledge of those ABIs.
+//!
+//! That table is **adjacent to** the LLM-backend alias tables in
+//! [`crate::llm`] (the `default_base_url_for_alias` / vendor URL +
+//! Bearer-key map used by the HTTP LLM client), but is *not* the same
+//! concern:
+//!
+//! - [`crate::llm`] is the **HTTP LLM client** — `POST
+//!   /v1/chat/completions`, Bearer auth, circuit breaker. The agent
+//!   name here means "wire-shape selector" (`xai`, `openai`, …).
+//! - This module is the **CLI process-spawning wrapper** —
+//!   `std::process::Command::new(<binary>)`, `Stdio::inherit`,
+//!   tempfile cleanup. The agent name here means "binary on `$PATH`"
+//!   (`codex`, `aider`, …).
+//!
+//! Keeping the two tables in sibling modules at the crate root
+//! preserves both concerns at one substrate level without conflating
+//! them into the HTTP client module. The CLI-binary-name detection
+//! logic that PICKS a `WrapStrategy` stays in [`crate::cli::wrap`]
+//! (it's CLI-specific); only the per-vendor TABLE lives here.
+
+/// Strategy for delivering the assembled system message to the wrapped
+/// agent. Each variant maps to a distinct CLI ABI an agent might
+/// expose.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WrapStrategy {
+    /// Pass the system message as the value of a CLI flag, e.g.
+    /// `codex --system "<msg>" <args...>`.
+    SystemFlag {
+        /// The flag name including any leading dashes — e.g. `--system`,
+        /// `--system-prompt`, `-s`.
+        flag: String,
+    },
+    /// Set the system message as an environment variable for the child
+    /// process. e.g. `OLLAMA_SYSTEM=<msg> ollama run hermes3:8b`.
+    SystemEnv {
+        /// The env var name, e.g. `OLLAMA_SYSTEM`.
+        name: String,
+    },
+    /// Write the system message to a tempfile and pass the path via a
+    /// CLI flag. e.g. `aider --message-file <path> <args...>`. Used by
+    /// agents whose system-message length exceeds shell argv limits or
+    /// whose CLI explicitly takes a file path.
+    MessageFile {
+        /// The flag that takes the file path, e.g. `--message-file`.
+        flag: String,
+    },
+    /// Resolve the strategy at runtime from [`default_strategy`].
+    /// This is the natural mode when the user hasn't passed any of the
+    /// strategy override flags.
+    Auto,
+}
+
+/// Built-in agent → strategy lookup. The list is small by design — we
+/// only encode strategies for agents we've actually verified. Anything
+/// not in the table falls through to `--system <msg>` because that's
+/// the most common contract across OpenAI-compatible CLIs.
+///
+/// PR-7 may extend this map; the matrix is intentionally tabular so
+/// adding a row is a one-line change.
+///
+/// **Substrate note (#1183).** This table sits next to
+/// [`crate::llm`]'s alias tables (`default_base_url_for_alias`,
+/// `alias_api_key_env_vars`) at the crate root so the "per-vendor
+/// behavior" substrate has one home per concern: HTTP wire shape in
+/// `llm.rs`, CLI ABI in `llm_cli_wrap.rs`. The agent-name strings here
+/// are CLI **binary names** on `$PATH`, NOT the
+/// `AI_MEMORY_LLM_BACKEND` wire-shape selector — overlap is
+/// coincidental (e.g. `ollama` is both a CLI binary AND a backend
+/// selector, but the two columns are independent).
+#[must_use]
+pub fn default_strategy(agent: &str) -> WrapStrategy {
+    match agent {
+        // OpenAI Codex CLI. The flag name varies between Codex variants
+        // (`--system`, `--system-prompt`, `OPENAI_CLI_SYSTEM`) but
+        // `--system` is the documented form on the upstream codex-cli
+        // crate (PR-1 recipe + Codex CLI README). Users running a
+        // variant that exposes a different flag can override with
+        // `--system-flag <flag>`.
+        "codex" | "codex-cli" => WrapStrategy::SystemFlag {
+            flag: "--system".into(),
+        },
+        // Aider takes its system / instructions input from a file via
+        // `--message-file`. Aider's CLI explicitly recommends this for
+        // anything longer than a one-liner because it doesn't shell-quote
+        // the arg-form for newlines reliably.
+        "aider" => WrapStrategy::MessageFile {
+            flag: "--message-file".into(),
+        },
+        // Google Gemini CLI. `--system` is the documented prepend form.
+        "gemini" => WrapStrategy::SystemFlag {
+            flag: "--system".into(),
+        },
+        // Ollama uses an env var because `ollama run <model>` doesn't
+        // expose a `--system` flag at the CLI level — it expects the
+        // system prompt either inside the prompt body or via the
+        // `OLLAMA_SYSTEM` env var (also the form `ollama serve` reads).
+        "ollama" => WrapStrategy::SystemEnv {
+            name: "OLLAMA_SYSTEM".into(),
+        },
+        // Default: most OpenAI-compatible CLIs accept `--system <msg>`.
+        // If that's wrong, users override with `--system-flag` /
+        // `--system-env` / `--message-file-flag`.
+        _ => WrapStrategy::SystemFlag {
+            flag: "--system".into(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Byte-for-byte preservation pin for the per-agent CLI-ABI table
+    /// after the #1183 move. If any of these assertions break, the
+    /// `ai-memory wrap` runtime contract with downstream agent CLIs is
+    /// broken too — the inputs to `Command::new(<agent>)` change shape
+    /// and existing integrations rely on the exact `--system` /
+    /// `OLLAMA_SYSTEM` / `--message-file` argv shape.
+    #[test]
+    fn default_strategy_per_known_agent_pins_1183() {
+        assert_eq!(
+            default_strategy("codex"),
+            WrapStrategy::SystemFlag {
+                flag: "--system".into()
+            }
+        );
+        assert_eq!(
+            default_strategy("codex-cli"),
+            WrapStrategy::SystemFlag {
+                flag: "--system".into()
+            }
+        );
+        assert_eq!(
+            default_strategy("aider"),
+            WrapStrategy::MessageFile {
+                flag: "--message-file".into()
+            }
+        );
+        assert_eq!(
+            default_strategy("gemini"),
+            WrapStrategy::SystemFlag {
+                flag: "--system".into()
+            }
+        );
+        assert_eq!(
+            default_strategy("ollama"),
+            WrapStrategy::SystemEnv {
+                name: "OLLAMA_SYSTEM".into()
+            }
+        );
+        // Unknown agent → fall through to --system.
+        assert_eq!(
+            default_strategy("some-future-cli"),
+            WrapStrategy::SystemFlag {
+                flag: "--system".into()
+            }
+        );
+    }
+}

--- a/tests/approval_reflect.rs
+++ b/tests/approval_reflect.rs
@@ -39,7 +39,7 @@ use chrono::Utc;
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). Pre-deflake the
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). Pre-deflake the
 /// literal `"claude"` was used here, which silently coupled this test
 /// to a single vendor identity and weakened the heterogeneous-NHI
 /// invariant pinned by `tests/issue_809_*` + `tests/capabilities_v3_*`.

--- a/tests/federation_reflection_replication.rs
+++ b/tests/federation_reflection_replication.rs
@@ -82,7 +82,7 @@ use tempfile::TempDir;
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this federation-replication
 /// test to a single vendor identity.

--- a/tests/l1_1_memory_kind.rs
+++ b/tests/l1_1_memory_kind.rs
@@ -30,7 +30,7 @@ use rusqlite::Connection;
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this test to a single
 /// vendor identity and weaken the heterogeneous-NHI invariant.

--- a/tests/recursive_learning_task4_memory_reflect.rs
+++ b/tests/recursive_learning_task4_memory_reflect.rs
@@ -75,7 +75,7 @@ use common::postgres_url;
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this test to a single
 /// vendor identity.

--- a/tests/recursive_learning_task5_audit_record.rs
+++ b/tests/recursive_learning_task5_audit_record.rs
@@ -64,7 +64,7 @@ use rusqlite::Connection;
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple the audit-record test
 /// to a single vendor identity.

--- a/tests/recursive_learning_task6_reflect_hooks.rs
+++ b/tests/recursive_learning_task6_reflect_hooks.rs
@@ -76,7 +76,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Vendor-neutral fixture source for this test file's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple the reflect-hooks test
 /// to a single vendor identity.

--- a/tests/recursive_learning_task7_shipgate_chaos_migration.rs
+++ b/tests/recursive_learning_task7_shipgate_chaos_migration.rs
@@ -75,7 +75,7 @@ use common::postgres_url;
 
 /// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this chaos / migration
 /// ship-gate scenario to a single vendor identity.

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -52,7 +52,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this functional ship-gate
 /// scenario to a single vendor identity.

--- a/tests/ship_gate/grand_slam_recursive_learning.rs
+++ b/tests/ship_gate/grand_slam_recursive_learning.rs
@@ -75,7 +75,7 @@ use tempfile::TempDir;
 
 /// Vendor-neutral fixture source for this ship-gate's `ReflectInput`
 /// builders, per PR #1175 (`validate::DEFAULT_NHI_SOURCE = "nhi"`)
-/// + PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
+/// Plus PR #1174 PR9 (vendor-deflake test fixtures). The substrate now
 /// stamps `source = "nhi"` by default for any AI NHI; pinning a
 /// vendor literal here would silently couple this ship-gate scenario
 /// to a single vendor identity.


### PR DESCRIPTION
## Summary

Closes #1183 (deferred from #1174 PR4 vendor-substrate cleanup).

Moves the `WrapStrategy` enum + per-CLI-binary table from `src/cli/wrap.rs` to a new sibling module `src/llm_cli_wrap.rs`, with explicit module-level documentation explaining the cli-wrap-vs-LLM-backend distinction.

## Architectural separation

Per the PR4 sub-agent's classification finding: `src/cli/wrap.rs`'s `WrapStrategy` table is a **CLI-process-wrapper agent map** (codex/aider/gemini/ollama as CLI binary names on `$PATH`), NOT an LLM-backend selector. Two distinct concerns:

| Module | Concern | Agent-name meaning |
|---|---|---|
| `src/llm.rs` | HTTP LLM client (`POST /v1/chat/completions`, Bearer auth, vendor URL + API-key tables) | wire-shape selector (`xai`, `openai`, `anthropic`, ...) |
| `src/llm_cli_wrap.rs` (NEW) | CLI process-spawning wrapper (`std::process::Command::new(<binary>)`, `Stdio::inherit`, tempfile cleanup) | binary on `$PATH` (`codex`, `aider`, `gemini`, `ollama`, ...) |

Sibling-modules-at-the-crate-root makes the distinction queryable; the previous shape buried the CLI-ABI table inside `cli/wrap.rs` where it implied "this is just CLI helper code" rather than "this is the canonical knowledge of how each downstream CLI accepts a system prompt."

## Bundled fix: clippy::doc_lazy_continuation in PR9 test doc-comments

PR9 (tests-vendor-deflake, #1189 merged at `b2da9b641`) introduced 9 doc-comment lines starting with `+ ` which `clippy::doc_lazy_continuation` (under `-D clippy::all`) parses as list markers. Caught by `cargo clippy --tests` during this PR's gate run; not by PR9's pre-merge gate because PR9's clippy run was incremental and missed the new lazy-continuation introduction.

Fixed by replacing `+ PR #1174 PR9` → `Plus PR #1174 PR9` in 9 test files. Pure documentation change; no behavior impact.

## Files (12)

- **`src/llm_cli_wrap.rs`** (new, 174 LOC) — `WrapStrategy` enum + per-CLI-binary table + module-level doc explaining the cli-wrap-vs-llm separation.
- **`src/cli/wrap.rs`** — 154 LOC removed (table relocated); kept the CLI-binary-name detection logic that PICKS a `WrapStrategy`.
- **`src/lib.rs`** — `pub mod llm_cli_wrap;` declaration with doc note cross-referencing the `llm.rs` sibling.
- **9 test files** — `clippy::doc_lazy_continuation` doc-comment fix.

Net: **+217 / -135** across 12 files.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | clean (after the PR9 doc-list fix) |
| `cargo test` (full suite) | will run on CI |
| `cargo audit` | clean |

## Provenance

Drafted by general-purpose worktree-isolated subagent (agent `a441a378e94552ef1`, 39 tool calls, ~21 min). The agent stopped at "wait for monitor notification" without completing commit/push/PR; parent orchestrator (Claude Opus 4.7) verified the diff was semantically correct (pm-v3 verify-before-claiming), caught + fixed the PR9-introduced `clippy::doc_lazy_continuation` regression, and opened this PR.

## AI involvement

Drafted by general-purpose subagent + verified/completed/PR by Claude Opus 4.7 (1M context).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>