### PR TITLE
test(mcp, #1315): pin memory_reflect wire-layer metadata passthrough

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -5015,6 +5015,169 @@ mod tests {
         }
     }
 
+    // Issue #1315 — `memory_reflect` MCP **wire-layer** metadata
+    // passthrough regression pin.
+    //
+    // The PR #1177 / issue #1172 fix landed the substrate pin
+    // (`db_reflect_preserves_caller_supplied_entity_id`) and a
+    // direct-handler pin (`mcp_handle_reflect_preserves_caller_
+    // supplied_entity_id` in `tests/issue_1172_reflect_metadata_
+    // passthrough.rs`) — but invariant 3 of that suite calls
+    // `mcp::handle_reflect` **directly**, bypassing the JSON-RPC
+    // `tools/call` dispatcher (`handle_request`'s `arguments`
+    // extraction → `lookup_dispatch` → `dispatch_memory_reflect` →
+    // `handle_reflect`). The gap left every layer between
+    // `req.params["arguments"]` extraction and the substrate write
+    // path unpinned — a future refactor that, say, threaded the
+    // dispatcher through `serde_json::from_value::<ReflectRequest>`
+    // with `#[schemars(deny_unknown_fields)]` would silently strip
+    // every custom caller key and the existing #1172 suite would
+    // still pass.
+    //
+    // This pin closes the gap. It builds a real JSON-RPC `tools/call`
+    // request and runs it through `handle_request` (the same surface
+    // `run_mcp_server`'s stdin loop drives) so a regression in any of
+    // the layers between `req.params["arguments"]` extraction and
+    // `handle_reflect`'s `params["metadata"]` read fires here, not in
+    // production. Asserts:
+    //
+    //   1. `metadata.entity_id` (the PERF-8 step-1 path) survives the
+    //      transport.
+    //   2. An arbitrary caller-supplied key (`probe="P2"`) survives —
+    //      pins that the drop point is not specific to `entity_id` but
+    //      preserves the full additive contract.
+    //   3. `mentioned_entity_id` denormalised column is populated, the
+    //      end-to-end persona-binding path (#1172 invariant 4) holds
+    //      via the wire layer too.
+    #[test]
+    fn issue_1315_memory_reflect_wire_layer_preserves_caller_metadata() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        // Seed three source observations the reflection will fan out
+        // to (matching the #815 test shape so the reflect transaction
+        // exercises the same code paths).
+        let mut source_ids = Vec::new();
+        for tag in ["src-a", "src-b", "src-c"] {
+            let mem = Memory {
+                id: uuid::Uuid::new_v4().to_string(),
+                tier: Tier::Mid,
+                namespace: "issue-1315-wire".into(),
+                title: tag.into(),
+                content: format!("body for {tag}"),
+                tags: vec![],
+                priority: 5,
+                confidence: 1.0,
+                source: "api".into(),
+                access_count: 0,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                last_accessed_at: None,
+                expires_at: None,
+                metadata: json!({}),
+                reflection_depth: 0,
+                memory_kind: crate::models::MemoryKind::Observation,
+                entity_id: None,
+                persona_version: None,
+                citations: Vec::new(),
+                source_uri: None,
+                source_span: None,
+                confidence_source: crate::models::ConfidenceSource::CallerProvided,
+                confidence_signals: None,
+                confidence_decayed_at: None,
+                version: 1,
+            };
+            source_ids.push(db::insert(&conn, &mem).unwrap());
+        }
+
+        // Build a wire-shape JSON-RPC tools/call with caller-supplied
+        // custom metadata keys. `entity_id` and `probe` are both
+        // expected to survive transport per the documented additive
+        // metadata contract — the #1172 PR claimed to fix entity_id,
+        // but the wire path drops every custom key in flight.
+        let req = make_tools_call(
+            "memory_reflect",
+            json!({
+                "source_ids": source_ids,
+                "title": "issue-1315 wire-layer metadata pin",
+                "content": "caller metadata.entity_id + probe must round-trip through tools/call",
+                "namespace": "issue-1315-wire",
+                "metadata": {
+                    "entity_id": "entity-1315-wire",
+                    "probe": "P2",
+                },
+            }),
+        );
+
+        let resp = invoke_handle_request(&conn, &req);
+        assert!(
+            resp.error.is_none(),
+            "expected ok rpc envelope; got error: {:?}",
+            resp.error
+        );
+        // MCP-spec tool envelope: success carries `content[0].text`
+        // with the handler's JSON result serialized as a string.
+        let result = resp.result.expect("result envelope");
+        assert!(
+            result.get("isError").is_none_or(|v| v != true),
+            "tools/call must not surface isError=true; result: {result}"
+        );
+        let text = result["content"][0]["text"]
+            .as_str()
+            .expect("content[0].text on memory_reflect ok envelope");
+        let parsed: Value = serde_json::from_str(text).expect("reflect result text is JSON");
+        let reflection_id = parsed["id"]
+            .as_str()
+            .expect("reflect result carries the new memory id")
+            .to_string();
+
+        // Pull the row's metadata + denormalised mention column
+        // straight from sqlite — this is the same shape the #1172
+        // suite probes and the same column `persona::load_
+        // reflections_for_entity` keys off in production.
+        let (meta_str, mention): (String, Option<String>) = conn
+            .query_row(
+                "SELECT metadata, mentioned_entity_id FROM memories WHERE id = ?1",
+                rusqlite::params![&reflection_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("select reflection row");
+        let meta: Value = serde_json::from_str(&meta_str).expect("metadata is JSON");
+
+        // Invariant (1): entity_id round-trips through the wire path.
+        assert_eq!(
+            meta.get("entity_id").and_then(Value::as_str),
+            Some("entity-1315-wire"),
+            "wire path must preserve metadata.entity_id; full metadata = {meta}"
+        );
+        // Invariant (2): arbitrary caller-supplied key survives too.
+        // The defect drops every custom key — not just entity_id — so
+        // pinning a second key proves the fix isn't a one-key hack.
+        assert_eq!(
+            meta.get("probe").and_then(Value::as_str),
+            Some("P2"),
+            "wire path must preserve every caller-supplied metadata key; full metadata = {meta}"
+        );
+        // Invariant (3): PERF-8 denormalised column reflects the
+        // round-tripped entity_id so the persona-binding query
+        // (`WHERE mentioned_entity_id = ?`) still finds the row when
+        // it was minted through the wire path.
+        assert_eq!(
+            mention.as_deref(),
+            Some("entity-1315-wire"),
+            "mentioned_entity_id column must be populated from the wire-supplied metadata.entity_id"
+        );
+        // The system-generated keys also land alongside (additive
+        // contract — caller wins on collision, but the system splices
+        // its own keys when the caller didn't pre-set them).
+        assert!(
+            meta.get("agent_id").is_some(),
+            "system-generated agent_id must still be present"
+        );
+        assert!(
+            meta.get("reflection_metadata").is_some(),
+            "system-generated reflection_metadata block must still be present"
+        );
+    }
+
     #[test]
     fn handle_link_error_missing_target_id() {
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();


### PR DESCRIPTION
## Summary

Closes #1315.

PR #1177 / issue #1172 added a 5-invariant regression suite for `memory_reflect` metadata passthrough, but invariant 3 (`mcp_handle_reflect_preserves_caller_supplied_entity_id`) calls `mcp::handle_reflect` DIRECTLY — bypassing the JSON-RPC `tools/call` dispatcher (`handle_request` → `lookup_dispatch` → `dispatch_memory_reflect` → `handle_reflect`) that `run_mcp_server` actually drives in production. The gap left every layer between `req.params[\"arguments\"]` extraction and the substrate write path unpinned: a future refactor (e.g. routing the dispatcher through `serde_json::from_value::<ReflectRequest>` with `#[schemars(deny_unknown_fields)]`) could silently strip every custom caller key while the existing #1172 suite stayed green.

This commit closes the gap by adding `issue_1315_memory_reflect_wire_layer_preserves_caller_metadata` to `src/mcp/mod.rs::tests`. The test:

1. Builds a real JSON-RPC `tools/call` request via the existing `make_tools_call` helper.
2. Drives it through `handle_request` (the same surface `run_mcp_server`'s stdin loop dispatches against).
3. Asserts that caller-supplied `metadata.entity_id` round-trips into the stored row (PERF-8 step-1 path for `extract_mentioned_entity_id`).
4. Asserts an arbitrary second caller key (`probe = \"P2\"`) survives — pinning that this is the additive metadata contract, not a one-key carve-out for `entity_id`.
5. Asserts the indexed `mentioned_entity_id` column is populated from wire-supplied metadata, so the persona-binding query (`WHERE mentioned_entity_id = ?`) resolves rows minted via the wire path.

## On the originating live observation (#1315)

The originally-filed defect at #1315 reported that the production binary dropped caller `metadata.entity_id`. **Investigation showed that the in-memory MCP daemon the original probe ran against pre-dated PR #1177's silent-fix landing in adjacent code.** Per CLAUDE.md §\"Recompile + batch retest discipline\", the running MCP session keeps the old binary in memory; retesting via a freshly-spawned `ai-memory mcp` subprocess against the rebuilt binary at base SHA `1e33b51d6` shows the wire path correctly preserves caller metadata (verified independently by the QC agent: caller `entity_id` + `probe` keys both round-trip; `mentioned_entity_id` populated).

So this PR does not add a production-code fix — there's nothing broken at base SHA. Instead it adds the wire-layer regression pin PR #1177 should have included. The next time someone refactors the dispatcher and accidentally introduces a `deny_unknown_fields` round-trip, the test will catch it at CI rather than at live-probe time.

## Negative-test discipline

Both fix-agent and QC-agent independently verified the test catches the regression: injecting `obj.remove(\"metadata\")` into `dispatch_memory_reflect` reproduced the exact `{agent_id, reflection_metadata}` defect signature from #1315; reverting restored PASS.

## Gates (all clean per QC-agent run on the worktree)

- `cargo fmt --check` — PASS
- `cargo clippy --tests --lib -- -D warnings -D clippy::all -D clippy::pedantic` — PASS
- `AI_MEMORY_NO_CONFIG=1 cargo test --test issue_1172_reflect_metadata_passthrough` — PASS (9/9)
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib issue_1315_memory_reflect_wire_layer_preserves_caller_metadata` — PASS (1/1)
- `cargo audit` — PASS (529 deps; 0 vulnerabilities)
- `AI_MEMORY_NO_CONFIG=1 cargo test --test recursive_learning_task4_memory_reflect` — PASS (16/16, no adjacent regression)

## Test plan

- [x] New wire-layer test PASS in isolation.
- [x] Injection of `obj.remove(\"metadata\")` into `dispatch_memory_reflect` causes new test to FAIL with exact #1315 signature.
- [x] Revert restores PASS.
- [x] All 4 cargo gates PASS.
- [x] Independent QC agent verifies stale-binary diagnosis via fresh subprocess + sqlite probe.
- [x] No adjacent test regression.

## Provenance

- Filed during Phase-1 of `docs/v0.7.0/heterogeneous-ai-nhi-assessment/` (issue #1171).
- Fix-agent dispatched in worktree off `release/v0.7.0` HEAD `1e33b51d6`. Base SHA pinned per CLAUDE.md multi-agent worktree discipline.
- QC-agent verdict: PASS-WITH-CAVEATS — safe to merge. Caveats: (1) update #1315 body to reflect stale-binary diagnosis, (2) post-merge orchestrator should reprobe operator's live MCP session, (3) HTTP / CLI wire-path parity tests not in this commit — possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context) parent, fix + QC subagents under pm-v3 prime directive.