### PR TITLE
fix(#1240): synthesis batch cycle-depth guard at cap=3

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,19 @@ pub enum MemoryError {
         cap: u32,
         namespace: String,
     },
+    /// Issue #1240 (HIGH) — emitted by the `memory_store` write path when
+    /// the synthesis-pass recursion depth (post-store hooks that fire
+    /// further `memory_store` calls, e.g. via curator chain-fire) exceeds
+    /// the compiled-in cap of 3. Mirrors the
+    /// [`Self::ReflectionDepthExceeded`] variant so audit + wire shape
+    /// stay symmetric across the two recursive-write primitives.
+    ///
+    /// Wire shape (HTTP): `409 CONFLICT` with code `SYNTHESIS_DEPTH_EXCEEDED`.
+    SynthesisDepthExceeded {
+        attempted: u32,
+        cap: u32,
+        namespace: String,
+    },
     /// v0.7.0 L1-2 (issue #659) — emitted by the `memory_link` write path
     /// when adding a `reflects_on` edge would close a cycle in the
     /// reflection graph. Carries `source`, `target`, and the reconstructed
@@ -91,6 +104,7 @@ impl MemoryError {
             Self::DatabaseError(_) => "DATABASE_ERROR",
             Self::Conflict(_) => "CONFLICT",
             Self::ReflectionDepthExceeded { .. } => "REFLECTION_DEPTH_EXCEEDED",
+            Self::SynthesisDepthExceeded { .. } => "SYNTHESIS_DEPTH_EXCEEDED",
             Self::ReflectionCycleDetected { .. } => "REFLECTION_CYCLE_DETECTED",
             Self::RefusedByGovernance(_) | Self::RefusedByGovernanceGate(_) => "GOVERNANCE_REFUSED",
         }
@@ -106,6 +120,7 @@ impl MemoryError {
             // the rest of governance-style refusals.
             Self::Conflict(_)
             | Self::ReflectionDepthExceeded { .. }
+            | Self::SynthesisDepthExceeded { .. }
             | Self::ReflectionCycleDetected { .. } => StatusCode::CONFLICT,
             // L1-6 Deliverable E — a pre-write hook refusal is a typed
             // authorization-style denial: the caller's request was
@@ -132,6 +147,14 @@ impl MemoryError {
             } => format!(
                 "reflection depth {attempted} would exceed namespace \
                  max_reflection_depth {cap} (namespace='{namespace}')"
+            ),
+            Self::SynthesisDepthExceeded {
+                attempted,
+                cap,
+                namespace,
+            } => format!(
+                "synthesis depth {attempted} would exceed compiled \
+                 max_synthesis_depth {cap} (namespace='{namespace}')"
             ),
             Self::ReflectionCycleDetected {
                 source,
@@ -516,6 +539,58 @@ mod tests {
         };
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #1240 — SynthesisDepthExceeded variant coverage. Mirrors
+    // the ReflectionDepthExceeded contract above so the two recursive-
+    // write primitives stay symmetric across audit + wire surfaces.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn synthesis_depth_exceeded_code() {
+        let err = MemoryError::SynthesisDepthExceeded {
+            attempted: 4,
+            cap: 3,
+            namespace: "ns/x".into(),
+        };
+        assert_eq!(err.code(), "SYNTHESIS_DEPTH_EXCEEDED");
+    }
+
+    #[test]
+    fn synthesis_depth_exceeded_status_is_conflict() {
+        let err = MemoryError::SynthesisDepthExceeded {
+            attempted: 5,
+            cap: 3,
+            namespace: "ns/y".into(),
+        };
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn synthesis_depth_exceeded_message_contains_triple() {
+        let err = MemoryError::SynthesisDepthExceeded {
+            attempted: 7,
+            cap: 3,
+            namespace: "ai-memory/research".into(),
+        };
+        let msg = err.message();
+        assert!(msg.contains("7"));
+        assert!(msg.contains("3"));
+        assert!(msg.contains("ai-memory/research"));
+        assert!(msg.contains("max_synthesis_depth"));
+    }
+
+    #[test]
+    fn synthesis_depth_exceeded_display() {
+        let err = MemoryError::SynthesisDepthExceeded {
+            attempted: 4,
+            cap: 3,
+            namespace: "ns".into(),
+        };
+        let s = format!("{err}");
+        assert!(s.contains("SYNTHESIS_DEPTH_EXCEEDED"));
+        assert!(s.contains("max_synthesis_depth"));
     }
 
     // -----------------------------------------------------------------

--- a/src/mcp/tools/store/mod.rs
+++ b/src/mcp/tools/store/mod.rs
@@ -409,6 +409,21 @@ pub(crate) fn handle_store(
     // Returns the per-candidate update/delete queue + the counts the
     // response envelope echoes back. SEC-1 / COR-5 / COR-6 contracts
     // are encapsulated inside the helper.
+    // Issue #1240 — synthesis-pass cycle-depth guard. Acquire the
+    // per-thread depth guard BEFORE invoking `run_synthesis_pass`; if
+    // the post-increment depth exceeds `MAX_SYNTHESIS_DEPTH` we refuse
+    // with `SYNTHESIS_DEPTH_EXCEEDED`. The guard is held across the
+    // synthesis-pass body so any post-store hooks that chain-fire a
+    // nested `memory_store` observe the higher depth and either stay
+    // within budget or refuse on entry.
+    //
+    // The guard is bound to `_synthesis_depth_guard` even when the
+    // pass is skipped so an `_` binding doesn't accidentally drop the
+    // guard early on the eligible branch (Rust drops `let _ = ...`
+    // bindings at the end of the statement, but
+    // `let _name = ...` retains the binding for the rest of the
+    // function — we want the latter).
+    let (_synthesis_depth, _synthesis_depth_guard) = crate::synthesis::enter_synthesis_pass();
     let synthesis_outcome = if synthesis::synthesis_eligible(
         autonomous_hooks,
         llm.is_some(),
@@ -416,6 +431,22 @@ pub(crate) fn handle_store(
         &mem.namespace,
         &ns_policy,
     ) {
+        if _synthesis_depth > crate::synthesis::MAX_SYNTHESIS_DEPTH {
+            tracing::warn!(
+                target: "synthesis",
+                namespace = %mem.namespace,
+                attempted = _synthesis_depth,
+                cap = crate::synthesis::MAX_SYNTHESIS_DEPTH,
+                "synthesis.depth_exceeded",
+            );
+            return Err(format!(
+                "SYNTHESIS_DEPTH_EXCEEDED: synthesis depth {} would exceed compiled \
+                 max_synthesis_depth {} (namespace='{}')",
+                _synthesis_depth,
+                crate::synthesis::MAX_SYNTHESIS_DEPTH,
+                mem.namespace,
+            ));
+        }
         let llm_client = llm.expect("synthesis_eligible guarantees llm.is_some()");
         synthesis::run_synthesis_pass(llm_client, &mem, &agent_id, &existing, &ns_policy)?
     } else {

--- a/src/synthesis/mod.rs
+++ b/src/synthesis/mod.rs
@@ -530,6 +530,90 @@ impl SynthesisCounts {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Issue #1240 — synthesis-pass cycle-depth guard.
+//
+// Pathological curator output that chain-fires (e.g. a Form-1 verdict whose
+// post-store hooks trigger a fresh `memory_store` whose synthesis pass then
+// chain-fires again, ad infinitum) is bounded by a thread-local depth counter
+// analogous to `reflection_depth`. The counter increments when the store
+// handler enters a synthesis-eligible write, gets checked against the cap,
+// and decrements when the write completes. Any nested `memory_store` call
+// on the same thread observes the higher depth and refuses past
+// `MAX_SYNTHESIS_DEPTH` with `SYNTHESIS_DEPTH_EXCEEDED`.
+//
+// Thread-local (not process-wide) so parallel HTTP / MCP requests don't
+// share state — each request walks its own call stack and either stays
+// shallow or hits the cap independently.
+// ---------------------------------------------------------------------------
+
+/// Compiled-in cap for the recursive synthesis-pass depth. A
+/// `memory_store` call site running at depth `N` may invoke another
+/// `memory_store` (via post-store hooks, curator chain-fire, etc.); each
+/// such nesting bumps the counter by 1. Once the counter exceeds this
+/// cap the substrate refuses the synthesis pass with
+/// `SYNTHESIS_DEPTH_EXCEEDED`. Mirrors
+/// [`crate::models::GovernancePolicy::effective_max_reflection_depth`]
+/// at 3 — bounds recursion without strangling legitimate two-step
+/// curator hand-offs.
+pub const MAX_SYNTHESIS_DEPTH: u32 = 3;
+
+thread_local! {
+    /// Per-thread counter tracking how deep into the synthesis-pass
+    /// call stack the current `memory_store` invocation is. Reset to
+    /// 0 between independent requests by the RAII guard returned from
+    /// [`enter_synthesis_pass`]. Cheap, no allocation per call.
+    static SYNTHESIS_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Read the current thread's synthesis-pass recursion depth. Returns
+/// `0` outside any active store handler (production callers); returns
+/// `N` while the `N`-th nested store handler is in flight on this
+/// thread.
+#[must_use]
+pub fn current_synthesis_depth() -> u32 {
+    SYNTHESIS_DEPTH.with(std::cell::Cell::get)
+}
+
+/// RAII guard returned by [`enter_synthesis_pass`]. While the guard is
+/// alive, the thread's synthesis depth is incremented by 1; on drop
+/// the depth decrements. The store handler holds the guard across the
+/// `run_synthesis_pass` call so any post-store hooks that re-enter
+/// `memory_store` observe the incremented depth.
+pub struct SynthesisDepthGuard {
+    /// Depth this guard was responsible for incrementing TO. On drop
+    /// we restore to `prior = depth - 1`. Stored explicitly so a
+    /// panicked guard doesn't leak the higher depth into the next
+    /// request reusing this thread.
+    prior: u32,
+}
+
+impl Drop for SynthesisDepthGuard {
+    fn drop(&mut self) {
+        SYNTHESIS_DEPTH.with(|cell| cell.set(self.prior));
+    }
+}
+
+/// Enter a synthesis-pass scope. Returns the new depth (post-increment)
+/// plus an RAII guard that restores the depth on drop. Callers MUST
+/// retain the guard across the full synthesis-pass body — dropping it
+/// mid-call would underflow the depth and let nested calls escape the
+/// cap.
+///
+/// The caller is expected to compare the returned depth against
+/// [`MAX_SYNTHESIS_DEPTH`] and refuse with `SYNTHESIS_DEPTH_EXCEEDED`
+/// when over-cap.
+#[must_use]
+pub fn enter_synthesis_pass() -> (u32, SynthesisDepthGuard) {
+    let (prior, new) = SYNTHESIS_DEPTH.with(|cell| {
+        let prior = cell.get();
+        let new = prior.saturating_add(1);
+        cell.set(new);
+        (prior, new)
+    });
+    (new, SynthesisDepthGuard { prior })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,5 +835,51 @@ mod tests {
         assert_eq!(SynthesisVerb::Update.as_str(), "update");
         assert_eq!(SynthesisVerb::Delete.as_str(), "delete");
         assert_eq!(SynthesisVerb::NoOp.as_str(), "no_op");
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #1240 — synthesis-pass cycle-depth guard.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn issue_1240_max_synthesis_depth_constant_is_three() {
+        // Mirrors `effective_max_reflection_depth`'s compiled default
+        // so the two recursive-write primitives have symmetric caps.
+        assert_eq!(MAX_SYNTHESIS_DEPTH, 3);
+    }
+
+    #[test]
+    fn issue_1240_enter_synthesis_pass_increments_and_guard_restores() {
+        // Per-thread counter — run on a dedicated worker thread so the
+        // assertion isn't contaminated by parallel-test depth state.
+        let t = std::thread::spawn(|| {
+            assert_eq!(current_synthesis_depth(), 0, "fresh thread starts at 0");
+            {
+                let (d1, _g1) = enter_synthesis_pass();
+                assert_eq!(d1, 1, "first entry returns 1");
+                assert_eq!(current_synthesis_depth(), 1);
+                {
+                    let (d2, _g2) = enter_synthesis_pass();
+                    assert_eq!(d2, 2, "second entry returns 2");
+                    assert_eq!(current_synthesis_depth(), 2);
+                    {
+                        let (d3, _g3) = enter_synthesis_pass();
+                        assert_eq!(d3, 3, "third entry returns 3");
+                        assert_eq!(current_synthesis_depth(), 3);
+                        {
+                            let (d4, _g4) = enter_synthesis_pass();
+                            assert_eq!(d4, 4, "fourth entry returns 4 — over cap");
+                            assert!(d4 > MAX_SYNTHESIS_DEPTH, "depth=4 exceeds cap=3");
+                        }
+                        // After g4 drops, depth restored to 3.
+                        assert_eq!(current_synthesis_depth(), 3, "g4 drop -> depth=3");
+                    }
+                    assert_eq!(current_synthesis_depth(), 2, "g3 drop -> depth=2");
+                }
+                assert_eq!(current_synthesis_depth(), 1, "g2 drop -> depth=1");
+            }
+            assert_eq!(current_synthesis_depth(), 0, "g1 drop -> depth=0");
+        });
+        t.join().expect("worker thread joins clean");
     }
 }

--- a/tests/form_1_synthesis.rs
+++ b/tests/form_1_synthesis.rs
@@ -1504,3 +1504,129 @@ fn issue_1239_synthesis_delete_reinsert_emits_supersedes_link() {
          both endpoints were alive"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1240 — synthesis-pass cycle-depth guard.
+//
+// A pathological curator (or post-store hook chain) could fire a fresh
+// `memory_store` from inside the synthesis pass; without a depth guard
+// each nested call would also synthesise, creating a recursive blow-up
+// that consumes the LLM budget and may stack-overflow.
+//
+// The substrate exposes a per-thread `enter_synthesis_pass()` RAII
+// helper that increments a depth counter on entry and decrements on
+// drop. `handle_store` checks the post-increment depth against the
+// compiled cap `MAX_SYNTHESIS_DEPTH = 3` BEFORE invoking
+// `run_synthesis_pass`; a depth of 4 refuses the write with
+// `SYNTHESIS_DEPTH_EXCEEDED`.
+// ---------------------------------------------------------------------------
+
+/// Issue #1240 — at depth=4 (after three nested synthesis-pass entries),
+/// the 4th `memory_store` synthesis-eligible call refuses with
+/// `SYNTHESIS_DEPTH_EXCEEDED`. Simulates the pathological chain-fire by
+/// holding three `enter_synthesis_pass()` guards across the test call.
+#[test]
+fn issue_1240_synthesis_depth_guard_refuses_at_depth_4() {
+    let (conn, db_path) = open_db();
+    let ns = "ns-1240-depth";
+    let _seed = seed_existing(&conn, "kubernetes deployment notes", "prior body", ns);
+
+    let verdict = json!({
+        "verdicts": [{"candidate_id": "any", "verb": "no_op"}]
+    });
+    let server = shared_mock_for_synthesis(verdict);
+    let uri = server.uri();
+    let llm = OllamaClient::new_with_url(&uri, "test-model").expect("mock client");
+
+    // Push the per-thread depth counter to 3 by acquiring three
+    // synthesis-pass guards. The 4th entry (inside `run_store` ->
+    // `handle_store`) will post-increment to 4 and trip the cap.
+    let (d1, _g1) = ai_memory::synthesis::enter_synthesis_pass();
+    let (d2, _g2) = ai_memory::synthesis::enter_synthesis_pass();
+    let (d3, _g3) = ai_memory::synthesis::enter_synthesis_pass();
+    assert_eq!(d1, 1, "first entry sets depth=1");
+    assert_eq!(d2, 2, "second entry sets depth=2");
+    assert_eq!(d3, 3, "third entry sets depth=3");
+    assert_eq!(
+        ai_memory::synthesis::current_synthesis_depth(),
+        3,
+        "depth counter reads back the active depth"
+    );
+
+    let err = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect_err("must refuse at depth=4");
+    assert!(
+        err.starts_with("SYNTHESIS_DEPTH_EXCEEDED:"),
+        "expected SYNTHESIS_DEPTH_EXCEEDED refusal, got: {err}"
+    );
+    assert!(
+        err.contains('4'),
+        "error message names the attempted depth (4): {err}"
+    );
+    assert!(
+        err.contains('3'),
+        "error message names the compiled cap (3): {err}"
+    );
+    assert!(
+        err.contains(ns),
+        "error message names the target namespace: {err}"
+    );
+}
+
+/// Issue #1240 — at depth <= cap (3 or below), the synthesis pass runs
+/// to completion (sanity guard so the depth-cap check doesn't refuse
+/// the happy-path single-store). Drops all guards before the call to
+/// confirm the counter starts at 0 in the absence of a parent scope.
+#[test]
+fn issue_1240_synthesis_depth_guard_admits_depth_under_cap() {
+    let (conn, db_path) = open_db();
+    let ns = "ns-1240-under-cap";
+    let _seed = seed_existing(&conn, "kubernetes deployment notes", "prior body", ns);
+
+    let verdict = json!({
+        "verdicts": [{"candidate_id": "any", "verb": "no_op"}]
+    });
+    let server = shared_mock_for_synthesis(verdict);
+    let uri = server.uri();
+    let llm = OllamaClient::new_with_url(&uri, "test-model").expect("mock client");
+
+    // Sanity: depth starts at 0 in a fresh test thread (the guards
+    // from the prior failing test were dropped at end-of-fn).
+    assert_eq!(
+        ai_memory::synthesis::current_synthesis_depth(),
+        0,
+        "depth counter is per-thread and resets between independent tests"
+    );
+
+    // Depth=1 (the store handler's own entry) — under the cap of 3.
+    let resp = run_store(
+        &conn,
+        &db_path,
+        &llm,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": BASE_CONTENT,
+            "namespace": ns,
+            "on_conflict": "version",
+        }),
+    )
+    .expect("store ok at depth=1");
+    assert!(resp["id"].is_string(), "store proceeded at depth=1");
+
+    // After the call returns, the depth counter is back at 0.
+    assert_eq!(
+        ai_memory::synthesis::current_synthesis_depth(),
+        0,
+        "RAII guard restored the depth on drop"
+    );
+}


### PR DESCRIPTION
## Summary

A pathological curator (or post-store hook chain) could fire fresh `memory_store` calls from inside the synthesis pass; without a depth guard each nested call would also synthesise, creating a recursive blow-up that consumes the LLM budget and can stack-overflow.

- New per-thread `enter_synthesis_pass()` RAII helper in `crate::synthesis` increments a `thread_local!` depth counter on entry and decrements on drop.
- `handle_store` acquires the guard BEFORE `run_synthesis_pass`; the post-increment depth is compared against `MAX_SYNTHESIS_DEPTH = 3` and any depth > cap refuses with `SYNTHESIS_DEPTH_EXCEEDED`.
- New `MemoryError::SynthesisDepthExceeded { attempted, cap, namespace }` variant (HTTP 409 CONFLICT, wire prefix `SYNTHESIS_DEPTH_EXCEEDED:`), mirroring the `ReflectionDepthExceeded` contract.

Thread-local (not process-wide) so parallel HTTP / MCP requests walk independent call stacks.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --bins --test form_1_synthesis -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo test --lib` 4781 tests pass (+4 SynthesisDepthExceeded variants + 2 enter_synthesis_pass guards from #1240)
- [x] `cargo test --test form_1_synthesis` 17/17 (includes 2 new regression tests `issue_1240_synthesis_depth_guard_refuses_at_depth_4` + `issue_1240_synthesis_depth_guard_admits_depth_under_cap`)
- [x] `cargo test --test form_1_synthesis_verdict_matrix` 20/20
- [x] `cargo test --test form_2_synchronous_atomise` 3/3
- [x] `cargo audit` clean

## AI involvement
Authored by Claude Opus 4.7 (1M context) per AI_DEVELOPER_WORKFLOW.md §8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)