### PR TITLE
fix(models, #1242): add ConfidenceSource::CuratorDerived for engine-output rows

### DIFF
--- a/src/atomisation/mod.rs
+++ b/src/atomisation/mod.rs
@@ -596,7 +596,18 @@ fn write_atom(
         citations: source.citations.clone(),
         source_uri: Some(format!("doc:{}", source.id)),
         source_span: span,
-        confidence_source: ConfidenceSource::CallerProvided,
+        // v0.7.0 issue #1242 — atom rows are curator-engine output, not
+        // caller-supplied. The curator inherits `confidence` from the
+        // parent memory (line 567 `confidence: source.confidence`) — that
+        // value is engine-propagated, not caller-supplied, so the
+        // discriminator must reflect the provenance. Pre-#1242 these
+        // rows mis-labelled `CallerProvided`, hiding them from the
+        // partial `idx_memories_confidence_source` enumeration the
+        // calibration sweep scans, and violating the audit-honesty
+        // invariant. Distinct from `AutoDerived`, which means the
+        // Form 5 derive engine computed the value from row signals;
+        // here the curator simply propagated the parent's number.
+        confidence_source: ConfidenceSource::CuratorDerived,
         confidence_signals: None,
         confidence_decayed_at: None,
         version: 1,

--- a/src/models/memory.rs
+++ b/src/models/memory.rs
@@ -241,6 +241,19 @@ pub enum ConfidenceSource {
     /// `AI_MEMORY_CONFIDENCE_DECAY=1` or the namespace policy
     /// `confidence_decay_half_life_days` is set.
     Decayed,
+    /// v0.7.0 issue #1242 — the curator engine (atomisation
+    /// `LlmCurator`, persona generator) computed the value at row-
+    /// mint time without an explicit caller-supplied number. Atom
+    /// rows inherit `confidence` from their parent memory; persona
+    /// rows pin `confidence = 1.0` per the QW-2 brief. In both
+    /// cases the value is engine-derived, not caller-supplied, and
+    /// must be discoverable to the calibration sweep + the partial
+    /// index `idx_memories_confidence_source` (which excludes
+    /// `caller_provided`). Pre-#1242 these rows mis-labelled
+    /// `confidence_source = CallerProvided`, hiding them from the
+    /// derived-row enumeration and violating the audit-honesty
+    /// invariant.
+    CuratorDerived,
 }
 
 impl ConfidenceSource {
@@ -253,6 +266,7 @@ impl ConfidenceSource {
             Self::AutoDerived => "auto_derived",
             Self::Calibrated => "calibrated",
             Self::Decayed => "decayed",
+            Self::CuratorDerived => "curator_derived",
         }
     }
 
@@ -267,6 +281,7 @@ impl ConfidenceSource {
             "auto_derived" => Some(Self::AutoDerived),
             "calibrated" => Some(Self::Calibrated),
             "decayed" => Some(Self::Decayed),
+            "curator_derived" => Some(Self::CuratorDerived),
             _ => None,
         }
     }
@@ -1641,6 +1656,11 @@ mod tests {
             ("auto_derived", ConfidenceSource::AutoDerived),
             ("calibrated", ConfidenceSource::Calibrated),
             ("decayed", ConfidenceSource::Decayed),
+            // v0.7.0 issue #1242 — curator-engine output bucket
+            // (atom rows + persona rows). Distinct from
+            // `auto_derived` (which is the Form 5 engine's
+            // signal-based derivation).
+            ("curator_derived", ConfidenceSource::CuratorDerived),
         ] {
             assert_eq!(ConfidenceSource::from_str(s), Some(v));
             assert_eq!(v.as_str(), s);

--- a/src/persona/mod.rs
+++ b/src/persona/mod.rs
@@ -394,7 +394,15 @@ impl<'a> PersonaGenerator<'a> {
             citations: Vec::new(),
             source_uri: None,
             source_span: None,
-            confidence_source: ConfidenceSource::CallerProvided,
+            // v0.7.0 issue #1242 — persona rows are curator-engine output,
+            // not caller-supplied. The QW-2 brief pins `confidence = 1.0`
+            // for every Persona; that value is engine-derived (the
+            // generator picked it), so the discriminator must reflect the
+            // provenance. Pre-#1242 these rows mis-labelled
+            // `CallerProvided`, hiding them from the partial
+            // `idx_memories_confidence_source` enumeration and violating
+            // the audit-honesty invariant.
+            confidence_source: ConfidenceSource::CuratorDerived,
             confidence_signals: None,
             confidence_decayed_at: None,
             version: 1,

--- a/tests/confidence_source_curator_derived_1242.rs
+++ b/tests/confidence_source_curator_derived_1242.rs
@@ -1,0 +1,332 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::needless_update)]
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::missing_panics_doc,
+    clippy::cast_possible_wrap
+)]
+
+//! v0.7.0 issue #1242 regression — persona + atom rows must stamp
+//! `confidence_source = "curator_derived"`, not `"caller_provided"`.
+//!
+//! # The bug
+//!
+//! Pre-#1242 both write sites — `src/persona/mod.rs:397` and
+//! `src/atomisation/mod.rs:599` — minted rows with
+//! `ConfidenceSource::CallerProvided` even though the value on the
+//! row was engine-derived (persona pins `confidence = 1.0` per the
+//! QW-2 brief; atoms inherit the parent's `confidence` from
+//! `source.confidence`). That mis-labelling hides those rows from
+//! the partial `idx_memories_confidence_source` enumeration the
+//! calibration sweep scans (the index `WHERE confidence_source !=
+//! 'caller_provided'` predicate excluded them), and violates the
+//! audit-honesty invariant that the discriminator must reflect the
+//! actual provenance.
+//!
+//! # The fix
+//!
+//! Added a fifth `ConfidenceSource::CuratorDerived` variant (wire
+//! string `"curator_derived"`), wired into both write sites. The
+//! partial index continues to filter on `!= 'caller_provided'`, so
+//! every curator-derived row now lands in the index and surfaces
+//! to the calibration sweep + forensic audit.
+//!
+//! # What this file pins
+//!
+//! Two integration tests that hit the SQLite write path through the
+//! public engine APIs and read the resulting `confidence_source`
+//! column back via raw SQL:
+//!
+//! 1. `persona_row_stamped_curator_derived` — drives
+//!    `PersonaGenerator::generate` against a seeded reflection
+//!    cluster and asserts the persona row's `confidence_source`
+//!    column reads `"curator_derived"`.
+//!
+//! 2. `atom_row_stamped_curator_derived` — drives
+//!    `Atomiser::atomise_sync` against a seeded long observation
+//!    and asserts EVERY atom row's `confidence_source` column reads
+//!    `"curator_derived"`.
+//!
+//! Both tests also confirm the discriminator passes the partial
+//! index's `!= 'caller_provided'` predicate by counting rows the
+//! calibration-style query would surface.
+
+use ai_memory::atomisation::curator::{Atom, Curator, CuratorError};
+use ai_memory::atomisation::{Atomiser, AtomiserConfig};
+use ai_memory::autonomy::AutonomyLlm;
+use ai_memory::config::FeatureTier;
+use ai_memory::db;
+use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
+use ai_memory::persona::{PersonaConfig, PersonaGenerator};
+use rusqlite::Connection;
+use std::path::Path;
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Shared scaffolding — fresh DB + stubs
+// ---------------------------------------------------------------------------
+
+fn fresh_db() -> (Connection, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("ai-memory.db");
+    let conn = db::open(Path::new(&path)).expect("open fresh db");
+    (conn, dir)
+}
+
+/// Deterministic stub for the persona curator LLM. Echoes a canned
+/// summary so the engine end-to-end runs without an Ollama
+/// round-trip.
+struct StubPersonaLlm;
+
+impl AutonomyLlm for StubPersonaLlm {
+    fn auto_tag(&self, _title: &str, _content: &str) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    fn summarize_memories(&self, _memories: &[(String, String)]) -> anyhow::Result<String> {
+        Ok("Alice is composed and thoughtful; she values clarity.".to_string())
+    }
+}
+
+/// Deterministic stub for the atomisation curator. Returns a canned
+/// atom list keyed off the call count (one queued response per call).
+struct StubAtomiseCurator {
+    responses: Mutex<Vec<Vec<Atom>>>,
+}
+
+impl StubAtomiseCurator {
+    fn new(responses: Vec<Vec<Atom>>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+impl Curator for StubAtomiseCurator {
+    fn decompose(
+        &self,
+        _body: &str,
+        _max_atom_tokens: u32,
+        _max_retries: u32,
+    ) -> Result<Vec<Atom>, CuratorError> {
+        let mut q = self.responses.lock().unwrap();
+        if q.is_empty() {
+            return Err(CuratorError::MalformedResponse(
+                "stub: queue exhausted".into(),
+            ));
+        }
+        Ok(q.remove(0))
+    }
+}
+
+fn seed_reflection_mentioning(conn: &Connection, namespace: &str, entity_id: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Mid,
+        namespace: namespace.to_string(),
+        title: format!("reflection about {entity_id}"),
+        content: format!(
+            "{entity_id} demonstrated calm decision-making during the deploy postmortem."
+        ),
+        tags: vec!["reflection".into()],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".into(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({
+            "agent_id": "test-agent",
+            "entity_id": entity_id,
+        }),
+        reflection_depth: 1,
+        memory_kind: MemoryKind::Reflection,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        ..Memory::default()
+    };
+    db::insert(conn, &mem).expect("seed reflection")
+}
+
+fn seed_long_observation(conn: &Connection, namespace: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    let body = (0..15).map(|i| format!(
+        "Paragraph {i}: The kubernetes rolling deploy strategy required canary instance health checks. \
+         The pod readiness probe must pass before traffic shifts. Failures roll back the deployment \
+         within 30 seconds. Operator dashboards track replica counts and error rates."
+    )).collect::<Vec<_>>().join(" ");
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: namespace.to_string(),
+        title: format!("long-obs-{}", uuid::Uuid::new_v4().simple()),
+        content: body,
+        tags: vec!["kubernetes".into()],
+        priority: 5,
+        // Distinct non-1.0 value so the inheritance assertion below
+        // is meaningful — atoms must carry THIS value while still
+        // stamping the engine-provenance discriminator.
+        confidence: 0.85,
+        source: "test".into(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({"agent_id": "test-agent"}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        ..Memory::default()
+    };
+    db::insert(conn, &mem).expect("seed long observation")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — persona row stamps curator_derived
+// ---------------------------------------------------------------------------
+
+#[test]
+fn persona_row_stamped_curator_derived() {
+    let (conn, _dir) = fresh_db();
+
+    // Seed enough reflections so the generator's source-pool minimum is
+    // satisfied (the engine requires at least one matching reflection).
+    let _r1 = seed_reflection_mentioning(&conn, "team/alpha", "alice");
+    let _r2 = seed_reflection_mentioning(&conn, "team/alpha", "alice");
+
+    let llm = StubPersonaLlm;
+    let generator = PersonaGenerator::new(&conn, &llm, None, PersonaConfig::default());
+    let persona = generator
+        .generate("alice", "team/alpha")
+        .expect("persona generates");
+
+    // Read the persona row's confidence_source column back via raw SQL.
+    let stored: String = conn
+        .query_row(
+            "SELECT confidence_source FROM memories WHERE id = ?1",
+            rusqlite::params![&persona.id],
+            |r| r.get(0),
+        )
+        .expect("persona row exists");
+
+    assert_eq!(
+        stored, "curator_derived",
+        "persona row must stamp confidence_source=curator_derived (issue #1242), got {stored:?}"
+    );
+
+    // The partial index `idx_memories_confidence_source` covers rows
+    // whose discriminator is NOT 'caller_provided'. A calibration-style
+    // enumeration must surface the persona row post-fix.
+    let n_visible: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE id = ?1 \
+               AND confidence_source != 'caller_provided'",
+            rusqlite::params![&persona.id],
+            |r| r.get(0),
+        )
+        .expect("count");
+    assert_eq!(
+        n_visible, 1,
+        "post-#1242 persona row must pass the partial-index predicate \
+         `confidence_source != 'caller_provided'` (calibration scan visibility)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — every atom row stamps curator_derived
+// ---------------------------------------------------------------------------
+
+#[test]
+fn atom_row_stamped_curator_derived() {
+    let (conn, _dir) = fresh_db();
+    let source_id = seed_long_observation(&conn, "ns/wt1b/atom_provenance");
+
+    // Three atoms; the engine writes one row per atom + stamps the
+    // `atom_of` column on each.
+    let curator = Box::new(StubAtomiseCurator::new(vec![vec![
+        Atom {
+            text: "First atom about kubernetes deploys.".into(),
+        },
+        Atom {
+            text: "Second atom about readiness probes.".into(),
+        },
+        Atom {
+            text: "Third atom about rollback windows.".into(),
+        },
+    ]]));
+    let atomiser = Atomiser::new(curator, None, AtomiserConfig::default(), FeatureTier::Smart);
+
+    let result = atomiser
+        .atomise_sync(&conn, &source_id, 200, false, "test-agent")
+        .expect("atomise must succeed against the seeded long body");
+    assert!(
+        result.atom_ids.len() >= 2,
+        "engine should mint at least 2 atoms (got {})",
+        result.atom_ids.len()
+    );
+
+    for atom_id in &result.atom_ids {
+        let stored: String = conn
+            .query_row(
+                "SELECT confidence_source FROM memories WHERE id = ?1",
+                rusqlite::params![atom_id],
+                |r| r.get(0),
+            )
+            .expect("atom row exists");
+
+        assert_eq!(
+            stored, "curator_derived",
+            "atom row {atom_id} must stamp confidence_source=curator_derived \
+             (issue #1242), got {stored:?}"
+        );
+
+        // Round-trip via the typed enum — parses back cleanly.
+        let parsed = ConfidenceSource::from_str(&stored)
+            .expect("curator_derived must round-trip through ConfidenceSource::from_str");
+        assert_eq!(parsed, ConfidenceSource::CuratorDerived);
+    }
+
+    // Partial-index visibility: every atom row passes the
+    // `!= 'caller_provided'` predicate so the calibration sweep
+    // surfaces them. Pre-fix this count was 0 (atom rows stamped
+    // CallerProvided and were excluded from the index).
+    let n_visible: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE atom_of = ?1 \
+               AND confidence_source != 'caller_provided'",
+            rusqlite::params![&source_id],
+            |r| r.get(0),
+        )
+        .expect("count atoms in partial-index slice");
+    assert_eq!(
+        n_visible,
+        result.atom_ids.len() as i64,
+        "post-#1242 every atom of {source_id} must pass the partial-index predicate \
+         `confidence_source != 'caller_provided'` (calibration scan visibility)"
+    );
+}

--- a/tests/form_5_confidence_calibration.rs
+++ b/tests/form_5_confidence_calibration.rs
@@ -434,6 +434,9 @@ fn confidence_source_serialises_to_canonical_strings() {
         (ConfidenceSource::AutoDerived, "auto_derived"),
         (ConfidenceSource::Calibrated, "calibrated"),
         (ConfidenceSource::Decayed, "decayed"),
+        // v0.7.0 issue #1242 — curator-engine output bucket
+        // (atom rows + persona rows).
+        (ConfidenceSource::CuratorDerived, "curator_derived"),
     ] {
         assert_eq!(variant.as_str(), wire);
         assert_eq!(ConfidenceSource::from_str(wire), Some(variant));


### PR DESCRIPTION
## Summary

Fixes #1242. Persona + atom rows are engine-output, not caller-supplied, but pre-fix they stamped `confidence_source = CallerProvided` and were therefore excluded from the partial `idx_memories_confidence_source` index (predicate `WHERE confidence_source != 'caller_provided'`). That hid them from the calibration sweep and the forensic audit slice.

- Adds a fifth `ConfidenceSource::CuratorDerived` variant (wire `"curator_derived"`), distinct from `AutoDerived` (Form 5 derive engine).
- Switches `src/persona/mod.rs:397` and `src/atomisation/mod.rs:599` to the new variant.
- No schema migration needed — the partial index's `!= 'caller_provided'` predicate already accepts the new value.

## Test plan

- [x] `tests/confidence_source_curator_derived_1242.rs` (new) — persona row stamps `curator_derived`; every atom row stamps `curator_derived`; both pass the partial-index `!= caller_provided` predicate.
- [x] `src/models/memory.rs` round-trip table updated for the new variant.
- [x] `tests/form_5_confidence_calibration.rs` canonical-wire-string table updated.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic` clean.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4767 passed.
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test {confidence_source_curator_derived_1242, form_5_confidence_calibration, atomisation, persona, persona_signing_pipeline_813, wt1c_mcp_atomise}` all green.
- [x] `cargo audit` clean.

## AI involvement

Authored by Claude Opus 4.7 (1M context) under the prime directive pm-v3 (memory `cd8ede94`).