### PR TITLE
feat(#1707): shadow consume-vs-access divergence evidence (observe-only, no ranking change)

### DIFF
--- a/src/cli/commands/calibrate_confidence.rs
+++ b/src/cli/commands/calibrate_confidence.rs
@@ -244,6 +244,7 @@ mod tests {
                 mean: 0.55,
                 buckets: [0, 0, 1, 0, 1, 1, 0, 0, 0, 0],
                 consumption_utility: Some(0.75),
+                consume_access_divergence: None,
             }],
         };
         let s = render_table(&r);
@@ -268,6 +269,7 @@ mod tests {
                 mean: 0.5,
                 buckets: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
                 consumption_utility: None,
+                consume_access_divergence: None,
             }],
         };
         let s = render_table(&r);

--- a/src/confidence/calibrate.rs
+++ b/src/confidence/calibrate.rs
@@ -53,12 +53,16 @@
 //!    buckets fold into 10 stack-allocated counters via the same
 //!    single pass.
 //!
-//! The denormalised `source` column (also schema v40) eliminates the
-//! join with `memories` entirely — orphan observation rows whose
+//! The denormalised `source` column (also schema v40) removed the
+//! grouping join with `memories` — orphan observation rows whose
 //! source memory has been CASCADE-deleted continue to surface in the
 //! report under their stamped `source` value, which is the audit-
 //! honest behaviour (the calibration sample was real; the source
-//! memory's later deletion doesn't unmake the observation).
+//! memory's later deletion doesn't unmake the observation). Pass 1
+//! does carry a read-only **`LEFT JOIN memories`** for the v1.0.0 §11.5
+//! (#1707) consume-vs-access divergence evidence (`access_count`); it is
+//! a LEFT join with `COALESCE(access_count, 0)`, so orphan rows still
+//! surface (as access 0) and the orphan-tolerant contract above holds.
 
 use anyhow::Result;
 use chrono::{Duration, Utc};
@@ -68,6 +72,10 @@ use serde::Serialize;
 /// Default sweep window. The Form 5 brief calls for 30 days; tunable
 /// per call via the CLI `--days N` flag and the MCP `days` parameter.
 pub const DEFAULT_WINDOW_DAYS: i64 = 30;
+
+/// `tracing` target for this module's shadow-mode calibration logs. One
+/// named const referenced at every emit site (pm-v3.1 no-scattered-literal).
+const LOG_TARGET: &str = "confidence.calibrate";
 
 /// One per-(namespace, source) row in the calibration report.
 ///
@@ -101,6 +109,40 @@ pub struct PerSourceBaseline {
     /// This is the future #1707/#C live-wire decision's evidence base,
     /// not a ranking input.
     pub consumption_utility: Option<f64>,
+    /// v1.0.0 §11.5 (#1707) — the shadow-divergence evidence the #1707
+    /// conditional gate requires ("execute the live recall-utility term
+    /// ONLY IF consume-rate diverges meaningfully from the existing
+    /// `access_count` usage proxy, else close won't-do"). **SHADOW MODE —
+    /// logged only, never consulted by [`crate::storage::recall`].**
+    /// `None` when the window has no judged (ledger-correlated) row.
+    pub consume_access_divergence: Option<ConsumeAccessDivergence>,
+}
+
+/// v1.0.0 §11.5 (#1707) — measured evidence for whether the recall-usage
+/// consume signal carries information the recall blend's existing
+/// `MIN(access_count, 50) * 0.1` usage proxy does not.
+///
+/// The #1707 gate ships the live recall-utility term ONLY IF this shows a
+/// meaningful divergence; otherwise the signal is redundant and #1707 is
+/// closed won't-do. The two `mean_access_*` fields are the collinearity
+/// tell: when `consumed` rows carry a systematically higher `access_count`
+/// than `unconsumed` rows (`mean_access_consumed` >> `mean_access_unconsumed`),
+/// the consume signal tracks the access proxy and adds no new ranking
+/// information. Paired with a low `consumed_count / (consumed + unconsumed)`
+/// (sparsity), that is the "does-not-diverge → close won't-do" branch.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ConsumeAccessDivergence {
+    /// Rows this window whose correlated ledger entry marked the memory
+    /// consumed (`recall_outcome = 'consumed'`).
+    pub consumed_count: u64,
+    /// Rows judged-but-not-consumed (`recall_outcome = 'unconsumed'`).
+    pub unconsumed_count: u64,
+    /// Mean `memories.access_count` across the consumed rows; `None` when
+    /// `consumed_count == 0`.
+    pub mean_access_consumed: Option<f64>,
+    /// Mean `memories.access_count` across the unconsumed rows; `None` when
+    /// `unconsumed_count == 0`.
+    pub mean_access_unconsumed: Option<f64>,
 }
 
 /// Top-level calibration report emitted by the sweep.
@@ -140,7 +182,7 @@ pub fn calibrate_from_shadow(
     let backfilled = crate::confidence::shadow::backfill_recall_outcomes(conn)?;
     if backfilled > 0 {
         tracing::info!(
-            target: "confidence.calibrate",
+            target: LOG_TARGET,
             backfilled,
             "shadow sweep: backfilled recall_outcome from the recall_observations ledger"
         );
@@ -150,16 +192,26 @@ pub fn calibrate_from_shadow(
     // entirely in SQL. The denormalised `source` column (schema v40)
     // lets us avoid the INNER JOIN against `memories` that
     // pre-Cluster-G code carried.
+    // v1.0.0 §11.5 (#1707) — the same offline pass also LEFT JOINs
+    // `memories` to sum `access_count` across the consumed vs unconsumed
+    // rows, so the report carries the consume-vs-access divergence evidence
+    // the #1707 gate requires. Still SHADOW MODE (log/report only); the JOIN
+    // is read-only and `crate::storage::recall` is untouched.
     let mut stmt = conn.prepare(
-        "SELECT namespace, source, COUNT(*), AVG(derived_confidence),
-                SUM(CASE WHEN recall_outcome = 'consumed' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN recall_outcome IS NOT NULL THEN 1 ELSE 0 END)
-         FROM confidence_shadow_observations
-         WHERE observed_at >= ?1
-         GROUP BY namespace, source
-         ORDER BY namespace, source",
+        "SELECT o.namespace, o.source, COUNT(*), AVG(o.derived_confidence),
+                SUM(CASE WHEN o.recall_outcome = 'consumed' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN o.recall_outcome IS NOT NULL THEN 1 ELSE 0 END),
+                SUM(CASE WHEN o.recall_outcome = 'consumed'
+                         THEN COALESCE(m.access_count, 0) ELSE 0 END),
+                SUM(CASE WHEN o.recall_outcome = 'unconsumed'
+                         THEN COALESCE(m.access_count, 0) ELSE 0 END)
+         FROM confidence_shadow_observations o
+         LEFT JOIN memories m ON m.id = o.memory_id
+         WHERE o.observed_at >= ?1
+         GROUP BY o.namespace, o.source
+         ORDER BY o.namespace, o.source",
     )?;
-    let groups: Vec<(String, String, i64, f64, i64, i64)> = stmt
+    let groups: Vec<(String, String, i64, f64, i64, i64, i64, i64)> = stmt
         .query_map(params![since.as_str()], |row| {
             Ok((
                 row.get::<_, String>(0)?,
@@ -168,6 +220,8 @@ pub fn calibrate_from_shadow(
                 row.get::<_, f64>(3)?,
                 row.get::<_, i64>(4)?,
                 row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, i64>(7)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -188,7 +242,17 @@ pub fn calibrate_from_shadow(
     )?;
 
     let mut baselines: Vec<PerSourceBaseline> = Vec::with_capacity(groups.len());
-    for (namespace, source, count_i64, mean, consumed_i64, judged_i64) in groups {
+    for (
+        namespace,
+        source,
+        count_i64,
+        mean,
+        consumed_i64,
+        judged_i64,
+        access_consumed_i64,
+        access_unconsumed_i64,
+    ) in groups
+    {
         if count_i64 <= 0 {
             continue;
         }
@@ -243,7 +307,7 @@ pub fn calibrate_from_shadow(
             // reads this. Evidence for the future #1707/#C live-wire
             // decision, not a ranking input.
             tracing::info!(
-                target: "confidence.calibrate",
+                target: LOG_TARGET,
                 namespace = %namespace,
                 source = %source,
                 consumption_utility = cu,
@@ -251,6 +315,40 @@ pub fn calibrate_from_shadow(
                 "shadow consumption utility (SHADOW MODE — not consulted by recall())"
             );
         }
+
+        // v1.0.0 §11.5 (#1707) — the consume-vs-access divergence evidence.
+        // `unconsumed = judged - consumed` (the SQL split is exhaustive over
+        // `recall_outcome IS NOT NULL`). Means are `None` when their bucket
+        // is empty (honest "no evidence", never a misleading 0.0).
+        let consume_access_divergence = if judged_i64 > 0 {
+            let consumed_count = consumed_i64.max(0) as u64;
+            let unconsumed_count = (judged_i64 - consumed_i64).max(0) as u64;
+            let mean_access_consumed =
+                (consumed_count > 0).then(|| access_consumed_i64 as f64 / consumed_count as f64);
+            let mean_access_unconsumed = (unconsumed_count > 0)
+                .then(|| access_unconsumed_i64 as f64 / unconsumed_count as f64);
+            // Log the divergence tell: sparsity + the collinearity ratio.
+            // A low consumed share AND consumed-rows-carry-higher-access is
+            // the "does-not-diverge → close won't-do" signal the gate names.
+            tracing::info!(
+                target: LOG_TARGET,
+                namespace = %namespace,
+                source = %source,
+                consumed = consumed_count,
+                unconsumed = unconsumed_count,
+                mean_access_consumed = mean_access_consumed.unwrap_or(f64::NAN),
+                mean_access_unconsumed = mean_access_unconsumed.unwrap_or(f64::NAN),
+                "shadow consume-vs-access divergence (SHADOW MODE — #1707 gate evidence, not consulted by recall())"
+            );
+            Some(ConsumeAccessDivergence {
+                consumed_count,
+                unconsumed_count,
+                mean_access_consumed,
+                mean_access_unconsumed,
+            })
+        } else {
+            None
+        };
 
         baselines.push(PerSourceBaseline {
             namespace,
@@ -260,6 +358,7 @@ pub fn calibrate_from_shadow(
             mean,
             buckets,
             consumption_utility,
+            consume_access_divergence,
         });
     }
     drop(median_stmt);

--- a/tests/form_5_confidence_calibration.rs
+++ b/tests/form_5_confidence_calibration.rs
@@ -956,6 +956,121 @@ fn sweep_backfills_recall_outcome_from_ledger_1706() {
     );
 }
 
+/// v1.0.0 §11.5 (#1707) — the calibrate sweep reports the consume-vs-access
+/// divergence evidence the #1707 conditional gate requires. A consumed
+/// candidate with a high `access_count` and an unconsumed sibling with a low
+/// one must surface as `consume_access_divergence` with the per-bucket means
+/// (the collinearity tell), observe-only — `recall()` is untouched.
+#[test]
+fn divergence_stat_reports_consume_vs_access_1707() {
+    let (_tmp, conn) = fresh_db();
+    let consumed_mem = fixture_memory("ns-1707", "consumed-candidate");
+    let unconsumed_mem = fixture_memory("ns-1707", "unconsumed-candidate");
+    let consumer = fixture_memory("ns-1707", "consumer");
+    db::insert(&conn, &consumed_mem).expect("insert consumed");
+    db::insert(&conn, &unconsumed_mem).expect("insert unconsumed");
+    db::insert(&conn, &consumer).expect("insert consumer");
+
+    // Known access_counts: consumed row is high-access, unconsumed is low —
+    // the collinearity scenario the gate tests for.
+    conn.execute(
+        "UPDATE memories SET access_count = ?1 WHERE id = ?2",
+        rusqlite::params![50_i64, consumed_mem.id],
+    )
+    .expect("set consumed access_count");
+    conn.execute(
+        "UPDATE memories SET access_count = ?1 WHERE id = ?2",
+        rusqlite::params![4_i64, unconsumed_mem.id],
+    )
+    .expect("set unconsumed access_count");
+
+    let s = ConfidenceSignals::default();
+    observe(
+        &conn,
+        &consumed_mem.id,
+        "ns-1707",
+        "user",
+        0.9,
+        0.5,
+        &s,
+        None,
+    )
+    .expect("observe c");
+    observe(
+        &conn,
+        &unconsumed_mem.id,
+        "ns-1707",
+        "user",
+        0.9,
+        0.5,
+        &s,
+        None,
+    )
+    .expect("observe u");
+
+    observations::record_recall(
+        &conn,
+        "r-1707",
+        &[
+            Candidate {
+                memory_id: &consumed_mem.id,
+                retriever: "hybrid",
+                rank: 1,
+                score: 0.9,
+            },
+            Candidate {
+                memory_id: &unconsumed_mem.id,
+                retriever: "hybrid",
+                rank: 2,
+                score: 0.8,
+            },
+        ],
+    )
+    .expect("record_recall");
+    observations::mark_consumed(&conn, "r-1707", &[consumed_mem.id.as_str()], &consumer.id)
+        .expect("mark_consumed");
+
+    // The sweep backfills recall_outcome then computes the divergence.
+    let report = calibrate_from_shadow(&conn, 30, Utc::now()).expect("calibrate");
+    let baseline = report
+        .baselines
+        .iter()
+        .find(|b| b.namespace == "ns-1707" && b.source == "user")
+        .expect("ns-1707/user baseline");
+    let div = baseline
+        .consume_access_divergence
+        .as_ref()
+        .expect("divergence present when rows are judged");
+    assert_eq!(div.consumed_count, 1);
+    assert_eq!(div.unconsumed_count, 1);
+    assert!((div.mean_access_consumed.expect("consumed mean") - 50.0).abs() < 1e-6);
+    assert!((div.mean_access_unconsumed.expect("unconsumed mean") - 4.0).abs() < 1e-6);
+    // Collinearity tell: consumed rows carry systematically higher access.
+    assert!(div.mean_access_consumed.unwrap() > div.mean_access_unconsumed.unwrap());
+}
+
+/// v1.0.0 §11.5 (#1707) — cold-start / no-ledger honesty: when no shadow row
+/// has a correlated ledger entry, the divergence stat is `None` (not a
+/// misleading zero), mirroring `consumption_utility`.
+#[test]
+fn divergence_stat_none_without_ledger_correlation_1707() {
+    let (_tmp, conn) = fresh_db();
+    let m = fixture_memory("ns-1707b", "u-1");
+    db::insert(&conn, &m).expect("ins");
+    let s = ConfidenceSignals::default();
+    // Observed but never recalled/consumed ⇒ recall_outcome stays NULL.
+    observe(&conn, &m.id, "ns-1707b", "user", 0.9, 0.5, &s, None).expect("observe");
+
+    let report = calibrate_from_shadow(&conn, 30, Utc::now()).expect("calibrate");
+    let baseline = report
+        .baselines
+        .iter()
+        .find(|b| b.namespace == "ns-1707b")
+        .expect("baseline");
+    assert!(baseline.consume_access_divergence.is_none());
+    assert!(baseline.consumption_utility.is_none());
+}
+
 /// #1706 item 4 — on a DB where the `recall_observations` ledger is
 /// absent, the sweep skips the consumption-utility backfill with a WARN
 /// and does not error. Exercised through the public
@@ -968,7 +1083,10 @@ fn calibrate_from_shadow_skips_gracefully_when_ledger_table_absent_1706() {
     let path = dir.path().join("no-ledger.db");
     let conn = rusqlite::Connection::open(&path).expect("open bare conn");
     conn.execute_batch(
-        "CREATE TABLE memories (id TEXT PRIMARY KEY);
+        // `access_count` is a core `memories` column in every real deployment
+        // (the #1707 divergence JOIN reads it); the bare fixture carries it so
+        // it stays representative while still omitting `recall_observations`.
+        "CREATE TABLE memories (id TEXT PRIMARY KEY, access_count INTEGER NOT NULL DEFAULT 0);
          CREATE TABLE confidence_shadow_observations (
              id INTEGER PRIMARY KEY AUTOINCREMENT,
              memory_id TEXT NOT NULL,


### PR DESCRIPTION
Refs #1707 (does **not** close it — see disposition below).

## Context — a conditional gate with an unmet precondition

#1707 ships the live recall-utility ranking term **only if** #1706's shadow data shows consume-rate diverges meaningfully from the existing `MIN(access_count,50)*0.1` usage proxy — **else close won't-do**. That precondition is **unmet**: #1706 shipped the `consumption_utility` metric but explicitly **cut item-5 (rank-delta telemetry)** and attached no divergence analysis. Building the live term now would violate the gate.

## Decision — 5-agent vote `4d3ea1c5` (verdict `6268ffe7`)

**UNANIMOUS 5/5 verdict B** (precondition-literalism 82, evidence-redteam 80, freeze-scope 72, locked-set-motion 88, verifiability 72); collapsed → wave-2 waived. Do **not** build the live-apply term (A violates the gate + ships an irreversible v82 schema at freeze); **produce the shadow-divergence evidence** the gate requires — observe-only, `recall()` byte-identical, no `memories`-schema change, no ranking change.

## What

Extends #1706's already-shipped offline `calibrate_from_shadow` sweep with a per-`(namespace,source)` **consume-vs-access divergence** statistic: a read-only `LEFT JOIN memories` sums `access_count` across the consumed vs unconsumed rows, so `CalibrationReport` now carries:

```
ConsumeAccessDivergence { consumed_count, unconsumed_count,
                          mean_access_consumed, mean_access_unconsumed }
```

logged + reported, **never read by `recall()`**. The collinearity tell (consumed rows carrying systematically higher `access_count` than unconsumed) is exactly the "does-not-diverge → close won't-do" branch.

## Evidence this instrument measures

The consume signal is structurally near-degenerate (evidence-redteam lens, verified in-tree): `consumed=1` requires a caller pass **both** `recall_id` **and** a non-empty `cited_memory_ids` array — an opt-in field wired at 2 sites that ~no MCP client populates. So it is sparse, and where non-zero it is collinear with the dense `access_count` proxy. This landed instrument measures that on real data, turning the close-vs-build call into an evidence-backed one.

## Verification

- `divergence_stat_reports_consume_vs_access_1707` — consumed(access=50) + unconsumed(access=4) → correct per-bucket means + collinearity assertion.
- `divergence_stat_none_without_ledger_correlation_1707` — cold-start = `None`, not a misleading 0.
- #1706 `recall_output_byte_identical_around_1706_shadow_sweep` still passes (recall untouched).
- All gates green: fmt, clippy `-D pedantic --all-features`, docs-ssot, vendor/hardcoded-literal (`LOG_TARGET` const-ified). sqlite-path only (calibrate is sqlite-conn-bound — same surface as #1706).

## Disposition — #1707 stays OPEN

The live-apply decision is now an **evidence-backed operator call**. The measured + structural evidence points to redundancy, so the recommendation is **close won't-do per the gate's own branch** — but that close is an operator disposition (locked-set item). A disposition comment is posted on #1707.

## AI involvement

Authored by Claude (Opus 4.8) under the v1.0.0 autonomous campaign; disposition decided by the crossroads 5-agent adversarial vote (CLAUDE.md). Stacked on \`feat/1979-claude-plugin\` (#2081).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY