### PR TITLE
feat(#1979): Claude Code plugin marketplace manifest (.claude-plugin/)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "ai-memory",
+  "owner": {
+    "name": "AlphaOne LLC",
+    "url": "https://github.com/alphaonedev/ai-memory-mcp"
+  },
+  "metadata": {
+    "description": "Persistent, tier-aware memory for AI agents — the ai-memory substrate as a Claude Code plugin.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "ai-memory",
+      "source": "./plugins/ai-memory",
+      "description": "Persistent memory for Claude Code: the ai-memory MCP server (full memory-tool surface at --profile full), a SessionStart recall hook that boots each session memory-aware, and an opt-in PreToolUse governance gate.",
+      "version": "0.1.0",
+      "author": {
+        "name": "AlphaOne LLC"
+      },
+      "homepage": "https://github.com/alphaonedev/ai-memory-mcp",
+      "license": "Apache-2.0",
+      "keywords": ["memory", "mcp", "persistent-memory", "recall", "governance"]
+    }
+  ]
+}

--- a/plugins/ai-memory/.claude-plugin/plugin.json
+++ b/plugins/ai-memory/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-memory",
+  "version": "0.1.0",
+  "description": "Persistent, tier-aware memory for Claude Code: the ai-memory MCP server + a SessionStart recall hook + an opt-in PreToolUse governance gate. Requires the `ai-memory` binary on PATH (see README).",
+  "author": {
+    "name": "AlphaOne LLC",
+    "url": "https://github.com/alphaonedev/ai-memory-mcp"
+  },
+  "homepage": "https://github.com/alphaonedev/ai-memory-mcp",
+  "repository": "https://github.com/alphaonedev/ai-memory-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "mcp", "persistent-memory", "recall", "governance"]
+}

--- a/plugins/ai-memory/.mcp.json
+++ b/plugins/ai-memory/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ai-memory": {
+      "command": "ai-memory",
+      "args": ["mcp", "--profile", "full"]
+    }
+  }
+}

--- a/plugins/ai-memory/README.md
+++ b/plugins/ai-memory/README.md
@@ -1,0 +1,64 @@
+# ai-memory — Claude Code plugin
+
+Persistent, tier-aware memory for Claude Code. This plugin wires up the three
+integration surfaces ai-memory already ships, so a fresh Claude Code session is
+memory-aware out of the box:
+
+| Surface | What it does | Command |
+|---|---|---|
+| **MCP server** | the full memory-tool surface at `--profile full` (`memory_store`, `memory_recall`, …) + the `recall-first` / `memory-workflow` prompts | `ai-memory mcp --profile full` |
+| **SessionStart hook** | Boots each session memory-aware — injects a short recall digest | `ai-memory boot --quiet --limit 10 --budget-tokens 4096` |
+| **PreToolUse hook** (opt-in) | Governance gate: maps a proposed Bash/Edit/Write to a substrate action and enforces signed rules | `ai-memory governance check-action --from-pretool-stdin` |
+
+## Prerequisite — install the `ai-memory` binary
+
+**This plugin wires configuration; it does not ship the `ai-memory` binary.**
+A git-based plugin marketplace cannot carry a platform-specific compiled
+binary, so install it first and make sure it is on your `PATH`:
+
+```bash
+# one of:
+brew install alphaonedev/tap/ai-memory
+cargo install ai-memory
+# or download a release binary from
+# https://github.com/alphaonedev/ai-memory-mcp/releases
+
+command -v ai-memory   # must print a path before the plugin is useful
+```
+
+If `ai-memory` is not on `PATH`, the plugin still installs, but the hooks
+no-op **gracefully** — a Claude Code `SessionStart` hook that exits non-zero is
+non-fatal, so your session is never blocked; you simply get no memory context
+until the binary is present.
+
+## Install
+
+```bash
+claude plugin marketplace add alphaonedev/ai-memory-mcp
+claude plugin install ai-memory@ai-memory
+```
+
+Then restart Claude Code. `claude plugin details ai-memory` shows the wired
+component inventory (MCP server + hooks).
+
+## The PreToolUse governance hook is opt-in
+
+The bundled `PreToolUse` hook calls `ai-memory governance check-action`. With
+**no signed governance rules configured, it is inert** — it allows every action
+(the seed rules ship disabled and require an operator's Ed25519 signature to
+activate). It is bundled so the enforcement surface is one signing step away,
+not so it blocks tools by default. If you do not want the per-tool
+`check-action` shell-out at all, remove the `PreToolUse` block from the plugin's
+`hooks/hooks.json` (or disable the plugin's hooks). See
+[`docs/integrations/claude-code.md`](../../docs/integrations/claude-code.md)
+§"PreToolUse governance" for the rule-signing workflow.
+
+## What this plugin does NOT add
+
+No net-new slash-commands or skills — ai-memory's workflow guidance ships as the
+two MCP prompts (`recall-first`, `memory-workflow`) surfaced by the MCP server
+above. The plugin bundles exactly the existing, documented assets.
+
+## License
+
+Apache-2.0

--- a/plugins/ai-memory/hooks/hooks.json
+++ b/plugins/ai-memory/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-memory boot --quiet --limit 10 --budget-tokens 4096"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-memory governance check-action --from-pretool-stdin"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/check-claude-plugin.sh
+++ b/scripts/check-claude-plugin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# #1979 — structural validator for the Claude Code plugin marketplace manifest
+# (.claude-plugin/marketplace.json + plugins/ai-memory/**). Runs at freeze / in
+# CI so the shipped manifest is a VERIFIED artifact, not a claimed one.
+#
+# Checks (all HARD-BLOCK):
+#   1. JSON well-formedness of every manifest file.
+#   2. Required fields present (marketplace name/plugins; plugin name/version).
+#   3. The plugin `source` path resolves to a dir with a plugin.json.
+#   4. Every bundled hook / MCP `command` is `ai-memory` (the on-PATH binary the
+#      plugin assumes) — no stray absolute paths or other binaries.
+#   5. If the `claude` CLI is present: `claude plugin validate` passes.
+#
+# `--self-test` proves the gate is load-bearing (a corrupted copy must fail).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MARKETPLACE="$ROOT/.claude-plugin/marketplace.json"
+PLUGIN_DIR="$ROOT/plugins/ai-memory"
+
+fail() { echo "check-claude-plugin: FAIL — $*" >&2; exit 1; }
+
+need_jq() { command -v jq >/dev/null 2>&1 || fail "jq is required"; }
+
+validate_tree() {
+  local mkt="$1" plugdir="$2"
+  need_jq
+
+  # 1. JSON well-formedness.
+  jq empty "$mkt" 2>/dev/null || fail "marketplace.json is not valid JSON"
+  local plugin_json="$plugdir/.claude-plugin/plugin.json"
+  local mcp_json="$plugdir/.mcp.json"
+  local hooks_json="$plugdir/hooks/hooks.json"
+  [ -f "$plugin_json" ] || fail "missing plugin.json at $plugin_json"
+  jq empty "$plugin_json" 2>/dev/null || fail "plugin.json is not valid JSON"
+  jq empty "$mcp_json" 2>/dev/null || fail ".mcp.json is not valid JSON"
+  jq empty "$hooks_json" 2>/dev/null || fail "hooks.json is not valid JSON"
+
+  # 2. Required fields.
+  [ "$(jq -r '.name // empty' "$mkt")" != "" ] || fail "marketplace.json: missing .name"
+  [ "$(jq -r '.plugins | length' "$mkt")" -ge 1 ] || fail "marketplace.json: empty .plugins"
+  [ "$(jq -r '.name // empty' "$plugin_json")" != "" ] || fail "plugin.json: missing .name"
+  [ "$(jq -r '.version // empty' "$plugin_json")" != "" ] || fail "plugin.json: missing .version"
+
+  # 3. The plugin source path resolves.
+  local src
+  src="$(jq -r '.plugins[0].source' "$mkt")"
+  local resolved="$ROOT/${src#./}"
+  [ -f "$resolved/.claude-plugin/plugin.json" ] \
+    || fail "plugins[0].source '$src' does not resolve to a plugin.json"
+
+  # 4. Every bundled command invokes the on-PATH `ai-memory` binary.
+  local cmds
+  cmds="$(jq -r '.mcpServers[].command' "$mcp_json"; \
+          jq -r '.hooks[][].hooks[].command' "$hooks_json")"
+  local c
+  while IFS= read -r c; do
+    [ -z "$c" ] && continue
+    case "$c" in
+      ai-memory|"ai-memory "*) : ;;
+      *) fail "bundled command must invoke the on-PATH 'ai-memory' binary, got: '$c'" ;;
+    esac
+  done <<< "$cmds"
+
+  # 5. Claude CLI structural validation, when available.
+  if command -v claude >/dev/null 2>&1; then
+    claude plugin validate "$mkt" >/dev/null 2>&1 \
+      || fail "claude plugin validate rejected $mkt"
+  else
+    echo "check-claude-plugin: note — 'claude' CLI absent; skipped its validate pass"
+  fi
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  need_jq
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "$tmp/.claude-plugin" "$tmp/plugins/ai-memory/.claude-plugin" \
+           "$tmp/plugins/ai-memory/hooks"
+  # A deliberately corrupt manifest: a bundled command that is NOT ai-memory.
+  cp "$MARKETPLACE" "$tmp/.claude-plugin/marketplace.json"
+  cp "$PLUGIN_DIR/.claude-plugin/plugin.json" "$tmp/plugins/ai-memory/.claude-plugin/plugin.json"
+  echo '{"mcpServers":{"ai-memory":{"command":"/bin/sh","args":["-c","evil"]}}}' \
+    > "$tmp/plugins/ai-memory/.mcp.json"
+  cp "$PLUGIN_DIR/hooks/hooks.json" "$tmp/plugins/ai-memory/hooks/hooks.json"
+  if ( ROOT="$tmp" MARKETPLACE="$tmp/.claude-plugin/marketplace.json" \
+       validate_tree "$tmp/.claude-plugin/marketplace.json" "$tmp/plugins/ai-memory" ) 2>/dev/null; then
+    echo "check-claude-plugin: SELF-TEST FAIL — gate accepted a non-ai-memory command" >&2
+    exit 1
+  fi
+  echo "check-claude-plugin: self-test PASS (gate rejects a corrupted manifest)"
+  exit 0
+fi
+
+validate_tree "$MARKETPLACE" "$PLUGIN_DIR"
+echo "check-claude-plugin: PASS (.claude-plugin/ manifest structurally valid)"


### PR DESCRIPTION
Closes #1979.

## What

Ships ai-memory as an installable **Claude Code plugin**. Bundles the three existing, documented integration assets — no net-new surface:

| Surface | Command |
|---|---|
| MCP server | `ai-memory mcp --profile full` (`plugins/ai-memory/.mcp.json`) |
| SessionStart recall hook | `ai-memory boot --quiet --limit 10 --budget-tokens 4096` |
| PreToolUse governance gate (opt-in, #1811) | `ai-memory governance check-action --from-pretool-stdin` |

```bash
claude plugin marketplace add alphaonedev/ai-memory-mcp
claude plugin install ai-memory@ai-memory
```

Layout: root `.claude-plugin/marketplace.json` (one plugin, `source: ./plugins/ai-memory`) + `plugins/ai-memory/.claude-plugin/plugin.json` + `.mcp.json` + `hooks/hooks.json` + README.

## Design — 5-agent vote `4d3ea1c5` (verdict `cf71e4ba`)

**UNANIMOUS 5/5 verdict B** (spec-fidelity 88 / existing-assets 84 / freeze-scope 82 / testability 84 / binary-deploy 82); collapsed → wave-2 waived.

- **Rejected A** (author net-new skills) as a wire-untruthful over-claim — **no** Claude Code skills/commands exist in-tree; the title's "skills" is honored by the two existing MCP prompts (`recall-first`, `memory-workflow`).
- **Rejected C** (MCP-only) as under-shipping the two documented hooks.

Reality folded in:
- The compiled `ai-memory` binary **cannot** ship in a git marketplace, so the manifest wires config assuming `ai-memory` on PATH; README documents the install prereq (brew/cargo/release) and that a missing binary **degrades gracefully** (a non-zero SessionStart hook is non-fatal in Claude Code).
- The PreToolUse governance hook is **opt-in / inert** until an operator signs rules; README declares this so it never blocks tools by default.

## Verification

The **real `claude plugin validate` CLI** (on PATH) passes on both the marketplace manifest and the plugin manifest ✔. New `scripts/check-claude-plugin.sh` structurally validates JSON + required fields + that every bundled command invokes the on-PATH `ai-memory` binary, and shells out to `claude plugin validate` when present; `--self-test` proves it's load-bearing (rejects a corrupted `/bin/sh` command). All script gates green (vendor-literal, hardcoded-literal, docs-vs-ssot, cloud-init-ascii). No Rust touched.

## AI involvement

Authored by Claude (Opus 4.8) under the v1.0.0 autonomous campaign; scope decided by the crossroads 5-agent adversarial vote (CLAUDE.md). Stacked on \`feat/1390-sdk-shims\` (#2080).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY