### PR TITLE
fix(atomisation, #1244): thread curator model name into atomisation_complete signed event

### DIFF
--- a/src/atomisation/mod.rs
+++ b/src/atomisation/mod.rs
@@ -219,6 +219,20 @@ pub struct Atomiser {
     /// before the source is even loaded. Matches the WT-1-B brief
     /// ("keyword → TierLocked"); other tiers proceed.
     tier: crate::config::FeatureTier,
+    /// v0.7.0 (issue #1244) — the resolved curator model name. Stamped
+    /// verbatim into the `atomisation_complete` signed-event payload's
+    /// `curator_model` field so a downstream auditor walking
+    /// `signed_events` can attribute the decomposition to the model
+    /// that ACTUALLY ran on this deployment. Defaults to `"unknown"`
+    /// (the "truly unresolvable" fallback per the issue) when the
+    /// caller doesn't thread the model name through; production sites
+    /// call [`Self::with_curator_model`] with the resolved LLM model
+    /// id (`OllamaClient::model_name()` etc.) at construction.
+    ///
+    /// Pre-#1244 the payload field was hardcoded to `"gemma4"`,
+    /// surfacing the wrong provenance on every non-gemma deployment
+    /// (grok-4.3, claude-opus-4.7, etc. via the post-#1067 path).
+    curator_model: String,
 }
 
 impl Atomiser {
@@ -239,7 +253,41 @@ impl Atomiser {
             keypair,
             config,
             tier,
+            // v0.7.0 (#1244) — "unknown" is the documented fallback
+            // for callers (and tests with mock curators) that don't
+            // resolve a model. Production sites chain
+            // `.with_curator_model(llm.model_name())` after `::new`.
+            curator_model: "unknown".to_string(),
         }
+    }
+
+    /// v0.7.0 (issue #1244) — builder method that stamps the resolved
+    /// curator model name into the atomiser. Threaded into the
+    /// `atomisation_complete` signed-event payload as the
+    /// `curator_model` field so downstream auditors see the model that
+    /// actually ran on this deployment (grok-4.3, claude-opus-4.7,
+    /// gemma3:4b, etc.), not the pre-#1244 hardcoded `"gemma4"`.
+    ///
+    /// Production wiring sites pass `llm_client.model_name()` (from
+    /// `crate::llm::OllamaClient`). The model id passes through
+    /// verbatim — no normalisation, no defaulting beyond the
+    /// `"unknown"` fallback applied by [`Self::new`].
+    #[must_use]
+    pub fn with_curator_model(mut self, curator_model: impl Into<String>) -> Self {
+        let resolved = curator_model.into();
+        if !resolved.trim().is_empty() {
+            self.curator_model = resolved;
+        }
+        self
+    }
+
+    /// v0.7.0 (issue #1244) — accessor for the resolved curator model.
+    /// Exposed for the regression test that pins the
+    /// `atomisation_complete` payload's `curator_model` field reflects
+    /// the model threaded in at construction.
+    #[must_use]
+    pub fn curator_model(&self) -> &str {
+        &self.curator_model
     }
 
     /// Cluster-F PERF-5 — accessor for the configured Synchronous-mode
@@ -449,6 +497,7 @@ impl Atomiser {
             calling_agent_id,
             &archived_at,
             self.keypair.as_deref(),
+            &self.curator_model,
         )
         .map_err(|e| AtomiseError::DbError(e.to_string()))?;
 
@@ -700,6 +749,10 @@ fn archive_source(
 /// Append the final `atomisation_complete` event to `signed_events`.
 /// The payload binds the source id, the atom-id list, and the curator
 /// model id so a downstream auditor can reproduce the decomposition.
+///
+/// v0.7.0 (issue #1244) — `curator_model` is threaded in from the
+/// caller's resolved LLM model name (via [`Atomiser::with_curator_model`])
+/// rather than hardcoded to `"gemma4"`. Default fallback is `"unknown"`.
 fn emit_atomisation_complete_event(
     conn: &Connection,
     source_id: &str,
@@ -708,6 +761,7 @@ fn emit_atomisation_complete_event(
     calling_agent_id: &str,
     archived_at: &str,
     keypair: Option<&AgentKeypair>,
+    curator_model: &str,
 ) -> anyhow::Result<()> {
     let payload = serde_json::json!({
         "event_type": "atomisation_complete",
@@ -716,7 +770,7 @@ fn emit_atomisation_complete_event(
         "atom_count": atom_count,
         "calling_agent_id": calling_agent_id,
         "atomisation_timestamp": archived_at,
-        "curator_model": "gemma4",
+        "curator_model": curator_model,
     });
     let bytes = serde_json::to_vec(&payload)?;
     let (signature, attest_level) = if let Some(kp) = keypair.filter(|k| k.can_sign()) {

--- a/src/cli/commands/atomise.rs
+++ b/src/cli/commands/atomise.rs
@@ -281,11 +281,17 @@ pub fn run_with_curator(
 
     // Build the curator. Tests inject; production constructs an
     // LlmCurator backed by the tier-resolved Ollama model.
-    let curator: Box<dyn Curator> = if let Some(c) = curator_override {
-        c
+    //
+    // v0.7.0 (#1244) — also resolve the curator model name so the
+    // signed-event payload's `curator_model` field reflects what
+    // actually ran on this deployment.
+    let (curator, curator_model): (Box<dyn Curator>, String) = if let Some(c) = curator_override {
+        // Test path: caller injected a mock curator; we don't have a
+        // model name handy. Atomiser's "unknown" fallback applies.
+        (c, "unknown".to_string())
     } else {
         match build_llm_curator(tier) {
-            Ok(c) => c,
+            Ok((c, model)) => (c, model),
             Err(e) => {
                 let err = AtomiseError::CuratorFailed(e);
                 return emit_error(&err, &args.memory_id, args.json, out);
@@ -297,7 +303,8 @@ pub fn run_with_curator(
     // disk, matching the curator-pass / reflection-pass discipline.
     let keypair = load_keypair_best_effort(&calling_agent_id);
 
-    let atomiser = Atomiser::new(curator, keypair, AtomiserConfig::default(), tier);
+    let atomiser = Atomiser::new(curator, keypair, AtomiserConfig::default(), tier)
+        .with_curator_model(curator_model);
 
     match atomiser.atomise_sync(
         &conn,
@@ -328,7 +335,7 @@ pub fn run_with_curator(
 /// `openai-compatible` backend), when the legacy tier has no curator
 /// LLM configured (only `Keyword`, which the caller has already
 /// gated), or when the underlying client construction fails.
-fn build_llm_curator(tier: FeatureTier) -> std::result::Result<Box<dyn Curator>, String> {
+fn build_llm_curator(tier: FeatureTier) -> std::result::Result<(Box<dyn Curator>, String), String> {
     // v0.7.x (#1146) — route through the canonical resolver. The
     // resolver folds CLI flags (none here), AI_MEMORY_LLM_* env vars,
     // the [llm] config section, the legacy `llm_model`/`ollama_url`
@@ -336,11 +343,17 @@ fn build_llm_curator(tier: FeatureTier) -> std::result::Result<Box<dyn Curator>,
     // precedence ladder. Atomise's tier gate already refused
     // `Keyword`; for the other three tiers the resolver always
     // produces a usable backend/model pair.
+    //
+    // v0.7.0 (#1244) — also return the resolved model id so the caller
+    // can thread it into the atomiser's `curator_model` provenance.
     let _ = tier;
     let app_config = AppConfig::load();
     let resolved = app_config.resolve_llm(None, None, None);
     match OllamaClient::build_from_resolved(&resolved) {
-        Ok(Some(client)) => Ok(Box::new(LlmCurator::new(client))),
+        Ok(Some(client)) => {
+            let model = client.model_name().to_string();
+            Ok((Box::new(LlmCurator::new(client)), model))
+        }
         Ok(None) => Err(format!(
             "atomise: LLM resolver returned no client \
              (backend={}, source={}); atomise requires a curator LLM",

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -219,6 +219,20 @@ pub struct OllamaClient {
 }
 
 impl OllamaClient {
+    /// v0.7.0 (issue #1244) — accessor for the resolved model name.
+    ///
+    /// Returns the model identifier the client was constructed with
+    /// (e.g. `gemma3:4b` on Ollama, `grok-4.3` on xAI, `claude-opus-4.7`
+    /// on Anthropic). Substrate sites that bind LLM provenance into
+    /// signed audit events (e.g. the atomisation_complete
+    /// `curator_model` payload field) read this verbatim — never a
+    /// hardcoded string — so the signed event reflects the model that
+    /// actually ran on a given deployment, not a v0.6.x-era default.
+    #[must_use]
+    pub fn model_name(&self) -> &str {
+        &self.model
+    }
+
     /// Creates a new `OllamaClient` with the default Ollama URL (<http://localhost:11434>).
     /// Checks that Ollama is reachable before returning.
     #[allow(dead_code)]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2491,12 +2491,21 @@ pub fn run_mcp_server(
             let keypair_arc = active_keypair
                 .as_ref()
                 .map(|kp| std::sync::Arc::new(kp.clone()));
-            let atomiser = std::sync::Arc::new(crate::atomisation::Atomiser::new(
-                curator,
-                keypair_arc,
-                crate::atomisation::AtomiserConfig::default(),
-                tier_config.tier,
-            ));
+            // v0.7.0 (#1244) — thread the resolved LLM model name into
+            // the atomiser so the `atomisation_complete` signed-event
+            // payload's `curator_model` field reflects what actually
+            // ran on this deployment, not the pre-#1244 hardcoded
+            // `"gemma4"`.
+            let curator_model = llm_client.model_name().to_string();
+            let atomiser = std::sync::Arc::new(
+                crate::atomisation::Atomiser::new(
+                    curator,
+                    keypair_arc,
+                    crate::atomisation::AtomiserConfig::default(),
+                    tier_config.tier,
+                )
+                .with_curator_model(curator_model),
+            );
             eprintln!("ai-memory: atomisation engine ready (curator=LlmCurator)");
             Some(std::sync::Arc::new(atomise::AtomiseToolHandler::new(
                 atomiser,

--- a/tests/atomisation/core.rs
+++ b/tests/atomisation/core.rs
@@ -32,7 +32,7 @@ use ai_memory::atomisation::{AtomiseError, Atomiser, AtomiserConfig};
 use ai_memory::config::FeatureTier;
 use ai_memory::db;
 use ai_memory::models::{Memory, MemoryKind, MemoryLinkRelation, Tier};
-use ai_memory::signed_events::list_signed_events;
+use ai_memory::signed_events::{list_signed_events, payload_hash};
 use ai_memory::storage;
 use ai_memory::storage::GovernanceRefusal;
 
@@ -638,6 +638,175 @@ fn test_atomiser_records_signed_events() {
     assert!(
         !summary.payload_hash.is_empty(),
         "summary event must carry a payload_hash"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8b — #1244 regression: non-gemma curator model surfaces in the
+// signed event's `curator_model` payload field, NOT the pre-#1244
+// hardcoded "gemma4" literal.
+// ---------------------------------------------------------------------------
+//
+// Approach: the signed_events table stores `payload_hash` (SHA-256
+// over the canonical payload JSON), not the raw payload. We can't
+// read the curator_model literal back from the row directly. Instead
+// we (a) construct an Atomiser with a known, non-gemma curator_model
+// via `Atomiser::with_curator_model`, (b) run atomise, (c)
+// reconstruct the expected payload JSON byte-for-byte (the production
+// `emit_atomisation_complete_event` builds it with serde_json::json!),
+// hash it, and assert the stored `payload_hash` matches.
+//
+// Cross-check (negative): we ALSO reconstruct the payload with the
+// pre-#1244 hardcoded literal `"gemma4"` and assert the hash does
+// NOT match — proves the fix actually threads the new value through,
+// not just that a payload hash exists.
+#[test]
+fn test_atomiser_signed_event_curator_model_threads_through_1244() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+    set_mode(HookMode::Allow);
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "ns/1244/curator_model", 30);
+
+    // The non-gemma model id we thread through. Picked to be a string
+    // that NOBODY would generate by accident if the curator_model
+    // field were still hardcoded — so a failure here unambiguously
+    // points at the pre-#1244 hardcoded `"gemma4"` regression.
+    let custom_curator_model = "grok-4.3-test-1244";
+
+    let curator = Box::new(MockCurator::new(vec![Ok(atoms(&[
+        "Atom α.", "Atom β.", "Atom γ.",
+    ]))]));
+    let atomiser = Atomiser::new(curator, None, AtomiserConfig::default(), FeatureTier::Smart)
+        .with_curator_model(custom_curator_model);
+
+    // Accessor sanity check (cheap, doesn't depend on the atomise run).
+    assert_eq!(
+        atomiser.curator_model(),
+        custom_curator_model,
+        "with_curator_model must store the resolved id verbatim (#1244)"
+    );
+
+    let result = atomiser
+        .atomise_sync(&conn, &source_id, 200, false, "test-agent")
+        .expect("atomise");
+    let archived_at = result.archived_at.clone();
+
+    // Pull the atomisation_complete signed event.
+    let events = list_signed_events(&conn, None, 1000, 0).expect("list signed_events");
+    let complete = events
+        .iter()
+        .find(|e| e.event_type == "atomisation_complete")
+        .expect("atomisation_complete signed_event must exist");
+
+    // Re-build the payload byte-for-byte. Field order MUST match the
+    // production `emit_atomisation_complete_event` `serde_json::json!`
+    // invocation (it's stable, the macro preserves declaration order
+    // for the resulting Value's serialisation when keys are unique
+    // strings, AND `serde_json::to_vec` walks `Value::Object`'s
+    // BTreeMap-backed entries — so the canonical bytes are
+    // map-iteration order. We compute the expected bytes by going
+    // through `serde_json::json!` ourselves and `to_vec`-ing them.
+    let expected_payload = serde_json::json!({
+        "event_type": "atomisation_complete",
+        "source_id": source_id,
+        "atom_ids": result.atom_ids,
+        "atom_count": result.atom_count,
+        "calling_agent_id": "test-agent",
+        "atomisation_timestamp": archived_at,
+        "curator_model": custom_curator_model,
+    });
+    let expected_bytes = serde_json::to_vec(&expected_payload).expect("serialize expected payload");
+    let expected_hash = payload_hash(&expected_bytes);
+
+    assert_eq!(
+        complete.payload_hash, expected_hash,
+        "atomisation_complete payload_hash must match a payload that carries the \
+         threaded curator_model `{custom_curator_model}` (#1244)"
+    );
+
+    // Negative cross-check: the pre-#1244 hardcoded literal `"gemma4"`
+    // produces a DIFFERENT hash — proves the fix actually substitutes
+    // the resolved value, not merely that we got SOME hash.
+    let pre_1244_payload = serde_json::json!({
+        "event_type": "atomisation_complete",
+        "source_id": source_id,
+        "atom_ids": result.atom_ids,
+        "atom_count": result.atom_count,
+        "calling_agent_id": "test-agent",
+        "atomisation_timestamp": archived_at,
+        "curator_model": "gemma4",
+    });
+    let pre_1244_bytes =
+        serde_json::to_vec(&pre_1244_payload).expect("serialize pre-#1244 payload");
+    let pre_1244_hash = payload_hash(&pre_1244_bytes);
+
+    assert_ne!(
+        complete.payload_hash, pre_1244_hash,
+        "pre-#1244 hardcoded `gemma4` payload MUST NOT match — the fix has to \
+         actually thread the model name (#1244)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8c — #1244 fallback contract: when no curator_model is threaded
+// through, the Atomiser defaults to `"unknown"` (not the pre-#1244
+// hardcoded `"gemma4"`).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_atomiser_signed_event_curator_model_defaults_to_unknown_1244() {
+    let _g = test_serial()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_hook_installed();
+    set_mode(HookMode::Allow);
+
+    let (_tmp, conn) = fresh_db();
+    let source_id = insert_long_source(&conn, "ns/1244/default_unknown", 30);
+
+    let curator = Box::new(MockCurator::new(vec![Ok(atoms(&[
+        "Atom α.", "Atom β.", "Atom γ.",
+    ]))]));
+    // Construct WITHOUT `.with_curator_model(...)`; the default must
+    // be `"unknown"` per the #1244 issue body ("Default to
+    // \"unknown\" only when truly unresolvable").
+    let atomiser = Atomiser::new(curator, None, AtomiserConfig::default(), FeatureTier::Smart);
+
+    assert_eq!(
+        atomiser.curator_model(),
+        "unknown",
+        "Atomiser::new must default curator_model to `unknown` (#1244)"
+    );
+
+    let result = atomiser
+        .atomise_sync(&conn, &source_id, 200, false, "test-agent")
+        .expect("atomise");
+
+    let events = list_signed_events(&conn, None, 1000, 0).expect("list signed_events");
+    let complete = events
+        .iter()
+        .find(|e| e.event_type == "atomisation_complete")
+        .expect("atomisation_complete signed_event must exist");
+
+    let expected_payload = serde_json::json!({
+        "event_type": "atomisation_complete",
+        "source_id": source_id,
+        "atom_ids": result.atom_ids,
+        "atom_count": result.atom_count,
+        "calling_agent_id": "test-agent",
+        "atomisation_timestamp": result.archived_at,
+        "curator_model": "unknown",
+    });
+    let expected_bytes = serde_json::to_vec(&expected_payload).expect("serialize expected payload");
+    let expected_hash = payload_hash(&expected_bytes);
+
+    assert_eq!(
+        complete.payload_hash, expected_hash,
+        "atomisation_complete payload_hash must reflect the `unknown` default \
+         (#1244), NOT the pre-#1244 hardcoded `gemma4`"
     );
 }
 

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -9,8 +9,8 @@
 //!
 //! When Apache AGE is enrolled in the same database AND a duplicate
 //! `memories` relation exists under any other schema (e.g.
-//! `ag_catalog.memories` from a per-tenant search_path bootstrap in
-//! the LAN-parity IronClaw stack), the unscoped query returns the
+//! `ag_catalog.memories` from a per-tenant `search_path` bootstrap in
+//! the LAN-parity `IronClaw` stack), the unscoped query returns the
 //! WRONG dim — whichever Postgres surfaces first by oid order.
 //!
 //! This regression test stages the exact catalog shape that
@@ -27,7 +27,7 @@
 //! `src/store/postgres.rs:2694`, `src/store/postgres.rs:3121`) all
 //! still carry the unscoped query at this HEAD; #1213's "on hold"
 //! posture is NOT structurally safe — the duplicate-table
-//! catalog shape is reachable any time a per-tenant search_path
+//! catalog shape is reachable any time a per-tenant `search_path`
 //! places ai-memory schema in a non-`public` namespace.
 //!
 //! ## Test discipline


### PR DESCRIPTION
## Summary

Fixes #1244 — `emit_atomisation_complete_event` at `src/atomisation/mod.rs:719` hardcoded `"curator_model": "gemma4"` regardless of what the curator actually ran. Auditors walking `signed_events` saw `gemma4` even when the curator actually ran against grok-4.3 / claude-opus-4.7 / etc. via the post-#1067 path. Atomisation provenance was wrong on every non-gemma deployment.

## Changes

- `src/llm.rs` — add `pub fn model_name(&self) -> &str` accessor on `OllamaClient`.
- `src/atomisation/mod.rs` — add `curator_model: String` field to `Atomiser` (default `"unknown"`); add `with_curator_model` builder method; thread the field into `emit_atomisation_complete_event` via a new `curator_model: &str` param.
- `src/mcp/mod.rs` — wire `llm_client.model_name()` into the MCP atomise tool handler's Atomiser construction.
- `src/cli/commands/atomise.rs` — extend `build_llm_curator` to surface the resolved model id; thread into the CLI atomise command.
- `tests/atomisation/core.rs` — two new regression tests:
  - Positive: threading `grok-4.3-test-1244` surfaces in the payload hash; cross-check confirms the pre-#1244 hardcoded `gemma4` payload produces a DIFFERENT hash.
  - Fallback: default `Atomiser::new` (no `.with_curator_model(...)` chain) produces `"unknown"`, NOT `"gemma4"`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo clippy --tests -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test atomisation` — 17 passed (incl. 2 new regression tests; 1 ignored = live Ollama)
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --lib` — 4767 passed
- [x] `cargo audit` — clean

## AI involvement

Authored end-to-end by Claude Opus 4.7 (1M context) per ai-memory-mcp's AI Developer Workflow §8.2.

Base SHA: `4f488b28b`
Refs: #1067 (post-provider-agnostic atomiser substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)