### PR TITLE
feat(#1937): minimal signed spawn-audit chokepoint (V08-PE-3)

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1276,7 +1276,9 @@ fn gpu_policy_warn_applicable(backend: &str, gpu_detected: bool) -> bool {
 /// non-zero exit) is treated as no-GPU. Deliberately simple — the
 /// GPU-policy WARN is advisory, not load-bearing.
 fn nvidia_gpu_detected() -> bool {
-    std::process::Command::new("nvidia-smi")
+    // #1937 V08-PE-3 — audited chokepoint: emits a signed `process.spawn_audited`
+    // row (argv0 + caller) before the best-effort `nvidia-smi` probe spawns.
+    crate::spawn_audit::audited_command("nvidia-smi", crate::spawn_audit::CALLER_CLI_DOCTOR_GPU)
         .arg("-L")
         .output()
         .map(|out| out.status.success())

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -58,10 +58,14 @@ pub fn resolve_namespace(explicit: Option<String>) -> String {
 /// 2. `current_dir`'s file_name component
 /// 3. The literal "global" fallback
 pub fn auto_namespace() -> String {
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .stderr(std::process::Stdio::null())
-        .output()
+    // #1937 V08-PE-3 — route the production `git` spawn through the audited
+    // chokepoint so it emits a signed `process.spawn_audited` row (argv0 +
+    // caller). Best-effort: the audit never blocks namespace resolution.
+    if let Ok(out) =
+        crate::spawn_audit::audited_command("git", crate::spawn_audit::CALLER_CLI_NAMESPACE_GIT)
+            .args(["remote", "get-url", "origin"])
+            .stderr(std::process::Stdio::null())
+            .output()
     {
         let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
         if !url.is_empty()

--- a/src/cli/wrap.rs
+++ b/src/cli/wrap.rs
@@ -289,7 +289,11 @@ fn build_command_for_strategy(
     system_msg: &str,
     trailing: &[String],
 ) -> Result<(Command, Option<tempfile::NamedTempFile>)> {
-    let mut cmd = Command::new(agent);
+    // #1937 V08-PE-3 — audited chokepoint: emit a signed `process.spawn_audited`
+    // row (argv0 = wrapped agent, caller = this builder) as the wrapped-agent
+    // `Command` is minted. Best-effort; the audit never blocks the launch.
+    let mut cmd =
+        crate::spawn_audit::audited_command(agent, crate::spawn_audit::CALLER_CLI_WRAP_AGENT);
     let mut tempfile_handle: Option<tempfile::NamedTempFile> = None;
     match strategy {
         WrapStrategy::SystemFlag { flag } => {

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -966,6 +966,13 @@ async fn dispatch_recover_previous_session(
 #[allow(clippy::too_many_lines)]
 pub async fn run(cli: Cli, app_config: &AppConfig) -> Result<()> {
     let db_path = app_config.effective_db(&cli.db);
+    // #1937 V08-PE-3 — seed the process-wide audit DB path for the best-effort
+    // spawn-audit chokepoint (`crate::spawn_audit`). Every serve / mcp / CLI
+    // subcommand dispatches through this fn, so every production `Command`
+    // spawn downstream (git namespace probe, nvidia-smi GPU probe, `wrap`
+    // agent launch, hook exec) has a live audit target. Idempotent; a spawn
+    // that fires before any seed (none do on this path) skips gracefully.
+    crate::spawn_audit::seed_spawn_audit_db_path(&db_path);
     // v1.0.0 #1961 (R23/R7) — resolve + enforce the security posture FIRST,
     // before any knob is read or the DB is opened. Under the default
     // `standard` posture this is a no-op; under `asi-hard` it PINS the

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -92,7 +92,7 @@ use std::time::{Duration, Instant};
 use serde::Serialize;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
@@ -694,19 +694,26 @@ impl ExecExecutor {
         //     caller, `FailMode::Open` masked it as `ChainResult::Allow`,
         //     and the child never actually ran.
         let command_path = self.config.command.clone();
-        let child = spawn_with_transient_retry(|| {
-            Command::new(&command_path)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()
-        })
-        .await
-        .map_err(|source| ExecutorError::Spawn {
-            command: self.config.command.display().to_string(),
-            source,
-        })?;
+        // #1937 V08-PE-3 — audited chokepoint. Mint the tokio `Command` via the
+        // audited helper (which emits ONE signed `process.spawn_audited` row:
+        // argv0 + caller) ONCE, then re-`spawn()` it across the transient-errno
+        // retry ladder — `tokio::process::Command::spawn` is `&mut self`, so a
+        // single built command is reused per attempt and the audit row is
+        // emitted exactly once per logical spawn (not per retry).
+        let mut cmd = crate::spawn_audit::audited_tokio_command(
+            &command_path,
+            crate::spawn_audit::CALLER_HOOK_EXEC,
+        );
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let child = spawn_with_transient_retry(|| cmd.spawn())
+            .await
+            .map_err(|source| ExecutorError::Spawn {
+                command: self.config.command.display().to_string(),
+                source,
+            })?;
 
         let started = Instant::now();
         let deadline = Duration::from_millis(u64::from(self.config.timeout_ms));
@@ -1048,18 +1055,21 @@ impl DaemonExecutor {
         // catches the narrow transient-errno class first so a brief
         // fork-pressure window doesn't even consume a reconnect slot.
         let command_path = self.config.command.clone();
-        let mut child = spawn_with_transient_retry(|| {
-            Command::new(&command_path)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-        })
-        .await
-        .map_err(|source| ExecutorError::Spawn {
-            command: self.config.command.display().to_string(),
-            source,
-        })?;
+        // #1937 V08-PE-3 — audited chokepoint (once per logical daemon-mode
+        // spawn, not per retry). Same rationale as the exec path above.
+        let mut cmd = crate::spawn_audit::audited_tokio_command(
+            &command_path,
+            crate::spawn_audit::CALLER_HOOK_DAEMON,
+        );
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = spawn_with_transient_retry(|| cmd.spawn())
+            .await
+            .map_err(|source| ExecutorError::Spawn {
+                command: self.config.command.display().to_string(),
+                source,
+            })?;
         let stdin = child.stdin.take().ok_or_else(|| {
             ExecutorError::Io(io::Error::new(
                 io::ErrorKind::BrokenPipe,
@@ -1224,6 +1234,10 @@ impl Default for ExecutorRegistry {
 mod tests {
     use super::*;
     use crate::hooks::config::HookMode;
+    // #1937 — production spawns now route through `crate::spawn_audit`, so
+    // `Command` is no longer referenced in non-test module code; the unit
+    // tests below that spawn real subprocesses import it directly.
+    use tokio::process::Command;
 
     fn cfg(mode: HookMode) -> HookConfig {
         HookConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,6 +723,11 @@ pub mod routines;
 pub mod signals;
 pub mod signed_events;
 pub mod sizes;
+// v1.0.0 V08-PE-3 (#1937) — MINIMAL signed spawn-audit chokepoint: exactly one
+// signed `process.spawn_audited` row per production `Command` spawn (argv0 +
+// caller), routing every production subprocess launch through one audited
+// helper so a new un-audited spawn site fails the CI gate.
+pub mod spawn_audit;
 pub mod subscriptions;
 pub mod synthesis;
 pub mod tls;

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -358,6 +358,26 @@ pub mod event_types {
     /// refused vendor — this row is the audit witness of that refusal.
     pub const EGRESS_INFERENCE_REFUSED: &str = "egress.inference_refused";
 
+    /// v1.0.0 V08-PE-3 (#1937, ratified spec — the `4d3ea1c5` minimal
+    /// shape recorded in #1840's closing 2×5 vote) —
+    /// `signed_events.event_type` for a MINIMAL signed spawn-audit row:
+    /// exactly ONE row per PRODUCTION `Command` spawn, emitted by the
+    /// [`crate::spawn_audit`] chokepoint the moment a production spawn
+    /// site launches a subprocess. `payload_hash` = SHA-256 over the
+    /// canonical, secret-free pre-image
+    /// [`crate::spawn_audit::spawn_audit_preimage`] carrying ONLY
+    /// `argv0` (the spawned program) + `caller` (the spawn-site
+    /// identity) — never the full argv, which may carry secrets.
+    /// Substrate-emitted (`daemon_signed` when an audit key is enrolled,
+    /// else `unsigned`), the same posture as [`EGRESS_INFERENCE_REFUSED`]
+    /// / [`REFLECTION_DECORRELATION_REFUSED`]. Chained + walked +
+    /// verified by [`verify_audit_trail`] as a FIRST-CLASS signed event
+    /// like every other row (the chain walk is event-type-agnostic, so a
+    /// spawn row participates in the same cross-row hash chain + per-row
+    /// signature verdict). The substrate attests its OWN spawns — this is
+    /// deliberately NOT eBPF / dtrace kernel process-tree tracing.
+    pub const PROCESS_SPAWN_AUDITED: &str = "process.spawn_audited";
+
     /// v1.0.0 G28 (#1838) — `signed_events.event_type` for a forbidden
     /// export-class refusal at an export boundary (forensic bundle,
     /// memory export). Emitted by

--- a/src/spawn_audit.rs
+++ b/src/spawn_audit.rs
@@ -200,6 +200,14 @@ pub fn emit_spawn_audit_best_effort(argv0: &str, caller: &str) {
     };
     match crate::db::open(db_path) {
         Ok(conn) => {
+            // #1937 — the spawn-audit is best-effort observability on the spawn
+            // HOT PATH; cap the WAL write-lock wait (default open path uses 5s,
+            // `storage::connection`) so a contended audit write can never add
+            // meaningful latency to — let alone block — the child spawn. On
+            // BUSY it errors fast and the WARN arm below records the miss; the
+            // spawn proceeds regardless (M-PANIC-IS-STOP: audit never gates a
+            // spawn).
+            let _ = conn.busy_timeout(std::time::Duration::from_millis(250));
             if let Err(e) = emit_spawn_audit(&conn, argv0, caller) {
                 tracing::warn!(
                     target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,

--- a/src/spawn_audit.rs
+++ b/src/spawn_audit.rs
@@ -1,0 +1,334 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 V08-PE-3 (#1937) — MINIMAL signed spawn-audit chokepoint.
+//!
+//! # Ratified spec (the `4d3ea1c5` minimal shape, #1840 closing 2×5 vote)
+//!
+//! Emit exactly **one** signed `signed_events`-table row (see
+//! [`crate::signed_events`]) per PRODUCTION `Command` spawn, carrying
+//! **`argv0` + `caller`**, by
+//! reusing the existing [`crate::signed_events::SignedEvent::with_daemon_signature`]
+//! idiom. Explicitly **NO eBPF / NO dtrace** — the substrate attests its OWN
+//! spawns, not the kernel's process tree. Claims-safe: v0.8/v0.9 advertise no
+//! subprocess-chain-visibility, so no shipped claim depends on this.
+//!
+//! # Chokepoint design (the anti-regression core)
+//!
+//! Every production subprocess launch routes through ONE audited helper
+//! ([`audited_command`] for `std::process::Command`, [`audited_tokio_command`]
+//! for the async `tokio::process::Command`). The helper emits the signed
+//! audit row (best-effort) and returns a ready-to-configure `Command`. A
+//! CI gate (`tests/spawn_audit_gate_1937.rs`) asserts NO raw `Command::new`
+//! escapes this module in production code — so a NEW un-audited spawn site
+//! fails CI. This makes the audit coverage future-proof: you cannot add a
+//! production spawn without either routing it through the chokepoint or
+//! tripping the gate.
+//!
+//! # Wired production spawn sites (#1937 acceptance item 1)
+//!
+//! | Site | Program | Caller const |
+//! |---|---|---|
+//! | `cli::helpers::auto_namespace` | `git` | [`CALLER_CLI_NAMESPACE_GIT`] |
+//! | `cli::doctor::nvidia_gpu_detected` | `nvidia-smi` | [`CALLER_CLI_DOCTOR_GPU`] |
+//! | `cli::wrap::build_command_for_strategy` | wrapped agent | [`CALLER_CLI_WRAP_AGENT`] |
+//! | `hooks::executor` exec path | hook command | [`CALLER_HOOK_EXEC`] |
+//! | `hooks::executor` daemon path | hook command | [`CALLER_HOOK_DAEMON`] |
+//!
+//! # Keyless-context handling (#1937 design guidance, M-PANIC-IS-STOP)
+//!
+//! Audit is best-effort OBSERVABILITY — it MUST NOT block or fail a spawn.
+//! The two soft-failure modes are handled gracefully, never by panic:
+//!
+//! - **No signing key** — [`crate::signed_events::SignedEvent::with_daemon_signature`]
+//!   already falls back to `attest_level = "unsigned"` + `signature: None`
+//!   when no daemon audit key is enrolled (the same posture as
+//!   `reflection.decorrelation_refused` / `egress.inference_refused`).
+//! - **No resolvable audit DB** — a spawn site (e.g. CLI `doctor` running
+//!   before the boot seed, or a unit test that never booted) has no seeded
+//!   audit DB path. [`emit_spawn_audit_best_effort`] then SKIPS with a trace
+//!   line and the spawn proceeds unaudited. The boot path
+//!   ([`crate::daemon_runtime::run`]) seeds the resolved DB path via
+//!   [`seed_spawn_audit_db_path`] so every serve / mcp / CLI subcommand
+//!   dispatch has a live audit target.
+//!
+//! # sqlite + postgres parity (#1937 acceptance item 4)
+//!
+//! The sqlite production emission opens a short-lived connection at the seeded
+//! DB path (mirroring the shipped #1963 `refuse_inference_egress_audited`
+//! precedent). The identical spawn-audit ROW shape persists + verifies on
+//! postgres via [`crate::store::postgres::PostgresStore::emit_spawn_audit`];
+//! both backends build the row from the SAME [`spawn_audit_payload_hash`]
+//! pre-image and the SAME `with_daemon_signature` idiom, and both walk it
+//! through their (K3-parity) `verify_audit_trail` twin.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::signed_events::{
+    SignedEvent, append_signed_event, event_types::PROCESS_SPAWN_AUDITED, payload_hash,
+};
+
+// ---------------------------------------------------------------------------
+// Caller-identity SSOT (M-DOCUMENTED-MAGIC). Each spawn site passes its own
+// stable `caller` slug so a downstream auditor can attribute a spawn row to
+// the exact production site without decoding argv. One const per site keeps
+// the strings out of the scattered call sites (pm-v3.1 no-literals discipline).
+// ---------------------------------------------------------------------------
+
+/// Caller slug for the `git remote get-url origin` spawn in
+/// [`crate::cli::helpers::auto_namespace`].
+pub const CALLER_CLI_NAMESPACE_GIT: &str = "cli::helpers::auto_namespace";
+
+/// Caller slug for the `nvidia-smi -L` GPU-detection spawn in
+/// `crate::cli::doctor::nvidia_gpu_detected`.
+pub const CALLER_CLI_DOCTOR_GPU: &str = "cli::doctor::nvidia_gpu_detected";
+
+/// Caller slug for the wrapped-agent spawn built in
+/// `crate::cli::wrap::build_command_for_strategy`.
+pub const CALLER_CLI_WRAP_AGENT: &str = "cli::wrap::build_command_for_strategy";
+
+/// Caller slug for the per-fire hook-command exec spawn in
+/// `crate::hooks::executor` (`ExecExecutor`).
+pub const CALLER_HOOK_EXEC: &str = "hooks::executor::exec_fire";
+
+/// Caller slug for the long-lived daemon-mode hook-command spawn in
+/// `crate::hooks::executor` (`DaemonExecutor`).
+pub const CALLER_HOOK_DAEMON: &str = "hooks::executor::daemon_connect";
+
+/// Field separator for the canonical spawn-audit pre-image. A single ASCII
+/// `|` mirrors the [`crate::egress::emit_inference_egress_refusal`] pre-image
+/// grammar; `argv0` / `caller` never contain a raw `|`-delimited structural
+/// ambiguity that matters because the auditor reads back the labelled fields,
+/// not a positional parse.
+const PREIMAGE_TAG: &str = "spawn-audit";
+
+/// Process-wide audit DB path, seeded once at boot by
+/// [`seed_spawn_audit_db_path`]. `None` until seeded (early boot / unit
+/// tests) → [`emit_spawn_audit_best_effort`] skips with a trace line.
+static SPAWN_AUDIT_DB_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Seed the process-wide audit DB path for the best-effort spawn-audit
+/// emission. Called once from the top-level CLI dispatch
+/// ([`crate::daemon_runtime::run`]) right after the effective DB path is
+/// resolved, so every serve / mcp / CLI subcommand has a live audit target
+/// before any production spawn fires. Idempotent — first writer wins
+/// (mirrors `crate::quotas::set_quota_defaults`); a later call is a silent
+/// no-op, which keeps re-entrant test harnesses from panicking.
+pub fn seed_spawn_audit_db_path(path: &Path) {
+    let _ = SPAWN_AUDIT_DB_PATH.set(path.to_path_buf());
+}
+
+/// The seeded audit DB path, or `None` when unseeded.
+#[must_use]
+fn audit_db_path() -> Option<&'static PathBuf> {
+    SPAWN_AUDIT_DB_PATH.get()
+}
+
+/// Canonical, secret-free pre-image bytes for a spawn-audit row.
+///
+/// Carries ONLY `argv0` (the spawned program) + `caller` (the spawn-site
+/// identity) — deliberately NOT the full argv, which can carry secrets
+/// (#1937 spec). Shared by the sqlite emitter and the postgres twin so both
+/// backends produce a byte-identical `payload_hash` (K3 parity).
+#[must_use]
+pub fn spawn_audit_preimage(argv0: &str, caller: &str) -> String {
+    format!("{PREIMAGE_TAG}|argv0={argv0}|caller={caller}")
+}
+
+/// SHA-256 `payload_hash` over [`spawn_audit_preimage`]. The single hashing
+/// site both backends call, so the postgres parity row and the sqlite
+/// production row commit to identical bytes.
+#[must_use]
+pub fn spawn_audit_payload_hash(argv0: &str, caller: &str) -> Vec<u8> {
+    payload_hash(spawn_audit_preimage(argv0, caller).as_bytes())
+}
+
+/// Lossy `argv0` for the audit pre-image + log lines. The spawned program is
+/// an `OsStr`; a non-UTF-8 program path is rendered with the standard lossy
+/// conversion (readability outweighs fidelity for an audit attribution — the
+/// governance wire-check matcher, not this row, is the load-bearing binary
+/// gate).
+fn argv0_lossy(program: &OsStr) -> String {
+    program.to_string_lossy().into_owned()
+}
+
+/// Build + append ONE signed `process.spawn_audited` row using an open
+/// sqlite connection. Reuses the `with_daemon_signature` idiom (daemon-signed
+/// when an audit key is enrolled, else `unsigned`); the sqlite append
+/// chokepoint ([`append_signed_event`]) re-signs the daemon row over the full
+/// identity tuple (#1925) exactly as for every other producer.
+///
+/// # Errors
+///
+/// Propagates the underlying [`append_signed_event`] error (typically a
+/// sqlite failure). Callers treat the emission as best-effort and WARN on
+/// error rather than failing the spawn (M-PANIC-IS-STOP: audit never blocks).
+pub fn emit_spawn_audit(conn: &Connection, argv0: &str, caller: &str) -> Result<()> {
+    let event = SignedEvent::with_daemon_signature(
+        spawn_audit_payload_hash(argv0, caller),
+        crate::identity::sentinels::DAEMON_PRINCIPAL.to_string(),
+        PROCESS_SPAWN_AUDITED.to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        None,
+    );
+    append_signed_event(conn, &event)
+}
+
+/// Best-effort audited emission for the spawn chokepoint, which holds a
+/// program name (not an open connection). Resolves the seeded audit DB path,
+/// opens a short-lived connection — mirroring
+/// [`crate::egress::refuse_inference_egress_audited`] — appends the signed
+/// row, and WARNs on any failure WITHOUT disturbing the spawn (the caller
+/// spawns the child regardless).
+///
+/// Keyless-context handling (M-PANIC-IS-STOP): an unseeded DB path (early
+/// boot / no-daemon unit test) SKIPS with a `debug` trace line — never a
+/// panic, never a blocked spawn.
+pub fn emit_spawn_audit_best_effort(argv0: &str, caller: &str) {
+    let Some(db_path) = audit_db_path() else {
+        tracing::debug!(
+            target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,
+            argv0, caller,
+            "spawn-audit skipped: no audit DB path seeded (pre-boot / no-daemon context)"
+        );
+        return;
+    };
+    match crate::db::open(db_path) {
+        Ok(conn) => {
+            if let Err(e) = emit_spawn_audit(&conn, argv0, caller) {
+                tracing::warn!(
+                    target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,
+                    argv0, caller,
+                    "spawn-audit row NOT recorded (append failed): {e}"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,
+                argv0, caller,
+                "spawn-audit row NOT recorded (db open failed): {e}"
+            );
+        }
+    }
+}
+
+/// THE production chokepoint for a `std::process::Command` spawn. Emits ONE
+/// best-effort signed `process.spawn_audited` row for `program` + `caller`,
+/// then returns a fresh `std::process::Command::new(program)` for the caller
+/// to configure (args / env / stdio) and spawn. Every production
+/// `std::process::Command` launch MUST route through here — the CI gate
+/// forbids a raw `Command::new` in production code outside this module.
+#[must_use]
+pub fn audited_command<S: AsRef<OsStr>>(program: S, caller: &str) -> std::process::Command {
+    emit_spawn_audit_best_effort(&argv0_lossy(program.as_ref()), caller);
+    std::process::Command::new(program)
+}
+
+/// THE production chokepoint for a `tokio::process::Command` spawn (the async
+/// hook executor path). Emits ONE best-effort signed `process.spawn_audited`
+/// row, then returns a fresh `tokio::process::Command::new(program)`. The
+/// returned command is built ONCE and re-`spawn()`-ed across the executor's
+/// transient-errno retry ladder, so the audit row is emitted exactly once per
+/// logical spawn (not per retry).
+#[must_use]
+pub fn audited_tokio_command<S: AsRef<OsStr>>(program: S, caller: &str) -> tokio::process::Command {
+    emit_spawn_audit_best_effort(&argv0_lossy(program.as_ref()), caller);
+    tokio::process::Command::new(program)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preimage_is_secret_free_and_labelled() {
+        let pre = spawn_audit_preimage("git", CALLER_CLI_NAMESPACE_GIT);
+        assert_eq!(
+            pre,
+            "spawn-audit|argv0=git|caller=cli::helpers::auto_namespace"
+        );
+        // argv0 + caller ONLY — the pre-image must never carry positional args.
+        assert!(
+            !pre.contains("--"),
+            "pre-image must not carry full argv: {pre}"
+        );
+    }
+
+    #[test]
+    fn payload_hash_is_stable_and_field_sensitive() {
+        let a = spawn_audit_payload_hash("git", CALLER_CLI_NAMESPACE_GIT);
+        let a2 = spawn_audit_payload_hash("git", CALLER_CLI_NAMESPACE_GIT);
+        let b = spawn_audit_payload_hash("nvidia-smi", CALLER_CLI_DOCTOR_GPU);
+        assert_eq!(a, a2, "same inputs → same hash");
+        assert_ne!(a, b, "distinct inputs → distinct hash");
+        assert_eq!(a.len(), 32, "SHA-256 is 32 bytes");
+    }
+
+    #[test]
+    fn caller_slugs_are_distinct() {
+        let slugs = [
+            CALLER_CLI_NAMESPACE_GIT,
+            CALLER_CLI_DOCTOR_GPU,
+            CALLER_CLI_WRAP_AGENT,
+            CALLER_HOOK_EXEC,
+            CALLER_HOOK_DAEMON,
+        ];
+        let mut sorted = slugs.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), slugs.len(), "caller slugs must be unique");
+    }
+
+    #[test]
+    fn best_effort_is_a_noop_without_a_seeded_db_path() {
+        // No DB seeded in this unit-test context → the best-effort emitter
+        // skips gracefully (never panics, M-PANIC-IS-STOP).
+        emit_spawn_audit_best_effort("git", CALLER_CLI_NAMESPACE_GIT);
+    }
+
+    #[test]
+    fn audited_command_returns_a_usable_command() {
+        // The chokepoint returns a configurable Command even with no audit
+        // target seeded; the spawn must never be blocked by the audit.
+        let mut cmd = audited_command("true", CALLER_CLI_NAMESPACE_GIT);
+        cmd.arg("--version");
+        let program = cmd.get_program().to_string_lossy().into_owned();
+        assert_eq!(program, "true");
+    }
+
+    #[test]
+    fn emit_writes_one_verifiable_row() {
+        let dir = tempfile::Builder::new()
+            .prefix("spawn-audit-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("audit.db");
+        {
+            let conn = crate::db::open(&path).expect("init db");
+            emit_spawn_audit(&conn, "git", CALLER_CLI_NAMESPACE_GIT).expect("emit");
+        }
+        let conn = crate::db::open(&path).expect("reopen");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+                [PROCESS_SPAWN_AUDITED],
+                |r| r.get(0),
+            )
+            .expect("count spawn rows");
+        assert_eq!(count, 1, "exactly one process.spawn_audited row expected");
+        // The row is a first-class member of the chain — verify_audit_trail
+        // walks it and reports a clean, intact chain.
+        let report = crate::signed_events::verify_audit_trail(&conn, None).expect("verify");
+        assert!(report.chain_intact, "chain must be intact: {report:?}");
+        assert_eq!(
+            report.total_events, 1,
+            "the spawn row is counted: {report:?}"
+        );
+    }
+}

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -9864,6 +9864,42 @@ impl PostgresStore {
             );
         }
     }
+
+    /// v1.0.0 V08-PE-3 (#1937) — append a signed `process.spawn_audited` row
+    /// to `signed_events` on the postgres backend (the backend-parity twin of
+    /// the sqlite `crate::spawn_audit::emit_spawn_audit`). Builds the row from
+    /// the SAME [`crate::spawn_audit::spawn_audit_payload_hash`] pre-image
+    /// (argv0 + caller, secret-free) and the SAME `with_daemon_signature`
+    /// idiom, so the row persists + verifies identically on both backends
+    /// (K3 parity). Best-effort: a failure is WARN-logged and swallowed — the
+    /// spawn is never blocked on the audit (M-PANIC-IS-STOP).
+    pub async fn emit_spawn_audit(&self, argv0: &str, caller: &str) {
+        let ts = Utc::now();
+        let event = crate::signed_events::SignedEvent::with_daemon_signature(
+            crate::spawn_audit::spawn_audit_payload_hash(argv0, caller),
+            crate::identity::sentinels::DAEMON_PRINCIPAL.to_string(),
+            crate::signed_events::event_types::PROCESS_SPAWN_AUDITED.to_string(),
+            ts.to_rfc3339(),
+            None,
+        );
+        let insert_row = PgSignedEventInsert {
+            id: &event.id,
+            agent_id: &event.agent_id,
+            event_type: &event.event_type,
+            payload_hash: &event.payload_hash,
+            signature: event.signature.as_deref(),
+            attest_level: &event.attest_level,
+            timestamp: ts,
+            cause_hash: None,
+        };
+        if let Err(e) = pg_append_signed_event_with_chain(&self.pool, insert_row).await {
+            tracing::warn!(
+                target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,
+                argv0, caller,
+                "failed to append process.spawn_audited audit row: {e}"
+            );
+        }
+    }
 }
 
 /// Caller-supplied fields for [`pg_append_signed_event_with_chain`].

--- a/tests/spawn_audit_gate_1937.rs
+++ b/tests/spawn_audit_gate_1937.rs
@@ -1,0 +1,318 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 V08-PE-3 (#1937) — the test-pinned GATE for the MINIMAL signed
+//! spawn-audit chokepoint (ratified spec: the `4d3ea1c5` minimal shape,
+//! #1840 closing 2×5 vote).
+//!
+//! # The anti-regression core (acceptance item 2)
+//!
+//! [`chokepoint_no_raw_command_new_in_production`] is a static gate: it walks
+//! every production line of `src/**/*.rs` (test modules + comments stripped)
+//! and asserts NO raw `Command::new(` escapes the ONE allowlisted chokepoint
+//! module `src/spawn_audit.rs`. A NEW un-audited production spawn site — a
+//! `std::process::Command::new` / `tokio::process::Command::new` added
+//! anywhere else — makes this test FAIL, so CI blocks it. This is designed to
+//! be non-tautological (M-TAUTOLOGICAL-TESTS): it does not hardcode the known
+//! site list, it asserts the structural invariant "all production spawns route
+//! through the audited helper", which a new spawn would violate by
+//! construction.
+//!
+//! [`every_known_production_site_routes_through_the_chokepoint`] complements
+//! the perma-ban with a POSITIVE enumeration: each of the five wired
+//! production spawn sites references the audited helper + its caller const, so
+//! a refactor that silently drops the audit from a site is also caught.
+//!
+//! # Real emission, verified as a first-class event (acceptance items 1 + 3)
+//!
+//! [`emit_is_a_first_class_verifiable_event`] appends a `process.spawn_audited`
+//! row and asserts `verify_audit_trail` walks + verifies it exactly like every
+//! other signed event. [`chokepoint_emits_via_seeded_db_path`] exercises the
+//! full `audited_command` path (best-effort emission via the seeded DB).
+//!
+//! # sqlite + postgres parity (acceptance item 4)
+//!
+//! The `postgres_parity` module (feature `sal-postgres`, `#[ignore]` unless
+//! `AI_MEMORY_TEST_POSTGRES_URL` is set) appends the identical spawn-audit row
+//! shape through `PostgresStore::emit_spawn_audit` and asserts the postgres
+//! `verify_audit_trail` twin walks + verifies it.
+
+use ai_memory::signed_events::{event_types::PROCESS_SPAWN_AUDITED, verify_audit_trail};
+use ai_memory::spawn_audit::{
+    self, CALLER_CLI_DOCTOR_GPU, CALLER_CLI_NAMESPACE_GIT, CALLER_CLI_WRAP_AGENT,
+    CALLER_HOOK_DAEMON, CALLER_HOOK_EXEC,
+};
+use std::path::{Path, PathBuf};
+
+/// The single allowlisted production module that may construct a raw
+/// `Command::new` — it IS the audited chokepoint.
+const CHOKEPOINT_REL_PATH: &str = "src/spawn_audit.rs";
+
+/// The spawn-constructor token the gate perma-bans outside the chokepoint.
+/// Matches both `std::process::Command::new` and `tokio::process::Command::new`
+/// (both spell the constructor `Command::new`).
+const SPAWN_CTOR_TOKEN: &str = "Command::new";
+
+fn repo_src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// Recursively collect every `.rs` file under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries =
+        std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Is this a comment / doc-comment / block-comment continuation line? Mirrors
+/// the production-vs-comment heuristic the `scripts/check-*.sh` gates use.
+fn is_comment_line(trimmed: &str) -> bool {
+    trimmed.starts_with("//")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("*/")
+}
+
+/// Scan a file's PRODUCTION lines (everything before the first `mod tests`,
+/// comments stripped) and return the 1-based line numbers that contain a raw
+/// spawn constructor.
+fn production_spawn_ctor_lines(path: &Path) -> Vec<usize> {
+    let src =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let mut hits = Vec::new();
+    for (idx, line) in src.lines().enumerate() {
+        let trimmed = line.trim_start();
+        // Stop at the unit-test module boundary — test spawns are exempt
+        // (they exercise real subprocesses and are not production paths).
+        if trimmed.starts_with("mod tests") || trimmed.starts_with("pub mod tests") {
+            break;
+        }
+        if is_comment_line(trimmed) {
+            continue;
+        }
+        if line.contains(SPAWN_CTOR_TOKEN) {
+            hits.push(idx + 1);
+        }
+    }
+    hits
+}
+
+#[test]
+fn chokepoint_no_raw_command_new_in_production() {
+    let src_dir = repo_src_dir();
+    let chokepoint = Path::new(env!("CARGO_MANIFEST_DIR")).join(CHOKEPOINT_REL_PATH);
+    let mut files = Vec::new();
+    collect_rs_files(&src_dir, &mut files);
+    assert!(
+        !files.is_empty(),
+        "expected to find .rs files under {}",
+        src_dir.display()
+    );
+
+    let mut violations: Vec<String> = Vec::new();
+    for path in &files {
+        if path == &chokepoint {
+            continue; // the audited chokepoint IS allowed to build a Command.
+        }
+        for line_no in production_spawn_ctor_lines(path) {
+            let rel = path.strip_prefix(&src_dir).unwrap_or(path);
+            violations.push(format!("src/{}:{line_no}", rel.display()));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1937 spawn-audit gate: raw `{SPAWN_CTOR_TOKEN}` found in production code OUTSIDE the \
+         audited chokepoint `{CHOKEPOINT_REL_PATH}`. Every production subprocess launch MUST go \
+         through `spawn_audit::audited_command` / `audited_tokio_command` so it emits a signed \
+         `process.spawn_audited` row. Offending site(s):\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+#[test]
+fn every_known_production_site_routes_through_the_chokepoint() {
+    // Positive enumeration: each wired production spawn site references the
+    // audited helper AND its caller const. Catches a refactor that silently
+    // drops the audit from a site (the perma-ban above only catches ADDING a
+    // raw spawn, not REMOVING an audited one).
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "src/cli/helpers.rs",
+            "audited_command",
+            "CALLER_CLI_NAMESPACE_GIT",
+        ),
+        (
+            "src/cli/doctor.rs",
+            "audited_command",
+            "CALLER_CLI_DOCTOR_GPU",
+        ),
+        (
+            "src/cli/wrap.rs",
+            "audited_command",
+            "CALLER_CLI_WRAP_AGENT",
+        ),
+        (
+            "src/hooks/executor.rs",
+            "audited_tokio_command",
+            "CALLER_HOOK_EXEC",
+        ),
+        (
+            "src/hooks/executor.rs",
+            "audited_tokio_command",
+            "CALLER_HOOK_DAEMON",
+        ),
+    ];
+    for (rel, helper, caller_const) in cases {
+        let src =
+            std::fs::read_to_string(root.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+        assert!(
+            src.contains(helper),
+            "{rel} must route its production spawn through `spawn_audit::{helper}`"
+        );
+        assert!(
+            src.contains(caller_const),
+            "{rel} must attribute its spawn via `spawn_audit::{caller_const}`"
+        );
+    }
+}
+
+fn fresh_db(label: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::Builder::new()
+        .prefix("spawn-audit-gate-")
+        .tempdir()
+        .expect("tempdir");
+    let path = dir.path().join(format!("{label}.db"));
+    drop(ai_memory::db::open(&path).expect("init db"));
+    (dir, path)
+}
+
+fn spawn_row_count(conn: &rusqlite::Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+        [PROCESS_SPAWN_AUDITED],
+        |r| r.get(0),
+    )
+    .expect("count spawn rows")
+}
+
+#[test]
+fn emit_is_a_first_class_verifiable_event() {
+    let (_dir, path) = fresh_db("emit");
+    {
+        let conn = ai_memory::db::open(&path).expect("open");
+        spawn_audit::emit_spawn_audit(&conn, "git", CALLER_CLI_NAMESPACE_GIT).expect("emit");
+    }
+    let conn = ai_memory::db::open(&path).expect("reopen");
+    assert_eq!(spawn_row_count(&conn), 1, "exactly one spawn-audit row");
+    // Item 3: verify_audit_trail walks + verifies the spawn row like any other.
+    let report = verify_audit_trail(&conn, None).expect("verify");
+    assert!(
+        report.chain_intact,
+        "chain intact with the spawn row: {report:?}"
+    );
+    assert!(report.is_clean(), "clean audit trail: {report:?}");
+    assert_eq!(report.total_events, 1, "the spawn row is counted");
+}
+
+#[test]
+fn chokepoint_emits_via_seeded_db_path() {
+    // Exercise the FULL production chokepoint path: seed the process-wide audit
+    // DB, then mint a Command via `audited_command` and confirm the best-effort
+    // emission landed a signed spawn row that verifies. This test is the ONLY
+    // seeder in this binary (the OnceLock is first-writer-wins), so the path is
+    // deterministic.
+    let (_dir, path) = fresh_db("seeded");
+    spawn_audit::seed_spawn_audit_db_path(&path);
+    let _cmd = spawn_audit::audited_command("true", CALLER_CLI_WRAP_AGENT);
+    let conn = ai_memory::db::open(&path).expect("reopen");
+    assert!(
+        spawn_row_count(&conn) >= 1,
+        "audited_command must emit at least one spawn-audit row via the seeded DB"
+    );
+    let report = verify_audit_trail(&conn, None).expect("verify");
+    assert!(report.chain_intact, "chain intact: {report:?}");
+}
+
+#[test]
+fn caller_slugs_are_stable_wire_values() {
+    // The caller slugs are persisted (via the payload_hash pre-image) and read
+    // by downstream auditors — pin their exact wire values so a rename is a
+    // conscious, reviewed change.
+    assert_eq!(CALLER_CLI_NAMESPACE_GIT, "cli::helpers::auto_namespace");
+    assert_eq!(CALLER_CLI_DOCTOR_GPU, "cli::doctor::nvidia_gpu_detected");
+    assert_eq!(
+        CALLER_CLI_WRAP_AGENT,
+        "cli::wrap::build_command_for_strategy"
+    );
+    assert_eq!(CALLER_HOOK_EXEC, "hooks::executor::exec_fire");
+    assert_eq!(CALLER_HOOK_DAEMON, "hooks::executor::daemon_connect");
+    assert_eq!(PROCESS_SPAWN_AUDITED, "process.spawn_audited");
+}
+
+#[cfg(feature = "sal-postgres")]
+mod postgres_parity {
+    use super::*;
+    use ai_memory::store::postgres::PostgresStore;
+
+    async fn live_pg() -> Option<PostgresStore> {
+        let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        match PostgresStore::connect(&url).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!("skip: postgres connect failed: {e}");
+                None
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL — live postgres"]
+    async fn pg_spawn_audit_row_persists_and_verifies() {
+        let Some(pg) = live_pg().await else {
+            return;
+        };
+        // Append the identical spawn-audit row shape through the postgres twin.
+        pg.emit_spawn_audit("git", CALLER_CLI_NAMESPACE_GIT).await;
+
+        // The row persisted with the parity payload_hash (same pre-image bytes
+        // as the sqlite emitter).
+        let want_hash = spawn_audit::spawn_audit_payload_hash("git", CALLER_CLI_NAMESPACE_GIT);
+        let row: Option<(String, Vec<u8>)> = sqlx::query_as(
+            "SELECT id, payload_hash FROM signed_events \
+             WHERE event_type = $1 AND payload_hash = $2 \
+             ORDER BY sequence DESC LIMIT 1",
+        )
+        .bind(PROCESS_SPAWN_AUDITED)
+        .bind(&want_hash)
+        .fetch_optional(pg.pool())
+        .await
+        .expect("query pg spawn row");
+        let (id, got_hash) = row.expect("a process.spawn_audited row must persist on postgres");
+        assert_eq!(got_hash, want_hash, "payload_hash parity with sqlite");
+
+        // The postgres verify_audit_trail twin walks + verifies it (K3 parity):
+        // a single freshly-appended spawn row keeps the chain intact.
+        let report = pg.verify_audit_trail(None).await.expect("pg verify");
+        assert!(
+            report.chain_intact,
+            "pg verify twin must keep the chain intact with the spawn row: {report:?}"
+        );
+
+        // Cleanup (append-only table; direct-SQL delete is the sanctioned
+        // test escape hatch, same as tests/audit_witness_truncation_1822.rs).
+        sqlx::query("DELETE FROM signed_events WHERE id = $1")
+            .bind(&id)
+            .execute(pg.pool())
+            .await
+            .ok();
+    }
+}


### PR DESCRIPTION
## #1937 V08-PE-3 — minimal signed spawn-audit hook

Implements the **ratified** spec (the `4d3ea1c5` minimal shape recorded in **#1840's closing 2×5 vote**, 2026-07-02): emit exactly **one** signed `signed_events` row per production `Command` spawn, carrying **argv0 + caller**, reusing the existing `SignedEvent::with_daemon_signature` idiom. **No eBPF / no dtrace** — the substrate attests its OWN spawns, not the kernel's process tree. Claims-safe (v0.8/v0.9 advertise no subprocess-chain-visibility).

This is the last code gate-blocker of the v1.0.0 GA epic.

### Acceptance mapping

**1 — every production `Command` spawn site emits a signed audit row.** Confirmed the prep set against HEAD `c5ffd39f` (fresh grep) and wired all five through the audited chokepoint:

| Site | Program | file:line (wired) |
|---|---|---|
| `cli::helpers::auto_namespace` | `git` | `src/cli/helpers.rs:64` |
| `cli::doctor::nvidia_gpu_detected` | `nvidia-smi` | `src/cli/doctor.rs:1281` |
| `cli::wrap::build_command_for_strategy` | wrapped agent | `src/cli/wrap.rs:295` |
| `hooks::executor` exec path | hook command | `src/hooks/executor.rs:702` |
| `hooks::executor` daemon path | hook command | `src/hooks/executor.rs:1061` |

The two `tokio::process::Command` sites build the audited command **once** (single emit) and re-`spawn()` it across the transient-errno retry ladder (`spawn()` is `&mut self`), so the row fires once per **logical** spawn, not per retry. Test-only `Command::new` sites (`wrap` 744-758, `executor` 1674-1757, under `mod tests`) are correctly excluded.

**2 — test-pinned GATE (anti-regression core).** `tests/spawn_audit_gate_1937.rs::chokepoint_no_raw_command_new_in_production` walks every production line of `src/**/*.rs` (test modules + comments stripped) and asserts **no raw `Command::new` escapes the one allowlisted chokepoint** `src/spawn_audit.rs`. A NEW un-audited production spawn fails CI by construction. It does not hardcode the site list (M-TAUTOLOGICAL-TESTS) — it asserts the structural invariant. Complemented by a positive per-site enumeration (catches *removing* an audit) and a real emit→`verify_audit_trail` test.

**3 — `verify-audit-trail` walks spawn rows as first-class events.** The `process.spawn_audited` event kind is added to the `signed_events::event_types` SSOT taxonomy (`src/signed_events.rs`). `verify_chain` (reused by `verify_audit_trail`, `src/signed_events.rs:1801`) is event-type-agnostic, so a spawn row participates in the same cross-row hash chain + per-row signature verdict as every other signed event — proven by `emit_is_a_first_class_verifiable_event`.

**4 — sqlite + postgres parity.** sqlite production emission opens a short-lived connection at the boot-seeded DB path (`daemon_runtime::run` → `spawn_audit::seed_spawn_audit_db_path`), mirroring the **shipped #1963 egress precedent** (`refuse_inference_egress_audited`). `PostgresStore::emit_spawn_audit` (`src/store/postgres.rs`) appends the **identical row shape** built from the SAME `spawn_audit_payload_hash` pre-image + `with_daemon_signature` idiom; the `AI_MEMORY_TEST_POSTGRES_URL`-gated `pg_spawn_audit_row_persists_and_verifies` asserts it persists + verifies through the postgres `verify_audit_trail` twin (K3 parity).

### Chokepoint / gate design

Every production subprocess launch routes through **one** helper in the new `src/spawn_audit.rs`: `audited_command` (std) / `audited_tokio_command` (tokio). Each emits the signed row (best-effort) then returns a ready-to-configure `Command`. Payload = **argv0 + caller only** — never the full argv (secret-safety, per spec). The gate makes coverage future-proof: you cannot add a production spawn without routing it through the chokepoint or tripping CI.

### Keyless-context handling (M-PANIC-IS-STOP)

Audit is best-effort observability and **never blocks or fails a spawn**:
- **No signing key** → `with_daemon_signature` already falls back to `attest_level="unsigned"`.
- **No seeded audit DB** (pre-boot / no-daemon unit test) → `emit_spawn_audit_best_effort` skips with a `debug` trace line and the spawn proceeds.

### Excluded / honest notes

- Production emission is the **sqlite path** (consistent with the shipped #1963 egress audit, also sqlite-only in production). Postgres **row-shape parity** (persist+verify) is delivered via `PostgresStore::emit_spawn_audit` + the gated pg test; wiring the postgres-serve hooks-executor to call the SAL method (the deep spawn sites carry no store handle) is the only residual and is out of the ratified minimal scope.

### Verification (targeted battery — DISK-PROHIBITIVE discipline, never the full suite)

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --features sal -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy --features sal-postgres --test spawn_audit_gate_1937 -- -D warnings -D clippy::pedantic` — clean
- `cargo check --examples` — clean
- `cargo test --lib --features sal spawn_audit` — 6/6
- `cargo test --test spawn_audit_gate_1937 --features sal` — 5/5
- `cargo test --lib --features sal hooks::executor::tests` — 36/36; `--test hooks_executor_test` — 20/20 (real-subprocess retry path)
- `cargo test --lib --features sal cli::wrap::tests` — 20/20
- `scripts/check-hardcoded-literals.sh` / `check-vendor-literals.sh` / `check-const-name-literals.sh` — all PASS

CI (the 3× Check(os) + Per-Module + Postgres gates) is the full verifier.

Ratified spec: **5-agent vote (4d3ea1c5)** via #1840. Do not merge — Fable audits + merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY