### PR TITLE
feat(#1868): B7-STREAM disposition — MCP tool responses single-terminal; streaming feasible but deferred + char-test

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2680,6 +2680,19 @@ fn handle_request(
             {
                 obj.insert("ai_memory_identity".to_string(), identity_block);
             }
+            // #1868 (B7-STREAM) — the advertised capabilities are `tools` +
+            // `prompts` ONLY: NO progress/streaming capability. MCP tool
+            // responses are single-terminal here — the stdio loop dispatches
+            // `handle_request` inline and writes exactly ONE response per
+            // request (stdout is response-only; diagnostics go to stderr; the
+            // one-in-one-out model is pinned by `issue_965_audit_serial_dispatch_*`).
+            // Incremental `notifications/progress` streaming is FEASIBLE on this
+            // inline single-threaded loop (progress writes serialize for free —
+            // it is NOT blocked by any sync↔async transport re-architecture), but
+            // is DEFERRED to v1.x (#2076): shipping the first-ever unsolicited
+            // server→stdout frame + the emit contract at a GA compat freeze,
+            // with zero in-tree consumer and a T1 ripple through `handle_request`,
+            // is premature. Pinned by `initialize_advertises_no_streaming_capability_1868`.
             ok_response(
                 id,
                 json!({
@@ -7274,6 +7287,47 @@ mod tests {
         let result = resp.result.unwrap();
         assert_eq!(result["protocolVersion"], "2024-11-05");
         assert_eq!(result["serverInfo"]["name"], "ai-memory");
+    }
+
+    /// #1868 (B7-STREAM) — the `initialize` response advertises `tools` +
+    /// `prompts` capabilities ONLY, with NO progress/streaming capability: MCP
+    /// tool responses are single-terminal today (§ the doc at
+    /// `METHOD_INITIALIZE`). This is an observable drift-guard — a future
+    /// `notifications/progress` streaming impl (#2076) would add a progress
+    /// capability here, deliberately flipping this test.
+    #[test]
+    fn initialize_advertises_no_streaming_capability_1868() {
+        let conn = db::open(std::path::Path::new(":memory:")).unwrap();
+        let req = RpcRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "initialize".into(),
+            params: json!({"clientInfo": {"name": "test-client"}}),
+        };
+        let resp = invoke_handle_request(&conn, &req);
+        let caps = resp.result.unwrap()["capabilities"].clone();
+        let keys: std::collections::BTreeSet<String> = caps
+            .as_object()
+            .expect("capabilities is an object")
+            .keys()
+            .cloned()
+            .collect();
+        assert_eq!(
+            keys,
+            ["prompts", "tools"]
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            "MCP advertises tools+prompts ONLY — no progress/streaming capability \
+             at v1.0.0 (streaming is deferred to #2076); got {keys:?}"
+        );
+        // Explicitly: no progress/streaming/logging capability is advertised.
+        for absent in ["progress", "streaming", "logging", "experimental"] {
+            assert!(
+                caps.get(absent).is_none(),
+                "no `{absent}` capability should be advertised at v1.0.0"
+            );
+        }
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Closes #1868 (§11.5 B7-STREAM — streaming tool responses for long-running MCP tools; **explicit cutline candidate**).

## Scope — the honest v1.0.0 disposition (NOT the streaming impl)
The 5-agent vote (`4d3ea1c5`, 4 A / 1 B) verdicted **defer** — with an important factual correction to the naive framing (deferred to **#2076**).

## The correction (verified in-tree, incl. my C5)
Streaming is **NOT blocked by a sync↔async transport re-architecture** — the stdio loop dispatches `handle_request` **inline on the single stdout-owning thread** (`src/mcp/mod.rs:4070`), no `spawn_blocking`, so progress writes would serialize for free. (My initial anchoring wrongly assumed `spawn_blocking`; the deepest-verifying refuter caught it.)

## Why deferred anyway (unwise at GA freeze — the B vote's own conclusion)
- **Breaks the stdout-response-only convention.** Today the only server→stdout write per request is the single terminal response ("stdout owns JSON-RPC framing, diagnostics → stderr"); an unsolicited `notifications/progress` frame is a first-ever behavior, **pinned against** by `issue_965_audit_serial_dispatch_*`.
- **T1 signature ripple** — `handle_request` takes ~24 params + is called from ~20 dispatch/test sites.
- **Zero in-tree consumer** — no client parses progress; `initialize` advertises no progress capability. Freezing the emit contract now is premature (sensor-without-consumer).
- **Explicit cutline candidate** + not a GA-blocker (agents function on one-in-one-out today).

## What ships — honest disposition + genuine drift-guard
- **Doc-comment at `METHOD_INITIALIZE`** recording the disposition (feasible-but-deferred, honest rationale, *not* transport-blocked).
- **`initialize_advertises_no_streaming_capability_1868`** — an **observable** char-test asserting the `initialize` response advertises `tools`+`prompts` ONLY (no progress/streaming/logging/experimental capability). A future streaming impl (#2076) adds a progress capability, **deliberately flipping** it — this pins the wire capability advertisement, not merely the return type (so it is not the tautological anchor the campaign standard forbids).

## Deferred (v1.x, #2076)
Streaming impl: `progressToken` parsing, emitter threaded through `handle_request`, one-tool ref-impl, opt-in back-compat, the `issue_965` test update, its own design vote.

## Tests / gates
1 new observable char-test (passes). `cargo fmt` ✓ · `clippy -D pedantic --all-features` ✓ · docs-vs-ssot ✓ · vendor ✓ · hardcoded ✓ · cli-count (88/90) ✓.

## Stacking
Stacked on **feat/1864** (#2075) → … → #2053. Retarget to `main` as bases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)