### PR TITLE
ci(release): pin cross-compile jobs to 1.96.0 (fix E0463 blocking GA publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,15 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.tag }}
 
-      - name: Install Rust stable
+      - name: Install Rust 1.96.0 + target std
+        # Pin to the rust-toolchain.toml channel (1.96.0). The build below
+        # resolves the toolchain from rust-toolchain.toml, so the cross
+        # target std must be installed onto THAT toolchain — installing it
+        # onto `stable` left non-host targets (e.g. x86_64-apple-darwin on
+        # the arm64 macOS runner) without `core`, failing with E0463.
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -220,9 +226,12 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.tag }}
 
-      - name: Install Rust stable + iOS targets
+      - name: Install Rust 1.96.0 + iOS targets
+        # Pin to rust-toolchain.toml (1.96.0) so the iOS cross-target std
+        # lands on the build toolchain (see release-matrix note above).
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.96.0
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
 
       - uses: Swatinem/rust-cache@v2
@@ -336,9 +345,12 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.tag }}
 
-      - name: Install Rust stable + Android targets
+      - name: Install Rust 1.96.0 + Android targets
+        # Pin to rust-toolchain.toml (1.96.0) so the Android cross-target
+        # std lands on the build toolchain (see release-matrix note above).
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.96.0
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Fixes the v0.7.0 GA publish blocker: `release.yml`'s first-ever run failed `Release (x86_64-apple-darwin)`, `mobile-ios`, `mobile-android` with `error[E0463]: can't find crate for core`.

Root cause: the build resolves its toolchain from `rust-toolchain.toml` (1.96.0), but the `dtolnay/rust-toolchain@stable` step installed the cross-target std onto `stable` — so non-host targets had no `core` under 1.96.0. The `x86_64-apple-darwin` leg failing blocked `crates-io`/`homebrew`/`copr` (they `needs: release`).

Fix: pass `toolchain: 1.96.0` to the three cross-compile dtolnay steps. Workflow-only; does not touch source or the `v0.7.0` tag/golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)