### PR TITLE
test(#2127): migrate cli/rules.rs + recover/transcript_paths.rs HOME tests to shared test_env_lock

### DIFF
--- a/src/cli/rules.rs
+++ b/src/cli/rules.rs
@@ -2229,12 +2229,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_rules_sign_seed_neither_layout_falls_through_to_legacy_path_and_errors() {
-        // Serialize HOME/XDG mutation against parallel tests in this
-        // module so we don't race other tests that read those vars.
-        static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Serialize HOME/XDG mutation against every other `$HOME`-mutating
+        // test in the crate (#2127, residual of #2115): a module-local
+        // lock only covers this module's own tests, so it still races the
+        // shared `test_env_lock` cohort (e.g. `src/embeddings.rs` /
+        // `src/reranker.rs` / `src/config.rs` / `src/cli/commands/config.rs`)
+        // under parallel `cargo test`.
+        let _guard = crate::config::test_env_lock();
 
         // Snapshot prior values so we restore even on assertion panic.
         let prev_home = std::env::var("HOME").ok();
@@ -2263,7 +2264,8 @@ mod tests {
         let fake_xdg = dir.path().join("fake-xdg-config");
         std::fs::create_dir_all(&fake_home).unwrap();
         std::fs::create_dir_all(&fake_xdg).unwrap();
-        // SAFETY: env mutation is serialized by `HOME_ENV_LOCK` above.
+        // SAFETY: env mutation is serialized by `_guard` (shared
+        // `crate::config::test_env_lock()`) above.
         unsafe {
             std::env::set_var("HOME", &fake_home);
             std::env::set_var("XDG_CONFIG_HOME", &fake_xdg);
@@ -2310,7 +2312,8 @@ mod tests {
 
         // Restore env BEFORE assertions so we don't leak state on
         // assertion panic.
-        // SAFETY: env mutation is serialized by `HOME_ENV_LOCK` above.
+        // SAFETY: env mutation is serialized by `_guard` (shared
+        // `crate::config::test_env_lock()`) above.
         unsafe {
             match prev_home {
                 Some(v) => std::env::set_var("HOME", v),

--- a/src/recover/transcript_paths.rs
+++ b/src/recover/transcript_paths.rs
@@ -204,13 +204,17 @@ mod tests {
         root
     }
 
-    /// Serialize HOME mutations across the env-touching tests in this
-    /// module so they cannot clobber each other under `--test-threads>1`.
+    /// Serialize HOME mutations against every other `$HOME`-mutating test
+    /// in the crate, not just this module's own tests (#2127, residual of
+    /// #2115). A module-local mutex only covers this module's own
+    /// `--test-threads>1` races; it still races the shared `test_env_lock`
+    /// cohort in `src/embeddings.rs` / `src/reranker.rs` / `src/config.rs`
+    /// / `src/cli/commands/config.rs` / `src/cli/rules.rs`, so this
+    /// delegates to the single crate-canonical
+    /// [`crate::config::test_env_lock`] (mirrors
+    /// `src/cli/commands/config.rs::tests::env_lock`).
     fn home_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        crate::config::test_env_lock()
     }
 
     /// RAII guard that points `$HOME` at a temp dir and restores the


### PR DESCRIPTION
## Summary

- Fixes #2127 — the `#2115` residual flagged by the Fable pre-merge audit of #2098: `src/cli/rules.rs` and `src/recover/transcript_paths.rs` still serialized their `$HOME`-mutating tests on **module-local** locks (`static HOME_ENV_LOCK` / a private `OnceLock<Mutex<()>>`), which race the **shared** `crate::config::test_env_lock()` cohort (`src/embeddings.rs`, `src/reranker.rs`, `src/config.rs`, `src/cli/commands/config.rs`) under parallel `cargo test` — the exact cross-module `$HOME`-swap flake mechanism #2115 fixed for the embeddings/reranker pair, just with different counterparties.
- Both modules now delegate to the crate-canonical `crate::config::test_env_lock()`, mirroring the established `src/cli/commands/config.rs::tests::env_lock()` thin-wrapper pattern (`fn env_lock() -> ... { crate::config::test_env_lock() }`).
- Test-only mechanical change. No production code touched; no new behavior.

## Applied rust-skills / rust-microsoft rules

- `test-fixture-raii` (rust-skills) — the returned `MutexGuard` is bound to a `let _guard = ...` local for the duration of the critical section, never dropped early.
- `err-no-unwrap-prod` (rust-skills) — `test_env_lock()` recovers from mutex poisoning (`unwrap_or_else(PoisonError::into_inner)`) so one panicking test doesn't cascade-poison the shared lock for the rest of the suite; preserved by delegating rather than reimplementing.
- `unsafe-safety-comment` (rust-skills) — the `unsafe { std::env::set_var(...) }` blocks in `cli/rules.rs` keep (and correct) their `// SAFETY:` comments to point at the new shared guard.
- `M-AVOID-STATICS` (rust-microsoft) — removes the module-local `static HOME_ENV_LOCK: Mutex<()>` and the module-local `static LOCK: OnceLock<Mutex<()>>`, consolidating on the one process-global static already owned by `crate::config`.
- `M-DESIGN-FOR-AI` (rust-microsoft) — doc comments at both call sites now name the shared-lock rationale and the sibling modules that share it, so a future migration follows the same trail #2115 → #2127 did.

## Tests migrated

- `src/cli/rules.rs::tests::run_rules_sign_seed_neither_layout_falls_through_to_legacy_path_and_errors`
- `src/recover/transcript_paths.rs::tests::claude_code_resolver_finds_most_recent_jsonl`
- `src/recover/transcript_paths.rs::tests::codex_and_gemini_resolvers_walk_their_dirs`
- `src/recover/transcript_paths.rs::tests::resolver_returns_none_when_home_unset`

## Validation

- `cargo check --all-targets` (default, `--features sal`, `--features sal-postgres`) — all green
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` (default AND `--features sal`) — clean
- `cargo fmt --all -- --check` — clean
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib cli::rules:: -- --test-threads=8` — 64 passed
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib recover::transcript_paths:: -- --test-threads=8` — 7 passed
- Combined `rules:: transcript_paths::` filter re-run 3× at `--test-threads=16` — 71 passed each time (no flakes)
- `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` — green, no baseline bump needed

Per the operator HARD RULE, no `cargo llvm-cov` / no full `cargo test --lib --tests` was run locally — CI covers that.

## Test plan

- [x] CI: fmt / clippy (default + sal) / cargo test / cargo audit
- [x] CI: qual_10 + qual_6_7 lockstep gates
- [ ] Fable pre-merge audit (per #2127's own provenance — this PR does not self-merge)

Closes #2127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY