### PR TITLE
fix(FX-E1): cascade #[cfg(feature=sal)] gate + HNSW PERF-7 sr3 pin

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -95,6 +95,17 @@ mod arch_9_slug_tests {
         assert_eq!(STORE_VERSION_CONFLICT, "VERSION_CONFLICT");
     }
 
+    // FX-E1 (2026-05-27) — `crate::store` is gated behind
+    // `#[cfg(feature = "sal")]` in `src/lib.rs:336`. Without this
+    // matching gate the test fails to compile under the default
+    // feature set (the `cargo build --tests` invocation used by
+    // `token-budget.yml`, `mobile-cross-compile`, etc.), which
+    // cascaded into the Per-Module Coverage / CI Check x3 / Postgres
+    // gate failures observed on `release/v0.7.0`. The SAL-feature
+    // gating is intentional — the round-trip test exercises
+    // `StoreError::code()` which only exists when the SAL trait
+    // surface is compiled in.
+    #[cfg(feature = "sal")]
     #[test]
     fn arch_9_store_error_slug_round_trip() {
         use crate::store::{BoxBackendError, StoreError};

--- a/tests/sr3_perf_regressions.rs
+++ b/tests/sr3_perf_regressions.rs
@@ -313,9 +313,20 @@ fn sr3_1084_crossencoder_neural_no_mutex() {
 #[test]
 fn sr3_1087_hnsw_search_caches_valid_ids() {
     let source = lf(include_str!("../src/hnsw.rs"));
+    // FX-E1 (2026-05-27) — PERF-7 (commit c9579686e, FX-C4-batch2)
+    // narrowed the cache element type from `String` to
+    // `Arc<str>` for ~halved per-rebuild allocator pressure on the
+    // 100k-entry warmup (UUIDs are 36 bytes; `Arc<str>` is a
+    // 16-byte fat pointer with the bytes heap-shared and no spare
+    // capacity, vs. `String`'s 24-byte ptr/len/cap struct PLUS the
+    // heap-side bytes). Membership against `&str` still works
+    // through the `Borrow<str>` impl. The original sr3 pin still
+    // asserted the pre-PERF-7 `String` shape; this update tracks
+    // the canonical post-PERF-7 invariant (also pinned by
+    // `src/hnsw.rs::tests::perf_7_valid_ids_cache_is_arc_str_typed`).
     assert!(
-        source.contains("valid_ids_cache: Option<std::collections::HashSet<String>>"),
-        "IndexState must carry a cached valid_ids set post-#1087"
+        source.contains("valid_ids_cache: Option<std::collections::HashSet<std::sync::Arc<str>>>"),
+        "IndexState must carry a cached valid_ids set typed as Arc<str> post-#1087/PERF-7"
     );
     // The mutation paths must invalidate the cache.
     let invalidations = source.matches("state.valid_ids_cache = None;").count();


### PR DESCRIPTION
Post-Wave-D regression fixes. Defect 1: arch_9_store_error_slug_round_trip test in src/errors.rs missing #[cfg(feature=sal)] gate (cascade root — broke token-budget + CI Check x3 + Per-Module Coverage + Postgres gate when default-features cargo build hit the gated crate::store import). Defect 2: tests/sr3_perf_regressions.rs:317 source-text assertion lagged PERF-7's Arc<str> cache migration. QC PASS.