### PR TITLE
ci: add hung-test watchdog to impact-aware test step (#1492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,24 +334,48 @@ jobs:
           echo "count:  ${TEST_IMPACT_COUNT:-unset} / ${TEST_IMPACT_TOTAL:-unset}"
           echo "impact: ${TEST_IMPACT:-unset}"
           echo "::endgroup::"
+
+          # #1492 hung-test watchdog. libtest has no built-in per-test
+          # timeout, so a single wedged integration test (e.g. an ephemeral
+          # TCP port-bind / wait_for_ready race) used to stall this step
+          # silently until the job-level `timeout-minutes: 45` killed it —
+          # ~34 min of wasted budget and ZERO diagnosability (the hung
+          # test's name never printed). Wrap each invocation in GNU
+          # `timeout` so a hang fails the STEP fast (25 min < the 45 min
+          # job cap) with a named ::error:: pointing at the logged impact
+          # set, instead of a silent job-level cancel. SIGTERM lets libtest
+          # flush partial output; --kill-after escalates to SIGKILL for a
+          # truly wedged process.
+          run_tests() {
+            local label="$1"; shift
+            local rc=0
+            timeout --signal=TERM --kill-after=60 1500 cargo test "$@" || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+                echo "::error::[#1492 watchdog] '${label}' exceeded the 1500s per-invocation timeout and was terminated (previously a silent ~34min hang until the 45min job cap). Reproduce with the impact set logged above; then file a follow-up for the specific flaky test."
+              fi
+              return "$rc"
+            fi
+          }
+
           case "${TEST_IMPACT:-__ALL__}" in
             __SKIP__)
               echo "::notice::docs-only diff — test step is a no-op"
               ;;
             __ALL__|"")
               echo "::notice::running FULL test suite"
-              cargo test
+              run_tests "full suite (cargo test)"
               ;;
             *)
               # Always run --lib first (catches every inline unit test)
               echo "::notice::running cargo test --lib + impact-selected integration binaries"
-              cargo test --lib
+              run_tests "cargo test --lib" --lib
               # Dispatch each impacted tests/*.rs binary
               ARGS=()
               for t in $TEST_IMPACT; do
                 ARGS+=(--test "$t")
               done
-              cargo test "${ARGS[@]}"
+              run_tests "impact-selected integration binaries (${TEST_IMPACT})" "${ARGS[@]}"
               ;;
           esac
 


### PR DESCRIPTION
## Summary
Fixes #1492 — the impact-aware test step could hang silently for ~34 min until the job-level `timeout-minutes: 45` killed it (last seen on PR #1491: a 45m16s "operation was canceled"; a clean re-run confirmed a transient hang, not a regression).

## Root cause
`cargo test`'s libtest harness has no per-test/per-binary timeout. When one integration test wedges (most likely an ephemeral-TCP-port-bind / `wait_for_ready` race), the whole step stalls invisibly until the job cap fires — wasting ~34 min of runner budget AND printing nothing, so the offending test can't be identified.

## Fix
Wrap each `cargo test` invocation in `.github/workflows/ci.yml`'s impact-aware step with a GNU `timeout` watchdog:
- `timeout --signal=TERM --kill-after=60 1500 cargo test …` — 1500s (25 min) is comfortably under the 45-min job cap, so the **step** fails fast instead of a silent job-level cancel.
- `SIGTERM` first (lets libtest flush partial output), `--kill-after=60` escalates to `SIGKILL` for a truly wedged process.
- On timeout (exit 124/137) a named `::error::` points at the already-logged impact set, restoring diagnosability.
- Implemented as a small `run_tests()` bash helper so all three invocations (`--lib`, selective `--test` set, full suite) share the guard.

Chose the issue's option-2 stopgap over the nextest migration (option 1) deliberately: `cargo nextest` does **not** run doctests, so migrating the step would silently drop doctest coverage from CI. The `timeout` wrapper solves both stated costs (wasted budget + zero diagnosability) with no change to the test surface.

CI-workflow-only change — no `src/` delta.

## Test evidence
- `python3 -c "yaml.safe_load(...)"` ✅ (valid YAML)
- actionlint-embedded shellcheck ✅ — zero warnings in the edited step (the 3 pre-existing SC21xx notes are in unrelated steps at lines 101/519/647)

Follow-up (per the issue): once a future hang names the specific test, file a second issue to fix that test's port-bind/readiness race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)