### PR TITLE
fix(#1998): serialize config env-mutating tests on one process-global lock

### DIFF
--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -449,11 +449,15 @@ mod tests {
     /// Serialise the `$HOME`-mutating `run`/`migrate` tests — env
     /// mutation is process-global, so two of these running concurrently
     /// would race on `AppConfig::config_path()`.
+    ///
+    /// #1998: delegates to the single crate-canonical
+    /// [`crate::config::test_env_lock`]. These tests mutate `HOME`, and the
+    /// `config::tests` filter runs this module alongside `config::tests`;
+    /// a private per-module mutex here let a `HOME` restore land inside a
+    /// `config::tests` critical section (which then read the real
+    /// `~/.config/ai-memory/config.toml`). One shared lock closes the race.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        crate::config::test_env_lock()
     }
 
     /// Run `migrate` against a `config.toml` materialised under a

--- a/src/config.rs
+++ b/src/config.rs
@@ -4511,7 +4511,10 @@ mod recall_purity_flag_tests {
 
     #[test]
     fn access_fold_interval_default_zero_and_garbage() {
-        // SAFETY: single test owns this var (see above).
+        // #1998: serialise on the crate-canonical env lock so a concurrent
+        // env-mutating test in another module cannot race this var.
+        let _guard = super::test_env_lock();
+        // SAFETY: env mutation serialised by `_guard`; restored on exit.
         unsafe { std::env::remove_var(ENV_ACCESS_FOLD_INTERVAL_SECS) };
         assert_eq!(
             access_fold_interval_secs(),
@@ -4558,7 +4561,9 @@ mod recall_purity_flag_tests {
         // Post-#1952 the compiled default is Advisory, so UNSET resolves ACTIVE
         // (the probe runs by default — "defaults stop lying"). The opt-out
         // advisory notice fires only when the mode is explicitly inactive (`off`).
-        // SAFETY: single test owns this var.
+        // #1998: serialise on the crate-canonical env lock.
+        let _guard = super::test_env_lock();
+        // SAFETY: env mutation serialised by `_guard`; restored on exit.
         unsafe { std::env::remove_var(ENV_REFLECT_DECORRELATION_MODE) };
         assert_eq!(
             reflect_decorrelation_mode(),
@@ -8696,6 +8701,38 @@ impl AppConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Test-only process-global env serializer (issue #1998)
+// ---------------------------------------------------------------------------
+
+/// The ONE canonical process-global mutex serialising every test in this
+/// crate that mutates a process-global `AI_MEMORY_*` / `HOME` env var.
+///
+/// Env mutation is process-global, so two tests touching the same key under
+/// the default multi-threaded runner (`cargo test`) race non-deterministically
+/// (issue #1998). Before this existed, `config::tests`,
+/// `recall_purity_flag_tests`, and `cli::commands::config::tests` each guarded
+/// `HOME` with a *different* module-local mutex — so a `cli::commands::config`
+/// test could restore `HOME` to the real value mid-critical-section of a
+/// `config::tests` scenario, which then read the operator's real
+/// `~/.config/ai-memory/config.toml`. All three modules now funnel through this
+/// single lock so the guarantee is a genuine process-wide critical section, not
+/// a per-module one.
+///
+/// Poison-OK (rust-skills `err-no-unwrap-prod`): a scenario that panics while
+/// holding the guard still hands the next caller a usable lock, so one failing
+/// test does not cascade. Callers bind the returned guard to a
+/// `let _guard = ...` local (test-fixture-raii) — never `let _ = ...`, which
+/// would drop it immediately and defeat the serialization.
+#[cfg(test)]
+pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -8711,15 +8748,13 @@ mod tests {
     /// non-deterministically. Every test in this module that flips an
     /// env var MUST hold this mutex for the duration of its body.
     ///
-    /// Poison-OK: a panicking scenario that drops the guard mid-mutation
-    /// still hands the next caller a usable lock. Subsequent tests
-    /// re-establish the env state they need on entry.
+    /// #1998: this delegates to the single crate-canonical
+    /// [`super::test_env_lock`] so `config::tests`,
+    /// `recall_purity_flag_tests`, and `cli::commands::config::tests` all
+    /// serialise on ONE process-global mutex instead of three per-module
+    /// mutexes that raced on `HOME`. Poison-OK; bind to `let _guard = ...`.
     fn env_var_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::{Mutex, OnceLock};
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        super::test_env_lock()
     }
 
     #[test]
@@ -10681,6 +10716,15 @@ legacy_scoring = false
     #[test]
     fn default_capability_governance_helper_returns_current() {
         // Lines 1125-1127.
+        // #1998: `CapabilityGovernance::current()` reads `l1_6_attest` from
+        // the on-disk operator pubkey (a HOME/`AI_MEMORY_KEY_DIR`-derived
+        // path). Under the default multi-threaded runner a sibling test that
+        // mutates HOME / `AI_MEMORY_KEY_DIR` can flip that global BETWEEN the
+        // two `current()` reads below, so `helper != current` non-
+        // deterministically. Pin the thread's pubkey resolution to `None`
+        // (the crate-wide clean-CI escape hatch) so both reads observe the
+        // same `l1_6_attest=false` regardless of any concurrent env mutation.
+        let _no_pubkey = crate::governance::rules_store::force_no_operator_pubkey_for_test();
         let helper = default_capability_governance();
         let current = CapabilityGovernance::current();
         assert_eq!(helper, current);


### PR DESCRIPTION
Closes #1998

## Problem

`config::tests` intermittently FAILED under the default multi-threaded test runner (~30-40% of runs on this host) while passing deterministically under `-- --test-threads=1`.

## Root cause

The `config::tests` cargo filter also matches `cli::commands::config::tests`. Both modules mutate the **process-global `HOME`** env var, but each guarded it with a **separate module-local `Mutex`** (`config::tests::env_var_lock` vs `cli::commands::config::tests::env_lock`). Two different locks do not serialize against each other, so a `cli::commands::config` test restoring `HOME` to the real value landed inside a `config::tests` critical section — `auto_tag_model_default_...` then read the operator's real `~/.config/ai-memory/config.toml` (`backend = "xai"`) and its `assert!(contents.contains("auto_tag_model"))` failed.

Captured failure (pre-fix):
```
thread 'config::tests::auto_tag_model_default_...' panicked at src/config.rs:10066:9:
default config.toml must document the auto_tag_model knob; got:
schema_version = 2
tier = "autonomous"
[llm]
backend = "xai"
```

A second latent race: `default_capability_governance_helper_returns_current` read the operator-pubkey-derived `l1_6_attest` global twice (`helper` vs `current`) and compared them; a concurrent `HOME`/`AI_MEMORY_KEY_DIR` mutation flipped it between the two reads.

## Fix (test-only — no production behavior change)

- New crate-canonical `#[cfg(test)] pub(crate) fn test_env_lock()` (`OnceLock<Mutex<()>>`, poison-OK) in `src/config.rs`.
- `config::tests::env_var_lock` and `cli::commands::config::tests::env_lock` now **delegate to it** — all env-mutating tests across both modules serialize on ONE process-global mutex (zero per-callsite churn for the 41 existing `env_var_lock()` callers).
- Guarded the two previously-unlocked `recall_purity_flag_tests` env-mutating tests on the same lock.
- Pinned `default_capability_governance_helper_returns_current` via the existing crate-wide `force_no_operator_pubkey_for_test()` thread-local escape hatch.

## Verification

3× consecutive multi-threaded runs (`AI_MEMORY_NO_CONFIG=1 cargo test --lib --features sal config::tests`, **no** `--test-threads=1`):
```
RUN 1: test result: ok. 214 passed; 0 failed; 0 ignored; 0 measured; 6798 filtered out; finished in 0.05s
RUN 2: test result: ok. 214 passed; 0 failed; 0 ignored; 0 measured; 6798 filtered out; finished in 0.05s
RUN 3: test result: ok. 214 passed; 0 failed; 0 ignored; 0 measured; 6798 filtered out; finished in 0.07s
```
Plus an additional 50/50 stress loop green (was ~30-40% flaky before the fix). `cargo fmt --check` clean; `cargo clippy --lib --features sal -- -D warnings -D clippy::pedantic` clean (exit 0).

## Rule IDs applied
- rust-skills: `own-mutex-interior`, `conc-thread-local`, `test-fixture-raii`, `err-no-unwrap-prod` (poison-OK via `unwrap_or_else(PoisonError::into_inner)`)
- rust-microsoft: `M-AVOID-STATICS` (test-scoped, justified), `M-DOCUMENTED-MAGIC`

## AI involvement
Authored by Claude (Opus 4.8) under operator direction: root-cause diagnosis (reproduced the race, captured the failing read), fix design, implementation, and 3×+50× multi-threaded verification. All changes are confined to `#[cfg(test)]` code.

> Note: task directive specified base `main`; the repo's general CLAUDE.md convention is base `develop`. Retarget if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY