### PR TITLE
fix(#1877): clamp SqliteStore::list limit to LIST_MAX_LIMIT (SAL parity)

### DIFF
--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -295,7 +295,15 @@ impl MemoryStore for SqliteStore {
             &conn,
             filter.namespace.as_deref(),
             filter.tier.as_ref(),
-            if filter.limit == 0 { 100 } else { filter.limit },
+            // #1877 — clamp to `LIST_MAX_LIMIT` for SAL parity with
+            // `PostgresStore::list` (which clamps to the same cap). Without this
+            // a caller with `limit > 1000` read a different window per backend.
+            // Paging past the first window rides #1876 (a `Filter` offset).
+            if filter.limit == 0 {
+                100
+            } else {
+                filter.limit.min(crate::storage::LIST_MAX_LIMIT)
+            },
             0,
             None,
             since.as_deref(),

--- a/tests/sqlite_list_limit_clamp_1877.rs
+++ b/tests/sqlite_list_limit_clamp_1877.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1877 — SAL `list()` limit-clamp parity. `PostgresStore::list` clamps
+//! `filter.limit` to `LIST_MAX_LIMIT` (1000); `SqliteStore::list` previously
+//! passed it through UNCLAMPED, so any SAL caller with `limit > 1000` read a
+//! different window on each backend. This regression pins the sqlite side to
+//! the same cap: with more than `LIST_MAX_LIMIT` rows and `limit > cap`, the
+//! returned window must be exactly `LIST_MAX_LIMIT`.
+
+#![cfg(feature = "sal")]
+#![allow(clippy::missing_panics_doc, clippy::field_reassign_with_default)]
+
+use ai_memory::models::Memory;
+use ai_memory::store::sqlite::SqliteStore;
+use ai_memory::store::{CallerContext, Filter, MemoryStore};
+
+#[tokio::test]
+async fn sqlite_list_clamps_limit_to_list_max_limit_1877() {
+    let max = ai_memory::storage::LIST_MAX_LIMIT;
+    let f = tempfile::NamedTempFile::new().expect("tempfile");
+    let conn = ai_memory::db::open(f.path()).expect("db::open");
+
+    // Seed LIST_MAX_LIMIT + 25 rows in one namespace via the low-level insert.
+    for i in 0..(max + 25) {
+        let mut m = Memory::default();
+        m.id = format!("clamp-{i:05}");
+        m.namespace = "clamp_ns_1877".to_string();
+        m.title = format!("row {i}");
+        m.content = "x".to_string();
+        ai_memory::db::insert(&conn, &m).expect("insert");
+    }
+    drop(conn);
+
+    let store = SqliteStore::open(f.path()).expect("open SqliteStore");
+    let ctx = CallerContext::for_admin("test-1877"); // bypass_visibility
+    let filter = Filter {
+        namespace: Some("clamp_ns_1877".to_string()),
+        tier: None,
+        tags_any: Vec::new(),
+        agent_id: None,
+        since: None,
+        until: None,
+        limit: 5000, // > LIST_MAX_LIMIT
+    };
+
+    let rows = store.list(&ctx, &filter).await.expect("list");
+    assert!(
+        rows.len() <= max,
+        "SqliteStore::list returned {} rows for limit=5000 — must clamp to LIST_MAX_LIMIT ({max}); #1877 regressed",
+        rows.len()
+    );
+    assert_eq!(
+        rows.len(),
+        max,
+        "with {} rows and limit>cap, the clamped window must be exactly LIST_MAX_LIMIT ({max})",
+        max + 25
+    );
+}


### PR DESCRIPTION
**Perfect-endpoint dev-set item (Tier-D quality; validated DEVELOP by the 2×5 vote wf_6f43ca8d).**

`PostgresStore::list` clamps `filter.limit` to `LIST_MAX_LIMIT` (1000); `SqliteStore::list` passed it through **unclamped**, so every SAL caller with `limit > 1000` read a different window per backend (RQ-PARITY-01 #1872 residue). This clamps the sqlite side to the same cap — the canonical behavior already established by postgres + the decorrelation-probe pinning. Paging past the first window rides #1876 (a `Filter` offset).

**Behavior:** identical for `limit ≤ 1000`; `limit > 1000` now returns the canonical 1000-row window on both backends (a caller needing more uses #1876 paging when it lands).

**Regression** (`tests/sqlite_list_limit_clamp_1877.rs`): seeds `LIST_MAX_LIMIT+25` rows, lists with `limit=5000`, asserts exactly `LIST_MAX_LIMIT` returned — **green**. clippy pedantic (lib, sal) clean.

No 2×5 vote: copies the established postgres precedent (T6-exempt). Closes #1877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)