### PR TITLE
refactor(llm): reword curator prompts for clarity

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -466,15 +466,15 @@ fn parse_openai_embeddings_batch(body: &Value, expected_len: usize) -> Result<Ve
     Ok(out.into_iter().flatten().collect())
 }
 
-const QUERY_EXPANSION_PROMPT: &str = r"You are a search query expander. Given a search query, generate 5-8 additional search terms that are semantically related. Return ONLY the terms, one per line, no numbering or explanation.
+const QUERY_EXPANSION_PROMPT: &str = r"Expand the search query below into 5 to 8 closely related search terms. Output only the terms — one per line, with no numbering, bullets, or commentary.
 
 Query: {query}";
 
-const SUMMARIZE_PROMPT: &str = r"Summarize the following memories into a single concise paragraph. Preserve all key facts, decisions, and technical details.
+const SUMMARIZE_PROMPT: &str = r"Condense the memories below into one tight paragraph that retains every key fact, decision, and technical detail.
 
 {memories}";
 
-const AUTO_TAG_PROMPT: &str = r"Generate 3-5 short tags for categorizing this memory. Return ONLY the tags, one per line, lowercase, no symbols.
+const AUTO_TAG_PROMPT: &str = r"Produce 3 to 5 concise categorization tags for the memory below. Output only the tags — one per line, lowercase, with no punctuation or symbols.
 
 Title: {title}
 Content: {content}";


### PR DESCRIPTION
## Summary

Rewords the three curator prompt constants in `src/llm.rs` (query expansion, summarize, auto-tag) for clearer, more direct instruction phrasing.

Placeholders (`{query}` / `{memories}` / `{title}` / `{content}`) and the exact output constraints (term/tag counts, one-per-line, lowercase, no symbols) are preserved, so curator behavior and the placeholder-assertion unit tests are unchanged.

## Scope
- `src/llm.rs` — 3 lines changed (string literals only). No logic, no signatures, no schema.

## Gates
- String-literal-only change; placeholder-assertion tests (`QUERY_EXPANSION_PROMPT`/`SUMMARIZE_PROMPT`/`AUTO_TAG_PROMPT` contain their placeholders) unaffected. CI is authoritative (fmt / clippy-pedantic / test / audit / coverage).

## AI involvement
Authored by Claude Opus 4.8 under direct operator authorization (alphaonedev sole-authority). Commit signed (verified alphaonedev); base SHA recorded in the commit trailer per the worktree discipline.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>