### PR TITLE
chore(ci, #1343): coverage.yml docs-only short-circuit — mirror ci.yml classify pattern

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,9 +47,70 @@ env:
   AI_MEMORY_TEST_AGE_URL: "postgres://ai_memory:ai_memory_test@127.0.0.1:5432/ai_memory_test"
 
 jobs:
+  # Issue #1343 — docs-only PRs should skip the heavy llvm-cov sweep.
+  # Mirrors the same classify pattern used by `.github/workflows/ci.yml`
+  # (see the classify job there for the canonical implementation).
+  # When `docs_only == 'true'`, the `per-module-thresholds` job below
+  # is skipped, which GitHub reports as `status: skipping` on the PR
+  # check page — branch-protection treats a skipped required check as
+  # passing (same handling that ci.yml's downstream jobs already rely
+  # on for docs-only PRs).
+  classify:
+    name: Coverage classify (docs-only short-circuit)
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.cls.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - id: cls
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            base="${{ github.event.before }}"
+          else
+            base=""
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] || ! git rev-parse "$base" >/dev/null 2>&1; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::cannot resolve base commit ($base) — running full pipeline"
+            exit 0
+          fi
+          # Per issue #1193 / PR #1203 — fetch-depth=2 is too shallow
+          # when the PR base SHA is more than one commit behind the
+          # merge ref. Fetch on demand if the base tree isn't local.
+          if ! git cat-file -e "$base^{tree}" 2>/dev/null; then
+            git fetch --depth=50 origin "$base" 2>/dev/null || \
+              git fetch --depth=200 origin "$base" 2>/dev/null || \
+              git fetch --unshallow origin 2>/dev/null || true
+          fi
+          if ! git cat-file -e "$base^{tree}" 2>/dev/null; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::cannot fetch base tree ($base) after retry — running full pipeline"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$base" HEAD)
+          if [ -z "$changed" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::no diff vs base — treating as docs-only no-op"
+            exit 0
+          fi
+          # docs-only iff every changed file matches docs/** OR *.md anywhere
+          if echo "$changed" | grep -qvE '^(docs/|.*\.md$)'; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::changed files include non-docs paths — running full pipeline"
+          else
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::all changed files are docs-only — skipping heavy llvm-cov sweep"
+          fi
+
   per-module-thresholds:
     name: Per-Module Coverage Thresholds
     runs-on: ubuntu-latest
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Closes #1343. Implements the path-based CI gate filtering the operator authorized.

## What this changes

`coverage.yml` adds the same `classify` job that `ci.yml` already uses to short-circuit docs-only PRs. When all changed files are under `docs/` or match `*.md`, the heavy `Per-Module Coverage Thresholds` job is skipped.

## Why

Currently `Per-Module Coverage Thresholds` runs on every PR regardless of changed files. Docs-only PRs (#1322, #1323, #1328, #1330 in the current v0.7.0 cascade) trigger the full ~20-minute llvm-cov sweep with no possibility of affecting coverage. Pure CI runner waste.

`ci.yml`'s existing classify pattern is battle-tested — PR #1322/1323/1328/1330 all correctly classified docs-only on the existing pattern (verified live: their heavy ci.yml jobs show `skipping`, the cheap ones pass). This PR replicates the same shell logic in `coverage.yml`.

## Mechanics

1. **New `classify` job** with the same shell logic as `ci.yml` (base SHA resolution, fetch-on-demand for shallow clones, diff-against-base, docs-only iff `^(docs/|.*\.md$)`, fail-open on classifier uncertainty).
2. **Existing `per-module-thresholds` job gains** `needs: classify` + `if: needs.classify.outputs.docs_only != 'true'`.

When `docs_only == 'true'`, GitHub reports the check as `status: skipping`. Branch-protection already treats this as passing for ci.yml's downstream jobs; same semantics applies here.

## Verification

YAML validated via `python3 -c "import yaml; yaml.safe_load(...)"`.

The shell classify logic is byte-equal to the one in `.github/workflows/ci.yml` (which has been working correctly across the current cascade).

## Net savings

- Docs-only PRs save ~20 min wall-clock on the Per-Module Coverage Thresholds gate
- Code/test PRs: no change
- Current v0.7.0 ship campaign: ~80 minutes saved (4 docs-only PRs × ~20 min)
- Long-term: every docs-only PR going forward saves ~20 min

## Test plan

- [x] YAML syntax validated locally
- [x] Same classify shell logic as ci.yml (already validated in production)
- [x] Backward-compatible: code/test PRs run the heavy job as before; only docs-only short-circuit changes behavior
- [x] Fail-open on classifier uncertainty (never fail-closed; if base can't be resolved, the heavy job runs)

Operator authorized 2026-05-26 in the same conversation where this issue was filed ("YES - approved do it").

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (1M context)