### PR TITLE
docs: explain why CLI omits flat reflect verb (preserves §2.6 bias-displacement architecture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.7.x doc follow-ups + Wave-2 refactor (post-tag)
 
+### Documentation
+
+- **Add `docs/cli-design-rationale.md`** — documents why the CLI surface omits a flat `ai-memory reflect` verb despite providing `ai-memory store` and `ai-memory recall`. Reflection composes with the §2.6 bias-displacement architecture (cross-model reflection boundary); the CLI surfaces reflection through actor-named higher-level verbs (`curator --reflect`, `consolidate`) rather than as a flat primitive verb. The substrate primitive remains accessible via `ai-memory mcp` JSON-RPC for debugging and bridge tooling. `ROADMAP.md` §17 cross-references this rationale alongside the existing quality-gate enumeration.
+
 ### refactor(#1174) — pm-v3.1 Variables + Constants + Vendor-Neutrality 10-PR train (2026-05-24/25)
 
 Closes [#1174](https://github.com/alphaonedev/ai-memory-mcp/issues/1174) (parent) with unanimous ZERO-DEFECTS-CONFIRMED across three independent decorrelated codegraph-driven QC audits per pm-v3.2 NO FAIL MISSION closure discipline (ai-memory `global/policies` memory `2cb15d34-2399-4611-a020-df6ef91683fe`): Audit A literal enumeration (0 substrate violations across all 6 gated categories), Audit B structural call-graph (25 callers of `DEFAULT_NAMESPACE`, 46 of `SECS_PER_HOUR`, 185 of `tool_names::MEMORY_*`, 132 of `Tier::*.as_str()`, 36 cross-surface refs of `RuntimeContext::global()` — every abstraction exceeds expected minimums), Audit C regression-invariance fault injection (6 contrived violations × 6 categories all caught by `scripts/check-vendor-literals.sh` with cleanup-clean + final-clean exit 0 = GATE-LOAD-BEARING-CONFIRMED).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -855,6 +855,7 @@ Plus per-release:
 - Public-surface landing pages (ship-gate, A2A-gate) auto-update from result JSON.
 - **NEW: §2 property contribution declared per release.** Each release's CHANGELOG.md must name which of the seven properties (§2.1–§2.7) the release strengthens, with code anchors. If a release strengthens none, the release proposal must be re-evaluated against the §3 scope test before merge.
 - **NEW for major versions: heterogeneous AI NHI panel review** ([#1171](https://github.com/alphaonedev/ai-memory-mcp/issues/1171) methodology) on strategic-layer claims before tag. Single-evaluator strategic claims are not procurement-defensible; heterogeneous-evaluator strategic claims are.
+- **CLI design rationale.** For why the CLI exposes some MCP tools as flat verbs and others through actor-named higher-level verbs, see [`docs/cli-design-rationale.md`](docs/cli-design-rationale.md). The asymmetry between `ai-memory store` / `ai-memory recall` (flat) and `ai-memory curator --reflect` / `ai-memory consolidate` (actor-named) preserves the §2.6 bias-displacement architectural distinction at the operator interface.
 
 ---
 

--- a/docs/cli-design-rationale.md
+++ b/docs/cli-design-rationale.md
@@ -1,0 +1,46 @@
+# CLI Design Rationale
+
+## Why there is no flat `ai-memory reflect` verb
+
+The CLI exposes `ai-memory store` and `ai-memory recall` as flat verbs because storage and retrieval are model-neutral substrate operations — the operator invoking them is the author of the operation, and no architectural property depends on which model family is in the loop at invocation time.
+
+Reflection is structurally different. Reflection composes with the **bias-displacement architecture** named in [`docs/strategy/moonshot-synthesis.md`](strategy/moonshot-synthesis.md) §2.6 — the cross-model reflection boundary where a decorrelated-family LLM reflects on the producing LLM's work to produce bias-displaced cognitive artifacts. This is the federalist-papers move applied to AI cognition: the substrate does not trust any single cognition's account of its own actions; it trusts only the intersection of cognitions with decorrelated errors.
+
+There are two structurally distinct operations both called "reflection":
+
+| Operation | What it is | How it is invoked |
+|---|---|---|
+| **Substrate-primitive reflection** | A depth-N memory write with `reflects_on` link edges (`memory_reflect` MCP tool). Model-neutral. The mechanism. | `ai-memory mcp` JSON-RPC subprocess; direct handler call from substrate-internal code paths |
+| **Bias-displacement reflection** | The cross-model reflection pass where the second LLM (currently `models.llm` from capabilities — e.g., xAI Grok 4.3) reflects on the producing LLM's memories. The architectural property §2.6 requires. | `ai-memory curator --reflect`; periodic curator-daemon passes; `memory_consolidate` |
+
+A flat `ai-memory reflect` CLI verb would expose the substrate primitive to the operator in a shape that visually parallels `ai-memory store` and `ai-memory recall`. The visual parallel is the problem: it would suggest reflection is a model-neutral storage operation, when in fact whether a reflection produces bias-displacement depends on which model family invoked it. An operator typing `ai-memory reflect --source-ids ... --content ...` would write a reflection authored by the operator (not by a decorrelated LLM), and the cognitive artifact would carry the visual shape of a reflection without the architectural property the substrate's §2.6 alignment claim depends on.
+
+## The current CLI surface
+
+The CLI surfaces reflection only through actor-named higher-level verbs that name what is happening:
+
+- **`ai-memory curator --reflect`** — fires a curator pass. The curator uses `models.llm` (the configured second LLM, decorrelated from the producing LLM by deployment discipline) to reflect on memories in the namespace. This is the bias-displaced path.
+- **`ai-memory consolidate`** — substrate-side merge of multiple source memories into a synthesized memory. Uses the curator path internally.
+- **`ai-memory export-reflections`** — file-backed export of existing reflection chains for audit, archival, or pipeline handoff.
+- **`ai-memory verify-reflection-chain`** — external verifier walking `reflects_on` edges. Audits chain integrity, not writes.
+- **`ai-memory verify-signed-events-chain`** — V-4 cross-row hash chain integrity verifier. Confirms the audit chain that records reflections.
+- **`ai-memory mcp`** — JSON-RPC subprocess. Direct primitive invocation when needed (debugging, bridge tooling, batch ingestion from upstream substrates).
+
+The asymmetry with `store` / `recall` is intentional. Storage and retrieval do not compose with the bias-displacement architecture; reflection does. The CLI surface preserves the distinction by surfacing reflection through actor-named verbs at the shell layer and primitive invocation through MCP at the protocol layer.
+
+## When this rationale might evolve
+
+The current design is correct for v0.7.0's deployment shape (developer + single-agent + curator-mediated reflection). It may need to evolve in later releases:
+
+- **If batch ingestion from upstream substrates needs operator-facing reflection invocation at scale** (e.g., a Knowledge Atlas → ai-memory bridge for multi-year corpus loading), address it as `ai-memory curator --reflect --batch < cards.jsonl` — preserving the bias-displacement path — not as a flat `reflect` verb.
+- **If operator debugging needs direct primitive invocation outside JSON-RPC**, address it as a `dev`-tier subcommand explicitly named as bypassing the curator path: e.g., `ai-memory dev reflect-direct` with documentation that names what it does and does not do.
+- **If the §2.6 bias-displacement architecture is ever explicitly removed from the substrate's load-bearing claims** (it is not, and is unlikely to be), revisit whether the CLI distinction is still necessary.
+
+Any future revision of this rationale should engage the §2.6 architectural property explicitly. The question "should there be `ai-memory reflect`" cannot be answered by ergonomic symmetry alone; it requires engaging which structural property the verb would or would not preserve.
+
+## Provenance
+
+- Verification report at `release/v0.7.0` HEAD confirmed the CLI inventory (58 subcommands; no `Reflect(ReflectArgs)` variant on the `Command` enum) and recommended Hold Position.
+- Operator-led architectural review surfaced the §2.6 composition that the verification report named only structurally.
+- Final decision: hold position. Ship v0.7.0 with the current CLI surface unchanged. Document the rationale here so the question cannot resurface without engaging the architecture.
+- See also: [`docs/strategy/moonshot-synthesis.md`](strategy/moonshot-synthesis.md) §2.6 (bias-displacement through architectural separation-of-powers); [`ROADMAP.md`](../ROADMAP.md) §2.6 (the seven properties that remain load-bearing through ASI).


### PR DESCRIPTION
## Summary

**Documentation-only PR. No code changes.**

Adds [`docs/cli-design-rationale.md`](docs/cli-design-rationale.md) — the load-bearing artifact — which records why the CLI exposes `ai-memory store` / `ai-memory recall` as flat verbs but does NOT expose a flat `ai-memory reflect` verb. The asymmetry preserves the §2.6 bias-displacement architectural distinction (cross-model reflection boundary; the federalist-papers move applied to AI cognition) at the operator interface.

The decision is final. The rationale doc names the conditions under which a future revision might be warranted; any future revision must engage the §2.6 architectural property explicitly.

## Files changed

- `docs/cli-design-rationale.md` — NEW (46 lines)
- `ROADMAP.md` — one cross-reference line added to §17 (Quality gates — every release)
- `CHANGELOG.md` — one entry under a new `Documentation` subsection at the head of `[Unreleased]`

## Test plan

- [x] No code changes — recompile-retest discipline does not apply
- [x] All three files render correctly as markdown (links resolve)
- [x] Cross-references verified: `docs/strategy/moonshot-synthesis.md` §2.6 exists at line 100; `ROADMAP.md` §2.6 exists at line 94
- [x] No new issues filed (decision is final, not reopenable)

## Provenance

- Verification report at `release/v0.7.0` HEAD confirmed 58 CLI subcommands; zero `Reflect(ReflectArgs)` variant on the `Command` enum (verified independently via `awk '/^pub enum Command/,/^}/' src/daemon_runtime.rs | grep -cE '^    [A-Z]'`)
- Operator-led architectural review (2026-05-25) surfaced the §2.6 composition that the structural verification report named only via ergonomic-asymmetry framing
- See also: [`docs/strategy/moonshot-synthesis.md`](docs/strategy/moonshot-synthesis.md) §2.6 (bias-displaced through architectural separation-of-powers); [`ROADMAP.md`](ROADMAP.md) §2.6 (the seven properties that remain load-bearing through ASI)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context)