### PR TITLE
coverage: add fragile-floor canary + audit paper-thin pins (#1424)

### DIFF
--- a/coverage/check-thresholds.sh
+++ b/coverage/check-thresholds.sh
@@ -6,6 +6,10 @@
 # its threshold. Passes (exit 0) when all per-module thresholds hold
 # AND the global floor is met.
 #
+# Also emits non-fatal CANARY warnings (#1424) for any module that clears
+# its floor by less than 0.5pp — a proactive flag for fragile floors that
+# are one unrelated-churn commit away from a CI regression.
+#
 # Usage:
 #   bash coverage/check-thresholds.sh [thresholds.toml] [cov.json]
 #
@@ -109,6 +113,17 @@ while IFS= read -r line; do
 
     if awk "BEGIN { exit !($current >= $threshold) }"; then
       pass_count=$((pass_count + 1))
+      # Canary (#1424): a module that clears its floor by <0.5pp is one churn
+      # commit away from a fragile-floor CI regression (the failure mode that
+      # filed #1424 — daemon_runtime.rs slipping 85.88%→84.89% on unrelated
+      # whole-workspace branch-count drift). Warn, never fail: this is a
+      # proactive flag for maintainers to add headroom before it trips.
+      if awk "BEGIN { exit !(($current - $threshold) < 0.5) }"; then
+        headroom=$(awk "BEGIN { printf \"%.2f\", $current - $threshold }")
+        printf 'CANARY: %-44s measured %.2f%% clears floor %s%% by only %spp (<0.5pp)\n' \
+          "$path" "$current" "$threshold" "$headroom"
+        warn_count=$((warn_count + 1))
+      fi
     else
       printf 'FAIL: %-44s measured %.2f%% < threshold %s%%\n' \
         "$path" "$current" "$threshold"

--- a/coverage/thresholds.toml
+++ b/coverage/thresholds.toml
@@ -15,6 +15,20 @@
 #   - measured 99.0% → threshold 98   (~1pp tolerance below)
 #   - measured 100.0% → threshold 99  (never set 100 to avoid 1-line jitter trips)
 #
+# FRAGILE-PIN AUDIT (#1424 item 2, 2026-06-04): five floors were set at
+# floor(measured) instead of floor(measured - 0.5), leaving <0.5pp headroom
+# (one churn commit from a fragile-floor CI trip like the 2026-05-30
+# daemon_runtime.rs regression):
+#   mcp/tools/kg_query.rs (73, measured 73.21, 0.21pp)
+#   cli/shell.rs          (92, measured 92.29, 0.29pp)
+#   mcp/tools/update.rs   (83, measured 83.33, 0.33pp)
+#   hooks/config.rs       (94, measured 94.47, 0.47pp)
+#   mcp/tools/promote.rs  (88, measured 88.48, 0.48pp)
+# These are NOT lowered (§8 thresholds rise / never fall without operator
+# approval); instead coverage/check-thresholds.sh emits a non-fatal CANARY
+# for every sub-0.5pp module so maintainers add test headroom before a trip.
+# Each is tagged inline below with `# CANARY <0.5pp (#1424)`.
+#
 # Tier targets (raise per-module floor to these by v0.8.0):
 #   A=98% (pure logic), B=95% (MCP/HTTP/CLI), C=92% (substrate),
 #   D=85% (LLM-bound, documented rationale), E=90% (wire/IO, documented exceptions)
@@ -118,7 +132,7 @@ min_line_coverage = 90.0
 "cli/schema_init.rs"       = 72    # tier B, measured 72.91 (C-3 #699 uplift; was 68.46) — EXCEPTION: postgres init/enumerate body (lines 388-585) is sal-postgres only and structurally unreachable without a live Postgres + pgvector (see coverage/policy.md)
 "cli/search.rs"            = 96    # tier B, measured 97.09
 "cli/serve_banner.rs"      = 99    # tier B, measured 100.00
-"cli/shell.rs"             = 92    # tier B, measured 92.29 (CI); uplift TODO
+"cli/shell.rs"             = 92    # tier B, measured 92.29 (CI); uplift TODO — CANARY <0.5pp (#1424)
 "cli/store.rs"             = 98    # tier B, measured 98.70
 "cli/sync.rs"              = 97    # tier B, measured 97.82
 "cli/test_utils.rs"        = 99    # tier B, measured 100.00
@@ -160,7 +174,7 @@ min_line_coverage = 90.0
 "mcp/tools/get.rs"         = 97    # tier B, measured 97.89
 "mcp/tools/get_taxonomy.rs"= 96    # tier B, measured 96.87
 "mcp/tools/kg_invalidate.rs" = 96  # tier B, measured 97.01
-"mcp/tools/kg_query.rs"    = 73    # tier B, measured 73.21 (CI, post-#889 Gap 6 by_source_uri branch); uplift TODO — large new branch added without proportional test coverage
+"mcp/tools/kg_query.rs"    = 73    # tier B, measured 73.21 (CI, post-#889 Gap 6 by_source_uri branch); uplift TODO — large new branch added without proportional test coverage — CANARY <0.5pp (#1424)
 "mcp/tools/kg_timeline.rs" = 95    # tier B, measured 96.29
 "mcp/tools/link.rs"        = 96    # tier B, measured 97.37 (C-2)
 "mcp/tools/list.rs"        = 98    # tier B, measured 99.00
@@ -168,7 +182,7 @@ min_line_coverage = 90.0
 "mcp/tools/namespace.rs"   = 92    # tier B, measured 92.59 (C-2) — auto_register_path_hierarchy walks the filesystem, hermetic floor at this level
 "mcp/tools/notify.rs"      = 95    # tier B, measured 95.96
 "mcp/tools/pending.rs"     = 92    # tier B, measured 93.08 (C-2) — multi-approver quorum path lives in storage tests
-"mcp/tools/promote.rs"     = 88    # tier B, measured 88.48 (CI, post-#831 target_tier param); uplift TODO — EXCEPTION: chunk-C defensive map_err closures preserved
+"mcp/tools/promote.rs"     = 88    # tier B, measured 88.48 (CI, post-#831 target_tier param); uplift TODO — EXCEPTION: chunk-C defensive map_err closures preserved — CANARY <0.5pp (#1424)
 "mcp/tools/quota_status.rs"= 95    # tier B, measured 96.08 (C-2)
 "mcp/tools/recall.rs"      = 94    # tier B, measured 94.62 post-#1148 profile recalibration (was 95.74/95)
 "mcp/tools/reflect.rs"     = 95    # tier B, measured 96.59 (C-2)
@@ -192,7 +206,7 @@ min_line_coverage = 90.0
 "mcp/tools/store/transport.rs"  = 85    # tier B, post-#881 split; uplift TODO
 "mcp/tools/store/legacy_classifier.rs" = 85    # tier B, post-#881 split; uplift TODO
 "mcp/tools/subscribe.rs"   = 96    # tier B, measured 97.04 (C-2)
-"mcp/tools/update.rs"      = 83    # tier B, measured 83.33 (CI, post-#884 version+expected_version + #888 edit_source split-write + #885 source_uri thread); uplift TODO
+"mcp/tools/update.rs"      = 83    # tier B, measured 83.33 (CI, post-#884 version+expected_version + #888 edit_source split-write + #885 source_uri thread); uplift TODO — CANARY <0.5pp (#1424)
 "mcp/tools/verify.rs"      = 95    # tier B, measured 96.10
 "migrate.rs"               = 95    # tier B, measured 95.85
 "mine.rs"                  = 98    # tier B, measured 99.30
@@ -217,7 +231,7 @@ min_line_coverage = 90.0
 "governance/mod.rs"        = 93    # tier C, post-C-4 measured 94.10 (#699)
 "governance/rules_store.rs" = 97   # tier C, measured 98.35 — NEW MODULE
 "hooks/chain.rs"           = 92    # tier C, baseline 7721bb8 measured 93.01 — RECONCILED post-C-4 #699: workspace floor preserved at 92 (C-4 proposed 85 from lib-only; workspace integration tests reach chain.fire() async-loop arms via real ExecutorRegistry per coverage/policy.md). NEVER LOWER below 92 without operator approval per L0.7 playbook §8 thresholds-rise-never-fall discipline.
-"hooks/config.rs"          = 94    # tier C, post-C-4 measured 94.47 (#699)
+"hooks/config.rs"          = 94    # tier C, post-C-4 measured 94.47 (#699) — CANARY <0.5pp (#1424)
 "hooks/decision.rs"        = 96    # tier C, post-C-4 measured 96.55 (#699) — EXCEEDED tier-C target
 "hooks/executor.rs"        = 87    # tier C, baseline 7721bb8 measured 88.03 — RECONCILED post-C-4 #699: workspace floor preserved at 87 (C-4 proposed 51 from lib-only; workspace integration tests reach ExecExecutor/DaemonExecutor fire_inner async branches via real subprocess spawn). EXCEPTION: L0.7-4 structural ceiling (see coverage/policy.md); raise to 92 by v0.8.0. NEVER LOWER below 87 without operator approval per L0.7 playbook §8.
 "hooks/post_reflect/auto_persona.rs" = 84   # tier C, measured 84.73 (2026-05-19 cov-baseline @ 407a56744); 2026-05-19 coverage-uplift campaign added 6 tests (cadence=0 early-out, no-entity skip, no-export branch, build_post_reflect_hook closure activation, default_for_home, open-error propagation) — expected lift to ~89%, floor pending re-measurement — NEW MODULE
@@ -236,7 +250,7 @@ min_line_coverage = 90.0
 "mcp/tools/expand_query.rs" = 99   # tier D, measured 100.00 (raised materially in L0.7-6)
 
 # ----- Tier E (target >=90%, wire/IO — documented exceptions per coverage/policy.md) -----
-"daemon_runtime.rs"        = 85    # tier E, measured 85.88 (CI, post-#886 Gap 3 schema init); EXCEPTION: bootstrap/sync-net (see coverage/policy.md); uplift TODO
+"daemon_runtime.rs"        = 85    # tier E, measured 85.88 (CI, post-#886 Gap 3 schema init + FX-F2 #1424 commit 094abe811: build_store_handle URL-scheme arms + resolve_configured_embedding_dim ladder, ~0.37pp uplift restoring ~0.88pp headroom over the 85 floor after the 2026-05-30 fragile-floor regression where unrelated whole-workspace churn drifted it 85.88%→84.89%); EXCEPTION: bootstrap/sync-net (see coverage/policy.md); the check-thresholds.sh CANARY (#1424) now flags any sub-0.5pp module proactively; tier-E target 90% by v0.8.0 — uplift TODO via serve()/sync_cycle_once/run_curator_daemon error arms (#1424 item 3)
 "embeddings.rs"            = 95    # tier E, measured 96.16 post-C5
 "handlers/mod.rs"          = 98    # tier E, measured 98.67
 "handlers/transport.rs"    = 94    # tier E, measured 94.97 post-#1148 profile recalibration (was 95.54/95) — PARTIAL EXCEPTION: listener integration (see coverage/policy.md)


### PR DESCRIPTION
## Summary
Addresses #1424 — the systemic fragile-floor guard. The 2026-05-30 `daemon_runtime.rs` CI regression (85.88%→84.89% from unrelated whole-workspace branch-count drift) showed that floors pinned at `floor(measured)` instead of `floor(measured - 0.5)` are one churn commit from a fragile-floor trip. The immediate fix (FX-F2, `094abe811`) restored `daemon_runtime.rs` headroom; this PR lands the preventive guard.

## Changes
- **Canary (#1424 item 4):** `coverage/check-thresholds.sh` now emits a non-fatal `CANARY` for any module clearing its floor by `<0.5pp`, so maintainers add test headroom *before* a trip rather than after. Warn-only — never changes the exit code.
- **Paper-thin-pin audit (#1424 item 2):** found 5 floors set above `floor(measured - 0.5)` with `<0.5pp` headroom — `kg_query.rs` (0.21), `cli/shell.rs` (0.29), `mcp/tools/update.rs` (0.33), `hooks/config.rs` (0.47), `mcp/tools/promote.rs` (0.48). Per §8 (thresholds rise / never fall without operator approval) these are **not lowered**; documented in the toml header and tagged inline `# CANARY <0.5pp (#1424)`.
- **Doc (#1424 items 1 + 3):** expanded the `daemon_runtime.rs` comment with the FX-F2 measured value, the ~0.88pp headroom, and the tier-E 90% v0.8.0 uplift target.

## Test evidence
- Canary logic unit-validated against a synthetic fixture: a comfortable module (5pp) stays silent; both sub-0.5pp modules (0.30pp, 0.49pp boundary) emit `CANARY`; a below-floor module still `FAIL`s with exit 1; canaries increment `warn`, not `fail`.
- `bash -n` ✅ · `shellcheck coverage/check-thresholds.sh` ✅ (clean) · `cargo fmt --check` ✅ · `bash scripts/check-vendor-literals.sh` ✅
- Shell/TOML-only change — no Rust delta, so clippy/test trees are unaffected.

Note: #1424 item 3 (raising `daemon_runtime.rs` to its tier-E 90% target via `serve()`/`sync_cycle_once`/`run_curator_daemon` error-arm tests) is the documented v0.8.0 tier-raise target, tracked by the existing per-module `by v0.8.0` discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)