### PR TITLE
sec(llm, #1237): wire NetworkRequest gate into generate + generate_with_model_override

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -674,6 +674,13 @@ impl OllamaClient {
                 self.base_url,
             ));
         }
+        // v0.7.0 (issue #1237, #691 fold-1) — consult the governance
+        // NetworkRequest wire-point hook BEFORE issuing the outbound
+        // HTTP. Mirrors the gate in generate_with_body (line ~1005).
+        // The post-#1067 chat surface forgot this call; an operator
+        // `refuse` rule against the LLM host was being silently
+        // ignored on the production chat path.
+        self.check_outbound()?;
 
         // #1066 — branch on provider for endpoint path, auth header,
         // payload shape, and response parsing.
@@ -862,6 +869,10 @@ impl OllamaClient {
                 self.base_url,
             ));
         }
+        // v0.7.0 (issue #1237, #691 fold-1) — consult the governance
+        // NetworkRequest wire-point hook BEFORE issuing the outbound
+        // HTTP. Mirrors the gate in generate_with_body (line ~1005).
+        self.check_outbound()?;
         let model = model_override.unwrap_or(&self.model);
 
         let (url, payload, bearer): (String, Value, Option<&str>) = match &self.provider {

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline

--- a/tests/wire_check_sole_path_pin.rs
+++ b/tests/wire_check_sole_path_pin.rs
@@ -149,6 +149,74 @@ fn llm_invokes_wire_check_before_ollama_request() {
     );
 }
 
+/// v0.7.0 (issue #1237) — extend the wire-point pin to cover the
+/// post-#1067 production chat surfaces. Both `OllamaClient::generate`
+/// and `OllamaClient::generate_with_model_override` MUST invoke
+/// `self.check_outbound()` immediately after the `breaker_is_open()`
+/// short-circuit and BEFORE the outbound `reqwest::post`. The
+/// pre-#1237 code shipped both fns without the gate, so an operator
+/// `refuse` rule against the LLM host was silently ignored on every
+/// vendor (Ollama + OpenAI-compatible) — a governance bypass.
+#[test]
+fn llm_generate_invokes_wire_check_before_post_1237() {
+    let body = src("src/llm.rs");
+
+    // Locate the body of `pub fn generate(`. The function spans from
+    // its signature through the next `fn ` that starts a SIBLING fn
+    // at the impl-block indentation. Approximating with a bounded
+    // window (up to the next `fn generate_with_model_override`).
+    let fn_start = body
+        .find("pub fn generate(&self, prompt: &str, system: Option<&str>)")
+        .expect("OllamaClient::generate signature must exist in src/llm.rs");
+    // Bound the search to the start of the next chat fn so we don't
+    // bleed into generate_with_model_override.
+    let fn_end = body[fn_start..]
+        .find("fn generate_with_model_override")
+        .map(|i| fn_start + i)
+        .expect("generate_with_model_override must follow generate");
+    let generate_body = &body[fn_start..fn_end];
+
+    let check_idx = generate_body.find("self.check_outbound()").expect(
+        "OllamaClient::generate must call self.check_outbound() before the outbound HTTP \
+         (#1237 fix)",
+    );
+    let post_idx = generate_body
+        .find(".post(")
+        .expect(".client.post(...) must exist in OllamaClient::generate");
+    assert!(
+        check_idx < post_idx,
+        "check_outbound must precede .client.post(...) in OllamaClient::generate \
+         (#1237)"
+    );
+}
+
+#[test]
+fn llm_generate_with_model_override_invokes_wire_check_before_post_1237() {
+    let body = src("src/llm.rs");
+    let fn_start = body
+        .find("fn generate_with_model_override(")
+        .expect("OllamaClient::generate_with_model_override signature must exist");
+    // Bound by the next fn in the impl (check_outbound is the next one).
+    let fn_end = body[fn_start..]
+        .find("fn check_outbound")
+        .map(|i| fn_start + i)
+        .expect("check_outbound must follow generate_with_model_override in source order");
+    let fn_body = &body[fn_start..fn_end];
+
+    let check_idx = fn_body.find("self.check_outbound()").expect(
+        "OllamaClient::generate_with_model_override must call self.check_outbound() before \
+         the outbound HTTP (#1237 fix)",
+    );
+    let post_idx = fn_body
+        .find(".post(")
+        .expect(".client.post(...) must exist in generate_with_model_override");
+    assert!(
+        check_idx < post_idx,
+        "check_outbound must precede .client.post(...) in \
+         OllamaClient::generate_with_model_override (#1237)"
+    );
+}
+
 #[test]
 fn skill_export_invokes_wire_check_before_each_filesystem_write() {
     let body = src("src/mcp/tools/skill_export.rs");


### PR DESCRIPTION
## Summary

Fixes #1237 — `OllamaClient::generate` (line ~668) and `OllamaClient::generate_with_model_override` (line ~851) were missing the `check_outbound()` governance gate that `generate_with_body` (line ~1005) carries. An operator `refuse` rule against the LLM host was silently ignored on the production chat path against every vendor (Ollama + OpenAI-compatible).

## Changes

- `src/llm.rs` — add `self.check_outbound()?;` immediately after `breaker_is_open()` in both production chat fns, mirroring the shape in `generate_with_body`.
- `tests/wire_check_sole_path_pin.rs` — extend with two new structural pins (`llm_generate_invokes_wire_check_before_post_1237` + `llm_generate_with_model_override_invokes_wire_check_before_post_1237`) so a future refactor removing the gate trips the test at PR time.
- `tests/issue_1213_atttypmod_age_schema_scope.rs` — fix 3 pre-existing `clippy::doc_markdown` violations (IronClaw, search_path) that were blocking the `--tests` clippy gate on a fresh checkout.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test wire_check_sole_path_pin` — 9 passed (incl. 2 new)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4768 passed
- [x] `cargo audit` — clean (0 vulnerabilities in 529 deps)

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) per ai-memory-mcp's AI Developer Workflow §8.2.

Base SHA: `acdd8b022ec13696ecf22ab075a64a6387ca0e11`
Refs: #691 fold-1, post-#1067 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)