### PR TITLE
fix(#1213): scope memories.embedding atttypmod probes to public schema

### DIFF
--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -755,10 +755,19 @@ impl PostgresStore {
         // log a WARN here so the operator notices before writes start
         // failing on a dim-mismatch insert. (#304 nit; v0.7.0 L3 made
         // the comparand parameterisable.)
+        // #1213 — scope to `public.memories` so an Apache AGE install
+        // that has landed its own `ag_catalog.memories` (e.g. via a
+        // per-IronClaw `search_path=ic_<name>,ag_catalog,public` that
+        // bootstrapped the ai-memory schema into `ag_catalog` because
+        // the IC schema was empty at boot) does not mask the real
+        // public-schema column dim with the unrelated ag_catalog one.
         let typmod: Option<(i32,)> = sqlx::query_as(
-            "SELECT atttypmod FROM pg_attribute a
+            "SELECT a.atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = 'public'
+               AND c.relname = 'memories'
+               AND a.attname = 'embedding'",
         )
         .fetch_optional(&pool)
         .await
@@ -2690,10 +2699,23 @@ impl PostgresStore {
     /// Returns `StoreError::BackendUnavailable` if the catalog probe
     /// fails (connection issue, etc.).
     pub async fn current_embedding_dim(&self) -> StoreResult<Option<i32>> {
+        // #1213 — scope to `public.memories` (see the bootstrap-WARN
+        // site at ~L759 for the full rationale). Apache AGE installs
+        // create an `ag_catalog.memories` table whose `embedding` column
+        // is unrelated to the ai-memory write surface; without the
+        // namespace filter `fetch_optional` returns whichever row
+        // postgres surfaces first (oid-ordered → ag_catalog wins on a
+        // fresh AGE-installed DB), and the issue-#877 auto-migrate
+        // gate at `connect_with_dim_and_timeout_auto_migrate` reads the
+        // wrong dim → silently no-ops (or runs destructively against
+        // the wrong column).
         let row: Option<(i32,)> = sqlx::query_as(
-            "SELECT atttypmod FROM pg_attribute a
+            "SELECT a.atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = 'public'
+               AND c.relname = 'memories'
+               AND a.attname = 'embedding'",
         )
         .fetch_optional(&self.pool)
         .await
@@ -3117,10 +3139,15 @@ impl PostgresStore {
         // exists with whatever dim the operator chose at connect time.
         // Falls back to DEFAULT_EMBEDDING_DIM if the probe comes back
         // empty (defensive — should never happen in practice).
+        // #1213 — scope to `public.memories` (see `current_embedding_dim`
+        // for the full rationale on the AGE / ag_catalog masking risk).
         let existing_dim: Option<(i32,)> = sqlx::query_as(
-            "SELECT atttypmod FROM pg_attribute a
+            "SELECT a.atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = 'public'
+               AND c.relname = 'memories'
+               AND a.attname = 'embedding'",
         )
         .fetch_optional(&mut *tx)
         .await

--- a/tests/embedding_dim_migration.rs
+++ b/tests/embedding_dim_migration.rs
@@ -103,10 +103,21 @@ async fn inspection_pool(url: &str) -> PgPool {
 }
 
 async fn current_dim(pool: &PgPool) -> Option<i32> {
+    // #1213 — scope to `public.memories`. When Apache AGE is installed
+    // on the same DB, `ag_catalog.memories` exists with its own
+    // `embedding vector(N)` column (landed at a different dim by some
+    // earlier IronClaw bootstrap that ran with
+    // `search_path=ic_<name>,ag_catalog,public`). The unscoped query
+    // surfaces whichever row postgres returns first (oid-ordered →
+    // ag_catalog wins on a fresh AGE-installed DB), masking the public-
+    // schema dim with the unrelated ag_catalog one.
     sqlx::query_scalar::<_, i32>(
-        "SELECT atttypmod FROM pg_attribute a
+        "SELECT a.atttypmod FROM pg_attribute a
          JOIN pg_class c ON c.oid = a.attrelid
-         WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relname = 'memories'
+           AND a.attname = 'embedding'",
     )
     .fetch_optional(pool)
     .await
@@ -262,4 +273,71 @@ async fn http_write_path_accepts_768_after_auto_migrate() {
         row.is_some(),
         "issue-877 row must persist through the postgres write path post-auto-migrate"
     );
+}
+
+/// #1213 regression: `current_embedding_dim()` must scope to
+/// `public.memories` so an unrelated `ag_catalog.memories` left behind
+/// by Apache AGE / per-IronClaw search-path bootstraps cannot mask the
+/// real public-schema dim with its own.
+///
+/// Mechanic: simulate the LAN-parity bootstrap state by installing a
+/// fake `ag_catalog.memories` at `vector(768)` alongside the
+/// `public.memories` at `vector(384)` the test bootstraps via
+/// `connect_with_dim`. Assert `current_embedding_dim()` returns 384
+/// (the public dim), not 768 (the `ag_catalog` dim).
+#[tokio::test]
+async fn current_embedding_dim_scopes_to_public_schema_1213() {
+    let Some(url) = postgres_url() else {
+        eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+        return;
+    };
+    let _guard = SUITE_LOCK.lock().await;
+
+    let inspect = inspection_pool(&url).await;
+    reset_schema(&inspect).await;
+
+    // Drop any prior fake ag_catalog table from a previous run (the
+    // test reset_schema helper above doesn't touch ag_catalog by design
+    // — production code must not depend on ag_catalog state).
+    let _ = sqlx::query("DROP TABLE IF EXISTS ag_catalog.memories")
+        .execute(&inspect)
+        .await;
+
+    // Bootstrap public.memories at vector(384) (the bug-trigger dim).
+    let store = PostgresStore::connect_with_dim(&url, 384)
+        .await
+        .expect("public bootstrap at dim=384");
+
+    // Install a fake ag_catalog.memories at vector(768) to simulate the
+    // AGE/search-path bootstrap that put ai-memory tables in ag_catalog
+    // because the per-IC schema was empty at boot.
+    sqlx::query(
+        "CREATE TABLE ag_catalog.memories (
+            id TEXT PRIMARY KEY,
+            embedding vector(768)
+         )",
+    )
+    .execute(&inspect)
+    .await
+    .expect("install fake ag_catalog.memories at vector(768)");
+
+    // The probe must now return 384 (public), not 768 (ag_catalog).
+    // Pre-fix this returned Some(768); post-fix it returns Some(384).
+    let dim = store
+        .current_embedding_dim()
+        .await
+        .expect("current_embedding_dim probe must succeed");
+    assert_eq!(
+        dim,
+        Some(384),
+        "#1213: current_embedding_dim must scope to public.memories \
+         (read back {dim:?}; expected Some(384) — ag_catalog.memories at \
+         vector(768) must NOT mask the real column)"
+    );
+
+    // Cleanup so a subsequent test in the same suite doesn't trip on
+    // the leftover fake table.
+    let _ = sqlx::query("DROP TABLE IF EXISTS ag_catalog.memories")
+        .execute(&inspect)
+        .await;
 }


### PR DESCRIPTION
## Summary

- Three production-code sites in `src/store/postgres.rs` probed `pg_attribute` for `relname='memories'` without scoping by `pg_namespace.nspname='public'`. When Apache AGE is installed and an unrelated `ag_catalog.memories` exists (LAN-parity stack scenario), the unscoped probe returns the wrong dim — silently no-op'ing the issue-#877 auto-migrate gate.
- Adds the namespace JOIN to all four sites (3 production + 1 test helper) and pins the fix with a new regression test that installs a fake `ag_catalog.memories` at vector(768) alongside `public.memories` at vector(384) and asserts `current_embedding_dim()` returns 384.

Surfaced during the #1182 NO FAIL MISSION A2A Docker + Postgres + Apache AGE full regression on the LAN-parity stack.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` (sqlite-only path)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` (4760/4760 green)
- [x] `AI_MEMORY_TEST_POSTGRES_URL=... cargo test --features sal-postgres --test embedding_dim_migration` (8/8 green incl. new regression)
- [x] `cargo audit` clean

## Closes

Fixes #1213.

## Filed by

Claude Opus 4.7 per #1182 NO FAIL MISSION execution, 2026-05-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)