### PR TITLE
feat(#1864): TRACT G10.4 bridge-capability — honest §14 (namespace is a filter, not a boundary) + char-tests

### DIFF
--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -531,6 +531,61 @@ GC'd), (b) **routes the direct `tier=long` write lane** to the promote court, an
 court-namespace exclusion-set bind mirroring `build_namespace_chain`), behind a
 flag + WARN cycle. **Not** court-gating the callerless fold.
 
+## 14. Namespace is a filter, not an enforced trust boundary (G10.4, #1864)
+
+TRACT §26 wants namespace to be a **trust boundary**: cross-namespace recall
+should require an explicit **bridge-capability** (the read-side analogue of the
+shipped G10.1 write-gate joiner). Today it does not — cross-namespace recall is
+**unrestricted**. This § pins the honest state; the machine-checks are
+`storage::tests::g10_4_*`.
+
+### 14.1 Honest current state
+
+- **Recall spans namespaces un-gated.** `RecallRequest.namespace` is an optional
+  filter; `None` returns rows from **every** namespace (the `(?N IS NULL OR
+  namespace = ?N)` predicate). The read path consults **no capability token** —
+  `search`/`recall`/`list`/`session_start` have no `capability` parameter and
+  never call `enforce_governance`.
+- **The filter is EXACT-match, not hierarchical.** `namespace = "team"` does NOT
+  match `team/eng` (`NS_FILTER_SARGABLE = "namespace = $1"`; sqlite exact-match).
+  So only `namespace = None` (span-all) is genuinely "cross-namespace".
+- **The only read isolation is the per-row scope ACL** (`scope = private / team /
+  unit / org` via `is_visible_to_caller` / `scope_idx`) — it bounds
+  *confidentiality*, but it is **not** a namespace bridge.
+
+So namespace is a **filter, not an enforced trust boundary** — an agent/operator
+who assumes namespace isolates reads is wrong at v1.0.0 GA.
+
+### 14.2 Why the bridge-capability is deferred (v1.x, #2074) — not a clean reuse, and underspecified
+
+The G10.1 capability primitive (`Caveat::NamespacePrefix`, `op_level_of("Reflect")
+→ OpLevel::Read`) is the **intended** bridge, but recall does not consume it, and
+wiring it is neither a clean reuse nor fully specified:
+
+- **Not a reuse.** `apply_capability_grant` is a write-gate joiner that only flips
+  `Deny`/`Ask`→`Allow`; recall is Allow-by-default, with no `GovernedAction::Read`
+  / `policy.core.read` and no gate call. A read-bridge must first *invent* a
+  base-`Deny`-on-cross-namespace posture (a security-posture inversion), then
+  thread a token through the recall chain (both SAL backends + MCP/HTTP/CLI
+  edge-parse).
+- **Semantics don't compose.** The exact-match recall filter vs the hierarchical
+  `NamespacePrefix` caveat; and there is **no home-namespace model** — recall's
+  namespace is a per-request filter with no identity referent, so "cross-namespace"
+  has nothing to gate against.
+- **Can't be built to spec.** The B4-4 bridge cap must be **co-signed**, but
+  co-signing/N-of-N is deferred (#1827); `require_bridge` has zero code.
+- **Multi-surface + substrate-dependent.** The boundary would have to hold on
+  recall + list + search + session_start at once, while **exempting** the
+  substrate's own cross-namespace reads (persona synthesis, reflection-pass
+  fan-out, the decorrelation probe, session bootstrap).
+
+### 14.3 v1.x migration (deferred, 1:1 issue)
+
+The read-side bridge-capability is v1.x, tracked as **#2074**, with the home-
+namespace model, exact-vs-hierarchical reconciliation, co-signing, all-read-surface
+token plumbing, substrate exemption, both backends, and a default-OFF flag + WARN
+cycle as acceptance criteria.
+
 ---
 
 *Normative for the v1.x G22 migration; NON-normative about v1.0.0 behavior except

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21887,6 +21887,110 @@ mod tests {
         );
     }
 
+    // ---- #1864 (TRACT-gap G10.4) bridge-capability characterization --------
+    //
+    // Pin the HONEST current state documented in contract §14: cross-namespace
+    // recall is UNRESTRICTED — the namespace filter is EXACT-match (not
+    // hierarchical), `None` spans every namespace, and the read path consults
+    // NO capability token (namespace is a filter, not an enforced trust
+    // boundary). A future v1.x read-side bridge-capability would make a
+    // cross-namespace read require a token, flipping test 1 — deliberately
+    // failing it so the behavior change is a conscious edit + a §14 update.
+
+    /// Test 1 — cross-namespace recall SPANS namespaces un-gated: a keyword
+    /// search with `namespace = None` returns rows from BOTH `A` and `B` with
+    /// no capability token presented (the search signature has no capability
+    /// parameter — the read path has no gate).
+    #[test]
+    fn g10_4_cross_namespace_recall_is_unrestricted() {
+        let conn = test_db();
+        let mut a = make_memory("bridgeword alpha", "g10-4/a", Tier::Mid, 5);
+        a.content = "bridgeword payload in namespace a".to_string();
+        let mut b = make_memory("bridgeword beta", "g10-4/b", Tier::Mid, 5);
+        b.content = "bridgeword payload in namespace b".to_string();
+        insert(&conn, &a).unwrap();
+        insert(&conn, &b).unwrap();
+
+        // namespace=None spans ALL namespaces — no capability required.
+        let all = search(
+            &conn,
+            "bridgeword",
+            None, // <- cross-namespace: no boundary, no token
+            None,
+            10,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        let namespaces: std::collections::HashSet<&str> =
+            all.iter().map(|m| m.namespace.as_str()).collect();
+        assert!(
+            namespaces.contains("g10-4/a") && namespaces.contains("g10-4/b"),
+            "cross-namespace recall is UNRESTRICTED (G10.4 §14): namespace=None returns \
+             rows from every namespace with NO bridge-capability; got {namespaces:?}"
+        );
+    }
+
+    /// Test 2 — the namespace filter is EXACT-match, NOT hierarchical: a search
+    /// scoped to the ancestor `g10-4` returns NOTHING from the child `g10-4/a`.
+    /// This is why the hierarchical `Caveat::NamespacePrefix` bridge-cap does
+    /// not compose with the recall filter (§14) — a v1.x concern.
+    #[test]
+    fn g10_4_namespace_filter_is_exact_match_not_hierarchical() {
+        let conn = test_db();
+        let mut child = make_memory("exactword one", "g10-4/a", Tier::Mid, 5);
+        child.content = "exactword lives in the child namespace".to_string();
+        insert(&conn, &child).unwrap();
+
+        // Exact-match: the ancestor filter does NOT match the child namespace.
+        let ancestor_scoped = search(
+            &conn,
+            "exactword",
+            Some("g10-4"),
+            None,
+            10,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(
+            ancestor_scoped.is_empty(),
+            "namespace filter is EXACT-match (§14): 'g10-4' does not match child \
+             'g10-4/a' — got {} rows",
+            ancestor_scoped.len()
+        );
+        // The exact child namespace DOES return it.
+        let exact = search(
+            &conn,
+            "exactword",
+            Some("g10-4/a"),
+            None,
+            10,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(exact.len(), 1, "exact-namespace recall returns the row");
+    }
+
     /// F1 regression (v0.7.0 round-2-fixes): when a parent namespace
     /// has `governance.write = owner` with `inherit: true` and a deep
     /// child has no standard of its own, the owner-level check must


### PR DESCRIPTION
Closes #1864 (TRACT-gap G10.4 — bridge-capability for cross-namespace recall). **This completes the Tier-B TRACT-gap tier (9 of 9).**

## Scope — the v1.0.0-correct slice (NOT the read-gate)
Cross-namespace recall is unrestricted; the read-side bridge-capability was found **freeze-hostile *and* underspecified** by the 5-agent vote (`4d3ea1c5`, **unanimous 5/5 A**; the crossroads collapsed decisively under deep verification, so wave-2 was waived per the #1862 precedent). Deferred 1:1 to **#2074**.

## Why NOT ship the read-gate (verified in-tree, incl. my own C5)
- **Not a clean G10.1 reuse.** `apply_capability_grant` is a **write-gate joiner** that only flips `Deny`/`Ask`→`Allow`; recall is Allow-by-default, with **no `GovernedAction::Read`** / `policy.core.read` and **never calls `enforce_governance`**. A read-bridge must first *invent* a base-`Deny`-on-cross-namespace posture (a T3 inversion), then thread a token through the recall chain (both SAL backends + MCP/HTTP/CLI edge-parse).
- **Semantics don't compose.** The recall filter is **exact-match** (`namespace = $1`) but `Caveat::NamespacePrefix` is **hierarchical**; and there is **no home-namespace model** (recall's namespace is a per-request filter with no identity referent — nothing to gate "cross-namespace" against).
- **Can't be built to its own spec.** The B4-4 bridge cap must be **co-signed**, but co-signing/N-of-N is deferred (#1827); `require_bridge` has zero code. The epic flags G10.4 as "the H-risk recall-semantics change, *after* the capability + gate paths are proven."
- **Multi-surface + substrate-dependent.** The boundary must hold on recall+list+search+session_start at once, while **exempting** the substrate's own cross-namespace reads (persona synthesis, reflection-pass fan-out, decorrelation probe, session bootstrap). A baseline per-row scope ACL already bounds confidentiality.

## What ships — honest §14 + machine-checked characterization
- **Contract §14** — the honest map: recall spans namespaces **un-gated**; the filter is **exact-match** (not hierarchical); the per-row `scope` ACL (`is_visible_to_caller`/`scope_idx`) is the only read isolation and bounds *confidentiality*, not namespace; the G10.1 capability primitive is the *intended* bridge but recall does not consume it — so **namespace is a filter, not an enforced trust boundary** at v1.0.0 GA.
- **`storage::tests::g10_4_*` (2)** — cross-namespace recall returns rows from both namespaces with **no token**; the namespace filter is **exact-match** (ancestor `g10-4` does not match child `g10-4/a`). Real behavioral drift-guards a future read-bridge would deliberately flip.

## Deferred (v1.x, #2074)
The read-side bridge-capability with the home-namespace model, exact-vs-hierarchical reconciliation, co-signing, all-read-surface token plumbing, substrate exemption, both backends, default-OFF flag + WARN cycle.

## Tests / gates
- 2 new characterization tests (pass). `cargo fmt` ✓ · `clippy -D pedantic --all-features` ✓ · docs-vs-ssot ✓ · vendor ✓ · hardcoded ✓ · cli-count (88/90) ✓.

## Stacking
Stacked on **feat/1863** (#2073) → #2071 → #2069 → #2067 → #2065 → #2063 → #2056 → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)