### PR TITLE
security(docs): scrub @binary2029 handle from ADR headers on main

### DIFF
--- a/docs/ADR-0001-quorum-replication.md
+++ b/docs/ADR-0001-quorum-replication.md
@@ -5,7 +5,7 @@ follow-up PRs as the QuorumWriter layer is instrumented and real chaos
 campaigns run against a multi-node fixture.
 
 Date: 2026-04-19
-Author: Claude Opus 4.7 (1M context) on behalf of @binary2029
+Author: Claude Opus 4.7 (1M context) on behalf of @alphaonedev
 Related: PR #277 (v0.6.0 GA), PR #279 (Track B — SAL + Postgres)
 
 ---

--- a/docs/ADR-0002-kg-schema-v15-backward-incompat.md
+++ b/docs/ADR-0002-kg-schema-v15-backward-incompat.md
@@ -3,7 +3,7 @@
 Status: **Accepted** — implemented in v0.6.3 (PRs #384, #388–#392).
 
 Date: 2026-04-26
-Author: Claude Opus 4.7 (1M context) on behalf of @binary2029
+Author: Claude Opus 4.7 (1M context) on behalf of @alphaonedev
 Related: ADR-0001 (Quorum replication), `docs/MIGRATION-v0.6.2-to-v0.6.3.md`
 
 ---

--- a/docs/ADR-0003-kg-invalidation-eventual-consistency.md
+++ b/docs/ADR-0003-kg-invalidation-eventual-consistency.md
@@ -3,7 +3,7 @@
 Status: **Accepted** — implemented in v0.6.3 (PR #390).
 
 Date: 2026-04-26
-Author: Claude Opus 4.7 (1M context) on behalf of @binary2029
+Author: Claude Opus 4.7 (1M context) on behalf of @alphaonedev
 Related: ADR-0001 (Quorum replication), ADR-0002 (Schema v15)
 
 ---


### PR DESCRIPTION
## Summary
Docs-only scrub of the `@binary2029` GitHub-handle form from the author
lines of three ADRs on `main`, mapping it to the approved `@alphaonedev`
identity. Closes the last public-content reference to that handle on the
production branch.

- `docs/ADR-0001-quorum-replication.md`
- `docs/ADR-0002-kg-schema-v15-backward-incompat.md`
- `docs/ADR-0003-kg-invalidation-eventual-consistency.md`

The email form (`binary2029@gmail.com`) is not present in `main`'s content.
Commit author/committer metadata is intentionally left untouched per
operator decision (no history rewrite / no force-push).

## Release safety
- **No tag, no version bump, no code change.** Pure docs.
- Does **not** trigger any release-publish workflow: `publish-sdks.yml`
  and the `ci.yml` tag arm fire only on `push: tags: v*`; this PR pushes
  no tag. crates.io/GHCR/npm/pypi publish remains gated on the operator
  `v*` tag cut.
- Ordinary build/test CI (`ci.yml`, `token-budget.yml`) runs as normal.

## Test plan
- [ ] `git grep -i binary2029 -- ':!*.jsonl'` returns 0 on the merge result
- [ ] CI green (build/test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI involvement
Authored by Claude Opus 4.7 acting under operator authorization for the
v0.7.0 security-scrub campaign. Operator merges (main is operator-gated).