### PR TITLE
chore(#1248): remove dead build.rs from Cargo.toml include array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ include = [
     "benches/**/*",
     "examples/**/*",
     "migrations/**/*",
-    "build.rs",
     "Cargo.toml",
     "Cargo.lock",
     "README.md",

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline


### PR DESCRIPTION
## Summary

Drops the dead `"build.rs"` entry from the `Cargo.toml` `include` array (line 24, pre-edit). No `build.rs` exists at the repo root and never has at v0.7.0 — `cargo build` confirms there is no build-script step. Listing it in `include` was cosmetic dead weight, not load-bearing.

Drive-by docstring fix: `tests/issue_1213_atttypmod_age_schema_scope.rs:12,13,30` carried three bare `search_path` / `IronClaw` mentions that `clippy::doc_markdown` flagged under `-D clippy::pedantic` on the CI workflow's `cargo clippy --features sal-postgres --tests` invocation (`.github/workflows/ci.yml:277`). Wrapped each in backticks so the sal-postgres clippy gate is green when this test file compiles. Pure docstring polish; no functional change.

Closes #1248.

## Test plan

- [x] `cargo metadata --no-deps` → exit 0 (issue-spec test from #1248).
- [x] `cargo fmt --check` → exit 0.
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (lib, per CLAUDE.md) → exit 0.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` → 4768 passed; 0 failed; 0 ignored; finished in 166.12s.
- [x] `cargo audit` → exit 0.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the v0.7.0 NO FAIL MISSION fix-wave for CI / supply-chain defects.