### PR TITLE
feat(#1969): reranker honors AI_MEMORY_EMBED_OFFLINE (fail-loud, no silent fetch)

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -985,7 +985,7 @@ impl Embedder {
     /// the dedicated `AI_MEMORY_EMBED_OFFLINE` knob. Used by hermetic CI (the
     /// integration suite sets it to dodge the #1501 cold-download race) and by
     /// air-gapped operators who pre-stage the weights in `FALLBACK_MODEL_SUBDIR`.
-    fn remote_fetch_disabled() -> bool {
+    pub(crate) fn remote_fetch_disabled() -> bool {
         let truthy = |name: &str| {
             std::env::var(name)
                 .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "on"))

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -587,24 +587,71 @@ impl CrossEncoder {
         }
     }
 
+    /// #1969 — resolve the cross-encoder's config/tokenizer/weights, honoring
+    /// the substrate offline guard. When
+    /// [`crate::embeddings::Embedder::remote_fetch_disabled`] is set
+    /// (`AI_MEMORY_EMBED_OFFLINE` / `HF_HUB_OFFLINE`), the files resolve from
+    /// the local HuggingFace cache ONLY — never a network fetch — and an absent
+    /// file bails LOUD. No silent network attempt and no silent lexical
+    /// fallback: `new_neural` logs `reranker.fallback` and the recall response
+    /// surfaces `reranker_used = "degraded_lexical"`. Pre-#1969, `load_neural`
+    /// went straight to `Api::new()` + `repo.get()`, so `AI_MEMORY_EMBED_OFFLINE`
+    /// was silently ignored by the reranker (only hf-hub's native
+    /// `HF_HUB_OFFLINE` was honored) and an offline install made a futile
+    /// network attempt before degrading.
+    fn resolve_cross_encoder_files()
+    -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)> {
+        let repo = Repo::new(CROSS_ENCODER_MODEL_ID.to_string(), RepoType::Model);
+        if crate::embeddings::Embedder::remote_fetch_disabled() {
+            let cache_repo = hf_hub::Cache::default().repo(repo);
+            Self::assemble_offline_cross_encoder_files(|file| cache_repo.get(file))
+        } else {
+            let online = Api::new()
+                .context("failed to init HuggingFace Hub API")?
+                .repo(repo);
+            Ok((
+                online
+                    .get(crate::embeddings::HF_CONFIG_FILE)
+                    .context("failed to download config.json")?,
+                online
+                    .get(crate::embeddings::HF_TOKENIZER_FILE)
+                    .context("failed to download tokenizer.json")?,
+                online
+                    .get(crate::embeddings::HF_WEIGHTS_FILE)
+                    .context("failed to download model.safetensors")?,
+            ))
+        }
+    }
+
+    /// #1969 — pure offline (cache-only) assembly of the three cross-encoder
+    /// file paths, bailing LOUD on the first file the resolver can't produce.
+    /// The resolver is injected (production passes `hf_hub::CacheRepo::get`,
+    /// which is network-free) so the fail-loud offline path is unit-testable
+    /// without env mutation or a network. NEVER touches the network — that is
+    /// the whole point of the offline guard.
+    fn assemble_offline_cross_encoder_files(
+        resolve: impl Fn(&str) -> Option<std::path::PathBuf>,
+    ) -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)> {
+        let need = |file: &str| -> Result<std::path::PathBuf> {
+            resolve(file).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "offline (AI_MEMORY_EMBED_OFFLINE/HF_HUB_OFFLINE): cross-encoder file \
+                     {file} is not in the local HuggingFace cache; pre-stage \
+                     {CROSS_ENCODER_MODEL_ID} or unset offline to enable neural reranking"
+                )
+            })
+        };
+        Ok((
+            need(crate::embeddings::HF_CONFIG_FILE)?,
+            need(crate::embeddings::HF_TOKENIZER_FILE)?,
+            need(crate::embeddings::HF_WEIGHTS_FILE)?,
+        ))
+    }
+
     fn load_neural() -> Result<Self> {
         let device = Device::Cpu;
 
-        let api = Api::new().context("failed to init HuggingFace Hub API")?;
-        let repo = api.repo(Repo::new(
-            CROSS_ENCODER_MODEL_ID.to_string(),
-            RepoType::Model,
-        ));
-
-        let config_path = repo
-            .get(crate::embeddings::HF_CONFIG_FILE)
-            .context("failed to download config.json")?;
-        let tokenizer_path = repo
-            .get(crate::embeddings::HF_TOKENIZER_FILE)
-            .context("failed to download tokenizer.json")?;
-        let weights_path = repo
-            .get(crate::embeddings::HF_WEIGHTS_FILE)
-            .context("failed to download model.safetensors")?;
+        let (config_path, tokenizer_path, weights_path) = Self::resolve_cross_encoder_files()?;
 
         // Load BERT config
         let config_data = std::fs::read_to_string(&config_path)
@@ -2466,6 +2513,43 @@ mod tests {
         let ce = CrossEncoder::new_neural();
         let s = ce.score("query", "title", "content");
         assert!((0.0..=1.0).contains(&s), "score {s} out of bounds");
+    }
+
+    // -----------------------------------------------------------------
+    // #1969 — offline-guard fail-loud (no silent network attempt, no silent
+    // lexical fallback). Pure resolver-injected assembly, so no env/network.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn offline_cross_encoder_files_bail_loud_when_uncached_1969() {
+        // Offline + an empty cache (resolver finds nothing) must bail LOUD with
+        // the offline message on the FIRST missing file — never a network fetch.
+        // `new_neural` then surfaces `reranker_used = degraded_lexical`.
+        let err = CrossEncoder::assemble_offline_cross_encoder_files(|_| None)
+            .expect_err("uncached offline must bail, not silently fetch");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("offline"),
+            "must be a loud offline error: {msg}"
+        );
+        assert!(
+            msg.contains(crate::embeddings::HF_CONFIG_FILE),
+            "error must name the missing file: {msg}"
+        );
+    }
+
+    #[test]
+    fn offline_cross_encoder_files_ok_when_prestaged_1969() {
+        // Offline but every file present in the cache → resolves all three paths
+        // with zero network (the air-gapped pre-staged path keeps working).
+        let (config, tokenizer, weights) =
+            CrossEncoder::assemble_offline_cross_encoder_files(|f| {
+                Some(std::path::PathBuf::from(format!("/hf-cache/{f}")))
+            })
+            .expect("pre-staged offline cache resolves");
+        assert!(config.ends_with(crate::embeddings::HF_CONFIG_FILE));
+        assert!(tokenizer.ends_with(crate::embeddings::HF_TOKENIZER_FILE));
+        assert!(weights.ends_with(crate::embeddings::HF_WEIGHTS_FILE));
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
Refs #1969 (does **not** close it — the flip is an operator disposition; see below). Follow-up: #2086.

## Decision — 5-agent vote `4d3ea1c5` (verdict `72316fb2`)

**4B/1A → dissent-concedes-at-freeze → wave-2 waived. Verdict B: SUSTAIN the #1867 unanimous refusal of the reranker global default-on flip.** 4 of #1867's 5 grounds are unchanged at HEAD (resolver-default dead-weight; default tier `semantic` has no reranker; **~90MB HF-Hub download on every stock/offline install → silent permanent degraded**; tier memory budgets). Only the Bench-gap closed (#1871), but the neural latency the flip risks is still not CI-gated (the handler bench scores with a lexical stand-in — the lone A-voter's own admission). The fail-loud degraded **signal** already ships (`meta.reranker_used ∈ {neural, lexical, degraded_lexical, none}`, `tests/recall_observability.rs`), so the flip decision needs no code.

## What this ships

The vote surfaced a real residual gap in #1969's own named ask (*"fail-loud degraded mode, no silent lexical fallback"*): `CrossEncoder::load_neural()` called `Api::new()` + `repo.get()` unconditionally, so **`AI_MEMORY_EMBED_OFFLINE` was silently ignored by the reranker** (only hf-hub's native `HF_HUB_OFFLINE` was honored) — an offline/air-gapped install made a futile network attempt before silently degrading.

- `load_neural` now routes through `resolve_cross_encoder_files()`, which consults `crate::embeddings::Embedder::remote_fetch_disabled()` (now `pub(crate)`). **Offline → resolve config/tokenizer/weights from the local HF cache only (`hf_hub::Cache`, network-free); an absent file bails LOUD** with an actionable message, and `new_neural()` surfaces `reranker_used=degraded_lexical`. A pre-staged air-gapped cache still loads. **Online path byte-unchanged.**
- The offline assembly is a **pure resolver-injected helper** (`assemble_offline_cross_encoder_files`), so the fail-loud path is unit-tested **without env mutation** (`unsafe` in edition 2024) **or a network**.

## Verification

- `offline_cross_encoder_files_bail_loud_when_uncached_1969` (loud error names the missing file), `offline_cross_encoder_files_ok_when_prestaged_1969`.
- 75 reranker lib tests pass. All gates green (fmt, clippy `-D pedantic --all-features`, hardcoded/vendor-literal).

## Disposition — #1969 stays OPEN

The global default-on flip is refused on unchanged grounds; the flip's constructive unlock path (offline/**bundled** reranker model pre-stage + a neural-mode CI perf assertion) is tracked as **#2086**. Recommendation posted on #1969: close won't-flip (operator call, locked-set item).

## AI involvement

Authored by Claude (Opus 4.8) under the v1.0.0 autonomous campaign; disposition decided by the crossroads 5-agent adversarial vote (CLAUDE.md). Stacked on \`feat/1707-recall-utility-shadow\` (#2082).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY