### PR TITLE
fix(gate-2): restore daemon_runtime coverage floor (#1963/#1961) + forbidden-export taxonomy (#1838)

### DIFF
--- a/src/export_taxonomy.rs
+++ b/src/export_taxonomy.rs
@@ -1,0 +1,559 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 G28 (#1838) — forbidden-export-class taxonomy + fail-closed
+//! export-boundary enforcement.
+//!
+//! ## What this is
+//!
+//! [`ForbiddenExportClass`] is the CLOSED taxonomy of record / material
+//! CLASSES that must NEVER cross an export boundary in the clear:
+//!
+//! 1. [`ForbiddenExportClass::PrivateKeyMaterial`] — any daemon / witness
+//!    / recorder / judge / stopper / recovery **private** signing key
+//!    (PEM-armored or a raw secret-key field).
+//! 2. [`ForbiddenExportClass::MasterThresholdSecret`] — a master secret or
+//!    a threshold / Shamir key share.
+//! 3. [`ForbiddenExportClass::SignedPolicyRuleSigningKey`] — the governance
+//!    (operator) rule **private** signing key. The DB only ever holds a
+//!    rule's public `signature`; the private signing key lives in the
+//!    key-dir. This class is the belt-and-suspenders guard against a
+//!    signing key that leaked into a memory content / metadata field.
+//! 4. [`ForbiddenExportClass::BiometricBehavioralEmbedding`] — a
+//!    biometric / behavioral embedding vector, identified by a
+//!    **producer-side** class tag (`metadata.embedding_class ∈
+//!    {biometric, behavioral}`). See the honest-scope note below.
+//!
+//! This is the D14-adjacent companion to [`crate::egress::EgressClass`]:
+//! that enum names the LANES bytes leave through (webhook / federation /
+//! forensic-export / inference); THIS enum names the record CLASSES that a
+//! lane must refuse. The two are orthogonal — a forensic-export lane
+//! consults BOTH (its lane guard is the secret-screen; its class guard is
+//! this taxonomy).
+//!
+//! ## Honest scope (ATTESTABLE vs ESTIMABLE)
+//!
+//! - **Structurally impossible to export via a DB egress (already true).**
+//!   Private keys, master/threshold secrets, and the governance signing
+//!   key all live in the KEY-DIR on the filesystem, NOT in the `memories`
+//!   / `memory_links` / `signed_events` tables. The forensic bundle and
+//!   the memory-export handler read only DB tables, so a well-formed key
+//!   file cannot appear in those artifacts. Biometric / behavioral
+//!   embedding VECTORS are likewise absent — neither the forensic-bundle
+//!   `MemoryEnvelope` nor the memory-export `Memory` row carries the raw
+//!   embedding vector.
+//! - **Actively gated (ATTESTABLE, this module).** The real residual risk
+//!   is key material / a signing key / a secret that leaked into a memory
+//!   ROW's content or `metadata` (a mis-store, a metadata stash) and would
+//!   then ride an export in the clear. [`classify_export_value`] inspects
+//!   the serialized record and REFUSES it fail-closed, emitting a signed
+//!   `export.forbidden_class_refused` audit row. That refusal + its audit
+//!   witness are cryptographically attestable.
+//! - **ESTIMABLE (producer-side tag).** The substrate does NOT tag an
+//!   arbitrary float vector as "biometric" — no classifier can decide that
+//!   from the bytes. [`ForbiddenExportClass::BiometricBehavioralEmbedding`]
+//!   is therefore keyed on a PRODUCER-side metadata tag
+//!   (`metadata.embedding_class`). The taxonomy NAMES the class and ships
+//!   the enforcement hook; per-embedding biometric classification is the
+//!   producer's obligation to tag. This is the honest boundary.
+//!
+//! ## Fail-closed disposition
+//!
+//! An export path that hits a forbidden class SKIPS the record (never
+//! bundles it in the clear) and records the refusal. A record that cannot
+//! even be serialized for classification is likewise dropped (fail-closed),
+//! never emitted unclassified.
+
+use rusqlite::Connection;
+use serde_json::Value;
+
+/// The closed taxonomy of record / material classes that must NEVER cross
+/// an export boundary. Ordered by severity — [`ForbiddenExportClass::rank`]
+/// makes the most-severe class win when a record matches several, so the
+/// audit row names the worst offender deterministically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForbiddenExportClass {
+    /// Private signing-key material — daemon / witness / recorder / judge /
+    /// stopper / recovery keys (PEM-armored or a raw secret-key field).
+    PrivateKeyMaterial,
+    /// A master secret or a threshold / Shamir key share.
+    MasterThresholdSecret,
+    /// The governance (operator) rule PRIVATE signing key. Distinct from a
+    /// rule's public `signature`, which is safe to export.
+    SignedPolicyRuleSigningKey,
+    /// A biometric / behavioral embedding, identified by the producer-side
+    /// `metadata.embedding_class` tag. ESTIMABLE — see the module docs.
+    BiometricBehavioralEmbedding,
+}
+
+/// The complete closed set, most-severe first. Any enforcement or
+/// documentation surface iterates THIS rather than re-listing the variants.
+pub const ALL_FORBIDDEN_EXPORT_CLASSES: [ForbiddenExportClass; 4] = [
+    ForbiddenExportClass::PrivateKeyMaterial,
+    ForbiddenExportClass::MasterThresholdSecret,
+    ForbiddenExportClass::SignedPolicyRuleSigningKey,
+    ForbiddenExportClass::BiometricBehavioralEmbedding,
+];
+
+// ── Classifier markers (structural; single-use in this module) ─────────
+//
+// PEM private-key armor is the "-----BEGIN … PRIVATE KEY-----" family. We
+// match on the opening sigil plus the "PRIVATE KEY" token so every RSA /
+// EC / OPENSSH / ENCRYPTED / PKCS8 spelling trips one check.
+const PEM_BEGIN_SIGIL: &str = "-----BEGIN";
+const PEM_PRIVATE_KEY_TOKEN: &str = "PRIVATE KEY-----";
+
+/// JSON object-key substrings whose presence marks private key material.
+/// Matched case-insensitively as a substring so `daemon_private_key`,
+/// `recorder_secret_key`, `ed25519_secret` … all trip.
+const PRIVATE_KEY_FIELD_MARKERS: [&str; 6] = [
+    "private_key",
+    "secret_key",
+    "secret_key_bytes",
+    "signing_secret",
+    "keypair_secret",
+    "ed25519_secret",
+];
+
+/// JSON object-key substrings whose presence marks a master / threshold
+/// secret.
+const MASTER_THRESHOLD_FIELD_MARKERS: [&str; 5] = [
+    "master_secret",
+    "master_key",
+    "threshold_share",
+    "threshold_secret",
+    "shamir_share",
+];
+
+/// JSON object-key substrings whose presence marks the governance-rule
+/// PRIVATE signing key (never the public `signature`).
+const RULE_SIGNING_KEY_FIELD_MARKERS: [&str; 4] = [
+    "rule_signing_key",
+    "governance_signing_key",
+    "policy_signing_key",
+    "operator_signing_key",
+];
+
+/// The producer-side metadata key that tags an embedding's class, plus the
+/// two tag values that mark it forbidden.
+const EMBEDDING_CLASS_KEYS: [&str; 3] = ["embedding_class", "embedding_kind", "biometric_class"];
+const EMBEDDING_CLASS_BIOMETRIC: &str = "biometric";
+const EMBEDDING_CLASS_BEHAVIORAL: &str = "behavioral";
+
+impl ForbiddenExportClass {
+    /// Severity rank — lower is more severe. Used to pick the worst class
+    /// when a record matches several.
+    #[must_use]
+    const fn rank(self) -> u8 {
+        match self {
+            Self::PrivateKeyMaterial => 0,
+            Self::MasterThresholdSecret => 1,
+            Self::SignedPolicyRuleSigningKey => 2,
+            Self::BiometricBehavioralEmbedding => 3,
+        }
+    }
+
+    /// The canonical wire / audit token for this class.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PrivateKeyMaterial => "private_key_material",
+            Self::MasterThresholdSecret => "master_threshold_secret",
+            Self::SignedPolicyRuleSigningKey => "signed_policy_rule_signing_key",
+            Self::BiometricBehavioralEmbedding => "biometric_behavioral_embedding",
+        }
+    }
+
+    /// A one-line human-readable description for the audit reason / docs.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::PrivateKeyMaterial => {
+                "private signing-key material (daemon/witness/recorder/judge/stopper/recovery)"
+            }
+            Self::MasterThresholdSecret => "master secret or threshold / Shamir key share",
+            Self::SignedPolicyRuleSigningKey => "governance-rule private signing key",
+            Self::BiometricBehavioralEmbedding => {
+                "biometric / behavioral embedding (producer-tagged)"
+            }
+        }
+    }
+
+    /// Keep `self` if it is at least as severe as `other`, else adopt
+    /// `other`. Small helper so the recursive classifier can fold matches.
+    #[must_use]
+    fn most_severe(self, other: Self) -> Self {
+        if other.rank() < self.rank() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+/// Classify a single JSON value against the forbidden-export taxonomy,
+/// returning the most-severe class that matches (or `None` when clean).
+///
+/// The scan is structural and fail-closed: it walks the value recursively,
+/// checking every object KEY against the field-name marker tables, every
+/// string VALUE for PEM private-key armor, and the producer-side
+/// `embedding_class` tag. It is side-effect-free — the single SSOT for the
+/// decision so the enforcement site and any audit re-evaluation agree.
+#[must_use]
+pub fn classify_export_value(value: &Value) -> Option<ForbiddenExportClass> {
+    let mut found: Option<ForbiddenExportClass> = None;
+    classify_into(value, &mut found);
+    found
+}
+
+/// Recursive worker: folds every match into `acc`, keeping the most-severe.
+/// Short-circuits once the top-severity class is found (nothing can beat it).
+fn classify_into(value: &Value, acc: &mut Option<ForbiddenExportClass>) {
+    if *acc == Some(ForbiddenExportClass::PrivateKeyMaterial) {
+        return; // already the worst; no need to keep scanning
+    }
+    match value {
+        Value::String(s) => {
+            if let Some(c) = classify_text(s) {
+                fold(acc, c);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                classify_into(item, acc);
+                if *acc == Some(ForbiddenExportClass::PrivateKeyMaterial) {
+                    return;
+                }
+            }
+        }
+        Value::Object(map) => {
+            for (key, child) in map {
+                if let Some(c) = classify_key(key, child) {
+                    fold(acc, c);
+                }
+                classify_into(child, acc);
+                if *acc == Some(ForbiddenExportClass::PrivateKeyMaterial) {
+                    return;
+                }
+            }
+        }
+        // Numbers / bools / null carry no forbidden class on their own.
+        _ => {}
+    }
+}
+
+/// Fold one match into the accumulator, keeping the most-severe class.
+fn fold(acc: &mut Option<ForbiddenExportClass>, c: ForbiddenExportClass) {
+    *acc = Some(match *acc {
+        Some(existing) => existing.most_severe(c),
+        None => c,
+    });
+}
+
+/// Classify a bare string value: only PEM private-key armor is detectable
+/// in an unkeyed string (a raw base64 blob is indistinguishable from benign
+/// high-entropy content — that is the secret-screen's anchored-pattern job,
+/// not this class taxonomy's).
+#[must_use]
+fn classify_text(s: &str) -> Option<ForbiddenExportClass> {
+    if s.contains(PEM_BEGIN_SIGIL) && s.contains(PEM_PRIVATE_KEY_TOKEN) {
+        return Some(ForbiddenExportClass::PrivateKeyMaterial);
+    }
+    None
+}
+
+/// Classify one object entry by its KEY (and, for the embedding tag, its
+/// VALUE). Returns the class the key marks, if any.
+#[must_use]
+fn classify_key(key: &str, child: &Value) -> Option<ForbiddenExportClass> {
+    let lower = key.to_ascii_lowercase();
+
+    // Producer-side biometric / behavioral embedding tag (value-sensitive).
+    if EMBEDDING_CLASS_KEYS.iter().any(|k| lower == *k) {
+        if let Value::String(v) = child {
+            let vv = v.trim().to_ascii_lowercase();
+            if vv == EMBEDDING_CLASS_BIOMETRIC || vv == EMBEDDING_CLASS_BEHAVIORAL {
+                return Some(ForbiddenExportClass::BiometricBehavioralEmbedding);
+            }
+        }
+    }
+
+    // Field-name markers, most-severe first.
+    if PRIVATE_KEY_FIELD_MARKERS.iter().any(|m| lower.contains(m)) {
+        return Some(ForbiddenExportClass::PrivateKeyMaterial);
+    }
+    if MASTER_THRESHOLD_FIELD_MARKERS
+        .iter()
+        .any(|m| lower.contains(m))
+    {
+        return Some(ForbiddenExportClass::MasterThresholdSecret);
+    }
+    if RULE_SIGNING_KEY_FIELD_MARKERS
+        .iter()
+        .any(|m| lower.contains(m))
+    {
+        return Some(ForbiddenExportClass::SignedPolicyRuleSigningKey);
+    }
+    None
+}
+
+/// Convenience: classify a [`crate::models::Memory`] by serializing it and
+/// running [`classify_export_value`] over the result. A serialize failure
+/// (structurally near-impossible for `Memory`) is treated fail-closed as a
+/// `PrivateKeyMaterial` hit so a record that cannot be inspected is never
+/// silently exported.
+#[must_use]
+pub fn classify_memory(mem: &crate::models::Memory) -> Option<ForbiddenExportClass> {
+    match serde_json::to_value(mem) {
+        Ok(v) => classify_export_value(&v),
+        Err(_) => Some(ForbiddenExportClass::PrivateKeyMaterial),
+    }
+}
+
+/// Append a signed refusal row for a forbidden-class export redaction to
+/// the append-only `signed_events` chain. Substrate-emitted: daemon-signed
+/// when an audit key is enrolled, else `unsigned` — the same posture as
+/// [`crate::egress::emit_inference_egress_refusal`]. The `payload_hash`
+/// commits the class, the artifact path the record would have occupied, and
+/// the reason.
+///
+/// # Errors
+///
+/// Propagates the underlying `append_signed_event` error (typically a
+/// sqlite failure). Callers treat the audit emission as best-effort and
+/// WARN on error rather than failing the export.
+pub fn emit_export_refusal(
+    conn: &Connection,
+    class: ForbiddenExportClass,
+    artifact_path: &str,
+    agent_id: &str,
+    reason: &str,
+) -> anyhow::Result<()> {
+    use crate::signed_events::{
+        SignedEvent, append_signed_event, event_types::EXPORT_FORBIDDEN_CLASS_REFUSED, payload_hash,
+    };
+    let preimage = format!(
+        "export-forbidden|class={}|artifact={}|reason={}",
+        class.as_str(),
+        artifact_path,
+        reason
+    );
+    let event = SignedEvent::with_daemon_signature(
+        payload_hash(preimage.as_bytes()),
+        agent_id.to_string(),
+        EXPORT_FORBIDDEN_CLASS_REFUSED.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        None,
+    );
+    append_signed_event(conn, &event)
+}
+
+/// Screen one candidate export record fail-closed. Classifies `value`; on a
+/// forbidden-class hit it emits a signed refusal (best-effort — a WARN on
+/// append failure, never fails the export) and returns the class so the
+/// caller can SKIP the record. `None` means the record is clean and may be
+/// emitted.
+///
+/// This is the single enforcement primitive every DB export path calls:
+/// the forensic-bundle assembler and the memory-export handler both consult
+/// it so the decision + the audit row cannot drift.
+#[must_use]
+pub fn screen_export_value_audited(
+    conn: &Connection,
+    artifact_path: &str,
+    agent_id: &str,
+    value: &Value,
+) -> Option<ForbiddenExportClass> {
+    let class = classify_export_value(value)?;
+    let reason = format!(
+        "export refused: record classified {} ({}) — not emitted into export artifact",
+        class.as_str(),
+        class.description()
+    );
+    if let Err(e) = emit_export_refusal(conn, class, artifact_path, agent_id, &reason) {
+        tracing::warn!(
+            "forbidden-export-class signed refusal NOT recorded (append failed) for {} \
+             artifact={artifact_path}: {e}",
+            class.as_str()
+        );
+    }
+    tracing::warn!(
+        "export boundary refused a {} record ({}) — artifact={artifact_path} withheld \
+         fail-closed",
+        class.as_str(),
+        class.description()
+    );
+    Some(class)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn class_tokens_are_stable() {
+        assert_eq!(
+            ForbiddenExportClass::PrivateKeyMaterial.as_str(),
+            "private_key_material"
+        );
+        assert_eq!(
+            ForbiddenExportClass::MasterThresholdSecret.as_str(),
+            "master_threshold_secret"
+        );
+        assert_eq!(
+            ForbiddenExportClass::SignedPolicyRuleSigningKey.as_str(),
+            "signed_policy_rule_signing_key"
+        );
+        assert_eq!(
+            ForbiddenExportClass::BiometricBehavioralEmbedding.as_str(),
+            "biometric_behavioral_embedding"
+        );
+    }
+
+    #[test]
+    fn all_set_is_complete_and_severity_ordered() {
+        assert_eq!(ALL_FORBIDDEN_EXPORT_CLASSES.len(), 4);
+        // Ranks strictly increase in declared order.
+        for pair in ALL_FORBIDDEN_EXPORT_CLASSES.windows(2) {
+            assert!(pair[0].rank() < pair[1].rank());
+        }
+    }
+
+    #[test]
+    fn clean_record_classifies_none() {
+        let v = json!({
+            "id": "abc",
+            "content": "an ordinary memory about a meeting",
+            "metadata": {"agent_id": "ai:alice", "scope": "collective"},
+            "signature": "cHVibGljLXNpZ25hdHVyZQ", // public sig field is FINE
+        });
+        assert_eq!(classify_export_value(&v), None);
+    }
+
+    #[test]
+    fn pem_private_key_in_content_is_refused() {
+        let v = json!({
+            "content": "here is my key:\n-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END",
+        });
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::PrivateKeyMaterial)
+        );
+    }
+
+    #[test]
+    fn secret_key_field_marks_private_key_material() {
+        let v = json!({"metadata": {"daemon_secret_key": "AAAA"}});
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::PrivateKeyMaterial)
+        );
+    }
+
+    #[test]
+    fn threshold_share_field_marks_master_threshold() {
+        let v = json!({"metadata": {"threshold_share": "1-abc"}});
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::MasterThresholdSecret)
+        );
+    }
+
+    #[test]
+    fn rule_signing_key_field_marks_governance_signing_key() {
+        let v = json!({"operator_signing_key": "AAAA"});
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::SignedPolicyRuleSigningKey)
+        );
+    }
+
+    #[test]
+    fn public_rule_signature_is_not_forbidden() {
+        // A rule row's public `signature` must NOT be classified forbidden.
+        let v = json!({"signature": "AAAA", "attest_level": "operator_signed"});
+        assert_eq!(classify_export_value(&v), None);
+    }
+
+    #[test]
+    fn producer_biometric_embedding_tag_is_refused() {
+        let v = json!({"metadata": {"embedding_class": "biometric"}});
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::BiometricBehavioralEmbedding)
+        );
+        let v2 = json!({"metadata": {"embedding_kind": "Behavioral"}});
+        assert_eq!(
+            classify_export_value(&v2),
+            Some(ForbiddenExportClass::BiometricBehavioralEmbedding)
+        );
+    }
+
+    #[test]
+    fn non_biometric_embedding_class_is_clean() {
+        let v = json!({"metadata": {"embedding_class": "semantic"}});
+        assert_eq!(classify_export_value(&v), None);
+    }
+
+    #[test]
+    fn most_severe_class_wins_when_several_match() {
+        // A record carrying BOTH a biometric tag AND a private key must
+        // report the private key (most severe).
+        let v = json!({
+            "metadata": {"embedding_class": "biometric", "secret_key": "AAAA"},
+        });
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::PrivateKeyMaterial)
+        );
+    }
+
+    #[test]
+    fn nested_arrays_are_scanned() {
+        let v = json!({"items": [{"x": 1}, {"master_secret": "s"}]});
+        assert_eq!(
+            classify_export_value(&v),
+            Some(ForbiddenExportClass::MasterThresholdSecret)
+        );
+    }
+
+    #[test]
+    fn screen_audited_emits_refusal_and_returns_class() {
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let v = json!({"content": "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END"});
+        let class = screen_export_value_audited(&conn, "memories/x.json", "daemon", &v);
+        assert_eq!(class, Some(ForbiddenExportClass::PrivateKeyMaterial));
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+                rusqlite::params![
+                    crate::signed_events::event_types::EXPORT_FORBIDDEN_CLASS_REFUSED
+                ],
+                |r| r.get(0),
+            )
+            .expect("count refusal rows");
+        assert_eq!(count, 1, "exactly one signed refusal row emitted");
+    }
+
+    #[test]
+    fn screen_audited_clean_record_emits_nothing() {
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let v = json!({"content": "ordinary memory"});
+        assert_eq!(
+            screen_export_value_audited(&conn, "memories/y.json", "daemon", &v),
+            None
+        );
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+                rusqlite::params![
+                    crate::signed_events::event_types::EXPORT_FORBIDDEN_CLASS_REFUSED
+                ],
+                |r| r.get(0),
+            )
+            .expect("count refusal rows");
+        assert_eq!(count, 0, "clean record emits no refusal row");
+    }
+}

--- a/src/forensic/bundle.rs
+++ b/src/forensic/bundle.rs
@@ -479,7 +479,28 @@ pub fn build_files(
                 confidence_decayed_at: mem.confidence_decayed_at.clone(),
             };
             let bytes = serde_json::to_vec_pretty(&env).context("serialise MemoryEnvelope")?;
-            files.insert(format!("memories/{}.json", mem.id), bytes);
+            let path = format!("memories/{}.json", mem.id);
+            // v1.0.0 G28 (#1838) — forbidden-export-class gate (fail-closed).
+            // The secret-screen above masks CREDENTIAL content; this class
+            // gate refuses a whole envelope whose content/metadata is
+            // classified private key material / master-threshold secret /
+            // governance signing key / a producer-tagged biometric embedding.
+            // Structurally these live in the key-dir, not the DB, so a hit
+            // means a mis-stored secret rode a memory row — it is SKIPPED
+            // (never bundled in the clear) and a signed refusal is emitted.
+            let record = serde_json::from_slice::<serde_json::Value>(&bytes)
+                .unwrap_or_else(|_| serde_json::json!(null));
+            if crate::export_taxonomy::screen_export_value_audited(
+                conn,
+                &path,
+                crate::identity::sentinels::DAEMON_PRINCIPAL,
+                &record,
+            )
+            .is_some()
+            {
+                continue;
+            }
+            files.insert(path, bytes);
         }
     }
 

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -610,6 +610,53 @@ pub async fn run_gc(State(app): State<AppState>, headers: HeaderMap) -> impl Int
     }
 }
 
+/// v1.0.0 G28 (#1838) — fail-closed forbidden-export-class filter for the
+/// corpus-export egress. Drops any memory whose serialized row is classified
+/// into a [`crate::export_taxonomy::ForbiddenExportClass`] (private key
+/// material / master-threshold secret / governance signing key / a
+/// producer-tagged biometric embedding) so it never leaves in the clear.
+/// When `audit_conn` is `Some` (the sqlite export path) each drop emits a
+/// signed `export.forbidden_class_refused` row; the postgres path has no
+/// rusqlite handle and WARN-only skips the audit row (documented honest
+/// boundary) — the DROP itself always holds.
+fn screen_exported_memories(
+    memories: Vec<crate::models::Memory>,
+    audit_conn: Option<&rusqlite::Connection>,
+) -> Vec<crate::models::Memory> {
+    memories
+        .into_iter()
+        .filter(|m| {
+            let Some(class) = crate::export_taxonomy::classify_memory(m) else {
+                return true;
+            };
+            let path = format!("memories/{}.json", m.id);
+            let reason = format!(
+                "export refused: memory classified {} ({}) — dropped from export artifact",
+                class.as_str(),
+                class.description()
+            );
+            if let Some(conn) = audit_conn {
+                if let Err(e) = crate::export_taxonomy::emit_export_refusal(
+                    conn,
+                    class,
+                    &path,
+                    crate::identity::sentinels::DAEMON_PRINCIPAL,
+                    &reason,
+                ) {
+                    tracing::warn!(
+                        "forbidden-export-class signed refusal NOT recorded for {path}: {e}"
+                    );
+                }
+            }
+            tracing::warn!(
+                "export boundary dropped a {} memory — {path} withheld fail-closed",
+                class.as_str()
+            );
+            false
+        })
+        .collect()
+}
+
 pub async fn export_memories(State(app): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     // #957 (security-critical, 2026-05-20) — admin-role gate.
     // Pre-#957 the handler took NO headers, accepted no caller, and
@@ -655,6 +702,11 @@ pub async fn export_memories(State(app): State<AppState>, headers: HeaderMap) ->
             Ok(v) => v,
             Err(e) => return store_err_to_response(e),
         };
+        // v1.0.0 G28 (#1838) — forbidden-export-class gate (fail-closed).
+        // The postgres export has no rusqlite audit handle, so the signed
+        // refusal is skipped with a WARN (documented honest boundary); the
+        // fail-closed DROP still holds so a forbidden-class row never leaves.
+        let mems = screen_exported_memories(mems, None);
         let links = match app.store.export_links().await {
             Ok(v) => v,
             Err(e) => return store_err_to_response(e),
@@ -674,6 +726,10 @@ pub async fn export_memories(State(app): State<AppState>, headers: HeaderMap) ->
     let lock = app.db.lock().await;
     match (db::export_all(&lock.0), db::export_links(&lock.0)) {
         (Ok(memories), Ok(links)) => {
+            // v1.0.0 G28 (#1838) — forbidden-export-class gate (fail-closed);
+            // sqlite path holds the audit connection so a drop emits a signed
+            // `export.forbidden_class_refused` row.
+            let memories = screen_exported_memories(memories, Some(&lock.0));
             let count = memories.len();
             Json(json!({"memories": memories, "links": links, "count": count, (field_names::EXPORTED_AT): Utc::now().to_rfc3339()})).into_response()
         }

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -1036,3 +1036,129 @@ pub async fn tools_list(State(app): State<AppState>) -> impl IntoResponse {
     let defs = crate::mcp::tool_definitions_for_profile(app.profile.as_ref());
     (StatusCode::OK, Json(defs)).into_response()
 }
+
+// v1.0.0 G28 (#1838) — direct unit coverage for the fail-closed
+// `screen_exported_memories` corpus-export filter. These exercise the
+// helper's branches that the HTTP export path cannot reach without a live
+// backend — in particular the `audit_conn = None` arm the postgres SAL
+// export path takes (WARN-only, no rusqlite handle). test-cfg-test-module
+// (co-located `#[cfg(test)] mod`), test-use-super (parent-item access),
+// test-descriptive-names, test-arrange-act-assert.
+#[cfg(test)]
+mod g28_export_screen_tests {
+    use super::*;
+    use crate::models::Memory;
+    use crate::signed_events::event_types::EXPORT_FORBIDDEN_CLASS_REFUSED;
+
+    /// A benign row that classifies clean under the export taxonomy.
+    fn clean_memory(id: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            content: "an ordinary memory about a standup".to_string(),
+            ..Memory::default()
+        }
+    }
+
+    /// A row that classifies `PrivateKeyMaterial` (PEM armor mis-stored in
+    /// content — the belt-and-suspenders case the gate exists for).
+    fn pem_key_memory(id: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            content: "leaked:\n-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END".to_string(),
+            ..Memory::default()
+        }
+    }
+
+    /// A row tagged `BiometricBehavioralEmbedding` by the producer-side
+    /// metadata tag.
+    fn biometric_memory(id: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            metadata: serde_json::json!({"scope": "collective", "embedding_class": "biometric"}),
+            ..Memory::default()
+        }
+    }
+
+    fn refusal_count(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+            rusqlite::params![EXPORT_FORBIDDEN_CLASS_REFUSED],
+            |r| r.get(0),
+        )
+        .expect("count refusal rows")
+    }
+
+    #[test]
+    fn clean_corpus_is_a_no_op_and_emits_no_refusal() {
+        // Arrange: all-clean corpus + an audit connection.
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let corpus = vec![clean_memory("a"), clean_memory("b")];
+
+        // Act.
+        let kept = screen_exported_memories(corpus, Some(&conn));
+
+        // Assert: every row survives; no refusal row appended.
+        assert_eq!(kept.len(), 2, "clean rows must all pass the screen");
+        assert_eq!(refusal_count(&conn), 0, "no refusal row for a clean corpus");
+    }
+
+    #[test]
+    fn sqlite_branch_screens_forbidden_row_and_emits_signed_refusal() {
+        // Arrange: two clean rows + one PEM-key row; audit conn present
+        // (the sqlite export path).
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let corpus = vec![
+            clean_memory("keep-1"),
+            pem_key_memory("forbidden"),
+            clean_memory("keep-2"),
+        ];
+
+        // Act.
+        let kept = screen_exported_memories(corpus, Some(&conn));
+
+        // Assert: the forbidden row is dropped, the clean rows remain, and
+        // exactly one signed refusal row witnesses the redaction.
+        assert_eq!(kept.len(), 2, "forbidden row must be screened out");
+        assert!(
+            kept.iter().all(|m| m.id != "forbidden"),
+            "the PEM-key row must be absent from the export set"
+        );
+        assert_eq!(refusal_count(&conn), 1, "one signed refusal emitted");
+    }
+
+    #[test]
+    fn postgres_branch_none_audit_conn_still_screens_without_a_refusal_row() {
+        // Arrange: the postgres SAL export path calls the helper with
+        // `audit_conn = None` (no rusqlite handle). A biometric-tagged row
+        // must STILL be screened out; the signed refusal is WARN-only
+        // skipped (honest-boundary note). A separate conn only lets us
+        // prove no row leaked onto a chain.
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let corpus = vec![clean_memory("ok"), biometric_memory("bio")];
+
+        // Act: None audit conn — the postgres arm.
+        let kept = screen_exported_memories(corpus, None);
+
+        // Assert: fail-closed drop still holds with no audit connection.
+        assert_eq!(kept.len(), 1, "biometric row screened out even on pg path");
+        assert_eq!(kept[0].id, "ok");
+        assert_eq!(
+            refusal_count(&conn),
+            0,
+            "None audit conn writes no refusal row anywhere"
+        );
+    }
+
+    #[test]
+    fn most_severe_forbidden_class_is_dropped_when_row_matches_several() {
+        // A row carrying BOTH a biometric tag and PEM key material is still
+        // a single drop (defense-in-depth): the row never exports.
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).expect("open");
+        let mut both = pem_key_memory("both");
+        both.metadata = serde_json::json!({"embedding_class": "biometric"});
+        let kept = screen_exported_memories(vec![clean_memory("x"), both], Some(&conn));
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, "x");
+        assert_eq!(refusal_count(&conn), 1);
+    }
+}

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -12480,6 +12480,99 @@ async fn http_export_memories_with_data_returns_count() {
     assert!(v["exported_at"].is_string());
 }
 
+/// v1.0.0 G28 (#1838) — insert a fixture row with caller-chosen metadata,
+/// bypassing the write-path secret screen (direct `db::insert`) so a
+/// forbidden-export-CLASS row (e.g. a producer-tagged biometric embedding)
+/// can be planted in the corpus to exercise the export-egress gate.
+async fn insert_test_memory_with_metadata(
+    state: &Db,
+    namespace: &str,
+    title: &str,
+    metadata: serde_json::Value,
+) -> String {
+    let lock = state.lock().await;
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: Uuid::new_v4().to_string(),
+        tier: Tier::Long,
+        namespace: namespace.into(),
+        title: title.into(),
+        content: format!("content for {title}"),
+        source: "test".into(),
+        created_at: now.clone(),
+        updated_at: now,
+        metadata,
+        ..Memory::default()
+    };
+    db::insert(&lock.0, &mem).unwrap()
+}
+
+#[tokio::test]
+async fn http_export_memories_screens_forbidden_class_row() {
+    // v1.0.0 G28 (#1838) — the sqlite `export_memories` branch must run the
+    // corpus through `screen_exported_memories`: a producer-tagged biometric
+    // embedding row is DROPPED from the export artifact, a signed
+    // `export.forbidden_class_refused` row is emitted (sqlite path holds the
+    // audit connection), and the clean rows still export.
+    let state = test_state();
+    let _ = insert_test_memory(&state, "ns-g28", "clean-1").await;
+    let _ = insert_test_memory(&state, "ns-g28", "clean-2").await;
+    let forbidden_id = insert_test_memory_with_metadata(
+        &state,
+        "ns-g28",
+        "biometric-row",
+        serde_json::json!({"scope": "collective", "embedding_class": "biometric"}),
+    )
+    .await;
+
+    let app = Router::new()
+        .route("/api/v1/export", axum_get(export_memories))
+        .with_state(test_app_state_with_admin(state.clone(), "ops:admin"));
+    let resp = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/export")
+                .header("x-agent-id", "ops:admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+    // Only the two clean rows survive the screen.
+    assert_eq!(
+        v["count"], 2,
+        "the forbidden-class row must be screened out"
+    );
+    let exported_ids: Vec<&str> = v["memories"]
+        .as_array()
+        .expect("memories array")
+        .iter()
+        .filter_map(|m| m["id"].as_str())
+        .collect();
+    assert!(
+        !exported_ids.contains(&forbidden_id.as_str()),
+        "the biometric-tagged row must be absent from the export artifact"
+    );
+
+    // The sqlite path emitted a signed refusal witnessing the redaction.
+    let lock = state.lock().await;
+    let refusals: i64 = lock
+        .0
+        .query_row(
+            "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+            rusqlite::params![crate::signed_events::event_types::EXPORT_FORBIDDEN_CLASS_REFUSED],
+            |r| r.get(0),
+        )
+        .expect("count refusal rows");
+    assert_eq!(refusals, 1, "one signed export refusal row emitted");
+}
+
 // ---- import_memories happy path ----
 
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,11 @@ pub mod hnsw;
 // refusals. Extends the substrate's default-deny-able egress posture to
 // outbound LLM/embedding vendor POSTs at the semantic/smart tiers.
 pub mod egress;
+// v1.0.0 G28 (#1838) — forbidden-export-class taxonomy + fail-closed
+// export-boundary enforcement (private key material / master-threshold
+// secrets / governance signing keys / biometric-behavioral embeddings must
+// never cross the export boundary in the clear).
+pub mod export_taxonomy;
 pub mod hooks;
 pub mod identity;
 // v0.7.0 L1-2 — knowledge-graph substrate helpers (anti-cycle check).

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -357,6 +357,23 @@ pub mod event_types {
     /// constructed, so no memory content ever leaves the host for the
     /// refused vendor — this row is the audit witness of that refusal.
     pub const EGRESS_INFERENCE_REFUSED: &str = "egress.inference_refused";
+
+    /// v1.0.0 G28 (#1838) — `signed_events.event_type` for a forbidden
+    /// export-class refusal at an export boundary (forensic bundle,
+    /// memory export). Emitted by
+    /// [`crate::export_taxonomy::screen_export_value_audited`] when a
+    /// candidate export record is classified into one of the closed
+    /// [`crate::export_taxonomy::ForbiddenExportClass`] classes (private
+    /// key material, master/threshold secret, governance-rule signing
+    /// key, biometric/behavioral embedding) that must NEVER cross the
+    /// export boundary. `payload_hash` = SHA-256 over the canonical
+    /// pre-image of the (non-secret) forbidden class + the artifact path
+    /// the record would have occupied + the reason; substrate-emitted
+    /// (`daemon_signed` when a key is enrolled, else `unsigned`), the
+    /// same posture as [`EGRESS_INFERENCE_REFUSED`]. The refused record
+    /// is never emitted into the export artifact — this row is the audit
+    /// witness of that fail-closed redaction.
+    pub const EXPORT_FORBIDDEN_CLASS_REFUSED: &str = "export.forbidden_class_refused";
 }
 
 /// v0.9.0 G13 (#1828) + v1.0.0 #1949 — the `identity.lineage.*` witness

--- a/tests/inference_egress_dispatch_1963.rs
+++ b/tests/inference_egress_dispatch_1963.rs
@@ -1,0 +1,381 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1963 (R68/D14) — subprocess coverage for the inference-plane egress
+//! gate's TWO boot chokepoints in `src/daemon_runtime.rs`:
+//! [`ai_memory::daemon_runtime::build_llm_client`] (reached through the
+//! `ai-memory expand` CLI dispatch arm, `Command::Expand` ->
+//! `cli::commands::expand::cmd_expand`) and
+//! [`ai_memory::daemon_runtime::build_embedder`] (reached through the
+//! `ai-memory recall` CLI dispatch arm, `Command::Recall` ->
+//! `cli::recall::run`).
+//!
+//! Per `coverage/policy.md`, `daemon_runtime.rs` is integration-only —
+//! covered by SUBPROCESS tests that spawn the real binary, not unit
+//! tests. The #1963 egress-gate `if let EgressDecision::Refuse { .. }`
+//! blocks landed inside `build_llm_client` / `build_embedder` (both
+//! called only from CLI dispatch / daemon boot, never from a plain
+//! `#[test]`), so they need the same subprocess treatment as the
+//! `Command::Stop` (#1955) and `bench --verified` (#1961) precedents
+//! (`tests/record_stop_cli_dispatch_1955.rs`,
+//! `tests/bench_verified_dispatch_1961.rs`).
+//!
+//! Neither `Command::Expand` nor `Command::Recall` nor `src/egress.rs`
+//! is gated behind `--features sal` (see `src/daemon_runtime.rs`'s
+//! dispatch match and `src/lib.rs::pub mod egress;`), so this file is
+//! NOT feature-gated — it runs in the default build.
+//!
+//! Ground truth for "did the refuse branch fire?" is the db side
+//! effect, not stdout/log text: a refused inference-plane egress
+//! appends a signed `egress.inference_refused` row to `signed_events`
+//! via `crate::egress::refuse_inference_egress_audited` (best-effort,
+//! opens its own connection at the resolved db path). CLI one-shot
+//! commands install no `tracing` subscriber (see `src/main.rs`'s
+//! COVERAGE NOTE), so the WARN text is not observable on stderr; the
+//! db row is. The ALLOW-path control tests point the resolved target
+//! at an unbound loopback port (`http://127.0.0.1:1`) so the
+//! non-refused fallthrough attempts a REAL connection that fails fast
+//! (`ECONNREFUSED`, no DNS, no timeout) — proving the `if let Refuse`
+//! evaluated false and control fell through to actual client
+//! construction, without any network dependency or hang risk.
+//!
+//! ## A load-bearing wrinkle discovered while writing this test
+//!
+//! `build_llm_client` / `build_embedder` do NOT thread the resolved
+//! `db_path` in from their caller for the audit write — they each
+//! independently recompute `app_config.effective_db(Path::new(DEFAULT_DB))`
+//! (`DEFAULT_DB` = the literal `"ai-memory.db"`). `AppConfig::effective_db`
+//! only honours its `cli_db` argument when it differs from the literal
+//! default (`"ai-memory.db"`); since the call site always passes that
+//! same literal, the operator's real `--db <path>` / `AI_MEMORY_DB` is
+//! NEVER reflected here — the audit row always lands in `ai-memory.db`
+//! relative to the process's CWD (or `[storage].db` from `config.toml`
+//! when one is loaded), regardless of what the command's OWN db-open
+//! path used. This is a real, observable quirk of the shipped #1963
+//! code, not a test artifact; the harness below pins each subprocess's
+//! CWD to a fresh per-test directory and names the `--db` target
+//! `ai-memory.db` inside that SAME directory so the command's
+//! functional db and the audit db resolve to the identical file,
+//! keeping the assertions both correct and hermetic (no shared mutable
+//! state with the repo root or with other tests).
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+/// Run `ai-memory --db <dir>/ai-memory.db <args...>` with the process
+/// CWD pinned to `dir` (see the module doc's "load-bearing wrinkle") and
+/// `AI_MEMORY_NO_CONFIG=1` plus the caller-supplied env overrides.
+/// Returns the captured [`Output`].
+fn run_ai_memory_in(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_ai-memory"));
+    cmd.current_dir(dir);
+    cmd.arg("--db").arg(dir.join("ai-memory.db"));
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.env("AI_MEMORY_NO_CONFIG", "1");
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("spawn ai-memory")
+}
+
+/// A fresh per-test working directory under `.local-runs/` (project
+/// no-`/tmp` HARD RULE), mirroring
+/// `tests/record_stop_cli_dispatch_1955.rs::fresh_db`. Returns the
+/// directory itself (not a db file path) — pass it straight to
+/// [`run_ai_memory_in`]; the db file (both the command's functional db
+/// AND the #1963 egress-audit db, per the module doc) lives at
+/// `<dir>/ai-memory.db`.
+fn fresh_workdir(label: &str) -> (tempfile::TempDir, PathBuf) {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-1963-egress-dispatch");
+    std::fs::create_dir_all(&root).ok();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("{label}-"))
+        .tempdir_in(&root)
+        .expect("tempdir under .local-runs");
+    let path = dir.path().to_path_buf();
+    (dir, path)
+}
+
+/// Count `signed_events` rows of type `egress.inference_refused` in the
+/// db at `db_path`. Panics (test failure) if the db can't be opened —
+/// every code path under test opens the db before the egress gate runs,
+/// so it must exist by the time the subprocess exits.
+fn count_egress_refusals(db_path: &Path) -> i64 {
+    let conn = ai_memory::db::open(db_path).expect("open db for post-hoc assertion");
+    conn.query_row(
+        "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+        [ai_memory::signed_events::event_types::EGRESS_INFERENCE_REFUSED],
+        |r| r.get(0),
+    )
+    .expect("count signed_events rows")
+}
+
+// ─── build_llm_client chokepoint (via `ai-memory expand`) ─────────────
+
+#[test]
+fn expand_llm_egress_deny_refuses_before_client_construction_and_records_signed_event() {
+    // Arrange: an LLM backend fully configured via env (so the
+    // no-preset-tier short-circuit in `build_llm_client` does not fire —
+    // ConfigSource::Env, not CompiledDefault) and the egress posture
+    // pinned to `deny`, which refuses every inference target including
+    // loopback ones.
+    let (_dir, workdir) = fresh_workdir("expand-deny");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_LLM_BACKEND", "openai-compatible"),
+        (
+            "AI_MEMORY_LLM_BASE_URL",
+            "https://inference.example.invalid/v1",
+        ),
+        ("AI_MEMORY_LLM_API_KEY", "test-key-1963"),
+        ("AI_MEMORY_INFERENCE_EGRESS", "deny"),
+    ];
+
+    // Act.
+    let out = run_ai_memory_in(&workdir, &["expand", "hello world", "--json"], envs);
+
+    // Assert: `build_llm_client` returned `None` via the refuse arm, so
+    // `cmd_expand` takes the no-LLM path — EXIT_NO_LLM (2) — NOT
+    // EXIT_LLM_FAILED (3), which would mean a client got constructed
+    // and made (or attempted) a real call.
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected EXIT_NO_LLM(2); stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("expand --json parses");
+    assert!(
+        v["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("LLM backend"),
+        "got: {v}"
+    );
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        1,
+        "exactly one signed egress.inference_refused row expected"
+    );
+}
+
+#[test]
+fn expand_llm_egress_loopback_only_refuses_external_target_and_records_signed_event() {
+    // Arrange: `loopback-only` permits local inference but must refuse
+    // an external vendor target — a distinct match arm from `deny`
+    // (which refuses unconditionally).
+    let (_dir, workdir) = fresh_workdir("expand-loopback-only");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_LLM_BACKEND", "openai-compatible"),
+        (
+            "AI_MEMORY_LLM_BASE_URL",
+            "https://inference.example.invalid/v1",
+        ),
+        ("AI_MEMORY_LLM_API_KEY", "test-key-1963"),
+        ("AI_MEMORY_INFERENCE_EGRESS", "loopback-only"),
+    ];
+
+    // Act.
+    let out = run_ai_memory_in(&workdir, &["expand", "hello world", "--json"], envs);
+
+    // Assert.
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected EXIT_NO_LLM(2); stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        1,
+        "loopback-only must refuse the external target and record one refusal"
+    );
+}
+
+#[test]
+fn expand_llm_egress_allow_default_falls_through_to_real_client_construction() {
+    // Arrange: egress posture left UNSET (compiled default `allow`).
+    // Point the resolved base_url at an unbound loopback port so the
+    // fallthrough path (client actually constructed and used) makes a
+    // REAL connection attempt that fails fast and deterministically
+    // (`ECONNREFUSED`) with no DNS lookup and no timeout wait — proving
+    // the `if let EgressDecision::Refuse` evaluated false at this
+    // chokepoint (branch coverage of the non-refuse arm), not merely
+    // that the line was entered.
+    let (_dir, workdir) = fresh_workdir("expand-allow");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_LLM_BACKEND", "openai-compatible"),
+        ("AI_MEMORY_LLM_BASE_URL", "http://127.0.0.1:1"),
+        ("AI_MEMORY_LLM_API_KEY", "test-key-1963"),
+    ];
+
+    // Act.
+    let out = run_ai_memory_in(&workdir, &["expand", "hello world", "--json"], envs);
+
+    // Assert: EXIT_LLM_FAILED(3) — the client WAS constructed (egress
+    // allowed it) and the subsequent expansion call failed upstream,
+    // which is a structurally different outcome from EXIT_NO_LLM(2).
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "expected EXIT_LLM_FAILED(3) (client built, upstream call failed); \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        0,
+        "allow mode must never record an egress refusal"
+    );
+}
+
+// ─── build_embedder chokepoint (via `ai-memory recall --tier semantic`) ─
+
+#[test]
+fn recall_embedder_egress_deny_refuses_and_degrades_to_keyword_with_signed_event() {
+    // Arrange: an API embedding backend (non-ollama, so
+    // `is_api_embed_backend` is true and the #1963 gate applies) with a
+    // known vector dim (avoids the unrelated unknown-dim bail in
+    // `Embedder::from_resolved`) and the egress posture pinned to
+    // `deny`.
+    let (_dir, workdir) = fresh_workdir("recall-embed-deny");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_EMBED_BACKEND", "openai-compatible"),
+        (
+            "AI_MEMORY_EMBED_BASE_URL",
+            "https://embed.example.invalid/v1",
+        ),
+        ("AI_MEMORY_EMBED_MODEL", "google/gemini-embedding-2"),
+        ("AI_MEMORY_EMBED_API_KEY", "test-key-1963"),
+        ("AI_MEMORY_INFERENCE_EGRESS", "deny"),
+    ];
+
+    // Act. An empty, freshly-created db + a keyword-fallback-safe
+    // recall: the embedder gate refusing must not fail the command —
+    // recall degrades to keyword/FTS (#1593 fail-closed precedent).
+    let out = run_ai_memory_in(
+        &workdir,
+        &[
+            "recall",
+            "test query",
+            "--tier",
+            "semantic",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+
+    // Assert: recall itself still succeeds (embedder=None is a
+    // legitimate degraded state, not a hard error) and the refusal was
+    // recorded.
+    assert!(
+        out.status.success(),
+        "recall must succeed even when the embedder is egress-refused; \
+         exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        1,
+        "exactly one signed egress.inference_refused row expected for the embedder gate"
+    );
+}
+
+#[test]
+fn recall_embedder_egress_loopback_only_refuses_external_target_with_signed_event() {
+    // Arrange: same as above but under `loopback-only`, exercising the
+    // distinct external-target-under-loopback-only match arm.
+    let (_dir, workdir) = fresh_workdir("recall-embed-loopback-only");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_EMBED_BACKEND", "openai-compatible"),
+        (
+            "AI_MEMORY_EMBED_BASE_URL",
+            "https://embed.example.invalid/v1",
+        ),
+        ("AI_MEMORY_EMBED_MODEL", "google/gemini-embedding-2"),
+        ("AI_MEMORY_EMBED_API_KEY", "test-key-1963"),
+        ("AI_MEMORY_INFERENCE_EGRESS", "loopback-only"),
+    ];
+
+    // Act.
+    let out = run_ai_memory_in(
+        &workdir,
+        &[
+            "recall",
+            "test query",
+            "--tier",
+            "semantic",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+
+    // Assert.
+    assert!(
+        out.status.success(),
+        "recall must succeed even when the embedder is egress-refused; \
+         exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        1,
+        "loopback-only must refuse the external embed target"
+    );
+}
+
+#[test]
+fn recall_embedder_egress_allow_default_falls_through_to_real_construction() {
+    // Arrange: egress posture left UNSET (compiled default `allow`).
+    // Point the resolved embed URL at an unbound loopback port; since
+    // `Embedder::from_resolved` builds the API-backend client lazily
+    // (no network probe at construction — verified by reading
+    // `src/embeddings.rs::from_resolved`), the embedder is
+    // successfully constructed and `build_embedder` returns `Some`,
+    // proving the `if let Refuse` branch evaluated false. Any
+    // subsequent semantic-search network attempt against the unbound
+    // port fails fast (`ECONNREFUSED`) and recall must still degrade
+    // gracefully rather than hang or crash.
+    let (_dir, workdir) = fresh_workdir("recall-embed-allow");
+    let envs: &[(&str, &str)] = &[
+        ("AI_MEMORY_EMBED_BACKEND", "openai-compatible"),
+        ("AI_MEMORY_EMBED_BASE_URL", "http://127.0.0.1:1"),
+        ("AI_MEMORY_EMBED_MODEL", "google/gemini-embedding-2"),
+        ("AI_MEMORY_EMBED_API_KEY", "test-key-1963"),
+    ];
+
+    // Act.
+    let out = run_ai_memory_in(
+        &workdir,
+        &[
+            "recall",
+            "test query",
+            "--tier",
+            "semantic",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+
+    // Assert: no refusal recorded — the gate allowed construction.
+    assert_eq!(
+        count_egress_refusals(&workdir.join("ai-memory.db")),
+        0,
+        "allow mode must never record an egress refusal; \
+         exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/security_profile_dispatch_1961.rs
+++ b/tests/security_profile_dispatch_1961.rs
@@ -1,0 +1,163 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1961 (R23/R7) — subprocess coverage for the `asi-hard` security-posture
+//! enforcement ARM at the very top of `src/daemon_runtime.rs::run` (the
+//! `crate::security_profile::enforce_at_boot()?` block that every CLI
+//! subcommand hits before the DB is opened). Driven through the real binary
+//! (`CARGO_BIN_EXE_ai-memory`) because the boot seam — posture resolve, the
+//! `posture == AsiHard` pin-logging loop, and the fail-closed `?`
+//! error-propagation on a loosening / garbage posture — is integration-only
+//! (see `coverage/policy.md` for the `daemon_runtime.rs` exception) and is
+//! reached ONLY when `AI_MEMORY_SECURITY_PROFILE` is set in the process
+//! environment. No existing subprocess test sets that env, so the entire
+//! `AsiHard` branch (the net-new #1961 lines) is otherwise uncovered.
+//!
+//! The pure posture-parse + knob-pin table is unit-tested in
+//! `src/security_profile.rs::tests`; the shipped `asi-hard` config/env
+//! TEMPLATES are pinned by `tests/deploy_templates.rs`. This file pins the
+//! CLI dispatch seam that neither of those exercises.
+//!
+//! NOT feature-gated: the `enforce_at_boot()` block is in the default-build
+//! dispatch path (not behind `--features sal`).
+//!
+//! Ground truth is the process EXIT CODE + the stderr error text, which the
+//! CLI's top-level error handler prints (the boot posture refusals surface as
+//! `Err(..)` propagated out of `run` — distinct from the tracing WARN/INFO
+//! the pin-logging loop emits, which CLI one-shots do NOT render because they
+//! install no subscriber; see `src/main.rs`'s COVERAGE NOTE).
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+/// Run `ai-memory --db <db> <args...>` with `AI_MEMORY_NO_CONFIG=1` plus the
+/// caller-supplied env overrides (the posture knobs). Returns the captured
+/// [`Output`].
+fn run_ai_memory(db_path: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_ai-memory"));
+    cmd.arg("--db").arg(db_path);
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.env("AI_MEMORY_NO_CONFIG", "1");
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("spawn ai-memory")
+}
+
+/// A fresh temp DB path under `.local-runs/` (project no-`/tmp` HARD RULE),
+/// mirroring `tests/record_stop_cli_dispatch_1955.rs::fresh_db`.
+fn fresh_db(label: &str) -> (tempfile::TempDir, PathBuf) {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-1961-security-profile-dispatch");
+    std::fs::create_dir_all(&root).ok();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("{label}-"))
+        .tempdir_in(&root)
+        .expect("tempdir under .local-runs");
+    let db = dir.path().join("ai-memory.db");
+    (dir, db)
+}
+
+/// Control: with NO posture set (the compiled-default `standard`), the
+/// `enforce_at_boot()` block is a no-op — `posture == Standard` short-circuits
+/// past the `AsiHard` pin-logging loop and the command proceeds normally.
+/// Pins the negative half of the boot branch so a future refactor that made
+/// `standard` accidentally fail-closed would trip here.
+#[test]
+fn standard_posture_is_a_noop_and_command_proceeds() {
+    let (_dir, db) = fresh_db("standard-noop");
+    let out = run_ai_memory(&db, &["stats", "--json"], &[]);
+    assert!(
+        out.status.success(),
+        "standard posture must be a boot no-op; exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stats --json parses under standard posture");
+    assert_eq!(v["total"], 0, "fresh db has zero memories; got: {v}");
+}
+
+/// `asi-hard` ENGAGED: the `posture == AsiHard` pin-logging branch runs and
+/// PINS the fail-closed knob set ON — including `AI_MEMORY_REQUIRE_ROLLBACK_CHECK`
+/// (#124), which then refuses to open a fresh DB that has no off-table witness
+/// head anchor. The refusal at the db-open seam is the observable PROOF that
+/// the asi-hard branch executed and its pins took effect (the pin loop runs
+/// BEFORE the db is opened). Exercises the net-new #1961 `AsiHard` arm.
+#[test]
+fn asi_hard_engaged_pins_rollback_check_and_refuses_open_on_fresh_db() {
+    let (_dir, db) = fresh_db("asi-hard-engaged");
+    let out = run_ai_memory(
+        &db,
+        &["stats", "--json"],
+        &[("AI_MEMORY_SECURITY_PROFILE", "asi-hard")],
+    );
+    assert!(
+        !out.status.success(),
+        "asi-hard pins require_rollback_check=1 → fresh-db open must be refused; \
+         exit={:?} stdout={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("rollback-check refuse-open")
+            || stderr.contains("AI_MEMORY_REQUIRE_ROLLBACK_CHECK"),
+        "expected the asi-hard-pinned rollback-check refusal; stderr={stderr}"
+    );
+}
+
+/// `asi-hard` + an operator LOOSENING override below the hard floor: boot is
+/// REFUSED by `enforce_at_boot`, which propagates `Err(..)` out through the
+/// `?` in `run`. Exercises the fail-closed error-propagation arm distinct from
+/// the successful-pin arm above.
+#[test]
+fn asi_hard_refuses_boot_when_operator_loosens_a_pinned_knob() {
+    let (_dir, db) = fresh_db("asi-hard-loosen");
+    let out = run_ai_memory(
+        &db,
+        &["stats", "--json"],
+        &[
+            ("AI_MEMORY_SECURITY_PROFILE", "asi-hard"),
+            ("AI_MEMORY_SECRET_SCREEN_MODE", "off"),
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "asi-hard must refuse to boot when a pinned knob is loosened; exit={:?}",
+        out.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("AI_MEMORY_SECRET_SCREEN_MODE")
+            && (stderr.contains("refuses to disable") || stderr.contains("hard floor")),
+        "expected the asi-hard loosening refusal naming the knob; stderr={stderr}"
+    );
+}
+
+/// A garbage `AI_MEMORY_SECURITY_PROFILE` token aborts the boot (fail-LOUD,
+/// never silent-standard) — the parse-error arm of `SecurityPosture::resolve`
+/// propagated through `enforce_at_boot()?` in `run`.
+#[test]
+fn unrecognised_security_profile_token_aborts_boot() {
+    let (_dir, db) = fresh_db("bogus-token");
+    let out = run_ai_memory(
+        &db,
+        &["stats", "--json"],
+        &[("AI_MEMORY_SECURITY_PROFILE", "bogus-not-a-posture")],
+    );
+    assert!(
+        !out.status.success(),
+        "an unrecognised security-profile token must abort the boot; exit={:?}",
+        out.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("AI_MEMORY_SECURITY_PROFILE") && stderr.contains("unrecognised"),
+        "expected the unrecognised-posture boot error; stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## What

Fix-forward for the RED base CI (`Per-Module Coverage Thresholds`: `daemon_runtime.rs` 85.65% < 86% floor) plus lands Gate-2 issue #1838.

- **`test(#1963)`** + **`test(#1961)`** — subprocess dispatch-coverage tests for the two daemon_runtime.rs arms whose landing outran their tests (inference-plane egress refuse blocks + asi-hard security-posture boot enforcement). Restores the floor via added coverage (never lowered — thresholds rise, not fall).
- **`feat(#1838)`** — closed `ForbiddenExportClass` taxonomy + fail-closed export-boundary enforcement + signed `export.forbidden_class_refused` refusal row (G28). No schema change.

CI's `coverage.yml` is the authoritative daemon_runtime measurement (local full `llvm-cov` is disk-prohibitive at ~130G target).

## Also filed
- #1991 — real #1963 production bug surfaced during test authoring (egress audit row ignores `--db`, lands in CWD `ai-memory.db`).

## Gates (merged-tree battery, all green locally)
fmt · clippy pedantic (default + sal + sal-postgres --tests) · check --examples · both #1838 test suites · qual-10 · 5 script gates (hardcoded / vendor / const-name / C8 codegraph / docs-vs-ssot) — **14/14 PASS**. Both new tests pass (egress 6/6, security-profile 4/4).

## AI involvement
Authored by AI-NHI agents under the v1.0.0 autonomous epic (operator grant memory f9a0f397). Coverage tests: Claude Sonnet 5. #1838 taxonomy: Claude Opus 4.8. Integration + merged-tree gate audit + rust-skills CRITICAL-category review: Claude Opus 4.8 (Fable-role orchestrator). 2×5 adversarial vote protocol applied at crossroads (memory 4d3ea1c5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)