### PR TITLE
docs(kg, #1267): clarify DEFAULT_MAX_DEPTH is a safety ceiling, not policy

### DIFF
--- a/src/kg/cycle_check.rs
+++ b/src/kg/cycle_check.rs
@@ -16,10 +16,13 @@
 
 use rusqlite::{Connection, params};
 
-/// Maximum number of hops the cycle-check walk follows before giving up.
-/// Mirrors `GovernancePolicy::effective_max_reflection_depth()` compiled-in
-/// default (3) as an upper bound; the caller passes the resolved cap so both
-/// are always consistent.
+/// Safety ceiling applied when a caller passes `max_depth = 0` (i.e. no
+/// explicit cap). The policy default for reflection depth lives elsewhere —
+/// see `GovernancePolicy::effective_max_reflection_depth()` for the runtime
+/// value the orchestration layer hands the cycle-check walk. This constant
+/// is intentionally larger than that policy default so it never silently
+/// truncates legitimate walks; it exists solely so an unset/zero cap can
+/// still bound a pathological reflection graph.
 const DEFAULT_MAX_DEPTH: u32 = 16;
 
 /// Result of a cycle-check walk: whether a cycle would be created, and if so,


### PR DESCRIPTION
## Summary

Closes #1267. The comment on \`DEFAULT_MAX_DEPTH\` in
\`src/kg/cycle_check.rs\` claimed it mirrored
\`GovernancePolicy::effective_max_reflection_depth() = 3\`, but the
const is 16. Per option (b) in the issue body, the const stays at
16 and the comment is rewritten to say what it actually does:
safety ceiling when the caller passes \`max_depth = 0\`; the policy
default lives elsewhere.

Doc-only change.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo check --lib\` clean (doc-only — full test suite not required per fix-wave protocol)

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context). See per-commit
\`Co-Authored-By\` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)