### PR TITLE
feat(#1987): wire bench --baseline regression guard into CI + baseline recipe

### DIFF
--- a/.github/scripts/median_baseline.py
+++ b/.github/scripts/median_baseline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""#1987 — build a self-describing `bench --baseline` file from N `bench --json`
+runs by taking the per-operation MEDIAN p95 (stable across shared-runner noise).
+
+Usage: median_baseline.py <binary_rev> <run1.json> [run2.json ...] > baseline.json
+
+The output is a superset of what `ai_memory::bench::load_baseline` consumes
+(`{results: [{operation, measured_p95_ms}, ...]}`); the extra top-level fields
+(`runner_class`, `bootstrap`, `generated_at_binary_rev`, ...) are self-describing
+metadata that `load_baseline` ignores. `runner_class` defaults to the
+`RUNNER_BASELINE_CLASS` env (set to `ubuntu-latest` by the workflow) and
+`bootstrap` is `false` — this is a REAL, CI-runner baseline, unlike the committed
+dev bootstrap.
+"""
+import json
+import os
+import statistics
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        sys.stderr.write("usage: median_baseline.py <binary_rev> <run1.json> [run2.json ...]\n")
+        return 2
+    rev = sys.argv[1]
+    runs = [json.load(open(p)) for p in sys.argv[2:]]
+
+    # Collect p95 samples per operation across the N runs.
+    p95_samples: dict[str, list[float]] = {}
+    label: dict[str, str] = {}
+    meta = runs[0]
+    for run in runs:
+        for r in run["results"]:
+            op = r["operation"]
+            p95_samples.setdefault(op, []).append(float(r["measured_p95_ms"]))
+            label[op] = r.get("label", op)
+
+    results = [
+        {
+            "operation": op,
+            "label": label[op],
+            "measured_p95_ms": round(statistics.median(samples), 6),
+        }
+        for op, samples in sorted(p95_samples.items())
+    ]
+
+    out = {
+        "_schema": "ai-memory bench --json baseline (#1987)",
+        "_note": (
+            "Median-of-%d baseline captured on the CI runner class. Refresh every "
+            "minor release (a baseline older than one minor should be regenerated)." % len(runs)
+        ),
+        "bootstrap": False,
+        "runner_class": os.environ.get("RUNNER_BASELINE_CLASS", "ubuntu-latest"),
+        "generated_at_binary_rev": rev,
+        "regression_threshold_pct_default": 50,
+        "runs": len(runs),
+        "iterations": meta.get("iterations"),
+        "warmup": meta.get("warmup"),
+        "scale": meta.get("scale"),
+        "results": results,
+    }
+    sys.stdout.write(json.dumps(out, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -105,6 +105,50 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"
 
+      # #1987 — baseline regression guard, ADVISORY (never blocks). Compares
+      # this run against the committed performance/baseline.json via the shipped
+      # `bench --baseline` CLI. It self-skips while the committed baseline is a
+      # dev-machine BOOTSTRAP (a dev-vs-ubuntu-latest compare is pure hardware
+      # noise); run the `regenerate-baseline` workflow_dispatch job to capture a
+      # real median-of-3 ubuntu-latest baseline, commit it with bootstrap:false,
+      # and this step activates. Promote to a BLOCKING gate only after a soak
+      # proves <1% false-positive across >=20 runs (ruling d6a366ea wave-2).
+      - name: Baseline regression (advisory, #1987)
+        if: always()
+        run: |
+          set +e
+          if [ ! -f performance/baseline.json ]; then
+            echo "no performance/baseline.json committed — skipping advisory compare" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          BOOTSTRAP=$(python3 -c "import json;print(json.load(open('performance/baseline.json')).get('bootstrap', False))")
+          if [ "$BOOTSTRAP" != "False" ]; then
+            {
+              echo '## Baseline regression (advisory, #1987)'
+              echo 'SKIPPED — the committed `performance/baseline.json` is a dev-machine'
+              echo 'BOOTSTRAP. Run the **regenerate-baseline** workflow_dispatch job on'
+              echo 'ubuntu-latest, commit the result with `bootstrap: false`, and this'
+              echo 'advisory compare activates.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          target/release/ai-memory bench --baseline performance/baseline.json \
+            --regression-threshold 50 | tee baseline-compare.txt
+          {
+            echo '## Baseline regression (advisory, #1987)'
+            echo ''
+            echo 'ADVISORY — never fails the build. Median-of-3 baseline vs this run,'
+            echo 'threshold +50%. Promote to blocking only after a soak proves a'
+            echo '<1% false-positive rate across >=20 runs.'
+            echo ''
+            echo '```'
+            cat baseline-compare.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # ADVISORY: swallow `bench --baseline`'s non-zero regression exit so
+          # this step is never a build failure.
+          exit 0
+
       - name: Run bench (JSON for artifact)
         if: always()
         run: target/release/ai-memory bench --json > bench-results.json || true
@@ -124,3 +168,52 @@ jobs:
             bench-table.txt
             bench-table-10k.txt
           if-no-files-found: warn
+
+  # #1987 — the baseline GENERATION recipe. Operator-triggered
+  # (workflow_dispatch) so a real median-of-3 baseline is captured ON the CI
+  # runner class it will gate (never a dev machine). Uploads the result as an
+  # artifact for the operator to commit as performance/baseline.json with
+  # bootstrap:false — the workflow has contents:read and never auto-commits.
+  regenerate-baseline:
+    name: Regenerate bench baseline (ubuntu-latest, median-of-3)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --bin ai-memory
+
+      - name: Capture median-of-3 baseline
+        env:
+          RUNNER_BASELINE_CLASS: ubuntu-latest
+        run: |
+          for i in 1 2 3; do
+            target/release/ai-memory bench --json > "run-$i.json"
+          done
+          python3 .github/scripts/median_baseline.py "$(git rev-parse --short HEAD)" \
+            run-1.json run-2.json run-3.json > performance/baseline.json
+          {
+            echo '## Regenerated bench baseline (median-of-3, ubuntu-latest)'
+            echo ''
+            echo 'Download the `bench-baseline` artifact and commit it as'
+            echo '`performance/baseline.json` (it already carries `bootstrap: false`)'
+            echo 'to activate the advisory regression compare in the Bench workflow.'
+            echo 'Refresh every minor release.'
+            echo ''
+            echo '```json'
+            cat performance/baseline.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload regenerated baseline
+        uses: actions/upload-artifact@v5
+        with:
+          name: bench-baseline
+          path: performance/baseline.json
+          if-no-files-found: error

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -161,6 +161,27 @@ default-workload gate) and uploads `bench-results-10k.json` with the
 artifact set. The run fails when any operation's measured p95 exceeds
 its scale budget by more than the published 10% tolerance.
 
+### Baseline regression guard (#1987)
+
+Beyond the **absolute** p95 budget gates above, `bench.yml` carries an
+**advisory** relative-regression step (`ai-memory bench --baseline
+performance/baseline.json --regression-threshold 50`). It compares each
+run against the committed baseline and reports per-operation deltas to the
+job summary; it **never fails the build** — a shared-runner p95 at a tight
+threshold is a flake generator, so it stays advisory until a soak proves a
+< 1% false-positive rate across ≥ 20 runs (ruling `d6a366ea`).
+
+`performance/baseline.json` must be captured **on the CI runner class it
+gates** (`ubuntu-latest`), not a dev machine. The committed file ships as a
+dev **bootstrap** (`bootstrap: true`), which makes the advisory step
+self-skip (a dev-vs-CI compare is pure hardware noise). To capture a real
+baseline, run the **regenerate-baseline** `workflow_dispatch` job (Bench
+workflow): it takes a **median-of-3** on `ubuntu-latest`, self-describes
+the runner class + binary rev, and uploads the result for an operator to
+commit as `performance/baseline.json` with `bootstrap: false` — which
+activates the advisory compare. **Refresh every minor release** (a baseline
+older than one minor should be regenerated).
+
 ## Verified-path benchmarks (#1961 / R23-R7)
 
 The default bench workload times the *plain* hot paths — `memory_store`

--- a/performance/baseline.json
+++ b/performance/baseline.json
@@ -1,0 +1,53 @@
+{
+  "_schema": "ai-memory bench --json baseline (#1987)",
+  "_note": "BOOTSTRAP baseline generated on a DEV machine \u2014 NOT the CI runner class. The p95 numbers are placeholders so the CI compare step is wired + schema-valid; bootstrap:true makes the advisory CI step SKIP the comparison (a dev-vs-ubuntu-latest compare is pure hardware noise). Run the regenerate-baseline workflow_dispatch job on ubuntu-latest for a real median-of-3 baseline, commit it with bootstrap:false, then the advisory compare activates. Refresh every minor release.",
+  "bootstrap": true,
+  "runner_class": "local-dev-bootstrap",
+  "generated_at_binary_rev": "f5697a95",
+  "regression_threshold_pct_default": 50,
+  "iterations": 200,
+  "warmup": 20,
+  "scale": null,
+  "results": [
+    {
+      "operation": "store_no_embedding",
+      "label": "memory_store (no embedding)",
+      "measured_p95_ms": 0.19113469999999996
+    },
+    {
+      "operation": "search_fts",
+      "label": "memory_search (FTS5)",
+      "measured_p95_ms": 0.44111674999999995
+    },
+    {
+      "operation": "recall_hot",
+      "label": "memory_recall (hot, depth=1)",
+      "measured_p95_ms": 1.5253473499999999
+    },
+    {
+      "operation": "recall_rerank_hot",
+      "label": "memory_recall (rerank stage, depth=1)",
+      "measured_p95_ms": 1.8469375499999998
+    },
+    {
+      "operation": "kg_query_depth1",
+      "label": "memory_kg_query (depth=1)",
+      "measured_p95_ms": 0.45441795
+    },
+    {
+      "operation": "kg_query_depth3",
+      "label": "memory_kg_query (depth=3)",
+      "measured_p95_ms": 0.5271624500000001
+    },
+    {
+      "operation": "kg_query_depth5",
+      "label": "memory_kg_query (depth=5)",
+      "measured_p95_ms": 0.56339215
+    },
+    {
+      "operation": "kg_timeline",
+      "label": "memory_kg_timeline",
+      "measured_p95_ms": 0.029518799999999998
+    }
+  ]
+}

--- a/tests/bench_baseline_1987.rs
+++ b/tests/bench_baseline_1987.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #1987 — regression guard for the committed `performance/baseline.json`.
+//!
+//! The CI-job wiring (`.github/workflows/bench.yml` advisory compare +
+//! `regenerate-baseline`) reads `performance/baseline.json` through the shipped
+//! `ai_memory::bench::load_baseline`. This test pins that the committed file
+//! stays loadable (so a hand-edit or a regeneration can't silently break the
+//! advisory gate) and that it self-describes its runner class + bootstrap state.
+
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::PathBuf;
+
+fn baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("performance/baseline.json")
+}
+
+#[test]
+fn committed_baseline_loads_via_the_shipped_loader() {
+    let path = baseline_path();
+    // The exact loader the `bench --baseline` CI step uses — a superset JSON
+    // (self-describing metadata) must still deserialize to the records.
+    let records = ai_memory::bench::load_baseline(&path)
+        .unwrap_or_else(|e| panic!("load_baseline({}) failed: {e}", path.display()));
+    assert!(
+        !records.is_empty(),
+        "baseline must carry at least one operation record"
+    );
+    // Every record has a usable p95 for the regression compare.
+    for r in &records {
+        assert!(
+            r.measured_p95_ms >= 0.0,
+            "operation {:?}: measured_p95_ms must be non-negative",
+            r.operation
+        );
+    }
+}
+
+#[test]
+fn committed_baseline_is_self_describing() {
+    // The #1987 recipe requires the baseline to pin its runner class +
+    // bootstrap state so the advisory step can decide whether to compare.
+    let raw = std::fs::read_to_string(baseline_path()).expect("read baseline");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("baseline is valid JSON");
+    assert!(
+        v.get("runner_class")
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "baseline must pin its runner_class"
+    );
+    assert!(
+        v.get("bootstrap")
+            .and_then(serde_json::Value::as_bool)
+            .is_some(),
+        "baseline must carry an explicit bootstrap flag (the advisory CI step keys off it)"
+    );
+    assert!(
+        v.get("generated_at_binary_rev").is_some(),
+        "baseline must pin the binary rev it was generated against"
+    );
+}


### PR DESCRIPTION
Closes #1987 (the PARTIAL-DEVELOP residue per the locked v1.0.0 dev-set: "bench CLI shipped → CI-JOB wiring only").

## What

The `ai-memory bench --baseline <path> --regression-threshold N` CLI has shipped since #1961; what never existed is a **committed `performance/baseline.json` + a CI job passing `--baseline`**. This wires exactly the recipe the Gate-0 ruling (`d6a366ea`, BENCH-BASELINE B/C 5/5) mandated so it can't rot as a bare "wire it later."

Vote-exempt: single-correct-answer infra wiring — the design (advisory-first, threshold 50, generate-on-the-CI-runner-class) was already voted in `d6a366ea`. **Never touches `release.yml`.**

## How

- **`bench.yml`** gains an **advisory** "Baseline regression" step (`bench --baseline performance/baseline.json --regression-threshold 50`) reported to the job summary — it **never fails the build** (a shared-runner p95 at a tight threshold is a flake generator, so advisory-first until a soak proves < 1% false-positive across ≥ 20 runs). It **self-skips** while the committed baseline is a dev bootstrap (a dev-vs-`ubuntu-latest` compare is pure hardware noise).
- A **`regenerate-baseline`** `workflow_dispatch` job captures a real **median-of-3** baseline **on `ubuntu-latest`** (the class it gates), self-describing (runner class, binary rev), and uploads it for the operator to commit with `bootstrap: false` — which activates the advisory compare. The workflow keeps `contents: read` and never auto-commits.
- **`.github/scripts/median_baseline.py`** — the per-operation median-of-N builder.
- **`performance/baseline.json`** — a self-describing dev **bootstrap** (`bootstrap: true`); schema-valid + loadable by the shipped `load_baseline`, but flagged so the advisory step self-skips until CI-regenerated.
- **`PERFORMANCE.md` §"Baseline regression guard (#1987)"** — the advisory framing + regeneration recipe + the every-minor-release refresh policy.

## Gates

`bench_baseline_1987` 2/2 (the committed baseline loads via the shipped `load_baseline` + is self-describing); docs-vs-ssot PASS; workflow YAML validated; clippy clean; **no src/ change**.

Cites Gate-0 ruling memory `d6a366ea`, locked dev-set `244b7229`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY