### PR TITLE
fix(identity, #1234): use shape-only validator at internal-bootstrap sites for reserved-sentinel agent_ids

### DIFF
--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -24,6 +24,7 @@ use ed25519_dalek::SigningKey;
 
 use crate::cli::CliOutput;
 use crate::identity::{self, keypair};
+use crate::validate;
 
 #[derive(Args)]
 pub struct IdentityArgs {
@@ -140,7 +141,26 @@ fn generate(
     json_out: bool,
     out: &mut CliOutput<'_>,
 ) -> Result<()> {
-    let id = resolve_id(explicit_agent_id)?;
+    // `identity generate` is an internal-bootstrap surface that must
+    // legitimately accept [`validate::RESERVED_AGENT_IDS`] sentinels
+    // (the daemon's own self-signing keypair label
+    // `DAEMON_KEYPAIR_LABEL` = "daemon", the federation-catchup label,
+    // etc.). Use [`validate::validate_agent_id_shape`] (shape-only,
+    // doesn't reject reserved sentinels) for the explicit caller path,
+    // bypassing the strict [`validate::validate_agent_id`] that
+    // `resolve_id` → `identity::resolve_agent_id` applies. The
+    // wire-side ingress boundaries (HTTP body, MCP tool param) still
+    // strict-validate at their own boundary — this carve-out is
+    // CLI-key-generation-only. Closes #1234 (RCA: this site was
+    // missed when #977 introduced RESERVED_AGENT_IDS + the
+    // shape/wire split).
+    let id = match explicit_agent_id {
+        Some(explicit) if !explicit.is_empty() => {
+            validate::validate_agent_id_shape(explicit)?;
+            explicit.to_string()
+        }
+        _ => resolve_id(explicit_agent_id)?,
+    };
     let pub_path = dir.join(format!("{id}.pub"));
     // Round-4 — refuse-by-default. The pre-Round-4 default was OVERWRITE,
     // which let a typo silently rotate (and destroy) a daemon or peer

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -146,11 +146,25 @@ pub fn resolve_agent_id(explicit: Option<&str>, mcp_client: Option<&str>) -> Res
     }
 
     // 2. AI_MEMORY_AGENT_ID env var (for MCP path; CLI clap merges this already,
-    //    but MCP callers that don't pass it explicitly need this fallback)
+    //    but MCP callers that don't pass it explicitly need this fallback).
+    //
+    //    Uses [`validate::validate_agent_id_shape`] (shape-only) rather than
+    //    [`validate::validate_agent_id`] (wire-strict, also rejects
+    //    [`validate::RESERVED_AGENT_IDS`]) because the env-var path is an
+    //    internal-bootstrap surface: the daemon's own self-signing keypair
+    //    label (`DAEMON_KEYPAIR_LABEL` = "daemon" at
+    //    `src/daemon_runtime.rs`) legitimately resolves through this path
+    //    when the operator (or `entrypoint.plan-c.sh` pre-#1231) injects
+    //    `AI_MEMORY_AGENT_ID=daemon` for daemon-process startup. Wire-side
+    //    callers (HTTP body `agent_id`, MCP `agent_id` tool param) still
+    //    flow through the strict `validate_agent_id` at their own ingress
+    //    boundary — the env-var carve-out does not loosen the wire posture.
+    //    Closes #1234 (RCA: this site was missed when #977 introduced
+    //    RESERVED_AGENT_IDS + the shape/wire split).
     if let Ok(v) = std::env::var(ENV_AGENT_ID)
         && !v.is_empty()
     {
-        validate::validate_agent_id(&v)?;
+        validate::validate_agent_id_shape(&v)?;
         return Ok(v);
     }
 

--- a/tests/issue_1234_daemon_sentinel_bootstrap.rs
+++ b/tests/issue_1234_daemon_sentinel_bootstrap.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression tests for issue #1234 — daemon-sentinel bootstrap rejection.
+//
+// Pre-fix bug: two production code paths used the wire-side validator
+// `validate::validate_agent_id` (which ALSO rejects RESERVED_AGENT_IDS
+// per #977) instead of the shape-only `validate::validate_agent_id_shape`,
+// breaking the daemon's own self-signing keypair bootstrap.
+//
+// The two sites:
+//
+// 1. `src/identity/mod.rs::resolve_agent_id` env-var path — rejected
+//    `AI_MEMORY_AGENT_ID=daemon` (or any reserved sentinel), which is
+//    the legitimate daemon-boot scenario.
+//
+// 2. `src/cli/identity.rs::generate` — rejected `ai-memory identity
+//    generate --agent-id daemon`, which is exactly what
+//    `entrypoint.plan-c.sh:30` runs to bootstrap the daemon's
+//    self-signing keypair on container start.
+//
+// Per validate.rs:319-321 doc-comment carve-out: internal callers
+// that legitimately need reserved-sentinel labels (the daemon's own
+// `DAEMON_KEYPAIR_LABEL = "daemon"` at src/daemon_runtime.rs:1887)
+// can opt into the looser shape-only check. The fix is to USE that
+// carve-out at the two miss-migrated sites.
+
+use ai_memory::{identity, validate};
+
+const RESERVED_SENTINELS: &[&str] = &[
+    "daemon",
+    "system",
+    "federation-catchup",
+];
+
+/// Probe 1 — `identity::resolve_agent_id` MUST accept reserved
+/// sentinels via the env-var path (internal-bootstrap surface).
+#[test]
+fn issue_1234_resolve_agent_id_env_accepts_daemon_sentinel() {
+    // Serialize env-var manipulation across this test file — env is
+    // process-global state.
+    let _guard = env_lock();
+    for sentinel in RESERVED_SENTINELS {
+        unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", sentinel) };
+        let resolved = identity::resolve_agent_id(None, None)
+            .unwrap_or_else(|e| panic!("resolve_agent_id for sentinel {sentinel:?}: {e}"));
+        assert_eq!(
+            resolved, *sentinel,
+            "env-var path must return the reserved sentinel verbatim"
+        );
+    }
+    unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") };
+}
+
+/// Probe 2 — `validate::validate_agent_id_shape` MUST accept
+/// reserved sentinels (the carve-out semantics).
+#[test]
+fn issue_1234_validate_agent_id_shape_accepts_reserved_sentinels() {
+    for sentinel in RESERVED_SENTINELS {
+        validate::validate_agent_id_shape(sentinel).unwrap_or_else(|e| {
+            panic!("validate_agent_id_shape({sentinel:?}) must accept: {e}")
+        });
+    }
+}
+
+/// Probe 3 — `validate::validate_agent_id` (wire-strict) MUST still
+/// reject reserved sentinels. The carve-out at the internal surfaces
+/// does NOT loosen the wire posture.
+#[test]
+fn issue_1234_validate_agent_id_wire_strict_still_rejects_reserved() {
+    for sentinel in RESERVED_SENTINELS {
+        let result = validate::validate_agent_id(sentinel);
+        assert!(
+            result.is_err(),
+            "wire-strict validate_agent_id({sentinel:?}) must reject — found Ok"
+        );
+    }
+}
+
+/// Probe 4 — env-var path with an invalid SHAPE (not just reserved)
+/// must still reject. Shape rules: max 128 chars, regex
+/// `^[A-Za-z0-9_\-:@./]+$`. We exercise the shape-rejection branch
+/// to prove we didn't accidentally bypass shape validation when
+/// we relaxed the reserved-sentinel rejection.
+#[test]
+fn issue_1234_env_var_path_still_rejects_invalid_shape() {
+    let _guard = env_lock();
+    // Note: null bytes are refused by `std::env::set_var` itself
+    // before reaching our validator, so they cannot be tested here.
+    // The shape rules in validate.rs forbid them at the validator
+    // level too, but the env-var path is short-circuited by libc.
+    let bad_shapes: &[&str] = &[
+        " ",              // whitespace
+        "with space",     // internal whitespace
+        "with\nnewline",  // control char
+        "with`backtick",  // shell metachar
+        "with$dollar",    // shell metachar
+    ];
+    for bad in bad_shapes {
+        unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", bad) };
+        let result = identity::resolve_agent_id(None, None);
+        assert!(
+            result.is_err(),
+            "shape-invalid env-var {bad:?} must reject — found Ok({:?})",
+            result.ok(),
+        );
+    }
+    unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") };
+}
+
+/// Probe 5 — explicit-caller path (the FIRST arm of
+/// `resolve_agent_id`) MUST still wire-strict-reject reserved
+/// sentinels. This is the carve-out boundary: env-var path is
+/// internal-bootstrap, explicit-caller is wire-side.
+#[test]
+fn issue_1234_explicit_caller_still_wire_strict_rejects_reserved() {
+    let _guard = env_lock();
+    unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") };
+    for sentinel in RESERVED_SENTINELS {
+        let result = identity::resolve_agent_id(Some(sentinel), None);
+        assert!(
+            result.is_err(),
+            "explicit-caller path is wire-strict; {sentinel:?} must reject — found Ok({:?})",
+            result.ok(),
+        );
+    }
+}
+
+/// Cross-test mutex — env-var state is process-global; serialize
+/// every test that touches `AI_MEMORY_AGENT_ID` so they don't race
+/// each other under `cargo test`'s default parallel scheduler.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock, PoisonError};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}

--- a/tests/issue_1234_daemon_sentinel_bootstrap.rs
+++ b/tests/issue_1234_daemon_sentinel_bootstrap.rs
@@ -27,11 +27,7 @@
 
 use ai_memory::{identity, validate};
 
-const RESERVED_SENTINELS: &[&str] = &[
-    "daemon",
-    "system",
-    "federation-catchup",
-];
+const RESERVED_SENTINELS: &[&str] = &["daemon", "system", "federation-catchup"];
 
 /// Probe 1 — `identity::resolve_agent_id` MUST accept reserved
 /// sentinels via the env-var path (internal-bootstrap surface).
@@ -57,9 +53,8 @@ fn issue_1234_resolve_agent_id_env_accepts_daemon_sentinel() {
 #[test]
 fn issue_1234_validate_agent_id_shape_accepts_reserved_sentinels() {
     for sentinel in RESERVED_SENTINELS {
-        validate::validate_agent_id_shape(sentinel).unwrap_or_else(|e| {
-            panic!("validate_agent_id_shape({sentinel:?}) must accept: {e}")
-        });
+        validate::validate_agent_id_shape(sentinel)
+            .unwrap_or_else(|e| panic!("validate_agent_id_shape({sentinel:?}) must accept: {e}"));
     }
 }
 
@@ -90,11 +85,11 @@ fn issue_1234_env_var_path_still_rejects_invalid_shape() {
     // The shape rules in validate.rs forbid them at the validator
     // level too, but the env-var path is short-circuited by libc.
     let bad_shapes: &[&str] = &[
-        " ",              // whitespace
-        "with space",     // internal whitespace
-        "with\nnewline",  // control char
-        "with`backtick",  // shell metachar
-        "with$dollar",    // shell metachar
+        " ",             // whitespace
+        "with space",    // internal whitespace
+        "with\nnewline", // control char
+        "with`backtick", // shell metachar
+        "with$dollar",   // shell metachar
     ];
     for bad in bad_shapes {
         unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", bad) };


### PR DESCRIPTION
## Summary

Closes #1234. Two production code paths used wire-side `validate::validate_agent_id` instead of shape-only `validate::validate_agent_id_shape`, breaking the daemon's own self-signing keypair bootstrap (`AI_MEMORY_AGENT_ID=daemon` rejected by env-var path; `ai-memory identity generate --agent-id daemon` rejected by `cli/identity::generate`).

Fix per the validate.rs:319-321 documented carve-out: internal callers (daemon bootstrap) use shape-only; wire callers (HTTP body, MCP tool param) stay strict.

## Files changed

- `src/identity/mod.rs::resolve_agent_id` env-var path → shape-only validator
- `src/cli/identity.rs::generate` explicit-caller path → shape-only validator (bypasses strict resolve_id chain)
- `tests/issue_1234_daemon_sentinel_bootstrap.rs` (NEW, 5 tests)

## Wire impact

NONE. HTTP body `agent_id` + MCP `agent_id` tool param still strict-validate at their own ingress boundary.

## Cargo gates

- `cargo fmt --check` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` ✓
- `AI_MEMORY_NO_CONFIG=1 cargo test --test issue_1234_daemon_sentinel_bootstrap` ✓ 5/5
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib identity::tests validate::tests` ✓ 59+143 passed
- `cargo audit` ✓ 529 deps / 0 vulns

## AI involvement

Authored by Claude Opus 4.7 (1M context) per operator directive 2026-05-25 "AI NHI APPROVED AUTONOMOUS — get v0.7.0 to final where all fixes merged + QC'd, THEN A2A". RCA documented by parallel A2A sub-agent during testing-loop discipline before #1234 was filed by `auto-filed-by-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)