### PR TITLE
feat(#1863): TRACT G10.3 promotion-court — honest §13 (3 lanes to long) + characterization tests

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -478,6 +478,59 @@ refusal is freeze-hostile:
 three-lane coverage, private owner-scoping, opt-in default-OFF, dedup/rate-limit,
 best-effort non-fatal, secret-screen, both backends) as acceptance criteria.
 
+## 13. Promotion is not fully court-gated — access-count auto-promote is maintenance (G10.3, #1863)
+
+TRACT L1 wants promotion above a configured tier to require an explicit, audited
+approval flow — "a memory reaches `long` by being adjudicated, not by being
+touched." The substrate has a promotion **court** for CALLER-initiated promotion,
+but `long` (permanent) tier is reachable by two other lanes it does not gate.
+This § pins the honest state; the machine-checks are
+`storage::tests::g10_3_*`.
+
+### 13.1 The three lanes to `long`
+
+| Lane | Mechanism | Governance |
+|---|---|---|
+| **Caller promote** | `memory_promote` (MCP/CLI) | ✅ **court-gated** — `GovernedAction::Promote` → the namespace `promote` `GovernanceLevel` (Deny at `owner`, Pending at `approve`); capability `Ask→Allow`; `pending_approve`. |
+| **Direct write** | `memory_store tier=long`, or upsert `mid→long` escalation (tier-monotonic-max) | ⚠️ gated by `GovernedAction::Store` → `policy.core.**write**`, **not** `promote`. So `long` is reachable via the write lane without the promote court. |
+| **Access-count auto-promote** | the fold "maintenance verb" (`fold_recall_accesses`) flips `mid→long` at `PROMOTION_THRESHOLD = 5` | ❌ **ungoverned** — see §13.2. |
+
+Consequence: **"no `long` past a configured court" is not achievable by gating the
+auto-promote lane alone** — an operator wanting adjudicated-only permanence must
+ALSO gate `write` (and even then access-count auto-promote applies).
+
+### 13.2 Access-count auto-promote is substrate maintenance, not an adjudicable grant
+
+The auto-promote lives in `fold_recall_accesses` — a callerless batch
+**maintenance verb** (#1869) that folds aggregated `recall_observations`
+(`GROUP BY memory_id`) with **no caller identity, no request context**. It is the
+same class as substrate eviction (`substrate:eviction`) and GC, which are
+deliberately exempt from caller-intent governance. Court-gating it is not merely
+inappropriate but **structurally un-runnable**: `enforce_governance`'s promote arm
+needs `agent_id` + `memory_owner` to adjudicate Owner/Approve, and a callerless
+fold has neither — so a court check there could only no-op or convert a retention
+function into court-gated **expiration** (a hot but unadjudicated memory GC'd).
+Gating it on the caller-intent `promote` level is a category error.
+
+### 13.3 The genuine residual (disclosed, not weaponized)
+
+Access-count is caller-**influenceable**: a principal that can recall a row
+`PROMOTION_THRESHOLD` times inflates it to permanent `long`, side-stepping a
+`promote: owner/approve` court by traffic. This is an **access-count-integrity**
+concern (partly mitigated by the #1705 recall-observations identity binding), NOT
+a promote-court concern — the honest fix is not to mis-apply the caller gate to a
+maintenance job.
+
+### 13.4 v1.x migration (deferred, 1:1 issue)
+
+Adjudicated-only permanence is v1.x, tracked as **#2072**: an opt-in, default-OFF
+posture that (a) **suppresses** maintenance auto-promote in adjudicated-permanence
+namespaces (keeping the row `mid` **with an expiry-hold** so it is not silently
+GC'd), (b) **routes the direct `tier=long` write lane** to the promote court, and
+(c) reaches both backends (the postgres set-based fold CTE needs a
+court-namespace exclusion-set bind mirroring `build_namespace_chain`), behind a
+flag + WARN cycle. **Not** court-gating the callerless fold.
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21751,6 +21751,142 @@ mod tests {
         assert_eq!(resolved.core.write, crate::models::GovernanceLevel::Owner);
     }
 
+    // ---- #1863 (TRACT-gap G10.3) promotion-court characterization ----------
+    //
+    // These pin the HONEST current state documented in contract §13: the
+    // `promote` GovernanceLevel governs CALLER-initiated promotion only; the
+    // access-count auto-promote in the fold MAINTENANCE verb is court-blind
+    // (maintenance-exempt, like substrate eviction), and `long` durability is
+    // ALSO reachable via the WRITE lane (gated by `write`, not `promote`). A
+    // future v1.x opt-in to suppress maintenance auto-promote in
+    // adjudicated-permanence namespaces would flip test 1's assertion —
+    // deliberately failing it so the behavior change is a conscious edit here +
+    // a §13 ledger update.
+
+    /// Insert a namespace standard with `promote: Owner` (a configured court)
+    /// but `write: Any` (the write lane open) and return the fresh conn.
+    fn court_ns_conn(ns: &str) -> Connection {
+        use crate::models::{ApproverType, CorePolicy, GovernanceLevel, GovernancePolicy};
+        let conn = test_db();
+        let policy = GovernancePolicy {
+            core: CorePolicy {
+                write: GovernanceLevel::Any,
+                promote: GovernanceLevel::Owner,
+                delete: GovernanceLevel::Owner,
+                approver: ApproverType::Human,
+                inherit: true,
+                max_reflection_depth: None,
+                required_scope: None,
+            },
+            ..Default::default()
+        };
+        let mut standard = make_memory("g10-3-std", &format!("_standards-{ns}"), Tier::Long, 9);
+        standard.metadata = serde_json::json!({"governance": policy});
+        let sid = insert(&conn, &standard).unwrap();
+        set_namespace_standard(&conn, ns, &sid, None).unwrap();
+        conn
+    }
+
+    /// Test 1 — the access-count auto-promote (fold/touch MAINTENANCE verb) is
+    /// COURT-BLIND: a `mid` row in a `promote: Owner` namespace still flips to
+    /// `long` at `PROMOTION_THRESHOLD`, because the fold is callerless frecency
+    /// bookkeeping and never consults the promote court.
+    #[test]
+    fn g10_3_access_count_auto_promote_is_court_blind() {
+        let ns = "g10-3/court";
+        let conn = court_ns_conn(ns);
+        let mut m = make_memory("hot", ns, Tier::Mid, 5);
+        m.access_count = PROMOTION_THRESHOLD - 1;
+        let id = insert(&conn, &m).unwrap();
+        // Drive the maintenance auto-promote (one bump crosses the threshold).
+        touch(
+            &conn,
+            &id,
+            crate::models::SHORT_TTL_EXTEND_SECS,
+            crate::models::MID_TTL_EXTEND_SECS,
+        )
+        .unwrap();
+        let tier: String = conn
+            .query_row(
+                "SELECT tier FROM memories WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            tier, "long",
+            "access-count auto-promote is maintenance-exempt / court-blind (G10.3 §13); \
+             a v1.x suppress-in-adjudicated-namespaces opt-in would keep it 'mid'"
+        );
+    }
+
+    /// Test 2 — CALLER-initiated promotion IS court-gated: `enforce_governance`
+    /// with `GovernedAction::Promote` against the `promote: Owner` namespace by
+    /// a non-owner is denied. (Contrast test 1 — same namespace, different lane.)
+    #[test]
+    fn g10_3_caller_promote_is_court_gated() {
+        use crate::config::{
+            PermissionsMode, lock_permissions_mode_for_test,
+            override_active_permissions_mode_for_test,
+        };
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let _gate = lock_permissions_mode_for_test();
+        override_active_permissions_mode_for_test(PermissionsMode::Enforce);
+
+        let ns = "g10-3/court-promote";
+        let conn = court_ns_conn(ns);
+        let decision = enforce_governance(
+            &conn,
+            GovernedAction::Promote,
+            ns,
+            "ai:not-the-owner",
+            None,
+            None,
+            &serde_json::json!({"title": "x"}),
+            None,
+        )
+        .expect("enforce_governance must not error");
+        assert!(
+            matches!(decision, GovernanceDecision::Deny(_)),
+            "caller-initiated promote IS court-gated (promote: Owner) — got {decision:?}"
+        );
+    }
+
+    /// Test 3 — the DIRECT `tier=long` WRITE lane uses the `write` level, NOT
+    /// `promote`: a store into the `promote: Owner` (but `write: Any`) namespace
+    /// is Allowed, so `long` durability is reachable WITHOUT the promote court.
+    /// This is why "no `long` past a configured court" is not achievable by
+    /// gating the auto-promote lane alone (§13).
+    #[test]
+    fn g10_3_direct_long_write_uses_write_level_not_promote() {
+        use crate::config::{
+            PermissionsMode, lock_permissions_mode_for_test,
+            override_active_permissions_mode_for_test,
+        };
+        use crate::models::{GovernanceDecision, GovernedAction};
+        let _gate = lock_permissions_mode_for_test();
+        override_active_permissions_mode_for_test(PermissionsMode::Enforce);
+
+        let ns = "g10-3/court-write";
+        let conn = court_ns_conn(ns);
+        let decision = enforce_governance(
+            &conn,
+            GovernedAction::Store,
+            ns,
+            "ai:anyone",
+            None,
+            None,
+            &serde_json::json!({"title": "x", "tier": "long"}),
+            None,
+        )
+        .expect("enforce_governance must not error");
+        assert!(
+            matches!(decision, GovernanceDecision::Allow),
+            "a tier=long store is gated by the WRITE level (Any here), NOT the promote \
+             court — long is reachable via the write lane (§13) — got {decision:?}"
+        );
+    }
+
     /// F1 regression (v0.7.0 round-2-fixes): when a parent namespace
     /// has `governance.write = owner` with `inherit: true` and a deep
     /// child has no standard of its own, the owner-level check must


### PR DESCRIPTION
Closes #1863 (TRACT-gap G10.3 — promotion-court replacing access-count auto-promote).

## Scope — the v1.0.0-correct slice (NOT court-gating the fold)
The naive fix (make the fold's access-count auto-promote respect the `promote` court) was found **wrong on three verified counts** by the 5-agent vote (`4d3ea1c5`; wave-1 3 A / 2 B + 5 deep-verified wave-2 refuters). This ships the honest disclosure + machine-checked characterization, and defers the semantically-correct enforcement to v1.x (#2072).

## Why NOT court-gate the fold
1. **Category error / un-runnable (verified).** The auto-promote lives in `fold_recall_accesses`, a callerless **maintenance verb** (#1869) over `GROUP BY memory_id` aggregates. `enforce_governance`'s Promote arm structurally needs `agent_id` + `memory_owner` to adjudicate Owner/Approve — a callerless fold has **neither** — so the promote-court gate is *un-runnable* there (it can only no-op or convert retention→**expiration**). Auto-promote is maintenance-class, like `substrate:eviction` (`for_admin`-exempt).
2. **Incomplete (verified).** `long` is *also* reachable via the **write lane** — `memory_store tier=long` (+ upsert `mid→long` escalation) is gated by `GovernedAction::Store → policy.core.write`, **not** `promote`. So gating the auto-promote lane cannot deliver "no `long` past a court."
3. **Freeze-hostile.** The postgres fold is a single set-based CTE; per-court gating needs an exclusion-set bind mirroring `build_namespace_chain` + parity tests + touching the concurrency-delicate #1869 fold keystone — a T1+T3 change, not freeze-window work.

## What ships — honest §13 + genuine machine-checked artifacts
- **Contract §13** — the honest **3-lane** map (caller-promote court-gated; direct write gated by `write` not `promote`; access-count auto-promote maintenance-exempt / un-runnable-to-court-gate), the caller-influenceable-access-count **residual** (disclosed responsibly, mitigated by #1705), and the v1.x fix shape.
- **`storage::tests::g10_3_*` (3 characterization tests)** — pinning: auto-promote is **court-blind** (flips `mid→long` despite `promote: owner`); caller-promote **is** court-gated (Deny for non-owner); direct `tier=long` store uses the **write** level (Allow). A future v1.x suppress-in-adjudicated-namespaces opt-in flips test 1, deliberately failing it so the behavior change is a conscious edit + §13 update (a real behavioral drift-guard, not a floating const).

## Design — 2×5 adversarial vote (`4d3ea1c5`), verdict A-refined (memory `23d57601`)
Genuinely contested (wave-1 3 A / 2 B). The deepest wave-2 verifications (category-error, incompleteness, freeze-safe-flagged-B, anchor-floating, prime-directive; 130k–230k tokens each) + my own C5 checks converged: don't court-gate the callerless fold (un-runnable + incomplete + freeze-hostile + net-negative), ship the honest map + drift-guard tests, defer the opt-in enforcement.

## Deferred (v1.x, #2072)
Opt-in default-OFF adjudicated-permanence: suppress maintenance auto-promote **with an expiry-hold**, route the `tier=long` write lane to the court, both backends, behind a flag + WARN cycle.

## Tests / gates
- 3 new characterization tests (all pass). `cargo fmt` ✓ · `clippy -D pedantic --all-features` ✓ · docs-vs-ssot ✓ · vendor ✓ · hardcoded ✓ · cli-count (88/90) ✓.

## Stacking
Stacked on **feat/1862** (#2071) → #2069 → #2067 → #2065 → #2063 → #2056 → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)