### PR TITLE
ci(#1245): pin C8 + vendor-literal lint gates as required checks

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -53,6 +53,8 @@ branches:
       - "Batman Mode acceptance gate / Rust integration (issue_800_batman_mode)"
       - "Batman Mode acceptance gate / Bash integration (test-batman-mode-suite.sh)"
       - "Batman Mode acceptance gate / Surface stability (load-bearing symbols)"
+      - "C8 caller-context allowlist check"
+      - "Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)"
     require_up_to_date: true
     enforce_admins: true
     allow_force_push: false
@@ -67,6 +69,8 @@ branches:
       - "Batman Mode acceptance gate / Rust integration (issue_800_batman_mode)"
       - "Batman Mode acceptance gate / Bash integration (test-batman-mode-suite.sh)"
       - "Batman Mode acceptance gate / Surface stability (load-bearing symbols)"
+      - "C8 caller-context allowlist check"
+      - "Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)"
     require_up_to_date: true
     enforce_admins: true
     allow_force_push: false
@@ -81,6 +85,8 @@ branches:
       - "Batman Mode acceptance gate / Rust integration (issue_800_batman_mode)"
       - "Batman Mode acceptance gate / Bash integration (test-batman-mode-suite.sh)"
       - "Batman Mode acceptance gate / Surface stability (load-bearing symbols)"
+      - "C8 caller-context allowlist check"
+      - "Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)"
     require_up_to_date: true
     enforce_admins: false
     allow_force_push: false


### PR DESCRIPTION
## Summary

Adds the two #1174 PR10 script-based lint gates to `required_checks` on the three protected branch patterns (main, release/**, develop) in `.github/branch-protection.yml`:

- `"C8 caller-context allowlist check"`
- `"Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)"`

Both strings match `jobs.<id>.name` in `.github/workflows/c8-precheck.yml` verbatim, so the operator-side wire-up (Repo Settings > Branches > Required status checks) can copy them directly per the in-file documentation header.

Closes #1245.

## Test plan

- [x] YAML lints cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/branch-protection.yml'))"` returns 0).
- [x] Job-name strings match the corresponding `jobs.<id>.name` entries in `.github/workflows/c8-precheck.yml` (lines 41 + 50).
- [ ] Operator copies the two new entries into the live branch-protection rule for each of the three patterns once merged.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the v0.7.0 NO FAIL MISSION fix-wave for CI / supply-chain defects.