### PR TITLE
fix(store, ARCH-2): all 21 SAL trait methods + 15 handler routings (FX-C2 final)

### DIFF
--- a/docs/v0.7.0/arch-2-sal-boundary-audit.md
+++ b/docs/v0.7.0/arch-2-sal-boundary-audit.md
@@ -112,28 +112,28 @@ as ARCH-2-followup with a proposed trait addition).
 | Line | Call | Class | Status |
 |---|---|---|---|
 | 130 | `db::list_pending_actions(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::list_pending_actions` landed in FX-C2-batch-3** (SQLite + Postgres impls + 1 SQLite test + 1 live-Postgres parity test). Postgres branch already routes through `list_pending_actions_via_store` (which accepts an extra namespace filter); the new trait method closes the missing-trait gap for the namespace-omitted shape. SQLite branch stays on `db::list_pending_actions` because tests seed via `db::queue_pending_action(&lock.0, …)`. |
-| 306-307 | `db::approve_with_approver_type` + `db::execute_pending_action` | Missing-trait | Deferred-to-followup |
+| 306-307 | `db::approve_with_approver_type` + `db::execute_pending_action` | Missing-trait (closed) / Test-blocked drift | **Trait methods `MemoryStore::approve_with_approver_type` and `MemoryStore::execute_pending_action` landed in FX-C2-batch-5** (both adapters override; SQLite `execute_pending_action` replaces the trait's default `UnsupportedCapability`). SQLite branch stays on `db::approve_with_approver_type` because the handler holds `app.db.lock()` for the upstream pending-row write + post-execute `db::get` capture in the same window. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 315 | `db::get(&lock.0, mid)` post-execute capture | Keeper | Pre-existing keeper (write-then-read in same lock window) |
-| 480 | `db::decide_pending_action(&lock.0, …)` | Missing-trait | Deferred-to-followup |
+| 480 | `db::decide_pending_action(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::decide_pending_action` landed in FX-C2-batch-5** (alias of `pending_decide`; both adapters override directly). SQLite branch stays on `db::decide_pending_action` because the handler holds `app.db.lock()` for the upstream pending-row read + decide in the same window. Reclassified Test-blocked drift. |
 
 ### `src/handlers/approvals.rs`
 
 | Line | Call | Class | Status |
 |---|---|---|---|
-| 277-328 | `db::get_pending_action` / `db::approve_with_approver_type` / `db::execute_pending_action` / `db::decide_pending_action` | Missing-trait | Deferred-to-followup |
+| 277-328 | `db::get_pending_action` / `db::approve_with_approver_type` / `db::execute_pending_action` / `db::decide_pending_action` | Missing-trait (closed) / Test-blocked drift | **Trait methods `MemoryStore::approve_with_approver_type`, `MemoryStore::execute_pending_action`, `MemoryStore::decide_pending_action` landed in FX-C2-batch-5** (both adapters override). SQLite branch stays on the legacy `db::*` free functions because the handler holds `app.db.lock()` across the full approve → execute → audit-emit window; the trait routes are exercised via the postgres branch (which inherits the same path via the trait dispatch on `app.store`). Reclassified Test-blocked drift. |
 
 ### `src/handlers/kg.rs`
 
 | Line | Call | Class | Status |
 |---|---|---|---|
-| 311 | `db::entity_register(…)` | Drift | Deferred-to-followup (SAL has no `entity_register`; trait extension required) |
+| 311 | `db::entity_register(…)` | Drift (closed) | **Trait method `MemoryStore::entity_register` landed in FX-C2-batch-5** (both adapters override; Postgres re-implements the alias-union + upsert on top of the SAL `list` + `find_by_title_namespace` + `store` so the 150-LOC handler-side path collapses to a single trait call). Postgres branch **Routed-in-this-PR** (replaces ~150 LOC of hand-rolled alias union + upsert with a single trait call; governance enforcement gate preserved verbatim). SQLite branch stays on `db::entity_register` because tests seed via the legacy `db::*` path. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 468 | `db::entity_get_by_alias(&lock.0, alias, namespace)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::entity_get_by_alias` landed in FX-C2-batch-3** (SQLite + Postgres impls + 3 SQLite tests + 1 live-Postgres parity test). Postgres branch **Routed-in-this-PR** for the exact-alias match; the title-eq-alias fallback walk preserved on the SAL `list` path so the case-insensitive title match shape stays intact. |
 | 479 | `db::get(&lock.0, &rec.entity_id)` post-resolve | Test-blocked drift | Deferred-to-followup |
 | 631, 647 | `db::get(&lock.0, &p.source_id)` for find_paths owner gate | Test-blocked drift | Deferred-to-followup |
-| 735 | `db::kg_timeline(&lock.0, …)` | Missing-trait | Deferred-to-followup |
+| 735 | `db::kg_timeline(&lock.0, …)` | Missing-trait (closed) | **Trait method `MemoryStore::kg_timeline` landed in FX-C2-batch-5** (both adapters override; Postgres inlines the AGE↔CTE dispatch from the inherent so the trait method works without name-collision against the inherent helper). Postgres branch **Routed-in-this-PR** (replaces the `kg_timeline_via_store` downcast hatch). SQLite branch stays on `db::kg_timeline` because the handler holds `app.db.lock()` for the source-owner gate + timeline scan in the same window. Reclassified Test-blocked drift. |
 | 833 | `db::get(&lock.0, &body.source_id)` for kg_invalidate owner gate | Test-blocked drift | Deferred-to-followup |
 | 932 | `db::invalidate_link(…)` | Missing-trait (closed) | **Trait method `MemoryStore::invalidate_link` landed in FX-C2-batch-4** (SQLite + Postgres impls + 2 SQLite parity tests + 2 live-Postgres parity tests). Postgres branch **Routed-in-this-PR** (replaces the `kg_invalidate_via_store` downcast hatch with a trait-native call). SQLite branch stays on `db::invalidate_link` because the audit-event append + `signed_events` row write happen inside the same locked transaction. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
-| 1359 | `db::kg_query(&lock.0, …)` | Missing-trait | Deferred-to-followup |
+| 1359 | `db::kg_query(&lock.0, …)` | Missing-trait (closed) | **Trait method `MemoryStore::kg_query` landed in FX-C2-batch-5** (3-arg `(source_id, max_depth, include_invalidated)` shape; both adapters override; Postgres delegates to the inherent `kg_query_with_history` which resolves AGE vs CTE at adapter connect time). Postgres branch **Routed-in-this-PR** (replaces the `kg_query_via_store` downcast hatch). SQLite branch stays on `db::kg_query` because the handler holds `app.db.lock()` for the kg_query + per-target visibility filter `db::get` in the same window. Reclassified Test-blocked drift. |
 | 1373 | `db::get(&lock.0, &n.target_id)` in kg_query result decoration | Test-blocked drift | Deferred-to-followup |
 
 ### `src/handlers/federation_receive.rs`
@@ -246,6 +246,25 @@ plus #3, #4, #5, #12, #17). The remaining 7 missing-trait additions +
 remaining deferred-drift handler routings + 25 test-blocked drift
 sites (19 original + 6 newly reclassified in batch-4) are tracked
 under the FX-C2-d … FX-C2-f sub-batch sequencing.
+
+FX-C2 **batch-5** follow-up (this PR — `fix/arch2-sal-routing-batch2`):
+
+| Action | Sites | Notes |
+|---|---|---|
+| New trait methods landed | 6 | `MemoryStore::approve_with_approver_type` (#7) — convenience alias whose default forwards to `governance_approve_with_consensus`; both adapters override directly. `MemoryStore::decide_pending_action` (#9) — convenience alias whose default forwards to `pending_decide`; both adapters override directly. `MemoryStore::kg_query` (#13) — 3-arg `(source_id, max_depth, include_invalidated)` shape that closes `kg.rs:1359`; the SQLite impl delegates to `db::kg_query`, the Postgres impl forwards to the inherent `kg_query_with_history` (which resolves AGE vs CTE at adapter connect time). `MemoryStore::kg_timeline` (#14) — closes `kg.rs:735`; SQLite delegates to `db::kg_timeline`, Postgres inlines the AGE↔CTE dispatch verbatim from the inherent (the inherent remains in `impl PostgresStore` for external test callers that bind to the concrete type). `MemoryStore::entity_register` (#15) — closes `kg.rs:311` (formerly a drift entry because no trait method existed); SQLite delegates to `db::entity_register`, Postgres re-implements the alias-union + upsert on top of `MemoryStore::list` + `find_by_title_namespace` + `store` so the 150-LOC handler-side path collapses to a single trait call. `MemoryStore::list_archived` (#19) — closes `archive.rs:85` (formerly going through the `list_archived_via_store` `as_any_for_postgres` downcast hatch); SQLite delegates to `db::list_archived`, Postgres delegates to the inherent helper (renamed `list_archived_pg` to avoid name collision with the trait method). Plus a SqliteStore `execute_pending_action` override (closes #8 by replacing the trait's default `UnsupportedCapability`). SQLite + Postgres adapter impls + 15 unit tests (9 SQLite + 6 live-Postgres parity, gated on `AI_MEMORY_TEST_POSTGRES_URL`). |
+| Routed-in-this-PR (Postgres) | 4 | `archive.rs:85` → `MemoryStore::list_archived` (replaces the `list_archived_via_store` downcast hatch; the helper stays in place for back-compat but new routes ride the trait surface). `kg.rs:311` postgres branch → `MemoryStore::entity_register` (replaces ~150 LOC of hand-rolled alias-union + upsert with a single trait call; governance enforcement gate preserved verbatim). `kg.rs:735` postgres branch → `MemoryStore::kg_timeline` (replaces the `kg_timeline_via_store` downcast hatch). `kg.rs:1359` postgres branch → `MemoryStore::kg_query` (replaces the `kg_query_via_store` downcast hatch). |
+| Reclassified Missing-trait → Test-blocked drift | 5 | `governance.rs:306` (approve_with_approver_type SQLite — held under `app.db.lock()`), `governance.rs:480` (decide_pending_action SQLite — same lock window), `approvals.rs:280` (approve_with_approver_type SQLite), `approvals.rs:328` (decide_pending_action SQLite), `federation_receive.rs:941` (decide_pending_action SQLite — held under same lock window as the upstream `apply_remote_*` write per the #961 federation-receive keeper carve-out). Trait methods now exist; SQLite-branch routing blocked on test-fixture convergence + the #961 federation-receive carve-out, per ARCH-2-followup §"Test-fixture convergence". |
+
+FX-C2 cumulative progress (after batch-5): 15 sites routed (2 from
+PR #1356, 1 from batch-2, 6 from batch-3, 2 from batch-4, 4 from
+batch-5); **21 of 21 proposed missing-trait additions landed** (batch-2
+#1; batch-3 #6, #10, #11, #16, #18, #20, #21; batch-4 #2, #3, #4, #5,
+#12, #17; batch-5 #7, #8, #9, #13, #14, #15, #19). Every "Missing-trait"
+entry in the FX-C2 audit is now closed at the trait surface; the
+remaining deferred-drift handler routings + 30 test-blocked drift
+sites (25 from prior batches + 5 newly reclassified in batch-5) are
+tracked under FX-C2-a (test-fixture convergence) + FX-C2-e
+(handler-routing residual).
 
 ### FX-C2 sub-batch dispatch plan
 

--- a/docs/v0.7.0/arch-2-sal-boundary-audit.md
+++ b/docs/v0.7.0/arch-2-sal-boundary-audit.md
@@ -45,7 +45,7 @@ as ARCH-2-followup with a proposed trait addition).
 | 745 | `db::delete_link(&lock.0, …)` — sqlite delete path (no source memory) | Drift | Deferred-to-followup |
 | 760 | `db::get(&lock.0, &target_id)` — fetch target memory owner for delete_link gate | Test-blocked drift | Deferred-to-followup |
 | 803 | `db::delete_link(&lock.0, &source_id, &target_id)` — sqlite delete write | Drift | Deferred-to-followup |
-| 894 | `db::get_links(&lock.0, &id)` — per-anchor edge probe in `get_links` sqlite branch | Missing-trait | Keeper-comment-added (no `MemoryStore::get_links_for_anchor`; SAL `list_links(namespace)` is namespace-scoped, not anchor-scoped) |
+| 894 | `db::get_links(&lock.0, &id)` — per-anchor edge probe in `get_links` sqlite branch | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::get_links_for_anchor` landed in PR #FX-C2-batch-2** (SQLite + Postgres impls + 6 parity tests, see `src/store/{mod,sqlite,postgres}.rs`); the Postgres branch above at `links.rs:850-887` is **Routed-in-this-PR** through the new trait method (drops the pre-fix `list_links(None)` + client-side filter). The SQLite branch at this line stays on `db::get_links` because `app.store` and `app.db` point at disjoint backing files in unit tests (`test_app_state` opens a fresh tempfile-backed `SqliteStore`; `test_state()` uses `:memory:` sqlite); routing here breaks ~30 tests that seed via `db::create_link(&lock.0, …)`. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 910-919 | `db::get(&lock.0, &link.{source,target}_id)` x2 inside per-edge visibility filter loop | Drift | **Routed-in-this-PR** — sqlite branch now routes through `app.store.get(&ctx, …)` to mirror the postgres branch's `#910` scope=private fold |
 | 619-625 | `e.downcast_ref::<db::StorageError>()` for `LinkReflectionCycle`/`LinkPermissionDenied` | Keeper | Pre-existing keeper (typed-error downcast; SAL `StoreError` doesn't carry these variants) |
 
@@ -170,7 +170,7 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 | Line | Call | Class | Status |
 |---|---|---|---|
 | 231 | `db::list(&lock.0, …)` candidate-set scan | Test-blocked drift | Deferred-to-followup |
-| 280 | `db::get_links(&lock.0, id)` per-anchor probe | Missing-trait | Deferred-to-followup |
+| 280 | `db::get_links(&lock.0, id)` per-anchor probe | Missing-trait (closed) / Test-blocked drift | Trait method `MemoryStore::get_links_for_anchor` landed in PR #FX-C2-batch-2; this SQLite branch stays on `db::get_links` because the contradiction-link assembly holds `app.db.lock()` for the upstream `db::list` + this `db::get_links` in the same window. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 411 | `db::list_namespaces(&lock.0)` | Missing-trait | Deferred-to-followup |
 | 620 | `db::get_taxonomy(&lock.0, …)` | Missing-trait | Deferred-to-followup |
 | 825 | `db::check_duplicate_with_text(…)` | Missing-trait | Deferred-to-followup |
@@ -185,7 +185,9 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 
 ## Summary counts
 
-| Class | Total sites | Routed in this PR | Keeper-comment added | Pre-existing keeper | Deferred to followup |
+Original FX-11 ARCH-2 PR (#1356):
+
+| Class | Total sites | Routed in PR #1356 | Keeper-comment added | Pre-existing keeper | Deferred to followup |
 |---|---|---|---|---|---|
 | Drift | 11 | 2 (links.rs:910/915) | 0 | 0 | 9 |
 | Test-blocked drift | 19 | 0 | 2 (power_consolidation.rs:199/716) | 0 | 17 |
@@ -193,11 +195,46 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 | Missing-trait | 27 | 0 | 1 (links.rs:894) | 0 | 26 |
 | **Total** | **76** | **2** | **3** | **19** | **52** |
 
+FX-C2 batch-2 follow-up (this PR — `fix/arch2-sal-routing-batch2`):
+
+| Action | Sites | Notes |
+|---|---|---|
+| New trait method landed | 1 | `MemoryStore::get_links_for_anchor` (proposed addition #1) — SQLite + Postgres adapter impls + 6 parity tests (3 SQLite + 3 live-Postgres) |
+| Routed-in-this-PR (Postgres) | 1 | `links.rs:850-887` — postgres branch of `get_links` now rides the trait method instead of `list_links(None) + client-side filter` |
+| Reclassified Missing-trait → Test-blocked drift | 2 | `links.rs:894`, `power.rs:280` — trait method now exists; SQLite-branch routing blocked on test-fixture convergence (option b) per ARCH-2-followup §"Test-fixture convergence" |
+
 Note: the original ARCH-2 finding cited "40+ sites". The full audit
 surfaces 76 sites once `crate::storage::*` typed-error downcasts and
 federation-receive write paths are counted; the gap is the
 typed-downcast carve-out (already documented in-place since #961)
 plus the federation-receive intentional sqlite path.
+
+FX-C2 cumulative progress: 3 sites routed (2 from PR #1356, 1 from
+this batch); 1 of 21 proposed missing-trait additions landed (#1
+`get_links_for_anchor`). The remaining 20 missing-trait additions
++ 27 deferred-drift handler routings + 19 test-blocked drift sites
+are tracked under the FX-C2-a … FX-C2-f sub-batch sequencing in
+sub-section §"FX-C2 sub-batch dispatch plan" below.
+
+### FX-C2 sub-batch dispatch plan
+
+Sized for single-agent landing with green gates on every batch:
+
+| Sub-batch | Scope | Notes |
+|---|---|---|
+| FX-C2-a | Test-fixture convergence — unify `test_state()` + `test_app_state` so `app.db` and `app.store` share the same backing | Unblocks all 19 Test-blocked drift sites + the 2 reclassified sites above |
+| FX-C2-b | 7 read-only trait additions (`list_agents`, `list_namespaces`, `list_pending_actions`, `entity_get_by_alias`, `get_taxonomy`, `health_check`, `stats`) | Read-only ⇒ no transaction-window concerns |
+| FX-C2-c | 7 write-path trait additions (`set_embedding`, `find_by_title_namespace`, `next_versioned_title`, `entity_register`, `invalidate_link`, `check_duplicate_with_text`, `find_contradictions`) | Single-row writes |
+| FX-C2-d | 6 governance/KG trait additions (`approve_with_approver_type`, `execute_pending_action`, `decide_pending_action`, `kg_query`, `kg_timeline`, `proactive_conflict_check`) | Multi-row state-machine writes |
+| FX-C2-e | Remaining handler routings (27 deferred-drift sites) | Depends on FX-C2-b/c/d |
+| FX-C2-f | Final pass: 19 test-blocked sites unblocked by FX-C2-a + `list_archived` / `get_namespace_meta_entry` trait additions | Closes the residual |
+
+Every sub-batch carries the same gating contract: `cargo fmt --check`,
+`cargo clippy --features sal,sal-postgres -- -D warnings -D
+clippy::pedantic`, `AI_MEMORY_NO_CONFIG=1 cargo test --features
+sal,sal-postgres`, plus SQLite + Postgres parity tests on every new
+trait method, plus this audit document updated with the
+"Routed-in-PR-#X" status for each site touched.
 
 ## ARCH-2-followup proposed trait additions
 

--- a/docs/v0.7.0/arch-2-sal-boundary-audit.md
+++ b/docs/v0.7.0/arch-2-sal-boundary-audit.md
@@ -53,14 +53,14 @@ as ARCH-2-followup with a proposed trait addition).
 
 | Line | Call | Class | Status |
 |---|---|---|---|
-| 187 | `db::find_by_title_namespace(conn, …)` | Drift | Deferred-to-followup |
-| 210 | `db::next_versioned_title(conn, …)` | Missing-trait | Deferred-to-followup |
+| 187 | `db::find_by_title_namespace(conn, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::find_by_title_namespace` landed in FX-C2-batch-4** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres test). SQLite branch stays on `db::find_by_title_namespace` because the lookup runs under `app.db.lock()` immediately before the upstream `db::insert` write; routing through `app.store` would break the same-lock-window write coherence (and the test harness's disjoint `app.db` vs `app.store` backings). The `create_memory_postgres` path doesn't need the trait method (its `store_with_embedding` upsert handles the conflict natively). |
+| 210 | `db::next_versioned_title(conn, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::next_versioned_title` landed in FX-C2-batch-4** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres test). SQLite branch stays on `db::next_versioned_title` for the same same-lock-window reason as line 187. |
 | 285 | `db::enforce_governance(…)` | Missing-trait | Deferred-to-followup (SAL has `enforce_governance_action` but signature differs; trait alignment work required) |
 | 308 | `db::get_pending_action(&lock.0, &pending_id)` | Drift | Deferred-to-followup (SAL `get_pending` exists) |
 | 466 | `db::insert(&lock.0, mem)` | Test-blocked drift | Deferred-to-followup (SAL `store` exists) |
-| 475 | `db::set_embedding(&lock.0, &actual_id, vec)` | Missing-trait | Deferred-to-followup (no `MemoryStore::set_embedding`; covered by `store_with_embedding` but split-write surface differs) |
+| 475 | `db::set_embedding(&lock.0, &actual_id, vec)` | Missing-trait (closed) / Test-blocked drift | **`SqliteStore::update_embedding` override landed in FX-C2-batch-4** — the trait method was already defined but the default impl was a no-op for SQLite; the override now delegates to `db::set_embedding` so `app.store.update_embedding` is the canonical embedding-update surface across backends (postgres already overrode this method via the `vector(N)` UPDATE). 1 SQLite parity test + 1 live-Postgres parity test landed. SQLite branch at line 475 stays on `db::set_embedding` because it runs under the same `app.db.lock()` window as the upstream `db::insert`. |
 | 516, 1337, 1341 | `crate::storage::GovernanceRefusal` typed downcast | Keeper | Pre-existing keeper |
-| 1025 | `db::find_contradictions(&lock.0, …)` | Missing-trait | Deferred-to-followup |
+| 1025 | `db::find_contradictions(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::find_contradictions` landed in FX-C2-batch-4** (SQLite + Postgres impls + 1 SQLite parity test + 1 live-Postgres parity test). SQLite branch stays on `db::find_contradictions` because it runs under `app.db.lock()` between governance and the proactive conflict check; routing through `app.store` would break the same-lock-window scan coherence. |
 | 1041 | `db::proactive_conflict_check(&lock.0, …)` | Missing-trait | Deferred-to-followup |
 
 ### `src/handlers/recall.rs`
@@ -132,7 +132,7 @@ as ARCH-2-followup with a proposed trait addition).
 | 631, 647 | `db::get(&lock.0, &p.source_id)` for find_paths owner gate | Test-blocked drift | Deferred-to-followup |
 | 735 | `db::kg_timeline(&lock.0, …)` | Missing-trait | Deferred-to-followup |
 | 833 | `db::get(&lock.0, &body.source_id)` for kg_invalidate owner gate | Test-blocked drift | Deferred-to-followup |
-| 932 | `db::invalidate_link(…)` | Missing-trait | Deferred-to-followup |
+| 932 | `db::invalidate_link(…)` | Missing-trait (closed) | **Trait method `MemoryStore::invalidate_link` landed in FX-C2-batch-4** (SQLite + Postgres impls + 2 SQLite parity tests + 2 live-Postgres parity tests). Postgres branch **Routed-in-this-PR** (replaces the `kg_invalidate_via_store` downcast hatch with a trait-native call). SQLite branch stays on `db::invalidate_link` because the audit-event append + `signed_events` row write happen inside the same locked transaction. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 1359 | `db::kg_query(&lock.0, …)` | Missing-trait | Deferred-to-followup |
 | 1373 | `db::get(&lock.0, &n.target_id)` in kg_query result decoration | Test-blocked drift | Deferred-to-followup |
 
@@ -173,7 +173,7 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 | 280 | `db::get_links(&lock.0, id)` per-anchor probe | Missing-trait (closed) / Test-blocked drift | Trait method `MemoryStore::get_links_for_anchor` landed in PR #FX-C2-batch-2; this SQLite branch stays on `db::get_links` because the contradiction-link assembly holds `app.db.lock()` for the upstream `db::list` + this `db::get_links` in the same window. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
 | 411 | `db::list_namespaces(&lock.0)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::list_namespaces` landed in FX-C2-batch-3** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres parity test). Postgres branch **Routed-in-this-PR** (replaces 1M-limit `list()` + BTreeSet fold with SQL `GROUP BY namespace`). |
 | 620 | `db::get_taxonomy(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::get_taxonomy` landed in FX-C2-batch-3** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres parity test); shared tree-fold helper `crate::storage::fold_taxonomy_groups` pins byte-equal output across backends. Postgres branch **Routed-in-this-PR**; the pre-fix in-handler tree assembly is preserved as opt-in legacy fallback gated on `AI_MEMORY_TAXONOMY_LEGACY_PG=1`. |
-| 825 | `db::check_duplicate_with_text(…)` | Missing-trait | Deferred-to-followup |
+| 825 | `db::check_duplicate_with_text(…)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::check_duplicate_with_text` landed in FX-C2-batch-4** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres test). Postgres branch (lines 736-810) is **Routed-in-this-PR** (replaces 75 LOC of hand-rolled `list` + exact-match + `recall_hybrid` fallback with a trait-native call). SQLite branch at line 856 stays on `db::check_duplicate_with_text` because the same-lock-window contract holds across the embedding write + scan + post-dedup decoration. |
 | 849 | `db::get(&lock.0, &near.id)` post-dedup decoration | Keeper | Pre-existing keeper (read inside same lock window) |
 
 ### `src/handlers/federation_sync_since.rs`
@@ -228,6 +228,24 @@ missing-trait additions landed (#1 `get_links_for_anchor`, #6
 deferred-drift handler routings + 19 test-blocked drift sites are
 tracked under the FX-C2-c … FX-C2-f sub-batch sequencing in
 sub-section §"FX-C2 sub-batch dispatch plan" below.
+
+FX-C2 **batch-4** follow-up (this PR — `fix/arch2-sal-routing-batch2`):
+
+| Action | Sites | Notes |
+|---|---|---|
+| New trait methods landed | 6 | `MemoryStore::find_by_title_namespace` (#3), `MemoryStore::next_versioned_title` (#4), `MemoryStore::find_contradictions` (#5), `MemoryStore::invalidate_link` (#17), `MemoryStore::check_duplicate_with_text` (#12), plus `SqliteStore::update_embedding` override (closes #2 `set_embedding` via the existing trait surface — the postgres adapter already overrode `update_embedding`; sqlite's default no-op is now replaced with a `db::set_embedding` delegate so the trait method is the canonical embedding-update surface across backends). SQLite + Postgres adapter impls + 17 unit tests (9 SQLite + 8 live-Postgres parity, gated on `AI_MEMORY_TEST_POSTGRES_URL`). |
+| Routed-in-this-PR (Postgres) | 2 | `kg.rs:932` → `MemoryStore::invalidate_link` (replaces the `kg_invalidate_via_store` `as_any_for_postgres` downcast hatch; the legacy helper stays in place for back-compat callers but new routes ride the trait surface); `power.rs:825` postgres branch (lines 736-810) → `MemoryStore::check_duplicate_with_text` (replaces the 75-LOC hand-rolled `list` + exact-match walk + `recall_hybrid` fallback with a single trait call whose phase-1 SHA-256 short-circuit + phase-2 pgvector cosine path mirror SQLite's `db::check_duplicate_with_text` byte-for-byte). |
+| Reclassified Missing-trait → Test-blocked drift | 5 | `create.rs:187` (find_by_title_namespace SQLite), `create.rs:210` (next_versioned_title SQLite), `create.rs:475` (set_embedding SQLite — held under `app.db.lock()` in same window as `db::insert`), `create.rs:1025` (find_contradictions SQLite — held under same lock), `federation_receive.rs:1052` (set_embedding SQLite — held under same lock window as the upstream `apply_remote_memory` write). Trait methods now exist; SQLite-branch routing blocked on test-fixture convergence per ARCH-2-followup §"Test-fixture convergence". |
+| Reclassified Missing-trait → Test-blocked drift (power.rs) | 1 | `power.rs:856` (check_duplicate_with_text SQLite) — trait method landed; SQLite-branch routing blocked on the same same-lock-window constraint as `create.rs` (the handler holds `app.db.lock()` for the upstream embedding write + check_duplicate scan + post-dedup decoration). |
+
+FX-C2 cumulative progress (after batch-4): 11 sites routed (2 from
+PR #1356, 1 from batch-2, 6 from batch-3, 2 from batch-4); 14 of 21
+proposed missing-trait additions landed (batch-2 #1; batch-3 #6, #10,
+#11, #16, #18, #20, #21; batch-4 #2 — via `update_embedding` override —
+plus #3, #4, #5, #12, #17). The remaining 7 missing-trait additions +
+remaining deferred-drift handler routings + 25 test-blocked drift
+sites (19 original + 6 newly reclassified in batch-4) are tracked
+under the FX-C2-d … FX-C2-f sub-batch sequencing.
 
 ### FX-C2 sub-batch dispatch plan
 

--- a/docs/v0.7.0/arch-2-sal-boundary-audit.md
+++ b/docs/v0.7.0/arch-2-sal-boundary-audit.md
@@ -111,7 +111,7 @@ as ARCH-2-followup with a proposed trait addition).
 
 | Line | Call | Class | Status |
 |---|---|---|---|
-| 130 | `db::list_pending_actions(&lock.0, …)` | Missing-trait | Deferred-to-followup (no SAL equivalent) |
+| 130 | `db::list_pending_actions(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::list_pending_actions` landed in FX-C2-batch-3** (SQLite + Postgres impls + 1 SQLite test + 1 live-Postgres parity test). Postgres branch already routes through `list_pending_actions_via_store` (which accepts an extra namespace filter); the new trait method closes the missing-trait gap for the namespace-omitted shape. SQLite branch stays on `db::list_pending_actions` because tests seed via `db::queue_pending_action(&lock.0, …)`. |
 | 306-307 | `db::approve_with_approver_type` + `db::execute_pending_action` | Missing-trait | Deferred-to-followup |
 | 315 | `db::get(&lock.0, mid)` post-execute capture | Keeper | Pre-existing keeper (write-then-read in same lock window) |
 | 480 | `db::decide_pending_action(&lock.0, …)` | Missing-trait | Deferred-to-followup |
@@ -127,7 +127,7 @@ as ARCH-2-followup with a proposed trait addition).
 | Line | Call | Class | Status |
 |---|---|---|---|
 | 311 | `db::entity_register(…)` | Drift | Deferred-to-followup (SAL has no `entity_register`; trait extension required) |
-| 468 | `db::entity_get_by_alias(&lock.0, alias, namespace)` | Missing-trait | Deferred-to-followup |
+| 468 | `db::entity_get_by_alias(&lock.0, alias, namespace)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::entity_get_by_alias` landed in FX-C2-batch-3** (SQLite + Postgres impls + 3 SQLite tests + 1 live-Postgres parity test). Postgres branch **Routed-in-this-PR** for the exact-alias match; the title-eq-alias fallback walk preserved on the SAL `list` path so the case-insensitive title match shape stays intact. |
 | 479 | `db::get(&lock.0, &rec.entity_id)` post-resolve | Test-blocked drift | Deferred-to-followup |
 | 631, 647 | `db::get(&lock.0, &p.source_id)` for find_paths owner gate | Test-blocked drift | Deferred-to-followup |
 | 735 | `db::kg_timeline(&lock.0, …)` | Missing-trait | Deferred-to-followup |
@@ -144,16 +144,16 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 
 | Line | Call | Class | Status |
 |---|---|---|---|
-| 840 | `db::health_check(&guard.0)` | Missing-trait | Deferred-to-followup (no `MemoryStore::health_check`) |
-| 876 | `db::stats(&guard.0, &guard.1)` | Missing-trait | Deferred-to-followup |
+| 840 | `db::health_check(&guard.0)` | Missing-trait (closed) | **Trait method `MemoryStore::health_check` landed in FX-C2-batch-3** + Postgres branch **Routed-in-this-PR** (natively-async sqlx round-trip, no blocking-pool dispatch). SQLite branch stays on `db_op + db::health_check` per PERF-1 (FX-3). |
+| 876 | `db::stats(&guard.0, &guard.1)` | Missing-trait (closed) / Test-blocked drift | Trait method landed in FX-C2-batch-3; prometheus_metrics fold takes `State<Db>` not `State<AppState>` so the routing closure can't reach `app.store` today. Deferred to FX-C2-a (state-shape convergence). |
 
 ### `src/handlers/admin.rs`
 
 | Line | Call | Class | Status |
 |---|---|---|---|
 | 175 | `db::get(&lock.0, id)` admin lookup | Test-blocked drift | Deferred-to-followup |
-| 280 | `db::list_agents(&lock.0)` | Missing-trait | Deferred-to-followup |
-| 505 | `db::stats(&lock.0, &lock.1)` | Missing-trait | Deferred-to-followup |
+| 280 | `db::list_agents(&lock.0)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::list_agents` landed in FX-C2-batch-3** (SQLite + Postgres impls + 2 SQLite parity tests + 1 live-Postgres parity test). Postgres branch is **Routed-in-this-PR** through the trait method (drops the prior `list()` + client-side metadata fold). SQLite branch stays on `db::list_agents` because tests seed `app.db` via `db::queue/insert_*` paths that don't reach `app.store`. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
+| 505 | `db::stats(&lock.0, &lock.1)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::stats` landed in FX-C2-batch-3** (SQLite + Postgres impls + 1 SQLite parity test + 1 live-Postgres parity test). Postgres branch **Routed-in-this-PR** (replaces the 1M-limit `list()` scan + per-tier client fold with SQL aggregates). SQLite branch stays on `db::stats`; reclassified Test-blocked drift. |
 
 ### `src/handlers/memories_query.rs`
 
@@ -171,8 +171,8 @@ All 12 reaches (`db::resolve_governance_policy`, `db::insert_if_newer`, `db::del
 |---|---|---|---|
 | 231 | `db::list(&lock.0, …)` candidate-set scan | Test-blocked drift | Deferred-to-followup |
 | 280 | `db::get_links(&lock.0, id)` per-anchor probe | Missing-trait (closed) / Test-blocked drift | Trait method `MemoryStore::get_links_for_anchor` landed in PR #FX-C2-batch-2; this SQLite branch stays on `db::get_links` because the contradiction-link assembly holds `app.db.lock()` for the upstream `db::list` + this `db::get_links` in the same window. Reclassified Test-blocked drift; tracked for FX-C2-a follow-up. |
-| 411 | `db::list_namespaces(&lock.0)` | Missing-trait | Deferred-to-followup |
-| 620 | `db::get_taxonomy(&lock.0, …)` | Missing-trait | Deferred-to-followup |
+| 411 | `db::list_namespaces(&lock.0)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::list_namespaces` landed in FX-C2-batch-3** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres parity test). Postgres branch **Routed-in-this-PR** (replaces 1M-limit `list()` + BTreeSet fold with SQL `GROUP BY namespace`). |
+| 620 | `db::get_taxonomy(&lock.0, …)` | Missing-trait (closed) / Test-blocked drift | **Trait method `MemoryStore::get_taxonomy` landed in FX-C2-batch-3** (SQLite + Postgres impls + 2 SQLite tests + 1 live-Postgres parity test); shared tree-fold helper `crate::storage::fold_taxonomy_groups` pins byte-equal output across backends. Postgres branch **Routed-in-this-PR**; the pre-fix in-handler tree assembly is preserved as opt-in legacy fallback gated on `AI_MEMORY_TAXONOMY_LEGACY_PG=1`. |
 | 825 | `db::check_duplicate_with_text(…)` | Missing-trait | Deferred-to-followup |
 | 849 | `db::get(&lock.0, &near.id)` post-dedup decoration | Keeper | Pre-existing keeper (read inside same lock window) |
 
@@ -203,17 +203,30 @@ FX-C2 batch-2 follow-up (this PR — `fix/arch2-sal-routing-batch2`):
 | Routed-in-this-PR (Postgres) | 1 | `links.rs:850-887` — postgres branch of `get_links` now rides the trait method instead of `list_links(None) + client-side filter` |
 | Reclassified Missing-trait → Test-blocked drift | 2 | `links.rs:894`, `power.rs:280` — trait method now exists; SQLite-branch routing blocked on test-fixture convergence (option b) per ARCH-2-followup §"Test-fixture convergence" |
 
+FX-C2 **batch-3** follow-up (this PR — `fix/arch2-sal-routing-batch2`):
+
+| Action | Sites | Notes |
+|---|---|---|
+| New trait methods landed | 7 | `MemoryStore::list_namespaces` (#10), `MemoryStore::get_taxonomy` (#11), `MemoryStore::list_agents` (#18), `MemoryStore::list_pending_actions` (#6), `MemoryStore::entity_get_by_alias` (#16), `MemoryStore::health_check` (#20), `MemoryStore::stats` (#21) — SQLite + Postgres adapter impls + 18 unit tests (11 SQLite + 7 live-Postgres parity, gated on `AI_MEMORY_TEST_POSTGRES_URL`) |
+| Backend-blind helper extracted | 1 | `crate::storage::fold_taxonomy_groups` — hoisted from `db::get_taxonomy` so both adapters share the exact same tree-folding logic; pins cross-backend wire shape byte-for-byte |
+| Routed-in-this-PR (Postgres) | 5 | `power.rs:411` → `list_namespaces` (replaces 1M-limit `list()` scan + client-side BTreeSet fold); `power.rs:620` → `get_taxonomy` (replaces the `taxonomy_namespaces_via_store` + in-handler tree assembly path, which is now an opt-in legacy fallback gated on `AI_MEMORY_TAXONOMY_LEGACY_PG=1`); `kg.rs:468` → `entity_get_by_alias` exact-match path with legacy SAL `list` fallback for the title-eq-alias branch; `admin.rs:280` → `list_agents` (replaces the `list()` + per-row metadata fold); `admin.rs:505` → `stats` (replaces the 1M-limit `list()` + per-tier client fold) |
+| Routed-in-this-PR (HTTP daemon, async-safe) | 1 | `transport.rs:840` — `/health` endpoint now routes Postgres-backed daemons through `MemoryStore::health_check` natively-async (no blocking-pool dispatch); SQLite path stays on `db_op` per PERF-1 (FX-3) |
+| Reclassified Missing-trait → Test-blocked drift | 7 | `power.rs:411` (SQLite), `power.rs:620` (SQLite), `kg.rs:468` (SQLite), `subscriptions.rs:454` (SQLite), `admin.rs:280` (SQLite), `admin.rs:505` (SQLite), `transport.rs:876` (SQLite stats via `prometheus_metrics`) — trait methods now exist; SQLite-branch routing blocked on test-fixture convergence per ARCH-2-followup §"Test-fixture convergence" |
+
 Note: the original ARCH-2 finding cited "40+ sites". The full audit
 surfaces 76 sites once `crate::storage::*` typed-error downcasts and
 federation-receive write paths are counted; the gap is the
 typed-downcast carve-out (already documented in-place since #961)
 plus the federation-receive intentional sqlite path.
 
-FX-C2 cumulative progress: 3 sites routed (2 from PR #1356, 1 from
-this batch); 1 of 21 proposed missing-trait additions landed (#1
-`get_links_for_anchor`). The remaining 20 missing-trait additions
-+ 27 deferred-drift handler routings + 19 test-blocked drift sites
-are tracked under the FX-C2-a … FX-C2-f sub-batch sequencing in
+FX-C2 cumulative progress (after batch-3): 9 sites routed (2 from
+PR #1356, 1 from batch-2, 6 from batch-3); 8 of 21 proposed
+missing-trait additions landed (#1 `get_links_for_anchor`, #6
+`list_pending_actions`, #10 `list_namespaces`, #11 `get_taxonomy`,
+#16 `entity_get_by_alias`, #18 `list_agents`, #20 `health_check`,
+#21 `stats`). The remaining 13 missing-trait additions + 21
+deferred-drift handler routings + 19 test-blocked drift sites are
+tracked under the FX-C2-c … FX-C2-f sub-batch sequencing in
 sub-section §"FX-C2 sub-batch dispatch plan" below.
 
 ### FX-C2 sub-batch dispatch plan

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -229,49 +229,21 @@ pub async fn list_agents(
     if let Err(resp) = crate::handlers::admin_role::require_admin(&app, &headers, "list_agents") {
         return resp;
     }
-    // v0.7.0 Wave-3 Continuation — postgres-backed daemons project from
-    // the `_agents` namespace via the SAL `list` trait method, mirroring
-    // how sqlite's `db::list_agents` reads from the same namespace.
-    #[cfg(feature = "sal")]
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — postgres-backed daemons
+    // route through `MemoryStore::list_agents`, which parses the
+    // `_agents`-namespace metadata blob into the canonical
+    // `AgentRegistration` shape exactly like SQLite's `db::list_agents`.
+    // Replaces the previous `list()` + client-side metadata-walk
+    // fold, which was a Drift cleanup target (audit doc, FX-C2 sub-
+    // batch dispatch plan §FX-C2-b).
+    #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // #910 — admin surface (registration / list_agents / stats);
-        // bypass the SAL visibility filter so admin endpoints see the
-        // full row set regardless of metadata.scope.
-        let ctx = crate::store::CallerContext::for_admin("daemon");
-        let filter = crate::store::Filter {
-            namespace: Some("_agents".to_string()),
-            limit: 1000,
-            ..Default::default()
-        };
-        return match app.store.list(&ctx, &filter).await {
-            Ok(memories) => {
-                let agents: Vec<serde_json::Value> = memories
-                    .iter()
-                    .filter_map(|m| {
-                        let meta = m.metadata.as_object()?;
-                        let agent_id = meta.get("agent_id")?.as_str()?;
-                        let agent_type = meta
-                            .get("agent_type")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown");
-                        let capabilities = meta
-                            .get("capabilities")
-                            .cloned()
-                            .unwrap_or_else(|| serde_json::json!([]));
-                        Some(json!({
-                            "agent_id": agent_id,
-                            "agent_type": agent_type,
-                            "capabilities": capabilities,
-                            "registered_at": m.created_at,
-                        }))
-                    })
-                    .collect();
-                (
-                    StatusCode::OK,
-                    Json(json!({"count": agents.len(), "agents": agents})),
-                )
-                    .into_response()
-            }
+        return match app.store.list_agents().await {
+            Ok(agents) => (
+                StatusCode::OK,
+                Json(json!({"count": agents.len(), "agents": agents})),
+            )
+                .into_response(),
             Err(e) => store_err_to_response(e),
         };
     }
@@ -448,51 +420,36 @@ pub async fn get_stats(
     if let Err(resp) = crate::handlers::admin_role::require_admin(&app, &headers, "get_stats") {
         return resp;
     }
-    // v0.7.0 Wave-3 Continuation — postgres-backed daemons project a
-    // basic count from the SAL `list` method. Detailed per-tier
-    // breakdown + DB file size + WAL counters are sqlite-only fields
-    // and surface as `null` on postgres so clients see a consistent
-    // top-level shape.
-    #[cfg(feature = "sal")]
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — postgres-backed daemons
+    // now route stats through `MemoryStore::stats`, which projects the
+    // full `Stats` shape via SQL aggregates (total + per-tier + per-
+    // namespace + expiring_soon + links_count + table-size). This
+    // replaces the previous client-side fold over a 1M-limit
+    // `list()` scan which was a Drift cleanup target and would not
+    // scale to large deployments.
+    #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // #910 — admin surface (registration / list_agents / stats);
-        // bypass the SAL visibility filter so admin endpoints see the
-        // full row set regardless of metadata.scope.
-        let ctx = crate::store::CallerContext::for_admin("daemon");
-        let filter = crate::store::Filter {
-            limit: 1_000_000,
-            ..Default::default()
-        };
-        return match app.store.list(&ctx, &filter).await {
-            Ok(memories) => {
-                let total = memories.len();
-                let mut short = 0usize;
-                let mut mid = 0usize;
-                let mut long = 0usize;
-                let mut by_namespace: std::collections::BTreeMap<String, usize> =
-                    std::collections::BTreeMap::new();
-                for m in &memories {
-                    match m.tier {
-                        Tier::Short => short += 1,
-                        Tier::Mid => mid += 1,
-                        Tier::Long => long += 1,
-                    }
-                    *by_namespace.entry(m.namespace.clone()).or_insert(0) += 1;
-                }
-                // by_tier wire shape: { <tier-wire-string>: <count> }.
-                // Keys are routed through `Tier::<X>.as_str()` so the
-                // wire-string mapping stays single-sourced (pm-v3.1 PR6,
-                // #1174). `json!` requires literal keys, so we build
-                // the inner map with `serde_json::Map` to interpolate
-                // the enum-derived keys.
+        return match app.store.stats().await {
+            Ok(s) => {
+                // Project the SAL Stats shape into the postgres wire
+                // shape: by_tier as a wire-string-keyed map (mirrors
+                // the previous postgres envelope), per-namespace as
+                // a `{namespace: count}` map.
                 let mut by_tier_map = serde_json::Map::new();
-                by_tier_map.insert(Tier::Short.as_str().to_string(), json!(short));
-                by_tier_map.insert(Tier::Mid.as_str().to_string(), json!(mid));
-                by_tier_map.insert(Tier::Long.as_str().to_string(), json!(long));
+                for tc in &s.by_tier {
+                    by_tier_map.insert(tc.tier.clone(), json!(tc.count));
+                }
+                let mut by_namespace_map = serde_json::Map::new();
+                for nc in &s.by_namespace {
+                    by_namespace_map.insert(nc.namespace.clone(), json!(nc.count));
+                }
                 Json(json!({
-                    "total_memories": total,
+                    "total_memories": s.total,
                     "by_tier": by_tier_map,
-                    "by_namespace": by_namespace,
+                    "by_namespace": by_namespace_map,
+                    "expiring_soon": s.expiring_soon,
+                    "links_count": s.links_count,
+                    "db_size_bytes": s.db_size_bytes,
                     "storage_backend": "postgres",
                 }))
                 .into_response()

--- a/src/handlers/archive.rs
+++ b/src/handlers/archive.rs
@@ -73,22 +73,22 @@ pub async fn list_archive(
             .into_response();
     }
 
-    // v0.7.0 Wave-3 Continuation — postgres-backed daemons project from
-    // the `archived_memories` table via the SAL adapter. The trait does
-    // not yet expose archive operations, so we dispatch via the typed
-    // `PostgresStore::list_archived` helper added under feature
-    // `sal-postgres`. Returns the same wire envelope as sqlite.
+    // v0.7.0 ARCH-2 FX-C2-batch5 (2026-05-27): route the postgres branch
+    // through the new `MemoryStore::list_archived` trait method (the
+    // SAL is now the canonical archive-list surface). The legacy
+    // `list_archived_via_store` downcast hatch still exists for
+    // out-of-tree callers but new routes ride the trait surface.
+    // Pre-batch5 the postgres branch dispatched through
+    // `list_archived_via_store`, which downcasted to `PostgresStore`
+    // via the `as_any_for_postgres` hatch.
     #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
         let limit = q.limit.unwrap_or(50).clamp(1, 1000);
         let offset = q.offset.unwrap_or(0);
-        return match crate::store::postgres::list_archived_via_store(
-            &app.store,
-            q.namespace.as_deref(),
-            limit,
-            offset,
-        )
-        .await
+        return match app
+            .store
+            .list_archived(q.namespace.as_deref(), limit, offset)
+            .await
         {
             Ok(items) => Json(json!({"archived": items, "count": items.len()})).into_response(),
             Err(e) => store_err_to_response(e),

--- a/src/handlers/kg.rs
+++ b/src/handlers/kg.rs
@@ -24,8 +24,6 @@
 
 #![allow(clippy::too_many_lines)]
 
-#[cfg(feature = "sal")]
-use crate::models::ConfidenceSource;
 use crate::models::Memory;
 use axum::{
     Json,
@@ -33,16 +31,10 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
-#[cfg(feature = "sal")]
-use chrono::Utc;
 use serde::Deserialize;
 use serde_json::json;
-#[cfg(feature = "sal")]
-use uuid::Uuid;
 
 use crate::db;
-#[cfg(feature = "sal")]
-use crate::models::Tier;
 use crate::validate;
 
 use super::AppState;
@@ -136,6 +128,15 @@ pub async fn entity_register(
     // canonical SQLite contract (`db::entity_register` unions aliases
     // across registrations), we first list any matching entity row and
     // union its prior aliases into the incoming set before the upsert.
+    // v0.7.0 ARCH-2 FX-C2-batch5 (2026-05-27): the postgres branch now
+    // rides the SAL trait `entity_register` (the alias-union walk +
+    // upsert is encapsulated inside the adapter, byte-for-byte aligned
+    // with the sqlite `db::entity_register` contract). Pre-batch5 the
+    // handler open-coded the alias union + `app.store.store` upsert in
+    // ~150 LOC; the trait method collapses that to a single call. The
+    // governance enforcement gate (F-A2A1.5 / #705) is preserved
+    // verbatim — entity rows remain governance-relevant writes and
+    // must consult the namespace policy before the underlying upsert.
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
         let aid = agent_id
@@ -143,110 +144,26 @@ pub async fn entity_register(
             .unwrap_or_else(|| "anonymous:entity-register".to_string());
         let ctx = crate::store::CallerContext::for_agent(aid.clone());
 
-        // Pull the prior entity row, if any, so we can union aliases
-        // across registrations. This is a single namespace-scoped
-        // `list` plus an in-memory match by canonical_name; the data
-        // volume per namespace is small (entities rather than memories
-        // proper) so the linear scan is acceptable.
-        let prior_aliases: Vec<String> = {
-            let filter = crate::store::Filter {
-                namespace: Some(body.namespace.clone()),
-                limit: 10_000,
-                ..Default::default()
-            };
-            match app.store.list(&ctx, &filter).await {
-                // #869 audit (Category B — safe default): a missing
-                // `aliases` field or a non-entity row collapses to
-                // empty `Vec<String>`, which is the documented
-                // "first-time registration" path (no prior aliases to
-                // union against the new ones).
-                Ok(rows) => rows
-                    .into_iter()
-                    .find(|m| {
-                        m.title == body.canonical_name
-                            && m.metadata.get("kind").and_then(|v| v.as_str()) == Some("entity")
-                    })
-                    .and_then(|m| {
-                        m.metadata
-                            .get("aliases")
-                            .and_then(|v| v.as_array())
-                            .map(|a| {
-                                a.iter()
-                                    .filter_map(|x| x.as_str().map(str::to_string))
-                                    .collect()
-                            })
-                    })
-                    .unwrap_or_default(),
-                Err(_) => Vec::new(),
-            }
-        };
-
-        // Union: preserve insertion order (prior first, then new),
-        // de-dup case-sensitively to match `db::entity_register`.
-        let mut union: Vec<String> = Vec::new();
-        for a in prior_aliases.iter().chain(body.aliases.iter()) {
-            if !union.iter().any(|x| x == a) {
-                union.push(a.clone());
-            }
-        }
-
-        let now = Utc::now().to_rfc3339();
-        let mut metadata = extra_metadata.clone();
-        let meta = metadata.as_object_mut().expect("verified above");
-        meta.insert("kind".to_string(), json!("entity"));
-        meta.insert("aliases".to_string(), json!(union.clone()));
-        meta.insert("agent_id".to_string(), json!(aid));
-        let mem = Memory {
-            id: Uuid::new_v4().to_string(),
-            tier: Tier::Long,
-            namespace: body.namespace.clone(),
-            title: body.canonical_name.clone(),
-            content: format!(
-                "Entity registration: {} (aliases: {})",
-                body.canonical_name,
-                union.join(", ")
-            ),
-            tags: vec!["entity".to_string()],
-            priority: 5,
-            confidence: 1.0,
-            source: "entity-register".to_string(),
-            access_count: 0,
-            created_at: now.clone(),
-            updated_at: now,
-            last_accessed_at: None,
-            expires_at: None,
-            metadata,
-            reflection_depth: 0,
-            memory_kind: crate::models::MemoryKind::Observation,
-            entity_id: None,
-            persona_version: None,
-            citations: Vec::new(),
-            source_uri: None,
-            source_span: None,
-            confidence_source: ConfidenceSource::CallerProvided,
-            confidence_signals: None,
-            confidence_decayed_at: None,
-            version: 1,
-        };
-        // F-A2A1.5 (#705) — governance enforcement on the postgres
-        // entity-register path. Mirrors the F-A2A1.2 delete/promote gates
-        // and the Wave-3 Continuation 3 create_memory gate: entity rows
-        // are governance-relevant writes (they upsert a `Memory` row in
-        // the requested namespace), so the postgres branch must consult
-        // `enforce_governance_action(Store, ...)` before the upsert. Deny
-        // returns 403; Pending returns 202 + pending_id. Without this
-        // gate, postgres-backed daemons silently allowed any caller to
-        // register entities into namespaces governed by `write=owner` or
-        // `write=approve` standards, defeating the same A2A surface
-        // F-A2A1.2 closed for delete/promote and create_memory.
+        // F-A2A1.5 (#705) — governance enforcement runs BEFORE the
+        // entity_register trait call so deny / pending / 403 / 202
+        // semantics match the sqlite path. The payload shape is the
+        // canonical entity-create body so a downstream approver replay
+        // can reconstruct the registration on `execute_pending_action`.
         {
             use crate::models::GovernanceDecision;
-            let payload_for_pending = serde_json::to_value(&mem).unwrap_or_else(|_| json!({}));
+            let payload_for_pending = serde_json::json!({
+                "title": body.canonical_name,
+                "namespace": body.namespace,
+                "tier": "long",
+                "tags": ["entity"],
+                "metadata": &extra_metadata,
+                "aliases": &body.aliases,
+            });
             match app
                 .store
                 .enforce_governance_action(
                     crate::store::GovernedAction::Store,
-                    &mem.namespace,
+                    &body.namespace,
                     &aid,
                     None,
                     None,
@@ -276,7 +193,7 @@ pub async fn entity_register(
                             "pending_id": pending_id,
                             "reason": "governance requires approval",
                             "action": "store",
-                            "namespace": mem.namespace,
+                            "namespace": body.namespace,
                             "storage_backend": "postgres",
                         })),
                     )
@@ -286,20 +203,30 @@ pub async fn entity_register(
             }
         }
 
-        let created = prior_aliases.is_empty();
-        return match app.store.store(&ctx, &mem).await {
-            Ok(id) => (
-                if created {
+        return match app
+            .store
+            .entity_register(
+                &ctx,
+                &body.canonical_name,
+                &body.namespace,
+                &body.aliases,
+                &extra_metadata,
+                Some(&aid),
+            )
+            .await
+        {
+            Ok(reg) => (
+                if reg.created {
                     StatusCode::CREATED
                 } else {
                     StatusCode::OK
                 },
                 Json(json!({
-                    "entity_id": id,
-                    "canonical_name": body.canonical_name,
-                    "namespace": body.namespace,
-                    "aliases": union,
-                    "created": created,
+                    "entity_id": reg.entity_id,
+                    "canonical_name": reg.canonical_name,
+                    "namespace": reg.namespace,
+                    "aliases": reg.aliases,
+                    "created": reg.created,
                 })),
             )
                 .into_response(),
@@ -730,22 +657,21 @@ pub async fn kg_timeline(
             .into_response();
     }
 
-    // v0.7.0 Wave-3 Continuation — postgres dispatches via the
-    // PostgresStore::kg_timeline helper. The adapter resolves AGE vs
-    // CTE backend at connect time and projects rows in the shared
-    // `KgTimelineRow` shape so the wire envelope stays parity-equal
-    // to the SQLite path.
+    // v0.7.0 ARCH-2 FX-C2-batch5 (2026-05-27): postgres dispatches via
+    // the new `MemoryStore::kg_timeline` trait method (the SAL is the
+    // canonical kg_timeline surface). The legacy
+    // `kg_timeline_via_store` helper stays in place for out-of-tree
+    // back-compat but new routes ride the trait. The adapter still
+    // resolves AGE vs CTE backend at connect time and projects rows in
+    // the shared `KgTimelineRow` shape so the wire envelope stays
+    // parity-equal to the SQLite path.
     #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
         let limit = p.limit;
-        return match crate::store::postgres::kg_timeline_via_store(
-            &app.store,
-            &p.source_id,
-            since,
-            until,
-            limit,
-        )
-        .await
+        return match app
+            .store
+            .kg_timeline(&p.source_id, since, until, limit)
+            .await
         {
             Ok(events) => {
                 let events_json: Vec<serde_json::Value> = events
@@ -1308,21 +1234,21 @@ pub async fn kg_query(
         }
     }
 
-    // v0.7.0 Wave-3 Continuation — postgres dispatches via the
-    // PostgresStore::kg_query helper. Backend (AGE vs CTE) is
-    // resolved at adapter connect time. Temporal/agent filters are
-    // applied client-side post-traversal because the AGE Cypher
-    // path returns the unfiltered topology — match the SQLite
-    // recursive-CTE wire shape.
+    // v0.7.0 ARCH-2 FX-C2-batch5 (2026-05-27): postgres dispatches via
+    // the new `MemoryStore::kg_query` trait method (the SAL is the
+    // canonical kg_query surface). The legacy `kg_query_via_store`
+    // helper stays in place for out-of-tree back-compat but new routes
+    // ride the trait. Backend (AGE vs CTE) is still resolved at
+    // adapter connect time inside `kg_query_with_history`.
+    // Temporal/agent filters are applied client-side post-traversal
+    // because the AGE Cypher path returns the unfiltered topology —
+    // match the SQLite recursive-CTE wire shape.
     #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        return match crate::store::postgres::kg_query_via_store(
-            &app.store,
-            &source_id,
-            max_depth,
-            body.include_invalidated,
-        )
-        .await
+        return match app
+            .store
+            .kg_query(&source_id, max_depth, body.include_invalidated)
+            .await
         {
             Ok(nodes) => {
                 // #910 — fetch each target's metadata, filter by the

--- a/src/handlers/kg.rs
+++ b/src/handlers/kg.rs
@@ -931,18 +931,22 @@ pub async fn kg_invalidate(
             .into_response();
     }
 
-    // v0.7.0 Wave-3 Continuation — postgres dispatches via the
-    // PostgresStore::kg_invalidate helper.
+    // v0.7.0 SAL-routing batch-4 (FX-C2) — postgres dispatches via the
+    // canonical `MemoryStore::invalidate_link` trait method. The
+    // pre-fix `kg_invalidate_via_store` helper (an `as_any_for_postgres`
+    // downcast hatch) stays in place for back-compat callers but new
+    // routes ride the trait surface — no SAL-boundary bypass.
     #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        return match crate::store::postgres::kg_invalidate_via_store(
-            &app.store,
-            &body.source_id,
-            &body.target_id,
-            &body.relation,
-            valid_until,
-        )
-        .await
+        return match app
+            .store
+            .invalidate_link(
+                &body.source_id,
+                &body.target_id,
+                &body.relation,
+                valid_until,
+            )
+            .await
         {
             Ok(res) if res.found => (
                 StatusCode::OK,

--- a/src/handlers/kg.rs
+++ b/src/handlers/kg.rs
@@ -387,15 +387,57 @@ pub async fn entity_get_by_alias(
             .into_response();
     }
 
-    // v0.7.0 Wave-3 Continuation — postgres-backed daemons walk the
-    // namespace's `kind=entity` memories via the SAL `list` method
-    // and match against `metadata.aliases` client-side.
-    #[cfg(feature = "sal")]
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — postgres-backed daemons
+    // route through `MemoryStore::entity_get_by_alias` first for an
+    // exact-alias match (the canonical resolution path). When the
+    // dedicated trait method returns `Ok(None)` we fall back to the
+    // legacy SAL `list` walk to preserve the `m.title.eq_ignore_ascii_case`
+    // fallback (alias-or-title match) and `metadata.aliases` array
+    // walk. Visibility filtering applies to the fallback path
+    // identically to pre-fix behaviour.
+    #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // QC P1 fix (2026-05-20): use header-resolved caller so the
-        // SAL #910 visibility filter applies to the entity walk.
-        // Pre-fix the hardcoded `for_agent("daemon")` caller mismatched
-        // every entity memory's owner and dropped the entire list.
+        // 1. Trait-method exact-alias match — sqlx-native, single
+        //    indexed lookup against `entity_aliases`.
+        match app.store.entity_get_by_alias(alias, namespace).await {
+            Ok(Some(rec)) => {
+                // Apply the post-fix visibility mask: hide the entity
+                // if the caller cannot see the underlying memory row.
+                let caller = {
+                    let header_agent_id = headers.get("x-agent-id").and_then(|v| v.to_str().ok());
+                    crate::identity::resolve_http_agent_id(None, header_agent_id)
+                        .unwrap_or_else(|_| format!("anonymous:req-{}", uuid::Uuid::new_v4()))
+                };
+                let caller_is_admin = crate::handlers::admin_role::is_admin_caller(&app, &caller);
+                let ctx_admin =
+                    crate::store::CallerContext::for_admin_checked(caller.clone(), caller_is_admin);
+                let visible = caller_is_admin
+                    || app
+                        .store
+                        .get(&ctx_admin, &rec.entity_id)
+                        .await
+                        .ok()
+                        .as_ref()
+                        .is_none_or(|m| crate::visibility::is_visible_to_caller(m, &caller));
+                if visible {
+                    return Json(json!({
+                        "found": true,
+                        "entity_id": rec.entity_id,
+                        "canonical_name": rec.canonical_name,
+                        "namespace": rec.namespace,
+                        "aliases": rec.aliases,
+                    }))
+                    .into_response();
+                }
+                // Fall through to fallback-walk shape on visibility mask
+                // — emits the `found:false` envelope below.
+            }
+            Ok(None) => { /* fall through to title-fallback walk */ }
+            Err(e) => return store_err_to_response(e),
+        }
+        // 2. Fallback walk: legacy SAL `list` so the title-eq-alias
+        //    branch and `metadata.aliases` array case-insensitive
+        //    match stay functional.
         let ctx = crate::handlers::parity::http_caller_ctx(&headers, None);
         let filter = crate::store::Filter {
             namespace: namespace.map(str::to_string),

--- a/src/handlers/links.rs
+++ b/src/handlers/links.rs
@@ -841,20 +841,17 @@ pub async fn get_links(
     };
     let caller_is_admin = crate::handlers::admin_role::is_admin_caller(&app, &caller);
 
-    // v0.7.0 Wave-3 — Postgres-backed daemons walk `list_links` (no
-    // namespace filter — the same projection as the legacy
-    // `db::get_links` returns) and narrow client-side to edges
-    // anchored at `id`. The trait does not (yet) expose a per-anchor
-    // edge probe; this filter is O(|edges|), which matches the
-    // SQLite path's behaviour for typical workloads.
+    // v0.7.0 Wave-3 + FX-C2 (ARCH-2 followup) — Postgres-backed daemons
+    // ride the SAL `get_links_for_anchor` trait method. Pre-FX-C2 this
+    // branch walked the full `list_links(None)` set and narrowed
+    // client-side; the per-anchor SAL surface lands the filter on the
+    // server, mirroring the SQLite `db::get_links` shape and dropping
+    // the over-fetch + linear-scan cost for daemons with non-trivial
+    // edge counts.
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        return match app.store.list_links(None).await {
-            Ok(rows) => {
-                let edges: Vec<_> = rows
-                    .into_iter()
-                    .filter(|l| l.source_id == id || l.target_id == id)
-                    .collect();
+        return match app.store.get_links_for_anchor(&id).await {
+            Ok(edges) => {
                 let visible = if caller_is_admin {
                     edges
                 } else {
@@ -891,10 +888,17 @@ pub async fn get_links(
     }
 
     let lock = app.db.lock().await;
-    // ARCH-2 keeper: `db::get_links` is a sqlite-only per-anchor edge
-    // probe with no SAL trait equivalent (`list_links(namespace)` is
-    // namespace-scoped, not anchor-scoped). Filed as a missing-trait
-    // follow-up under docs/v0.7.0/arch-2-sal-boundary-audit.md.
+    // ARCH-2 FX-C2 status: the SAL `get_links_for_anchor` trait method
+    // now exists (closes the missing-trait gap the audit cited at
+    // docs/v0.7.0/arch-2-sal-boundary-audit.md:48); the Postgres branch
+    // above already rides through it. The SQLite branch stays on
+    // `db::get_links` because the unit-test harness at
+    // `src/handlers/tests.rs::test_app_state` pins `app.store` to a
+    // disjoint tempfile from `app.db` (`:memory:` SQLite cannot share
+    // a backing connection across the trait + free-function paths).
+    // Routing here would break the ~30+ unit tests that seed via
+    // `db::create_link(&lock.0, …)`; classified as test-blocked drift,
+    // tracked for the FX-C2-a follow-up (test-fixture convergence).
     let links_for_anchor = db::get_links(&lock.0, &id);
     drop(lock);
     match links_for_anchor {

--- a/src/handlers/power.rs
+++ b/src/handlers/power.rs
@@ -389,31 +389,18 @@ pub async fn list_namespaces(
     {
         return resp;
     }
-    // v0.7.0 Wave-3 Continuation — postgres-backed daemons aggregate the
-    // distinct namespaces from `memories` via the SAL `list` method.
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — postgres-backed daemons
+    // now route through the dedicated `MemoryStore::list_namespaces`
+    // trait method (sqlx-native `GROUP BY namespace`) instead of
+    // fan-folding through a 1M-limit `list()` scan. The aggregate
+    // shape mirrors the SQLite `db::list_namespaces` result: namespace
+    // identifiers are structural metadata, not user data, so no #910
+    // visibility filter applies — same posture as the SQLite branch.
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // QC P1 follow-up (2026-05-20): namespace identifiers are
-        // structural metadata, not user data — same posture as
-        // `get_namespace_standard_qs` (which is also `for_admin`).
-        // Without bypass the SAL #910 visibility filter would gate
-        // every namespace name behind owner==caller and the list
-        // would only ever return the caller's own namespaces, which
-        // breaks the cert harness `namespaces_round_trip_via_sal`
-        // test and surfaces in production as a fragmented namespace
-        // catalog per-tenant.
-        let ctx = crate::store::CallerContext::for_admin("ai:http-internal");
-        let filter = crate::store::Filter {
-            limit: 1_000_000,
-            ..Default::default()
-        };
-        return match app.store.list(&ctx, &filter).await {
-            Ok(memories) => {
-                let mut ns: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-                for m in memories {
-                    ns.insert(m.namespace);
-                }
-                let v: Vec<String> = ns.into_iter().collect();
+        return match app.store.list_namespaces().await {
+            Ok(rows) => {
+                let v: Vec<String> = rows.into_iter().map(|r| r.namespace).collect();
                 Json(json!({"namespaces": v})).into_response()
             }
             Err(e) => store_err_to_response(e),
@@ -491,15 +478,46 @@ pub async fn get_taxonomy(
         .min(crate::models::MAX_NAMESPACE_DEPTH);
     let limit = p.limit.unwrap_or(1000).clamp(1, 10_000);
 
-    // v0.7.0 Wave-3 Continuation 4 (Bucket E / S44) — full hierarchical
-    // taxonomy walk for postgres-backed daemons. Uses
-    // `taxonomy_namespaces_via_store` to project a single `GROUP BY
-    // namespace` aggregate (so we don't pull every memory row into
-    // memory), then assembles the hierarchical tree with honest
-    // `subtree_count` so the cert oracle can detect dishonest
-    // truncation.
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — postgres-backed daemons
+    // now route taxonomy reads through `MemoryStore::get_taxonomy`.
+    // The new trait method shares its tree-folding logic with the
+    // SQLite path via `crate::storage::fold_taxonomy_groups`, so the
+    // wire shape is byte-equal across backends. We keep a
+    // `storage_backend: "postgres"` field on the response so the cert
+    // oracle can still distinguish backend provenance from a single
+    // capture.
     #[cfg(feature = "sal-postgres")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
+        return match app
+            .store
+            .get_taxonomy(prefix_owned.as_deref(), depth, limit)
+            .await
+        {
+            Ok(tax) => Json(json!({
+                "tree": tax.tree,
+                "total_count": tax.total_count,
+                "truncated": tax.truncated,
+                "storage_backend": "postgres",
+            }))
+            .into_response(),
+            Err(e) => store_err_to_response(e),
+        };
+    }
+
+    // Legacy postgres branch (pre-FX-C2-batch3): assembled the tree
+    // in-handler from a `(namespace, count)` pair list returned by
+    // `taxonomy_namespaces_via_store`. Now superseded by the SAL trait
+    // route above; the body is preserved as a debug-only fallback path
+    // (`AI_MEMORY_TAXONOMY_LEGACY_PG=1`) so operators can A/B the two
+    // assemblers if they suspect divergence. Without the env var set
+    // the branch never fires.
+    #[cfg(feature = "sal-postgres")]
+    if matches!(app.storage_backend, StorageBackend::Postgres)
+        && std::env::var("AI_MEMORY_TAXONOMY_LEGACY_PG")
+            .ok()
+            .as_deref()
+            == Some("1")
+    {
         let pairs = match crate::store::postgres::taxonomy_namespaces_via_store(
             &app.store,
             prefix_owned.as_deref(),

--- a/src/handlers/power.rs
+++ b/src/handlers/power.rs
@@ -273,6 +273,19 @@ pub async fn detect_contradictions(
     };
 
     // Existing contradicts links involving any candidate.
+    //
+    // ARCH-2 FX-C2 status: the SAL `MemoryStore::get_links_for_anchor`
+    // trait method now exists (proposed addition #1 in
+    // docs/v0.7.0/arch-2-sal-boundary-audit.md, landed in this commit).
+    // The Postgres branch's contradiction-link assembly above already
+    // rides the trait surface; this SQLite branch stays on the legacy
+    // `db::get_links` free-function because we hold `app.db.lock()` for
+    // the `db::list` + `db::get_links` lookups in the same window —
+    // routing through `app.store.get_links_for_anchor` here would
+    // either acquire a second mutex on the same connection (deadlock
+    // risk) or fail the disjoint-tempfile invariant under the unit-test
+    // harness. Classified as test-blocked drift, tracked for the
+    // FX-C2-a follow-up (test-fixture convergence).
     let candidate_ids: std::collections::HashSet<String> =
         candidates.iter().map(|m| m.id.clone()).collect();
     let mut existing_links: Vec<serde_json::Value> = Vec::new();

--- a/src/handlers/power.rs
+++ b/src/handlers/power.rs
@@ -722,91 +722,53 @@ pub async fn check_duplicate(
     }
     let threshold = body.threshold.unwrap_or(db::DUPLICATE_THRESHOLD_DEFAULT);
 
-    // v0.7.0 Wave-3 Continuation 4 (Bucket E / S48) — postgres-backed
-    // daemons now perform an exact-content sweep through the SAL
-    // `list` projection. When an embedder is loaded the call also
-    // computes the query embedding and hands it to
-    // `recall_hybrid`; the highest-cosine match becomes the nearest
-    // candidate. Without an embedder the fallback walks the
-    // namespace via `list` and surfaces any row whose
-    // `(title, content)` tuple matches exactly (the same content-hash
-    // short-circuit `db::check_duplicate_with_text` uses on sqlite,
-    // before the embedding pass).
+    // v0.7.0 SAL-routing batch-4 (FX-C2) — postgres-backed daemons
+    // route through the canonical `MemoryStore::check_duplicate_with_text`
+    // trait method. Mirrors the SQLite `db::check_duplicate_with_text`
+    // shape byte-for-byte: SHA-256 exact-content short-circuit (returns
+    // `similarity=1.0` on byte-equal `format!("{title} {content}")`),
+    // then pgvector cosine distance for nearest-neighbor on near hits.
+    // Pre-fix branch was hand-rolled (`list` + client-side exact-match
+    // walk + `recall_hybrid` fallback); the trait method consolidates
+    // both phases into single SQL round-trips so the byte-shape stays
+    // identical across backends.
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // QC P1 fix (2026-05-20): use header-resolved caller so the
-        // SAL #910 visibility filter applies — duplicate-detection
-        // only sees memories the caller owns (or scope=shared/public).
-        // Pre-fix `for_agent("daemon")` mismatched every memory's
-        // metadata.agent_id and the candidate pool was zero.
-        let ctx = crate::handlers::parity::http_caller_ctx(&headers, None);
-        let filter = crate::store::Filter {
-            namespace: namespace.map(str::to_string),
-            limit: 1000,
-            ..Default::default()
+        let embedding_text = format!("{} {}", body.title, body.content);
+        // Best-effort: when the embedder is loaded, compute the query
+        // vector so phase 2 (cosine nearest) is available. Without it
+        // the trait method falls through to phase-1 hash-only.
+        let query_embedding: Vec<f32> = match app.embedder.as_ref().as_ref() {
+            Some(emb) => emb.embed(&embedding_text).unwrap_or_default(),
+            None => Vec::new(),
         };
-        let mut nearest: Option<(crate::models::Memory, f64)> = None;
-        let mut scanned = 0_u64;
-        // Exact-content sweep first — cheap, deterministic, no embed.
-        match app.store.list(&ctx, &filter).await {
-            Ok(rows) => {
-                for m in rows {
-                    scanned += 1;
-                    if m.content == body.content && m.title == body.title {
-                        nearest = Some((m, 1.0));
-                        break;
-                    }
-                }
-            }
-            Err(e) => return store_err_to_response(e),
-        }
-        // If exact match didn't surface, optionally try embedding-based
-        // hybrid recall with the title+content as the query.
-        if nearest.is_none()
-            && let Some(emb) = app.embedder.as_ref().as_ref()
+        return match app
+            .store
+            .check_duplicate_with_text(&query_embedding, &embedding_text, namespace, threshold)
+            .await
         {
-            let embedding_text = format!("{} {}", body.title, body.content);
-            if let Ok(qe) = emb.embed(&embedding_text) {
-                let recall_filter = crate::store::Filter {
-                    namespace: namespace.map(str::to_string),
-                    limit: 5,
-                    ..Default::default()
+            Ok(check) => {
+                let near_json = match check.nearest {
+                    Some(n) => json!({
+                        "id": n.id,
+                        "title": n.title,
+                        "namespace": n.namespace,
+                        "score": n.similarity,
+                    }),
+                    None => serde_json::Value::Null,
                 };
-                if let Ok(scored_pairs) = app
-                    .store
-                    .recall_hybrid(&ctx, &embedding_text, Some(&qe), &recall_filter)
-                    .await
-                {
-                    if let Some((m, s)) = scored_pairs.into_iter().next() {
-                        nearest = Some((m, s));
-                    }
-                }
-                drop(qe);
+                Json(json!({
+                    "is_duplicate": check.is_duplicate,
+                    "threshold": check.threshold,
+                    "nearest": near_json,
+                    "suggested_merge": check.is_duplicate,
+                    "candidates_scanned": check.candidates_scanned,
+                    "storage_backend": "postgres",
+                }))
+                .into_response()
             }
-        }
-        let (is_duplicate, near_json) = if let Some((m, score)) = nearest {
-            let is_dup = score >= f64::from(threshold);
-            (
-                is_dup,
-                json!({
-                    "id": m.id,
-                    "title": m.title,
-                    "namespace": m.namespace,
-                    "score": score,
-                }),
-            )
-        } else {
-            (false, serde_json::Value::Null)
+            Err(e) => store_err_to_response(e),
         };
-        return Json(json!({
-            "is_duplicate": is_duplicate,
-            "threshold": threshold,
-            "nearest": near_json,
-            "suggested_merge": is_duplicate,
-            "candidates_scanned": scanned,
-            "storage_backend": "postgres",
-        }))
-        .into_response();
     }
 
     // Embed before taking the DB lock — same rationale as create_memory

--- a/src/handlers/transport.rs
+++ b/src/handlers/transport.rs
@@ -831,11 +831,24 @@ pub async fn api_key_auth(
 }
 
 pub async fn health(State(app): State<AppState>) -> impl IntoResponse {
-    // PERF-1 (FX-3): route the rusqlite health_check through `db_op`
-    // so it runs on the blocking pool. /health is the most-frequently
-    // scraped endpoint (every Prometheus / k8s liveness probe hits it
-    // every few seconds); pinning a tokio worker on a sync sqlite
-    // PRAGMA query starves the runtime under concurrent load.
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — Postgres-backed daemons
+    // ride the new `MemoryStore::health_check` trait method which is
+    // natively async (sqlx round-trip), so we can skip the blocking
+    // pool for that path entirely. SQLite-backed daemons stay on the
+    // `db_op` blocking-pool route per PERF-1 (FX-3); /health is the
+    // most-frequently scraped endpoint and pinning a tokio worker on
+    // a sync sqlite PRAGMA query would starve the runtime under
+    // concurrent scrape load.
+    #[cfg(feature = "sal-postgres")]
+    let ok = if matches!(app.storage_backend, StorageBackend::Postgres) {
+        app.store.health_check().await.unwrap_or(false)
+    } else {
+        db_op(app.db.clone(), |guard| {
+            db::health_check(&guard.0).unwrap_or(false)
+        })
+        .await
+    };
+    #[cfg(not(feature = "sal-postgres"))]
     let ok = db_op(app.db.clone(), |guard| {
         db::health_check(&guard.0).unwrap_or(false)
     })

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4218,6 +4218,102 @@ fn sort_taxonomy(node: &mut TaxonomyNode) {
     }
 }
 
+/// v0.7.0 ARCH-2 followup (FX-C2-batch3) — backend-blind taxonomy
+/// tree-folding helper. Lifted out of `get_taxonomy` so the Postgres
+/// SAL adapter can share the exact same fold logic with the SQLite
+/// adapter, holding the cross-backend wire shape byte-for-byte.
+///
+/// Inputs:
+/// - `prefix`: the namespace prefix the caller queried (`""` = global root).
+/// - `effective_depth`: clamped depth, already `min(MAX_NAMESPACE_DEPTH)`.
+/// - `total_count`: full prefix total (NOT truncated by the row walk).
+/// - `truncated`: caller-computed truncation flag.
+/// - `groups`: walked `(namespace, count)` rows.
+///
+/// Returns the assembled [`Taxonomy`] tree with sorted children.
+#[doc(hidden)]
+pub fn fold_taxonomy_groups(
+    prefix: &str,
+    effective_depth: usize,
+    total_count: usize,
+    truncated: bool,
+    groups: Vec<(String, usize)>,
+) -> Taxonomy {
+    let root_name = prefix.rsplit('/').next().unwrap_or("").to_string();
+    let mut root = TaxonomyNode {
+        namespace: prefix.to_string(),
+        name: root_name,
+        count: 0,
+        subtree_count: 0,
+        children: Vec::new(),
+    };
+
+    for (ns, c) in groups {
+        let suffix: &str = if prefix.is_empty() {
+            ns.as_str()
+        } else if ns == prefix {
+            ""
+        } else if ns.len() > prefix.len() + 1
+            && ns.starts_with(prefix)
+            && ns.as_bytes()[prefix.len()] == b'/'
+        {
+            &ns[prefix.len() + 1..]
+        } else {
+            continue;
+        };
+        let all_segments: Vec<&str> = if suffix.is_empty() {
+            Vec::new()
+        } else {
+            suffix.split('/').collect()
+        };
+        let take = all_segments.len().min(effective_depth);
+        let used = &all_segments[..take];
+        let exact_match_in_view = take == all_segments.len();
+
+        root.subtree_count += c;
+        if used.is_empty() {
+            root.count += c;
+            continue;
+        }
+
+        let mut path_so_far = prefix.to_string();
+        let mut node = &mut root;
+        for (i, seg) in used.iter().enumerate() {
+            if !path_so_far.is_empty() {
+                path_so_far.push('/');
+            }
+            path_so_far.push_str(seg);
+            let pos = node.children.iter().position(|ch| ch.name == *seg);
+            let idx = if let Some(p) = pos {
+                p
+            } else {
+                node.children.push(TaxonomyNode {
+                    namespace: path_so_far.clone(),
+                    name: (*seg).to_string(),
+                    count: 0,
+                    subtree_count: 0,
+                    children: Vec::new(),
+                });
+                node.children.len() - 1
+            };
+            node = &mut node.children[idx];
+            node.subtree_count += c;
+            let is_leaf = i + 1 == used.len();
+            if is_leaf && exact_match_in_view {
+                node.count += c;
+            }
+        }
+    }
+
+    sort_taxonomy(&mut root);
+
+    Taxonomy {
+        tree: root,
+        total_count,
+        truncated,
+    }
+}
+
 /// Hard floor for duplicate-check threshold. Below this, anything can match
 /// random unrelated content — refuse to honor the lookup so callers don't
 /// silently get garbage merge suggestions.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -648,6 +648,41 @@ pub trait MemoryStore: Send + Sync {
     /// resume mid-stream without losing rows.
     async fn list_links(&self, namespace: Option<&str>) -> StoreResult<Vec<MemoryLink>>;
 
+    /// v0.7.0 ARCH-2 followup (FX-C2) — per-anchor edge probe. Returns
+    /// every link where `anchor_id` is either the source or the target
+    /// (the inbound + outbound union — same shape `db::get_links` has
+    /// returned since v0.6 for the `memory_get_links` MCP tool).
+    ///
+    /// Replaces the audit's missing-trait reach at `links.rs:894` and
+    /// `power.rs:280` so the per-anchor scan can ride the SAL trait
+    /// instead of falling through to the legacy free-function path.
+    /// [`MemoryStore::list_links`] is namespace-scoped, not
+    /// anchor-scoped, so the two methods are complementary — list_links
+    /// powers migrate/export; get_links_for_anchor powers the graph
+    /// view at a specific node.
+    ///
+    /// Wire-shape contract (matches `db::get_links`):
+    /// - `source_id`, `target_id`, `relation` populated from the row.
+    /// - `created_at`, `valid_from`, `valid_until`, `observed_by`,
+    ///   `attest_level` projected so the `memory_get_links` MCP tool's
+    ///   docstring promise holds on both backends.
+    /// - `signature` stays `None` (the verifier surface owns the bytes
+    ///   blob; exposing it here would force every existing caller to
+    ///   ignore a base64 blob in the response).
+    ///
+    /// Ordering: descending by `created_at` (most-recent edges first)
+    /// to match the SQLite `db::get_links` natural ordering after the
+    /// v0.7.0 issue #860 row-projection widening.
+    ///
+    /// Default returns `UnsupportedCapability` so adapters that don't
+    /// yet wire the per-anchor probe fail loudly rather than silently
+    /// degrade to an empty list (which would mask graph data loss).
+    async fn get_links_for_anchor(&self, _anchor_id: &str) -> StoreResult<Vec<MemoryLink>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "GET_LINKS_FOR_ANCHOR".to_string(),
+        })
+    }
+
     /// Register an agent in the adapter's `_agents` namespace (Task
     /// 1.3).
     async fn register_agent(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1358,6 +1358,169 @@ pub trait MemoryStore: Send + Sync {
             capability: "FIND_PATHS".to_string(),
         })
     }
+
+    // ==================================================================
+    // v0.7.0 ARCH-2 followup (FX-C2-batch3) — read-only trait
+    // completions. Each closes a "Missing-trait" handler reach so the
+    // SAL becomes the canonical read surface for these probes.
+    // Defaults return `UnsupportedCapability` so adapters that don't
+    // implement the probe fail loudly rather than silently returning
+    // empty results.
+    // ==================================================================
+
+    /// Enumerate live (non-expired) namespaces with their memory counts.
+    /// Closes `db::list_namespaces` (handler reach at `power.rs:411`).
+    ///
+    /// Ordering: descending by count, then ascending by name for stable
+    /// tie-breaking. The result excludes namespaces whose entire content
+    /// has expired but does NOT cascade through TTL semantics for
+    /// individual rows (callers requesting that should use `list` with a
+    /// namespace filter).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn list_namespaces(&self) -> StoreResult<Vec<crate::models::NamespaceCount>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "LIST_NAMESPACES".to_string(),
+        })
+    }
+
+    /// Hierarchical namespace taxonomy. Closes `db::get_taxonomy`
+    /// (handler reach at `power.rs:620`).
+    ///
+    /// `namespace_prefix` filters the tree root; `max_depth` caps how
+    /// many `/`-separated segments are surfaced below the prefix;
+    /// `limit` caps the number of `(namespace, count)` rows walked.
+    /// Adapters MUST clamp `max_depth` and `limit` to safe bounds so
+    /// pathological callers cannot exhaust memory.
+    ///
+    /// Returned [`Taxonomy::total_count`] reflects the FULL prefix
+    /// total (not the truncated walk) and [`Taxonomy::truncated`] is
+    /// set when `limit` dropped rows so callers can warn the user.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn get_taxonomy(
+        &self,
+        _namespace_prefix: Option<&str>,
+        _max_depth: usize,
+        _limit: usize,
+    ) -> StoreResult<crate::models::Taxonomy> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "GET_TAXONOMY".to_string(),
+        })
+    }
+
+    /// Enumerate registered agents in the `_agents` namespace. Closes
+    /// `db::list_agents` (handler reaches at `subscriptions.rs:454`,
+    /// `admin.rs:280`).
+    ///
+    /// Ordering: ascending by `registered_at` so audit consumers can
+    /// observe stable enrollment chronology. Each [`AgentRegistration`]
+    /// projects `agent_id`, `agent_type`, `capabilities`,
+    /// `registered_at`, `last_seen_at` parsed out of the underlying
+    /// memory row's metadata blob.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error or
+    /// when metadata fails to parse as JSON.
+    async fn list_agents(&self) -> StoreResult<Vec<AgentRegistration>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "LIST_AGENTS".to_string(),
+        })
+    }
+
+    /// Enumerate pending governance actions with optional status
+    /// filter. Closes `db::list_pending_actions` (handler reaches at
+    /// `governance.rs:130`, `approvals.rs:277` indirectly).
+    ///
+    /// `status` filters by the exact status string (`"pending"`,
+    /// `"approved"`, `"rejected"`, `"expired"`). `None` returns every
+    /// row regardless of status. `limit` caps row count; callers MUST
+    /// pass a positive value (zero behaves as "no rows" by SQL
+    /// convention).
+    ///
+    /// Ordering: descending by `requested_at` so the freshest entries
+    /// surface first, matching the legacy `db::list_pending_actions`
+    /// shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn list_pending_actions(
+        &self,
+        _status: Option<&str>,
+        _limit: usize,
+    ) -> StoreResult<Vec<crate::models::PendingAction>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "LIST_PENDING_ACTIONS".to_string(),
+        })
+    }
+
+    /// Resolve a knowledge-graph entity by alias (case-sensitive
+    /// match). Closes `db::entity_get_by_alias` (handler reach at
+    /// `kg.rs:468`).
+    ///
+    /// `namespace`, when set, restricts the alias resolution to a
+    /// specific tenant. When `None`, the most-recently-created
+    /// matching entity wins (deterministic disambiguation if the same
+    /// alias was registered in multiple namespaces).
+    ///
+    /// Returns `Ok(None)` if no entity claims this alias; returns the
+    /// full alias set for the resolved entity otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn entity_get_by_alias(
+        &self,
+        _alias: &str,
+        _namespace: Option<&str>,
+    ) -> StoreResult<Option<crate::models::EntityRecord>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "ENTITY_GET_BY_ALIAS".to_string(),
+        })
+    }
+
+    /// Deep health check — verifies the underlying store is reachable
+    /// AND the full-text index (or postgres equivalent) is functional.
+    /// Closes `db::health_check` (handler reach at `transport.rs:840`).
+    ///
+    /// Returns `Ok(true)` on success. Implementations SHOULD perform a
+    /// cheap write-side probe (e.g. SQLite FTS integrity-check) so
+    /// degradation surfaces before the next user-facing recall fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store is unreachable or
+    /// the FTS / index probe fails.
+    async fn health_check(&self) -> StoreResult<bool> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "HEALTH_CHECK".to_string(),
+        })
+    }
+
+    /// Aggregate database statistics — total rows, per-tier counts,
+    /// per-namespace counts, expiring-soon count, link count, on-disk
+    /// size, dim violations, HNSW evictions. Closes `db::stats`
+    /// (handler reaches at `transport.rs:876`, `admin.rs:505`).
+    ///
+    /// Adapters SHOULD populate every field they can; missing fields
+    /// (e.g. `db_size_bytes` on Postgres where path-based sizing isn't
+    /// meaningful) default to zero so the response shape stays
+    /// constant across backends.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn stats(&self) -> StoreResult<crate::models::Stats> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "STATS".to_string(),
+        })
+    }
 }
 
 /// v0.7.0 Wave-3 Continuation 3 (Phase 20) — action class threaded

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1521,6 +1521,132 @@ pub trait MemoryStore: Send + Sync {
             capability: "STATS".to_string(),
         })
     }
+
+    /// Resolve a memory id by `(title, namespace)` — used by the
+    /// `on_conflict=error` path during `memory_store` to surface a
+    /// `409 CONFLICT` envelope citing the colliding row's id. Closes
+    /// `db::find_by_title_namespace` (handler reach at
+    /// `create.rs:187`).
+    ///
+    /// Returns `Ok(None)` when no live row matches the tuple.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn find_by_title_namespace(
+        &self,
+        _title: &str,
+        _namespace: &str,
+    ) -> StoreResult<Option<String>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "FIND_BY_TITLE_NAMESPACE".to_string(),
+        })
+    }
+
+    /// Pick a title that does not collide with an existing
+    /// `(title, namespace)` row by appending `(2)`, `(3)`, ... up to
+    /// the substrate's hard cap. Used by `on_conflict='version'`.
+    /// Closes `db::next_versioned_title` (handler reach at
+    /// `create.rs:210`).
+    ///
+    /// Returns the original title when no row claims it; otherwise
+    /// the first available `"<base> (N)"` suffix. Errors with the
+    /// substrate's `UniqueConflict` envelope when the cap is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` on store errors; `UniqueConflict` when the
+    /// substrate cap is exhausted.
+    async fn next_versioned_title(
+        &self,
+        _base_title: &str,
+        _namespace: &str,
+    ) -> StoreResult<String> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "NEXT_VERSIONED_TITLE".to_string(),
+        })
+    }
+
+    /// Detect potential contradictions: memories in the same
+    /// namespace with FTS-similar titles. Closes
+    /// `db::find_contradictions` (handler reach at `create.rs:1025`).
+    ///
+    /// Returns up to 5 candidates ranked by FTS score (no embedding
+    /// pass). Used by the autonomous-hooks fan-out to seed the
+    /// contradiction-detection LLM with deterministic candidates
+    /// before pricing the cosine pass.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn find_contradictions(
+        &self,
+        _title: &str,
+        _namespace: &str,
+    ) -> StoreResult<Vec<Memory>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "FIND_CONTRADICTIONS".to_string(),
+        })
+    }
+
+    /// Mark a KG link as superseded by setting its `valid_until`
+    /// column. Closes `db::invalidate_link` (handler reach at
+    /// `kg.rs:932`); the Postgres branch routes through the inherent
+    /// `PostgresStore::kg_invalidate` method which preserves the
+    /// AGE↔CTE dual-path discipline.
+    ///
+    /// Returns a [`KgInvalidateRow`] carrying `found = false` when the
+    /// `(source_id, target_id, relation)` triple does not match an
+    /// existing link, matching the SQLite-side `Ok(None)` contract
+    /// projected into the SAL row shape.
+    ///
+    /// Idempotent: calling repeatedly overwrites the prior
+    /// `valid_until` (the prior value is returned in
+    /// `previous_valid_until` so callers can detect the overwrite).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn invalidate_link(
+        &self,
+        _source_id: &str,
+        _target_id: &str,
+        _relation: &str,
+        _valid_until: Option<&str>,
+    ) -> StoreResult<KgInvalidateRow> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "INVALIDATE_LINK".to_string(),
+        })
+    }
+
+    /// Content-hash + embedding-cosine duplicate detector. Closes
+    /// `db::check_duplicate_with_text` (handler reach at
+    /// `power.rs:825`).
+    ///
+    /// Phase 1 SHA-256-matches the canonical `title content` text
+    /// against every live, namespace-matching candidate; an exact
+    /// match short-circuits at `similarity=1.0`. Phase 2 falls
+    /// through to the embedding-based nearest-neighbor scan so
+    /// near-but-not-exact hits still surface a closest-existing
+    /// signal.
+    ///
+    /// `query_text` MUST be the exact string used to produce
+    /// `query_embedding` (typically `format!("{title} {content}")`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` when the underlying store reports an error.
+    async fn check_duplicate_with_text(
+        &self,
+        _query_embedding: &[f32],
+        _query_text: &str,
+        _namespace: Option<&str>,
+        _threshold: f32,
+    ) -> StoreResult<crate::models::DuplicateCheck> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "CHECK_DUPLICATE_WITH_TEXT".to_string(),
+        })
+    }
 }
 
 /// v0.7.0 Wave-3 Continuation 3 (Phase 20) — action class threaded

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1647,6 +1647,184 @@ pub trait MemoryStore: Send + Sync {
             capability: "CHECK_DUPLICATE_WITH_TEXT".to_string(),
         })
     }
+
+    // ==================================================================
+    // v0.7.0 ARCH-2 followup (FX-C2-batch5) — final 6 trait additions
+    // that close the last "Missing-trait" handler reaches on the
+    // governance + KG + archive surfaces. Each default returns
+    // `UnsupportedCapability` so backends that don't wire the operation
+    // fail loudly rather than silently returning empty / stale results.
+    // ==================================================================
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — approver_type-aware approve. Mirrors
+    /// the canonical sqlite primitive `db::approve_with_approver_type`
+    /// (see `src/storage/mod.rs::approve_with_approver_type`); closes
+    /// the missing-trait reach at `governance.rs:306` / `approvals.rs:280`.
+    ///
+    /// Wire-shape contract: identical to
+    /// [`MemoryStore::governance_approve_with_consensus`] — both fan in
+    /// to the same `ApproveOutcome` enum, both enforce the same
+    /// Human / Agent(required) / Consensus(quorum) state machine. The
+    /// two names are the same operation; this alias exists so the
+    /// handler-side routing stays nominally aligned with the SQLite
+    /// primitive name (`db::approve_with_approver_type`) the audit doc
+    /// cites and so future backends can override either method.
+    ///
+    /// Default forwards to
+    /// [`MemoryStore::governance_approve_with_consensus`] so adapters
+    /// only have to wire one entry point. Override either if the
+    /// adapter wants nominally-distinct implementations.
+    async fn approve_with_approver_type(
+        &self,
+        ctx: &CallerContext,
+        pending_id: &str,
+        approver_agent_id: &str,
+    ) -> StoreResult<ApproveOutcome> {
+        self.governance_approve_with_consensus(ctx, pending_id, approver_agent_id)
+            .await
+    }
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — decide a pending action (approve /
+    /// reject). Closes the missing-trait reach at `governance.rs:480` /
+    /// `approvals.rs:328` / `federation_receive.rs:941`.
+    ///
+    /// Wire-shape contract: identical to
+    /// [`MemoryStore::pending_decide`] (same `(id, approve, decided_by)`
+    /// signature, same `bool` return semantics — `true` when the row
+    /// transitioned from `pending`, `false` otherwise). The two names
+    /// are the same operation; this alias preserves nominal parity with
+    /// the SQLite primitive name (`db::decide_pending_action`) the
+    /// audit doc cites.
+    ///
+    /// Default forwards to [`MemoryStore::pending_decide`].
+    async fn decide_pending_action(
+        &self,
+        ctx: &CallerContext,
+        id: &str,
+        approve: bool,
+        decided_by: &str,
+    ) -> StoreResult<bool> {
+        self.pending_decide(ctx, id, approve, decided_by).await
+    }
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — outbound knowledge-graph traversal.
+    /// Closes the missing-trait reach at `kg.rs:1359`.
+    ///
+    /// Returns up to `limit` reachable nodes from `source_id`, walking
+    /// the link graph up to `max_depth` hops. `include_invalidated`
+    /// lifts the default `valid_until` filter so callers can see the
+    /// full historical edge graph (S45's `as_of=past` semantics). The
+    /// Postgres adapter resolves AGE vs the CTE fallback at adapter
+    /// connect time; SQLite uses the recursive CTE in
+    /// `db::kg_query`.
+    ///
+    /// Default returns `UnsupportedCapability`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidInput` when `max_depth` is zero or exceeds the
+    /// adapter's supported ceiling. Returns `Backend` for storage errors.
+    async fn kg_query(
+        &self,
+        _source_id: &str,
+        _max_depth: usize,
+        _include_invalidated: bool,
+    ) -> StoreResult<Vec<KgQueryRow>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "KG_QUERY".to_string(),
+        })
+    }
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — knowledge-graph timeline scan.
+    /// Closes the missing-trait reach at `kg.rs:735`.
+    ///
+    /// Returns outbound link assertions from `source_id` ordered by
+    /// `valid_from` ASC (most recent → oldest scan via tie-broken
+    /// `created_at`). `since` / `until` constrain the window;
+    /// `limit` caps row count. Adapters MUST drop rows whose
+    /// `valid_from` is NULL — the timeline is anchored on the
+    /// authoritative validity timestamp.
+    ///
+    /// Default returns `UnsupportedCapability`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` for storage errors.
+    async fn kg_timeline(
+        &self,
+        _source_id: &str,
+        _since: Option<&str>,
+        _until: Option<&str>,
+        _limit: Option<usize>,
+    ) -> StoreResult<Vec<KgTimelineRow>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "KG_TIMELINE".to_string(),
+        })
+    }
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — register a knowledge-graph entity.
+    /// Closes the missing-trait reach at `kg.rs:311` (drift — postgres
+    /// adapter previously bypassed the trait via a bespoke handler-side
+    /// store + alias-union walk).
+    ///
+    /// Idempotent on `(canonical_name, namespace)`: on first call
+    /// inserts an entity-tagged Memory row; on subsequent calls unions
+    /// the new aliases into the existing row's
+    /// `metadata.aliases` array. Returns the resolved
+    /// [`crate::models::EntityRegistration`] so callers can surface
+    /// `entity_id` + the post-union alias set + the `created` flag.
+    ///
+    /// Default returns `UnsupportedCapability`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Conflict` (mapped to 409) when a non-entity memory
+    /// already claims the `(canonical_name, namespace)` tuple.
+    /// Returns `Backend` for storage errors.
+    async fn entity_register(
+        &self,
+        _ctx: &CallerContext,
+        _canonical_name: &str,
+        _namespace: &str,
+        _aliases: &[String],
+        _extra_metadata: &serde_json::Value,
+        _agent_id: Option<&str>,
+    ) -> StoreResult<crate::models::EntityRegistration> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "ENTITY_REGISTER".to_string(),
+        })
+    }
+
+    /// v0.7.0 ARCH-2 FX-C2-batch5 — list archived memories. Closes the
+    /// archive-list reach currently going through the
+    /// `list_archived_via_store` downcast hatch (`archive.rs:85`); the
+    /// SAL trait method makes the read backend-blind.
+    ///
+    /// Returns up to `limit` archived rows skipping `offset`, ordered
+    /// descending by `archived_at` (newest first). `namespace`, when
+    /// set, restricts the projection to a single tenant. The wire
+    /// shape mirrors `db::list_archived` on the SQLite path and
+    /// `PostgresStore::list_archived` on the Postgres path — a
+    /// JSON-shaped row per archived memory carrying every column on the
+    /// `archived_memories` table, including the v49 14-column expansion
+    /// for round-trip restore parity.
+    ///
+    /// Default returns `UnsupportedCapability`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Backend` for storage errors. Returns `InvalidInput`
+    /// when the adapter's `limit` clamp rejects the supplied value.
+    async fn list_archived(
+        &self,
+        _namespace: Option<&str>,
+        _limit: usize,
+        _offset: usize,
+    ) -> StoreResult<Vec<serde_json::Value>> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "LIST_ARCHIVED".to_string(),
+        })
+    }
 }
 
 /// v0.7.0 Wave-3 Continuation 3 (Phase 20) — action class threaded

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -10826,6 +10826,267 @@ impl MemoryStore for PostgresStore {
             index_evictions_total: 0,
         })
     }
+
+    async fn find_by_title_namespace(
+        &self,
+        title: &str,
+        namespace: &str,
+    ) -> StoreResult<Option<String>> {
+        // Mirror SQLite's `db::find_by_title_namespace`: project the id
+        // for the first live row matching `(title, namespace)`. The
+        // SAL contract is "no live row matches" → `Ok(None)`, not an
+        // error — `fetch_optional` is the right primitive.
+        let id: Option<String> = sqlx::query_scalar(
+            "SELECT id FROM memories WHERE title = $1 AND namespace = $2 LIMIT 1",
+        )
+        .bind(title)
+        .bind(namespace)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| to_store_err("find_by_title_namespace", e))?;
+        Ok(id)
+    }
+
+    async fn next_versioned_title(&self, base_title: &str, namespace: &str) -> StoreResult<String> {
+        // Byte-for-byte mirror of `db::next_versioned_title` — try the
+        // base title first, then `(2)`, `(3)`, ... up to the substrate's
+        // hard cap. The cap (1024) prevents pathological infinite loops
+        // and matches SQLite's `MAX_VERSION_SUFFIX` exactly so the wire
+        // shape stays identical across backends.
+        const MAX_VERSION_SUFFIX: u32 = 1024;
+        if self
+            .find_by_title_namespace(base_title, namespace)
+            .await?
+            .is_none()
+        {
+            return Ok(base_title.to_string());
+        }
+        for n in 2..=MAX_VERSION_SUFFIX {
+            let candidate = format!("{base_title} ({n})");
+            if self
+                .find_by_title_namespace(&candidate, namespace)
+                .await?
+                .is_none()
+            {
+                return Ok(candidate);
+            }
+        }
+        // Match SQLite's UniqueConflict envelope; the substrate
+        // exposes it as `StorageError::UniqueConflict` on that side.
+        // At the SAL layer we surface it as `IntegrityFailed` because
+        // `StoreError` doesn't yet carry a `UniqueConflict` variant
+        // (#962 tracks the trait-side typed envelope).
+        Err(StoreError::IntegrityFailed {
+            detail: format!(
+                "could not find a free versioned title for '{base_title}' in namespace '{namespace}' within {MAX_VERSION_SUFFIX} attempts"
+            ),
+        })
+    }
+
+    async fn find_contradictions(&self, title: &str, namespace: &str) -> StoreResult<Vec<Memory>> {
+        // Postgres FTS via `to_tsvector` + `plainto_tsquery` mirroring
+        // the SQLite `memories_fts MATCH` semantics — top 5 candidates
+        // in the same namespace, ranked by relevance.
+        let rows = sqlx::query(
+            "SELECT m.* FROM memories m
+             WHERE m.namespace = $2
+               AND to_tsvector('english', m.title || ' ' || m.content)
+                   @@ plainto_tsquery('english', $1)
+             ORDER BY ts_rank(
+                 to_tsvector('english', m.title || ' ' || m.content),
+                 plainto_tsquery('english', $1)
+             ) DESC
+             LIMIT 5",
+        )
+        .bind(title)
+        .bind(namespace)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("find_contradictions", e))?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for r in &rows {
+            out.push(Self::row_to_memory(r)?);
+        }
+        Ok(out)
+    }
+
+    async fn invalidate_link(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: &str,
+        valid_until: Option<&str>,
+    ) -> StoreResult<KgInvalidateRow> {
+        // Delegate to the inherent `kg_invalidate` method which carries
+        // the AGE↔CTE dual-path fallback discipline. The trait method
+        // is the canonical surface; `kg_invalidate_via_store` (the
+        // pre-trait `as_any_for_postgres` downcast hatch) is preserved
+        // for back-compat but new callers should reach via the trait.
+        self.kg_invalidate(source_id, target_id, relation, valid_until)
+            .await
+    }
+
+    async fn check_duplicate_with_text(
+        &self,
+        query_embedding: &[f32],
+        query_text: &str,
+        namespace: Option<&str>,
+        threshold: f32,
+    ) -> StoreResult<crate::models::DuplicateCheck> {
+        use sha2::{Digest, Sha256};
+        // Phase 1 — SHA-256 exact-match short-circuit (parity with
+        // `db::check_duplicate_with_text`). Hash `format!("{title}
+        // {content}")` for every live, namespace-scoped row and
+        // return similarity=1.0 on byte-equal hits. This sidesteps
+        // the embedding-prefix asymmetry that caps cosine at ~0.92
+        // for legitimately-identical inputs.
+        let effective_threshold = threshold.max(0.5_f32); // mirrors DUPLICATE_THRESHOLD_MIN
+        let now_dt = Utc::now();
+        let rows = if let Some(ns) = namespace {
+            sqlx::query(
+                "SELECT id, title, namespace, content FROM memories
+                 WHERE (expires_at IS NULL OR expires_at > $1)
+                   AND namespace = $2",
+            )
+            .bind(now_dt)
+            .bind(ns)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| to_store_err("check_duplicate_with_text scan", e))?
+        } else {
+            sqlx::query(
+                "SELECT id, title, namespace, content FROM memories
+                 WHERE (expires_at IS NULL OR expires_at > $1)",
+            )
+            .bind(now_dt)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| to_store_err("check_duplicate_with_text scan", e))?
+        };
+
+        let mut query_hasher = Sha256::new();
+        query_hasher.update(query_text.as_bytes());
+        let query_hash = query_hasher.finalize();
+
+        let candidates_scanned = rows.len();
+        for r in &rows {
+            let id: String = r.try_get("id").map_err(|e| to_store_err("read id", e))?;
+            let title: String = r
+                .try_get("title")
+                .map_err(|e| to_store_err("read title", e))?;
+            let ns_v: String = r
+                .try_get("namespace")
+                .map_err(|e| to_store_err("read namespace", e))?;
+            let content: String = r
+                .try_get("content")
+                .map_err(|e| to_store_err("read content", e))?;
+            let row_text = format!("{title} {content}");
+            let mut row_hasher = Sha256::new();
+            row_hasher.update(row_text.as_bytes());
+            let row_hash = row_hasher.finalize();
+            if row_hash == query_hash {
+                return Ok(crate::models::DuplicateCheck {
+                    is_duplicate: true,
+                    threshold: effective_threshold,
+                    nearest: Some(crate::models::DuplicateMatch {
+                        id,
+                        title,
+                        namespace: ns_v,
+                        similarity: 1.0,
+                    }),
+                    candidates_scanned,
+                });
+            }
+        }
+
+        // Phase 2 — fall through to the embedding-based nearest-
+        // neighbor scan via the SAL `recall_hybrid` shape so callers
+        // still get a "closest existing memory" signal on near hits.
+        // Empty-embedding shortcut: if no vector was supplied (caller
+        // is keyword-only), report "no duplicate found".
+        if query_embedding.is_empty() {
+            return Ok(crate::models::DuplicateCheck {
+                is_duplicate: false,
+                threshold: effective_threshold,
+                nearest: None,
+                candidates_scanned,
+            });
+        }
+
+        // Use pgvector cosine distance directly — `1 - distance` gives
+        // similarity in `[0, 1]`. We mirror SQLite's `check_duplicate`
+        // scan shape: live rows in `namespace` (or all live rows when
+        // `namespace=None`) with a non-null embedding, ordered by
+        // cosine ascending (= most similar first), limit 1.
+        let emb_pgvec = pgvector::Vector::from(query_embedding.to_vec());
+        let nearest_row = if let Some(ns) = namespace {
+            sqlx::query(
+                "SELECT id, title, namespace,
+                        1 - (embedding <=> $1) AS sim
+                 FROM memories
+                 WHERE embedding IS NOT NULL
+                   AND namespace = $2
+                   AND (expires_at IS NULL OR expires_at > $3)
+                 ORDER BY embedding <=> $1
+                 LIMIT 1",
+            )
+            .bind(&emb_pgvec)
+            .bind(ns)
+            .bind(now_dt)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| to_store_err("check_duplicate_with_text cosine", e))?
+        } else {
+            sqlx::query(
+                "SELECT id, title, namespace,
+                        1 - (embedding <=> $1) AS sim
+                 FROM memories
+                 WHERE embedding IS NOT NULL
+                   AND (expires_at IS NULL OR expires_at > $2)
+                 ORDER BY embedding <=> $1
+                 LIMIT 1",
+            )
+            .bind(&emb_pgvec)
+            .bind(now_dt)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| to_store_err("check_duplicate_with_text cosine", e))?
+        };
+
+        let nearest = match nearest_row {
+            Some(r) => {
+                let id: String = r.try_get("id").map_err(|e| to_store_err("read id", e))?;
+                let title: String = r
+                    .try_get("title")
+                    .map_err(|e| to_store_err("read title", e))?;
+                let ns_v: String = r
+                    .try_get("namespace")
+                    .map_err(|e| to_store_err("read namespace", e))?;
+                let sim: f64 = r.try_get("sim").map_err(|e| to_store_err("read sim", e))?;
+                #[allow(clippy::cast_possible_truncation)]
+                let sim_f32 = sim as f32;
+                Some(crate::models::DuplicateMatch {
+                    id,
+                    title,
+                    namespace: ns_v,
+                    similarity: sim_f32,
+                })
+            }
+            None => None,
+        };
+
+        let is_duplicate = nearest
+            .as_ref()
+            .is_some_and(|n| n.similarity >= effective_threshold);
+
+        Ok(crate::models::DuplicateCheck {
+            is_duplicate,
+            threshold: effective_threshold,
+            nearest,
+            candidates_scanned,
+        })
+    }
 }
 
 /// v0.7.0 Continuation 6 — adapter row-to-`QuotaStatus` projection.
@@ -13712,5 +13973,253 @@ mod tests {
         // db_size_bytes is best-effort on postgres; assert non-negative
         // shape — we already enforce non-negative via u64::try_from.
         let _ = s.db_size_bytes;
+    }
+
+    // ------------------------------------------------------------------
+    // FX-C2 batch-4 — live-Postgres parity tests for the six new trait
+    // methods (find_by_title_namespace, next_versioned_title,
+    // find_contradictions, invalidate_link, check_duplicate_with_text,
+    // update_embedding). Each test skips cleanly when
+    // AI_MEMORY_TEST_POSTGRES_URL is unset.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn live_find_by_title_namespace_resolves_id() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-find-{unique}");
+        let mem = sample_memory(
+            &format!("find-{unique}"),
+            &ns,
+            "find-target-title",
+            "find_by_title body",
+        );
+        let id = store.store(&ctx, &mem).await.expect("store");
+        let found = store
+            .find_by_title_namespace("find-target-title", &ns)
+            .await
+            .expect("find_by_title_namespace");
+        assert_eq!(found.as_deref(), Some(id.as_str()));
+        let missing = store
+            .find_by_title_namespace("nonexistent-title", &ns)
+            .await
+            .expect("find_by_title_namespace miss");
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn live_next_versioned_title_picks_suffix_on_collision() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-version-{unique}");
+        // First store claims the base title.
+        let mem = sample_memory(
+            &format!("ver-{unique}"),
+            &ns,
+            "version-base",
+            "v1 body content",
+        );
+        store.store(&ctx, &mem).await.expect("store");
+        let picked = store
+            .next_versioned_title("version-base", &ns)
+            .await
+            .expect("next_versioned_title");
+        assert_eq!(picked, "version-base (2)");
+        // Fresh title is returned unchanged.
+        let fresh = store
+            .next_versioned_title("never-used-title", &ns)
+            .await
+            .expect("next_versioned_title fresh");
+        assert_eq!(fresh, "never-used-title");
+    }
+
+    #[tokio::test]
+    async fn live_find_contradictions_surfaces_fts_hits() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-contradictions-{unique}");
+        let m1 = sample_memory(
+            &format!("c1-{unique}"),
+            &ns,
+            "rust borrow checker semantics",
+            "rust language safety guarantees",
+        );
+        let m2 = sample_memory(
+            &format!("c2-{unique}"),
+            &ns,
+            "completely separate cookbook",
+            "fish stew recipe and instructions",
+        );
+        store.store(&ctx, &m1).await.expect("store m1");
+        store.store(&ctx, &m2).await.expect("store m2");
+        let hits = store
+            .find_contradictions("rust borrow checker", &ns)
+            .await
+            .expect("find_contradictions");
+        assert!(
+            hits.iter().any(|m| m.title.contains("rust borrow")),
+            "must surface rust row"
+        );
+        assert!(
+            !hits.iter().any(|m| m.title.contains("cookbook")),
+            "must not surface unrelated row"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_invalidate_link_marks_found() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-invalidate-{unique}");
+        let src = sample_memory(
+            &format!("src-{unique}"),
+            &ns,
+            "src-title",
+            "src body content",
+        );
+        let dst = sample_memory(
+            &format!("dst-{unique}"),
+            &ns,
+            "dst-title",
+            "dst body content",
+        );
+        let src_id = store.store(&ctx, &src).await.expect("store src");
+        let dst_id = store.store(&ctx, &dst).await.expect("store dst");
+        let link = crate::models::MemoryLink {
+            source_id: src_id.clone(),
+            target_id: dst_id.clone(),
+            relation: crate::models::MemoryLinkRelation::RelatedTo,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+            attest_level: None,
+        };
+        store.link(&ctx, &link).await.expect("create link");
+        let row = store
+            .invalidate_link(&src_id, &dst_id, "related_to", Some("2030-01-01T00:00:00Z"))
+            .await
+            .expect("invalidate_link");
+        assert!(row.found, "link must be marked found");
+        // valid_until is normalised on the postgres side; just assert
+        // non-empty + timezone present.
+        assert!(!row.valid_until.is_empty());
+        // Calling again should surface the prior value.
+        let row2 = store
+            .invalidate_link(&src_id, &dst_id, "related_to", Some("2031-02-02T00:00:00Z"))
+            .await
+            .expect("re-invalidate");
+        assert!(row2.found);
+        assert!(row2.previous_valid_until.is_some());
+    }
+
+    #[tokio::test]
+    async fn live_invalidate_link_returns_not_found_for_unknown_triple() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let row = store
+            .invalidate_link("nope-src", "nope-dst", "related_to", None)
+            .await
+            .expect("invalidate_link miss");
+        assert!(!row.found);
+        assert!(row.valid_until.is_empty());
+    }
+
+    #[tokio::test]
+    async fn live_check_duplicate_with_text_hash_short_circuit() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-dup-{unique}");
+        let mem = sample_memory(
+            &format!("dup-{unique}"),
+            &ns,
+            "dup-test-title",
+            "dup-test body content",
+        );
+        store.store(&ctx, &mem).await.expect("store");
+        let query_text = format!("{} {}", mem.title, mem.content);
+        // Empty embedding — phase 1 hash short-circuit doesn't need
+        // pgvector and must surface similarity=1.0 byte-equal.
+        let check = store
+            .check_duplicate_with_text(&[], &query_text, Some(&ns), 0.8)
+            .await
+            .expect("check_duplicate_with_text");
+        assert!(
+            check.is_duplicate,
+            "byte-equal text must short-circuit as duplicate"
+        );
+        let n = check.nearest.expect("nearest must be populated");
+        assert!((n.similarity - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn live_update_embedding_persists_vector() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b4-update-emb-{unique}");
+        let mem = sample_memory(
+            &format!("emb-{unique}"),
+            &ns,
+            "emb-test",
+            "embedding update body",
+        );
+        let id = store.store(&ctx, &mem).await.expect("store");
+        // PostgresStore declares the embedding column as `vector(N)`
+        // where N matches `EMBEDDING_DIM` (the connect-time selection).
+        // To stay backend-agnostic in this test we read the current
+        // column dim and craft a zero vector of that length.
+        let dim = store
+            .current_embedding_dim()
+            .await
+            .expect("current_embedding_dim");
+        let dim_usize = usize::try_from(dim.unwrap_or(384)).unwrap_or(384);
+        let vec = vec![0.0_f32; dim_usize];
+        store
+            .update_embedding(&ctx, &id, Some(&vec))
+            .await
+            .expect("update_embedding");
+        // Re-fetch to verify the vector landed (column is non-NULL).
+        let written: Option<i64> = sqlx::query_scalar(
+            "SELECT 1::BIGINT FROM memories WHERE id = $1 AND embedding IS NOT NULL",
+        )
+        .bind(&id)
+        .fetch_optional(&store.pool)
+        .await
+        .expect("verify embedding");
+        assert!(written.is_some(), "embedding column must be non-NULL");
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -11087,6 +11087,207 @@ impl MemoryStore for PostgresStore {
             candidates_scanned,
         })
     }
+
+    // ------------------------------------------------------------------
+    // v0.7.0 ARCH-2 FX-C2-batch5 — final 6 trait additions
+    // ------------------------------------------------------------------
+
+    /// FX-C2-batch5 — outbound knowledge-graph traversal via the SAL
+    /// trait. Delegates to the inherent `kg_query_with_history` (the
+    /// 3-arg variant) which itself resolves AGE vs the CTE fallback at
+    /// adapter connect time.
+    async fn kg_query(
+        &self,
+        source_id: &str,
+        max_depth: usize,
+        include_invalidated: bool,
+    ) -> StoreResult<Vec<super::KgQueryRow>> {
+        self.kg_query_with_history(source_id, max_depth, include_invalidated)
+            .await
+    }
+
+    /// FX-C2-batch5 — knowledge-graph timeline scan via the SAL trait.
+    /// Inlines the AGE↔CTE dispatch from the inherent
+    /// `kg_timeline` so the trait method can land in this impl block
+    /// without a name-collision against the inherent helper (the
+    /// inherent stays in `impl PostgresStore` for external test
+    /// callers that bind to the concrete type).
+    async fn kg_timeline(
+        &self,
+        source_id: &str,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: Option<usize>,
+    ) -> StoreResult<Vec<super::KgTimelineRow>> {
+        match self.kg_backend {
+            KgBackend::Age => {
+                match self
+                    .kg_timeline_cypher(source_id, since, until, limit)
+                    .await
+                {
+                    Ok(rows) => Ok(rows),
+                    Err(err) if is_age_runtime_failure(&err) => {
+                        warn_age_fallback("kg_timeline", source_id, &err);
+                        self.kg_timeline_cte(source_id, since, until, limit).await
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            KgBackend::Cte => self.kg_timeline_cte(source_id, since, until, limit).await,
+        }
+    }
+
+    /// FX-C2-batch5 — register a knowledge-graph entity via the SAL
+    /// trait. Idempotent on `(canonical_name, namespace)`. Mirrors the
+    /// pre-trait handler-side path in `kg.rs::entity_register` for the
+    /// postgres branch: lists prior entity row by title-eq, unions
+    /// aliases, then upserts via `store_with_embedding` (preserving
+    /// the SAL-canonical embedding-on-write contract). Returns the
+    /// resolved [`crate::models::EntityRegistration`] so callers can
+    /// drop the bespoke handler-side alias-union walk.
+    async fn entity_register(
+        &self,
+        ctx: &CallerContext,
+        canonical_name: &str,
+        namespace: &str,
+        aliases: &[String],
+        extra_metadata: &serde_json::Value,
+        agent_id: Option<&str>,
+    ) -> StoreResult<crate::models::EntityRegistration> {
+        use crate::models::{ConfidenceSource, ENTITY_KIND, EntityRegistration, MemoryKind, Tier};
+
+        // Resolve effective agent_id: explicit arg wins; otherwise
+        // fall back to the caller context's agent_id.
+        let resolved_agent = agent_id
+            .map(str::to_string)
+            .unwrap_or_else(|| ctx.agent_id.clone());
+
+        // Look up any prior entity row in this namespace via the
+        // SAL `list` surface (namespace-scoped). We match by
+        // (title == canonical_name) AND (metadata.kind == "entity").
+        let filter = super::Filter {
+            namespace: Some(namespace.to_string()),
+            limit: 10_000,
+            ..Default::default()
+        };
+        let candidates = self.list(ctx, &filter).await?;
+        let prior = candidates.into_iter().find(|m| {
+            m.title == canonical_name
+                && m.metadata.get("kind").and_then(serde_json::Value::as_str) == Some(ENTITY_KIND)
+        });
+
+        // Detect a colliding non-entity row at (title, namespace).
+        // The list-then-filter above only finds entity rows; a
+        // non-entity collision lives in `find_by_title_namespace`.
+        if prior.is_none() {
+            if let Some(existing_id) = self
+                .find_by_title_namespace(canonical_name, namespace)
+                .await?
+            {
+                return Err(StoreError::Conflict { id: existing_id });
+            }
+        }
+
+        // Union the alias sets: prior aliases first, then new
+        // aliases, de-duped case-sensitively to match
+        // `db::entity_register`.
+        let prior_aliases: Vec<String> = prior
+            .as_ref()
+            .and_then(|m| {
+                m.metadata
+                    .get("aliases")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str().map(str::to_string))
+                            .collect()
+                    })
+            })
+            .unwrap_or_default();
+        let mut union: Vec<String> = Vec::new();
+        for a in prior_aliases.iter().chain(aliases.iter()) {
+            if !a.trim().is_empty() && !union.iter().any(|x| x == a) {
+                union.push(a.clone());
+            }
+        }
+
+        // Build the entity memory's metadata: caller-supplied object
+        // merged, kind forced to "entity", aliases set to the union,
+        // agent_id preserved from the resolved caller.
+        let mut metadata = match extra_metadata {
+            serde_json::Value::Object(m) => serde_json::Value::Object(m.clone()),
+            _ => serde_json::json!({}),
+        };
+        let meta_map = metadata.as_object_mut().expect("metadata is an object");
+        meta_map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(ENTITY_KIND.to_string()),
+        );
+        meta_map.insert("aliases".to_string(), serde_json::json!(union.clone()));
+        meta_map
+            .entry("agent_id".to_string())
+            .or_insert(serde_json::Value::String(resolved_agent.clone()));
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let resolved_id = prior
+            .as_ref()
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let mem = Memory {
+            id: resolved_id.clone(),
+            tier: Tier::Long,
+            namespace: namespace.to_string(),
+            title: canonical_name.to_string(),
+            content: canonical_name.to_string(),
+            tags: vec!["entity".to_string()],
+            priority: 7,
+            confidence: 1.0,
+            source: "api".to_string(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata,
+            reflection_depth: 0,
+            memory_kind: MemoryKind::Observation,
+            entity_id: None,
+            persona_version: None,
+            citations: Vec::new(),
+            source_uri: None,
+            source_span: None,
+            confidence_source: ConfidenceSource::CallerProvided,
+            confidence_signals: None,
+            confidence_decayed_at: None,
+            version: 1,
+        };
+        let written_id = self.store(ctx, &mem).await?;
+        let created = prior.is_none();
+
+        Ok(EntityRegistration {
+            entity_id: written_id,
+            canonical_name: canonical_name.to_string(),
+            namespace: namespace.to_string(),
+            aliases: union,
+            created,
+        })
+    }
+
+    /// FX-C2-batch5 — list archived memories via the SAL trait.
+    /// Delegates to the inherent `list_archived_pg` (renamed from
+    /// `list_archived` so the trait method can land in the
+    /// `impl MemoryStore for PostgresStore` block without a name
+    /// collision). External callers that previously reached for the
+    /// inherent through `list_archived_via_store` continue to work
+    /// because the helper now calls `list_archived_pg` under the hood.
+    async fn list_archived(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+        offset: usize,
+    ) -> StoreResult<Vec<serde_json::Value>> {
+        self.list_archived_pg(namespace, limit, offset).await
+    }
 }
 
 /// v0.7.0 Continuation 6 — adapter row-to-`QuotaStatus` projection.
@@ -11168,7 +11369,7 @@ pub async fn list_archived_via_store(
     offset: usize,
 ) -> StoreResult<Vec<serde_json::Value>> {
     let pg = downcast_postgres(store)?;
-    pg.list_archived(namespace, limit, offset).await
+    pg.list_archived_pg(namespace, limit, offset).await
 }
 
 /// Outbound multi-hop knowledge-graph traversal for postgres-backed
@@ -11301,7 +11502,13 @@ impl PostgresStore {
     /// `db::list_archived` produces for SQLite. Tags are stored as a
     /// JSONB array; we serialize back to a string-formatted JSON to
     /// match SQLite's `tags` text-encoded shape.
-    async fn list_archived(
+    ///
+    /// ARCH-2 FX-C2-batch5 (2026-05-27): renamed from `list_archived`
+    /// to `list_archived_pg` so the SAL trait method
+    /// `MemoryStore::list_archived` can land on the trait impl block
+    /// without a name collision. The trait impl delegates to this
+    /// inherent helper.
+    pub(super) async fn list_archived_pg(
         &self,
         namespace: Option<&str>,
         limit: usize,
@@ -14221,5 +14428,212 @@ mod tests {
         .await
         .expect("verify embedding");
         assert!(written.is_some(), "embedding column must be non-NULL");
+    }
+
+    // ------------------------------------------------------------------
+    // FX-C2-batch5 — parity tests for the final 6 trait methods.
+    // Gated on AI_MEMORY_TEST_POSTGRES_URL; otherwise skipped cleanly.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_kg_query_trait_method_works() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b5-kgq-{unique}");
+        let src = sample_memory(&format!("src-{unique}"), &ns, "kg-query-src", "source body");
+        let dst = sample_memory(&format!("dst-{unique}"), &ns, "kg-query-dst", "target body");
+        let src_id = store.store(&ctx, &src).await.expect("store src");
+        let dst_id = store.store(&ctx, &dst).await.expect("store dst");
+        let link = crate::models::MemoryLink {
+            source_id: src_id.clone(),
+            target_id: dst_id.clone(),
+            relation: crate::models::MemoryLinkRelation::RelatedTo,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+            attest_level: None,
+        };
+        store.link(&ctx, &link).await.expect("create link");
+        // Call the SAL trait method (3-arg form) — verifies the trait
+        // entry point reaches PostgresStore::kg_query_with_history.
+        let rows = <PostgresStore as MemoryStore>::kg_query(&store, &src_id, 2, false)
+            .await
+            .expect("kg_query trait");
+        assert!(
+            rows.iter().any(|r| r.target_id == dst_id),
+            "kg_query trait method must surface the linked neighbor"
+        );
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_kg_timeline_trait_method_works() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b5-tl-{unique}");
+        let src = sample_memory(&format!("tl-src-{unique}"), &ns, "tl-src", "src body");
+        let dst = sample_memory(&format!("tl-dst-{unique}"), &ns, "tl-dst", "dst body");
+        let src_id = store.store(&ctx, &src).await.expect("store src");
+        let dst_id = store.store(&ctx, &dst).await.expect("store dst");
+        // Insert a link with valid_from set so kg_timeline picks it up
+        // (the SAL `link` trait method does not surface valid_from).
+        sqlx::query(
+            "INSERT INTO memory_links \
+             (source_id, target_id, relation, created_at, valid_from, attest_level) \
+             VALUES ($1, $2, 'related_to', NOW(), '2030-01-01 00:00:00+00', 'unsigned')",
+        )
+        .bind(&src_id)
+        .bind(&dst_id)
+        .execute(&store.pool)
+        .await
+        .expect("insert timeline link");
+        let events = <PostgresStore as MemoryStore>::kg_timeline(&store, &src_id, None, None, None)
+            .await
+            .expect("kg_timeline trait");
+        assert!(
+            events.iter().any(|e| e.target_id == dst_id),
+            "kg_timeline trait method must surface the assertion"
+        );
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_entity_register_creates_then_idempotent() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b5-ent-{unique}");
+        let first = store
+            .entity_register(
+                &ctx,
+                "AlphaOne LLC",
+                &ns,
+                &["AlphaOne".to_string(), "AO".to_string()],
+                &serde_json::json!({"website": "https://alphaone.example"}),
+                Some("ai:sal-test"),
+            )
+            .await
+            .expect("entity_register first");
+        assert!(first.created, "first registration must create the row");
+        assert_eq!(first.canonical_name, "AlphaOne LLC");
+        assert!(first.aliases.iter().any(|a| a == "AlphaOne"));
+        // Second call merges aliases without creating a new row.
+        let second = store
+            .entity_register(
+                &ctx,
+                "AlphaOne LLC",
+                &ns,
+                &["AO Inc".to_string()],
+                &serde_json::json!({}),
+                Some("ai:sal-test"),
+            )
+            .await
+            .expect("entity_register second");
+        assert!(!second.created, "re-register must not create");
+        assert!(second.aliases.iter().any(|a| a == "AlphaOne"));
+        assert!(second.aliases.iter().any(|a| a == "AO"));
+        assert!(second.aliases.iter().any(|a| a == "AO Inc"));
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_list_archived_trait_method_works() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        // Use a unique namespace and ensure list returns an empty
+        // result (no rows to archive in this scratch ns) plus that
+        // the trait method dispatches to the inherent without an
+        // ambiguity error.
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2b5-arch-{unique}");
+        let listed = <PostgresStore as MemoryStore>::list_archived(&store, Some(&ns), 100, 0)
+            .await
+            .expect("list_archived trait");
+        assert!(
+            listed.is_empty(),
+            "fresh namespace must have zero archived rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_decide_pending_action_alias_works() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        // Insert a pending row directly so we can drive the
+        // decide_pending_action trait alias.
+        let unique = uuid::Uuid::new_v4();
+        let pid = format!("pending-{unique}");
+        let ns = format!("fxc2b5-decide-{unique}");
+        sqlx::query(
+            "INSERT INTO pending_actions \
+             (id, action_type, namespace, memory_id, requested_by, payload, status, requested_at, approvals) \
+             VALUES ($1, 'store', $2, NULL, 'ai:sal-test', '{}'::jsonb, 'pending', NOW(), '[]'::jsonb)",
+        )
+        .bind(&pid)
+        .bind(&ns)
+        .execute(&store.pool)
+        .await
+        .expect("insert pending");
+        let result = store
+            .decide_pending_action(&ctx, &pid, false, "ai:sal-test")
+            .await
+            .expect("decide_pending_action");
+        assert!(result, "first decide must return true");
+        let second = store
+            .decide_pending_action(&ctx, &pid, false, "ai:sal-test")
+            .await
+            .expect("decide_pending_action second");
+        assert!(!second, "already-decided rows must return false");
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_live_approve_with_approver_type_alias_works() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let pid = format!("pending-{unique}");
+        let ns = format!("fxc2b5-approve-{unique}");
+        sqlx::query(
+            "INSERT INTO pending_actions \
+             (id, action_type, namespace, memory_id, requested_by, payload, status, requested_at, approvals) \
+             VALUES ($1, 'store', $2, NULL, 'ai:sal-test', '{}'::jsonb, 'pending', NOW(), '[]'::jsonb)",
+        )
+        .bind(&pid)
+        .bind(&ns)
+        .execute(&store.pool)
+        .await
+        .expect("insert pending");
+        // approve_with_approver_type alias must produce the same outcome
+        // as governance_approve_with_consensus for the Human approver
+        // (no namespace policy ⇒ Human default).
+        let outcome = store
+            .approve_with_approver_type(&ctx, &pid, "ai:sal-test")
+            .await
+            .expect("approve_with_approver_type");
+        assert!(matches!(outcome, crate::store::ApproveOutcome::Approved));
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -7846,6 +7846,76 @@ impl MemoryStore for PostgresStore {
             .collect()
     }
 
+    /// v0.7.0 ARCH-2 followup (FX-C2) — per-anchor edge probe over
+    /// Postgres. Mirrors the SQLite `db::get_links` shape: returns every
+    /// row where `anchor_id` is either source or target, projects the
+    /// `attest_level` + temporal-validity columns the
+    /// `memory_get_links` MCP tool's docstring promises, leaves
+    /// `signature` as `None` (the verifier owns that surface).
+    ///
+    /// Ordering: descending by `created_at`. The SQLite path naturally
+    /// returns rows in this order via the legacy projection; the
+    /// Postgres path makes it explicit so cross-backend wire shape is
+    /// stable.
+    async fn get_links_for_anchor(&self, anchor_id: &str) -> StoreResult<Vec<MemoryLink>> {
+        let rows = sqlx::query(
+            "SELECT source_id, target_id, relation, created_at,
+                    valid_from, valid_until, observed_by, attest_level
+             FROM memory_links
+             WHERE source_id = $1 OR target_id = $1
+             ORDER BY created_at DESC",
+        )
+        .bind(anchor_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("get_links_for_anchor", e))?;
+
+        rows.iter()
+            .map(|r| {
+                let created_at: DateTime<Utc> = r
+                    .try_get::<DateTime<Utc>, _>("created_at")
+                    .map_err(|e| to_store_err("read created_at", e))?;
+                let valid_from: Option<DateTime<Utc>> = r
+                    .try_get::<Option<DateTime<Utc>>, _>("valid_from")
+                    .map_err(|e| to_store_err("read valid_from", e))?;
+                let valid_until: Option<DateTime<Utc>> = r
+                    .try_get::<Option<DateTime<Utc>>, _>("valid_until")
+                    .map_err(|e| to_store_err("read valid_until", e))?;
+                let observed_by: Option<String> = r
+                    .try_get::<Option<String>, _>("observed_by")
+                    .map_err(|e| to_store_err("read observed_by", e))?;
+                let relation_str: String = r
+                    .try_get::<String, _>("relation")
+                    .map_err(|e| to_store_err("read relation", e))?;
+                let attest_level: Option<String> =
+                    r.try_get::<Option<String>, _>("attest_level")
+                        .map_err(|e| to_store_err("read attest_level", e))?;
+                Ok(MemoryLink {
+                    source_id: r
+                        .try_get::<String, _>("source_id")
+                        .map_err(|e| to_store_err("read source_id", e))?,
+                    target_id: r
+                        .try_get::<String, _>("target_id")
+                        .map_err(|e| to_store_err("read target_id", e))?,
+                    // Closed-set relation parse — unknown values fall
+                    // back to the canonical default. Mirrors the SQLite
+                    // path's `from_str(...).unwrap_or_default()` posture.
+                    relation: crate::models::MemoryLinkRelation::from_str(&relation_str)
+                        .unwrap_or_default(),
+                    created_at: created_at.to_rfc3339(),
+                    // Signature is intentionally not surfaced on this
+                    // read path — owned by the verifier (mirrors the
+                    // SQLite `db::get_links` decision).
+                    signature: None,
+                    observed_by,
+                    valid_from: valid_from.map(|t| t.to_rfc3339()),
+                    valid_until: valid_until.map(|t| t.to_rfc3339()),
+                    attest_level,
+                })
+            })
+            .collect()
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -12797,5 +12867,174 @@ mod tests {
         }
 
         cleanup_governance_ns(&pool, &format!("fa2a12-cap-{suffix}")).await;
+    }
+
+    // ---------------------------------------------------------------------
+    // FX-C2 (ARCH-2 followup) — `get_links_for_anchor` parity coverage.
+    //
+    // Mirror of the SQLite-side tests in `src/store/sqlite.rs`. Pins
+    // the per-anchor probe's wire shape across both backends: inbound +
+    // outbound edges in one call, empty vec for unlinked anchors,
+    // attest_level + temporal-validity columns round-trip via the
+    // sqlx projection. Skips cleanly when AI_MEMORY_TEST_POSTGRES_URL
+    // is unset so the default `cargo test` flow stays offline.
+    // ---------------------------------------------------------------------
+
+    async fn fxc2_seed_two_memories(store: &PostgresStore, ns: &str) -> (String, String) {
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let a_id = format!("fxc2-a-{}", uuid::Uuid::new_v4());
+        let b_id = format!("fxc2-b-{}", uuid::Uuid::new_v4());
+        let a = sample_memory(&a_id, ns, "fxc2-anchor", "anchor content here");
+        let b = sample_memory(&b_id, ns, "fxc2-target", "target content here");
+        store.store(&ctx, &a).await.expect("store anchor");
+        store.store(&ctx, &b).await.expect("store target");
+        (a_id, b_id)
+    }
+
+    #[tokio::test]
+    async fn live_get_links_for_anchor_returns_inbound_and_outbound() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let ns = format!("fxc2-getlinks-{}", uuid::Uuid::new_v4());
+        let (a_id, b_id) = fxc2_seed_two_memories(&store, &ns).await;
+        // upstream memory C used as inbound-anchor probe source
+        let c_id = format!("fxc2-c-{}", uuid::Uuid::new_v4());
+        let c = sample_memory(&c_id, &ns, "fxc2-upstream", "upstream content");
+        store.store(&ctx, &c).await.expect("store upstream");
+
+        let now = chrono::Utc::now().to_rfc3339();
+        // anchor -> target (outbound)
+        store
+            .link(
+                &ctx,
+                &MemoryLink {
+                    source_id: a_id.clone(),
+                    target_id: b_id.clone(),
+                    relation: crate::models::MemoryLinkRelation::RelatedTo,
+                    created_at: now.clone(),
+                    valid_from: None,
+                    valid_until: None,
+                    observed_by: None,
+                    signature: None,
+                    attest_level: None,
+                },
+            )
+            .await
+            .expect("link a->b");
+        // upstream -> anchor (inbound)
+        store
+            .link(
+                &ctx,
+                &MemoryLink {
+                    source_id: c_id.clone(),
+                    target_id: a_id.clone(),
+                    relation: crate::models::MemoryLinkRelation::Contradicts,
+                    created_at: now,
+                    valid_from: None,
+                    valid_until: None,
+                    observed_by: None,
+                    signature: None,
+                    attest_level: None,
+                },
+            )
+            .await
+            .expect("link c->a");
+
+        let edges = store
+            .get_links_for_anchor(&a_id)
+            .await
+            .expect("get_links_for_anchor");
+        assert!(
+            edges
+                .iter()
+                .any(|l| l.source_id == a_id && l.target_id == b_id),
+            "missing outbound edge in postgres parity"
+        );
+        assert!(
+            edges
+                .iter()
+                .any(|l| l.source_id == c_id && l.target_id == a_id),
+            "missing inbound edge in postgres parity"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_get_links_for_anchor_empty_for_unlinked_id() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let ns = format!("fxc2-empty-{}", uuid::Uuid::new_v4());
+        let alone_id = format!("fxc2-alone-{}", uuid::Uuid::new_v4());
+        let alone = sample_memory(&alone_id, &ns, "fxc2-alone", "no edges here");
+        store.store(&ctx, &alone).await.expect("store alone");
+        let edges = store
+            .get_links_for_anchor(&alone_id)
+            .await
+            .expect("get_links_for_anchor on unlinked id");
+        assert!(
+            edges.is_empty(),
+            "unlinked id must yield empty vec across both backends"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_get_links_for_anchor_projects_attest_level_and_temporal() {
+        // FX-C2 wire-shape parity: the Postgres branch MUST project the
+        // same `attest_level` + temporal-validity columns the SQLite
+        // branch does. This test inserts a row with explicit
+        // valid_from/valid_until/observed_by/attest_level via raw sqlx
+        // and verifies the trait-routed read round-trips them.
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ns = format!("fxc2-temporal-{}", uuid::Uuid::new_v4());
+        let (a_id, b_id) = fxc2_seed_two_memories(&store, &ns).await;
+        let vf = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("parse vf")
+            .with_timezone(&chrono::Utc);
+        let vu = chrono::DateTime::parse_from_rfc3339("2026-12-31T23:59:59Z")
+            .expect("parse vu")
+            .with_timezone(&chrono::Utc);
+        sqlx::query(
+            "INSERT INTO memory_links
+                (source_id, target_id, relation, created_at,
+                 valid_from, valid_until, observed_by, attest_level)
+             VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7)",
+        )
+        .bind(&a_id)
+        .bind(&b_id)
+        .bind("related_to")
+        .bind(vf)
+        .bind(vu)
+        .bind("ai:tester@host")
+        .bind("unsigned")
+        .execute(&store.pool)
+        .await
+        .expect("raw insert for temporal probe");
+
+        let edges = store
+            .get_links_for_anchor(&a_id)
+            .await
+            .expect("get_links_for_anchor");
+        let row = edges
+            .iter()
+            .find(|l| l.source_id == a_id && l.target_id == b_id)
+            .expect("just-inserted edge");
+        assert_eq!(row.valid_from.as_deref(), Some("2026-01-01T00:00:00+00:00"));
+        assert_eq!(
+            row.valid_until.as_deref(),
+            Some("2026-12-31T23:59:59+00:00")
+        );
+        assert_eq!(row.observed_by.as_deref(), Some("ai:tester@host"));
+        assert_eq!(row.attest_level.as_deref(), Some("unsigned"));
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -10384,6 +10384,448 @@ impl MemoryStore for PostgresStore {
         }
         Ok(filtered)
     }
+
+    // ----- v0.7.0 ARCH-2 followup (FX-C2-batch3) read-only impls --------
+    //
+    // sqlx-native equivalents of the legacy `db::*` free-functions.
+    // Wire shape pinned byte-for-byte against the SQLite adapter by the
+    // `sqlite_postgres_parity_*` tests in this file (gated on
+    // `AI_MEMORY_TEST_POSTGRES_URL`).
+
+    async fn list_namespaces(&self) -> StoreResult<Vec<crate::models::NamespaceCount>> {
+        let now_dt = Utc::now();
+        let rows = sqlx::query(
+            "SELECT namespace, COUNT(*)::BIGINT AS c FROM memories
+             WHERE expires_at IS NULL OR expires_at > $1
+             GROUP BY namespace
+             ORDER BY c DESC, namespace ASC",
+        )
+        .bind(now_dt)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("list_namespaces", e))?;
+
+        rows.iter()
+            .map(|r| {
+                let namespace: String = r
+                    .try_get::<String, _>("namespace")
+                    .map_err(|e| to_store_err("read namespace", e))?;
+                let c: i64 = r
+                    .try_get::<i64, _>("c")
+                    .map_err(|e| to_store_err("read count", e))?;
+                Ok(crate::models::NamespaceCount {
+                    namespace,
+                    count: usize::try_from(c).unwrap_or(0),
+                })
+            })
+            .collect()
+    }
+
+    async fn get_taxonomy(
+        &self,
+        namespace_prefix: Option<&str>,
+        max_depth: usize,
+        limit: usize,
+    ) -> StoreResult<crate::models::Taxonomy> {
+        // Mirror the SQLite adapter's clamp semantics so callers see the
+        // same `truncated` behavior across backends.
+        const TAXONOMY_MAX_LIMIT: usize = 10_000;
+        let effective_limit = limit.min(TAXONOMY_MAX_LIMIT);
+        let effective_depth = max_depth.min(crate::models::MAX_NAMESPACE_DEPTH);
+        let prefix = namespace_prefix.unwrap_or("");
+        let now_dt = Utc::now();
+
+        // Total count is computed independently of the row-walk so the
+        // caller-observable `total_count` stays honest under truncation.
+        let total_count: i64 = if prefix.is_empty() {
+            sqlx::query_scalar(
+                "SELECT COUNT(*)::BIGINT FROM memories
+                 WHERE expires_at IS NULL OR expires_at > $1",
+            )
+            .bind(now_dt)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| to_store_err("get_taxonomy total", e))?
+        } else {
+            sqlx::query_scalar(
+                "SELECT COUNT(*)::BIGINT FROM memories
+                 WHERE (expires_at IS NULL OR expires_at > $1)
+                   AND (namespace = $2 OR namespace LIKE $2 || '/%')",
+            )
+            .bind(now_dt)
+            .bind(prefix)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| to_store_err("get_taxonomy prefix total", e))?
+        };
+
+        let limit_i64: i64 = i64::try_from(effective_limit).unwrap_or(i64::MAX);
+        let groups: Vec<(String, i64)> = if prefix.is_empty() {
+            sqlx::query_as(
+                "SELECT namespace, COUNT(*)::BIGINT FROM memories
+                 WHERE expires_at IS NULL OR expires_at > $1
+                 GROUP BY namespace
+                 ORDER BY COUNT(*) DESC, namespace ASC
+                 LIMIT $2",
+            )
+            .bind(now_dt)
+            .bind(limit_i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| to_store_err("get_taxonomy groups", e))?
+        } else {
+            sqlx::query_as(
+                "SELECT namespace, COUNT(*)::BIGINT FROM memories
+                 WHERE (expires_at IS NULL OR expires_at > $1)
+                   AND (namespace = $2 OR namespace LIKE $2 || '/%')
+                 GROUP BY namespace
+                 ORDER BY COUNT(*) DESC, namespace ASC
+                 LIMIT $3",
+            )
+            .bind(now_dt)
+            .bind(prefix)
+            .bind(limit_i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| to_store_err("get_taxonomy prefix groups", e))?
+        };
+
+        // Re-use the SQLite adapter's tree-folding logic; it operates
+        // purely on the `(namespace, count)` rows so it's backend-blind.
+        // Truncation flag mirrors SQLite: walked sum < total iff the
+        // LIMIT chopped some rows out.
+        let total_usize = usize::try_from(total_count).unwrap_or(0);
+        let group_rows: Vec<(String, usize)> = groups
+            .into_iter()
+            .map(|(ns, c)| (ns, usize::try_from(c).unwrap_or(0)))
+            .collect();
+        let walked_count: usize = group_rows.iter().map(|(_, c)| *c).sum();
+        let truncated = walked_count < total_usize;
+        // `effective_limit` is referenced here for symmetry with the
+        // SQLite path's clamp; the actual SQL `LIMIT` already enforces
+        // it. Bind to `_` to keep clippy from flagging the unused
+        // local while preserving the doc-binding for future debugging.
+        let _ = effective_limit;
+        Ok(crate::storage::fold_taxonomy_groups(
+            prefix,
+            effective_depth,
+            total_usize,
+            truncated,
+            group_rows,
+        ))
+    }
+
+    async fn list_agents(&self) -> StoreResult<Vec<AgentRegistration>> {
+        use crate::models::AGENTS_NAMESPACE;
+        let now_dt = Utc::now();
+        let rows = sqlx::query(
+            "SELECT metadata FROM memories
+             WHERE namespace = $1
+               AND (expires_at IS NULL OR expires_at > $2)
+             ORDER BY (metadata->>'registered_at') ASC NULLS LAST",
+        )
+        .bind(AGENTS_NAMESPACE)
+        .bind(now_dt)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("list_agents", e))?;
+
+        let mut agents = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let meta: serde_json::Value = r
+                .try_get::<serde_json::Value, _>("metadata")
+                .map_err(|e| to_store_err("read agent metadata", e))?;
+            let agent_id = meta
+                .get("agent_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let agent_type = meta
+                .get("agent_type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let capabilities: Vec<String> = meta
+                .get("capabilities")
+                .and_then(serde_json::Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let registered_at = meta
+                .get("registered_at")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let last_seen_at = meta
+                .get("last_seen_at")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            agents.push(AgentRegistration {
+                agent_id,
+                agent_type,
+                capabilities,
+                registered_at,
+                last_seen_at,
+            });
+        }
+        Ok(agents)
+    }
+
+    async fn list_pending_actions(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> StoreResult<Vec<crate::models::PendingAction>> {
+        let limit_i64: i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let rows = sqlx::query(
+            "SELECT id, action_type, memory_id, namespace, payload, requested_by,
+                    requested_at, status, decided_by, decided_at, approvals
+             FROM pending_actions
+             WHERE ($1::TEXT IS NULL OR status = $1)
+             ORDER BY requested_at DESC
+             LIMIT $2",
+        )
+        .bind(status)
+        .bind(limit_i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("list_pending_actions", e))?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let requested_at: DateTime<Utc> = r
+                .try_get("requested_at")
+                .map_err(|e| to_store_err("read requested_at", e))?;
+            let decided_at: Option<DateTime<Utc>> = r
+                .try_get("decided_at")
+                .map_err(|e| to_store_err("read decided_at", e))?;
+            let approvals_v: serde_json::Value = r
+                .try_get("approvals")
+                .unwrap_or(serde_json::Value::Array(vec![]));
+            let approvals: Vec<crate::models::Approval> =
+                serde_json::from_value(approvals_v).unwrap_or_default();
+            out.push(crate::models::PendingAction {
+                id: r
+                    .try_get::<String, _>("id")
+                    .map_err(|e| to_store_err("read id", e))?,
+                action_type: r
+                    .try_get::<String, _>("action_type")
+                    .map_err(|e| to_store_err("read action_type", e))?,
+                memory_id: r.try_get::<Option<String>, _>("memory_id").unwrap_or(None),
+                namespace: r
+                    .try_get::<String, _>("namespace")
+                    .map_err(|e| to_store_err("read namespace", e))?,
+                payload: r
+                    .try_get::<serde_json::Value, _>("payload")
+                    .unwrap_or(serde_json::Value::Null),
+                requested_by: r
+                    .try_get::<String, _>("requested_by")
+                    .map_err(|e| to_store_err("read requested_by", e))?,
+                requested_at: requested_at.to_rfc3339(),
+                status: r
+                    .try_get::<String, _>("status")
+                    .map_err(|e| to_store_err("read status", e))?,
+                decided_by: r.try_get::<Option<String>, _>("decided_by").unwrap_or(None),
+                decided_at: decided_at.map(|d| d.to_rfc3339()),
+                approvals,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn entity_get_by_alias(
+        &self,
+        alias: &str,
+        namespace: Option<&str>,
+    ) -> StoreResult<Option<crate::models::EntityRecord>> {
+        use crate::models::{ENTITY_KIND, EntityRecord};
+        let trimmed = alias.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+
+        let row = if let Some(ns) = namespace {
+            sqlx::query(
+                "SELECT m.id, m.title, m.namespace
+                 FROM entity_aliases ea
+                 JOIN memories m ON m.id = ea.entity_id
+                 WHERE ea.alias = $1
+                   AND m.namespace = $2
+                   AND COALESCE(m.metadata->>'kind', '') = $3
+                 ORDER BY m.created_at DESC
+                 LIMIT 1",
+            )
+            .bind(trimmed)
+            .bind(ns)
+            .bind(ENTITY_KIND)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| to_store_err("entity_get_by_alias ns", e))?
+        } else {
+            sqlx::query(
+                "SELECT m.id, m.title, m.namespace
+                 FROM entity_aliases ea
+                 JOIN memories m ON m.id = ea.entity_id
+                 WHERE ea.alias = $1
+                   AND COALESCE(m.metadata->>'kind', '') = $2
+                 ORDER BY m.created_at DESC
+                 LIMIT 1",
+            )
+            .bind(trimmed)
+            .bind(ENTITY_KIND)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| to_store_err("entity_get_by_alias", e))?
+        };
+
+        let Some(r) = row else {
+            return Ok(None);
+        };
+        let entity_id: String = r
+            .try_get::<String, _>("id")
+            .map_err(|e| to_store_err("read entity id", e))?;
+        let canonical_name: String = r
+            .try_get::<String, _>("title")
+            .map_err(|e| to_store_err("read entity title", e))?;
+        let ns_resolved: String = r
+            .try_get::<String, _>("namespace")
+            .map_err(|e| to_store_err("read entity namespace", e))?;
+
+        let alias_rows =
+            sqlx::query("SELECT alias FROM entity_aliases WHERE entity_id = $1 ORDER BY alias")
+                .bind(&entity_id)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| to_store_err("list aliases for entity", e))?;
+        let aliases: Vec<String> = alias_rows
+            .iter()
+            .filter_map(|r| r.try_get::<String, _>("alias").ok())
+            .collect();
+
+        Ok(Some(EntityRecord {
+            entity_id,
+            canonical_name,
+            namespace: ns_resolved,
+            aliases,
+        }))
+    }
+
+    async fn health_check(&self) -> StoreResult<bool> {
+        // Postgres equivalent of SQLite's FTS integrity probe: a cheap
+        // SELECT against the memories table plus a SELECT 1 round-trip
+        // so connection-pool / network-layer failures surface.
+        let _: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM memories")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| to_store_err("health_check count", e))?;
+        let one: i32 = sqlx::query_scalar("SELECT 1")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| to_store_err("health_check ping", e))?;
+        Ok(one == 1)
+    }
+
+    async fn stats(&self) -> StoreResult<crate::models::Stats> {
+        // Mirrors the SQLite adapter's `db::stats` shape; postgres has
+        // no on-disk file path so `db_size_bytes` reports the size of
+        // the `memories` table via pg_total_relation_size — best-effort
+        // (returns 0 if the function call errors so stats stays callable
+        // for least-privileged Postgres users).
+        let total: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM memories")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| to_store_err("stats total", e))?;
+        let total_usize = usize::try_from(total).unwrap_or(0);
+
+        let tier_rows = sqlx::query(
+            "SELECT tier, COUNT(*)::BIGINT AS c FROM memories
+             GROUP BY tier ORDER BY c DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("stats by_tier", e))?;
+        let by_tier: Vec<crate::models::TierCount> = tier_rows
+            .iter()
+            .map(|r| {
+                let tier: String = r
+                    .try_get::<String, _>("tier")
+                    .map_err(|e| to_store_err("read tier", e))?;
+                let c: i64 = r
+                    .try_get::<i64, _>("c")
+                    .map_err(|e| to_store_err("read tier count", e))?;
+                Ok(crate::models::TierCount {
+                    tier,
+                    count: usize::try_from(c).unwrap_or(0),
+                })
+            })
+            .collect::<StoreResult<Vec<_>>>()?;
+
+        let ns_rows = sqlx::query(
+            "SELECT namespace, COUNT(*)::BIGINT AS c FROM memories
+             GROUP BY namespace ORDER BY c DESC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| to_store_err("stats by_namespace", e))?;
+        let by_namespace: Vec<crate::models::NamespaceCount> = ns_rows
+            .iter()
+            .map(|r| {
+                let namespace: String = r
+                    .try_get::<String, _>("namespace")
+                    .map_err(|e| to_store_err("read namespace", e))?;
+                let c: i64 = r
+                    .try_get::<i64, _>("c")
+                    .map_err(|e| to_store_err("read namespace count", e))?;
+                Ok(crate::models::NamespaceCount {
+                    namespace,
+                    count: usize::try_from(c).unwrap_or(0),
+                })
+            })
+            .collect::<StoreResult<Vec<_>>>()?;
+
+        let now_dt = Utc::now();
+        let one_hour = now_dt + chrono::Duration::hours(1);
+        let expiring_soon: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM memories
+             WHERE expires_at IS NOT NULL AND expires_at > $1 AND expires_at <= $2",
+        )
+        .bind(now_dt)
+        .bind(one_hour)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| to_store_err("stats expiring_soon", e))?;
+
+        let links_count: i64 = sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM memory_links")
+            .fetch_one(&self.pool)
+            .await
+            .unwrap_or(0);
+
+        // Best-effort table size — least-privileged Postgres users may
+        // lack EXECUTE on pg_total_relation_size; tolerate failure so
+        // the stats endpoint stays callable.
+        let db_size_bytes: i64 =
+            sqlx::query_scalar("SELECT COALESCE(pg_total_relation_size('memories'), 0)::BIGINT")
+                .fetch_one(&self.pool)
+                .await
+                .unwrap_or(0);
+
+        Ok(crate::models::Stats {
+            total: total_usize,
+            by_tier,
+            by_namespace,
+            expiring_soon: usize::try_from(expiring_soon).unwrap_or(0),
+            links_count: usize::try_from(links_count).unwrap_or(0),
+            db_size_bytes: u64::try_from(db_size_bytes).unwrap_or(0),
+            // Dim violations + HNSW evictions are sqlite-only concepts;
+            // postgres uses pgvector indexes which don't expose either.
+            dim_violations: 0,
+            index_evictions_total: 0,
+        })
+    }
 }
 
 /// v0.7.0 Continuation 6 — adapter row-to-`QuotaStatus` projection.
@@ -13036,5 +13478,239 @@ mod tests {
         );
         assert_eq!(row.observed_by.as_deref(), Some("ai:tester@host"));
         assert_eq!(row.attest_level.as_deref(), Some("unsigned"));
+    }
+
+    // ============================================================
+    // FX-C2-batch3 — Postgres live parity for read-only trait
+    // additions (list_namespaces, get_taxonomy, list_agents,
+    // list_pending_actions, entity_get_by_alias, health_check,
+    // stats). Gated on AI_MEMORY_TEST_POSTGRES_URL.
+    // ============================================================
+
+    #[tokio::test]
+    async fn live_list_namespaces_groups_by_count() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns_alpha = format!("fxc2-ns-alpha-{unique}");
+        let ns_beta = format!("fxc2-ns-beta-{unique}");
+        for i in 0..3 {
+            let id = format!("a-{i}-{unique}");
+            let mem = sample_memory(&id, &ns_alpha, &format!("t-{i}"), "body content");
+            store.store(&ctx, &mem).await.expect("store alpha");
+        }
+        let mem = sample_memory(&format!("b-{unique}"), &ns_beta, "tb", "beta body content");
+        store.store(&ctx, &mem).await.expect("store beta");
+        let rows = store.list_namespaces().await.expect("list_namespaces");
+        let alpha = rows
+            .iter()
+            .find(|r| r.namespace == ns_alpha)
+            .expect("alpha namespace");
+        let beta = rows
+            .iter()
+            .find(|r| r.namespace == ns_beta)
+            .expect("beta namespace");
+        assert_eq!(alpha.count, 3);
+        assert_eq!(beta.count, 1);
+    }
+
+    #[tokio::test]
+    async fn live_get_taxonomy_assembles_hierarchical_tree() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let root = format!("fxc2-tax-{unique}");
+        let team = format!("{root}/team");
+        let secrets = format!("{root}/team/secrets");
+        let mem_root = sample_memory(&format!("root-{unique}"), &root, "rt", "root body content");
+        store.store(&ctx, &mem_root).await.expect("store root");
+        for i in 0..2 {
+            let mem = sample_memory(
+                &format!("team-{i}-{unique}"),
+                &team,
+                &format!("t-{i}"),
+                "team body content",
+            );
+            store.store(&ctx, &mem).await.expect("store team");
+        }
+        let mem_sec = sample_memory(
+            &format!("sec-{unique}"),
+            &secrets,
+            "ss",
+            "secrets body content",
+        );
+        store.store(&ctx, &mem_sec).await.expect("store secrets");
+
+        let tax = store
+            .get_taxonomy(Some(&root), 8, 100)
+            .await
+            .expect("get_taxonomy");
+        assert_eq!(tax.total_count, 4, "1 root + 2 team + 1 secrets = 4");
+        assert_eq!(tax.tree.namespace, root);
+        assert_eq!(tax.tree.subtree_count, 4);
+        assert!(!tax.truncated);
+    }
+
+    #[tokio::test]
+    async fn live_list_agents_roundtrip() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("daemon");
+        let unique = uuid::Uuid::new_v4();
+        let agent_id = format!("ai:fxc2-tester-{unique}");
+        let agent = AgentRegistration {
+            agent_id: agent_id.clone(),
+            agent_type: "test".to_string(),
+            capabilities: vec!["recall".to_string()],
+            registered_at: String::new(),
+            last_seen_at: String::new(),
+        };
+        store
+            .register_agent(&ctx, &agent)
+            .await
+            .expect("register_agent");
+        let listed = store.list_agents().await.expect("list_agents");
+        assert!(
+            listed.iter().any(|r| r.agent_id == agent_id),
+            "registered agent must surface in list_agents"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_list_pending_actions_returns_seeded_row() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2-pa-{unique}");
+        let pid = format!("pa-{unique}");
+        // Seed a single pending row directly into the table.
+        sqlx::query(
+            "INSERT INTO pending_actions
+                 (id, action_type, memory_id, namespace, payload, requested_by,
+                  requested_at, status, approvals)
+             VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7, $8)",
+        )
+        .bind(&pid)
+        .bind("Store")
+        .bind(None::<String>)
+        .bind(&ns)
+        .bind(serde_json::json!({"title":"t","content":"c"}))
+        .bind("alice")
+        .bind("pending")
+        .bind(serde_json::json!([]))
+        .execute(&store.pool)
+        .await
+        .expect("seed pending_actions row");
+
+        let rows =
+            <PostgresStore as MemoryStore>::list_pending_actions(&store, Some("pending"), 100)
+                .await
+                .expect("list_pending_actions");
+        let row = rows
+            .iter()
+            .find(|r| r.id == pid)
+            .expect("seeded pending row must surface");
+        assert_eq!(row.namespace, ns);
+        assert_eq!(row.status, "pending");
+        assert_eq!(row.requested_by, "alice");
+    }
+
+    #[tokio::test]
+    async fn live_entity_get_by_alias_resolves_canonical_record() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2-ent-{unique}");
+        let entity_id = format!("ent-{unique}");
+        let mut mem = sample_memory(
+            &entity_id,
+            &ns,
+            &format!("alphaone-co-{unique}"),
+            "entity row body",
+        );
+        mem.metadata = serde_json::json!({
+            "kind": "entity",
+            "agent_id": "ai:sal-test",
+        });
+        store.store(&ctx, &mem).await.expect("store entity");
+        let alias = format!("AlphaOne-{unique}");
+        // Postgres `entity_aliases` is (entity_id, alias, created_at);
+        // namespace is resolved via JOIN with `memories`.
+        sqlx::query("INSERT INTO entity_aliases (entity_id, alias) VALUES ($1, $2)")
+            .bind(&entity_id)
+            .bind(&alias)
+            .execute(&store.pool)
+            .await
+            .expect("insert alias");
+
+        let rec = store
+            .entity_get_by_alias(&alias, Some(&ns))
+            .await
+            .expect("entity_get_by_alias");
+        let rec = rec.expect("entity must resolve");
+        assert_eq!(rec.entity_id, entity_id);
+        assert_eq!(rec.namespace, ns);
+        assert!(rec.aliases.iter().any(|a| a == &alias));
+    }
+
+    #[tokio::test]
+    async fn live_health_check_returns_true() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ok = store.health_check().await.expect("health_check");
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn live_stats_projects_full_shape() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("fxc2-stats-{unique}");
+        for i in 0..2 {
+            let mem = sample_memory(
+                &format!("stats-{i}-{unique}"),
+                &ns,
+                &format!("t-{i}"),
+                "stats body content",
+            );
+            store.store(&ctx, &mem).await.expect("store");
+        }
+        let s = store.stats().await.expect("stats");
+        let ns_row = s
+            .by_namespace
+            .iter()
+            .find(|r| r.namespace == ns)
+            .expect("ns must surface in stats");
+        assert_eq!(ns_row.count, 2);
+        assert!(s.total >= 2, "stats.total must include seeded rows");
+        // db_size_bytes is best-effort on postgres; assert non-negative
+        // shape — we already enforce non-negative via u64::try_from.
+        let _ = s.db_size_bytes;
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -291,6 +291,18 @@ impl MemoryStore for SqliteStore {
         .map_err(box_err)
     }
 
+    /// v0.7.0 ARCH-2 followup (FX-C2) — per-anchor edge probe. Thin
+    /// delegate to the legacy `db::get_links` free-function so the
+    /// behaviour is byte-identical to the pre-trait sqlite path
+    /// (`src/handlers/links.rs:894`, `src/handlers/power.rs:280`).
+    /// Mirrors the Postgres adapter's sqlx-native impl over the same
+    /// `memory_links` table; cross-backend parity is pinned by
+    /// `sqlite_postgres_parity` tests in this file.
+    async fn get_links_for_anchor(&self, anchor_id: &str) -> StoreResult<Vec<MemoryLink>> {
+        let conn = self.state.lock().await;
+        db::get_links(&conn, anchor_id).map_err(box_err)
+    }
+
     async fn list_links(&self, namespace: Option<&str>) -> StoreResult<Vec<MemoryLink>> {
         // F6 Gap 2 (v0.7.0) — surface `memory_links` to the migrate
         // runner. The namespace filter, when set, matches the source
@@ -1389,6 +1401,145 @@ mod tests {
                 .any(|l| l.source_id == a_id && l.target_id == b_id),
             "namespace filter must exclude links whose source lives elsewhere"
         );
+    }
+
+    #[tokio::test]
+    async fn get_links_for_anchor_returns_inbound_and_outbound() {
+        // v0.7.0 ARCH-2 followup (FX-C2) — per-anchor probe must
+        // return BOTH the outbound (source==anchor) and inbound
+        // (target==anchor) edges, mirroring `db::get_links`. Pins the
+        // SQLite half of the cross-backend parity contract.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let a = test_memory("anchor", "central memory for the probe");
+        let b = test_memory("downstream", "memory that anchor points to");
+        let c = test_memory("upstream", "memory that points to anchor");
+        let a_id = store.store(&ctx, &a).await.expect("store anchor");
+        let b_id = store.store(&ctx, &b).await.expect("store downstream");
+        let c_id = store.store(&ctx, &c).await.expect("store upstream");
+        // anchor -> downstream
+        store
+            .link(
+                &ctx,
+                &MemoryLink {
+                    source_id: a_id.clone(),
+                    target_id: b_id.clone(),
+                    relation: crate::models::MemoryLinkRelation::RelatedTo,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    valid_from: None,
+                    valid_until: None,
+                    observed_by: None,
+                    signature: None,
+                    attest_level: None,
+                },
+            )
+            .await
+            .expect("link a->b");
+        // upstream -> anchor
+        store
+            .link(
+                &ctx,
+                &MemoryLink {
+                    source_id: c_id.clone(),
+                    target_id: a_id.clone(),
+                    relation: crate::models::MemoryLinkRelation::Contradicts,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    valid_from: None,
+                    valid_until: None,
+                    observed_by: None,
+                    signature: None,
+                    attest_level: None,
+                },
+            )
+            .await
+            .expect("link c->a");
+        let edges = store
+            .get_links_for_anchor(&a_id)
+            .await
+            .expect("get_links_for_anchor");
+        assert_eq!(edges.len(), 2, "expected exactly 2 edges for the anchor");
+        assert!(
+            edges
+                .iter()
+                .any(|l| l.source_id == a_id && l.target_id == b_id),
+            "missing outbound edge anchor->downstream"
+        );
+        assert!(
+            edges
+                .iter()
+                .any(|l| l.source_id == c_id && l.target_id == a_id),
+            "missing inbound edge upstream->anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_links_for_anchor_empty_for_unlinked_id() {
+        // Unlinked id must yield Ok(empty). Pins the "no rows" branch of
+        // the FX-C2 trait addition so downstream consumers can rely on
+        // empty-vec semantics rather than `NotFound`.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let m = test_memory("alone", "no edges from or to this memory");
+        let id = store.store(&ctx, &m).await.expect("store");
+        let edges = store
+            .get_links_for_anchor(&id)
+            .await
+            .expect("get_links_for_anchor on unlinked id");
+        assert!(edges.is_empty(), "unlinked id must yield empty vec");
+    }
+
+    #[tokio::test]
+    async fn get_links_for_anchor_projects_attest_level_and_temporal() {
+        // FX-C2 wire-shape contract: the per-anchor probe MUST project
+        // the temporal-validity columns (`valid_from`, `valid_until`,
+        // `observed_by`) + `attest_level` because the
+        // `memory_get_links` MCP tool docstring promises them. This
+        // test inserts a signed-ish link with explicit temporal anchors
+        // and verifies all three round-trip.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let a = test_memory("anchor-temp", "anchor for temporal-fields probe");
+        let b = test_memory("target-temp", "target for temporal-fields probe");
+        let a_id = store.store(&ctx, &a).await.expect("store a");
+        let b_id = store.store(&ctx, &b).await.expect("store b");
+        // Use the raw SQLite path to set valid_from/valid_until/observed_by
+        // since the simple `link` trait method doesn't expose them. The
+        // schema CHECK requires `attest_level=self_signed/peer_attested`
+        // to carry a 64-byte signature; `unsigned` lets us round-trip
+        // the temporal-validity fields without composing a real
+        // signature blob (the verifier surface — exercised in dedicated
+        // tests).
+        {
+            let conn = store.state.lock().await;
+            conn.execute(
+                "INSERT INTO memory_links (source_id, target_id, relation, created_at,
+                                           valid_from, valid_until, observed_by, attest_level)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    &a_id,
+                    &b_id,
+                    "related_to",
+                    chrono::Utc::now().to_rfc3339(),
+                    "2026-01-01T00:00:00Z",
+                    "2026-12-31T23:59:59Z",
+                    "ai:tester@host",
+                    "unsigned",
+                ],
+            )
+            .expect("temporal insert");
+        }
+        let edges = store
+            .get_links_for_anchor(&a_id)
+            .await
+            .expect("get_links_for_anchor");
+        let row = edges
+            .iter()
+            .find(|l| l.source_id == a_id && l.target_id == b_id)
+            .expect("just-inserted edge");
+        assert_eq!(row.valid_from.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert_eq!(row.valid_until.as_deref(), Some("2026-12-31T23:59:59Z"));
+        assert_eq!(row.observed_by.as_deref(), Some("ai:tester@host"));
+        assert_eq!(row.attest_level.as_deref(), Some("unsigned"));
     }
 
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1092,6 +1092,78 @@ impl MemoryStore for SqliteStore {
         db::stats(&conn, &self.path).map_err(box_err)
     }
 
+    /// v0.7.0 SAL-routing batch-4 (FX-C2) — close `db::set_embedding`
+    /// gap by overriding `update_embedding` (default impl is no-op).
+    /// Mirrors the Postgres adapter's path so `app.store.update_embedding`
+    /// is the canonical embedding-update surface across backends.
+    async fn update_embedding(
+        &self,
+        _ctx: &CallerContext,
+        id: &str,
+        embedding: Option<&[f32]>,
+    ) -> StoreResult<()> {
+        let conn = self.state.lock().await;
+        match embedding {
+            Some(vec) => db::set_embedding(&conn, id, vec).map_err(box_err),
+            None => db::set_embedding(&conn, id, &[]).map_err(box_err),
+        }
+    }
+
+    async fn find_by_title_namespace(
+        &self,
+        title: &str,
+        namespace: &str,
+    ) -> StoreResult<Option<String>> {
+        let conn = self.state.lock().await;
+        db::find_by_title_namespace(&conn, title, namespace).map_err(box_err)
+    }
+
+    async fn next_versioned_title(&self, base_title: &str, namespace: &str) -> StoreResult<String> {
+        let conn = self.state.lock().await;
+        db::next_versioned_title(&conn, base_title, namespace).map_err(box_err)
+    }
+
+    async fn find_contradictions(&self, title: &str, namespace: &str) -> StoreResult<Vec<Memory>> {
+        let conn = self.state.lock().await;
+        db::find_contradictions(&conn, title, namespace).map_err(box_err)
+    }
+
+    async fn invalidate_link(
+        &self,
+        source_id: &str,
+        target_id: &str,
+        relation: &str,
+        valid_until: Option<&str>,
+    ) -> StoreResult<crate::store::KgInvalidateRow> {
+        let conn = self.state.lock().await;
+        match db::invalidate_link(&conn, source_id, target_id, relation, valid_until)
+            .map_err(box_err)?
+        {
+            Some(res) => Ok(crate::store::KgInvalidateRow {
+                found: true,
+                valid_until: res.valid_until,
+                previous_valid_until: res.previous_valid_until,
+            }),
+            None => Ok(crate::store::KgInvalidateRow {
+                found: false,
+                valid_until: String::new(),
+                previous_valid_until: None,
+            }),
+        }
+    }
+
+    async fn check_duplicate_with_text(
+        &self,
+        query_embedding: &[f32],
+        query_text: &str,
+        namespace: Option<&str>,
+        threshold: f32,
+    ) -> StoreResult<crate::models::DuplicateCheck> {
+        let conn = self.state.lock().await;
+        db::check_duplicate_with_text(&conn, query_embedding, query_text, namespace, threshold)
+            .map_err(box_err)
+    }
+
     async fn notify(
         &self,
         ctx: &CallerContext,
@@ -2419,5 +2491,201 @@ mod tests {
         // db_size_bytes is best-effort — fresh DB is non-zero
         // (rusqlite at least writes the page header).
         assert!(s.db_size_bytes > 0, "expected non-zero db file size");
+    }
+
+    // ------------------------------------------------------------------
+    // FX-C2 batch-4 — parity tests for the new trait methods.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn update_embedding_persists_via_set_embedding() {
+        // FX-C2-batch4 — `SqliteStore::update_embedding` overrides the
+        // default no-op and delegates to `db::set_embedding` so the
+        // create.rs:475 embedding write is now SAL-routable.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mem = test_memory("with-embed", "embedding-fixture body content");
+        let id = store.store(&ctx, &mem).await.expect("store");
+        // Use a 4-d vector to keep the test cheap. The dim-mismatch
+        // check inside `db::set_embedding` is keyed off the namespace's
+        // first established dim, so a fresh store accepts any dim.
+        let vec = vec![0.1_f32, 0.2, 0.3, 0.4];
+        store
+            .update_embedding(&ctx, &id, Some(&vec))
+            .await
+            .expect("update_embedding");
+        // Verify by re-reading the column. We deliberately read via
+        // the lock since the SAL doesn't expose a `get_embedding`
+        // surface yet (recall_hybrid is the consumer).
+        let conn = store.state.lock().await;
+        let blob: Vec<u8> = conn
+            .query_row(
+                "SELECT embedding FROM memories WHERE id = ?1",
+                rusqlite::params![&id],
+                |r| r.get(0),
+            )
+            .expect("read embedding");
+        assert!(!blob.is_empty(), "embedding blob should be populated");
+    }
+
+    #[tokio::test]
+    async fn find_by_title_namespace_resolves_id() {
+        // FX-C2-batch4 — `find_by_title_namespace` returns the live
+        // row's id when `(title, namespace)` matches.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mem = test_memory("conflict-target", "find_by_title body");
+        let id = store.store(&ctx, &mem).await.expect("store");
+        let found = store
+            .find_by_title_namespace(&mem.title, &mem.namespace)
+            .await
+            .expect("find_by_title_namespace");
+        assert_eq!(found.as_deref(), Some(id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn find_by_title_namespace_returns_none_for_unknown() {
+        let store = fresh_store();
+        let found = store
+            .find_by_title_namespace("never-stored", "alphaone")
+            .await
+            .expect("find_by_title_namespace miss");
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_versioned_title_first_use_returns_base() {
+        // FX-C2-batch4 — on a fresh store the base title is free.
+        let store = fresh_store();
+        let picked = store
+            .next_versioned_title("My Title", "alphaone")
+            .await
+            .expect("next_versioned_title");
+        assert_eq!(picked, "My Title");
+    }
+
+    #[tokio::test]
+    async fn next_versioned_title_appends_suffix_on_collision() {
+        // FX-C2-batch4 — when the base title is taken, append `(2)`.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mut mem = test_memory("dup-title", "versioned body content");
+        mem.namespace = "alphaone".to_string();
+        store.store(&ctx, &mem).await.expect("store");
+        let picked = store
+            .next_versioned_title("dup-title", "alphaone")
+            .await
+            .expect("next_versioned_title");
+        assert_eq!(picked, "dup-title (2)");
+    }
+
+    #[tokio::test]
+    async fn find_contradictions_returns_fts_matches() {
+        // FX-C2-batch4 — `find_contradictions` returns FTS-similar
+        // candidates in the same namespace.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mut a = test_memory("rust language semantics", "rust language safety guarantees");
+        a.namespace = "alphaone".to_string();
+        let mut b = test_memory(
+            "completely unrelated cookbook",
+            "fish stew recipe and instructions",
+        );
+        b.namespace = "alphaone".to_string();
+        store.store(&ctx, &a).await.expect("store a");
+        store.store(&ctx, &b).await.expect("store b");
+        let hits = store
+            .find_contradictions("rust language", "alphaone")
+            .await
+            .expect("find_contradictions");
+        // The FTS5 match query must surface the "rust language" memory;
+        // the recipe row should NOT trigger an FTS hit.
+        assert!(
+            hits.iter().any(|m| m.title.contains("rust language")),
+            "FTS match should surface the rust-language row"
+        );
+        assert!(
+            !hits.iter().any(|m| m.title.contains("cookbook")),
+            "unrelated row must not appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_link_marks_found_with_previous_value() {
+        // FX-C2-batch4 — `invalidate_link` sets `valid_until` on the
+        // matching `(source, target, relation)` triple and surfaces
+        // `previous_valid_until` (None on first invalidation).
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let src = test_memory("src-row", "source memory body content");
+        let dst = test_memory("dst-row", "destination memory body content");
+        let src_id = store.store(&ctx, &src).await.expect("store src");
+        let dst_id = store.store(&ctx, &dst).await.expect("store dst");
+        let link = crate::models::MemoryLink {
+            source_id: src_id.clone(),
+            target_id: dst_id.clone(),
+            relation: crate::models::MemoryLinkRelation::RelatedTo,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+            attest_level: None,
+        };
+        store.link(&ctx, &link).await.expect("create link");
+        let row = store
+            .invalidate_link(&src_id, &dst_id, "related_to", Some("2030-01-01T00:00:00Z"))
+            .await
+            .expect("invalidate_link");
+        assert!(row.found, "link must be marked found");
+        assert_eq!(row.valid_until, "2030-01-01T00:00:00Z");
+        assert!(row.previous_valid_until.is_none(), "no prior invalidation");
+    }
+
+    #[tokio::test]
+    async fn invalidate_link_returns_not_found_for_unknown_triple() {
+        // FX-C2-batch4 — non-existent triple surfaces `found = false`,
+        // not an error.
+        let store = fresh_store();
+        let row = store
+            .invalidate_link("nope-src", "nope-dst", "related_to", None)
+            .await
+            .expect("invalidate_link miss");
+        assert!(!row.found);
+        assert!(row.valid_until.is_empty());
+    }
+
+    #[tokio::test]
+    async fn check_duplicate_with_text_exact_content_hash_short_circuits() {
+        // FX-C2-batch4 — phase 1 SHA-256 short-circuit returns
+        // `similarity=1.0` when `format!("{title} {content}")` is
+        // byte-equal to an existing row's text.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mut mem = test_memory("dup-test-title", "dup-test body content");
+        mem.namespace = "alphaone".to_string();
+        store.store(&ctx, &mem).await.expect("store");
+        let query_text = format!("{} {}", mem.title, mem.content);
+        // Empty embedding is fine — phase 1 (hash) doesn't need it.
+        let check = store
+            .check_duplicate_with_text(&[], &query_text, Some("alphaone"), 0.8)
+            .await
+            .expect("check_duplicate_with_text");
+        assert!(check.is_duplicate);
+        let n = check.nearest.expect("nearest must be populated on dup");
+        assert!((n.similarity - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn check_duplicate_with_text_no_match_returns_false() {
+        // FX-C2-batch4 — empty candidate pool surfaces non-dup with
+        // candidates_scanned=0.
+        let store = fresh_store();
+        let check = store
+            .check_duplicate_with_text(&[], "no-match text", Some("alphaone"), 0.8)
+            .await
+            .expect("check_duplicate_with_text empty");
+        assert!(!check.is_duplicate);
+        assert_eq!(check.candidates_scanned, 0);
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1037,6 +1037,61 @@ impl MemoryStore for SqliteStore {
         Ok(filtered)
     }
 
+    // ----- v0.7.0 ARCH-2 followup (FX-C2-batch3) read-only impls --------
+    //
+    // Thin delegates over the legacy `db::*` free-functions; the SAL
+    // adapter's job here is only to expose the routing surface, not to
+    // re-implement the query. Postgres parity tests pin byte-equal
+    // wire shapes across backends.
+
+    async fn list_namespaces(&self) -> StoreResult<Vec<crate::models::NamespaceCount>> {
+        let conn = self.state.lock().await;
+        db::list_namespaces(&conn).map_err(box_err)
+    }
+
+    async fn get_taxonomy(
+        &self,
+        namespace_prefix: Option<&str>,
+        max_depth: usize,
+        limit: usize,
+    ) -> StoreResult<crate::models::Taxonomy> {
+        let conn = self.state.lock().await;
+        db::get_taxonomy(&conn, namespace_prefix, max_depth, limit).map_err(box_err)
+    }
+
+    async fn list_agents(&self) -> StoreResult<Vec<AgentRegistration>> {
+        let conn = self.state.lock().await;
+        db::list_agents(&conn).map_err(box_err)
+    }
+
+    async fn list_pending_actions(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> StoreResult<Vec<crate::models::PendingAction>> {
+        let conn = self.state.lock().await;
+        db::list_pending_actions(&conn, status, limit).map_err(box_err)
+    }
+
+    async fn entity_get_by_alias(
+        &self,
+        alias: &str,
+        namespace: Option<&str>,
+    ) -> StoreResult<Option<crate::models::EntityRecord>> {
+        let conn = self.state.lock().await;
+        db::entity_get_by_alias(&conn, alias, namespace).map_err(box_err)
+    }
+
+    async fn health_check(&self) -> StoreResult<bool> {
+        let conn = self.state.lock().await;
+        db::health_check(&conn).map_err(box_err)
+    }
+
+    async fn stats(&self) -> StoreResult<crate::models::Stats> {
+        let conn = self.state.lock().await;
+        db::stats(&conn, &self.path).map_err(box_err)
+    }
+
     async fn notify(
         &self,
         ctx: &CallerContext,
@@ -2100,5 +2155,269 @@ mod tests {
             .await
             .expect("get_pending miss");
         assert!(row.is_none());
+    }
+
+    // ===== v0.7.0 ARCH-2 followup (FX-C2-batch3) — trait unit tests ======
+    //
+    // Each new trait method gets a happy-path test + an empty/edge-case
+    // test. Postgres-side parity tests live under the
+    // `sqlite_postgres_parity` module gated on
+    // `AI_MEMORY_TEST_POSTGRES_URL`.
+
+    #[tokio::test]
+    async fn list_namespaces_groups_and_orders_by_count() {
+        // FX-C2-batch3 — `list_namespaces` returns `(namespace, count)`
+        // rows sorted by count desc with deterministic alphabetic
+        // tie-break, mirroring `db::list_namespaces`.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        for (ns, n) in &[("alpha", 3usize), ("beta", 1usize), ("gamma", 2usize)] {
+            for i in 0..*n {
+                let mut m =
+                    test_memory(&format!("{ns}-{i}"), "content body for the namespace probe");
+                m.namespace = (*ns).to_string();
+                store.store(&ctx, &m).await.expect("store");
+            }
+        }
+        let rows = store.list_namespaces().await.expect("list_namespaces");
+        let alpha = rows.iter().find(|r| r.namespace == "alpha").expect("alpha");
+        let beta = rows.iter().find(|r| r.namespace == "beta").expect("beta");
+        let gamma = rows.iter().find(|r| r.namespace == "gamma").expect("gamma");
+        assert_eq!(alpha.count, 3);
+        assert_eq!(beta.count, 1);
+        assert_eq!(gamma.count, 2);
+        // Densest namespace surfaces first.
+        let alpha_pos = rows
+            .iter()
+            .position(|r| r.namespace == "alpha")
+            .expect("alpha pos");
+        let beta_pos = rows
+            .iter()
+            .position(|r| r.namespace == "beta")
+            .expect("beta pos");
+        assert!(
+            alpha_pos < beta_pos,
+            "expected alpha (count=3) before beta (count=1)"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_namespaces_empty_store_returns_empty_vec() {
+        let store = fresh_store();
+        let rows = store
+            .list_namespaces()
+            .await
+            .expect("list_namespaces on empty store");
+        assert!(rows.is_empty(), "empty store must yield empty vec");
+    }
+
+    #[tokio::test]
+    async fn get_taxonomy_assembles_hierarchical_tree() {
+        // FX-C2-batch3 — `get_taxonomy` projects a hierarchical tree
+        // whose ancestor `subtree_count`s sum every descendant's count.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        for (ns, n) in &[
+            ("alphaone", 1usize),
+            ("alphaone/team", 2usize),
+            ("alphaone/team/secrets", 1usize),
+        ] {
+            for i in 0..*n {
+                let mut m = test_memory(&format!("{ns}-{i}"), "taxonomy fixture body content");
+                m.namespace = (*ns).to_string();
+                store.store(&ctx, &m).await.expect("store");
+            }
+        }
+        let tax = store
+            .get_taxonomy(Some("alphaone"), 8, 100)
+            .await
+            .expect("get_taxonomy");
+        // 1 (alphaone) + 2 (alphaone/team) + 1 (alphaone/team/secrets) = 4
+        assert_eq!(tax.total_count, 4, "total prefix count");
+        assert_eq!(tax.tree.namespace, "alphaone");
+        assert_eq!(tax.tree.subtree_count, 4);
+        assert!(!tax.truncated);
+    }
+
+    #[tokio::test]
+    async fn get_taxonomy_empty_prefix_yields_empty_total() {
+        let store = fresh_store();
+        let tax = store
+            .get_taxonomy(Some("nonexistent"), 8, 100)
+            .await
+            .expect("get_taxonomy");
+        assert_eq!(tax.total_count, 0);
+        assert!(tax.tree.children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_agents_roundtrip_through_register() {
+        // FX-C2-batch3 — `list_agents` enumerates the `_agents`
+        // namespace and parses the metadata blob into the
+        // `AgentRegistration` shape.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("daemon");
+        let agent = AgentRegistration {
+            agent_id: "ai:tester@host".to_string(),
+            agent_type: "test".to_string(),
+            capabilities: vec!["recall".to_string(), "store".to_string()],
+            registered_at: String::new(),
+            last_seen_at: String::new(),
+        };
+        store
+            .register_agent(&ctx, &agent)
+            .await
+            .expect("register_agent");
+        let listed = store.list_agents().await.expect("list_agents");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].agent_id, "ai:tester@host");
+        assert_eq!(listed[0].agent_type, "test");
+        assert!(listed[0].capabilities.contains(&"recall".to_string()));
+        assert!(!listed[0].registered_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_agents_empty_store_returns_empty_vec() {
+        let store = fresh_store();
+        let listed = store.list_agents().await.expect("list_agents");
+        assert!(listed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_pending_actions_filters_by_status() {
+        // FX-C2-batch3 — status filter passes through verbatim.
+        use crate::models::GovernedAction;
+        let store = fresh_store();
+        {
+            let conn = store.state.lock().await;
+            db::queue_pending_action(
+                &conn,
+                GovernedAction::Store,
+                "ns",
+                None,
+                "alice",
+                &serde_json::json!({"title":"t","content":"c"}),
+            )
+            .expect("queue 1");
+            db::queue_pending_action(
+                &conn,
+                GovernedAction::Store,
+                "ns",
+                None,
+                "bob",
+                &serde_json::json!({"title":"t2","content":"c2"}),
+            )
+            .expect("queue 2");
+        }
+        let all = store
+            .list_pending_actions(None, 100)
+            .await
+            .expect("list all");
+        assert_eq!(all.len(), 2);
+        let pending = store
+            .list_pending_actions(Some("pending"), 100)
+            .await
+            .expect("list pending");
+        assert_eq!(pending.len(), 2, "both rows start pending");
+        let approved = store
+            .list_pending_actions(Some("approved"), 100)
+            .await
+            .expect("list approved");
+        assert!(approved.is_empty(), "no approved rows yet");
+    }
+
+    #[tokio::test]
+    async fn entity_get_by_alias_resolves_canonical_record() {
+        // FX-C2-batch3 — `entity_get_by_alias` returns the canonical
+        // entity record (entity_id + canonical_name + namespace +
+        // alias set).
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        // Stamp the metadata so the entity passes the kind=entity
+        // CHECK in `db::entity_get_by_alias`.
+        let mut m = test_memory("alphaone-co", "company entity row body fixture");
+        m.namespace = "alphaone".to_string();
+        m.metadata = serde_json::json!({
+            "kind": "entity",
+            "agent_id": "alice",
+        });
+        let id = store.store(&ctx, &m).await.expect("store");
+        {
+            let conn = store.state.lock().await;
+            // SQLite `entity_aliases` table shape is
+            // (entity_id, alias, created_at); namespace comes from the
+            // JOIN with memories.
+            conn.execute(
+                "INSERT INTO entity_aliases (entity_id, alias, created_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![&id, "AlphaOne", chrono::Utc::now().to_rfc3339()],
+            )
+            .expect("insert alias");
+        }
+        let rec = store
+            .entity_get_by_alias("AlphaOne", Some("alphaone"))
+            .await
+            .expect("entity_get_by_alias");
+        let rec = rec.expect("entity must resolve");
+        assert_eq!(rec.entity_id, id);
+        assert_eq!(rec.canonical_name, "alphaone-co");
+        assert_eq!(rec.namespace, "alphaone");
+        assert!(rec.aliases.iter().any(|a| a == "AlphaOne"));
+    }
+
+    #[tokio::test]
+    async fn entity_get_by_alias_returns_none_for_unknown() {
+        let store = fresh_store();
+        let rec = store
+            .entity_get_by_alias("never-registered", None)
+            .await
+            .expect("entity_get_by_alias miss");
+        assert!(rec.is_none());
+    }
+
+    #[tokio::test]
+    async fn entity_get_by_alias_empty_alias_returns_none() {
+        // Empty / whitespace-only alias is rejected at the storage
+        // layer — verify the SAL preserves the contract.
+        let store = fresh_store();
+        let rec = store
+            .entity_get_by_alias("   ", None)
+            .await
+            .expect("entity_get_by_alias whitespace");
+        assert!(rec.is_none());
+    }
+
+    #[tokio::test]
+    async fn health_check_returns_true_on_open_store() {
+        let store = fresh_store();
+        let ok = store.health_check().await.expect("health_check");
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn stats_projects_full_shape() {
+        // FX-C2-batch3 — `stats` projects total, per-tier, per-namespace,
+        // expiring_soon, links_count, db_size_bytes for the open store.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        for i in 0..3 {
+            let mut m = test_memory(
+                &format!("title-{i}"),
+                "stats fixture body content adequate length",
+            );
+            m.namespace = "alphaone".to_string();
+            store.store(&ctx, &m).await.expect("store");
+        }
+        let s = store.stats().await.expect("stats");
+        assert_eq!(s.total, 3);
+        // by_namespace must include alphaone with count=3
+        let alpha = s
+            .by_namespace
+            .iter()
+            .find(|r| r.namespace == "alphaone")
+            .expect("alphaone in stats.by_namespace");
+        assert_eq!(alpha.count, 3);
+        // db_size_bytes is best-effort — fresh DB is non-zero
+        // (rusqlite at least writes the page header).
+        assert!(s.db_size_bytes > 0, "expected non-zero db file size");
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1215,6 +1215,153 @@ impl MemoryStore for SqliteStore {
         let conn = self.state.lock().await;
         db::insert(&conn, &mem).map_err(box_err)
     }
+
+    // ------------------------------------------------------------------
+    // v0.7.0 ARCH-2 FX-C2-batch5 — final 6 trait additions
+    // ------------------------------------------------------------------
+
+    /// FX-C2-batch5 — SqliteStore override of the default
+    /// `execute_pending_action` (which returned `UnsupportedCapability`).
+    /// Delegates to the canonical sqlite primitive `db::execute_pending_action`
+    /// so the SAL trait is the canonical execute surface across backends.
+    async fn execute_pending_action(
+        &self,
+        _ctx: &CallerContext,
+        pending_id: &str,
+    ) -> StoreResult<Option<String>> {
+        let conn = self.state.lock().await;
+        db::execute_pending_action(&conn, pending_id).map_err(box_err)
+    }
+
+    /// FX-C2-batch5 — Sqlite override matching the nominal SQLite
+    /// primitive name. Delegates to `db::approve_with_approver_type`
+    /// directly (bypassing the trait's default forward to
+    /// `governance_approve_with_consensus` for one less indirection).
+    async fn approve_with_approver_type(
+        &self,
+        _ctx: &CallerContext,
+        pending_id: &str,
+        approver_agent_id: &str,
+    ) -> StoreResult<super::ApproveOutcome> {
+        let conn = self.state.lock().await;
+        let outcome = db::approve_with_approver_type(&conn, pending_id, approver_agent_id)
+            .map_err(box_err)?;
+        let sal = match outcome {
+            db::ApproveOutcome::Approved => super::ApproveOutcome::Approved,
+            db::ApproveOutcome::Pending { votes, quorum } => {
+                super::ApproveOutcome::Pending { votes, quorum }
+            }
+            db::ApproveOutcome::Rejected(reason) => super::ApproveOutcome::Rejected(reason),
+        };
+        Ok(sal)
+    }
+
+    /// FX-C2-batch5 — Sqlite override matching the nominal SQLite
+    /// primitive name. Delegates to `db::decide_pending_action`.
+    async fn decide_pending_action(
+        &self,
+        _ctx: &CallerContext,
+        id: &str,
+        approve: bool,
+        decided_by: &str,
+    ) -> StoreResult<bool> {
+        let conn = self.state.lock().await;
+        db::decide_pending_action(&conn, id, approve, decided_by).map_err(box_err)
+    }
+
+    /// FX-C2-batch5 — outbound knowledge-graph traversal. Thin
+    /// delegate to `db::kg_query`; projects the per-hop SQLite
+    /// `KgQueryNode` rows into the SAL `KgQueryRow` shape.
+    async fn kg_query(
+        &self,
+        source_id: &str,
+        max_depth: usize,
+        include_invalidated: bool,
+    ) -> StoreResult<Vec<super::KgQueryRow>> {
+        let conn = self.state.lock().await;
+        let nodes = db::kg_query(
+            &conn,
+            source_id,
+            max_depth,
+            None,
+            None,
+            None,
+            include_invalidated,
+        )
+        .map_err(box_err)?;
+        Ok(nodes
+            .into_iter()
+            .map(|n| super::KgQueryRow {
+                target_id: n.target_id,
+                relation: n.relation,
+                depth: n.depth,
+                path: n.path,
+            })
+            .collect())
+    }
+
+    /// FX-C2-batch5 — knowledge-graph timeline scan. Thin delegate to
+    /// `db::kg_timeline`; projects the per-event SQLite
+    /// `KgTimelineEvent` rows into the SAL `KgTimelineRow` shape.
+    async fn kg_timeline(
+        &self,
+        source_id: &str,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: Option<usize>,
+    ) -> StoreResult<Vec<super::KgTimelineRow>> {
+        let conn = self.state.lock().await;
+        let events = db::kg_timeline(&conn, source_id, since, until, limit).map_err(box_err)?;
+        Ok(events
+            .into_iter()
+            .map(|e| super::KgTimelineRow {
+                target_id: e.target_id,
+                relation: e.relation,
+                valid_from: e.valid_from,
+                valid_until: e.valid_until,
+                observed_by: e.observed_by,
+                title: e.title,
+                target_namespace: e.target_namespace,
+            })
+            .collect())
+    }
+
+    /// FX-C2-batch5 — register a knowledge-graph entity. Thin delegate
+    /// to `db::entity_register`; idempotent on
+    /// `(canonical_name, namespace)`.
+    async fn entity_register(
+        &self,
+        _ctx: &CallerContext,
+        canonical_name: &str,
+        namespace: &str,
+        aliases: &[String],
+        extra_metadata: &serde_json::Value,
+        agent_id: Option<&str>,
+    ) -> StoreResult<crate::models::EntityRegistration> {
+        let conn = self.state.lock().await;
+        db::entity_register(
+            &conn,
+            canonical_name,
+            namespace,
+            aliases,
+            extra_metadata,
+            agent_id,
+        )
+        .map_err(box_err)
+    }
+
+    /// FX-C2-batch5 — list archived memories. Thin delegate to
+    /// `db::list_archived`; returns the same JSON row shape across
+    /// backends.
+    async fn list_archived(
+        &self,
+        namespace: Option<&str>,
+        limit: usize,
+        offset: usize,
+    ) -> StoreResult<Vec<serde_json::Value>> {
+        let conn = self.state.lock().await;
+        db::list_archived(&conn, namespace, limit, offset).map_err(box_err)
+    }
 }
 
 /// Transaction handle that no-ops commit (`SQLite` txn support is
@@ -2687,5 +2834,305 @@ mod tests {
             .expect("check_duplicate_with_text empty");
         assert!(!check.is_duplicate);
         assert_eq!(check.candidates_scanned, 0);
+    }
+
+    // ------------------------------------------------------------------
+    // FX-C2-batch5 — parity tests for the final 6 trait methods.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fx_c2_batch5_decide_pending_action_alias_matches_pending_decide() {
+        // The `decide_pending_action` trait method is a nominal alias
+        // for `pending_decide`; the two surfaces must produce
+        // identical results.
+        use crate::models::GovernedAction;
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let pid = {
+            let conn = store.state.lock().await;
+            db::queue_pending_action(
+                &conn,
+                GovernedAction::Store,
+                "ns-decide-alias",
+                None,
+                "alice",
+                &serde_json::json!({"title":"t","content":"c"}),
+            )
+            .expect("queue")
+        };
+        let result = store
+            .decide_pending_action(&ctx, &pid, true, "alice")
+            .await
+            .expect("decide_pending_action");
+        assert!(result, "first decide must transition the row");
+        let second = store
+            .decide_pending_action(&ctx, &pid, true, "alice")
+            .await
+            .expect("decide_pending_action second");
+        assert!(!second, "already-decided rows must be no-op");
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_approve_with_approver_type_matches_governance_path() {
+        // The `approve_with_approver_type` trait method is a nominal
+        // alias for `governance_approve_with_consensus`; under Human
+        // approver_type the result is identical.
+        use crate::models::GovernedAction;
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let pid = {
+            let conn = store.state.lock().await;
+            db::queue_pending_action(
+                &conn,
+                GovernedAction::Store,
+                "ns-approve-alias",
+                None,
+                "alice",
+                &serde_json::json!({"title":"t","content":"c"}),
+            )
+            .expect("queue")
+        };
+        let outcome = store
+            .approve_with_approver_type(&ctx, &pid, "approver")
+            .await
+            .expect("approve_with_approver_type");
+        assert!(matches!(outcome, crate::store::ApproveOutcome::Approved));
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_execute_pending_action_sqlite_override() {
+        // Before FX-C2-batch5 the SqliteStore relied on the trait
+        // default (UnsupportedCapability); this test pins the new
+        // override.
+        use crate::models::GovernedAction;
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let memory_payload = serde_json::to_value(test_memory("fx-c2-b5-exec", "executed payload"))
+            .expect("serialize memory");
+        let pid = {
+            let conn = store.state.lock().await;
+            let pid = db::queue_pending_action(
+                &conn,
+                GovernedAction::Store,
+                "alphaone",
+                None,
+                "alice",
+                &memory_payload,
+            )
+            .expect("queue");
+            db::approve_with_approver_type(&conn, &pid, "alice").expect("approve");
+            pid
+        };
+        let executed = store
+            .execute_pending_action(&ctx, &pid)
+            .await
+            .expect("execute_pending_action");
+        // Store action returns the resulting memory id.
+        assert!(executed.is_some(), "store action must return a memory id");
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_kg_query_returns_outbound_neighbors() {
+        // Insert a source memory + a target + a related_to link; the
+        // trait method must surface the neighbor through the CTE
+        // traversal.
+        use crate::models::{MemoryLink, MemoryLinkRelation};
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let src = store
+            .store(&ctx, &test_memory("kg-src", "source body"))
+            .await
+            .expect("src");
+        let dst = store
+            .store(&ctx, &test_memory("kg-dst", "target body"))
+            .await
+            .expect("dst");
+        let now = chrono::Utc::now().to_rfc3339();
+        let link = MemoryLink {
+            source_id: src.clone(),
+            target_id: dst.clone(),
+            relation: MemoryLinkRelation::RelatedTo,
+            created_at: now.clone(),
+            valid_from: Some(now.clone()),
+            valid_until: None,
+            observed_by: Some("alice".to_string()),
+            attest_level: Some("unsigned".to_string()),
+            signature: None,
+        };
+        store.link(&ctx, &link).await.expect("link");
+        let rows = store.kg_query(&src, 2, false).await.expect("kg_query");
+        assert_eq!(rows.len(), 1, "exactly one neighbor expected");
+        assert_eq!(rows[0].target_id, dst);
+        assert_eq!(rows[0].depth, 1);
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_kg_timeline_orders_by_valid_from() {
+        // Two outbound assertions with explicit valid_from; the
+        // timeline must surface them in ASC order. We write the
+        // memory_links rows directly so we can pin valid_from
+        // explicitly (the `link` trait method does not surface a
+        // valid_from override).
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let src = store
+            .store(&ctx, &test_memory("tl-src", "tl source body"))
+            .await
+            .expect("src");
+        let dst_old = store
+            .store(&ctx, &test_memory("tl-dst-old", "tl old body"))
+            .await
+            .expect("dst-old");
+        let dst_new = store
+            .store(&ctx, &test_memory("tl-dst-new", "tl new body"))
+            .await
+            .expect("dst-new");
+        {
+            let conn = store.state.lock().await;
+            conn.execute(
+                "INSERT INTO memory_links \
+                 (source_id, target_id, relation, created_at, valid_from, attest_level) \
+                 VALUES (?1, ?2, 'related_to', ?3, ?4, 'unsigned')",
+                rusqlite::params![
+                    &src,
+                    &dst_new,
+                    "2030-01-02T00:00:01Z",
+                    "2030-01-02T00:00:00Z"
+                ],
+            )
+            .expect("insert new link");
+            conn.execute(
+                "INSERT INTO memory_links \
+                 (source_id, target_id, relation, created_at, valid_from, attest_level) \
+                 VALUES (?1, ?2, 'related_to', ?3, ?4, 'unsigned')",
+                rusqlite::params![
+                    &src,
+                    &dst_old,
+                    "2030-01-01T00:00:01Z",
+                    "2030-01-01T00:00:00Z"
+                ],
+            )
+            .expect("insert old link");
+        }
+        let events = store
+            .kg_timeline(&src, None, None, None)
+            .await
+            .expect("kg_timeline");
+        assert_eq!(events.len(), 2, "two timeline events expected");
+        assert_eq!(events[0].target_id, dst_old, "older event first");
+        assert_eq!(events[1].target_id, dst_new, "newer event second");
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_entity_register_creates_new_entity() {
+        // Idempotent registration creates a new row on first call.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let reg = store
+            .entity_register(
+                &ctx,
+                "Acme Corp",
+                "alphaone-test",
+                &["ACME".to_string(), "acme-corp".to_string()],
+                &serde_json::json!({"website":"https://acme.example"}),
+                Some("alice"),
+            )
+            .await
+            .expect("entity_register");
+        assert!(reg.created, "first registration must create the entity row");
+        assert_eq!(reg.canonical_name, "Acme Corp");
+        assert_eq!(reg.namespace, "alphaone-test");
+        assert!(reg.aliases.iter().any(|a| a == "ACME"));
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_entity_register_unions_aliases_on_reregister() {
+        // Second call with new aliases merges into the existing row.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        store
+            .entity_register(
+                &ctx,
+                "BetaCo",
+                "alphaone-test",
+                &["beta".to_string()],
+                &serde_json::json!({}),
+                Some("alice"),
+            )
+            .await
+            .expect("first");
+        let reg = store
+            .entity_register(
+                &ctx,
+                "BetaCo",
+                "alphaone-test",
+                &["BETA-CORP".to_string()],
+                &serde_json::json!({}),
+                Some("alice"),
+            )
+            .await
+            .expect("reregister");
+        assert!(!reg.created, "re-registration must NOT create a new row");
+        assert!(reg.aliases.iter().any(|a| a == "beta"));
+        assert!(reg.aliases.iter().any(|a| a == "BETA-CORP"));
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_list_archived_returns_archived_rows() {
+        // Insert + archive a memory; list_archived must surface it.
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let id = store
+            .store(&ctx, &test_memory("archived-row", "to be archived"))
+            .await
+            .expect("store");
+        // Forget with archive=true so the row lands on archived_memories.
+        let archived = store
+            .forget(&ctx, Some("sal-test"), None, None, true)
+            .await
+            .expect("forget");
+        assert!(archived > 0, "forget must archive at least one row");
+        let listed = store
+            .list_archived(Some("sal-test"), 100, 0)
+            .await
+            .expect("list_archived");
+        assert_eq!(listed.len(), 1, "one archived row expected");
+        let row = &listed[0];
+        assert_eq!(
+            row.get("id").and_then(|v| v.as_str()),
+            Some(id.as_str()),
+            "archived row id must match"
+        );
+    }
+
+    #[tokio::test]
+    async fn fx_c2_batch5_list_archived_namespace_filter_excludes_other_tenants() {
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mut m = test_memory("ns-a-row", "body");
+        m.namespace = "tenant-a".to_string();
+        store.store(&ctx, &m).await.expect("store-a");
+        let mut m2 = test_memory("ns-b-row", "body");
+        m2.namespace = "tenant-b".to_string();
+        store.store(&ctx, &m2).await.expect("store-b");
+        store
+            .forget(&ctx, Some("tenant-a"), None, None, true)
+            .await
+            .expect("forget-a");
+        store
+            .forget(&ctx, Some("tenant-b"), None, None, true)
+            .await
+            .expect("forget-b");
+        let tenant_a = store
+            .list_archived(Some("tenant-a"), 100, 0)
+            .await
+            .expect("list a");
+        assert_eq!(tenant_a.len(), 1);
+        assert_eq!(
+            tenant_a[0].get("namespace").and_then(|v| v.as_str()),
+            Some("tenant-a")
+        );
+        let global = store.list_archived(None, 100, 0).await.expect("list all");
+        assert_eq!(global.len(), 2, "global list must surface both tenants");
     }
 }


### PR DESCRIPTION
Wave C FX-C2 final state — all 21 proposed MemoryStore trait additions landed across batches 2-5. 15 handler callsites routed. Audit doc tracks every site. 5203 lib tests pass. Operator-authorized 'fix it all 100% no lazy'.