### PR TITLE
test(storage): restore storage/mod.rs coverage floor to >=94%

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10573,6 +10573,128 @@ mod tests {
         }
     }
 
+    fn mem_with_scope(ns: &str, scope: Option<&str>) -> Memory {
+        let mut m = make_memory("scoped", ns, Tier::Long, 5);
+        if let Some(s) = scope {
+            let mut map = serde_json::Map::new();
+            map.insert(
+                crate::META_KEY_SCOPE.to_string(),
+                serde_json::Value::String(s.to_string()),
+            );
+            m.metadata = serde_json::Value::Object(map);
+        }
+        m
+    }
+
+    // Pins the Rust-side visibility predicate (`is_visible`) that the HNSW
+    // recall branch uses when SQL-side visibility can't be attached. Exercises
+    // every `MemoryScope` arm plus `matches_subtree`, which the integration
+    // recall paths only hit for whichever scope the fixture corpus happens to
+    // carry — leaving the other arms uncovered. Deterministic, no DB.
+    #[test]
+    fn is_visible_scope_matrix_covers_every_arm() {
+        // No-agent caller (all-None prefixes) bypasses the filter entirely.
+        let unfiltered = (None, None, None, None);
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng/web", Some("private")),
+            &unfiltered
+        ));
+
+        // 4-level agent ns populates every prefix slot:
+        // p=acme/eng/web/team, t=acme/eng/web, u=acme/eng, o=acme.
+        let prefixes = super::compute_visibility_prefixes(Some("acme/eng/web/team"));
+        assert_eq!(
+            prefixes,
+            (
+                Some("acme/eng/web/team".to_string()),
+                Some("acme/eng/web".to_string()),
+                Some("acme/eng".to_string()),
+                Some("acme".to_string()),
+            )
+        );
+
+        // Collective: visible to anyone.
+        assert!(super::is_visible(
+            &mem_with_scope("zzz/other", Some("collective")),
+            &prefixes
+        ));
+
+        // Private: only the caller's own namespace (p) is visible.
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng/web/team", Some("private")),
+            &prefixes
+        ));
+        assert!(!super::is_visible(
+            &mem_with_scope("acme/eng/web", Some("private")),
+            &prefixes
+        ));
+
+        // Absent scope key → MemoryScope::default() (Private) semantics.
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng/web/team", None),
+            &prefixes
+        ));
+        assert!(!super::is_visible(
+            &mem_with_scope("acme/other", None),
+            &prefixes
+        ));
+
+        // Team subtree (t = acme/eng/web): exact + descendant in, sibling out.
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng/web", Some("team")),
+            &prefixes
+        ));
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng/web/team/v2", Some("team")),
+            &prefixes
+        ));
+        assert!(!super::is_visible(
+            &mem_with_scope("acme/eng/api", Some("team")),
+            &prefixes
+        ));
+
+        // Unit subtree (u = acme/eng).
+        assert!(super::is_visible(
+            &mem_with_scope("acme/eng", Some("unit")),
+            &prefixes
+        ));
+        assert!(!super::is_visible(
+            &mem_with_scope("acme/sales", Some("unit")),
+            &prefixes
+        ));
+
+        // Org subtree (o = acme).
+        assert!(super::is_visible(
+            &mem_with_scope("acme", Some("org")),
+            &prefixes
+        ));
+        assert!(!super::is_visible(
+            &mem_with_scope("globex", Some("org")),
+            &prefixes
+        ));
+
+        // matches_subtree None arm: a shallow agent leaves the org slot empty,
+        // so an org-scoped memory is denied (no prefix to match against).
+        let shallow = super::compute_visibility_prefixes(Some("acme"));
+        assert_eq!(shallow.3, None);
+        assert!(!super::is_visible(
+            &mem_with_scope("acme", Some("org")),
+            &shallow
+        ));
+
+        // Unknown scope string → from_str None → caller denied.
+        assert!(!super::is_visible(
+            &mem_with_scope("acme/eng/web/team", Some("definitely-not-a-scope")),
+            &prefixes
+        ));
+
+        // None-agent → all-None tuple (the no-filter sentinel).
+        assert_eq!(
+            super::compute_visibility_prefixes(None),
+            (None, None, None, None)
+        );
+    }
+
     #[test]
     fn open_creates_schema() {
         let conn = test_db();

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -64,7 +64,22 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // hot-path query rewrite plus its plan-shape + behavioral regression
     // coverage, zero speculative surface. 16_300 = 16_248 + 52 headroom;
     // far under the 1.5x cap.
-    ("src/storage/mod.rs", 16_300),
+    //
+    // 2026-06-05 — bumped 16_300 → 16_400 by the storage/mod.rs coverage
+    // floor restoration: the Per-Module Coverage Thresholds gate flagged
+    // storage/mod.rs at 93.90% < its 94% floor (a latent regression
+    // unmasked once the #92 hnsw concurrent-rebuild flake stopped
+    // short-circuiting the run at test-exec). The fix adds a DB-free
+    // `is_visible_scope_matrix_covers_every_arm` test pinning every
+    // MemoryScope arm of the Rust-side visibility predicate
+    // (`is_visible` / `matches_subtree` / `compute_visibility_prefixes`),
+    // which integration recall only exercises for whichever scope the
+    // fixture corpus carries — leaving the other arms uncovered. The
+    // ~122-LOC `mod tests` addition pushed the file to 16_370. Growth is
+    // justified: pure regression coverage that lifts the file back over
+    // its 94% floor, zero new production surface. 16_400 = 16_370 + 30
+    // headroom; far under the 1.5x cap.
+    ("src/storage/mod.rs", 16_400),
     ("src/mcp/mod.rs", 14_000),
     // postgres.rs bumped 13_000 → 15_200 by FX-D2 to accommodate
     // FX-C2-batch{1..5} ARCH-2 SAL trait method implementations


### PR DESCRIPTION
## Summary
The **Per-Module Coverage Thresholds** gate on release/v0.7.0 (merge SHA `60c987a25`) failed: `storage/mod.rs` measured **93.90% < 94% floor** (floor pinned at measured 95.04%).

This was a **latent regression the gate never previously reached** — prior coverage runs failed earlier at the test-execution step on the hnsw concurrent-rebuild flake (#92, fixed in `60c987a25`), short-circuiting before threshold enforcement ran. With the flake fixed, the run reached enforcement and surfaced the floor breach.

## Root cause
The Rust-side visibility predicate `is_visible` (HNSW recall branch, used when SQL-side visibility can't be attached) plus `matches_subtree` / `compute_visibility_prefixes` had **no direct unit test**. Integration recall paths only exercise whichever `MemoryScope` arm the fixture corpus carries, leaving the other arms uncovered.

## Fix
Add a deterministic, DB-free test (`is_visible_scope_matrix_covers_every_arm`) pinning:
- every scope arm — Collective / Private / Team / Unit / Org
- both `matches_subtree` outcomes (exact + descendant in; sibling + None-prefix out)
- the absent-scope → `MemoryScope::default()` (Private) fallback
- the unknown-scope → `from_str` None → deny path
- the all-None no-filter sentinel + `compute_visibility_prefixes(None)`

Lifts ~21 previously-uncovered lines (need only ~10) back over the 94% floor. **No threshold lowered** (lowering is operator-gated per coverage playbook §8).

## Test plan
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` exit 0
- [x] new test green; vendor-literal gate PASS
- [ ] Per-Module Coverage Thresholds gate green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)