### PR TITLE
feat(reference-configs): EC-1 three compute-archetype config.toml + decision tree (#1526)

### DIFF
--- a/deploy/reference-configs/README.md
+++ b/deploy/reference-configs/README.md
@@ -1,0 +1,127 @@
+# Enterprise Compute Reference Configurations (EC-1)
+
+Three benchmark-ready `config.toml` reference files, one per compute archetype,
+plus the selection decision tree. These are the concrete substrate the
+downstream EC benchmark harness measures against. Every value is annotated with
+the exact code path that consumes it; the resolvers are pure (no network I/O),
+so the resolution semantics are fully determined by the file content and proven
+by [`tests/ec1_reference_configs_resolve.rs`](../../tests/ec1_reference_configs_resolve.rs).
+
+| File | Archetype | Embedder | Ollama? | GPU? |
+|------|-----------|----------|---------|------|
+| [`ec-cpu.toml`](./ec-cpu.toml) | **EC-CPU** | candle, in-process (`EmbeddingModel::MiniLmL6V2`) | no | no |
+| [`ec-gpu.toml`](./ec-gpu.toml) | **EC-GPU** | Ollama HTTP (`EmbeddingModel::NomicEmbedV15`) | dedicated | yes |
+| [`ec-gpu-shared.toml`](./ec-gpu-shared.toml) | **EC-GPU-SHARED** | Ollama HTTP (`EmbeddingModel::NomicEmbedV15`) | shared / co-tenant | yes |
+
+> Model identifiers in these files are **operator-facing aliases only** —
+> irreducible configuration data the resolver canonicalises. No vector-dimension
+> literal appears in any TOML; the dim is derived at runtime from the
+> `EmbeddingModel` SSOT enum (`.dim()`) via `canonical_embedding_dim()`. The
+> validation test asserts against those SSOT symbols, never against bare
+> model-id or dimension literals.
+
+---
+
+## Selection decision tree — "Ollama or no Ollama?"
+
+The first and load-bearing question is whether a GPU-backed Ollama endpoint is
+available to the daemon. That single decision picks the embedder family, which
+in turn picks the entire archetype.
+
+```
+                       ┌────────────────────────────────────────┐
+                       │ Is a GPU-backed Ollama endpoint         │
+                       │ available to the daemon for embeddings? │
+                       └───────────────┬────────────────────────┘
+                                       │
+                ┌──────────────────────┴──────────────────────┐
+                │ NO                                           │ YES
+                ▼                                              ▼
+        ┌───────────────┐                       ┌──────────────────────────────┐
+        │   EC-CPU      │                       │ Is the GPU DEDICATED to       │
+        │               │                       │ ai-memory, or SHARED with     │
+        │ candle MiniLM │                       │ other co-tenant workloads?    │
+        │ 384-dim,      │                       └───────────────┬───────────────┘
+        │ in-process,   │                                       │
+        │ NO Ollama.    │              ┌────────────────────────┴───────────┐
+        │ LLM = cloud   │              │ DEDICATED                          │ SHARED
+        │ provider.     │              ▼                                    ▼
+        └───────────────┘      ┌───────────────┐               ┌────────────────────────┐
+                               │   EC-GPU      │               │    EC-GPU-SHARED       │
+                               │               │               │                        │
+                               │ nomic 768-dim │               │ nomic 768-dim over a   │
+                               │ over local    │               │ SHARED Ollama host;    │
+                               │ Ollama GPU.   │               │ smaller batch + pool,  │
+                               │ Full local    │               │ longer acquire timeout │
+                               │ AI surface.   │               │ (good-neighbour).      │
+                               └───────────────┘               └────────────────────────┘
+```
+
+### EC-CPU — no GPU, no Ollama
+Choose when the fleet has **no GPU budget**. The embedder is the candle
+in-process `all-MiniLM-L6-v2` (384-dim) running on CPU; the daemon never opens
+an Ollama connection for embeddings. LLM autonomy runs against a **cloud**
+provider (OpenRouter/etc.) so the host needs no local accelerator at all. This
+is the posture of the free do-1461 CPU swarm.
+
+### EC-GPU — dedicated GPU, Ollama
+Choose when ai-memory **owns** a GPU. Both the embedder (768-dim nomic) and the
+LLM run on the local Ollama, so the full AI surface is local with no co-tenant
+contention. Larger pool and batch sizes exploit the dedicated silicon.
+
+### EC-GPU-SHARED — shared GPU, Ollama
+Choose when a **central Ollama host** serves several daemons/workloads. Model
+resolution is byte-identical to EC-GPU; only the resource envelope changes:
+smaller `backfill_batch` (gentler bursts on the shared endpoint), a tighter
+connection pool (don't hoard substrate connections), and a longer acquire
+timeout (ride out contention instead of failing fast).
+
+---
+
+## Code-precedence map
+
+Every resolved field follows one uniform precedence ladder (highest wins):
+
+```
+CLI flag  >  AI_MEMORY_* env var  >  config.toml section
+          >  legacy flat field (one-shot deprecation WARN)  >  compiled default
+```
+
+| Concern | Resolver | What it does for these configs |
+|---------|----------|--------------------------------|
+| Embedder URL + model + dim | `AppConfig::resolve_embeddings()` (`src/config.rs`) | `[embeddings].model` wins, is canonicalised via `canonicalise_embedding_model()`, and its dim is looked up in `KNOWN_EMBEDDING_DIMS` via `canonical_embedding_dim()`. `[embeddings].url` wins the URL sub-ladder over the legacy `embed_url` / `ollama_url` flat fields. |
+| Daemon embedder model | `resolve_embedder_model()` (`src/daemon_runtime.rs`) | Parses the resolved alias via `EmbeddingModel::from_canonical_id()`. EC-CPU → `MiniLmL6V2`; EC-GPU / EC-GPU-SHARED → `NomicEmbedV15`. |
+| Embedder backend wiring | `Embedder::for_model()` (`src/embeddings.rs`) | `MiniLmL6V2` → `Embedder::new_local()` (candle, **Ollama client ignored** → the no-Ollama path). `NomicEmbedV15` → `Embedder::new_ollama()` (**requires** the Ollama client → the GPU path). |
+| Reranker | `AppConfig::resolve_reranker()` | `[reranker].enabled` / `model`; folds the legacy `cross_encoder` flag. |
+| Storage | `AppConfig::resolve_storage()` | `[storage]` namespace + archive policy. |
+| Limits | `AppConfig::resolve_limits()` | `[limits]` quotas + page-size cap; `AI_MEMORY_MAX_*` env overrides. |
+| Postgres pool | `AppConfig::resolve_pg_pool()` | top-level `postgres_pool_*` / `postgres_acquire_timeout_secs`; `AI_MEMORY_PG_*` env overrides. |
+| Permissions | `AppConfig::effective_permissions_mode()` | `[permissions].mode`; v0.7.0 secure default is `enforce`. |
+
+---
+
+## Secrets posture
+
+No secret is ever inlined in these files:
+
+- **LLM API key** — supplied at runtime via the env var named by
+  `[llm].api_key_env` (or `[llm].api_key_file`). Inline `[llm].api_key` is
+  **rejected at parse time** with a security-rationale message.
+- **HTTP API key** — supplied via the `AI_MEMORY_API_KEY` env override, never
+  written to the file.
+- **Database password** — supplied out-of-band via the `AI_MEMORY_DB` env
+  override or the `PG*` environment; the `db` URL here carries no password.
+
+---
+
+## Validation
+
+`tests/ec1_reference_configs_resolve.rs` parses each file in this directory and
+asserts that the resolvers yield the intended `(EmbeddingModel variant, dim)`
+tuple per archetype — using only the `EmbeddingModel` SSOT symbols
+(`from_canonical_id`, `.dim()`, `.hf_model_id()`) and `canonical_embedding_dim`,
+with zero bare model-id / dimension literals.
+
+```sh
+AI_MEMORY_NO_CONFIG=1 cargo test --test ec1_reference_configs_resolve
+```

--- a/deploy/reference-configs/ec-cpu.toml
+++ b/deploy/reference-configs/ec-cpu.toml
@@ -1,0 +1,124 @@
+# =============================================================================
+# EC-CPU — Enterprise Compute archetype: CPU-only, NO Ollama
+# =============================================================================
+# Embedder runs IN-PROCESS on CPU (candle). The daemon never opens an Ollama
+# connection for embeddings. LLM autonomy (auto_tag / contradiction / query
+# expansion) runs against a CLOUD provider so the host needs no local GPU at
+# all. This is the archetype for fleets with no GPU budget — the do-1461 free
+# CPU swarm is the canonical deployment.
+#
+# Code path this file exercises (all resolvers are PURE, no network I/O):
+#   * config.rs  AppConfig::resolve_embeddings()
+#                 -> [embeddings].model wins the precedence ladder, is run
+#                    through canonicalise_embedding_model(), and its dim is
+#                    looked up in KNOWN_EMBEDDING_DIMS.
+#   * daemon_runtime.rs  resolve_embedder_model()
+#                 -> EmbeddingModel::from_canonical_id("all-MiniLM-L6-v2")
+#                    == EmbeddingModel::MiniLmL6V2.
+#   * embeddings.rs  Embedder::for_model(MiniLmL6V2, _client)
+#                 -> Embedder::new_local() (candle, in-process). The Ollama
+#                    client argument is IGNORED for this model — that is what
+#                    makes EC-CPU the "no-Ollama" archetype.
+#
+# Precedence ladder for every resolved field (highest wins):
+#   CLI flag  >  AI_MEMORY_* env var  >  config.toml section
+#             >  legacy flat field (deprecation WARN)  >  compiled default
+# =============================================================================
+
+# v2 sectioned schema (#1146). MUST be 2 to select the sectioned parse path.
+schema_version = 2
+
+# Feature tier. `autonomous` enables the full LLM-autonomy hook surface.
+tier = "autonomous"
+
+# Storage backend connection. For the Postgres substrate this is the
+# connection URL; the password is supplied out-of-band via the
+# AI_MEMORY_DB env override or the PG* environment — NEVER inline here.
+db = "postgres://ai_memory@localhost:5432/ai_memory"
+
+# --- Postgres connection-pool ceilings (resolve_pg_pool) ---------------------
+# Sized for a dedicated CPU node. Env overrides: AI_MEMORY_PG_POOL_MAX /
+# AI_MEMORY_PG_POOL_MIN / AI_MEMORY_PG_ACQUIRE_TIMEOUT_SECS.
+postgres_pool_max_connections = 16
+postgres_pool_min_connections = 2
+postgres_acquire_timeout_secs = 30
+
+# -----------------------------------------------------------------------------
+# [llm] — cloud LLM provider (no local GPU required).
+# The model id is a provider tag passed verbatim to the chat endpoint and is
+# operator-selectable; swap backend/model for any supported provider. The API
+# key is read at runtime from the named env var — NEVER inline a secret here
+# (inline `api_key` is REJECTED at parse time; use api_key_env / api_key_file).
+# -----------------------------------------------------------------------------
+[llm]
+backend = "openrouter"
+model = "google/gemma-4-26b-a4b-it"
+api_key_env = "OPENROUTER_API_KEY"
+
+# Fast structured-output sibling for auto_tag / query-expansion. Inherits every
+# unset field from the parent [llm]; override `model` to a cheaper/faster tag.
+[llm.auto_tag]
+model = "google/gemma-4-26b-a4b-it"
+
+# -----------------------------------------------------------------------------
+# [embeddings] — THE archetype-defining block.
+# `model` carries ONLY the operator-facing model alias (irreducible config
+# data). MiniLmL6V2 is the candle in-process CPU embedder: the daemon resolves
+# it via EmbeddingModel::from_canonical_id and builds Embedder::new_local(),
+# so `backend`/`url` below are inert for this model (present for schema
+# uniformity and for operators who later switch to an Ollama-served model).
+# -----------------------------------------------------------------------------
+[embeddings]
+backend = "ollama"
+url = "http://localhost:11434"
+model = "all-MiniLM-L6-v2"
+backfill_batch = 100
+
+# -----------------------------------------------------------------------------
+# [reranker] — cross-encoder rerank stage. Runs on CPU; the single v0.7.0
+# variant is the default. `model` is reserved for future bake-offs.
+# -----------------------------------------------------------------------------
+[reranker]
+enabled = true
+model = "ms-marco-MiniLM-L-6-v2"
+
+# -----------------------------------------------------------------------------
+# [storage] — namespace + archive policy.
+# -----------------------------------------------------------------------------
+[storage]
+default_namespace = "alphaone"
+archive_on_gc = true
+archive_max_days = 90
+max_memory_mb = 4096
+
+# -----------------------------------------------------------------------------
+# [limits] — per-(agent, namespace) capacity bounds + request page-size cap.
+# Env overrides: AI_MEMORY_MAX_MEMORIES_PER_DAY / _MAX_STORAGE_BYTES /
+# _MAX_LINKS_PER_DAY / _MAX_PAGE_SIZE.
+# -----------------------------------------------------------------------------
+[limits]
+max_memories_per_day = 10000000
+max_storage_bytes = 1073741824
+max_links_per_day = 5000
+max_page_size = 1000
+
+# -----------------------------------------------------------------------------
+# [permissions] — v0.7.0 secure default is `enforce`.
+# -----------------------------------------------------------------------------
+[permissions]
+mode = "enforce"
+
+# -----------------------------------------------------------------------------
+# [audit] — tamper-evident hash-chained audit trail (SIEM / SOC2 / HIPAA).
+# -----------------------------------------------------------------------------
+[audit]
+enabled = true
+hash_chain = true
+append_only = true
+retention_days = 90
+
+# -----------------------------------------------------------------------------
+# [mcp] — named MCP tool profile (production-secure default surface).
+# -----------------------------------------------------------------------------
+[mcp]
+profile = "core"

--- a/deploy/reference-configs/ec-gpu-shared.toml
+++ b/deploy/reference-configs/ec-gpu-shared.toml
@@ -1,0 +1,116 @@
+# =============================================================================
+# EC-GPU-SHARED — Enterprise Compute archetype: SHARED GPU, Ollama
+# =============================================================================
+# Same embedder family as EC-GPU (768-dim nomic over Ollama) but the GPU is a
+# SHARED, co-tenant resource (a central Ollama host serving several daemons /
+# workloads). The config posture is therefore a GOOD-NEIGHBOUR one: smaller
+# backfill batch (lighter bursts on the shared embed endpoint), a tighter
+# connection pool, and a longer acquire timeout to ride out contention rather
+# than failing fast. The model resolution is byte-identical to EC-GPU — only
+# the resource envelope differs.
+#
+# Code path this file exercises (all resolvers are PURE, no network I/O):
+#   * config.rs  AppConfig::resolve_embeddings()
+#                 -> [embeddings].model wins, canonicalised, dim from
+#                    KNOWN_EMBEDDING_DIMS; [embeddings].url points at the
+#                    SHARED Ollama host (not localhost).
+#   * daemon_runtime.rs  resolve_embedder_model()
+#                 -> EmbeddingModel::from_canonical_id("nomic-embed-text-v1.5")
+#                    == EmbeddingModel::NomicEmbedV15.
+#   * embeddings.rs  Embedder::for_model(NomicEmbedV15, Some(client))
+#                 -> Embedder::new_ollama(): REQUIRES the Ollama client.
+#
+# Precedence ladder for every resolved field (highest wins):
+#   CLI flag  >  AI_MEMORY_* env var  >  config.toml section
+#             >  legacy flat field (deprecation WARN)  >  compiled default
+# =============================================================================
+
+# v2 sectioned schema (#1146). MUST be 2 to select the sectioned parse path.
+schema_version = 2
+
+# Feature tier. `autonomous` enables the full LLM-autonomy hook surface.
+tier = "autonomous"
+
+# Storage backend connection. Password supplied out-of-band via AI_MEMORY_DB /
+# PG* env — NEVER inline here.
+db = "postgres://ai_memory@localhost:5432/ai_memory"
+
+# --- Postgres connection-pool ceilings (resolve_pg_pool) ---------------------
+# Tighter than EC-GPU: a co-tenant daemon should not hoard substrate
+# connections. Longer acquire timeout absorbs contention on the shared box.
+# Env overrides: AI_MEMORY_PG_POOL_MAX / _MIN / AI_MEMORY_PG_ACQUIRE_TIMEOUT_SECS.
+postgres_pool_max_connections = 12
+postgres_pool_min_connections = 2
+postgres_acquire_timeout_secs = 45
+
+# -----------------------------------------------------------------------------
+# [llm] — points at the SHARED Ollama host. Native Ollama backend needs no
+# API key (KeySource::None is correct).
+# -----------------------------------------------------------------------------
+[llm]
+backend = "ollama"
+base_url = "http://gpu-shared.internal:11434"
+model = "gemma3:4b"
+
+# Fast structured-output sibling. Inherits backend/base_url from parent [llm].
+[llm.auto_tag]
+model = "gemma3:4b"
+
+# -----------------------------------------------------------------------------
+# [embeddings] — THE archetype-defining block.
+# NomicEmbedV15 (768-dim) over the SHARED Ollama host. `backfill_batch` is
+# deliberately smaller than EC-GPU to keep bursts gentle on the co-tenant
+# endpoint.
+# -----------------------------------------------------------------------------
+[embeddings]
+backend = "ollama"
+url = "http://gpu-shared.internal:11434"
+model = "nomic-embed-text-v1.5"
+backfill_batch = 64
+
+# -----------------------------------------------------------------------------
+# [reranker] — cross-encoder rerank stage (runs in-process, not on the shared
+# GPU, so it carries no co-tenant cost).
+# -----------------------------------------------------------------------------
+[reranker]
+enabled = true
+model = "ms-marco-MiniLM-L-6-v2"
+
+# -----------------------------------------------------------------------------
+# [storage]
+# -----------------------------------------------------------------------------
+[storage]
+default_namespace = "alphaone"
+archive_on_gc = true
+archive_max_days = 90
+max_memory_mb = 8192
+
+# -----------------------------------------------------------------------------
+# [limits]
+# -----------------------------------------------------------------------------
+[limits]
+max_memories_per_day = 10000000
+max_storage_bytes = 1073741824
+max_links_per_day = 5000
+max_page_size = 1000
+
+# -----------------------------------------------------------------------------
+# [permissions]
+# -----------------------------------------------------------------------------
+[permissions]
+mode = "enforce"
+
+# -----------------------------------------------------------------------------
+# [audit]
+# -----------------------------------------------------------------------------
+[audit]
+enabled = true
+hash_chain = true
+append_only = true
+retention_days = 90
+
+# -----------------------------------------------------------------------------
+# [mcp]
+# -----------------------------------------------------------------------------
+[mcp]
+profile = "core"

--- a/deploy/reference-configs/ec-gpu.toml
+++ b/deploy/reference-configs/ec-gpu.toml
@@ -1,0 +1,115 @@
+# =============================================================================
+# EC-GPU — Enterprise Compute archetype: DEDICATED GPU, Ollama
+# =============================================================================
+# Embedder is served by a DEDICATED Ollama instance on the host's own GPU.
+# The daemon opens an Ollama HTTP connection for embeddings (768-dim nomic)
+# AND for LLM autonomy, so the whole AI surface runs locally on owned silicon
+# with no co-tenant contention. This is the archetype for a single-tenant box
+# with a GPU reserved for ai-memory.
+#
+# Code path this file exercises (all resolvers are PURE, no network I/O):
+#   * config.rs  AppConfig::resolve_embeddings()
+#                 -> [embeddings].model wins, canonicalised, dim from
+#                    KNOWN_EMBEDDING_DIMS; [embeddings].url wins the url ladder.
+#   * daemon_runtime.rs  resolve_embedder_model()
+#                 -> EmbeddingModel::from_canonical_id("nomic-embed-text-v1.5")
+#                    == EmbeddingModel::NomicEmbedV15.
+#   * embeddings.rs  Embedder::for_model(NomicEmbedV15, Some(client))
+#                 -> Embedder::new_ollama(): REQUIRES the Ollama client; the
+#                    daemon errors if none is built. This is what makes EC-GPU
+#                    an "Ollama" archetype.
+#
+# Precedence ladder for every resolved field (highest wins):
+#   CLI flag  >  AI_MEMORY_* env var  >  config.toml section
+#             >  legacy flat field (deprecation WARN)  >  compiled default
+# =============================================================================
+
+# v2 sectioned schema (#1146). MUST be 2 to select the sectioned parse path.
+schema_version = 2
+
+# Feature tier. `autonomous` enables the full LLM-autonomy hook surface.
+tier = "autonomous"
+
+# Storage backend connection. Password supplied out-of-band via AI_MEMORY_DB /
+# PG* env — NEVER inline here.
+db = "postgres://ai_memory@localhost:5432/ai_memory"
+
+# --- Postgres connection-pool ceilings (resolve_pg_pool) ---------------------
+# Larger floor/ceiling than EC-CPU: a dedicated GPU node sustains higher
+# concurrent throughput. Env overrides: AI_MEMORY_PG_POOL_MAX / _MIN /
+# AI_MEMORY_PG_ACQUIRE_TIMEOUT_SECS.
+postgres_pool_max_connections = 32
+postgres_pool_min_connections = 4
+postgres_acquire_timeout_secs = 30
+
+# -----------------------------------------------------------------------------
+# [llm] — local Ollama on the dedicated GPU. No API key needed for the native
+# Ollama backend (the resolver yields KeySource::None, which is correct here).
+# `model` is an operator-selectable Ollama tag.
+# -----------------------------------------------------------------------------
+[llm]
+backend = "ollama"
+base_url = "http://localhost:11434"
+model = "gemma3:4b"
+
+# Fast structured-output sibling. Inherits backend/base_url from parent [llm].
+[llm.auto_tag]
+model = "gemma3:4b"
+
+# -----------------------------------------------------------------------------
+# [embeddings] — THE archetype-defining block.
+# NomicEmbedV15 (768-dim) is served over Ollama's /api/embed on the dedicated
+# GPU. `url` points at the local Ollama; for this model the daemon builds
+# Embedder::new_ollama() and the client is load-bearing (unlike EC-CPU).
+# -----------------------------------------------------------------------------
+[embeddings]
+backend = "ollama"
+url = "http://localhost:11434"
+model = "nomic-embed-text-v1.5"
+backfill_batch = 256
+
+# -----------------------------------------------------------------------------
+# [reranker] — cross-encoder rerank stage.
+# -----------------------------------------------------------------------------
+[reranker]
+enabled = true
+model = "ms-marco-MiniLM-L-6-v2"
+
+# -----------------------------------------------------------------------------
+# [storage]
+# -----------------------------------------------------------------------------
+[storage]
+default_namespace = "alphaone"
+archive_on_gc = true
+archive_max_days = 90
+max_memory_mb = 16384
+
+# -----------------------------------------------------------------------------
+# [limits]
+# -----------------------------------------------------------------------------
+[limits]
+max_memories_per_day = 10000000
+max_storage_bytes = 1073741824
+max_links_per_day = 5000
+max_page_size = 1000
+
+# -----------------------------------------------------------------------------
+# [permissions]
+# -----------------------------------------------------------------------------
+[permissions]
+mode = "enforce"
+
+# -----------------------------------------------------------------------------
+# [audit]
+# -----------------------------------------------------------------------------
+[audit]
+enabled = true
+hash_chain = true
+append_only = true
+retention_days = 90
+
+# -----------------------------------------------------------------------------
+# [mcp]
+# -----------------------------------------------------------------------------
+[mcp]
+profile = "core"

--- a/tests/ec1_reference_configs_resolve.rs
+++ b/tests/ec1_reference_configs_resolve.rs
@@ -1,0 +1,212 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! EC-1 — validation suite for the three compute-archetype reference
+//! `config.toml` files under `deploy/reference-configs/`.
+//!
+//! ## What this pins
+//!
+//! Each reference config must round-trip through the production config
+//! resolvers to the intended embedder for its compute archetype:
+//!
+//! | File                  | Archetype       | `EmbeddingModel` variant | Ollama? |
+//! |-----------------------|-----------------|--------------------------|---------|
+//! | `ec-cpu.toml`         | EC-CPU          | `MiniLmL6V2` (candle)    | no      |
+//! | `ec-gpu.toml`         | EC-GPU          | `NomicEmbedV15`          | yes     |
+//! | `ec-gpu-shared.toml`  | EC-GPU-SHARED   | `NomicEmbedV15`          | yes     |
+//!
+//! ## No-hardcoded-literals discipline (QC-GATE #97)
+//!
+//! The reference TOMLs carry ONLY the operator-facing model **alias**
+//! string (irreducible configuration data the resolver canonicalises) and
+//! never a vector-dimension literal. This test therefore asserts ONLY
+//! against the `EmbeddingModel` SSOT symbols —
+//! [`EmbeddingModel::from_canonical_id`], [`EmbeddingModel::dim`],
+//! [`EmbeddingModel::hf_model_id`] — and [`canonical_embedding_dim`]. No
+//! bare model-id or dimension literal appears anywhere below; the expected
+//! variant IS the SSOT enum and the expected dim is derived from it.
+
+use std::path::PathBuf;
+
+use ai_memory::config::{AppConfig, EmbeddingModel, canonical_embedding_dim};
+
+// ---------------------------------------------------------------------------
+// Reference-config file locations (the only string literals in this suite —
+// fixture paths, not model-ids or dims). Named constants per pm-v3.1 scoping
+// discipline.
+// ---------------------------------------------------------------------------
+
+const REFERENCE_CONFIG_DIR: &str = "deploy/reference-configs";
+const EC_CPU_FILE: &str = "ec-cpu.toml";
+const EC_GPU_FILE: &str = "ec-gpu.toml";
+const EC_GPU_SHARED_FILE: &str = "ec-gpu-shared.toml";
+
+const ALL_REFERENCE_FILES: &[&str] = &[EC_CPU_FILE, EC_GPU_FILE, EC_GPU_SHARED_FILE];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn reference_config_path(file: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(REFERENCE_CONFIG_DIR)
+        .join(file)
+}
+
+fn read_reference_config(file: &str) -> String {
+    let path = reference_config_path(file);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reference config {} must be readable: {e}", path.display()))
+}
+
+fn parse_reference_config(file: &str) -> AppConfig {
+    toml::from_str(&read_reference_config(file))
+        .unwrap_or_else(|e| panic!("reference config {file} must parse as AppConfig: {e}"))
+}
+
+/// Assert that a reference config resolves its embedder to `expected` and
+/// that the resolved dim agrees with the SSOT `expected.dim()`.
+fn assert_resolves_to(file: &str, expected: EmbeddingModel) {
+    let cfg = parse_reference_config(file);
+    let resolved = cfg.resolve_embeddings();
+
+    // The resolved alias must parse back to the intended SSOT variant.
+    let actual = EmbeddingModel::from_canonical_id(&resolved.model).unwrap_or_else(|| {
+        panic!(
+            "{file}: [embeddings].model = {:?} must be a daemon-constructible \
+             EmbeddingModel via from_canonical_id",
+            resolved.model
+        )
+    });
+    assert_eq!(
+        actual, expected,
+        "{file}: resolved embedder must be the archetype's intended model"
+    );
+
+    // The resolved dim must equal the SSOT dim for that variant — derived,
+    // never a literal.
+    let expected_dim = u32::try_from(expected.dim()).expect("embedding dim fits u32");
+    assert_eq!(
+        resolved.embedding_dim,
+        Some(expected_dim),
+        "{file}: ResolvedEmbeddings.embedding_dim must equal EmbeddingModel::dim() SSOT"
+    );
+
+    // Cross-check the resolver's standalone dim lookup against the same SSOT.
+    assert_eq!(
+        canonical_embedding_dim(&resolved.model),
+        Some(expected_dim),
+        "{file}: canonical_embedding_dim must agree with EmbeddingModel::dim() SSOT"
+    );
+
+    // The SSOT variant must carry a non-empty HF id (guards a future enum edit
+    // that drops the mapping).
+    assert!(
+        !expected.hf_model_id().trim().is_empty(),
+        "{file}: resolved EmbeddingModel must expose a non-empty hf_model_id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1) EC-CPU resolves to the candle in-process MiniLM embedder (no Ollama).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ec_cpu_resolves_to_minilm_local() {
+    assert_resolves_to(EC_CPU_FILE, EmbeddingModel::MiniLmL6V2);
+}
+
+// ---------------------------------------------------------------------------
+// (2) EC-GPU resolves to the Ollama-served nomic embedder.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ec_gpu_resolves_to_nomic_ollama() {
+    assert_resolves_to(EC_GPU_FILE, EmbeddingModel::NomicEmbedV15);
+}
+
+// ---------------------------------------------------------------------------
+// (3) EC-GPU-SHARED resolves to the same nomic embedder as EC-GPU.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ec_gpu_shared_resolves_to_nomic_ollama() {
+    assert_resolves_to(EC_GPU_SHARED_FILE, EmbeddingModel::NomicEmbedV15);
+}
+
+// ---------------------------------------------------------------------------
+// (4) The CPU and GPU archetypes resolve to DISTINCT embedders — proves the
+//     test is meaningfully discriminating (both SSOT dims differ).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cpu_and_gpu_archetypes_resolve_to_distinct_embedders() {
+    let cpu = parse_reference_config(EC_CPU_FILE).resolve_embeddings();
+    let gpu = parse_reference_config(EC_GPU_FILE).resolve_embeddings();
+
+    let cpu_model = EmbeddingModel::from_canonical_id(&cpu.model).expect("EC-CPU model resolvable");
+    let gpu_model = EmbeddingModel::from_canonical_id(&gpu.model).expect("EC-GPU model resolvable");
+
+    assert_ne!(
+        cpu_model, gpu_model,
+        "EC-CPU and EC-GPU must resolve to different embedder families"
+    );
+    assert_ne!(
+        cpu_model.dim(),
+        gpu_model.dim(),
+        "the two archetypes' embedders must have different vector dims (SSOT)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (5) Every archetype shares one [embeddings].backend wire shape and resolves
+//     a non-empty endpoint URL (the daemon always materialises a URL even when
+//     the candle path ignores it).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_reference_config_resolves_a_nonempty_url() {
+    for file in ALL_REFERENCE_FILES {
+        let resolved = parse_reference_config(file).resolve_embeddings();
+        assert!(
+            !resolved.url.trim().is_empty(),
+            "{file}: resolve_embeddings must yield a non-empty endpoint URL"
+        );
+        assert!(
+            !resolved.backend.trim().is_empty(),
+            "{file}: resolve_embeddings must yield a non-empty backend selector"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (6) Secrets posture — no reference config inlines an `api_key` value. Only
+//     `api_key_env` / `api_key_file` indirection is permitted (inline api_key
+//     is rejected at parse time, but a doc-grade reference file must never
+//     even tempt an operator with the shape).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_reference_config_inlines_a_secret() {
+    const INLINE_KEY_PREFIX: &str = "api_key";
+    const ENV_INDIRECTION: &str = "api_key_env";
+    const FILE_INDIRECTION: &str = "api_key_file";
+
+    for file in ALL_REFERENCE_FILES {
+        for (lineno, raw) in read_reference_config(file).lines().enumerate() {
+            let line = raw.trim_start();
+            if line.starts_with('#') {
+                continue;
+            }
+            let is_indirection =
+                line.starts_with(ENV_INDIRECTION) || line.starts_with(FILE_INDIRECTION);
+            let inlines_secret = line.starts_with(INLINE_KEY_PREFIX) && !is_indirection;
+            assert!(
+                !inlines_secret,
+                "{file}:{}: reference config must not inline an api_key; \
+                 use api_key_env / api_key_file: {raw:?}",
+                lineno + 1
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1526. Ships the three benchmark-ready enterprise compute-archetype reference configs, the Ollama-or-no-Ollama selection decision tree, and an SSOT-asserting validation test — the concrete substrate the downstream EC benchmark harness measures against.

| File | Archetype | Embedder | Ollama? | GPU? |
|---|---|---|---|---|
| `deploy/reference-configs/ec-cpu.toml` | EC-CPU | candle `MiniLmL6V2`, in-process | no | no |
| `deploy/reference-configs/ec-gpu.toml` | EC-GPU | Ollama `NomicEmbedV15` | dedicated | yes |
| `deploy/reference-configs/ec-gpu-shared.toml` | EC-GPU-SHARED | Ollama `NomicEmbedV15` | shared | yes |
| `deploy/reference-configs/README.md` | — | decision tree + per-archetype rationale + code-precedence map | — | — |
| `tests/ec1_reference_configs_resolve.rs` | — | parses each file, asserts resolver output | — | — |

## No-hardcoded-literals discipline (QC-GATE #97)
- TOMLs carry **only** the operator-facing model **alias** string (irreducible config data the resolver canonicalises); **never** a dimension literal.
- The test asserts **only** against `EmbeddingModel` SSOT symbols (`from_canonical_id`, `dim`, `hf_model_id`) and `canonical_embedding_dim` — **zero** bare model-id / dim literals.
- No secret is inlined: LLM key via `api_key_env`, HTTP key via `AI_MEMORY_API_KEY`, DB password out-of-band. A test guard (`no_reference_config_inlines_a_secret`) enforces this.

## Code paths exercised (pure resolvers, no network I/O)
- `AppConfig::resolve_embeddings()` — `[embeddings].model` precedence + `canonical_embedding_dim()`.
- `resolve_embedder_model()` — `EmbeddingModel::from_canonical_id()` → EC-CPU `MiniLmL6V2`, EC-GPU(-SHARED) `NomicEmbedV15`.
- `Embedder::for_model()` — `MiniLmL6V2` → `new_local()` (no-Ollama), `NomicEmbedV15` → `new_ollama()` (GPU path).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --test ec1_reference_configs_resolve -- -W clippy::pedantic` clean
- [x] `AI_MEMORY_NO_CONFIG=1 cargo test --test ec1_reference_configs_resolve` — 6/6 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)