### PR TITLE
docs(landing): no-GPU "any LLM" autonomous backend callout (#1460)

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -6,6 +6,19 @@ sectioned configuration format introduced in
 Every deployment of `ai-memory` (MCP server, HTTP daemon, CLI) reads
 configuration from a single file at `~/.config/ai-memory/config.toml`.
 
+> **No GPU required.** Nothing in this schema is hard-wired to a GPU,
+> to Ollama, or to Gemma — those are the local-first default, not a
+> requirement. Post-[#1067](https://github.com/alphaonedev/ai-memory-mcp/issues/1067)
+> + #1146 the autonomous tier drives every feature through **any
+> OpenAI-compatible endpoint**: a remote cloud API (e.g. OpenRouter as
+> a low-cost example) *where you have API access*, or an internal
+> air-gapped HA inference VIP *where you have systems with no GPUs* and
+> want to run ai-memory in autonomous mode with `--profile full`. Set
+> `[llm].backend` to a cloud/`openai-compatible` value and the daemon
+> host carries no model weight at all (only the ~90 MB CPU
+> cross-encoder if `[reranker].enabled = true`). The model names below
+> are examples — substitute whatever your provider or endpoint serves.
+
 ## Quick reference
 
 ```toml

--- a/docs/RUNBOOK-digitalocean-testing.md
+++ b/docs/RUNBOOK-digitalocean-testing.md
@@ -287,11 +287,19 @@ report as `docs/CAMPAIGN-v0.6.0.0.md` on the release.
 
 ## Not included (deliberate)
 
-- **LLM / Ollama installation** on the droplets. Gemma 4 via Ollama
-  is compute-heavy and the DO test focuses on the memory system
-  itself. The curator phase runs with `--dry-run`; operators who
-  want the full LLM-mediated autonomy test should size up to
-  `s-4vcpu-16gb` and follow `RUNBOOK-curator-soak.md`.
+- **Local LLM (Ollama) installation** on the droplets. Running Gemma 4
+  *locally* via Ollama is compute-heavy, and this DO test focuses on the
+  memory system itself, so the curator phase runs with `--dry-run` on a
+  CPU-only droplet. This is a sizing choice for the local-model path, **not
+  a GPU requirement of ai-memory** — post-#1067/#1146 the autonomous tier
+  drives every feature through any OpenAI-compatible endpoint (a remote
+  cloud API like OpenRouter, or an internal HA inference VIP) with **no
+  local model and no GPU on the droplet**. Operators who want the full
+  LLM-mediated autonomy test on a small droplet point `[llm]` at a remote
+  backend (`AI_MEMORY_LLM_BACKEND` + `AI_MEMORY_LLM_API_KEY` +
+  `AI_MEMORY_LLM_MODEL`) per `docs/integrations/llm-backends.md`; those who
+  prefer the local-model path should size up to `s-4vcpu-16gb` and follow
+  `RUNBOOK-curator-soak.md`.
 - **TurboQuant compression** — scrapped (#284/#287). See CHANGELOG
   scrap note.
 - **Week-long soak** — not a ship-gate. Post-release validation; see

--- a/docs/autonomous.html
+++ b/docs/autonomous.html
@@ -209,7 +209,7 @@ footer a{color:var(--text-muted)}
   <div class="container">
     <span class="eyebrow">The four feature tiers</span>
     <h2 style="font-family:var(--font-sans);font-size:1.75rem">Pick the model size your hardware allows.</h2>
-    <p class="lede">Autonomous features unlock as the operator allocates more memory to the daemon. Keyword tier needs zero extra RAM — just FTS5. Semantic tier loads embeddings (~256 MB). Smart tier adds Gemma 4 E2B (~1 GB). Autonomous tier upgrades to Gemma 4 E4B + cross-encoder reranker (~4 GB total).</p>
+    <p class="lede">Autonomous features unlock as the operator allocates more memory to the daemon. Keyword tier needs zero extra RAM — just FTS5. Semantic tier loads embeddings (~256 MB). Smart tier adds Gemma 4 E2B (~1 GB). Autonomous tier upgrades to Gemma 4 E4B + cross-encoder reranker (~4 GB total). <strong>The RAM figures below are the local-model path</strong> (Ollama serving Gemma + a local embedder); when you point <code>[llm]</code> + <code>[embeddings]</code> at a remote API (see <a href="#no-gpu">No GPU required</a> below), the daemon host carries no model weight at all — only the ~90 MB CPU cross-encoder if reranking is enabled.</p>
     <div class="tier-cards">
       <div class="tier kw">
         <div class="nm">Keyword</div>
@@ -410,8 +410,73 @@ EOF
   </div>
 </section>
 
+<section id="no-gpu">
+  <div class="container">
+    <span class="eyebrow">No GPU required — any LLM backend</span>
+    <h2 style="font-family:var(--font-sans);font-size:1.75rem">Autonomous mode on CPU-only or air-gapped hosts — point <code>[llm]</code> at any LLM you have API access to.</h2>
+    <p class="lede">Nothing on this page is hard-wired to a GPU, to Ollama, or to Gemma. The Ollama + Gemma quick-start above is the <strong>local-first default</strong>, not a requirement. As of v0.7.0 (#1067 + #1146) <strong>any LLM reachable over an HTTP endpoint can drive every autonomous feature</strong> — wherever you have API access, wherever you run on hosts with no GPUs, and you want to run ai-memory in autonomous mode with <code>--profile full</code>. The backend is a config choice (<code>[llm]</code> in <code>config.toml</code> or the <code>AI_MEMORY_LLM_*</code> env vars), resolved through the canonical precedence ladder <code>CLI&nbsp;&gt;&nbsp;env&nbsp;&gt;&nbsp;[llm]&nbsp;&gt;&nbsp;legacy&nbsp;&gt;&nbsp;default</code>.</p>
+    <p class="lede" style="margin-top:.5rem">Two CPU-only / air-gap postures below. The model names are <strong>examples, not requirements</strong> — substitute whatever model your provider or internal endpoint serves.</p>
+
+    <h3 style="font-family:var(--font-sans);font-size:1.15rem;margin-top:1.75rem">A. Cloud API — no local model, no GPU (OpenRouter shown as one low-cost example)</h3>
+    <div class="snip"><span class="cm"># Any OpenAI-compatible vendor works (openai | xai | anthropic | gemini |</span>
+<span class="cm"># deepseek | kimi | qwen | mistral | groq | together | cerebras |</span>
+<span class="cm"># openrouter | fireworks | …). OpenRouter + a Gemma 4 chat model is shown</span>
+<span class="cm"># here only as a low-cost EXAMPLE — swap `model` for any model the vendor serves.</span>
+<span class="ok">$</span> cat &gt; ~/.config/ai-memory/config.toml &lt;&lt;EOF
+schema_version = <span class="num">2</span>
+tier = <span class="val">"autonomous"</span>
+
+[llm]
+backend     = <span class="val">"openrouter"</span>
+model       = <span class="val">"google/gemma-4-26b-it"</span>   <span class="cm"># example; any served model is fine</span>
+api_key_env = <span class="val">"OPENROUTER_API_KEY"</span>      <span class="cm"># env-var reference — never inline the key</span>
+
+[embeddings]
+backend = <span class="val">"openai-compatible"</span>          <span class="cm"># CPU-only remote embeddings — no local model</span>
+url     = <span class="val">"https://api.openai.com/v1"</span>
+model   = <span class="val">"text-embedding-3-small"</span>
+
+[reranker]
+enabled = <span class="ok">true</span>
+model   = <span class="val">"ms-marco-MiniLM-L-6-v2"</span>     <span class="cm"># ~90 MB CPU cross-encoder; no GPU</span>
+EOF
+
+<span class="ok">$</span> export OPENROUTER_API_KEY=<span class="val">"sk-or-…"</span>     <span class="cm"># secret via env, never written to config</span>
+<span class="ok">$</span> ai-memory serve --profile full
+<span class="ok">$</span> ai-memory doctor                       <span class="cm"># LLM Reachability (#1146) — confirms which layer won</span>
+<span class="ok">→ "tier": "autonomous"</span></div>
+
+    <h3 style="font-family:var(--font-sans);font-size:1.15rem;margin-top:1.5rem">B. Air-gapped — internal HA inference endpoint (no public internet, no GPU on the ai-memory host)</h3>
+    <div class="snip"><span class="cm"># The ai-memory host needs no GPU and no public egress — it speaks HTTP to an</span>
+<span class="cm"># internal load-balanced inference endpoint (vLLM / llama.cpp server / TGI /</span>
+<span class="cm"># your own gateway). `openai-compatible` requires an explicit base_url.</span>
+<span class="ok">$</span> cat &gt; ~/.config/ai-memory/config.toml &lt;&lt;EOF
+schema_version = <span class="num">2</span>
+tier = <span class="val">"autonomous"</span>
+
+[llm]
+backend  = <span class="val">"openai-compatible"</span>
+model    = <span class="val">"gemma-4-26b"</span>                       <span class="cm"># example; whatever your gateway serves</span>
+base_url = <span class="val">"https://llm-ha.internal.corp/v1"</span>    <span class="cm"># internal HA VIP, mTLS terminated upstream</span>
+api_key_env = <span class="val">"AI_MEMORY_LLM_API_KEY"</span>
+
+[embeddings]
+backend = <span class="val">"openai-compatible"</span>
+url     = <span class="val">"https://llm-ha.internal.corp/v1"</span>
+model   = <span class="val">"nomic-embed-text-v1.5"</span>
+
+[reranker]
+enabled = <span class="ok">true</span>
+model   = <span class="val">"ms-marco-MiniLM-L-6-v2"</span>
+EOF
+
+<span class="ok">$</span> ai-memory serve --profile full</div>
+    <p class="lede" style="margin-top:1rem"><strong>Secrets discipline:</strong> the key is referenced by env-var name (<code>api_key_env</code>) or by a mode-0400 file (<code>api_key_file</code>) — an inline <code>api_key = "…"</code> literal is rejected at parse time. <strong>Canonical schema + per-vendor recipes:</strong> <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/CONFIG_SCHEMA.md">CONFIG_SCHEMA.md</a> · <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/docs/integrations/llm-backends.md">integrations/llm-backends.md</a>.</p>
+  </div>
+</section>
+
 <footer>
-  <p>ai-memory v0.7.0 · Apache 2.0 · LLM bridge in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/llm.rs">llm.rs</a> · models served via <a href="https://ollama.com">Ollama</a></p>
+  <p>ai-memory v0.7.0 · Apache 2.0 · LLM bridge in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/src/llm.rs">llm.rs</a> · models served via <a href="https://ollama.com">Ollama</a> by default, or <a href="#no-gpu">any OpenAI-compatible endpoint</a> (cloud or air-gap, no GPU)</p>
   <p style="margin-top:.7rem;color:var(--google)">▸ <strong>Thanks to Google for open-sourcing Gemma 4.</strong> The autonomous tier of ai-memory is built on the foundation Gemma provides.</p>
   <p style="margin-top:.5rem"><a href="./">← Back to ai-memory</a> · <a href="at-a-glance.html">Atlas</a> · <a href="memory-tiers.html">Tiers</a> · <a href="credits.html">Credits</a></p>
 </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -434,6 +434,13 @@ cd ai-memory-mcp &amp;&amp; cargo build --release</code></pre>
         (recommended, post-<a href="https://github.com/alphaonedev/ai-memory-mcp/issues/1146">#1146</a>)
         or via <code>AI_MEMORY_LLM_BACKEND</code> env vars (override path).
       </p>
+      <p class="lede" style="margin-top:0.5rem">
+        <strong>No GPU required.</strong> Nothing here is hard-wired to a GPU, to Ollama, or to Gemma &mdash; those are the
+        local-first default, not a requirement. Wherever you have API access, run on hosts with no GPUs, and want
+        autonomous mode with <code>--profile full</code>, point <code>[llm]</code> at a remote cloud API (e.g. OpenRouter as a
+        low-cost example) or an internal air-gapped HA inference endpoint. See the
+        <a href="autonomous.html#no-gpu">No GPU required &mdash; any LLM backend</a> walkthrough on the autonomous page.
+      </p>
       <p>
         <strong>Single source of truth.</strong> <code>config.toml</code> is consumed by every surface —
         the MCP server, the HTTP daemon, <code>ai-memory atomise</code>, <code>ai-memory curator</code>, the boot

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -376,7 +376,7 @@ curl https://memory.local:9077/api/v1/recall \
             <span class="client-tier t2">▸ TIER 2 · TESTED</span>
           </div>
         </div>
-        <p class="client-desc">Local LLM hosts. Post-#1067 (v0.7.0), any of 15 OpenAI-compatible vendors or local Ollama works; Ollama shown here for zero-network installs.</p>
+        <p class="client-desc">Local LLM hosts. Post-#1067 (v0.7.0), any of 15 OpenAI-compatible vendors or local Ollama works; Ollama shown here for zero-network installs. <strong>No GPU required</strong> — on CPU-only or air-gapped hosts, point <code>[llm]</code> at a remote cloud API or internal HA endpoint instead (no local model). See the <a href="autonomous.html#no-gpu">No GPU required</a> walkthrough.</p>
         <pre class="client-config"><span class="cmt"># Smart/autonomous tier — any LLM backend post-#1067; default Ollama model is gemma3:4b</span>
 ollama pull gemma3:4b
 ai-memory mcp --tier smart</pre>


### PR DESCRIPTION
## Summary

Closes #1460. Makes explicit across the docs surface that the autonomous
tier is **not hard-wired to a GPU, to Ollama, or to Gemma** — those are
the local-first default, not a requirement. Post-#1067/#1146 any
OpenAI-compatible endpoint drives every autonomous feature:

- a **remote cloud API** (OpenRouter shown as one low-cost *example*, with
  a Gemma 4 chat model) *where you have API access*, or
- an **internal air-gapped HA inference VIP** *where you have systems with
  no GPUs* and want autonomous mode with `--profile full`.

Model names are framed as examples, not requirements. Secrets stay via
`api_key_env` / `api_key_file` (inline `api_key` rejected at parse time).

## Changes

- **docs/autonomous.html** — new `#no-gpu` section with two copy-pasteable
  `[llm]` configs: (A) cloud API / no local model / no GPU, (B) air-gapped
  internal HA endpoint. Reconciled tier-card RAM framing (clarified the
  figures are the local-model path) and the footer line.
- **docs/index.html** — "No GPU required" paragraph in the LLM-backend
  block linking the walkthrough.
- **docs/integrations.html** — Ollama card notes the CPU-only / air-gap
  remote-API alternative.
- **docs/CONFIG_SCHEMA.md** — canonical "No GPU required" note on the
  `[llm]` schema intro.
- **docs/RUNBOOK-digitalocean-testing.md** — reconciled the Ollama-exclusion
  note: CPU-only droplets drive autonomy via a remote backend; the local
  Ollama+Gemma sizing is a choice, not a GPU requirement of ai-memory.

## Test plan

- [x] `scripts/check-docs-vs-ssot.sh` — docs-vs-SSOT drift gate PASS
- [x] Docs-only change; no Rust gates applicable (no `src/` touched)
- [x] New `#no-gpu` anchor + cross-links resolve within the docs set

## AI involvement

Authored autonomously by Claude Opus 4.7 under the operator's v0.7.0
full-autonomy directive. Branch based off `origin/release/v0.7.0` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)