### PR TITLE
fix(test): hermetic offline embedder in integration suite — fixes #1501 cold-download hang

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -197,14 +197,26 @@ impl Embedder {
     pub fn new_local() -> Result<Self> {
         let device = Device::Cpu;
 
-        let (config_path, tokenizer_path, weights_path) =
+        let (config_path, tokenizer_path, weights_path) = if Self::remote_fetch_disabled() {
+            // Offline mode (#1501): skip the network HF-Hub fetch entirely and
+            // rely solely on a pre-staged cache. This eliminates the cold-cache
+            // concurrent-download race — many parallel `ai-memory recall`
+            // subprocesses (the integration suite spawns one per test, all
+            // first-touch-downloading the same MiniLM weights) serialise on the
+            // hf-hub cache lock at up to HF_DOWNLOAD_TIMEOUT each, stacking to a
+            // multi-minute stall. When the cache is absent this `?` errors fast
+            // and the caller degrades to the keyword path (same contract as a
+            // timed-out download), but without any network wait.
+            Self::load_from_fallback()?
+        } else {
             match Self::download_within(HF_DOWNLOAD_TIMEOUT, Self::download_via_hf_hub) {
                 Ok(paths) => paths,
                 Err(e) => {
                     eprintln!("ai-memory: hf-hub download failed ({e}), trying fallback dir");
                     Self::load_from_fallback()?
                 }
-            };
+            }
+        };
 
         let config_data =
             std::fs::read_to_string(&config_path).context("failed to read config.json")?;
@@ -613,6 +625,20 @@ impl Embedder {
             .get("model.safetensors")
             .context("failed to download model.safetensors")?;
         Ok((config_path, tokenizer_path, weights_path))
+    }
+
+    /// Whether the local MiniLM embedder must avoid the network and use only
+    /// a pre-staged cache. Honors the de-facto-standard `HF_HUB_OFFLINE` plus
+    /// the dedicated `AI_MEMORY_EMBED_OFFLINE` knob. Used by hermetic CI (the
+    /// integration suite sets it to dodge the #1501 cold-download race) and by
+    /// air-gapped operators who pre-stage the weights in `FALLBACK_MODEL_SUBDIR`.
+    fn remote_fetch_disabled() -> bool {
+        let truthy = |name: &str| {
+            std::env::var(name)
+                .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+                .unwrap_or(false)
+        };
+        truthy("AI_MEMORY_EMBED_OFFLINE") || truthy("HF_HUB_OFFLINE")
     }
 
     fn load_from_fallback() -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)>
@@ -1506,6 +1532,60 @@ fn load_from_fallback_succeeds_when_files_present() {
     assert!(cfg.ends_with("config.json"));
     assert!(tok.ends_with("tokenizer.json"));
     assert!(w.ends_with("model.safetensors"));
+}
+
+#[test]
+fn offline_env_skips_network_and_errors_fast_on_empty_cache() {
+    // #1501 — with the offline knob set and no pre-staged cache, `new_local`
+    // must take the no-network branch and surface the fallback error fast
+    // (the caller then degrades to keyword). This proves the cold-download
+    // race can't happen: no HF-Hub fetch is attempted at all.
+    use std::sync::Mutex;
+    // env::set_var + HOME are process-wide; serialize against the other
+    // env-mutating tests in this module.
+    static LOCK: Mutex<()> = Mutex::new(());
+    let _guard = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let tmp = std::env::temp_dir().join(format!(
+        "ai-memory-1501-offline-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&tmp).expect("mk empty home");
+    let prev_home = std::env::var("HOME").ok();
+    let prev_off = std::env::var("AI_MEMORY_EMBED_OFFLINE").ok();
+    // SAFETY: serialized via LOCK; no other thread mutates these here.
+    unsafe {
+        std::env::set_var("HOME", &tmp);
+        std::env::set_var("AI_MEMORY_EMBED_OFFLINE", "1");
+    }
+    assert!(
+        Embedder::remote_fetch_disabled(),
+        "offline knob must be honored"
+    );
+    let result = Embedder::new_local();
+    // Restore env before any assertion that could panic.
+    unsafe {
+        match prev_home {
+            Some(p) => std::env::set_var("HOME", p),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_off {
+            Some(v) => std::env::set_var("AI_MEMORY_EMBED_OFFLINE", v),
+            None => std::env::remove_var("AI_MEMORY_EMBED_OFFLINE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    let msg = match result {
+        Ok(_) => panic!("empty cache + offline must error (degrades to keyword)"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("not found") || msg.contains("fallback"),
+        "offline empty-cache error should point at the fallback dir: {msg}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,6 +27,16 @@ const INTEGRATION_TEST_ADMIN: &str = "ai:integration-test-admin";
 fn cmd(binary: &str) -> std::process::Command {
     let mut c = std::process::Command::new(binary);
     c.env("AI_MEMORY_NO_CONFIG", "1");
+    // #1501 — the CLI `recall`/`store` subprocesses default to the semantic
+    // tier, which lazily downloads the MiniLM weights from HuggingFace Hub on
+    // first touch. Spawned once per test, many of these race on the shared
+    // hf-hub cache lock on a cold CI cache and stack into a multi-minute hang
+    // (caught by the #1492 watchdog). These tests assert budget/ranking/wire
+    // behavior, not embedding quality, and already tolerate the keyword
+    // fallback — so force the embedder offline to keep the suite hermetic and
+    // deterministic. The model-load path itself is covered by the embeddings
+    // unit tests.
+    c.env("AI_MEMORY_EMBED_OFFLINE", "1");
     // v0.7.0 K3 — the integration suite asserts the gate's strict
     // semantics (Pending/Deny on policy violation). The v0.7.0
     // process default for `permissions.mode` is `advisory` (log +


### PR DESCRIPTION
## Summary
- Fixes #1501 — the intermittent ~13min integration-test hang on `Check (ubuntu-latest)` that the #1492 watchdog correctly caught (exit 124).
- Root cause: CLI `recall`/`store` subprocesses default to the semantic tier and lazily download the MiniLM weights from HuggingFace Hub on first touch. The integration suite spawns one subprocess per test, so on a **cold** CI cache many race on the shared hf-hub cache lock, each bounded at `HF_DOWNLOAD_TIMEOUT = 180s`, stacking into an N×180s stall that blows past the 1500s watchdog cap. Intermittent because it only bites when the download runs slow under contention (run #1499 fit under the cap; the next run did not).
- Fix: add `Embedder::remote_fetch_disabled()` (honors `AI_MEMORY_EMBED_OFFLINE` + the de-facto `HF_HUB_OFFLINE`) and a no-network branch in `new_local()` that uses only the pre-staged cache. On an empty cache it errors fast and the caller degrades to keyword — the **same** contract as a timed-out download, minus the network wait. The integration harness `cmd()` sets `AI_MEMORY_EMBED_OFFLINE=1`, making the suite hermetic and deterministic. Also benefits air-gapped operators who pre-stage weights.

These tests assert budget/ranking/wire behavior, not embedding quality, and already tolerated the keyword fallback (which is why #1501 was intermittent, not fatal). The model-load path remains covered by the `embeddings` unit tests, plus a new `offline_env_skips_network_and_errors_fast_on_empty_cache`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test` (full suite, rc=0, zero failures)
- [x] `cargo audit` (clean)
- [x] `bash scripts/check-vendor-literals.sh` (PASS)
- [x] Previously-hanging `test_auto_promotion` + `test_budget_*` now finish in 2.0s
- [ ] CI ubuntu/macos/windows green (windows-latest will run to completion once ubuntu is green — fail-fast no longer cancels it, confirming the #1492 Linux-gating fix too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)