### PR TITLE
fix(tests, #1370): make SEC-2 fail-closed test hermetic on dev hosts

### DIFF
--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -6365,8 +6365,7 @@ decision = "allow"
         // CI passes on clean-HOME runners; local fails. The guard
         // below forces `resolve_operator_pubkey()` to return None
         // for the test scope, matching the CI posture deterministically.
-        let _no_pubkey_guard =
-            crate::governance::rules_store::force_no_operator_pubkey_for_test();
+        let _no_pubkey_guard = crate::governance::rules_store::force_no_operator_pubkey_for_test();
         let _gate = env_var_lock();
         let env = TestEnv::fresh();
         let conn = db::open(&env.db_path).unwrap();

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -6351,6 +6351,22 @@ decision = "allow"
         // bootstrap_serve MUST refuse to start. This pins the
         // fail-closed posture documented at lines 2118-2153 in
         // bootstrap_serve.
+        //
+        // Dev-host hermeticity (issue #1370, 2026-05-27). The test
+        // pre-#1370 cleared `AI_MEMORY_OPERATOR_PUBKEY` but did not
+        // engage the `ForceNoOperatorPubkeyGuard` escape hatch added
+        // under issue #819. `resolve_operator_pubkey()` checks TWO
+        // sources — the env var AND `~/.config/ai-memory/operator.key.pub`
+        // on disk (via `dirs::config_dir()`). On a dev host that has
+        // staged a real operator pubkey at the platform config dir
+        // (e.g. `~/Library/Application Support/ai-memory/` on macOS),
+        // the on-disk lookup wins, `pubkey_resolved = true`, and the
+        // SEC-2 fail-closed bail at `bootstrap_serve` never fires.
+        // CI passes on clean-HOME runners; local fails. The guard
+        // below forces `resolve_operator_pubkey()` to return None
+        // for the test scope, matching the CI posture deterministically.
+        let _no_pubkey_guard =
+            crate::governance::rules_store::force_no_operator_pubkey_for_test();
         let _gate = env_var_lock();
         let env = TestEnv::fresh();
         let conn = db::open(&env.db_path).unwrap();


### PR DESCRIPTION
## Summary

Closes #1370.

`test_bootstrap_serve_sec2_fail_closed_when_pubkey_missing_and_rules_enabled` (added in PR #795, commit `e4c12f547`) fails locally on dev hosts that have a staged operator pubkey at the platform config dir. CI passes on clean-HOME runners. Fix: engage the pre-existing `ForceNoOperatorPubkeyGuard` (issue #819) for the test scope.

## Root cause

`resolve_operator_pubkey()` (`src/governance/rules_store.rs:262`) checks two sources:

1. `AI_MEMORY_OPERATOR_PUBKEY` env var (cleared by the test)
2. `dirs::config_dir() / "ai-memory/operator.key.pub"` on disk (NOT cleared)

On a dev host with `~/Library/Application Support/ai-memory/operator.key.pub` (macOS) the on-disk lookup wins, `pubkey_resolved = true`, and the SEC-2 fail-closed bail at `bootstrap_serve` (`src/daemon_runtime.rs:2435`) never fires.

Documented test-only escape hatch already exists for exactly this case at `src/governance/rules_store.rs:262-308` (`force_no_operator_pubkey_for_test()`); PR #795 missed wiring it into the SEC-2 test.

## Fix

Acquire the guard at the top of the test, before any other state setup. 16 lines net (15 explanatory doc-comment + 2 lines code):

```rust
let _no_pubkey_guard =
    crate::governance::rules_store::force_no_operator_pubkey_for_test();
```

Drop impl restores prior state automatically. Mirrors the hermetic-test pattern FX-F1 PR #1369 applied to the #1053 DNS-fail-closed test.

## Verification

```
cargo check --lib --tests                                    — exit 0 (8m45s)
cargo test --lib -- daemon_runtime::tests::test_bootstrap_serve
                                                              — 11/11 passed
                                                                (was 10/11 on
                                                                 this host pre-fix)
```

The fix is single-test-scoped; no impact on other tests or production code paths (the guard is `#[cfg(test)]`-gated).

## Test plan

- [ ] All CI gates pass against `release/v0.7.0`
- [ ] No regression in `daemon_runtime::tests::test_bootstrap_serve_*` family
- [ ] No regression in `governance::*` tests (they use the same guard pattern from #819 — load-bearing for them too)
- [ ] Operator review

Base: `5bfbb109c06aba8ac71b1c473ab89052494ef5ce`

Related: #819 (escape hatch origin), #795 (test origin), #1370 (this defect), #1369 (FX-F1 PR that surfaced the finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)