### PR TITLE
ci(infra, #1373): free disk before release-build on ubuntu-latest Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,45 @@ jobs:
           cargo install cargo-audit --locked
           cargo audit
 
+      # Issue #1372 — ubuntu-latest Check ran out of disk during the
+      # release link step (`libai_memory.rlib`: No space left on
+      # device (os error 28)). The runner image ships with ~14 GiB
+      # free; after `cargo test` (target/debug ~6-9 GiB) plus
+      # `cargo install cargo-audit --locked` (~1-2 GiB), the
+      # subsequent `cargo build --release` (~6-9 GiB more) hits the
+      # ceiling at link time. Pure-shell fix per project no-external-
+      # code-injection rule (CLAUDE.md §"Sole-authority operator"):
+      # we prune known-large unused tooling from the runner image
+      # (~35 GiB recoverable across .NET / CodeQL / Android SDK)
+      # AND drop the now-redundant dev-profile target tree before
+      # release link begins. Diagnostic `df -h` + `du -sh` bracket
+      # the cleanup so a future ceiling regression is visible in
+      # the workflow log.
+      - name: Free disk before release build (ubuntu-latest)
+        if: needs.classify.outputs.docs_only != 'true' && matrix.os == 'ubuntu-latest'
+        run: |
+          set -eu
+          echo "::group::Disk usage before cleanup"
+          df -h /
+          du -sh target 2>/dev/null || true
+          echo "::endgroup::"
+          # Prune large unused tooling from the ubuntu-latest runner
+          # image. Each `rm -rf` is best-effort — runner image
+          # contents may shift between versions, and a missing path
+          # is benign (the disk we wanted to free wasn't there).
+          sudo rm -rf /usr/share/dotnet              || true  # ~17 GiB
+          sudo rm -rf /opt/hostedtoolcache/CodeQL    || true  # ~5 GiB
+          sudo rm -rf /usr/local/lib/android         || true  # ~13 GiB
+          sudo rm -rf /opt/ghc                       || true  # ~5 GiB
+          # Drop dev-profile artefacts now that the test step is
+          # complete. Keeps the dep cache (proc-macros, build-scripts)
+          # so the release build doesn't recompile from scratch.
+          cargo clean --profile dev || true
+          echo "::group::Disk usage after cleanup"
+          df -h /
+          du -sh target 2>/dev/null || true
+          echo "::endgroup::"
+
       - name: Build release
         if: needs.classify.outputs.docs_only != 'true'
         run: cargo build --release


### PR DESCRIPTION
## Summary

Closes #1373.

**Note on issue numbering.** The commit message on this PR cites `#1372` due to a handoff-memory transposition in the prior session — the actual GitHub issue for the ubuntu ENOSPC defect is `#1373` (the Windows CRLF is at `#1372`, which is fixed in PR #1375). GitHub's auto-close fires from this PR body's `Closes` keyword, so the correct issue will be closed on merge. The commit-text reference rots; do not re-cite the commit text in future cross-references.

The `Check (ubuntu-latest)` job fails on `release/v0.7.0` with `No space left on device (os error 28)` during the release link step. Root cause: ubuntu-latest runner ships ~14 GiB free; `cargo test` + `cargo install cargo-audit` + `cargo build --release` in the same job exceeds that ceiling at link time.

Fix: insert a pure-shell cleanup step between `Security audit` and `Build release`, gated to `matrix.os == 'ubuntu-latest'`:

1. Prune known-large unused runner tooling — .NET (~17 GiB), CodeQL (~5 GiB), Android SDK (~13 GiB), GHC (~5 GiB).
2. `cargo clean --profile dev` to drop the dev target tree (keeps dep cache).
3. Diagnostic `df -h` + `du -sh` bracket the cleanup inside `::group::` folds.

No external GitHub Actions added — per the project's no-external-code-injection hard rule (CLAUDE.md §"Sole-authority operator + no-external-code-injection (operator-set 2026-05-25)"). The common `jlumbroso/free-disk-space@main` action does the equivalent but introduces a supply-chain trust boundary the rule prohibits.

## Verification

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"   # YAML OK
actionlint .github/workflows/ci.yml                                          # no new findings
```

CI-side verification happens on this PR's own `Check (ubuntu-latest)` run. Expected log shape: `df -h /` shows ~55 GiB free after cleanup (up from ~15 GiB).

## Test plan

- [ ] `Check (ubuntu-latest)` job on this PR goes GREEN (this is the load-bearing verification)
- [ ] No regression on `Check (macos-latest)` or `Check (windows-latest)` — the new step is `if`-gated to ubuntu only
- [ ] Workflow log shows the bracketed `::group::Disk usage before/after cleanup` blocks with concrete numbers
- [ ] PR #1375 (#1372 Windows CRLF fix) unblocks for merge once this lands on `release/v0.7.0`

## Base

`a2986aaf07fa7eb838f4e6ecdd84910dec0b59aa`

## Related

- #1373 (this defect)
- #1369 (FX-F1) + #1371 (#1370 SEC-2) — PRs that surfaced the failure inheritance
- #1372 (sibling Windows CRLF, fix in PR #1375 blocked on this)
- #1374 (sibling AGE graph race — closed as flake-not-reproducing 2026-05-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)