### PR TITLE
test(#1263): isolate list_enabled_by_kind_filters_correctly from dev-host operator key

### DIFF
--- a/src/governance/rules_store.rs
+++ b/src/governance/rules_store.rs
@@ -700,6 +700,13 @@ mod tests {
 
     #[test]
     fn list_enabled_by_kind_filters_correctly() {
+        // #1263 — on dev hosts where the operator already has an
+        // `operator.key.pub` configured, the substrate's enrichment
+        // hook reads + applies signed-rule semantics that this test
+        // doesn't seed; the result is a spurious failure isolated to
+        // dev hosts. Pin the no-pubkey posture via the RAII guard
+        // pattern documented in `governance/agent_action.rs::no_operator_pubkey`.
+        let _no_pubkey = force_no_operator_pubkey_for_test();
         let conn = fresh_conn();
         insert(&conn, &make_rule("R1", "bash", true)).unwrap();
         insert(&conn, &make_rule("R2", "bash", false)).unwrap();


### PR DESCRIPTION
## Summary

Closes #1263. \`governance::rules_store::tests::list_enabled_by_kind_filters_correctly\` fails on dev hosts where the operator already has an \`operator.key.pub\` configured. The substrate's enrichment hook reads + applies signed-rule semantics that the test fixture doesn't seed, producing a spurious failure isolated to dev hosts (CI never enrolls a pubkey so it always passed there).

Fix mirrors the established RAII guard pattern from \`governance::agent_action::tests::no_operator_pubkey\`:

\`\`\`rust
let _no_pubkey = force_no_operator_pubkey_for_test();
\`\`\`

added as the first line of the test body. The guard pins the no-pubkey posture for the test's duration; on drop it restores the prior value (matching every other governance test in the module).

\`force_no_operator_pubkey_for_test()\` already lives at \`src/governance/rules_store.rs:344\` (\`pub fn\`, process-wide lock-backed) and is in scope here via the existing \`use super::*;\` in the \`mod tests\` block — no import churn.

## Test plan

- [x] \`cargo fmt --check\`: clean
- [x] \`cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic\`: clean
- [x] \`cargo test --lib governance::rules_store::tests::list_enabled_by_kind_filters_correctly\`: 1/1 passed
- [x] \`cargo test --lib governance::rules_store\`: 33/33 passed (no regression on the wider rules_store suite)

## AI involvement

Authored by Claude Opus 4.7 (1M context).