### PR TITLE
fix(embeddings): wire sectioned [embeddings] config into daemon build_embedder (#1521)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,66 @@ impl EmbeddingModel {
             Self::NomicEmbedV15 => "nomic-ai/nomic-embed-text-v1.5",
         }
     }
+
+    /// Canonical-id aliases recognised by [`Self::from_canonical_id`]:
+    /// the snake wire form ([`FromStr`]), the HF id (also the
+    /// [`canonicalise_embedding_model`] output), the unprefixed
+    /// shortname, and the Ollama tag. Centralising the alias strings
+    /// here keeps the model-id literals in one place (#1521).
+    fn canonical_aliases(self) -> &'static [&'static str] {
+        match self {
+            Self::MiniLmL6V2 => MINILM_CANONICAL_ALIASES,
+            Self::NomicEmbedV15 => NOMIC_CANONICAL_ALIASES,
+        }
+    }
+
+    /// Parse any recognised canonical id form — the snake wire form, the
+    /// HF id, the unprefixed shortname, or the Ollama tag — into a
+    /// daemon-constructible model. Returns `None` for ids the 2-model
+    /// daemon embedder cannot build (e.g. `bge-large-en`); callers fall
+    /// back to the tier preset. Case-insensitive; surrounding whitespace
+    /// is trimmed (#1521).
+    ///
+    /// Unlike [`FromStr`] (which only accepts the snake wire form), this
+    /// also accepts whatever an operator wrote in `[embeddings].model`
+    /// after [`canonicalise_embedding_model`], so the sectioned config
+    /// block drives the daemon embedder.
+    #[must_use]
+    pub fn from_canonical_id(s: &str) -> Option<Self> {
+        let needle = s.trim();
+        if needle.is_empty() {
+            return None;
+        }
+        [Self::MiniLmL6V2, Self::NomicEmbedV15]
+            .into_iter()
+            .find(|model| {
+                model
+                    .canonical_aliases()
+                    .iter()
+                    .any(|alias| alias.eq_ignore_ascii_case(needle))
+            })
+    }
 }
+
+/// Canonical-id aliases for [`EmbeddingModel::MiniLmL6V2`] — snake wire
+/// form, HF id ([`canonicalise_embedding_model`] output), unprefixed
+/// shortname, Ollama tag. See [`EmbeddingModel::from_canonical_id`].
+const MINILM_CANONICAL_ALIASES: &[&str] = &[
+    "mini_lm_l6_v2",
+    "sentence-transformers/all-MiniLM-L6-v2",
+    "all-MiniLM-L6-v2",
+    "all-minilm",
+];
+
+/// Canonical-id aliases for [`EmbeddingModel::NomicEmbedV15`] — snake
+/// wire form, HF id ([`canonicalise_embedding_model`] output), Ollama
+/// tag, prefixed HF id. See [`EmbeddingModel::from_canonical_id`].
+const NOMIC_CANONICAL_ALIASES: &[&str] = &[
+    "nomic_embed_v15",
+    "nomic-embed-text-v1.5",
+    "nomic-embed-text",
+    "nomic-ai/nomic-embed-text-v1.5",
+];
 
 // ---------------------------------------------------------------------------
 // LLM model defaults
@@ -6484,6 +6543,59 @@ mod tests {
             err.contains("mini_lm_l6_v2") && err.contains("nomic_embed_v15"),
             "err message should list valid options: {err}"
         );
+    }
+
+    /// #1521 — `from_canonical_id` must accept every form an operator
+    /// might write in `[embeddings].model`: the snake wire form, the HF
+    /// id (the `canonicalise_embedding_model` output), the unprefixed
+    /// shortname, and the Ollama tag. This is what lets the sectioned
+    /// config block drive the daemon embedder.
+    #[test]
+    fn embedding_model_from_canonical_id_accepts_all_forms() {
+        // nomic family — snake, canonical HF id, Ollama tag, prefixed id.
+        for id in [
+            "nomic_embed_v15",
+            "nomic-embed-text-v1.5",
+            "nomic-embed-text",
+            "nomic-ai/nomic-embed-text-v1.5",
+        ] {
+            assert_eq!(
+                EmbeddingModel::from_canonical_id(id),
+                Some(EmbeddingModel::NomicEmbedV15),
+                "nomic alias {id:?} must resolve"
+            );
+        }
+        // MiniLM family — snake, canonical HF id, shortname, Ollama tag.
+        for id in [
+            "mini_lm_l6_v2",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "all-MiniLM-L6-v2",
+            "all-minilm",
+        ] {
+            assert_eq!(
+                EmbeddingModel::from_canonical_id(id),
+                Some(EmbeddingModel::MiniLmL6V2),
+                "minilm alias {id:?} must resolve"
+            );
+        }
+        // The canonicalised output of a legacy alias must round-trip.
+        assert_eq!(
+            EmbeddingModel::from_canonical_id(&canonicalise_embedding_model(
+                "nomic_embed_v15".to_string()
+            )),
+            Some(EmbeddingModel::NomicEmbedV15)
+        );
+        // Case-insensitive + whitespace-trimmed.
+        assert_eq!(
+            EmbeddingModel::from_canonical_id("  NOMIC-EMBED-TEXT-V1.5  "),
+            Some(EmbeddingModel::NomicEmbedV15)
+        );
+        // Models the 2-model daemon embedder cannot construct → None
+        // (caller falls back to the tier preset), and empty → None.
+        assert_eq!(EmbeddingModel::from_canonical_id("bge-large-en"), None);
+        assert_eq!(EmbeddingModel::from_canonical_id("mxbai-embed-large"), None);
+        assert_eq!(EmbeddingModel::from_canonical_id(""), None);
+        assert_eq!(EmbeddingModel::from_canonical_id("   "), None);
     }
 
     #[test]

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1988,6 +1988,70 @@ pub fn resolve_admin_agent_ids(admin_cfg: Option<&crate::config::AdminConfig>) -
 // Embedder / vector-index canonical builders
 // ---------------------------------------------------------------------------
 
+/// #1521 — resolve the daemon embedder model under the canonical
+/// precedence ladder, mirroring the [`AppConfig::resolve_embeddings`]
+/// layering for the model dimension:
+///
+///   1. `[embeddings].model` (sectioned v2 config, #1146)
+///   2. legacy flat `embedding_model` (deprecated)
+///   3. tier-preset `embedding_model`
+///   4. `None` (keyword-only / embeddings disabled)
+///
+/// The model is read from the explicit section/flat fields rather than
+/// `ResolvedEmbeddings.model` (which defaults to nomic whenever ANY
+/// `[embeddings]` key is present), so a url-only section on the semantic
+/// tier still keeps the tier-preset MiniLM model. A configured id the
+/// 2-model daemon embedder cannot construct (or an unparseable one)
+/// degrades to the tier preset — the operator picked a pin, not
+/// keyword-only. Pure: no network I/O, so the precedence is unit-testable
+/// without an HF-Hub fetch (`build_embedder` does the construction).
+#[allow(deprecated)]
+fn resolve_embedder_model(
+    tier_config: &crate::config::TierConfig,
+    app_config: &AppConfig,
+) -> Option<crate::config::EmbeddingModel> {
+    let preset = tier_config.embedding_model;
+    let preset_label = preset
+        .map(|m| m.hf_model_id().to_string())
+        .unwrap_or_else(|| "none".to_string());
+
+    let configured = app_config
+        .embeddings
+        .as_ref()
+        .and_then(|section| section.model.clone())
+        .filter(|raw| !raw.trim().is_empty())
+        .map(|raw| (raw, "[embeddings].model"))
+        .or_else(|| {
+            app_config
+                .embedding_model
+                .clone()
+                .filter(|raw| !raw.trim().is_empty())
+                .map(|raw| (raw, "legacy embedding_model"))
+        });
+
+    let Some((raw, origin)) = configured else {
+        return preset;
+    };
+    match crate::config::EmbeddingModel::from_canonical_id(&raw) {
+        Some(model) => {
+            tracing::info!(
+                "embedder: using configured model {} from {origin} (tier-preset would have been {})",
+                model.hf_model_id(),
+                preset_label
+            );
+            Some(model)
+        }
+        None => {
+            tracing::warn!(
+                "embedder: configured model {raw:?} (from {origin}) is not constructible by the \
+                 daemon embedder (supported: nomic-embed-text-v1.5, all-MiniLM-L6-v2); \
+                 falling back to tier-preset {preset_label}"
+            );
+            preset
+        }
+    }
+}
+
 /// Construct the [`Embedder`] for a given tier. Returns `None` for the
 /// keyword tier (no embedder requested) and on load failure (caller
 /// degrades to keyword fallback). On failure the diagnostic is emitted
@@ -2000,47 +2064,22 @@ pub fn resolve_admin_agent_ids(admin_cfg: Option<&crate::config::AdminConfig>) -
 #[allow(deprecated)]
 pub async fn build_embedder(feature_tier: FeatureTier, app_config: &AppConfig) -> Option<Embedder> {
     let tier_config = feature_tier.config();
-    // L2 fix: honor the documented top-level `embedding_model` override
-    // before falling back to the tier preset. Resolution order:
-    //   1. `AppConfig.embedding_model` override (if parseable)
-    //   2. Tier-preset `embedding_model` (existing behavior)
-    //   3. Disabled (keyword-only)
-    // A parse failure on the override degrades to the tier preset rather
-    // than disabling embeddings outright — the operator only mistyped a
-    // pin, they didn't ask for keyword-only.
-    let preset = tier_config.embedding_model;
-    let preset_label = preset
-        .map(|m| m.hf_model_id().to_string())
-        .unwrap_or_else(|| "none".to_string());
-    let resolved = match app_config.embedding_model.as_deref() {
-        Some(raw) => match raw.parse::<crate::config::EmbeddingModel>() {
-            Ok(model) => {
-                tracing::info!(
-                    "embedder: using app_config override {} (tier-preset would have been {})",
-                    model.hf_model_id(),
-                    preset_label
-                );
-                Some(model)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "embedder: ignoring invalid app_config.embedding_model={raw:?} ({e}); \
-                     falling back to tier-preset {}",
-                    preset_label
-                );
-                preset
-            }
-        },
-        None => preset,
-    };
-    let Some(emb_model) = resolved else {
+    // #1521: consume the canonical embeddings resolver so the sectioned
+    // `[embeddings]` block (#1146) drives the daemon embedder, not just
+    // the deprecated flat fields. The model is resolved by the pure
+    // `resolve_embedder_model` helper (precedence: `[embeddings].model`
+    // section > legacy flat `embedding_model` > tier preset); the URL is
+    // taken from the resolver, which layers `[embeddings].url` > legacy
+    // `embed_url`/`ollama_url` > default.
+    let resolved_embeddings = app_config.resolve_embeddings();
+    let Some(emb_model) = resolve_embedder_model(&tier_config, app_config) else {
         tracing::info!(
             "embedder disabled — tier={} keyword-only (FTS5); semantic recall not wired",
             feature_tier.as_str()
         );
         return None;
     };
-    let embed_url = app_config.effective_embed_url().to_string();
+    let embed_url = resolved_embeddings.url.clone();
     // #1143: the daemon embed client is always Ollama-wire-shape (it
     // talks to a local Ollama OR a compatible nomic-embed-text host).
     // Using `new_with_url` here is correct regardless of
@@ -5147,6 +5186,112 @@ mod tests {
         assert!(
             emb.is_none(),
             "unparseable override + keyword tier must return None"
+        );
+    }
+
+    // ----- resolve_embedder_model (#1521 precedence) --------------------
+
+    /// #1521 — the sectioned `[embeddings].model` block must beat the
+    /// tier preset. Semantic tier presets MiniLM; a section pinning nomic
+    /// must win. This is the core regression the issue describes (the
+    /// section was silently dropped in favour of the preset).
+    #[test]
+    fn resolve_embedder_model_section_beats_tier_preset() {
+        let mut cfg = AppConfig::default();
+        cfg.embeddings = Some(crate::config::EmbeddingsSection {
+            model: Some("nomic_embed_v15".to_string()),
+            ..crate::config::EmbeddingsSection::default()
+        });
+        let tier = FeatureTier::Semantic.config();
+        assert_eq!(
+            resolve_embedder_model(&tier, &cfg),
+            Some(crate::config::EmbeddingModel::NomicEmbedV15),
+            "[embeddings].model must override the Semantic tier MiniLM preset"
+        );
+    }
+
+    /// #1521 — the deprecated flat `embedding_model` field must still be
+    /// honored when no section is present (backward compat).
+    #[test]
+    fn resolve_embedder_model_legacy_flat_still_honored() {
+        let mut cfg = AppConfig::default();
+        cfg.embedding_model = Some("nomic_embed_v15".to_string());
+        let tier = FeatureTier::Semantic.config();
+        assert_eq!(
+            resolve_embedder_model(&tier, &cfg),
+            Some(crate::config::EmbeddingModel::NomicEmbedV15),
+            "legacy flat embedding_model must still override the preset"
+        );
+    }
+
+    /// #1521 — when BOTH are set the section wins over the legacy flat
+    /// field (precedence ladder ordering).
+    #[test]
+    fn resolve_embedder_model_section_beats_legacy_flat() {
+        let mut cfg = AppConfig::default();
+        cfg.embedding_model = Some("nomic_embed_v15".to_string());
+        cfg.embeddings = Some(crate::config::EmbeddingsSection {
+            model: Some("mini_lm_l6_v2".to_string()),
+            ..crate::config::EmbeddingsSection::default()
+        });
+        let tier = FeatureTier::Semantic.config();
+        assert_eq!(
+            resolve_embedder_model(&tier, &cfg),
+            Some(crate::config::EmbeddingModel::MiniLmL6V2),
+            "[embeddings].model must win over legacy flat embedding_model"
+        );
+    }
+
+    /// #1521 — a url-only section (no model key) must NOT force a model;
+    /// the tier preset is kept. Guards against keying the model decision
+    /// off `ResolvedEmbeddings.model` (which defaults to nomic whenever
+    /// any `[embeddings]` key is present).
+    #[test]
+    fn resolve_embedder_model_url_only_section_keeps_preset() {
+        let mut cfg = AppConfig::default();
+        cfg.embeddings = Some(crate::config::EmbeddingsSection {
+            url: Some("http://127.0.0.1:11435".to_string()),
+            ..crate::config::EmbeddingsSection::default()
+        });
+        let tier = FeatureTier::Semantic.config();
+        assert_eq!(
+            resolve_embedder_model(&tier, &cfg),
+            Some(crate::config::EmbeddingModel::MiniLmL6V2),
+            "url-only section must keep the Semantic MiniLM preset"
+        );
+    }
+
+    /// #1521 — a configured model the 2-model daemon embedder cannot
+    /// construct degrades to the tier preset rather than disabling.
+    #[test]
+    fn resolve_embedder_model_unsupported_id_falls_back_to_preset() {
+        let mut cfg = AppConfig::default();
+        cfg.embeddings = Some(crate::config::EmbeddingsSection {
+            model: Some("bge-large-en".to_string()),
+            ..crate::config::EmbeddingsSection::default()
+        });
+        let tier = FeatureTier::Semantic.config();
+        assert_eq!(
+            resolve_embedder_model(&tier, &cfg),
+            Some(crate::config::EmbeddingModel::MiniLmL6V2),
+            "unsupported model id must fall back to the tier preset"
+        );
+    }
+
+    /// #1521 — nothing configured at any layer: keyword tier (no preset)
+    /// yields None; semantic tier yields its MiniLM preset.
+    #[test]
+    fn resolve_embedder_model_unconfigured_uses_tier_preset() {
+        let cfg = AppConfig::default();
+        assert_eq!(
+            resolve_embedder_model(&FeatureTier::Keyword.config(), &cfg),
+            None,
+            "keyword tier has no preset → None"
+        );
+        assert_eq!(
+            resolve_embedder_model(&FeatureTier::Semantic.config(), &cfg),
+            Some(crate::config::EmbeddingModel::MiniLmL6V2),
+            "semantic tier preset is MiniLM"
         );
     }
 

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -199,7 +199,16 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // change wires an existing daemon-boot path for first-party-CA identity
     // resolution / credential renewal (no speculative surface). 7700 = 7621
     // + 79 headroom; far under the 1.5x cap.
-    ("src/daemon_runtime.rs", 7_700),
+    //
+    // 2026-06-06 — bumped 7_700 → 7_850 by the #1521 sectioned-[embeddings]
+    // wiring: the pure `resolve_embedder_model` precedence helper (section
+    // model > legacy flat > tier preset) plus `build_embedder` consuming it
+    // and `resolve_embeddings().url`, with 6 in-file precedence regression
+    // tests, grew the file to 7766. Growth is justified: it wires the
+    // existing [embeddings] config block into the daemon embedder build
+    // path (no speculative surface). 7850 = 7766 + 84 headroom; far under
+    // the 1.5x cap.
+    ("src/daemon_runtime.rs", 7_850),
     ("src/subscriptions.rs", 4_500),
     ("src/cli/install.rs", 3_500),
     // 2026-06-05 — bumped 3_500 → 3_700 by the #1508 v0.6.4→v0.7.0


### PR DESCRIPTION
## Summary
- `build_embedder` consumed only the deprecated flat `embedding_model` + `effective_embed_url()`, silently ignoring the sectioned `[embeddings]` block (#1146). Operators setting `[embeddings].model` got the tier preset instead of their configured model.
- Adds a pure, unit-testable `resolve_embedder_model` helper implementing the precedence ladder: `[embeddings].model` > legacy flat `embedding_model` > tier preset. URL now flows through `resolve_embeddings()`.
- New `EmbeddingModel::from_canonical_id` accepts every canonical alias form (snake, HF id, short id) case-insensitively; an unconstructible id falls back to the tier preset with a warning rather than failing the daemon.

## Critical correctness guard
`ResolvedEmbeddings.model` defaults to nomic whenever **any** `[embeddings]` key is present, so the model override reads the explicit section/flat fields **directly** (not `resolved.model`) — a url-only `[embeddings]` section must NOT force nomic. Regression-locked by `resolve_embedder_model_url_only_section_keeps_preset`.

## Tests
- 6 `daemon_runtime` precedence tests: section>preset, legacy-flat honored, section>legacy-flat, url-only-keeps-preset, unsupported-id→preset, unconfigured→preset.
- 1 `config` alias-parse test covering all canonical forms + case-insensitivity + reject of unknown/empty ids.

## QC gates (all green)
- `cargo fmt --check`: clean
- `cargo clippy --lib -- -D warnings -D clippy::all -D clippy::pedantic`: clean
- `cargo audit`: clean (0 vulns, 529 deps)
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib`: **5266 passed / 0 failed**

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)