### PR TITLE
refactor(#1174): pm-v3.1 PR10 — lint-gate enforcement (clippy.toml docs + scripts/check-vendor-literals.sh + CI job)

### DIFF
--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -1,18 +1,32 @@
 # C8 orchestrator safeguard CI gate (issue #953, CLAUDE.md §"Enforceable
-# Orchestrator Safeguards").
+# Orchestrator Safeguards") + #1174 PR10 vendor-monoculture lint-gate.
 #
-# HARD-BLOCKs PRs that introduce a new `CallerContext::for_agent("<literal>")`
-# site or a new `for_admin` privacy-bypass site outside the allowlists at
-# `scripts/qc-codegraph-allowlists/`. These literals bypass the
-# request-scoped caller identity that the SAL #910 visibility filter
-# depends on; an un-reviewed addition would silently re-introduce
-# cross-tenant leak surfaces of the kind QC sweep #947/#955/#959
-# remediated.
+# Two HARD-BLOCK jobs:
 #
-# Mirrors the local-developer flow: `scripts/qc-codegraph-precheck.sh`
-# is the same script. Run `scripts/qc-codegraph-precheck.sh --update`
-# locally to regenerate the allowlist when you deliberately add a new
-# exception, then review the diff before committing.
+#   1. c8-precheck — `CallerContext::for_agent("<literal>")` /
+#      `for_admin("<literal>")` allowlist enforcement (issue #953).
+#      These literals bypass the request-scoped caller identity that
+#      the SAL #910 visibility filter depends on; an un-reviewed
+#      addition would silently re-introduce cross-tenant leak surfaces
+#      of the kind QC sweep #947/#955/#959 remediated.
+#
+#   2. vendor-literal-gate — vendor-identifier + SECS_PER_* magic-number
+#      regression detection (issue #1174 PR10, pm-v3.1 lint-gate). Without
+#      this gate, the Wave 1+2 refactor's vendor-monoculture cleanup
+#      (PRs 1-9) decays as new code lands with hardcoded `"claude"` /
+#      `"openai"` / `"anthropic"` strings outside the 6-file substrate
+#      allowlist, AND the SECS_PER_* named-constant discipline (PR3)
+#      regresses as new `Duration::from_secs(3600)` etc. land. Both
+#      gates are load-bearing per the pm-v3.2 NO FAIL MISSION closure
+#      audit (ai-memory global/policies memory
+#      2cb15d34-2399-4611-a020-df6ef91683fe).
+#
+# Mirrors the local-developer flow: both `scripts/qc-codegraph-precheck.sh`
+# and `scripts/check-vendor-literals.sh` are the same scripts CI uses.
+# Run `scripts/qc-codegraph-precheck.sh --update` locally to regenerate
+# the C8 allowlist when you deliberately add a new exception; run
+# `scripts/check-vendor-literals.sh --self-test` locally to confirm the
+# vendor gate still catches a contrived violation.
 
 name: c8-precheck
 
@@ -31,3 +45,21 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run C8 precheck
         run: bash scripts/qc-codegraph-precheck.sh
+
+  vendor-literal-gate:
+    name: Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run vendor-literal gate
+        run: bash scripts/check-vendor-literals.sh
+      - name: Self-test the gate (regression evidence)
+        # Pm-v3.2 NO FAIL MISSION closure-audit discipline: the gate
+        # itself must be load-bearing. The --self-test mode injects a
+        # contrived `"anthropic"` literal at a production site outside
+        # the allowlist, runs the gate, verifies the gate exits non-zero
+        # + emits the expected violation message, then cleans up. Any
+        # regression in the gate's detection logic (e.g. an over-broad
+        # allowlist, a broken test-boundary heuristic) trips here.
+        run: bash scripts/check-vendor-literals.sh --self-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,6 +647,86 @@ but new public operations live on the trait.
   `coverage` for `coverage/thresholds.toml` and floor adjustments, `qc` for
   QC-review artefacts + remediation. Scope is encouraged but optional.
 
+### Lint gates (issue #1174 PR10 — pm-v3.1 vendor-monoculture + SECS_PER_*)
+
+Two script-based lint gates run in CI alongside the four cargo gates
+(fmt / clippy / test / audit). Both are HARD-BLOCK and are wired into
+`.github/workflows/c8-precheck.yml`.
+
+**1. C8 caller-context allowlist** —
+`scripts/qc-codegraph-precheck.sh`. Blocks any new
+`CallerContext::for_agent("<literal>")` or
+`CallerContext::for_admin("<literal>")` site outside
+`scripts/qc-codegraph-allowlists/*.txt`. See the §"Enforceable
+Orchestrator Safeguards" section above for the full contract.
+
+**2. Vendor-monoculture + SECS_PER_* gate** —
+`scripts/check-vendor-literals.sh`. Blocks regressions in two
+disciplines the Wave 1+2 #1174 refactor train landed:
+
+- **Vendor identifiers** (`"claude" | "openai" | "xai" |
+  "anthropic" | "gemini" | "deepseek" | "groq" | "ollama" |
+  "grok" | "mistral" | "cohere" | "huggingface"`) are legitimate
+  ONLY in the 6 substrate carve-outs:
+  - `src/llm.rs` — canonical alias tables, default URLs
+  - `src/config.rs` — per-vendor URL/key/model defaults
+  - `src/mine.rs` — `Format::Claude` conversation-mining enum
+  - `src/validate.rs` — `VALID_SOURCES` back-compat allowlist
+  - `src/cli/wrap.rs` — per-vendor CLI-binary `WrapStrategy` table
+  - `src/harness.rs` — harness vendor-variant enum
+
+  Every other production-code site must read the vendor string
+  from `crate::llm::*` / `crate::config::*` (e.g.
+  `crate::llm::BACKEND_OLLAMA` instead of the literal `"ollama"`).
+  Per pm-v3.1 (ai-memory `global/policies` memory
+  `f5334545-c1f5-4f5c-9efb-a0ec3a0c1fcd`): vendor identifiers
+  scattered across substrate/wire code violate the heterogeneous-NHI
+  design.
+
+- **SECS_PER_* magic numbers** —
+  `Duration::from_secs(3600 | 86400 | 604800 | 3_600 | 86_400 |
+  604_800 | 7200 | 21600 | 172800)` and the underscore variants are
+  HARD-BLOCKed. Use the named constants from `src/lib.rs`:
+  `SECS_PER_HOUR` (3_600), `SECS_PER_DAY` (86_400),
+  `SECS_PER_WEEK` (604_800).
+
+  Why script-based instead of clippy `disallowed_methods`:
+  `Duration::from_secs` is called 90+ times in the codebase with
+  legitimate small-int timeouts (5, 10, 30 seconds for HTTP /
+  health probes / circuit-breaker cooldowns); clippy can't
+  distinguish "literal magic number" from "named const argument",
+  so a blanket disallow would block all 90+ sites including the
+  legitimate ones.
+
+**Self-test (load-bearing evidence).**
+`scripts/check-vendor-literals.sh --self-test` injects a contrived
+`"anthropic"` literal at a production site, runs the gate, verifies
+the gate exits non-zero with the expected violation message, then
+cleans up. The CI workflow runs the self-test step after the main
+check so a regression in the gate's detection logic (e.g. an
+over-broad allowlist, a broken test-boundary heuristic) trips
+immediately. Per pm-v3.2 NO FAIL MISSION closure discipline
+(ai-memory `global/policies` memory
+`2cb15d34-2399-4611-a020-df6ef91683fe`): the gate itself must be
+load-bearing, not decorative.
+
+**Adding a legitimate exception.** If a new vendor-specific
+surface genuinely belongs outside the 6-file allowlist (e.g. a
+new dedicated subsystem the way `src/mine.rs` carries
+`Format::Claude`), edit `scripts/check-vendor-literals.sh` to
+extend the `ALLOWED_FILES` array AND document the carve-out in
+this section. Operator-approved review before merge.
+
+**Production-vs-test heuristic.** The script skips:
+- Files whose basename matches `*test*.rs` or `tests.rs`
+- Lines at or below the first `mod tests {` / `pub mod tests {`
+  occurrence in each file
+- Comment lines (`//`, `///`) and block-comment continuations (`*`)
+
+The heuristic mirrors `scripts/qc-codegraph-precheck.sh` so the
+two gates have the same production-vs-test boundary across the
+codebase.
+
 ## Prime directive (operator-set, 2026-05-17)
 
 > This is a **prime directive** — it overrides any general-purpose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,12 +667,13 @@ disciplines the Wave 1+2 #1174 refactor train landed:
 - **Vendor identifiers** (`"claude" | "openai" | "xai" |
   "anthropic" | "gemini" | "deepseek" | "groq" | "ollama" |
   "grok" | "mistral" | "cohere" | "huggingface"`) are legitimate
-  ONLY in the 6 substrate carve-outs:
+  ONLY in the 7 substrate carve-outs:
   - `src/llm.rs` — canonical alias tables, default URLs
   - `src/config.rs` — per-vendor URL/key/model defaults
   - `src/mine.rs` — `Format::Claude` conversation-mining enum
   - `src/validate.rs` — `VALID_SOURCES` back-compat allowlist
-  - `src/cli/wrap.rs` — per-vendor CLI-binary `WrapStrategy` table
+  - `src/cli/wrap.rs` — CLI-binary-name → `WrapStrategy` picker
+  - `src/llm_cli_wrap.rs` — per-vendor CLI-binary `WrapStrategy` table (split from `src/cli/wrap.rs` per #1183)
   - `src/harness.rs` — harness vendor-variant enum
 
   Every other production-code site must read the vendor string
@@ -711,7 +712,7 @@ immediately. Per pm-v3.2 NO FAIL MISSION closure discipline
 load-bearing, not decorative.
 
 **Adding a legitimate exception.** If a new vendor-specific
-surface genuinely belongs outside the 6-file allowlist (e.g. a
+surface genuinely belongs outside the 7-file allowlist (e.g. a
 new dedicated subsystem the way `src/mine.rs` carries
 `Format::Claude`), edit `scripts/check-vendor-literals.sh` to
 extend the `ALLOWED_FILES` array AND document the carve-out in

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,3 +10,24 @@
 # allowance keeps CI green while the split lands; removing the
 # allowance is the gate that says "this file is now under-budget".
 too-many-lines-threshold = 250
+
+# #1174 PR10 — pm-v3.1 lint-gate. Vendor-monoculture detection lives
+# in the script gate `scripts/check-vendor-literals.sh` (file-level
+# allowlist: `src/llm.rs` / `src/config.rs` / `src/mine.rs` /
+# `src/validate.rs` / `src/cli/wrap.rs` / `src/harness.rs`); the script
+# is wired into `.github/workflows/c8-precheck.yml` for CI enforcement.
+#
+# Why no `disallowed_methods = ["std::time::Duration::from_secs"]` entry
+# (PR3 SECS_PER_* discipline): `Duration::from_secs` is called 90+ times
+# in the codebase with legitimate small-int timeouts (5, 10, 30 seconds
+# for HTTP / health probes / circuit-breaker cooldowns); clippy's
+# `disallowed_methods` lint cannot distinguish "literal magic number"
+# from "named const argument", so a blanket disallow would block all
+# 90+ sites including the legitimate ones. The SECS_PER_* discipline
+# (use `crate::SECS_PER_HOUR` / `SECS_PER_DAY` / `SECS_PER_WEEK` instead
+# of raw `3600` / `86400` / `604_800` literals) is enforced at the
+# code-review layer + grep-as-gate (the script also greps for the
+# specific literal forms `Duration::from_secs(3600|86400|604800|3_600|
+# 86_400|604_800|7200|21600)` to catch the documented regression
+# patterns). See `scripts/check-vendor-literals.sh` for the full
+# discipline.

--- a/scripts/check-vendor-literals.sh
+++ b/scripts/check-vendor-literals.sh
@@ -15,14 +15,15 @@
 #   (A) Vendor-monoculture gate. Every `"claude" | "openai" | "xai" |
 #       "anthropic" | "gemini" | "deepseek" | "groq" | "ollama" |
 #       "grok" | "mistral" | "cohere" | "huggingface"` literal outside
-#       the 6-file substrate allowlist is a HARD-BLOCK. Vendor strings
+#       the 7-file substrate allowlist is a HARD-BLOCK. Vendor strings
 #       are legitimate only in:
-#         - `src/llm.rs`        (canonical alias tables, default URLs)
-#         - `src/config.rs`     (per-vendor URL/key/model defaults)
-#         - `src/mine.rs`       (Format::Claude conversation-mining enum)
-#         - `src/validate.rs`   (VALID_SOURCES back-compat allowlist)
-#         - `src/cli/wrap.rs`   (per-vendor CLI-binary WrapStrategy)
-#         - `src/harness.rs`    (harness vendor-variant enum)
+#         - `src/llm.rs`           (canonical alias tables, default URLs)
+#         - `src/config.rs`        (per-vendor URL/key/model defaults)
+#         - `src/mine.rs`          (Format::Claude conversation-mining enum)
+#         - `src/validate.rs`      (VALID_SOURCES back-compat allowlist)
+#         - `src/cli/wrap.rs`      (CLI-binary-name → WrapStrategy picker)
+#         - `src/llm_cli_wrap.rs`  (per-vendor CLI-binary WrapStrategy table; #1183 split from src/cli/wrap.rs)
+#         - `src/harness.rs`       (harness vendor-variant enum)
 #
 #   (B) SECS_PER_* regression gate. PR3 (#1188 lineage) extracted
 #       named constants `SECS_PER_HOUR` / `SECS_PER_DAY` / `SECS_PER_WEEK`
@@ -59,13 +60,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-# 6-file allowlist. Repo-root-relative paths.
+# 7-file allowlist. Repo-root-relative paths.
 ALLOWED_FILES=(
     "src/llm.rs"
     "src/config.rs"
     "src/mine.rs"
     "src/validate.rs"
     "src/cli/wrap.rs"
+    "src/llm_cli_wrap.rs"
     "src/harness.rs"
 )
 
@@ -212,12 +214,13 @@ if [[ -n "${vendor_violations//[[:space:]]/}" ]]; then
         printf '%s' "$vendor_violations" | sed -E 's/^/  /'
         echo ""
         echo "Vendor identifiers are only allowed in:"
-        echo "  - src/llm.rs       (canonical alias tables)"
-        echo "  - src/config.rs    (per-vendor URL/key/model defaults)"
-        echo "  - src/mine.rs      (Format::Claude conversation-mining enum)"
-        echo "  - src/validate.rs  (VALID_SOURCES back-compat allowlist)"
-        echo "  - src/cli/wrap.rs  (per-vendor CLI-binary WrapStrategy)"
-        echo "  - src/harness.rs   (harness vendor-variant enum)"
+        echo "  - src/llm.rs           (canonical alias tables)"
+        echo "  - src/config.rs        (per-vendor URL/key/model defaults)"
+        echo "  - src/mine.rs          (Format::Claude conversation-mining enum)"
+        echo "  - src/validate.rs      (VALID_SOURCES back-compat allowlist)"
+        echo "  - src/cli/wrap.rs      (CLI-binary-name → WrapStrategy picker)"
+        echo "  - src/llm_cli_wrap.rs  (per-vendor CLI-binary WrapStrategy table; #1183)"
+        echo "  - src/harness.rs       (harness vendor-variant enum)"
         echo ""
         echo "Per pm-v3.1 (ai-memory global/policies memory f5334545-c1f5-4f5c-9efb-a0ec3a0c1fcd):"
         echo "vendor identifiers in substrate/wire code violate the heterogeneous-NHI design."

--- a/scripts/check-vendor-literals.sh
+++ b/scripts/check-vendor-literals.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# v0.7.x (issue #1174 PR10 — pm-v3.1 lint-gate).
+#
+# HARD-BLOCK any new vendor-identifier literal outside the allowed
+# substrate locations, AND any new magic-number SECS_PER_* literal
+# passed to `Duration::from_secs()`. Enforced in CI per the pm-v3.1
+# prime-directive addendum (ai-memory global/policies memory
+# f5334545-c1f5-4f5c-9efb-a0ec3a0c1fcd).
+#
+# Two checks:
+#
+#   (A) Vendor-monoculture gate. Every `"claude" | "openai" | "xai" |
+#       "anthropic" | "gemini" | "deepseek" | "groq" | "ollama" |
+#       "grok" | "mistral" | "cohere" | "huggingface"` literal outside
+#       the 6-file substrate allowlist is a HARD-BLOCK. Vendor strings
+#       are legitimate only in:
+#         - `src/llm.rs`        (canonical alias tables, default URLs)
+#         - `src/config.rs`     (per-vendor URL/key/model defaults)
+#         - `src/mine.rs`       (Format::Claude conversation-mining enum)
+#         - `src/validate.rs`   (VALID_SOURCES back-compat allowlist)
+#         - `src/cli/wrap.rs`   (per-vendor CLI-binary WrapStrategy)
+#         - `src/harness.rs`    (harness vendor-variant enum)
+#
+#   (B) SECS_PER_* regression gate. PR3 (#1188 lineage) extracted
+#       named constants `SECS_PER_HOUR` / `SECS_PER_DAY` / `SECS_PER_WEEK`
+#       in `src/lib.rs` so duration computations carry semantic intent
+#       at the call site. Any new `Duration::from_secs(3600)` /
+#       `Duration::from_secs(86400)` / `Duration::from_secs(604800)`
+#       (with or without underscore separators) is a HARD-BLOCK.
+#
+# Production-vs-test boundary heuristic (mirrors
+# `scripts/qc-codegraph-precheck.sh`):
+#   - Test files (basename `*test*.rs` or `tests.rs`) are skipped entirely.
+#   - Per-file, the first occurrence of `mod tests {` (or
+#     `pub mod tests {`) starts the test region; lines at or below that
+#     are skipped. The `#[cfg(test)]` attribute alone is too noisy
+#     because it also guards single-item test-helper declarations near
+#     the top of files.
+#   - Single-line comments (`//` and `///`) and block-comment lines
+#     (`*`) are skipped.
+#
+# Why no codegraph dependency: codegraph indexes live under .codegraph/
+# (gitignored, per-developer; not available in CI). `grep` works on
+# every checkout and is sufficient for literal-site enumeration.
+#
+# Usage:
+#   scripts/check-vendor-literals.sh
+#     - exit 0 on clean, exit 1 on any violation
+#   scripts/check-vendor-literals.sh --self-test
+#     - injects a contrived violation, verifies the gate catches it,
+#       removes the violation. Proves the gate is load-bearing
+#       (pm-v3.2 NO FAIL MISSION closure discipline). Exit 0 on
+#       PASS, exit 1 on FAIL.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# 6-file allowlist. Repo-root-relative paths.
+ALLOWED_FILES=(
+    "src/llm.rs"
+    "src/config.rs"
+    "src/mine.rs"
+    "src/validate.rs"
+    "src/cli/wrap.rs"
+    "src/harness.rs"
+)
+
+# Vendor identifiers to gate. Keep this list narrow — over-broad gates
+# create reviewer friction. Add a new vendor only when an actual
+# alias-table entry lands in `src/llm.rs`.
+VENDOR_PATTERN='(claude|openai|xai|anthropic|gemini|deepseek|groq|ollama|grok|mistral|cohere|huggingface)'
+
+# SECS_PER_* magic numbers. Catches the literal forms PR3 extracted
+# named constants for — both unseparated (`3600`) and underscore-
+# separated (`3_600`) variants, plus the common hour multiples
+# (`7200`, `21600`).
+SECS_LITERAL_PATTERN='Duration::from_secs\((3600|86400|604800|3_600|86_400|604_800|7200|21600|172800|172_800)\)'
+
+# is_allowed_file <repo-root-relative-path>
+is_allowed_file () {
+    local f="$1"
+    local allowed
+    for allowed in "${ALLOWED_FILES[@]}"; do
+        if [[ "$f" == "$allowed" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# find_test_boundary <file>
+# Echoes the line number of the first `mod tests {` (or `pub mod tests {`,
+# or attribute-prefixed variants like `#[cfg(test)] mod tests {`); echoes
+# `999999999` if no test module is found in the file.
+find_test_boundary () {
+    local f="$1"
+    local line
+    line=$(grep -nE '^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]]+tests?[[:space:]]*\{' "$f" 2>/dev/null | head -1 | cut -d: -f1)
+    if [[ -z "$line" ]]; then
+        echo 999999999
+    else
+        echo "$line"
+    fi
+}
+
+# scan_production_lines <file> <regex>
+# Emits "<repo-relative-file>:<lineno>:<content>" for matches in
+# production code. Skips test files by basename + skips lines at or
+# below the file's first `mod tests {` boundary + skips comment lines.
+scan_production_lines () {
+    local f="$1"
+    local pattern="$2"
+    local bn
+    bn="$(basename "$f")"
+    case "$bn" in
+        *test*.rs|tests.rs) return 0 ;;
+    esac
+    local boundary
+    boundary=$(find_test_boundary "$f")
+    local rel="${f#"${ROOT}/"}"
+    while IFS=: read -r lineno content; do
+        [[ -z "$lineno" ]] && continue
+        if (( lineno >= boundary )); then
+            continue
+        fi
+        # Skip comments and doc-comment lines.
+        local stripped
+        stripped=$(printf '%s' "$content" | sed -E 's/^[[:space:]]+//')
+        case "$stripped" in
+            //*|/\**|\**) continue ;;
+        esac
+        printf '%s:%s:%s\n' "$rel" "$lineno" "$content"
+    done < <(grep -En "$pattern" "$f" 2>/dev/null || true)
+}
+
+# Self-test mode — inject a contrived violation, run the gate, confirm
+# it catches the violation, then clean up.
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "Vendor-literal gate: self-test mode (contrived violation -> expect HARD-BLOCK -> cleanup)"
+    # Use a name that does NOT match `*test*.rs` (the production-vs-test
+    # filename heuristic skips those) so the self-test's contrived
+    # violation actually reaches the scanner.
+    contrived="${ROOT}/src/.vendor_literal_gate_probe.rs"
+    if [[ -e "$contrived" ]]; then
+        echo "ERROR: self-test scratch file already exists: $contrived" >&2
+        echo "(cleanup may have failed in a prior run — remove manually)" >&2
+        exit 2
+    fi
+    # Deliberately write a vendor literal at a "production" line (no
+    # tests boundary above it) outside the allowlist.
+    cat > "$contrived" <<'EOF'
+// CONTRIVED VIOLATION for scripts/check-vendor-literals.sh --self-test.
+// This file is created + deleted by the self-test; if it persists,
+// the self-test was killed mid-run — remove it manually.
+pub const BACKEND_PROBE: &str = "anthropic";
+EOF
+    # Run the gate. Expect non-zero exit + a violation message. Capture
+    # the combined output so we can pattern-match on it deterministically
+    # (a piped `tee /dev/stderr | grep -q` would race + drop status).
+    set +e
+    gate_output="$("$0" 2>&1)"
+    gate_exit=$?
+    set -e
+    rm -f "$contrived"
+    printf '%s\n' "$gate_output"
+    if (( gate_exit != 0 )) && printf '%s' "$gate_output" | grep -q 'Vendor monoculture violation'; then
+        echo ""
+        echo "Vendor-literal gate self-test: PASS (gate caught the contrived violation; exit=${gate_exit})"
+        exit 0
+    else
+        echo "" >&2
+        echo "Vendor-literal gate self-test: FAIL (gate did not catch the contrived violation; exit=${gate_exit})" >&2
+        exit 1
+    fi
+fi
+
+# Main check.
+cd "$ROOT"
+
+vendor_violations=""
+secs_violations=""
+
+while IFS= read -r -d '' f; do
+    rel="${f#"${ROOT}/"}"
+    # Vendor scan: skip files in the allowlist; the file itself is the
+    # carve-out, not individual line entries.
+    if ! is_allowed_file "$rel"; then
+        v=$(scan_production_lines "$f" "\"${VENDOR_PATTERN}\"")
+        if [[ -n "$v" ]]; then
+            vendor_violations+="$v"$'\n'
+        fi
+    fi
+    # SECS_PER_* scan: applies to every file (no per-file carve-out).
+    # PR3 cleaned up every production site; any new one is a regression.
+    s=$(scan_production_lines "$f" "$SECS_LITERAL_PATTERN")
+    if [[ -n "$s" ]]; then
+        secs_violations+="$s"$'\n'
+    fi
+done < <(find "${ROOT}/src" -type f -name '*.rs' -print0)
+
+violations=0
+
+if [[ -n "${vendor_violations//[[:space:]]/}" ]]; then
+    {
+        echo "Vendor monoculture violation (issue #1174 PR10 pm-v3.1 lint-gate):"
+        # `vendor_violations` is a multi-line "file:line:content" payload;
+        # print each line as-is with a two-space indent.
+        printf '%s' "$vendor_violations" | sed -E 's/^/  /'
+        echo ""
+        echo "Vendor identifiers are only allowed in:"
+        echo "  - src/llm.rs       (canonical alias tables)"
+        echo "  - src/config.rs    (per-vendor URL/key/model defaults)"
+        echo "  - src/mine.rs      (Format::Claude conversation-mining enum)"
+        echo "  - src/validate.rs  (VALID_SOURCES back-compat allowlist)"
+        echo "  - src/cli/wrap.rs  (per-vendor CLI-binary WrapStrategy)"
+        echo "  - src/harness.rs   (harness vendor-variant enum)"
+        echo ""
+        echo "Per pm-v3.1 (ai-memory global/policies memory f5334545-c1f5-4f5c-9efb-a0ec3a0c1fcd):"
+        echo "vendor identifiers in substrate/wire code violate the heterogeneous-NHI design."
+        echo "Move new vendor-specific code into one of the allowed locations, or refactor"
+        echo "the call site to read the vendor string from \`crate::llm::*\` / \`crate::config::*\`"
+        echo "(e.g. \`crate::llm::BACKEND_OLLAMA\` instead of the literal \"ollama\")."
+    } >&2
+    violations=$(( violations + 1 ))
+fi
+
+if [[ -n "${secs_violations//[[:space:]]/}" ]]; then
+    {
+        echo "SECS_PER_* magic-number regression (issue #1174 PR3 / PR10 pm-v3.1 lint-gate):"
+        printf '%s' "$secs_violations" | sed -E 's/^/  /'
+        echo ""
+        echo "Use a named const from src/lib.rs instead of a magic number:"
+        echo "  - SECS_PER_HOUR = 3_600"
+        echo "  - SECS_PER_DAY  = 86_400"
+        echo "  - SECS_PER_WEEK = 604_800"
+        echo ""
+        echo "Example: \`Duration::from_secs(SECS_PER_HOUR as u64)\`."
+    } >&2
+    violations=$(( violations + 1 ))
+fi
+
+if (( violations > 0 )); then
+    echo "" >&2
+    echo "Vendor-literal gate: FAIL (${violations} category/categories of violation)" >&2
+    exit 1
+fi
+
+echo "Vendor-literal gate: PASS (no vendor-monoculture or SECS_PER_* regressions detected)"

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2299,8 +2299,10 @@ pub fn run_mcp_server(
                 );
                 // For ollama backends, exercise the legacy ensure_model
                 // pull step so first-run UX (model not on disk) still
-                // emits the pull-progress hint.
-                if resolved_llm.backend == "ollama" {
+                // emits the pull-progress hint. Backend identifier comes
+                // from `crate::llm::BACKEND_OLLAMA` per the PR10 vendor-
+                // monoculture lint gate (issue #1174).
+                if resolved_llm.backend == crate::llm::BACKEND_OLLAMA {
                     if let Err(e) = client.ensure_model() {
                         eprintln!("ai-memory: model pull failed: {e} (LLM features disabled)");
                         None


### PR DESCRIPTION
## Summary

PR10 of the #1174 codegraph-driven pm-v3.1 global refactor sweep —
the **load-bearing closure piece** that prevents Wave 1+2's
vendor-monoculture + SECS_PER_* discipline from decaying as new code
lands. Per pm-v3.2 NO FAIL MISSION discipline (ai-memory
`global/policies` memory `2cb15d34-2399-4611-a020-df6ef91683fe`):
without this gate, every Wave 1+2 PR's cleanup gradually decays over
the next 6-12 months. PR10 prevents that mechanically.

Base SHA: `74cc92d35` (release/v0.7.0 head post-Wave-2).
Commit SHA: `015328e5c4260e89c83068f7bccb52ff88b43c5d`.

## Lint gate components

1. **`scripts/check-vendor-literals.sh`** (new, executable, ~9.5 KB).
   - **Vendor-monoculture gate** — HARD-BLOCKs any new
     `\"claude\" | \"openai\" | \"xai\" | \"anthropic\" | \"gemini\" |
      \"deepseek\" | \"groq\" | \"ollama\" | \"grok\" | \"mistral\" |
      \"cohere\" | \"huggingface\"` literal outside the 6-file
     substrate allowlist.
   - **SECS_PER_* gate** — HARD-BLOCKs any new
     `Duration::from_secs(3600 | 86400 | 604800 | 3_600 | 86_400 |
     604_800 | 7200 | 21600 | 172800)` literal that should use
     `crate::SECS_PER_HOUR / SECS_PER_DAY / SECS_PER_WEEK` from
     `src/lib.rs` (PR3 lineage).
   - **Production-vs-test heuristic** — mirrors
     `scripts/qc-codegraph-precheck.sh`: skips `*test*.rs` /
     `tests.rs` files, skips lines at or below each file's first
     `mod tests {` boundary, skips comment lines (`//`, `///`, `*`).
   - **`--self-test` mode** injects a contrived `\"anthropic\"`
     literal at a production site, runs the gate, verifies non-zero
     exit + expected violation message, then cleans up. Pm-v3.2 NO
     FAIL MISSION closure-audit discipline: gate must be load-bearing,
     not decorative.

2. **`.github/workflows/c8-precheck.yml`** (extended).
   - New job `vendor-literal-gate` runs the script on every PR + push
     to `main` / `develop` / `release/**` / `local/**`.
   - A second step in the same job runs `--self-test` for regression
     evidence (catches over-broad allowlist, broken test-boundary
     heuristic, broken self-test scaffold). Mirrors the existing
     C8 caller-context job pattern.

3. **`clippy.toml`** (documented).
   - Comment block explaining why `disallowed_methods` for
     `Duration::from_secs` is **NOT** added: clippy can't distinguish
     literal magic numbers from named const arguments, so a blanket
     disallow would block all 90+ legitimate small-int timeout sites
     (HTTP / health probes / circuit-breaker cooldowns). Script gate
     carries the discipline.

## Allowed-location allowlist

Vendor identifiers are legitimate ONLY in these 6 substrate files
(each carve-out is where the vendor identifier **is** the data, not
an accidental literal):

| File | Why it's legitimate |
|---|---|
| `src/llm.rs` | Canonical alias tables, default per-vendor URLs, vendor-specific API key env-var fallback lists. Every other vendor string in the codebase reads from here (e.g. \`BACKEND_OLLAMA\`). |
| `src/config.rs` | Per-vendor URL / key / model defaults consumed by \`AppConfig::resolve_llm\` and the sister resolvers. |
| `src/mine.rs` | \`Format::Claude\` conversation-mining enum variant (parses \`claude.json\` exports). The vendor identifier IS the file-format selector here; renaming it would break export imports. |
| `src/validate.rs` | \`VALID_SOURCES\` back-compat allowlist for the pre-#1175 \`\"claude\"\` source value (deprecated, retained for back-compat with existing rows in deployed databases). |
| `src/cli/wrap.rs` | Per-vendor CLI-binary \`WrapStrategy\` table (\`ai-memory wrap claude\` / \`wrap openai\` etc. picks the right argv-translation strategy for each vendor's CLI). |
| `src/harness.rs` | Harness vendor-variant enum (chooses the right harness adapter for vendor-specific CLI agent harnesses). |

Every other production-code site must read the vendor string from
these surfaces (e.g. `crate::llm::BACKEND_OLLAMA` instead of
`\"ollama\"`).

## Regression evidence

Pre-PR10 verification ran `scripts/check-vendor-literals.sh` against
the post-Wave-2 codebase. Found **one remaining production violation**
that Waves 1+2 missed: `src/mcp/mod.rs:2303` had a bare \`\"ollama\"\`
literal. Fixed in this PR by switching to the existing
`crate::llm::BACKEND_OLLAMA` constant.

After the fix:

\`\`\`
$ scripts/check-vendor-literals.sh
Vendor-literal gate: PASS (no vendor-monoculture or SECS_PER_*
regressions detected)
\`\`\`

Self-test (contrived-violation regression evidence — proves the
gate is load-bearing):

\`\`\`
$ scripts/check-vendor-literals.sh --self-test
Vendor-literal gate: self-test mode (contrived violation -> expect
HARD-BLOCK -> cleanup)
Vendor monoculture violation (issue #1174 PR10 pm-v3.1 lint-gate):
  src/.vendor_literal_gate_probe.rs:4:pub const BACKEND_PROBE: &str
  = \"anthropic\";

Vendor identifiers are only allowed in:
  - src/llm.rs       (canonical alias tables)
  - src/config.rs    (per-vendor URL/key/model defaults)
  - src/mine.rs      (Format::Claude conversation-mining enum)
  - src/validate.rs  (VALID_SOURCES back-compat allowlist)
  - src/cli/wrap.rs  (per-vendor CLI-binary WrapStrategy)
  - src/harness.rs   (harness vendor-variant enum)
...
Vendor-literal gate: FAIL (1 category/categories of violation)

Vendor-literal gate self-test: PASS (gate caught the contrived
violation; exit=1)
\`\`\`

Also fixed an unrelated pre-existing clippy 1.95.0
`doc_lazy_continuation` trip in `tests/approval_reflect.rs`
(PR9-introduced doc comment used `+ PR #1174` which clippy interprets
as a list-item continuation; changed to `and PR #1174`). Without
this, gate 2 (`cargo clippy --tests`) trips against base SHA
`74cc92d35`.

## Test plan

- [x] `cargo fmt --check` — OK
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — OK
- [x] `scripts/qc-codegraph-precheck.sh` — OK (C8 caller-context gate)
- [x] `scripts/check-vendor-literals.sh` — OK (vendor + SECS_PER_* gate)
- [x] `scripts/check-vendor-literals.sh --self-test` — PASS (load-bearing evidence)
- [x] `cargo audit` — OK
- [x] `cargo test --test webhook_coverage` — PASS 7/7 in isolation
- [ ] `AI_MEMORY_NO_CONFIG=1 cargo test` (full suite) — passes
      per-binary in isolation; trips a pre-existing mock-HTTP-server
      port-collision flake in `tests/webhook_coverage.rs` under
      parallel-binary load against base SHA `74cc92d35`. Unrelated
      to this PR — no source change here touches webhook /
      mock-server / governance code paths.

## Documentation

A new §"Lint gates" section under `CLAUDE.md` documents both gates,
the 6-file allowlist with rationale, the self-test discipline, the
escape hatch for legitimate exceptions, and the production-vs-test
heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)