### PR TITLE
feat(#1980): signed-rule-pack refuse-by-default template + workflow docs

### DIFF
--- a/docs/governance/refuse-by-default-rules.template.json
+++ b/docs/governance/refuse-by-default-rules.template.json
@@ -1,0 +1,51 @@
+{
+  "_template": "signed-rule-pack/illustrative-v1",
+  "_note": [
+    "#1980 — an ILLUSTRATIVE refuse-by-default agent-action rule template. This is",
+    "NOT a blessed, complete, or prescriptive security policy: the safe refusal set",
+    "is DEPLOYMENT-SPECIFIC. The example matchers below are deliberately fake",
+    "(*.invalid hosts, /example/ paths, example-* tools) so that copying this file",
+    "verbatim refuses NOTHING real. Author + tune every rule for your deployment",
+    "before you sign and enable it.",
+    "",
+    "These rules ship DISABLED and UNSIGNED. refuse-by-default is OPT-IN — the",
+    "substrate does NOT enable them for you. To activate the posture:",
+    "  1. edit these rules for your environment (real matchers, real reasons);",
+    "  2. `ai-memory rules keygen` (once) to mint the operator key;",
+    "  3. `ai-memory rules add --id <id> --kind <kind> --matcher '<json>' --severity refuse \\",
+    "        --reason '<why>' --disabled --sign` for each rule;",
+    "  4. review with `ai-memory rules list`, then `ai-memory rules enable <id> --sign`;",
+    "  5. confirm the installed set with `ai-memory doctor` (the policy-version digest",
+    "     drift check) and pin this file's published hash out-of-band.",
+    "See docs/governance/signed-rule-pack.md for the full workflow + the honest limits."
+  ],
+  "rules": [
+    {
+      "id": "example-fs-refuse",
+      "kind": "filesystem_write",
+      "matcher": { "glob": "/example/forbidden/path/**" },
+      "severity": "refuse",
+      "reason": "EXAMPLE ONLY — refuse writes outside the agent workspace. Replace this glob with your deployment's forbidden write paths.",
+      "namespace": "_global",
+      "enabled": false
+    },
+    {
+      "id": "example-net-refuse",
+      "kind": "network_request",
+      "matcher": { "host": "exfil.example.invalid" },
+      "severity": "refuse",
+      "reason": "EXAMPLE ONLY — refuse egress to an unapproved host. Replace with your deployment's egress denylist.",
+      "namespace": "_global",
+      "enabled": false
+    },
+    {
+      "id": "example-proc-refuse",
+      "kind": "process_spawn",
+      "matcher": { "binary": "example-forbidden-tool" },
+      "severity": "refuse",
+      "reason": "EXAMPLE ONLY — refuse spawning an unapproved tool. Replace with your deployment's binary denylist.",
+      "namespace": "_global",
+      "enabled": false
+    }
+  ]
+}

--- a/docs/governance/signed-rule-pack.md
+++ b/docs/governance/signed-rule-pack.md
@@ -1,0 +1,104 @@
+---
+layout: doc
+---
+# Signed rule packs (refuse-by-default template)
+
+**Status:** v1.0.0 (#1980). Ships the **template + workflow** for an
+operator-signed refuse-by-default agent-action rule set. The refuse-by-default
+posture is **opt-in** — the substrate does **not** enable it for you. The full
+one-file *pack apply* mechanism (a `rules apply-pack` verb + a versioned pack
+container + a set-manifest) is deferred to v1.x, to land **with** the
+refuse-by-default enforcement consumer (tracked separately — see *Deferred*
+below). This doc + [`refuse-by-default-rules.template.json`](./refuse-by-default-rules.template.json)
+are the v1.0.0 residue.
+
+## What this is (and is not)
+
+- **Is:** an *illustrative* template rule set + the workflow to sign each rule
+  with the operator key (the existing per-rule signing posture, #1961) and
+  enable it deliberately.
+- **Is not:** a blessed, complete, or prescriptive security policy. The safe
+  refusal set is **deployment-specific**. The template's matchers are
+  deliberately fake (`*.invalid` hosts, `/example/` paths, `example-*` tools) so
+  copying it verbatim refuses **nothing real**. There is no "refuse everything
+  dangerous" list — a fixed matcher set cannot deliver the completeness the
+  phrase "refuse-by-default" implies (an un-refused escalation path is always
+  possible), so **do not** read the template as an attestation of coverage.
+
+## The rule model
+
+An agent-action rule is one row in `governance_rules`
+(`docs/governance/agent-action-rules.md` has the full engine + the per-kind
+matcher shapes). The signature-bearing fields — the eight covered by the
+operator signature — are `id, kind, matcher, severity, reason, namespace,
+created_by, enabled`; `created_at`, `attest_level`, and the `signature` itself
+are **not** signed and must never be trusted from a file.
+
+Per-kind matcher JSON:
+
+| `kind`             | matcher example                       |
+|--------------------|---------------------------------------|
+| `filesystem_write` | `{"glob":"/example/forbidden/**"}`    |
+| `network_request`  | `{"host":"exfil.example.invalid"}`    |
+| `process_spawn`    | `{"binary":"example-forbidden-tool"}` |
+| `bash`             | `{"command_substring":"…"}` or `{"command_regex":"…"}` |
+
+## Workflow — activate refuse-by-default (opt-in)
+
+```bash
+# 0. Author your policy: copy the template and edit every rule for your
+#    deployment (real matchers, real reasons). NEVER ship the example matchers.
+cp docs/governance/refuse-by-default-rules.template.json my-rules.json
+$EDITOR my-rules.json
+
+# 1. Mint the operator key once (holds the sole authority to sign law).
+ai-memory rules keygen
+
+# 2. Sign + install each rule DISABLED (the substrate default is unchanged).
+ai-memory rules add \
+  --id fs-workspace-only \
+  --kind filesystem_write \
+  --matcher '{"glob":"/srv/agent-forbidden/**"}' \
+  --severity refuse \
+  --reason 'no writes outside the agent workspace' \
+  --disabled --sign
+
+# 3. Review what will enforce BEFORE activating.
+ai-memory rules list
+
+# 4. Enable each reviewed rule (re-signs the enabled state).
+ai-memory rules enable fs-workspace-only --sign
+
+# 5. Confirm the installed, enabled set matches your intent.
+ai-memory doctor          # runs the policy-version digest drift check
+```
+
+Each rule is operator-signed over its canonical bytes and re-verified at
+enforcement time; an unverifiable rule is not honored (see
+`rules_store::enforced_rule_passes`).
+
+## Honest limits
+
+- **Opt-in, no default flip.** Installing these rules — even enabled — changes
+  only the actions your operator chose to refuse. The substrate does **not**
+  turn refuse-by-default on globally; there is no compat-breaking default change
+  at v1.0.0.
+- **Completeness is your responsibility.** The template is a starting point, not
+  a covered-everything guarantee.
+- **Pin the set out-of-band.** Until the v1.x pack-apply mechanism lands, confirm
+  the installed set against a published hash of your reviewed rule file (and the
+  `policy_version` digest surfaced by `doctor`) so a dropped or edited rule is
+  detectable — per-rule signatures attest each rule's authenticity but not the
+  *completeness* of the set.
+
+## Deferred to v1.x
+
+The single-file **pack apply** mechanism — a `rules apply-pack <file>` verb that
+verifies an operator-signed **set-manifest** (`{epoch, sorted rule
+content-hashes}`, closing the subset/omission + replay gaps that per-rule
+signatures alone do not) inside a versioned pack container, and installs every
+rule in one atomic transaction — is deferred to v1.x so it lands together with
+the refuse-by-default **enforcement** consumer. It will reuse the existing
+`epoch-apply` signed-atomic-apply pattern + the `policy_version` set-digest
+rather than mint new crypto. Freezing that wire format at v1.0.0 — before its
+consumer exists — is the higher-regret path.

--- a/tests/signed_rule_pack_template_1980.rs
+++ b/tests/signed_rule_pack_template_1980.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #1980 (2×5 vote 288ef0ef) — regression guard for the illustrative
+//! refuse-by-default signed-rule-pack TEMPLATE.
+//!
+//! The vote's content finding (refuter a0f92306): the shipped template must be
+//! ILLUSTRATIVE (fake matchers) + DISABLED + UNSIGNED — never a prescriptive
+//! "blessed" policy, and never one whose matchers refuse real common operations
+//! (`refuse process_spawn cargo` / `refuse /tmp` would break the substrate's own
+//! build). This test pins those properties so the template can't silently drift
+//! into a dangerous or auto-active state.
+
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+fn template() -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("docs/governance/refuse-by-default-rules.template.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read template {}: {e}", path.display()));
+    serde_json::from_str(&raw).expect("template is valid JSON")
+}
+
+/// The closed action-kind vocabulary the agent-action engine accepts.
+const VALID_KINDS: &[&str] = &[
+    "filesystem_write",
+    "network_request",
+    "process_spawn",
+    "bash",
+    "custom",
+];
+
+#[test]
+fn template_rules_are_disabled_unsigned_refuse_and_well_formed() {
+    let t = template();
+    let rules = t
+        .get("rules")
+        .and_then(Value::as_array)
+        .expect("template has a rules array");
+    assert!(
+        !rules.is_empty(),
+        "template ships at least one example rule"
+    );
+
+    for r in rules {
+        let id = r.get("id").and_then(Value::as_str).expect("rule has id");
+
+        // DISABLED — the substrate default is never flipped by shipping this.
+        assert_eq!(
+            r.get("enabled").and_then(Value::as_bool),
+            Some(false),
+            "rule {id} must ship DISABLED"
+        );
+
+        // UNSIGNED — the template carries NO signature (the operator signs it).
+        assert!(
+            r.get("signature").is_none(),
+            "rule {id} must ship UNSIGNED (no signature field)"
+        );
+
+        // Well-formed kind + a non-empty per-kind matcher object.
+        let kind = r
+            .get("kind")
+            .and_then(Value::as_str)
+            .expect("rule has kind");
+        assert!(
+            VALID_KINDS.contains(&kind),
+            "rule {id}: unknown kind {kind}"
+        );
+        let matcher = r
+            .get("matcher")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("rule {id}: matcher must be a JSON object"));
+        assert!(!matcher.is_empty(), "rule {id}: matcher must be non-empty");
+
+        // severity present (the template is a refuse-by-default illustration).
+        assert!(
+            r.get("severity").and_then(Value::as_str).is_some(),
+            "rule {id}: severity present"
+        );
+    }
+}
+
+#[test]
+fn template_matchers_are_illustrative_never_real_operations() {
+    // The load-bearing safety property: copying the template verbatim must
+    // refuse NOTHING real. Every matcher value is a deliberately-fake token, and
+    // must NOT collide with operations the substrate itself performs (writing
+    // /tmp, spawning cargo) — those would be a false-positive footgun.
+    let t = template();
+    let rules = t.get("rules").and_then(Value::as_array).expect("rules");
+
+    // Tokens that would indicate a REAL (dangerous-to-bless) matcher.
+    const FORBIDDEN_REAL: &[&str] = &["/tmp", "/var/tmp", "cargo", "/usr", "/etc", "/home"];
+    // Tokens that mark a value as deliberately illustrative/fake.
+    const ILLUSTRATIVE: &[&str] = &["example", "invalid", "forbidden"];
+
+    for r in rules {
+        let id = r.get("id").and_then(Value::as_str).unwrap_or("?");
+        let matcher = r.get("matcher").expect("matcher");
+        let matcher_str = serde_json::to_string(matcher).unwrap();
+
+        for real in FORBIDDEN_REAL {
+            assert!(
+                !matcher_str.contains(real),
+                "rule {id}: matcher {matcher_str} names a REAL path/binary ({real}) — the \
+                 template must stay illustrative so it refuses nothing real"
+            );
+        }
+        assert!(
+            ILLUSTRATIVE.iter().any(|tok| matcher_str.contains(tok)),
+            "rule {id}: matcher {matcher_str} must be visibly illustrative \
+             (contain example/invalid/forbidden)"
+        );
+
+        // The reason must flag the rule as an example the operator replaces.
+        let reason = r.get("reason").and_then(Value::as_str).unwrap_or("");
+        assert!(
+            reason.to_uppercase().contains("EXAMPLE"),
+            "rule {id}: reason must mark it as an EXAMPLE to replace; got {reason:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1980 (the PARTIAL-DEVELOP residue per the locked v1.0.0 dev-set: "signed-rule-pack TEMPLATE residue").

## What

Ships the refuse-by-default rule-set **template** + the operator-signing **workflow** — the opt-in artifact that lets an operator adopt refuse-by-default, **without** the substrate flipping any default (the default-flip is deferred, per Sprint-0 ruling `8c5e9f2a`: enabling-by-default in a compat freeze is high-regret).

Adjudicated by a **2×5 adversarial vote** (verdict memory `288ef0ef`, wave-1 4A/1B; all 5 refuters NO/PARTIAL against shipping a pack *mechanism* at v1.0). Decisive findings:
- Freezing a pack **wire-format** at v1.0.0 *before its enforcement consumer exists* is high-regret (T4 both ways).
- **Per-rule signatures alone are insecure** for a pack (subset/omission attack, zero forgery); a secure pack needs a set-manifest — premature to freeze now.
- The per-rule signature covers only **8 enumerated fields** (`canonical_bytes_for_signing`), so a raw-serde pack would let an attacker mutate an unsigned field and still verify.
- The pack primitives already exist (`epoch-apply`, `policy_version`, `rules --sign`) → the real mechanism is a thin v1.x wrapper.

## Ships (v1.0.0)

- **`docs/governance/refuse-by-default-rules.template.json`** — an **illustrative** template. Matchers are deliberately fake (`*.invalid` hosts, `/example/` paths, `example-*` tools) so copying it verbatim refuses **nothing real**; ships **DISABLED + UNSIGNED**; explicitly not a blessed/complete policy. Real matchers like `refuse cargo` / `refuse /tmp` would break the substrate's own build — deliberately excluded.
- **`docs/governance/signed-rule-pack.md`** — the opt-in workflow + the 8 signature-covered fields + honest limits (opt-in / no default flip; completeness is the operator's; pin the set by out-of-band hash until v1.x).
- **`tests/signed_rule_pack_template_1980.rs`** — regression guard: rules are disabled + unsigned + well-formed, every matcher illustrative (never a real path/binary).

## Deferred (filed 1:1)

The full pack-apply mechanism (`rules apply-pack` + versioned container + set-manifest + authoritative-field allowlist) → **#2047**, to land with the refuse-by-default enforcement consumer.

## Gates

`signed_rule_pack_template_1980` 2/2; docs-vs-ssot PASS; clippy clean. **No src/ change** — no new CLI verb / pack file-format frozen (cli-subcommand-count unaffected).

Cites 2×5 vote verdict `288ef0ef`, ruling `8c5e9f2a`, locked dev-set `244b7229`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY