### PR TITLE
feat(#1830): TRACT G16 durability-model disclosure anchor (no erasure cold tier)

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -254,6 +254,52 @@ enforcement (**#2060**); permanent-dissent conservation G7 (**#2061**). A
 postgres/HTTP/MCP forget-receipt surface beyond the sqlite CLI is a separate
 additive v1.x follow-up (**#2062**).
 
+## 9. Durability model — no erasure-coded no-primary cold tier (G16, #1830)
+
+TRACT L2 wants an **(n,k) erasure-coded, no-primary cold tier** so any k-of-n
+shards reconstruct the original. The substrate does **not** have one — durability
+rests on replication/local persistence, not erasure coding. This § pins the
+durability posture the substrate ACTUALLY provides, so the claim cannot silently
+drift; the executable anchor is `crate::durability`.
+
+### 9.1 The actual durability model (honest taxonomy)
+
+Codegraph-verified. There is **no** automatic full-copy replication; the label
+"full-copy replication" would itself be an overclaim.
+
+| Posture | When | Guarantee |
+|---|---|---|
+| **Local single-node** (default) | `synchronous = NORMAL` (`storage::connection::DEFAULT_DB_SYNCHRONOUS`), no quorum | One local SQLite DB (WAL). Survives a process crash; a **power loss** can lose the tail of un-checkpointed commits. **No replication.** |
+| **Local single-node, power-loss-safe** | `AI_MEMORY_DB_SYNCHRONOUS = FULL`/`EXTRA`, or the `asi-hard` posture (#1961) | fsync-per-commit power-loss durability. Still single-node. |
+| **Quorum-replicated** (opt-in) | `--quorum-writes > 0` with configured peers | Opt-in **W-of-N quorum** federation replication (`crate::replication` `QuorumPolicy`/`AckTracker`). This is quorum, **not** full-copy-to-N, and `crate::replication` is scaffolding **not wired into the store write path** (default `quorum_writes = 0`). |
+| **Erasure-coded no-primary cold tier** | — | **UNIMPLEMENTED** (gap G16). No erasure/shard/Reed-Solomon code exists. |
+
+### 9.2 The forcing-function anchor
+
+`crate::durability::DurabilityModel` is a `#[non_exhaustive]` enum with exactly
+the three shipped postures above and **deliberately no erasure variant**;
+`resolve_durability_model` computes the live posture from the REAL config
+(`synchronous` level, `quorum_writes`, peers). The absent variant IS the
+machine-checked gap record: the enum is consumed by wildcard-free exhaustive
+matches (`label`, `is_multi_node`), so adding an erasure-coded cold-tier variant
+hard-breaks the build until the tier is consciously wired AND this ledger is
+updated. (Low fan-out — honest for a total gap: this is a disclosure anchor, not
+a load-bearing projection like §3's `ClaimView`.) No erasure codec ships — not
+compiled, not test-only (a hand-rolled or self-generated reference construction
+would freeze a shard format the eventual audited crate won't match; the #1830
+5-agent vote `4d3ea1c5` rejected it unanimously).
+
+### 9.3 v1.x migration (deferred — subsystem BLOCKED on an operator decision)
+
+#1830 stays on the v1.0.0 tracker (NOT silently re-milestoned). The v1.0.0 slice
+shipped is this §9 disclosure anchor; the erasure **subsystem** (codec + shard
+placement + no-primary coordination + reconstruction-on-read + repair) is v1.x
+and is BLOCKED on an operator **dependency-authorization** decision (**#2064**):
+a vetted erasure crate (e.g. `reed-solomon-simd`) requires operator sign-off
+(sole-authority rule), and hand-rolling was vote-rejected. The
+construction-independent acceptance invariant for whichever path is authorized:
+**any k-of-n shards reconstruct the original bytes exactly.**
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/durability.rs
+++ b/src/durability.rs
@@ -1,0 +1,190 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1830 (TRACT-gap G16) — the substrate's DURABILITY-MODEL disclosure anchor.
+//!
+//! # What this is (and is NOT)
+//!
+//! TRACT L2 wants an (n,k) erasure-coded, no-primary cold tier so any k-of-n
+//! shards reconstruct — the substrate does **not** have one (gap G16, #1830,
+//! `docs/spec/TRACT-L1-CLAIM-CONTRACT.md` §9). This module ships **no** erasure
+//! coding. It does exactly one humble thing: it pins the durability postures the
+//! substrate ACTUALLY provides into an enum + a pure resolver over the REAL
+//! durability config, so the contract §9 honesty claim cannot silently drift
+//! from the code.
+//!
+//! The deliberate ABSENCE of an erasure-coded / no-primary variant on
+//! [`DurabilityModel`] is the machine-checked record of the gap: the enum is
+//! `#[non_exhaustive]` and consumed by wildcard-free exhaustive matches
+//! ([`DurabilityModel::label`], [`DurabilityModel::is_multi_node`]), so adding
+//! such a variant hard-breaks the build until the new tier is consciously wired
+//! AND the §9 ledger is updated. It is a genuine (if low-fan-out) drift-gate,
+//! not a self-referential boolean — [`resolve_durability_model`] computes the
+//! live posture from actual config inputs.
+//!
+//! The real (n,k) erasure subsystem is v1.x and is BLOCKED on an operator
+//! dependency-authorization decision (a vetted erasure crate vs a hand-rolled
+//! finite-field codec — the latter was rejected by the #1830 5-agent vote
+//! `4d3ea1c5`). Adding a dependency requires operator sign-off (sole-authority
+//! rule), so it cannot be done autonomously.
+
+/// The durability postures the substrate ACTUALLY provides today.
+///
+/// There is deliberately NO erasure-coded / no-primary cold-tier variant — that
+/// gap (TRACT G16, #1830) is UNIMPLEMENTED. Adding a variant here breaks every
+/// exhaustive match below until the new tier is consciously wired AND the
+/// contract §9 ledger is updated (the drift-gate). `#[non_exhaustive]` so
+/// out-of-crate matchers must also account for a future tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DurabilityModel {
+    /// Default: a single local SQLite DB (WAL). Survives a process crash, but a
+    /// power loss can lose the tail of commits not yet checkpoint-fsync'd
+    /// (`synchronous = NORMAL`, the compiled default).
+    LocalSingleNode,
+    /// A single local SQLite DB with fsync-per-commit power-loss durability
+    /// (`AI_MEMORY_DB_SYNCHRONOUS = FULL`/`EXTRA`, or the `asi-hard` posture,
+    /// #1961). Still single-node — no replication.
+    LocalSingleNodePowerLossSafe,
+    /// Opt-in W-of-N quorum federation replication (`crate::replication`
+    /// `QuorumPolicy` / `AckTracker`), active only under `--quorum-writes > 0`
+    /// with configured peers. This is QUORUM, not full-copy-to-N, and does not
+    /// change the local power-loss posture.
+    QuorumReplicated,
+}
+
+impl DurabilityModel {
+    /// A short, stable label. EXHAUSTIVE wildcard-free match — the drift-gate: a
+    /// new [`DurabilityModel`] variant (e.g. an erasure-coded cold tier)
+    /// hard-breaks the build here until deliberately handled.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::LocalSingleNode => "local-single-node",
+            Self::LocalSingleNodePowerLossSafe => "local-single-node-power-loss-safe",
+            Self::QuorumReplicated => "quorum-replicated",
+        }
+    }
+
+    /// `true` iff this model survives the loss of a whole node. Only
+    /// [`QuorumReplicated`](Self::QuorumReplicated) does today; an erasure-coded
+    /// no-primary cold tier WOULD (G16, unimplemented). EXHAUSTIVE wildcard-free
+    /// match — a second drift-gate site.
+    #[must_use]
+    pub fn is_multi_node(self) -> bool {
+        match self {
+            Self::QuorumReplicated => true,
+            Self::LocalSingleNode | Self::LocalSingleNodePowerLossSafe => false,
+        }
+    }
+}
+
+/// Whether a `synchronous` PRAGMA level fsyncs on every commit (power-loss
+/// durable). `FULL` and `EXTRA` do; `NORMAL` (the default) and `OFF` do not.
+#[must_use]
+fn sync_is_power_loss_safe(sync_level: &str) -> bool {
+    sync_level.eq_ignore_ascii_case("FULL") || sync_level.eq_ignore_ascii_case("EXTRA")
+}
+
+/// #1830 (G16) — resolve the substrate's live [`DurabilityModel`] from the REAL
+/// durability config: the resolved `synchronous` PRAGMA level (pass
+/// [`crate::storage::connection::db_synchronous`]), the configured
+/// `quorum_writes`, and whether federation peers are configured. Pure and
+/// total. A genuine consumer of real config — NOT a self-referential constant.
+///
+/// Quorum replication (when active) is the dominant multi-node guarantee; absent
+/// quorum, the posture is local, upgraded to power-loss-safe only when the
+/// `synchronous` level fsyncs every commit.
+#[must_use]
+pub fn resolve_durability_model(
+    sync_level: &str,
+    quorum_writes: usize,
+    peers_configured: bool,
+) -> DurabilityModel {
+    if quorum_writes > 0 && peers_configured {
+        DurabilityModel::QuorumReplicated
+    } else if sync_is_power_loss_safe(sync_level) {
+        DurabilityModel::LocalSingleNodePowerLossSafe
+    } else {
+        DurabilityModel::LocalSingleNode
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::connection::DEFAULT_DB_SYNCHRONOUS;
+
+    #[test]
+    fn default_config_resolves_local_single_node() {
+        // The compiled default posture: NORMAL sync, no quorum, no peers.
+        let m = resolve_durability_model(DEFAULT_DB_SYNCHRONOUS, 0, false);
+        assert_eq!(m, DurabilityModel::LocalSingleNode);
+        assert!(!m.is_multi_node(), "default posture is single-node");
+    }
+
+    #[test]
+    fn full_sync_upgrades_to_power_loss_safe() {
+        assert_eq!(
+            resolve_durability_model("FULL", 0, false),
+            DurabilityModel::LocalSingleNodePowerLossSafe
+        );
+        assert_eq!(
+            resolve_durability_model("extra", 0, false),
+            DurabilityModel::LocalSingleNodePowerLossSafe,
+            "case-insensitive; EXTRA also fsyncs per commit"
+        );
+    }
+
+    #[test]
+    fn quorum_requires_both_writes_and_peers() {
+        // quorum_writes>0 alone is inert without configured peers.
+        assert_eq!(
+            resolve_durability_model("NORMAL", 3, false),
+            DurabilityModel::LocalSingleNode,
+            "quorum_writes without peers does not replicate"
+        );
+        assert_eq!(
+            resolve_durability_model("NORMAL", 3, true),
+            DurabilityModel::QuorumReplicated
+        );
+    }
+
+    /// #1830 / G16 honesty pin: multi-node durability is QUORUM-only today.
+    /// There is NO erasure-coded no-primary cold-tier model — the gap is real.
+    /// If a future edit adds an erasure `DurabilityModel` variant, the exhaustive
+    /// matches in `label`/`is_multi_node` break the build and this test must be
+    /// revisited alongside the contract §9 ledger.
+    #[test]
+    fn g16_only_quorum_is_multi_node_no_erasure_tier() {
+        let multi: Vec<DurabilityModel> = [
+            DurabilityModel::LocalSingleNode,
+            DurabilityModel::LocalSingleNodePowerLossSafe,
+            DurabilityModel::QuorumReplicated,
+        ]
+        .into_iter()
+        .filter(|m| m.is_multi_node())
+        .collect();
+        assert_eq!(
+            multi,
+            vec![DurabilityModel::QuorumReplicated],
+            "the ONLY multi-node durability today is quorum replication; \
+             an erasure-coded no-primary cold tier (G16) is UNIMPLEMENTED"
+        );
+    }
+
+    #[test]
+    fn labels_are_stable_and_distinct() {
+        for m in [
+            DurabilityModel::LocalSingleNode,
+            DurabilityModel::LocalSingleNodePowerLossSafe,
+            DurabilityModel::QuorumReplicated,
+        ] {
+            assert!(!m.label().is_empty());
+        }
+        assert_ne!(
+            DurabilityModel::LocalSingleNode.label(),
+            DurabilityModel::QuorumReplicated.label()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,6 +533,8 @@ pub mod checkpoints;
 // v1.0.0 #1836 (TRACT-gap G22) — non-authoritative Claim view + divergence record.
 pub mod claim;
 pub mod cli;
+// v1.0.0 #1830 (TRACT-gap G16) — durability-model disclosure anchor (no erasure
+// cold tier; the deliberate absent-variant is the machine-checked gap record).
 pub mod color;
 /// v0.7.0 Form 5 (issue #758) — auto-confidence + shadow-mode +
 /// freshness-decay + calibration tooling. Closes the FORM 5 PARTIAL
@@ -550,6 +552,7 @@ pub mod config;
 pub mod coordination_audit;
 pub mod curator;
 pub mod daemon_runtime;
+pub mod durability;
 // v0.7.0 L0.5-3 — module renamed from `db` → `storage` as part of
 // the flat-to-modular refactor. The `pub use storage as db;` shim
 // below preserves every `crate::db::*` path across the codebase


### PR DESCRIPTION
Advances #1830 (TRACT-gap G16 — no (n,k) erasure-coded no-primary cold tier). **Does NOT close #1830** — see "Governance" below.

## Scope — the v1.0.0-correct slice (NOT the subsystem)
Codegraph: ZERO erasure/shard/Reed-Solomon code exists; durability today is local persistence + opt-in quorum replication. The full erasure subsystem is freeze-hostile (a T4 shard byte-format + no-primary coordination) and needs an **operator-gated** erasure dependency — it cannot ship autonomously under GA freeze. What ships:

- **`src/durability.rs`** — `DurabilityModel` (`#[non_exhaustive]`) pinning the three postures the substrate *actually* provides, with **deliberately no erasure variant**. `resolve_durability_model` computes the live posture from REAL config (`synchronous` level, `quorum_writes`, peers) — a genuine consumer, not a self-referential bool. The absent variant IS the machine-checked gap: wildcard-free exhaustive matches (`label`, `is_multi_node`) hard-break the build if an erasure variant is added, forcing conscious wiring + a §9 ledger update.
- **contract §9** — the HONEST durability taxonomy (default = local single-node SQLite / WAL / `synchronous=NORMAL`; `FULL`/asi-hard = power-loss-safe; opt-in **W-of-N quorum** federation, *not* full-copy, *not* wired into the store write path). Records the construction-independent v1.x acceptance invariant: **any k-of-n shards reconstruct**.

## What does NOT ship (by design)
**No erasure codec — not compiled, not test-only.** A hand-rolled or self-generated GF(2⁸) reference construction would freeze a shard byte-format the eventual audited crate won't match, ship error-prone finite-field math in the GA binary, and route around the operator dependency gate.

## Governance (why #1830 stays open)
Per the defer-rots vote finding: #1830 is on the **locked v1.0.0 set** and is **not** silently re-milestoned to v1.x (that would be the banned rot-defer). This PR ships the v1.0.0-shippable disclosure anchor; the erasure **subsystem** (codec + shard placement + no-primary coordination + reconstruction + repair) is genuinely BLOCKED on an operator **dependency-authorization** decision — filed as **#2064** (reed-solomon crate vs hand-roll; a Cargo dep add is operator-authority under sole-authority). That escalation is what makes this honest-blocked, not a dodge.

## Design — 2×5 adversarial vote (`4d3ea1c5`)
Verdict **A**, **UNANIMOUS 10/10** (wave-1 5/5 A, wave-2 5/5 hold-A/ship-A; memory `5551f037`). Every lens rejected the hand-rolled codec: freezes a T4 shard format before any spec, zero durability gain (dead code / the #1833 shape), routes around the operator dep-gate, and "banks the easy 10%" (the codec) while the hard part (no-primary coordination) stays deferred. The durability-correctness refuter verified in-tree that "full-copy replication" would itself be an overclaim — §9 uses the honest taxonomy instead.

## Tests / gates
- New: `durability::tests::*` (5 — default→local-single-node, FULL→power-loss-safe, quorum requires writes+peers, the G16 "only quorum is multi-node / no erasure tier" honesty pin, stable labels).
- `cargo fmt` ✓ · `clippy -D pedantic` ✓ · docs-vs-ssot ✓ · vendor-literal ✓ · hardcoded-literal ✓ · cli-count invariant (88/90, unchanged) ✓.

## Stacking
Stacked on **feat/1832** (#2063) → **feat/1833** (#2056) → **feat/1836** (#2053). Retarget to `main` as the bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)