### PR TITLE
feat(#1836): TRACT L1 Claim contract (G22) + non-authoritative ClaimView divergence anchor

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -1,0 +1,141 @@
+---
+layout: doc
+---
+# TRACT L1 Claim contract (G22) — NORMATIVE / UNIMPLEMENTED
+
+> **STATUS — read this first.** This document is the **normative migration
+> contract** for TRACT gap **G22** (#1836): the frozen 9-field Claim object +
+> the six-verb closed algebra that TRACT L1 specifies. **The substrate does
+> NOT implement the closed Claim algebra at v1.0.0.** ai-memory stores a thick
+> 28-field `Memory` row (`src/models/memory.rs`) manipulated by RPC-style verbs;
+> the TRACT L1 kernel is the INVERSE arrangement (a thin Claim kernel that the
+> thick row *projects from*). Per the TRACT canonical-gaps doc, the full G22
+> inversion is **Phase-C / v1.x** work and MUST NOT be attempted inside the
+> v1.0.0 compat freeze. Do **not** read this as a claim of TRACT-/L1-
+> conformance — the honesty ledger (§5) explicitly forbids that until the
+> inversion lands. This contract exists so the gap is a *tracked, specified*
+> defect (§24 prime directive) with a concrete v1.x target, and so the other
+> Tier-B TRACT-gap items reference one canonical L1 kernel definition.
+
+This is the **canonical root** for the Tier-B TRACT-gap conformance work: the
+data-model divergences in the sibling items (#1833/#1832/#1830/#1829/#1839/
+#1862/#1863/#1864) are described against the kernel defined here.
+
+## 1. The frozen 9-field Claim (TRACT §1/§2)
+
+A field is frozen-core iff it cannot be recomputed from {the rest of L1} +
+{the active Reference Profile}. Everything recomputable is a derived projection
+below the frozen line.
+
+| # | Claim field | TRACT shape | Purpose |
+|---|---|---|---|
+| 1 | `id` | `BLAKE3-256(dCBOR(content) ‖ 0x00 ‖ dCBOR(provenance))` — CIDv1 | content+origin identity; `owner` deliberately NOT in the preimage |
+| 2 | `kind` | `fact \| episode \| skill \| policy \| relation` (5, authored, hashed) | a *kind* tag, not a class |
+| 3 | `content` | `{ mime, bytes }` — L1 is content-BLIND | the asserted payload |
+| 4 | `provenance` | `{ asserter, source, span, valid_time, transaction_time }` — bitemporal, hashed | who/where/when |
+| 5 | `owner` | lineage-DAG node ref — transferable by succession, NOT hashed | governs the claim |
+| 6 | `confidence` | `{ value_at_assert, basis }` — immutable authored record, NOT hashed | confidence AT ASSERT |
+| 7 | `attestation` | `{ level: claimed\|attested, sig_writer, sig_witnesses[], algorithm_id }` — append-monotone | trust ladder |
+| 8 | `lifecycle` | `asserted \| superseded(by) \| forgotten(receipt)` — append-only | never in-place edited |
+| 9 | `links` | `[ RELATE{ predicate: kernel-id \| open-CID, target, sig } ]` — ≤10 kernel + open CIDs | typed signed edges |
+
+**Derived / residency (L2/L3 — NEVER frozen, NEVER hashed):** embedding, tier
+(hot/warm/cold/tombstone), lod, cache_key, schema_cid, the `confidence_value(t)`
+decay overlay, salience/access/CONSUME counts — carried as columns of the
+Reference-Profile row, which is a *documented projection* of the Claim.
+
+## 2. The six-verb closed algebra (TRACT §2)
+
+The entire write surface; everything else composes from these.
+
+| Verb | Meaning | Discipline |
+|---|---|---|
+| **ASSERT** | add a Claim with provenance; born *claimed* | no content without a binding |
+| **RELATE** | typed directional signed edge | belief revision is a graph op |
+| **RECALL** | owner-scoped relevance retrieval | **a pure read — reads never write** |
+| **ATTEST** | raise *claimed → attested* | the only path to trust |
+| **SUPERSEDE** | forward correction (new Claim + link) | **no UPDATE** |
+| **FORGET** | witnessed-policy erasure; signed tombstone remains | **no silent DELETE** |
+
+Kernel link predicates (frozen floor, ≤10): `supersedes · contradicts ·
+derived_from · caused_by · attests · part_of · relates_to · invalidates`
+(8 load-bearing + 2 reserved). Every non-kernel predicate is a content-addressed
+CID resolving to a self-describing definition-Claim.
+
+## 3. Projection mapping — 9-field Claim ⇄ 28-field `Memory` (with divergences)
+
+The v1.x kernel must satisfy this mapping (Claim → row). At v1.0.0 the arrangement
+is inverted (row is the source of truth), and the projection is **lossy** — the
+`Option`/⚠️ rows below are the exact divergences the executable
+[`crate::claim::ClaimView`](../../src/claim/mod.rs) records as a machine-checked
+drift-guard.
+
+| Claim field | `Memory` source | Divergence |
+|---|---|---|
+| `id` | `Memory.id` (UUID) / `Memory.cid` (v74 `b3:…`) | ⚠️ **UUID is the PK/FK/LWW-tiebreak, NOT TRACT CIDv1.** `cid` is BLAKE3 but over a DIFFERENT preimage (`agent_id+namespace+screen(title)+kind+created_at+SHA256(screen(content))`), not `dCBOR(content)‖dCBOR(provenance)` under a CIDv1 envelope. |
+| `kind` | `Memory.memory_kind` (`MemoryKind`, 13–16 variants) | ⚠️ lossy: a 16→5 collapse to the frozen `fact\|episode\|skill\|policy\|relation` is not canonically specified. |
+| `content` | `Memory.content` (`String`) | ⚠️ no `mime`; bytes are a UTF-8 `String`, not `{mime, bytes}`. |
+| `provenance` | `metadata.agent_id` + `source` + `source_span` + `valid_from`/`valid_until` (v79) + `created_at` | ⚠️ synthesized from ≥4 columns; `valid_time` (bitemporal) only exists since schema v79. |
+| `owner` | — | ⚠️ **UN-PROJECTABLE.** No lineage-DAG owner ref exists; `metadata.agent_id` is a claimed string, `scope`/`target_agent_id` are visibility, not ownership. `ClaimView.owner` is always `None`. |
+| `confidence` | `Memory.confidence` (`f64`) + `confidence_source`/`confidence_signals` | ⚠️ `Memory.confidence` is MUTABLE (the decay sweep overwrites it, `confidence_decayed_at`), so `value_at_assert` may be unrecoverable. |
+| `attestation` | `metadata.write_signature` + `attest_level` | ⚠️ single writer sig only; **no `sig_witnesses[]`** on a `Memory` row. |
+| `lifecycle` | `Memory.lifecycle_state` (`LifecycleState`) | ⚠️ **different vocabulary** (Open/Active/Blocked/Done/Abandoned/Quarantined/Goal/Plan/Step), NOT `asserted\|superseded\|forgotten`; and see §4. |
+| `links` | `MemoryLink` (separate table) | ⚠️ **not a column of `Memory`** — `ClaimView` requires the caller to pass link rows; a bare `&Memory` cannot populate it. |
+
+## 4. Verb-semantics divergence (the DEFAULT path violates the closed algebra)
+
+The closed algebra forbids in-place UPDATE (mutation is SUPERSEDE = a new claim)
+and silent DELETE (removal is FORGET = a signed tombstone leaf that remains). The
+substrate's **default** write path violates both:
+
+- **No-UPDATE is violated by default.** For `human`/`agent` callers — and an
+  `ai:*` NHI caller derives to `agent` — `memory_update` falls through to
+  `db::update_with_expected_version` (`src/storage/mod.rs`), a plain in-place
+  `UPDATE memories SET … version = version + 1`. SUPERSEDE-forward
+  (`update_with_archive_on_supersede`) is selected ONLY for `edit_source ∈
+  {llm, hook}`; the append-only revision-leaf spine is gated behind
+  `AI_MEMORY_APPEND_ONLY` (default `false`).
+- **No-silent-DELETE is violated by default.** The FORGET path
+  (`storage::forget`) runs a literal `DELETE FROM memories` (both backends) and
+  appends an identity+time+signature `forget_tombstones` row — a delete-plus-
+  sidecar, not TRACT's "removal via a tombstone LEAF that remains in the claim
+  spine."
+- **RECALL purity** is *close* (post-#1869 recall does no synchronous
+  write-back; access ladders fold off the hot path) but `access_count` still
+  exists as a mutated field, so recall is not the strictly pure read TRACT
+  specifies.
+
+The TRACT-conformant machinery therefore **exists in-tree but is default-off** —
+closing G22 is a default-flip (append-only / supersede / tombstone-leaf) **plus**
+the kernel inversion, not building a new verb subsystem.
+
+## 5. Conformance ledger (honesty)
+
+| Property | v1.0.0 state |
+|---|---|
+| Six verbs exist as operations (ASSERT=store, RELATE=link, RECALL=recall, ATTEST=attest, SUPERSEDE=supersede, FORGET=forget) | ✅ present |
+| Closed-algebra invariants (no-UPDATE, no-silent-DELETE) enforced by default | ❌ **NO** (§4) |
+| 9-field Claim is the source of truth (row projects from it) | ❌ **NO** (row is source of truth) |
+| TRACT-CIDv1 `id` | ❌ NO (UUID) |
+| `owner` lineage-DAG | ❌ NO (un-projectable) |
+| `ClaimView` read-only lossy projection (drift-guard) | ✅ shipped (`src/claim/`) — **non-authoritative, NOT conformance** |
+
+**Forbidden claims (do NOT make):** "TRACT-/L1-conformant", "implements the Claim
+algebra". These remain false at v1.0.0.
+
+## 6. v1.x migration (the real G22 inversion — deferred)
+
+Tracked as its own issue (filed 1:1 from #1836). The freeze-hostile redesign:
+invert source-of-truth so the thin 9-field Claim kernel is authoritative and the
+28-field row projects from it; flip the closed-algebra defaults (append-only /
+supersede / tombstone-leaf ON); add the `owner` lineage-DAG ref; mint the
+TRACT-CIDv1 `id`; move `links` into the kernel; and enforce no-UPDATE /
+no-silent-DELETE. Gated on the CC0 conformance vectors (G24/#1837, now shipped)
+so it is buildable against test-vectors, not prose.
+
+---
+
+*Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except
+where it states what is UNIMPLEMENTED. Byte layouts for the signed record classes
+are authoritative in the format-decisions spec; TRACT L1 semantics are
+authoritative here.*

--- a/src/claim/mod.rs
+++ b/src/claim/mod.rs
@@ -1,0 +1,250 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1836 (TRACT-gap G22) — a NON-AUTHORITATIVE, read-only "Claim view" of the
+//! thick 28-field [`Memory`] row, and a machine-checked record of exactly where
+//! it diverges from the frozen 9-field TRACT L1 Claim.
+//!
+//! # This is NOT the Claim algebra
+//!
+//! The substrate does **not** implement the TRACT L1 closed Claim algebra (see
+//! `docs/spec/TRACT-L1-CLAIM-CONTRACT.md`). This module is deliberately small
+//! and deliberately humble:
+//!
+//! - [`ClaimView`] is a **derived view** — it projects the CURRENT row through
+//!   the Claim shape. TRACT's arrangement is the INVERSE (the thin Claim kernel
+//!   is authoritative and the row projects *from* it); that inversion is
+//!   v1.x work and is **UNBUILT**. `ClaimView` therefore encodes the
+//!   status-quo direction (row → view) and MUST NOT be read as the kernel.
+//! - The projection is **lossy by construction**. Several Claim fields have no
+//!   faithful home on the row (`owner` is un-projectable, `id` is a UUID not a
+//!   TRACT CIDv1, `sig_witnesses` do not exist, `confidence` is mutable, the
+//!   `kind`/`lifecycle` vocabularies differ). Those holes are represented as
+//!   `Option`/empty and enumerated in [`KNOWN_DIVERGENCES`] — the `Option`s ARE
+//!   the divergence record.
+//! - [`CLOSED_ALGEBRA_ENFORCED_BY_DEFAULT`] is `false`: the default write path
+//!   still performs in-place UPDATE + hard DELETE (spec §4).
+//!
+//! Its only jobs are (1) to give the migration contract an executable, typed
+//! anchor so the 28→9 mapping typechecks against the real struct, and (2) to
+//! act as a drift-guard: the test suite asserts the known divergences still
+//! hold, so a future change that silently "fixed" one (or broke the projection)
+//! is caught.
+
+use crate::models::{Memory, MemoryLink};
+
+/// The exact points where the [`Memory`] row diverges from the frozen 9-field
+/// TRACT L1 Claim (spec `docs/spec/TRACT-L1-CLAIM-CONTRACT.md` §3/§4). Machine-
+/// readable so the drift-guard test pins the set.
+pub const KNOWN_DIVERGENCES: &[&str] = &[
+    "id: UUID primary key, not a TRACT CIDv1 (cid is a different preimage)",
+    "kind: MemoryKind (13-16 variants), not collapsed to the frozen 5-kind vocabulary",
+    "content: UTF-8 String, no {mime, bytes}",
+    "provenance: synthesized from >=4 columns; valid_time only since schema v79",
+    "owner: UN-PROJECTABLE — no lineage-DAG owner ref on the row",
+    "confidence: mutable f64 (decay overwrites), not the immutable value_at_assert",
+    "attestation: single writer signature, no sig_witnesses[] on the row",
+    "lifecycle: LifecycleState vocabulary, not asserted|superseded|forgotten",
+    "links: live in a separate MemoryLink table, not on the Memory struct",
+];
+
+/// `true` only when the substrate enforces the closed-algebra invariants
+/// (no in-place UPDATE, no silent DELETE) BY DEFAULT. It does not at v1.0.0 —
+/// the default `human`/`agent` path UPDATEs in place and FORGET hard-DELETEs
+/// (spec §4). Pinned as a const so the honesty state is machine-checked; the
+/// day this flips to `true` is a deliberate edit here + in the spec ledger.
+pub const CLOSED_ALGEBRA_ENFORCED_BY_DEFAULT: bool = false;
+
+/// Synthesized provenance (Claim field 4). Assembled from several row columns;
+/// `valid_time` only exists on schema-v79+ rows.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProvenanceView {
+    /// From `metadata.agent_id` (a claimed string, not a lineage node).
+    pub asserter: Option<String>,
+    /// From `Memory.source`.
+    pub source: String,
+    /// From `Memory.source_uri`, when present.
+    pub source_uri: Option<String>,
+    /// Bitemporal `valid_from` (schema v79+), when present.
+    pub valid_from: Option<String>,
+    /// Bitemporal `valid_until` (schema v79+), when present.
+    pub valid_until: Option<String>,
+    /// `Memory.created_at` (transaction time).
+    pub created_at: String,
+}
+
+/// One RELATE edge, projected from a caller-supplied [`MemoryLink`] row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimLinkView {
+    pub predicate: String,
+    pub target: String,
+}
+
+/// A read-only, NON-AUTHORITATIVE view of a [`Memory`] through the frozen
+/// 9-field Claim shape. Lossy by construction — see [`KNOWN_DIVERGENCES`]. This
+/// is NOT the Claim kernel and NOT evidence of algebra conformance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimView {
+    /// Field 1 — the row's UUID id. NOT the TRACT CIDv1.
+    pub id_uuid: String,
+    /// Field 1 (divergent) — the v74 content-address (`b3:…`) when present; a
+    /// DIFFERENT preimage than TRACT's `dCBOR(content)‖dCBOR(provenance)` CIDv1.
+    pub cid: Option<String>,
+    /// Field 2 — the NATIVE `memory_kind` slug, not collapsed to the frozen 5.
+    pub kind_native: String,
+    /// Field 3 — the content bytes as UTF-8; no `mime`.
+    pub content: String,
+    /// Field 4 — synthesized provenance.
+    pub provenance: ProvenanceView,
+    /// Field 5 — TRACT `owner` (lineage-DAG ref). ALWAYS `None`: un-projectable.
+    pub owner: Option<()>,
+    /// Field 6 — the CURRENT (possibly decay-mutated) confidence, NOT the
+    /// immutable `value_at_assert`.
+    pub confidence_current: f64,
+    /// Field 7 — attest level (`claimed`/`attested` analogue).
+    pub attest_level: String,
+    /// Field 7 — the witness signatures. ALWAYS empty: a `Memory` row carries a
+    /// single writer signature, no `sig_witnesses[]`.
+    pub sig_witnesses: Vec<Vec<u8>>,
+    /// Field 8 — the NATIVE `lifecycle_state` slug, not the TRACT
+    /// `asserted|superseded|forgotten` vocabulary.
+    pub lifecycle_native: String,
+    /// Field 9 — RELATE edges, from the caller-supplied link rows (links are NOT
+    /// a column of `Memory`).
+    pub links: Vec<ClaimLinkView>,
+}
+
+impl ClaimView {
+    /// Derive a [`ClaimView`] from a row + its link rows. **Non-authoritative,
+    /// read-only, lossy** — see the module docs. Total: never panics; round-
+    /// trips every field the row genuinely carries and represents every
+    /// divergence as an `Option`/empty per [`KNOWN_DIVERGENCES`]. The caller
+    /// supplies `links` because they live in a separate table.
+    #[must_use]
+    pub fn of_memory(mem: &Memory, links: &[MemoryLink]) -> Self {
+        let asserter = mem
+            .metadata
+            .get("agent_id")
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string);
+        Self {
+            id_uuid: mem.id.clone(),
+            cid: mem.cid.clone(),
+            kind_native: mem.memory_kind.as_str().to_string(),
+            content: mem.content.clone(),
+            provenance: ProvenanceView {
+                asserter,
+                source: mem.source.clone(),
+                source_uri: mem.source_uri.clone(),
+                // valid_from/valid_until are v79 bitemporal columns not on the
+                // Memory struct's public fields; left None here (a further
+                // divergence surfaced by the mapping, not fabricated).
+                valid_from: None,
+                valid_until: None,
+                created_at: mem.created_at.clone(),
+            },
+            // Un-projectable: TRACT owner is a lineage-DAG node ref; the row has
+            // no such field. NEVER synthesized.
+            owner: None,
+            confidence_current: mem.confidence,
+            attest_level: mem
+                .metadata
+                .get("attest_level")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("claimed")
+                .to_string(),
+            // No witness array exists on a Memory row.
+            sig_witnesses: Vec::new(),
+            lifecycle_native: mem.lifecycle_state.as_str().to_string(),
+            links: links
+                .iter()
+                .map(|l| ClaimLinkView {
+                    predicate: l.relation.as_str().to_string(),
+                    target: l.target_id.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Memory;
+
+    fn sample() -> Memory {
+        Memory {
+            id: "11111111-2222-3333-4444-555555555555".into(),
+            content: "hello".into(),
+            source: "unit-test".into(),
+            confidence: 0.9,
+            created_at: "2026-07-15T00:00:00Z".into(),
+            ..Memory::default()
+        }
+    }
+
+    // The anchor's job: projection TOTALITY (never panics + round-trips present
+    // fields) — NOT algebra conformance.
+    #[test]
+    fn projection_is_total_and_round_trips_present_fields() {
+        let mem = sample();
+        let view = ClaimView::of_memory(&mem, &[]);
+        assert_eq!(view.id_uuid, mem.id, "id round-trips (as the UUID)");
+        assert_eq!(view.content, mem.content, "content round-trips");
+        assert_eq!(view.confidence_current, mem.confidence);
+        assert_eq!(view.provenance.source, mem.source);
+        assert_eq!(view.provenance.created_at, mem.created_at);
+        assert_eq!(view.kind_native, mem.memory_kind.as_str());
+        assert_eq!(view.lifecycle_native, mem.lifecycle_state.as_str());
+    }
+
+    // The drift-guard: the KNOWN divergences must still hold. If a future change
+    // "fixes" one silently, this fails and forces a deliberate spec + ledger
+    // update (it is NOT a conformance test).
+    #[test]
+    fn known_divergences_still_hold() {
+        let view = ClaimView::of_memory(&sample(), &[]);
+        // owner is un-projectable — never synthesized.
+        assert!(view.owner.is_none(), "TRACT owner has no row home");
+        // No witness array on a row.
+        assert!(
+            view.sig_witnesses.is_empty(),
+            "no sig_witnesses[] on Memory"
+        );
+        // id is the UUID, not a TRACT CIDv1 (`b3:`-prefixed cid is separate).
+        assert!(
+            !view.id_uuid.starts_with("b3:"),
+            "id_uuid is the UUID PK, not the content-address"
+        );
+        // The closed algebra is NOT enforced by default (spec §4).
+        assert!(
+            !CLOSED_ALGEBRA_ENFORCED_BY_DEFAULT,
+            "the default path still UPDATEs in place + hard-DELETEs"
+        );
+        // The divergence record is the frozen set of 9.
+        assert_eq!(KNOWN_DIVERGENCES.len(), 9, "one divergence per Claim field");
+    }
+
+    #[test]
+    fn links_project_from_supplied_rows_not_the_memory_struct() {
+        use crate::models::{MemoryLink, MemoryLinkRelation};
+        let link = MemoryLink {
+            source_id: "a".into(),
+            target_id: "b".into(),
+            relation: MemoryLinkRelation::RelatedTo,
+            created_at: "2026-07-15T00:00:00Z".into(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+            attest_level: None,
+        };
+        let view = ClaimView::of_memory(&sample(), std::slice::from_ref(&link));
+        assert_eq!(
+            view.links.len(),
+            1,
+            "links come from the caller, not &Memory"
+        );
+        assert_eq!(view.links[0].target, "b");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,6 +530,8 @@ pub mod background;
 // (mirrors `crate::signals`); backs the SAL `checkpoint_*` surface + the
 // future MCP `memory_checkpoint_*` handlers over a bare rusqlite Connection.
 pub mod checkpoints;
+// v1.0.0 #1836 (TRACT-gap G22) — non-authoritative Claim view + divergence record.
+pub mod claim;
 pub mod cli;
 pub mod color;
 /// v0.7.0 Form 5 (issue #758) — auto-confidence + shadow-mode +


### PR DESCRIPTION
Closes #1836 (TRACT-gap G22 — "RPC-verbs, not the six-verb Claim algebra; thick 27/28-field row").

## What

The v1.0.0-correct slice of the keystone data-model divergence, adjudicated by a **2×5 adversarial vote** (verdict memory `01bce11e`; wave-1 **unanimous A**; all 5 refuters PARTIAL/NO, each sharpening rather than overturning). The full G22 inversion (a thin 9-field Claim kernel as source of truth from which the 28-field `Memory` row projects, with closed-algebra no-UPDATE/no-silent-DELETE enforced) is a **v1.x, freeze-hostile rewrite** — the TRACT canonical-gaps doc itself files G22 as Phase-C/v1.x. So this ships the **tracked, specified contract + an honest executable anchor**, not the rewrite, and defers the inversion 1:1 (**#2052**).

Key finding the refuters grounded: the gap is **both the kernel and the verb-semantics** (the default path UPDATEs in place + hard-DELETEs), and a *clean* 9-field projection is impossible (`owner` un-projectable, `id`=UUID-not-CIDv1, `links` off-struct, `confidence` mutable, vocabularies differ) — so the honest artifact **surfaces** the divergence with a typecheck rather than pretending to close it.

## Ships (v1.0.0, no storage change — freeze-safe)

- **`docs/spec/TRACT-L1-CLAIM-CONTRACT.md`** — the **canonical** L1 contract (the other 8 Tier-B TRACT-gap items reference it): the frozen 9-field Claim + six-verb closed algebra + the explicit 9→28 projection mapping *with every per-field divergence* + a prominent verb-semantics-default-divergence section. Conspicuously **NORMATIVE/UNIMPLEMENTED** with an honesty ledger — "implements the Claim algebra" / "L1-conformant" stay false at v1.0.0.
- **`src/claim/`** — `ClaimView` (not a bare `Claim` type): a read-only, **non-authoritative** derived lens whose `Option`/empty fields *are* the machine-checked divergence record (`owner` always `None`, `sig_witnesses` always empty, `id` is the UUID). Direction-disciplined (encodes the status-quo row→view; the TRACT Claim→row direction is unbuilt); `CLOSED_ALGEBRA_ENFORCED_BY_DEFAULT = false` pins the honesty state.
- **3 tests** — projection totality (never-panics + round-trips present fields, *not* algebra conformance) + a drift-guard asserting the 9 divergences still hold + links-from-caller.

## Deferred (filed 1:1)

**#2052** — the real G22 kernel inversion + closed-algebra default-flip, gated on the now-shipped CC0 vectors (#1837).

## Gates

`claim` 3/3; docs-vs-ssot PASS; qual_10; cli-count; clippy **default AND `sal,sal-postgres`** clean. No new CLI surface.

Cites 2×5 vote verdict memory `01bce11e`, locked dev-set `244b7229`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY