### PR TITLE
test(postgres): per-test schema isolation for 4 lan-parity-shared-container failures

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -34,6 +34,24 @@
 
 // Per-test postgres schema isolation helper (issue #1381).
 // See module-level docs in `postgres_env.rs`.
+//
+// Gated on `feature = "sal-postgres"` because the helper depends on
+// `sqlx::PgPool` (which is a dev-dependency but still bloats the
+// per-binary compile + link work in the default-features cargo test
+// invocation). Pre-#1381-gating, `tests/common/mod.rs` exposed
+// `postgres_env` to all 74 integration test binaries unconditionally,
+// pulling sqlx into every link unit. The doctest link step (which
+// happens at the END of `cargo test`) then hit a `ld terminated with
+// signal 7 [Bus error]` on ubuntu-latest, deterministically, across
+// 3 consecutive CI runs — the runner image's tmpfs ran out of room
+// for the mmap'd rlib aggregate during doctest link. Gating
+// `postgres_env` to `sal-postgres` is the minimal fix that keeps the
+// helper available to the 3 tests that actually use it
+// (`migrate_links_roundtrip`, `embedding_dim_migration`,
+// `issue_1213_atttypmod_age_schema_scope` — all `#![cfg(feature =
+// "sal-postgres")]`) while dropping the per-binary sqlx pull from
+// the other 71 binaries.
+#[cfg(feature = "sal-postgres")]
 pub mod postgres_env;
 
 use std::path::PathBuf;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,6 +32,10 @@
 
 #![allow(dead_code)]
 
+// Per-test postgres schema isolation helper (issue #1381).
+// See module-level docs in `postgres_env.rs`.
+pub mod postgres_env;
+
 use std::path::PathBuf;
 use std::sync::Mutex;
 

--- a/tests/common/postgres_env.rs
+++ b/tests/common/postgres_env.rs
@@ -1,0 +1,421 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-test Postgres schema isolation helper (issue #1381).
+//!
+//! ## Why this exists
+//!
+//! The full v0.7.0 postgres+AGE regression run on the LAN-parity
+//! container at `127.0.0.1:15432` (2026-05-28) surfaced 4 deterministic
+//! test failures (filed as issue #1381) that all share a single root
+//! cause: tests assume an empty / known `public.memories` schema state
+//! but the container accumulates state from prior tests in the same
+//! `cargo test --features sal,sal-postgres` invocation. CI's
+//! Postgres-feature gate uses `--test-threads=1` and a one-shot
+//! container per job so it doesn't manifest there; the lan-parity
+//! shared-container path is what surfaces it.
+//!
+//! ## What this helper does
+//!
+//! [`PostgresTestEnv::new`] connects to the base
+//! `AI_MEMORY_TEST_POSTGRES_URL`, `CREATE SCHEMA test_<test>_<uuid8>`,
+//! and returns a per-test URL with `?options=-c%20search_path=<schema>`
+//! appended so every connect from that URL lands its tables in the
+//! isolated schema. Postgres tables created via unqualified
+//! `CREATE TABLE IF NOT EXISTS memories (…)` (the shape used by the
+//! production bootstrap in `src/store/postgres_schema.sql`) honour
+//! `search_path` and land in the test schema, not in `public`.
+//!
+//! [`SchemaCleanupGuard`] is the `Drop`-time worker that issues
+//! `DROP SCHEMA <schema> CASCADE` against the base URL so the test
+//! container doesn't accumulate schema clutter across test runs. The
+//! drop is best-effort (drop-on-panic safe) and surfaces failures via
+//! `eprintln!` rather than propagating — drop is infallible by trait
+//! contract.
+//!
+//! ## What this helper does NOT do
+//!
+//! - It does NOT touch `public.memories`. Tests that need a clean
+//!   `public.*` for some reason (e.g., the post-fix `current_dim`
+//!   probes that hardcode `n.nspname='public'` in
+//!   `src/store/postgres.rs`) need their own scope discipline — see
+//!   [`PostgresTestEnv::schema_name`] for the test-schema name to
+//!   filter catalog probes against.
+//! - It does NOT acquire the `MIGRATION_ADVISORY_LOCK_KEY`; the
+//!   substrate's `PostgresStore::connect` does that already and the
+//!   lock is process-global, not schema-scoped.
+//!
+//! ## When per-test schema isolation is NOT enough
+//!
+//! A handful of tests (e.g. `embedding_dim_migration`) specifically
+//! exercise the substrate's `connect_with_dim_and_timeout_auto_migrate`
+//! path which is HARDCODED to probe + migrate `public.memories` (see
+//! `current_embedding_dim` at `src/store/postgres.rs:2782` — the
+//! `n.nspname = 'public'` filter is intentional, not bug). For those
+//! tests, [`PublicSchemaLock::acquire`] returns a cross-process
+//! advisory lock that serialises ownership of `public.memories`
+//! across every parallel test binary in the same cargo invocation.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! mod common;
+//! use common::postgres_env::PostgresTestEnv;
+//!
+//! #[tokio::test]
+//! async fn my_test() {
+//!     let Some(env) = PostgresTestEnv::new("my_test").await else {
+//!         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+//!         return;
+//!     };
+//!     let store = PostgresStore::connect(env.url()).await.unwrap();
+//!     // … test body; schema dropped automatically on `env` drop …
+//! }
+//! ```
+
+#![allow(dead_code)]
+
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+
+/// Per-test isolated Postgres schema + URL wrapper.
+///
+/// Created via [`PostgresTestEnv::new`]; the returned struct holds a
+/// [`SchemaCleanupGuard`] that fires `DROP SCHEMA <name> CASCADE` on
+/// drop. Hold the env for the lifetime of the test body so the schema
+/// isn't dropped out from under live connections.
+pub struct PostgresTestEnv {
+    base_url: String,
+    url_with_search_path: String,
+    schema_name: String,
+    // Held purely for Drop side effects.
+    _cleanup: SchemaCleanupGuard,
+}
+
+impl PostgresTestEnv {
+    /// Connect to the base `AI_MEMORY_TEST_POSTGRES_URL`, create a
+    /// unique schema `test_<test_name>_<uuid8>`, and return a wrapper
+    /// whose `url()` accessor yields a URL with
+    /// `?options=-c%20search_path=<schema>` appended so every connect
+    /// from that URL lands in the isolated schema.
+    ///
+    /// Returns `None` when `AI_MEMORY_TEST_POSTGRES_URL` is unset, so
+    /// the caller can `eprintln!("skip: …")` and return early — same
+    /// shape as the existing per-test `postgres_url()` skip pattern.
+    ///
+    /// `test_name` is sanitised to be a valid postgres identifier:
+    /// lowercased, non-alphanumeric characters mapped to `_`, and
+    /// truncated to 24 chars. Combined with the 8-hex uuid suffix the
+    /// final schema name fits comfortably within Postgres's 63-char
+    /// `NAMEDATALEN` limit.
+    pub async fn new(test_name: &str) -> Option<Self> {
+        let base_url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        let sanitised = sanitise_for_pg_ident(test_name, 24);
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let schema_name = format!("test_{sanitised}_{}", &suffix[..8]);
+
+        let pool = connect_admin_pool(&base_url).await;
+        sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema_name}"))
+            .execute(&pool)
+            .await
+            .unwrap_or_else(|e| panic!("create schema {schema_name}: {e}"));
+
+        let url_with_search_path = append_search_path_option(&base_url, &schema_name);
+
+        let cleanup = SchemaCleanupGuard {
+            base_url: base_url.clone(),
+            schema_name: schema_name.clone(),
+        };
+
+        Some(Self {
+            base_url,
+            url_with_search_path,
+            schema_name,
+            _cleanup: cleanup,
+        })
+    }
+
+    /// The per-test URL with `?options=-c%20search_path=<schema>`
+    /// appended. Pass this to `PostgresStore::connect(...)` or any
+    /// `sqlx` connect call so the session's `search_path` lands the
+    /// isolated schema first.
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url_with_search_path
+    }
+
+    /// The bare `AI_MEMORY_TEST_POSTGRES_URL` without the
+    /// `search_path` override — useful when a test needs an inspection
+    /// pool that explicitly bypasses the `search_path` scoping so it can
+    /// probe catalog rows across all schemas.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// The unique per-test schema name. Use this to filter catalog
+    /// probes against `pg_namespace.nspname` so they only see the
+    /// test's own schema and not residue from other tests in the
+    /// shared container.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+}
+
+/// Drop-time worker that issues `DROP SCHEMA <name> CASCADE` against
+/// the base URL so the test container doesn't accumulate schema
+/// clutter across test runs.
+///
+/// The drop is best-effort — failures are surfaced via `eprintln!`
+/// (drop is infallible by trait contract). A spawned blocking thread
+/// is used because `drop` is not async and we cannot await the sqlx
+/// drop inline.
+pub struct SchemaCleanupGuard {
+    base_url: String,
+    schema_name: String,
+}
+
+impl Drop for SchemaCleanupGuard {
+    fn drop(&mut self) {
+        let base_url = self.base_url.clone();
+        let schema_name = self.schema_name.clone();
+        // Drop is sync; sqlx is async. Spawn a thread that builds its
+        // own tokio runtime to run the DROP SCHEMA. The thread joins
+        // on drop completion so the schema is gone before the next
+        // test's setup runs (important for the issue #1213 tests that
+        // assert exact catalog row counts).
+        let join = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build drop-time tokio runtime");
+            rt.block_on(async move {
+                let pool = match PgPoolOptions::new()
+                    .max_connections(1)
+                    .acquire_timeout(std::time::Duration::from_secs(10))
+                    .connect(&base_url)
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!(
+                            "PostgresTestEnv cleanup: failed to connect for drop of {schema_name}: {e}"
+                        );
+                        return;
+                    }
+                };
+                if let Err(e) = sqlx::query(&format!(
+                    "DROP SCHEMA IF EXISTS {schema_name} CASCADE"
+                ))
+                .execute(&pool)
+                .await
+                {
+                    eprintln!(
+                        "PostgresTestEnv cleanup: DROP SCHEMA {schema_name} CASCADE failed: {e}"
+                    );
+                }
+            });
+        });
+        // We deliberately let the thread join here so the cleanup
+        // completes before the next test's PostgresTestEnv::new runs.
+        // join() returning an Err means the thread panicked during
+        // cleanup; we surface that to stderr but do NOT re-panic from
+        // Drop (double-panic during unwind would abort the process).
+        if let Err(e) = join.join() {
+            eprintln!(
+                "PostgresTestEnv cleanup thread for {} panicked: {:?}",
+                self.schema_name, e
+            );
+        }
+    }
+}
+
+/// Build a one-shot inspection pool against the base URL with the
+/// `search_path` NOT scoped — used internally by [`PostgresTestEnv::new`]
+/// to issue the `CREATE SCHEMA` and re-used by callers via
+/// [`PostgresTestEnv::base_url`] when a test needs a cross-schema
+/// inspection view.
+async fn connect_admin_pool(base_url: &str) -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(std::time::Duration::from_secs(10))
+        .connect(base_url)
+        .await
+        .unwrap_or_else(|e| panic!("PostgresTestEnv: connect base pool: {e}"))
+}
+
+/// Append `?options=-c%20search_path=<schema>,public` to a Postgres
+/// URL, preserving any pre-existing query string. We avoid pulling
+/// in `url` just for this and stick to manual string handling
+/// because the shape we need is small + stable.
+///
+/// `public` is appended after the test schema so DDL like
+/// `CREATE TABLE memories (... embedding vector(N))` (the production
+/// bootstrap shape from `src/store/postgres_schema.sql`) can still
+/// resolve `vector` against the `public.vector` extension type
+/// while `CREATE TABLE` (etc.) lands the `memories` row into the
+/// test's schema (the first writable schema in `search_path` is the
+/// default-write-target).
+fn append_search_path_option(base_url: &str, schema: &str) -> String {
+    // Postgres URL `options` query-string accepts the same `-c key=val`
+    // syntax as a libpq connection string; we URL-encode the space
+    // as `%20`. Multiple `-c` settings can be chained but we only
+    // need search_path here.
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    format!("{base_url}{separator}options=-c%20search_path%3D{schema}%2Cpublic")
+}
+
+/// Sanitise an arbitrary string into a valid lowercase Postgres
+/// identifier fragment. Maps non-`[a-z0-9_]` characters to `_` and
+/// truncates to `max_len` chars.
+fn sanitise_for_pg_ident(s: &str, max_len: usize) -> String {
+    let lower = s.to_ascii_lowercase();
+    let mapped: String = lower
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed: String = mapped.chars().take(max_len).collect();
+    if trimmed.is_empty() {
+        "test".to_string()
+    } else {
+        trimmed
+    }
+}
+
+/// Cross-process advisory lock that serialises ownership of
+/// `public.memories` across every parallel test binary in the same
+/// cargo invocation.
+///
+/// Used by tests that exercise substrate paths hardcoded to probe
+/// `public.memories` (e.g. `current_embedding_dim` at
+/// `src/store/postgres.rs:2782`). The substrate already uses
+/// `MIGRATION_ADVISORY_LOCK_KEY` for bootstrap-serialisation; we pick
+/// a different magic number so we don't deadlock against
+/// `PostgresStore::connect` itself.
+///
+/// The lock is session-scoped: the held connection in
+/// [`PublicSchemaLock`] keeps the lock for the lifetime of the
+/// guard, and the explicit `pg_advisory_unlock` in `Drop` releases
+/// it deterministically (rather than relying on session-end
+/// release on connection drop).
+pub struct PublicSchemaLock {
+    pool: PgPool,
+    key: i64,
+}
+
+impl PublicSchemaLock {
+    /// Magic integer keyed for the `public.memories` ownership lock.
+    /// Picked outside the substrate's `MIGRATION_ADVISORY_LOCK_KEY`
+    /// range so we don't accidentally re-acquire its lock and
+    /// deadlock against the bootstrap path.
+    const PUBLIC_MEMORIES_LOCK_KEY: i64 = 0x1381_5081_1F50_1357_u64.cast_signed();
+
+    /// Acquire the cross-process advisory lock that serialises
+    /// ownership of `public.memories`. Returns `None` when
+    /// `AI_MEMORY_TEST_POSTGRES_URL` is unset so the caller can
+    /// `eprintln!("skip: …")` and return early.
+    ///
+    /// The acquisition queues behind any existing holder
+    /// (`pg_advisory_lock` is the queued, not the try-shape, variant)
+    /// — slow peer tests simply make us wait.
+    ///
+    /// Designed to be `await`-ed from inside a `#[tokio::test]`
+    /// runtime — we deliberately do NOT spin up a private runtime
+    /// here because nested runtimes panic with "Cannot start a
+    /// runtime from within a runtime" under sqlx's current-thread
+    /// driver.
+    pub async fn acquire() -> Option<Self> {
+        let base_url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(std::time::Duration::from_secs(10))
+            .connect(&base_url)
+            .await
+            .unwrap_or_else(|e| panic!("PublicSchemaLock: connect: {e}"));
+        let key = Self::PUBLIC_MEMORIES_LOCK_KEY;
+        sqlx::query("SELECT pg_advisory_lock($1)")
+            .bind(key)
+            .execute(&pool)
+            .await
+            .unwrap_or_else(|e| panic!("PublicSchemaLock: pg_advisory_lock: {e}"));
+        Some(Self { pool, key })
+    }
+}
+
+impl Drop for PublicSchemaLock {
+    fn drop(&mut self) {
+        // Release the advisory lock explicitly. Best-effort — Drop
+        // is infallible by trait contract, so we eprintln on
+        // failure rather than propagating.
+        //
+        // Drop is sync; sqlx is async. Spawn a thread that builds its
+        // OWN tokio runtime so we don't double-enter the test
+        // runtime. The thread joins before Drop returns so the lock
+        // is reliably released by the time the next test's
+        // `acquire()` can re-take it.
+        let key = self.key;
+        let pool = self.pool.clone();
+        let join = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build PublicSchemaLock drop-time tokio runtime");
+            rt.block_on(async move {
+                sqlx::query("SELECT pg_advisory_unlock($1)")
+                    .bind(key)
+                    .execute(&pool)
+                    .await
+            })
+        });
+        match join.join() {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => eprintln!("PublicSchemaLock: pg_advisory_unlock failed: {e}"),
+            Err(e) => eprintln!("PublicSchemaLock: unlock thread panicked: {e:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_search_path_option, sanitise_for_pg_ident};
+
+    #[test]
+    fn append_search_path_uses_question_mark_when_no_query() {
+        let url = append_search_path_option("postgres://u:p@h/db", "test_schema");
+        // `,public` is appended so DDL like `embedding vector(N)` can
+        // still resolve the `vector` type from the `public.vector`
+        // extension while the test's own schema receives newly
+        // CREATEd tables (first writable schema in search_path wins).
+        assert_eq!(
+            url,
+            "postgres://u:p@h/db?options=-c%20search_path%3Dtest_schema%2Cpublic"
+        );
+    }
+
+    #[test]
+    fn append_search_path_uses_ampersand_when_query_present() {
+        let url = append_search_path_option("postgres://u:p@h/db?sslmode=disable", "t1");
+        assert_eq!(
+            url,
+            "postgres://u:p@h/db?sslmode=disable&options=-c%20search_path%3Dt1%2Cpublic"
+        );
+    }
+
+    #[test]
+    fn sanitise_maps_punctuation_to_underscore_and_truncates() {
+        let s = sanitise_for_pg_ident("issue-1213::probe with spaces", 16);
+        assert_eq!(s, "issue_1213__prob");
+    }
+
+    #[test]
+    fn sanitise_empty_input_falls_back_to_test() {
+        assert_eq!(sanitise_for_pg_ident("", 16), "test");
+    }
+}

--- a/tests/embedding_dim_migration.rs
+++ b/tests/embedding_dim_migration.rs
@@ -43,23 +43,33 @@ use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 
 mod common;
+use common::postgres_env::PublicSchemaLock;
 use common::postgres_url;
 
-/// Process-wide async mutex serializing the 3 dim-migration tests in
-/// this binary against a shared postgres scratch DB.
-///
-/// v0.7.0 ship-hardening (2026-05-19): the tests each call
-/// `reset_schema` then bootstrap the schema at their target dim.
-/// Without serialization they race: test A drops tables, test B drops
-/// (no-op), test B bootstraps at 768, test A bootstraps at 384 — but
-/// `connect_with_dim` is a NO-OP on an existing schema, so test A sees
-/// 768 from test B's bootstrap and asserts fail. The race was
-/// observable but uncommon until the connect-time advisory lock
-/// (`MIGRATION_ADVISORY_LOCK_KEY`) introduced a small queueing delay
-/// that widened the interleaving window. Holding this mutex from
-/// `reset_schema` through the assertion keeps each test's
-/// (reset → bootstrap → verify) sequence atomic relative to peers.
-static SUITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+// Issue #1381 (2026-05-28): the three tests in this file exercise
+// substrate paths that are HARDCODED to probe + mutate
+// `public.memories` (see `current_embedding_dim` at
+// `src/store/postgres.rs:2782` — the `n.nspname = 'public'` filter
+// is intentional). Per-test schema isolation via `PostgresTestEnv`
+// does NOT fit this file, because the substrate's auto-migrate
+// path would still target `public.memories` regardless of the
+// test's `search_path`.
+//
+// Instead, every `#[tokio::test]` here acquires the cross-process
+// `PublicSchemaLock` (defined in `tests/common/postgres_env.rs`) at
+// the top of the body. The lock serialises ownership of
+// `public.memories` across every parallel test binary in the same
+// `cargo test --features sal,sal-postgres` invocation, not just
+// the three tests in this file — that is the actual race the
+// pre-#1381 in-process `tokio::sync::Mutex` could not close,
+// because a sibling test binary (e.g. `migrate_links_roundtrip`)
+// running in parallel would still race us on `public.memories`.
+//
+// `current_dim` is ALSO scoped to `n.nspname = 'public'` so a
+// stale `memories` relation in `ic_alice`/`ic_bob`/etc on the
+// LAN-parity stack does NOT shadow our reset → bootstrap sequence
+// (the pre-#1381 unscoped probe surfaced whichever schema's
+// row Postgres picked first by oid, often the wrong one).
 
 /// Drop ai-memory tables so each test gets a fresh schema. The postgres
 /// fixture is shared across tests in the suite, so we tear down the
@@ -103,10 +113,17 @@ async fn inspection_pool(url: &str) -> PgPool {
 }
 
 async fn current_dim(pool: &PgPool) -> Option<i32> {
+    // Issue #1381: scope to `public.memories` so a sibling
+    // `<other_schema>.memories` (e.g. the LAN-parity stack's
+    // long-lived `ic_alice`/`ic_bob` daemon schemas or any other
+    // test binary's residual schema) does NOT shadow the dim we
+    // just bootstrapped into `public`. Mirrors the substrate's own
+    // probe at `src/store/postgres.rs:2787` (`current_embedding_dim`).
     sqlx::query_scalar::<_, i32>(
         "SELECT atttypmod FROM pg_attribute a
          JOIN pg_class c ON c.oid = a.attrelid
-         WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public' AND c.relname = 'memories' AND a.attname = 'embedding'",
     )
     .fetch_optional(pool)
     .await
@@ -122,7 +139,11 @@ async fn auto_migrate_converts_384_schema_to_768_on_daemon_bootstrap() {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
-    let _guard = SUITE_LOCK.lock().await;
+    // Issue #1381: cross-process serialise on `public.memories`
+    // ownership so a sibling test binary's bootstrap can't race us.
+    let _public_lock = PublicSchemaLock::acquire()
+        .await
+        .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;
     reset_schema(&inspect).await;
@@ -179,7 +200,9 @@ async fn auto_migrate_no_op_when_fresh_schema_already_matches() {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
-    let _guard = SUITE_LOCK.lock().await;
+    let _public_lock = PublicSchemaLock::acquire()
+        .await
+        .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;
     reset_schema(&inspect).await;
@@ -210,7 +233,9 @@ async fn http_write_path_accepts_768_after_auto_migrate() {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
-    let _guard = SUITE_LOCK.lock().await;
+    let _public_lock = PublicSchemaLock::acquire()
+        .await
+        .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;
     reset_schema(&inspect).await;

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -43,6 +43,9 @@ use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+mod common;
+use common::postgres_env::PublicSchemaLock;
+
 fn postgres_url() -> Option<String> {
     std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
 }
@@ -171,6 +174,13 @@ async fn issue_1213_atttypmod_probe_scopes_to_public_schema() {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
+    // #1381: cross-process serialise on `public.memories` ownership
+    // so a sibling test binary's bootstrap of `public.memories`
+    // doesn't conflict with this test's `CREATE TABLE public.memories`
+    // staging.
+    let _public_lock = PublicSchemaLock::acquire()
+        .await
+        .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     // pgvector is required for `vector(N)` columns; refuse to run if
     // the extension isn't enrolled so the failure mode is "skip"
@@ -212,14 +222,26 @@ async fn issue_1213_atttypmod_probe_scopes_to_public_schema() {
     // Step 3: confirm BOTH tables exist with their respective dims
     // (this is a sanity check; failure here would mean the test
     // staging is wrong, not the production bug).
+    //
+    // #1381: filter to only the schemas this test OWNS (public +
+    // `other_schema`). The LAN-parity shared-container path leaves
+    // long-lived `ic_alice`/`ic_bob` daemon schemas (each with their
+    // own `memories` table) in `pg_class` — an unfiltered probe sees
+    // 5+ rows on that stack, breaking the `dims.len() == 2`
+    // staging-sanity check even though the test's OWN staging is
+    // correct. The post-#1381 filter scopes the assertion to the
+    // test's surface so the staging-sanity check stays
+    // load-bearing without false-positives on shared infra.
     let dims: Vec<(String, i32)> = sqlx::query_as(
         "SELECT n.nspname::text, a.atttypmod
          FROM pg_attribute a
          JOIN pg_class c ON c.oid = a.attrelid
          JOIN pg_namespace n ON n.oid = c.relnamespace
          WHERE c.relname = 'memories' AND a.attname = 'embedding'
+         AND n.nspname IN ('public', $1)
          ORDER BY n.nspname",
     )
+    .bind(other_schema)
     .fetch_all(&pool)
     .await
     .expect("inspect both memories tables");
@@ -292,6 +314,10 @@ async fn issue_1213_unscoped_probe_demonstrates_root_cause() {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
+    // #1381: see sibling test for rationale on PublicSchemaLock.
+    let _public_lock = PublicSchemaLock::acquire()
+        .await
+        .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let pool = inspect_pool(&url).await;
     let pgvector_present: Option<(i32,)> =
@@ -331,11 +357,25 @@ async fn issue_1213_unscoped_probe_demonstrates_root_cause() {
     // Pre-fix probe — `fetch_all` so the test is deterministic on
     // either oid-order outcome; we then assert the scoped probe
     // disagrees with at-least-one of the unscoped rows.
+    //
+    // #1381: filter to only the schemas this test OWNS (public +
+    // `other_schema`). Same rationale as the sibling test: the
+    // LAN-parity shared container has long-lived `ic_alice`/`ic_bob`
+    // daemon schemas whose `memories` rows shadow the test's own
+    // staging when the probe is unfiltered. The pre-#1381 "unscoped"
+    // semantics being demonstrated here is "no `n.nspname=…public`
+    // filter against the test's OWN staging surface", not "no
+    // `nspname IN (…)` filter at all" — the latter has nothing to
+    // do with #1213's root cause and only exists as test-rig
+    // staging.
     let unscoped: Vec<(i32,)> = sqlx::query_as(
         "SELECT atttypmod FROM pg_attribute a
          JOIN pg_class c ON c.oid = a.attrelid
-         WHERE c.relname = 'memories' AND a.attname = 'embedding'",
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relname = 'memories' AND a.attname = 'embedding'
+         AND n.nspname IN ('public', $1)",
     )
+    .bind(other_schema)
     .fetch_all(&pool)
     .await
     .expect("unscoped probe");

--- a/tests/migrate_links_roundtrip.rs
+++ b/tests/migrate_links_roundtrip.rs
@@ -27,6 +27,9 @@ use ai_memory::models::{Memory, MemoryLink, Tier};
 use ai_memory::store::sqlite::SqliteStore;
 use ai_memory::store::{CallerContext, MemoryStore};
 
+#[cfg(feature = "sal-postgres")]
+mod common;
+
 fn ctx() -> CallerContext {
     CallerContext::for_agent("ai:migrate-roundtrip")
 }
@@ -265,11 +268,22 @@ async fn migrate_links_sqlite_to_postgres_to_sqlite_roundtrip() {
     // be identical, proving the link set survives a full cross-backend
     // round trip.
     use ai_memory::store::postgres::PostgresStore;
+    use common::postgres_env::PostgresTestEnv;
 
-    let Ok(pg_url) = std::env::var("AI_MEMORY_TEST_POSTGRES_URL") else {
+    // #1381: per-test schema isolation via search_path. Pre-#1381 the
+    // test connected to the bare base URL which bootstrapped into
+    // `public.memories`; a sibling test (e.g. `issue_1213_*`) leaving
+    // `public.memories` in a partially-migrated state (only `(id,
+    // embedding)` columns) caused this test's bootstrap-time
+    // `CREATE UNIQUE INDEX ... ON memories (title, namespace)` to fail
+    // with `column "title" does not exist`. Per-test schema isolation
+    // sidesteps the shared-state race entirely: the bootstrap creates
+    // a fresh `memories` table inside the test's own schema.
+    let Some(env) = PostgresTestEnv::new("migrate_links_roundtrip").await else {
         eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
         return;
     };
+    let pg_url = env.url().to_string();
 
     let src_tmp = tempfile::NamedTempFile::new().unwrap();
     let dst_tmp = tempfile::NamedTempFile::new().unwrap();
@@ -279,7 +293,10 @@ async fn migrate_links_sqlite_to_postgres_to_sqlite_roundtrip() {
 
     // Pre-clean the live PG so a previous run's seed corpus doesn't
     // leak into this run's count assertions. We delete only memories
-    // in our test namespace; cascade drops the linked rows.
+    // in our test namespace; cascade drops the linked rows. With #1381
+    // schema isolation this is also defence-in-depth — a fresh
+    // per-test schema starts empty, but the cleanup keeps the test
+    // robust if `PostgresTestEnv::new` ever reused a leftover schema.
     sqlx_cleanup_namespace(&pg_url, "roundtrip").await;
 
     seed_corpus(&src).await;


### PR DESCRIPTION
## Summary

Closes the 4 deterministic test failures the 2026-05-28 v0.7.0 ship-campaign's postgres+AGE regression run surfaced against the shared LAN-parity container at `127.0.0.1:15432` (issue #1381):

- `embedding_dim_migration::auto_migrate_converts_384_schema_to_768_on_daemon_bootstrap`
- `issue_1213_atttypmod_age_schema_scope::issue_1213_unscoped_probe_demonstrates_root_cause`
- `issue_1213_atttypmod_age_schema_scope::issue_1213_atttypmod_probe_scopes_to_public_schema`
- `migrate_links_roundtrip::migrate_links_sqlite_to_postgres_to_sqlite_roundtrip`

All four share one root cause: tests assume an empty / known schema state on the postgres container but other tests in the same cargo invocation (and the long-lived `ic_alice` / `ic_bob` daemon schemas from the LAN-parity stack) accumulate state. CI's Postgres-feature gate runs `--test-threads=1` against a one-shot container per job so the issue doesn't manifest there; only the LAN-parity shared-container path surfaces it. **Substrate itself is GREEN — this is a test-isolation defect, not a substrate bug.**

## Fix shape

Two helpers in the new `tests/common/postgres_env.rs`:

1. **`PostgresTestEnv`** — per-test schema isolation. Connects to the base `AI_MEMORY_TEST_POSTGRES_URL`, `CREATE SCHEMA test_<name>_<uuid8>`, returns a URL with `?options=-c%20search_path=<schema>,public` appended. `Drop` runs `DROP SCHEMA … CASCADE`. `public` is in the search_path so `vector(N)` resolves; the test schema is FIRST so `CREATE TABLE IF NOT EXISTS memories` lands in the test's schema (PG's IF NOT EXISTS checks the first writable schema only — verified empirically against the LAN-parity stack).

2. **`PublicSchemaLock`** — cross-process advisory lock that serialises ownership of `public.memories` across every parallel test binary in the same cargo invocation. Used by tests that exercise substrate paths hardcoded to probe / mutate `public.memories` (the `current_embedding_dim` family at `src/store/postgres.rs:2782/3217`) where per-test schema isolation can't help. Key is picked outside the substrate's `MIGRATION_ADVISORY_LOCK_KEY` range to avoid bootstrap deadlock.

### Per-test migration

| Test file | Mechanism | Why |
|---|---|---|
| `embedding_dim_migration.rs` | `PublicSchemaLock` + `current_dim` scoped to `n.nspname = 'public'` | Substrate's `connect_with_dim_and_timeout_auto_migrate` is hardcoded to `public.memories`; can't schema-isolate. |
| `issue_1213_atttypmod_age_schema_scope.rs` | `PublicSchemaLock` + catalog probe filtered to `n.nspname IN ('public', $other_schema)` | Test explicitly stages `public.memories`; need cross-process lock to avoid races with sibling test binaries. |
| `migrate_links_roundtrip.rs` | `PostgresTestEnv` (per-test schema) | Test doesn't care about `public.memories` specifically; schema isolation sidesteps the partial-state race entirely. |

## Test plan

- [x] Tear down + rebuild lan-parity stack and run the 3 target test files (33/33 PASS including the 4 originally-failing tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features sal,sal-postgres --tests --release -- -D warnings -D clippy::all -D clippy::pedantic` clean
- [x] `cargo audit` clean
- [ ] Full `cargo test --release --no-fail-fast` (sqlite path, no postgres URL) — running, will update on completion
- [x] No substrate (`src/`) changes — only `tests/`

## Verification command

```bash
docker compose -f infra/lan-parity-test/docker-compose.yml down -v
docker compose -f infra/lan-parity-test/docker-compose.yml up -d --build
AI_MEMORY_TEST_POSTGRES_URL='postgres://ai_memory:ai_memory_test@127.0.0.1:15432/ai_memory_test' \
AI_MEMORY_NO_CONFIG=1 \
cargo test --features sal,sal-postgres --release \
  --test embedding_dim_migration \
  --test issue_1213_atttypmod_age_schema_scope \
  --test migrate_links_roundtrip
```

Result:

```
embedding_dim_migration .............. 11/11 PASS (30.72s)
issue_1213_atttypmod_age_schema_scope . 10/10 PASS (20.10s)
migrate_links_roundtrip .............. 12/12 PASS (0.52s)
```

Log: `.local-runs/2026-05-28-postgres-iso/three-test-run-final.log`

## Originating issue

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)