### PR TITLE
docs(enterprise): 100% TOML coverage + PG18.4/AGE1.7.0/pgvector0.8.2 version pins

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -99,6 +99,231 @@ profile = "full"
 mode = "enforce"
 ```
 
+## Substrate component versions (Enterprise Federated)
+
+The postgres-backed Enterprise Federated substrate pins an exact,
+tested component matrix. These versions are the **single source of
+truth** in
+[`deploy/docker-1461/provision/lib.sh`](../deploy/docker-1461/provision/lib.sh)
+and are asserted at bring-up by the validate harness (the daemon refuses
+to certify a stack whose probed versions drift from the pins below).
+
+| Component | Canonical version | SSOT pin (`deploy/docker-1461/provision/lib.sh`) |
+|---|---|---|
+| PostgreSQL | **18.4** | `PG_APT_VERSION=18.4-1.pgdg13+1`, `EXPECTED_PG_VERSION=18.4` |
+| Apache AGE | **1.7.0** | `AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`, `EXPECTED_AGE_VERSION=1.7.0` |
+| pgvector (server extension) | **0.8.2** | `PGVECTOR_APT_VERSION=0.8.2-1.pgdg13+1` |
+| pgvector (Rust binding crate) | **0.4** | `Cargo.toml` → `pgvector = "0.4"` |
+| ai-memory postgres schema | **v28** | schema parity with SQLite at v28 (v0.7.0) |
+
+The bundled stacked image at
+[`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector)
+(`ARG AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`, `ARG PG_MAJOR=18`)
+layers pgvector 0.8.2 onto the AGE base so K8s / ECS / Cloud Run
+operators do not build AGE from source. See
+[`postgres-age-guide.md`](postgres-age-guide.md) for the from-source
+install recipe and the Docker layering rationale (#1065).
+
+> **Alternate tested matrix.** `infra/lan-parity-test/` and the
+> lan-parity compose harness legitimately run **PG 16 + AGE 1.6.0 +
+> pgvector 0.8.2** as a second tested combination. Those references are
+> factual (not drift); the *recommended* Enterprise Federated install
+> targets the PG 18.4 / AGE 1.7.0 matrix above.
+
+## Enterprise & operational sections
+
+Beyond the four #1146 sectioned blocks (`[llm]` / `[embeddings]` /
+`[reranker]` / `[storage]`) and `[limits]` shown in the Quick reference,
+`AppConfig` (`src/config.rs`) parses the following operator-facing
+sections. Each is **default-safe** — absent blocks select the compiled
+default and preserve the pre-existing behaviour. Fields are listed
+exactly as the SSOT struct declares them.
+
+### Top-level operational fields
+
+```toml
+schema_version = 2          # None/1 = legacy flat parse; >=2 = sectioned parse
+
+# Postgres connection-pool + query bounds (resolved by AppConfig::resolve_pg_pool).
+postgres_pool_max_connections   = 16    # env: AI_MEMORY_PG_POOL_MAX
+postgres_pool_min_connections   = 2     # env: AI_MEMORY_PG_POOL_MIN
+postgres_acquire_timeout_secs   = 30    # env: AI_MEMORY_PG_ACQUIRE_TIMEOUT_SECS
+postgres_statement_timeout_secs = 30    # after_connect SET statement_timeout; 0 = disable
+
+# Per-request / per-LLM-call wall-clock timeouts (DoS bounds).
+request_timeout_secs  = 60    # axum middleware ceiling (slowloris guard)
+llm_call_timeout_secs = 30    # wraps every spawn_blocking LLM call in tokio timeout
+
+# MCP-stdio → HTTP daemon write forwarder (federation fanout).
+mcp_federation_forward_url = "http://localhost:9077"
+```
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `schema_version` | `u32?` | `1` (legacy) | `>= 2` selects the sectioned parse path; warns if legacy flat fields coexist. |
+| `postgres_pool_max_connections` | `u32?` | `DEFAULT_MAX_CONNECTIONS` | sqlx `max_connections`; non-positive falls through to default. |
+| `postgres_pool_min_connections` | `u32?` | `DEFAULT_MIN_CONNECTIONS` | sqlx `min_connections` (warm floor). |
+| `postgres_acquire_timeout_secs` | `u64?` | derived from `DEFAULT_ACQUIRE_TIMEOUT` | sqlx `acquire_timeout`, whole seconds. |
+| `postgres_statement_timeout_secs` | `u64?` | `30` | per-connection `statement_timeout`; `0` disables. |
+| `request_timeout_secs` | `u64?` | `60` | per-HTTP-request wall-clock cap (H7). |
+| `llm_call_timeout_secs` | `u64?` | `30` | per-LLM-call timeout; on timeout falls back to the LLM-absent path (H8). |
+| `mcp_federation_forward_url` | `String?` | unset (direct SQLite) | when set, MCP-stdio write tools POST to this daemon so federation fanout runs (#318). |
+
+### `[identity]` — identity-resolution fallback (#198)
+
+```toml
+[identity]
+anonymize_default = false   # true → anonymous:pid-<pid>-<uuid8> instead of host:<hostname>:...
+```
+
+`anonymize_default = true` swaps the hostname-revealing default
+`agent_id` fallback for `anonymous:pid-<pid>-<uuid8>` (the persistent
+equivalent of `AI_MEMORY_ANONYMIZE=1`).
+
+### `[audit]` — tamper-evident audit trail (#487)
+
+Default-OFF. When enabled, emits a hash-chained, append-only JSON audit
+log suitable for SIEM ingestion and SOC2 / HIPAA / GDPR / FedRAMP
+evidence. See [`security/audit-trail.md`](security/audit-trail.md).
+
+```toml
+[audit]
+enabled                     = true
+path                        = "~/.local/state/ai-memory/audit/"   # dir or file
+schema_version              = 1       # reserved; must equal the binary's emitted version
+redact_content              = true    # v1 only supports true (no content field on the wire)
+hash_chain                  = true    # per-line hash chain (load-bearing tamper evidence)
+attestation_cadence_minutes = 60      # periodic CHECKPOINT.sig marker; 0 disables
+append_only                 = true    # best-effort platform append-only file flag
+retention_days              = 90      # purge/verify horizon; compliance presets override
+
+  [audit.compliance]
+  # Industry presets layered on top of the base config. The strictest
+  # (longest retention / most-frequent attestation) applied preset wins.
+  [audit.compliance.soc2]
+  applied                     = true
+  retention_days              = 365
+  [audit.compliance.hipaa]
+  applied                     = false
+  retention_days              = 2190    # 6 years
+  encrypt_at_rest             = true    # pair with --features sqlcipher
+  [audit.compliance.gdpr]
+  applied                     = false
+  pseudonymize_actors         = true
+  [audit.compliance.fedramp]
+  applied                     = false
+  attestation_cadence_minutes = 15
+```
+
+Each `[audit.compliance.<preset>]` table is a `CompliancePreset`:
+`applied` / `retention_days` / `redact_content` /
+`attestation_cadence_minutes` / `encrypt_at_rest` /
+`pseudonymize_actors`. `AuditConfig::effective_retention_days()` and
+`effective_attestation_cadence_minutes()` resolve the strictest active
+policy.
+
+### `[transcripts]` — transcript lifecycle sweeper (I3)
+
+```toml
+[transcripts]
+default_ttl_secs       = 2592000     # 30d archive-eligibility; None → DEFAULT_TRANSCRIPT_TTL_SECS
+archive_grace_secs     = 604800      # 7d linger before prune; None → DEFAULT_..._ARCHIVE_GRACE_SECS
+max_decompressed_bytes = 16777216    # 16 MiB decompression-bomb cap (per fetch call)
+
+  # Per-namespace overrides. Literal match first; trailing "/*" = subtree; "*" = catch-all (last).
+  [transcripts.namespaces."projects/atlas"]
+  default_ttl_secs   = 7776000       # 90d for this namespace
+  archive_grace_secs = 1209600       # 14d
+  auto_extract       = true          # opt into the R5 pre_store transcript-extractor hook
+```
+
+### `[hooks]` — outgoing-webhook signing (K7)
+
+```toml
+[hooks]
+  [hooks.subscription]
+  hmac_secret = "..."   # server-wide HMAC override; signs every webhook payload
+```
+
+`hmac_secret` is a secret: it is `skip_serializing`, redacted to
+`<redacted>` in `Debug`, and zeroized on drop. Keep the config file
+`chmod 600`. When unset, only per-subscription secrets apply.
+
+### `[subscriptions]` — webhook SSRF guard (H11, #628)
+
+```toml
+[subscriptions]
+allow_loopback_webhooks = false   # default false closes an authenticated SSRF gadget
+```
+
+Default-OFF rejects webhook URLs resolving to `127.0.0.0/8` /
+`localhost` / `::1` (which are reachable from the daemon and would
+expose locally-bound services such as Postgres on 5432). Set `true`
+only for CI / dev.
+
+### `[verify]` — link-verification replay protection (H5)
+
+```toml
+[verify]
+require_nonce = false   # true → every POST /api/v1/links/verify must carry verification_nonce
+```
+
+When `true`, missing nonces → 400; replayed `(link_id, signature,
+nonce)` tuples → 409 Conflict. Default-OFF preserves v0.6.x
+verify-anytime semantics.
+
+### `[agents]` — session-default recall scope (#518)
+
+```toml
+[agents]
+  [agents.defaults]
+    [agents.defaults.recall_scope]
+    namespaces = ["projects/atlas"]   # default namespace filter (first applied today)
+    since      = "24h"                # duration → since = now() - 24h
+    tier       = "long"              # "short" / "mid" / "long"
+    limit      = 50                  # default cap (still clamped to per-tool max 50)
+```
+
+Splices defaults into recall requests that pass `session_default=true`
+and omit a field. Resolution: **explicit request args > recall_scope
+defaults > compiled defaults** — the splice never overrides an explicit
+filter.
+
+### `[governance]` — fail-closed rule enforcement (SEC-2, #767)
+
+```toml
+[governance]
+require_operator_pubkey = false   # true → refuse boot if enabled rules exist but no operator pubkey
+```
+
+When `true`, daemon `serve` refuses to start if `governance_rules`
+contains any `enabled = 1` row AND no operator pubkey is resolved (env
+`AI_MEMORY_OPERATOR_PUBKEY` or `~/.config/ai-memory/operator.key.pub`),
+closing the fail-OPEN gap where a SQL-write gadget could install
+unsigned enabled rules.
+
+### `[confidence]` — shadow-observation retention (Cluster G, #767)
+
+```toml
+[confidence]
+shadow_retention_days = 30   # GC purge window; None → 30; 0/negative → sweep is a no-op
+```
+
+### `[admin]` — admin-class caller allowlist (SHIP cluster, #946/#957/#960/#961)
+
+```toml
+[admin]
+agent_ids = ["ops:admin", "ai:claude@workstation"]
+```
+
+**Default-closed.** When absent, every admin-class endpoint
+(`GET /api/v1/export`, `GET /api/v1/agents`, `GET /api/v1/stats`, the
+`POST /api/v1/quota/status` list path) returns `403 Forbidden`. Entries
+must match a caller's resolved `agent_id` verbatim (no glob); entries
+failing `validate_agent_id` are logged at `warn` and dropped so a typo
+cannot lock the operator out. The role gate runs **after**
+`api_key_auth` — set `api_key` too for sensitive corpora.
+
 ## Canonical resolver
 
 Every LLM / embedder / reranker / storage decision in the binary

--- a/docs/architectures-t3.html
+++ b/docs/architectures-t3.html
@@ -459,6 +459,67 @@ ai-memory --db /var/lib/ai-memory/store.db serve \
 
 <section>
   <div class="container">
+    <span class="eyebrow">Substrate</span>
+    <h2>Pinned Enterprise Federated component versions.</h2>
+    <p>The postgres-backed substrate pins an exact, tested matrix. These are the single source of truth in <code>deploy/docker-1461/provision/lib.sh</code> and are asserted at bring-up — the validate harness refuses to certify a stack whose probed versions drift from the pins below.</p>
+    <table>
+      <thead>
+        <tr><th>Component</th><th>Canonical version</th><th>SSOT pin</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>PostgreSQL</td><td><strong>18.4</strong></td><td><code>PG_APT_VERSION=18.4-1.pgdg13+1</code> · <code>EXPECTED_PG_VERSION=18.4</code></td></tr>
+        <tr><td>Apache AGE</td><td><strong>1.7.0</strong></td><td><code>AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0</code> · <code>EXPECTED_AGE_VERSION=1.7.0</code></td></tr>
+        <tr><td>pgvector (server extension)</td><td><strong>0.8.2</strong></td><td><code>PGVECTOR_APT_VERSION=0.8.2-1.pgdg13+1</code></td></tr>
+        <tr><td>pgvector (Rust binding crate)</td><td><strong>0.4</strong></td><td><code>Cargo.toml</code> → <code>pgvector = "0.4"</code></td></tr>
+        <tr><td>ai-memory postgres schema</td><td><strong>v28</strong></td><td>schema parity with SQLite at v28 (v0.7.0)</td></tr>
+      </tbody>
+    </table>
+    <p>The bundled stacked image at <code>deploy/docker-1461/Dockerfile.pg-age-vector</code> (<code>ARG AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0</code>, <code>ARG PG_MAJOR=18</code>) layers pgvector 0.8.2 onto the AGE base so K8s / ECS / Cloud Run operators don't build AGE from source. <strong>Alternate tested matrix:</strong> <code>infra/lan-parity-test/</code> legitimately runs PG 16 + AGE 1.6.0 + pgvector 0.8.2 as a second tested combination; the <em>recommended</em> install targets the PG 18.4 / AGE 1.7.0 matrix above.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
+    <span class="eyebrow">Configuration</span>
+    <h2>Federated <code>config.toml</code> — the full option surface.</h2>
+    <p>Every deployment reads a single schema-versioned file at <code>~/.config/ai-memory/config.toml</code>. The precedence ladder is uniform: <strong>CLI flag &gt; <code>AI_MEMORY_*</code> env &gt; <code>[section]</code> &gt; legacy flat field &gt; compiled default</strong>. The complete field-by-field reference (with types, defaults, and resolver semantics) lives in <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/release/v0.7.0/docs/CONFIG_SCHEMA.md">docs/CONFIG_SCHEMA.md</a>.</p>
+<pre><code>schema_version = 2
+tier = "autonomous"
+db   = "/var/lib/ai-memory/store.db"
+
+# Postgres connection-pool + query bounds.
+postgres_pool_max_connections   = 16    # env: AI_MEMORY_PG_POOL_MAX
+postgres_pool_min_connections   = 2     # env: AI_MEMORY_PG_POOL_MIN
+postgres_acquire_timeout_secs   = 30    # env: AI_MEMORY_PG_ACQUIRE_TIMEOUT_SECS
+postgres_statement_timeout_secs = 30    # 0 disables
+request_timeout_secs  = 60              # axum slowloris guard
+llm_call_timeout_secs = 30
+
+[llm]            # backend / model / base_url / api_key_env|api_key_file
+[embeddings]     # backend / url / model / backfill_batch
+[reranker]       # enabled / model
+[storage]        # default_namespace / archive_on_gc / archive_max_days / max_memory_mb
+[limits]         # max_memories_per_day / max_storage_bytes / max_links_per_day / max_page_size
+[identity]       # anonymize_default
+[audit]          # enabled / path / hash_chain / attestation_cadence_minutes / retention_days
+                 #   + [audit.compliance.{soc2,hipaa,gdpr,fedramp}]
+[transcripts]    # default_ttl_secs / archive_grace_secs / max_decompressed_bytes
+                 #   + [transcripts.namespaces."&lt;pattern&gt;"]
+[hooks]          # [hooks.subscription] hmac_secret  (secret; chmod 600)
+[subscriptions]  # allow_loopback_webhooks  (default false — SSRF guard)
+[verify]         # require_nonce  (link-verify replay protection)
+[agents]         # [agents.defaults.recall_scope] namespaces / since / tier / limit
+[governance]     # require_operator_pubkey  (fail-closed rule enforcement)
+[confidence]     # shadow_retention_days
+[admin]          # agent_ids = [...]  (default-closed admin allowlist)
+[mcp]            # profile
+[permissions]    # mode = "enforce" | "advisory" | "off"</code></pre>
+    <p>All sections are <strong>default-safe</strong> — an absent block selects the compiled default and preserves existing behaviour. Inline <code>api_key = "&lt;literal&gt;"</code> is rejected at parse time; reference secrets via <code>api_key_env</code> / <code>api_key_file</code> (mode 0400) only.</p>
+  </div>
+</section>
+
+<section>
+  <div class="container">
     <span class="eyebrow">Wiring</span>
     <h2>Governance, skills, and attestations at T3.</h2>
     <ul>

--- a/docs/enterprise-deployment.md
+++ b/docs/enterprise-deployment.md
@@ -69,7 +69,7 @@ right when a constraint listed in the "use case" column is breached.
 |---|---|---|---|---|---|---|---|---|---|
 | **T1 — Singleton** | Solo developer; 1 NHI experimentation; offline | SQLite (WAL) | One process; one host | 1 | 1 | <10 ms | none | none | `ai-memory backup --keep 48` |
 | **T2 — Multi-agent / single server** | Engineering team (≤5 agents) on a shared workstation or single VM | SQLite (WAL) shared | Many agents → one daemon | 2–10 | 1 | <15 ms | none (local mTLS optional) | none | hourly local + weekly off-host |
-| **T3 — Single-rack / same DC** | Team or small product cluster; HA pair or 3-node | Postgres 16 + AGE 1.5 + pgvector 0.8 (single primary) | Hub-spoke OR W-of-N (3 peers) | 5–50 | 2–5 | <30 ms (LAN RTT-bound) | mandatory between peers | hub-spoke or W-of-N | pg_basebackup + WAL archive |
+| **T3 — Single-rack / same DC** | Team or small product cluster; HA pair or 3-node | Postgres 18.4 + AGE 1.7.0 + pgvector 0.8.2 (single primary) | Hub-spoke OR W-of-N (3 peers) | 5–50 | 2–5 | <30 ms (LAN RTT-bound) | mandatory between peers | hub-spoke or W-of-N | pg_basebackup + WAL archive |
 | **T4 — Multi-rack / same DC** | Production cluster with rack-affinity routing | Postgres primary + ≥1 streaming replicas; AGE on primary | Rack-affinity W-of-N; per-rack ai-memory replicas | 50–250 | 5–15 | <50 ms (cross-rack RTT) | mandatory | rack-aware W-of-N | pg_basebackup + WAL archive + rack-tagged snapshots |
 | **T5 — Multi-DC / same region** | Multi-AZ within a region; DR ready | Postgres primary + sync replica in second DC (or async-with-RPO) + AGE | Cross-DC federation peers; quorum spans DCs | 250–1000 | 15–50 | 50–150 ms (intra-region WAN) | mandatory | cross-DC W-of-N with quorum tuned for partition | pg_basebackup + WAL ship + off-region | 
 | **T6 — Multi-region / global** | Global product; data-residency requirements | Postgres + AGE **per region**; federation peers between regions | Regional clusters federate; local-first recall | 1000+ | 50–500 | <30 ms local recall; 150–500 ms global propagation | mandatory; per-region CA | regional clusters peer via signed `X-Memory-Sig` + `X-Memory-Nonce` | regional pg snapshots + cross-region object store |
@@ -357,9 +357,9 @@ production Dockerfile. Quick summary:
 
 | Component | Pinned version |
 |---|---|
-| PostgreSQL | 16.x (16.4+ recommended; the AGE 1.5.x target is PG 16) |
-| Apache AGE | 1.5.0 (1.6.0 supported via bundled Dockerfile) |
-| pgvector | 0.8.x preferred; 0.7.x acceptable |
+| PostgreSQL | **18.4** (canonical; SSOT `deploy/docker-1461/provision/lib.sh`). PG 16.x + AGE 1.6.0 is a tested alternate matrix (`infra/lan-parity-test/`). |
+| Apache AGE | **1.7.0** (targets PG 18; bundled `deploy/docker-1461/Dockerfile.pg-age-vector`) |
+| pgvector | **0.8.2** (`PGVECTOR_APT_VERSION=0.8.2-1.pgdg13+1`; Rust binding crate `pgvector = "0.4"`) |
 | ai-memory build | `cargo build --release --features sal-postgres` |
 
 Bootstrap a fresh postgres backend with:
@@ -500,7 +500,7 @@ mTLS + `X-Memory-Sig` + `X-Memory-Nonce` envelope.
 
 ### 5.3 Postgres streaming replication
 
-Standard PG 16 streaming replication. Primary `postgresql.conf`:
+Standard PG 18 streaming replication. Primary `postgresql.conf`:
 
 ```ini
 wal_level = replica
@@ -522,7 +522,7 @@ Replica: `primary_conninfo = 'host=primary.rackA.internal user=aimemory_repl pas
 | Sync (`synchronous_standby_names`) | Primary + slowest sync replica RTT | 0 (committed only after replica ack) | Safest durability; any replica outage stalls writes |
 | Sync with quorum (`ANY 1 (replica1, replica2)`) | Primary + fastest of N RTT | 0 if any synced replica survives | Best balance for T4 |
 
-PG 16's `synchronous_standby_names = 'ANY 1 (replica_b)'` is the
+PG 18's `synchronous_standby_names = 'ANY 1 (replica_b)'` is the
 recommended T4 default: any one named replica must ack before commit,
 so a single-replica outage doesn't stall writes but a primary loss
 guarantees the survivor has every committed transaction.
@@ -1272,10 +1272,10 @@ build time and `hnsw.ef_search=80` at query time
 ### 10.3 AGE extension install + permissions
 
 See [`postgres-age-guide.md §"Install — Ubuntu 24.04 example"`](postgres-age-guide.md)
-for the AGE 1.5.0-from-source recipe. The bundled
-`infra/lan-parity-test/Dockerfile.pg-age-vector` (#1065) stacks
-pgvector on top of `apache/age:release_PG16_*` so K8s / ECS / Cloud
-Run users don't have to build AGE themselves.
+for the AGE 1.7.0-from-source recipe. The bundled
+`deploy/docker-1461/Dockerfile.pg-age-vector` (#1065) stacks
+pgvector 0.8.2 on top of `apache/age:release_PG18_1.7.0` so K8s / ECS /
+Cloud Run users don't have to build AGE themselves.
 
 Permissions:
 
@@ -1326,17 +1326,17 @@ Retention sizing reference:
 ### 10.6 Upgrade path — AGE minor version pinning
 
 **Pin AGE to a specific minor.** The v0.7.0 reference is
-`apache/age:release_PG16_1.5.0` (with the bundled pgvector layer).
+`apache/age:release_PG18_1.7.0` (with the bundled pgvector 0.8.2 layer).
 Do not let your Postgres host's apt-update silently upgrade AGE
-across a minor — the Cypher binding semantics changed between
-1.5.x and 1.6.x and the v0.7.0 tests target 1.5.0.
+across a minor — the Cypher binding semantics have changed between AGE
+minors historically, and the v0.7.0 canonical substrate targets 1.7.0.
 
 Upgrade procedure:
 
 1. Snapshot the primary (`pg_basebackup` + verify).
 2. Stop the ai-memory daemons.
-3. Stop Postgres (`systemctl stop postgresql@16-main`).
-4. Upgrade AGE (`apt install postgresql-age-1.6.x`) — operator-paced.
+3. Stop Postgres (`systemctl stop postgresql@18-main`).
+4. Upgrade AGE (`apt install postgresql-age-1.7.x`) — operator-paced.
 5. Start Postgres; verify `SELECT * FROM pg_extension WHERE
    extname='age';` shows the new version.
 6. Start the ai-memory daemons.
@@ -1630,7 +1630,7 @@ for the single-instance baseline.
 ### 14.8 Backup + tooling discipline
 
 - [ ] Backup cadence per §13.1; quarterly restore drill against a scratch host (§13.2).
-- [ ] Daemon binary version pinned per-host (no auto-update); AGE minor pinned (v0.7.0 reference: 1.5.0; upgrade procedure §10.6); PgBouncer version pinned with `pool_mode = transaction`.
+- [ ] Daemon binary version pinned per-host (no auto-update); AGE minor pinned (v0.7.0 reference: 1.7.0; upgrade procedure §10.6); PgBouncer version pinned with `pool_mode = transaction`.
 
 ### 14.9 Cross-references
 

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -43,37 +43,39 @@ feature that works on sqlite works on postgres.
 
 | Component | Version | Notes |
 |---|---|---|
-| PostgreSQL | 16.x (16.4+ recommended) | 15.x works for the SAL adapter but Apache AGE 1.5.x targets PG 16. |
-| Apache AGE | 1.5.0 (1.6.0 supported in the bundled Dockerfile) | Built from source against your PG 16, or use the bundled `Dockerfile.pg-age-vector` (see below). |
-| pgvector | 0.7.x or 0.8.x | 0.8 is preferred (faster HNSW); 0.7 is fine. **Required**: the `sal-postgres` Cargo feature pulls `dep:pgvector` which maps Rust vectors to the Postgres `vector` column type. |
+| PostgreSQL | **18.4** (canonical) | The recommended Enterprise Federated substrate. SSOT: `deploy/docker-1461/provision/lib.sh` (`EXPECTED_PG_VERSION=18.4`). PG 16.x + AGE 1.6.0 remains a tested alternate matrix (`infra/lan-parity-test/`). |
+| Apache AGE | **1.7.0** (canonical) | Targets PG 18. Use the bundled `deploy/docker-1461/Dockerfile.pg-age-vector` (`apache/age:release_PG18_1.7.0`) or build from source (see below). |
+| pgvector | **0.8.2** (canonical) | Faster HNSW. SSOT: `PGVECTOR_APT_VERSION=0.8.2-1.pgdg13+1`. **Required**: the `sal-postgres` Cargo feature pulls `dep:pgvector` (Rust binding crate `pgvector = "0.4"`) which maps Rust vectors to the Postgres `vector` column type. |
 | ai-memory | v0.7.0 with `--features sal-postgres` | The sql-postgres feature is **off by default** to keep the no-postgres build hermetic. |
 
-### Bundled Dockerfile (Apache AGE + pgvector on PG16, #1065)
+### Bundled Dockerfile (Apache AGE + pgvector on PG18, #1065)
 
-The upstream `apache/age:release_PG16_1.6.0` image ships AGE but **not**
+The upstream `apache/age:release_PG18_1.7.0` image ships AGE but **not**
 pgvector. Because the ai-memory v0.7 SAL postgres adapter REQUIRES
 pgvector (the `sal-postgres` Cargo feature pulls `dep:pgvector` which
 maps Rust vectors to Postgres `vector` columns), the repo ships a
 ready-made stacked image at
-[`infra/lan-parity-test/Dockerfile.pg-age-vector`](../infra/lan-parity-test/Dockerfile.pg-age-vector)
-(#1065). It stacks `postgresql-16-pgvector` (precompiled .deb from the
-pgdg apt repo) onto the AGE base — no source build needed. Use this
-image for any deployment that backs ai-memory onto Postgres+AGE.
+[`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector)
+(#1065). It layers pgvector `0.8.2` (precompiled .deb from the pgdg apt
+repo) onto the `apache/age:release_PG18_1.7.0` base — no source build
+needed. Use this image for any deployment that backs ai-memory onto
+Postgres+AGE. (The `infra/lan-parity-test/` image — PG 16 + AGE 1.6.0 +
+pgvector 0.8.2 — remains as a tested alternate matrix.)
 
-> **AGE 1.5 + PG 16 cypher-binding compat.** AGE 1.5.0 has a known
-> quirk where parameter binding against `cypher()` plus PostgreSQL 16's
-> stricter `prepare`-path causes a "could not find parameter $N"
-> error in some bind shapes. ai-memory's production code interpolates
+> **Cypher parameter binding.** ai-memory's production code interpolates
 > parameters into the Cypher string through the AGE-recommended
-> `cypher()` SQL-function form and never hits this — but if you write
-> your own SQL probes, prefer the SQL-function form. Wave 1 Stream C
-> fixed our equivalence test harness to use the safe form; production
-> code never needed the fix.
+> `cypher()` SQL-function form, which is portable across AGE releases —
+> if you write your own SQL probes, prefer the SQL-function form. (A
+> historical AGE 1.5.0 + PG 16 quirk could emit "could not find
+> parameter $N" for some bind shapes against the raw `prepare`-path;
+> the SQL-function form sidesteps it entirely and AGE 1.7.0 on PG 18 is
+> unaffected. Wave 1 Stream C fixed our equivalence test harness to use
+> the safe form; production code never needed the fix.)
 
 ## Install — Ubuntu 24.04 example
 
 ```bash
-# 1. PostgreSQL 16 from PGDG.
+# 1. PostgreSQL 18 from PGDG.
 sudo apt install -y curl ca-certificates gnupg lsb-release
 sudo install -d /usr/share/postgresql-common/pgdg
 sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
@@ -82,32 +84,32 @@ echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
      https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
      | sudo tee /etc/apt/sources.list.d/pgdg.list
 sudo apt update
-sudo apt install -y postgresql-16 postgresql-server-dev-16 \
-                    postgresql-contrib-16 build-essential bison flex git
+sudo apt install -y postgresql-18 postgresql-server-dev-18 \
+                    postgresql-contrib-18 build-essential bison flex git
 
-# 2. pgvector 0.8.0 from the upstream release tag.
-git clone --depth 1 --branch v0.8.0 https://github.com/pgvector/pgvector.git
+# 2. pgvector 0.8.2 from the upstream release tag.
+git clone --depth 1 --branch v0.8.2 https://github.com/pgvector/pgvector.git
 cd pgvector
-sudo make USE_PGXS=1 PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config install
+sudo make USE_PGXS=1 PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config install
 cd ..
 
-# 3. Apache AGE 1.5.0 from source against PG 16.
-git clone --depth 1 --branch PG16/v1.5.0 https://github.com/apache/age.git
+# 3. Apache AGE 1.7.0 from source against PG 18.
+git clone --depth 1 --branch PG18/v1.7.0 https://github.com/apache/age.git
 cd age
-sudo make PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config install
+sudo make PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config install
 cd ..
 
 # 4. Restart postgres to pick up the shared libraries.
-sudo systemctl restart postgresql@16-main
+sudo systemctl restart postgresql@18-main
 ```
 
 For RHEL / Fedora / Amazon Linux: replace the `apt` lines with the
-PGDG yum repo equivalents and ensure `postgresql16-devel` /
-`postgresql16-contrib` are installed before building AGE.
+PGDG yum repo equivalents and ensure `postgresql18-devel` /
+`postgresql18-contrib` are installed before building AGE.
 
 ### Docker — pgvector is required, not optional ([#1065](https://github.com/alphaonedev/ai-memory-mcp/issues/1065))
 
-The popular `apache/age:release_PG16_*` Docker images **do not bundle
+The popular `apache/age:release_PG18_*` Docker images **do not bundle
 pgvector**. The SAL postgres adapter's `init schema` step calls
 `CREATE EXTENSION IF NOT EXISTS vector` and fails-fast on missing
 extension with the message `extension "vector" is not available` —
@@ -118,18 +120,18 @@ The canonical fix is a 2-line Dockerfile that layers pgvector on top
 of the upstream Apache AGE image:
 
 ```dockerfile
-# Dockerfile.pg-age-vector — see infra/lan-parity-test/Dockerfile.pg-age-vector
-FROM apache/age:release_PG16_1.5.0
+# Dockerfile.pg-age-vector — see deploy/docker-1461/Dockerfile.pg-age-vector
+FROM apache/age:release_PG18_1.7.0
 USER root
 RUN apt-get update \
- && apt-get install -y --no-install-recommends postgresql-16-pgvector \
+ && apt-get install -y --no-install-recommends postgresql-18-pgvector \
  && rm -rf /var/lib/apt/lists/*
 USER postgres
 ```
 
 The ai-memory repo ships this Dockerfile at
-[`infra/lan-parity-test/Dockerfile.pg-age-vector`](../infra/lan-parity-test/Dockerfile.pg-age-vector);
-the lan-parity compose file uses it via:
+[`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector);
+the lan-parity compose file uses its PG 16 + AGE 1.6.0 counterpart via:
 
 ```yaml
 services:
@@ -140,7 +142,7 @@ services:
 ```
 
 Plan C operators running on K8s / ECS / Cloud Run build this image
-once, tag it (`pg-age-vector:PG16-1.5.0-pgvector0.8`), and reference
+once, tag it (`pg-age-vector:PG18.4-1.7.0-pgvector0.8.2`), and reference
 the tag from their workload manifests instead of the bare upstream
 image.
 
@@ -653,7 +655,7 @@ recommendation; the v0.7.0 release does not yet expose these as
 The four KG operations dispatch on the `KgBackend` tag the postgres
 adapter probes at connect time:
 
-| Op | AGE 1.5 (Cypher) | CTE fallback | Speedup at depth=5 |
+| Op | AGE 1.7.0 (Cypher) | CTE fallback | Speedup at depth=5 |
 |---|---|---|---|
 | `kg_query` | `MATCH (a)-[*1..d]->(b) WHERE a.id = $1` | recursive `WITH` join | ≥30% (S76 gate) |
 | `kg_timeline` | `MATCH ... WHERE valid_from < $1 AND (valid_until IS NULL OR valid_until > $1)` | recursive temporal join | ≥30% |
@@ -692,9 +694,10 @@ the v15→v28 migrations idempotently. (See
 
 ### "could not find parameter $N" against a Cypher query
 
-This is the AGE 1.5 + PG 16 binding quirk mentioned above. ai-memory's
-production code never hits it — if you see it, you're running a
-custom psql probe. Use the AGE-recommended SQL-function shape:
+This is the historical AGE 1.5.0 + PG 16 binding quirk mentioned above
+(AGE 1.7.0 on PG 18 is unaffected). ai-memory's production code never
+hits it — if you see it, you're running a custom psql probe. Use the
+AGE-recommended SQL-function shape:
 
 ```sql
 SELECT * FROM cypher('ai_memory_kg', $$
@@ -749,8 +752,8 @@ parity test is the gate that prevents it.
 
 ## References
 
-- Apache AGE 1.5 docs: https://age.apache.org/
-- pgvector 0.8 docs: https://github.com/pgvector/pgvector
+- Apache AGE 1.7.0 docs: https://age.apache.org/
+- pgvector 0.8.2 docs: https://github.com/pgvector/pgvector
 - ai-memory v0.7.0 release notes: [`v0.7.0/release-notes.md`](v0.7.0/release-notes.md)
 - A2A campaign Pages: https://alphaonedev.github.io/ai-memory-a2a-v0.7.0/
 - Adapter-selection design: [`RUNBOOK-adapter-selection.md`](RUNBOOK-adapter-selection.md)


### PR DESCRIPTION
## Summary
Closes the Enterprise Federated config documentation drift (#1528) — world-class, 100%-coverage docs for the federated `ai-memory` configuration surface, across both Markdown and GitHub Pages, aligned to the `src/config.rs` + `deploy/docker-1461/provision/lib.sh` SSOT.

- **`docs/CONFIG_SCHEMA.md`** — new **substrate version matrix** (PostgreSQL **18.4**, Apache AGE **1.7.0**, pgvector **0.8.2** server extension, pgvector **0.4** Rust binding crate, postgres schema **v28**) anchored to `deploy/docker-1461/provision/lib.sh`; plus a complete **section inventory** documenting every remaining `AppConfig` block field-for-field: top-level `postgres_*` / `request_timeout_secs` / `llm_call_timeout_secs` / `mcp_federation_forward_url`, `[identity]`, `[audit]` + `[audit.compliance.{soc2,hipaa,gdpr,fedramp}]`, `[transcripts]` + `[transcripts.namespaces."<pattern>"]`, `[hooks.subscription]`, `[subscriptions]`, `[verify]`, `[agents.defaults.recall_scope]`, `[governance]`, `[confidence]`, `[admin]`.
- **`docs/postgres-age-guide.md`** + **`docs/enterprise-deployment.md`** — migrated stale operator-facing PG16 / AGE 1.5–1.6 / pgvector 0.7–0.8 install + recommended pins to the canonical **PG 18.4 / AGE 1.7.0 / pgvector 0.8.2** matrix (prerequisites tables, bundled Dockerfile, from-source install script, Docker layering, streaming-replication, AGE-pin upgrade procedure). Factual `infra/lan-parity-test/` **PG 16 + AGE 1.6.0** alternate-matrix references preserved deliberately.
- **`docs/architectures-t3.html`** (GitHub Pages) — surfaces the substrate version matrix + the full `config.toml` option surface on the postgres-tier page.

## Drift / QC
- [x] `scripts/check-docs-vs-ssot.sh` → **PASS** (`schema=55, full_tools=74, routes=88, …`)
- [x] All section fields verified against `src/config.rs` structs (no phantom sections/fields)
- [x] Version pins verified against `deploy/docker-1461/provision/lib.sh` + `Dockerfile.pg-age-vector` + `Cargo.toml`
- [x] Factual PG16 alternate-matrix references preserved (not drift)

## Test plan
- [ ] Render-check the four pages (Markdown + GitHub Pages) in review
- [ ] Confirm no operator-facing recommended/install pin still reads PG16/AGE1.5

Closes #1528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)