### PR TITLE
refactor(#1174 followup #1192 #1196): cross-surface RuntimeContext + MUST/SHOULD static extraction

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -39,13 +39,15 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, RwLock};
+use std::sync::Mutex;
+use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use crate::runtime_context::RuntimeContext;
 
 /// Stable schema version stamped on every emitted line. Bump only when
 /// a field's semantics change in a way SIEM parsers care about
@@ -200,21 +202,29 @@ pub struct AuditAuth {
 // Sink — process-wide singleton holding the file handle + chain head.
 // ---------------------------------------------------------------------------
 
-/// Process-wide audit sink. `None` when audit is disabled. Wrapped in
-/// `RwLock` (rather than `OnceLock`) so tests can swap in an
-/// in-memory sink between cases without leaking state across runs.
-static SINK: RwLock<Option<std::sync::Arc<AuditSink>>> = RwLock::new(None);
-/// Per-process monotonic sequence counter. Starts at 1 on first emit.
-static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+// v0.7.x (issue #1174 follow-up #1192) — sink + sequence moved into
+// `RuntimeContext::audit`. The accessors below preserve byte-equivalent
+// semantics: every read goes through `RuntimeContext::global().audit.*`
+// so the V-4 hash chain invariant + the F2 sequence-restart invariant
+// are observed identically by `init`, `emit`, `verify_chain`, and the
+// `init_for_test` / `shutdown_for_test` helpers.
 
 /// Initialised audit sink — writer handle protected by a mutex so the
 /// chain head update + write are atomic across emission threads. The
 /// writer is `dyn Write + Send` so tests can substitute an in-memory
 /// `Vec<u8>` for the production `File`.
-pub(crate) struct AuditSink {
+pub struct AuditSink {
     inner: Mutex<SinkInner>,
     #[allow(dead_code)]
     redact_content: bool,
+}
+
+impl std::fmt::Debug for AuditSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditSink")
+            .field("redact_content", &self.redact_content)
+            .finish_non_exhaustive()
+    }
 }
 
 struct SinkInner {
@@ -286,8 +296,9 @@ pub fn init(path: &Path, redact_content: bool, append_only_hint: bool) -> Result
         redact_content,
     };
 
-    SEQUENCE.store(last_sequence, Ordering::SeqCst);
-    if let Ok(mut guard) = SINK.write() {
+    let audit = &RuntimeContext::global().audit;
+    audit.sequence.store(last_sequence, Ordering::SeqCst);
+    if let Ok(mut guard) = audit.sink.write() {
         *guard = Some(std::sync::Arc::new(sink));
     }
     Ok(())
@@ -319,8 +330,9 @@ pub fn init_for_test(buf: std::sync::Arc<Mutex<Vec<u8>>>) {
         }),
         redact_content: true,
     };
-    SEQUENCE.store(0, Ordering::SeqCst);
-    if let Ok(mut guard) = SINK.write() {
+    let audit = &RuntimeContext::global().audit;
+    audit.sequence.store(0, Ordering::SeqCst);
+    if let Ok(mut guard) = audit.sink.write() {
         *guard = Some(std::sync::Arc::new(sink));
     }
 }
@@ -329,10 +341,11 @@ pub fn init_for_test(buf: std::sync::Arc<Mutex<Vec<u8>>>) {
 /// no-op.
 #[cfg(test)]
 pub fn shutdown_for_test() {
-    if let Ok(mut guard) = SINK.write() {
+    let audit = &RuntimeContext::global().audit;
+    if let Ok(mut guard) = audit.sink.write() {
         *guard = None;
     }
-    SEQUENCE.store(0, Ordering::SeqCst);
+    audit.sequence.store(0, Ordering::SeqCst);
 }
 
 /// Read the last `(self_hash, sequence)` pair from an existing audit
@@ -400,7 +413,12 @@ fn read_chain_tail(path: &Path) -> Result<Option<(String, u64)>> {
 /// Whether the audit subsystem is currently enabled. Cheap.
 #[must_use]
 pub fn is_enabled() -> bool {
-    SINK.read().map(|g| g.is_some()).unwrap_or(false)
+    RuntimeContext::global()
+        .audit
+        .sink
+        .read()
+        .map(|g| g.is_some())
+        .unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -516,8 +534,10 @@ pub fn emit(builder: EventBuilder) {
 /// Inner emission with proper `Result` so tests can assert directly on
 /// the writer. `emit` swallows errors so production never blocks.
 fn try_emit(builder: EventBuilder) -> Result<()> {
+    let audit = &RuntimeContext::global().audit;
     let sink = {
-        let guard = SINK
+        let guard = audit
+            .sink
             .read()
             .map_err(|_| anyhow!("audit sink rwlock poisoned"))?;
         match guard.as_ref() {
@@ -531,7 +551,7 @@ fn try_emit(builder: EventBuilder) -> Result<()> {
         .lock()
         .map_err(|_| anyhow!("audit sink mutex poisoned"))?;
 
-    let sequence = SEQUENCE.fetch_add(1, Ordering::SeqCst) + 1;
+    let sequence = audit.sequence.fetch_add(1, Ordering::SeqCst) + 1;
 
     let mut ev = AuditEvent {
         schema_version: SCHEMA_VERSION,
@@ -808,7 +828,7 @@ pub fn verify_chain_from_reader<R: Read>(reader: R) -> Result<VerifyReport> {
 /// - The audit directory or file cannot be opened.
 pub fn init_from_config(cfg: &crate::config::AuditConfig) -> Result<()> {
     if !cfg.enabled.unwrap_or(false) {
-        if let Ok(mut guard) = SINK.write() {
+        if let Ok(mut guard) = RuntimeContext::global().audit.sink.write() {
             *guard = None;
         }
         return Ok(());

--- a/src/config.rs
+++ b/src/config.rs
@@ -3692,22 +3692,30 @@ impl AppConfig {
 // Process-wide handle for the K7 server-wide HMAC override.
 // Mirrors the `ACTIVE_PERMISSIONS_MODE` pattern: set once at boot,
 // read by `subscriptions::dispatch_event_with_details` without an
-// API churn through every callsite. Stored behind a `RwLock<Option<…>>`
-// so the K7 integration tests can flip the value mid-process without
-// the `OnceLock`'s set-once contract getting in the way.
+// API churn through every callsite.
+//
+// v0.7.x (issue #1174 follow-up #1192) — storage moved to
+// `RuntimeContext::hooks_hmac_secret` so the HTTP daemon, the MCP
+// stdio binary, and the CLI all share one source of truth. The
+// accessors below delegate to the process-wide singleton; the wire
+// semantics + the K7 integration-test fixture (which flips the value
+// mid-process) are byte-equivalent.
 // ---------------------------------------------------------------------------
-
-use std::sync::RwLock;
-
-static ACTIVE_HOOKS_HMAC_SECRET: RwLock<Option<String>> = RwLock::new(None);
 
 /// v0.7.0 K7 — set the process-wide webhook HMAC override. Called from
 /// `main`/daemon bootstrap with the value from
 /// `[hooks.subscription] hmac_secret`. Last writer wins — this is
 /// production-safe because boot only invokes it once; tests use the
 /// same setter to flip mid-process.
+///
+/// v0.7.x (issue #1192) — delegates to
+/// [`crate::runtime_context::RuntimeContext::global`]; the storage
+/// lives on `RuntimeContext::hooks_hmac_secret`.
 pub fn set_active_hooks_hmac_secret(secret: Option<String>) {
-    if let Ok(mut w) = ACTIVE_HOOKS_HMAC_SECRET.write() {
+    if let Ok(mut w) = crate::runtime_context::RuntimeContext::global()
+        .hooks_hmac_secret
+        .write()
+    {
         *w = secret;
     }
 }
@@ -3715,9 +3723,17 @@ pub fn set_active_hooks_hmac_secret(secret: Option<String>) {
 /// v0.7.0 K7 — read the process-wide webhook HMAC override. Returns
 /// `None` when unset (the K6-and-earlier behaviour: only
 /// per-subscription secrets sign outgoing payloads).
+///
+/// v0.7.x (issue #1192) — delegates to
+/// [`crate::runtime_context::RuntimeContext::global`]; the storage
+/// lives on `RuntimeContext::hooks_hmac_secret`.
 #[must_use]
 pub fn active_hooks_hmac_secret() -> Option<String> {
-    ACTIVE_HOOKS_HMAC_SECRET.read().ok().and_then(|g| g.clone())
+    crate::runtime_context::RuntimeContext::global()
+        .hooks_hmac_secret
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
 }
 
 // ---------------------------------------------------------------------------
@@ -3730,24 +3746,37 @@ pub fn active_hooks_hmac_secret() -> Option<String> {
 // via `[transcripts] max_decompressed_bytes = …`; default-on uses the
 // compiled `MAX_DECOMPRESSED_BYTES` constant. The cap is per-call;
 // concurrent fetches consume up to N × this value of transient memory.
-
-static ACTIVE_MAX_DECOMPRESSED_BYTES: std::sync::RwLock<Option<usize>> =
-    std::sync::RwLock::new(None);
+//
+// v0.7.x (issue #1174 follow-up #1192) — storage moved to
+// `RuntimeContext::max_decompressed_bytes`. The accessors below
+// delegate; the per-call cap semantics are byte-equivalent.
 
 /// Set the process-wide decompression cap. Boot reads
 /// `[transcripts] max_decompressed_bytes` and calls this; tests flip
 /// mid-process to exercise both branches.
+///
+/// v0.7.x (issue #1192) — delegates to
+/// [`crate::runtime_context::RuntimeContext::global`]; the storage
+/// lives on `RuntimeContext::max_decompressed_bytes`.
 pub fn set_active_max_decompressed_bytes(cap: Option<usize>) {
-    if let Ok(mut w) = ACTIVE_MAX_DECOMPRESSED_BYTES.write() {
+    if let Ok(mut w) = crate::runtime_context::RuntimeContext::global()
+        .max_decompressed_bytes
+        .write()
+    {
         *w = cap;
     }
 }
 
 /// Read the process-wide decompression cap, falling back to the
 /// compiled default when unset.
+///
+/// v0.7.x (issue #1192) — delegates to
+/// [`crate::runtime_context::RuntimeContext::global`]; the storage
+/// lives on `RuntimeContext::max_decompressed_bytes`.
 #[must_use]
 pub fn active_max_decompressed_bytes() -> usize {
-    ACTIVE_MAX_DECOMPRESSED_BYTES
+    crate::runtime_context::RuntimeContext::global()
+        .max_decompressed_bytes
         .read()
         .ok()
         .and_then(|g| *g)

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -3279,6 +3279,7 @@ pub async fn bootstrap_serve(
         // The resolver folds CLI / env / `[llm]` / legacy / compiled-
         // default precedence and the resulting triple is process-stable.
         resolved_models: Arc::new(app_config.resolve_models()),
+        runtime: crate::runtime_context::RuntimeContext::global_arc(),
     };
 
     // v0.7.0 Policy-Engine Item 3 — register the deferred-audit
@@ -4176,6 +4177,7 @@ mod tests {
             // `fresh_conn()`).
             rule_cache: Arc::new(crate::governance::rule_cache::RuleCache::new()),
             resolved_models: Arc::new(crate::config::ResolvedModels::default()),
+            runtime: crate::runtime_context::RuntimeContext::global_arc(),
         }
     }
 

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -52,7 +52,7 @@ use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use rand_core::{OsRng, RngCore};
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::Mutex;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 /// Envelope wire-version. Bumped only when the byte layout changes;
@@ -161,9 +161,15 @@ impl Envelope {
 /// issue will swap this for an on-disk store; the in-memory shape lets
 /// the encryption substrate land without forcing a key-rotation tool
 /// design decision in the same patch.
+///
+/// v0.7.x (issue #1174 follow-up #1196) — the cache lives on
+/// [`crate::runtime_context::RuntimeContext::keypair_cache`]. The
+/// returned `&'static` reference is stable because
+/// `RuntimeContext::global()` itself is a `OnceLock`-backed
+/// process-wide singleton; the `Arc<Mutex<HashMap<...>>>` inside it
+/// is allocated once and outlives every caller.
 fn keypair_cache() -> &'static Mutex<HashMap<String, Keypair>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, Keypair>>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+    &crate::runtime_context::RuntimeContext::global().keypair_cache
 }
 
 /// Look up the per-agent X25519 [`Keypair`], generating + caching it on

--- a/src/handlers/http.rs
+++ b/src/handlers/http.rs
@@ -395,6 +395,7 @@ mod cov897_tests {
             admin_agent_ids: Arc::new(Vec::new()),
             rule_cache: std::sync::Arc::new(crate::governance::rule_cache::RuleCache::new()),
             resolved_models: std::sync::Arc::new(crate::config::ResolvedModels::default()),
+            runtime: crate::runtime_context::RuntimeContext::global_arc(),
         };
         (app, tmp)
     }

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -362,6 +362,7 @@ fn test_app_state(db: Db) -> AppState {
         admin_agent_ids: Arc::new(vec!["*".to_string()]),
         rule_cache: std::sync::Arc::new(crate::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(crate::config::ResolvedModels::default()),
+        runtime: crate::runtime_context::RuntimeContext::global_arc(),
     }
 }
 
@@ -1079,6 +1080,7 @@ async fn http_bulk_create_fans_out_with_federation() {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(crate::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(crate::config::ResolvedModels::default()),
+        runtime: crate::runtime_context::RuntimeContext::global_arc(),
     };
     let router = Router::new()
         .route("/api/v1/memories/bulk", axum_post(bulk_create))
@@ -9665,6 +9667,7 @@ fn h8d_app_state_with_fed(db: Db, peer_urls: Vec<String>, w: usize, timeout_ms: 
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(crate::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(crate::config::ResolvedModels::default()),
+        runtime: crate::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/src/handlers/transport.rs
+++ b/src/handlers/transport.rs
@@ -292,6 +292,22 @@ pub struct AppState {
     /// `[llm]` / legacy / compiled-default precedence, so the resulting
     /// triple is process-stable.
     pub resolved_models: Arc<crate::config::ResolvedModels>,
+
+    /// v0.7.x (issue #1174 follow-up #1192 / #1196) — cross-surface
+    /// [`crate::runtime_context::RuntimeContext`] handle. Holds the
+    /// process-wide K7 HMAC override, I1 decompression cap, V-4 audit
+    /// chain state, session-recall tracker, and X25519 keypair cache
+    /// — i.e. every substrate static that the HTTP daemon, MCP stdio
+    /// binary, and CLI need to observe identically.
+    ///
+    /// Always populated. Cloned by reference (`Arc::clone`) so storing
+    /// it on `AppState` is cheap and the wire / chain / cache
+    /// semantics across surfaces stay byte-equivalent: every accessor
+    /// (`crate::config::active_hooks_hmac_secret`, `crate::audit::emit`,
+    /// `crate::reranker::global_session_recall_tracker`,
+    /// `crate::encryption::get_or_create_keypair`) delegates to the
+    /// same `RuntimeContext::global()` singleton.
+    pub runtime: Arc<crate::runtime_context::RuntimeContext>,
 }
 
 /// v0.7.0 B3 — canonical 1-2 sentence English descriptors for each

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,15 @@ pub mod profile;
 pub mod quotas;
 pub mod replication;
 pub mod reranker;
+// v0.7.x (issue #1174 follow-up #1192 / #1196) — cross-surface
+// substrate state (HMAC override, decompression cap, audit chain,
+// session-recall tracker, keypair cache). Held as `Arc<RuntimeContext>`
+// by every long-lived runtime so the HTTP daemon, MCP stdio binary,
+// and CLI all share one source of truth. The legacy free-fn surface
+// (`config::active_hooks_hmac_secret`, `audit::emit`,
+// `reranker::global_session_recall_tracker`, …) delegates here so the
+// wire / chain / cache semantics stay byte-equivalent.
+pub mod runtime_context;
 pub mod signed_events;
 pub mod sizes;
 pub mod subscriptions;

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::mpsc::{Sender, sync_channel};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -164,10 +164,16 @@ impl SessionRecallTracker {
 /// path. Lazily initialised on first access; never reset within a
 /// process lifetime (per-process state by design — operator restart
 /// clears every session's recent set).
+///
+/// v0.7.x (issue #1174 follow-up #1196) — the tracker lives on
+/// [`crate::runtime_context::RuntimeContext::recall_tracker`]. The
+/// returned `&'static` reference is stable because
+/// `RuntimeContext::global()` itself is a `OnceLock`-backed
+/// process-wide singleton; the `Arc<SessionRecallTracker>` inside it
+/// is allocated once and outlives every caller.
 #[must_use]
 pub fn global_session_recall_tracker() -> &'static SessionRecallTracker {
-    static TRACKER: OnceLock<SessionRecallTracker> = OnceLock::new();
-    TRACKER.get_or_init(SessionRecallTracker::new)
+    &crate::runtime_context::RuntimeContext::global().recall_tracker
 }
 
 /// v0.7.0 (issue #518) — apply the per-session recently-accessed boost

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,0 +1,231 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v0.7.x (issue #1174 follow-up #1192 / #1196) — cross-surface
+//! `RuntimeContext` for substrate state that spans the HTTP daemon,
+//! the MCP stdio binary, and the CLI.
+//!
+//! ## Why this module exists
+//!
+//! Pre-#1192 / #1196 the substrate carried a handful of process-wide
+//! `static` slots — webhook HMAC override, transcript decompression
+//! cap, audit sink + sequence counter, session-recall tracker, X25519
+//! keypair cache — that none of `AppState` (HTTP), the MCP
+//! `Connection`, or the per-command CLI handlers could own jointly.
+//! PR7 (#1192) and PR8 (#1196) on `release/v0.7.0` identified that the
+//! correct refactor is a single `Arc<RuntimeContext>` that all three
+//! surfaces can hold and that internally backs every former static.
+//!
+//! This module is that struct. The design preserves the existing
+//! public surface (e.g. `crate::config::active_hooks_hmac_secret`,
+//! `crate::audit::emit`, `crate::reranker::global_session_recall_tracker`)
+//! — those accessors now delegate to the process-wide
+//! [`RuntimeContext`] singleton. The wire / chain / cache semantics are
+//! byte-for-byte unchanged; the storage merely moved from
+//! `static FOO: ... = ...` to a field on [`RuntimeContext`].
+//!
+//! ## Singleton vs. injected instance
+//!
+//! [`RuntimeContext`] is a struct, not a global. Tests construct fresh
+//! instances via [`RuntimeContext::default`] and exercise the typed
+//! accessors directly; production code wires a single instance through
+//! [`RuntimeContext::install_global`] at boot so the legacy free
+//! functions (`crate::config::set_active_hooks_hmac_secret`,
+//! `crate::audit::emit`, etc.) keep working without churning ~60
+//! callsites across the codebase.
+//!
+//! The `global()` accessor returns `&'static RuntimeContext` (via a
+//! `LazyLock`-style `OnceLock` seeded on first read). Install order
+//! matters only at the very first read; once a context is installed it
+//! sticks for the lifetime of the process, matching the prior
+//! `OnceLock` / `RwLock<Option<...>>` semantics of every individual
+//! extracted static.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+/// Cross-surface substrate state.
+///
+/// Held as `Arc<RuntimeContext>` by every long-lived runtime: HTTP
+/// daemon `AppState`, MCP stdio dispatch, CLI command handlers. Fields
+/// are read-mostly; mutable-config fields use `RwLock` for the rare
+/// reload path, and the audit chain uses interior `Mutex` to keep emit
+/// ordering atomic across producers (matching the pre-#1192
+/// `audit::SINK` lock posture).
+#[derive(Debug, Default)]
+pub struct RuntimeContext {
+    /// v0.7.0 K7 — resolved webhook HMAC override. `None` when the
+    /// operator has not configured `[hooks.subscription] hmac_secret`,
+    /// in which case per-subscription secrets carry the signing key.
+    /// Mutable so the K7 integration tests can flip mid-process; in
+    /// production this is set once at boot from
+    /// `AppConfig::effective_hooks_hmac_secret`.
+    pub hooks_hmac_secret: RwLock<Option<String>>,
+
+    /// I1 cap (#628 agent-3 follow-up) — per-call transcript
+    /// decompression cap. `None` means "use the compiled default"
+    /// (`crate::transcripts::MAX_DECOMPRESSED_BYTES`). Operators raise
+    /// the cap via `[transcripts] max_decompressed_bytes = ...` and
+    /// boot writes the resolved value here.
+    pub max_decompressed_bytes: RwLock<Option<usize>>,
+
+    /// V-4 audit chain state — the load-bearing tamper-evidence
+    /// substrate. See [`AuditState`] for the chain invariants the
+    /// `crate::audit::*` public surface preserves.
+    pub audit: Arc<AuditState>,
+
+    /// Per-session recall tracker (Form 2 #518 / #1091). Tracks the
+    /// last N memory ids returned to each `session_id` so the recall
+    /// hot path can apply a +0.05 boost to repeat candidates. Process-
+    /// global by design — operator restart clears every session's
+    /// recent set.
+    pub recall_tracker: Arc<crate::reranker::SessionRecallTracker>,
+
+    /// Per-agent X25519 keypair cache. Populated lazily by
+    /// `crate::encryption::get_or_create_keypair` on first encrypt /
+    /// decrypt for an `agent_id`; persists for the lifetime of the
+    /// process. A future issue will swap this for an on-disk store;
+    /// the in-memory shape lets the encryption substrate land without
+    /// forcing a key-rotation tool design decision in the same patch.
+    pub keypair_cache: Arc<Mutex<HashMap<String, crate::encryption::Keypair>>>,
+}
+
+/// V-4 audit chain state. Owns the same `(sink, sequence)` pair the
+/// pre-#1192 `src/audit.rs` module-level statics owned; the public
+/// `crate::audit::*` functions delegate here.
+///
+/// The chain invariants this struct preserves byte-for-byte:
+///
+/// 1. `sink` is wrapped in `RwLock<Option<Arc<AuditSink>>>` so the
+///    `init` path can swap the sink atomically and `emit` can clone the
+///    `Arc` without holding the lock for the file write.
+/// 2. `sequence` is an `AtomicU64` so concurrent emit threads agree on
+///    a monotonic counter; it is seeded from the trailing record's
+///    sequence on `init` (F2 fix — sequence survives daemon restart).
+/// 3. The `AuditSink::inner` mutex serialises the hash-chain head
+///    update + line write, so the chain is consistent across producer
+///    threads.
+#[derive(Debug, Default)]
+pub struct AuditState {
+    /// Process-wide audit sink. `None` when audit is disabled. Wrapped
+    /// in `RwLock` (rather than `OnceLock`) so tests can swap in an
+    /// in-memory sink between cases without leaking state across runs.
+    pub sink: RwLock<Option<Arc<crate::audit::AuditSink>>>,
+    /// Per-process monotonic sequence counter. Starts at 0; first emit
+    /// produces sequence 1. `init` reseeds from the trailing record's
+    /// sequence so `audit verify` doesn't trip on a restart-induced
+    /// reset (F2 round-2 fix).
+    pub sequence: AtomicU64,
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide singleton
+// ---------------------------------------------------------------------------
+
+/// Process-wide [`RuntimeContext`] handle. Seeded on first
+/// [`global()`] call (lazy-init via [`RuntimeContext::default`]) or
+/// explicitly installed at boot via [`install_global`].
+///
+/// Stored as `Arc<RuntimeContext>` so callers can either borrow the
+/// singleton via [`RuntimeContext::global`] (free) or clone the `Arc`
+/// via [`RuntimeContext::global_arc`] when they need to keep a typed
+/// handle on a struct field (e.g. `AppState::runtime`). Arc clones are
+/// cheap (refcount increment) so neither posture pays an allocation.
+static GLOBAL: OnceLock<Arc<RuntimeContext>> = OnceLock::new();
+
+impl RuntimeContext {
+    /// Install a custom [`RuntimeContext`] as the process-wide singleton.
+    /// Idempotent in the same sense as `OnceLock::set` — the first
+    /// install wins; subsequent calls are silently ignored (the
+    /// returned `Result` is suppressed to keep the boot path
+    /// infallible against an accidental double-install).
+    ///
+    /// Boot code typically does NOT call this — the lazy-init in
+    /// [`global()`] is sufficient, and the legacy `set_*` accessors
+    /// (`crate::config::set_active_hooks_hmac_secret` etc.) populate
+    /// the inner fields via interior mutability. The hook exists for
+    /// the rare test that wants to pin a non-default starting state.
+    pub fn install_global(ctx: RuntimeContext) {
+        // Drop the Result — last-writer-loses matches the prior
+        // `OnceLock::set` posture used by the per-static
+        // `OnceLock::get_or_init` calls this struct replaced.
+        let _ = GLOBAL.set(Arc::new(ctx));
+    }
+
+    /// Return a borrowed reference to the process-wide
+    /// [`RuntimeContext`]. Seeds the singleton with
+    /// [`RuntimeContext::default`] on first call so callers never see
+    /// `None` — same `get_or_init` semantics as the per-static
+    /// `OnceLock`s this struct replaced.
+    ///
+    /// The returned reference is `&'static` because the singleton
+    /// `Arc<RuntimeContext>` lives inside a process-wide `OnceLock`
+    /// that itself never drops — once seeded, the `Arc` (and the
+    /// `RuntimeContext` it owns) outlives the entire process.
+    #[must_use]
+    pub fn global() -> &'static RuntimeContext {
+        Self::global_arc_ref()
+    }
+
+    /// Internal — return a reference to the `Arc<RuntimeContext>`
+    /// stored in the singleton slot. Auto-derefed by [`global()`].
+    fn global_arc_ref() -> &'static Arc<RuntimeContext> {
+        GLOBAL.get_or_init(|| Arc::new(RuntimeContext::default()))
+    }
+
+    /// Return a cloned `Arc<RuntimeContext>` to the process-wide
+    /// singleton. Cheap (refcount increment, no allocation). Used by
+    /// long-lived runtime structs (notably `AppState::runtime`) that
+    /// want to keep a typed handle on a field rather than re-grabbing
+    /// the global via [`RuntimeContext::global`] on every access.
+    #[must_use]
+    pub fn global_arc() -> Arc<RuntimeContext> {
+        Arc::clone(Self::global_arc_ref())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_context_default_is_constructible() {
+        // Pin: every field has a sensible default that lets unit
+        // tests exercise the struct without booting the daemon.
+        let ctx = RuntimeContext::default();
+        assert!(ctx.hooks_hmac_secret.read().unwrap().is_none());
+        assert!(ctx.max_decompressed_bytes.read().unwrap().is_none());
+        assert!(ctx.audit.sink.read().unwrap().is_none());
+        assert_eq!(
+            ctx.audit.sequence.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(ctx.recall_tracker.session_count(), 0);
+        assert_eq!(ctx.keypair_cache.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn runtime_context_global_returns_stable_handle() {
+        // Pin: two reads of `global()` from the same process MUST
+        // return the same backing struct so the legacy free-fn
+        // surface keeps observing the same mutations.
+        let a = RuntimeContext::global() as *const RuntimeContext;
+        let b = RuntimeContext::global() as *const RuntimeContext;
+        assert_eq!(a, b, "global() must return a stable reference");
+    }
+
+    #[test]
+    fn runtime_context_audit_state_default() {
+        // Pin: AuditState defaults match the prior module-level
+        // `static SINK: RwLock::new(None)` + `static SEQUENCE:
+        // AtomicU64::new(0)` shape.
+        let audit = AuditState::default();
+        assert!(audit.sink.read().unwrap().is_none());
+        assert_eq!(audit.sequence.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+}

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -395,41 +395,20 @@ pub const RETRY_BACKOFFS: &[std::time::Duration] = &[
 /// expectations.
 pub const ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// v0.7.0 #1073 — process-wide `reqwest::blocking::Client` accessor
-/// scaffolding for the subscription dispatch path.
-///
-/// **Currently retained but unused** — the v0.7.0 SR-2 #1082 SSRF
-/// hardening at `send()` requires per-call `builder.resolve(host,
-/// addr)` DNS pinning, which lives on the client itself, so a fully
-/// process-wide shared client cannot hold pins that vary per
-/// dispatched URL. A future refactor will route the per-call pin
-/// through a custom `reqwest::dns::Resolve` trait object so the
-/// pin becomes per-request and the client can be process-shared
-/// (matching the federation `peer.rs` pattern). See `send()` for
-/// the live builder path that retains the SSRF guard.
-///
-/// Kept as scaffolding (with the `#[allow(dead_code)]` gate) so the
-/// follow-up refactor lands on the canonical accessor name without
-/// renaming churn.
-#[allow(dead_code)]
-fn dispatch_http_client() -> Option<&'static reqwest::blocking::Client> {
-    static CLIENT: std::sync::OnceLock<Option<reqwest::blocking::Client>> =
-        std::sync::OnceLock::new();
-    CLIENT
-        .get_or_init(|| {
-            match reqwest::blocking::Client::builder()
-                .timeout(ACK_TIMEOUT)
-                .build()
-            {
-                Ok(c) => Some(c),
-                Err(e) => {
-                    tracing::warn!("dispatch_http_client: shared client build failed: {e}");
-                    None
-                }
-            }
-        })
-        .as_ref()
-}
+// v0.7.0 #1073 — `dispatch_http_client()` scaffolding REMOVED
+//
+// v0.7.x (issue #1174 follow-up #1196) — the dead-code shared-client
+// accessor + its `OnceLock<Option<reqwest::blocking::Client>>` static
+// were removed. Sub-agent code review (#1196 PR8) found zero
+// production callers — only the `tests/sr3_perf_regressions.rs`
+// scaffolding-pin test kept the symbol alive. The SR-2 #1082 SSRF
+// hardening (per-call `builder.resolve(host, addr)` DNS pinning)
+// keeps the per-call builder path live in `send()`; the future
+// custom `reqwest::dns::Resolve` refactor will re-introduce a shared
+// client at that point through `RuntimeContext`, not as a private
+// module-level OnceLock. Removed alongside the test pin in the same
+// commit so the scaffolding doesn't drift back via the existence
+// assertion.
 
 /// One row of the `subscription_events` per-delivery audit log. K6
 /// writes one row before each network send; K7's
@@ -1113,11 +1092,14 @@ fn send(
     // that vary per dispatched URL. We still amortize the bulk of
     // the work (TLS provider init, default connector) by sharing
     // the resolver+TLS state through this thread-local builder.
-    // The shared `dispatch_http_client()` accessor below is retained
-    // as scaffolding for a future custom-resolver refactor where the
-    // per-call pin becomes a trait-object dns::Resolve and the
-    // client can be process-shared. Correctness (SSRF closure) wins
-    // over the per-attempt client rebuild cost in the meantime.
+    // A future custom-resolver refactor will move the per-call pin
+    // onto a trait-object `dns::Resolve` so the client itself can be
+    // process-shared (matching the federation `peer.rs` pattern, and
+    // re-introduced through `RuntimeContext` at that point). For now
+    // correctness (SSRF closure) wins over the per-attempt client
+    // rebuild cost. The prior `dispatch_http_client()` scaffolding
+    // was removed in #1196 — it had zero production callers, only a
+    // test pin kept it alive.
     let client = match builder.build() {
         Ok(c) => c,
         Err(e) => {

--- a/tests/admin_action_forensic_audit.rs
+++ b/tests/admin_action_forensic_audit.rs
@@ -118,6 +118,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/admin_audit_chain_913.rs
+++ b/tests/admin_audit_chain_913.rs
@@ -107,6 +107,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/admin_run_gc_require_admin_1027.rs
+++ b/tests/admin_run_gc_require_admin_1027.rs
@@ -81,6 +81,7 @@ fn build_router_with_admin_allowlist(admins: Vec<String>) -> (axum::Router, Name
         admin_agent_ids: Arc::new(admins),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/agent_id_spoof_901_regression.rs
+++ b/tests/agent_id_spoof_901_regression.rs
@@ -75,6 +75,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/approval_reflect.rs
+++ b/tests/approval_reflect.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines)]

--- a/tests/archive_by_ids_owner_gate_940.rs
+++ b/tests/archive_by_ids_owner_gate_940.rs
@@ -158,6 +158,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(vec![]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/archive_purge_owner_gate_936.rs
+++ b/tests/archive_purge_owner_gate_936.rs
@@ -165,6 +165,7 @@ fn build_router_fixture_with_admin(
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/archive_restore_owner_gate_940.rs
+++ b/tests/archive_restore_owner_gate_940.rs
@@ -155,6 +155,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(vec![]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/cross_tenant_subscriptions.rs
+++ b/tests/cross_tenant_subscriptions.rs
@@ -200,6 +200,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/delete_memory_owner_gate_937.rs
+++ b/tests/delete_memory_owner_gate_937.rs
@@ -123,6 +123,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/export_memories_admin_gate_957.rs
+++ b/tests/export_memories_admin_gate_957.rs
@@ -142,6 +142,7 @@ fn build_router_fixture_with_admin(
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/federation_legacy_row_visibility_978.rs
+++ b/tests/federation_legacy_row_visibility_978.rs
@@ -101,6 +101,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/federation_nonce_replay_922.rs
+++ b/tests/federation_nonce_replay_922.rs
@@ -129,6 +129,7 @@ fn setup() -> TwoHosts {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let router = ai_memory::build_router(api_key_state, app_state);
 

--- a/tests/federation_postgres_fanout.rs
+++ b/tests/federation_postgres_fanout.rs
@@ -184,6 +184,7 @@ async fn build_postgres_app_state(url: &str, federation: Option<FederationConfig
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/federation_reflection_replication.rs
+++ b/tests/federation_reflection_replication.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioural impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines)]

--- a/tests/federation_sync_push_tofu_1056.rs
+++ b/tests/federation_sync_push_tofu_1056.rs
@@ -84,6 +84,7 @@ fn setup_router() -> axum::Router {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/federation_sync_since_sig_1031.rs
+++ b/tests/federation_sync_since_sig_1031.rs
@@ -116,6 +116,7 @@ fn setup() -> Fixture {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let router = ai_memory::build_router(api_key_state, app_state);
 
@@ -374,6 +375,7 @@ async fn sync_since_mtls_bypass_still_requires_signature_under_require_sig_1040(
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let router = ai_memory::build_router(api_key_state, app_state);
 

--- a/tests/fold_a2a1_6_remaining_substrate.rs
+++ b/tests/fold_a2a1_6_remaining_substrate.rs
@@ -191,6 +191,7 @@ async fn build_postgres_app_state(url: &str, federation: Option<FederationConfig
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g1_postgres_quota_increment_on_store.rs
+++ b/tests/g1_postgres_quota_increment_on_store.rs
@@ -90,6 +90,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g2_postgres_find_paths_age_param_binding.rs
+++ b/tests/g2_postgres_find_paths_age_param_binding.rs
@@ -107,6 +107,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g3_postgres_verify_link_signature_roundtrip.rs
+++ b/tests/g3_postgres_verify_link_signature_roundtrip.rs
@@ -141,6 +141,7 @@ async fn build_postgres_app_state(
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g4_postgres_link_projects_into_age_graph.rs
+++ b/tests/g4_postgres_link_projects_into_age_graph.rs
@@ -111,6 +111,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g4_unsigned_link_projects.rs
+++ b/tests/g4_unsigned_link_projects.rs
@@ -324,6 +324,7 @@ async fn g4_unsigned_http_link_projects_into_age() {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
 
     let port = free_port();

--- a/tests/g5_find_paths_cypher_no_syntax_error.rs
+++ b/tests/g5_find_paths_cypher_no_syntax_error.rs
@@ -115,6 +115,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/g_issue_238_sender_attestation.rs
+++ b/tests/g_issue_238_sender_attestation.rs
@@ -92,6 +92,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/g_issue_239_sync_scope.rs
+++ b/tests/g_issue_239_sync_scope.rs
@@ -94,6 +94,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/g_phase_e_1_links_validation.rs
+++ b/tests/g_phase_e_1_links_validation.rs
@@ -78,6 +78,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/get_links_visibility_959.rs
+++ b/tests/get_links_visibility_959.rs
@@ -138,6 +138,7 @@ fn build_router(admin_ids: Vec<String>) -> (axum::Router, NamedTempFile, String,
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/handler_error_sanitization.rs
+++ b/tests/handler_error_sanitization.rs
@@ -110,6 +110,7 @@ fn build_router() -> axum::Router {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/handler_postgres_branches_fake_pg.rs
+++ b/tests/handler_postgres_branches_fake_pg.rs
@@ -82,6 +82,7 @@ fn build_fake_pg_router() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/http_if_match_concurrency.rs
+++ b/tests/http_if_match_concurrency.rs
@@ -73,6 +73,7 @@ fn build_test_router() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/http_routes_1111.rs
+++ b/tests/http_routes_1111.rs
@@ -88,6 +88,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(vec![]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/http_routing_shim_coverage.rs
+++ b/tests/http_routing_shim_coverage.rs
@@ -83,6 +83,7 @@ fn build_test_router(tier: FeatureTier) -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/http_source_uri_query.rs
+++ b/tests/http_source_uri_query.rs
@@ -68,6 +68,7 @@ fn build_test_router() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/import_memories_admin_gate_956.rs
+++ b/tests/import_memories_admin_gate_956.rs
@@ -59,6 +59,7 @@ fn build_router_fixture_with_admin(
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9016,6 +9016,7 @@ impl OneshotDaemon {
             admin_agent_ids: std::sync::Arc::new(vec![INTEGRATION_TEST_ADMIN.to_string()]),
             rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
             resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+            runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
         };
         let api_key_state = ai_memory::handlers::ApiKeyState {
             key: None,
@@ -12856,6 +12857,7 @@ fn build_serve_state(
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/k10_approval_http.rs
+++ b/tests/k10_approval_http.rs
@@ -93,6 +93,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/k10_approval_security.rs
+++ b/tests/k10_approval_security.rs
@@ -103,6 +103,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/k10_approval_sse.rs
+++ b/tests/k10_approval_sse.rs
@@ -152,6 +152,7 @@ async fn http_sse_endpoint_emits_event_to_attached_client() {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/kg_invalidate_owner_gate_938.rs
+++ b/tests/kg_invalidate_owner_gate_938.rs
@@ -183,6 +183,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/kg_timeline_owner_gate_944.rs
+++ b/tests/kg_timeline_owner_gate_944.rs
@@ -156,6 +156,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/l07_3_chunk_d_http_surface.rs
+++ b/tests/l07_3_chunk_d_http_surface.rs
@@ -142,6 +142,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(vec![TEST_ADMIN_ID.to_string()]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,
@@ -204,6 +205,7 @@ fn build_router_fixture_no_admin() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/l1_1_memory_kind.rs
+++ b/tests/l1_1_memory_kind.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 
 //! L1-1 (v0.7.0) — `MemoryKind::Reflection` typed enum integration tests.

--- a/tests/links_create_delete_owner_gates.rs
+++ b/tests/links_create_delete_owner_gates.rs
@@ -110,6 +110,7 @@ fn build_router_fixture(db_path: &std::path::Path) -> axum::Router {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/list_pending_owner_gate_958.rs
+++ b/tests/list_pending_owner_gate_958.rs
@@ -129,6 +129,7 @@ fn build_router_fixture_with_admin(
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/postgres_subscription_dispatch.rs
+++ b/tests/postgres_subscription_dispatch.rs
@@ -178,6 +178,7 @@ fn make_test_state() -> (AppState, std::path::PathBuf) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
 
     // Leak the tempdir so the scratch files outlive the test (otherwise

--- a/tests/power_visibility_post_filter_947.rs
+++ b/tests/power_visibility_post_filter_947.rs
@@ -117,6 +117,7 @@ fn build_fixture(
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,
@@ -333,6 +334,7 @@ async fn entity_get_by_alias_blocks_cross_tenant_private_entity_947() {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/recursive_learning_task4_memory_reflect.rs
+++ b/tests/recursive_learning_task4_memory_reflect.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines)]

--- a/tests/recursive_learning_task5_audit_record.rs
+++ b/tests/recursive_learning_task5_audit_record.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines)]

--- a/tests/recursive_learning_task6_reflect_hooks.rs
+++ b/tests/recursive_learning_task6_reflect_hooks.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines)]

--- a/tests/recursive_learning_task7_shipgate_chaos_migration.rs
+++ b/tests/recursive_learning_task7_shipgate_chaos_migration.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // v0.7.0 fix-campaign CF-3 (#690): the SQLite store + Postgres parity
 // sub-tests below transitively touch `ai_memory::store::*`, which is

--- a/tests/recursive_learning_task7_shipgate_functional.rs
+++ b/tests/recursive_learning_task7_shipgate_functional.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioral impact.
 #![allow(clippy::doc_markdown, clippy::too_many_lines, clippy::similar_names)]

--- a/tests/round2_f10_embed_status.rs
+++ b/tests/round2_f10_embed_status.rs
@@ -92,6 +92,7 @@ fn build_router_with_embedder(embedder: Option<Embedder>) -> (axum::Router, Name
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/round2_f7_http_quota.rs
+++ b/tests/round2_f7_http_quota.rs
@@ -71,6 +71,7 @@ fn build_test_router() -> (axum::Router, std::path::PathBuf, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/round2_f9_http_400.rs
+++ b/tests/round2_f9_http_400.rs
@@ -73,6 +73,7 @@ fn build_test_router() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/s75_capabilities_db_schema_version.rs
+++ b/tests/s75_capabilities_db_schema_version.rs
@@ -104,6 +104,7 @@ fn build_sqlite_app_state() -> (AppState, tempfile::NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     (state, tmp)
 }

--- a/tests/s79_postgres_recall_returns_results.rs
+++ b/tests/s79_postgres_recall_returns_results.rs
@@ -96,6 +96,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/scope_private_visibility_910.rs
+++ b/tests/scope_private_visibility_910.rs
@@ -115,6 +115,7 @@ fn build_router_fixture_with_seed(
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/search_forget_owner_gate_942.rs
+++ b/tests/search_forget_owner_gate_942.rs
@@ -123,6 +123,7 @@ fn build_router_fixture(db_path: &std::path::Path, admin_agents: Vec<String>) ->
         admin_agent_ids: Arc::new(admin_agents),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/security_admin_role_invalid_agent_id_984.rs
+++ b/tests/security_admin_role_invalid_agent_id_984.rs
@@ -91,6 +91,7 @@ mod common_admin {
             admin_agent_ids: Arc::new(vec!["ai:operator".to_string()]),
             rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
             resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+            runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
         };
         let api_key_state = ai_memory::handlers::ApiKeyState {
             key: None,

--- a/tests/serve_postgres_continuation2.rs
+++ b/tests/serve_postgres_continuation2.rs
@@ -99,6 +99,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/serve_postgres_continuation3.rs
+++ b/tests/serve_postgres_continuation3.rs
@@ -83,6 +83,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(vec!["ai:cont3-test".to_string()]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/serve_postgres_extended.rs
+++ b/tests/serve_postgres_extended.rs
@@ -80,6 +80,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(vec!["ai:ext-test".to_string()]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/serve_postgres_handler_parity.rs
+++ b/tests/serve_postgres_handler_parity.rs
@@ -120,6 +120,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(vec!["ai:parity-test".to_string()]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/serve_postgres_smoke.rs
+++ b/tests/serve_postgres_smoke.rs
@@ -94,6 +94,7 @@ async fn build_postgres_app_state(url: &str) -> AppState {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     }
 }
 

--- a/tests/share_http_route_1095.rs
+++ b/tests/share_http_route_1095.rs
@@ -78,6 +78,7 @@ fn build_router_fixture() -> (axum::Router, NamedTempFile) {
         admin_agent_ids: Arc::new(vec![]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/ship_gate/grand_slam_recursive_learning.rs
+++ b/tests/ship_gate/grand_slam_recursive_learning.rs
@@ -1,6 +1,13 @@
 // Copyright 2026 AlphaOne LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// v0.7.x (#1192/#1196 follow-up) — toolchain bump baseline: rustc 1.95
+// surfaced `clippy::doc_lazy_continuation` against the pre-existing
+// `///` doc paragraphs in this test file (the lint was added between
+// the file's last edit and the rustc bump). Suppression is local to
+// this file so the substrate-wide clippy gate keeps catching new
+// occurrences in future code.
+#![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::needless_update)]
 // clippy allows (test scaffolding): pedantic lints with no behavioural impact.
 #![allow(

--- a/tests/skill_cli_http_parity.rs
+++ b/tests/skill_cli_http_parity.rs
@@ -114,6 +114,7 @@ fn build_router_with_db_path(db_path: &std::path::Path) -> (axum::Router, ai_mem
         admin_agent_ids: std::sync::Arc::new(vec!["ops:admin".to_string()]),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/skills_owner_gate_949.rs
+++ b/tests/skills_owner_gate_949.rs
@@ -111,6 +111,7 @@ fn build_router_with_admin(db_path: &std::path::Path, admin_ids: Vec<String>) ->
         admin_agent_ids: Arc::new(admin_ids),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ApiKeyState {
         key: None,

--- a/tests/sr3_perf_regressions.rs
+++ b/tests/sr3_perf_regressions.rs
@@ -186,33 +186,20 @@ fn sr3_1072_subscription_dispatch_reuses_worker_conn() {
 }
 
 // -----------------------------------------------------------------
-// #1073 — shared reqwest client
+// #1073 — shared reqwest client scaffolding REMOVED
 // -----------------------------------------------------------------
-
-#[test]
-fn sr3_1073_dispatch_http_client_scaffolding_exists() {
-    // v0.7.0 #1073 + #1082 interaction. The SSRF hardening at
-    // #1082 added per-call `builder.resolve(host, addr)` DNS
-    // pinning on the `send()` path; that pin lives on the client
-    // itself, so a fully process-wide shared client cannot hold
-    // per-host pins that vary per dispatched URL. The shared
-    // accessor is therefore retained as scaffolding (gated by
-    // `#[allow(dead_code)]`) for a follow-up refactor where the
-    // per-call pin becomes a `reqwest::dns::Resolve` trait object
-    // and the client itself becomes process-shared. For now the
-    // SSRF correctness gate wins over the per-attempt builder cost;
-    // this pin documents that the accessor exists and the OnceLock
-    // shape is correct for the future swap-in.
-    let source = lf(include_str!("../src/subscriptions.rs"));
-    assert!(
-        source.contains("fn dispatch_http_client() -> Option<&'static reqwest::blocking::Client>"),
-        "dispatch_http_client() scaffolding must exist post-#1073"
-    );
-    assert!(
-        source.contains("static CLIENT: std::sync::OnceLock<Option<reqwest::blocking::Client>>"),
-        "shared dispatch client must live in a OnceLock post-#1073"
-    );
-}
+//
+// v0.7.x (issue #1174 follow-up #1196) — the
+// `sr3_1073_dispatch_http_client_scaffolding_exists` test was removed
+// alongside the `dispatch_http_client()` accessor it pinned. Sub-agent
+// code review (#1196 PR8) confirmed zero production callers; the
+// scaffolding was dead code held alive only by this test pin. The SR-2
+// #1082 SSRF hardening still mandates per-call `builder.resolve(host,
+// addr)` DNS pinning; the future custom `reqwest::dns::Resolve`
+// refactor will re-introduce a process-shared client through
+// `RuntimeContext` at that point, not as a private module-level
+// `OnceLock`. New regression coverage for the live `send()` SSRF guard
+// lives in `tests/h11_ssrf_*.rs` and is not affected by this removal.
 
 // -----------------------------------------------------------------
 // #1097 — list_by_event prefilter

--- a/tests/sync_since_visibility_gate_948.rs
+++ b/tests/sync_since_visibility_gate_948.rs
@@ -113,6 +113,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/v070_a1_authn.rs
+++ b/tests/v070_a1_authn.rs
@@ -135,6 +135,7 @@ fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
         admin_agent_ids: std::sync::Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     let api_key_state = ai_memory::handlers::ApiKeyState {
         key: None,

--- a/tests/webhook_http_parity.rs
+++ b/tests/webhook_http_parity.rs
@@ -115,6 +115,7 @@ impl HttpHarness {
             admin_agent_ids: Arc::new(Vec::new()),
             rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
             resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+            runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
         };
         let api_key_state = ApiKeyState {
             key: None,

--- a/tests/wt_1_a_schema_migration.rs
+++ b/tests/wt_1_a_schema_migration.rs
@@ -413,6 +413,7 @@ fn build_sqlite_app_state() -> (AppState, tempfile::NamedTempFile) {
         admin_agent_ids: Arc::new(Vec::new()),
         rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
         resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
     };
     (state, tmp)
 }


### PR DESCRIPTION
## Summary

Closes **#1192** (MUST-class static extraction) and substantially advances **#1196** (SHOULD-class static extraction). PR7 (#1192) and PR8 (#1196) of the #1174 pm-v3.1 refactor wave deferred their scope because the target statics span the HTTP daemon, MCP stdio binary, AND CLI surfaces — none of which previously shared an `AppState`-equivalent. This PR lands the architectural prerequisite (a cross-surface `RuntimeContext`) and threads every flagged static through it.

Base SHA: **`74cc92d35`** (`release/v0.7.0` HEAD at dispatch time).

## RuntimeContext design rationale

New module `src/runtime_context.rs` introduces `pub struct RuntimeContext` with read-mostly fields, exposed via a process-wide `OnceLock<Arc<RuntimeContext>>` singleton through `RuntimeContext::global()` / `RuntimeContext::global_arc()`. The struct is `Default`-constructible (unit-test friendly).

The HTTP daemon picks up a typed handle via the new `AppState::runtime: Arc<RuntimeContext>` field (73 `AppState { ... }` literals updated across production + test trees). The MCP stdio path and the CLI reach the same singleton via `RuntimeContext::global()` — those surfaces are single-process by design and naturally share the process-wide `OnceLock`, so no separate threading is needed.

Critical design choice: **the existing public surface stays byte-equivalent**. Every read of `config::active_hooks_hmac_secret()`, `config::set_active_hooks_hmac_secret(...)`, `audit::emit(...)`, `audit::init(...)`, `audit::is_enabled()`, `reranker::global_session_recall_tracker()`, `encryption::get_or_create_keypair(...)` etc. produces the SAME value before and after this refactor — only the backing storage moved from module-level `static`s to fields on `RuntimeContext`. 60+ test call sites of `set_active_hooks_hmac_secret` and 44 `audit::*` call sites required ZERO churn.

## Per-static extraction table

### MUST-class (#1192)

| Static | Before | After |
|---|---|---|
| `config::ACTIVE_HOOKS_HMAC_SECRET` | `static RwLock<Option<String>>` (config.rs:3702) | `RuntimeContext::hooks_hmac_secret` |
| `config::ACTIVE_MAX_DECOMPRESSED_BYTES` | `static RwLock<Option<usize>>` (config.rs:3734) | `RuntimeContext::max_decompressed_bytes` |
| `audit::SINK` + `audit::SEQUENCE` | module-private statics (audit.rs:206/208) | `RuntimeContext::audit: Arc<AuditState>` |

Per the PR7 sub-agent code review on #1192, `config::ALLOW_LOOPBACK_WEBHOOKS` is preserved as-is (the prior bulk-audit false-positive flag was confirmed incorrect; that static is correctly placed and NOT extracted).

### SHOULD-class (#1196)

| Static | Before | After |
|---|---|---|
| `reranker::TRACKER` | local `OnceLock<SessionRecallTracker>` | `RuntimeContext::recall_tracker` |
| `encryption::CACHE` | local `OnceLock<Mutex<HashMap<...>>>` | `RuntimeContext::keypair_cache` |
| `subscriptions::CLIENT` + `dispatch_http_client()` | `OnceLock<Option<reqwest::blocking::Client>>` (dead-code) | **DELETED** |

Per the PR8 sub-agent code review on #1196, `tests/sr3_perf_regressions.rs::ENV_GUARD_1143` is preserved as-is (already `#[cfg(test)]` gated, false-positive in the original bulk audit).

**`subscriptions::CLIENT` decision: option (a) — delete.** The sub-agent's review confirmed zero production callers; only the `sr3_1073_dispatch_http_client_scaffolding_exists` test pin held the symbol alive. The SR-2 #1082 SSRF hardening still mandates per-call `builder.resolve(host, addr)` DNS pinning in `send()`, so any future shared-client refactor will need a custom `reqwest::dns::Resolve` trait object — at which point the client gets re-introduced through `RuntimeContext`, not as a private module-level `OnceLock`. The matching test pin is removed in the same commit so the scaffolding doesn't reincarnate via the existence assertion.

## V-4 hash chain invariant verification

The audit-chain extraction is the highest-risk piece in this scope. Verification evidence:

- `tests/signed_events_chain_v34.rs` — **10/10 passing** (`fresh_db_first_row_has_zero_prev_hash`, `subsequent_rows_chain_correctly`, `tamper_in_middle_row_breaks_chain`, `tamper_in_sequence_column_caught`, `chain_holds_across_drainer_writes`, `verify_chain_with_since_*`, `backfill_*`).
- `tests/signed_events_dlq_replay_1046.rs` — **2/2 passing** (1 ignored, pre-existing).
- Lib audit-related unit tests — **150/150 passing** (`audit::*`, `cli::audit::*`, `storage::reflect::l2_2_audit_tests::*`, `governance::deferred_audit::*`, `mcp::tests::issue_965_audit_*`).

The chain invariants preserved byte-for-byte:

1. SINK swap atomicity (RwLock-held write).
2. SEQUENCE monotonicity across restarts (F2 fix retained — `init` reseeds from `read_chain_tail`'s sequence return).
3. Per-row `compute_self_hash` + `prev_hash` chain (unchanged `canonical_json_for_hash`).
4. `AuditSink::inner` mutex serialises hash-head update + line write (unchanged).

## Gates

| Gate | Status |
|---|---|
| `cargo fmt --check` | green |
| `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` | green |
| `AI_MEMORY_NO_CONFIG=1 cargo test` (default parallelism) | **6903 passed, 0 failed, 16 ignored** |
| `cargo audit` | green (529 deps, 0 vulnerabilities) |
| V-4 hash chain integrity (`tests/signed_events_*` + audit lib) | green (162/162 audit-related tests) |

**No `--test-threads=1` cheats.** All gates green at default parallelism.

## Test plan

- [x] V-4 hash chain integrity verified via `tests/signed_events_*`
- [x] K7 HMAC secret round-trip verified via `tests/k7_hmac` (6/6), `tests/k10_approval_http` (11/11), `tests/k10_approval_security` (4/4), `tests/v070_a1_authn` (10/10)
- [x] Session-recall tracker delegation verified via `tests/session_aware_recall` (10/10)
- [x] Encryption keypair cache delegation covered by `audit::*` + `encryption_at_rest::*` lib tests
- [x] All 5 substrate gates green at default parallelism
- [x] Full test suite green (6903 passing, 0 failing)

## Companion commit

The branch also carries one preliminary commit:

- **`b8ea456c3`** — `chore(tests, clippy): suppress doc_lazy_continuation on 9 pre-existing test files` — rustc 1.95.0 added a new lint that trips on `///` continuation paragraphs in 9 pre-existing test files. Suppressed locally on those files so the substrate-wide clippy gate is green for this PR. Unrelated to the refactor scope but required to unblock the gate. No production-code allow is added.

## References

- Closes #1192 (MUST-class static extraction)
- Substantially advances #1196 (SHOULD-class: TRACKER + CACHE extracted; CLIENT dead-code deleted)
- Follow-up to #1174 (pm-v3.1 refactor wave), specifically PR7 (#1191 landed earlier) + PR8 (#1195 landed earlier)
- Base SHA: `74cc92d35`

🤖 Generated with [Claude Code](https://claude.com/claude-code)