### PR TITLE
feat(#1829): TRACT G15 retention-model anchor (discrete TTL tiers, no cost gradient)

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -300,6 +300,71 @@ a vetted erasure crate (e.g. `reed-solomon-simd`) requires operator sign-off
 construction-independent acceptance invariant for whichever path is authorized:
 **any k-of-n shards reconstruct the original bytes exactly.**
 
+## 10. Retention — discrete TTL tiers, not a cost-of-access gradient (G15, #1829)
+
+TRACT L2 wants retention to be a **continuous cost-of-access (Landauer)
+gradient** — a single cost that scales with archival depth/age and GOVERNS
+eviction, replacing discrete tiers. The substrate's retention/eviction is a
+**discrete 3-tier TTL** model. The executable anchor is `crate::retention`.
+
+> **"Landauer" here is a METAPHOR** (recall/retention should get *more expensive
+> with depth/age*), NOT a literal `kT ln 2` thermodynamic model — the substrate
+> implements no energy accounting, and §10 does not claim one.
+
+### 10.1 Honest current state — do NOT claim "no gradient exists"
+
+The eviction DECISION is discrete: a row's lifetime is `created_at +
+Tier::default_ttl_secs()` (Short 6h / Mid 7d / Long permanent), and GC evicts on
+expiry. That discreteness is the real gap. **But the substrate already has FOUR
+partial age/access-gradient surfaces** — omitting them would be an
+overclaim-by-omission (the inverse of §9's "glib label" trap). None GOVERNS
+eviction; they are unbundled and serve different purposes:
+
+| # | Surface | What it is | Symbol |
+|---|---|---|---|
+| 1 | **Recall ranking** | recency + capped access-count + tier bonus tilt *ordering* toward fresh/hot rows | the FTS score `+ MIN(access_count,50)*0.1 + … + recency_factor + tier_bonus` (`storage::mod`) |
+| 2 | **TTL floor-extend on access** | an access raises `expires_at` by a per-tier floor — frequently-recalled rows live longer | `SHORT_TTL_EXTEND_SECS` / `MID_TTL_EXTEND_SECS` (`models::mod`), #1596 |
+| 3 | **Confidence decay on touch** | a memory's `confidence` decays with age on recall touch | `crate::confidence::decay`, `ConfidenceSource::Decayed` |
+| 4 | **Access-count promotion** | mid→long auto-promotion at 5 accesses; priority increments every 10 | recall-pipeline touch ops |
+
+### 10.2 The true gap (localized)
+
+There is **no single continuous cost that REPLACES discrete-tier eviction**. The
+four surfaces above are *ranking / retention-extend / decay / promotion* signals,
+each a different shape and unit; **none is an eviction-governing cost**, and they
+are not unified. TRACT L2 wants one continuous cost-of-access function that
+subsumes them and decides retention on a gradient rather than a 3-way tier cliff.
+
+### 10.3 The forcing-function anchor
+
+`crate::retention::RetentionModel` is a `#[non_exhaustive]` enum with the single
+posture `DiscreteTtlTiers` and **no `CostOfAccessGradient` variant** — the absent
+variant IS the machine-checked gap. It is **not** a floating anchor:
+`Tier::default_ttl_secs` (the most-called TTL function — every eviction /
+TTL-floor / archival / config-seed path) delegates through
+`RetentionModel::current().ttl_secs_for(tier)`, so the enum has a real live
+consumer on the hot path. The `ttl_secs_for` / `label` / `is_cost_of_access_gradient`
+matches are exhaustive + wildcard-free, so adding a gradient variant hard-breaks
+the build until it is consciously resolved AND this ledger is updated. The wiring
+is provably byte-identical (the `DiscreteTtlTiers` arm returns exactly
+`Tier::discrete_ttl_secs`) — pinned by
+`retention::tests::model_ttl_matches_raw_discrete_values_for_every_tier` — so no
+eviction behavior changed.
+
+**No cost function ships** — not a GA `access_cost()` metric (an arbitrary,
+consumer-less curve would freeze false-precision numbers via Hyrum's Law and
+mint a fifth partial signal), not a test-only reference curve (property tests
+over an unconsumed self-defined function are a tautology). The #1829 5-agent
+vote `4d3ea1c5` rejected both.
+
+### 10.4 v1.x migration (deferred, 1:1 issue)
+
+A unified continuous cost-of-access model that GOVERNS eviction (subsuming the
+four surfaces above) is v1.x, tracked 1:1 as **#2066**. Construction-independent acceptance
+criteria for the eventual cost: **monotonically non-decreasing in age/archival
+depth, non-increasing in recent access, and consistent with the current tier
+ordering (cost `long < mid < short`).**
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,10 @@ pub mod quotas;
 // `recover_from_transcript` handler in this module.
 pub mod recover;
 pub mod replication;
+// v1.0.0 #1829 (TRACT-gap G15) — retention-model anchor (discrete TTL tiers; no
+// cost-of-access gradient). `Tier::default_ttl_secs` routes through it.
 pub mod reranker;
+pub mod retention;
 pub mod revisions;
 pub mod secret_screen;
 // v1.0.0 #1961 (R23/R7) — the `asi-hard` hardened, no-disable security posture.

--- a/src/models/memory.rs
+++ b/src/models/memory.rs
@@ -849,7 +849,28 @@ impl Tier {
         }
     }
 
+    /// The per-tier default TTL. Routes through the substrate's
+    /// [`RetentionModel`](crate::retention::RetentionModel) so the retention
+    /// posture is resolved in ONE place (TRACT-gap G15, #1829): the discrete
+    /// per-tier values live in [`Tier::discrete_ttl_secs`], and this delegates
+    /// via the model. Byte-identical to the pre-#1829 direct match — the
+    /// `RetentionModel::DiscreteTtlTiers` arm returns exactly these values — so
+    /// every eviction/TTL-floor caller is unchanged, but the model now has a
+    /// real live consumer (this, the most-called TTL function) rather than
+    /// being an inert anchor.
+    #[must_use]
     pub fn default_ttl_secs(&self) -> Option<i64> {
+        crate::retention::RetentionModel::current().ttl_secs_for(self)
+    }
+
+    /// The raw per-tier TTL under the CURRENT discrete-tier retention model
+    /// (Short 6h / Mid 7d / Long permanent). The canonical value source; callers
+    /// go through [`Tier::default_ttl_secs`] (which routes via
+    /// [`RetentionModel`](crate::retention::RetentionModel)). Kept separate so a
+    /// future continuous cost-of-access model (G15) adds a `RetentionModel`
+    /// variant + its own resolution WITHOUT rewriting these baseline values.
+    #[must_use]
+    pub fn discrete_ttl_secs(&self) -> Option<i64> {
         match self {
             Self::Short => Some(6 * crate::SECS_PER_HOUR),
             Self::Mid => Some(crate::SECS_PER_WEEK),

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,0 +1,143 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1829 (TRACT-gap G15) — the substrate's RETENTION-MODEL anchor.
+//!
+//! # What this is (and is NOT)
+//!
+//! TRACT L2 wants retention to be a **continuous cost-of-access (Landauer)
+//! gradient** — a single cost that rises with archival depth/age and GOVERNS
+//! eviction, replacing discrete tiers. The substrate's retention is instead a
+//! **discrete 3-tier TTL** model (`Tier::Short` 6h / `Tier::Mid` 7d /
+//! `Tier::Long` permanent); the gap is real (`docs/spec/TRACT-L1-CLAIM-CONTRACT.md`
+//! §10). This module ships **no** cost gradient and changes **no** eviction
+//! behavior.
+//!
+//! It does exactly one humble thing: it makes the retention posture resolvable
+//! in ONE place so the §10 honesty claim cannot silently drift. The deliberate
+//! ABSENCE of a cost-of-access variant on [`RetentionModel`] is the
+//! machine-checked record of the gap.
+//!
+//! # Not a floating anchor
+//!
+//! [`crate::models::Tier::default_ttl_secs`] — the most-called TTL function,
+//! read by every eviction / TTL-floor / archival / config-seed path — now
+//! delegates through [`RetentionModel::current`] + [`RetentionModel::ttl_secs_for`].
+//! So the enum has a REAL live consumer on the hot path (not a self-referential
+//! tripwire): the `match` in [`RetentionModel::ttl_secs_for`] is exhaustive and
+//! wildcard-free, so adding a `CostOfAccessGradient` variant hard-breaks the
+//! build there (and in [`RetentionModel::label`]) until the new model is
+//! consciously resolved AND the §10 ledger is updated. The wiring is provably
+//! byte-identical — the `DiscreteTtlTiers` arm returns exactly
+//! [`Tier::discrete_ttl_secs`] — so no eviction behavior changed.
+
+use crate::models::Tier;
+
+/// The retention posture the substrate ACTUALLY implements.
+///
+/// There is deliberately NO `CostOfAccessGradient` variant — the continuous
+/// Landauer cost-of-access model (TRACT G15, #1829) is UNIMPLEMENTED. Adding one
+/// breaks the exhaustive matches below until the new model is consciously
+/// resolved AND the contract §10 ledger is updated (the drift-gate).
+/// `#[non_exhaustive]` so out-of-crate matchers must also account for a future
+/// model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RetentionModel {
+    /// Retention/eviction is a fixed set of discrete tiers, each with a static
+    /// default TTL (`Tier::Short` 6h / `Tier::Mid` 7d / `Tier::Long` permanent),
+    /// extended on access by a per-tier floor. This is the ONLY posture today.
+    DiscreteTtlTiers,
+}
+
+impl RetentionModel {
+    /// The substrate's live retention model. Constant today — the substrate has
+    /// only [`DiscreteTtlTiers`](Self::DiscreteTtlTiers). A future continuous
+    /// cost-of-access model (G15) would resolve here (e.g. from config), which
+    /// is why callers route through this rather than hardcoding the posture.
+    #[must_use]
+    pub fn current() -> Self {
+        RetentionModel::DiscreteTtlTiers
+    }
+
+    /// The default TTL (seconds) a `tier` receives UNDER THIS MODEL, or `None`
+    /// for permanent. EXHAUSTIVE wildcard-free match — the drift-gate: a new
+    /// [`RetentionModel`] variant hard-breaks the build here until it defines
+    /// how retention resolves. The `DiscreteTtlTiers` arm is byte-identical to
+    /// the pre-#1829 `Tier::default_ttl_secs` values.
+    #[must_use]
+    pub fn ttl_secs_for(self, tier: &Tier) -> Option<i64> {
+        match self {
+            Self::DiscreteTtlTiers => tier.discrete_ttl_secs(),
+        }
+    }
+
+    /// A short, stable label. EXHAUSTIVE wildcard-free match — a second
+    /// drift-gate site.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::DiscreteTtlTiers => "discrete-ttl-tiers",
+        }
+    }
+
+    /// `true` iff retention is governed by a continuous cost-of-access gradient
+    /// (the TRACT L2 ideal). Always `false` today — G15 is UNIMPLEMENTED. When a
+    /// gradient variant is added it must return `true`, which is why this is an
+    /// exhaustive match, not a hardcoded constant.
+    #[must_use]
+    pub fn is_cost_of_access_gradient(self) -> bool {
+        match self {
+            Self::DiscreteTtlTiers => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The wiring is byte-identical: the live model resolves each tier's TTL to
+    /// exactly the raw `discrete_ttl_secs` value. If this ever diverges, the
+    /// #1829 anchor silently changed eviction behavior — a hard failure.
+    #[test]
+    fn model_ttl_matches_raw_discrete_values_for_every_tier() {
+        for tier in [Tier::Short, Tier::Mid, Tier::Long] {
+            assert_eq!(
+                RetentionModel::current().ttl_secs_for(&tier),
+                tier.discrete_ttl_secs(),
+                "RetentionModel must resolve the SAME TTL as the raw discrete value"
+            );
+            // And Tier::default_ttl_secs (the public entry every caller uses)
+            // routes through the model, so it too must match.
+            assert_eq!(tier.default_ttl_secs(), tier.discrete_ttl_secs());
+        }
+    }
+
+    /// #1829 / G15 honesty pin: the ONLY retention posture is discrete tiers;
+    /// there is NO cost-of-access gradient. If a future edit adds a gradient
+    /// variant, the exhaustive matches break the build and this must be revisited
+    /// alongside the contract §10 ledger.
+    #[test]
+    fn g15_retention_is_discrete_tiers_no_gradient() {
+        let m = RetentionModel::current();
+        assert_eq!(m, RetentionModel::DiscreteTtlTiers);
+        assert!(
+            !m.is_cost_of_access_gradient(),
+            "retention is discrete TTL tiers; the Landauer cost-of-access \
+             gradient (G15) is UNIMPLEMENTED"
+        );
+        assert_eq!(m.label(), "discrete-ttl-tiers");
+    }
+
+    /// The concrete baseline values are preserved (the pre-#1829 contract).
+    #[test]
+    fn discrete_baseline_values_preserved() {
+        assert_eq!(
+            Tier::Short.default_ttl_secs(),
+            Some(6 * crate::SECS_PER_HOUR)
+        );
+        assert_eq!(Tier::Mid.default_ttl_secs(), Some(crate::SECS_PER_WEEK));
+        assert_eq!(Tier::Long.default_ttl_secs(), None);
+    }
+}


### PR DESCRIPTION
Closes #1829 (TRACT-gap G15 — retention is discrete TTL tiers, not a continuous cost-of-access/Landauer gradient).

## Scope — the v1.0.0-correct slice (NOT the eviction redesign)
Retention/eviction is a discrete 3-tier TTL model; a continuous cost-of-access gradient that *governs* eviction is a freeze-hostile retention-economics redesign, deferred 1:1 to **#2066**. What ships:

- **`src/retention.rs`** — `RetentionModel` (`#[non_exhaustive]`) with the single posture `DiscreteTtlTiers` and **deliberately no `CostOfAccessGradient` variant** (the absent variant is the machine-checked gap). **Not a floating anchor:** `Tier::default_ttl_secs` (the most-called TTL fn — every eviction / TTL-floor / archival / config-seed path) delegates through `RetentionModel::current().ttl_secs_for(tier)`, so the enum has a **real live consumer on the hot path**. Exhaustive wildcard-free matches hard-break the build if a gradient variant is added. **Provably byte-identical** (`DiscreteTtlTiers` arm returns exactly `Tier::discrete_ttl_secs`) — pinned by a parity test; all pre-existing `tier_default_ttl_secs_*` tests still pass.
- **contract §10** — the **rigorous** honest map. A lazy "no gradient exists" would be overclaim-by-omission, so §10 enumerates the **four** existing partial age/access-gradient surfaces (recall-ranking recency+access+tier_bonus; TTL floor-extend-on-access; confidence-decay-on-touch; access-count promotion), states they are *ranking/extend/decay/promotion* signals **not** a unified eviction cost, and localizes the true gap: *no single continuous cost REPLACES discrete-tier eviction*. "Landauer" is flagged as a metaphor, not literal kT·ln2.

## What does NOT ship (by design)
**No cost function** — not a GA `access_cost()` metric (an arbitrary, consumer-less curve freezes false-precision numbers via Hyrum's Law and mints a 5th partial signal), not a test-only reference curve (property tests over an unconsumed self-defined function are a tautology). Both were rejected by the vote.

## Design — 2×5 adversarial vote (`4d3ea1c5`)
Verdict **A**; wave-1 **UNANIMOUS 5/5 A**, wave-2 **5/5 hold-A/ship-A** (memory `399e5f84`). Two wave-2 findings shaped the final form: the **wired** anchor answers the "inert self-referential theater" refutation (verified in-tree that every expiry site calls `default_ttl_secs()` directly), and the **four-surface map** answers the "honest §10 must not omit existing gradients" refutation. The freeze objection against B was conceded overstated — B still lost on no-consumer + arbitrary/false-precision + redundancy.

## Tests / gates
- New: `retention::tests::*` (3 — byte-identical parity across all tiers, the G15 no-gradient honesty pin, baseline values preserved). All pre-existing Tier TTL tests pass unchanged.
- `cargo fmt` ✓ · `clippy -D pedantic` ✓ · docs-vs-ssot ✓ · vendor-literal ✓ · hardcoded-literal ✓ · cli-count (88/90, unchanged) ✓.

## Stacking
Stacked on **feat/1830** (#2065) → #2063 → #2056 → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)