### PR TITLE
refactor(llm, #1243): replace 4 literal "ollama" duplicates with BACKEND_OLLAMA const

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -281,7 +281,7 @@ impl OllamaClient {
         let backend = std::env::var("AI_MEMORY_LLM_BACKEND")
             .ok()
             .map(|s| s.trim().to_ascii_lowercase())
-            .unwrap_or_else(|| "ollama".to_string());
+            .unwrap_or_else(|| BACKEND_OLLAMA.to_string());
 
         let model = std::env::var("AI_MEMORY_LLM_MODEL")
             .ok()
@@ -305,7 +305,7 @@ impl OllamaClient {
             });
 
         match backend.as_str() {
-            "ollama" => {
+            BACKEND_OLLAMA => {
                 let base_url = std::env::var("AI_MEMORY_LLM_BASE_URL")
                     .ok()
                     .or_else(|| std::env::var("OLLAMA_BASE_URL").ok())
@@ -442,7 +442,7 @@ impl OllamaClient {
             resolved.source.as_str(),
         );
 
-        if resolved.backend == "ollama" {
+        if resolved.backend == BACKEND_OLLAMA {
             return Self::new_with_url(&resolved.base_url, &resolved.model).map(Some);
         }
 
@@ -1292,7 +1292,7 @@ mod tests {
             ("cerebras", &["CEREBRAS_API_KEY"]),
             ("openrouter", &["OPENROUTER_API_KEY"]),
             ("fireworks", &["FIREWORKS_API_KEY"]),
-            ("ollama", &[]),
+            (BACKEND_OLLAMA, &[]),
             ("lmstudio", &[]),
             ("openai-compatible", &[]),
             ("totally-unknown-vendor", &[]),

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline


### PR DESCRIPTION
## Summary

Fixes #1243 — `pub const BACKEND_OLLAMA: &str = "ollama"` defined at `src/llm.rs:58` per the PR10 vendor-monoculture discipline, but the same file uses raw `"ollama"` at lines 284, 308, 445, 1295. The C8 lint-gate exempts `src/llm.rs` (the canonical-table carve-out), so the script doesn't fire — but the discipline still calls the constant canonical. A search-and-replace rename (e.g. `"ollama"` → `"ollama-native"`) would compile but break runtime resolution.

## Changes

- `src/llm.rs:284` (`from_env` legacy fallback) → `.unwrap_or_else(|| BACKEND_OLLAMA.to_string())`
- `src/llm.rs:308` (`from_env` match arm) → `BACKEND_OLLAMA =>` as const-pattern arm
- `src/llm.rs:445` (`from_resolved` selector) → `if resolved.backend == BACKEND_OLLAMA`
- `src/llm.rs:1295` (per-vendor env-var test fixture) → `(BACKEND_OLLAMA, &[])`
- `tests/issue_1213_atttypmod_age_schema_scope.rs` — same pre-existing `clippy::doc_markdown` fixes

Behavior-preserving: `BACKEND_OLLAMA` is `&str = "ollama"`, runtime semantics byte-equal.

## Test plan

No new test added per the issue body ("covered by existing tests that pass on either form"). Verified by:

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4767 passed
- [x] `cargo audit` — clean

The line-1295 site is covered by `alias_api_key_env_vars_pin_1067`; line-284/308/445 sites are covered by `config_precedence.rs` + `from_env` unit tests in `src/llm.rs::tests`.

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) per ai-memory-mcp's AI Developer Workflow §8.2.

Base SHA: `4f488b28b`
Refs: #1174 PR10 (vendor-monoculture discipline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)