### PR TITLE
fix(#1257): close recall DTO parity gap — CLI --session-id flag

### DIFF
--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -119,6 +119,15 @@ pub struct RecallArgs {
     /// preserves v0.6.x CLI semantics.
     #[arg(long = "format", value_name = "FORMAT", value_parser = ["human", "json", "toon"], default_value = "human")]
     pub format: String,
+    /// v0.7.0 #1257 — session-id parity flag (DTO C2 #967, +0.05
+    /// rerank boost under #518). Pre-#1257 this was hard-coded to
+    /// `None` in `RecallRequest::from_cli_args`, so a CLI caller
+    /// could not reach the in-session ring boost even though MCP
+    /// (`{"session_id": "…"}` param) and HTTP (`?session_id=…` or
+    /// JSON body) callers could. Optional; omit to preserve v0.6.x
+    /// recall semantics.
+    #[arg(long = "session-id", value_name = "SESSION_ID")]
+    pub session_id: Option<String>,
 }
 
 /// v0.7.0 Form 4 (issue #757) — post-filter a recall result set by
@@ -541,6 +550,10 @@ mod tests {
             confidence_tier: None,
             verbose_provenance: false,
             format: "human".to_string(),
+            // v0.7.0 #1257 — CLI parity for session_id (DTO C2 #967).
+            // Test fixtures default to None so existing tests keep
+            // their pre-#1257 semantics (no in-session boost).
+            session_id: None,
         }
     }
 

--- a/src/models/recall_request.rs
+++ b/src/models/recall_request.rs
@@ -328,7 +328,11 @@ impl RecallRequest {
             budget_tokens: args.budget_tokens.and_then(|v| i64::try_from(v).ok()),
             context_tokens: args.context_tokens.clone(),
             session_default: Some(args.session_default),
-            session_id: None,
+            // v0.7.0 #1257 — CLI parity for the session_id boost
+            // (#518). Pre-#1257 this was hard-coded to `None`, so
+            // a CLI caller could not reach the in-session ring
+            // rerank boost even though MCP / HTTP callers could.
+            session_id: args.session_id.clone(),
             include_archived: Some(args.include_archived),
             has_citations: Some(args.has_citations),
             source_uri_prefix: args.source_uri_prefix.clone(),
@@ -611,6 +615,8 @@ mod tests {
             confidence_tier: Some("high".to_string()),
             verbose_provenance: true,
             format: "toon".to_string(),
+            // v0.7.0 #1257 — CLI parity for session_id (DTO C2 #967).
+            session_id: Some("sess-1".to_string()),
         };
         let req = RecallRequest::from_cli_args(&cli_args);
         assert_eq!(req.context, "hello");
@@ -638,6 +644,12 @@ mod tests {
             req.format.as_deref(),
             Some("toon"),
             "#1098: --format marshals into DTO.format"
+        );
+        // #1257: pin --session-id round-trip into DTO.session_id.
+        assert_eq!(
+            req.session_id.as_deref(),
+            Some("sess-1"),
+            "#1257: --session-id marshals into DTO.session_id"
         );
         // CLI `tier` has no DTO field — it's a CLI-only knob that
         // drives embedder construction, not a wire-level filter.

--- a/tests/issue_1257_recall_cli_session_id.rs
+++ b/tests/issue_1257_recall_cli_session_id.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::type_complexity)]
+#![allow(clippy::doc_lazy_continuation)]
+
+//! Regression suite for issue #1257 — Recall DTO parity gap: CLI lacked
+//! `--session-id` flag.
+//!
+//! ## Defect
+//!
+//! `RecallRequest::from_cli_args` (`src/models/recall_request.rs`) hard-coded
+//! `session_id: None`. The CLI clap struct [`RecallArgs`] had no
+//! `--session-id` flag at all. The MCP, HTTP-body, and HTTP-query surfaces
+//! all wire `session_id` through to [`RecallRequest`], so the CLI surface
+//! was the only one that could not exercise the +0.05 rerank boost for
+//! the in-session ring (cap 50) introduced under #518.
+//!
+//! Per CLAUDE.md Wave-2 Tier-C2 (#967) the three-surface DTO parity
+//! contract is load-bearing — adding a new field is "one struct field +
+//! one constructor branch per surface", not three out of four with the
+//! fourth silently dropped.
+//!
+//! ## Invariants pinned by this file
+//!
+//! 1. `RecallArgs::session_id` is a public field (compile-time check).
+//! 2. `RecallRequest::from_cli_args` round-trips the CLI value into the
+//!    DTO byte-for-byte.
+//! 3. The clap parser accepts `--session-id <value>` and rejects no
+//!    legitimate value shape.
+
+use ai_memory::cli::recall::RecallArgs;
+use ai_memory::models::RecallRequest;
+use clap::Parser;
+
+/// Minimal clap host so the test can drive `RecallArgs` through the
+/// parser without dragging in the full top-level `Command` enum (which
+/// pulls SAL feature flags + a wider surface than this test cares
+/// about).
+#[derive(Parser)]
+struct TestHost {
+    #[command(flatten)]
+    args: RecallArgs,
+}
+
+#[test]
+fn recall_args_carries_session_id_field() {
+    // Compile-time check: the struct field exists and is the expected
+    // type. If a future refactor renames or removes it, this test fails
+    // at compilation, not at runtime — exactly the contract we want.
+    let args = RecallArgs {
+        context: "hello".to_string(),
+        namespace: None,
+        limit: 10,
+        tags: None,
+        since: None,
+        until: None,
+        tier: None,
+        as_agent: None,
+        budget_tokens: None,
+        context_tokens: None,
+        session_default: false,
+        include_archived: false,
+        has_citations: false,
+        source_uri_prefix: None,
+        kind: None,
+        confidence_tier: None,
+        verbose_provenance: false,
+        format: "human".to_string(),
+        session_id: Some("sess-7".to_string()),
+    };
+    assert_eq!(args.session_id.as_deref(), Some("sess-7"));
+}
+
+#[test]
+fn from_cli_args_round_trips_session_id_into_dto() {
+    let args = RecallArgs {
+        context: "hello".to_string(),
+        namespace: None,
+        limit: 10,
+        tags: None,
+        since: None,
+        until: None,
+        tier: None,
+        as_agent: None,
+        budget_tokens: None,
+        context_tokens: None,
+        session_default: false,
+        include_archived: false,
+        has_citations: false,
+        source_uri_prefix: None,
+        kind: None,
+        confidence_tier: None,
+        verbose_provenance: false,
+        format: "human".to_string(),
+        session_id: Some("sess-42".to_string()),
+    };
+    let req = RecallRequest::from_cli_args(&args);
+    assert_eq!(
+        req.session_id.as_deref(),
+        Some("sess-42"),
+        "#1257: CLI --session-id must round-trip into RecallRequest.session_id"
+    );
+}
+
+#[test]
+fn from_cli_args_session_id_none_when_omitted() {
+    // Omitting the flag preserves v0.6.x recall semantics (None).
+    let args = RecallArgs {
+        context: "hello".to_string(),
+        namespace: None,
+        limit: 10,
+        tags: None,
+        since: None,
+        until: None,
+        tier: None,
+        as_agent: None,
+        budget_tokens: None,
+        context_tokens: None,
+        session_default: false,
+        include_archived: false,
+        has_citations: false,
+        source_uri_prefix: None,
+        kind: None,
+        confidence_tier: None,
+        verbose_provenance: false,
+        format: "human".to_string(),
+        session_id: None,
+    };
+    let req = RecallRequest::from_cli_args(&args);
+    assert!(
+        req.session_id.is_none(),
+        "#1257: omitted --session-id must remain None in the DTO"
+    );
+}
+
+#[test]
+fn clap_accepts_session_id_long_flag() {
+    // Drive the actual clap parser to ensure the `--session-id` long
+    // flag is recognised and bound to the field. This catches
+    // attribute-typo regressions (e.g. `long = "session_id"` vs
+    // `long = "session-id"`).
+    let parsed = TestHost::try_parse_from(["test", "--session-id", "sess-clap", "hello"])
+        .expect("clap must accept --session-id");
+    assert_eq!(parsed.args.session_id.as_deref(), Some("sess-clap"));
+    assert_eq!(parsed.args.context, "hello");
+}
+
+#[test]
+fn clap_session_id_optional() {
+    // Without --session-id, parsing should still succeed and the field
+    // remains None.
+    let parsed =
+        TestHost::try_parse_from(["test", "hello"]).expect("clap must parse without --session-id");
+    assert!(parsed.args.session_id.is_none());
+}


### PR DESCRIPTION
## Summary

- Add `--session-id <value>` flag to `ai-memory recall` (clap `RecallArgs`)
- Wire `args.session_id.clone()` through `RecallRequest::from_cli_args` (replaces the pre-#1257 hard-coded `None`)
- New regression suite `tests/issue_1257_recall_cli_session_id.rs` (5 tests) + extend existing lib `from_cli_args_round_trips_all_fields` test

Closes #1257. Per CLAUDE.md Wave-2 Tier-C2 (#967): three-surface DTO parity is load-bearing — adding a field is "one struct field + one constructor branch per surface", not three out of four with the fourth silently dropped. Pre-#1257 the +0.05 in-session-ring rerank boost (#518) was unreachable from CLI even though MCP / HTTP callers had it.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test issue_1257_recall_cli_session_id` — 5/5 pass
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib recall_request::tests::from_cli` — pass (extended round-trip asserts session_id)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib cli::recall` — 31/31 pass (no regressions in cli::recall fixture)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib recall` — 134/134 pass
- [x] `cargo audit` — clean (529 crates scanned, no advisories)

Base: 7f93bac80801f614c6d16b8d2eba352859a1f8da

🤖 Generated with [Claude Code](https://claude.com/claude-code)