### PR TITLE
test(#1259): extend test_secret_not_in_capabilities to cover V3 envelope

### DIFF
--- a/tests/config_precedence.rs
+++ b/tests/config_precedence.rs
@@ -45,7 +45,10 @@ use std::path::PathBuf;
 
 use ai_memory::config::{AppConfig, FeatureTier, ResolvedModels, TierConfig};
 use ai_memory::daemon_runtime::Cli;
-use ai_memory::mcp::{CapabilitiesAccept, handle_capabilities_with_conn};
+use ai_memory::mcp::{
+    CapabilitiesAccept, handle_capabilities_with_conn, handle_capabilities_with_conn_v3,
+};
+use ai_memory::profile::Profile;
 use clap::Parser;
 
 mod common;
@@ -186,5 +189,36 @@ fn test_secret_not_in_capabilities() {
         !response_str.contains("AI_MEMORY_DB_PASSPHRASE"),
         "memory_capabilities response MUST NOT mention the secret env-var \
          name either; got: {response_str}",
+    );
+
+    // #1259 — extend the no-secret invariant to the V3 capabilities
+    // envelope. V3 carries additional overlays (summary / describe /
+    // tools[] / agent_permitted_families / harness deferred-registration
+    // probe) any of which a future refactor might absent-mindedly pipe
+    // env state through; pin the same no-leak property here so the
+    // V3 wire surface is mechanically covered.
+    let response_v3 = handle_capabilities_with_conn_v3(
+        &tier_config,
+        &ResolvedModels::from_tier_preset(&tier_config),
+        None,
+        false,
+        None,
+        &Profile::full(),
+        None,
+        None,
+        None,
+    )
+    .expect("v3 capabilities serialize");
+    let response_v3_str =
+        serde_json::to_string(&response_v3).expect("v3 capabilities response JSON-serializes");
+    assert!(
+        !response_v3_str.contains(SECRET),
+        "v3 memory_capabilities response MUST NOT contain AI_MEMORY_DB_PASSPHRASE; \
+         secret leaked into JSON: {response_v3_str}",
+    );
+    assert!(
+        !response_v3_str.contains("AI_MEMORY_DB_PASSPHRASE"),
+        "v3 memory_capabilities response MUST NOT mention the secret env-var \
+         name either; got: {response_v3_str}",
     );
 }


### PR DESCRIPTION
## Summary

Closes #1259. Extends \`tests/config_precedence.rs::test_secret_not_in_capabilities\` so the no-secret invariant pins **both** the V2 and V3 capabilities wire paths.

V2 was already pinned via \`handle_capabilities_with_conn\` with \`CapabilitiesAccept::V2\`. V3 is the v0.7.0 wire default and carries additional overlays (summary, describe-to-user, tools[], agent_permitted_families, harness deferred-registration probe) — any of which a future refactor might absent-mindedly pipe env state through.

The test now also invokes \`handle_capabilities_with_conn_v3\` with \`AI_MEMORY_DB_PASSPHRASE=mysecret-config-precedence-canary-9f3a\` set and asserts the serialized V3 response contains neither the secret value nor the env-var name. Both assertions mirror the existing V2 wire-shape pins so the test discipline is symmetric across the two paths.

## Test plan

- [x] \`cargo test --test config_precedence test_secret_not_in_capabilities\`: 1/1 passed
- [x] \`cargo test --test config_precedence\`: 7/7 passed (no regression)
- [x] \`cargo fmt --check\`: clean
- [x] \`cargo clippy --test config_precedence -- -D warnings -D clippy::all -D clippy::pedantic\`: clean

## AI involvement

Authored by Claude Opus 4.7 (1M context).