### PR TITLE
feat(#1832): TRACT L1 covenant clause 4 — signed forget-receipt (G18)

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -195,6 +195,64 @@ migrate the 5 substrate extras to authored predicates or reversed-kernel
 mappings; add the 4 missing kernel relations with real producers; resolve the
 §7.2 bisection + the §7.3 near-homophone. Gated on the CC0 vectors (#1837).
 
+## 8. The human↔AI covenant (G18, #1832) — 1-of-4 clauses shipped
+
+TRACT L1's human↔AI covenant is a four-clause mutual-obligation contract. It is
+**NOT enforced** at v1.0.0: three of its four clauses are UNIMPLEMENTED and one
+is shipped as a narrow, honestly-scoped primitive. Nothing in the substrate may
+assert "the covenant is enforced" while §8.1 stands.
+
+### 8.1 Clause ledger (honesty)
+
+| # | Covenant clause | Substrate state at v1.0.0 |
+|---|---|---|
+| 1 | **`why_trace` write-gate** — a mutation must carry a recorded cause | ⚠️ PARTIAL. The cause exists as DATA (`signed_events.cause_hash`, schema v73) + an opt-in VERIFY-time require-mode (`AI_MEMORY_REQUIRE_CAUSE_BINDING`), but it is NOT a mandatory WRITE-gate. Making it mandatory-by-default is a default-flip → **freeze-hostile / v1.x**. |
+| 2 | **Immutable authorship** — authorship cannot be silently rewritten | ⚠️ PARTIAL. `agent_lineage` (schema v76) is an append-only signed succession record + `metadata.agent_id` is preserved across every mutation path, but there is no covenant-level enforcement LAYER binding a write to an immutable author. **Freeze-hostile / v1.x.** |
+| 3 | **Permanent-dissent conservation (G7)** — a recorded dissent is never destroyed | ❌ ABSENT. No net-new dissent-conservation mechanism exists. **Freeze-hostile / v1.x** (net-new representation + write-path enforcement). |
+| 4 | **Signed forget-receipt returned to the requester** — proof-of-erasure the requester actually receives | ✅ SHIPPED (v1.0.0, #1832). See §8.2. |
+
+### 8.2 Clause 4 — the signed erasure attestation (shipped, de-branded)
+
+The forget path (`storage::purge_and_tombstone_forget`) ALREADY computes and
+persists, at forget time, a `forget_tombstones` row `{memory_id, namespace,
+forgotten_at, agent_id, signature}` (schema v71, both backends), where
+`signature` is the daemon audit key's Ed25519 over the versioned, content-FREE
+[`forget_tombstone_signable_bytes`] pre-image (`forget-tombstone-v1\x00 ‖ id ‖
+0x00 ‖ ns ‖ 0x00 ‖ forgotten_at`). Before #1832 that signature was DISCARDED —
+`forget()` returned only a count.
+
+#1832 surfaces it as a **read-only projection**, deliberately minimal so it
+freezes essentially nothing new (the crypto contract — table columns, signable
+pre-image, signature semantics — was already frozen at v71 / v0.8.1):
+
+- `crate::db::ForgetReceipt` — `{memory_id, namespace, forgotten_at, agent_id,
+  signature: Option<…>, signed: bool}`, `#[non_exhaustive]`.
+- `crate::db::get_forget_tombstone(conn, id)` — projects the persisted row; never
+  forgets, never re-signs.
+- `crate::db::verify_forget_receipt(receipt, verifying_key)` — recomputes the
+  signable bytes from the receipt's OWN fields (never a presented digest) and
+  `verify_strict`s; verdict `Valid | Invalid | Unsigned`.
+- CLI: `ai-memory forget --show-receipt <id>` / `--verify-receipt <id>`
+  (query-only sub-modes of the existing `forget` command — no new top-level
+  command, no MCP tool / HTTP route, mirroring the #1727 `undo-edit` CLI-only
+  precedent).
+
+**Honest scope (§2.5 discipline).** This is a right-to-be-forgotten RECEIPT
+(proof a forget was RECORDED), **NOT** covenant enforcement — it is never named
+"covenant" in any symbol. The signature commits ONLY to `{id, ns, forgotten_at}`,
+NEVER content. On an unsigned daemon (no enrolled audit key — a common posture)
+`signed = false` and the receipt carries identity + time but NO cryptographic
+proof; `verify` returns `Unsigned`, never `Valid`. Because clauses 1-3 are
+unenforced, a receipt can attest an erasure the full covenant might have governed
+differently — the receipt makes NO claim beyond "this forget was recorded."
+
+### 8.3 v1.x migration (deferred, 1:1 issues)
+
+Clauses 1-3 are each tracked as their own v1.x issue (never bundled): the
+mandatory `why_trace` write-gate default-flip; immutable-authorship enforcement;
+permanent-dissent conservation (G7). A postgres/HTTP/MCP forget-receipt surface
+(beyond the sqlite CLI) is a separate additive v1.x follow-up.
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -249,9 +249,10 @@ differently — the receipt makes NO claim beyond "this forget was recorded."
 ### 8.3 v1.x migration (deferred, 1:1 issues)
 
 Clauses 1-3 are each tracked as their own v1.x issue (never bundled): the
-mandatory `why_trace` write-gate default-flip; immutable-authorship enforcement;
-permanent-dissent conservation (G7). A postgres/HTTP/MCP forget-receipt surface
-(beyond the sqlite CLI) is a separate additive v1.x follow-up.
+mandatory `why_trace` write-gate default-flip (**#2059**); immutable-authorship
+enforcement (**#2060**); permanent-dissent conservation G7 (**#2061**). A
+postgres/HTTP/MCP forget-receipt surface beyond the sqlite CLI is a separate
+additive v1.x follow-up (**#2062**).
 
 ---
 

--- a/src/claim/mod.rs
+++ b/src/claim/mod.rs
@@ -151,7 +151,7 @@ impl ClaimView {
             confidence_current: mem.confidence,
             attest_level: mem
                 .metadata
-                .get("attest_level")
+                .get(crate::models::field_names::ATTEST_LEVEL)
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("claimed")
                 .to_string(),

--- a/src/cli/forget.rs
+++ b/src/cli/forget.rs
@@ -37,6 +37,20 @@ pub struct ForgetArgs {
     /// the handler refuses to run without this confirmation.
     #[arg(long, default_value_t = false)]
     pub confirm_global: bool,
+    /// #1832 (TRACT-gap G18) — QUERY-ONLY: print the SIGNED ERASURE ATTESTATION
+    /// (forget receipt) for an already-forgotten `<memory_id>` instead of
+    /// forgetting anything. The receipt is the proof-of-erasure the substrate
+    /// already recorded at forget time (identity + time, NEVER content). Its
+    /// `signed` flag is `false` on an unsigned daemon. Not a covenant-enforcement
+    /// guarantee — see `docs/spec/TRACT-L1-CLAIM-CONTRACT.md` §8.
+    #[arg(long, value_name = "MEMORY_ID")]
+    pub show_receipt: Option<String>,
+    /// #1832 (TRACT-gap G18) — QUERY-ONLY: verify the forget receipt for an
+    /// already-forgotten `<memory_id>` against the daemon audit key, recomputing
+    /// the canonical signable bytes from the receipt itself. Prints
+    /// `valid`/`invalid`/`unsigned`/`no key`. Does not forget anything.
+    #[arg(long, value_name = "MEMORY_ID")]
+    pub verify_receipt: Option<String>,
 }
 
 /// Round-2 F11 — return the safety-rail error string when the operator
@@ -68,6 +82,15 @@ pub fn cmd_forget(
     json_out: bool,
     out: &mut CliOutput<'_>,
 ) -> Result<()> {
+    // #1832 — QUERY-ONLY sub-modes: inspect / verify a past forget's receipt.
+    // These never forget; they short-circuit before the delete path.
+    if let Some(id) = args.show_receipt.as_deref() {
+        return cmd_show_receipt(db_path, id, json_out, out);
+    }
+    if let Some(id) = args.verify_receipt.as_deref() {
+        return cmd_verify_receipt(db_path, id, json_out, out);
+    }
+
     // Round-2 F11 — refuse global-scope deletes without explicit
     // confirmation. The error is propagated via `bail!` (not stderr +
     // process::exit) so test code can assert on the message without
@@ -100,6 +123,134 @@ pub fn cmd_forget(
     Ok(())
 }
 
+/// #1832 — base64 (url-safe, no pad) render of a receipt signature, matching
+/// the witness/approval-key encoding used elsewhere in the CLI.
+fn sig_b64(sig: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sig)
+}
+
+/// #1832 — `forget --show-receipt <id>`: print the signed erasure attestation
+/// for an already-forgotten memory id. Query-only.
+fn cmd_show_receipt(
+    db_path: &Path,
+    memory_id: &str,
+    json_out: bool,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let conn = db::open(db_path)?;
+    let Some(receipt) = db::get_forget_tombstone(&conn, memory_id)? else {
+        if json_out {
+            writeln!(
+                out.stdout,
+                "{}",
+                serde_json::json!({"memory_id": memory_id, "receipt": null})
+            )?;
+        } else {
+            writeln!(out.stdout, "no forget receipt for {memory_id}")?;
+        }
+        return Ok(());
+    };
+    if json_out {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "memory_id": receipt.memory_id,
+                "namespace": receipt.namespace,
+                "forgotten_at": receipt.forgotten_at,
+                "agent_id": receipt.agent_id,
+                "signed": receipt.signed,
+                "signature": receipt.signature.as_deref().map(sig_b64),
+            })
+        )?;
+    } else {
+        writeln!(out.stdout, "forget receipt for {}", receipt.memory_id)?;
+        writeln!(out.stdout, "  namespace:    {}", receipt.namespace)?;
+        writeln!(out.stdout, "  forgotten_at: {}", receipt.forgotten_at)?;
+        writeln!(
+            out.stdout,
+            "  agent_id:     {}",
+            receipt.agent_id.as_deref().unwrap_or("(none)")
+        )?;
+        match receipt.signature.as_deref() {
+            Some(sig) => writeln!(out.stdout, "  signature:    {} (signed)", sig_b64(sig))?,
+            None => writeln!(
+                out.stdout,
+                "  signature:    (unsigned — daemon had no enrolled audit key)"
+            )?,
+        }
+    }
+    Ok(())
+}
+
+/// #1832 — `forget --verify-receipt <id>`: verify the forget receipt's
+/// signature against the daemon audit key. Query-only. Reuses the same
+/// verifying-key resolution ladder as `verify-audit-trail` (`src/cli/audit.rs`).
+fn cmd_verify_receipt(
+    db_path: &Path,
+    memory_id: &str,
+    json_out: bool,
+    out: &mut CliOutput<'_>,
+) -> Result<()> {
+    let conn = db::open(db_path)?;
+    let Some(receipt) = db::get_forget_tombstone(&conn, memory_id)? else {
+        if json_out {
+            writeln!(
+                out.stdout,
+                "{}",
+                serde_json::json!({"memory_id": memory_id, "verdict": "no receipt"})
+            )?;
+        } else {
+            writeln!(out.stdout, "no forget receipt for {memory_id}")?;
+        }
+        return Ok(());
+    };
+
+    // Resolve the daemon audit verifying key (same ladder as verify-audit-trail).
+    let agent_id =
+        crate::identity::resolve_agent_id(None, None).unwrap_or_else(|_| "ai-memory".to_string());
+    let verifying_key =
+        crate::governance::audit::load_daemon_verifying_key(&agent_id).unwrap_or(None);
+
+    let verdict = match (&verifying_key, receipt.signed) {
+        // No key on this host — cannot verify a signed receipt here.
+        (None, true) => "no key",
+        (Some(vk), _) => match db::verify_forget_receipt(&receipt, vk) {
+            db::ForgetReceiptVerdict::Valid => "valid",
+            db::ForgetReceiptVerdict::Invalid => "invalid",
+            db::ForgetReceiptVerdict::Unsigned => "unsigned",
+        },
+        // Unsigned receipt, no key needed to say so.
+        (None, false) => "unsigned",
+    };
+
+    if json_out {
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({
+                "memory_id": receipt.memory_id,
+                "namespace": receipt.namespace,
+                "forgotten_at": receipt.forgotten_at,
+                "signed": receipt.signed,
+                "verdict": verdict,
+            })
+        )?;
+    } else {
+        writeln!(
+            out.stdout,
+            "forget receipt {}: {verdict}",
+            receipt.memory_id
+        )?;
+    }
+    // A tampered/invalid signature is a hard failure signal for scripting.
+    if verdict == "invalid" {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,6 +262,8 @@ mod tests {
             pattern: None,
             tier: None,
             confirm_global: false,
+            show_receipt: None,
+            verify_receipt: None,
         }
     }
 
@@ -341,5 +494,95 @@ mod tests {
         }
         let stdout = env.stdout_str();
         assert!(stdout.contains("forgot 2 memories"), "got: {stdout}");
+    }
+
+    // ---- #1832 forget-receipt query sub-modes -----------------------------
+
+    #[test]
+    fn show_receipt_after_forget_returns_unsigned_receipt() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let id = seed_memory(&db, "ns", "gone", "bye");
+        // Forget it (records the tombstone).
+        {
+            let mut a = args();
+            a.namespace = Some("ns".to_string());
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        // Now inspect the receipt for the forgotten id.
+        let mut a = args();
+        a.show_receipt = Some(id.clone());
+        {
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        // stdout carries both the forget line and the receipt line — the
+        // receipt JSON is the last line.
+        let last = env.stdout_str().trim().lines().last().unwrap().to_string();
+        let v: serde_json::Value = serde_json::from_str(&last).unwrap();
+        assert_eq!(v["memory_id"].as_str().unwrap(), id);
+        assert_eq!(v["namespace"].as_str().unwrap(), "ns");
+        // The test daemon has no enrolled audit key → unsigned receipt.
+        assert_eq!(v["signed"].as_bool().unwrap(), false);
+        assert!(v["signature"].is_null());
+        assert!(v["forgotten_at"].as_str().is_some());
+    }
+
+    #[test]
+    fn show_receipt_missing_id_reports_none() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let mut a = args();
+        a.show_receipt = Some("never-forgotten".to_string());
+        {
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+        assert!(v["receipt"].is_null());
+    }
+
+    #[test]
+    fn verify_receipt_unsigned_daemon_reports_unsigned() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let id = seed_memory(&db, "ns", "gone", "bye");
+        {
+            let mut a = args();
+            a.namespace = Some("ns".to_string());
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        let mut a = args();
+        a.verify_receipt = Some(id.clone());
+        {
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        let last = env.stdout_str().trim().lines().last().unwrap().to_string();
+        let v: serde_json::Value = serde_json::from_str(&last).unwrap();
+        // No enrolled audit key + unsigned tombstone → "unsigned".
+        assert_eq!(v["verdict"].as_str().unwrap(), "unsigned");
+        assert_eq!(v["signed"].as_bool().unwrap(), false);
+    }
+
+    #[test]
+    fn show_receipt_does_not_forget() {
+        // The query sub-mode must never delete: a live row survives an
+        // invocation that carries --show-receipt.
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let _ = seed_memory(&db, "ns", "keep", "me");
+        let mut a = args();
+        a.namespace = Some("ns".to_string()); // present but must be IGNORED
+        a.show_receipt = Some("whatever".to_string());
+        {
+            let mut out = env.output();
+            cmd_forget(&db, &a, true, &mut out).unwrap();
+        }
+        let conn = db::open(&db).unwrap();
+        let still = db::list(&conn, Some("ns"), None, 10, 0, None, None, None, None, None).unwrap();
+        assert_eq!(still.len(), 1, "show-receipt must not forget anything");
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3656,6 +3656,134 @@ pub fn memory_is_tombstoned(conn: &Connection, memory_id: &str) -> Result<bool> 
     Ok(exists)
 }
 
+/// #1832 (TRACT-gap G18) — a read-only projection of a persisted v71
+/// `forget_tombstones` row: the SIGNED ERASURE ATTESTATION the substrate
+/// ALREADY computes at forget time (`purge_and_tombstone_forget`) and stores,
+/// surfaced so the requester can actually RECEIVE their proof-of-erasure.
+///
+/// # This is a receipt, NOT covenant enforcement
+///
+/// This is deliberately narrow: a right-to-be-forgotten RECEIPT (proof that a
+/// forget was RECORDED), **not** an assertion that the TRACT human↔AI covenant
+/// is enforced (its other clauses — a mandatory `why_trace` write-gate,
+/// immutable-authorship enforcement, permanent-dissent conservation — are
+/// UNIMPLEMENTED; see `docs/spec/TRACT-L1-CLAIM-CONTRACT.md` §8). The receipt is
+/// never re-signed here — it projects the bytes signed once at forget time.
+///
+/// The signature commits ONLY to `{memory_id, namespace, forgotten_at}` (the
+/// [`forget_tombstone_signable_bytes`] pre-image) — NEVER content (a content
+/// fingerprint would re-leak the erased row). [`signed`](Self::signed) is
+/// `false` on an unsigned daemon (no enrolled audit key — a common posture),
+/// in which case the receipt carries identity + time but NO cryptographic
+/// proof: read `signed` BEFORE trusting `signature`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ForgetReceipt {
+    /// The forgotten memory's id (a `forget_tombstones` row exists for it).
+    pub memory_id: String,
+    /// The namespace the forgotten memory lived in.
+    pub namespace: String,
+    /// RFC3339 instant the forget was recorded (`forgotten_at`).
+    pub forgotten_at: String,
+    /// The forgotten row's owner `agent_id`, when it carried one. This is the
+    /// VICTIM's owner, NOT the signer (the signer is always the daemon audit
+    /// key).
+    pub agent_id: Option<String>,
+    /// The daemon-audit-key Ed25519 signature over
+    /// [`forget_tombstone_signable_bytes`], when the daemon had an enrolled
+    /// key at forget time. `None` on an unsigned daemon.
+    pub signature: Option<Vec<u8>>,
+    /// `true` iff [`signature`](Self::signature) is present. A convenience
+    /// mirror so a consumer never mistakes an unsigned receipt for a proof.
+    pub signed: bool,
+}
+
+/// #1832 — the verdict of verifying a [`ForgetReceipt`] against a daemon audit
+/// verifying key. An UNSIGNED receipt is [`Unsigned`](Self::Unsigned) — never
+/// [`Valid`](Self::Valid): a missing signature is the absence of proof, not
+/// proof of anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForgetReceiptVerdict {
+    /// The signature verified against the supplied key over the receipt's own
+    /// recomputed signable bytes.
+    Valid,
+    /// A signature is present but did not verify (wrong key, tampered receipt,
+    /// or malformed signature).
+    Invalid,
+    /// No signature on the receipt — the forget was recorded on an unsigned
+    /// daemon, so there is nothing to verify.
+    Unsigned,
+}
+
+/// #1832 — read the [`ForgetReceipt`] for an already-forgotten `memory_id`, or
+/// `Ok(None)` when no `forget_tombstones` row exists for it. A pure read
+/// projection of the v71 columns — it neither forgets nor re-signs.
+///
+/// # Errors
+/// - The underlying `SELECT` fails (I/O / corruption).
+pub fn get_forget_tombstone(conn: &Connection, memory_id: &str) -> Result<Option<ForgetReceipt>> {
+    use rusqlite::OptionalExtension;
+    let row = conn
+        .query_row(
+            "SELECT memory_id, namespace, forgotten_at, agent_id, signature \
+             FROM forget_tombstones WHERE memory_id = ?1",
+            params![memory_id],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<Vec<u8>>>(4)?,
+                ))
+            },
+        )
+        .optional()?;
+    Ok(row.map(
+        |(memory_id, namespace, forgotten_at, agent_id, signature)| {
+            let signed = signature.is_some();
+            ForgetReceipt {
+                memory_id,
+                namespace,
+                forgotten_at,
+                agent_id,
+                signature,
+                signed,
+            }
+        },
+    ))
+}
+
+/// #1832 — verify a [`ForgetReceipt`]'s signature against a daemon audit
+/// `verifying_key`, RECOMPUTING the canonical signable bytes from the receipt's
+/// OWN `{memory_id, namespace, forgotten_at}` (never a presented digest — the
+/// #1464 / #626 discipline). Reuses the already-public
+/// [`forget_tombstone_signable_bytes`] pre-image + Ed25519 `verify_strict`, so
+/// this adds no new crypto contract — only exposes the one the forget path
+/// already froze at schema v71.
+#[must_use]
+pub fn verify_forget_receipt(
+    receipt: &ForgetReceipt,
+    verifying_key: &ed25519_dalek::VerifyingKey,
+) -> ForgetReceiptVerdict {
+    use ed25519_dalek::Signature;
+    let Some(sig_bytes) = receipt.signature.as_deref() else {
+        return ForgetReceiptVerdict::Unsigned;
+    };
+    let Ok(sig) = Signature::from_slice(sig_bytes) else {
+        return ForgetReceiptVerdict::Invalid;
+    };
+    let signable = forget_tombstone_signable_bytes(
+        &receipt.memory_id,
+        &receipt.namespace,
+        &receipt.forgotten_at,
+    );
+    match verifying_key.verify_strict(&signable, &sig) {
+        Ok(()) => ForgetReceiptVerdict::Valid,
+        Err(_) => ForgetReceiptVerdict::Invalid,
+    }
+}
+
 /// v0.9.0 G8 (#1825) — read a row's storage-internal `cid_genesis`
 /// pre-image on demand (it is deliberately NOT a [`Memory`] field). The
 /// verify path uses it to recompute + check the BLAKE3 address. Returns
@@ -16353,6 +16481,90 @@ mod tests {
 
     fn test_db() -> Connection {
         open(std::path::Path::new(":memory:")).unwrap()
+    }
+
+    /// #1832 (TRACT-gap G18) — forget-receipt round-trip: a receipt whose
+    /// signature was minted over the canonical [`forget_tombstone_signable_bytes`]
+    /// verifies `Valid`; tampering ANY signed field flips it to `Invalid`; a
+    /// receipt with no signature is `Unsigned` (never `Valid`).
+    #[test]
+    fn forget_receipt_1832_verify_round_trip() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let vk = sk.verifying_key();
+        let (id, ns, at) = ("mem-abc", "team/eng", "2026-07-15T00:00:00Z");
+        let sig = sk.sign(&forget_tombstone_signable_bytes(id, ns, at));
+
+        let receipt = ForgetReceipt {
+            memory_id: id.to_string(),
+            namespace: ns.to_string(),
+            forgotten_at: at.to_string(),
+            agent_id: Some("ai:owner".to_string()),
+            signature: Some(sig.to_bytes().to_vec()),
+            signed: true,
+        };
+        assert_eq!(
+            verify_forget_receipt(&receipt, &vk),
+            ForgetReceiptVerdict::Valid,
+            "a faithfully-signed receipt must verify"
+        );
+
+        // Tamper a signed field — recompute of the signable diverges → Invalid.
+        let mut tampered = receipt.clone();
+        tampered.namespace = "attacker/ns".to_string();
+        assert_eq!(
+            verify_forget_receipt(&tampered, &vk),
+            ForgetReceiptVerdict::Invalid,
+            "tampering the namespace must break verification"
+        );
+
+        // Wrong key → Invalid.
+        let other = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+        assert_eq!(
+            verify_forget_receipt(&receipt, &other),
+            ForgetReceiptVerdict::Invalid,
+            "a different key must not verify"
+        );
+
+        // Unsigned receipt is never Valid.
+        let unsigned = ForgetReceipt {
+            signature: None,
+            signed: false,
+            ..receipt.clone()
+        };
+        assert_eq!(
+            verify_forget_receipt(&unsigned, &vk),
+            ForgetReceiptVerdict::Unsigned,
+            "a missing signature is the absence of proof, not proof"
+        );
+    }
+
+    /// #1832 — the accessor projects a persisted tombstone; on an unsigned
+    /// test daemon (no audit key) the receipt is present but `signed = false`,
+    /// and a never-forgotten id yields `None`.
+    #[test]
+    fn forget_receipt_1832_accessor_projects_tombstone() {
+        let conn = test_db();
+        conn.execute(
+            "INSERT INTO forget_tombstones \
+                 (memory_id, namespace, forgotten_at, agent_id, signature) \
+             VALUES ('m1', 'ns', '2026-07-15T00:00:00Z', 'ai:owner', NULL)",
+            [],
+        )
+        .unwrap();
+
+        let got = get_forget_tombstone(&conn, "m1").unwrap().unwrap();
+        assert_eq!(got.memory_id, "m1");
+        assert_eq!(got.namespace, "ns");
+        assert_eq!(got.agent_id.as_deref(), Some("ai:owner"));
+        assert!(!got.signed, "NULL signature column → unsigned receipt");
+        assert!(got.signature.is_none());
+
+        assert!(
+            get_forget_tombstone(&conn, "never").unwrap().is_none(),
+            "no tombstone → None"
+        );
     }
 
     /// v1.0.0 #1831 (G17) — end-to-end persisted M-of-N key-loss recovery:

--- a/tests/round2_f11_forget_safety.rs
+++ b/tests/round2_f11_forget_safety.rs
@@ -31,6 +31,8 @@ fn args_blank() -> ForgetArgs {
         pattern: None,
         tier: None,
         confirm_global: false,
+        show_receipt: None,
+        verify_receipt: None,
     }
 }
 


### PR DESCRIPTION
Closes #1832 (TRACT-gap G18 — human↔AI covenant clauses).

## Scope — the v1.0.0-correct slice (NOT feature-complete)
TRACT's human↔AI covenant has **4 clauses**; this ships the **one** genuinely-additive, freeze-safe clause and defers the 3 freeze-hostile clauses **1:1** to v1.x.

| # | Clause | State |
|---|---|---|
| 1 | mandatory `why_trace` write-gate | ⚠️ PARTIAL → deferred #2059 (default-flip) |
| 2 | immutable-authorship enforcement | ⚠️ PARTIAL → deferred #2060 |
| 3 | permanent-dissent conservation (G7) | ❌ ABSENT → deferred #2061 |
| 4 | **signed forget-receipt returned to requester** | ✅ **SHIPPED (this PR)** |

## What ships
The forget path already computes + persists a signed `forget_tombstones` row (schema **v71**, both backends) over the content-FREE `forget_tombstone_signable_bytes` pre-image — then **discarded** the signature (`forget()` returned only a count). This surfaces it as a **read-only projection**, freezing essentially nothing new (the crypto contract was frozen at v71 / v0.8.1):

- **storage**: `ForgetReceipt` (`#[non_exhaustive]`), `get_forget_tombstone`, `verify_forget_receipt` (recomputes the signable from the receipt itself, `verify_strict`; `Valid`/`Invalid`/`Unsigned`). **`forget()` keeps `Result<usize>` — no T1 trait break.**
- **CLI**: `forget --show-receipt <id>` / `--verify-receipt <id>` — query-only sub-modes of the **existing** `forget` command. **No new top-level command (CLI count unchanged 88/90), no MCP tool / HTTP route** — mirrors the #1727 undo-edit CLI-only precedent.
- **spec**: contract `§8` documents all 4 clauses + the honest 1-of-4 ledger.

## Honesty (§2.5)
A right-to-be-forgotten **RECEIPT** (proof a forget was *recorded*), never named "covenant" in any symbol. Signature commits **only** to `{id, ns, forgotten_at}`, never content. On an unsigned daemon `signed=false` → verify returns `Unsigned`, never `Valid`.

## Design — 2×5 adversarial vote (`4d3ea1c5`)
Verdict **B-minimal** (memory `7992090a`). Wave-1 4B/1A; wave-2 code-grounded refuters (reading the tree) confirmed the crypto contract is already frozen at v71, so minimal-B is a projection, not a new feature. Every "favors A" refuter was refuting *maximal*-B (return-type break + net-new wire format), which this avoids.

## Tests / gates
- New: `storage::tests::forget_receipt_1832_*` (signed round-trip Valid/Invalid/wrong-key/Unsigned + accessor), `cli::forget::tests::{show_receipt_*, verify_receipt_*}` (4).
- `cargo fmt` ✓ · `clippy -D pedantic` ✓ · docs-vs-ssot ✓ · vendor-literal ✓ · hardcoded-literal ✓ · cli-count invariant ✓.
- Folds a pm-v3.1 ratchet fix: `src/claim/mod.rs` (#1836) `.get("attest_level")` → named const `models::field_names::ATTEST_LEVEL`.

## Stacking
Stacked on **feat/1833** (#2056) → **feat/1836** (#2053). Retarget to `main` as the base merges.

Deferred issues (never bundled): #2059 · #2060 · #2061 · #2062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)