### PR TITLE
chore(sdks): bump Python + TypeScript SDKs to 0.7.1

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-memory-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python SDK for the ai-memory HTTP API (persistent memory for AI agents)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alphaone/ai-memory",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alphaone/ai-memory",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^6.21.0"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphaone/ai-memory",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript SDK for the ai-memory HTTP API — persistent, tier-aware memory for AI agents.",
   "license": "Apache-2.0",
   "author": "AlphaOne LLC",


### PR DESCRIPTION
Land the v0.7.1 SDK version bump on main (lockstep with the server release). The SDKs are published from release/v0.7.1 via the publish-sdks workflow; this keeps main's `sdk/python/pyproject.toml` + `sdk/typescript/package.json`/`package-lock.json` at 0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)