### PR TITLE
ci(release): lipo iOS simulator slices before -create-xcframework

### DIFF
--- a/.github/workflows/mobile-ios-republish.yml
+++ b/.github/workflows/mobile-ios-republish.yml
@@ -83,10 +83,18 @@ jobs:
               export *
           }
           MODULEMAP
+          # The two simulator slices (arm64-sim + x86_64-sim) are the same
+          # platform-variant; -create-xcframework rejects them as separate
+          # -library args ("equivalent library definitions"). lipo them into
+          # one fat simulator lib first, then pass device + fat-sim.
+          mkdir -p target/ios-sim-universal/release
+          lipo -create \
+            target/aarch64-apple-ios-sim/release/libai_memory.a \
+            target/x86_64-apple-ios/release/libai_memory.a \
+            -output target/ios-sim-universal/release/libai_memory.a
           xcodebuild -create-xcframework \
             -library target/aarch64-apple-ios/release/libai_memory.a -headers dist/headers \
-            -library target/aarch64-apple-ios-sim/release/libai_memory.a -headers dist/headers \
-            -library target/x86_64-apple-ios/release/libai_memory.a -headers dist/headers \
+            -library target/ios-sim-universal/release/libai_memory.a -headers dist/headers \
             -output dist/AiMemory.xcframework
           ls -la dist/AiMemory.xcframework/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,10 +282,18 @@ jobs:
               export *
           }
           MODULEMAP
+          # The two simulator slices (arm64-sim + x86_64-sim) are the same
+          # platform-variant; -create-xcframework rejects them as separate
+          # -library args ("equivalent library definitions"). lipo them into
+          # one fat simulator lib first, then pass device + fat-sim.
+          mkdir -p target/ios-sim-universal/release
+          lipo -create \
+            target/aarch64-apple-ios-sim/release/libai_memory.a \
+            target/x86_64-apple-ios/release/libai_memory.a \
+            -output target/ios-sim-universal/release/libai_memory.a
           xcodebuild -create-xcframework \
             -library target/aarch64-apple-ios/release/libai_memory.a -headers dist/headers \
-            -library target/aarch64-apple-ios-sim/release/libai_memory.a -headers dist/headers \
-            -library target/x86_64-apple-ios/release/libai_memory.a -headers dist/headers \
+            -library target/ios-sim-universal/release/libai_memory.a -headers dist/headers \
             -output dist/AiMemory.xcframework
           ls -la dist/AiMemory.xcframework/
 


### PR DESCRIPTION
Second iOS mobile-build fix: -create-xcframework rejects the two simulator slices as separate -library args. lipo arm64-sim + x86_64-sim into one fat lib, then device + fat-sim. 🤖 Generated with [Claude Code](https://claude.com/claude-code)