### PR TITLE
fix(#1213): scope memories atttypmod probes to public schema (post-#1268 production fix)

### DIFF
--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -758,7 +758,9 @@ impl PostgresStore {
         let typmod: Option<(i32,)> = sqlx::query_as(
             "SELECT atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON c.relnamespace = n.oid
+             WHERE c.relname = 'memories' AND a.attname = 'embedding'
+             AND n.nspname = 'public'",
         )
         .fetch_optional(&pool)
         .await
@@ -2693,7 +2695,9 @@ impl PostgresStore {
         let row: Option<(i32,)> = sqlx::query_as(
             "SELECT atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON c.relnamespace = n.oid
+             WHERE c.relname = 'memories' AND a.attname = 'embedding'
+             AND n.nspname = 'public'",
         )
         .fetch_optional(&self.pool)
         .await
@@ -3120,7 +3124,9 @@ impl PostgresStore {
         let existing_dim: Option<(i32,)> = sqlx::query_as(
             "SELECT atttypmod FROM pg_attribute a
              JOIN pg_class c ON c.oid = a.attrelid
-             WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+             JOIN pg_namespace n ON c.relnamespace = n.oid
+             WHERE c.relname = 'memories' AND a.attname = 'embedding'
+             AND n.nspname = 'public'",
         )
         .fetch_optional(&mut *tx)
         .await

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline


### PR DESCRIPTION
## Summary

Three production probe sites in `src/store/postgres.rs` that read `atttypmod` for `memories.embedding` used an unscoped `WHERE c.relname = 'memories'`. When Apache AGE is installed AND a per-tenant `search_path` bootstrap is in effect, the unfiltered `pg_class` lookup can resolve to `ag_catalog.memories` (or any schema-shadowed `memories`) instead of `public.memories`, returning a stale/zero `atttypmod` that trips the embedding-dim sanity check.

**Fix.** Join `pg_namespace n ON c.relnamespace = n.oid` and constrain `n.nspname = 'public'` on all three sites:

| Site | Purpose |
|---|---|
| L758-767 | ctor sanity-check warn (operator-visible embedding-dim mismatch at connect time) |
| L2693-2702 | `current_embedding_dim()` SAL probe |
| L3120-3130 | `migrate_v18()` archive-side dim discovery |

## Regression test

`tests/issue_1213_atttypmod_age_schema_scope.rs` already merged on `release/v0.7.0` via **PR #1268**. The test is gated on `AI_MEMORY_TEST_POSTGRES_URL` so it runs in CI under the postgres matrix; it pins post-fix behaviour against a fixture that installs a shadow `ag_catalog.memories` row.

## Gates (local)

- `cargo fmt --check` OK
- `cargo clippy --features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` OK
- `cargo check --features sal-postgres --tests` OK
- `cargo audit` OK (529 deps, 0 vulns)

## Test plan

- [ ] CI green on this PR (postgres matrix runs the #1268 regression test against the fixed code)
- [ ] No regression in non-AGE postgres deployments (the added join is a pure narrowing of the existing filter)

## AI involvement

Authored by Claude Opus 4.7 (1M context) per `AI_DEVELOPER_WORKFLOW.md` §8.2. Closes #1213.

Base: 4f488b28b9206a772ba47cc0526c3cc96ab7df7b

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>