### PR TITLE
fix(test)+ci: kill PublicSchemaLock advisory-lock leak that cancelled CI run 26998232157

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,16 @@ jobs:
     # #1487 — bound the job so a wedged test (e.g. a stalled HF-Hub model
     # download on the semantic-tier CLI recall path) fails fast instead of
     # pinning a runner for hours. Normal run is well under this.
-    timeout-minutes: 45
+    #
+    # windows-latest gets a wider 60-min budget: this branch's
+    # Cargo.toml/src changes force the full test suite (TEST_IMPACT=__ALL__
+    # via scripts/ci-test-impact.sh), and the Windows runner's slower test
+    # execution + `cargo build --release` step legitimately approached the
+    # 45-min cap (run 26998232157 cancelled Check (windows-latest) at the
+    # cap with no hang). The Linux watchdog (`timeout` wrapper on the
+    # impact-aware test step, #1492) is Linux-gated, so Windows relies on
+    # this job-level budget instead.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 45 }}
     env:
       # #1407/#1405/#1387 — the ubuntu `cargo test` link step OOM'd the
       # linker (`collect2: ld terminated with signal 7 [Bus error]`).
@@ -600,22 +609,65 @@ jobs:
           echo "count:  ${TEST_IMPACT_COUNT:-unset} / ${TEST_IMPACT_TOTAL:-unset}"
           echo "impact: ${TEST_IMPACT:-unset}"
           echo "::endgroup::"
+
+          # #1492 hung-test watchdog (postgres-gate arm). The default
+          # `check` job already wraps its test step in GNU `timeout`; this
+          # gate needs the same guard because run 26998232157 cancelled
+          # here: the `embedding_dim_migration` binary hung ~26 min on a
+          # leaked Postgres advisory lock (a `PublicSchemaLock` Drop bug
+          # released the lock from a cross-runtime sqlx pool, which failed
+          # 100% and leaked the lock; the next test's unbounded
+          # `pg_advisory_lock` then blocked until the 45-min job cap). The
+          # test-side defect is fixed in tests/common/postgres_env.rs, but
+          # the watchdog stays so any future hang fails the STEP fast (25
+          # min < the 45-min job cap) with a named ::error:: instead of a
+          # silent job-level cancel. This job is always Linux (ubuntu + a
+          # postgres service container), so GNU coreutils `timeout` is
+          # reliably present — no per-OS gating needed (unlike the cross-OS
+          # `check` matrix).
+          TIMEOUT_BIN=""
+          if command -v gtimeout >/dev/null 2>&1; then
+            TIMEOUT_BIN=gtimeout
+          elif timeout --version 2>/dev/null | grep -qi coreutils; then
+            TIMEOUT_BIN=timeout
+          fi
+          if [ -n "$TIMEOUT_BIN" ]; then
+            echo "::notice::[#1492] sal-postgres hung-test watchdog active via '$TIMEOUT_BIN' (1500s per invocation)"
+          else
+            echo "::warning::[#1492] sal-postgres watchdog could not find GNU timeout — relying on job-level timeout-minutes"
+          fi
+          pg_test() {
+            local label="$1"; shift
+            local rc=0
+            if [ -n "$TIMEOUT_BIN" ]; then
+              "$TIMEOUT_BIN" --signal=TERM --kill-after=60 1500 cargo test "$@" || rc=$?
+            else
+              cargo test "$@" || rc=$?
+            fi
+            if [ "$rc" -ne 0 ]; then
+              if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+                echo "::error::[#1492 watchdog] sal-postgres '${label}' exceeded the 1500s per-invocation timeout and was terminated (previously a silent hang until the 45min job cap; see run 26998232157 embedding_dim_migration / leaked advisory lock). Reproduce with the impact set logged above."
+              fi
+              return "$rc"
+            fi
+          }
+
           case "${TEST_IMPACT:-__ALL__}" in
             __SKIP__)
               echo "::notice::docs-only diff — sal-postgres test step is a no-op"
               ;;
             __ALL__|"")
               echo "::notice::running FULL sal-postgres test suite"
-              cargo test --features sal-postgres -- --test-threads=1
+              pg_test "full sal-postgres suite" --features sal-postgres -- --test-threads=1
               ;;
             *)
               echo "::notice::running --lib + impact-selected sal-postgres integration binaries"
-              cargo test --features sal-postgres --lib -- --test-threads=1
+              pg_test "sal-postgres --lib" --features sal-postgres --lib -- --test-threads=1
               ARGS=()
               for t in $TEST_IMPACT; do
                 ARGS+=(--test "$t")
               done
-              cargo test --features sal-postgres "${ARGS[@]}" -- --test-threads=1
+              pg_test "impact-selected sal-postgres binaries (${TEST_IMPACT})" --features sal-postgres "${ARGS[@]}" -- --test-threads=1
               ;;
           esac
 

--- a/tests/common/postgres_env.rs
+++ b/tests/common/postgres_env.rs
@@ -300,14 +300,22 @@ fn sanitise_for_pg_ident(s: &str, max_len: usize) -> String {
 /// a different magic number so we don't deadlock against
 /// `PostgresStore::connect` itself.
 ///
-/// The lock is session-scoped: the held connection in
-/// [`PublicSchemaLock`] keeps the lock for the lifetime of the
-/// guard, and the explicit `pg_advisory_unlock` in `Drop` releases
-/// it deterministically (rather than relying on session-end
-/// release on connection drop).
+/// The lock is session-scoped: a dedicated owner thread (see
+/// [`PublicSchemaLock::acquire`]) holds the locking connection for
+/// the lifetime of the guard, and `Drop` signals that thread to run
+/// `pg_advisory_unlock` on the SAME connection before joining — so
+/// release is deterministic rather than relying on racy session-end
+/// release on connection drop.
 pub struct PublicSchemaLock {
-    pool: PgPool,
-    key: i64,
+    /// Signalling channel to the owner thread. Dropping the `Sender`
+    /// (in [`PublicSchemaLock::drop`]) tells the owner thread to run
+    /// `pg_advisory_unlock` on the SAME connection that took the lock
+    /// and then exit.
+    release_tx: Option<std::sync::mpsc::Sender<()>>,
+    /// Handle to the owner thread that holds the locking connection
+    /// for the lifetime of the guard. Joined in `Drop` so the lock is
+    /// reliably released before the next test's `acquire()` runs.
+    owner: Option<std::thread::JoinHandle<()>>,
 }
 
 impl PublicSchemaLock {
@@ -317,67 +325,156 @@ impl PublicSchemaLock {
     /// deadlock against the bootstrap path.
     const PUBLIC_MEMORIES_LOCK_KEY: i64 = 0x1381_5081_1F50_1357_u64.cast_signed();
 
+    /// Upper bound on how long `acquire()` waits for a leaked / busy
+    /// holder before giving up. A bounded wait surfaces a stuck lock
+    /// as a fast, legible test failure instead of an unbounded hang
+    /// that CI only kills at the 45-min job `timeout-minutes` cap.
+    const ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(2);
+
+    /// Poll cadence for the `pg_try_advisory_lock` deadline-loop.
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
     /// Acquire the cross-process advisory lock that serialises
     /// ownership of `public.memories`. Returns `None` when
     /// `AI_MEMORY_TEST_POSTGRES_URL` is unset so the caller can
     /// `eprintln!("skip: …")` and return early.
     ///
-    /// The acquisition queues behind any existing holder
-    /// (`pg_advisory_lock` is the queued, not the try-shape, variant)
-    /// — slow peer tests simply make us wait.
+    /// ## Why a dedicated owner thread
     ///
-    /// Designed to be `await`-ed from inside a `#[tokio::test]`
-    /// runtime — we deliberately do NOT spin up a private runtime
-    /// here because nested runtimes panic with "Cannot start a
-    /// runtime from within a runtime" under sqlx's current-thread
-    /// driver.
-    pub async fn acquire() -> Option<Self> {
+    /// Postgres advisory locks are *session-scoped*: a lock taken on
+    /// one connection can only be released by `pg_advisory_unlock` on
+    /// that SAME connection (or by the session closing). The lock is
+    /// also held for the whole lifetime of the guard, which spans
+    /// `.await` points back on the caller's `#[tokio::test]` runtime.
+    ///
+    /// A single dedicated owner thread (with its own current-thread
+    /// runtime) opens one `PgConnection`, takes the lock, signals
+    /// readiness, then parks until `Drop`. The unlock therefore runs
+    /// on the same runtime + connection that took the lock, which is
+    /// what makes the release reliable. The pre-fix design cloned a
+    /// pool built on the test runtime and tried to unlock it from a
+    /// throwaway Drop-time runtime; that cross-runtime pool use failed
+    /// 100% with "pool timed out while waiting for an open connection",
+    /// leaking the lock and hanging the *next* test's acquire until the
+    /// CI job timeout.
+    ///
+    /// ## Why bounded `pg_try_advisory_lock` instead of `pg_advisory_lock`
+    ///
+    /// `pg_advisory_lock` waits unboundedly behind any holder — and a
+    /// holder leaked by the old Drop bug meant the next acquire blocked
+    /// until the 45-min job cap. The deadline-loop over the try-shape
+    /// caps the wait at [`Self::ACQUIRE_TIMEOUT`] so a stuck lock fails
+    /// fast and legibly.
+    pub fn acquire() -> Option<Self> {
         let base_url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
-        let pool = PgPoolOptions::new()
-            .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(10))
-            .connect(&base_url)
-            .await
-            .unwrap_or_else(|e| panic!("PublicSchemaLock: connect: {e}"));
         let key = Self::PUBLIC_MEMORIES_LOCK_KEY;
-        sqlx::query("SELECT pg_advisory_lock($1)")
-            .bind(key)
-            .execute(&pool)
-            .await
-            .unwrap_or_else(|e| panic!("PublicSchemaLock: pg_advisory_lock: {e}"));
-        Some(Self { pool, key })
+
+        // `ready_rx` carries the owner thread's lock-acquisition result;
+        // `release_rx` is how `Drop` later signals release + exit.
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
+        let owner = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build PublicSchemaLock owner runtime");
+            rt.block_on(async move {
+                use sqlx::Connection as _;
+                let mut conn = match sqlx::PgConnection::connect(&base_url).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(format!("connect: {e}")));
+                        return;
+                    }
+                };
+
+                // Bounded deadline-loop: a leaked / busy holder surfaces
+                // as a fast failure instead of an unbounded wait.
+                let deadline = std::time::Instant::now() + Self::ACQUIRE_TIMEOUT;
+                let got = loop {
+                    match sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+                        .bind(key)
+                        .fetch_one(&mut conn)
+                        .await
+                    {
+                        Ok(true) => break true,
+                        Ok(false) => {
+                            if std::time::Instant::now() >= deadline {
+                                break false;
+                            }
+                            tokio::time::sleep(Self::POLL_INTERVAL).await;
+                        }
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(format!("pg_try_advisory_lock: {e}")));
+                            return;
+                        }
+                    }
+                };
+                if !got {
+                    let _ = ready_tx.send(Err(format!(
+                        "timed out after {:?} waiting for advisory lock {key} \
+                         (a prior holder leaked the lock?)",
+                        Self::ACQUIRE_TIMEOUT
+                    )));
+                    return;
+                }
+
+                // Signal success, then park until Drop drops `release_tx`.
+                if ready_tx.send(Ok(())).is_err() {
+                    // The acquire() caller went away before we signalled;
+                    // release and exit so we don't leak the lock.
+                    let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
+                        .bind(key)
+                        .execute(&mut conn)
+                        .await;
+                    return;
+                }
+                // We are the only task on this current-thread runtime, so a
+                // blocking std-channel recv here is fine — it parks the
+                // thread until Drop signals (or disconnects).
+                let _ = release_rx.recv();
+                if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
+                    .bind(key)
+                    .execute(&mut conn)
+                    .await
+                {
+                    eprintln!("PublicSchemaLock: pg_advisory_unlock failed: {e}");
+                }
+                // `conn` drops here on its own runtime — clean session close.
+            });
+        });
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => Some(Self {
+                release_tx: Some(release_tx),
+                owner: Some(owner),
+            }),
+            Ok(Err(e)) => {
+                let _ = owner.join();
+                panic!("PublicSchemaLock: {e}");
+            }
+            Err(_) => {
+                let _ = owner.join();
+                panic!("PublicSchemaLock: owner thread exited before signalling readiness");
+            }
+        }
     }
 }
 
 impl Drop for PublicSchemaLock {
     fn drop(&mut self) {
-        // Release the advisory lock explicitly. Best-effort — Drop
-        // is infallible by trait contract, so we eprintln on
-        // failure rather than propagating.
-        //
-        // Drop is sync; sqlx is async. Spawn a thread that builds its
-        // OWN tokio runtime so we don't double-enter the test
-        // runtime. The thread joins before Drop returns so the lock
-        // is reliably released by the time the next test's
-        // `acquire()` can re-take it.
-        let key = self.key;
-        let pool = self.pool.clone();
-        let join = std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build PublicSchemaLock drop-time tokio runtime");
-            rt.block_on(async move {
-                sqlx::query("SELECT pg_advisory_unlock($1)")
-                    .bind(key)
-                    .execute(&pool)
-                    .await
-            })
-        });
-        match join.join() {
-            Ok(Ok(_)) => {}
-            Ok(Err(e)) => eprintln!("PublicSchemaLock: pg_advisory_unlock failed: {e}"),
-            Err(e) => eprintln!("PublicSchemaLock: unlock thread panicked: {e:?}"),
+        // Tell the owner thread to release the advisory lock + exit by
+        // dropping the Sender (disconnects `release_rx.recv()`), then
+        // join so the lock is reliably gone before the next test's
+        // `acquire()` runs. The unlock executes on the SAME connection
+        // + runtime that took the lock (advisory locks are
+        // session-scoped), which is what makes release reliable.
+        drop(self.release_tx.take());
+        if let Some(owner) = self.owner.take()
+            && let Err(e) = owner.join()
+        {
+            eprintln!("PublicSchemaLock: owner thread panicked: {e:?}");
         }
     }
 }

--- a/tests/embedding_dim_migration.rs
+++ b/tests/embedding_dim_migration.rs
@@ -142,7 +142,6 @@ async fn auto_migrate_converts_384_schema_to_768_on_daemon_bootstrap() {
     // Issue #1381: cross-process serialise on `public.memories`
     // ownership so a sibling test binary's bootstrap can't race us.
     let _public_lock = PublicSchemaLock::acquire()
-        .await
         .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;
@@ -211,7 +210,6 @@ async fn auto_migrate_no_op_when_fresh_schema_already_matches() {
         return;
     };
     let _public_lock = PublicSchemaLock::acquire()
-        .await
         .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;
@@ -249,7 +247,6 @@ async fn http_write_path_accepts_768_after_auto_migrate() {
         return;
     };
     let _public_lock = PublicSchemaLock::acquire()
-        .await
         .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let inspect = inspection_pool(&url).await;

--- a/tests/issue_1213_atttypmod_age_schema_scope.rs
+++ b/tests/issue_1213_atttypmod_age_schema_scope.rs
@@ -179,7 +179,6 @@ async fn issue_1213_atttypmod_probe_scopes_to_public_schema() {
     // doesn't conflict with this test's `CREATE TABLE public.memories`
     // staging.
     let _public_lock = PublicSchemaLock::acquire()
-        .await
         .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     // pgvector is required for `vector(N)` columns; refuse to run if
@@ -316,7 +315,6 @@ async fn issue_1213_unscoped_probe_demonstrates_root_cause() {
     };
     // #1381: see sibling test for rationale on PublicSchemaLock.
     let _public_lock = PublicSchemaLock::acquire()
-        .await
         .expect("PublicSchemaLock requires AI_MEMORY_TEST_POSTGRES_URL (already checked above)");
 
     let pool = inspect_pool(&url).await;


### PR DESCRIPTION
## Summary

Root-causes and fixes the cancellation of CI run **26998232157** on `release/v0.7.0` (the gate keeping #1501 open). The run reported `overall=cancelled` (not failed) because two jobs hit their `timeout-minutes` cap:

- **Postgres feature gate** — `embedding_dim_migration` hung ~26 min on a **leaked Postgres advisory lock**, then the next test's unbounded `pg_advisory_lock` blocked until the 45-min cap.
- **Check (windows-latest)** — legitimately reached the 45-min cap with no hang (this branch forces `TEST_IMPACT=__ALL__`; the Windows runner is slower).

### Root cause (advisory-lock leak)
`PublicSchemaLock::Drop` reused a `sqlx` pool built on the **test's** tokio runtime from a throwaway **Drop-time** runtime. sqlx pools are bound to their owning runtime, so the cross-runtime acquire stalled and `pg_advisory_unlock` failed 100% (`pool timed out while waiting for an open connection`). The session-scoped advisory lock then leaked and wedged the next test.

### Fixes
1. **`tests/common/postgres_env.rs`** — rewrite `PublicSchemaLock` around a single **dedicated owner thread** that owns one `PgConnection` for the guard's lifetime: takes the lock, signals readiness, parks until `Drop`, then runs `pg_advisory_unlock` on the **same connection/runtime** (the only reliable release for a session-scoped lock). Acquisition uses a bounded `pg_try_advisory_lock` deadline-loop (2 min / 100 ms poll) so a stuck lock fails fast. `acquire()` is now sync; callers drop `.await`.
2. **`.github/workflows/ci.yml`** — (a) wrap every `cargo test` in the sal-postgres gate in the #1492 `timeout` watchdog (25 min < 45 min cap) so a future hang fails the **step** fast with a named `::error::`; (b) give `windows-latest` Check a 60-min budget via a matrix expression (others keep 45).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --features sal-postgres -- -D warnings -D clippy::all -D clippy::pedantic` — clean
- [x] `cargo test --features sal-postgres --test embedding_dim_migration --test issue_1213_atttypmod_age_schema_scope -- --test-threads=1` — 11 + 10 pass, **no unlock failure**, 7.4s/6.1s (was 32.9s with the leak)
- [x] `cargo audit` — no vulnerabilities
- [x] `bash scripts/check-vendor-literals.sh` — PASS
- [x] `ci.yml` parses as valid YAML
- [ ] Green CI on `release/v0.7.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)