### PR TITLE
fix(#1838): unify export confidentiality boundary across all 3 egress paths (Gate-3 GA-blocker)

### DIFF
--- a/src/cli/io.rs
+++ b/src/cli/io.rs
@@ -112,6 +112,20 @@ pub fn export(db_path: &Path, out: &mut CliOutput<'_>) -> Result<()> {
     use crate::models::field_names;
     let conn = db::open(db_path)?;
     let memories = db::export_all(&conn)?;
+    // v1.0.0 Gate-3 (#1838/G28 + #1844) — unify the export confidentiality
+    // boundary with the HTTP admin sibling (`handlers::admin::export_memories`).
+    // This CLI path is the documented operator backup surface
+    // (`ai-memory export > backup.json`) and historically serialized every row
+    // VERBATIM — bypassing BOTH the fail-closed forbidden-class gate and the
+    // secret screen — so a PEM private key / `threshold_share` /
+    // `operator_signing_key` / `metadata.embedding_class="biometric"` /
+    // metadata- or title-stashed credential rode the export in the clear.
+    // Screen BEFORE the pretty-print (drop forbidden-class rows + emit the
+    // signed `export.forbidden_class_refused` audit row via the local conn,
+    // and mask credential VALUES in content/title/tags/metadata); the surviving
+    // rows keep the #1944 in-band scope markers below and stdout stays valid
+    // JSON.
+    let memories = crate::export_taxonomy::screen_memories_for_export(memories, Some(&conn));
     let links = db::export_links(&conn)?;
     // In-band, additive, non-breaking scope markers (critical: the stderr
     // WARN below is invisible to a pipe-to-file consumer).

--- a/src/export_taxonomy.rs
+++ b/src/export_taxonomy.rs
@@ -386,6 +386,73 @@ pub fn screen_export_value_audited(
     Some(class)
 }
 
+/// Unified export-egress screen for a corpus of memory ROWS — the single
+/// SSOT the CLI `export`, the HTTP admin `export_memories`, and (row-wise)
+/// the forensic bundle share so the three egress paths cannot drift (M2:
+/// three parallel egress paths previously gated inconsistently). Applies
+/// BOTH guards the confidentiality invariant requires, per row, in THIS
+/// order (order is load-bearing — see below):
+///
+/// 1. **Forbidden-class drop** ([`classify_memory`], #1838/G28): a row that
+///    classifies into a [`ForbiddenExportClass`] (private-key material /
+///    master-threshold secret / governance signing key / producer-tagged
+///    biometric embedding) is DROPPED — never emitted in the clear — and a
+///    signed `export.forbidden_class_refused` row is emitted when
+///    `audit_conn` is `Some` (the sqlite path holds the audit handle; the
+///    postgres SAL path passes `None` and WARN-only skips the audit row — the
+///    DROP itself always holds). This runs on the UN-redacted row and is
+///    INDEPENDENT of the secret-screen mode, so the fail-closed drop cannot be
+///    softened into a mere mask by the secret screen having already redacted a
+///    PEM block out of `content` (which would otherwise flip a `DROP + audit`
+///    into a silent `keep-redacted`, weakening the pre-existing HTTP gate).
+/// 2. **Secret redaction** ([`crate::secret_screen::redact_memory_for_storage`]),
+///    on the SURVIVORS only: masks credential VALUES (AWS `AKIA…` / GitHub
+///    `ghp_` / OpenAI `sk-` / xAI `xai-` keys, `Bearer` tokens, JWTs) in
+///    EVERY cleartext-indexed field — `content`, `title`, `tags`, and
+///    non-carve-out `metadata` string leaves — so a credential stashed in a
+///    metadata field or the title is masked too, not just one in `content`
+///    (#1844). No-op unless screening was seeded non-`off`.
+#[must_use]
+pub fn screen_memories_for_export(
+    memories: Vec<crate::models::Memory>,
+    audit_conn: Option<&Connection>,
+) -> Vec<crate::models::Memory> {
+    memories
+        .into_iter()
+        .filter_map(|m| {
+            // (1) forbidden-class fail-closed drop (+ signed refusal, #1838).
+            if let Some(class) = classify_memory(&m) {
+                let path = format!("memories/{}.json", m.id);
+                let reason = format!(
+                    "export refused: memory classified {} ({}) — dropped from export artifact",
+                    class.as_str(),
+                    class.description()
+                );
+                if let Some(conn) = audit_conn {
+                    if let Err(e) = emit_export_refusal(
+                        conn,
+                        class,
+                        &path,
+                        crate::identity::sentinels::DAEMON_PRINCIPAL,
+                        &reason,
+                    ) {
+                        tracing::warn!(
+                            "forbidden-export-class signed refusal NOT recorded for {path}: {e}"
+                        );
+                    }
+                }
+                tracing::warn!(
+                    "export boundary dropped a {} memory — {path} withheld fail-closed",
+                    class.as_str()
+                );
+                return None;
+            }
+            // (2) secret-screen the survivor: content + title + tags + metadata.
+            Some(crate::secret_screen::redact_memory_for_storage(&m).unwrap_or(m))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/forensic/bundle.rs
+++ b/src/forensic/bundle.rs
@@ -441,6 +441,38 @@ pub fn build_files(
     };
     for mid in &memory_ids_to_emit {
         if let Some(mem) = crate::db::get(conn, mid).context("db::get for bundle")? {
+            let path = format!("memories/{}.json", mem.id);
+            // v1.0.0 G28 (#1838) — forbidden-export-class gate (fail-closed),
+            // FIRST + on the UN-redacted row so a class hit is always a DROP
+            // (never softened to a mask by the secret screen redacting a PEM
+            // block out first), unified with the CLI + HTTP export siblings.
+            // A whole envelope whose content/metadata classifies as private
+            // key material / master-threshold secret / governance signing key
+            // / a producer-tagged biometric embedding is SKIPPED (never
+            // bundled in the clear) and a signed refusal is emitted.
+            // Structurally these live in the key-dir, not the DB, so a hit
+            // means a mis-stored secret rode a memory row.
+            let record = serde_json::to_value(&mem).unwrap_or(serde_json::Value::Null);
+            if crate::export_taxonomy::screen_export_value_audited(
+                conn,
+                &path,
+                crate::identity::sentinels::DAEMON_PRINCIPAL,
+                &record,
+            )
+            .is_some()
+            {
+                continue;
+            }
+            // v0.8.1 W1.3 (#1821 / gap G29) → v1.0.0 Gate-3 (#1844) — egress
+            // credential screen (defense-in-depth) on the SURVIVOR. A secret
+            // that PRE-DATES the write screen must not leak through a forensic
+            // export; mask credential VALUES on the way out across EVERY
+            // cleartext field — `content` AND `title` AND `tags` AND
+            // non-carve-out `metadata` leaves — not `content` alone (the
+            // pre-#1844 gap that cloned title/metadata verbatim). One
+            // `redact_memory_for_storage` call = the same helper the CLI/HTTP
+            // corpus screen uses. No-op unless screening was seeded non-`off`.
+            let mem = crate::secret_screen::redact_memory_for_storage(&mem).unwrap_or(mem);
             let atomisation = if args.include_atomisation_chain {
                 build_atomisation_envelope(conn, &mem)?
             } else {
@@ -450,12 +482,7 @@ pub fn build_files(
                 id: mem.id.clone(),
                 namespace: mem.namespace.clone(),
                 title: mem.title.clone(),
-                // v0.8.1 W1.3 (#1821 / gap G29) — egress credential screen
-                // (defense-in-depth). A secret that PRE-DATES the write screen
-                // must not leak through a forensic export; mask it on the way
-                // out. No-op unless screening was seeded non-`off`.
-                content: crate::secret_screen::redact_for_storage(&mem.content)
-                    .unwrap_or_else(|| mem.content.clone()),
+                content: mem.content.clone(),
                 tier: mem.tier.as_str().to_string(),
                 memory_kind: format!("{:?}", mem.memory_kind).to_ascii_lowercase(),
                 reflection_depth: mem.reflection_depth,
@@ -479,27 +506,6 @@ pub fn build_files(
                 confidence_decayed_at: mem.confidence_decayed_at.clone(),
             };
             let bytes = serde_json::to_vec_pretty(&env).context("serialise MemoryEnvelope")?;
-            let path = format!("memories/{}.json", mem.id);
-            // v1.0.0 G28 (#1838) — forbidden-export-class gate (fail-closed).
-            // The secret-screen above masks CREDENTIAL content; this class
-            // gate refuses a whole envelope whose content/metadata is
-            // classified private key material / master-threshold secret /
-            // governance signing key / a producer-tagged biometric embedding.
-            // Structurally these live in the key-dir, not the DB, so a hit
-            // means a mis-stored secret rode a memory row — it is SKIPPED
-            // (never bundled in the clear) and a signed refusal is emitted.
-            let record = serde_json::from_slice::<serde_json::Value>(&bytes)
-                .unwrap_or_else(|_| serde_json::json!(null));
-            if crate::export_taxonomy::screen_export_value_audited(
-                conn,
-                &path,
-                crate::identity::sentinels::DAEMON_PRINCIPAL,
-                &record,
-            )
-            .is_some()
-            {
-                continue;
-            }
             files.insert(path, bytes);
         }
     }

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -610,8 +610,12 @@ pub async fn run_gc(State(app): State<AppState>, headers: HeaderMap) -> impl Int
     }
 }
 
-/// v1.0.0 G28 (#1838) — fail-closed forbidden-export-class filter for the
-/// corpus-export egress. Drops any memory whose serialized row is classified
+/// v1.0.0 G28 (#1838) + Gate-3 unification (#1844) — the corpus-export egress
+/// screen. Thin delegator to the shared SSOT
+/// [`crate::export_taxonomy::screen_memories_for_export`] so the HTTP admin
+/// export, the CLI `export`, and the forensic bundle apply the SAME two
+/// guards and cannot drift: (1) secret-screen content/title/tags/metadata
+/// credential VALUES (#1844), then (2) fail-closed DROP any memory classified
 /// into a [`crate::export_taxonomy::ForbiddenExportClass`] (private key
 /// material / master-threshold secret / governance signing key / a
 /// producer-tagged biometric embedding) so it never leaves in the clear.
@@ -623,38 +627,7 @@ fn screen_exported_memories(
     memories: Vec<crate::models::Memory>,
     audit_conn: Option<&rusqlite::Connection>,
 ) -> Vec<crate::models::Memory> {
-    memories
-        .into_iter()
-        .filter(|m| {
-            let Some(class) = crate::export_taxonomy::classify_memory(m) else {
-                return true;
-            };
-            let path = format!("memories/{}.json", m.id);
-            let reason = format!(
-                "export refused: memory classified {} ({}) — dropped from export artifact",
-                class.as_str(),
-                class.description()
-            );
-            if let Some(conn) = audit_conn {
-                if let Err(e) = crate::export_taxonomy::emit_export_refusal(
-                    conn,
-                    class,
-                    &path,
-                    crate::identity::sentinels::DAEMON_PRINCIPAL,
-                    &reason,
-                ) {
-                    tracing::warn!(
-                        "forbidden-export-class signed refusal NOT recorded for {path}: {e}"
-                    );
-                }
-            }
-            tracing::warn!(
-                "export boundary dropped a {} memory — {path} withheld fail-closed",
-                class.as_str()
-            );
-            false
-        })
-        .collect()
+    crate::export_taxonomy::screen_memories_for_export(memories, audit_conn)
 }
 
 pub async fn export_memories(State(app): State<AppState>, headers: HeaderMap) -> impl IntoResponse {

--- a/tests/gate3_export_boundary.rs
+++ b/tests/gate3_export_boundary.rs
@@ -1,0 +1,374 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 Gate-3 (#1838/G28 + #1844) — export/egress confidentiality-boundary
+//! regression pins.
+//!
+//! The confidentiality invariant: forbidden export CLASSES (private-key
+//! material, master/threshold secrets, policy-rule signing keys,
+//! biometric/behavioral embeddings) plus raw credential VALUES must NEVER
+//! cross an export boundary in the clear. This suite pins that invariant on
+//! all THREE egress paths that were previously gated inconsistently:
+//!
+//!   1. the shared SSOT `export_taxonomy::screen_memories_for_export`, which
+//!      the CLI `export` (`cli::io::export`) and the HTTP admin export
+//!      (`handlers::admin::export_memories`) both delegate to;
+//!   2. the CLI `export` command end-to-end (the documented
+//!      `ai-memory export > backup.json` operator-backup path — the
+//!      GA-blocker: it previously bypassed the gate entirely); and
+//!   3. the forensic bundle (`forensic::bundle::build_files`).
+//!
+//! Everything lives under `mod tests` so the repo's hardcoded-literal /
+//! vendor-literal CI gates treat the fixtures as test code.
+
+#[cfg(test)]
+mod tests {
+    use ai_memory::db;
+    use ai_memory::export_taxonomy::screen_memories_for_export;
+    use ai_memory::models::field_names;
+    use ai_memory::models::{Memory, Tier};
+    use ai_memory::secret_screen::{SecretScreenMode, set_screen_mode};
+    use ai_memory::signed_events::event_types::EXPORT_FORBIDDEN_CLASS_REFUSED;
+    use rusqlite::params;
+    use serde_json::Value;
+
+    // A canonical AWS access-key-id example (a raw credential VALUE the
+    // secret-screen `AKIA…` detector fires on). Defined once so the literal
+    // never repeats across sites.
+    const AWS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+    // A mis-stored PEM private key (forbidden CLASS = private-key material).
+    const PEM_CONTENT: &str = "leaked:\n-----BEGIN OPENSSH PRIVATE KEY-----\nAAAA\n-----END";
+    // The redaction placeholder the secret-screen substitutes for a hit.
+    const REDACTED: &str = "REDACTED";
+
+    /// Seed the process-wide screen mode to `Redact` so the credential-VALUE
+    /// screen is active (idempotent — `OnceLock` first-writer-wins; every test
+    /// in this binary wants `Redact`).
+    fn seed_redact() {
+        set_screen_mode(SecretScreenMode::Redact);
+    }
+
+    /// Build an insertable, non-expiring (`long`-tier) memory.
+    fn memory(id: &str, title: &str, content: &str, metadata: Value) -> Memory {
+        Memory {
+            id: id.to_string(),
+            namespace: "gate3".to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            tier: Tier::Long,
+            expires_at: None,
+            metadata,
+            ..Memory::default()
+        }
+    }
+
+    fn refusal_count(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+            params![EXPORT_FORBIDDEN_CLASS_REFUSED],
+            |r| r.get(0),
+        )
+        .expect("count refusal rows")
+    }
+
+    // ── Path 1 — the shared SSOT (CLI + HTTP both delegate here) ──────────
+
+    #[test]
+    fn helper_drops_every_forbidden_class_and_emits_signed_refusals() {
+        seed_redact();
+        let conn = db::open(std::path::Path::new(":memory:")).expect("open");
+
+        let corpus = vec![
+            memory("clean-1", "standup", "an ordinary note", Value::Null),
+            // (a) PEM private-key material in content.
+            memory("pem", "t", PEM_CONTENT, Value::Null),
+            // (b) producer-tagged biometric embedding.
+            memory(
+                "bio",
+                "t",
+                "c",
+                serde_json::json!({"embedding_class": "biometric"}),
+            ),
+            // (c) a threshold / Shamir key share (field-name marker).
+            memory(
+                "thr",
+                "t",
+                "c",
+                serde_json::json!({"threshold_share": "1-abc"}),
+            ),
+            // (d) the governance rule private signing key (field-name marker).
+            memory(
+                "gov",
+                "t",
+                "c",
+                serde_json::json!({"operator_signing_key": "AAAA"}),
+            ),
+            memory("clean-2", "retro", "another ordinary note", Value::Null),
+        ];
+
+        let kept = screen_memories_for_export(corpus, Some(&conn));
+
+        // Only the two clean rows survive; each of the four forbidden rows is
+        // dropped fail-closed and witnessed by exactly one signed refusal.
+        let kept_ids: Vec<&str> = kept.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(kept.len(), 2, "kept: {kept_ids:?}");
+        assert!(kept_ids.contains(&"clean-1") && kept_ids.contains(&"clean-2"));
+        assert!(
+            !kept_ids
+                .iter()
+                .any(|id| ["pem", "bio", "thr", "gov"].contains(id)),
+            "no forbidden-class row may survive: {kept_ids:?}"
+        );
+        assert_eq!(
+            refusal_count(&conn),
+            4,
+            "one signed export.forbidden_class_refused per dropped forbidden row"
+        );
+    }
+
+    #[test]
+    fn helper_redacts_credential_value_in_title_and_metadata_not_just_content() {
+        seed_redact();
+        // A clean-CLASS row (no forbidden class) that nonetheless stashes a raw
+        // credential VALUE in its title AND a nested metadata field — the #1844
+        // gap where the screen historically masked `content` alone.
+        let row = memory(
+            "cred",
+            AWS_KEY,
+            "body has one too: {AWS_KEY}",
+            serde_json::json!({"note": AWS_KEY, "nested": {"deep": AWS_KEY}}),
+        );
+        let out = screen_memories_for_export(vec![row], None);
+        assert_eq!(out.len(), 1, "a clean-class row must survive (redacted)");
+        let m = &out[0];
+
+        // The verbatim credential must appear in NONE of title / metadata.
+        assert!(
+            !m.title.contains(AWS_KEY),
+            "title still verbatim: {}",
+            m.title
+        );
+        let meta = serde_json::to_string(&m.metadata).unwrap();
+        assert!(!meta.contains(AWS_KEY), "metadata still verbatim: {meta}");
+        // And it was actually masked (not merely dropped from the fields).
+        assert!(
+            m.title.contains(REDACTED),
+            "title not redacted: {}",
+            m.title
+        );
+        assert!(meta.contains(REDACTED), "metadata not redacted: {meta}");
+    }
+
+    #[test]
+    fn helper_passes_a_clean_row_through_unchanged() {
+        seed_redact();
+        let row = memory(
+            "ok",
+            "clean title",
+            "clean body",
+            serde_json::json!({"k": "v"}),
+        );
+        let out = screen_memories_for_export(vec![row.clone()], None);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].title, row.title);
+        assert_eq!(out[0].content, row.content);
+        assert_eq!(out[0].metadata, row.metadata);
+    }
+
+    // ── Path 2 — the CLI `export` command end-to-end (the GA-blocker) ─────
+
+    /// Drive `cli::io::export` against a file-backed DB and capture stdout.
+    fn run_cli_export(db_path: &std::path::Path) -> String {
+        let mut stdout = Vec::<u8>::new();
+        let mut stderr = Vec::<u8>::new();
+        {
+            let mut out = ai_memory::cli::CliOutput::from_std(&mut stdout, &mut stderr);
+            ai_memory::cli::io::export(db_path, &mut out).expect("cli export");
+        }
+        String::from_utf8(stdout).expect("stdout is utf8")
+    }
+
+    #[test]
+    fn cli_export_drops_forbidden_class_keeps_clean_and_preserves_1944_markers() {
+        seed_redact();
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join("g3.db");
+        {
+            let conn = db::open(&dbp).expect("open");
+            db::insert(&conn, &memory("keep", "meeting", "ordinary", Value::Null))
+                .expect("insert clean");
+            // A biometric-tagged row survives the write funnel (the tag is not a
+            // credential VALUE) — so the EXPORT gate is what must drop it.
+            db::insert(
+                &conn,
+                &memory(
+                    "bio",
+                    "t",
+                    "c",
+                    serde_json::json!({"embedding_class": "biometric"}),
+                ),
+            )
+            .expect("insert biometric");
+        }
+
+        let stdout = run_cli_export(&dbp);
+        // stdout MUST be valid JSON (a piped `export > backup.json` stays parseable).
+        let v: Value = serde_json::from_str(stdout.trim()).expect("stdout is valid JSON");
+
+        // Forbidden row dropped; clean row present; count reflects survivors.
+        let mems = v["memories"].as_array().expect("memories array");
+        let ids: Vec<&str> = mems.iter().filter_map(|m| m["id"].as_str()).collect();
+        assert!(ids.contains(&"keep"), "clean row must export: {ids:?}");
+        assert!(
+            !ids.contains(&"bio"),
+            "biometric row must be dropped: {ids:?}"
+        );
+        assert_eq!(
+            v["count"].as_u64(),
+            Some(1),
+            "count is post-screen survivors"
+        );
+
+        // #1944 in-band scope markers must remain intact (do NOT regress them).
+        assert!(v[field_names::EXPORTED_AT].is_string());
+        assert_eq!(
+            v[field_names::EXPORT_SCOPE].as_str(),
+            Some(ai_memory::export_scope::SCOPE_MEMORIES_LINKS)
+        );
+        assert_eq!(
+            v[field_names::PORTABILITY_COMPLETE].as_bool(),
+            Some(ai_memory::export_scope::PORTABILITY_COMPLETE)
+        );
+        assert!(
+            v[field_names::EXCLUDES].is_array(),
+            "excludes marker present"
+        );
+    }
+
+    #[test]
+    fn cli_export_redacts_a_pre_screen_credential_in_title_and_metadata() {
+        seed_redact();
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join("g3c.db");
+        {
+            let conn = db::open(&dbp).expect("open");
+            db::insert(
+                &conn,
+                &memory("legacy", "clean", "clean", serde_json::json!({"k": "v"})),
+            )
+            .expect("insert");
+            // Inject a verbatim credential via a RAW UPDATE (bypasses the write
+            // screen) to simulate a row that PRE-DATES the screen. Only the
+            // EXPORT-time screen can catch it now.
+            conn.execute(
+                "UPDATE memories SET title = ?1, metadata = json_set(metadata, '$.note', ?2) WHERE id = 'legacy'",
+                params![AWS_KEY, AWS_KEY],
+            )
+            .expect("raw update inject");
+        }
+
+        let stdout = run_cli_export(&dbp);
+        assert!(
+            !stdout.contains(AWS_KEY),
+            "CLI export leaked a verbatim credential in title/metadata"
+        );
+        let v: Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+        let m = &v["memories"].as_array().unwrap()[0];
+        assert!(m["title"].as_str().unwrap().contains(REDACTED));
+        assert!(m["metadata"]["note"].as_str().unwrap().contains(REDACTED));
+    }
+
+    // ── Path 3 — the forensic bundle ─────────────────────────────────────
+
+    fn bundle_args(memory_id: &str) -> ai_memory::forensic::bundle::ExportForensicBundleArgs {
+        ai_memory::forensic::bundle::ExportForensicBundleArgs {
+            memory_id: memory_id.to_string(),
+            include_reflections: false,
+            include_transcripts: false,
+            output: None,
+            include_atomisation_chain: false,
+        }
+    }
+
+    #[test]
+    fn forensic_bundle_drops_forbidden_class_and_emits_refusal() {
+        seed_redact();
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join("g3f.db");
+        let conn = db::open(&dbp).expect("open");
+        db::insert(
+            &conn,
+            &memory(
+                "bio",
+                "t",
+                "c",
+                serde_json::json!({"embedding_class": "biometric"}),
+            ),
+        )
+        .expect("insert biometric");
+
+        let files = ai_memory::forensic::bundle::build_files(
+            &conn,
+            &bundle_args("bio"),
+            Some("2026-01-01T00:00:00Z"),
+        )
+        .expect("build_files");
+
+        // The forbidden row's envelope must NOT be in the bundle, and a signed
+        // refusal must witness the drop.
+        assert!(
+            !files.contains_key("memories/bio.json"),
+            "biometric envelope must not be bundled: {:?}",
+            files.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(refusal_count(&conn), 1, "one signed refusal for the drop");
+    }
+
+    #[test]
+    fn forensic_bundle_redacts_a_pre_screen_credential_in_title_and_metadata() {
+        seed_redact();
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join("g3fr.db");
+        let conn = db::open(&dbp).expect("open");
+        db::insert(
+            &conn,
+            &memory(
+                "legacy",
+                "clean",
+                "clean body",
+                serde_json::json!({"k": "v"}),
+            ),
+        )
+        .expect("insert");
+        // Simulate a pre-screen row via a raw UPDATE (bypasses the write screen).
+        conn.execute(
+            "UPDATE memories SET title = ?1, metadata = json_set(metadata, '$.note', ?2) WHERE id = 'legacy'",
+            params![AWS_KEY, AWS_KEY],
+        )
+        .expect("raw update inject");
+
+        let files = ai_memory::forensic::bundle::build_files(
+            &conn,
+            &bundle_args("legacy"),
+            Some("2026-01-01T00:00:00Z"),
+        )
+        .expect("build_files");
+
+        let bytes = files
+            .get("memories/legacy.json")
+            .expect("clean-class envelope must be bundled (redacted)");
+        let env: Value = serde_json::from_slice(bytes).expect("envelope JSON");
+        // Verbatim credential must be masked across title AND metadata.
+        assert!(
+            !env["title"].as_str().unwrap().contains(AWS_KEY),
+            "forensic bundle leaked a verbatim credential in title"
+        );
+        let meta = serde_json::to_string(&env["metadata"]).unwrap();
+        assert!(
+            !meta.contains(AWS_KEY),
+            "forensic bundle leaked a verbatim credential in metadata"
+        );
+        assert!(env["title"].as_str().unwrap().contains(REDACTED));
+        assert!(meta.contains(REDACTED));
+    }
+}


### PR DESCRIPTION
## Gate-3 GA-blocker — export/egress confidentiality boundary

Closes a **GA-blocker** surfaced by the Gate-3 review (workflow `wicgs16et`): the #1838/G28 forbidden-export-class gate and the #1844 credential screen were enforced **inconsistently** across the three DB egress paths. The review flagged the M2 complexity-tax pattern — *three parallel egress paths, gate on two*. This routes all three through one SSOT so the confidentiality invariant actually holds everywhere.

**The invariant:** forbidden export classes (private-key material, master/threshold secrets, policy-rule signing keys, biometric/behavioral embeddings) plus raw credential VALUES must NEVER cross an export boundary in the clear.

### Finding 1 — GA-BLOCKER (CLI export bypassed the gate entirely)
`cli::io::export` (`src/cli/io.rs`) serialized `db::export_all` **verbatim** — invoking NEITHER the forbidden-class gate NOR the secret screen. A row carrying a PEM private key / `threshold_share` / `operator_signing_key` / `metadata.embedding_class="biometric"` / a metadata- or title-stashed credential rode the documented `ai-memory export > backup.json` operator-backup path in the clear.

### Finding 5 — same-class should-fix (screens masked `content` only)
The forensic bundle masked `content` (`src/forensic/bundle.rs`) but cloned `title`/`metadata` verbatim; the HTTP path did not secret-screen at all.

### Before → after, per path
| Path | Before | After |
|---|---|---|
| CLI `export` (`src/cli/io.rs:110`) | **no class gate, no secret screen** (verbatim) | class-drop + signed refusal + secret-screen content/title/tags/metadata, before pretty-print; #1944 markers intact; stdout valid JSON |
| HTTP `export_memories` (`src/handlers/admin.rs:622`) | class-drop only (**no secret screen**) | class-drop **+ secret-screen** (delegates to shared helper); drop semantics unchanged |
| Forensic bundle (`src/forensic/bundle.rs:442`) | class-gate + `content`-only mask | class-gate + **whole-survivor** redact (content+title+tags+metadata) |

### Shared helper (M2)
`export_taxonomy::screen_memories_for_export` (`src/export_taxonomy.rs`) — the single SSOT the CLI + HTTP paths delegate to (forensic reuses the same `redact_memory_for_storage`). **Order is load-bearing:** CLASSIFY first (fail-closed DROP + signed `export.forbidden_class_refused`, independent of screen mode), THEN secret-screen survivors — so the drop can never be softened into a mask by the screen redacting a PEM out of `content` first. This does **not** weaken the HTTP path or the #1944 markers.

### File:line of each change
- `src/export_taxonomy.rs` — new `screen_memories_for_export` shared helper.
- `src/handlers/admin.rs:622` — `screen_exported_memories` now delegates to the helper (adds redaction).
- `src/cli/io.rs:110` — `export` screens before serialization (the GA-blocker fix).
- `src/forensic/bundle.rs:442` — class-gate first (un-redacted row) then whole-survivor redact.

### Tests
`tests/gate3_export_boundary.rs` (7 tests, non-tautological) — per egress path: forbidden-CLASS drop + signed refusal; raw credential VALUE in title+metadata redacted (raw-`UPDATE`-injected pre-screen rows to isolate export-time redaction); clean row unchanged; CLI stdout stays valid JSON with #1944 markers intact.

Verified locally: `cargo fmt --check`; `cargo clippy --all-targets --features sal -- -D warnings -D clippy::pedantic` (clean); `cargo check --examples`; new test (7/7) + existing `export_taxonomy` (14) / admin `g28_export_screen` (4) / `forensic::bundle` (40) / `cli::io` export (3) unit tests all green; `check-vendor-literals.sh` + `check-hardcoded-literals.sh` PASS. **CI is the full verifier.**

Do not merge — Fable audits + merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY