### PR TITLE
fix(#2028): scan attested-candidate set in decorrelation write-gate (enforce-bypass)

### DIFF
--- a/src/storage/reflect.rs
+++ b/src/storage/reflect.rs
@@ -887,29 +887,61 @@ fn run_decorrelation_write_gate(
         return Ok(());
     }
 
-    // Direct namespace-scoped corpus read (NOT recall). Bounded by the SSOT
-    // `crate::storage::LIST_MAX_LIMIT` (the same window the visibility probe's
-    // `PROBE_SCAN_LIMIT` reuses) so this per-write scan on the reflect hot path
-    // can never grow unbounded with the namespace's reflection count.
+    // #2028 — Full corpus size is an UNCAPPED `COUNT(*)`, distinct from the
+    // bounded attested-candidate scan below. `total_reflections` only feeds the
+    // advisory-message denominator ("N ATTESTED of M corpus"); it must reflect
+    // the true corpus size, not the scan window.
+    let total_reflections: usize = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories \
+             WHERE namespace = ?1 AND memory_kind = 'reflection'",
+            [target_namespace],
+            |r| r.get::<_, i64>(0),
+        )
+        .map_err(|e| ReflectError::Database(e.to_string()))?
+        .try_into()
+        .unwrap_or(usize::MAX);
+
+    // #2028 — Scan the ATTESTED-CANDIDATE set, NOT the whole corpus. Only a row
+    // whose metadata carries the loader-observed attest marker can EVER resolve
+    // an attested family (`model_attest::attested_family_candidate` requires
+    // `model_family_attest = "loader_observed"` + a non-empty `model_family`),
+    // so marker-filtering IS the security-correct population. The prior
+    // unordered `LIMIT LIST_MAX_LIMIT` over the FULL corpus could push the
+    // attested rows OUTSIDE the window whenever a namespace held more than
+    // `LIST_MAX_LIMIT` CLAIMED reflections — undercounting `attested_rows` below
+    // `MIN_REFLECTIONS_FLOOR` so an attested monoculture silently PROCEEDED
+    // (`InsufficientAttested`) instead of being REFUSED under `enforce`. The
+    // candidate set is naturally bounded by the attest-marked reflection count;
+    // `LIST_MAX_LIMIT` still caps the hot-path scan and is security-safe here
+    // (more candidates only push toward Refuse, never toward the bypass). The
+    // per-row `attested_family_of` (SSOT) still applies the forgery gate
+    // (stamp without a backing `model_attestations` row → CLAIMED).
+    let attest_path = format!("$.{}", crate::identity::META_KEY_MODEL_FAMILY_ATTEST);
     let scan_limit = i64::try_from(crate::storage::LIST_MAX_LIMIT).unwrap_or(i64::MAX);
     let mut corpus_attested: Vec<String> = Vec::new();
-    let mut total_reflections: usize = 0;
     {
         let mut stmt = conn
             .prepare(
                 "SELECT metadata FROM memories \
                  WHERE namespace = ?1 AND memory_kind = 'reflection' \
-                 LIMIT ?2",
+                   AND json_extract(metadata, ?2) = ?3 \
+                 LIMIT ?4",
             )
             .map_err(|e| ReflectError::Database(e.to_string()))?;
         let rows = stmt
-            .query_map((target_namespace, scan_limit), |row| {
-                row.get::<_, String>(0)
-            })
+            .query_map(
+                (
+                    target_namespace,
+                    &attest_path,
+                    crate::identity::ATTEST_MODEL_LOADER_OBSERVED,
+                    scan_limit,
+                ),
+                |row| row.get::<_, String>(0),
+            )
             .map_err(|e| ReflectError::Database(e.to_string()))?;
         for r in rows {
             let raw = r.map_err(|e| ReflectError::Database(e.to_string()))?;
-            total_reflections += 1;
             let meta: serde_json::Value =
                 serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
             if let Some(fam) = crate::storage::model_attest::attested_family_of(conn, &meta)

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -9730,17 +9730,45 @@ impl PostgresStore {
         }
         let quorum_n = crate::config::reflect_decorrelation_quorum_n();
 
-        // Direct namespace-scoped corpus read (NOT recall). Bounded by the SSOT
-        // `crate::storage::LIST_MAX_LIMIT` (sqlite-twin parity — the same window
-        // the visibility probe's `PROBE_SCAN_LIMIT` reuses) so this per-write
-        // scan on the reflect hot path can never grow unbounded.
+        // #2028 (sqlite-twin parity of `db::run_decorrelation_write_gate`) —
+        // Full corpus size is an UNCAPPED `COUNT(*)`; it only feeds the
+        // advisory-message denominator and must reflect the true corpus size,
+        // not the scan window.
+        let total_reflections: usize = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM memories \
+             WHERE namespace = $1 AND memory_kind = 'reflection'",
+        )
+        .bind(target_namespace)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            crate::db::ReflectError::Database(to_store_err("decorrelation count", e).to_string())
+        })?
+        .try_into()
+        .unwrap_or(usize::MAX);
+
+        // #2028 — Scan the ATTESTED-CANDIDATE set, NOT the whole corpus. Only a
+        // row carrying the loader-observed attest marker can EVER resolve an
+        // attested family, so marker-filtering is the security-correct
+        // population. The prior unordered `LIMIT LIST_MAX_LIMIT` over the FULL
+        // corpus could push attested rows outside the window whenever a
+        // namespace held more than `LIST_MAX_LIMIT` CLAIMED reflections —
+        // undercounting `attested_rows` below `MIN_REFLECTIONS_FLOOR` so an
+        // attested monoculture silently PROCEEDED instead of being REFUSED under
+        // `enforce`. `LIST_MAX_LIMIT` still caps the hot-path scan and is
+        // security-safe (more candidates only push toward Refuse). The per-row
+        // `pg_model_family_row_exists` still applies the forgery gate.
+        let attest_path = crate::identity::META_KEY_MODEL_FAMILY_ATTEST;
         let scan_limit = i64::try_from(crate::storage::LIST_MAX_LIMIT).unwrap_or(i64::MAX);
         let rows: Vec<(serde_json::Value,)> = sqlx::query_as(
             "SELECT metadata FROM memories \
              WHERE namespace = $1 AND memory_kind = 'reflection' \
-             LIMIT $2",
+               AND metadata->>$2 = $3 \
+             LIMIT $4",
         )
         .bind(target_namespace)
+        .bind(attest_path)
+        .bind(crate::identity::ATTEST_MODEL_LOADER_OBSERVED)
         .bind(scan_limit)
         .fetch_all(&self.pool)
         .await
@@ -9749,7 +9777,6 @@ impl PostgresStore {
         })?;
 
         let mut corpus_attested: Vec<String> = Vec::new();
-        let total_reflections = rows.len();
         for (meta,) in &rows {
             if let Some(fam) = crate::storage::model_attest::attested_family_candidate(meta) {
                 if self.pg_model_family_row_exists(&fam).await? {

--- a/tests/decorrelation_enforce_s2.rs
+++ b/tests/decorrelation_enforce_s2.rs
@@ -72,6 +72,22 @@ fn attested_llama_reflection(title: &str) -> Memory {
     )
 }
 
+/// A reflection-kind memory carrying a `llama` family stamp WITHOUT the
+/// loader-observed attest marker — reads CLAIMED, never ATTESTED, and is
+/// excluded from the #2028 attested-candidate scan (no `model_family_attest`
+/// key). Used to flood the corpus so an unordered window would evict the
+/// attested rows.
+fn claimed_reflection(title: &str) -> Memory {
+    base_memory(
+        title,
+        MemoryKind::Reflection,
+        serde_json::json!({
+            "agent_id": "curator",
+            "model_family": "llama",
+        }),
+    )
+}
+
 fn reflect_input(source_ids: Vec<String>, title: &str) -> db::ReflectInput {
     db::ReflectInput {
         source_ids,
@@ -175,6 +191,76 @@ fn enforce_refuses_attested_monoculture_then_off_is_inert() {
         )
         .unwrap();
     assert_eq!(written, 1, "off mode persists the reflection");
+
+    unsafe { std::env::remove_var(MODE_ENV) };
+}
+
+/// #2028 regression — the enforce gate must find an attested monoculture even
+/// when the corpus holds MORE than `LIST_MAX_LIMIT` CLAIMED reflections
+/// inserted BEFORE the attested rows. The pre-fix unordered `LIMIT
+/// LIST_MAX_LIMIT` scan over the whole corpus returned only the leading
+/// claimed rows, missed the trailing attested rows, undercounted
+/// `attested_rows` to 0 (`InsufficientAttested`), and silently PROCEEDED —
+/// a bypass of the enforce gate. The attested-CANDIDATE scan is marker-scoped,
+/// so it finds the attested rows regardless of their corpus position.
+#[test]
+fn enforce_finds_attested_rows_beyond_scan_window_2028() {
+    let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+
+    let base = base_memory(
+        "base-source",
+        MemoryKind::Observation,
+        serde_json::json!({}),
+    );
+    let base_id = db::insert(&conn, &base).expect("insert base");
+
+    // Flood the namespace with LIST_MAX_LIMIT CLAIMED reflections FIRST so the
+    // attested rows land beyond a whole-corpus LIMIT LIST_MAX_LIMIT window.
+    for i in 0..ai_memory::storage::LIST_MAX_LIMIT {
+        let r = claimed_reflection(&format!("claimed-refl-{i}"));
+        db::insert(&conn, &r).expect("insert claimed reflection");
+    }
+    // Then 3 ATTESTED `llama` reflections (an attested monoculture) at the tail.
+    for i in 0..3 {
+        let r = attested_llama_reflection(&format!("attested-tail-{i}"));
+        db::insert(&conn, &r).expect("insert attested reflection");
+    }
+    model_attest::record_loader_observed(&conn, "ollama", "llama3.1:8b", "llama")
+        .expect("record loader attestation");
+
+    unsafe { std::env::set_var(MODE_ENV, "enforce") };
+    let input = reflect_input(vec![base_id], "gated-beyond-window");
+    let err = db::reflect(&conn, &input)
+        .expect_err("enforce must refuse the attested monoculture beyond the scan window");
+    match err {
+        db::ReflectError::DecorrelationRefused {
+            distinct_attested_families,
+            attested_rows,
+            quorum_n,
+            namespace,
+        } => {
+            assert_eq!(
+                distinct_attested_families, 1,
+                "one distinct attested family"
+            );
+            assert!(
+                attested_rows >= 3,
+                "the 3 tail attested rows must be counted despite {} leading claimed rows",
+                ai_memory::storage::LIST_MAX_LIMIT
+            );
+            assert_eq!(quorum_n, 3, "default quorum N");
+            assert_eq!(namespace, NS);
+        }
+        other => panic!("expected DecorrelationRefused, got {other}"),
+    }
+    let gated: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE title = 'gated-beyond-window'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(gated, 0, "the refused reflection must not be persisted");
 
     unsafe { std::env::remove_var(MODE_ENV) };
 }

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -718,7 +718,11 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // 2026-07-12 (#1831 G17): the v81 migrate arm + the guardian_set_id /
     // recovery_threshold columns threaded through the lineage INSERT + read
     // land postgres.rs at 26_503; ceiling 26_600 (+97).
-    ("src/store/postgres.rs", 26_600),
+    // 2026-07-14 (#2028): the decorrelation write-gate twin now scans the
+    // attested-CANDIDATE set (uncapped COUNT(*) + marker-scoped query) to fix
+    // the enforce-bypass; +~30 lines land postgres.rs at 26_603; ceiling
+    // 26_650 (+47).
+    ("src/store/postgres.rs", 26_650),
     // 2026-06-10 (#1579 B7) — bumped 9_000 → 9_150: the
     // `db_mmap_size_bytes` knob (ENV_DB_MMAP_SIZE const +
     // StorageSection/ResolvedStorage fields + the resolve_storage env >


### PR DESCRIPTION
## Summary

Closes #2028 (security — enforce-gate bypass).

The write-time decorrelation gate (`db::run_decorrelation_write_gate` sqlite / `PostgresStore::decorrelation_write_gate_pg`) built `corpus_attested` from an **unordered `LIMIT LIST_MAX_LIMIT` scan of the entire reflection corpus**. When a namespace held more than `LIST_MAX_LIMIT` (1000) **claimed** reflections, an attested monoculture sorted outside that arbitrary window was missed → `attested_rows` undercounted below `MIN_REFLECTIONS_FLOOR` (3) → `InsufficientAttested` → the `enforce` gate silently **PROCEEDED** instead of **REFUSING**. A flood of claimed reflections bypasses the gate.

## Fix (both backends, sqlite + postgres parity)

- `total_reflections` → uncapped `COUNT(*)` (it only feeds the advisory-message denominator and must reflect the true corpus size, not the scan window).
- The row scan is **marker-scoped to the attested-candidate set** (`model_family_attest = 'loader_observed'`, built from the SSOT key consts and bound — not inlined). Only marker-carrying rows can ever resolve an attested family (`model_attest::attested_family_candidate`), so this is the security-correct population and is bounded by the attest-marked count, not the whole corpus. Per-row `attested_family_of` / `pg_model_family_row_exists` still applies the forgery gate (stamp without a backing `model_attestations` row → CLAIMED).
- `LIST_MAX_LIMIT` still caps the hot-path scan and is security-safe here (more candidates only push toward Refuse, never toward the bypass). `M-THROUGHPUT`.
- The #2016 empty-attestation `EXISTS` short-circuit is preserved.

## Test evidence

`tests/decorrelation_enforce_s2.rs::enforce_finds_attested_rows_beyond_scan_window_2028` — floods the namespace with `LIST_MAX_LIMIT` claimed reflections **before** 3 attested ones and asserts `enforce` **REFUSES**. Fails on the pre-fix window scan, passes now. The existing `enforce_refuses_attested_monoculture_then_off_is_inert` still passes (no behavior regression).

```
running 2 tests
test enforce_refuses_attested_monoculture_then_off_is_inert ... ok
test enforce_finds_attested_rows_beyond_scan_window_2028 ... ok
test result: ok. 2 passed; 0 failed
```

Gates: `cargo fmt --check` clean; `cargo clippy --features sal,sal-postgres --lib -- -D warnings -D clippy::all -D clippy::pedantic` clean.

## AI involvement

Authored by Claude Opus 4.8 under operator autonomous authority (v1.0.0 perfect-endpoint campaign). Single-correct-answer bug fix implementing the adjudicated design (ai-memory `3ec2c7c4`); #2028 was surfaced by the #1876 2×5 adversarial vote. No public-contract shape change (same fn signature + verdict semantics), so `Tn`-exempt per the crossroads protocol; decision recorded inline here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)