### PR TITLE
fix(infra, #1231): entrypoint.plan-c.sh no longer overrides AI_MEMORY_AGENT_ID=daemon

### DIFF
--- a/entrypoint.plan-c.sh
+++ b/entrypoint.plan-c.sh
@@ -139,7 +139,25 @@ echo "  tls_flags='$TLS_FLAGS'"
 echo "  quorum_flags='$QUORUM_FLAGS'"
 
 unset AI_MEMORY_DB
-export AI_MEMORY_AGENT_ID=daemon
+# #1231 (2026-05-25) — DO NOT override AI_MEMORY_AGENT_ID to the
+# reserved sentinel `daemon`. The wire-side validator
+# `validate::validate_agent_id` (src/validate.rs:366) was hardened by
+# #977 (commit d81df2d7c) to reject every member of
+# `RESERVED_AGENT_IDS` (which includes `daemon`) when supplied via env
+# var or wire callers. Setting AI_MEMORY_AGENT_ID=daemon here causes
+# `identity::resolve_agent_id` (src/identity/mod.rs:153) to bail with
+# `agent_id 'daemon' is reserved for internal use and cannot be
+# supplied by wire callers`, crashlooping the daemon container.
+#
+# The daemon's self-signing keypair is loaded by the LITERAL label
+# `DAEMON_KEYPAIR_LABEL = "daemon"` via
+# `crate::identity::keypair::load("daemon", &dir)`
+# (src/daemon_runtime.rs:1937, src/mcp/mod.rs:2038) — that path does
+# NOT read AI_MEMORY_AGENT_ID and stays correct regardless of the
+# daemon process's resolved agent_id. The operator-supplied
+# AI_MEMORY_AGENT_ID (e.g. `ai:ic-parity-alice@lan-parity` set by
+# docker-compose) flows through unchanged and is honoured by
+# `resolve_agent_id` step 2.
 export RUST_LOG="${RUST_LOG:-ai_memory=info}"
 
 exec /usr/local/bin/ai-memory serve \

--- a/tests/entrypoint_does_not_override_agent_id_1231.rs
+++ b/tests/entrypoint_does_not_override_agent_id_1231.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression pin for issue #1231: `entrypoint.plan-c.sh` must NOT
+// `export AI_MEMORY_AGENT_ID=daemon` before exec'ing `ai-memory serve`.
+//
+// Why this pins:
+//
+// The wire-side validator `validate::validate_agent_id` (hardened by
+// #977, commit `d81df2d7c`) rejects every member of
+// `RESERVED_AGENT_IDS` (`daemon`, …) when supplied via env var or
+// wire callers. The daemon's `serve` boot path takes the
+// `AI_MEMORY_AGENT_ID` env-var branch (`identity::resolve_agent_id`
+// step 2, `src/identity/mod.rs:153`) and bails with
+//
+//     Error: agent_id 'daemon' is reserved for internal use and
+//     cannot be supplied by wire callers
+//
+// which crashloops the Docker container. The daemon's own
+// self-signing keypair is loaded by the LITERAL label
+// `DAEMON_KEYPAIR_LABEL = "daemon"` via
+// `crate::identity::keypair::load("daemon", &dir)` — that path does
+// NOT read `AI_MEMORY_AGENT_ID`, so removing the env-var override is
+// safe. The fix is a 1-line delete in `entrypoint.plan-c.sh`; this
+// test fails if any future change re-introduces the override.
+//
+// Companion test `validate_agent_id_rejects_daemon_reserved_1231`
+// pins the inverse contract: `validate_agent_id("daemon")` must
+// bail. If a future refactor weakens the reserved-id gate without
+// also removing the entrypoint comment, the contract drift surfaces
+// here too.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn entrypoint_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("entrypoint.plan-c.sh")
+}
+
+#[test]
+fn entrypoint_does_not_export_agent_id_daemon_1231() {
+    let path = entrypoint_path();
+    let contents =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    // The fix removes the unconditional `export AI_MEMORY_AGENT_ID=daemon`
+    // line. The contract is: no live (non-comment) line in the
+    // entrypoint may set the env var to the reserved sentinel.
+    for (lineno, raw) in contents.lines().enumerate() {
+        let line = raw.trim_start();
+        // Skip comment-only lines so the explanatory # comment that
+        // documents the gone-forever override stays legal.
+        if line.starts_with('#') {
+            continue;
+        }
+        assert!(
+            !line.contains("AI_MEMORY_AGENT_ID=daemon"),
+            "issue #1231 regression: entrypoint.plan-c.sh line {} sets \
+             AI_MEMORY_AGENT_ID to the reserved sentinel `daemon`. \
+             The wire validator (#977) rejects it and the daemon \
+             container crashloops with `agent_id 'daemon' is reserved \
+             for internal use and cannot be supplied by wire callers`. \
+             Offending line: {raw:?}",
+            lineno + 1
+        );
+    }
+}
+
+#[test]
+fn validate_agent_id_rejects_daemon_reserved_1231() {
+    // Pin the inverse contract — if a future refactor weakens the
+    // reserved-id gate, the entrypoint fix becomes moot AND this
+    // test fails, surfacing the drift before re-shipping.
+    let err = ai_memory::validate::validate_agent_id("daemon")
+        .expect_err("validate_agent_id must reject the reserved sentinel `daemon`");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("reserved for internal use"),
+        "issue #1231 regression: expected reject-reserved-id error, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

- Removes the unconditional `export AI_MEMORY_AGENT_ID=daemon` from `entrypoint.plan-c.sh:142` which collided with the post-#977 wire-side reserved-id reject and crashlooped every container started from `Dockerfile.plan-c` / `Dockerfile.tier2-trackb`.
- The daemon's self-signing keypair is loaded by the literal label `DAEMON_KEYPAIR_LABEL = "daemon"` (`src/daemon_runtime.rs:1937`) — that path does not read `AI_MEMORY_AGENT_ID` and stays correct.
- Adds two regression tests under `tests/entrypoint_does_not_override_agent_id_1231.rs` that pin (a) the entrypoint has no live line setting the env var to the reserved sentinel and (b) `validate_agent_id("daemon")` still rejects.

Closes #1231.

## Evidence

While executing #1182 NO FAIL MISSION lan-parity stack-up against final v0.7.0 binary (commit `1cb95bbe7`), both `ic-parity-alice` and `ic-parity-bob` crashlooped with:

```
Error: agent_id 'daemon' is reserved for internal use and cannot be supplied by wire callers
```

Logs captured at `.local-runs/1182-final/{alice,bob}-crash.log`.

## Test plan

- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --release --test entrypoint_does_not_override_agent_id_1231` -> 2/2 pass.
- [x] `cargo fmt --check` -> exit 0.
- [x] `cargo clippy --tests --release --features sal-postgres -- -D warnings -D clippy::all -D clippy::pedantic` -> exit 0.
- [x] `cargo build --release --features sal-postgres` -> exit 0.
- [x] `cargo audit` -> exit 0 (529 deps, 0 advisories).
- [ ] Lan-parity stack-up re-driven against the fix; defect chain to #1182 records the green pass.

## AI involvement

Filed and fixed by Claude Opus 4.7 per pm-v3 testing-loop discipline while executing the #1182 NO FAIL MISSION (operator-approved 100% autonomous execution).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>