### PR TITLE
test(#1317): pin HTTP + CLI wire-layer parity for memory_reflect metadata passthrough

### DIFF
--- a/tests/issue_1317_cli_reflect_wire_layer_preserves_caller_metadata.rs
+++ b/tests/issue_1317_cli_reflect_wire_layer_preserves_caller_metadata.rs
@@ -1,0 +1,488 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::missing_panics_doc
+)]
+
+//! Wire-layer regression pin for issue #1317 — CLI-binary subprocess
+//! parallel of PR #1316's MCP `tools/call → handle_reflect`
+//! metadata-passthrough test, and sibling to
+//! `tests/issue_1317_http_reflect_wire_layer_preserves_caller_metadata.rs`.
+//!
+//! ## Why this surface counts as the CLI test
+//!
+//! The CLI binary does not expose a flat `ai-memory reflect <metadata
+//! json>` subcommand at v0.7.0 — the only CLI surface that reaches
+//! `db::reflect` programmatically is `ai-memory curator --reflect`,
+//! which synthesises its own `metadata: {}` from the cluster summary
+//! (see `src/curator/reflection_pass.rs:357`) and has no operator-
+//! supplied-metadata input. The CLI binary's substantive
+//! `memory_reflect` surface is therefore the `ai-memory mcp` stdio
+//! JSON-RPC sub-command (`src/daemon_runtime.rs::Command::Mcp`).
+//!
+//! That subcommand is a real CLI surface — it goes through the
+//! `ai-memory` binary's process boundary, its clap-parsed subcommand
+//! dispatch, the binary's stdio framing, the MCP protocol's
+//! `dispatch_memory_reflect` adapter, and finally `handle_reflect`.
+//! The in-process test in `tests/issue_1172_reflect_metadata_passthrough.rs::
+//! mcp_handle_reflect_preserves_caller_supplied_entity_id` skips
+//! every one of those layers by invoking `handle_reflect` directly as
+//! a library call. This file pins the SAME invariants end-to-end
+//! through the binary subprocess.
+//!
+//! ## Invariants pinned
+//!
+//! 1. **End-to-end entity-binding passthrough through the binary.**
+//!    The `ai-memory mcp` subprocess processing a
+//!    `tools/call memory_reflect` request with
+//!    `metadata: {entity_id: "X", probe: "Y"}` produces a stored row
+//!    whose `metadata` JSON column carries BOTH `entity_id = "X"` AND
+//!    `probe = "Y"`, alongside the system-spliced `agent_id` +
+//!    `reflection_metadata` keys.
+//! 2. **PERF-8 indexed column populated.** The same call populates
+//!    the `mentioned_entity_id` column with `"X"` via the
+//!    `extract_mentioned_entity_id` step-1 path.
+//! 3. **Back-compat.** Empty caller metadata (`{}`) still produces the
+//!    canonical `{agent_id, reflection_metadata}` shape with no
+//!    `entity_id` and a NULL `mentioned_entity_id` (mirrors invariant 4
+//!    of `tests/issue_1172_reflect_metadata_passthrough.rs` onto the
+//!    CLI subprocess path).
+//!
+//! ## Subprocess discipline
+//!
+//! Uses the same shape as `tests/mcp_integration.rs` —
+//! `Command::new(env!("CARGO_BIN_EXE_ai-memory"))` so cargo wires the
+//! binary built from THIS crate (not a stray brew install), with
+//! `AI_MEMORY_NO_CONFIG=1` so the user's `~/.config/ai-memory/config.toml`
+//! (which may set `tier=autonomous` triggering embedder / LLM init)
+//! is bypassed. Each test gets a unique tempdir for the DB.
+//!
+//! ## Source role-categorical value
+//!
+//! Per the rationale in `tests/issue_1172_reflect_metadata_passthrough.rs`
+//! §"On the choice of `source`": vendor-neutral role-categorical
+//! `"api"` (an LLM-agnostic role any frontier-model AI NHI writing
+//! through the substrate would naturally occupy).
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use ai_memory::db;
+use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
+use chrono::Utc;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Subprocess timing
+//
+// 10s mirrors `tests/mcp_integration.rs::READ_TIMEOUT`. The `initialize`
+// handshake is the load-bearing latency — a cold cargo-bin spawn under
+// release+thin-LTO compile pressure can run 2-3s on the first call;
+// every subsequent `tools/call` is sub-100ms. 10s leaves comfortable
+// headroom for both.
+// ---------------------------------------------------------------------------
+
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FIXTURE_AGENT_ID: &str = "test-agent-1317-cli";
+/// Vendor-neutral role-categorical source. See file-level docstring.
+const FIXTURE_SOURCE: &str = "api";
+const FIXTURE_ENTITY_ID: &str = "entity-uuid-1317-cli";
+const FIXTURE_PROBE_VALUE: &str = "probe-1317-cli";
+
+const NS_PASSTHROUGH: &str = "issue-1317-cli-pt";
+const NS_BACKCOMPAT: &str = "issue-1317-cli-bc";
+
+// ---------------------------------------------------------------------------
+// MCP subprocess harness — mirrors tests/mcp_integration.rs shape.
+// Kept self-contained because cargo treats each tests/*.rs as its own
+// integration binary.
+// ---------------------------------------------------------------------------
+
+/// RAII guard for the MCP child. Drops kill the child so a failed
+/// assertion doesn't leak the process.
+struct McpChild {
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+}
+
+impl Drop for McpChild {
+    fn drop(&mut self) {
+        // Closing stdin ends the MCP server's read loop cleanly.
+        drop(self.stdin.take());
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Spawn `ai-memory mcp --tier keyword --profile full` against the
+/// supplied DB path, returning the child guard + a worker-thread mpsc
+/// receiver fed by the child's stdout. Caller pops responses with a
+/// bounded `recv_timeout` so a hung response surfaces as a test
+/// failure rather than a CI hang.
+fn spawn_mcp(db: &std::path::Path) -> (McpChild, mpsc::Receiver<String>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_ai-memory"))
+        .env("AI_MEMORY_NO_CONFIG", "1")
+        // `--tier keyword` is the cheapest tier that doesn't try to
+        // load embedder / reranker models; `--profile full` exposes
+        // the full 73-tool surface so `memory_reflect` is callable.
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "mcp",
+            "--profile",
+            "full",
+            "--tier",
+            "keyword",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ai-memory mcp");
+
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    // Drain stderr so the child doesn't block writing to it.
+    if let Some(stderr) = child.stderr.take() {
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            let mut s = stderr;
+            while let Ok(n) = s.read(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+            }
+        });
+    }
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) if !line.trim().is_empty() => {
+                    if tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    (
+        McpChild {
+            child: Some(child),
+            stdin: Some(stdin),
+        },
+        rx,
+    )
+}
+
+/// Send a JSON-RPC request line to the MCP child's stdin, then wait up
+/// to `READ_TIMEOUT` for the next response line. Panics with a clear
+/// signature on timeout (mirrors `tests/mcp_integration.rs`).
+fn send_and_recv(stdin: &mut ChildStdin, rx: &mpsc::Receiver<String>, payload: &Value) -> Value {
+    let line = serde_json::to_string(payload).unwrap();
+    writeln!(stdin, "{line}").expect("write to mcp stdin");
+    stdin.flush().expect("flush mcp stdin");
+    let resp = rx
+        .recv_timeout(READ_TIMEOUT)
+        .expect("mcp response did not arrive within READ_TIMEOUT");
+    serde_json::from_str(&resp).unwrap_or_else(|e| panic!("parse mcp response: {e}: {resp}"))
+}
+
+/// Complete the MCP `initialize` handshake. Required before any
+/// `tools/call` will be accepted — the dispatcher refuses requests
+/// from unhandshaked clients. Mirrors the same shape `tests/mcp_integration.rs`
+/// uses.
+fn initialize(stdin: &mut ChildStdin, rx: &mpsc::Receiver<String>) {
+    let resp = send_and_recv(
+        stdin,
+        rx,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "issue-1317-cli-test", "version": "1.0"}
+            }
+        }),
+    );
+    assert_eq!(resp["jsonrpc"], "2.0", "initialize jsonrpc tag");
+    assert!(
+        resp["result"].is_object(),
+        "initialize result missing: {resp}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture seeding
+// ---------------------------------------------------------------------------
+
+/// Seed one Observation directly via `db::insert` into the supplied DB
+/// path. The MCP `tools/call memory_reflect` `source_ids` references
+/// this row. Using a direct insert keeps the seed step deterministic
+/// and avoids round-tripping through `ai-memory store` (which would
+/// double the subprocess startup cost without adding coverage; the
+/// invariant under test is `memory_reflect`, not `memory_store`).
+fn seed_observation(db_path: &std::path::Path, namespace: &str, title: &str) -> String {
+    let conn = db::open(db_path).expect("db::open for seed");
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Mid,
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        content: format!("issue_1317 cli fixture observation: {title}"),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: FIXTURE_SOURCE.to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"agent_id": FIXTURE_AGENT_ID}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+    };
+    db::insert(&conn, &mem).expect("insert observation")
+}
+
+/// Probe the sqlite row by id for the (`metadata` JSON,
+/// `mentioned_entity_id`) pair. Mirrors the read-back discipline used
+/// by `tests/issue_1172_reflect_metadata_passthrough.rs::
+/// read_metadata_and_mention`.
+fn read_metadata_and_mention(db_path: &std::path::Path, id: &str) -> (Value, Option<String>) {
+    let conn = db::open(db_path).expect("db::open for probe");
+    conn.query_row(
+        "SELECT metadata, mentioned_entity_id FROM memories WHERE id = ?1",
+        rusqlite::params![id],
+        |row| {
+            let meta_str: String = row.get(0)?;
+            let mention: Option<String> = row.get(1)?;
+            Ok((
+                serde_json::from_str(&meta_str).unwrap_or(Value::Null),
+                mention,
+            ))
+        },
+    )
+    .expect("read row by id")
+}
+
+/// Helper — extract the new memory id from the MCP
+/// `tools/call memory_reflect` response. The MCP wire shape wraps the
+/// substrate envelope in `result.content[0].text` (a JSON string the
+/// MCP host parses to get the structured payload). The MCP server
+/// also sets `result.structuredContent` for newer hosts. We try both.
+fn extract_new_id_from_mcp_resp(resp: &Value) -> String {
+    // Prefer structuredContent when present (modern MCP host shape).
+    if let Some(id) = resp
+        .pointer("/result/structuredContent/id")
+        .and_then(Value::as_str)
+    {
+        return id.to_string();
+    }
+    // Fallback: parse the legacy `content[0].text` JSON string.
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(Value::as_str)
+        && let Ok(parsed) = serde_json::from_str::<Value>(text)
+        && let Some(id) = parsed.get("id").and_then(Value::as_str)
+    {
+        return id.to_string();
+    }
+    panic!(
+        "MCP response did not carry an id in either result.structuredContent.id or result.content[0].text: {resp}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1) CLI subprocess wire-layer pin — `ai-memory mcp` subprocess
+//     processing `tools/call memory_reflect` with caller-supplied
+//     metadata.entity_id + probe key.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cli_mcp_subprocess_reflect_preserves_caller_supplied_entity_id_and_probe() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = tmp.path().join("issue-1317-cli-pt.db");
+    let src_id = seed_observation(&db, NS_PASSTHROUGH, "src-observation-1317-cli");
+
+    let (mut guard, rx) = spawn_mcp(&db);
+    let stdin = guard.stdin.as_mut().expect("mcp stdin");
+    initialize(stdin, &rx);
+
+    let resp = send_and_recv(
+        stdin,
+        &rx,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_reflect",
+                "arguments": {
+                    "source_ids": [src_id],
+                    "title": "reflection-via-cli-mcp-subprocess",
+                    "content": "synthesised reflection content via the CLI binary mcp surface",
+                    "namespace": NS_PASSTHROUGH,
+                    "agent_id": FIXTURE_AGENT_ID,
+                    "metadata": {
+                        "entity_id": FIXTURE_ENTITY_ID,
+                        "probe": FIXTURE_PROBE_VALUE,
+                    },
+                }
+            }
+        }),
+    );
+
+    // Wire-shape pin — the response must NOT carry an `error` object.
+    // A regression that drops `metadata` typically still produces a
+    // valid response (the substrate just writes the row with empty
+    // user-metadata), so the load-bearing check is on the row state,
+    // not the response envelope. But we still pin the no-error
+    // invariant so a transport-level regression (the MCP dispatcher
+    // failing entirely) is loud.
+    assert!(
+        resp.get("error").is_none(),
+        "CLI mcp subprocess returned an error for memory_reflect: {resp}"
+    );
+    let new_id = extract_new_id_from_mcp_resp(&resp);
+
+    // Read back via direct sqlite probe — the wire-layer invariant
+    // lives in the COLUMN state, not the response envelope.
+    let (meta, mention) = read_metadata_and_mention(&db, &new_id);
+
+    // Invariant 1a — caller-supplied entity_id round-trips into stored metadata.
+    assert_eq!(
+        meta.get("entity_id").and_then(Value::as_str),
+        Some(FIXTURE_ENTITY_ID),
+        "CLI mcp subprocess must preserve caller-supplied metadata.entity_id end-to-end; full metadata = {meta}"
+    );
+
+    // Invariant 1b — auxiliary key passthrough. Pre-#1172 the metadata
+    // splice DROPPED auxiliary keys alongside entity_id; this asserts
+    // the additive contract is honoured for arbitrary caller keys
+    // through the binary subprocess path.
+    assert_eq!(
+        meta.get("probe").and_then(Value::as_str),
+        Some(FIXTURE_PROBE_VALUE),
+        "CLI mcp subprocess must preserve auxiliary metadata keys (probe); full metadata = {meta}"
+    );
+
+    // System-spliced keys still land alongside caller keys.
+    assert!(
+        meta.get("agent_id").is_some(),
+        "system-spliced agent_id must coexist with caller keys; full metadata = {meta}"
+    );
+    assert!(
+        meta.get("reflection_metadata").is_some(),
+        "system-spliced reflection_metadata must coexist with caller keys; full metadata = {meta}"
+    );
+
+    // Invariant 2 — PERF-8 denormalised column populated from caller entity_id.
+    assert_eq!(
+        mention.as_deref(),
+        Some(FIXTURE_ENTITY_ID),
+        "CLI mcp subprocess must populate mentioned_entity_id from caller-supplied metadata.entity_id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) CLI subprocess back-compat pin — empty caller metadata still
+//     produces the canonical {agent_id, reflection_metadata} shape
+//     with NULL mentioned_entity_id. Mirrors invariant 4 of #1172
+//     onto the CLI subprocess path so a future refactor that "fixes"
+//     entity_id passthrough by ALWAYS injecting a synthetic entity_id
+//     can't slip past on this surface either.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cli_mcp_subprocess_reflect_empty_metadata_preserves_canonical_shape() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = tmp.path().join("issue-1317-cli-bc.db");
+    let src_id = seed_observation(&db, NS_BACKCOMPAT, "src-observation-1317-cli-bc");
+
+    let (mut guard, rx) = spawn_mcp(&db);
+    let stdin = guard.stdin.as_mut().expect("mcp stdin");
+    initialize(stdin, &rx);
+
+    let resp = send_and_recv(
+        stdin,
+        &rx,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_reflect",
+                "arguments": {
+                    "source_ids": [src_id],
+                    "title": "empty-metadata-reflection-1317-cli",
+                    "content": "synthesised reflection content with no caller metadata",
+                    "namespace": NS_BACKCOMPAT,
+                    "agent_id": FIXTURE_AGENT_ID,
+                    "metadata": {},
+                }
+            }
+        }),
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "CLI mcp subprocess returned an error for empty-metadata memory_reflect: {resp}"
+    );
+    let new_id = extract_new_id_from_mcp_resp(&resp);
+
+    let (meta, mention) = read_metadata_and_mention(&db, &new_id);
+
+    // Canonical shape — system-spliced keys present.
+    assert!(
+        meta.get("agent_id").is_some(),
+        "agent_id must be spliced into stored metadata; full metadata = {meta}"
+    );
+    assert!(
+        meta.get("reflection_metadata").is_some(),
+        "reflection_metadata block must be spliced in; full metadata = {meta}"
+    );
+
+    // No spurious entity_id when caller didn't supply one.
+    assert!(
+        meta.get("entity_id").is_none(),
+        "no entity_id should appear when caller didn't supply one; full metadata = {meta}"
+    );
+
+    // mentioned_entity_id column stays NULL on the back-compat path.
+    assert!(
+        mention.is_none(),
+        "mentioned_entity_id column stays NULL when caller supplied no entity binding; got {mention:?}"
+    );
+}

--- a/tests/issue_1317_http_reflect_wire_layer_preserves_caller_metadata.rs
+++ b/tests/issue_1317_http_reflect_wire_layer_preserves_caller_metadata.rs
@@ -1,0 +1,383 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "sal")]
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::missing_panics_doc,
+    clippy::needless_pass_by_value
+)]
+
+//! Wire-layer regression pin for issue #1317 — HTTP-side parallel of
+//! PR #1316's MCP `tools/call → handle_reflect` metadata-passthrough
+//! test. Extends the substrate-level #1172 coverage (which pins
+//! `db::reflect` directly) onto the HTTP surface so the three-surface
+//! stable-error-slug + metadata-shape invariants (v1 P18) hold
+//! end-to-end across all three surfaces (substrate / MCP / HTTP).
+//!
+//! ## Defect class
+//!
+//! The pre-#1172 defect dropped caller-supplied `metadata` keys (most
+//! notably `entity_id`) somewhere between the JSON-wire decode and the
+//! `ReflectInput.metadata` field carried into `db::reflect`. The MCP
+//! wire path is pinned by `tests/issue_1172_reflect_metadata_passthrough.rs::
+//! mcp_handle_reflect_preserves_caller_supplied_entity_id`. The HTTP
+//! handler [`crate::handlers::route_1111::handle_reflect_http`] is a
+//! thin async wrapper around the same `crate::mcp::handle_reflect`
+//! substrate primitive — but the JSON body decode + axum extractor
+//! chain is its own wire-decode surface and could regress
+//! independently of the MCP path. This file pins THAT specific edge:
+//! POST `/api/v1/memory_reflect` with `metadata.{entity_id, probe}`
+//! must round-trip both keys verbatim into the stored row, must
+//! populate the indexed `mentioned_entity_id` column (PERF-8 invariant
+//! 2 from #1172), and must not corrupt back-compat for callers that
+//! supply only `agent_id`.
+//!
+//! ## Invariants pinned (per surface)
+//!
+//! 1. **Entity-binding passthrough.** `POST /api/v1/memory_reflect`
+//!    with `metadata: {entity_id: "X", probe: "Y"}` produces a stored
+//!    reflection row whose `metadata` JSON column carries BOTH
+//!    `entity_id = "X"` AND `probe = "Y"`, alongside the system-spliced
+//!    `agent_id` + `reflection_metadata` keys (additive contract from
+//!    `src/storage/reflect.rs`).
+//! 2. **PERF-8 indexed column.** The same call populates the
+//!    `mentioned_entity_id` column with `"X"` via the
+//!    `extract_mentioned_entity_id` step-1 path.
+//! 3. **Back-compat.** Empty caller metadata (`{}`) still produces the
+//!    canonical `{agent_id, reflection_metadata}` shape with no
+//!    `entity_id` and a NULL `mentioned_entity_id` (mirrors invariant 4
+//!    of `tests/issue_1172_reflect_metadata_passthrough.rs`).
+//! 4. **Wire response carries the new id.** The HTTP envelope returns
+//!    the same `{id: ...}` shape that the MCP `handle_reflect`
+//!    response carries, so callers can chain a row read off the
+//!    response id without parsing different envelope shapes per
+//!    surface (P18 surface-parity invariant).
+//!
+//! ## Fixture discipline
+//!
+//! Each test uses its own namespace + tempfile DB so state isolation
+//! holds even when the suite runs in `cargo test --jobs N`. The
+//! axum router fixture mirrors the shape `tests/http_routes_1111.rs`
+//! uses for the #1111 HTTP-route integration tests — no new helper
+//! plumbing introduced.
+//!
+//! ## Source role-categorical value
+//!
+//! Per the rationale in `tests/issue_1172_reflect_metadata_passthrough.rs`
+//! §"On the choice of `source`": the substrate is heterogeneous-NHI by
+//! design (every LLM vendor writes reflections through the same
+//! primitive). The fixtures use the vendor-neutral `"api"` source so
+//! the regression isn't coupled to any single LLM vendor's identity.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::db;
+use ai_memory::handlers::{ApiKeyState, AppState, Db};
+use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use serde_json::{Value, json};
+use tempfile::{NamedTempFile, TempDir};
+use tower::ServiceExt as _;
+
+// ---------------------------------------------------------------------------
+// Constants — single source of truth so renaming a fixture is one edit
+// and the assertions read against the same names the fixtures produced.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_AGENT_ID: &str = "test-agent-1317-http";
+/// Vendor-neutral role-categorical source. See file-level docstring.
+const FIXTURE_SOURCE: &str = "api";
+const FIXTURE_ENTITY_ID: &str = "entity-uuid-1317-http";
+const FIXTURE_PROBE_VALUE: &str = "probe-1317-http";
+
+const NS_PASSTHROUGH: &str = "issue-1317-http-pt";
+const NS_BACKCOMPAT: &str = "issue-1317-http-bc";
+
+// ---------------------------------------------------------------------------
+// Router fixture — mirrors `tests/http_routes_1111.rs::build_router_fixture`.
+// Kept here so the test file is self-contained (the existing #1111 fixture
+// is private to that integration test binary; cargo's
+// one-binary-per-tests-file model means we can't cross-import).
+// ---------------------------------------------------------------------------
+
+fn local_runs_root() -> PathBuf {
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-1317-http-reflect")
+}
+
+fn fresh_dir() -> TempDir {
+    let root = local_runs_root();
+    std::fs::create_dir_all(&root).ok();
+    tempfile::tempdir_in(&root).expect("tempdir under .local-runs")
+}
+
+fn build_router_fixture() -> (axum::Router, NamedTempFile, PathBuf) {
+    let f = NamedTempFile::new().expect("tempfile");
+    let db_path = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&db_path).expect("db::open");
+    let conn = ai_memory::db::open(&db_path).expect("reopen for AppState");
+    let db: Db = Arc::new(tokio::sync::Mutex::new((
+        conn,
+        db_path.clone(),
+        ResolvedTtl::default(),
+        true,
+    )));
+    let store: Arc<dyn ai_memory::store::MemoryStore> =
+        Arc::new(ai_memory::store::sqlite::SqliteStore::open(&db_path).expect("open SqliteStore"));
+    let app_state = AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(tokio::sync::Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        store,
+        llm: Arc::new(None),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(vec![]),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::config::ResolvedModels::default()),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+    };
+    let router = ai_memory::build_router(api_key_state, app_state);
+    (router, f, db_path)
+}
+
+/// POST a JSON body to `path` and return the (status, parsed_body) tuple.
+async fn post_json(router: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let parsed = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    (status, parsed)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Seed one Observation in `db_path/namespace` and return its id. The
+/// HTTP `memory_reflect` body's `source_ids` references this row.
+fn seed_observation(db_path: &std::path::Path, namespace: &str, title: &str) -> String {
+    let conn = db::open(db_path).expect("db::open for seed");
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: Tier::Mid,
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        content: format!("issue_1317 fixture observation: {title}"),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: FIXTURE_SOURCE.to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({"agent_id": FIXTURE_AGENT_ID}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+    };
+    db::insert(&conn, &mem).expect("insert observation")
+}
+
+/// Probe the sqlite row for the (`metadata` JSON, `mentioned_entity_id`)
+/// pair the wire-layer just wrote. Used by every assertion — the
+/// HTTP-response envelope only carries the new id; the wire-layer
+/// invariant is OBSERVED IN THE DB COLUMN, not in the response body
+/// (mirrors the discipline in `tests/issue_1172_reflect_metadata_passthrough.rs`).
+fn read_metadata_and_mention(db_path: &std::path::Path, id: &str) -> (Value, Option<String>) {
+    let conn = db::open(db_path).expect("db::open for probe");
+    conn.query_row(
+        "SELECT metadata, mentioned_entity_id FROM memories WHERE id = ?1",
+        rusqlite::params![id],
+        |row| {
+            let meta_str: String = row.get(0)?;
+            let mention: Option<String> = row.get(1)?;
+            Ok((
+                serde_json::from_str(&meta_str).unwrap_or(Value::Null),
+                mention,
+            ))
+        },
+    )
+    .expect("read row by id")
+}
+
+// ---------------------------------------------------------------------------
+// (1) HTTP wire-layer pin — POST /api/v1/memory_reflect preserves
+//     caller-supplied metadata.entity_id AND auxiliary keys.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_reflect_preserves_caller_supplied_entity_id_and_probe() {
+    let _dir = fresh_dir();
+    let (router, f, db_path) = build_router_fixture();
+    let src_id = seed_observation(&db_path, NS_PASSTHROUGH, "src-observation-1317-http");
+
+    let body = json!({
+        "source_ids": [src_id],
+        "title": "reflection-via-http-handler",
+        "content": "synthesised reflection content via the HTTP surface",
+        "namespace": NS_PASSTHROUGH,
+        "agent_id": FIXTURE_AGENT_ID,
+        "metadata": {
+            "entity_id": FIXTURE_ENTITY_ID,
+            "probe": FIXTURE_PROBE_VALUE,
+        },
+    });
+
+    let (status, resp) = post_json(&router, "/api/v1/memory_reflect", body).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "#1317: HTTP reflect with caller metadata must 200 OK; got {status} {resp}"
+    );
+    let new_id = resp["id"]
+        .as_str()
+        .expect("response envelope must carry the new id (P18 surface-parity)")
+        .to_string();
+
+    let (meta, mention) = read_metadata_and_mention(&db_path, &new_id);
+
+    // Invariant 1a — caller-supplied entity_id round-trips into stored metadata.
+    assert_eq!(
+        meta.get("entity_id").and_then(Value::as_str),
+        Some(FIXTURE_ENTITY_ID),
+        "HTTP wire layer must preserve caller-supplied metadata.entity_id; full metadata = {meta}"
+    );
+
+    // Invariant 1b — auxiliary key passthrough. Pre-#1172 the metadata
+    // splice DROPPED auxiliary keys alongside entity_id; this asserts
+    // the additive contract is honoured for arbitrary caller keys.
+    assert_eq!(
+        meta.get("probe").and_then(Value::as_str),
+        Some(FIXTURE_PROBE_VALUE),
+        "HTTP wire layer must preserve auxiliary metadata keys (probe); full metadata = {meta}"
+    );
+
+    // System-spliced keys still land alongside caller keys (additive
+    // contract from `src/storage/reflect.rs`).
+    assert!(
+        meta.get("agent_id").is_some(),
+        "system-spliced agent_id must coexist with caller keys; full metadata = {meta}"
+    );
+    assert!(
+        meta.get("reflection_metadata").is_some(),
+        "system-spliced reflection_metadata must coexist with caller keys; full metadata = {meta}"
+    );
+
+    // Invariant 2 — PERF-8 denormalised column populated from caller entity_id.
+    assert_eq!(
+        mention.as_deref(),
+        Some(FIXTURE_ENTITY_ID),
+        "HTTP wire layer must populate mentioned_entity_id from caller-supplied metadata.entity_id"
+    );
+
+    // Keep the tempfile alive for the test body. Implicit lifetime via
+    // `f`'s drop at function-end; bind explicitly so a future
+    // 'unused-binding' lint doesn't strip the guard.
+    drop(f);
+}
+
+// ---------------------------------------------------------------------------
+// (2) HTTP back-compat pin — empty caller metadata still produces the
+//     canonical {agent_id, reflection_metadata} shape with NULL
+//     mentioned_entity_id. Mirrors invariant 4 of #1172 onto the HTTP
+//     surface so a future refactor that "fixes" entity_id passthrough
+//     by ALWAYS injecting a synthetic entity_id can't slip past.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_reflect_empty_metadata_preserves_canonical_shape() {
+    let _dir = fresh_dir();
+    let (router, f, db_path) = build_router_fixture();
+    let src_id = seed_observation(&db_path, NS_BACKCOMPAT, "src-observation-1317-http-bc");
+
+    let body = json!({
+        "source_ids": [src_id],
+        "title": "empty-metadata-reflection-1317-http",
+        "content": "synthesised reflection content with no caller metadata",
+        "namespace": NS_BACKCOMPAT,
+        "agent_id": FIXTURE_AGENT_ID,
+        "metadata": {},
+    });
+
+    let (status, resp) = post_json(&router, "/api/v1/memory_reflect", body).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "#1317: HTTP reflect with empty metadata must 200 OK; got {status} {resp}"
+    );
+    let new_id = resp["id"].as_str().expect("response id").to_string();
+
+    let (meta, mention) = read_metadata_and_mention(&db_path, &new_id);
+
+    // Canonical shape — system-spliced keys present.
+    assert!(
+        meta.get("agent_id").is_some(),
+        "agent_id must be spliced into stored metadata; full metadata = {meta}"
+    );
+    assert!(
+        meta.get("reflection_metadata").is_some(),
+        "reflection_metadata block must be spliced in; full metadata = {meta}"
+    );
+
+    // No spurious entity_id when caller didn't supply one.
+    assert!(
+        meta.get("entity_id").is_none(),
+        "no entity_id should appear when caller didn't supply one; full metadata = {meta}"
+    );
+
+    // mentioned_entity_id column stays NULL on the back-compat path.
+    assert!(
+        mention.is_none(),
+        "mentioned_entity_id column stays NULL when caller supplied no entity binding; got {mention:?}"
+    );
+
+    drop(f);
+}


### PR DESCRIPTION
## Summary

Closes #1317. Adds parallel wire-layer regression-pin tests for the HTTP and CLI surfaces of \`memory_reflect\`, mirroring PR #1316's MCP wire-layer test. The substrate's three-surface stable-error-slug invariant (v1 P18) now has parallel coverage across all three surfaces (MCP / HTTP / CLI).

### Coverage matrix (after this PR + #1316)

| Surface | Wire test | Coverage |
|---|---|---|
| Substrate \`db::reflect\` | \`tests/issue_1172_reflect_metadata_passthrough.rs\` invariant 1 | Pre-existing |
| MCP \`tools/call\` → \`handle_request\` → \`dispatch_memory_reflect\` | PR #1316 (in flight) | Already covered |
| **HTTP \`POST /api/v1/memory_reflect\`** | **This PR — \`tests/issue_1317_http_reflect_wire_layer_preserves_caller_metadata.rs\`** | **Added** |
| **CLI \`ai-memory mcp\` subprocess boundary** | **This PR — \`tests/issue_1317_cli_reflect_wire_layer_preserves_caller_metadata.rs\`** | **Added** |

### #1317 HTTP test

\`tests/issue_1317_http_reflect_wire_layer_preserves_caller_metadata.rs\` — uses the existing axum test harness (canonical \`tests/http_routes_1111.rs\` pattern). Constructs a real \`POST /api/v1/memory_reflect\` request, dispatches via \`router.clone().oneshot(req)\`. Asserts caller \`metadata.entity_id\` + arbitrary second caller key (\`probe\`) both survive in the stored row, system-spliced \`agent_id\` + \`reflection_metadata\` coexist correctly, and the \`mentioned_entity_id\` column is populated.

Two test functions:
- \`http_reflect_preserves_caller_supplied_entity_id_and_probe\` — happy-path round-trip
- \`http_reflect_empty_metadata_preserves_canonical_shape\` — back-compat pin (empty metadata gives the canonical \`{agent_id, reflection_metadata}\`-only shape)

### #1317 CLI test

\`tests/issue_1317_cli_reflect_wire_layer_preserves_caller_metadata.rs\` — fork-execs \`env!(\"CARGO_BIN_EXE_ai-memory\")\` with \`mcp --profile full --tier keyword\`, RAII child guard, mpsc stdout reader with 10s \`recv_timeout\`. Drives MCP \`initialize\` handshake + \`tools/call memory_reflect\` over stdio JSON-RPC. Asserts identical invariants. Reads row state via direct \`db::open\` probe (correct discipline — column truth, not response envelope).

This pins the **subprocess boundary** end-to-end through process spawn + clap dispatch + stdio framing + MCP dispatcher + \`dispatch_memory_reflect\` → \`handle_reflect\`. **More rigorous than PR #1316's in-process MCP test** — exercises the actual binary subprocess boundary the operator's running daemon uses in production.

### v0.7.0 design check (per the operator's review at PR-prep time)

There is **no flat \`ai-memory reflect <args>\` CLI subcommand** at v0.7.0 — per ROADMAP.md + CLI_REFERENCE.md the reflection primitive is MCP-primary by design, and the CLI surface wraps reflection through actor-named higher-level verbs (\`curator --reflect\`, \`consolidate\`, \`export-reflections\`) rather than as a flat primitive verb. The CLI test in this PR pins the canonical direct-invocation path (\`ai-memory mcp\` subprocess) which IS the documented CLI surface for direct reflection. Design rationale documented in PR #1328 / \`docs/cli-design-rationale.md\`.

## Negative-test discipline

Both fix-agent and independent QC subagent verified:

**HTTP:** Injected \`if let Some(obj) = body.as_object_mut() { obj.remove(\"metadata\"); }\` at \`handle_reflect_http\`. Test failed with verbatim signature: \`assertion 'left == right' failed: HTTP wire layer must preserve caller-supplied metadata.entity_id\`. Reverted → PASS.

**CLI:** Injected same metadata-strip in \`dispatch_memory_reflect\` (\`src/mcp/mod.rs:1148\`). Test failed: \`CLI mcp subprocess must preserve caller-supplied metadata.entity_id end-to-end\`. Reverted → PASS.

## QC subagent verdict: PASS

- Branch \`test/1317-http-cli-wire-parity\` at \`de20b15a4\`, 2 commits clean, base SHA + Co-Authored-By trailers, no banned phrases
- 2 + 2 + 9 (#1172 unchanged) + 3 (mcp_integration unchanged) + 15 (http_routes_1111 unchanged) = 31 tests PASS, 0 failed
- All 4 cargo gates green
- Negative-test discipline mechanically proven for both surfaces

## Commits

- \`198413e90\` — \`test(http, #1317): pin HTTP reflect wire-layer metadata passthrough\`
- \`de20b15a4\` — \`test(cli, #1317): pin CLI mcp-subprocess reflect metadata passthrough\`

Both carry \`Base: 1e33b51d63f6df879109604650b8c6220c6d12e2\`.

## Test plan

- [x] HTTP wire path round-trips caller metadata.entity_id + arbitrary second key
- [x] CLI mcp-subprocess wire path round-trips identically
- [x] Both negative-test under regression injection
- [x] mentioned_entity_id column populated via PERF-8 step-1 path
- [x] No flat \`ai-memory reflect\` CLI subcommand assumption (v0.7.0 design, documented in PR #1328)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context), fix-agent + QC-agent under pm-v3.3 prime directive.