### PR TITLE
fix(#1201): bypass wiremock pool + per-test path for webhook tests

### DIFF
--- a/tests/issue_1201_webhook_port_collision.rs
+++ b/tests/issue_1201_webhook_port_collision.rs
@@ -1,0 +1,153 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Issue #1201 — regression test for the webhook mock-HTTP
+//! port-collision flake under parallel-binary load.
+//!
+//! Root cause (from #1201 RCA):
+//!
+//! `wiremock::MockServer::start()` pools `BareMockServer` instances
+//! through a process-wide `MOCK_SERVER_POOL`
+//! (`wiremock-0.6.5/src/mock_server/pool.rs`). Each instance binds to
+//! `127.0.0.1:0` and the OS hands back an ephemeral port. When a test
+//! releases its `MockServer` and a sibling test reaches into the pool,
+//! the OS may reassign the SAME ephemeral port to a freshly-bound
+//! pool member. Meanwhile,
+//! `subscriptions::dispatch_event_with_details`
+//! (`src/subscriptions.rs:738`) spawns the actual HTTP POST on a
+//! detached `std::thread::spawn`, so a slow dispatch from a prior
+//! test can land its POST on a recycled mock server in a sibling
+//! test — corrupting the request count and breaking the sibling's
+//! assertions.
+//!
+//! Fix (this commit):
+//!
+//!   1. Bind a dedicated `127.0.0.1:0` `TcpListener` per webhook test
+//!      and feed it to `MockServer::builder().listener(...)`. This
+//!      bypasses the pool entirely — the kernel cannot reassign the
+//!      port until the listener is dropped, which doesn't happen
+//!      until the test returns.
+//!   2. Anchor every dispatch URL on a per-test UUID path
+//!      (`/hook/<uuid>`). The `wait_for_event` / `collect_event_bodies`
+//!      filters check the request URL path against that UUID so even
+//!      if port reuse did somehow align between tests, a foreign POST
+//!      cannot be mis-counted as a "real" event for this test.
+//!
+//! What this test pins:
+//!
+//!   - `TcpListener::bind("127.0.0.1:0")` returns an OS-assigned port
+//!     (the foundation primitive both fixes lean on).
+//!   - `MockServer::builder().listener(L).start()` honors the
+//!     supplied listener address (proves we successfully bypass the
+//!     pool — the resulting server is bound to the listener's port,
+//!     not a pool-recycled one).
+//!   - Many sequential `MockServer::builder().listener(L).start()`
+//!     calls in the same process produce non-overlapping ports (proves
+//!     that the pool-bypass path doesn't itself collide).
+//!   - Concurrent `MockServer::builder().listener(L).start()` calls
+//!     from many tokio tasks also produce non-overlapping ports —
+//!     this is the real-world parallel-binary stress shape.
+
+use std::collections::HashSet;
+use std::net::TcpListener;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use wiremock::MockServer;
+
+/// Layer 1: the kernel hands out distinct ephemeral ports under
+/// `127.0.0.1:0` binds. Foundation for the #1201 fix — every other
+/// guarantee derives from this one.
+#[test]
+fn issue_1201_ephemeral_bind_returns_unique_port() {
+    let l1 = TcpListener::bind("127.0.0.1:0").expect("bind 1");
+    let l2 = TcpListener::bind("127.0.0.1:0").expect("bind 2");
+    let p1 = l1.local_addr().expect("addr 1").port();
+    let p2 = l2.local_addr().expect("addr 2").port();
+    assert_ne!(
+        p1, p2,
+        "kernel must hand out distinct ephemeral ports while both \
+         listeners are alive — port-collision precondition for \
+         #1201's pool-bypass fix"
+    );
+    assert_ne!(p1, 0, "ephemeral port must be assigned");
+}
+
+/// Layer 2: `MockServer::builder().listener(L).start()` binds to the
+/// listener we hand it, NOT to a pool member. Verifies the
+/// pool-bypass mechanic the #1201 fix depends on.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_1201_mockserver_listener_bypasses_pool() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let expected_port = listener.local_addr().expect("addr").port();
+
+    let server = MockServer::builder().listener(listener).start().await;
+    let observed_port = server.address().port();
+
+    assert_eq!(
+        expected_port, observed_port,
+        "MockServer must use the listener we supplied (port {expected_port}) \
+         rather than a pool-recycled one (port {observed_port}) — this is \
+         the #1201 pool-bypass invariant"
+    );
+}
+
+/// Layer 3: many sequential pool-bypassed mock servers DO get
+/// distinct ports — the bind retry loop never spuriously hands back
+/// the same port to two concurrent listeners.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_1201_sequential_listeners_get_unique_ports() {
+    // Hold all listeners + servers alive in the vec so the kernel
+    // cannot recycle a port mid-loop.
+    let mut servers = Vec::new();
+    let mut seen_ports = HashSet::new();
+    for _ in 0..16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        assert!(
+            seen_ports.insert(port),
+            "#1201: kernel must NOT hand the same ephemeral port to \
+             two concurrently-alive listeners; port {port} collided"
+        );
+        let server = MockServer::builder().listener(listener).start().await;
+        assert_eq!(server.address().port(), port);
+        servers.push(server);
+    }
+    assert_eq!(seen_ports.len(), 16);
+}
+
+/// Layer 4: the real-world parallel stress shape — many concurrent
+/// tokio tasks each bind a listener + start a pool-bypassed mock
+/// server. None collide. This is the closure-gate fact that proves
+/// the #1201 fix tolerates parallel-binary load.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_1201_concurrent_listeners_get_unique_ports() {
+    let seen: Arc<Mutex<HashSet<u16>>> = Arc::new(Mutex::new(HashSet::new()));
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let seen = Arc::clone(&seen);
+        handles.push(tokio::spawn(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            let port = listener.local_addr().expect("addr").port();
+            let server = MockServer::builder().listener(listener).start().await;
+            assert_eq!(server.address().port(), port);
+            let mut guard = seen.lock().await;
+            assert!(
+                guard.insert(port),
+                "#1201: concurrent ephemeral-port allocation collided on \
+                 port {port} — pool-bypass fix is leaking the OS port back \
+                 between tasks"
+            );
+            // Hold the server until the task completes so the port
+            // can't be recycled mid-test.
+            drop(server);
+        }));
+    }
+    for h in handles {
+        h.await.expect("task join");
+    }
+    let final_count = seen.lock().await.len();
+    assert_eq!(
+        final_count, 32,
+        "#1201: all 32 concurrent listeners must have observed unique ports"
+    );
+}

--- a/tests/k7_hmac.rs
+++ b/tests/k7_hmac.rs
@@ -137,15 +137,22 @@ async fn k7_hmac_signature_header_present_when_global_secret_configured() {
     // carries a `x-ai-memory-signature: sha256=<hex>` header even
     // though the subscription itself was unsigned.
     // ----------------------------------------------------------------
-    let server = MockServer::start().await;
+    // #1201 — dedicated TcpListener + UUID-suffixed path keeps the
+    // mock server out of wiremock's MOCK_SERVER_POOL and ensures
+    // straggler dispatches from prior tests can't land on a
+    // recycled port + path collision.
+    let listener = fresh_mock_listener_1201();
+    let server = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/k7-hmac/{unique}");
     Mock::given(method("POST"))
-        .and(path("/k7-hmac"))
+        .and(path(path_str.clone()))
         .respond_with(AckEcho)
         .mount(&server)
         .await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/k7-hmac", server.uri());
+    let url = format!("{}{}", server.uri(), path_str);
     let _sub_id = {
         let conn = Connection::open(&db_path).unwrap();
         subscriptions::insert(
@@ -182,8 +189,9 @@ async fn k7_hmac_signature_header_present_when_global_secret_configured() {
         );
     }
 
-    // Poll the mock server for ~5s for the dispatch thread to land.
-    let req: Request = poll_for_first_request(&server).await;
+    // Poll the mock server for ~5s for the dispatch thread to land
+    // a request on OUR per-test path (#1201 — straggler-resilient).
+    let req: Request = poll_for_first_request(&server, &path_str).await;
 
     // The header must be present and shaped `sha256=<64-hex-chars>`.
     let sig_header = req
@@ -246,15 +254,20 @@ async fn k7_hmac_unset_refuses_dispatch_when_no_per_sub_secret() {
     let _guard = K7_HMAC_GLOBAL_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let server = MockServer::start().await;
+    // #1201 — dedicated TcpListener + UUID-suffixed path keeps the
+    // mock server out of wiremock's MOCK_SERVER_POOL.
+    let listener = fresh_mock_listener_1201();
+    let server = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/k7-unsigned/{unique}");
     Mock::given(method("POST"))
-        .and(path("/k7-unsigned"))
+        .and(path(path_str.clone()))
         .respond_with(AckEcho)
         .mount(&server)
         .await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/k7-unsigned", server.uri());
+    let url = format!("{}{}", server.uri(), path_str);
     let sub_id = {
         let conn = Connection::open(&db_path).unwrap();
         subscriptions::insert(
@@ -304,7 +317,17 @@ async fn k7_hmac_unset_refuses_dispatch_when_no_per_sub_secret() {
     .await
     .unwrap();
 
-    let received = server.received_requests().await.unwrap_or_default();
+    // #1201 — filter by per-test path to be robust against any
+    // straggler from a sibling test landing on this server even if
+    // port reuse aligned (with the dedicated listener, this is now
+    // essentially impossible — the filter is defense in depth).
+    let received: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| r.url.path() == path_str)
+        .collect();
     assert!(
         received.is_empty(),
         "dispatcher must NOT post an unsigned body — got {} request(s)",
@@ -322,16 +345,37 @@ async fn k7_hmac_unset_refuses_dispatch_when_no_per_sub_secret() {
 }
 
 /// Poll the wiremock server for ~5s waiting for at least one request to
-/// land. Panics on timeout so the failure mode is loud.
-async fn poll_for_first_request(server: &MockServer) -> Request {
+/// land on `expected_path`. Panics on timeout so the failure mode is
+/// loud. The path filter (#1201) makes the poll resilient to
+/// stragglers from concurrent webhook tests in the same binary.
+async fn poll_for_first_request(server: &MockServer, expected_path: &str) -> Request {
     for _ in 0..50 {
         let received = server.received_requests().await.unwrap_or_default();
-        if let Some(req) = received.into_iter().next() {
+        if let Some(req) = received.into_iter().find(|r| r.url.path() == expected_path) {
             return req;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     panic!("K7 dispatch thread never reached wiremock");
+}
+
+/// #1201 — bind a fresh `127.0.0.1:0` `TcpListener` for use with
+/// `MockServer::builder().listener(...)`. Bypasses wiremock's internal
+/// `MOCK_SERVER_POOL` so the ephemeral port the kernel hands us
+/// cannot be reassigned for the duration of the test. Retries on
+/// transient EADDRINUSE.
+fn fresh_mock_listener_1201() -> std::net::TcpListener {
+    let mut last_err = None;
+    for _ in 0..5 {
+        match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => return l,
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+    panic!("#1201: failed to bind ephemeral port for mock after 5 attempts: {last_err:?}");
 }
 
 /// Independent reference implementation of the K7 canonical signature

--- a/tests/postgres_subscription_dispatch.rs
+++ b/tests/postgres_subscription_dispatch.rs
@@ -41,6 +41,25 @@ use tokio::sync::{Mutex, RwLock};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// #1201 — bind a fresh `127.0.0.1:0` `TcpListener` for use with
+/// `MockServer::builder().listener(...)`. Bypasses wiremock's internal
+/// `MOCK_SERVER_POOL` so the ephemeral port the kernel hands us
+/// cannot be reassigned for the duration of the test. Retries on
+/// transient EADDRINUSE.
+fn fresh_mock_listener_1201() -> std::net::TcpListener {
+    let mut last_err = None;
+    for _ in 0..5 {
+        match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => return l,
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+    panic!("#1201: failed to bind ephemeral port for mock after 5 attempts: {last_err:?}");
+}
+
 /// Local SHA-256 helper — the `ai_memory::subscriptions::sha256_hex`
 /// helper is `pub(crate)` so it isn't reachable from the integration
 /// test crate. Re-implement the byte-for-byte equivalent here using
@@ -201,9 +220,15 @@ async fn dispatch_event_postgres_fires_hmac_signed_post() {
     // sink URL outright.
     ai_memory::config::set_allow_loopback_webhooks(true);
 
-    let server = MockServer::start().await;
+    // #1201 — dedicated listener + UUID path keeps this mock out of
+    // wiremock's pool and shields it from straggler POSTs from
+    // sibling tests in the same binary.
+    let listener = fresh_mock_listener_1201();
+    let server = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/sink/{unique}");
     Mock::given(method("POST"))
-        .and(path("/sink"))
+        .and(path(path_str.clone()))
         .respond_with(AckEcho)
         .mount(&server)
         .await;
@@ -215,7 +240,7 @@ async fn dispatch_event_postgres_fires_hmac_signed_post() {
     // postgres branch persists at subscribe time — SHA-256 of the
     // plaintext, mirroring the sqlite path's `secret_hash` column.
     let sub_secret_hash = sha256_hex_local("track-d-test-secret");
-    let url = format!("{}/sink", server.uri());
+    let url = format!("{}{}", server.uri(), path_str);
     let sub_mem = make_subscription_memory(
         "track-d-sub-1",
         "probe",
@@ -242,11 +267,11 @@ async fn dispatch_event_postgres_fires_hmac_signed_post() {
     )
     .await;
 
-    // Poll until the wiremock observes the dispatched POST.
+    // Poll until the wiremock observes the dispatched POST on OUR
+    // per-test path (#1201).
     for _ in 0..50 {
         let received = server.received_requests().await.unwrap_or_default();
-        if !received.is_empty() {
-            let req = &received[0];
+        if let Some(req) = received.iter().find(|r| r.url.path() == path_str) {
             let sig = req
                 .headers
                 .get("x-ai-memory-signature")
@@ -272,9 +297,13 @@ async fn dispatch_event_postgres_fires_hmac_signed_post() {
 /// sqlite and postgres paths.
 #[tokio::test(flavor = "multi_thread")]
 async fn dispatch_event_postgres_respects_namespace_filter() {
-    let server = MockServer::start().await;
+    // #1201 — dedicated listener + UUID path.
+    let listener = fresh_mock_listener_1201();
+    let server = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/sink/{unique}");
     Mock::given(method("POST"))
-        .and(path("/sink"))
+        .and(path(path_str.clone()))
         .respond_with(ResponseTemplate::new(200))
         .expect(0)
         .mount(&server)
@@ -282,7 +311,7 @@ async fn dispatch_event_postgres_respects_namespace_filter() {
 
     let (state, _audit_path) = make_test_state();
 
-    let url = format!("{}/sink", server.uri());
+    let url = format!("{}{}", server.uri(), path_str);
     let sub_mem = make_subscription_memory(
         "ns-mismatch-sub",
         "probe",
@@ -307,7 +336,14 @@ async fn dispatch_event_postgres_respects_namespace_filter() {
 
     // Wait briefly to confirm no dispatch fires.
     tokio::time::sleep(Duration::from_millis(300)).await;
-    let received = server.received_requests().await.unwrap_or_default();
+    // #1201 — filter to OUR per-test path to be straggler-resilient.
+    let received: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| r.url.path() == path_str)
+        .collect();
     assert!(
         received.is_empty(),
         "namespace-filtered subscription must NOT receive an event \

--- a/tests/webhook_coverage.rs
+++ b/tests/webhook_coverage.rs
@@ -95,12 +95,74 @@ fn subscribe_event_types(
     .expect("insert subscription")
 }
 
+/// Build a fresh `MockServer` bound to a dedicated, unique-path-anchored
+/// listener. Returns the server, the unique path component, and the
+/// full mock URL the test should hand to `subscribe_*`.
+///
+/// #1201 — under full-suite parallel-binary load, wiremock pools
+/// `BareMockServer` instances and the OS may reassign the same port
+/// across pool churn. `subscriptions::dispatch_event_with_details`
+/// spawns the HTTP POST on a detached `std::thread::spawn` (see
+/// `src/subscriptions.rs:738`), so a straggler POST from a prior test
+/// in the same binary can land on a recycled mock after port-reuse
+/// aligns. Two layers of isolation here:
+///   1. Bind a fresh `127.0.0.1:0` `TcpListener` per test and hand it
+///      to `MockServer::builder().listener(...)`. This bypasses the
+///      `MOCK_SERVER_POOL` (`wiremock-0.6.5/src/mock_server/pool.rs`)
+///      and pins the listener for the test's lifetime — the
+///      ephemeral port the kernel hands us cannot be reassigned until
+///      the listener is dropped.
+///   2. Anchor every dispatch URL on a per-test UUID path
+///      (`/hook/<uuid>`). The `wait_for_event` / `collect_event_bodies`
+///      filters check the request URL against that UUID so even if
+///      port reuse did somehow align, a foreign POST cannot be
+///      mis-counted as a "real" event for this test.
+fn fresh_mock_listener() -> std::net::TcpListener {
+    // bind retries on EADDRINUSE (5 attempts, 50 ms backoff) — under
+    // parallel binary load the ephemeral pool can briefly exhaust;
+    // the loop converts a rare transient into a deterministic bind.
+    let mut last_err = None;
+    for _ in 0..5 {
+        match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => return l,
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+    panic!("#1201: failed to bind ephemeral port for mock after 5 attempts: {last_err:?}");
+}
+
+async fn fresh_mock_with_unique_path() -> (MockServer, String, String) {
+    let listener = fresh_mock_listener();
+    let server = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/hook/{unique}");
+    Mock::given(method("POST"))
+        .and(path(path_str.clone()))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    let url = format!("{}{}", server.uri(), path_str);
+    (server, path_str, url)
+}
+
 /// Wait up to ~5 s for the wiremock server to receive at least one
-/// request matching `event_name` in its JSON body.
-async fn wait_for_event(server: &MockServer, event_name: &str) -> Option<Request> {
+/// request matching `event_name` in its JSON body AND `expected_path`
+/// as its URL path. The path filter rejects straggler POSTs from
+/// concurrent tests that may have landed on a recycled port (#1201).
+async fn wait_for_event(
+    server: &MockServer,
+    event_name: &str,
+    expected_path: &str,
+) -> Option<Request> {
     for _ in 0..50 {
         let received = server.received_requests().await.unwrap_or_default();
         for req in received {
+            if req.url.path() != expected_path {
+                continue;
+            }
             if let Ok(body_str) = std::str::from_utf8(&req.body)
                 && let Ok(val) = serde_json::from_str::<serde_json::Value>(body_str)
                 && val["event"].as_str() == Some(event_name)
@@ -113,13 +175,23 @@ async fn wait_for_event(server: &MockServer, event_name: &str) -> Option<Request
     None
 }
 
-/// Wait until at least `n` requests have landed at the mock, then
-/// return the parsed JSON bodies.
-async fn collect_event_bodies(server: &MockServer, n: usize) -> Vec<serde_json::Value> {
+/// Wait until at least `n` requests matching `expected_path` have
+/// landed at the mock, then return the parsed JSON bodies.
+async fn collect_event_bodies(
+    server: &MockServer,
+    expected_path: &str,
+    n: usize,
+) -> Vec<serde_json::Value> {
     for _ in 0..50 {
-        let received = server.received_requests().await.unwrap_or_default();
-        if received.len() >= n {
-            return received
+        let matching: Vec<_> = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|r| r.url.path() == expected_path)
+            .collect();
+        if matching.len() >= n {
+            return matching
                 .into_iter()
                 .filter_map(|r| {
                     std::str::from_utf8(&r.body)
@@ -130,9 +202,12 @@ async fn collect_event_bodies(server: &MockServer, n: usize) -> Vec<serde_json::
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    let received = server.received_requests().await.unwrap_or_default();
-    received
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
         .into_iter()
+        .filter(|r| r.url.path() == expected_path)
         .filter_map(|r| {
             std::str::from_utf8(&r.body)
                 .ok()
@@ -147,15 +222,9 @@ async fn collect_event_bodies(server: &MockServer, n: usize) -> Vec<serde_json::
 
 #[tokio::test(flavor = "multi_thread")]
 async fn webhook_fires_on_promote() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/hook"))
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&server)
-        .await;
+    let (server, mock_path, url) = fresh_mock_with_unique_path().await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/hook", server.uri());
     let _sub_id = subscribe_all(&db_path, &url);
 
     // Mirror the handle_promote (tier mode) call shape.
@@ -179,7 +248,7 @@ async fn webhook_fires_on_promote() {
         );
     }
 
-    let req = wait_for_event(&server, "memory_promote")
+    let req = wait_for_event(&server, "memory_promote", &mock_path)
         .await
         .expect("memory_promote webhook should reach mock");
 
@@ -203,15 +272,9 @@ async fn webhook_fires_on_promote() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn webhook_fires_on_delete() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/hook"))
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&server)
-        .await;
+    let (server, mock_path, url) = fresh_mock_with_unique_path().await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/hook", server.uri());
     let _sub_id = subscribe_all(&db_path, &url);
 
     let details = serde_json::to_value(DeleteEventDetails {
@@ -232,7 +295,7 @@ async fn webhook_fires_on_delete() {
         );
     }
 
-    let req = wait_for_event(&server, "memory_delete")
+    let req = wait_for_event(&server, "memory_delete", &mock_path)
         .await
         .expect("memory_delete webhook should reach mock");
     let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
@@ -249,15 +312,9 @@ async fn webhook_fires_on_delete() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn webhook_fires_on_link_created() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/hook"))
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&server)
-        .await;
+    let (server, mock_path, url) = fresh_mock_with_unique_path().await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/hook", server.uri());
     let _sub_id = subscribe_all(&db_path, &url);
 
     let details = serde_json::to_value(LinkCreatedEventDetails {
@@ -278,7 +335,7 @@ async fn webhook_fires_on_link_created() {
         );
     }
 
-    let req = wait_for_event(&server, "memory_link_created")
+    let req = wait_for_event(&server, "memory_link_created", &mock_path)
         .await
         .expect("memory_link_created webhook should reach mock");
     let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
@@ -294,15 +351,9 @@ async fn webhook_fires_on_link_created() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn webhook_fires_on_consolidate() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/hook"))
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&server)
-        .await;
+    let (server, mock_path, url) = fresh_mock_with_unique_path().await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/hook", server.uri());
     let _sub_id = subscribe_all(&db_path, &url);
 
     let source_ids = vec![
@@ -328,7 +379,7 @@ async fn webhook_fires_on_consolidate() {
         );
     }
 
-    let req = wait_for_event(&server, "memory_consolidated")
+    let req = wait_for_event(&server, "memory_consolidated", &mock_path)
         .await
         .expect("memory_consolidated webhook should reach mock");
     let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
@@ -352,15 +403,9 @@ async fn webhook_fires_on_consolidate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn subscriber_filtered_to_store_does_not_get_delete() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/hook"))
-        .respond_with(ResponseTemplate::new(200))
-        .mount(&server)
-        .await;
+    let (server, mock_path, url) = fresh_mock_with_unique_path().await;
 
     let (_keep, db_path) = fresh_db();
-    let url = format!("{}/hook", server.uri());
 
     // Opt-in to memory_store ONLY.
     let _sub_id = subscribe_event_types(&db_path, &url, &["memory_store".to_string()]);
@@ -395,14 +440,14 @@ async fn subscriber_filtered_to_store_does_not_get_delete() {
     }
 
     // Wait for the store event to land. The delete must NOT show up.
-    let _ = wait_for_event(&server, "memory_store")
+    let _ = wait_for_event(&server, "memory_store", &mock_path)
         .await
         .expect("store event must reach narrow subscriber");
 
     // Give any delete dispatch a chance to fire (it shouldn't), then
     // check that no delete event landed.
     tokio::time::sleep(Duration::from_millis(500)).await;
-    let bodies = collect_event_bodies(&server, 1).await;
+    let bodies = collect_event_bodies(&server, &mock_path, 1).await;
     let delete_count = bodies
         .iter()
         .filter(|b| b["event"].as_str() == Some("memory_delete"))

--- a/tests/webhook_http_parity.rs
+++ b/tests/webhook_http_parity.rs
@@ -180,20 +180,28 @@ fn subscribe_all(db_path: &Path, mock_url: &str) -> String {
 }
 
 /// Wait for the mock server to receive a request whose JSON body has
-/// `event == expected_event`. Tolerates cross-test bleed: dispatch
-/// from prior `#[tokio::test]` runs `std::thread::spawn`-detached, so
-/// a slow dispatch from a prior test can land on this test's mock if
-/// port reuse aligns. Filtering by `event` makes each test resilient
-/// to straggler events from siblings.
+/// `event == expected_event` AND whose URL path matches `expected_path`.
+/// Tolerates cross-test bleed: dispatch from prior `#[tokio::test]`
+/// runs `std::thread::spawn`-detached
+/// (`src/subscriptions.rs:738`), so a slow dispatch from a prior test
+/// can land on this test's mock if port reuse aligns under wiremock's
+/// internal `MOCK_SERVER_POOL`
+/// (`wiremock-0.6.5/src/mock_server/pool.rs`). #1201 — the per-test
+/// UUID path + the dedicated listener pin in `fresh_mock` together
+/// ensure stragglers cannot pollute the count.
 async fn wait_for_event(
     mock: &MockServer,
     expected_event: &str,
+    expected_path: &str,
     total: Duration,
 ) -> Option<wiremock::Request> {
     let deadline = std::time::Instant::now() + total;
     loop {
         let received = mock.received_requests().await.unwrap_or_default();
         for req in &received {
+            if req.url.path() != expected_path {
+                continue;
+            }
             if let Ok(body) = serde_json::from_slice::<Value>(&req.body)
                 && body["event"].as_str() == Some(expected_event)
             {
@@ -207,16 +215,39 @@ async fn wait_for_event(
     }
 }
 
-/// Stand up a wiremock that always returns 200 OK on POST `/hook`.
-async fn fresh_mock() -> (MockServer, String) {
-    let mock = MockServer::start().await;
+/// Stand up a wiremock that always returns 200 OK on POST `/hook/<uuid>`.
+///
+/// #1201 — every test gets a dedicated `TcpListener` (bypassing the
+/// `MOCK_SERVER_POOL`) AND a unique per-test path. Both layers
+/// independently prevent the cross-test bleed surfaced under
+/// full-suite parallel-binary load.
+fn fresh_mock_listener() -> std::net::TcpListener {
+    // bind retries on EADDRINUSE (5 attempts, 50 ms backoff).
+    let mut last_err = None;
+    for _ in 0..5 {
+        match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => return l,
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+    panic!("#1201: failed to bind ephemeral port for mock after 5 attempts: {last_err:?}");
+}
+
+async fn fresh_mock() -> (MockServer, String, String) {
+    let listener = fresh_mock_listener();
+    let mock = MockServer::builder().listener(listener).start().await;
+    let unique = uuid::Uuid::new_v4().simple().to_string();
+    let path_str = format!("/hook/{unique}");
     Mock::given(method("POST"))
-        .and(path("/hook"))
+        .and(path(path_str.clone()))
         .respond_with(ResponseTemplate::new(200))
         .mount(&mock)
         .await;
-    let url = format!("{}/hook", mock.uri());
-    (mock, url)
+    let url = format!("{}{}", mock.uri(), path_str);
+    (mock, path_str, url)
 }
 
 /// Insert a memory directly via the DB layer (skipping the HTTP create
@@ -243,7 +274,7 @@ fn seed_memory(db_path: &Path, title: &str, namespace: &str) -> String {
 #[tokio::test]
 async fn webhook_fires_on_http_delete() {
     let harness = HttpHarness::new();
-    let (mock, hook_url) = fresh_mock().await;
+    let (mock, mock_path, hook_url) = fresh_mock().await;
     let _sub_id = subscribe_all(&harness.db_path, &hook_url);
 
     let mem_id = seed_memory(&harness.db_path, "delete-target", "v064-017");
@@ -255,7 +286,7 @@ async fn webhook_fires_on_http_delete() {
     // Windows CI is consistently slower than Linux/macOS on the
     // std::thread::spawn dispatch + Connection::open cycle. 5s gives
     // enough headroom on every supported platform.
-    let req = wait_for_event(&mock, "memory_delete", Duration::from_secs(5))
+    let req = wait_for_event(&mock, "memory_delete", &mock_path, Duration::from_secs(5))
         .await
         .expect("memory_delete webhook must fire on HTTP DELETE within 2s");
 
@@ -276,7 +307,7 @@ async fn webhook_fires_on_http_delete() {
 #[tokio::test]
 async fn webhook_fires_on_http_promote() {
     let harness = HttpHarness::new();
-    let (mock, hook_url) = fresh_mock().await;
+    let (mock, mock_path, hook_url) = fresh_mock().await;
     subscribe_all(&harness.db_path, &hook_url);
 
     let mem_id = seed_memory(&harness.db_path, "promote-target", "v064-017");
@@ -285,7 +316,7 @@ async fn webhook_fires_on_http_promote() {
         .await;
     assert_eq!(status, StatusCode::OK, "promote should succeed");
 
-    let req = wait_for_event(&mock, "memory_promote", Duration::from_secs(5))
+    let req = wait_for_event(&mock, "memory_promote", &mock_path, Duration::from_secs(5))
         .await
         .expect("memory_promote webhook must fire on HTTP promote within 2s");
 
@@ -301,7 +332,7 @@ async fn webhook_fires_on_http_promote() {
 #[tokio::test]
 async fn webhook_fires_on_http_link_created() {
     let harness = HttpHarness::new();
-    let (mock, hook_url) = fresh_mock().await;
+    let (mock, mock_path, hook_url) = fresh_mock().await;
     subscribe_all(&harness.db_path, &hook_url);
 
     let src_id = seed_memory(&harness.db_path, "link-source", "v064-017");
@@ -318,9 +349,14 @@ async fn webhook_fires_on_http_link_created() {
         .await;
     assert_eq!(status, StatusCode::CREATED, "link should be created");
 
-    let req = wait_for_event(&mock, "memory_link_created", Duration::from_secs(5))
-        .await
-        .expect("memory_link_created webhook must fire on HTTP link within 2s");
+    let req = wait_for_event(
+        &mock,
+        "memory_link_created",
+        &mock_path,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("memory_link_created webhook must fire on HTTP link within 2s");
 
     let body: Value = serde_json::from_slice(&req.body).unwrap();
     assert_eq!(body["event"], "memory_link_created");
@@ -334,7 +370,7 @@ async fn webhook_fires_on_http_link_created() {
 #[tokio::test]
 async fn webhook_fires_on_http_consolidate() {
     let harness = HttpHarness::new();
-    let (mock, hook_url) = fresh_mock().await;
+    let (mock, mock_path, hook_url) = fresh_mock().await;
     subscribe_all(&harness.db_path, &hook_url);
 
     let src_a = seed_memory(&harness.db_path, "consolidate-a", "v064-017");
@@ -360,9 +396,14 @@ async fn webhook_fires_on_http_consolidate() {
         .expect("response carries new id")
         .to_string();
 
-    let req = wait_for_event(&mock, "memory_consolidated", Duration::from_secs(5))
-        .await
-        .expect("memory_consolidated webhook must fire on HTTP consolidate within 2s");
+    let req = wait_for_event(
+        &mock,
+        "memory_consolidated",
+        &mock_path,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("memory_consolidated webhook must fire on HTTP consolidate within 2s");
 
     let body: Value = serde_json::from_slice(&req.body).unwrap();
     assert_eq!(body["event"], "memory_consolidated");


### PR DESCRIPTION
## Summary

- Closes #1201 — webhook test mock-HTTP port-collision flake under parallel-binary load.
- Roots out the actual mechanism: `wiremock 0.6` pools `BareMockServer` instances; under parallel load the OS reassigns ephemeral ports between tests; detached `std::thread::spawn` dispatch threads (`src/subscriptions.rs:738`) land straggler POSTs on recycled mocks, corrupting sibling tests' request counts.
- Two layers of defense per webhook test:
  1. Bind a dedicated `127.0.0.1:0` `TcpListener` and hand it to `MockServer::builder().listener(...)` — bypasses the `MOCK_SERVER_POOL` so the kernel cannot recycle the port until the listener drops.
  2. Anchor every dispatch URL on a per-test UUID path (`/hook/<uuid>`); helpers filter `received_requests()` by that path so foreign POSTs cannot be mis-counted.
- Adds bind-retry on EADDRINUSE (5 attempts, 50ms backoff) for defense-in-depth.
- Adds 4 regression tests in `tests/issue_1201_webhook_port_collision.rs` pinning the ephemeral-port allocation primitives the fix depends on.

## Files touched

- `tests/webhook_coverage.rs` — 5 webhook lifecycle tests rewired through `fresh_mock_with_unique_path()`; helpers filter by path.
- `tests/webhook_http_parity.rs` — 4 HTTP-parity webhook tests rewired; helper `fresh_mock()` now returns `(server, path, url)` tuple.
- `tests/k7_hmac.rs` — 2 HMAC-signing tests rewired with dedicated listener + UUID path; `poll_for_first_request` filters by path.
- `tests/postgres_subscription_dispatch.rs` — 2 postgres-dispatch tests rewired; `received_requests()` filtered by path.
- `tests/issue_1201_webhook_port_collision.rs` — NEW. Four regression tests covering: ephemeral bind uniqueness, MockServer listener-bypass invariant, sequential pool-bypass non-overlap, concurrent (32 tasks) pool-bypass non-overlap.

## Test plan

- [x] `cargo fmt --check` — green
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — green
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test webhook_coverage --test webhook_http_parity --test k7_hmac --test postgres_subscription_dispatch --test issue_1201_webhook_port_collision` — all pass
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test postgres_subscription_dispatch --features sal` — 3/3 pass
- [x] `cargo audit` — clean (529 deps scanned, 0 advisories)
- [x] Five+ consecutive `AI_MEMORY_NO_CONFIG=1 cargo test --tests` runs (closure gate per pm-v3.2 NO FAIL MISSION standard) — see `.local-runs/issue-1201/five-runs.log`

## AI involvement

This PR was authored by Claude Opus 4.7 (1M context) per the pm-v3 prime directive (memory `cd8ede94-3376-4837-b570-9d975290ae08`). Base SHA pinned: `9bc0d325313bdeee39f321c53c7acc1d48c40a69` (current `release/v0.7.0` head post-#1202 merge).

Per the worktree-discipline section of CLAUDE.md (§"Multi-agent worktree discipline"), commit message carries the `Base:` trailer for cherry-pick / merge audit.