### PR TITLE
ci(publish): working npm token-auth publish + SDK metadata fixes

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org/"
+      # npm's OIDC Trusted Publishing token exchange requires npm >= 11.5.1.
+      # Node 20 bundles npm 10.x, which publishes *unauthenticated* and the
+      # registry then returns a disguised 404 on PUT. Pin a modern npm.
+      - name: upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: install + build
         working-directory: sdk/typescript
         run: |

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi-publish
-      url: https://pypi.org/project/ai-memory/
+      url: https://pypi.org/project/ai-memory-mcp/
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -65,13 +65,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      # NOTE: deliberately NOT passing registry-url here. setup-node's
+      # registry-url writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}`
+      # and a placeholder token, which npm sends as auth and the registry
+      # rejects with a disguised 404 — short-circuiting OIDC. Omitting it
+      # lets npm 11 perform a clean OIDC Trusted-Publishing exchange.
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org/"
-      # npm's OIDC Trusted Publishing token exchange requires npm >= 11.5.1.
-      # Node 20 bundles npm 10.x, which publishes *unauthenticated* and the
-      # registry then returns a disguised 404 on PUT. Pin a modern npm.
+      # npm's OIDC Trusted Publishing requires npm >= 11.5.1 (Node 20 ships 10.x).
       - name: upgrade npm for OIDC trusted publishing
         run: npm install -g npm@latest
       - name: install + build
@@ -81,4 +83,6 @@ jobs:
           npm run build
       - name: publish via npm Trusted Publisher (OIDC + provenance)
         working-directory: sdk/typescript
-        run: npm publish --provenance --access public
+        run: |
+          echo "npm version: $(npm -v)"
+          npm publish --provenance --access public

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -65,24 +65,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      # NOTE: deliberately NOT passing registry-url here. setup-node's
-      # registry-url writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}`
-      # and a placeholder token, which npm sends as auth and the registry
-      # rejects with a disguised 404 — short-circuiting OIDC. Omitting it
-      # lets npm 11 perform a clean OIDC Trusted-Publishing exchange.
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      # npm's OIDC Trusted Publishing requires npm >= 11.5.1 (Node 20 ships 10.x).
-      - name: upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+          registry-url: "https://registry.npmjs.org/"
       - name: install + build
         working-directory: sdk/typescript
         run: |
           npm ci
           npm run build
-      - name: publish via npm Trusted Publisher (OIDC + provenance)
+      # Auth via the npm automation token (env-scoped secret on the
+      # npm-publish environment). id-token:write still enables --provenance.
+      - name: publish to npm (token auth + provenance)
         working-directory: sdk/typescript
-        run: |
-          echo "npm version: $(npm -v)"
-          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,11 +4,14 @@
   "description": "TypeScript SDK for the ai-memory HTTP API — persistent, tier-aware memory for AI agents.",
   "license": "Apache-2.0",
   "author": "AlphaOne LLC",
-  "homepage": "https://github.com/alphaone/ai-memory",
+  "homepage": "https://github.com/alphaonedev/ai-memory-mcp/tree/main/sdk/typescript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alphaone/ai-memory.git",
+    "url": "git+https://github.com/alphaonedev/ai-memory-mcp.git",
     "directory": "sdk/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/alphaonedev/ai-memory-mcp/issues"
   },
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Lands the **working** npm publish path on `main` (validated by the live publish of `@alphaone/ai-memory@0.7.0` with provenance from this branch).

## Changes
- **npm token auth** — publish via `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` (env-scoped secret on the `npm-publish` environment). Root cause of the failures was an **expired** npm automation token, not missing OIDC. Keeps `--provenance` via `id-token: write`.
- **`package.json` metadata** — `repository.url`/`homepage`/`bugs` now point at `alphaonedev/ai-memory-mcp` (was `alphaone/ai-memory`), so `--provenance` source matches the build repo.
- **pypi-publish env URL** — `pypi.org/project/ai-memory/` (404) → `ai-memory-mcp`.

(Lockfile + PyPI `skip-existing` already landed via #1663.)

## Not triggering a release
Workflow/metadata only. `publish-sdks.yml` fires on `v*` tag push or manual dispatch; this merge creates no tag and runs no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)