### PR TITLE
ci(coverage): consolidate coverage gate (#1993) + verify staged HF cache (#2019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # This workflow performs VERIFICATION ONLY: lint, cross-platform check
-# matrix, feature-gate jobs, dockerfile-validate, code coverage. It does
+# matrix, feature-gate jobs, dockerfile-validate. It does
 # NOT publish releases — that lives in `release.yml` and only fires from
 # an explicit `workflow_dispatch` invocation (operator-gated). The
 # separation is deliberate: ci.yml passing on a tag-push is necessary
@@ -979,194 +979,13 @@ jobs:
           docker run --rm ai-memory:ci-validate --version
           docker run --rm ai-memory:ci-validate --help | head -20
 
-  # Coverage is now a HARD GATE (top-shelf engineering). Two enforcement
-  # tiers protect the line-coverage number from regression:
-  #
-  #   1. Absolute floor (`MIN_COVERAGE_PCT`) — the line below which CI
-  #      simply refuses to merge regardless of the historical baseline.
-  #      Set at the current measured coverage, rounded DOWN to the nearest
-  #      5 percentage points so it can only ever be raised, never lowered.
-  #
-  #   2. Ratchet (`.coverage-baseline`) — the file at the repo root pins
-  #      the most recent measured coverage. Each run re-asserts that the
-  #      current number is >= baseline - 0.5% (small slack absorbs the
-  #      sub-percent jitter that comes from `target/` cache differences).
-  #      When a PR materially raises coverage, a follow-up commit can
-  #      bump the file; CI never lowers it automatically.
-  #
-  # Skipped on docs-only PRs (no Rust changed, no coverage delta possible).
-  # Job name is `Code Coverage` — must be added to branch protection
-  # required-status-checks for the gate to actually block merges.
-  coverage:
-    name: Code Coverage
-    needs: classify
-    if: needs.classify.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
-    # #1487 — this job hung 2h13m on run 26944887140 when a semantic-tier
-    # CLI recall stalled on an unbounded HF-Hub model download and there
-    # was no timeout to kill it. The root cause is fixed in
-    # embeddings::Embedder::download_within; this bound is the
-    # defense-in-depth backstop. Normal instrumented run is ~25 min.
-    timeout-minutes: 60
-    env:
-      # v0.7.x (#1148) — mold linker + line-only DWARF keep peak
-      # linker RSS under the 7 GB ubuntu-latest ceiling for the
-      # instrumented `--features sal` build. We apply the trim via
-      # CARGO_PROFILE_DEV_* env vars (NOT `--profile coverage`) so the
-      # post-build `cargo llvm-cov report` step finds the object
-      # files under the default `target/llvm-cov-target/debug/` path
-      # the `[profile.coverage]` artifact dir would have shifted.
-      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      CARGO_PROFILE_DEV_DEBUG: "1"
-      CARGO_PROFILE_DEV_LTO: "false"
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Free disk + add swap (#1148 belt-and-suspenders)
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
-          sudo apt-get clean
-          sudo fallocate -l 8G /swapfile-1148
-          sudo chmod 600 /swapfile-1148
-          sudo mkswap /swapfile-1148
-          sudo swapon /swapfile-1148
-          echo "::group::memory + disk after"
-          free -h
-          df -h /
-          echo "::endgroup::"
-
-      - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
-        uses: dtolnay/rust-toolchain@1.96.0
-        with:
-          components: rustfmt, clippy, llvm-tools-preview
-
-      - name: Install mold linker (#1148)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-          mold --version
-
-      - uses: Swatinem/rust-cache@v2
-
-      # v0.6.3 W12-CI-fix: switched from cargo-tarpaulin to cargo-llvm-cov.
-      # tarpaulin 0.32.x trips a `pulp` 0.22.2 const-eval panic
-      # (`CheckSameSize::<i8, u16>::VALID`) under its source-based
-      # instrumentation. llvm-cov uses LLVM-native source-based instrumentation
-      # which doesn't hit the bug, and matches the canonical local measurement
-      # command the coverage campaign used (93.08% headline number per
-      # docs/evidence.html).
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Generate coverage report
-        env:
-          AI_MEMORY_NO_CONFIG: "1"
-        # v0.7.x (#1148) — dev profile WITH env-var overrides
-        # (debuginfo=1, lto=false from the job-level env block above)
-        # keeps artifacts under target/llvm-cov-target/debug/ where
-        # the report step expects them, while still trimming the
-        # instrumented binary enough that mold can link it under the
-        # 7 GB runner ceiling. `--test-threads=1` caps memory-parallel
-        # test execution under the trimmed runner profile.
-        run: |
-          cargo llvm-cov --features sal --no-fail-fast --html --output-dir coverage -- --test-threads=1
-          # `cargo llvm-cov report` reads the saved profile data and does
-          # not accept `--features` (would error: "invalid option
-          # '--features' for subcommand 'report'"). The earlier pipe-to-
-          # `tee` form masked that failure since `tee` always exits 0.
-          cargo llvm-cov report --summary-only | tee coverage/summary.txt
-
-      # Hard absolute floor — the catastrophic-regression backstop. The
-      # locally measured TOTAL line coverage at the time of this commit
-      # was 93.13% (cargo llvm-cov, --features sal, --test-threads=2).
-      # The absolute floor is 90 — that value is current coverage rounded
-      # DOWN to the nearest 5 percentage points so it can only ever be
-      # raised, never lowered, and so routine churn doesn't trip it.
-      # The tight day-to-day enforcement happens in the ratchet step
-      # below; this floor is the "delete-half-the-tests" backstop.
-      - name: Enforce absolute coverage floor (>=90% lines)
-        env:
-          AI_MEMORY_NO_CONFIG: "1"
-          MIN_COVERAGE_PCT: "90"
-        run: |
-          set -euo pipefail
-          # Extract TOTAL line-coverage % from the saved summary. The
-          # llvm-cov text summary's last row is the TOTAL; the line-cov
-          # column is the 10th whitespace-separated field and includes a
-          # trailing %.
-          PCT=$(awk '/^TOTAL/ {gsub("%","",$10); print $10}' coverage/summary.txt)
-          if [ -z "${PCT:-}" ]; then
-            echo "::error::could not parse line-coverage % from coverage/summary.txt"
-            cat coverage/summary.txt
-            exit 1
-          fi
-          echo "::notice::measured line coverage = ${PCT}% (absolute floor ${MIN_COVERAGE_PCT}%)"
-          echo "COVERAGE_PCT=${PCT}" >> "$GITHUB_ENV"
-          awk -v pct="$PCT" -v floor="$MIN_COVERAGE_PCT" 'BEGIN { if (pct + 0 < floor + 0) { printf "::error::coverage %.2f%% is below absolute floor %s%%\n", pct, floor; exit 1 } }'
-
-      # Ratchet — re-assert that we have not regressed against the
-      # tracked baseline more than the 0.5% slack window. PRs that raise
-      # coverage are encouraged to bump `.coverage-baseline` in the same
-      # commit so future PRs benefit from the higher floor.
-      - name: Enforce coverage ratchet (>= baseline - 0.5%)
-        env:
-          AI_MEMORY_NO_CONFIG: "1"
-          RATCHET_SLACK_PCT: "0.5"
-        run: |
-          set -euo pipefail
-          if [ ! -f .coverage-baseline ]; then
-            echo "::warning::.coverage-baseline missing — skipping ratchet (absolute floor still applies)"
-            exit 0
-          fi
-          BASELINE=$(tr -d '[:space:]' < .coverage-baseline)
-          PCT="${COVERAGE_PCT:-0}"
-          echo "::notice::ratchet check: coverage=${PCT}% baseline=${BASELINE}% slack=${RATCHET_SLACK_PCT}%"
-          awk -v pct="$PCT" -v base="$BASELINE" -v slack="$RATCHET_SLACK_PCT" 'BEGIN { min = base + 0 - slack - 0; if (pct + 0 < min) { printf "::error::coverage %.2f%% regressed below ratchet floor %.2f%% (baseline %.2f%% - %.2f%% slack)\n", pct, min, base, slack; exit 1 } printf "::notice::ratchet OK: %.2f%% >= %.2f%%\n", pct, min }'
-
-      # Render the sticky-comment markdown to a file so the action can
-      # `path:`-include it. Inlining `$(cat ...)` inside the action's
-      # `message:` value would NOT shell-expand — it would post the
-      # literal `$(cat ...)` text — so we materialise the body here.
-      - name: Render coverage comment body
-        if: github.event_name == 'pull_request'
-        env:
-          COVERAGE_PCT: ${{ env.COVERAGE_PCT }}
-        run: |
-          set -euo pipefail
-          BASELINE=$(tr -d '[:space:]' < .coverage-baseline 2>/dev/null || echo "(unset)")
-          {
-            echo "### Code Coverage Gate"
-            echo ""
-            echo "| metric | value |"
-            echo "| --- | --- |"
-            echo "| measured | **${COVERAGE_PCT}%** lines |"
-            echo "| absolute floor | 90% |"
-            echo "| ratchet baseline | ${BASELINE}% (slack 0.5%) |"
-            echo ""
-            echo "<details><summary>llvm-cov summary</summary>"
-            echo ""
-            echo '```'
-            cat coverage/summary.txt 2>/dev/null || echo "(summary not available)"
-            echo '```'
-            echo ""
-            echo "</details>"
-          } > coverage/comment.md
-
-      # Sticky PR comment with the measured coverage number. Re-uses a
-      # marker so the comment is updated in place across pushes instead
-      # of accumulating one comment per CI run.
-      - name: Post coverage to PR (sticky)
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: coverage-gate
-          path: coverage/comment.md
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v5
-        with:
-          name: coverage-report
-          path: coverage/
+  # NOTE (#1993): the former `Code Coverage` job (full `cargo llvm-cov`
+  # sweep + sticky PR comment) was REMOVED here to stop it spuriously
+  # failing on every substantial PR — the heavy instrumented build died
+  # mid-`Generate coverage report` (~22-23 min, disk/wall pressure) and
+  # duplicated the authoritative `Per-Module Coverage Thresholds` gate in
+  # `.github/workflows/coverage.yml`, which already enforces BOTH the
+  # global line floor (`coverage/thresholds.toml [global].min_line_coverage`)
+  # AND every per-module floor and now also posts the sticky coverage PR
+  # comment. Coverage is owned end-to-end by `coverage.yml`; running the
+  # full instrumented sweep twice per PR was pure waste.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,12 +6,16 @@
 # threshold, this job fails and the PR cannot merge until coverage is
 # restored.
 #
-# Complementary to the `Code Coverage` job in `ci.yml`:
-#   - `Code Coverage` (ci.yml) enforces the absolute floor + ratchet on
-#     TOTAL line coverage (catastrophic-regression backstop).
-#   - `Per-Module Coverage Thresholds` (this file) enforces a per-module
-#     floor so that no single module can quietly slide while the workspace
-#     average stays high.
+# This workflow OWNS code coverage end-to-end (#1993). It enforces both:
+#   - the GLOBAL line floor (`coverage/thresholds.toml [global]
+#     .min_line_coverage`) — the catastrophic-regression backstop that the
+#     former `Code Coverage` job in `ci.yml` used to guard; AND
+#   - the per-module floors, so no single module can quietly slide while
+#     the workspace average stays high.
+# It also posts the sticky coverage PR comment (see the `Post coverage to
+# PR` step below). The redundant `ci.yml` `Code Coverage` job (a second
+# full instrumented `cargo llvm-cov` sweep per PR) was removed in #1993
+# because it timed out mid-generation and duplicated this gate's work.
 #
 # v0.7.0 ship-hardening (2026-05-20) — instrument with live PG+AGE+pgvector
 # service container so postgres-store tests connect at runtime instead of
@@ -223,7 +227,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-models-minilm-l6-v2-marco-l6-v2-v1
+          # Bump the version suffix (…-v2) whenever the pinned model set or
+          # the staged cache layout changes. `restore-keys` lets a stale-but-
+          # compatible cache seed the dir so the pre-stage step only has to
+          # top up deltas instead of a full cold re-download on every key bump.
+          key: hf-models-minilm-l6-v2-marco-l6-v2-v2
+          restore-keys: |
+            hf-models-minilm-l6-v2-marco-l6-v2-
 
       - name: Pre-stage HF models with retry (#2019)
         env:
@@ -246,6 +256,41 @@ jobs:
               sleep $((attempt*10))
             done
             [ "$ok" = 1 ] || { echo "::error::could not stage $m after 5 attempts"; exit 1; }
+          done
+
+      # #2019 — VERIFY the Python-staged cache is resolvable by the RUST
+      # `hf-hub` 0.5 loader the tests actually use. `ApiRepo::get()` is
+      # cache-first: it reads `refs/main` → resolves `snapshots/<commit>/
+      # <file>` and returns it WITHOUT any network call, falling through to
+      # a live download ONLY on a cache MISS. So the reranker
+      # (`Api::new().get(...)`) + embedder (`download_via_hf_hub` → `.get()`)
+      # never touch the network as long as the staged layout matches what
+      # `hf-hub::Cache::get` expects. `huggingface_hub` (the pre-stage tool)
+      # and `hf-hub` (the test loader) are DIFFERENT tools, so this step
+      # asserts the layout the Rust side resolves rather than trusting the
+      # Python writer — a mismatch fails LOUD here (deterministic staging
+      # error) instead of silently degrading to the keyword path and
+      # dropping reranker.rs / embeddings.rs / daemon_runtime.rs below floor.
+      - name: Verify staged HF cache is hf-hub-resolvable (#2019)
+        run: |
+          set -euo pipefail
+          hub="$HOME/.cache/huggingface/hub"
+          # repo dir name = models--<org>--<name>; artifact files mirror the
+          # crate consts HF_{CONFIG,TOKENIZER,WEIGHTS}_FILE in src/embeddings.rs.
+          for repo in \
+            models--sentence-transformers--all-MiniLM-L6-v2 \
+            models--cross-encoder--ms-marco-MiniLM-L-6-v2; do
+            base="$hub/$repo"
+            ref="$base/refs/main"
+            [ -f "$ref" ] || { echo "::error::missing ref $ref — cache not hf-hub-resolvable"; exit 1; }
+            commit="$(tr -d '[:space:]' < "$ref")"
+            snap="$base/snapshots/$commit"
+            [ -d "$snap" ] || { echo "::error::missing snapshot dir $snap for $repo"; exit 1; }
+            for f in config.json tokenizer.json model.safetensors; do
+              # -e follows symlinks (hf cache snapshots are symlinks into blobs/).
+              [ -e "$snap/$f" ] || { echo "::error::missing $f in $snap ($repo)"; exit 1; }
+            done
+            echo "::notice::$repo resolvable at $snap (all 3 artifacts present)"
           done
 
       - name: Install cargo-llvm-cov
@@ -307,10 +352,55 @@ jobs:
         # are unaffected; the 75-minute job timeout absorbs the serial run.
 
       - name: Enforce per-module thresholds
+        id: thresholds
         run: |
           bash coverage/check-thresholds.sh \
             coverage/thresholds.toml \
             coverage/current.json
+
+      # #1993 — the sticky coverage PR comment moved here from the removed
+      # `ci.yml` `Code Coverage` job so `coverage.yml` owns coverage
+      # end-to-end. Rendered from the authoritative `coverage/current.json`
+      # (the same sal,sal-postgres sweep the gate enforces). Runs on
+      # `always()` so the numbers post even when the threshold gate FAILS
+      # (the failed `Enforce per-module thresholds` step still blocks — this
+      # comment is informational, not a bypass).
+      - name: Render coverage comment body (#1993)
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          global_floor=$(grep -E '^min_line_coverage[[:space:]]*=' coverage/thresholds.toml \
+            | head -1 | awk -F= '{print $2}' | awk '{print $1}' | tr -d ' ')
+          if [ -f coverage/current.json ] && command -v jq >/dev/null 2>&1; then
+            global_pct=$(jq -r '.data[0].totals.lines.percent // empty' coverage/current.json 2>/dev/null || echo "")
+          else
+            global_pct=""
+          fi
+          gate="${{ steps.thresholds.outcome }}"
+          case "$gate" in
+            success) gate_line="PASS — all per-module floors + global floor hold" ;;
+            failure) gate_line="FAIL — a module (or the global total) dropped below its floor; see the \`Enforce per-module thresholds\` step log" ;;
+            *)       gate_line="$gate (coverage JSON may be unavailable — see the sweep step log)" ;;
+          esac
+          {
+            echo "### Per-Module Coverage Gate"
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| measured (global lines) | **${global_pct:-n/a}%** |"
+            echo "| global floor | ${global_floor:-n/a}% |"
+            echo "| gate result | ${gate_line} |"
+            echo ""
+            echo "Feature set: \`--features sal,sal-postgres --lib --tests --workspace\` (live PG + AGE + pgvector)."
+            echo "Per-module floors live in \`coverage/thresholds.toml\`; the gate is \`coverage/check-thresholds.sh\`."
+          } > coverage/comment.md
+
+      - name: Post coverage to PR (sticky) (#1993)
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage-gate
+          path: coverage/comment.md
 
       - name: Upload coverage JSON
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,13 @@ scripts/check-cloud-init-ascii.sh       # cloud-init template ASCII-only HARD-BL
 
 ## Per-module coverage discipline (v0.7.0 forward)
 
-ai-memory enforces **per-module line coverage thresholds** in CI, on top
-of the workspace-wide absolute floor and ratchet that the `Code Coverage`
-job in `ci.yml` already enforces. The per-module gate is the
+ai-memory enforces **per-module line coverage thresholds** in CI, plus a
+workspace-wide global line floor — both owned by the single
 `Per-Module Coverage Thresholds` workflow (`.github/workflows/coverage.yml`).
+The global floor is `coverage/thresholds.toml` `[global].min_line_coverage`
+(>= 90%). (Before #1993 the workspace floor lived in a separate `Code
+Coverage` job in `ci.yml`; that job was removed because it duplicated this
+gate and timed out mid-generation.)
 
 - Thresholds are defined in [`coverage/thresholds.toml`](coverage/thresholds.toml).
 - Thresholds **rise across releases; never fall.** If a module's threshold
@@ -120,7 +123,7 @@ bash coverage/check-thresholds.sh
 
 ## CI infrastructure (v0.7.x — #1148)
 
-The `Code Coverage`, `Per-Module Coverage Thresholds`, and
+The `Per-Module Coverage Thresholds` and
 `Postgres feature gate` jobs run on GitHub-hosted `ubuntu-latest`
 (7 GB RAM + 14 GB swap). Without belt-and-suspenders these workloads
 hit `collect2: signal 7 [Bus error]` linker-OOM under the
@@ -152,7 +155,8 @@ landed a 12-layer mitigation stack you inherit automatically:
 - **`concurrency: cancel-in-progress`** group on both `ci.yml`
   and `coverage.yml` so force-push during PR iteration cancels
   the stale run and frees the runner pool.
-- **`--test-threads=1`** on the Code Coverage job (was 2) caps
+- **`--test-threads=1`** on the `Per-Module Coverage Thresholds` job
+  serialises the sal-postgres suite (shared test DB) and caps
   memory-parallel test execution under the trimmed profile.
 
 If you fork the repo and run CI on your own GitHub-hosted runners,

--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (92 route registrations 
 - **GitHub Actions CI/CD** -- fmt, clippy, test, build on Ubuntu + macOS, release on tag
 
 ### Coverage Floor (hard CI gate)
-The `Code Coverage` job is a **required status check**. CI re-asserts two invariants on every PR: an **absolute floor of >= 90% lines** (catastrophic-regression backstop, set at the current measurement rounded down to the nearest 5%), and a **ratchet against the value pinned in [`.coverage-baseline`](.coverage-baseline)** with a 0.5% slack window (the day-to-day enforcement). PRs that raise coverage should bump the baseline file in the same commit so future PRs benefit from the new floor; PRs that regress more than 0.5% are blocked from merging. Current measurement: **93.13%** lines.
+The `Per-Module Coverage Thresholds` job (`.github/workflows/coverage.yml`) is the coverage gate. It re-asserts two invariants on every PR over the `--features sal,sal-postgres --lib --tests --workspace` sweep (live PG + AGE + pgvector): a **global line floor** (`coverage/thresholds.toml` `[global].min_line_coverage`, >= 90%, the catastrophic-regression backstop) and a **per-module floor** for every module, so no single module can quietly slide while the workspace average stays high. A PR that drops any module — or the workspace total — below its floor is blocked from merging; thresholds rise across releases and never fall without explicit operator approval. (The redundant `Code Coverage` job in `ci.yml` was removed in #1993 — it duplicated this gate and timed out mid-generation.)
 
 ### Token-Budget Gate (hard CI gate, v0.7 C5)
 The `token-budget` workflow is a **required status check**. It enforces three cl100k_base-measured invariants on every PR:

--- a/coverage/thresholds.toml
+++ b/coverage/thresholds.toml
@@ -61,10 +61,12 @@
 # `init-age.sql`-equivalent step ensures both pgvector AND apache/age
 # extensions are loaded before cargo-llvm-cov runs.
 #
-# The `Code Coverage` job in .github/workflows/ci.yml runs a different
-# feature set (`--features sal` only) and has its own absolute floor
-# (90%) plus ratchet against `.coverage-baseline` (93.13). That job is
-# unaffected by this gate.
+# This `min_line_coverage` IS the workspace-total absolute floor (#1993):
+# the redundant `Code Coverage` job in .github/workflows/ci.yml — which
+# used to enforce its own absolute floor + `.coverage-baseline` ratchet on
+# the `--features sal`-only total — was removed because it timed out and
+# duplicated this gate. `coverage.yml` now owns the global floor here plus
+# every per-module floor, measured over `--features sal,sal-postgres`.
 min_line_coverage = 90.0
 
 [modules]

--- a/tests/serve_integration.rs
+++ b/tests/serve_integration.rs
@@ -29,8 +29,8 @@ use tempfile::TempDir;
 mod common;
 use common::free_port;
 
-// CI's Code Coverage job runs the test binary under `cargo llvm-cov`
-// instrumentation, which inflates startup time by 3-5x. 60s gives
+// CI's `Per-Module Coverage Thresholds` job runs the test binary under
+// `cargo llvm-cov` instrumentation, which inflates startup time by 3-5x. 60s gives
 // enough headroom on every supported CI surface (Linux/macOS/Windows)
 // regardless of instrumentation overhead.
 const SPAWN_TIMEOUT: Duration = Duration::from_mins(1);


### PR DESCRIPTION
## Summary

Two CI-infrastructure fixes on the coverage gates, no Rust source behavior change.

### #1993 — `Code Coverage` job spuriously fails on PRs
The `ci.yml` `Code Coverage` job ran a **second** full instrumented `cargo llvm-cov` sweep on every PR and died mid-`Generate coverage report` (~22-23 min, disk/wall pressure), concluding `failure` while the authoritative `Per-Module Coverage Thresholds` gate in `coverage.yml` already completed and reported the same coverage.

**Approach chosen: deduplicate (the issue's recommended option 3).** Remove the redundant `Code Coverage` job from `ci.yml`; `coverage.yml` now owns coverage end-to-end. This is defensible because:
- `coverage/check-thresholds.sh` (run by `coverage.yml`) already enforces **both** the GLOBAL line floor (`coverage/thresholds.toml` `[global].min_line_coverage`, >= 90%) **and** every per-module floor — a strict superset of the removed job's absolute-floor check.
- `release/v1.0.0` is **not** a protected branch and the removed job was **not** a required status check (only the 3 `Check (os)` jobs are required), so nothing is gated on its name.
- The sticky coverage PR comment moves into `coverage.yml`, rendered from the authoritative `coverage/current.json`.
- **No floor is lowered** (operator no-lowering rule). The former `.coverage-baseline` ratchet was tied to the removed job's `--features sal`-only total and is genuinely orphaned in the `sal,sal-postgres` context; the global 90% floor persists.
- Eliminates running full instrumented `llvm-cov` **twice per PR**.

### #2019 — Per-Module gate non-deterministic on HF-Hub download flake
When the HuggingFace model download flaked, the reranker/embedder tests took the offline/keyword path and `reranker.rs` / `embeddings.rs` / `daemon_runtime.rs` dropped below floor.

**Approach chosen: make the warm cache authoritative + verify it.** Investigation of `hf-hub` 0.5 (the loader the Rust tests use) showed `ApiRepo::get()` is **cache-first** — on a warm, resolvable cache it returns the local path with **zero** network calls, only downloading on a cache MISS. Both loaders use it (embedder `download_via_hf_hub` → `.get()`; reranker `Api::new().get(...)`). hf-hub 0.5 has **no** `HF_HUB_OFFLINE` support, so determinism rests entirely on the staged cache matching what the Rust side resolves. The existing pre-stage (Python `huggingface_hub`) populates the cache but the Python-writer / Rust-reader layout was never verified.

- Add a **`Verify staged HF cache is hf-hub-resolvable`** step asserting, per repo, `refs/main` → `snapshots/<commit>/{config.json,tokenizer.json,model.safetensors}` exist (following symlinks) — exactly what `hf-hub::Cache::get` resolves. A mismatch now fails **LOUD** (deterministic staging error) instead of silently degrading and dropping coverage.
- Add `restore-keys` so a key bump tops up deltas instead of a cold re-download.
- **No floor lowered.**

### Files changed
- `.github/workflows/ci.yml` — remove the `Code Coverage` job (+ header/note).
- `.github/workflows/coverage.yml` — HF-cache verification step, `restore-keys`, sticky PR comment.
- `coverage/thresholds.toml`, `README.md`, `CONTRIBUTING.md`, `tests/serve_integration.rs` — reconcile references to the removed job.

Both workflows pass `yaml.safe_load` (actionlint binary unavailable on the host).

Closes #1993
Closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY