### PR TITLE
fix(#1340 + #1341): postgres schema_parity constant drift (SSOT-derived) + atttypmod test-isolation race (shared mutex)

### DIFF
--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -41,9 +41,38 @@
 
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 fn postgres_url() -> Option<String> {
     std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
+}
+
+/// Serialize the two `#[tokio::test]` functions in this file against
+/// each other under the canonical Per-Module Coverage Thresholds CI
+/// invocation (`--test-threads=2`).
+///
+/// Issue #1341 — both tests create a non-`public` `<schema>.memories`
+/// table to stage the duplicate-table catalog shape. When they run in
+/// parallel, the `pg_class WHERE relname = 'memories'` probe in the
+/// first test observes THREE rows (its own duplicate + `public` + the
+/// sibling test's duplicate that has not yet cleaned up), tripping the
+/// `assert_eq!(dims.len(), 2, ...)` staging-sanity check. `cleanup()`
+/// only drops the schema name it's handed, so the cross-test residue
+/// is invisible to the per-test cleanup.
+///
+/// Smallest fix: a shared module-scoped `Mutex<()>` both tests lock at
+/// entry. No new dependencies (`std::sync` only), no async lock needed
+/// (the critical section spans the whole test body which is already
+/// `await`-blocking — `std::sync::Mutex` is fine because each test
+/// runs in its own `tokio::test` runtime and the guard is dropped at
+/// scope end, not held across an await *between* tests). Poison
+/// recovery via `unwrap_or_else(PoisonError::into_inner)` so a panic
+/// in one test doesn't permanently lock out the next.
+fn issue_1213_serial_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 async fn inspect_pool(url: &str) -> PgPool {
@@ -81,8 +110,26 @@ async fn cleanup(pool: &PgPool, other_schema: &str) {
 /// `public` schema. If the test fails on a binary built against the
 /// pre-fix code, the failure mode is precisely the #1213 bug
 /// (returns 768 instead of 384).
+// #1341: holding `std::sync::MutexGuard` across `await` is the
+// INTENDED behaviour — the whole point of `issue_1213_serial_lock`
+// is to serialize the two `#[tokio::test]` bodies, so the guard MUST
+// stay live for the duration of every `await` in the test body.
+// An async `tokio::sync::Mutex` would relax the lock between await
+// points (which is exactly what we don't want — that would let the
+// sibling test interleave staging steps with this one). Each
+// `#[tokio::test]` spawns its own current-thread runtime, so there
+// is no within-runtime deadlock risk: only ONE async task is alive
+// per runtime per test invocation, so the synchronous lock is held
+// only for "this test's exclusive turn" semantics.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn issue_1213_atttypmod_probe_scopes_to_public_schema() {
+    // #1341: serialize against `issue_1213_unscoped_probe_demonstrates_root_cause`
+    // so the unscoped `pg_class WHERE relname='memories'` probe (and
+    // the parallel scoped staging check) sees exactly two rows, not
+    // three.
+    let _serial = issue_1213_serial_lock();
+
     let Some(url) = postgres_url() else {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
@@ -191,8 +238,19 @@ async fn issue_1213_atttypmod_probe_scopes_to_public_schema() {
 /// fixed returns 384) by checking that the unscoped query returns
 /// AT LEAST one row and the scoped query returns exactly the
 /// public-schema row.
+// #1341: see allow rationale on
+// `issue_1213_atttypmod_probe_scopes_to_public_schema` above. Same
+// intent: the sync lock holds across awaits BY DESIGN to serialize
+// against the sibling test.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn issue_1213_unscoped_probe_demonstrates_root_cause() {
+    // #1341: serialize against `issue_1213_atttypmod_probe_scopes_to_public_schema`
+    // so the `assert_eq!(unscoped.len(), 2, ...)` staging-sanity check
+    // observes exactly the two rows this test stages (public + its
+    // own `ai_memory_issue_1213_demo` duplicate), not three.
+    let _serial = issue_1213_serial_lock();
+
     let Some(url) = postgres_url() else {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;

--- a/tests/postgres_schema_parity.rs
+++ b/tests/postgres_schema_parity.rs
@@ -70,7 +70,26 @@ use common::postgres_url;
 // dimension extending `agent_quotas` PK from `(agent_id)` to
 // `(agent_id, namespace)`). The constant is kept in lock-step with
 // `src/store/postgres.rs::CURRENT_SCHEMA_VERSION`.
-const POSTGRES_CURRENT_VERSION: i64 = 50;
+//
+// #1340 (fix): the previous `const POSTGRES_CURRENT_VERSION: i64 = 50;`
+// drifted past the v51 `federation_nonces` bump (#1296 / PR #1296) — the
+// SQLite-side schema-pin tests had been updated to read through the
+// SSOT accessor `ai_memory::storage::current_schema_version_for_tests()`
+// (#1311) but this Postgres parity literal was missed and CI tripped on
+// the now-real drift. Deriving the floor from the SSOT accessor makes
+// the constant impossible to drift again: any future bump in
+// `src/storage/migrations.rs::CURRENT_SCHEMA_VERSION` will be picked up
+// here automatically. The accessor returns `i64` already, so no cast is
+// needed.
+//
+// The two ladders SHARE one logical schema number at v0.7.0+ (see
+// CLAUDE.md §Database) — sqlite and postgres both report v51 at the
+// release/v0.7.0 HEAD that this test pins against. Should the two
+// ladders ever diverge in the future, this wrapper becomes the single
+// point at which to introduce a per-adapter override.
+fn postgres_current_version() -> i64 {
+    ai_memory::storage::current_schema_version_for_tests()
+}
 
 /// Open an out-of-band `sqlx` pool against the same URL the adapter
 /// uses. We deliberately bypass `PostgresStore` for the inspection
@@ -145,18 +164,22 @@ async fn schema_versions_match_across_adapters() {
 
     let pg_version_i64 = i64::from(pg_version.expect("schema_version row must exist"));
     // The two ladders are independent integer namespaces (see the
-    // POSTGRES_CURRENT_VERSION docstring); a direct `>=` cross-ladder
+    // postgres_current_version() docstring); a direct `>=` cross-ladder
     // comparison is no longer meaningful now that SQLite trails Postgres
     // numerically while still leading functionally. The equality
     // assertion below is the load-bearing parity check — if Postgres'
     // `migrate()` did not reach its own CURRENT_SCHEMA_VERSION constant
     // (because a `migrate_vN` arm panicked, was skipped, or the
     // constant was bumped without the corresponding function), this
-    // test fails.
+    // test fails. The expected version is derived from the SSOT
+    // accessor `ai_memory::storage::current_schema_version_for_tests()`
+    // (#1340) so a future bump cannot drift this constant out of step
+    // again.
+    let expected = postgres_current_version();
     assert_eq!(
-        pg_version_i64, POSTGRES_CURRENT_VERSION,
+        pg_version_i64, expected,
         "Postgres schema_version ({pg_version_i64}) must match the \
-         Postgres CURRENT_SCHEMA_VERSION ({POSTGRES_CURRENT_VERSION}). \
+         Postgres CURRENT_SCHEMA_VERSION ({expected}). \
          A drift here means a Postgres ladder step didn't run, or the \
          constant was bumped without the corresponding migrate_vN \
          function in src/store/postgres.rs."


### PR DESCRIPTION
## Summary

Closes #1340, #1341. Two pre-existing base CI defects diagnosed by Agent A3's pm-v3.3-disciplined investigation while triaging PR #1335's remaining red checks. Neither defect was introduced by PR #1335 (Agent A); both were latent on \`release/v0.7.0\` HEAD \`1e33b51d6\`, masked behind the failures Agent A's fix removed.

### #1340 — \`POSTGRES_CURRENT_VERSION\` stale constant drift

\`tests/postgres_schema_parity.rs:73\` had \`const POSTGRES_CURRENT_VERSION: i64 = 50;\` while production at \`src/store/postgres.rs:424\` had \`CURRENT_SCHEMA_VERSION: i32 = 51\` (bumped by PR #1296 for the \`migrate_v51\` federation_nonces table). PR #1311 updated the SQLite-side schema-pinning tests via the new SSOT accessor \`ai_memory::storage::current_schema_version_for_tests()\` but missed this Postgres parity test literal.

Failure masked on base because the postgres-feature-gate job failed first on \`migrate_v36_*\`. Once Agent A's fix removed that mask (in PR #1335), this latent stale-constant bug got promoted.

**Fix:** Replace the literal const with \`fn postgres_current_version() -> i64\` deriving from the SSOT accessor. Future bumps in \`src/storage/migrations.rs::CURRENT_SCHEMA_VERSION\` will be picked up automatically — the constant cannot drift again. Detailed in-file comment explaining the chain.

### #1341 — \`tests/issue_1213_atttypmod_age_schema_scope.rs\` test-isolation race

Two \`#[tokio::test]\` functions both stage non-\`public\` \`<schema>.memories\` tables to demonstrate the #1213 duplicate-table catalog shape. Under \`cargo test --test-threads=2\` (the canonical Per-Module Coverage Thresholds CI invocation), they race: the \`pg_class WHERE relname='memories'\` probe in test 1 observes THREE rows (its own + \`public\` + the sibling test's duplicate) where it expects two.

\`cleanup()\` only drops the schema name it's handed, so cross-test residue is invisible to per-test cleanup.

**Fix:** Shared module-scoped \`Mutex<()>\` via \`OnceLock\`; both tests \`lock()\` at entry to serialize. No new dependencies. Poison recovery via \`unwrap_or_else(PoisonError::into_inner)\`. The \`#[allow(clippy::await_holding_lock)]\` is INTENTIONAL (and documented inline) — holding the sync mutex across awaits IS the point of the serialization. Each \`#[tokio::test]\` spawns its own current-thread runtime, so no within-runtime deadlock risk.

## Diagnosis discipline (pm-v3.3 + pm-v3.4 applied)

Agent A3 verified both failures pre-existing on base SHA \`1e33b51d6\` via:
- Direct \`git show\` of the affected file contents at base SHA (drift was present)
- Cross-reference to base CI run \`26416503723\` showing identical failures (when not masked by other failures running first)
- Code-anchor verification that neither file was modified by Agent A's commits (zero-byte diff)

Per the just-landed pm-v3.4 attribution discipline: this is OBSERVATION of pre-existing defects, NOT attribution of intent to any prior PR author.

## Order in the merge sequence

This PR should land **BEFORE PR #1335** so when #1335's CI re-runs, it has a green base. The merge order is:

1. **This PR (#1340 + #1341)** — fully resolves the 2 remaining base CI failures
2. **PR #1335** — re-CI should now go fully green; merges to unblock the rest
3. PRs #1316, #1322, #1323, #1328, #1330, #1337, #1338, #1339 — re-CI green on the new base; batch merge

## Test plan

- [x] #1340 — replaced literal with SSOT-derived accessor; deriving from the same source-of-truth that production uses
- [x] #1341 — added serialization mutex; documented \`#[allow(clippy::await_holding_lock)]\` rationale
- [x] No production-code changes — both fixes test-only
- [x] No new dependencies
- [x] Diagnosis verified pre-existing on base by Agent A3 with code anchors

## Commits

- \`7fc6d20cb\` — \`fix(#1340): derive POSTGRES_CURRENT_VERSION from SSOT accessor\`
- \`53b847a4e\` — \`fix(#1341): serialize tests/issue_1213_atttypmod_age_schema_scope tests under shared mutex\`

Both carry \`Base: 1e33b51d63f6df879109604650b8c6220c6d12e2\` per multi-agent worktree discipline.

## Provenance

Filed during Phase-1 heterogeneous AI NHI assessment (#1171) cascade — Agent A3's investigation of PR #1335's remaining red checks per the operator's \"100% fix everything\" directive (2026-05-25 22:00 UTC). Agent A4 authored the fixes; orchestrator (Claude Opus 4.7, parent) finished the commit cycle when the A4 dispatch hit its harness timeout pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context), fix-agent A4 (authored) + orchestrator (committed) under pm-v3.3 + pm-v3.4 prime directive.