### PR TITLE
docs(v0.7.1): self-contained EPIC execution prompt (#1683)

### DIFF
--- a/docs/v0.7.1/v0.7.1-execution-prompt.md
+++ b/docs/v0.7.1/v0.7.1-execution-prompt.md
@@ -1,0 +1,1566 @@
+# v0.7.1 EPIC — Master Execution Prompt (self-contained)
+
+> **Purpose.** This is the single, context-rot-proof execution document for the v0.7.1 patch line (EPIC [#1683](https://github.com/alphaonedev/ai-memory-mcp/issues/1683)). An AI-NHI (or human) can drive the entire v0.7.1 build from this one file — ground rules, build order, validated task specs, starter code, tests, and the audit refinements — with **zero dependence on any chat history**. If you only read one file to ship v0.7.1, read this one.
+>
+> **Provenance.** Findings: 7-finder + 3-roadmap + 5-panel full-spectrum AI-NHI audit (campaign [#1696](https://github.com/alphaonedev/ai-memory-mcp/issues/1696), 31/31 confirmed). Specs + starter code: 5-agent build-spec workflow + coverage critic (100%-covered). Final validation: 5-agent codegraph re-verification, **overall confidence 0.88**, all 26 findings REAL + in-scope. Every file:line below was machine-verified against `release/v0.7.1`; treat them as starting points to re-confirm, not gospel.
+
+---
+
+## 0. How to use this document
+
+**Branch:** `release/v0.7.1` · **Working dir:** `/home/fate_two/v07/v07-f5` · **Backend default:** SQLite (non-`sal`); `--features sal` / `sal-postgres` for the SAL/Postgres paths.
+
+**Execution model.** Work the tasks in **§3 build-order** (waves). Each wave's tasks can run in parallel *except* where they share a file (noted). For each task, dispatch a fresh agent with the **per-task dispatch prompt** (template below) + that task's **§5 spec block**. This keeps each agent's context minimal and clean.
+
+**Per-task dispatch prompt template** (fill `<REF>` + paste the task's §5 block):
+
+```
+You are implementing <REF> for the ai-memory-mcp v0.7.1 patch line.
+Branch: release/v0.7.1 · cwd: /home/fate_two/v07/v07-f5.
+
+1. RE-VERIFY every cited file:line via codegraph (codegraph_explore/_search,
+   projectPath /home/fate_two/v07/v07-f5) and Read BEFORE editing. NO fabrication —
+   if a citation does not resolve to what the spec claims, stop and report.
+2. Read §4 (Validation refinements) for THIS ref and honor it — it overrides the
+   raw spec where they differ.
+3. Implement the fix from the spec's `starter_code` (a starting point — make it
+   compile and be correct, it is not a finished patch).
+4. Add the regression test from `test_plan`.
+5. Run the four gates:
+     cargo fmt --check
+     cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic
+     AI_MEMORY_NO_CONFIG=1 cargo test <relevant filter>
+     cargo audit
+6. Commit (stage explicit paths) with a message referencing <REF> and the
+   Co-Authored-By trailer. Do NOT push to main; push to release/v0.7.1 only when
+   authorized.
+7. Report: commit SHA, the exact `cargo test` result line, and any deviation from
+   the spec you had to make.
+
+ACCEPTANCE: <paste the task's `acceptance`>.
+```
+
+---
+
+## 1. Mission & scope
+
+v0.7.1 **hardens what v0.7.0 shipped** — bug/honesty/atomicity/wiring fixes on the shipping default binary. **No net-new §2-property surface** (that is v0.8+, EPIC [#1695](https://github.com/alphaonedev/ai-memory-mcp/issues/1695)). Scope = **25 buildable code tasks + 1 verified-clean** (n18-verify). Merged already (no task): #1663/#1664/#1666/#1667. Blocked (operator-`notify`-gated, not v0.7.1): L3 substrate watcher (#1388/#1389).
+
+---
+
+## 2. Ground rules (non-negotiable)
+
+- **No fabrication.** Every file:line you cite must be one you actually saw via codegraph/Read. The repo has a documented fabricated-citation history; the final audit itself caught a validator error (see §4 #1675). Verify before claiming.
+- **Prime directive.** Every gap gets fixed; no "non-blocking"/"out-of-scope"/"P2 follow-up" framing. Doc-drift is a real defect.
+- **Four gates** must pass before any commit (fmt / clippy-pedantic / test / audit).
+- **No hardcoded literals** — fix via a named `const`, not a scattered literal (CI gate `check-vendor-literals.sh`).
+- **No agent-created files under `/tmp`** — scratch lives under `.local-runs/`.
+- **Commit discipline:** stage explicit paths, group by intent, `Co-Authored-By` trailer naming the model. Push to `release/v0.7.1` only; never `main` directly.
+
+---
+
+## 3. Build order (6 waves)
+
+| Wave | Tasks (in order) | Why |
+|---|---|---|
+| **0** | **#1684** (CRIT HNSW NaN→abort) → **#1687** (catchup row-loss) → **#1690** (pruners never spawned) | independent crash / data-loss; land first |
+| **1** | **#1692** (HNSW dim-check + seed finiteness) → **#1688** (persona atomicity) → **#1700** (synthesis-apply atomicity) → **#1689** (find_paths invalidated edges) | high-severity correctness; serialize storage/mod.rs editors (#1692) |
+| **2** | **#1685** (MCP PRE_ACTION install — extract helper) → **n26-split** (fix 4-variant doc on that helper) → **#1686** (rules-keygen warning) | governance; serialize the PRE_ACTION region |
+| **3** | **#1691** (HTTP recall rerank — long pole, 132 AppState refs) → **n14** (RerankerScoreFloor wiring) → **n22** (capabilities exposure) → **n23** (docstring becomes true) | one reranker-construction batch |
+| **4** | **#1671** + **n15** (both touch CorePolicy — batch) → **#1674** (schema_version=0) → **#1673** (verify_link/find_paths 501) → **#1672** (curator_mode cfg-gate) → **n13** (callable_now honesty) | medium config/policy/capability |
+| **5** | **n17** (pair #1671) → **n24** → **n18-verify** (0-LOC, close) → **#1675** (cli-rationale caveat) → **#1676** (validate.rs counts) → **n19** (schema-parity, needs live PG) | low / docs |
+
+---
+
+## 4. Validation refinements & coverage additions (READ FIRST — from the 0.88 final audit)
+
+These **override** the raw §5 spec where they differ. Locked by the 5-agent codegraph validation.
+
+| Ref | Refinement (authoritative) |
+|---|---|
+| **#1675** | **Validator flag REJECTED — keep the broad caveat.** A validator wrongly claimed `curator --reflect` is not sal-gated; it IS — `#[cfg(not(feature="sal"))] run_reflect` hard-bails at `cli/curator.rs:548-560` ("requires --features sal") and the live binary confirms. The doc caveat must say `curator --reflect` requires `--features sal` (broad), **not** scope it to only `--store-url`. |
+| **#1700** | Real caller is **`src/mcp/tools/store/mod.rs:560`** (NOT the SAL trait `src/store/mod.rs`). **Widen the txn** to span the whole store-write region: helper apply (N updates + N deletes) + the standard `db::insert` (add/no_op verdicts) + the #1239 `pending_synthesis_delete_targets` delete-after-insert (all run after the helper, mod.rs:577+). |
+| **#1689** | **Coverage+:** also patch **`kg_query_cypher` (`store/postgres.rs:4720`, the AGE `kg_query` branch)** — same `valid_until` current-view bug. "pg kg_query DOES filter" is true ONLY of `kg_query_cte_filtered` (4862/4878), not the AGE path. Cover BOTH find_paths branches AND kg_query_cypher. AGE caveat: confirm AGE edges carry `valid_until` as a property before writing the cypher filter; CTE branches are safe. |
+| **#1692** | **Coverage+:** also reject non-finite floats in the seed path **`get_all_embeddings` (storage/mod.rs:8057-8083)** so a poison vector cannot enter the HNSW graph. |
+| **#1690** | **Coverage+ (two):** (a) **postgres offload TTL sweep** — `sweep_expired` (offload/mod.rs:606) is rusqlite-bound; pg has `offloaded_blobs` (v34) so pg daemons never TTL-sweep → needs a SAL sweep method. (b) **`federation_nonce_cache` has NO disk pruner** — in-memory FIFO/LRU never DELETEs from disk → unbounded on-disk growth; new prune fn + spawn. |
+| **n14** | **Coverage+:** thread the new `[reranker].score_floor*` config through ALL 3 prod `BatchedReranker::new` sites (`mcp/mod.rs:3024`, `cli/recall.rs:367`, `mcp/tools/recall.rs:1418`) + fix the dead doc at `reranker.rs:1337-1338`. Compose with n22 (add the `memory_capabilities` exposure once it is live). |
+| **n13** | **Scope split:** ship the `callable_now` honesty fix (resolve `X-Agent-Id`, OR omit on `None` like `build_agent_permitted_families` does — `capabilities.rs:899`) in **v0.7.1**. Defer HTTP allowlist *enforcement* (new behavior; HTTP has its own auth model) to **v0.8 / #1695** unless operator wants HTTP/MCP allowlist parity. |
+| **n19** | Add ONLY **`transcript_line_dedup`** to `SQLITE_RELATIONAL_TABLES` (pg `migrate_v52` creates it, `store/postgres.rs:2253`). Put `federation_nonce_cache` in a separate **`SQLITE_ONLY_DAEMON_LOCAL_TABLES`** doc-list — adding it to the parity assertion breaks CI (pg `migrate_v51` is a no-op). Needs a live PG instance for the test. |
+| **n18-verify** | **CLOSE as verified-clean (0-LOC).** v52 doc-drift already reconciled (sqlite BLOB sha256 WITHOUT ROWID / pg BYTEA sha256 PK; `memory_id` non-FK both). Not-a-defect; EPIC expects no diff. |
+| **#1685** | The single `OnceLock` install in `run_mcp_server` (reuse `mcp_hook_conn`) covers skill_export + llm **by construction** (federation/hooks are not independently MCP-reachable) — verify, don't multi-install. |
+| **#1671** | `enabled_check` is a **sync** `Fn(&str)->bool` — do NOT `block_on` inside it (deadlock); pre-resolve an enabled-namespace `HashSet`. Cover BOTH `curator.rs:523` AND `curator.rs:395`. |
+| **#1672** | Citation: `curator_mode` is in **`src/config.rs`** (struct@1240, `IMPLEMENTED` const@1338), NOT `capabilities.rs`. Gate on `cfg!(feature="sal")` in `config.rs::CapabilityReflection::current()`. |
+| **#1676** | Keep `expected_tool_count()=74` UNCHANGED; only 87→89, 78→80, 80→82 change (validate.rs:1093/1095/1183/1186 vs lib.rs:297/329/336). |
+| **n17** | Severity LOW — the "CLI-only" claim is REFUTED (`store_backed_reflection_sweep` DOES run per `--daemon`); fix is docstring disambiguation, not a behavior change. |
+
+---
+
+## 5. Per-task execution specs (starter prompt + starter code + tests)
+
+Each block below = re-verified files, fix approach, **starter Rust code**, test plan, acceptance, deps, and the agent's adversarial note. Combine with the §0 dispatch template and the §4 refinement for that ref. Ordered by §3 build waves.
+
+### 🌊 Wave 0 — independent crash / data-loss
+
+## #1684 — [CRITICAL] HNSW sort partial_cmp().unwrap() panics on NaN → MCP process-abort; cosine_distance unguarded against non-finite
+
+**▶ Dispatch:** implement #1684 per the §0 template; honor the §4 refinement for this ref. **Deps:** Independent. Conceptually pairs with #1692 (prevents poison vectors at ingress); #1684 is the last-line-of-defense and must land regardless.  **Effort:** ~15 LOC + 25 LOC tests; 1 session
+
+- **Files:** src/hnsw.rs:825 (overflow_hits.sort_by ... partial_cmp().unwrap()), src/hnsw.rs:834 (results.sort_by ... partial_cmp().unwrap()), src/hnsw.rs:218-221 (cosine_distance — 1.0 - dot, NO finiteness floor), src/hnsw.rs:523-539 (insert — NO finiteness guard on ingress), src/hnsw.rs:1094-1116 (seed_entries — NO finiteness guard)
+- **Root cause:** confirmed
+
+**Fix approach:** Two-layer fix. (1) Make cosine_distance finiteness-safe: collapse any non-finite result to a sentinel that ranks LAST (same defense-in-depth as Embedder::cosine_similarity at src/embeddings.rs:884, `if score.is_finite() { score } else { 0.0 }`). For a DISTANCE (lower = better) the last-ranked sentinel is the MAX, so collapse non-finite distance to f32::MAX. (2) Replace BOTH `partial_cmp(&b.distance).unwrap()` sites with `a.distance.total_cmp(&b.distance)` (f32::total_cmp is std since 1.62, deterministic even if a NaN slips through). Both layers needed: total_cmp alone stops the panic but a NaN distance still sorts unpredictably; the floor makes the score meaningful. Audit fix-sketch ('total_cmp + finiteness-floor') is correct.
+
+**Adversarial note:** Holds — hnsw.rs:825 and 834 BOTH carry `.partial_cmp(&b.distance).unwrap()` verbatim; cosine_distance (218-221) has no finiteness guard while sibling Embedder::cosine_similarity (embeddings.rs:884) DOES. insert() (523-539) and seed_entries() (1094-1116) push embeddings with no finiteness check, so a poison vector is reachable in prod via local store + boot-seed. CAUTION: I did NOT verify the zero-entry constructor name — codegraph referenced `VectorIndex::empty()` (hnsw.rs:861 doc) but confirm the real public constructor before relying on `empty()`. f32::total_cmp is the idiomatic clippy-pedantic-clean float-sort fix. Sentinel f32::MAX (not INFINITY) avoids any downstream `1.0 - distance` re-deriving -Inf cosine at storage/mod.rs:8492 (#1692 gates that site anyway).
+
+**Starter code:**
+```rust
+// ---- STARTING POINT (must compile + pass tests before merge) ----
+// src/hnsw.rs — verified body at 218-221:
+//   fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+//       let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+//       1.0 - dot
+//   }
+// EDIT (mirrors src/embeddings.rs:884):
+#[inline]
+fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let dist = 1.0 - dot;
+    // #1684 — NaN/+-Inf component (local seed/insert bypasses
+    // federation::sanitize_shipped_vector) makes `dist` non-finite; NaN is
+    // UNORDERED under partial_cmp and aborts the sort. Collapse to f32::MAX
+    // so a poisoned row ranks LAST instead of corrupting the candidate set.
+    if dist.is_finite() { dist } else { f32::MAX }
+}
+
+// src/hnsw.rs:825 — verified line:
+//   overflow_hits.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+overflow_hits.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+
+// src/hnsw.rs:834 — verified line:
+//   results.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+
+// ---- TEST SKELETON (new #[test] in src/hnsw.rs mod tests, ~1166) ----
+// `use super::*` in scope; make_embedding(&[f32]) helper exists at tests line 1170.
+#[test]
+fn search_with_nan_overflow_vector_does_not_panic_and_ranks_last_1684() {
+    let idx = VectorIndex::empty(); // CONFIRM constructor name before relying on it
+    idx.insert("good".to_string(), make_embedding(&[1.0, 0.0, 0.0]));
+    idx.insert("poison".to_string(), vec![f32::NAN, 0.0, 0.0]);
+    let q = make_embedding(&[1.0, 0.0, 0.0]);
+    let hits = idx.search(&q, 5); // MUST NOT panic (pre-fix unwrap on None aborts)
+    assert!(hits.iter().any(|h| h.id == "good"));
+    if let Some(pp) = hits.iter().position(|h| h.id == "poison") {
+        assert!(hits.iter().position(|h| h.id == "good").unwrap() < pp);
+    }
+}
+#[test]
+fn cosine_distance_nan_component_is_finite_max_1684() {
+    assert_eq!(super::cosine_distance(&[f32::NAN, 1.0], &[1.0, 1.0]), f32::MAX);
+}
+```
+
+**Test plan:** Two new #[test] in src/hnsw.rs `mod tests` (module at line 1166): `search_with_nan_overflow_vector_does_not_panic_and_ranks_last_1684` asserts idx.search() returns without panic with a NaN overflow vector and poison ranks after good; `cosine_distance_nan_component_is_finite_max_1684` asserts NaN→f32::MAX. Run `AI_MEMORY_NO_CONFIG=1 cargo test --lib hnsw 1684`. Pre-fix the first test aborts the process.
+
+**Acceptance:** Both partial_cmp().unwrap() sites replaced with total_cmp; cosine_distance returns finite for any input; both new tests green; existing hnsw tests (embedding_point_distance_orthogonal, embedding_point_distance_identical_is_zero) still green; clippy pedantic clean.
+
+---
+
+## #1687 — [HIGH] Federation catchup cursor advances past failed-apply rows → silent permanent row loss (3 branches)
+
+**▶ Dispatch:** implement #1687 per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** ~25 LOC across 3 branches + ~60 LOC test; 1 session.
+
+- **Files:** src/federation/receive.rs — SAL branch: latest_ts set at 268-273 BEFORE apply_remote_memory at 274, sync_state_observe gated only on latest_ts.is_some() at 284-289; legacy(sal) branch: latest_ts 303-308 before insert_if_newer 309, observe 313-317; non-sal catchup_once_legacy: latest_ts 421-426 before insert_if_newer 427, observe 431-435. (File is src/federation/receive.rs, NOT the audit's nonexistent src/handlers/federation/receive.rs; line numbers match exactly.)
+- **Root cause:** confirmed
+
+**Fix approach:** In ALL THREE write loops, only advance latest_ts inside the SUCCESS arm of the apply call so the per-peer cursor (db::sync_state_observe, monotonic-max, src/storage/mod.rs:9067) can never move past a row that failed to persist. SAL branch (268-282): move `latest_ts = Some(mem.updated_at.clone())` into the `Ok(_)` arm. Both legacy branches: set latest_ts inside the `insert_if_newer(...).is_ok()` block. This keeps the high-water mark of durably-applied rows while leaving a failed row to be re-pulled next tick. Adversarial refinement of the audit's 'skip observe on batch failure': advancing-only-on-success is strictly better than skipping observe entirely (the latter would also re-pull succeeded rows forever).
+
+**Adversarial note:** Finding HOLDS — read all three branches directly. Audit's file path was wrong (src/federation/receive.rs is correct) but its line numbers map exactly. STRONGER fix for strict no-loss: rows in a batch are NOT guaranteed sorted by updated_at, so a failing OLDER row could still be skipped if a newer durable row advances the cursor past it. Recommend tracking min_failed_ts and capping latest_ts strictly below it; document the chosen semantics in the test. apply_remote_memory verified at src/store/mod.rs:1084.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass new test before merge. Call site: src/federation/receive.rs:268-282 (SAL branch).
+// AFTER:
+            match store.apply_remote_memory(&ctx, &mem).await {
+                Ok(_) => {
+                    applied += 1;
+                    // #1687 — advance cursor ONLY for durably-persisted rows.
+                    if latest_ts.as_deref().is_none_or(|cur| mem.updated_at.as_str() > cur) {
+                        latest_ts = Some(mem.updated_at.clone());
+                    }
+                }
+                Err(e) => tracing::warn!("catchup: apply_remote_memory failed for peer {}: {e}", peer.id),
+            }
+// Apply the SAME shape to legacy(sal) 303-311 and non-sal catchup_once_legacy 421-429:
+// fold the latest_ts update into the `if crate::db::insert_if_newer(&lock.0,&mem).is_ok() {..}` block.
+```
+
+**Test plan:** New test catchup_cursor_does_not_advance_past_failed_apply (sal-gated, in src/federation/receive.rs #[cfg(test)] or tests/federation_catchup_failed_apply_1687.rs). Stub MemoryStore whose apply_remote_memory returns Err for the newest mem.updated_at and Ok for older ones; drive catchup_once_with_store; assert db::sync_state_load(conn,local_id).entries[peer.id] == max updated_at of the SUCCEEDING rows (strictly below the failed row). Add a second case where ALL applies fail and assert the cursor is unchanged (None / prior value). Asserts live alongside the existing federation_catchup tests.
+
+**Acceptance:** On a batch where a row fails apply, sync_state last_seen_at equals the max updated_at among succeeding rows (below the failed row when it is newest); next tick re-pulls the failed row. All three branches patched. fmt/clippy/test green.
+
+---
+
+## #1690 — [HIGH] Three background pruners never spawned: offloaded_blobs TTL, recall_observations GC, federation_nonce_cache disk table
+
+**▶ Dispatch:** implement #1690 per the §0 template; honor the §4 refinement for this ref. **Deps:** none (independent of #1687); CI-audit-script aligns with the no-hardcoded-literals enforcement ratchet pattern.  **Effort:** ~120 LOC + ~80 LOC tests + ~60 LOC CI script; 2 sessions.
+
+- **Files:** src/background/offload_ttl_sweep.rs:54 (spawn<T>, ZERO prod callers; doc 12-13 falsely claims spawned by bootstrap_serve); src/observations/gc.rs:51/67 (prune/prune_before, ZERO prod callers — only tests + doc refs at src/store/postgres.rs:2568,3330); src/identity/replay.rs:624-666 (persist_fingerprint INSERT OR REPLACE, never DELETEs evicted rows; in-memory eviction at 689,709 never propagates to disk); bootstrap spawn list src/daemon_runtime.rs:4284-4351; existing GC loop spawn_gc_loop_with_shadow_retention at src/daemon_runtime.rs:2598-2628; Db tuple type src/handlers/transport.rs:22 (already impls offload_ttl_sweep::SweepAdapter via blanket impl offload_ttl_sweep.rs:87-98).
+- **Root cause:** revised
+
+**Fix approach:** (A) offloaded_blobs TTL: db_state (Arc<Mutex<(Connection,PathBuf,ResolvedTtl,bool)>>) already impls SweepAdapter — add task_handles.push(offload_ttl_sweep::spawn(db_state.clone(), offload_ttl_sweep::DEFAULT_INTERVAL)) near daemon_runtime.rs:4351. (B) recall_observations GC: fold observations::gc::prune(&lock.0) into the existing GC loop body (2604-2626) which already holds the lock every 30min. (C) federation_nonce_cache disk: new helper prune_nonce_cache_disk(conn) DELETEing aged rows, called from the GC loop. (D) postgres SAL sweeps REQUIRED for (A)+(B) — offloaded_blobs (PG migrate v34) + recall_observations (PG migrate v44) BOTH exist on postgres; add default-noop trait methods on MemoryStore + PostgresStore overrides; NOT needed for (C) (nonce cache sqlite-only on PG, migrate_v51 no-op). (E) CI audit: scripts/check-background-loops.sh (model on check-vendor-literals.sh) that HARD-BLOCKs any spawn_*_loop/*_sweep::spawn with no task_handles.push caller.
+
+**Adversarial note:** Finding HOLDS, audit scope REVISED. (1) federation_nonce_cache is SQLITE-ONLY on PG — migrate_v51 (postgres.rs:2208-2226) is a deliberate no-op, so NO PG nonce sweep is possible/needed. (2) offloaded_blobs (PG migrate v34, postgres.rs:134) AND recall_observations (PG migrate v44, postgres.rs:240 + postgres_schema.sql:794) BOTH exist on postgres — PG SAL sweeps for those two ARE needed; SQLite sweep_expired/gc::prune won't touch a PG daemon's copies. Nonce unbounded growth confirmed: persist_fingerprint only INSERT-OR-REPLACEs while eviction (replay.rs:689,709) never DELETEs from disk. Retention policy is a design choice — age-based shown; a global-row-cap LRU delete mirrors the in-memory FEDERATION_NONCE_MAX_PEERS bound more faithfully. Folding (B)+(C) into the GC loop runs them at 30min not daily — acceptable.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge.
+// (A) src/daemon_runtime.rs near line 4351:
+    task_handles.push(crate::background::offload_ttl_sweep::spawn(
+        db_state.clone(),
+        crate::background::offload_ttl_sweep::DEFAULT_INTERVAL,
+    ));
+// (B)+(C) extend spawn_gc_loop_with_shadow_retention body (after 2625):
+    match crate::observations::gc::prune(&lock.0) {
+        Ok(n) if n > 0 => tracing::info!("gc: pruned {n} recall_observation rows"),
+        Ok(_) => {} Err(e) => tracing::warn!("recall_observations prune failed: {e}"),
+    }
+    match crate::identity::replay::prune_nonce_cache_disk(&lock.0) {
+        Ok(n) if n > 0 => tracing::info!("gc: pruned {n} federation_nonce_cache rows"),
+        Ok(_) => {} Err(e) => tracing::warn!("federation_nonce_cache prune failed: {e}"),
+    }
+// (C) NEW helper src/identity/replay.rs (table cols from migrations/sqlite/0043:
+//     peer_id,fingerprint,last_touch,inserted_at):
+pub fn prune_nonce_cache_disk(conn: &rusqlite::Connection) -> anyhow::Result<usize> {
+    let cutoff = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+    let n = conn.execute("DELETE FROM federation_nonce_cache WHERE inserted_at < ?1",
+        rusqlite::params![cutoff])?;
+    Ok(n)
+}
+// (D) src/store/mod.rs default-noop trait methods (signatures modeled on
+// list_unembedded at mod.rs:682), overridden on PostgresStore with DELETEs.
+```
+
+**Test plan:** (1) src/identity/replay.rs #[cfg(test)] prune_nonce_cache_disk_drops_aged_rows: seed old+fresh rows via persist path, call helper, assert only aged rows deleted. (2) Update the bootstrap handle-count assertion in test_bootstrap_serve_keyword_tier_no_embedder (referenced daemon_runtime.rs:4281) for the +1 offload handle. (3) PG SAL sweep tests gated on AI_MEMORY_TEST_POSTGRES_URL (pattern from postgres_schema_parity.rs): seed expired offloaded_blobs + old recall_observations rows on PG, call the override, assert rows deleted. (4) CI: scripts/check-background-loops.sh --self-test injects an unwired loop and asserts non-zero exit.
+
+**Acceptance:** task_handles count +1 (offload sweep); GC loop runs observations::gc::prune + prune_nonce_cache_disk each tick; new unit tests pass; PG SAL sweeps have live-DB coverage; CI audit script self-test trips on an unwired loop; offload_ttl_sweep.rs doc 12-13 updated to match reality.
+
+---
+
+### 🌊 Wave 1 — high-severity correctness
+
+## #1692 — [HIGH] HNSW semantic branch trusts hit.distance with no dim-check + no dim_mismatch_count bump (silent wrong cosine after embedder swap); seed/insert vectors bypass finiteness sanitization
+
+**▶ Dispatch:** implement #1692 per the §0 template; honor the §4 refinement for this ref. **Deps:** Pairs with #1684 (defense-in-depth at the sort site). Part B (seed sanitization) overlaps #1684's poison-vector concern — coordinate so the finiteness gate lands once. Touches large storage/mod.rs; serialize against other agents editing semantic_phase.  **Effort:** ~40 LOC (incl. get_many_embeddings helper) + 30 LOC tests; 1-2 sessions
+
+- **Files:** src/storage/mod.rs:8466-8557 (HNSW-precompute branch of semantic_phase), src/storage/mod.rs:8492 (`let cosine = f64::from(1.0 - hit.distance);` — no dim/finiteness guard), src/storage/mod.rs:8457 (`dim_mismatch_count: &mut usize` threaded but NEVER bumped in this branch), src/storage/mod.rs:8645-8656 (linear-scan branch — CORRECT: cosine_similarity_checked + `*dim_mismatch_count += 1`), src/storage/mod.rs:8957-8983 (FTS branch — correct: cosine_similarity_checked + `dim_mismatch_count += 1`), src/storage/mod.rs:8057-8083 (get_all_embeddings — seed source, NO finiteness check), src/embeddings.rs:896-904 (cosine_similarity_checked), src/embeddings.rs:307-320 (CosineComparison), src/federation/mod.rs:255-269 (sanitize_shipped_vector — federation-only guard)
+- **Root cause:** confirmed
+
+**Fix approach:** Two sub-fixes. (A) Gate HNSW hits on dimension parity + bump dim_mismatch_count, matching FTS (8965-8970) and linear-scan (8649-8655). The precompute path has only id+distance at the gate, NOT the stored vector — so the dim-check must recompute cosine from the stored vector. get_many at 8500 fetches Memory rows but (per the linear-scan SELECT at 8560-8563 which explicitly adds `embedding`) those rows likely do NOT carry the embedding column. Correct approach: batch-fetch embeddings (new get_many_embeddings, sibling of get_all_embeddings) and run cosine_similarity_checked(query_embedding, stored): Comparable→use it, DimensionMismatch→bump counter + continue. This fixes the dim-count gap AND the finiteness gap (cosine_similarity has the #1584 floor) AND stops trusting raw hit.distance. (B) Sanitize seed/insert vectors: route get_all_embeddings decode output (8071-8072) through a finiteness gate before they reach the HNSW index. Audit fix-sketch correct but understates that the branch lacks the stored vector at the gate — must recompute from a vector, not from hit.distance.
+
+**Adversarial note:** CONFIRMED, and the audit fix-sketch is RIGHT but INCOMPLETE: it says 'gate hits on len==stored_dim' — but at the HNSW gate (8488-8499) the code has only hit.id + hit.distance, NOT the stored vector, so `len==stored_dim` is not computable there. The stored vector is fetched at 8500 via get_many (Memory rows); I could NOT confirm those rows carry `embedding` (the linear-scan SELECT at 8560-8563 explicitly ADDS embedding, implying the default get_many omits it). Corrected approach: batch-fetch embeddings + recompute via cosine_similarity_checked. VERIFY get_many's return shape first; if it already includes embedding, skip the extra query. Re-using federation::sanitize_shipped_vector creates a storage→federation dep — prefer hoisting to embeddings.rs if disallowed.
+
+**Starter code:**
+```rust
+// ---- STARTING POINT (must compile + pass before merge) ----
+// PART A — src/storage/mod.rs HNSW-precompute branch. Verified 8486-8556:
+//   for hit in hits { if scored.contains_key(&hit.id) { continue; }
+//       let cosine = f64::from(1.0 - hit.distance);            // <-- 8492 BUG
+//       if cosine > crate::RECALL_COSINE_GATE { needed_ids.push(..); hit_meta.push((hit.id.clone(), cosine)); } }
+//   let fetched = get_many(conn, &needed_ids)?;
+//   for (id, cosine) in hit_meta { let Some(mem) = fetched.get(&id) else { continue }; ...; scored.insert(...) }
+//
+// FIX: stop trusting hit.distance; recompute via cosine_similarity_checked.
+// If get_many's Memory rows lack `embedding`, add a batch helper:
+let emb_map = get_many_embeddings(conn, &needed_ids)?; // NEW — mirror get_all_embeddings decode (8057-8083)
+for (id, _trusted) in hit_meta {
+    let Some(mem) = fetched.get(&id) else { continue; };
+    let cosine = match emb_map.get(&id) {
+        Some(stored) => match crate::embeddings::Embedder::cosine_similarity_checked(query_embedding, stored) {
+            crate::embeddings::CosineComparison::Comparable(c) => f64::from(c),
+            crate::embeddings::CosineComparison::DimensionMismatch { .. } => {
+                *dim_mismatch_count += 1; // mirror linear-scan 8653 / FTS 8969
+                continue;
+            }
+        },
+        None => continue,
+    };
+    if cosine <= crate::RECALL_COSINE_GATE { continue; }
+    // ... existing namespace/expiry/tags/since/until/visibility/archived/source_uri ladder UNCHANGED ...
+    scored.insert(mem.id.clone(), (mem.clone(), 0.0, cosine));
+    hnsw_candidates_count += 1;
+}
+
+// PART B — src/storage/mod.rs:8071-8072 (get_all_embeddings). Verified:
+//   Ok(floats) => entries.push((id, floats)),
+Ok(floats) => match crate::federation::sanitize_shipped_vector(&floats) {
+    Some(clean) => entries.push((id, clean)),
+    None => tracing::warn!(memory_id = %id, "skipping non-finite/zero embedding during HNSW build (#1692)"),
+},
+// sanitize_shipped_vector verified at federation/mod.rs:255 (drops empty/non-finite,
+// L2-normalizes, Option<Vec<f32>>). Confirm storage→federation dep is OK; else hoist to embeddings.rs.
+
+// ---- TEST SKELETON ----
+#[test]
+fn hnsw_branch_counts_dim_mismatch_like_linear_scan_1692() {
+    // conn with one memory whose stored embedding dim != query_embedding dim;
+    // force HNSW-precompute path (pass precomputed_hnsw_hits); assert
+    // dim_mismatch_count == 1 and the stale row is excluded from `scored`.
+}
+```
+
+**Test plan:** New test: (A) HNSW-precompute branch increments dim_mismatch_count when a stored embedding differs in dimension from query_embedding (parity with the linear-scan assertion) and excludes the row; (B) get_all_embeddings drops a NaN-bearing vector. Honor existing pins: embeddings.rs cosine_similarity_checked_flags_dimension_mismatch (1424) and tests/recall_semantic_batch_fetch_981.rs (referenced at 8485 — must stay green to prove no same-dim drift). Run `AI_MEMORY_NO_CONFIG=1 cargo test recall_hnsw 1692` + the 981 batch-fetch test.
+
+**Acceptance:** HNSW-precompute branch routes cosine through cosine_similarity_checked (not raw 1.0-hit.distance), bumps dim_mismatch_count on mismatch identically to FTS+linear branches; get_all_embeddings sanitizes vectors so non-finite/zero seeds are dropped with a WARN; recall_semantic_batch_fetch_981 still green; clippy pedantic clean.
+
+---
+
+## #1688 — [HIGH] Persona generation not atomic — orphaned/mis-attested row on partial failure
+
+**▶ Dispatch:** implement #1688 per the §0 template; honor the §4 refinement for this ref. **Deps:** none (self-contained; reuses existing SQL_* consts and db helpers).  **Effort:** ~60-90 LOC (restructure write ordering + closure + 2 tests); 1 session.
+
+- **Files:** src/persona/mod.rs:298-536 (generate_in_scope); insert@412, create_link_signed loop@421-430, metadata UPDATE@509-514, emit_persona_generated_event@516-524. Pattern reference: src/storage/reflect.rs:530/590/612 (BEGIN IMMEDIATE/COMMIT/ROLLBACK closure); src/atomisation/mod.rs:876/906/910. Const SSOT: src/storage/connection.rs:36-38 (SQL_BEGIN_IMMEDIATE/SQL_COMMIT/SQL_ROLLBACK). Struct field: src/persona/mod.rs:202 (conn: &'a Connection).
+- **Root cause:** confirmed
+
+**Fix approach:** Wrap the four sequential writes (insert 412 → N×create_link_signed 421-430 → metadata UPDATE 509-514 → emit_persona_generated_event 516-524) in a single BEGIN IMMEDIATE...COMMIT, mirroring reflect.rs exactly: open a `(|| -> Result<_, PersonaError> { ... })()` closure that performs all four writes and returns the persona payload; on Ok run execute_batch(SQL_COMMIT), on Err run execute_batch(SQL_ROLLBACK) and propagate. The pre-write phases (validate, load sources, version, LLM summarize 303-348) and the body_hash/signature computation 439-461 should stay OUTSIDE the transaction (the LLM call is slow and must not hold the write lock). The link-attest resolution at 471-486 (db::strongest_attest_level_for_source) reads the link rows just written, so it must be INSIDE the txn (after the link inserts). Map execute_batch errors to PersonaError::Db(anyhow). conn is &Connection (not &mut), so execute_batch is the correct API (matches reflect.rs — rusqlite Transaction RAII guard would need &mut).
+
+**Adversarial note:** Audit fix-sketch ('wrap 412-517') is directionally correct but INCOMPLETE in one way and slightly OVERSTATED in another. (1) OVERSTATED: the audit says doc 356-361 'claims atomic' — it does NOT; lines 355-361 say the write order is 'auditable', not atomic. Real defect stands (no txn) but the doc-contradiction framing is wrong. (2) INCOMPLETE: naively wrapping 412-517 leaves the signature computation (439-461) and the LLM summarize (344-348) ambiguous. The LLM call MUST stay outside the lock (slow); signature_bytes can be computed before the txn (depends only on body_md+source_ids); but db::strongest_attest_level_for_source (471) reads the just-written links so MUST be inside. My starter code reorders accordingly. (3) The 'also audit synthesis/multistep-persist/consolidate' sub-task: VERIFIED — consolidate_cluster (autonomy.rs) uses RollbackEntry compensation (NOT a SQL txn) which is a legitimate alternative atomicity model — NOT a defect. synthesis/mod.rs and multistep_ingest/mod.rs contain NO execute_batch transaction; these warrant a separate follow-up investigation but should NOT be folded into #1688 (different persist shapes; scope creep risk). Recommend filing them as distinct issues per the prime-directive one-finding-one-issue rule.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge. Real signatures from src/persona/mod.rs.
+// In generate_in_scope, AFTER signature_bytes is computed (line ~461) and BEFORE the insert at 412.
+// NOTE: the current code computes signature_bytes (439-461) AFTER the insert+links. To keep the
+// LLM call outside the txn but the link-attest read inside it, restructure so body_hash/signature
+// (which depend only on body_md + source_ids, NOT on persona_id-in-db) are computed BEFORE the txn,
+// then open the txn for insert+links+attest+metadata+event.
+
+use crate::storage::connection::{SQL_BEGIN_IMMEDIATE, SQL_COMMIT, SQL_ROLLBACK};
+
+// ... after `let signature_bytes: Option<Vec<u8>> = match self.signer { ... };` (moved up) ...
+
+self.conn
+    .execute_batch(SQL_BEGIN_IMMEDIATE)
+    .map_err(|e| PersonaError::Db(anyhow::anyhow!(e)))?;
+
+let txn_result = (|| -> std::result::Result<(String, String), PersonaError> {
+    // (1) insert persona row
+    let persona_id = db::insert(self.conn, &persona_mem)
+        .with_context(|| format!("inserting persona for {entity_id} v{version}"))?;
+    // (2) N derived_from links
+    for source in &sources {
+        db::create_link_signed(
+            self.conn,
+            &persona_id,
+            &source.id,
+            crate::models::MemoryLinkRelation::DerivedFrom.as_str(),
+            self.signer,
+        )
+        .with_context(|| format!("linking persona {persona_id} -> source {}", source.id))?;
+    }
+    // (3) resolve attest_level from the links just written (must be in-txn)
+    let link_attest = db::strongest_attest_level_for_source(self.conn, &persona_id)
+        .context("resolve strongest link attest_level")?;
+    let attest_level = if signature_bytes.is_some() {
+        match link_attest.as_str() {
+            s if s == crate::models::AttestLevel::PeerAttested.as_str() =>
+                crate::models::AttestLevel::PeerAttested.as_str().to_string(),
+            _ => crate::models::AttestLevel::SelfSigned.as_str().to_string(),
+        }
+    } else { link_attest };
+    // (4) patch metadata envelope (existing 492-514 logic) — build new_metadata_str then UPDATE
+    if let Some(env) = metadata.get_mut("persona").and_then(serde_json::Value::as_object_mut) {
+        env.insert(field_names::ATTEST_LEVEL.to_string(), serde_json::Value::String(attest_level.clone()));
+        if let Some(sig) = signature_bytes.as_ref() {
+            env.insert("signature".to_string(), serde_json::Value::String(BASE64_STANDARD.encode(sig)));
+        }
+    }
+    let new_metadata_str = serde_json::to_string(&metadata).context("serialise updated persona metadata envelope")?;
+    self.conn.execute(
+        "UPDATE memories SET metadata = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![new_metadata_str, &now, &persona_id],
+    ).context("patch persona metadata with signature/attest_level")?;
+    // (5) signed_events append
+    emit_persona_generated_event(self.conn, &persona_id, &agent_id, &source_ids, &now,
+        signature_bytes.as_deref(), &attest_level)?;
+    Ok((persona_id, attest_level))
+})();
+
+match txn_result {
+    Ok((persona_id, attest_level)) => {
+        self.conn.execute_batch(SQL_COMMIT).map_err(|e| PersonaError::Db(anyhow::anyhow!(e)))?;
+        Ok(Persona { id: persona_id, entity_id: entity_id.to_string(), namespace: namespace.to_string(),
+            body_md, sources: source_ids, generated_at: now, version, attest_level })
+    }
+    Err(e) => {
+        if let Err(rb) = self.conn.execute_batch(SQL_ROLLBACK) {
+            tracing::error!("ROLLBACK failed in persona generate_in_scope: {rb}");
+        }
+        Err(e)
+    }
+}
+
+// TEST SKELETON (add to mod tests in src/persona/mod.rs):
+#[test]
+fn generate_rolls_back_on_link_failure() {
+    // Use a generator whose source-id list contains an id that forces a
+    // create_link_signed failure (e.g. a self-link or a non-existent target if
+    // FK-enforced), then assert NO MemoryKind::Persona row landed for the entity.
+    // Pattern mirrors reflect.rs rollback test. Assert db::list / get_latest_persona
+    // returns None after the failed generate(), proving no orphaned/mis-attested row.
+}
+```
+
+**Test plan:** New test `generate_rolls_back_on_link_failure` in src/persona/mod.rs tests mod: drive a generate() where one create_link_signed fails mid-loop; assert get_latest_persona(entity)==None AND no signed_events persona_generated row AND no half-attested metadata row. Plus a happy-path `generate_commits_atomically` asserting the row, all N links, patched metadata.attest_level, and the signed_event ALL exist after success. Mirror the existing reflect.rs rollback-test structure.
+
+**Acceptance:** On any failure in insert/link/metadata-patch/event-emit, the DB has zero trace of the persona (no memories row, no links, no signed_events row). On success all four writes are visible. cargo fmt/clippy-pedantic/test green. The persona doc comment 355-361 updated to state the writes are now transactional (BEGIN IMMEDIATE).
+
+---
+
+## #1700 — [HIGH] Online synthesis apply path is not atomic (memory_store)
+
+**▶ Dispatch:** implement #1700 per the §0 template; honor the §4 refinement (citation + widened txn). **Deps:** same fix shape as #1688.  **Effort:** ~10-20 LOC + test; 1 session
+
+- **Files:** `src/mcp/tools/store/synthesis.rs:265` (`apply_synthesis_updates_and_deletes` — updates 282-292 + deletes 396-400 + insert 409); caller `src/mcp/tools/store/mod.rs:560` (post-helper `db::insert` + #1239 supersedes-delete at mod.rs:577+); `src/storage/reflect.rs:530` (BEGIN IMMEDIATE pattern to mirror).
+- **Root cause:** confirmed — N `db::update` + N `db::delete` + insert with no enclosing transaction; `store/mod.rs` has zero txn markers. Mid-sequence failure → half-synthesized store.
+
+**Fix approach:** Wrap the whole store-handler synthesis-write region in one `BEGIN IMMEDIATE … COMMIT` with `ROLLBACK` on error — spanning the apply helper (updates+deletes) + the standard `db::insert` (add/no_op verdicts) + the #1239 `pending_synthesis_delete_targets` delete-after-insert (all run after the helper, mod.rs:577+). Mirror `src/storage/reflect.rs:530`. Single-surface (sqlite/MCP; postgres has no apply_synthesis path).
+
+**Adversarial note:** the #1688 suspicion that `synthesis/mod.rs` + `multistep_ingest` were the bug was REFUTED (no multi-row writes there); the real defect is this apply path. Confirm `store/mod.rs:560` is the MCP handler (`src/mcp/tools/store/mod.rs`), NOT the SAL trait (`src/store/mod.rs`).
+
+**Starter code:**
+```rust
+// src/mcp/tools/store/mod.rs ~560 — wrap the synthesis-write region.
+// Confirm the `conn` in scope supports execute_batch; if memory_store already
+// holds an outer write scope, prefer a SAVEPOINT instead of BEGIN IMMEDIATE.
+conn.execute_batch("BEGIN IMMEDIATE")?;
+let write = (|| -> anyhow::Result<_> {
+    if let Some(resp) = synthesis::apply_synthesis_updates_and_deletes(conn, &outcome, &existing)? {
+        /* existing apply-result handling */
+    }
+    /* standard db::insert(...) for add/no_op verdicts (runs AFTER the helper) */
+    /* #1239 pending_synthesis_delete_targets supersedes-delete */
+    Ok(())
+})();
+match write {
+    Ok(v)  => { conn.execute_batch("COMMIT")?; v }
+    Err(e) => { let _ = conn.execute_batch("ROLLBACK"); return Err(e); }
+}
+```
+
+**Test plan:** new test under `src/mcp/tools/store/` that injects a failure on the 2nd update (or the post-helper insert) and asserts NO partial application (candidates unchanged, incoming not inserted). `AI_MEMORY_NO_CONFIG=1 cargo test 1700`.
+
+**Acceptance:** synthesis apply on `memory_store` is all-or-nothing; regression test green; clippy pedantic clean.
+
+---
+## #1689 — [HIGH] Postgres find_paths traverses invalidated KG edges by default (sqlite excludes them)
+
+**▶ Dispatch:** implement #1689 per the §0 template; honor the §4 refinement for this ref. **Deps:** Shares the find_paths code path with #1673 (kg.rs) but edits different files (store/postgres.rs); coordinate so both land cleanly.  **Effort:** ~25-40 LOC (2 SQL strings + 1 gated test); 1 session. Needs a live Postgres+AGE instance for the AGE branch; the CTE branch is testable on plain pg.
+
+- **Files:** src/store/postgres.rs:5678-5741 (find_paths_cte SQL at 5705-5722), src/store/postgres.rs:5760-5879 (find_paths_cypher SQL at 5849-5857); reference impl src/storage/mod.rs:6212-6316 (sqlite, filter at 6251-6255). Inherent dispatcher src/store/postgres.rs:5631-5663. Trait + sqlite impl that hardcode current-view: src/store/mod.rs:1703-1714, src/store/sqlite.rs:1107-1150 (false at 1118), src/store/postgres.rs:12805-12821.
+- **Root cause:** confirmed
+
+**Fix approach:** MINIMAL + CORRECT: add a current-view valid_until predicate to BOTH postgres non-AGE and AGE branches so postgres matches sqlite's current trait behavior (which hardcodes include_invalidated=false). The trait MemoryStore::find_paths does NOT carry an include_invalidated param and SqliteStore hardcodes false (sqlite.rs:1118), so the reachable contract today is 'current-view only'. The pg CTE edges sub-selects (both UNION arms over memory_links) must gain WHERE (valid_until IS NULL OR valid_until > NOW()); the AGE Cypher MATCH must add a relationship-property predicate on valid_until. Do NOT thread a new param through the trait for this fix — that is a larger API change (trait + sqlite + HTTP body + MCP/CLI already-wired-separately) and is out of scope for closing the default-traversal defect. MCP/CLI already get correct include_invalidated handling because they call db::find_paths directly (find_paths.rs:69, cmd_find_paths), bypassing the trait.
+
+**Adversarial note:** Audit fix-sketch ('thread include_invalidated + add valid_until filter to both pg branches') is PARTIALLY WRONG on scope. There is NO include_invalidated param to thread on the trait MemoryStore::find_paths (store/mod.rs:1703); SqliteStore hardcodes false (sqlite.rs:1118) and HTTP FindPathsBody (kg.rs:942-958) has no such field. The reachable contract through trait/HTTP is current-view-ONLY, so the correct fix is to make postgres MATCH that, NOT add a new flag. Audit line anchors are correct (5631/5705-5722/5849-5856). REAL RISK: I verified the AGE edge valid_until property only by analogy to kg_query_cypher; the cypher RETURN currently projects only nodes(p), never relationship props, so r.valid_until availability in the AGE projection is UNVERIFIED — implementer must confirm before relying on the ALL(...) form; if AGE edges don't carry valid_until, the AGE branch needs a different guard. Treat the CTE edit as solid, the cypher edit as a sketch.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge. Real signatures/line-anchors verified.
+// --- src/store/postgres.rs : find_paths_cte (currently 5678-5741) ---
+// edges sub-SELECT today (verified 5710-5714): two UNION arms over memory_links with no filter.
+// Add the current-view filter to BOTH arms (mirrors sqlite invalidated_filter storage/mod.rs:6254):
+let sql = "WITH RECURSIVE traversal(current_id, depth, path) AS (
+        SELECT $1::TEXT, 0, ARRAY[$1::TEXT]
+        UNION ALL
+        SELECT edges.next_id, t.depth + 1, t.path || edges.next_id
+        FROM traversal t
+        JOIN (
+            SELECT source_id AS from_id, target_id AS next_id FROM memory_links
+              WHERE (valid_until IS NULL OR valid_until > NOW())
+            UNION
+            SELECT target_id AS from_id, source_id AS next_id FROM memory_links
+              WHERE (valid_until IS NULL OR valid_until > NOW())
+        ) edges ON edges.from_id = t.current_id
+        WHERE t.depth < $3 AND NOT (edges.next_id = ANY(t.path))
+    )
+    SELECT path FROM traversal WHERE current_id = $2 AND depth >= 1
+    ORDER BY depth ASC, path ASC LIMIT $4";
+
+// --- src/store/postgres.rs : find_paths_cypher (currently 5760-5879) ---
+// Current body (verified 5849-5857): MATCH p = (a)-[*1..{depth}]-(b) WHERE a.id=... RETURN nodes(p).
+// Add ALL(r IN relationships(p) WHERE r.valid_until IS NULL OR r.valid_until > '{now}') guard.
+// UNVERIFIED: confirm AGE memory_graph edges actually carry valid_until as a relationship prop
+// (the RETURN only projects nodes(p) today, never edge props) — see kg_query_cypher analogue.
+let sql = format!(
+    "SELECT path FROM cypher('memory_graph', $$ \
+     MATCH p = (a)-[*1..{depth}]-(b) \
+     WHERE a.id = '{source_id}' AND b.id = '{target_id}' \
+       AND ALL(r IN relationships(p) WHERE r.valid_until IS NULL OR r.valid_until > '{now_rfc3339}') \
+     RETURN nodes(p) AS path ORDER BY length(p) ASC LIMIT {cap} $$) AS (path agtype)"
+);
+
+// --- regression test (new tests/i1689_pg_find_paths_excludes_invalidated.rs, gated like g2_postgres_find_paths_*) ---
+#[tokio::test]
+async fn i1689_pg_find_paths_excludes_invalidated_edge_by_default() {
+    // seed a->b link, invalidate it (valid_until in past), find_paths(a,b) must be []
+    // — matching sqlite db::find_paths(...,false).
+}
+```
+
+**Test plan:** New gated pg test tests/i1689_pg_find_paths_excludes_invalidated.rs (mirror g2_postgres_find_paths_age_param_binding.rs harness, AI_MEMORY_TEST_POSTGRES_URL / AI_MEMORY_TEST_AGE_URL gated): seed a->b, invalidate edge, assert find_paths(a,b)==[] by default. Parity: the same scenario on sqlite (db::find_paths(conn,a,b,None,None,false)) already returns [] (tests/memory_find_paths.rs covers the sqlite contract).
+
+**Acceptance:** Default postgres find_paths (both AGE and CTE backends) excludes edges whose valid_until is in the past, matching the sqlite trait contract (current-view). No trait signature change. cargo build --features sal-postgres + the new gated test green on a live pg/AGE instance.
+
+---
+
+### 🌊 Wave 2 — governance
+
+## #1685 — [HIGH] run_mcp_server installs only GOVERNANCE_PRE_WRITE, never GOVERNANCE_PRE_ACTION — skill_export(FilesystemWrite) + LLM(NetworkRequest) wire-checks fail-open under MCP
+
+**▶ Dispatch:** implement #1685 per the §0 template; honor the §4 refinement for this ref. **Deps:** n26-split touches the same daemon_runtime.rs PRE_ACTION block region — land #1685's helper extraction first, then apply n26's comment fix to the extracted helper / call sites to avoid a conflict.  **Effort:** ~60-110 LOC (helper extraction in daemon_runtime ~20, MCP install ~20, new test ~120 incl. harness copy). 1 session.
+
+- **Files:** src/mcp/mod.rs:2745-2780 (run_mcp_server, the PRE_WRITE-only install block); src/governance/wire_check.rs:77 (GOVERNANCE_PRE_ACTION OnceLock), :92-100 (check() fail-open on empty OnceLock); src/daemon_runtime.rs:3592-3597 (HTTP/serve PRE_WRITE install via install_governance_pre_write_hook), :3599-3725 (HTTP/serve PRE_ACTION install block — the closure to mirror); src/mcp/tools/skill_export.rs:160-169,241-250 (FilesystemWrite wire_check::check sinks); src/llm.rs:1533-1539 (NetworkRequest wire_check::check_anyhow sink); tests/mcp_governance_pre_write_hook_1583.rs (the subprocess pattern to mirror)
+- **Root cause:** confirmed
+
+**Fix approach:** In run_mcp_server (src/mcp/mod.rs), after the existing install_governance_pre_write_hook call at :2775-2780, add a GOVERNANCE_PRE_ACTION install that mirrors the serve-side block at daemon_runtime.rs:3599-3725. Preferred shape: extract the serve-side PRE_ACTION closure into a new pub(crate) helper install_governance_pre_action_hook(db_path, queue, cache, conn) in daemon_runtime.rs paralleling install_governance_pre_write_hook, then call it from BOTH serve and run_mcp_server (single closure, no drift, matches the #1582/#1583 'same closure on every surface' design already documented at daemon_runtime.rs:3587-3591). The MCP server already builds mcp_governance_queue, mcp_rule_cache, and mcp_hook_conn (mod.rs:2761-2774) for PRE_WRITE; reuse the SAME rule_cache and queue. The PRE_ACTION closure needs a consultation Connection Arc: simplest correct move is to clone the Arc before it is moved into the PRE_WRITE install (matching serve, which clones one hook_consultation_conn for both hooks at daemon_runtime.rs:3596), or open a second db::open(db_path) Arc. Fail-CLOSED on open failure, identical to the existing mcp_hook_conn None-branch at mod.rs:2767-2773.
+
+**Adversarial note:** Finding holds — verified run_mcp_server (mod.rs:2745-2780) installs ONLY PRE_WRITE; the only GOVERNANCE_PRE_ACTION.set in the codebase is the serve-side block at daemon_runtime.rs:3631. wire_check::check (wire_check.rs:92-100) returns Ok when the OnceLock is empty, so under MCP the skill_export/llm sinks silently fail-open. CORRECTION to the audit fix-sketch's 'mirroring the PRE_WRITE install': you CANNOT reuse mcp_hook_conn directly — it is moved by value into the PRE_WRITE install at mod.rs:2775-2780. Either clone the Arc before that call (serve does this at 3596: two hooks share ONE Arc<Mutex<Connection>> and serialize on its mutex — acceptable) or open a second db::open. Cloning the Arc is the lower-risk choice. SECOND caveat: GOVERNANCE_PRE_ACTION is process-wide; if a process ever runs both serve and mcp the first install wins (handled by the is_err() branch). Purely additive, low risk.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge. Signatures below are REAL
+// (install_governance_pre_write_hook verified at src/daemon_runtime.rs:3117-3122).
+//
+// STEP 1 — src/daemon_runtime.rs: extract the existing serve-side PRE_ACTION block
+// (currently inline at lines 3599-3725) into a helper paralleling
+// install_governance_pre_write_hook. The new fn body is the SAME closure already
+// at 3620-3725 (WIRE_ACTION_ACTOR actor tag, governance_consultation_unavailable
+// fail-closed leg, AI_MEMORY_GOVERNANCE_FAIL_OPEN_ON_ERROR escape hatch).
+
+pub(crate) fn install_governance_pre_action_hook(
+    db_path: &Path,
+    deferred_audit_queue: &crate::governance::deferred_audit::DeferredAuditQueue,
+    rule_cache: &Arc<crate::governance::rule_cache::RuleCache>,
+    hook_consultation_conn: Option<Arc<std::sync::Mutex<rusqlite::Connection>>>,
+) {
+    use crate::governance::agent_action::{
+        AgentAction, Decision as RuleDecision, check_agent_action_deferred_cached,
+    };
+    let rules_db_path = db_path.to_path_buf();
+    let cache_for_wire_check = Arc::clone(rule_cache);
+    let queue_for_wire_check = deferred_audit_queue.clone();
+    let conn_for_wire_check = hook_consultation_conn;
+    let install_result = crate::governance::wire_check::GOVERNANCE_PRE_ACTION.set(Box::new(
+        move |action: &AgentAction| -> std::result::Result<(), String> {
+            // ... MOVE the verified body from daemon_runtime.rs:3633-3723 here verbatim ...
+            // (None-conn -> governance_consultation_unavailable(.., WIRE_ACTION_ACTOR, ..);
+            //  lock; check_agent_action_deferred_cached(.., WIRE_ACTION_ACTOR, ..); Allow/Warn=>Ok;
+            //  Refuse=>Err(reason); Err(e)=> fail-closed unless env escape hatch)
+            unimplemented!("move existing serve-side closure body here")
+        },
+    ));
+    if install_result.is_err() {
+        tracing::debug!("wire_check pre-action hook already installed (process-wide OnceLock)");
+    } else {
+        tracing::info!("wire_check GOVERNANCE_PRE_ACTION hook installed (MCP/serve agent-external gate)");
+    }
+    // then replace the inline serve block (3620-3725) with a call to this helper.
+}
+
+// STEP 2 — src/mcp/mod.rs, immediately AFTER the existing PRE_WRITE install at
+// run_mcp_server line 2775-2780. The MCP fn already has mcp_governance_queue +
+// mcp_rule_cache in scope (mod.rs:2761-2763). Provide a consultation conn for the
+// action hook (clone the Arc before PRE_WRITE consumes it, OR open a second):
+let mcp_action_hook_conn: Option<std::sync::Arc<std::sync::Mutex<rusqlite::Connection>>> =
+    match db::open(db_path) {
+        Ok(c) => Some(std::sync::Arc::new(std::sync::Mutex::new(c))),
+        Err(e) => {
+            eprintln!(
+                "ai-memory: #1685 — failed to open wire-check consultation connection \
+                 ({e}); GOVERNANCE_PRE_ACTION will fail CLOSED on every MCP wire action"
+            );
+            None
+        }
+    };
+crate::daemon_runtime::install_governance_pre_action_hook(
+    db_path,
+    &mcp_governance_queue,
+    &mcp_rule_cache,
+    mcp_action_hook_conn,
+);
+
+// STEP 3 — regression test (new file tests/mcp_governance_pre_action_hook_1685.rs).
+// Mirror tests/mcp_governance_pre_write_hook_1583.rs's spawn_mcp + send_and_recv
+// harness. The MCP-reachable PRE_ACTION sink is memory_skill_export (FilesystemWrite
+// via skill_export.rs:160-169). Seed a filesystem_write REFUSE rule, register a skill,
+// drive memory_skill_export, assert refusal.
+#[test]
+fn mcp_skill_export_is_refused_by_filesystem_write_rule_1685() {
+    let db_path = local_runs_db();
+    {
+        let conn = db::open(&db_path).expect("open seed db");
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO governance_rules (id,kind,matcher,severity,reason,namespace,\
+             created_by,created_at,enabled,signature,attest_level) \
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,NULL,?10)",
+            rusqlite::params![
+                "R-mcp-1685", "filesystem_write",
+                r#"{"path_glob":"**"}"#,            // VERIFY exact matcher shape via
+                                                      // match_filesystem_write in agent_action.rs
+                "refuse", "MCP skill_export MUST consult PRE_ACTION (#1685)",
+                "_global", "test", now, 1, "unsigned",
+            ],
+        ).expect("seed rule");
+        // ... register a skill row so export has something to write ...
+    }
+    // spawn_mcp, initialize, then tools/call memory_skill_export, assert blob refused.
+}
+```
+
+**Test plan:** New tests/mcp_governance_pre_action_hook_1685.rs (gated #![cfg(feature = "sal")] like the #1583 test). Primary: mcp_skill_export_is_refused_by_filesystem_write_rule_1685 — spawn real ai-memory mcp subprocess, seed a filesystem_write refuse rule, drive memory_skill_export, assert the response is refused (proving PRE_ACTION is installed). Prefer the subprocess test over an in-process GOVERNANCE_PRE_ACTION.get().is_some() assertion because the OnceLock is process-wide and would cross-contaminate other tests (the #1583 test chose subprocess for exactly this reason). Verify the exact filesystem_write matcher JSON shape against match_filesystem_write in src/governance/agent_action.rs before finalizing the seed row.
+
+**Acceptance:** After boot of `ai-memory mcp`, crate::governance::wire_check::GOVERNANCE_PRE_ACTION is populated; a seeded filesystem_write/network_request refuse rule is enforced on memory_skill_export (and any LLM-backed tool's outbound call) over MCP exactly as it is over HTTP serve. cargo fmt/clippy pedantic/test/audit all green. The new subprocess test passes and the refused export persists no side-effect file.
+
+---
+
+## n26-split — [MEDIUM] daemon_runtime PRE_ACTION install doc-comment overstates wire-check coverage as '4-variant (Bash,FilesystemWrite,NetworkRequest,ProcessSpawn)' — only 3 of 5 AgentAction kinds have structural sinks
+
+**▶ Dispatch:** implement n26-split per the §0 template; honor the §4 refinement for this ref. **Deps:** Coordinate with #1685: if #1685 extracts the PRE_ACTION closure into install_governance_pre_action_hook, land that extraction first, then apply this comment fix to the extracted helper / call sites to avoid a merge conflict in the 3599-3606 region.  **Effort:** ~10 LOC comment rewrite. <0.25 session.
+
+- **Files:** src/daemon_runtime.rs:3599-3606 (the 'covers the FOUR agent-EXTERNAL action variants (Bash, FilesystemWrite, NetworkRequest, ProcessSpawn)' comment); evidence for actual coverage: src/governance/agent_action.rs:124-165 (5 variants: Bash, FilesystemWrite, NetworkRequest, ProcessSpawn, Custom); wire_check::check structural sinks = src/mcp/tools/skill_export.rs:164,245 (FilesystemWrite), src/federation/sync.rs:80 (NetworkRequest), src/llm.rs:1537 (NetworkRequest), src/hooks/executor.rs:671,1041 (ProcessSpawn)
+- **Root cause:** confirmed
+
+**Fix approach:** Correct the comment to state the truth: the AgentAction enum has FIVE variants (Bash, FilesystemWrite, NetworkRequest, ProcessSpawn, Custom); the hook can evaluate any of them, but only THREE kinds currently have structural wire-point sinks calling wire_check::check — FilesystemWrite (skill_export), NetworkRequest (federation::sync, llm), ProcessSpawn (hooks::executor). Bash and Custom have NO structural PRE_ACTION sink (Custom is reached only via the storage PRE_WRITE 'memory_write' synthetic action at daemon_runtime.rs:3132, not via PRE_ACTION; Bash has no sink at all). State that the structural Bash/Custom sink work is tracked for v0.8 (#1695). Comment-only — no behavior change. If #1685's helper extraction lands first, this corrected comment moves onto install_governance_pre_action_hook and/or its call sites.
+
+**Adversarial note:** Finding holds and is precise. Verified all 5 AgentAction variants (agent_action.rs:124-165) and grepped every wire_check::check call site in src/: structural sinks cover exactly FilesystemWrite (skill_export ×2), NetworkRequest (federation/sync + llm), ProcessSpawn (hooks/executor ×2). There is NO Bash sink and NO Custom PRE_ACTION sink. The comment's 'FOUR ... (Bash, ...)' is doubly wrong: it undercounts the enum (5 not 4) AND overstates coverage (lists Bash, which has no sink). The audit phrasing 'only 3 of 5 AgentAction kinds guarded' is correct for PRE_ACTION sinks. The corrected comment must preserve the distinction that Custom IS evaluated, but via the SEPARATE storage GOVERNANCE_PRE_WRITE hook (daemon_runtime.rs:3132 synthesizes AgentAction::Custom{custom_kind:"memory_write"}), so a future reader does not add a redundant Custom PRE_ACTION sink. Correctly scoped as v0.7.1 comment-only with structural sink work deferred to the TRACKED issue #1695 (not a DEFER/WONTFIX dismissal — compliant with the prime directive).
+
+**Starter code:**
+```rust
+// STARTING POINT — comment-only edit at src/daemon_runtime.rs:3599-3606.
+// Replace the existing block:
+//
+//   // v0.7.0 (issue #691 fold-1) — install the universal AgentAction
+//   // wire-point hook BEFORE any daemon-side write/network/spawn paths
+//   // come live. Mirrors the L1-6 E pattern above but covers the FOUR
+//   // agent-EXTERNAL action variants (Bash, FilesystemWrite,
+//   // NetworkRequest, ProcessSpawn) consulted by skill_export,
+//   // federation::sync, hooks::executor, and the LLM client. ...
+//
+// with:
+
+    // v0.7.0 (issue #691 fold-1) — install the universal AgentAction
+    // wire-point hook BEFORE any daemon-side write/network/spawn paths
+    // come live. The AgentAction enum has FIVE variants (Bash,
+    // FilesystemWrite, NetworkRequest, ProcessSpawn, Custom) and the
+    // hook can evaluate any of them, but only THREE kinds currently have
+    // structural wire-point sinks calling wire_check::check:
+    //   - FilesystemWrite  -> skill_export (SKILL.md + per-resource writes)
+    //   - NetworkRequest   -> federation::sync, the LLM client
+    //   - ProcessSpawn     -> hooks::executor
+    // Bash and Custom have NO structural sink today (Custom is reached
+    // only via the storage PRE_WRITE `memory_write` synthetic action, not
+    // through PRE_ACTION). Adding structural Bash/Custom sinks is tracked
+    // for v0.8 (#1695). CLI one-shot binaries never reach this path so
+    // the hook stays empty for direct operator ops (L1-6 E
+    // operator-as-actor exemption).
+
+// No test code — pure comment. Belt-and-suspenders: Read tests/governance_wire_points.rs
+// and tests/wire_check_sole_path_pin.rs first to confirm the existing pins enumerate
+// exactly the three guarded kinds and do NOT assert a Bash sink (none exists).
+```
+
+**Test plan:** Comment-only — no new test. Before merge, Read tests/governance_wire_points.rs and tests/wire_check_sole_path_pin.rs to confirm the existing pins enumerate exactly the three guarded kinds (FilesystemWrite/NetworkRequest/ProcessSpawn) and do not claim a Bash/Custom sink. If those pins already assert the 3-kind set, the corrected comment is consistent; if they assert 4, that is a SECOND defect to file. cargo fmt --check validates the comment edit.
+
+**Acceptance:** The doc-comment at the PRE_ACTION install site accurately states 5 enum variants / 3 structurally-guarded kinds, names the v0.8 #1695 follow-up for Bash+Custom sinks, and no longer claims Bash is covered. cargo fmt --check passes.
+
+---
+
+## #1686 — [HIGH] rules keygen silently flips enforcement fail-open→attest-active, disabling every enabled-but-unsigned rule, with no fresh-keygen warning
+
+**▶ Dispatch:** implement #1686 per the §0 template; honor the §4 refinement for this ref. **Deps:** none — self-contained in cli/rules.rs. Independent of #1685/n26/n24.  **Effort:** ~25-40 LOC (warn block ~15, two tests ~40). <1 session.
+
+- **Files:** src/governance/rules_store.rs:205-247 (enforced_rule_passes — the (Some(_),_) arm at 223-235 skips enabled-unsigned rules once a pubkey exists; the (None,_) arm at 236-245 passes everything when no pubkey); src/cli/rules.rs:389-412 (RulesAction::Keygen dispatch arm), :527-586 (keygen_operator), :539-546 (the ONLY warning — fires only on --force when a key already exists); src/cli/rules.rs:316 (rules_store::list usage), :310 (OPERATOR_SIGNED_LEVEL in scope)
+- **Root cause:** confirmed
+
+**Fix approach:** A fresh (non-force) keygen writes operator.key + operator.key.pub where none existed. The instant that pubkey is resolvable, resolve_operator_pubkey() returns Some, so enforced_rule_passes flips from the (None,_) allow-all arm to the (Some,_) arms: every enabled rule that is NOT operator_signed is now SKIPPED (warn only at rule-load time deep in the daemon, never surfaced to the operator running keygen). Fix: in the RulesAction::Keygen arm (cli/rules.rs:389-412), AFTER keygen_operator succeeds, query the rules DB (the `conn` built at rules.rs:230 is in scope) via rules_store::list(&conn) filtered to r.enabled && r.attest_level != OPERATOR_SIGNED_LEVEL, and if any exist emit a loud WARN to out.stderr naming the count + ids + the exact remediation `ai-memory rules sign-seed`. Do NOT refuse by default (keygen is legitimately the first step before sign-seed) — make the consequence impossible to miss. Use raw rules_store::list, NOT list_enabled_by_kind (the latter itself calls enforced_rule_passes and would already filter out the very rows we must warn about — rules_store.rs:191).
+
+**Adversarial note:** Finding holds — the keygen arm (rules.rs:389-412) emits NO warning about already-enabled-unsigned rules; the only existing warning (rules.rs:539-546) is gated on `force && (path.exists() || pub_path.exists())`, so it fires only when OVERWRITING an existing key, never on a first keygen. enforced_rule_passes (rules_store.rs:209-247) does flip exactly: (None,_)=>true allow-all vs (Some,_) non-signed=>false skip. REFINEMENT: the warn must target enabled && attest_level != operator_signed regardless of rule ORIGIN — any enabled unsigned rule gets skipped post-keygen, not just seed rules (though `rules add` requires --sign at rules.rs:245-247, so the at-risk rows are pre-seeded R001..R004 plus any inserted via raw SQL). CRITICAL implementation note: do NOT use list_enabled_by_kind for the count — it calls enforced_rule_passes internally (rules_store.rs:191) and would already drop the very rows we want to warn about; use rules_store::list + manual r.enabled filter. Low risk; additive stderr only.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge.
+// REAL signatures verified: keygen_operator(path,force,out)->Result<String> (rules.rs:527);
+// rules_store::list(&conn)->Result<Vec<Rule>> (called in the List arm at rules.rs:316);
+// Rule has `enabled: bool` and `attest_level: String` (rules_store.rs:745-758 row_to_rule);
+// OPERATOR_SIGNED_LEVEL const is in scope (used at rules.rs:310,349,369,384).
+
+// src/cli/rules.rs — inside `RulesAction::Keygen { out: out_path, force } => { ... }`
+// AFTER the existing `let fingerprint = keygen_operator(&resolved, force, out)?;` (line 404):
+
+    // #1686 — generating an operator key flips enforced_rule_passes from the
+    // pre-L1-6 allow-all arm (rules_store.rs:236) to the operator_signed-only
+    // arm (rules_store.rs:223): every ENABLED rule that is not yet
+    // operator_signed silently stops being enforced. Warn loudly and point at
+    // `rules sign-seed` so the operator is not blindsided.
+    let unsigned_enabled: Vec<String> = rules_store::list(&conn)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| r.enabled && r.attest_level != OPERATOR_SIGNED_LEVEL)
+        .map(|r| r.id)
+        .collect();
+    if !unsigned_enabled.is_empty() {
+        writeln!(
+            out.stderr,
+            "WARNING: an operator key now exists, so the L1-6 enforcement gate \
+             will SKIP {} enabled-but-unsigned rule(s): {}. These rules are NO \
+             LONGER ENFORCED until you run `ai-memory rules sign-seed` (and \
+             activate with `rules enable --sign`). See #1686.",
+            unsigned_enabled.len(),
+            unsigned_enabled.join(", "),
+        )?;
+    }
+    let payload = serde_json::json!({
+        "path": resolved.display().to_string(),
+        "public_path": format!("{}.pub", resolved.display()),
+        "fingerprint": fingerprint,
+    });
+    emit_ok(json, out, "rules.keygen", &payload)?;
+    Ok(())
+
+// Test skeleton — extend src/cli/rules.rs::tests (sibling of the keygen tests
+// at rules.rs:1284/1331/1355/1379, which already build a CliOutput + key_path).
+#[test]
+fn keygen_warns_when_enabled_unsigned_rules_exist_1686() {
+    // 1. open a scratch DB (reuse the rules test env helper), insert an ENABLED
+    //    rule with attest_level='unsigned'.
+    // 2. run the Keygen dispatch (or keygen_operator + the new warn block) against
+    //    a CliOutput capturing stderr into a Vec<u8>.
+    // 3. assert captured stderr contains "sign-seed" AND the rule id AND "#1686".
+}
+#[test]
+fn keygen_no_warn_when_all_signed_or_empty_1686() {
+    // seed zero enabled-unsigned rules; assert the warn line is ABSENT.
+}
+```
+
+**Test plan:** Add keygen_warns_when_enabled_unsigned_rules_exist_1686 + keygen_no_warn_when_all_signed_or_empty_1686 to the existing #[cfg(test)] mod in src/cli/rules.rs (which already has keygen tests using a captured CliOutput at 1284/1331/1355/1379). The warn test seeds one enabled unsigned rule, runs the Keygen arm, asserts out.stderr contains the rule id + 'sign-seed'. The negative test seeds an enabled operator_signed rule (or no rules) and asserts the warn line is absent. Pure in-process CLI handler tests, no subprocess — matching the existing keygen test style.
+
+**Acceptance:** `ai-memory rules keygen` on a DB with >=1 enabled non-operator-signed rule prints a stderr WARNING naming the count, the rule ids, and the `rules sign-seed` remediation. Keygen with all-signed (or no) enabled rules prints no such warning. The actual key write + fingerprint output is unchanged. All four gates green.
+
+---
+
+### 🌊 Wave 3 — reranker batch
+
+## #1691 — [HIGH] HTTP /api/v1/recall never cross-encoder reranks (MCP-only); AppState has no reranker field; sole prod BatchedReranker is MCP boot
+
+**▶ Dispatch:** implement #1691 per the §0 template; honor the §4 refinement for this ref. **Deps:** Pairs with n23 (landing #1691 makes the recall.rs:244 docstring true — close n23 as fixed-by-#1691). Independent of #1684/#1692. AppState field addition has wide blast radius (132 references) — serialize against other agents touching AppState. Coordinate with n14 if it also edits the bootstrap_serve reranker construction.  **Effort:** ~50 LOC prod + (N test scaffolds × 1 line) + 40 LOC new test; 2 sessions (the scaffold sweep is the long pole — AppState has 132 referencing sites per codegraph)
+
+- **Files:** src/handlers/recall.rs:412 + 655 (only apply_session_recency_boost — a session recency boost, NOT a cross-encoder rerank), src/handlers/recall.rs:578 (db::recall_hybrid_precomputed_hnsw call — no reranker arg), src/handlers/transport.rs:137-end (AppState struct — no reranker field), src/mcp/mod.rs:3016-3027 (sole prod BatchedReranker construction, gated on tier_config.cross_encoder), src/mcp/tools/recall.rs:640-714 (handle_recall* thread reranker: Option<&BatchedReranker>), src/storage/mod.rs:8148 (recall_hybrid_precomputed_hnsw sig), src/reranker.rs:726 (BatchedReranker::rerank)
+- **Root cause:** confirmed
+
+**Fix approach:** Add a reranker handle to AppState and invoke it in the HTTP recall handler, mirroring MCP. (1) Add `pub reranker: Arc<Option<crate::reranker::BatchedReranker>>` to AppState (transport.rs:137). BatchedReranker is NOT Clone (holds mpsc Sender + JoinHandle), so Arc<Option<...>> keeps AppState cheaply cloneable. (2) In bootstrap_serve build it like MCP (mcp/mod.rs:3016-3027): if tier_config.cross_encoder { Some(BatchedReranker::new(CrossEncoder::new_neural())) } else { None }. (3) In recall_response, after recall returns r: Vec<(Memory,f64)>, call ce.rerank(context, r) BEFORE apply_session_recency_boost (matching MCP order) on BOTH the sqlite branch (~636-655) and the postgres branch (384-416 — scored_pairs is also Vec<(Memory,f64)>). (4) Pass app.reranker.as_ref().as_ref() to the HTTP capabilities overlay (capabilities.rs:341-378; #1647 note says HTTP passes no handle) so reranker_active stops falsely reporting Off. Audit fix-sketch correct.
+
+**Adversarial note:** CONFIRMED: recall.rs:412 and :655 call ONLY apply_session_recency_boost (per-session ring-buffer recency bump, distinct from cross-encoder rerank); neither HTTP branch calls BatchedReranker::rerank. AppState (transport.rs:137-end, fully read) has no reranker field. mcp/mod.rs:3024 is the sole prod BatchedReranker::new. RISK 1: BatchedReranker spawns a worker thread (reranker.rs:1493) on construction — adds one daemon thread to HTTP serve (MCP already does this; acceptable). RISK 2: blast radius — a non-Default AppState field breaks EVERY AppState{...} literal in tests (132 references); budget the scaffold sweep or add a test-only default. RISK 3: replicate MCP order (rerank, THEN session boost, THEN confidence/visibility filters). RISK 4: postgres branch returns the same (Memory,f64) shape so rerank applies there too; even on keyword-only postgres the cross-encoder improves ordering. Do NOT change recall_hybrid_precomputed_hnsw's storage-layer signature — rerank belongs in the handler post-recall, like MCP's handle_recall_dto.
+
+**Starter code:**
+```rust
+// ---- STARTING POINT (must compile + pass before merge) ----
+// (1) src/handlers/transport.rs — add to `pub struct AppState { ... }` (verified opens at 137):
+    /// #1691 — cross-encoder reranker handle, mirroring the MCP daemon
+    /// (sole prior prod construction at src/mcp/mod.rs:3024). Arc<Option<...>>
+    /// because BatchedReranker holds an mpsc Sender + worker JoinHandle (not
+    /// Clone) and AppState must stay cheaply cloneable. None when the tier has
+    /// no cross-encoder.
+    pub reranker: Arc<Option<crate::reranker::BatchedReranker>>,
+
+// (2) bootstrap_serve (daemon_runtime.rs) — mirror mcp/mod.rs:3016-3027:
+let reranker = if tier_config.cross_encoder {
+    let ce = crate::reranker::CrossEncoder::new_neural();
+    Some(crate::reranker::BatchedReranker::new(ce))
+} else { None };
+// AppState { ..., reranker: Arc::new(reranker), ... }
+
+// (3) src/handlers/recall.rs — sqlite branch. Verified line 655:
+//   let r = crate::reranker::apply_session_recency_boost(r, session_id, session_tracker);
+// EDIT to rerank FIRST (MCP applies cross-encoder before the session boost):
+let r = if let Some(ce) = app.reranker.as_ref().as_ref() {
+    ce.rerank(context, r) // verified sig reranker.rs:726: rerank(&self, query: &str, Vec<(Memory,f64)>) -> Vec<(Memory,f64)>
+} else { r };
+let r = crate::reranker::apply_session_recency_boost(r, session_id, session_tracker);
+// Apply the same ce.rerank(context, scored_pairs) on the postgres branch at
+// recall.rs:412 before apply_session_recency_boost.
+
+// (4) capabilities call site — pass app.reranker.as_ref().as_ref() where it
+//     currently passes None (capabilities.rs:363 #1647 note).
+
+// ---- TEST SKELETON ----
+#[tokio::test]
+async fn http_recall_applies_cross_encoder_rerank_1691() {
+    // Build AppState with reranker: Arc::new(Some(BatchedReranker::new(CrossEncoder::new())))
+    // + two memories whose cross-encoder order differs from FTS/semantic order;
+    // POST /api/v1/recall; assert response memories[] order reflects the rerank.
+}
+```
+
+**Test plan:** New integration test tests/http_recall_reranks_1691.rs: with a reranker wired into AppState, POST /api/v1/recall reorders candidates per the cross-encoder (distinct from pre-fix FTS/semantic order). Add a unit assertion that AppState builds with reranker: Arc<None> when tier_config.cross_encoder == false. Confirm existing serve_* test scaffolds compile (the new non-Default field needs setting in every AppState literal — grep scaffolds). Run `AI_MEMORY_NO_CONFIG=1 cargo test http_recall 1691` + `cargo test --test serve_postgres_handler_parity`.
+
+**Acceptance:** AppState carries reranker; bootstrap_serve builds it identically to MCP; recall_response applies ce.rerank on both sqlite and postgres branches before the session-recency boost; HTTP capabilities reports reranker_active correctly (closes #1647 false-Off); new test green; ALL AppState literals (prod + every test scaffold) updated; clippy pedantic clean. Landing this also makes the recall.rs:244 docstring (n23) true.
+
+---
+
+## n14 — [MEDIUM] RerankerScoreFloor (#1319) unreachable in production — no config/env/CLI path calls with_score_floor
+
+**▶ Dispatch:** implement n14 per the §0 template; honor the §4 refinement for this ref. **Deps:** Touches the same mcp/mod.rs:3024 site as #1691. If #1691 lands first, the bootstrap_serve reranker construction must ALSO honor score_floor — coordinate ordering (land #1691 then n14, or fold both into one reranker-construction helper). RerankerScoreFloor enum + apply already exist (reranker.rs:1352-1396); n14 only wires config plumbing.  **Effort:** ~45 LOC + 25 LOC tests; 1-2 sessions
+
+- **Files:** src/reranker.rs:1462 (with_score_floor — callers ALL tests per codegraph_callers: reranker.rs:2738 + tests/cov_ga2_misc.rs:134,168), src/mcp/mod.rs:3024 (sole prod construction uses ::new → floor Off), src/config.rs:3429-3448 (RerankerSection — has enabled/model/max_seq_tokens, NO score_floor field), src/config.rs:6631-6672 (resolve_reranker — no score_floor), src/config.rs:3834-3846 (ResolvedReranker — no score_floor field), src/reranker.rs:1338-1339 (RerankerScoreFloor doc admits '[reranker].score_floor* config fields once they land')
+- **Root cause:** confirmed
+
+**Fix approach:** Wire a config/env path so operators can opt into the floor (the #1604 max_seq_tokens wiring is the exact template). (1) Add score_floor_mode: Option<String> + score_floor_value: Option<f64> to RerankerSection (config.rs:3429). (2) Add score_floor: RerankerScoreFloor to ResolvedReranker (config.rs:3834). (3) In resolve_reranker (config.rs:6631) resolve via env (AI_MEMORY_RERANK_SCORE_FLOOR + _VALUE) > [reranker] section > compiled Off, mirroring the max_seq_tokens block at 6647-6656; register named env consts, add to the CLAUDE.md env table + tests/config_precedence.rs. (4) At prod construction (mcp/mod.rs:3024, plus bootstrap_serve once #1691 lands) select the constructor: match resolved.score_floor { Off => new(ce), f => with_score_floor(ce, f) }. Audit fix-sketch ('wire a config/env path to with_score_floor') is correct.
+
+**Adversarial note:** CONFIRMED unreachable: codegraph_callers(with_score_floor) returns exactly 3 callers, ALL tests (reranker.rs:2738, tests/cov_ga2_misc.rs:134,168). Sole prod construction mcp/mod.rs:3024 uses ::new (floor Off). RerankerSection (3429-3448) verified to lack any score_floor field; the RerankerScoreFloor doc (1338-1339) self-documents the gap ('once they land'). Addition to the sketch: TWO hardcoded ResolvedReranker literals (config.rs:4077, 4135 — default/test fixtures) must also get the new field or the build breaks — grep `ResolvedReranker {` before editing. RerankerMode (config.rs:608, the Off/lexical/neural capabilities enum) is DISTINCT from RerankerScoreFloor — do not conflate. Env names must follow AI_MEMORY_RERANK_* and be named consts (hardcoded-literal ratchet). No runtime behavior change unless an operator opts in — low blast radius.
+
+**Starter code:**
+```rust
+// ---- STARTING POINT (must compile + pass before merge) ----
+// (1) src/config.rs:3429 RerankerSection — add fields (template: max_seq_tokens at 3447):
+    /// #1319/n14 — opt-in post-blend score floor mode. "off" (default) |
+    /// "absolute" | "relative_to_top". Env: AI_MEMORY_RERANK_SCORE_FLOOR.
+    pub score_floor_mode: Option<String>,
+    /// #1319/n14 — floor value for absolute/relative_to_top, clamped [0,1].
+    /// Env: AI_MEMORY_RERANK_SCORE_FLOOR_VALUE.
+    pub score_floor_value: Option<f64>,
+
+// (2) src/config.rs:3834 ResolvedReranker — add:
+    pub score_floor: crate::reranker::RerankerScoreFloor,
+
+// (3) src/config.rs:6631 resolve_reranker — after the max_seq_tokens block (6647-6656):
+let score_floor = {
+    let mode = std::env::var(ENV_RERANK_SCORE_FLOOR).ok()
+        .or_else(|| cfg.and_then(|r| r.score_floor_mode.clone()));
+    let value = std::env::var(ENV_RERANK_SCORE_FLOOR_VALUE).ok()
+        .and_then(|s| s.trim().parse::<f64>().ok())
+        .or_else(|| cfg.and_then(|r| r.score_floor_value));
+    match (mode.as_deref().map(str::trim).map(str::to_ascii_lowercase).as_deref(), value) {
+        (Some("absolute"), Some(v)) => crate::reranker::RerankerScoreFloor::Absolute(v.clamp(0.0, 1.0)),
+        (Some("relative_to_top"), Some(v)) => crate::reranker::RerankerScoreFloor::RelativeToTop(v.clamp(0.0, 1.0)),
+        _ => crate::reranker::RerankerScoreFloor::Off,
+    }
+};
+// include `score_floor` in the returned ResolvedReranker AND the two hardcoded
+// literals at config.rs:4077 and 4135 (set RerankerScoreFloor::Off).
+
+// (4) src/mcp/mod.rs:3016-3027 — verified `Some(BatchedReranker::new(ce))` at 3024. EDIT:
+let reranker = if tier_config.cross_encoder {
+    let ce = CrossEncoder::new_neural();
+    Some(match resolved_reranker.score_floor { // thread ResolvedReranker into run_mcp_server
+        crate::reranker::RerankerScoreFloor::Off => BatchedReranker::new(ce),
+        f => BatchedReranker::with_score_floor(ce, f),
+    })
+} else { None };
+
+// ---- TEST SKELETON (mirror resolve_reranker_1146_folds_legacy_cross_encoder at 9946) ----
+#[test]
+fn resolve_reranker_score_floor_env_over_section_n14() {
+    let _g = env_var_lock();
+    let mut cfg = AppConfig::default();
+    cfg.reranker = Some(RerankerSection { score_floor_mode: Some("absolute".into()), score_floor_value: Some(0.5), ..Default::default() });
+    assert_eq!(cfg.resolve_reranker().score_floor, crate::reranker::RerankerScoreFloor::Absolute(0.5));
+}
+```
+
+**Test plan:** New test in src/config.rs::tests (next to resolve_reranker_1146_folds_legacy_cross_encoder at 9946): env > section > Off ladder, a clamping case (1.5 → 1.0), and a garbage-mode→Off case. Extend tests/config_precedence.rs with the two new env vars (mandatory per CLAUDE.md). Run `AI_MEMORY_NO_CONFIG=1 cargo test resolve_reranker config_precedence`.
+
+**Acceptance:** RerankerSection + ResolvedReranker carry score_floor; resolve_reranker resolves it via env>section>Off with clamping; prod construction (mcp/mod.rs:3024, plus bootstrap_serve if #1691 landed) selects with_score_floor when configured; new + existing reranker config tests green; two new env vars added to the CLAUDE.md env table AND tests/config_precedence.rs; clippy pedantic clean. with_score_floor now has a non-test caller.
+
+---
+
+## n22 — [LOW] BatchedReranker::score_floor() doc claims memory_capabilities exposure that does not exist
+
+**▶ Dispatch:** implement n22 per the §0 template; honor the §4 refinement for this ref. **Deps:** Tightly coupled to n14: if n14 lands (score_floor becomes operator-configurable), do Option B so the configured floor is observable. If n14 is deferred, Option A is the honest minimum. Recommend landing n14 + n22-Option-B together.  **Effort:** Option A: ~5 LOC, <1 session. Option B: ~25 LOC + 15 LOC test + a ScoreFloorReport type, ~1 session.
+
+- **Files:** src/reranker.rs:1690-1696 (score_floor() — doc says 'expose ... for the memory_capabilities reporter', but codegraph_callers(score_floor) = No callers found), src/mcp/tools/capabilities.rs:341-378 (overlay — surfaces reranker_active at 354 + reflection_boost at 377 via ce.reflection_boost(), NEVER calls ce.score_floor()), src/reranker.rs:1698-1703 (reflection_boost() — the sibling accessor that IS consumed by the reporter)
+- **Root cause:** confirmed
+
+**Fix approach:** Two honest options; pick based on n14. OPTION A (doc-honesty, minimal — if n14 is NOT landing this release): correct the score_floor() doc to drop the false 'memory_capabilities reporter' claim and say it is currently used only by tests/diagnostics. OPTION B (add the exposure, preferred if n14 lands): in build_capabilities_overlay (capabilities.rs, the `if let Some(ce) = reranker` block at 376-378) add caps.features.score_floor = ScoreFloorReport::from(ce.score_floor()) alongside reflection_boost, which requires a new additive score_floor report field on the capabilities Features struct (mirror ReflectionBoostReport at config.rs:755-779). Audit fix-sketch ('correct doc OR add the exposure') is correct; B is world-class and composes with n14.
+
+**Adversarial note:** CONFIRMED: codegraph_callers(score_floor) = 'No callers found' (zero, incl. the capabilities reporter). Read capabilities.rs:354-378 directly — it wires reranker_active and reflection_boost (line 377: ce.reflection_boost()) but NO ce.score_floor() call anywhere. The doc at reranker.rs:1691 is factually false. The sibling reflection_boost() doc (1699) makes the SAME claim but is TRUE (consumed at capabilities.rs:377) — that asymmetry is the tell. Watch (Option B): adding a capabilities wire field is a schema-surface change — confirm it does not break capabilities schema_version negotiation tests (capabilities is schema_version '3' at v0.7.0); add the field additively/optionally so v1/v2 projections are unaffected.
+
+**Starter code:**
+```rust
+// ---- OPTION A (doc-only) — src/reranker.rs:1690-1696, verified current: ----
+//   /// v0.7.0 #1319 — expose the configured score floor for the
+//   /// `memory_capabilities` reporter and for operator-facing diagnostics.
+//   pub fn score_floor(&self) -> RerankerScoreFloor { self.score_floor }
+// EDIT doc to:
+/// v0.7.0 #1319 — accessor for the configured post-blend score floor.
+/// Currently consumed by unit tests + operator-facing diagnostics; it is
+/// NOT yet surfaced on the `memory_capabilities` report (the overlay
+/// exposes `reranker_active` + `reflection_boost` only — see
+/// `src/mcp/tools/capabilities.rs`). Add the exposure under n22/#1319 if
+/// score_floor becomes operator-configurable (n14).
+pub fn score_floor(&self) -> RerankerScoreFloor { self.score_floor }
+
+// ---- OPTION B (add real exposure) — src/mcp/tools/capabilities.rs ~376, verified: ----
+//   if let Some(ce) = reranker {
+//       caps.features.reflection_boost =
+//           crate::config::ReflectionBoostReport::from(ce.reflection_boost());
+//   }
+// EDIT to also surface the floor (needs a new caps.features.score_floor field +
+// a ScoreFloorReport in config.rs mirroring ReflectionBoostReport at 755):
+    if let Some(ce) = reranker {
+        caps.features.reflection_boost =
+            crate::config::ReflectionBoostReport::from(ce.reflection_boost());
+        caps.features.score_floor =
+            crate::config::ScoreFloorReport::from(ce.score_floor());
+    }
+
+// ---- TEST SKELETON (Option B) — mirror no_reranker_handle_flips_cross_encoder_flag_1647 (1482):
+#[test]
+fn capabilities_surfaces_score_floor_when_reranker_present_n22() {
+    let batched = BatchedReranker::with_score_floor(CrossEncoder::new(), RerankerScoreFloor::Absolute(0.4));
+    // build overlay with Some(&batched); assert caps.features.score_floor reflects Absolute(0.4)
+}
+```
+
+**Test plan:** Option A: no behavioral test (covered by the prime-directive doc-honesty standard); optionally a doctest. Option B: a test in capabilities.rs::tests (next to no_reranker_handle_flips_cross_encoder_flag_1647 at 1482) asserting caps.features.score_floor mirrors ce.score_floor() when a reranker handle is present, absent/Off otherwise. Run `AI_MEMORY_NO_CONFIG=1 cargo test capabilities n22`.
+
+**Acceptance:** Either the score_floor() doc no longer claims a memory_capabilities exposure that does not exist (Option A), OR the capabilities overlay actually surfaces score_floor with a pinning test (Option B). No dangling false claim remains; doc and behavior agree per the prime directive.
+
+---
+
+## n23 — [LOW] recall.rs hybrid docstring claims a reranker stage the HTTP path does not run (pairs with #1691)
+
+**▶ Dispatch:** implement n23 per the §0 template; honor the §4 refinement for this ref. **Deps:** Directly coupled to #1691 — n23 is the documentation face of the same defect. RECOMMENDED: land #1691 and close n23 in the same PR (the rerank wiring makes the docstring true). Only do the standalone doc-correction if #1691 is explicitly deferred (which the prime directive discourages).  **Effort:** Doc-only: ~6 LOC, <1 session. Zero if folded into #1691.
+
+- **Files:** src/handlers/recall.rs:242-249 (recall_response docstring: 'The full hybrid (FTS + semantic + adaptive blend + reranker + touch ops) pipeline remains sqlite-only in v0.7.0'), src/handlers/recall.rs:412 + 655 (actual HTTP code — only apply_session_recency_boost, NO cross-encoder rerank on either branch), src/handlers/recall.rs:578 (recall_hybrid_precomputed_hnsw — no reranker arg)
+- **Root cause:** confirmed
+
+**Fix approach:** Honesty-vs-land choice, gated on #1691. IF #1691 lands (reranker wired into HTTP), the docstring at recall.rs:244 BECOMES TRUE for sqlite — close n23 as 'fixed by #1691' with a one-line confirmation that the sqlite branch now reranks. IF #1691 is deferred, correct the docstring so it stops claiming a 'reranker' stage the HTTP path never runs: the sqlite HTTP pipeline today is FTS + semantic + adaptive blend + (session recency boost) + touch ops; the cross-encoder rerank is MCP-only. Audit fix-sketch ('docstring honesty or land #1691') is exactly right; preferred resolution is land #1691.
+
+**Adversarial note:** CONFIRMED: docstring at recall.rs:244 literally lists 'reranker' in the sqlite hybrid pipeline, but I read both HTTP branches — postgres (384-416) and sqlite (636-655) — and NEITHER calls BatchedReranker::rerank; both call only apply_session_recency_boost (412, 655), a session ring-buffer recency bump, not a cross-encoder. The MCP path (mcp/tools/recall.rs:640+) is the only surface threading a reranker. So the docstring overclaims — a true doc-drift defect. Best fix is #1691 (makes it true); standalone doc edit is the fallback. Note the recall.rs module-level docstring (lines 1-10) does NOT make the false claim — it is specifically the recall_response item docstring at 242-249. Keep the edit scoped there; do not touch the module header.
+
+**Starter code:**
+```rust
+// ---- STARTING POINT — src/handlers/recall.rs:242-249, verified current docstring: ----
+//   /// v0.7.0 Wave-3 Continuation — when `app.storage_backend` is
+//   /// `Postgres`, dispatch through `app.store.search` for keyword recall.
+//   /// The full hybrid (FTS + semantic + adaptive blend + reranker + touch
+//   /// ops) pipeline remains sqlite-only in v0.7.0; postgres deployments
+//   /// fall back to keyword-only recall ...
+//
+// IF #1691 DEFERRED — EDIT to match reality (drop the false 'reranker' claim):
+//   /// The full hybrid (FTS + semantic + adaptive blend + session-recency
+//   /// boost + touch ops) pipeline remains sqlite-only in v0.7.0. The
+//   /// cross-encoder rerank stage runs ONLY on the MCP `memory_recall`
+//   /// surface (see `crate::mcp::tools::recall::handle_recall_dto`,
+//   /// `reranker: Option<&BatchedReranker>`); the HTTP recall handler does
+//   /// not yet wire a reranker handle (tracked in #1691). Postgres
+//   /// deployments fall back to keyword-only recall ...
+//
+// IF #1691 LANDS — leave the docstring as-is (it becomes true once the handler
+//   calls app.reranker.rerank); add a `// #1691` reference comment.
+
+// ---- TEST SKELETON ----
+// No behavioral test for the doc-only path (prime-directive doc-honesty).
+// If #1691 lands, its integration test (http_recall_applies_cross_encoder_rerank_1691)
+// is the proof the docstring is now accurate.
+```
+
+**Test plan:** Doc-only when #1691 deferred — no automated test (the prime directive treats docstring/behavior drift as a defect to fix, not test). When #1691 lands, n23 accuracy is proven by #1691's http_recall_applies_cross_encoder_rerank_1691 integration test. No new test file specific to n23.
+
+**Acceptance:** The recall_response docstring at recall.rs:244 agrees with the code: EITHER the HTTP path now reranks (via #1691) so 'reranker' is accurate, OR the docstring is corrected to say cross-encoder rerank is MCP-only and the HTTP path applies a session-recency boost. No false 'reranker' claim remains on a path that does not run it.
+
+---
+
+### 🌊 Wave 4 — medium config / policy / capability
+
+## #1671 — [MEDIUM] reflection_pass.enabled dead config — --all-namespaces gate hardcoded, never reads per-namespace standard
+
+**▶ Dispatch:** implement #1671 per the §0 template; honor the §4 refinement for this ref. **Deps:** Shares the GovernancePolicy/namespace-standard surface with #1688's domain but no code conflict. Pairs conceptually with n17 (the docstrings that promise this wiring). If MemoryStore::resolve_governance_policy is not yet on the trait, that's a small precursor (the free-fn db::resolve_governance_policy at storage/mod.rs:9498 exists; SAL trait method may need adding — verify before estimating).  **Effort:** ~80-120 LOC (sub-policy struct + accessor + resolver wiring at 2 call sites + 3 tests); 1 session.
+
+- **Files:** src/cli/curator.rs:522-523 (enabled_check = |_ns| scope_single), 386-398 (store_backed_reflection_sweep hardcodes |_ns:&str| true). Config carrier: src/curator/mod.rs:102 (CuratorConfig.reflection_pass: ReflectionPassConfig), src/curator/reflection_pass.rs:182-205 (ReflectionPassConfig { enabled: bool default false }). Policy resolver: src/storage/mod.rs:9498 (resolve_governance_policy(conn,&str) -> Option<GovernancePolicy>). Predicate consumer: src/curator/reflection_pass.rs:711 (if !enabled_check(ns) continue).
+- **Root cause:** confirmed
+
+**Fix approach:** Replace the hardcoded `|_ns| scope_single` (curator.rs:523) and `|_ns| true` (curator.rs:395) enabled-checks with a real per-namespace resolver. The cleanest landing: add a `reflection_pass_enabled: Option<bool>` (or reuse a governance sub-policy) resolvable per-namespace. Two viable designs: (A) thread it through GovernancePolicy — add `ReflectionPassPolicy { enabled: bool }` as a #[serde(flatten)] sub-struct on GovernancePolicy (namespace.rs, alongside the 8 existing sub-policies like ExportPolicy/PersonaPolicy), persisted in metadata.governance, and have enabled_check call db::resolve_governance_policy(conn, ns).map(|p| p.reflection_pass.enabled).unwrap_or(false). (B) load ReflectionPassConfig from a per-namespace standard lookup. Design (A) is consistent with how max_reflection_depth already lives in CorePolicy and is read via resolve_governance_policy at reflect.rs:487 / link.rs:176. For --reflect single-namespace (scope_single), preserve the operator-opted-in bypass (the operator named the namespace explicitly) OR consult the gate — operator decision; the current single-ns bypass is documented behavior at curator.rs:516-521, recommend keeping it. The load-bearing fix is the --all-namespaces path (curator.rs, the |_ns| scope_single -> false branch) and store_backed_reflection_sweep (|_ns| true).
+
+**Adversarial note:** Audit fix-sketch is correct in intent. CAVEAT confirmed by reading: the enabled_check is a SYNC `impl Fn(&str)->bool` (reflection_pass.rs:681), but per-namespace policy resolution on the SAL store path is likely ASYNC. Do NOT call block_on/futures::executor inside the closure (deadlock risk on the curator's tokio runtime). The correct shape is to pre-resolve an enabled-namespace HashSet BEFORE invoking run_reflection_pass, then close over it — I flagged this in the starter code. Second caveat: the audit names only curator.rs:466-473,516-523, but the SAME hardcode exists at store_backed_reflection_sweep curator.rs:395 (|_ns| true) which feeds BOTH --once and --daemon SAL sweeps — the fix MUST cover that site too or the --daemon path stays ungated. Third: whether single-ns --reflect should ALSO consult the gate is a genuine semantic choice (current code bypasses it as 'operator opted in'); recommend preserving the bypass and documenting it, not silently gating it.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests. Real sigs from the files read.
+// DESIGN A: add a sub-policy on GovernancePolicy (src/models/namespace.rs).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReflectionPassPolicy {
+    /// When true, the curator --all-namespaces / --daemon reflection sweep
+    /// processes this namespace. Default false (opt-in, per #666 acceptance).
+    #[serde(default)]
+    pub reflection_pass_enabled: bool,
+}
+// add to GovernancePolicy struct (namespace.rs:478) as: #[serde(flatten)] pub reflection: ReflectionPassPolicy,
+// add accessor:
+impl GovernancePolicy {
+    #[must_use]
+    pub fn reflection_pass_enabled(&self) -> bool { self.reflection.reflection_pass_enabled }
+}
+
+// In src/cli/curator.rs run_reflect (replace 522-523). The enabled_check needs a Connection;
+// the SAL path uses a store handle, so resolve via a SqliteStore-bound conn OR add a
+// MemoryStore::resolve_governance_policy call (already exists per CLAUDE.md SAL notes).
+// For the SAL trait path use the store; sketch with the trait method:
+let store_ref = store.as_ref();
+let enabled_check = |ns: &str| -> bool {
+    if args.namespace.is_some() { return true; } // operator opted in for single-ns run
+    // --all-namespaces: consult per-namespace standard
+    // (resolve_governance_policy is a SAL MemoryStore method per CLAUDE.md;
+    //  if only the free-fn db::resolve_governance_policy(conn,ns) is available,
+    //  open a conn at db_path once and capture it in the closure.)
+    futures::executor::block_on(store_ref.resolve_governance_policy(ns))
+        .ok()
+        .flatten()
+        .map(|p| p.reflection_pass_enabled())
+        .unwrap_or(false)
+};
+// NOTE: enabled_check is `impl Fn(&str)->bool` (sync) per run_reflection_pass sig
+// (reflection_pass.rs:681). resolve_governance_policy may be async on the trait — if so,
+// pre-resolve the enabled set BEFORE calling run_reflection_pass: enumerate namespaces,
+// await the policy for each, build a HashSet<String> of enabled ns, then
+// enabled_check = move |ns| set.contains(ns). This avoids block_on inside the closure.
+
+// In src/cli/curator.rs store_backed_reflection_sweep (replace 395 |_ns| true) with the
+// same pre-resolved HashSet approach.
+
+// TEST SKELETON (tests live in src/curator/reflection_pass.rs tests mod, async):
+#[tokio::test]
+async fn all_namespaces_skips_disabled_namespace() {
+    // store with 2 namespaces, one carrying reflection_pass_enabled=true standard,
+    // one without. run_reflection_pass(None, enabled_check=resolved-from-standard).
+    // Assert report.namespaces_visited counts both but only the enabled ns
+    // contributes observations_scanned / reflections.
+}
+```
+
+**Test plan:** Add `all_namespaces_skips_disabled_namespace` and `all_namespaces_processes_enabled_namespace` in src/curator/reflection_pass.rs tests: set a namespace standard with reflection_pass_enabled=true on ns A only; run the sweep with the real resolver-derived enabled_check; assert ns B is skipped (no observations_scanned increment, no reflection rows) and ns A is processed. Plus a serde round-trip test for ReflectionPassPolicy in namespace.rs tests (mirrors the existing max_reflection_depth round-trip).
+
+**Acceptance:** curator --reflect --all-namespaces and curator --store-url --daemon process ONLY namespaces whose standard carries reflection_pass_enabled=true; namespaces with no standard default to skipped. Single-namespace --reflect --namespace <ns> keeps the documented operator-opt-in bypass. The CLI docstring at curator.rs:464-473 and 516-521 (which explicitly say config-file wiring is a 'v0.7.1 follow-up') updated to reflect the landed wiring. cargo gates green.
+
+---
+
+## n15 — [MEDIUM] per-namespace confidence_decay_half_life_days documented but unresolvable — decay always uses compiled default
+
+**▶ Dispatch:** implement n15 per the §0 template; honor the §4 refinement for this ref. **Deps:** Shares the resolve_governance_policy/CorePolicy surface with #1671 — if both land, coordinate the CorePolicy/sub-policy additions to avoid merge churn (recommend both adding to GovernancePolicy via separate sub-policy structs, or both into CorePolicy in one batch). The postgres parity arm requires AI_MEMORY_TEST_POSTGRES_URL to test live (sqlite arm is the load-bearing unit test).  **Effort:** ~70-110 LOC (CorePolicy field + accessor + decay.rs resolver + postgres parity + 3 tests); 1 session.
+
+- **Files:** src/confidence/decay.rs:77-131 (apply_decay_touch), hardcodes crate::confidence::DEFAULT_HALF_LIFE_DAYS at decay.rs:104. The decayed() fn (decay.rs:52) ALREADY takes half_life_days as a param. DEFAULT_HALF_LIFE_DAYS=30.0 at src/confidence/mod.rs:119. Doc sites claiming the per-ns knob exists: src/confidence/mod.rs:42, src/confidence/decay.rs:11/40-41/63-64, src/config.rs:1668/1699, src/models/memory.rs:247, docs/confidence-calibration.md:36/113, docs/migration-v064-to-v070.md:424, docs/v0.7.0/audit/sections/07-cognition-lifecycle.md:103. Policy struct lacking the field: src/models/namespace.rs:512 (CorePolicy). Resolver: src/storage/mod.rs:9498 (resolve_governance_policy). Callers of apply_decay_touch: src/store/sqlite.rs:588, src/store/postgres.rs:10860.
+- **Root cause:** confirmed
+
+**Fix approach:** Add `confidence_decay_half_life_days: Option<f64>` to CorePolicy (or a new ConfidenceDecayPolicy #[serde(flatten)] sub-struct on GovernancePolicy, consistent with the 8 existing sub-policies). Then make apply_decay_touch resolve it: (1) extend the SELECT at decay.rs:83-89 to also fetch the row's `namespace`; (2) call db::resolve_governance_policy(conn, &namespace) to get the per-ns half-life, falling back to DEFAULT_HALF_LIFE_DAYS; (3) pass the resolved value into decayed() at decay.rs:101-105 instead of the hardcoded const. Add an accessor effective_confidence_decay_half_life_days() -> f64 on GovernancePolicy returning self.core.confidence_decay_half_life_days.unwrap_or(DEFAULT_HALF_LIFE_DAYS). Mirror in the postgres decay path (store/postgres.rs:10860) for parity.
+
+**Adversarial note:** Audit finding CONFIRMED and is a REAL defect (decayed() already parameterizes half_life but apply_decay_touch hardcodes the default at decay.rs:104). IMPORTANT disambiguation I verified: there are TWO unrelated half-life systems — (a) RecallScoringConfig/ResolvedScoring (config.rs:2552+, tier-based half_life_days_short/mid/long) which IS resolvable and threaded into recall SCORING; and (b) the confidence-COLUMN decay (apply_decay_touch) which is the n15 subject. Do NOT conflate them — the fix is ONLY in path (b). Second note: apply_decay_touch currently has no namespace in scope (only id), so the fix necessarily widens the SELECT — cheap (same query_row). Third: resolve_governance_policy does an extra DB read per decayed row; since decay is a touch-time sweep this is acceptable but worth a comment; an optimization (cache per-namespace half-life across a batch sweep) is a possible follow-up, not required for correctness. The decay.rs:63-64 comment explicitly calls the per-ns override 'a future-Cluster knob' — this confirms it was always known-unimplemented, not a regression.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests. Real sigs from files read.
+// (1) src/models/namespace.rs CorePolicy (struct@512) — add field after max_reflection_depth (544):
+    /// Per-namespace confidence-decay half-life in days for the
+    /// AI_MEMORY_CONFIDENCE_DECAY freshness sweep. None -> compiled
+    /// DEFAULT_HALF_LIFE_DAYS. Persisted in metadata.governance JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence_decay_half_life_days: Option<f64>,
+// and in CorePolicy::Default (547-558) add: confidence_decay_half_life_days: None,
+// accessor on GovernancePolicy (impl block near effective_max_reflection_depth@955):
+    #[must_use]
+    pub fn effective_confidence_decay_half_life_days(&self) -> f64 {
+        self.core.confidence_decay_half_life_days
+            .unwrap_or(crate::confidence::DEFAULT_HALF_LIFE_DAYS)
+    }
+
+// (2) src/confidence/decay.rs apply_decay_touch (77) — extend the query + resolve:
+pub fn apply_decay_touch(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
+    use chrono::{DateTime, Utc};
+    let row: Option<(f64, String, Option<String>, String)> = conn
+        .query_row(
+            "SELECT confidence, created_at, confidence_decayed_at, namespace
+             FROM memories WHERE id = ?1",
+            params![id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .ok();
+    let Some((current_confidence, created_at, decayed_at, namespace)) = row else {
+        return Ok(false);
+    };
+    // resolve per-namespace half-life (falls back to DEFAULT_HALF_LIFE_DAYS)
+    let half_life = crate::storage::resolve_governance_policy(conn, &namespace)
+        .map(|p| p.effective_confidence_decay_half_life_days())
+        .unwrap_or(crate::confidence::DEFAULT_HALF_LIFE_DAYS);
+    // ... existing anchor/age_days math (95-100) ...
+    let new_value = decayed(current_confidence, age_days, half_life); // was DEFAULT_HALF_LIFE_DAYS@104
+    // ... existing write-back (122-130) unchanged ...
+}
+
+// TEST SKELETON (src/confidence/decay.rs tests mod):
+#[test]
+fn apply_decay_uses_per_namespace_half_life() {
+    // open db; set a namespace standard on ns 'fast' with
+    // confidence_decay_half_life_days = Some(1.0); insert a memory in 'fast'
+    // aged exactly 1 day with confidence 1.0; apply_decay_touch; assert new
+    // confidence ~= 0.5 (1-day half-life), NOT ~0.977 (30-day default).
+}
+```
+
+**Test plan:** `apply_decay_uses_per_namespace_half_life` in src/confidence/decay.rs tests: namespace standard with half_life=1.0 day; a 1-day-old row decays to ~0.5 (proving the per-ns knob is consulted) vs the default-30d expectation of ~0.977. Plus `apply_decay_falls_back_to_default_when_no_policy` (no standard -> ~0.977). Plus a CorePolicy serde round-trip test for the new field in namespace.rs tests. Verify the existing non_version_bumping_sites_1036.rs pin still passes (the write-back UPDATE is unchanged).
+
+**Acceptance:** A namespace whose standard carries confidence_decay_half_life_days actually decays at that rate; namespaces without it use DEFAULT_HALF_LIFE_DAYS. The capability surface CapabilityConfidenceCalibration.default_half_life_days (config.rs:1700) doc no longer overstates (it currently says 'tunable per namespace' — that becomes TRUE). Postgres decay path (store/postgres.rs:10860) updated for parity. cargo gates green.
+
+---
+
+## #1674 — [MEDIUM] System capabilities db_schema_version hardcoded 0 on default (non-sal) build vs live MAX(version) on sal build
+
+**▶ Dispatch:** implement #1674 per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** ~10 LOC + ~30 LOC test; 1 session.
+
+- **Files:** src/handlers/system.rs:123-124 (`#[cfg(not(feature="sal"))] let db_schema_version: i64 = 0;`); sal path :111-122 (app.store.schema_version().await); SAL SqliteStore live read at src/store/sqlite.rs:79-92 using crate::storage::migrations::SELECT_SCHEMA_VERSION_SQL; const at src/storage/migrations.rs:33-34 = "SELECT COALESCE(MAX(version), 0) FROM schema_version" (pub(crate)); live conn in scope at system.rs:71-72 as lock.0/conn, dropped at :102.
+- **Root cause:** confirmed
+
+**Fix approach:** In the non-sal cfg branch, run the same live MAX(version) read the SqliteStore SAL impl does, over the daemon's shared connection, instead of hardcoding 0. Reuse SELECT_SCHEMA_VERSION_SQL (already pub(crate), already COALESCEs to 0 on empty table → preserves cold-start fallback). The conn is dropped at line 102, so place the non-sal read inside the pre-drop scope (just above `drop(lock);`). Leave the sal branch untouched.
+
+**Adversarial note:** Finding HOLDS exactly. The read must land before `drop(lock)` at :102 since after drop there is no connection without re-locking. SELECT_SCHEMA_VERSION_SQL pub(crate) visibility confirmed at migrations.rs:33. Low risk, isolated, additive; the COALESCE in the const preserves the documented cold-start safety the SqliteStore SAL impl relies on.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass test. src/handlers/system.rs.
+// Insert just above `drop(lock);` (line 102), and DELETE the old hardcoded
+// lines 123-124:
+    // #1674 — non-sal build must report the LIVE applied migration version,
+    // matching the sal path + the SqliteStore SAL adapter (src/store/sqlite.rs:79-92).
+    // COALESCE(MAX(version),0) keeps the empty-table cold-start fallback at 0.
+    #[cfg(not(feature = "sal"))]
+    let db_schema_version: i64 = conn
+        .query_row(crate::storage::migrations::SELECT_SCHEMA_VERSION_SQL, [], |row| row.get(0))
+        .unwrap_or(0);
+// (SELECT_SCHEMA_VERSION_SQL is pub(crate) at migrations.rs:33 — visible to handlers.)
+```
+
+**Test plan:** New tests/capabilities_db_schema_version_nonsal.rs (must build on default/non-sal feature set): open a migrated sqlite DB via crate::storage::open, build minimal AppState, call get_capabilities, parse the JSON body, assert body["db_schema_version"] == ai_memory::storage::current_schema_version_for_tests() (57). Add a second case on a fresh un-migrated DB asserting 0 (COALESCE fallback).
+
+**Acceptance:** On a default (non-sal) build, GET /api/v1/capabilities returns the live MAX(version) (57 at HEAD), 0 on an empty DB. Regression test pins it without requiring the sal feature. fmt/clippy/test green on default features.
+
+---
+
+## #1673 — [MEDIUM] verify_link + find_paths HTTP routes 501 on default (non-sal) build while MCP/CLI work
+
+**▶ Dispatch:** implement #1673 per the §0 template; honor the §4 refinement for this ref. **Deps:** Touches the same kg.rs find_paths region as #1689 (which edits store/postgres.rs); independent logic but coordinate edits to avoid conflicts.  **Effort:** ~60-100 LOC (find_paths branch ~25 LOC; verify_link needs free-fn extraction ~50 LOC + 2 tests). 1 session.
+
+- **Files:** src/handlers/kg.rs:968-1068 (kg_find_paths; non-sal 501 at 1057-1067), src/handlers/links.rs:89-226 (verify_link_handler; non-sal 501 at 216-225). Routes registered unconditionally src/lib.rs:859-876. AppState src/handlers/transport.rs:137-223 (pub db always; pub store #[cfg(sal)] at 222). Reference sqlite-direct-via-app.db pattern src/handlers/kg.rs:1324-1333 (kg_query). MCP find_paths that works without sal src/mcp/tools/find_paths.rs:69-114. SAL verify_link src/store/sqlite.rs:917-1105.
+- **Root cause:** confirmed
+
+**Fix approach:** Provide a non-sal sqlite HTTP impl for BOTH handlers using app.db (available in all builds), exactly like kg_query (kg.rs:1324: let lock = app.db.lock().await; &lock.0). kg_find_paths non-sal branch: db::find_paths(&lock.0, source, target, max_depth, max_results, false) -> same {paths,count,source_id,target_id} envelope (no visibility filter, matching MCP handle_find_paths). verify_link non-sal branch: needs a sqlite-direct equivalent of SqliteStore::verify_link (sqlite.rs:917-1105) — extract a db:: free-fn from that impl (DRY) and call from both. ALSO document the sal-gating in the lib.rs route-row comments. Per prime directive the sqlite impl is the real fix; the doc note is supplementary.
+
+**Adversarial note:** Audit fix-sketch ('document the sal-gating AND/OR provide a sqlite HTTP impl; confirm exact handler+router cfg sites') is CORRECT and I confirmed exact sites: the 501 is NOT at the router (routes unconditional, lib.rs:859-876) but inside handlers via #[cfg(not(feature=sal))] blocks (kg.rs:1057-1067, links.rs:216-225). The sqlite impl is feasible because app.db is non-gated (transport.rs:138) and kg_query already uses the sal-blind app.db.lock() pattern (kg.rs:1324). RISK: verify_link has NO pre-existing db:: free-fn — its logic (incl. a crypto verify path via crate::identity::verify) is embedded in SqliteStore::verify_link (sqlite.rs:917-1105); the non-sal handler must extract it (preferred, DRY) or duplicate it. find_paths half is low-risk; verify_link half is the larger/riskier piece.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge.
+// --- src/handlers/kg.rs : replace the non-sal 501 block (verified 1057-1067) ---
+#[cfg(not(feature = "sal"))]
+{
+    let lock = app.db.lock().await;            // app.db available in ALL builds (transport.rs:138)
+    return match crate::storage::find_paths(   // db alias; sig verified storage/mod.rs:6212
+        &lock.0, &body.source_id, &body.target_id, body.max_depth, body.max_results, false,
+    ) {
+        Ok(paths) => {
+            let count = paths.len(); let _ = caller;
+            Json(json!({"paths": paths, "count": count,
+                        "source_id": body.source_id, "target_id": body.target_id})).into_response()
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("max_depth") || msg.contains("depth") {
+                (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({"error": msg}))).into_response()
+            } else { crate::handlers::errors::handler_error_500(&e) }
+        }
+    };
+}
+// --- src/handlers/links.rs : replace the non-sal 501 block (verified 216-225) ---
+// verify_link logic lives ONLY in SqliteStore::verify_link (sqlite.rs:917-1105, incl. crypto verify
+// via crate::identity::verify). Cleanest: extract a `pub fn verify_link(conn, filter)` into
+// src/storage/mod.rs and call from BOTH the SAL impl and this non-sal branch:
+#[cfg(not(feature = "sal"))]
+{
+    let lock = app.db.lock().await;
+    // construct (source_id,target_id,link_id) filter exactly as sqlite.rs:933-951
+    return match crate::storage::verify_link(&lock.0, &filter) { // NEW extracted free-fn
+        Ok(report) => { /* nonce replay check (links.rs:177-193) + audit + Json(report) */ }
+        Err(e) => /* map NotFound->404, InvalidInput->400, else 500 */,
+    };
+}
+// --- regression tests (extend src/handlers/tests.rs, builds without sal; test_state() at tests.rs:80) ---
+#[tokio::test]
+async fn i1673_find_paths_http_nonsal_returns_200_not_501() { /* seed a->b, POST kg/find_paths, assert 200 + paths */ }
+```
+
+**Test plan:** Add to src/handlers/tests.rs (compiled in the default non-sal build): i1673_find_paths_http_nonsal_returns_200 (seed link, POST kg/find_paths, assert 200 + paths) and i1673_verify_link_http_nonsal_returns_200 (seed link, POST links/verify, assert 200 + report, not 501). Use existing test_state() (tests.rs:80). Guard assertions so the sal build also passes (both branches now 200).
+
+**Acceptance:** On a default cargo build (no sal), POST /api/v1/kg/find_paths and POST /api/v1/links/verify return 200 with the same envelope shape as the sal build (minus the SAL visibility filter, which non-sal omits as MCP does). The two new non-sal handler tests pass under the default feature set.
+
+---
+
+## #1672 — [MEDIUM] curator_mode capability reports 'implemented' on non-sal build though curator --reflect hard-bails
+
+**▶ Dispatch:** implement #1672 per the §0 template; honor the §4 refinement for this ref. **Deps:** none. Independent of #1671/#1688. Verify the IMPLEMENTED const location and whether a DEGRADED-style const already exists before adding a new one.  **Effort:** ~15-25 LOC (one cfg-select + one const + 2 cfg-gated tests + doc update); 0.5 session.
+
+- **Files:** CITATION CORRECTED — the field is NOT in src/mcp/tools/capabilities.rs. It lives at src/config.rs:1240 (CapabilityReflection.curator_mode: String) and is set unconditionally at src/config.rs:1255 (curator_mode: IMPLEMENTED.to_string()) inside CapabilityReflection::current(). The non-sal hard-bail is src/cli/curator.rs:548-560 (run_reflect cfg(not(feature="sal")) -> anyhow::bail!). Doc audit-anchor at config.rs:1217-1220 claims it's 'implemented in curator::reflection_pass'.
+- **Root cause:** revised
+
+**Fix approach:** Gate the curator_mode value at config.rs:1255 on cfg!(feature="sal"). On a non-sal build the reflection pass (ReflectionPass, run_reflection_pass) is entirely cfg(feature="sal")-gated (reflection_pass.rs:222,673) and curator --reflect bails (curator.rs:556), so the honest value is a degraded marker. Since the field is a String specifically so 'future increments can grow new values without a wire-shape break' (config.rs:1238-1239), introduce a named const e.g. DEGRADED or NOT_AVAILABLE (alongside the existing IMPLEMENTED const) and select it via cfg!. This matches the SqliteStore::capabilities honesty precedent (store/sqlite.rs:63-72: 'capability bits must match runtime behaviour').
+
+**Adversarial note:** MAJOR CITATION CORRECTION to the audit: the audit says 'report degraded on non-sal in mcp/tools/capabilities.rs' — but curator_mode is NOT in that file. It is in src/config.rs (CapabilityReflection struct@1221, ::current()@1249, set@1255). mcp/tools/capabilities.rs consumes CapabilityReflection but does not set curator_mode. The fix belongs in config.rs. This is exactly the kind of fabricated/imprecise citation the repo's history warrants re-verifying — I confirmed via grep across all of src/ that curator_mode appears only at config.rs:1240/1255 (plus unrelated atomisation 'curator_model' fields). Second note: confirm whether the DEFAULT build actually excludes sal — per CLAUDE.md the default build is non-sal (Migrate/SchemaInit are sal-gated and absent from the 80-subcommand default), so this defect IS live in the shipped default binary, raising its real-world impact. Severity 'medium' is defensible but lean toward making sure the capabilities honesty regression test (#1052/#302-item-6 lineage) covers it.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests. Real code at src/config.rs:1249-1257.
+// Find the IMPLEMENTED const (used at config.rs:1255 and many capability sites) and add a sibling.
+// (IMPLEMENTED is a crate-internal const string "implemented"; locate its declaration — grep `const IMPLEMENTED`.)
+
+/// Curator reflection-pass mode is sal-gated; non-sal builds cannot run it
+/// (curator --reflect bails — src/cli/curator.rs:556). Report degraded so the
+/// capability envelope matches runtime behaviour.
+const CURATOR_MODE_UNAVAILABLE: &str = "unavailable_non_sal"; // or reuse an existing DEGRADED const if present
+
+impl CapabilityReflection {
+    #[must_use]
+    pub fn current() -> Self {
+        Self {
+            implemented: true,
+            depth_bounded: true,
+            max_default: crate::reranker::DEFAULT_REFLECTION_MAX_DEPTH_CAP,
+            attestation: "Ed25519".to_string(),
+            curator_mode: {
+                #[cfg(feature = "sal")]
+                { IMPLEMENTED.to_string() }
+                #[cfg(not(feature = "sal"))]
+                { CURATOR_MODE_UNAVAILABLE.to_string() }
+            },
+        }
+    }
+}
+
+// Also update the audit-anchor doc at config.rs:1217-1220 + the field doc 1236-1239
+// to state the sal-gating.
+
+// TEST SKELETON: a cfg-split test in src/config.rs tests mod (these compile per-feature).
+#[cfg(not(feature = "sal"))]
+#[test]
+fn curator_mode_degraded_without_sal() {
+    assert_eq!(CapabilityReflection::current().curator_mode, CURATOR_MODE_UNAVAILABLE);
+}
+#[cfg(feature = "sal")]
+#[test]
+fn curator_mode_implemented_with_sal() {
+    assert_eq!(CapabilityReflection::current().curator_mode, IMPLEMENTED);
+}
+```
+
+**Test plan:** Two cfg-gated tests in src/config.rs tests: `curator_mode_degraded_without_sal` (cfg(not(sal))) asserts the degraded const, `curator_mode_implemented_with_sal` (cfg(sal)) asserts IMPLEMENTED. Since CI runs both the default (sal-less per Cargo features?) and sal builds, both arms get exercised. Confirm which feature set the capability honesty test (tests/form_*.rs or the existing capabilities pin) runs under and extend it. Verify no wire-shape break: curator_mode stays a String.
+
+**Acceptance:** memory_capabilities on a non-sal binary reports curator_mode as a degraded/unavailable string (NOT 'implemented'); the sal build still reports 'implemented'. The config.rs:1217-1220 audit-anchor doc updated to note the sal gate. cargo gates green on BOTH `cargo test` (default features) and `cargo test --features sal`.
+
+---
+
+## n13 — [MEDIUM] HTTP capabilities v3 computes callable_now from agent_id=None, mis-reporting allowlisted callers; HTTP allowlist not enforced
+
+**▶ Dispatch:** implement n13 per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** ~15-25 LOC (system.rs threading + 1 test); 0.5 session.
+
+- **Files:** src/handlers/system.rs:22-101 (get_capabilities; passes None as agent_id at line 81), src/mcp/tools/capabilities.rs:270-331 (handle_capabilities_with_conn_v3), src/mcp/tools/capabilities.rs:669-719 (build_capabilities_tools; callable_now at 698), src/config.rs:5206-5234 (allowlist_decision; aid="" at 5213). Reference helper crate::identity::resolve_http_agent_id (kg.rs:995, kg.rs:1168). MCP-only allowlist gate src/mcp/registry.rs:858-907 (handle_capabilities_family).
+- **Root cause:** confirmed
+
+**Fix approach:** Part A (concrete, verified): resolve the caller from the X-Agent-Id header in get_capabilities and thread it into handle_capabilities_with_conn_v3 (currently None at system.rs:81). Use crate::identity::resolve_http_agent_id(None, header_agent_id) like kg.rs:995, but .ok() to None on a malformed header (read-only GET must not 400). Pass Some(&caller) so build_capabilities_tools -> allowlist_decision(Some(caller),family) returns the caller's true Allow/Deny instead of the wildcard fallback; this also fixes build_agent_permitted_families (capabilities.rs:297). Part B ('enforce allowlist on HTTP'): the allowlist is only a capabilities-DRILLDOWN gate (registry.rs:884), which has NO HTTP route equivalent — HTTP /capabilities is a flat GET. Recommend SCOPING n13 to Part A and noting in the issue that HTTP has no drilldown surface to enforce on (the allowlist was never a write-path gate even on MCP); a write-path HTTP gate would be a NEW feature, separate issue.
+
+**Adversarial note:** Audit fix-sketch is HALF-right. Part A confirmed concrete: system.rs:81 passes None; allowlist_decision(None,...) sets aid="" (config.rs:5213) so only the wildcard rule applies — a caller with a specific rule is mis-reported. Threading X-Agent-Id fixes it. Part B ('HTTP also doesn't enforce the allowlist') is OVERSTATED: on MCP the allowlist is enforced ONLY at the capabilities family-drilldown (registry.rs:884, include_schema=true), NOT at tool-dispatch/write-path. HTTP exposes no family-drilldown route, so there is no equivalent surface to enforce on — adding write-path enforcement is a NEW security feature, its own issue if the operator wants it. Recommend scoping n13 to Part A and documenting Part B's non-existence-of-surface. CAUTION: do NOT 400 the capabilities GET on a malformed X-Agent-Id (it is read-only) — use .ok() to fall back to None, unlike kg.rs:995 which 400s on the write path.
+
+**Starter code:**
+```rust
+// STARTING POINT — must compile + pass tests before merge.
+// --- src/handlers/system.rs : get_capabilities (sig verified 22-25) ---
+pub async fn get_capabilities(State(app): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+    // ... existing accept + embedder_loaded (47-70) unchanged ...
+    let header_agent_id = headers.get(crate::HEADER_AGENT_ID).and_then(|v| v.to_str().ok());
+    // read-only GET: malformed header must NOT 400 — fall back to None (wildcard).
+    let caller_id: Option<String> =
+        crate::identity::resolve_http_agent_id(None, header_agent_id).ok();
+    // ... lock app.db (71-72) unchanged ...
+    let result = match accept {
+        crate::mcp::CapabilitiesAccept::V3 => crate::mcp::handle_capabilities_with_conn_v3(
+            app.tier_config.as_ref(), app.resolved_models.as_ref(), None, embedder_loaded,
+            Some(conn), app.profile.as_ref(), app.mcp_config.as_ref().as_ref(),
+            caller_id.as_deref(),   // <-- was `None` at system.rs:81
+            None,                   // harness unchanged
+        ),
+        _ => /* v2 path unchanged */
+    };
+    // ... rest unchanged ...
+}
+// --- regression test (extend src/handlers/tests.rs) ---
+#[tokio::test]
+async fn n13_capabilities_callable_now_honors_x_agent_id_allowlist() {
+    // AppState mcp_config allowlist {"alice":["core"]} (shape per mcp/mod.rs:13061-13073).
+    // GET /api/v1/capabilities + X-Agent-Id: alice -> core callable_now=true, non-core=false.
+    // No header -> wildcard behavior.
+}
+```
+
+**Test plan:** src/handlers/tests.rs new test n13_capabilities_callable_now_honors_x_agent_id_allowlist: AppState whose mcp_config carries allowlist {alice:[core]} (mirror unit shape mcp/mod.rs:13061-13073), GET /api/v1/capabilities with and without X-Agent-Id: alice, assert tools[].callable_now differs correctly (alice: core callable, non-core not; absent header -> wildcard). Also assert agent_permitted_families reflects alice.
+
+**Acceptance:** HTTP /api/v1/capabilities reports callable_now and agent_permitted_families relative to the X-Agent-Id caller (not the wildcard rule); absent/invalid header degrades to None without 400ing the GET. Test green.
+
+---
+
+### 🌊 Wave 5 — low / docs
+
+## n17 — [LOW] reflection_pass docstrings about --daemon upkeep are mutually confusing (apparent self-contradiction)
+
+**▶ Dispatch:** implement n17 per the §0 template; honor the §4 refinement for this ref. **Deps:** Conceptually paired with #1671 (which lands the per-namespace enabled gating the docstrings reference). If #1671 lands first, the struct doc can also note the enabled-gate is now wired. No code dependency.  **Effort:** ~10-15 LOC of doc text across 2 sites; 0.25 session.
+
+- **Files:** src/curator/reflection_pass.rs:214-219 (ReflectionPass struct doc: 'Wired into the curator's --reflect CLI mode via run_reflection_pass and the --store-url --daemon upkeep sweep') and src/curator/reflection_pass.rs:669-672 (run_reflection_pass fn doc: 'This is the CLI entry-point... The autonomy daemon's per-cycle sweep does NOT call this today'). Verification of actual wiring: src/cli/curator.rs:195-196 (--store-url routes to run_store_backed_sweep), 282-366 (run_store_backed_sweep --daemon loop), 338 (daemon loop calls store_backed_reflection_sweep -> run_reflection_pass_with_optional_llm -> run_reflection_pass). Legacy SQLite --daemon: curator.rs:236 (run_curator_daemon_with_primitives — does NOT run the reflection pass).
+- **Root cause:** revised
+
+**Fix approach:** Docstring-only correction for clarity. The two docstrings are each TRUE but describe DIFFERENT daemon modes, reading as a contradiction. Disambiguate: (struct doc 214-219) keep — but clarify it refers to the SAL store-url-backed daemon sweep specifically. (fn doc 669-672) tighten 'The autonomy daemon's per-cycle sweep does NOT call this' to explicitly name that it means the LEGACY SQLite autonomy loop (run_curator_daemon_with_primitives), NOT the SAL --store-url --daemon sweep (which DOES call this via store_backed_reflection_sweep). No behavior change. Optionally cross-link the two docs.
+
+**Adversarial note:** The audit finding is REVISED/PARTIALLY REFUTED. The audit says the doc 'claims --store-url --daemon upkeep runs the pass but it is CLI-only' — that is FALSE. I verified: curator.rs:195-196 routes --store-url invocations to run_store_backed_sweep, whose --daemon loop (curator.rs:337-361) calls store_backed_reflection_sweep -> run_reflection_pass_with_optional_llm -> run_reflection_pass on every cycle. So the struct doc (line 218) is CORRECT, not a false claim. The REAL issue is that a SECOND docstring (run_reflection_pass fn, 669-672) says 'autonomy daemon per-cycle sweep does NOT call this', which is ALSO correct but about the DIFFERENT legacy-SQLite autonomy loop — the two together are confusing, not wrong. Therefore the fix is disambiguation, NOT 'docstring honesty' (there is no dishonest claim to correct). Severity correctly drops to LOW (clarity nit, no behavioral or wire impact). Recommend the issue title/body be amended to 'ambiguous/confusing docstrings' rather than 'self-contradicts / CLI-only', so the fix isn't mis-scoped into a behavior change.
+
+**Starter code:**
+```rust
+// STARTING POINT — doc-only. Real text from reflection_pass.rs.
+// (A) struct doc src/curator/reflection_pass.rs:214-219 — make the daemon mode explicit:
+/// Operates over the SAL [`MemoryStore`] trait (issue #1548) so it runs
+/// against the SQLite *or* Postgres adapter; gated on the `sal` feature.
+/// Wired in two places, both via [`run_reflection_pass`]:
+///   * the curator `--reflect` CLI mode (manual, one-shot); and
+///   * the `--store-url` SAL upkeep sweep in `--once` / `--daemon` mode
+///     (`src/cli/curator.rs::store_backed_reflection_sweep`).
+/// The LEGACY SQLite `--daemon` autonomy loop
+/// (`run_curator_daemon_with_primitives`) does NOT run this pass — that
+/// per-cycle integration is a v0.7.1+ pivot.
+
+// (B) fn doc src/curator/reflection_pass.rs:669-672 — name the daemon precisely:
+/// Called from `src/cli/curator.rs` by BOTH the `--reflect` CLI mode AND
+/// the `--store-url` SAL upkeep sweep (`store_backed_reflection_sweep`,
+/// `--once`/`--daemon`). The LEGACY SQLite autonomy daemon's per-cycle
+/// sweep (`run_curator_daemon_with_primitives`) does NOT call this today
+/// (manual-/SAL-only for v0.7.0 per #666 acceptance).
+
+// No test code — doc change. A doctest is unnecessary; the grep -n "CLI entry-point"
+// anchor disappears, which is fine.
+```
+
+**Test plan:** No runtime test (doc-only). Verification is `cargo doc` builds clean and `cargo test --doc` passes (no broken intra-doc links — both reference real items run_reflection_pass / store_backed_reflection_sweep / run_curator_daemon_with_primitives). Optionally add a comment-grep CI check if the repo has a docstring-honesty harness, but none is required.
+
+**Acceptance:** The two docstrings no longer read as contradictory: a reader can tell that the SAL --store-url --daemon sweep DOES run the pass while the legacy SQLite autonomy --daemon loop does NOT. cargo doc + cargo test --doc green; no intra-doc-link warnings under clippy::pedantic.
+
+---
+
+## n24 — [LOW] MCP stdio is structurally sqlite-only; CLAUDE.md SAL-abstraction language does not disclose the MCP path cannot speak postgres
+
+**▶ Dispatch:** implement n24 per the §0 template; honor the §4 refinement for this ref. **Deps:** none — pure CLAUDE.md edit, independent of the other three tasks.  **Effort:** ~6 LOC doc paragraph. <0.25 session.
+
+- **Files:** CLAUDE.md (Architecture section — the 'MCP stdio (src/mcp/mod.rs::run_mcp_server) uses a plain rusqlite::Connection' bullet, and the 'v0.7 SAL trait ... ai-memory serve --store-url postgres://... selects the postgres path' line); src/mcp/mod.rs:2724-2745 (run_mcp_server signature + `let mut conn = db::open(db_path)?` — a rusqlite::Connection, no SAL MemoryStore / no --store-url plumbing)
+- **Root cause:** confirmed
+
+**Fix approach:** Documentation-only. CLAUDE.md already correctly states the MCP connection is a 'plain rusqlite::Connection' but frames it purely as a concurrency/locking fact and never states the consequence: the MCP stdio surface is structurally sqlite-ONLY and has no postgres/SAL path — `--store-url postgres://...` is honored only by `ai-memory serve` (HTTP), not by `ai-memory mcp`. Add a one-paragraph disclosure note adjacent to the SAL-trait sentence (and/or the MCP topology bullet) stating: the SAL MemoryStore abstraction (sqlite vs postgres+AGE) is consumed only by the HTTP daemon's build_store_handle path; `ai-memory mcp` opens a direct rusqlite::Connection and runs sqlite-only — postgres-backed deployments expose memory over HTTP, not MCP stdio. Keep it factual; do not assert a fix/ETA unless an issue number is confirmed.
+
+**Adversarial note:** Finding holds. Verified run_mcp_server (src/mcp/mod.rs:2724-2745) takes (db_path, tier, app_config, profile) and immediately does `let mut conn = db::open(db_path)?` — a concrete rusqlite::Connection with no SAL MemoryStore trait object and no --store-url plumbing; the postgres/SAL selection lives only on the serve path (build_store_handle, per CLAUDE.md §Key Modules). So the MCP surface is genuinely sqlite-only. Per the prime directive 'docs drift is a real defect' — this task FIXES it (adds the disclosure) rather than dismissing it, so it complies despite LOW severity. Wording nuance to get right: do not claim postgres CANNOT serve memory at all — it can, via HTTP; the gap is specifically that the MCP stdio transport has no postgres backend. The starter wording captures that. No risk — additive documentation matching verified code.
+
+**Starter code:**
+```rust
+// STARTING POINT — CLAUDE.md doc edit only (no Rust). Verify the disclosure against
+// code before writing: confirm run_mcp_server does `let mut conn = db::open(db_path)?;`
+// (src/mcp/mod.rs:2745, VERIFIED) and takes NO --store-url / StoreHandle, whereas
+// `serve` threads store-url through build_store_handle. Then add, adjacent to the
+// existing SAL-trait sentence in CLAUDE.md Architecture:
+//
+//   > **MCP stdio is sqlite-only (SAL disclosure).** The v0.7 SAL
+//   > `MemoryStore` trait (sqlite vs postgres+AGE) is consumed ONLY by the
+//   > HTTP daemon (`ai-memory serve` -> `build_store_handle`). `ai-memory
+//   > mcp` opens a direct `rusqlite::Connection` (`run_mcp_server`,
+//   > src/mcp/mod.rs) and has no `--store-url` / postgres path — it runs
+//   > sqlite-only. Postgres-backed deployments expose memory over HTTP,
+//   > not MCP stdio. (A SAL-over-MCP path is not implemented at v0.7.1.)
+//
+// Keep it factual; do not assert a fix/ETA unless an issue number is confirmed.
+```
+
+**Test plan:** Documentation-only — no automated test. Verification is the codegraph/Read confirmation already done: run_mcp_server (src/mcp/mod.rs:2724-2745) opens db::open -> rusqlite::Connection and has no StoreHandle/--store-url parameter, while `serve` does. Manual check before claiming the disclosure is accurate: grep the run_mcp_server signature + body for any postgres/StoreHandle reference (there is none).
+
+**Acceptance:** CLAUDE.md Architecture section explicitly discloses that MCP stdio is sqlite-only and the SAL/postgres path is HTTP-serve-only, so a reader cannot infer from the 'SAL abstracts sqlite vs postgres' line that `ai-memory mcp` can run on postgres. No code change; the new note agrees with the existing 'plain rusqlite::Connection' MCP topology bullet.
+
+---
+
+## n18-verify — [LOW] v52 transcript_line_dedup schema doc-drift verification — PK(sha256) single-column, no composite/FK (CONFIRMED already correct)
+
+**▶ Dispatch:** implement n18-verify per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** 0 LOC (verification) or ~20 LOC for the optional doc-lint; <1 session.
+
+- **Files:** migrations/sqlite/0044_v52_transcript_line_dedup.sql:47-58 (single-column PRIMARY KEY (sha256) + WITHOUT ROWID; doc 24-26 'FOREIGN KEY is intentionally NOT enforced'); src/store/postgres.rs::migrate_v52 2228-2303 (doc 2235-2238; DDL 2261-2269 single-column inline PK, no FK). The 'composite' grep hits at postgres.rs:481/2444-2475/4114 are all v56 list/archive INDEXES + a pending_actions sweep index — unrelated.
+- **Root cause:** confirmed
+
+**Fix approach:** VERIFICATION-ONLY. Confirmed: NO residual composite+FK doc-drift in either the sqlite migration file or postgres migrate_v52 — both DDL and surrounding comments correctly describe single-column PRIMARY KEY(sha256), WITHOUT ROWID, memory_id NOT FK-constrained. CLAUDE.md §Database text also already matches. No code change needed. Optional: a doc-lint guard that fails if a composite PK or memory_id FOREIGN KEY is reintroduced on transcript_line_dedup, consistent with the project's ratchet philosophy.
+
+**Adversarial note:** Finding CONFIRMED — the drift is ALREADY fixed; this was verify-no-residual and there is none. Both surfaces + CLAUDE.md §Database correctly state single-column PRIMARY KEY(sha256), WITHOUT ROWID, memory_id not FK-constrained. Per the prime directive's ban on hand-wave 'clean' claims, the safe close attaches file:line evidence (done). An optional grep doc-lint would make it mechanically enforced against future regression but is not strictly required by the issue.
+
+**Starter code:**
+```rust
+// NO CODE CHANGE REQUIRED — verification result with evidence.
+// migrations/sqlite/0044_v52_transcript_line_dedup.sql:47-58
+//   CREATE TABLE IF NOT EXISTS transcript_line_dedup (
+//       sha256  BLOB NOT NULL, memory_id TEXT NOT NULL, ... recovered_at INTEGER NOT NULL,
+//       PRIMARY KEY (sha256)        <-- single-column, NOT composite
+//   ) WITHOUT ROWID;                <-- no FOREIGN KEY clause
+// src/store/postgres.rs:2261-2269 (migrate_v52)
+//   sha256 BYTEA NOT NULL PRIMARY KEY,  <-- single-column inline PK
+//   memory_id TEXT NOT NULL,            <-- no REFERENCES/FK
+// OPTIONAL doc-lint (scripts/, model on check-vendor-literals.sh): grep both
+// surfaces, fail on 'PRIMARY KEY (sha256,' or 'REFERENCES memories' near
+// transcript_line_dedup.
+```
+
+**Test plan:** No functional test required (verification task). If the optional doc-lint guard is added: a --self-test that injects a contrived composite-PK / FK line into a temp copy of the two surfaces, runs the gate, asserts non-zero exit + expected message, then cleans up (mirrors check-vendor-literals.sh --self-test).
+
+**Acceptance:** Issue closed verified-clean with the cited file:line evidence; OR (optional) a doc-lint regression added that fails if a composite PK or memory_id FK is reintroduced on transcript_line_dedup in either surface.
+
+---
+
+## #1675 — [MEDIUM] docs/cli-design-rationale.md missing --features sal caveat for curator --reflect
+
+**▶ Dispatch:** implement #1675 per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** ~5 LOC docs; 0.25 session.
+
+- **Files:** docs/cli-design-rationale.md:14, :22, :35 (references to `ai-memory curator --reflect` with no build-feature caveat; line 43 mentions sal only in a CLI-count context). Gating code: src/cli/curator.rs:544-560 (run_reflect non-sal variant bails 'curator --reflect requires a binary built with --features sal'); dispatch src/cli/curator.rs:178.
+- **Root cause:** confirmed
+
+**Fix approach:** Add a short caveat note beside the first `ai-memory curator --reflect` reference (line 22 bullet is the primary surface description; line 14 is the table 'How it is invoked' cell) stating --reflect requires a binary built with --features sal (the reflection pass operates over the SAL MemoryStore trait); a default build emits a capability error. Match the wording to the actual bail! string at curator.rs:556-559 so doc and code agree. Optionally add the same note at line 35 (the --reflect --batch evolution example), which inherits the gating.
+
+**Adversarial note:** Audit fix-sketch is CORRECT but has a path detail: the gating file is src/cli/curator.rs (NOT src/cli/commands/curator.rs — no commands/ subdir for curator). Line anchors 548-560 accurate (run_reflect non-sal variant). Doc refs 14/22/35 accurate. Pure doc caveat, low risk. SIDE NOTE: line 43 already says 'sal' but only in the CLI-subcommand-count sense and is itself stale (says 79/81, live 80/82) — that overlaps #1676's concern but in a DIFFERENT file; flag it, out of this task's strict scope unless the operator folds it in.
+
+**Starter code:**
+```rust
+<!-- STARTING POINT — docs/cli-design-rationale.md. Anchors verified: line 14 table cell, 22 bullet, 35 evolution bullet, 43 sal CLI-count mention. -->
+<!-- After the line 22 bullet describing `ai-memory curator --reflect`, add: -->
+
+> **Build requirement.** `ai-memory curator --reflect` requires a binary built
+> with `--features sal` — the reflection pass operates over the SAL `MemoryStore`
+> trait (`src/cli/curator.rs`). A default (non-`sal`) build does not silently drop
+> the mode; it returns a clear capability error:
+> *"curator --reflect requires a binary built with --features sal"*.
+> (The flat `store` / `recall` verbs carry no such requirement.)
+
+<!-- In the line 14 table 'How it is invoked' cell for Bias-displacement reflection,
+     append: '(requires --features sal)'. -->
+```
+
+**Test plan:** Docs-only; no Rust test. Verify grep -n 'features sal' docs/cli-design-rationale.md returns the new caveat; cross-check the caveat string against the live bail! at src/cli/curator.rs:556-559 so they don't drift. Run any repo docs-link/lint gate if present. Per prime directive this is a real doc/behavior-drift defect, not a docs-only dismissal.
+
+**Acceptance:** docs/cli-design-rationale.md states the --features sal requirement for curator --reflect at the primary invocation reference, wording consistent with the runtime error at src/cli/curator.rs:556-559.
+
+---
+
+## #1676 — [MEDIUM] src/validate.rs SSOT doc-comments cite stale route/CLI counts (87/78/80) vs live lib.rs consts (89/80/82)
+
+**▶ Dispatch:** implement #1676 per the §0 template; honor the §4 refinement for this ref. **Deps:** none  **Effort:** ~8 LOC (4 comment figures + optional 12-LOC test); 0.25 session.
+
+- **Files:** src/validate.rs:1093 (EXPECTED_PRODUCTION_ROUTES_COUNT=87), :1095 (EXPECTED_CLI_SUBCOMMANDS_DEFAULT=78 / _SAL=80), :1183 (ROUTES=87), :1186 (CLI_DEFAULT=78 / _SAL=80). Live SSOT src/lib.rs:297 (=89), :329 (=80), :336 (=82). MCP count cited at validate.rs:1094 + :1184 (expected_tool_count()=74) is CURRENT — do NOT change (tool_names::ALL has exactly 74 entries, src/mcp/registry.rs:128-201).
+- **Root cause:** confirmed
+
+**Fix approach:** Update the four stale figures in the two doc-comment blocks: 87->89 (routes, both sites), 78->80 (CLI default, both sites), 80->82 (CLI sal, both sites). Leave MCP 74 unchanged. Add a doc-vs-SSOT pin: a code comment beside lib.rs:297/329/336 ('when bumping, also update validate.rs ~:1093/1095/1183/1186 + CLAUDE.md'), and optionally a small test asserting the three consts equal the documented figures with assert messages naming the validate.rs anchors (comments aren't runtime-introspectable, so the test is a reminder-trip, not a true comment-checker).
+
+**Adversarial note:** Audit fix-sketch is CORRECT on every figure verified: stale 87/78/80 in validate.rs vs live 89/80/82 in lib.rs:297/329/336 (all four lib.rs values confirmed by grep, all four validate.rs sites by Read). CORRECTION the audit omitted: validate.rs ALSO cites the MCP tool count expected_tool_count()=74 at :1094/:1184 — I verified that is STILL CORRECT (tool_names::ALL = exactly 74 entries, registry.rs:128-201) so it must NOT be 'fixed'; do not let a sweep bump 74->75. The 'doc-vs-SSOT pin' can only honestly assert the consts (comments can't be asserted), so the test is a reminder-trip — I noted that limitation in the assert messages rather than overclaiming a real comment-checker.
+
+**Starter code:**
+```rust
+// STARTING POINT — src/validate.rs. Stale strings verified at 1093-1095 and 1183-1186.
+// Block 1 (~1092-1096): `EXPECTED_PRODUCTION_ROUTES_COUNT=87` -> `=89`;
+//   keep `expected_tool_count()=74` (CURRENT); `EXPECTED_CLI_SUBCOMMANDS_DEFAULT=78` -> `=80`,
+//   `_SAL=80` -> `_SAL=82`.
+// Block 2 (~1182-1186): same 87->89, 78->80, 80->82 substitutions; keep 74.
+//
+// Doc-vs-SSOT pin (code comment near src/lib.rs:297/329/336):
+//   // SSOT: bumping this requires updating the cited figures in
+//   // src/validate.rs (~:1093/1095/1183/1186) and CLAUDE.md.
+//
+// Optional mechanical pin (new tests/ssot_doc_counts.rs):
+#[test]
+fn ssot_consts_are_the_documented_values() {
+    assert_eq!(ai_memory::EXPECTED_PRODUCTION_ROUTES_COUNT, 89,
+        "bumped routes? update validate.rs:1093/1183 + CLAUDE.md");
+    assert_eq!(ai_memory::EXPECTED_CLI_SUBCOMMANDS_DEFAULT, 80,
+        "bumped CLI default? update validate.rs:1095/1186 + CLAUDE.md");
+    assert_eq!(ai_memory::EXPECTED_CLI_SUBCOMMANDS_SAL, 82,
+        "bumped CLI sal? update validate.rs:1095/1186 + CLAUDE.md");
+}
+```
+
+**Test plan:** Optional new tests/ssot_doc_counts.rs asserting the three lib.rs consts equal the figures written into validate.rs comments, with assert messages naming the exact validate.rs line anchors to fix on a future bump. This is the realistic doc-vs-SSOT pin since comment text isn't runtime-introspectable. Run AI_MEMORY_NO_CONFIG=1 cargo test --test ssot_doc_counts.
+
+**Acceptance:** validate.rs:1093/1095/1183/1186 cite 89 routes, 80 CLI-default, 82 CLI-sal (74 MCP unchanged), matching lib.rs:297/329/336. A pin (code comment + optional test) exists so the next const bump surfaces the doc obligation.
+
+---
+
+## n19 — [MEDIUM] postgres_schema_parity SQLITE_RELATIONAL_TABLES omits v52 transcript_line_dedup (real gap); v51 federation_nonce_cache must NOT be added there
+
+**▶ Dispatch:** implement n19 per the §0 template; honor the §4 refinement for this ref. **Deps:** Requires a live PG test DB (AI_MEMORY_TEST_POSTGRES_URL) to actually exercise; the code change is independent.  **Effort:** ~15 LOC (slice + test) or ~60 LOC with column-parity; 1 session.
+
+- **Files:** tests/postgres_schema_parity.rs:123-140 (SQLITE_RELATIONAL_TABLES) + :145-149 (POSTGRES_ONLY_RELATIONS) + :191-219 (existence-only parity test). Table names: migrations/sqlite/0043_v51_federation_nonce_cache.sql:36; migrations/sqlite/0044_v52_transcript_line_dedup.sql:48. PG side: migrate_v52 CREATEs transcript_line_dedup (src/store/postgres.rs:2253-2303); migrate_v51 is a NO-OP (postgres.rs:2208-2226).
+- **Root cause:** revised
+
+**Fix approach:** Add ONLY transcript_line_dedup to SQLITE_RELATIONAL_TABLES (PG migrate_v52 creates it — real omission). Do NOT add federation_nonce_cache: PG migrate_v51 is a deliberate no-op (nonce cache lives in the sqlite daemon-local file even on PG), so adding it would make postgres_covers_every_sqlite_relational_table FAIL with a false 'missing table'. Instead add a documented SQLITE_ONLY_DAEMON_LOCAL_TABLES slice (mirror of POSTGRES_ONLY_RELATIONS) and assert it is ABSENT-by-design on PG. For the 'assert per-table parity' ask: the current test is existence-only; scope a genuine column-set assertion to the 2 new tables (and optionally memories/memory_links) rather than all 16 to keep it maintainable.
+
+**Adversarial note:** Audit fix-sketch is HALF WRONG and would break CI if followed literally. transcript_line_dedup IS valid (PG migrate_v52 at postgres.rs:2253-2303 creates it). federation_nonce_cache is NOT — PG migrate_v51 is an intentional no-op (postgres.rs:2208-2226), so adding it to SQLITE_RELATIONAL_TABLES makes the existence test FAIL. Corrected approach (separate SQLITE_ONLY_DAEMON_LOCAL_TABLES + absent-by-design assertion) matches the file's existing POSTGRES_ONLY_RELATIONS / sqlite_only_artefacts_documented patterns. Full per-table column parity across all 16+ tables is heavier than warranted — scope column-parity to the 2 relevant tables.
+
+**Starter code:**
+```rust
+// STARTING POINT — gated on AI_MEMORY_TEST_POSTGRES_URL. tests/postgres_schema_parity.rs
+// (1) add to the existing slice (real gap):
+//   "agent_quotas",
+    "transcript_line_dedup", // v52 (#1389) — PG migrate_v52 creates it
+// ];
+// (2) NEW documented slice (do NOT put nonce cache in SQLITE_RELATIONAL_TABLES):
+/// SQLite daemon-local tables intentionally NOT mirrored on Postgres.
+/// federation_nonce_cache (v51,#1255) lives in the sqlite ai-memory.db even on
+/// postgres daemons; PG migrate_v51 is a no-op (src/store/postgres.rs:2208-2226).
+const SQLITE_ONLY_DAEMON_LOCAL_TABLES: &[&str] = &["federation_nonce_cache"];
+// (3) new absent-by-design test:
+#[tokio::test]
+async fn postgres_omits_sqlite_only_daemon_local_tables() {
+    let Some(url) = postgres_url() else { eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set"); return; };
+    let _s = PostgresStore::connect(&url).await.expect("connect");
+    let pool = inspection_pool(&url).await;
+    for t in SQLITE_ONLY_DAEMON_LOCAL_TABLES {
+        let exists: Option<i32> = sqlx::query_scalar(
+            "SELECT 1 FROM pg_class WHERE relname=$1 AND relkind='r'")
+            .bind(*t).fetch_optional(&pool).await.expect("query pg_class");
+        assert!(exists.is_none(), "{t} is sqlite-only (migrate_v51 no-op); unexpected on PG");
+    }
+}
+```
+
+**Test plan:** postgres_covers_every_sqlite_relational_table (existing, :191) now exercises transcript_line_dedup and must PASS against a live PG (created by migrate_v52). New postgres_omits_sqlite_only_daemon_local_tables asserts federation_nonce_cache absent. Both skip cleanly without AI_MEMORY_TEST_POSTGRES_URL / sal-postgres. Optional: a per-column assertion test comparing PG information_schema.columns for transcript_line_dedup against the 7 sqlite columns (sha256,memory_id,host_kind,transcript_path,host_session_id,host_turn_index,recovered_at).
+
+**Acceptance:** transcript_line_dedup included + parity test passes against live PG; nonce-cache absent-by-design test passes; no false-positive failures; tests still skip without PG creds/feature.
+
+---
+
+## 6. Verified-clean / blocked / out-of-scope
+
+- **n18-verify — verified-clean (0-LOC):** v52 schema doc-drift already reconciled across sqlite/pg/CLAUDE.md. Close, no diff.
+- **MERGED (no task):** #1663 #1664 (publish) · #1666 (entity_id) · #1667 (install hardening).
+- **BLOCKED (not v0.7.1):** L3 substrate watcher — operator-`notify`-gated (#1388/#1389).
+- **OUT-OF-SCOPE follow-ups (file separately, one-finding-one-issue):** `synthesis/mod.rs` + `multistep_ingest/mod.rs` do NOT have the #1700 bug (verified — no multi-row writes); but if a future path adds multi-row persist there, apply the same txn-wrap. `consolidate_cluster` uses `RollbackEntry` compensation (not a defect).
+- **v0.8 cross-refs (EPIC #1695):** #302/#1670, #1672-adjacent structural Bash/Custom egress sinks, #1677, #1678, #1679, #1680, and the n13 HTTP-allowlist-enforcement half.
+
+## 7. Release gate (v0.7.1 tag-cut — operator-gated)
+
+- [ ] All 25 buildable tasks closed (fix → test → re-verify → close); n18-verify closed verified-clean.
+- [ ] Every fix has a regression test; the four gates green on `release/v0.7.1` HEAD.
+- [ ] AI-NHI / full-spectrum re-test pass; any newly-surfaced issue filed + resolved (no silent deferral).
+- [ ] ROADMAP §11.3.1 + CLAUDE.md + capabilities envelope in sync with the shipped surface.
+- [ ] Tag-cut (operator-gated).
+
+---
+
+*Generated 2026-06-15 from EPIC #1683 (build spec wf_542d03fd + final validation wf_ae002bb7, confidence 0.88). Starter code = verified edit skeletons (real signatures/call-sites), starting points to compile + test, NOT finished patches. Re-verify every citation via codegraph before editing.*


### PR DESCRIPTION
Adds `docs/v0.7.1/v0.7.1-execution-prompt.md` — the single self-contained execution document for the v0.7.1 patch line (EPIC #1683). Contains ground rules, the 6-wave build order, the 0.88-confidence validation refinements (authoritative), and per-task starter prompts + starter Rust code + tests + acceptance for all 26 tasks. Lets any AI-NHI drive the v0.7.1 build from one file with zero chat-history dependence (avoids context rot). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)