### PR TITLE
ci: make #1492 hung-test watchdog portable (fix macOS/Windows regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,10 +346,33 @@ jobs:
           # set, instead of a silent job-level cancel. SIGTERM lets libtest
           # flush partial output; --kill-after escalates to SIGKILL for a
           # truly wedged process.
+          #
+          # GNU `timeout` only ships on the ubuntu runner (where the #1492
+          # hang occurred). macOS has no `timeout` (coreutils, if present,
+          # is g-prefixed) and Windows' `timeout.exe` is an unrelated
+          # console-pause command — so detect a *GNU* timeout binary and
+          # degrade gracefully to a bare `cargo test` (job-level cap still
+          # applies, i.e. the pre-#1492 behaviour) where none exists,
+          # rather than crashing the step with `timeout: command not found`.
+          TIMEOUT_BIN=""
+          if command -v gtimeout >/dev/null 2>&1; then
+            TIMEOUT_BIN=gtimeout
+          elif timeout --version 2>/dev/null | grep -qi coreutils; then
+            TIMEOUT_BIN=timeout
+          fi
+          if [ -n "$TIMEOUT_BIN" ]; then
+            echo "::notice::[#1492] hung-test watchdog active via '$TIMEOUT_BIN' (1500s per invocation)"
+          else
+            echo "::notice::[#1492] no GNU timeout on this runner — watchdog disabled; job-level timeout-minutes still applies"
+          fi
           run_tests() {
             local label="$1"; shift
             local rc=0
-            timeout --signal=TERM --kill-after=60 1500 cargo test "$@" || rc=$?
+            if [ -n "$TIMEOUT_BIN" ]; then
+              "$TIMEOUT_BIN" --signal=TERM --kill-after=60 1500 cargo test "$@" || rc=$?
+            else
+              cargo test "$@" || rc=$?
+            fi
             if [ "$rc" -ne 0 ]; then
               if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
                 echo "::error::[#1492 watchdog] '${label}' exceeded the 1500s per-invocation timeout and was terminated (previously a silent ~34min hang until the 45min job cap). Reproduce with the impact set logged above; then file a follow-up for the specific flaky test."


### PR DESCRIPTION
## Summary
Follow-on fix to the #1492 watchdog (merged as `93b31c3ed`). That change called GNU `timeout` unconditionally and broke the **macos-latest** Check job with `timeout: command not found` (run 26991213345). ubuntu-latest — the platform where the original silent hang occurred — was unaffected and passed; only macOS regressed (Windows would have hit the unrelated `timeout.exe`).

## Root cause
- macOS ships **no** `timeout` (GNU coreutils, if installed, is `gtimeout`).
- Windows' `timeout` resolves to `C:\Windows\System32\timeout.exe`, an unrelated console-pause command that doesn't accept `--signal`/`--kill-after`.

## Fix
Detect a **GNU** timeout binary before using it:
- prefer `gtimeout` (macOS coreutils prefix);
- else use `timeout` **only when `timeout --version` reports `coreutils`** — which excludes both BSD `timeout` and Windows `timeout.exe`.

Where no GNU timeout exists, degrade gracefully to a bare `cargo test` (the pre-#1492 job-level-cap behaviour) instead of crashing the step. The watchdog stays fully active on ubuntu-latest, the platform that actually exhibited the 34-min hang.

## Test evidence
- YAML parse ✅; actionlint ✅ (no findings in the edited step).
- Detection + fallback unit-tested on a macOS host (no GNU timeout): `TIMEOUT_BIN` resolves empty → graceful `cargo test` fallback, `set -euo pipefail` survives both invocations.
- On ubuntu, `timeout --version | grep coreutils` matches → watchdog active (unchanged from the validated ubuntu run).

CI-workflow-only change; no `src/` delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)