### PR TITLE
feat(#1862): TRACT G10.2 refusal-as-Claim — wired RefusalClaim anchor + §12 (defer persist)

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -418,6 +418,66 @@ the vote's wrong-axis finding it must reserve an **orthogonal actuation axis**
 (candidate-set caps / per-stage time-boxing / partial results *within* a mode),
 NOT assume the capability stages are the latency ladder.
 
+## 12. Refusal is a typed error, not a recallable Claim (G10.2, #1862)
+
+TRACT L1 wants a governance refusal to be a first-class **recallable Claim** so a
+refused agent can `memory_recall` "was I denied X?" and let its own denial
+history inform later reasoning + governance review. The substrate does **not**
+persist refusals. The executable anchor is `crate::claim::refusal`.
+
+### 12.1 Honest current state
+
+A governance refusal is a typed `GovernanceRefusal` envelope
+(`src/governance/refusal.rs`: `agent_id` + `action` + `namespace` +
+`denied_level` + `owner` + `reason`) that is **minted in three independent
+lanes** and returned as an **error** — never written to `memories`, never
+recallable:
+
+| Lane | Mint site | Handle |
+|---|---|---|
+| Permission-rule (K9) | `Permissions::evaluate` (`governance::mod`) — *stateless, every input a parameter* | no DB handle |
+| Substrate-governance | `storage::enforce_governance` (`storage::mod`) via `evaluate_level` | `&Connection` (a choke for **this lane only**) |
+| Agent-external | `wire_check::GOVERNANCE_PRE_ACTION` (`OnceLock` hook) | hook-scoped |
+
+The ~21 `Deny` consumption sites (MCP tools + HTTP handlers) each render the
+refusal to a string via the pure, identity-blind formatter
+`governance::deny_message(action, gate, reason)` and return it. `REFUSAL_
+PERSISTED_AS_CLAIM` (`crate::claim::refusal`) is `false`.
+
+### 12.2 The forcing-function anchor
+
+`crate::claim::refusal::RefusalClaim::of_refusal(&GovernanceRefusal)` projects a
+refusal onto the read-only Claim shape it WOULD persist as (asserter + action +
+namespace + denied_level + reason). It is **wired, not floating**:
+`GovernanceRefusal`'s `Display` renders through the projection (its live
+constructor on every refusal-format path), byte-identically — pinned by
+`claim::refusal::tests::display_is_byte_identical_through_the_projection`. The
+`#[non_exhaustive]` type + the `REFUSAL_PERSISTED_AS_CLAIM = false` honesty const
++ the round-trip drift-test machine-check the gap. **No persistence ships.**
+
+### 12.3 Why persistence is deferred (v1.x, #2070) — the safety model is unbuilt
+
+The #1862 5-agent vote (`4d3ea1c5`) verified in-tree that a naive persist-on-
+refusal is freeze-hostile:
+
+- **Re-entrancy.** The refusal-memory write re-enters `consult_governance_pre_
+  write` UNCONDITIONALLY, and `CallerContext::for_admin` does **not** bypass it
+  (it sets only `bypass_visibility`; the gate takes no caller context). So the
+  refusal-write can itself be refused (silent audit loss) or recurse — no guard
+  exists.
+- **No central choke** across the three lanes → a single-lane persist is a
+  misleading partial ledger (an agent reasons "I was never denied X" when it was,
+  on an unwired lane).
+- **Quota** is lose-lose: tool-layer → self-DOS the 1000/day cap under a denied-
+  action retry loop; bypassed → unbounded flooding. No dedup.
+- **Visibility/ownership** of a recallable refusal-Claim is undesigned; the safe
+  answer (`scope=private`, owned by the refused agent) must be a hard acceptance
+  criterion, not an assumption.
+
+#2070 tracks the persist mechanism with the full safety model (re-entrancy guard,
+three-lane coverage, private owner-scoping, opt-in default-OFF, dedup/rate-limit,
+best-effort non-fatal, secret-screen, both backends) as acceptance criteria.
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/claim/mod.rs
+++ b/src/claim/mod.rs
@@ -31,6 +31,7 @@
 //! hold, so a future change that silently "fixed" one (or broke the projection)
 //! is caught.
 
+pub mod refusal;
 pub mod relation;
 
 use crate::models::{Memory, MemoryLink};

--- a/src/claim/refusal.rs
+++ b/src/claim/refusal.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #1862 (TRACT-gap G10.2) — [`RefusalClaim`], the read-only Claim-shape a
+//! governance refusal WOULD persist as.
+//!
+//! # This is NOT a persisted, recallable Claim
+//!
+//! TRACT L1 wants a governance refusal to be a first-class **recallable Claim**
+//! (`docs/spec/TRACT-L1-CLAIM-CONTRACT.md` §12) so a refused agent can recall
+//! "was I denied X?" and let it inform later reasoning / governance review. The
+//! substrate does NOT persist refusals: a [`GovernanceRefusal`] is minted (in
+//! three independent lanes — the stateless `Permissions::evaluate`, the
+//! conn-bearing `storage::enforce_governance`, and the `wire_check`
+//! pre-action hook) and returned as a typed error via
+//! [`crate::governance::deny_message`], never written to `memories`.
+//! [`REFUSAL_PERSISTED_AS_CLAIM`] is `false`.
+//!
+//! This module ships NO persistence. It is the machine-checked projection of a
+//! refusal onto the Claim fields the gap enumerates (identity + action +
+//! namespace + denied level + reason), giving the deferred v1.x persist path a
+//! typed target and pinning the honest state. The projection has a live
+//! constructor: [`GovernanceRefusal`]'s `Display` renders through it.
+//!
+//! # Why persistence is deferred to v1.x — the safety model does not exist
+//!
+//! Persisting a refusal-memory re-enters the write path's
+//! `consult_governance_pre_write` gate UNCONDITIONALLY, and
+//! `CallerContext::for_admin` does **not** bypass it (it sets only
+//! `bypass_visibility`; the gate takes no caller context). So a naive persist
+//! can be refused (silent audit loss) or recurse, with no guard; the daily
+//! write quota makes it either self-DOSing (tool-layer) or unbounded (bypassed);
+//! and the refusal-Claim's visibility/ownership scope is undesigned. The full
+//! safety model is v1.x — see §12.
+
+use crate::governance::refusal::GovernanceRefusal;
+use crate::models::MemoryKind;
+
+/// `true` only when governance refusals are persisted as recallable Claim-kind
+/// memories. They are NOT at v1.0.0 (TRACT G10.2, #1862) — a refusal is a typed
+/// error, not a row. Pinned as a const so the honesty state is machine-checked;
+/// flipping it is a deliberate edit here + a §12 ledger update + a real,
+/// re-entrancy-safe persist path.
+pub const REFUSAL_PERSISTED_AS_CLAIM: bool = false;
+
+/// The read-only Claim-shape a [`GovernanceRefusal`] WOULD persist as under
+/// TRACT G10.2. A **projection**, NOT a persisted memory. `#[non_exhaustive]`
+/// because the eventual persisted shape (owner/scope/timestamps) is still being
+/// designed (§12).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RefusalClaim {
+    /// The Claim asserter — the caller principal that failed the gate
+    /// (`GovernanceRefusal::agent_id`). The identity that WOULD own + recall the
+    /// refusal-Claim (v1.x acceptance criterion: `scope=private`, owned by this
+    /// agent, so no cross-agent "who-was-denied-what" leak).
+    pub asserter: String,
+    /// The governed action that was denied.
+    pub action: String,
+    /// The namespace the action targeted, when scoped.
+    pub namespace: Option<String>,
+    /// The governance level that denied the action
+    /// (`any` / `registered` / `owner` / `approve`).
+    pub denied_level: String,
+    /// The principal who WOULD have satisfied an Owner-level gate, when relevant.
+    pub owner: Option<String>,
+    /// The human-readable refusal reason. Structurally identity/action/namespace/
+    /// level ONLY — never the refused payload; any future persist re-enters the
+    /// secret screen regardless.
+    pub reason: String,
+}
+
+impl RefusalClaim {
+    /// Project a [`GovernanceRefusal`] onto its would-be Claim shape. Read-only,
+    /// total, never persists.
+    #[must_use]
+    pub fn of_refusal(r: &GovernanceRefusal) -> Self {
+        Self {
+            asserter: r.agent_id.clone(),
+            action: r.action.as_str().to_string(),
+            namespace: r.namespace.clone(),
+            denied_level: r.denied_level.as_str().to_string(),
+            owner: r.owner.clone(),
+            reason: r.reason.clone(),
+        }
+    }
+
+    /// The `MemoryKind` a persisted refusal-Claim would carry (G10.2 says
+    /// Claim-kind). Fixed today; here so the v1.x persist path has one source of
+    /// truth rather than re-deciding the kind at the write site.
+    #[must_use]
+    pub fn would_be_memory_kind() -> MemoryKind {
+        MemoryKind::Claim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::GovernedAction;
+    use crate::models::namespace::GovernanceLevel;
+
+    fn sample() -> GovernanceRefusal {
+        GovernanceRefusal::new(
+            GovernedAction::Store,
+            GovernanceLevel::Owner,
+            "ai:bob",
+            "caller 'ai:bob' is not the owner ('ai:alice')",
+        )
+        .with_namespace("team/eng")
+        .with_owner("ai:alice")
+    }
+
+    /// The projection round-trips every field of the real, live-constructed
+    /// `GovernanceRefusal`. If a future edit drops a field, this fails and forces
+    /// a deliberate spec + ledger update.
+    #[test]
+    fn projection_round_trips_every_refusal_field() {
+        let r = sample();
+        let c = RefusalClaim::of_refusal(&r);
+        assert_eq!(c.asserter, "ai:bob");
+        assert_eq!(c.action, r.action.as_str());
+        assert_eq!(c.namespace.as_deref(), Some("team/eng"));
+        assert_eq!(c.denied_level, r.denied_level.as_str());
+        assert_eq!(c.owner.as_deref(), Some("ai:alice"));
+        assert_eq!(c.reason, r.reason);
+    }
+
+    /// #1862 / G10.2 honesty pin: refusals are NOT persisted as recallable
+    /// Claims at v1.0.0. If a future edit flips this without a real persist path
+    /// + §12 update, the const change is caught here.
+    #[test]
+    fn g10_2_refusals_are_not_persisted_as_claims() {
+        assert!(
+            !REFUSAL_PERSISTED_AS_CLAIM,
+            "refusals are typed errors, not recallable Claim rows (G10.2)"
+        );
+        assert_eq!(RefusalClaim::would_be_memory_kind(), MemoryKind::Claim);
+    }
+
+    /// The projection is the live constructor behind `GovernanceRefusal`'s
+    /// `Display`, so the rendered error is byte-identical whether or not it
+    /// routes through the projection (the anchor is wired, not floating).
+    #[test]
+    fn display_is_byte_identical_through_the_projection() {
+        let r = sample();
+        let c = RefusalClaim::of_refusal(&r);
+        let via_projection = crate::governance::deny_message(
+            &c.action,
+            crate::governance::DenyGate::Governance,
+            &c.reason,
+        );
+        assert_eq!(via_projection, r.to_string());
+    }
+}

--- a/src/governance/refusal.rs
+++ b/src/governance/refusal.rs
@@ -168,10 +168,18 @@ impl std::fmt::Display for GovernanceRefusal {
         // Byte-identical to pre-#963 `Deny(String)` Display: routes
         // through the canonical deny_message helper so the wire shape
         // ("<action> denied by governance: <reason>") cannot drift.
+        //
+        // #1862 (TRACT-gap G10.2) — render through the read-only
+        // [`crate::claim::refusal::RefusalClaim`] projection so the
+        // would-be-recallable-Claim anchor has a genuine LIVE constructor on
+        // the real refusal-format path (not a floating, test-only type). The
+        // projection copies `action`/`reason` verbatim, so the rendered string
+        // is byte-identical.
+        let claim = crate::claim::refusal::RefusalClaim::of_refusal(self);
         let msg = crate::governance::deny_message(
-            self.action.as_str(),
+            &claim.action,
             crate::governance::DenyGate::Governance,
-            &self.reason,
+            &claim.reason,
         );
         f.write_str(&msg)
     }


### PR DESCRIPTION
Closes #1862 (TRACT-gap G10.2 — refusal-as-recallable-Claim).

## Scope — the v1.0.0-correct slice (NOT the persist mechanism)
A governance refusal is a typed `GovernanceRefusal` error, not a recallable Claim. Persisting refusals as recallable memories is freeze-hostile without a designed safety model, deferred 1:1 to **#2070**.

## Why the persist mechanism is deferred (5-agent vote `4d3ea1c5`, 4 A / 1 B — verified in-tree, incl. by me)
- **Re-entrancy (verified):** the refusal-memory write re-enters `consult_governance_pre_write` (`storage/mod.rs:166`) **unconditionally**, and `CallerContext::for_admin` does **not** bypass it — it sets *only* `bypass_visibility`, and the gate takes no caller context. So a naive persist can be refused (silent audit loss) or recurse, with no guard. (This corrected my own anchoring assumption.)
- **No central choke:** refusals are minted in **three** independent lanes (stateless `Permissions::evaluate` / conn-bearing `enforce_governance` / `wire_check` hook); a single-lane persist silently drops the others → a misleading partial ledger (worse than none, since the value depends on completeness — "was I denied X?").
- **Quota lose-lose:** tool-layer → self-DOS the 1000/day cap under a denied-action retry loop; bypassed → unbounded corpus flooding. No dedup.
- **Undesigned visibility/ownership:** default cross-namespace recall is unrestricted; a wrongly-scoped refusal-Claim leaks "who-was-denied-what."

## What ships instead — a wired anchor + §12
- **`src/claim/refusal.rs`** — `RefusalClaim::of_refusal(&GovernanceRefusal)`: the read-only Claim shape a refusal *would* persist as (asserter + action + namespace + denied_level + reason). **Wired, not floating:** `GovernanceRefusal`'s `Display` renders through the projection (its live constructor on every refusal-format path), **byte-identical** — the existing 9 refusal tests + a new byte-identical test pass. `#[non_exhaustive]` + `REFUSAL_PERSISTED_AS_CLAIM = false` honesty const + a round-trip drift-test. **No persistence ships.**
- **Contract §12** — the honest map (three mint lanes, no choke, typed-error-not-Claim) + the deferred safety model as acceptance criteria (#2070).

## Design
5-agent vote (`4d3ea1c5`), verdict **A** (memory `379e941f`). Wave-1 4 A / 1 B; the two deepest verifications (150k+ tokens each) + my own C5 check confirmed B's `for_admin` safety premise is factually broken. The lone B vote was about anchor-wiredness and self-conceded A-sufficiency by precedent parity (`ClaimView`/`DurabilityModel` were accepted with zero live readers; this projection has a live `Display` constructor, so it *exceeds* that bar).

## Tests / gates
- New: `claim::refusal::tests::*` (3 — field round-trip, G10.2 honesty pin, byte-identical Display). Existing 9 `governance::refusal` tests pass (Display unchanged).
- `cargo fmt` ✓ · `clippy -D pedantic --all-features` ✓ · docs-vs-ssot ✓ · vendor-literal ✓ · hardcoded-literal ✓ · cli-count (88/90) ✓.

## Stacking
Stacked on **feat/1839** (#2069) → #2067 → #2065 → #2063 → #2056 → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)