### PR TITLE
fix(tests, #1372): normalize CRLF → LF in arch_14_route_count_invariant

### DIFF
--- a/tests/route_count_invariant.rs
+++ b/tests/route_count_invariant.rs
@@ -22,7 +22,16 @@ use std::fs;
 
 #[test]
 fn arch_14_route_count_invariant() {
-    let src = fs::read_to_string("src/lib.rs").expect("read src/lib.rs");
+    // Normalize CRLF → LF at read time. The static-text scan below
+    // uses literal `\n` anchors (e.g. `"\n#[cfg(test)]\nmod "`); on
+    // Windows the runner checkout converts `\n` → `\r\n` via
+    // `core.autocrlf=true`, so the literal `\n` patterns never match
+    // and `.find(...)` returns None. Issue #1374 documents the
+    // failure on the windows-latest Check job. Stripping `\r` makes
+    // the test hermetic across every checkout configuration.
+    let src = fs::read_to_string("src/lib.rs")
+        .expect("read src/lib.rs")
+        .replace("\r\n", "\n");
 
     // Locate the build_router_with_timeout fn — its body contains
     // every production route. Then locate the `#[cfg(test)]\nmod


### PR DESCRIPTION
## Summary

Closes #1372.

**Note on issue numbering.** The commit message on this PR cites `#1374` due to a handoff-memory transposition in the prior session — the actual GitHub issue for the Windows CRLF defect is `#1372` (the AGE graph race is at `#1374`, which has been closed separately as flake-not-reproducing). GitHub's auto-close fires from this PR body's `Closes` keyword, so the correct issue will be closed on merge. The commit-text reference rots; do not re-cite the commit text in future cross-references.

`arch_14_route_count_invariant` panics on the Check (windows-latest) job with `"locate inline #[cfg(test)] mod sentinel after build_router_with_timeout"`. Root cause: the test uses literal `\n` anchors in `.find(...)` patterns, but the Windows checkout with `core.autocrlf=true` converts `\n` → `\r\n` on disk, so the patterns never match.

Fix: normalize CRLF → LF on read (10-line change including the explanatory comment).

```rust
let src = fs::read_to_string("src/lib.rs")
    .expect("read src/lib.rs")
    .replace("\r\n", "\n");
```

Pre-existing on `release/v0.7.0` baseline (`5bfbb109c` and forward); affected every recent PR that ran the Windows job. PR #1369 (FX-F1) and PR #1371 (#1370 SEC-2 fix) both inherited the failure — they merged with the macOS gate fixed but Windows still red.

## Verification (local macOS, dev host)

```
cargo fmt --check                       — exit 0
cargo test --test route_count_invariant — 1/1 passed
```

The `.replace("\r\n", "\n")` is a no-op on LF input, so the change is non-breaking on the platforms that already worked. Windows correctness is verified by CI on this PR — `Check (windows-latest)`: PASS (1h0m47s) on workflow run 26533974559.

## Test plan

- [x] All CI gates pass except `Check (ubuntu-latest)` (blocked by sibling #1373 ENOSPC — fix in PR #1376)
- [x] Windows Check job specifically green
- [x] No regression on Linux / macOS / iOS / Android cross-compile

Base: `a2986aaf07fa7eb838f4e6ecdd84910dec0b59aa`

Related: #1372 (this defect), #1369 (FX-F1) + #1371 (#1370 SEC-2) which surfaced the failure inheritance, commit `67535c159` (test origin in FX-C4-batch2), PR #1376 (#1373 ubuntu ENOSPC fix that unblocks this PR's merge), #1374 (sibling AGE graph race — closed as flake-not-reproducing 2026-05-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)