### PR TITLE
fix(llm-cli-wrap, #1238): add claude/claude-cli rows + document gpt/grok/anthropic-cli gaps

### DIFF
--- a/src/llm_cli_wrap.rs
+++ b/src/llm_cli_wrap.rs
@@ -94,6 +94,20 @@ pub fn default_strategy(agent: &str) -> WrapStrategy {
         "codex" | "codex-cli" => WrapStrategy::SystemFlag {
             flag: "--system".into(),
         },
+        // Anthropic Claude Code CLI (#1238). The canonical flag for
+        // appending a system prompt onto a `claude` invocation is
+        // `--append-system-prompt "<msg>"` per the upstream
+        // `@anthropic-ai/claude-code` CLI docs. The env-var equivalent
+        // is `CLAUDE_SYSTEM_PROMPT` but the flag form is preferred —
+        // it composes with `claude -p` (one-shot mode) without forcing
+        // operators to leak the prompt into the child's env block.
+        // Pre-#1238 this fell through to the generic `--system`
+        // fallback, which `claude` either rejects or silently
+        // ignores — the project's own primary use case sat in the
+        // unverified fallback.
+        "claude" | "claude-cli" => WrapStrategy::SystemFlag {
+            flag: "--append-system-prompt".into(),
+        },
         // Aider takes its system / instructions input from a file via
         // `--message-file`. Aider's CLI explicitly recommends this for
         // anything longer than a one-liner because it doesn't shell-quote
@@ -115,6 +129,30 @@ pub fn default_strategy(agent: &str) -> WrapStrategy {
         // Default: most OpenAI-compatible CLIs accept `--system <msg>`.
         // If that's wrong, users override with `--system-flag` /
         // `--system-env` / `--message-file-flag`.
+        //
+        // # Documented gaps (#1238)
+        //
+        // The following vendor CLI binaries are intentionally LEFT in
+        // the generic fallback rather than pinned to a flag, because
+        // upstream documentation does not surface a canonical
+        // `--system`-equivalent flag the way the entries above do:
+        //
+        // - `gpt` — no canonical first-party OpenAI CLI binary uses
+        //   that name; multiple community wrappers exist with
+        //   incompatible flag shapes. Falls through to `--system`.
+        // - `grok` — xAI ships no first-party CLI binary at v0.7.0
+        //   (the Grok surface is API-only); falls through to
+        //   `--system` for any community wrapper that defaults to it.
+        // - `anthropic-cli` — there is no first-party CLI binary
+        //   named `anthropic-cli` at v0.7.0 (Anthropic ships the
+        //   Python SDK + the `claude` Claude Code CLI handled above);
+        //   falls through to `--system` for any third-party tool.
+        //
+        // Operators running a vendor CLI in any of the three gaps
+        // above pass `--system-flag <flag>` (or `--system-env <name>`
+        // / `--message-file-flag <flag>`) explicitly. If a canonical
+        // upstream form lands for any of these later, add a row
+        // here + extend `default_strategy_per_known_agent_pins_1183`.
         _ => WrapStrategy::SystemFlag {
             flag: "--system".into(),
         },
@@ -163,6 +201,38 @@ mod tests {
                 name: "OLLAMA_SYSTEM".into()
             }
         );
+        // #1238 — Claude Code CLI uses --append-system-prompt; the
+        // pre-#1238 default fall-through to `--system` is wrong for
+        // `claude` and `claude-cli` (the project's own primary
+        // wrapped agent).
+        assert_eq!(
+            default_strategy("claude"),
+            WrapStrategy::SystemFlag {
+                flag: "--append-system-prompt".into()
+            }
+        );
+        assert_eq!(
+            default_strategy("claude-cli"),
+            WrapStrategy::SystemFlag {
+                flag: "--append-system-prompt".into()
+            }
+        );
+        // #1238 — documented gaps. `gpt`, `grok`, `anthropic-cli`
+        // have no canonical first-party CLI flag at v0.7.0 ship;
+        // they intentionally fall through to the generic --system
+        // default. If a canonical form lands for any of these
+        // later, add a row in `default_strategy` AND extend this
+        // assertion.
+        for gap in ["gpt", "grok", "anthropic-cli"] {
+            assert_eq!(
+                default_strategy(gap),
+                WrapStrategy::SystemFlag {
+                    flag: "--system".into()
+                },
+                "documented #1238 gap `{gap}` must fall through to the generic --system \
+                 default until a canonical upstream form is verifiable"
+            );
+        }
         // Unknown agent → fall through to --system.
         assert_eq!(
             default_strategy("some-future-cli"),

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline


### PR DESCRIPTION
## Summary

Fixes #1238 — the `default_strategy` table in `src/llm_cli_wrap.rs` carried only codex/codex-cli/aider/gemini/ollama rows. The Claude Code CLI binary (`claude`, the project's own primary wrap target) silently fell through to the generic `--system` fallback, which `claude` either rejects or silently ignores. The canonical flag is `--append-system-prompt`.

## Changes

- `src/llm_cli_wrap.rs` — add `"claude" | "claude-cli"` rows mapping to `SystemFlag { flag: "--append-system-prompt" }` per the upstream `@anthropic-ai/claude-code` CLI docs.
- Inline-document the three remaining gaps (`gpt`, `grok`, `anthropic-cli`) as intentional fall-throughs to the generic `--system` default because no canonical first-party CLI flag is verifiable at v0.7.0.
- Extend `default_strategy_per_known_agent_pins_1183` with:
  - Positive pin for `claude` + `claude-cli` → `--append-system-prompt`.
  - Documented-gap pin asserting `gpt` / `grok` / `anthropic-cli` continue to fall through to `--system` (so a future contributor adding a guessed flag without upstream evidence trips the test at PR time).
- Pre-existing `clippy::doc_markdown` fixes in `tests/issue_1213_atttypmod_age_schema_scope.rs` so the clippy `--tests` gate compiles cleanly.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib llm_cli_wrap` — `default_strategy_per_known_agent_pins_1183` passes
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4768 passed
- [x] `cargo audit` — clean

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) per ai-memory-mcp's AI Developer Workflow §8.2.

Base SHA: `4f488b28b`
Refs: #1183 (table-split origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)