### PR TITLE
ci(#1246): close yank.yml GHA shell-injection via env-var indirection

### DIFF
--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -26,7 +26,17 @@ jobs:
       - name: Yank version
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # Route untrusted workflow_dispatch inputs through env vars
+          # instead of inlining `${{ inputs.X }}` directly in `run:`.
+          # The template interpolation form expands BEFORE the shell
+          # parses the line, so an input like `1.0.0"; rm -rf /; #`
+          # would land in the script verbatim and run. Reading the
+          # values via `"$VERSION"` / `"$REASON"` shell variables
+          # forces the shell to treat them as data, not code.
+          # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          VERSION: ${{ github.event.inputs.version }}
+          REASON: ${{ github.event.inputs.reason }}
         run: |
-          echo "Yanking ai-memory@${{ github.event.inputs.version }}"
-          echo "Reason: ${{ github.event.inputs.reason }}"
-          cargo yank --version "${{ github.event.inputs.version }}" ai-memory
+          echo "Yanking ai-memory@$VERSION"
+          echo "Reason: $REASON"
+          cargo yank --version "$VERSION" ai-memory


### PR DESCRIPTION
## Summary

Routes the `workflow_dispatch` inputs (`version`, `reason`) of `.github/workflows/yank.yml` through an `env:` block, then reads them in `run:` as `"$VERSION"` / `"$REASON"` shell variables instead of inlining `${{ github.event.inputs.X }}` directly into the shell script.

The template-interpolation form expands BEFORE the shell parses the line, so a hostile input like `1.0.0"; rm -rf /; #` would land in the script verbatim and execute. Env-var indirection forces the shell to treat the values as data, not code. Standard GitHub Actions [security hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

Workflow is `workflow_dispatch`-only so blast radius is bounded to operators with workflow-write, but defense-in-depth says fix it anyway.

Closes #1246.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/yank.yml'))"` exits 0.
- [x] `actionlint .github/workflows/yank.yml` is clean.
- [ ] (Manual, post-merge) operator dry-runs the workflow with a non-existent version to confirm the indirection works end-to-end.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the v0.7.0 NO FAIL MISSION fix-wave for CI / supply-chain defects.