### PR TITLE
fix(llm, FX-D1): OllamaClient bridge — no panic on current-thread tokio

### DIFF
--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -2036,10 +2036,25 @@ pub async fn build_embedder(feature_tier: FeatureTier, app_config: &AppConfig) -
 /// killing the daemon — autonomy hooks are best-effort and the
 /// store path must keep working when Ollama is offline.
 ///
-/// Mirrors [`build_embedder`]'s shape (spawn_blocking around the
-/// blocking `reqwest::blocking::Client::builder` chain Ollama uses)
-/// because the LLM client also internally spins a sync HTTP client
-/// that would panic if constructed directly in an async context.
+/// **FX-D1 (v0.7.0, 2026-05-27).** Pre-FX-D1 this function wrapped
+/// the sync [`llm::OllamaClient::build_from_resolved`] in
+/// `tokio::task::spawn_blocking`. The sync constructor went through
+/// `block_on_local`, whose FX-C1 design panicked on the current-thread
+/// arm. Production tests that defaulted to `#[tokio::test]`
+/// (current-thread) hit the panic — `spawn_blocking`'s blocking-pool
+/// thread inherits the outer runtime handle, so `Handle::try_current()`
+/// resolved to a `CurrentThread` flavor and tripped the panic. The
+/// log line was: `task 294 panicked with message "OllamaClient sync
+/// wrapper called from inside a current-thread tokio runtime."`.
+///
+/// The surgical fix is to call the async constructor
+/// [`llm::OllamaClient::build_from_resolved_async`] directly — no
+/// `spawn_blocking`, no `block_on_local`, no sync→async bridge — so
+/// the construction runs on whichever tokio runtime the caller
+/// brought. The defensive fix in `block_on_local` (replace the panic
+/// with a fresh-OS-thread bridge) catches every other unknown
+/// callsite that might hit the same shape; this surgical fix is the
+/// optimal path at this known callsite.
 pub async fn build_llm_client(
     feature_tier: FeatureTier,
     app_config: &AppConfig,
@@ -2083,23 +2098,14 @@ pub async fn build_llm_client(
     let key_source = resolved.api_key_source.as_str().to_string();
     let tier_str = feature_tier.as_str().to_string();
 
-    // The resolver pin is sync, but the actual client construction
-    // (which spins reqwest::blocking inside the http builder chain)
-    // must still run in `spawn_blocking` to avoid panicking the
-    // tokio executor.
-    let build = match tokio::task::spawn_blocking(move || {
-        llm::OllamaClient::build_from_resolved(&resolved)
-    })
-    .await
-    {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::warn!(
-                "L5: build_llm_client spawn_blocking join failed (tier={tier_str}): {e}"
-            );
-            return None;
-        }
-    };
+    // FX-D1 (2026-05-27): call the async constructor directly. The
+    // pre-FX-D1 `spawn_blocking` wrapper drove the sync constructor
+    // through `block_on_local`, which panicked on the current-thread
+    // tokio arm (the default `#[tokio::test]` flavor). The async
+    // path skips the sync→async bridge entirely so the construction
+    // runs on whichever tokio runtime the caller brought, with no
+    // re-entry hazard.
+    let build = llm::OllamaClient::build_from_resolved_async(&resolved).await;
 
     match build {
         Ok(Some(client)) => {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -43,6 +43,29 @@ const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 /// PERF-9 (v0.7.0 FX-C1, 2026-05-26) — bridge sync API to the new async
 /// `reqwest::Client` without double-blocking or panicking.
 ///
+/// **FX-D1 (v0.7.0, 2026-05-27) — regression fix.** The original
+/// FX-C1 design panicked on the current-thread arm because every
+/// in-repo `#[tokio::test]` used `flavor = "multi_thread"`. Production
+/// hit the panic via `daemon_runtime::build_llm_client` →
+/// `spawn_blocking(|| OllamaClient::build_from_resolved(...))`:
+/// `tokio::task::spawn_blocking` inherits the runtime handle on its
+/// blocking pool thread, so `Handle::try_current()` resolves and
+/// `runtime_flavor()` is `CurrentThread` whenever the outer runtime
+/// is current-thread (the default for `#[tokio::test]`). The panic
+/// surfaced as a `task panicked with message "OllamaClient sync
+/// wrapper called from inside a current-thread tokio runtime."`
+/// warning in the daemon log.
+///
+/// The fix is to never panic — instead, on the current-thread arm,
+/// spawn a fresh OS thread (which has no inherited tokio context),
+/// build a one-shot current-thread runtime on it, drive the future
+/// there, and join the thread back. This costs one thread spawn +
+/// one join per current-thread bridge call, but it keeps every
+/// existing sync wrapper signature intact and removes the
+/// recurrence-risk panic surface entirely. Multi-thread runtimes
+/// still use the productive `block_in_place` path; no runtime at
+/// all still uses the in-line ephemeral runtime path.
+///
 /// Three cases the helper handles:
 ///
 /// 1. **Inside a multi-thread tokio runtime** (the `#[tokio::main]`
@@ -51,11 +74,15 @@ const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 ///    `tokio::task::block_in_place` + `Handle::current().block_on` so
 ///    the runtime keeps the worker thread productive for other tasks
 ///    while the LLM HTTP call is in flight.
-/// 2. **Inside a current-thread tokio runtime** (some `#[tokio::test]`
-///    defaults to current-thread) — `block_in_place` panics there, so
-///    we fall back to constructing an ephemeral current-thread
-///    runtime in a fresh OS thread (via `std::thread::spawn`) so the
-///    outer runtime is not re-entered.
+/// 2. **Inside a current-thread tokio runtime** (the default
+///    `#[tokio::test]` flavor; production hit through
+///    `daemon_runtime::build_llm_client` → `spawn_blocking` when the
+///    outer runtime was current-thread) — `block_in_place` panics
+///    there, and re-entering the existing runtime via a fresh
+///    `block_on` deadlocks. We construct an ephemeral current-thread
+///    runtime on a freshly-spawned OS thread (via
+///    `std::thread::spawn`) so the outer runtime is not re-entered
+///    and the future drives to completion on an isolated thread.
 /// 3. **No tokio runtime at all** (a `#[test]` regression in a
 ///    non-async test file, the legacy synchronous CLI path that
 ///    bypasses `#[tokio::main]`) — build a fresh current-thread
@@ -65,11 +92,14 @@ const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 /// shapes keeps the every-callsite-stays-sync contract intact while
 /// allowing the underlying HTTP I/O to migrate to async. Production
 /// hot paths (HTTP handlers, daemon dispatch) should prefer the
-/// `*_async` variants and skip the bridge entirely.
+/// `*_async` variants and skip the bridge entirely — the FX-D1
+/// surgical fix at `daemon_runtime::build_llm_client` does exactly
+/// this for the known callsite that surfaced the regression.
 fn block_on_local<F, Fut, T>(make_fut: F) -> T
 where
-    F: FnOnce() -> Fut,
+    F: FnOnce() -> Fut + Send,
     Fut: std::future::Future<Output = T>,
+    T: Send,
 {
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         match handle.runtime_flavor() {
@@ -85,19 +115,49 @@ where
             _ => {
                 // Current-thread runtime — `block_in_place` panics
                 // there, and re-entering the runtime via a fresh
-                // `block_on` deadlocks. Production never hits this
-                // branch (the daemon's `#[tokio::main]` is
-                // multi-thread); tests that want to drive the sync
-                // wrapper from inside a current-thread test must
-                // mark the test as `#[tokio::test(flavor =
-                // "multi_thread")]` — every existing llm.rs test
-                // already does. We surface a clear panic so a
-                // regression is loud, not silent.
-                panic!(
-                    "OllamaClient sync wrapper called from inside a current-thread \
-                     tokio runtime. Use the `*_async` variant or annotate the test \
-                     `#[tokio::test(flavor = \"multi_thread\")]`."
-                )
+                // `block_on` deadlocks. FX-D1 (2026-05-27): the
+                // previous design panicked here, but production hit
+                // this branch via `daemon_runtime::build_llm_client`'s
+                // `spawn_blocking` (the blocking pool thread inherits
+                // the outer current-thread runtime handle). We now
+                // move the `FnOnce` future-builder onto a freshly-
+                // scoped OS thread that owns its own one-shot
+                // current-thread runtime. That thread has no
+                // inherited tokio context, so the inner `block_on`
+                // does not re-enter the outer runtime and does not
+                // deadlock.
+                //
+                // We use `std::thread::scope` instead of
+                // `std::thread::spawn` so the closure can borrow
+                // non-`'static` data from the caller (e.g. the
+                // `&self` capture every `block_on_local(|| self.foo_async(...))`
+                // wrapper carries). Scoped threads guarantee the
+                // borrow outlives the spawn-and-join pair.
+                //
+                // Cost: one thread spawn + one join per call. The sync
+                // wrapper is a bridge-of-last-resort surface — every
+                // production hot path either runs on a multi-thread
+                // runtime (which uses the productive arm above) or
+                // calls the `*_async` variant directly. The
+                // current-thread arm is exercised only by tests that
+                // defaulted to current-thread and by the legacy
+                // `spawn_blocking → sync wrapper` chain that FX-D1
+                // surgically migrated to the async path at known
+                // callsites.
+                std::thread::scope(|s| {
+                    s.spawn(move || {
+                        tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("ephemeral runtime builds")
+                            .block_on(make_fut())
+                    })
+                    .join()
+                    .expect(
+                        "block_on_local current-thread bridge thread panicked; \
+                         underlying future panicked",
+                    )
+                })
             }
         }
     } else {
@@ -592,6 +652,63 @@ impl OllamaClient {
         // Non-Ollama backends require an API key. If the resolver
         // could not produce one, surface the error via a returned
         // `Err` (consistent with the pre-#1143 `from_env` posture).
+        let Some(api_key) = resolved.api_key() else {
+            return Err(anyhow!(
+                "LLM backend `{}` requires an API key but the resolver \
+                 produced none. KeySource = {}. Configure either \
+                 AI_MEMORY_LLM_API_KEY, a per-vendor env var (e.g. \
+                 XAI_API_KEY), [llm].api_key_env, or [llm].api_key_file \
+                 in config.toml. See \
+                 https://github.com/alphaonedev/ai-memory-mcp/issues/1146",
+                resolved.backend,
+                resolved.api_key_source.as_str(),
+            ));
+        };
+
+        Self::new_openai_compatible(&resolved.base_url, &resolved.model, api_key).map(Some)
+    }
+
+    /// FX-D1 (v0.7.0, 2026-05-27) — async sibling of
+    /// [`Self::build_from_resolved`]. Surgical fix for the
+    /// `daemon_runtime::build_llm_client` callsite that hit the
+    /// FX-C1 `block_on_local` current-thread panic: the daemon
+    /// wrapped this sync constructor in `tokio::task::spawn_blocking`,
+    /// and the blocking pool thread inherited the outer (current-
+    /// thread, in `#[tokio::test]`) runtime handle, which drove
+    /// `block_on_local` into its panic arm.
+    ///
+    /// Callers already on a tokio runtime — the daemon's
+    /// `build_llm_client`, `mcp/mod.rs::run_mcp_server` once it
+    /// migrates, and CLI atomise/curator builders — should call this
+    /// directly to bypass the sync→async bridge entirely. The Ollama
+    /// arm now goes through [`Self::new_with_url_async`] (no
+    /// `block_on_local`); the non-Ollama arm uses
+    /// [`Self::new_openai_compatible`] which is already pure-sync
+    /// (no I/O — just a `reqwest::Client::builder`).
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`Self::build_from_resolved`]: Ollama
+    /// reachability failure, missing API key for a non-Ollama
+    /// backend, or HTTP client build failure.
+    pub async fn build_from_resolved_async(
+        resolved: &crate::config::ResolvedLlm,
+    ) -> Result<Option<Self>> {
+        tracing::debug!(
+            "LLM client construction via #1146 resolver (async, FX-D1) — backend={}, model={}, base_url={}, key_source={}, source={}",
+            resolved.backend,
+            resolved.model,
+            resolved.base_url,
+            resolved.api_key_source.as_str(),
+            resolved.source.as_str(),
+        );
+
+        if resolved.backend == BACKEND_OLLAMA {
+            return Self::new_with_url_async(&resolved.base_url, &resolved.model)
+                .await
+                .map(Some);
+        }
+
         let Some(api_key) = resolved.api_key() else {
             return Err(anyhow!(
                 "LLM backend `{}` requires an API key but the resolver \

--- a/tests/ollama_client_current_thread_tokio_no_panic.rs
+++ b/tests/ollama_client_current_thread_tokio_no_panic.rs
@@ -1,0 +1,239 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// clippy allows (test scaffolding): pedantic lints with no behavioral impact.
+#![allow(clippy::doc_markdown, clippy::manual_let_else)]
+// Mirrors the existing `test_build_llm_client_returns_none_when_ollama_unreachable`
+// pattern at `src/daemon_runtime.rs:6411` — the legacy `ollama_url`
+// field still feeds the resolver via the `Legacy` precedence arm at
+// v0.7.x; removal is slated for v0.8.0. Using it here keeps this
+// regression test wire-shape-equivalent to the original failing
+// invocation that surfaced FX-D1.
+#![allow(deprecated)]
+//! FX-D1 (v0.7.0, 2026-05-27) — regression test for the FX-C1 panic
+//! when an `OllamaClient` sync wrapper is invoked from inside a
+//! current-thread tokio runtime.
+//!
+//! # Lineage
+//!
+//! FX-C1 (PERF-9) shipped the v0.7.0 sync→async bridge in
+//! `src/llm.rs::block_on_local`. The original design panicked on the
+//! current-thread arm with:
+//!
+//! ```text
+//! OllamaClient sync wrapper called from inside a current-thread
+//! tokio runtime. Use the `*_async` variant or annotate the test
+//! `#[tokio::test(flavor = "multi_thread")]`.
+//! ```
+//!
+//! The rationale was "every in-repo `#[tokio::test]` is multi-thread,
+//! so this branch should be unreachable in practice — make it a loud
+//! panic so a regression surfaces immediately". Production hit it via
+//! `daemon_runtime::build_llm_client` →
+//! `tokio::task::spawn_blocking(|| OllamaClient::build_from_resolved(...))`:
+//! the blocking-pool thread inherits the outer runtime handle, so when
+//! the outer runtime was current-thread (the default for
+//! `#[tokio::test]`), `Handle::try_current()` resolved to a
+//! `CurrentThread` flavor and the panic fired.
+//!
+//! CI evidence post-merge on `release/v0.7.0` HEAD
+//! `2a8fb45634b196d38875fa34618071d1a7b12ba9`:
+//!
+//! ```text
+//! WARN ai_memory::daemon_runtime: L5: build_llm_client spawn_blocking
+//! join failed (tier=smart): task 294 panicked with message
+//! "OllamaClient sync wrapper called from inside a current-thread
+//! tokio runtime. …"
+//! ```
+//!
+//! # What this test pins
+//!
+//! 1. The defensive fix in `block_on_local`: spawning the sync wrapper
+//!    from inside a current-thread tokio runtime no longer panics. The
+//!    helper now bridges through a freshly-scoped OS thread that owns
+//!    its own one-shot current-thread runtime.
+//! 2. The surgical fix in `daemon_runtime::build_llm_client`: the
+//!    callsite that surfaced the regression now goes through the
+//!    async constructor and never re-enters `block_on_local`.
+//!
+//! Both fixes are exercised by the body below: every scenario builds
+//! a current-thread tokio runtime (matching the original failing
+//! shape) and drives the sync wrapper through `spawn_blocking`. The
+//! assertion is that NO panic occurs — the wrapper either returns a
+//! clean `Ok` (improbable on a closed port — usually impossible) or
+//! a clean `Err`.
+//!
+//! Companion tests:
+//! - `tests/round2_f6_llm.rs` pins the F6 circuit-breaker semantics.
+//! - `src/llm.rs::tests::*` pins the multi-thread block_in_place path.
+
+use ai_memory::llm::OllamaClient;
+use std::net::TcpListener;
+
+/// Allocate an `127.0.0.1:<port>` URL with NO listener so any TCP
+/// connect against it fails immediately. The reservation listener is
+/// dropped before we return so the port is left closed; this gives us
+/// a deterministic "Ollama is unreachable" target without depending
+/// on any OS-level firewall rule.
+fn closed_local_url() -> String {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").expect("bind a free 127.0.0.1 port for the test");
+    let addr = listener
+        .local_addr()
+        .expect("local_addr resolves on a freshly-bound listener");
+    drop(listener);
+    format!("http://{addr}")
+}
+
+/// Driver — build a current-thread tokio runtime (matching the
+/// `#[tokio::test]` default flavor that surfaced the FX-D1
+/// regression), then call `spawn_blocking` to drive the sync
+/// `OllamaClient` constructor. The sync constructor uses
+/// `block_on_local` internally; pre-FX-D1 this combination panicked.
+///
+/// Asserts: the spawn_blocking join returns without a panic — either
+/// `Ok(_)` (the underlying constructor returned something) or an
+/// `Err`-shaped result, but never a `JoinError::is_panic()`.
+fn drive_sync_constructor_under_current_thread_runtime(url: String) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime builds");
+
+    let result = rt.block_on(async move {
+        // Mirror production shape: daemon_runtime::build_llm_client
+        // pre-FX-D1 was `spawn_blocking(move || OllamaClient::build_from_resolved(...))`
+        // and surfaced as task panicked.
+        tokio::task::spawn_blocking(move || {
+            // The sync constructor `new_with_url` calls into
+            // `block_on_local`; this is the wrapper that panicked.
+            // We aim a closed-port URL at it so the constructor
+            // returns Err (Ollama unreachable) — but the LOAD-BEARING
+            // assertion is no-panic, not Err-vs-Ok.
+            OllamaClient::new_with_url(&url, "test-model")
+        })
+        .await
+    });
+
+    match result {
+        Ok(Ok(_client)) => {
+            // Improbable but allowed — if the connect-timeout window
+            // happened to overlap with some other listener on the
+            // host. The contract is "no panic".
+        }
+        Ok(Err(_err)) => {
+            // Expected path: Ollama unreachable. Clean error envelope,
+            // no panic. This is the load-bearing post-FX-D1 outcome.
+        }
+        Err(join_err) => {
+            assert!(
+                !join_err.is_panic(),
+                "FX-D1 regression: spawn_blocking task panicked when sync \
+                 OllamaClient wrapper was called from inside a current-thread \
+                 tokio runtime. Original panic message reproduction lineage: \
+                 src/llm.rs::block_on_local (FX-C1) → daemon_runtime::build_llm_client \
+                 (FX-D1 surgical fix at known callsite + block_on_local defensive \
+                 fix for unknown callsites). Join error: {join_err:?}"
+            );
+            // Cancellation is acceptable; panic is not.
+        }
+    }
+}
+
+#[test]
+fn sync_constructor_in_current_thread_tokio_does_not_panic() {
+    // Direct exercise of the original failing shape:
+    //   current-thread tokio runtime  +  spawn_blocking  +  sync wrapper
+    let url = closed_local_url();
+    drive_sync_constructor_under_current_thread_runtime(url);
+}
+
+#[test]
+fn nested_spawn_blocking_sync_constructor_does_not_panic() {
+    // Double-nested exercise — spawn_blocking inside spawn_blocking.
+    // Earlier FX-C1 design relied on `block_in_place` being a no-op
+    // when called from outside a worker thread; this test pins that
+    // the fallback path (current-thread arm of `block_on_local`) is
+    // also panic-free when reached via a doubly-nested blocking
+    // dispatch chain.
+    let url = closed_local_url();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime builds");
+
+    let result = rt.block_on(async move {
+        tokio::task::spawn_blocking(move || {
+            // Nested: build a fresh runtime *inside* this blocking
+            // thread (some real-world call sites do this when
+            // adapting between executors).
+            let inner_rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("nested current-thread tokio runtime builds");
+            inner_rt.block_on(async move {
+                tokio::task::spawn_blocking(move || OllamaClient::new_with_url(&url, "test-model"))
+                    .await
+            })
+        })
+        .await
+    });
+
+    match result {
+        Ok(Ok(Ok(_) | Err(_))) => { /* either is fine — no panic */ }
+        Ok(Err(inner_join)) => {
+            assert!(
+                !inner_join.is_panic(),
+                "FX-D1 regression: nested spawn_blocking inner task panicked: {inner_join:?}"
+            );
+        }
+        Err(outer_join) => {
+            assert!(
+                !outer_join.is_panic(),
+                "FX-D1 regression: outer spawn_blocking task panicked: {outer_join:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn build_llm_client_known_callsite_does_not_panic() {
+    // FX-D1 surgical fix verification: the daemon's
+    // `build_llm_client` no longer wraps `build_from_resolved` in
+    // `spawn_blocking`. It now calls `build_from_resolved_async`
+    // directly. This test exercises that path under the same
+    // current-thread runtime shape that surfaced the original
+    // regression.
+    //
+    // The Smart tier is chosen because it has a compiled `llm_model`
+    // preset, which forces `build_llm_client` past the early-return
+    // gate and into the construction path. We point at a closed
+    // 127.0.0.1 port so the construction fails cleanly (Ollama
+    // unreachable) — but again, the load-bearing assertion is
+    // no-panic, not Err-vs-None.
+    use ai_memory::config::{AppConfig, FeatureTier};
+    use ai_memory::daemon_runtime::build_llm_client;
+
+    let url = closed_local_url();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread tokio runtime builds");
+
+    let result = rt.block_on(async {
+        let cfg = AppConfig {
+            ollama_url: Some(url),
+            ..AppConfig::default()
+        };
+        build_llm_client(FeatureTier::Smart, &cfg).await
+    });
+
+    // `build_llm_client` returns `Option<OllamaClient>` and never
+    // panics post-FX-D1. Either an `Option::None` (reachability
+    // failure) or `Option::Some(_)` (impossibly lucky port) is
+    // acceptable; the assertion is implicit in reaching this line
+    // without unwinding.
+    let _ = result;
+}


### PR DESCRIPTION
Wave D regression fix — FX-C1 PERF-9 panicked in current-thread tokio context (production daemon_runtime::build_llm_client hit it). Both fixes applied: (a) defensive std::thread::scope in block_on_local, (b) surgical build_llm_client → build_from_resolved_async direct .await. QC PASS, 3 new regression tests, 140 LLM tests + 81 daemon_runtime tests pass.