### PR TITLE
feat(#2004): wire the crypto-agility re-anchor ceremony into a signed checkpoint

### DIFF
--- a/docs/security/audit-trail.md
+++ b/docs/security/audit-trail.md
@@ -331,6 +331,34 @@ ai-memory audit restore-attest
 ai-memory audit restore-attest --sign
 ```
 
+### `ai-memory audit re-anchor [--json]`
+
+**[#2004, v1.0.0]** The **crypto-agility re-anchor ceremony**. Per-record
+post-quantum signatures are forbidden (spec §2.4 — arithmetically
+incompatible with endpoint budgets), so PQ strength binds at **checkpoint
+granularity**: this command countersigns the CURRENT `signed_events`
+chain head — "the new-suite key has seen prior head `H` at sequence `N`"
+— under the enrolled suite (the FROZEN `re-anchor/v1` format), and
+persists it as a signed `re_anchor` checkpoint. Enabling a stronger / PQ
+suite on a live corpus later then causes **zero** write failures and
+**zero** record rewrites, and every pre-break record stays attributable
+across the suite boundary.
+
+The countersignature is produced by the **distinct off-daemon
+audit-witness custody key** (the same K1-pinnable custody as the #1822
+witness anchor), so the ceremony is opt-in: with no witness key enrolled
+(`AI_MEMORY_WITNESS_KEY_DIR`) it is a no-op. The persisted anchor is
+immediately self-verified via the read-back path (K1-pinned to
+`AI_MEMORY_WITNESS_PUBKEY`) so the operator sees the ceremony round-trip,
+not just a write. A universal per-signed-class `suite_tag` is deferred to
+v1.x; today the only enrolled suite is Ed25519-SHA256.
+
+```bash
+# Countersign + anchor the current head (loads the witness key from
+# AI_MEMORY_WITNESS_KEY_DIR; verifies against AI_MEMORY_WITNESS_PUBKEY).
+ai-memory audit re-anchor
+```
+
 ### `ai-memory logs tail [--follow]`
 
 Tail and (optionally) stream operational logs. Accepts the global

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -59,6 +59,13 @@ pub enum AuditAction {
     /// the next `db::open`. The operator signature is the ONLY
     /// discriminator (at the byte level a DR restore IS a rollback).
     RestoreAttest(RestoreAttestArgs),
+    /// v1.0.0 #2004 (spec §5.3) — the crypto-agility RE-ANCHOR ceremony.
+    /// Countersign the CURRENT `signed_events` chain head under the enrolled
+    /// suite and persist it as a signed `re_anchor` checkpoint, so enabling a
+    /// stronger / PQ suite later causes zero record rewrites and every
+    /// pre-break record stays attributable. Signed by the DISTINCT off-daemon
+    /// audit-witness custody key (opt-in — a no-op when none is enrolled).
+    ReAnchor(ReAnchorArgs),
 }
 
 #[derive(Args)]
@@ -145,6 +152,14 @@ pub struct RestoreAttestArgs {
     pub json: bool,
 }
 
+/// v1.0.0 #2004 — arguments for `ai-memory audit re-anchor`.
+#[derive(Args)]
+pub struct ReAnchorArgs {
+    /// Emit a JSON summary instead of the human-readable line.
+    #[arg(long)]
+    pub json: bool,
+}
+
 /// `ai-memory audit` entry point. Returns the desired process exit
 /// code so the caller can surface a non-zero status from the top-level
 /// dispatch without panicking.
@@ -156,7 +171,66 @@ pub fn run(args: AuditArgs, app_config: &AppConfig, out: &mut CliOutput<'_>) -> 
         AuditAction::Path => run_path(audit_dir.as_deref(), app_config, out),
         AuditAction::Show(s) => run_show(&s, app_config, out),
         AuditAction::RestoreAttest(r) => run_restore_attest(&r, app_config, out),
+        AuditAction::ReAnchor(r) => run_re_anchor(&r, app_config, out),
     }
+}
+
+/// v1.0.0 #2004 (spec §5.3) — the crypto-agility re-anchor ceremony. Reads the
+/// current `signed_events` head, countersigns it under the enrolled suite with
+/// the audit-witness custody key, and persists a signed `re_anchor` checkpoint
+/// (both backends). The freshly-persisted anchor is then self-verified via the
+/// read-back path (K1-pinned to the enrolled witness pubkey) so the operator
+/// sees the ceremony round-trip, not just a write.
+fn run_re_anchor(
+    args: &ReAnchorArgs,
+    app_config: &AppConfig,
+    out: &mut CliOutput<'_>,
+) -> Result<i32> {
+    use anyhow::Context;
+    let db_path = app_config.effective_db(std::path::Path::new("ai-memory.db"));
+    let conn = crate::db::open(&db_path)
+        .with_context(|| format!("audit re-anchor: open db at {}", db_path.display()))?;
+    let Some(cp) =
+        crate::signed_events::emit_reanchor_ceremony(&conn).context("emit re-anchor ceremony")?
+    else {
+        writeln!(
+            out.stderr,
+            "re-anchor: no ceremony emitted — enrol an audit-witness signing key \
+             (AI_MEMORY_WITNESS_KEY_DIR) and ensure the signed_events chain is non-empty"
+        )?;
+        return Ok(0);
+    };
+    // Self-verify the persisted anchor against the OUT-OF-BAND enrolled witness
+    // pubkey (K1) — the same read-back a fresh verifier performs.
+    let verified = match crate::governance::audit::load_enrolled_witness_pubkey()? {
+        Some(vk) => crate::governance::audit::verify_reanchor_checkpoint(&cp, &vk).is_ok(),
+        None => false,
+    };
+    if args.json {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "status": "ok",
+                "checkpoint_id": cp.id,
+                "namespace": cp.namespace,
+                "verified": verified,
+            })
+        )?;
+    } else {
+        let readback = if verified {
+            "PASS"
+        } else {
+            "unverified (no enrolled witness pubkey — set AI_MEMORY_WITNESS_PUBKEY to K1-pin)"
+        };
+        writeln!(
+            out.stdout,
+            "re-anchor OK: crypto-agility ceremony anchor {} recorded (namespace {}); \
+             read-back verify: {readback}",
+            cp.id, cp.namespace
+        )?;
+    }
+    Ok(0)
 }
 
 /// v1.0.0 #1946 (A1) — the sanctioned-restore ceremony. Reads the

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -1892,6 +1892,236 @@ pub fn build_signed_witness_checkpoint(
 }
 
 // ---------------------------------------------------------------------------
+// v1.0.0 #2004 (R75 · spec §5.3 · vote `4d3ea1c5`) — RE-ANCHOR CEREMONY ANCHOR
+// ---------------------------------------------------------------------------
+//
+// Crypto-agility bridge: per-record PQ signatures are forbidden (spec §2.4),
+// so post-quantum strength binds at CHECKPOINT granularity via a re-anchor
+// ceremony — the new-suite key countersigns "seen prior chain head H @ seq N"
+// under a new suite ([`crate::identity::re_anchor`], FROZEN §5.3 format). This
+// block WIRES that frozen primitive into the same off-daemon-custody,
+// K1-pinnable `checkpoints`-row persistence the #1822 audit-head witness uses:
+// the ceremony record's canonical CBOR + its detached countersignature ride in
+// a signed [`crate::models::ConditionType::ReAnchor`] checkpoint resolution,
+// so the anchor is loadable + verifiable exactly like a witness anchor. The
+// re-anchor signer is the SAME distinct off-daemon audit-witness custody key
+// (a separate PQ-capable key becomes its own enrolment lever at the v1.x
+// suite flip; the universal per-class `suite_tag` stays v1.x-deferred).
+
+/// Reserved `checkpoints.namespace` the re-anchor ceremony anchors live in.
+/// Distinct so an operator can grep the crypto-agility bridge records apart
+/// from coordination checkpoints and the witness anchors (the
+/// [`WITNESS_CHECKPOINT_NAMESPACE`] precedent).
+pub const REANCHOR_CHECKPOINT_NAMESPACE: &str = "_reanchor_ceremony";
+
+/// `checkpoints.title` stamped on every re-anchor ceremony anchor.
+const REANCHOR_CHECKPOINT_TITLE: &str = "crypto-agility re-anchor";
+
+/// `checkpoints.created_by` / `resolved_by` pseudo-actor for re-anchor anchors.
+pub const REANCHOR_RESOLVED_BY: &str = "audit:reanchor";
+
+/// Schema version embedded in the re-anchor `resolution` JSON (`"v": N`).
+const REANCHOR_RESOLUTION_VERSION: i64 = 1;
+
+/// The signed `resolution` payload of a [`crate::models::ConditionType::ReAnchor`]
+/// checkpoint (spec §5.3). Carries the FROZEN ceremony artifact — the canonical
+/// `re-anchor/v1` CBOR pre-image + its detached new-suite countersignature —
+/// base64 (STANDARD) encoded. The authoritative signed bytes are the CBOR (a
+/// verifier `decode_re_anchor_v1`s it, NEVER trusts a re-derived projection);
+/// the enclosing checkpoint envelope signature then binds this whole payload
+/// into the K1-pinnable row.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ReAnchorResolutionWire {
+    /// Resolution schema version (`REANCHOR_RESOLUTION_VERSION`).
+    v: i64,
+    /// Base64 (STANDARD) of [`crate::identity::re_anchor::canonical_cbor_re_anchor_v1`]
+    /// — the exact pre-image the detached signature is computed over.
+    re_anchor_cbor: String,
+    /// Base64 (STANDARD) of the 64-byte detached `re-anchor/v1` countersignature.
+    re_anchor_sig: String,
+}
+
+/// Build + SIGN a resolved [`crate::models::ConditionType::ReAnchor`] checkpoint
+/// countersigning the prior-suite chain head (`prior_head_hash` @
+/// `prior_head_sequence`) at wall-clock `now` (epoch seconds) / `anchored_at`
+/// (RFC3339), signed by `keypair` (the audit-witness custody signer — its
+/// private key produces BOTH the detached `re-anchor/v1` countersignature and
+/// the enclosing checkpoint envelope signature). The returned checkpoint is
+/// ready to `checkpoints::insert` into either backend.
+///
+/// The committed `new_suite_tag` is [`SuiteId::Ed25519Sha256`] — the only
+/// suite that exists at v1.0.0 (a future PQ suite supplies its own signer over
+/// the SAME pinned pre-image; verification cross-checks the enrolled suite).
+///
+/// # Errors
+/// - `keypair` is public-only (cannot produce the detached countersignature).
+/// - Propagates the [`crate::checkpoints::sign_resolution_into`] envelope error.
+pub fn build_signed_reanchor_checkpoint(
+    prior_head_hash: &[u8],
+    prior_head_sequence: u64,
+    anchored_at: &str,
+    now: i64,
+    keypair: &crate::identity::keypair::AgentKeypair,
+) -> Result<crate::models::Checkpoint> {
+    use crate::identity::re_anchor::{
+        SignableReAnchorV1, canonical_cbor_re_anchor_v1, sign_re_anchor,
+    };
+    use crate::identity::suite::SuiteId;
+    use crate::models::{CheckpointState, ConditionType};
+
+    let signing_key = keypair.private.as_ref().ok_or_else(|| {
+        anyhow!("re-anchor ceremony requires a private witness key (public-only)")
+    })?;
+
+    // FROZEN §5.3 pre-image: the new-suite key countersigns the prior head.
+    let signable = SignableReAnchorV1 {
+        prior_chain_head_hash: prior_head_hash,
+        prior_head_sequence,
+        new_suite_tag: SuiteId::Ed25519Sha256.tag(),
+        anchored_at,
+    };
+    let cbor = canonical_cbor_re_anchor_v1(&signable);
+    let sig = sign_re_anchor(signing_key, &signable);
+
+    let wire = ReAnchorResolutionWire {
+        v: REANCHOR_RESOLUTION_VERSION,
+        re_anchor_cbor: B64.encode(&cbor),
+        re_anchor_sig: B64.encode(sig),
+    };
+    // to_string on a fixed-shape struct is infallible in practice.
+    let resolution = serde_json::to_string(&wire).unwrap_or_default();
+
+    let mut cp = crate::models::Checkpoint {
+        id: uuid::Uuid::new_v4().to_string(),
+        namespace: REANCHOR_CHECKPOINT_NAMESPACE.to_string(),
+        title: REANCHOR_CHECKPOINT_TITLE.to_string(),
+        condition_type: ConditionType::ReAnchor,
+        condition: serde_json::Value::Null,
+        state: CheckpointState::Resolved,
+        created_by: REANCHOR_RESOLVED_BY.to_string(),
+        resolved_by: Some(REANCHOR_RESOLVED_BY.to_string()),
+        resolution: Some(resolution),
+        resolution_note: None,
+        signature: Vec::new(),
+        resolver_pubkey: Vec::new(),
+        created_at: now,
+        deadline_at: None,
+        resolved_at: Some(now),
+        metadata: serde_json::Value::Null,
+    };
+    crate::checkpoints::sign_resolution_into(&mut cp, keypair)
+        .context("sign re-anchor ceremony resolution")?;
+    Ok(cp)
+}
+
+/// Why a [`verify_reanchor_checkpoint`] read-back was refused (spec §5.3).
+///
+/// Fail-closed: every non-`Ok` disposition is a rejection. The distinct
+/// variants are for logs / audit envelopes, mirroring
+/// [`crate::identity::re_anchor::ReAnchorError`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReAnchorCheckpointError {
+    /// The checkpoint is not a [`crate::models::ConditionType::ReAnchor`] anchor.
+    NotReAnchor,
+    /// The `resolver_pubkey` did not equal the ENROLLED witness key (K1 pin).
+    PubkeyNotEnrolled,
+    /// The checkpoint envelope signature did not validate over its resolution.
+    EnvelopeInvalid,
+    /// The `resolution` was absent, not the expected schema version, or its
+    /// base64 CBOR / signature fields did not decode.
+    MalformedResolution,
+    /// The embedded CBOR failed the frozen `re-anchor/v1` structural decode.
+    DecodeFailed(crate::identity::re_anchor::ReAnchorDecodeError),
+    /// The detached countersignature (or its suite cross-check) failed.
+    CountersignatureInvalid(crate::identity::re_anchor::ReAnchorError),
+}
+
+impl ReAnchorCheckpointError {
+    /// Stable machine-readable tag for logs + JSON error envelopes.
+    #[must_use]
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::NotReAnchor => "reanchor_checkpoint_not_reanchor",
+            Self::PubkeyNotEnrolled => "reanchor_checkpoint_pubkey_not_enrolled",
+            Self::EnvelopeInvalid => "reanchor_checkpoint_envelope_invalid",
+            Self::MalformedResolution => "reanchor_checkpoint_malformed_resolution",
+            Self::DecodeFailed(e) => e.tag(),
+            Self::CountersignatureInvalid(e) => e.tag(),
+        }
+    }
+}
+
+impl std::fmt::Display for ReAnchorCheckpointError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.tag())
+    }
+}
+
+impl std::error::Error for ReAnchorCheckpointError {}
+
+/// Verify a re-anchor ceremony checkpoint read back from either backend
+/// (spec §5.3 / §2.4), K1-pinned to the OUT-OF-BAND `enrolled_witness_vk`.
+///
+/// The check order is deliberate and fail-closed:
+/// 1. the anchor is a [`crate::models::ConditionType::ReAnchor`];
+/// 2. K1 pin — `resolver_pubkey` equals the enrolled witness key (the anchor
+///    never self-describes its trust root);
+/// 3. the checkpoint ENVELOPE signature validates over the resolution
+///    ([`crate::checkpoints::verify`]);
+/// 4. the embedded CBOR passes the FROZEN `re-anchor/v1` structural decode
+///    ([`crate::identity::re_anchor::decode_re_anchor_v1`]) — the persisted
+///    bytes are decoded, never a re-derived projection;
+/// 5. the detached countersignature validates under the enrolled key + the
+///    §2.4 suite cross-check ([`crate::identity::re_anchor::verify_re_anchor`]).
+///
+/// # Errors
+/// A [`ReAnchorCheckpointError`] describing the first failing step.
+pub fn verify_reanchor_checkpoint(
+    cp: &crate::models::Checkpoint,
+    enrolled_witness_vk: &VerifyingKey,
+) -> Result<crate::identity::re_anchor::ReAnchorRecord, ReAnchorCheckpointError> {
+    use crate::identity::re_anchor::{decode_re_anchor_v1, verify_re_anchor};
+    use crate::identity::suite::SuiteId;
+    use crate::models::ConditionType;
+
+    if cp.condition_type != ConditionType::ReAnchor {
+        return Err(ReAnchorCheckpointError::NotReAnchor);
+    }
+    // K1 — pin against the enrolled witness key BEFORE trusting any signature.
+    if cp.resolver_pubkey.as_slice() != enrolled_witness_vk.to_bytes().as_slice() {
+        return Err(ReAnchorCheckpointError::PubkeyNotEnrolled);
+    }
+    if !crate::checkpoints::verify(cp) {
+        return Err(ReAnchorCheckpointError::EnvelopeInvalid);
+    }
+    let res = cp
+        .resolution
+        .as_deref()
+        .ok_or(ReAnchorCheckpointError::MalformedResolution)?;
+    let wire: ReAnchorResolutionWire =
+        serde_json::from_str(res).map_err(|_| ReAnchorCheckpointError::MalformedResolution)?;
+    if wire.v != REANCHOR_RESOLUTION_VERSION {
+        return Err(ReAnchorCheckpointError::MalformedResolution);
+    }
+    let cbor = B64
+        .decode(wire.re_anchor_cbor.as_bytes())
+        .map_err(|_| ReAnchorCheckpointError::MalformedResolution)?;
+    let sig = B64
+        .decode(wire.re_anchor_sig.as_bytes())
+        .map_err(|_| ReAnchorCheckpointError::MalformedResolution)?;
+
+    let record = decode_re_anchor_v1(&cbor).map_err(ReAnchorCheckpointError::DecodeFailed)?;
+    verify_re_anchor(
+        enrolled_witness_vk,
+        SuiteId::Ed25519Sha256,
+        &record.as_signable(),
+        &sig,
+    )
+    .map_err(ReAnchorCheckpointError::CountersignatureInvalid)?;
+    Ok(record)
+}
+
+// ---------------------------------------------------------------------------
 // v1.0.0 #1946 (A1 · decision 5 · `aeb891a4`) — ROLLBACK-EVIDENCE ANCHOR
 // ---------------------------------------------------------------------------
 //

--- a/src/models/checkpoint.rs
+++ b/src/models/checkpoint.rs
@@ -220,6 +220,7 @@ mod tests {
             ConditionType::GovernanceEnforcement,
             ConditionType::EpochAdvance,
             ConditionType::PeerHeadEntanglement,
+            ConditionType::ReAnchor,
         ] {
             assert_eq!(ConditionType::from_str(c.as_str()), Some(c));
         }

--- a/src/models/checkpoint.rs
+++ b/src/models/checkpoint.rs
@@ -78,6 +78,20 @@ pub enum ConditionType {
     /// `GovernanceVerdict` precedent). Lives under the reserved
     /// [`crate::identity::equivocation::PEER_HEAD_ENTANGLEMENT_NAMESPACE`].
     PeerHeadEntanglement,
+    /// v1.0.0 #2004 (R75) — an operator-invoked crypto-agility RE-ANCHOR
+    /// ceremony record. The `re-anchor/v1` signed bridge (spec §5.3,
+    /// [`crate::identity::re_anchor`]) countersigns "the NEW suite key has seen
+    /// the prior-suite `signed_events` chain head H at sequence N," so a future
+    /// crypto-suite rotation (PQ at checkpoint granularity) does not break the
+    /// audit chain. Its `resolution` carries the `ReAnchorRecord` fields + the
+    /// detached `re_anchor` signature; a verify path re-runs
+    /// [`crate::identity::re_anchor::verify_re_anchor`] +
+    /// [`crate::identity::suite::verify_suite_binding`]. Mirrors the
+    /// [`Self::AuditHeadWitness`] off-daemon-custody, K1-pinnable persistence
+    /// (2×5 vote `4d3ea1c5`; verdict A-synthesis). Free-TEXT condition type —
+    /// no schema migration (the SAL enforces the closed set). Universal
+    /// `suite_tag` across all signed classes stays v1.x-deferred.
+    ReAnchor,
 }
 
 impl ConditionType {
@@ -94,6 +108,7 @@ impl ConditionType {
             Self::GovernanceEnforcement => "governance_enforcement",
             Self::EpochAdvance => "epoch_advance",
             Self::PeerHeadEntanglement => "peer_head_entanglement",
+            Self::ReAnchor => "re_anchor",
         }
     }
 
@@ -110,6 +125,7 @@ impl ConditionType {
             "governance_enforcement" => Some(Self::GovernanceEnforcement),
             "epoch_advance" => Some(Self::EpochAdvance),
             "peer_head_entanglement" => Some(Self::PeerHeadEntanglement),
+            "re_anchor" => Some(Self::ReAnchor),
             _ => None,
         }
     }

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -2371,6 +2371,45 @@ pub fn force_emit_audit_head_witness(conn: &Connection) {
     maybe_emit_audit_head_witness(conn, head_seq, &head_hash, true);
 }
 
+/// v1.0.0 #2004 (spec §5.3) — OPERATOR-INVOKED crypto-agility re-anchor
+/// ceremony: countersign the CURRENT `signed_events` chain head under the
+/// enrolled suite and persist it as a signed
+/// [`crate::models::ConditionType::ReAnchor`] checkpoint (the #1822
+/// witness-anchor persistence, both backends). Unlike the witness cadence this
+/// is NOT throttled and NOT fire-and-forget — it is an explicit ceremony whose
+/// success / failure the operator must see, so the disposition is returned
+/// rather than swallowed.
+///
+/// Returns `Ok(None)` when no audit-witness key is enrolled (opt-in: the same
+/// distinct off-daemon custody key that signs witness anchors produces the
+/// re-anchor countersignature) or the chain is empty (nothing to anchor). On
+/// success the inserted checkpoint is returned for display / read-back
+/// verification ([`crate::governance::audit::verify_reanchor_checkpoint`]).
+///
+/// # Errors
+/// The head read, witness-key load, checkpoint build (a public-only key), or
+/// the insert failed.
+pub fn emit_reanchor_ceremony(conn: &Connection) -> Result<Option<crate::models::Checkpoint>> {
+    use crate::governance::audit as witness;
+    let (head_seq, head_hash) = read_chain_head(conn).context("re-anchor: read chain head")?;
+    if head_seq <= 0 {
+        return Ok(None); // empty chain — nothing to anchor.
+    }
+    let Some(keypair) = witness::load_witness_signing_key()? else {
+        return Ok(None); // opt-in: no audit-witness key enrolled.
+    };
+    let now_dt = chrono::Utc::now();
+    let cp = witness::build_signed_reanchor_checkpoint(
+        &head_hash,
+        u64::try_from(head_seq).unwrap_or(0),
+        &now_dt.to_rfc3339(),
+        now_dt.timestamp(),
+        &keypair,
+    )?;
+    crate::checkpoints::insert(conn, &cp).context("re-anchor: insert checkpoint")?;
+    Ok(Some(cp))
+}
+
 /// Lowercase-hex encode a byte slice. Centralised so the #1850 watermark
 /// hash and any future hex producer share one stable rendering.
 pub(crate) fn hex_lower(bytes: &[u8]) -> String {

--- a/tests/reanchor_ceremony_2004.rs
+++ b/tests/reanchor_ceremony_2004.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #2004 (spec §5.3, vote `4d3ea1c5`) — end-to-end tests for the
+//! crypto-agility RE-ANCHOR ceremony wired into the `checkpoints` table.
+//!
+//! The ceremony countersigns the current `signed_events` chain head under the
+//! enrolled suite (the FROZEN `re-anchor/v1` format,
+//! `ai_memory::identity::re_anchor`) and persists it as a signed
+//! [`ConditionType::ReAnchor`] checkpoint — mirroring the #1822 audit-head
+//! witness's off-daemon-custody, K1-pinnable persistence. These tests prove
+//! the ceremony ROUND-TRIPS (emit → reload → verify) and FAIL-CLOSES on every
+//! tamper class, on both backends (K3).
+//!
+//! Pins:
+//! - (a) emit → the persisted anchor verifies; the decoded record binds the
+//!   real head sequence + the Ed25519 suite tag.
+//! - (b) a tampered `resolution` (envelope broken) → `EnvelopeInvalid`.
+//! - (c) a tampered detached countersignature (envelope RE-SIGNED so only the
+//!   inner signature is wrong) → `CountersignatureInvalid`.
+//! - (d) verify under a DIFFERENT enrolled key → `PubkeyNotEnrolled` (K1).
+//! - (e) a non-re-anchor checkpoint → `NotReAnchor`.
+//! - (f) no witness key enrolled / an empty chain → `Ok(None)` (opt-in no-op).
+//! - (g) `#[cfg(feature = "sal-postgres")]` postgres parity: the same built
+//!   anchor inserted + read back through the pg SAL verifies identically.
+//!
+//! The witness key-dir / pubkey env vars are process-global, so every test
+//! serialises via a module-local lock and clears the env on exit (the #1822
+//! discipline).
+
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use ai_memory::governance::audit::{self as witness, ReAnchorCheckpointError};
+use ai_memory::identity::cbor_array::SUITE_ED25519_SHA256;
+use ai_memory::models::ConditionType;
+use ai_memory::signed_events::{
+    SignedEvent, append_signed_event, emit_reanchor_ceremony, payload_hash,
+};
+use rusqlite::Connection;
+
+/// Process-global serialisation for the witness ENV.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn lock() -> MutexGuard<'static, ()> {
+    env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Tempdirs under `.local-runs/` (project no-`/tmp` HARD RULE).
+fn fresh_dir(label: &str) -> tempfile::TempDir {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-2004-reanchor");
+    std::fs::create_dir_all(&root).ok();
+    tempfile::Builder::new()
+        .prefix(&format!("{label}-"))
+        .tempdir_in(&root)
+        .expect("tempdir under .local-runs")
+}
+
+fn open_db(dir: &std::path::Path) -> (PathBuf, Connection) {
+    let path = dir.join("audit.db");
+    drop(ai_memory::db::open(&path).expect("init db"));
+    let conn = ai_memory::db::open(&path).expect("open db");
+    (path, conn)
+}
+
+/// Enrol a fresh witness keypair into a temp custody dir + the out-of-band
+/// pubkey env. Returns the keypair (private held by the test). Caller MUST
+/// already hold [`lock`]. Paired with [`clear_witness_env`].
+fn enrol_witness(dir: &std::path::Path) -> ai_memory::identity::keypair::AgentKeypair {
+    let kp = ai_memory::identity::keypair::generate(witness::WITNESS_KEY_LABEL).expect("gen");
+    ai_memory::identity::keypair::save(&kp, dir).expect("save witness key");
+    unsafe {
+        std::env::set_var(witness::WITNESS_KEY_DIR_ENV, dir);
+        std::env::set_var(witness::WITNESS_PUBKEY_ENV, kp.public_base64());
+    }
+    kp
+}
+
+fn clear_witness_env() {
+    unsafe {
+        std::env::remove_var(witness::WITNESS_KEY_DIR_ENV);
+        std::env::remove_var(witness::WITNESS_PUBKEY_ENV);
+    }
+}
+
+fn append_rows(conn: &Connection, n: usize) {
+    for i in 0..n {
+        let payload = format!("payload-{i}");
+        let ev = SignedEvent {
+            id: uuid::Uuid::new_v4().to_string(),
+            agent_id: "alice".to_string(),
+            event_type: "memory_link.created".to_string(),
+            payload_hash: payload_hash(payload.as_bytes()),
+            signature: None,
+            attest_level: "unsigned".to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            ..SignedEvent::default()
+        };
+        append_signed_event(conn, &ev).expect("append");
+    }
+}
+
+// ── (a) emit → persisted anchor verifies + binds the real head ──────────────
+
+#[test]
+fn emit_then_verify_round_trips() {
+    let _g = lock();
+    let kdir = fresh_dir("a-keys");
+    let ddir = fresh_dir("a-db");
+    let kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+
+    append_rows(&conn, 5);
+    let cp = emit_reanchor_ceremony(&conn)
+        .expect("emit ok")
+        .expect("a witness key is enrolled and the chain is non-empty → Some");
+
+    assert_eq!(cp.condition_type, ConditionType::ReAnchor);
+    assert_eq!(cp.namespace, witness::REANCHOR_CHECKPOINT_NAMESPACE);
+    assert_eq!(cp.resolver_pubkey, kp.public.to_bytes().to_vec());
+
+    let record = witness::verify_reanchor_checkpoint(&cp, &kp.public)
+        .expect("the freshly-persisted anchor verifies under the enrolled key");
+    // The ceremony countersigned the CURRENT head (sequence 5) under Ed25519.
+    assert_eq!(record.prior_head_sequence, 5);
+    assert_eq!(record.new_suite_tag, SUITE_ED25519_SHA256);
+
+    clear_witness_env();
+}
+
+// ── (b) tampered resolution → the ENVELOPE signature catches it ─────────────
+
+#[test]
+fn verify_rejects_tampered_resolution() {
+    let _g = lock();
+    let kdir = fresh_dir("b-keys");
+    let ddir = fresh_dir("b-db");
+    let kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+
+    append_rows(&conn, 3);
+    let mut cp = emit_reanchor_ceremony(&conn)
+        .expect("emit ok")
+        .expect("Some");
+
+    // Flip a byte inside the signed resolution string — the checkpoint envelope
+    // signature is computed over the whole resolution, so ANY mutation breaks
+    // it BEFORE the inner countersignature is even reached.
+    let mut res = cp.resolution.take().expect("resolution present");
+    let last = res.pop().expect("non-empty");
+    res.push(if last == 'A' { 'B' } else { 'A' });
+    cp.resolution = Some(res);
+
+    assert_eq!(
+        witness::verify_reanchor_checkpoint(&cp, &kp.public),
+        Err(ReAnchorCheckpointError::EnvelopeInvalid),
+    );
+
+    clear_witness_env();
+}
+
+// ── (c) tampered inner countersig (envelope re-signed) → CountersignatureInvalid ──
+
+#[test]
+fn verify_rejects_tampered_countersignature() {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as B64;
+
+    let _g = lock();
+    let kdir = fresh_dir("c-keys");
+    let ddir = fresh_dir("c-db");
+    let kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+
+    append_rows(&conn, 4);
+    let mut cp = emit_reanchor_ceremony(&conn)
+        .expect("emit ok")
+        .expect("Some");
+
+    // Swap the detached countersignature for a valid-length-but-wrong one
+    // (64 zero bytes), then RE-SIGN the envelope so the outer signature passes
+    // — isolating the inner-countersignature check as the sole gate.
+    let mut wire: serde_json::Value =
+        serde_json::from_str(cp.resolution.as_deref().unwrap()).expect("resolution json");
+    wire["re_anchor_sig"] = serde_json::Value::String(B64.encode([0u8; 64]));
+    cp.resolution = Some(serde_json::to_string(&wire).unwrap());
+    ai_memory::checkpoints::sign_resolution_into(&mut cp, &kp).expect("re-sign envelope");
+
+    match witness::verify_reanchor_checkpoint(&cp, &kp.public) {
+        Err(ReAnchorCheckpointError::CountersignatureInvalid(_)) => {}
+        other => panic!("expected CountersignatureInvalid, got {other:?}"),
+    }
+
+    clear_witness_env();
+}
+
+// ── (d) K1: verify under a DIFFERENT enrolled key → PubkeyNotEnrolled ────────
+
+#[test]
+fn verify_rejects_wrong_enrolled_pubkey() {
+    let _g = lock();
+    let kdir = fresh_dir("d-keys");
+    let ddir = fresh_dir("d-db");
+    let _kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+
+    append_rows(&conn, 3);
+    let cp = emit_reanchor_ceremony(&conn)
+        .expect("emit ok")
+        .expect("Some");
+
+    let attacker = ai_memory::identity::keypair::generate("attacker").expect("gen");
+    assert_eq!(
+        witness::verify_reanchor_checkpoint(&cp, &attacker.public),
+        Err(ReAnchorCheckpointError::PubkeyNotEnrolled),
+    );
+
+    clear_witness_env();
+}
+
+// ── (e) a non-re-anchor checkpoint → NotReAnchor ────────────────────────────
+
+#[test]
+fn verify_rejects_non_reanchor_checkpoint() {
+    let _g = lock();
+    let kdir = fresh_dir("e-keys");
+    let ddir = fresh_dir("e-db");
+    let kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+
+    append_rows(&conn, 3);
+    let mut cp = emit_reanchor_ceremony(&conn)
+        .expect("emit ok")
+        .expect("Some");
+    // Re-label the condition type: the type guard refuses it up-front, before
+    // any signature work.
+    cp.condition_type = ConditionType::AuditHeadWitness;
+    assert_eq!(
+        witness::verify_reanchor_checkpoint(&cp, &kp.public),
+        Err(ReAnchorCheckpointError::NotReAnchor),
+    );
+
+    clear_witness_env();
+}
+
+// ── (f) opt-in no-op: no key enrolled / empty chain → Ok(None) ──────────────
+
+#[test]
+fn no_witness_key_is_noop() {
+    let _g = lock();
+    let ddir = fresh_dir("f-db");
+    clear_witness_env(); // ensure no key is enrolled
+    let (_path, conn) = open_db(ddir.path());
+    append_rows(&conn, 3);
+    assert!(
+        emit_reanchor_ceremony(&conn).expect("ok").is_none(),
+        "no enrolled witness key → the ceremony is a no-op",
+    );
+}
+
+#[test]
+fn empty_chain_is_noop() {
+    let _g = lock();
+    let kdir = fresh_dir("g-keys");
+    let ddir = fresh_dir("g-db");
+    let _kp = enrol_witness(kdir.path());
+    let (_path, conn) = open_db(ddir.path());
+    // No rows appended → head sequence 0 → nothing to anchor.
+    assert!(
+        emit_reanchor_ceremony(&conn).expect("ok").is_none(),
+        "an empty signed_events chain → the ceremony is a no-op",
+    );
+    clear_witness_env();
+}
+
+// ── (g) postgres parity (live-gated) — same anchor, pg round-trip verifies ──
+
+#[cfg(feature = "sal-postgres")]
+mod postgres_parity {
+    use super::*;
+    use ai_memory::store::MemoryStore;
+    use ai_memory::store::postgres::PostgresStore;
+
+    async fn live_pg() -> Option<PostgresStore> {
+        let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        match PostgresStore::connect(&url).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!("skip: postgres connect failed: {e}");
+                None
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL — live postgres"]
+    async fn reanchor_checkpoint_round_trips_through_pg() {
+        let Some(pg) = live_pg().await else {
+            return;
+        };
+        let kp = ai_memory::identity::keypair::generate(witness::WITNESS_KEY_LABEL).expect("gen");
+        // Build the anchor backend-agnostically (a synthetic head), then persist
+        // + reload through the pg SAL: proves the ConditionType::ReAnchor text
+        // spelling + the resolution/signature BYTEA survive the pg round-trip.
+        let head = [0xAB_u8; 32];
+        let now = chrono::Utc::now();
+        let cp = witness::build_signed_reanchor_checkpoint(
+            &head,
+            7,
+            &now.to_rfc3339(),
+            now.timestamp(),
+            &kp,
+        )
+        .expect("build re-anchor checkpoint");
+
+        let ctx = ai_memory::store::CallerContext::for_agent("ai:2004-pg-parity");
+        pg.checkpoint_create(&ctx, &cp)
+            .await
+            .expect("pg checkpoint_create");
+        let reloaded = pg
+            .checkpoint_get(&ctx, &cp.id)
+            .await
+            .expect("pg checkpoint_get")
+            .expect("row present");
+
+        assert_eq!(reloaded.condition_type, ConditionType::ReAnchor);
+        let record = witness::verify_reanchor_checkpoint(&reloaded, &kp.public)
+            .expect("pg-reloaded anchor verifies identically to sqlite (K3)");
+        assert_eq!(record.prior_head_sequence, 7);
+        assert_eq!(record.new_suite_tag, SUITE_ED25519_SHA256);
+
+        sqlx::query("DELETE FROM checkpoints WHERE id = $1")
+            .bind(&cp.id)
+            .execute(pg.pool())
+            .await
+            .ok();
+    }
+}


### PR DESCRIPTION
Closes #2004 (the PARTIAL-DEVELOP residue per the locked v1.0.0 dev-set: "wire callers + re-anchor ceremony").

## What

The frozen `re-anchor/v1` primitive (`src/identity/re_anchor.rs`) shipped at the v1.0.0 crypto-core close-out with **zero non-test callers** — pure types + sign/verify + a structural decoder, bytes frozen but unwired. This PR wires it into the SAME off-daemon-custody, K1-pinnable `checkpoints`-row persistence the #1822 audit-head witness uses, so an operator can actually **run** the ceremony and the anchor is loadable + verifiable on both backends.

Per-record PQ signatures are forbidden (spec §2.4 — incompatible with endpoint budgets), so post-quantum strength binds at **checkpoint granularity**: the new-suite key countersigns "seen prior chain head `H` @ sequence `N`", so enabling a stronger / PQ suite on a live corpus later causes **zero** write failures and **zero** record rewrites, and every pre-break record stays attributable.

## How (mirrors the #1822 witness + #1946 restore-attest precedents)

- **`build_signed_reanchor_checkpoint`** (`governance/audit.rs`) — pure builder mirroring `build_signed_witness_checkpoint`: countersigns the prior head under `SuiteId::Ed25519Sha256` (`sign_re_anchor`, witness custody key), rides the canonical `re-anchor/v1` CBOR + its detached signature (base64) in a signed `ConditionType::ReAnchor` resolution, envelope-signed via `checkpoints::sign_resolution_into`.
- **`verify_reanchor_checkpoint` + `ReAnchorCheckpointError`** — fail-closed read-back: type guard → **K1 pin** (`resolver_pubkey == enrolled witness key`) → envelope-sig → `decode_re_anchor_v1` the **persisted** bytes (never a re-derived projection) → `verify_re_anchor` (+ the §2.4 suite cross-check). Returns the decoded `ReAnchorRecord`.
- **`signed_events::emit_reanchor_ceremony`** — operator entry point (has the private `read_chain_head`): reads the head, loads the witness key, builds + inserts. **Not** throttled / **not** fire-and-forget — an explicit ceremony whose disposition is returned; `Ok(None)` when no witness key is enrolled or the chain is empty (opt-in no-op).
- **`ai-memory audit re-anchor [--json]`** — a **sub-verb** under the existing `audit` Command (no new top-level Command → no cli-subcommand-count bump), mirroring `audit restore-attest`. Self-verifies the persisted anchor (K1) so the operator sees the round-trip.
- `ConditionType::ReAnchor` (free-text, **no schema migration** — the SAL enforces the closed set).

## Deferred to v1.x (unanimous vote)

The universal per-signed-class `suite_tag` + a separate PQ-capable enrolment key. Today the only enrolled suite is Ed25519-SHA256.

## Tests

`tests/reanchor_ceremony_2004.rs` — 7 sqlite + 1 live-pg:
- emit → reload → verify round-trip binds the real head sequence + the Ed25519 suite tag;
- every tamper class fail-closes (broken envelope → `EnvelopeInvalid`; re-signed-envelope tampered countersig → `CountersignatureInvalid`; wrong enrolled key → `PubkeyNotEnrolled`; non-re-anchor → `NotReAnchor`);
- opt-in no-op when no key / empty chain;
- `#[cfg(feature = "sal-postgres")]` `#[ignore]` parity: the anchor round-trips through the pg SAL and verifies identically (K3).

## Gates

fmt + clippy (default **and** `sal,sal-postgres`, `-D warnings` pedantic) clean; `reanchor_ceremony_2004` 7/7; `cli_subcommand_count_invariant`, `qual_10` (no bump), `models::checkpoint` roundtrip, docs-vs-ssot, `re_anchor`(15) + `audit`(40) lib — all green.

Cites 2×5 adversarial vote `4d3ea1c5`, verdict memory `8ded47fe`, locked dev-set `244b7229`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY