### PR TITLE
fix(gate3): resolve 4 code-review findings (forensic fail-open, cause-token consts, reflect scan short-circuit, receive_auth rustdoc)

### DIFF
--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -252,6 +252,21 @@ pub const FED_REQUIRE_SIGNAL_SIG_DEFAULT: bool = true;
 /// manual substitute for the deferred TOFU key distribution.
 pub const CAUSE_UNENROLLED_AUTHOR_STRICT: &str = "unenrolled_author_strict";
 
+/// Closed-set attestation-refusal cause label: an HONORED third-party relay
+/// under the strict write-sig flip carried no `metadata.write_signature`.
+/// Observability-only (a `tracing` field, NOT matched by
+/// [`crate::federation::push_dlq::classify_quarantine_cause`]); the
+/// SSOT-shared sibling of [`CAUSE_UNENROLLED_AUTHOR_STRICT`] so the two
+/// receive twins (`federation_receive.rs` sqlite + `federation_signing_check.rs`
+/// postgres) cannot drift the token.
+pub const CAUSE_MISSING_SIGNATURE: &str = "missing_signature";
+
+/// Closed-set attestation-refusal cause label: a `write_signature` was present
+/// but failed verification (forged / malformed) against the enrolled key.
+/// Observability-only; SSOT-shared across the two receive twins (see
+/// [`CAUSE_MISSING_SIGNATURE`]).
+pub const CAUSE_FORGED_OR_MALFORMED: &str = "forged_or_malformed";
+
 /// Resolve a DATA-lane fed-sig requirement against its (flip-ready) default:
 ///
 /// - an explicit FALSY token (`0`/`false`/`no`/`off`, trimmed) is the
@@ -282,24 +297,22 @@ pub const REQUIRE_WRITE_SIG_ENV: &str = "AI_MEMORY_FED_REQUIRE_WRITE_SIG";
 /// Whether HONORED third-party relayed memory writes must carry a valid
 /// per-write content signature.
 ///
-/// **Default permissive (`false`)** per the #1464 5-agent vote (`4d3ea1c5`):
-/// a relayed memory is *data* (replication), not an authority-granting write,
-/// so it keeps the documented accept-and-flag posture — an unsigned relayed
-/// write lands `attest_level=claimed` rather than being refused (contrast the
-/// authority lane [`require_transition_sig_enabled`], default fail-closed).
-/// Defaulting this ON would self-DOS a heterogeneous mesh whose authors do
-/// not yet emit per-write signatures.
-///
-/// When the operator opts in (`1`/`true`/`yes`/`on`), a HONORED third-party
-/// relayed claim (`attribute_agent != sender`) without a valid signature is
-/// refused; self-authored relays (`attribute_agent == sender`, already gated
-/// by the #238 envelope attestation + #29 signature + #30 nonce + #43
-/// enrollment) stay faith-based. A *forged* signature is rejected
-/// unconditionally regardless of this knob (the [`crate::identity::verify::attest_write`]
-/// gate). Mirrors the pre-v0.9 secure-opt-in shape of
-/// `AI_MEMORY_REQUIRE_AGENT_ATTESTATION` (#48, the local-write sibling,
-/// whose store-path default flipped to required in v0.9 per #1751 — this
-/// federation knob deliberately keeps its own permissive opt-in default).
+/// **Default fail-closed (`true`)** as of the v1.0.0 flip
+/// ([`FED_REQUIRE_WRITE_SIG_DEFAULT`], #1801→#1954, 5-agent vote `w9mr01vi8`):
+/// federation inbound IS the network surface (ruling `9e9c3cf2` condition 7),
+/// so an UNSET env resolves STRICT (v0.10.0 shipped the one-cycle deprecation
+/// WARN via [`FED_REQUIRE_WRITE_SIG_FLIP_WARNING`]). Under the flip a HONORED
+/// third-party relayed claim (`attribute_agent != sender`) without a valid
+/// signature is refused; the staged-rollout opt-out
+/// `AI_MEMORY_FED_REQUIRE_WRITE_SIG=0` reverts to the permissive
+/// accept-and-flag posture (`attest_level=claimed`) during peer key-enrollment.
+/// Self-authored relays (`attribute_agent == sender`, already gated by the
+/// #238 envelope attestation + #29 signature + #30 nonce + #43 enrollment)
+/// stay faith-based, so the flip never bricks self-authored replication. A
+/// *forged* signature is rejected unconditionally regardless of this knob (the
+/// [`crate::identity::verify::attest_write`] gate). Contrast the authority lane
+/// [`require_transition_sig_enabled`] (also fail-closed); the signal sibling is
+/// [`require_signal_sig_enabled`].
 #[must_use]
 pub fn require_write_sig_enabled() -> bool {
     resolve_fed_sig_flag(REQUIRE_WRITE_SIG_ENV, FED_REQUIRE_WRITE_SIG_DEFAULT)
@@ -313,16 +326,16 @@ pub const REQUIRE_SIGNAL_SIG_ENV: &str = "AI_MEMORY_FED_REQUIRE_SIGNAL_SIG";
 /// Whether an inbound relayed signal must be cryptographically signed by its
 /// `from_agent`'s locally-**enrolled** key.
 ///
-/// **Default permissive (`false`)** per the #1843 5-agent vote (`4d3ea1c5`):
-/// a relayed signal is *data* (a message), not an authority-granting write, so
-/// it keeps the documented accept-and-flag posture (contrast the authority lane
-/// [`require_transition_sig_enabled`], default fail-closed). The always-on base
-/// gate (Layer 1, in the `/sync/push` signal loop) already binds `from_agent`
-/// to the enrolled peer's authorship allowlist under an enrolled posture;
-/// defaulting this ON would self-DOS a heterogeneous mesh whose signal authors
-/// are not yet key-enrolled locally.
+/// **Default fail-closed (`true`)** as of the v1.0.0 flip
+/// ([`FED_REQUIRE_SIGNAL_SIG_DEFAULT`], #1801→#1954 item 5): an UNSET env
+/// resolves STRICT and an explicit `=0`/falsy token is the staged-rollout
+/// opt-out during peer key-enrollment. The always-on base gate (Layer 1, in
+/// the `/sync/push` signal loop) already binds `from_agent` to the enrolled
+/// peer's authorship allowlist under an enrolled posture; this knob adds the
+/// per-signal enrolled-key verification. Contrast the authority lane
+/// [`require_transition_sig_enabled`] (also fail-closed).
 ///
-/// When the operator opts in (`1`/`true`/`yes`/`on`), an inbound signal is
+/// When enabled (the v1.0.0 default; or an explicit `1`/`true`/`yes`/`on`), an inbound signal is
 /// applied only when `signal.signature` verifies against `from_agent`'s
 /// locally-enrolled Ed25519 key (binds `from_agent → enrolled key`; the wire
 /// `sender_pubkey` is NOT trusted for this check — verifying against it would

--- a/src/forensic/bundle.rs
+++ b/src/forensic/bundle.rs
@@ -452,7 +452,25 @@ pub fn build_files(
             // bundled in the clear) and a signed refusal is emitted.
             // Structurally these live in the key-dir, not the DB, so a hit
             // means a mis-stored secret rode a memory row.
-            let record = serde_json::to_value(&mem).unwrap_or(serde_json::Value::Null);
+            // Fail-CLOSED on a serialize failure, mirroring `classify_memory`'s
+            // `Err => PrivateKeyMaterial` DROP disposition in the CLI/HTTP
+            // corpus screen (#2008 unification): an un-serializable row cannot
+            // be screened for a forbidden export class, so it must never be
+            // bundled in the clear. Practically unreachable (`Memory` carries no
+            // fallible serializers — a non-finite f64 confidence serializes to
+            // `null`, not an error), but the prior `unwrap_or(Null)` fail-OPENED
+            // (Null classifies as clean → bundled), the opposite of both siblings.
+            let record = match serde_json::to_value(&mem) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        memory_id = %mem.id,
+                        error = %e,
+                        "forensic export: row failed to serialize for export-class screening — dropping (fail-closed)"
+                    );
+                    continue;
+                }
+            };
             if crate::export_taxonomy::screen_export_value_audited(
                 conn,
                 &path,

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -1257,7 +1257,8 @@ pub async fn sync_push(
             crate::federation::receive_auth::require_write_sig_enabled(),
         ) {
             // #1801→#1954 item 7 — split the generic AttestationRequired WARN
-            // into two actionable causes so an operator gets a precise signal.
+            // into three actionable causes (unenrolled-author / missing-signature
+            // / forged-or-malformed) so an operator gets a precise signal.
             // A missing/unenrolled author key under the strict flip carries the
             // closed-set DLQ cause token `unenrolled_author_strict`
             // (`push_dlq::classify_quarantine_cause`).
@@ -1284,7 +1285,7 @@ pub async fn sync_push(
                     memory_id = %to_insert.id,
                     attribute_agent = %attribute_agent,
                     sender = %body.sender_agent_id,
-                    cause = "missing_signature",
+                    cause = crate::federation::receive_auth::CAUSE_MISSING_SIGNATURE,
                     error = %e,
                     "sync_push: honored third-party relay refused — no metadata.write_signature \
                      present under the strict flip (author must EMIT the signature at store time, #1801→#1954)"
@@ -1295,7 +1296,7 @@ pub async fn sync_push(
                     memory_id = %to_insert.id,
                     attribute_agent = %attribute_agent,
                     sender = %body.sender_agent_id,
-                    cause = "forged_or_malformed",
+                    cause = crate::federation::receive_auth::CAUSE_FORGED_OR_MALFORMED,
                     error = %e,
                     "sync_push: per-write content attestation failed; rejecting memory (#1464)"
                 );

--- a/src/handlers/federation_signing_check.rs
+++ b/src/handlers/federation_signing_check.rs
@@ -238,7 +238,7 @@ pub(super) async fn sync_push_via_store(
                     memory_id = %to_insert.id,
                     attribute_agent = %attribute_agent,
                     sender = %body.sender_agent_id,
-                    cause = "missing_signature",
+                    cause = crate::federation::receive_auth::CAUSE_MISSING_SIGNATURE,
                     error = %e,
                     "sync_push (postgres): honored third-party relay refused — no metadata.write_signature \
                      present under the strict flip (author must EMIT the signature at store time, #1801→#1954)"
@@ -249,7 +249,7 @@ pub(super) async fn sync_push_via_store(
                     memory_id = %to_insert.id,
                     attribute_agent = %attribute_agent,
                     sender = %body.sender_agent_id,
-                    cause = "forged_or_malformed",
+                    cause = crate::federation::receive_auth::CAUSE_FORGED_OR_MALFORMED,
                     error = %e,
                     "sync_push (postgres): per-write content attestation failed; rejecting memory (#1464)"
                 );

--- a/src/storage/reflect.rs
+++ b/src/storage/reflect.rs
@@ -869,6 +869,24 @@ fn run_decorrelation_write_gate(
     }
     let quorum_n = crate::config::reflect_decorrelation_quorum_n();
 
+    // Empty-attestation short-circuit (M-THROUGHPUT): the write-gate can only
+    // ever REFUSE/ADVISE on an ATTESTED-family signal, and `attested_family_of`
+    // resolves a family ONLY from a `model_attestations` row. With that table
+    // empty (the default posture), every row's attested lookup is `None`, so
+    // `attested_rows == 0` and `decorrelation_write_action` returns `Proceed`
+    // UNCONDITIONALLY (decorrelation_probe.rs — `InsufficientAttested { 0 } =>
+    // Proceed`, silent, mode-independent). Skip the up-to-`LIST_MAX_LIMIT`
+    // corpus scan + per-row JSON parse in that case — provably the same
+    // observable outcome (a bare `Ok(())`, no advisory emitted) at O(1).
+    let any_attested: bool = conn
+        .query_row("SELECT EXISTS(SELECT 1 FROM model_attestations)", [], |r| {
+            r.get(0)
+        })
+        .map_err(|e| ReflectError::Database(e.to_string()))?;
+    if !any_attested {
+        return Ok(());
+    }
+
     // Direct namespace-scoped corpus read (NOT recall). Bounded by the SSOT
     // `crate::storage::LIST_MAX_LIMIT` (the same window the visibility probe's
     // `PROBE_SCAN_LIMIT` reuses) so this per-write scan on the reflect hot path


### PR DESCRIPTION
Gate-3 step-2 multi-agent code review (codegraph-anchored, fresh reindex) → 7 confirmed findings / **0 GA-blockers** → 4 distinct defects, each filed 1:1 (#2014-#2017) and fixed here.

| Issue | Defect | Fix |
|---|---|---|
| #2014 | forensic export fail-OPENS on serialize err | drop fail-closed (match classify_memory / CLI+HTTP siblings) |
| #2015 | cause tokens split const/literal + comment drift | SSOT consts + comment fix |
| #2016 | reflect decorrelation scans 1000 rows wasted (default posture) | EXISTS(model_attestations) O(1) short-circuit |
| #2017 | receive_auth rustdoc says 'permissive/false' but v1.0.0 default is true | rewrite both rustdocs fail-closed |

**Gates:** fmt + clippy pedantic (--lib, sal+sal-postgres) clean; decorrelation_enforce_s2 / forensic / forensic_audit_log / gate3_export_boundary green (19 tests, 0 fail).

Closes #2014, #2015, #2016, #2017.

## AI involvement
Authored by Claude (Opus 4.8) under the v1.0.0 autonomous epic. Findings adversarially verified before filing; behavior-preservation of the reflect short-circuit confirmed against decorrelation_probe.rs:316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)