### PR TITLE
feat(#1839): TRACT G31 latency-degrade honesty — wire dead p95 metric + const-ify mode + §11

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -365,6 +365,59 @@ criteria for the eventual cost: **monotonically non-decreasing in age/archival
 depth, non-increasing in recent access, and consistent with the current tier
 ordering (cost `long < mid < short`).**
 
+## 11. No latency-SLO degrade governor (G31, #1839)
+
+TRACT L2 (Pillar 14) wants a **latency governor** that reads recall p95 and
+selects a named degradation tier on a **latency budget** (full → drop rerank →
+drop semantic → keyword-only), surfaced in the response — so "graceful
+degradation tiers / latency-bounded recall" can be claimed. The substrate has
+**no such governor**. This § pins the honest current state.
+
+### 11.1 Honest current state — degrades are capability/load-cut, NOT latency
+
+Do NOT claim a "degradation ladder." What actually exists:
+
+| Degrade | Trigger | Axis |
+|---|---|---|
+| Embedder-failure → keyword (#1593) | the embedder is absent or `is_degraded()` — the query gets no semantic vector | **capability** (availability), not latency |
+| Reranker-degraded → `degraded_lexical` (`reranker.rs`) | the cross-encoder fell back to a lexical scorer | **capability** |
+| Admission-shed `503` (#1733) | global in-flight request cap exceeded | **load** — and it *rejects* the request (outermost middleware; it never reaches recall, produces no recall envelope, and is NOT a recall tier) |
+
+The recall `mode` field (`hybrid+rerank` / `hybrid` / `keyword`;
+`RECALL_MODE_*` in `models::recall_request`) reflects **which stages ran** — a
+**capability cut** (embedder present → `hybrid`; + reranker re-order →
+`hybrid+rerank`; else `keyword`). It is **not** latency-selected: a
+`hybrid+rerank` recall may be slow and a `keyword` recall fast. All degrades
+fire on FAILURE/LOAD, **never on a latency budget**. There is **no latency
+governor** and **no named degradation ladder**; the G31 ladder's "drop semantic
+*for latency*" rung **never occurs** (a `keyword` result only comes from
+embedder absence, never a deliberate latency-driven semantic drop).
+
+### 11.2 What #1839 shipped (honesty fixes, not the governor)
+
+- **Recall p95 is now measured.** The `ai_memory_recall_latency_seconds`
+  histogram was registered + `/metrics`-exposed (HELP "Recall latency in
+  seconds, labeled by mode") but **never observed** — it reported permanent
+  zeros (a §2.5 lie in the shipped surface). #1839 times the HTTP recall path
+  and `record_recall(mode, elapsed)`s into it, so the scraped metric is now
+  truthful. This is **observability only** — nothing acts on it (measurement ≠
+  governance).
+- **Mode vocabulary const-ified** (`RECALL_MODE_HYBRID`/`RECALL_MODE_KEYWORD`
+  beside the existing `RECALL_MODE_HYBRID_RERANK`) — one typed source of truth,
+  clearing a hardcoded-literal smell. NO degradation-tier type is minted: the
+  recall modes are a 3-value capability vocabulary, and a `DegradationTier`
+  enum would (a) fabricate arity (the 4th "drop-semantic" rung is unreachable),
+  (b) be inert (nothing parses `mode` back — no read side / no forcing
+  function), and (c) overclaim the very "graceful degradation tiers" the gap
+  says cannot be claimed. The #1839 5-agent vote `4d3ea1c5` rejected it.
+
+### 11.3 v1.x migration (deferred, 1:1 issue)
+
+The latency governor (a p95-reading actuator) is v1.x, tracked as **#2068**. Per
+the vote's wrong-axis finding it must reserve an **orthogonal actuation axis**
+(candidate-set caps / per-stage time-boxing / partial results *within* a mode),
+NOT assume the capability stages are the latency ladder.
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -340,6 +340,11 @@ async fn recall_response(
     // hook_subscribers.rs.
     #[cfg(not(feature = "sal"))]
     let _ = recall_scope_tier;
+    // #1839 (TRACT-gap G31) — time the recall so the already-registered
+    // `ai_memory_recall_latency_seconds` histogram (labeled by `mode`) is
+    // actually observed instead of reporting permanent zeros. Observability
+    // ONLY — no latency governor acts on it (that is the deferred G31 gap).
+    let recall_started = std::time::Instant::now();
     // v0.7.0 Wave-3 Continuation 2 (Phase 10) — postgres-backed
     // hybrid recall via the SAL trait. Embeds the query AND dispatches
     // through `app.store.recall_hybrid` so the postgres adapter applies
@@ -365,9 +370,9 @@ async fn recall_response(
             None
         };
         let mode = if query_emb.is_some() {
-            "hybrid"
+            crate::models::RECALL_MODE_HYBRID
         } else {
-            "keyword"
+            crate::models::RECALL_MODE_KEYWORD
         };
 
         // `as_agent` is the explicit query-param override (admin /
@@ -557,6 +562,9 @@ async fn recall_response(
                 if let Some(b) = budget_tokens {
                     resp[field_names::BUDGET_TOKENS] = json!(b);
                 }
+                // #1839 G31 — observe recall latency (postgres path), labeled
+                // by the final post-rerank `mode`.
+                crate::metrics::record_recall(mode, recall_started.elapsed().as_secs_f64());
                 // #1579 B4 — serialize per the negotiated format.
                 crate::handlers::wire_format::memories_response(format, resp)
             }
@@ -741,7 +749,7 @@ async fn recall_response(
                 // v0.8.0 #1720 A3 — owner-keyed visibility caller.
                 caller_owned.as_deref(),
             );
-            (r, "hybrid")
+            (r, crate::models::RECALL_MODE_HYBRID)
         } else {
             let r = db::recall(
                 conn,
@@ -759,7 +767,7 @@ async fn recall_response(
                 source_uri_owned.as_deref(),
                 caller_owned.as_deref(),
             );
-            (r, "keyword")
+            (r, crate::models::RECALL_MODE_KEYWORD)
         }
     })
     .await;
@@ -918,6 +926,9 @@ async fn recall_response(
                     "budget_overflow": outcome.budget_overflow,
                 });
             }
+            // #1839 G31 — observe recall latency (sqlite path), labeled by the
+            // final post-rerank `mode`.
+            crate::metrics::record_recall(mode, recall_started.elapsed().as_secs_f64());
             // #1579 B4 — serialize per the negotiated format.
             crate::handlers::wire_format::memories_response(format, resp)
         }

--- a/src/mcp/tools/recall.rs
+++ b/src/mcp/tools/recall.rs
@@ -1285,15 +1285,23 @@ pub fn handle_recall_dto(
                 );
                 let memories = scored_memories(results, conn);
                 record_recall_observations(
-                    conn, &recall_id, &memories, "hybrid", caller, namespace,
+                    conn,
+                    &recall_id,
+                    &memories,
+                    crate::models::RECALL_MODE_HYBRID,
+                    caller,
+                    namespace,
                 );
                 let mut resp = json!({
                     "recall_id": recall_id,
                     "memories": memories,
                     "count": memories.len(),
-                    "mode": "hybrid",
+                    "mode": crate::models::RECALL_MODE_HYBRID,
                 });
                 decorate_budget(&mut resp, &outcome);
+                // NB: `meta.recall_mode` is a DELIBERATELY separate telemetry
+                // vocabulary (e.g. "keyword_only" vs the mode field "keyword");
+                // left as a literal so the two lanes stay decoupled (#1839).
                 attach_meta(&mut resp, "hybrid", &telemetry);
                 if confidence_tier_filter.is_some() {
                     insert_confidence_filter_meta(&mut resp, confidence_filtered_out);
@@ -1353,14 +1361,22 @@ pub fn handle_recall_dto(
         session_tracker,
     );
     let memories = scored_memories(results, conn);
-    record_recall_observations(conn, &recall_id, &memories, "keyword", caller, namespace);
+    record_recall_observations(
+        conn,
+        &recall_id,
+        &memories,
+        crate::models::RECALL_MODE_KEYWORD,
+        caller,
+        namespace,
+    );
     let mut resp = json!({
         "recall_id": recall_id,
         "memories": memories,
         "count": memories.len(),
-        "mode": "keyword",
+        "mode": crate::models::RECALL_MODE_KEYWORD,
     });
     decorate_budget(&mut resp, &outcome);
+    // `keyword_only` is the separate telemetry-lane label — left literal (#1839).
     attach_meta(&mut resp, "keyword_only", &telemetry);
     if confidence_tier_filter.is_some() {
         insert_confidence_filter_meta(&mut resp, confidence_filtered_out);

--- a/src/models/recall_request.rs
+++ b/src/models/recall_request.rs
@@ -37,9 +37,24 @@ use serde_json::Value;
 /// #1558 batch 5 wave 3 — canonical recall-mode label stamped on the
 /// `mode` response field and the `recall_observations` ledger when the
 /// hybrid (FTS+semantic) pipeline ran AND the cross-encoder reranker
-/// re-ordered the results. The plain `"hybrid"` / `"keyword"` labels
-/// stay short literals at the two emit sites.
+/// re-ordered the results.
 pub const RECALL_MODE_HYBRID_RERANK: &str = "hybrid+rerank";
+
+/// #1839 (TRACT-gap G31) — canonical `mode` field label when the hybrid
+/// (FTS + semantic) pipeline ran WITHOUT a reranker re-order. Const-ified
+/// from the bare `"hybrid"` literals at the recall-`mode`-field emit sites so
+/// the mode vocabulary has one typed source of truth (pm-v3.1 no-hardcoded-
+/// literals). Capability-cut (embedder present), NOT a latency tier — see the
+/// contract §11 (G31 degradation ledger).
+pub const RECALL_MODE_HYBRID: &str = "hybrid";
+
+/// #1839 (TRACT-gap G31) — canonical `mode` field label when only the FTS
+/// keyword half ran (no semantic component — embedder absent or degraded).
+/// Const-ified from the bare `"keyword"` literals at the recall-`mode`-field
+/// emit sites. Capability-cut, NOT a latency tier. NB: distinct from the
+/// `meta.recall_mode = "keyword_only"` telemetry label, which is deliberately
+/// a different string and is left untouched.
+pub const RECALL_MODE_KEYWORD: &str = "keyword";
 
 /// v0.7.0 #972 D1.3 (#984) — `kinds` filter shape for `memory_recall`.
 ///
@@ -408,6 +423,16 @@ impl RecallRequest {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// #1839 (G31) — the recall-`mode` vocabulary SSOT. These exact strings are
+    /// the frozen wire contract every recall surface (HTTP/MCP) emits; a change
+    /// here is a wire regression. Capability-cut labels, NOT latency tiers.
+    #[test]
+    fn recall_mode_vocabulary_is_frozen() {
+        assert_eq!(RECALL_MODE_HYBRID_RERANK, "hybrid+rerank");
+        assert_eq!(RECALL_MODE_HYBRID, "hybrid");
+        assert_eq!(RECALL_MODE_KEYWORD, "keyword");
+    }
 
     #[test]
     fn from_mcp_params_requires_context() {


### PR DESCRIPTION
Closes #1839 (TRACT-gap G31 — no latency-SLO degrade governor).

## Scope — the v1.0.0-correct slice (NOT the governor)
The latency governor (a p95-reading actuator selecting a degradation tier on a latency budget) is a freeze-hostile v1.x actuator, deferred 1:1 to **#2068**. This is the 6th Tier-B item, and the one where deep vote-verification changed the deliverable materially.

## Why NO `DegradationTier` enum (the vote's unanimous finding)
The recall `mode` field is a **3-value capability vocabulary** (`hybrid+rerank`/`hybrid`/`keyword`) decided by embedder/rerank *availability* — zero latency reference. A `{Full, DropRerank, DropSemantic, KeywordOnly}` enum would:
- **fabricate arity** — the "drop-semantic-for-latency" rung *never occurs* (a `keyword` result only comes from embedder absence, never a deliberate latency drop);
- be **inert** — nothing parses `mode` back, so there's no read side / no forcing function (verified in-tree);
- **overclaim** the exact "graceful degradation tiers / latency-bounded recall" the gap says *cannot* be claimed;
- and routing all emit sites through it is a **wire-regression trap** (`mode` vs `meta.recall_mode` deliberately diverge — `"keyword"` vs `"keyword_only"` — and `"hybrid"/"keyword"` is overloaded across ≥4 subsystems incl. an existing `config::RecallMode`).

## What ships instead — two real in-tree honesty fixes + §11
- **Wire the dead p95 histogram.** `ai_memory_recall_latency_seconds` was registered + `/metrics`-exposed (HELP "Recall latency in seconds") but **never observed** — permanent zeros, a §2.5 lie in the shipped surface. This times the HTTP recall path (both sqlite + postgres backends) and `record_recall(mode, elapsed)`s into it. **Observability only** — no governor acts on it (measurement ≠ governance). MCP stdio has no `/metrics` endpoint, so it's not wired there (the scraped HTTP surface is the one that lied).
- **Const-ify the `mode` vocabulary** — `RECALL_MODE_HYBRID`/`RECALL_MODE_KEYWORD` beside the existing `RECALL_MODE_HYBRID_RERANK`. One typed source of truth, clearing a hardcoded-literal smell at the mode-field emit sites (HTTP + MCP + matching `record_recall_observations` args). **Byte-identical** (const = same `&str`; the divergent `meta.recall_mode="keyword_only"` telemetry lane is deliberately left decoupled).
- **Contract §11** — the honest map: degrades are capability/load-cut *not* latency; `#1733` admission-shed is a separate outermost-middleware axis that rejects (never a recall tier); no governor; ladder not claimable; the "drop-semantic" rung never occurs.

## Design — 2×5 adversarial vote (`4d3ea1c5`)
Verdict **A'** (memory `3e255ea0`). Wave-1 **unanimous 5/5 A**; wave-2 deep verification (2 refuters read the code at 25k+/139k tokens) **refuted the enum** and surfaced the two honesty fixes. I independently confirmed in-tree: `metrics::record_recall` has zero live callers, no recall timing existed, `config::RecallMode` collision, and the `mode`/`meta` string divergence.

## Tests / gates
- New: `recall_mode_vocabulary_is_frozen` (SSOT pin). Existing mode-string assertions (`keyword_only_path`, `issue_1691_rerank_tests`, `record_recall_emits_latency_histogram`) all pass — byte-identical.
- `cargo fmt` ✓ · `clippy -D pedantic --all-features` ✓ · docs-vs-ssot ✓ · vendor-literal ✓ · **hardcoded-literal ✓ (this REMOVES literals)** · cli-count (88/90) ✓.

## Stacking
Stacked on **feat/1829** (#2067) → #2065 → #2063 → #2056 → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)