### PR TITLE
docs(pages, #1216): schema-version drift v49 -> v50

### DIFF
--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -130,7 +130,7 @@
     <!-- DB -->
     <text x="220" y="355" text-anchor="middle" class="title">SQLite + FTS5</text>
     <text x="220" y="372" text-anchor="middle" class="subtitle">WAL mode · 3 tables</text>
-    <text x="220" y="398" text-anchor="middle" class="subtitle">storage/ · schema v49</text>
+    <text x="220" y="398" text-anchor="middle" class="subtitle">storage/ · schema v50</text>
 
     <!-- Divider -->
     <line x1="330" y1="340" x2="330" y2="400" class="line" style="opacity:0.3"/>

--- a/docs/audience/operator.html
+++ b/docs/audience/operator.html
@@ -245,7 +245,7 @@ WantedBy=multi-user.target</code></pre>
 <section class="wrap-mid">
   <div class="eyebrow-h2">7. Upgrade</div>
   <h2>Schema-versioned, migration-tested.</h2>
-  <p>The SQLite store carries an integer schema version (<strong>currently v49 at v0.7.0</strong>; was v33 at v0.6.4). Migrations run on first open of the new binary; the migration set is dry-run-tested against the operator's own DB by the project's dogfood script before a release ships.</p>
+  <p>The SQLite store carries an integer schema version (<strong>currently v50 at v0.7.0</strong>; was v33 at v0.6.4). v50 extended <code>agent_quotas</code> PRIMARY KEY from <code>(agent_id)</code> to <code>(agent_id, namespace)</code> per #1156 so per-namespace K8 quota allotments hold even when a single agent operates across many namespaces (pre-v50 rows backfill to the <code>_global</code> sentinel namespace). Migrations run on first open of the new binary; the migration set is dry-run-tested against the operator's own DB by the project's dogfood script before a release ships.</p>
   <ul>
     <li>Backup the DB before upgrade: <code>cp ai-memory.db ai-memory.db.bak</code>.</li>
     <li>Stop the daemon, install the new binary, restart. Migrations run automatically.</li>

--- a/docs/whats-new-v07.html
+++ b/docs/whats-new-v07.html
@@ -129,7 +129,7 @@ footer a:hover{color:var(--accent)}
     </p>
     <div class="meta">
       <span>capabilities v2 &rarr; v3</span>
-      <span>schema v33 &rarr; v49</span>
+      <span>schema v33 &rarr; v50</span>
       <span>25 hook events</span>
       <span>Ed25519 attestation</span>
     </div>
@@ -256,7 +256,7 @@ ai-memory identity generate --agent-id ai:claude-code@$(hostname)</pre>
         <h3>Programmable hooks. Real attestation. New loaders. Tighter token budget.</h3>
         <ul class="checked">
           <li><strong>Hook pipeline:</strong> 25 lifecycle events (<code>pre_store</code>, <code>post_store</code>, <code>pre_recall</code>, <code>post_recall</code>, &hellip;), subprocess + daemon-mode IPC, <code>Allow</code>/<code>Modify</code>/<code>Deny</code>/<code>AskUser</code> decision contract, chain ordering with <strong>first-deny-wins</strong> short-circuit. Hot-path events default to daemon mode to preserve the v0.6.3 50ms recall budget.</li>
-          <li><strong>Ed25519 attestation:</strong> per-agent keypair (<code>ai-memory identity generate</code>), outbound link signing, inbound verification against <code>observed_by</code>, <code>signed_events</code> append-only audit table with V-4 cross-row hash chain (schema v34, part of the v33 &rarr; v49 migration ladder).</li>
+          <li><strong>Ed25519 attestation:</strong> per-agent keypair (<code>ai-memory identity generate</code>), outbound link signing, inbound verification against <code>observed_by</code>, <code>signed_events</code> append-only audit table with V-4 cross-row hash chain (schema v34, part of the v33 &rarr; v50 migration ladder).</li>
           <li><strong>Sidechain transcripts:</strong> zstd-3 compressed BLOBs in <code>memory_transcripts</code>, joined to memories via <code>memory_transcript_links</code>, per-namespace TTL with archive&rarr;prune lifecycle, <code>memory_replay(memory_id)</code> reconstructs the chain.</li>
           <li><strong>Apache AGE:</strong> opt-in property graph backend (Postgres only); auto-detected via <code>pg_extension</code>. SQLite installs fall back to recursive CTE. Cypher implementations of <code>memory_kg_query</code>, <code>memory_kg_timeline</code>, <code>memory_kg_invalidate</code> &mdash; and the new <code>memory_find_paths(source, target, max_depth=5)</code> tool (recovers commitment R2).</li>
           <li><strong>New permission system:</strong> replaces v0.6.x advisory governance. Rules + modes (<code>enforce</code>/<code>advisory</code>/<code>off</code>) + hooks &rarr; <code>Decision</code>; deny-first semantics. Migration tool: <code>ai-memory governance migrate-to-permissions</code> (idempotent, dry-run by default).</li>
@@ -334,7 +334,7 @@ ai-memory identity generate --agent-id ai:claude-code@$(hostname)</pre>
       <div class="card violet">
         <span class="tag">Track H &middot; Ed25519 attestation</span>
         <h3>The dead column gets filled</h3>
-        <p>The <code>signature</code> column shipped in v0.6.3 finally carries real Ed25519 signatures. Per-agent keypairs at <code>~/.config/ai-memory/keys/&lt;agent_id&gt;.{pub,priv}</code> (mode 0600 / 0644). Outbound link writes sign canonical-CBOR-encoded link content. <code>attest_level</code> enum: <code>unsigned</code> / <code>self_signed</code> / <code>peer_attested</code>. Append-only <code>signed_events</code> audit table with V-4 cross-row hash chain (<code>prev_hash</code> + <code>sequence</code>) landed at schema v34 as part of the v33 &rarr; v49 migration ladder.</p>
+        <p>The <code>signature</code> column shipped in v0.6.3 finally carries real Ed25519 signatures. Per-agent keypairs at <code>~/.config/ai-memory/keys/&lt;agent_id&gt;.{pub,priv}</code> (mode 0600 / 0644). Outbound link writes sign canonical-CBOR-encoded link content. <code>attest_level</code> enum: <code>unsigned</code> / <code>self_signed</code> / <code>peer_attested</code>. Append-only <code>signed_events</code> audit table with V-4 cross-row hash chain (<code>prev_hash</code> + <code>sequence</code>) landed at schema v34 as part of the v33 &rarr; v50 migration ladder.</p>
         <p><a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/v0.7/rfc-attested-cortex.md">RFC &sect;Why Ed25519 over X25519+ChaCha20 &rarr;</a></p>
       </div>
 
@@ -419,7 +419,7 @@ ai-memory identity generate --agent-id ai:claude-code@$(hostname)</pre>
         <tr><td>Pre-computed capabilities calibration</td><td>n/a (v2)</td><td>✅ v3 default (<code>summary</code>, <code>to_describe_to_user</code>)</td></tr>
         <tr><td>Named loader tools</td><td>via <code>memory_capabilities --include-schema</code></td><td>✅ <code>memory_load_family</code>, <code>memory_smart_load(intent)</code></td></tr>
         <tr><td>Per-agent capability allowlist</td><td>✅ phase 1 (<code>[mcp.allowlist]</code>)</td><td>✅ + <code>callable_now</code> + <code>agent_permitted_families</code></td></tr>
-        <tr><td>Capability-expansion audit log</td><td>✅ v0.6.3 baseline (<code>audit_log</code>)</td><td>✅ + <code>signed_events</code> append-only chain with V-4 cross-row hash chain (schema v34, part of v33 &rarr; v49 migration ladder)</td></tr>
+        <tr><td>Capability-expansion audit log</td><td>✅ v0.6.3 baseline (<code>audit_log</code>)</td><td>✅ + <code>signed_events</code> append-only chain with V-4 cross-row hash chain (schema v34, part of v33 &rarr; v50 migration ladder)</td></tr>
         <tr><td>Ed25519 link signing</td><td>❌ dead column</td><td>✅ filled (per-agent keypair, canonical-CBOR signing)</td></tr>
         <tr><td>Inbound signature verification</td><td>❌</td><td>✅ verified against <code>observed_by</code> claim</td></tr>
         <tr><td>Programmable lifecycle hooks</td><td>❌ (subscriptions only)</td><td>✅ 25 events, exec + daemon modes, decision contract</td></tr>


### PR DESCRIPTION
## Summary

Lane 6 NO FAIL MISSION (#1198) drift fix — five GitHub Pages docs cited \`schema v49\` / \`v33 → v49\` after #1156 bumped \`CURRENT_SCHEMA_VERSION\` to 50.

## Drift surface (verified against \`release/v0.7.0 @ 1cb95bbe7\`)

- \`src/storage/migrations.rs:CURRENT_SCHEMA_VERSION = 50\`
- \`src/store/postgres.rs:CURRENT_SCHEMA_VERSION = 50\`

## Files fixed

- \`docs/audience/operator.html:248\` — v49 → v50 + #1156 explainer
- \`docs/whats-new-v07.html\` lines 132, 259, 337, 422 — \`v33 → v49\` → \`v33 → v50\`
- \`docs/architecture.svg:133\` — \`storage/ · schema v49\` → \`storage/ · schema v50\`

## Test plan

- [x] Static HTML / SVG (no Jekyll build step — Pages source = \`main\` branch, \`/docs\` path per \`gh api repos/.../pages\`)
- [x] All five drift sites confirmed updated
- [x] No other v49 schema refs in \`docs/\* .html\` per \`grep -r "v49" docs/\`

Closes #1216 (drift remediation issue spawned under Lane 6 #1198).

## AI involvement

Generated end-to-end by Claude Opus 4.7 (1M context) per operator pre-approved Lane 6 autonomous-execution scope (memory \`f970d6f6-...\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)