### PR TITLE
fix(gate3): land 6 should-fix cleanups pre-GA (#2007)

### DIFF
--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -177,8 +177,11 @@ pub enum IdentityAction {
     /// `recover-prepare`), assemble the collected guardian attestations, and
     /// persist it — verifying the M-of-N quorum against the enrolled
     /// guardian set (`AI_MEMORY_RECOVERY_GUARDIAN_PUBKEYS` /
-    /// `AI_MEMORY_RECOVERY_THRESHOLD`) + the optional dead-man window BEFORE
-    /// any write. On success the fresh key is the new authoritative head.
+    /// `AI_MEMORY_RECOVERY_THRESHOLD`) + the committed trust bar in the signed
+    /// record body, ordered by `not_before` anti-rollback monotonicity, BEFORE
+    /// any write. There is NO wall-clock / liveness / dead-man silence-window
+    /// gate (that time-windowed resolution is deferred to a future release).
+    /// On success the fresh key is the new authoritative head.
     Recover {
         /// Agent identifier whose identity is being recovered.
         #[arg(long)]

--- a/src/curator/decorrelation_probe.rs
+++ b/src/curator/decorrelation_probe.rs
@@ -11,30 +11,29 @@
 //! model-family-distinct quorum that REFUSES a bias-displaced reflection unless
 //! N≥3 attestation-passing, model-family-DISTINCT reflections agree.
 //!
-//! ## Why this module is VISIBILITY-only (not enforcement)
+//! ## Why THIS module is VISIBILITY-only (enforcement lives at the write gate)
 //!
-//! The 5-agent adversarial vote (memory `4d3ea1c5`; synthesis `4a5c041f`) found
-//! unanimously that the full N≥3 REFUSAL cannot honestly ship at v0.8.0:
+//! This module is the background `curator --reflect` corpus sweep. It is
+//! deliberately read-only and never refuses — it surfaces CLAIMED producer
+//! dominance for operator visibility, carrying a first-class caveat that
+//! distinctness measured HERE is CLAIMED, not ATTESTED (`agent_id`/`source`/
+//! `metadata` free strings).
 //!
-//! * There is **no model-family provenance primitive** — a reflection's only
-//!   producer signals (`agent_id`, `source`, `metadata`) are caller-CLAIMED
-//!   free strings, and the attestation surface binds an Ed25519 signature to an
-//!   AGENT IDENTITY, never to a model family (#1719 / #1171 are unbuilt).
-//! * At present single-operator swarm scale there is typically ONE model family,
-//!   so an N≥3-distinct REFUSE default would either brick every reflection write
-//!   (self-DOS) or — worse — stamp a false "decorrelated" badge on a monoculture
-//!   (the very laundering vector the audit fears: security theater).
-//!
-//! So the v0.8.0 slice ships the **honest** increment: make the EXISTING latent
-//! producer-correlation in the Reflection corpus *visible* (what an auditor
-//! actually wants from a pre-enforcement substrate), carrying a first-class
-//! caveat that distinctness here is CLAIMED, not ATTESTED. The binding write-time
-//! REFUSAL is a separate, tracked v0.9 issue gated on attested model-family
-//! provenance (#1719) + the heterogeneous evaluator panel (#1171).
+//! The binding write-time N≥3 attested-model-family REFUSAL is a SEPARATE,
+//! SHIPPED surface: `db::run_decorrelation_write_gate` (sqlite) /
+//! `PostgresStore::decorrelation_write_gate_pg` (postgres), added in #1767 and
+//! backed by the `model_attestations` provenance substrate (#1870). The refusal
+//! fires ONLY on ATTESTED evidence (attested rows `>= MIN_REFLECTIONS_FLOOR`
+//! AND distinct attested families `< quorum_n`), so a CLAIMED-only corpus is
+//! never laundered into a "decorrelated" badge NOR weaponized into a refusal
+//! (anti-theater — the 5-agent finding, memory `4d3ea1c5`). This sweep and the
+//! write gate share the pure decision core ([`evaluate_write_quorum`] /
+//! [`decorrelation_write_action`]) so their attested-family semantics never drift.
 //!
 //! Read-only and `sal`-gated (operates through the [`MemoryStore`] trait, SQLite
-//! *or* Postgres). Opt-in via `AI_MEMORY_REFLECT_DECORRELATION_MODE` (default
-//! `off`) at the CLI wiring layer (`src/cli/curator.rs`).
+//! *or* Postgres). `AI_MEMORY_REFLECT_DECORRELATION_MODE` compiled default is
+//! `advisory` at v1.0.0 (#1952 flipped it Off→Advisory), wired at the CLI layer
+//! (`src/cli/curator.rs`).
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -285,11 +284,14 @@ pub enum WriteGateAction {
 /// v0.9.0 §25.3 S2 (D3-021, #1767) — PURE mapping from
 /// `(mode, outcome)` to the write-gate action. The ONLY outcome an
 /// `enforce` mode refuses on is [`QuorumOutcome::AttestedMonoculture`]
-/// (attested evidence of monoculture); a CLAIMED-only / below-floor
-/// corpus ([`QuorumOutcome::InsufficientAttested`]) is advised, never
-/// refused (anti-theater). `total_reflections` is the full corpus size
-/// (attested + claimed) reported in the advisory payload for honest
-/// coverage.
+/// (attested evidence of monoculture); a below-floor corpus
+/// ([`QuorumOutcome::InsufficientAttested`]) is NEVER refused (anti-theater).
+/// A zero-attestation corpus (the common posture) yields
+/// [`WriteGateAction::Proceed`] SILENTLY — a per-write advisory on every
+/// reflection write would be pure noise with no decorrelation signal (#2007);
+/// only a partial below-floor attested corpus (`attested_rows > 0`) is advised.
+/// `total_reflections` is the full corpus size (attested + claimed) reported in
+/// the advisory payload for honest coverage.
 #[must_use]
 pub fn decorrelation_write_action(
     mode: crate::config::ReflectDecorrelationMode,
@@ -303,6 +305,15 @@ pub fn decorrelation_write_action(
     }
     match *outcome {
         QuorumOutcome::MeetsQuorum { .. } => WriteGateAction::Proceed,
+        // #2007 Gate-3 cleanup — in the DEFAULT zero-attestation posture (no
+        // `model_attestations` enrolled) EVERY reflection write would otherwise
+        // fire a per-write advisory WARN that carries no actual decorrelation
+        // signal (you cannot observe a monoculture without attestation). Stay
+        // SILENT when there is zero attested evidence (`obs-levels-filter`); only
+        // surface an advisory once SOME attested rows exist but the corpus is
+        // still below the floor (a genuine partial-attestation signal). The
+        // enforce-mode refusal path (`AttestedMonoculture`) is UNCHANGED.
+        QuorumOutcome::InsufficientAttested { attested_rows: 0 } => WriteGateAction::Proceed,
         QuorumOutcome::InsufficientAttested { attested_rows } => WriteGateAction::Advise(format!(
             "reflection decorrelation: only {attested_rows} ATTESTED of {total_reflections} \
              corpus reflections (quorum_n={quorum_n}); insufficient attested evidence — \
@@ -438,9 +449,12 @@ const PROBE_SCAN_LIMIT: usize = crate::storage::LIST_MAX_LIMIT;
 /// each corpus dominated past `threshold`.
 ///
 /// `mode` MUST be active ([`ReflectDecorrelationMode::is_active`]); `Off` returns
-/// an empty report. `Enforce` is INERT at v0.8.0 and runs as advisory (with a
-/// one-shot WARN) because binding REFUSAL needs attested provenance (v0.9
-/// #1719 / #1171). `agent_id` is the curator's identity (operator-class read so
+/// an empty report. This background sweep is VISIBILITY-only on EVERY active
+/// mode — under `Enforce` it still runs as advisory (with a one-shot WARN)
+/// because the binding write-time REFUSAL is enforced at the reflect WRITE
+/// chokepoint (`db::run_decorrelation_write_gate`, #1767, backed by the
+/// `model_attestations` substrate #1870), NOT in this read-only corpus sweep.
+/// `agent_id` is the curator's identity (operator-class read so
 /// the sweep sees every row regardless of `metadata.scope`, mirroring the
 /// reflection / transcript-classify passes).
 ///
@@ -474,10 +488,11 @@ pub async fn run_decorrelation_probe(
         report.enforce_degraded_to_advisory = true;
         tracing::warn!(
             target: TRACE_TARGET,
-            "AI_MEMORY_REFLECT_DECORRELATION_MODE=enforce is INERT at v0.8.0 — running \
-             ADVISORY. Write-time N≥3 model-family-distinct REFUSAL is gated on attested \
-             model-family provenance (v0.9 #1719/#1171); CLAIMED distinctness cannot bind \
-             a refusal without becoming security theater (5-agent vote 4d3ea1c5)."
+            "AI_MEMORY_REFLECT_DECORRELATION_MODE=enforce runs this background VISIBILITY \
+             sweep as ADVISORY — the binding write-time N>=3 attested-model-family REFUSAL is \
+             enforced at the reflect WRITE chokepoint (db::run_decorrelation_write_gate, #1767, \
+             backed by the model_attestations substrate #1870), NOT in this read-only corpus \
+             sweep, which only surfaces CLAIMED producer dominance for operator visibility."
         );
     }
 
@@ -606,6 +621,55 @@ mod tests {
         assert_eq!(
             out,
             QuorumOutcome::InsufficientAttested { attested_rows: 0 }
+        );
+    }
+
+    #[test]
+    fn zero_attested_advisory_proceeds_silently() {
+        // #2007 Gate-3 — the DEFAULT zero-attestation posture must NOT fire a
+        // per-write advisory WARN. Advisory mode + no attested evidence =
+        // Proceed (silent), NOT Advise.
+        use crate::config::ReflectDecorrelationMode as Mode;
+        let outcome = QuorumOutcome::InsufficientAttested { attested_rows: 0 };
+        assert_eq!(
+            decorrelation_write_action(Mode::Advisory, &outcome, 3, 42),
+            WriteGateAction::Proceed,
+            "zero attested rows must proceed silently (no per-write WARN)"
+        );
+    }
+
+    #[test]
+    fn partial_below_floor_attested_still_advises() {
+        // A genuine partial-attestation signal (some attested rows, still below
+        // the floor) is surfaced as an advisory — only the zero-attested common
+        // case is silenced.
+        use crate::config::ReflectDecorrelationMode as Mode;
+        let outcome = QuorumOutcome::InsufficientAttested { attested_rows: 2 };
+        assert!(
+            matches!(
+                decorrelation_write_action(Mode::Advisory, &outcome, 3, 42),
+                WriteGateAction::Advise(_)
+            ),
+            "partial attested evidence must still advise"
+        );
+    }
+
+    #[test]
+    fn enforce_still_refuses_attested_monoculture() {
+        // Guard the UNCHANGED enforce-mode refusal semantics through the #2007
+        // WARN-gating change.
+        use crate::config::ReflectDecorrelationMode as Mode;
+        let outcome = QuorumOutcome::AttestedMonoculture {
+            distinct_attested_families: 1,
+            attested_rows: 3,
+        };
+        assert_eq!(
+            decorrelation_write_action(Mode::Enforce, &outcome, 3, 3),
+            WriteGateAction::Refuse {
+                distinct_attested_families: 1,
+                attested_rows: 3,
+            },
+            "enforce mode must still refuse an attested monoculture"
         );
     }
 

--- a/src/handlers/federation_signing_check.rs
+++ b/src/handlers/federation_signing_check.rs
@@ -210,14 +210,50 @@ pub(super) async fn sync_push_via_store(
             bound_pubkey.as_deref(),
             crate::federation::receive_auth::require_write_sig_enabled(),
         ) {
-            tracing::warn!(
-                target: ATTESTATION_TRACE_TARGET,
-                memory_id = %to_insert.id,
-                attribute_agent = %attribute_agent,
-                sender = %body.sender_agent_id,
-                error = %e,
-                "sync_push (postgres): per-write content attestation failed; rejecting memory (#1464)"
-            );
+            // #1801→#1954 item 7 (postgres twin of `federation_receive.rs`) —
+            // split the generic AttestationRequired refusal into the SAME three
+            // actionable causes the sqlite path emits, so an operator gets a
+            // precise signal + the closed-set DLQ cause token. `bound_pubkey`
+            // was already hoisted above for the attestation lookup.
+            let has_write_sig = to_insert
+                .metadata
+                .get(crate::models::field_names::WRITE_SIGNATURE)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|s| !s.trim().is_empty());
+            if bound_pubkey.is_none() {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    memory_id = %to_insert.id,
+                    attribute_agent = %attribute_agent,
+                    sender = %body.sender_agent_id,
+                    cause = crate::federation::receive_auth::CAUSE_UNENROLLED_AUTHOR_STRICT,
+                    error = %e,
+                    "sync_push (postgres): honored third-party relay refused — ORIGIN author has no \
+                     locally-enrolled key to verify the propagated write_signature against; \
+                     enroll author {attribute_agent}'s Ed25519 key at this node (unenrolled_author_strict, #1464/#1801→#1954)"
+                );
+            } else if !has_write_sig {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    memory_id = %to_insert.id,
+                    attribute_agent = %attribute_agent,
+                    sender = %body.sender_agent_id,
+                    cause = "missing_signature",
+                    error = %e,
+                    "sync_push (postgres): honored third-party relay refused — no metadata.write_signature \
+                     present under the strict flip (author must EMIT the signature at store time, #1801→#1954)"
+                );
+            } else {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    memory_id = %to_insert.id,
+                    attribute_agent = %attribute_agent,
+                    sender = %body.sender_agent_id,
+                    cause = "forged_or_malformed",
+                    error = %e,
+                    "sync_push (postgres): per-write content attestation failed; rejecting memory (#1464)"
+                );
+            }
             skipped += 1;
             continue;
         }

--- a/src/spawn_audit.rs
+++ b/src/spawn_audit.rs
@@ -246,7 +246,23 @@ pub fn audited_command<S: AsRef<OsStr>>(program: S, caller: &str) -> std::proces
 /// logical spawn (not per retry).
 #[must_use]
 pub fn audited_tokio_command<S: AsRef<OsStr>>(program: S, caller: &str) -> tokio::process::Command {
-    emit_spawn_audit_best_effort(&argv0_lossy(program.as_ref()), caller);
+    // M4 / rust `M-BLOCKING-IN-ASYNC` / `async-spawn-blocking` (#2007): the
+    // best-effort emit opens a sqlite connection via `crate::db::open` — the full
+    // schema/migrate/rollback-check funnel, SYNCHRONOUS I/O. This chokepoint fires
+    // on the async hook-executor path (`hooks::executor`), so an inline emit would
+    // block a tokio worker per hook-fired spawn. Route the blocking open+append
+    // onto the blocking pool (fire-and-forget — the spawn NEVER waits;
+    // M-PANIC-IS-STOP: audit never gates a spawn). With no runtime present (a
+    // non-async caller / unit test) fall back to a synchronous emit so the
+    // seeded-path / no-key skip semantics are byte-identical either way.
+    let argv0 = argv0_lossy(program.as_ref());
+    let caller_owned = caller.to_string();
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn_blocking(move || emit_spawn_audit_best_effort(&argv0, &caller_owned));
+        }
+        Err(_) => emit_spawn_audit_best_effort(&argv0, &caller_owned),
+    }
     tokio::process::Command::new(program)
 }
 
@@ -308,6 +324,23 @@ mod tests {
         cmd.arg("--version");
         let program = cmd.get_program().to_string_lossy().into_owned();
         assert_eq!(program, "true");
+    }
+
+    #[tokio::test]
+    async fn tokio_chokepoint_returns_usable_command_off_reactor() {
+        // #2007 — inside a tokio runtime the audit emit is routed onto the
+        // blocking pool (the `Handle::try_current().Ok` arm), so the chokepoint
+        // returns a configurable Command WITHOUT running the synchronous
+        // `db::open` funnel on the reactor thread. No seeded audit DB here, so
+        // the off-reactor emit is itself a graceful no-op; the point is that the
+        // call returns a usable Command and never panics/blocks.
+        let mut cmd = audited_tokio_command("true", CALLER_HOOK_EXEC);
+        cmd.arg("--version");
+        let program = cmd.as_std().get_program().to_string_lossy().into_owned();
+        assert_eq!(program, "true");
+        // Yield so any spawned blocking task can run to completion (no assertion
+        // on its result — it is best-effort observability).
+        tokio::task::yield_now().await;
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10404,15 +10404,19 @@ pub fn prepare_recovery_challenge(
 /// [`prepare_recovery_challenge`]), assemble the collected M-of-N guardian
 /// attestations into the quorum blob, and persist it via
 /// [`append_lineage_record`] — which verifies the quorum against the
-/// env-enrolled guardian set (M-of-N) + the dead-man gate BEFORE anything
-/// is written. On success the fresh `successor_pubkey_b64` is the new head
-/// and the identity has survived key LOSS.
+/// env-enrolled guardian set (M-of-N) + the committed trust bar (threshold
+/// + guardian-set id, read from the SIGNED record body) BEFORE anything is
+/// written. Ordering is pure `not_before` anti-rollback monotonicity; there
+/// is NO wall-clock / liveness / dead-man silence-window check — that
+/// time-windowed resolution is deferred to a future release (see the
+/// honest-scope note in [`crate::identity::lineage`]). On success the fresh
+/// `successor_pubkey_b64` is the new head and the identity has survived key LOSS.
 ///
 /// # Errors
 /// No enrolled lineage, an undecodable key, a quorum that fails to meet the
-/// M-of-N threshold (or a forged / unenrolled / stale signature), a
-/// dead-man window not yet elapsed, or any [`append_lineage_record`]
-/// failure. Nothing is persisted on any failure.
+/// committed M-of-N threshold (or a forged / unenrolled / stale signature),
+/// a `not_before` that violates the anti-rollback ordering, or any
+/// [`append_lineage_record`] failure. Nothing is persisted on any failure.
 pub fn append_recovery(
     conn: &Connection,
     agent_id: &str,

--- a/src/storage/reflect.rs
+++ b/src/storage/reflect.rs
@@ -485,9 +485,10 @@ pub fn reflect_with_hooks(
 
     // ─── 5.6 Write-time attested-family decorrelation gate (§25.3 S2) ─
     //
-    // Compiled default OFF (G5b inert-until-enabled): when
-    // AI_MEMORY_REFLECT_DECORRELATION_MODE is unset/`off` this is an
-    // early return and the write is byte-identical. `advisory` warns;
+    // Compiled default ADVISORY at v1.0.0 (#1952 flipped Off->Advisory): ONLY
+    // an explicit AI_MEMORY_REFLECT_DECORRELATION_MODE=off early-returns
+    // byte-identical — an UNSET env now resolves ACTIVE (Advisory), so the gate
+    // runs. `advisory` WARNs only on an actual attested decorrelation signal;
     // `enforce` refuses ONLY on attested evidence (signed
     // `reflection.decorrelation_refused` row + DecorrelationRefused).
     run_decorrelation_write_gate(
@@ -832,10 +833,14 @@ const DECORRELATION_ADVISORY_TARGET: &str = "reflection.decorrelation.advisory";
 /// decorrelation gate, run at the sqlite reflect chokepoint BETWEEN
 /// validation/cap and the atomic insert.
 ///
-/// Posture (compiled default OFF — G5b inert-until-enabled):
-/// - `off` (default): early return; the write is byte-identical.
-/// - `advisory`: WARN (`reflection.decorrelation.advisory`) on an
-///   attested monoculture / insufficient attested evidence, then proceed.
+/// Posture (compiled default ADVISORY at v1.0.0 — #1952 flipped Off->Advisory;
+/// the postgres twin carries the matching "ADVISORY at v1.0.0" note):
+/// - `off`: early return; the write is byte-identical. This is the ONLY
+///   byte-identical posture — an UNSET env resolves to Advisory, not Off.
+/// - `advisory` (default): WARN (`reflection.decorrelation.advisory`) ONLY on
+///   an actual attested decorrelation signal (an attested monoculture, or a
+///   partial below-floor attested corpus). A zero-attestation corpus — the
+///   common deployment — is SILENT (no per-write WARN), then proceed.
 /// - `enforce`: REFUSE **only on attested evidence** (attested rows
 ///   `>= MIN_REFLECTIONS_FLOOR` AND distinct attested families
 ///   `< quorum_n`) with a signed `reflection.decorrelation_refused` row;
@@ -864,18 +869,25 @@ fn run_decorrelation_write_gate(
     }
     let quorum_n = crate::config::reflect_decorrelation_quorum_n();
 
-    // Direct namespace-scoped corpus read (NOT recall).
+    // Direct namespace-scoped corpus read (NOT recall). Bounded by the SSOT
+    // `crate::storage::LIST_MAX_LIMIT` (the same window the visibility probe's
+    // `PROBE_SCAN_LIMIT` reuses) so this per-write scan on the reflect hot path
+    // can never grow unbounded with the namespace's reflection count.
+    let scan_limit = i64::try_from(crate::storage::LIST_MAX_LIMIT).unwrap_or(i64::MAX);
     let mut corpus_attested: Vec<String> = Vec::new();
     let mut total_reflections: usize = 0;
     {
         let mut stmt = conn
             .prepare(
                 "SELECT metadata FROM memories \
-                 WHERE namespace = ?1 AND memory_kind = 'reflection'",
+                 WHERE namespace = ?1 AND memory_kind = 'reflection' \
+                 LIMIT ?2",
             )
             .map_err(|e| ReflectError::Database(e.to_string()))?;
         let rows = stmt
-            .query_map([target_namespace], |row| row.get::<_, String>(0))
+            .query_map((target_namespace, scan_limit), |row| {
+                row.get::<_, String>(0)
+            })
             .map_err(|e| ReflectError::Database(e.to_string()))?;
         for r in rows {
             let raw = r.map_err(|e| ReflectError::Database(e.to_string()))?;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -9390,7 +9390,8 @@ impl PostgresStore {
 
         // ─── 5.6 Write-time attested-family decorrelation gate (§25.3 S2) ─
         // Postgres twin of `db::run_decorrelation_write_gate`. Compiled
-        // default OFF (byte-identical when the mode is unset/`off`).
+        // default ADVISORY at v1.0.0 (#1952 flipped Off->Advisory) — ONLY an
+        // explicit mode=off is byte-identical; unset now resolves ACTIVE.
         self.decorrelation_write_gate_pg(
             &target_namespace,
             &input.metadata,
@@ -9729,12 +9730,18 @@ impl PostgresStore {
         }
         let quorum_n = crate::config::reflect_decorrelation_quorum_n();
 
-        // Direct namespace-scoped corpus read (NOT recall).
+        // Direct namespace-scoped corpus read (NOT recall). Bounded by the SSOT
+        // `crate::storage::LIST_MAX_LIMIT` (sqlite-twin parity — the same window
+        // the visibility probe's `PROBE_SCAN_LIMIT` reuses) so this per-write
+        // scan on the reflect hot path can never grow unbounded.
+        let scan_limit = i64::try_from(crate::storage::LIST_MAX_LIMIT).unwrap_or(i64::MAX);
         let rows: Vec<(serde_json::Value,)> = sqlx::query_as(
             "SELECT metadata FROM memories \
-             WHERE namespace = $1 AND memory_kind = 'reflection'",
+             WHERE namespace = $1 AND memory_kind = 'reflection' \
+             LIMIT $2",
         )
         .bind(target_namespace)
+        .bind(scan_limit)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| {
@@ -10571,10 +10578,16 @@ impl PostgresStore {
         let records = self.read_lineage(agent_id).await?;
         let witnesses = self.lineage_witness_hashes(agent_id).await?;
         let bound = self.agent_pubkey(agent_id).await?;
-        Ok(crate::identity::lineage::verify_lineage(
+        // v1.0.0 #1831 (G17) — recovery-aware resolution (K3 parity with the
+        // sqlite SSOT `crate::storage::verify_agent_lineage`): a head that
+        // arrived via a valid M-of-N guardian quorum must verify. `None`
+        // (no guardians enrolled) fail-closes any recovery record.
+        let recovery_policy = crate::identity::lineage::RecoveryPolicy::from_env();
+        Ok(crate::identity::lineage::verify_lineage_with_recovery(
             &records,
             &witnesses,
             bound.as_deref(),
+            recovery_policy.as_ref(),
         ))
     }
 
@@ -16452,13 +16465,10 @@ impl MemoryStore for PostgresStore {
                 record.agent_id
             )));
         }
-        if record.reason == LineageReason::Recovery {
-            return Err(invalid(
-                "recovery lineage records cannot be minted in v0.9.0 — the recovery \
-                 VERIFY path lands in v1.0"
-                    .to_string(),
-            ));
-        }
+        // v1.0.0 #1831 (G17) — recovery records ARE now mintable on postgres too
+        // (K3 parity with the sqlite SSOT `crate::storage::append_lineage_record`):
+        // authorized by an M-of-N guardian quorum (verified below via
+        // `verify_recovery_record`) instead of a single predecessor signature.
         // v1.0.0 #1949 — CODE refuse-guard: the OSS build STRUCTURALLY
         // REFUSES to mint any non-`software-file` custody class
         // (fail-closed BEFORE any write). Identical to the sqlite SSOT.
@@ -16500,15 +16510,35 @@ impl MemoryStore for PostgresStore {
                 }
             }
         }
-        // Never persist a record the walk would reject.
-        let predecessor =
-            crate::identity::keypair::decode_public_base64(&record.predecessor_pubkey_b64)
-                .map_err(|e| invalid(format!("lineage predecessor pubkey: {e:#}")))?;
-        verify_succession(record, signature, &predecessor).map_err(|e| {
-            invalid(format!(
-                "refusing to persist unverifiable lineage record: {e}"
-            ))
-        })?;
+        // Never persist a record the walk would reject. Recovery (#1831 G17) is
+        // authorized by the M-of-N guardian quorum (the stored `signature` blob
+        // is the CBOR quorum, NOT a single Ed25519 sig); every other reason is a
+        // single predecessor signature. Mirrors the sqlite SSOT branch.
+        if record.reason == LineageReason::Recovery {
+            let policy = crate::identity::lineage::RecoveryPolicy::from_env().ok_or_else(|| {
+                invalid(
+                    "cannot mint a recovery record — no recovery guardians enrolled \
+                     (set AI_MEMORY_RECOVERY_GUARDIAN_PUBKEYS)"
+                        .to_string(),
+                )
+            })?;
+            crate::identity::lineage::verify_recovery_record(record, signature, &policy).map_err(
+                |e| {
+                    invalid(format!(
+                        "refusing to persist unverifiable recovery record: {e}"
+                    ))
+                },
+            )?;
+        } else {
+            let predecessor =
+                crate::identity::keypair::decode_public_base64(&record.predecessor_pubkey_b64)
+                    .map_err(|e| invalid(format!("lineage predecessor pubkey: {e:#}")))?;
+            verify_succession(record, signature, &predecessor).map_err(|e| {
+                invalid(format!(
+                    "refusing to persist unverifiable lineage record: {e}"
+                ))
+            })?;
+        }
 
         let record_bytes = record
             .canonical_bytes()
@@ -16786,7 +16816,15 @@ impl MemoryStore for PostgresStore {
         }
         let witnesses = self.lineage_witness_hashes(agent_id).await?;
         let bound = self.agent_pubkey(agent_id).await?;
-        match crate::identity::lineage::verify_lineage(&records, &witnesses, bound.as_deref()) {
+        // v1.0.0 #1831 (G17) — recovery-aware resolution (K3 parity with the
+        // sqlite SSOT `crate::storage::current_authoritative_key`).
+        let recovery_policy = crate::identity::lineage::RecoveryPolicy::from_env();
+        match crate::identity::lineage::verify_lineage_with_recovery(
+            &records,
+            &witnesses,
+            bound.as_deref(),
+            recovery_policy.as_ref(),
+        ) {
             Ok(verified) => Ok(Some(crate::identity::lineage::pubkey_b64(
                 &verified.head_key,
             ))),

--- a/tests/cov_postgres_recovery.rs
+++ b/tests/cov_postgres_recovery.rs
@@ -1,0 +1,328 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 G17 (#1831 / #2007) — live-Postgres integration coverage for the
+//! M-of-N threshold key-RECOVERY mint + recovery-aware resolution on the
+//! Postgres SAL adapter.
+//!
+//! The pre-#2007 postgres `append_lineage_record` unconditionally REFUSED a
+//! `LineageReason::Recovery` mint ("cannot be minted in v0.9.0"), and
+//! `current_authoritative_key` used the recovery-BLIND `verify_lineage`. The
+//! Gate-3 cleanup (#2007) brought the postgres path to K3 parity with the
+//! sqlite SSOT (`crate::storage::{append_lineage_record,current_authoritative_key}`):
+//! the recovery branch verifies the M-of-N guardian quorum via
+//! `verify_recovery_record`, and resolution routes through
+//! `verify_lineage_with_recovery`. These tests exercise those exact new lines
+//! against a live Postgres backend (the existing pg lineage tests only cover
+//! genesis/rotation, so the recovery branch was uncovered → the Per-Module
+//! coverage floor regressed).
+//!
+//! Mirrors the sqlite twin `storage::tests::recovery_1831_ceremony_persists_and_verifies`
+//! + the negative arm in `tests/identity_lineage_succession.rs`.
+//!
+//! Gated on `AI_MEMORY_TEST_POSTGRES_URL`; self-skips cleanly when unset (the
+//! CI Per-Module coverage leg sets it, so the recovery lines are covered there).
+
+#![cfg(feature = "sal-postgres")]
+#![allow(clippy::missing_panics_doc, clippy::too_many_lines)]
+// The recovery-guardian env vars are process-global; hold the file-local lock
+// across the whole test body (incl. awaits) so a sibling test in this binary
+// can't flip them mid-ceremony. Each #[tokio::test] runs on its own runtime
+// thread, so holding the std Mutex across awaits merely serialises the file's
+// tests — which is the point.
+#![allow(clippy::await_holding_lock)]
+
+use std::sync::Mutex;
+
+use ed25519_dalek::Signer;
+
+use ai_memory::identity::keypair;
+use ai_memory::identity::lineage::{
+    LineageRecord, RECOVERY_GUARDIAN_PUBKEYS_ENV, RECOVERY_THRESHOLD_ENV, RecoveryAttestation,
+    encode_recovery_quorum, guardian_set_id_digest,
+};
+use ai_memory::identity::sign::sign_succession;
+use ai_memory::models::AgentRegistration;
+use ai_memory::store::postgres::PostgresStore;
+use ai_memory::store::{CallerContext, MemoryStore};
+
+/// Serialises this file's tests — the recovery-guardian env vars are global.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+async fn connect() -> Option<PostgresStore> {
+    let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+    Some(
+        PostgresStore::connect(&url)
+            .await
+            .expect("connect postgres"),
+    )
+}
+
+fn set_guardian_env(guardians: &[keypair::AgentKeypair], threshold: usize) {
+    let joined = guardians
+        .iter()
+        .map(keypair::AgentKeypair::public_base64)
+        .collect::<Vec<_>>()
+        .join(",");
+    // SAFETY: test-only env mutation, serialised by `env_guard()` above; each
+    // tokio::test owns its runtime thread so there is no concurrent reader.
+    unsafe {
+        std::env::set_var(RECOVERY_GUARDIAN_PUBKEYS_ENV, joined);
+        std::env::set_var(RECOVERY_THRESHOLD_ENV, threshold.to_string());
+    }
+}
+
+fn clear_guardian_env() {
+    // SAFETY: see `set_guardian_env`.
+    unsafe {
+        std::env::remove_var(RECOVERY_GUARDIAN_PUBKEYS_ENV);
+        std::env::remove_var(RECOVERY_THRESHOLD_ENV);
+    }
+}
+
+async fn register(store: &PostgresStore, ctx: &CallerContext, agent_id: &str) {
+    let reg = AgentRegistration {
+        agent_id: agent_id.to_string(),
+        agent_type: "nhi".to_string(),
+        capabilities: vec!["read".to_string(), "write".to_string()],
+        registered_at: chrono::Utc::now().to_rfc3339(),
+        last_seen_at: chrono::Utc::now().to_rfc3339(),
+    };
+    store
+        .register_agent(ctx, &reg)
+        .await
+        .expect("register agent");
+}
+
+/// Enroll a genesis record (epoch 0, self-signed by `k0`) through the postgres
+/// SAL `append_lineage_record` — the same funnel the recovery record uses —
+/// and return it so the recovery record can hash-link to the persisted head.
+async fn enroll_genesis(
+    store: &PostgresStore,
+    ctx: &CallerContext,
+    agent_id: &str,
+    k0: &keypair::AgentKeypair,
+    recovery_pub_b64: &str,
+) -> LineageRecord {
+    let genesis = LineageRecord::genesis(
+        agent_id,
+        &k0.public_base64(),
+        Some(recovery_pub_b64.to_string()),
+        "2026-07-10T00:00:00+00:00",
+    );
+    let sig = sign_succession(k0, &genesis.to_signable()).expect("sign genesis");
+    store
+        .append_lineage_record(ctx, agent_id, &genesis, &sig)
+        .await
+        .expect("enroll genesis on postgres");
+    genesis
+}
+
+/// A guardian's detached Ed25519 attestation over the recovery signing input.
+fn guardian_attest(recovery: &LineageRecord, g: &keypair::AgentKeypair) -> RecoveryAttestation {
+    let input = recovery.signing_input().expect("recovery signing input");
+    let sig = g
+        .private
+        .as_ref()
+        .expect("guardian keypair can sign")
+        .sign(&input);
+    RecoveryAttestation {
+        guardian_pubkey_b64: g.public_base64(),
+        signature: sig.to_bytes().to_vec(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path — a 2-of-3 guardian quorum mints a fresh head through the
+//    postgres recovery branch, and `current_authoritative_key` resolves it via
+//    `verify_lineage_with_recovery`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pg_recovery_mint_persists_and_resolves_authoritative_head() {
+    let Some(store) = connect().await else { return };
+    let _g = env_guard();
+
+    let agent_id = format!("ai:rec-{}", uuid::Uuid::new_v4());
+    let ctx = CallerContext::for_agent(&agent_id);
+    register(&store, &ctx, &agent_id).await;
+
+    let k0 = keypair::generate(&agent_id).expect("k0");
+    let cold = keypair::generate(&agent_id).expect("cold recovery key");
+    let genesis = enroll_genesis(&store, &ctx, &agent_id, &k0, &cold.public_base64()).await;
+
+    // K0 is LOST. Enroll 3 guardians (2-of-3) and mint a fresh head k_new.
+    let k_new = keypair::generate(&agent_id).expect("k_new");
+    let guardians: Vec<keypair::AgentKeypair> = (0..3)
+        .map(|_| keypair::generate("guardian").expect("guardian"))
+        .collect();
+    let gid = guardian_set_id_digest(&guardians.iter().map(|g| g.public).collect::<Vec<_>>());
+    set_guardian_env(&guardians, 2);
+
+    let recovery = LineageRecord::recovery(
+        &genesis,
+        &k_new.public_base64(),
+        None,
+        None,
+        gid,
+        2,
+        "2026-07-11T00:00:00+00:00",
+    )
+    .expect("recovery record");
+    let quorum = vec![
+        guardian_attest(&recovery, &guardians[0]),
+        guardian_attest(&recovery, &guardians[1]),
+    ];
+    let quorum_blob = encode_recovery_quorum(&quorum).expect("encode quorum");
+
+    // The pre-#2007 postgres path REFUSED this unconditionally; now it verifies
+    // the M-of-N quorum and persists.
+    store
+        .append_lineage_record(&ctx, &agent_id, &recovery, &quorum_blob)
+        .await
+        .expect("postgres recovery mint must persist the fresh head");
+
+    // Recovery-aware resolution (verify_lineage_with_recovery) resolves the
+    // fresh primary as the authoritative head.
+    let head = store
+        .current_authoritative_key(&agent_id)
+        .await
+        .expect("infra ok")
+        .expect("chain resolves to a head via the guardian quorum");
+    assert_eq!(
+        head,
+        k_new.public_base64(),
+        "postgres current_authoritative_key must resolve the recovered head"
+    );
+
+    // Also drive the lineage check inside `verify_audit_trail`, which routes
+    // through `verify_agent_lineage_pg` → the recovery-aware
+    // `verify_lineage_with_recovery` (#2007 parity). The recovery env is still
+    // set, so the enrolled recovered chain verifies rather than fail-closing.
+    // The shared test DB carries unrelated rows, so we assert only that the
+    // walk succeeds at the infra level (not a whole-chain verdict).
+    store
+        .verify_audit_trail(None)
+        .await
+        .expect("verify_audit_trail walks the recovery-aware lineage check");
+
+    clear_guardian_env();
+}
+
+// ---------------------------------------------------------------------------
+// 2. Fail-closed — a quorum of ONE (below the committed threshold of 2) is
+//    refused by `verify_recovery_record`; nothing persists.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pg_recovery_mint_below_threshold_is_refused() {
+    let Some(store) = connect().await else { return };
+    let _g = env_guard();
+
+    let agent_id = format!("ai:rec-under-{}", uuid::Uuid::new_v4());
+    let ctx = CallerContext::for_agent(&agent_id);
+    register(&store, &ctx, &agent_id).await;
+
+    let k0 = keypair::generate(&agent_id).expect("k0");
+    let cold = keypair::generate(&agent_id).expect("cold");
+    let genesis = enroll_genesis(&store, &ctx, &agent_id, &k0, &cold.public_base64()).await;
+
+    let k_new = keypair::generate(&agent_id).expect("k_new");
+    let guardians: Vec<keypair::AgentKeypair> = (0..3)
+        .map(|_| keypair::generate("guardian").expect("guardian"))
+        .collect();
+    let gid = guardian_set_id_digest(&guardians.iter().map(|g| g.public).collect::<Vec<_>>());
+    set_guardian_env(&guardians, 2);
+
+    let recovery = LineageRecord::recovery(
+        &genesis,
+        &k_new.public_base64(),
+        None,
+        None,
+        gid,
+        2, // committed threshold 2
+        "2026-07-11T00:00:00+00:00",
+    )
+    .expect("recovery record");
+    // Only ONE guardian signs — below the committed threshold.
+    let quorum = vec![guardian_attest(&recovery, &guardians[0])];
+    let quorum_blob = encode_recovery_quorum(&quorum).expect("encode quorum");
+
+    let err = store
+        .append_lineage_record(&ctx, &agent_id, &recovery, &quorum_blob)
+        .await
+        .expect_err("under-threshold quorum must be refused");
+    assert!(
+        err.to_string().contains("unverifiable recovery record"),
+        "expected the recovery-verify refusal, got: {err}"
+    );
+
+    // Nothing was persisted — the head is still unset (no rotation applied).
+    let head = store
+        .current_authoritative_key(&agent_id)
+        .await
+        .expect("infra ok");
+    assert_eq!(
+        head.as_deref(),
+        Some(k0.public_base64().as_str()),
+        "a refused recovery must leave the genesis head unchanged"
+    );
+
+    clear_guardian_env();
+}
+
+// ---------------------------------------------------------------------------
+// 3. Fail-closed — no guardians enrolled (RecoveryPolicy::from_env == None)
+//    refuses the mint before any signature check.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pg_recovery_mint_without_enrolled_guardians_is_refused() {
+    let Some(store) = connect().await else { return };
+    let _g = env_guard();
+    clear_guardian_env(); // ensure no policy resolvable
+
+    let agent_id = format!("ai:rec-noguard-{}", uuid::Uuid::new_v4());
+    let ctx = CallerContext::for_agent(&agent_id);
+    register(&store, &ctx, &agent_id).await;
+
+    let k0 = keypair::generate(&agent_id).expect("k0");
+    let cold = keypair::generate(&agent_id).expect("cold");
+    let genesis = enroll_genesis(&store, &ctx, &agent_id, &k0, &cold.public_base64()).await;
+
+    let k_new = keypair::generate(&agent_id).expect("k_new");
+    let guardians: Vec<keypair::AgentKeypair> = (0..3)
+        .map(|_| keypair::generate("guardian").expect("guardian"))
+        .collect();
+    let gid = guardian_set_id_digest(&guardians.iter().map(|g| g.public).collect::<Vec<_>>());
+    let recovery = LineageRecord::recovery(
+        &genesis,
+        &k_new.public_base64(),
+        None,
+        None,
+        gid,
+        2,
+        "2026-07-11T00:00:00+00:00",
+    )
+    .expect("recovery record");
+    let quorum = vec![
+        guardian_attest(&recovery, &guardians[0]),
+        guardian_attest(&recovery, &guardians[1]),
+    ];
+    let quorum_blob = encode_recovery_quorum(&quorum).expect("encode quorum");
+
+    let err = store
+        .append_lineage_record(&ctx, &agent_id, &recovery, &quorum_blob)
+        .await
+        .expect_err("no enrolled guardians must refuse the mint");
+    assert!(
+        err.to_string().contains("no recovery guardians enrolled"),
+        "expected the no-guardians refusal, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #2007

Lands the 6 confirmed should-fix/minor findings from the ai-memory Gate-3 security review (re-verified at HEAD `9b510d2c`), branched off `main`. None are GA-blockers; all are prime-directive real defects fixed for a clean v1.0.0 GA cut. CI is the gate — do not merge; Fable audits + merges.

## The 6 fixes (file:line, doc vs behavior)

| # | Fix | Site(s) | Class |
|---|-----|---------|-------|
| 1 | Reflect decorrelation: correct stale "default OFF / unset = byte-identical" docstrings to the v1.0.0 Advisory default (#1952); bound the per-write namespace corpus scan with the SSOT `LIST_MAX_LIMIT`; silence the per-write advisory WARN in the default zero-attestation posture | `src/storage/reflect.rs:~488`,`~835` (doc); `src/storage/reflect.rs:~873` scan (behavior); `src/curator/decorrelation_probe.rs` `decorrelation_write_action` WARN-gate (behavior) | doc + **behavior** |
| 2 | Visibility probe: correct module doc (`default off`) + `run_decorrelation_probe` doc/WARN that called the shipped write-time REFUSAL (#1767, backed by model_attestations #1870) "security theater / unbuilt provenance" | `src/curator/decorrelation_probe.rs:~4`,`~37`,`~440`,`~475` | doc |
| 3 | Recovery M-of-N: correct docstrings promising a "dead-man gate/window" that does not exist — the control is pure quorum + committed trust-bar + `not_before` anti-rollback ordering; note the liveness window is deferred | `src/storage/mod.rs:~10407`,`~10414`; `src/cli/identity.rs:~180` | doc |
| 4 | spawn_audit: route the synchronous `db::open`+append off the tokio reactor via `Handle::spawn_blocking` (sync fallback when no runtime); keeps best-effort / never-blocks-spawn + seeded-path/no-key skip | `src/spawn_audit.rs:~248` `audited_tokio_command` | **behavior** |
| 5 | Federation write-sig refusal (postgres SAL): mirror the sqlite twin's 3-way cause split (`unenrolled_author_strict`/`missing_signature`/`forged_or_malformed`) + `cause=` field + remediation | `src/handlers/federation_signing_check.rs:~213` | **behavior** (logging) |
| 6 | Postgres recovery-mint parity: drop the self-contradicting "cannot be minted in v0.9.0 — lands in v1.0" guard, route through `verify_recovery_record` (M-of-N) + switch `verify_agent_lineage_pg`/`current_authoritative_key` to `verify_lineage_with_recovery` — full parity with the sqlite SSOT (#1831) | `src/store/postgres.rs:~16455` (guard/verify), `~10574`,`~16789` (recovery-aware resolve) | doc + **behavior** |

Behavior changes: the scan-LIMIT bound (#1, both backends), the zero-attestation WARN-gate (#1, shared pure core), the `spawn_blocking` off-reactor route (#4), the postgres 3-way cause split (#5), and the postgres recovery-mint + recovery-aware resolution parity (#6). The rest is doc-only. Enforce-mode reflection refusal semantics are UNCHANGED; the federation refusal itself is unchanged (observability parity only).

## Commits
- `fix(reflect): bound decorrelation write-gate scan, silence zero-attestation WARN, correct posture docs` (#1, #2)
- `docs(identity): correct recovery M-of-N docstrings — no dead-man gate exists` (#3)
- `perf(spawn-audit): route best-effort db::open off the tokio reactor` (#4)
- `fix(postgres): sqlite-SSOT parity — federation cause-split, recovery-mint, decorrelation scan` (#5, #6, #1 pg-twin)

## Verification (all green, run locally against HEAD)
- `cargo fmt --check` — clean
- `cargo clippy --lib --features sal-postgres -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy --all-targets --features sal-postgres -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` (default) — clean
- `cargo check --examples` — clean
- `cargo test --lib --features sal-postgres decorrelation_probe::tests` — 19 passed (incl. 3 new: zero-attested silent proceed / partial advise / enforce still refuses)
- `cargo test --lib --features sal-postgres spawn_audit::tests` — 7 passed (incl. new off-reactor tokio test)
- `cargo test --test spawn_audit_gate_1937 --features sal-postgres` — 5 passed, 1 ignored (live-PG); #1937 gate not regressed
- `cargo test --lib --features sal-postgres lineage` — 59 passed
- `cargo test --lib --features sal-postgres recovery` — 16 passed (incl. sqlite recovery ceremony persists+verifies)
- `cargo test --lib --features sal-postgres federation_receive::tests` — 19 passed
- `cargo test --test decorrelation_enforce_s2 --features sal-postgres` — 1 passed (enforce refuses attested monoculture; off inert)
- Script gates: `check-docs-vs-ssot.sh`, `check-vendor-literals.sh`, `check-hardcoded-literals.sh`, `check-l3-boundary.sh` — all PASS

No hardcoded literals (scan bounds reuse the `LIST_MAX_LIMIT` SSOT; cause tokens reuse `CAUSE_UNENROLLED_AUTHOR_STRICT`). Postgres recovery-mint parity landed in full (no partial-string fallback needed). Live-postgres parity tests (`decorrelation_enforce_s2_pg`, `decorrelation_probe_postgres_parity`, `cov_postgres_lineage`) compile under `sal-postgres` and self-skip without `AI_MEMORY_TEST_POSTGRES_URL`; CI's live-PG leg is the authoritative verifier for the #5/#6 postgres paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
