### PR TITLE
test-infra(#2151,#2152,#2153): close three gate-script residual evasion vectors

### DIFF
--- a/scripts/check-test-env-lock.sh
+++ b/scripts/check-test-env-lock.sh
@@ -45,19 +45,56 @@
 # mutation also contains the test_env_lock token") -- verified true
 # against every current site as of this gate's authorship.
 #
-# KNOWN RESIDUAL GAP (documented, not silently overclaimed): a NEW test
-# fn added to a file that is ALREADY compliant (contains test_env_lock
-# somewhere, for its OTHER tests) could theoretically hand-roll its own
-# unserialized $HOME mutation without tripping this file-scoped gate.
-# Closing that gap needs fn-scoped tracking of every test_env_lock
-# DELEGATE wrapper fn (generalizing the config.rs pattern above), which
-# is a real but narrower follow-up. Today: (a) every one of the six
-# production sites (src/embeddings.rs, src/reranker.rs, src/config.rs,
-# src/cli/commands/config.rs, src/cli/rules.rs,
-# src/recover/transcript_paths.rs) is correctly gated, and (b) any
-# wholesale-NEW file that mutates $HOME without EVER mentioning
-# test_env_lock is caught unconditionally -- the class the issue's
-# recurrence history (#1998/#2115/#2127) actually exhibited each time.
+# CLOSED-BY-#2153 RESIDUAL: the file-scope pairing above only proves the
+# literal token `test_env_lock` appears SOMEWHERE in the file -- it does
+# not distinguish a real call from a bare MENTION inside a `//` comment
+# (issue #2153a: a file could hand-roll its own local lock while merely
+# commenting "unlike test_env_lock, we use our own local mutex here" and
+# still pass), nor did it catch the KNOWN RESIDUAL GAP #2146 originally
+# flagged: a NEW test fn added to a file that is ALREADY compliant
+# (contains test_env_lock somewhere, for its OTHER tests) hand-rolling
+# its own unserialized $HOME mutation nearby. Two arms close both:
+#
+#   (a) Comment-insensitive pairing. The token search now runs over
+#       comment-STRIPPED content (`//` to end-of-line removed per line,
+#       mirroring the sibling stdin gate's per-line strip) before the
+#       whole-file `grep -q` -- a comment-only mention of the token no
+#       longer satisfies the pairing. This is a single-line strip: it
+#       does not understand block comments (`/* ... */`) or a `//`
+#       inside a string literal (e.g. a URL) -- both out of scope for
+#       this bash gate, same bound as the stdin gate's twin.
+#
+#   (b) Module-local-lock adjacency arm (the #2146-proposed detector
+#       arm PR #2149 did not deliver). Independent of whole-file
+#       pairing, any `static <NAME>: ...Mutex<()>`-style module-local
+#       lock declaration WITHIN A WINDOW_LINES-line window of a $HOME
+#       mutation, with no (comment-stripped) `test_env_lock` reference
+#       in that SAME window, is flagged -- even in a file that is
+#       otherwise file-scope-compliant for its OTHER tests. The window
+#       (not a whole-file "any local lock anywhere" check) is what lets
+#       this arm coexist with src/config.rs, which legitimately declares
+#       several UNRELATED module-local locks (GATE_LOCK, CAP_LOCK, and
+#       test_env_lock()'s own internal static) thousands of lines away
+#       from its $HOME-mutating tests -- a whole-file check would
+#       false-positive there; a windowed one does not (verified against
+#       the live tree at authorship).
+#
+# Every one of the six production sites (src/embeddings.rs,
+# src/reranker.rs, src/config.rs, src/cli/commands/config.rs,
+# src/cli/rules.rs, src/recover/transcript_paths.rs) is correctly gated
+# under both arms, and any wholesale-NEW file that mutates $HOME without
+# EVER mentioning test_env_lock in real code is caught unconditionally --
+# the class the issue's recurrence history (#1998/#2115/#2127) actually
+# exhibited each time.
+#
+# NARROWER RESIDUAL (documented, not silently overclaimed): a hand-
+# rolled local lock declared MORE than WINDOW_LINES lines from the
+# $HOME mutation it guards (e.g. at the top of a very large file, used
+# far below) would still evade arm (b) while the file stays file-scope
+# "compliant" if it also references test_env_lock elsewhere. This is a
+# real but narrower gap than the one #2153 closes; a fn/block-scoped
+# structural scan (generalizing the config.rs delegate-wrapper pattern)
+# is the follow-up if this shape is ever observed in practice.
 #
 # ALLOWLIST (a structural exception, not a denylist of bad patterns): a
 # SEPARATE TEST BINARY that documents its own out-of-process
@@ -72,14 +109,19 @@
 #   scripts/check-test-env-lock.sh
 #     - exit 0 on clean, exit 1 on any violation
 #   scripts/check-test-env-lock.sh --self-test
-#     - injects a violating fixture ($HOME mutation, zero test_env_lock
+#     - injects: a violating fixture ($HOME mutation, zero test_env_lock
 #       reference anywhere in the file), a compliant fixture (same
-#       shape, but the file also references test_env_lock), and a
+#       shape, but the file also references test_env_lock), a
 #       hand-rolled-local-lock fixture (defines its own static
 #       Mutex<()> and never references test_env_lock -- exercises the
-#       #1998/#2115/#2127 recurrent class directly), verifies the gate
-#       catches both violators and spares the compliant fixture, then
-#       cleans up. Exit 0 on PASS.
+#       #1998/#2115/#2127 recurrent class directly), a comment-only-
+#       mention fixture (issue #2153a -- the token appears ONLY inside
+#       a `//` comment), and a module-local-lock-adjacency fixture
+#       (issue #2153b -- file-scope-compliant for its FIRST test, but a
+#       SECOND test >WINDOW_LINES away hand-rolls its own local lock for
+#       its own $HOME mutation); verifies the gate catches all four
+#       violators and spares the compliant fixture, then cleans up.
+#       Exit 0 on PASS.
 
 set -euo pipefail
 
@@ -108,11 +150,54 @@ is_allowlisted () {
 HOME_PATTERN='(set_var|remove_var)\("HOME"'
 
 # The crate-canonical guard token. A file passes when this literal
-# substring appears ANYWHERE in it -- either a direct
-# `crate::config::test_env_lock()` call, or (per the config.rs
+# substring appears ANYWHERE in its NON-COMMENT content -- either a
+# direct `crate::config::test_env_lock()` call, or (per the config.rs
 # delegate pattern documented above) a local wrapper fn whose own body
 # cites it.
 LOCK_TOKEN='test_env_lock'
+
+# strip_line_comments <file>
+# Echoes <file> with everything from the first `//` to end-of-line
+# removed on every line (issue #2153a comment-insensitivity fix, mirrors
+# the sibling scripts/check-test-stdin-reads.sh per-line strip). A
+# single-line heuristic: it does not understand block comments
+# (`/* ... */`) and does not special-case a `//` occurring inside a
+# string literal (e.g. a URL) -- both are out of scope for this bash
+# gate. `LOCK_TOKEN` has no legitimate reason to appear only after a
+# `//` inside a URL-bearing string in this codebase, so the residual
+# false-negative surface is negligible.
+strip_line_comments () {
+    sed -E 's#//.*$##' "$1" 2>/dev/null
+}
+
+# WINDOW_LINES: the adjacency window (in source lines) the module-
+# local-lock detector arm (issue #2153b) uses to decide whether a
+# hand-rolled static lock declaration is "adjacent to" a $HOME mutation
+# site, as opposed to merely co-resident somewhere else in a large file.
+# src/config.rs legitimately declares several UNRELATED module-local
+# locks (GATE_LOCK, CAP_LOCK, and test_env_lock()'s own internal static)
+# thousands of lines away from its $HOME-mutating tests -- a whole-file
+# "any local lock anywhere" check would false-positive on that file; a
+# windowed check does not (the nearest unrelated static in that file is
+# ~870 lines from the nearest $HOME mutation, verified at authorship).
+# 50 lines comfortably covers the recurrent shape (a static declared a
+# handful of lines above the #[test] fn that acquires it).
+WINDOW_LINES=50
+
+# LOCAL_LOCK_PATTERN matches a module-local lock declaration in any of
+# its shapes observed in this codebase: a bare `static X: Mutex<()>`, a
+# `static X: std::sync::Mutex<()>` / `StdMutex<()>` / `tokio::sync::
+# Mutex<()>` alias, or an `OnceLock<Mutex<()>>`-wrapped lazy-init (all
+# contain the literal substring `Mutex<()>`, which the trailing `.*`
+# reaches regardless of prefix -- this also structurally covers a
+# `Lazy<Mutex<()>>` (once_cell-style) shape, per issue #2153b's ask,
+# even though no live site of that exact spelling exists in this repo
+# today). The canonical test_env_lock() function's OWN internal
+# `static LOCK: OnceLock<Mutex<()>>` self-protects against a false
+# match: that declaration line sits inside the SAME function body as
+# the literal `fn test_env_lock` name, so any window reaching it also
+# reaches the token itself.
+LOCAL_LOCK_PATTERN='static[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:.*Mutex<\(\)>'
 
 # Self-test mode -- inject contrived fixtures, run the gate, confirm it
 # catches the violators and spares the compliant fixture, then clean up.
@@ -122,8 +207,10 @@ if [[ "${1:-}" == "--self-test" ]]; then
     probe_violation="${ROOT}/src/.check_home_lock_violation_probe.rs"
     probe_compliant="${ROOT}/src/.check_home_lock_compliant_probe.rs"
     probe_handrolled="${ROOT}/src/.check_home_lock_handrolled_probe.rs"
+    probe_comment_only="${ROOT}/src/.check_home_lock_comment_only_probe.rs"
+    probe_arm_b="${ROOT}/src/.check_home_lock_arm_b_probe.rs"
 
-    for p in "$probe_violation" "$probe_compliant" "$probe_handrolled"; do
+    for p in "$probe_violation" "$probe_compliant" "$probe_handrolled" "$probe_comment_only" "$probe_arm_b"; do
         if [[ -e "$p" ]]; then
             echo "ERROR: self-test scratch file already exists: $p" >&2
             echo "(cleanup may have failed in a prior run -- remove manually)" >&2
@@ -205,28 +292,116 @@ fn contrived_home_mutation_with_handrolled_lock() {
 }
 EOF
 
+    # Case 4 (issue #2153a): the shared guard's identifier appears ONLY
+    # inside a `//` comment -- never actually called. Pre-fix, the naive
+    # whole-file `grep -q test_env_lock` pairing treated ANY textual
+    # occurrence (including this comment) as compliant; the
+    # comment-stripped pairing check must still catch this.
+    cat > "$probe_comment_only" <<'EOF'
+// CONTRIVED VIOLATION for scripts/check-test-env-lock.sh --self-test.
+// Exercises issue #2153a: this file mentions the canonical guard's
+// name only inside a comment -- unlike test_env_lock, this test uses
+// its own local mutex, and never actually calls the shared guard.
+static CONTRIVED_COMMENT_ONLY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[test]
+fn contrived_home_mutation_comment_only_mention() {
+    let _guard = CONTRIVED_COMMENT_ONLY_LOCK.lock().unwrap();
+    let prev = std::env::var("HOME").ok();
+    unsafe {
+        std::env::set_var("HOME", "/tmp/contrived_comment_only");
+    }
+    match prev {
+        Some(p) => unsafe { std::env::set_var("HOME", p) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+}
+EOF
+
+    # Case 5 (issue #2153b): a file that IS file-scope-compliant for its
+    # FIRST test (references the canonical guard for real, non-comment,
+    # code) but whose SECOND test -- far enough below that it falls
+    # outside the module-local-lock adjacency window -- hand-rolls its
+    # own local lock for its own $HOME mutation instead of reusing the
+    # shared guard. Whole-file pairing alone (arm a) would NOT catch
+    # this (the file DOES contain the token); the module-local-lock
+    # adjacency arm (b) must catch it independently. The padding block
+    # below is deliberately > WINDOW_LINES lines so the first test's
+    # token reference cannot be "seen" from the second test's window.
+    {
+        cat <<'EOF'
+// CONTRIVED FIXTURE for scripts/check-test-env-lock.sh --self-test.
+// Exercises issue #2153b: file-scope-compliant for its FIRST test (this
+// one, which correctly uses the shared guard); a SECOND test far below
+// hand-rolls its own module-local lock instead -- the "already-
+// compliant file gains a new hand-rolled lock" residual the #2146
+// header originally documented as open. Only the module-local-lock
+// adjacency arm (b) catches the second test; whole-file pairing (a)
+// alone would not, since the file DOES contain the token (right here).
+#[test]
+fn contrived_compliant_first_test() {
+    let _guard = crate::config::test_env_lock();
+    let prev = std::env::var("HOME").ok();
+    unsafe {
+        std::env::set_var("HOME", "/tmp/contrived_b_first");
+    }
+    match prev {
+        Some(p) => unsafe { std::env::set_var("HOME", p) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+}
+EOF
+        for i in $(seq 1 60); do
+            printf '// padding line %d -- pushes the second test outside the WINDOW_LINES adjacency window used by arm (b)\n' "$i"
+        done
+        cat <<'EOF'
+
+static CONTRIVED_LOCAL_LOCK_ARM_B: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[test]
+fn contrived_handrolled_second_test() {
+    let _guard = CONTRIVED_LOCAL_LOCK_ARM_B.lock().unwrap();
+    let prev = std::env::var("HOME").ok();
+    unsafe {
+        std::env::set_var("HOME", "/tmp/contrived_b_second");
+    }
+    match prev {
+        Some(p) => unsafe { std::env::set_var("HOME", p) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+}
+EOF
+    } > "$probe_arm_b"
+
     set +e
     gate_output="$("$0" 2>&1)"
     gate_exit=$?
     set -e
 
-    rm -f "$probe_violation" "$probe_compliant" "$probe_handrolled"
+    rm -f "$probe_violation" "$probe_compliant" "$probe_handrolled" "$probe_comment_only" "$probe_arm_b"
     printf '%s\n' "$gate_output"
 
-    # PASS requires: non-zero exit, BOTH violators reported, and the
-    # compliant fixture NOT reported.
+    # PASS requires: non-zero exit, ALL FOUR violators reported (no-lock,
+    # hand-rolled-lock, comment-only-mention #2153a, and the module-
+    # local-lock-adjacency #2153b shape), and the compliant fixture NOT
+    # reported.
     ok=1
     (( gate_exit != 0 )) || ok=0
     printf '%s' "$gate_output" | grep -q '\.check_home_lock_violation_probe\.rs' || ok=0
     printf '%s' "$gate_output" | grep -q '\.check_home_lock_handrolled_probe\.rs' || ok=0
+    printf '%s' "$gate_output" | grep -q '\.check_home_lock_comment_only_probe\.rs' || ok=0
+    printf '%s' "$gate_output" | grep -q 'contrived_handrolled_second_test\|\.check_home_lock_arm_b_probe\.rs' || ok=0
     if printf '%s' "$gate_output" | grep -q '\.check_home_lock_compliant_probe\.rs'; then
         echo "" >&2
         echo "Test-env-lock gate self-test: FAIL (over-widened: the compliant fixture was flagged)" >&2
         exit 1
     fi
+    if printf '%s' "$gate_output" | grep -q 'contrived_compliant_first_test'; then
+        echo "" >&2
+        echo "Test-env-lock gate self-test: FAIL (over-widened: arm (b) flagged the ARM-B probe's own compliant FIRST test, not just the hand-rolled second one)" >&2
+        exit 1
+    fi
     if (( ok == 1 )); then
         echo ""
-        echo "Test-env-lock gate self-test: PASS (caught both contrived violations, spared the compliant fixture; exit=${gate_exit})"
+        echo "Test-env-lock gate self-test: PASS (caught all four contrived violations, spared the compliant fixture; exit=${gate_exit})"
         exit 0
     else
         echo "" >&2
@@ -247,12 +422,80 @@ while IFS= read -r -d '' f; do
     home_lines="$(grep -nE "$HOME_PATTERN" "$f" 2>/dev/null || true)"
     [[ -z "$home_lines" ]] && continue
 
-    if ! grep -q "$LOCK_TOKEN" "$f" 2>/dev/null; then
+    # Materialize the comment-stripped content ONCE per file and reuse
+    # it via here-strings (`<<<`) below, rather than piping a live
+    # `strip_line_comments "$f" | grep -q ...` process substitution
+    # directly into `grep -q`. `grep -q` exits the instant it finds its
+    # first match, which -- under this script's `set -o pipefail` --
+    # can SIGPIPE the still-writing `sed` upstream of it; pipefail then
+    # reports the PIPELINE's exit status as sed's SIGPIPE failure (a
+    # nonzero/signal status) even though grep DID find a real match,
+    # false-flagging every $HOME line in an otherwise fully-compliant
+    # file (verified: this exact shape false-positived on the live
+    # src/reranker.rs / src/cli/rules.rs / src/config.rs / src/
+    # embeddings.rs sites during this fix's own authorship -- caught by
+    # the mandatory clean-tree false-positive check before merge). A
+    # here-string reads from an already-fully-materialized temp
+    # file/fd, so `grep -q` reading it early never signals a live
+    # writer process.
+    stripped_content="$(strip_line_comments "$f")"
+
+    # Arm (a): file-scope pairing over comment-stripped content (issue
+    # #2153a). A whole-file miss flags every $HOME line in the file and
+    # skips arm (b) for it -- no point double-checking adjacency in a
+    # file that has no real reference to the guard at all.
+    if ! grep -q "$LOCK_TOKEN" <<< "$stripped_content"; then
         while IFS=: read -r lineno content; do
             [[ -z "$lineno" ]] && continue
             violations+="${rel}:${lineno}:${content}"$'\n'
         done <<< "$home_lines"
+        continue
     fi
+
+    # Arm (b): module-local-lock adjacency (issue #2153b). Only reached
+    # for files that PASSED arm (a) -- i.e. the file references the
+    # shared guard somewhere for real, but a specific $HOME mutation may
+    # still be guarded by its own nearby hand-rolled lock instead.
+    # `|| true` on the `grep | cut` pipeline: under `set -o pipefail`
+    # (in effect via the script's `set -euo pipefail`), a `grep` that
+    # matches nothing exits 1, which -- for a bare `$(pipeline)`
+    # assignment -- trips `set -e` and kills the WHOLE script on the
+    # very first file with no local-lock declarations (the common
+    # case). `|| true` neutralizes that without masking a genuine
+    # pattern/regex error, since grep's only failure mode here is "no
+    # match" (2>/dev/null already swallows any file-read error) or "no
+    # match" propagated through `cut`. Neither `grep -n` here nor `cut`
+    # exits early the way `grep -q` does, so no SIGPIPE risk on this
+    # pipeline even with a live writer.
+    lock_decl_lines="$(grep -nE "$LOCAL_LOCK_PATTERN" "$f" 2>/dev/null | cut -d: -f1 || true)"
+    [[ -z "$lock_decl_lines" ]] && continue
+
+    token_lines="$(grep -n "$LOCK_TOKEN" <<< "$stripped_content" | cut -d: -f1 || true)"
+
+    while IFS=: read -r lineno content; do
+        [[ -z "$lineno" ]] && continue
+        adjacent_lock=0
+        for d in $lock_decl_lines; do
+            diff=$(( d - lineno )); (( diff < 0 )) && diff=$(( -diff ))
+            if (( diff <= WINDOW_LINES )); then
+                adjacent_lock=1
+                break
+            fi
+        done
+        (( adjacent_lock == 0 )) && continue
+
+        token_nearby=0
+        for t in $token_lines; do
+            diff=$(( t - lineno )); (( diff < 0 )) && diff=$(( -diff ))
+            if (( diff <= WINDOW_LINES )); then
+                token_nearby=1
+                break
+            fi
+        done
+        if (( token_nearby == 0 )); then
+            violations+="${rel}:${lineno}:${content}"$'\n'
+        fi
+    done <<< "$home_lines"
 done < <(
     find "${ROOT}/src" "${ROOT}/tests" -type f -name '*.rs' -print0 2>/dev/null
 )

--- a/scripts/check-test-stdin-reads.sh
+++ b/scripts/check-test-stdin-reads.sh
@@ -36,10 +36,14 @@
 # suite wedges."
 #
 # WHAT IS GATED. The process-global handle acquisition — `io::stdin()`,
-# `std::io::stdin()`, AND a bare `stdin()` call (e.g. after
+# `std::io::stdin()`, a bare `stdin()` call (e.g. after
 # `use std::io::stdin;`, which evades a pattern anchored on the
-# fully-qualified `io::stdin(` form — issue #2120 finding 1) — appearing
-# in TEST-reachable code:
+# fully-qualified `io::stdin(` form — issue #2120 finding 1), AND an
+# item-renaming `stdin as <alias>` import in EITHER its plain form
+# (`use std::io::stdin as input;`, issue #2145) or a GROUPED use-list
+# form (`use std::io::{stdin as input, Write};`, issue #2151 — the `{`
+# breaks the unbroken `io::stdin` substring #2145's fix anchors on, so
+# the grouped spelling evaded it) — appearing in TEST-reachable code:
 #   - every line in a `tests/**/*.rs` integration-test file (wholly test)
 #   - lines at or below the first `mod tests {` boundary in any
 #     `src/**/*.rs`, `examples/**/*.rs`, or `tools/**/*.rs` file (the
@@ -80,6 +84,29 @@
 # the same comment-line skip, the same here-string loop to avoid the
 # macOS bash 3.2 nested-process-substitution SIGTRAP).
 #
+# KNOWN LIMITATION (issue #2152 — threat-model bound, not silently
+# mis-parsed). `cfg_test_ranges`' brace-balance scan strips string
+# literals PER-LINE (`gsub(/"[^"]*"/, "", counted)`), so it has no
+# state for a string that SPANS multiple lines. A multi-line raw
+# string (`r#"..."#`) whose body carries a line with more `}` than `{`
+# can therefore close an item's range one or more braces early — this
+# repo's own `src/` carries live multi-line `r#"`-fixture strings this
+# can affect. A bash grep-gate is fundamentally not a Rust lexer/parser
+# and a full multi-line-string state machine is deliberately OUT OF
+# SCOPE here (fragile, easy to get subtly wrong, and the failure mode
+# it would replace is already bounded below). What this gate DOES do:
+# whenever the per-line brace count drives `depth` NEGATIVE inside an
+# active `#[cfg(test)]` range — the single-line-evaluable subset of the
+# truncation class (e.g. a line whose stripped content carries two net
+# `}` with no matching `{` on that same line) — it emits a loud WARN to
+# stderr naming the file + line, so a truncation in THAT shape is
+# visible rather than silently mis-scoping the range. A truncation that
+# instead lands EXACTLY at `depth == 0` (the coincidental "looks like a
+# normal close" shape) is NOT distinguishable from a legitimate close by
+# a brace-count alone and is NOT WARNed on — that residual is real and
+# stays open; see self-test probe 10 below for the shape this gate CAN
+# catch loud.
+#
 # Usage:
 #   scripts/check-test-stdin-reads.sh
 #     - exit 0 on clean, exit 1 on any violation
@@ -91,13 +118,16 @@
 #       position (#2143), a `#[cfg(test)] mod` whose unbalanced `"}"`
 #       string literal would otherwise truncate the range early (#2144),
 #       an item-renaming `use std::io::stdin as input;` import (#2145),
-#       and a fn-pointer `let f = std::io::stdin;` binding (#2145)),
-#       verifies the gate catches all of them, verifies the sanctioned
-#       helper line and a `.stdin(` builder call are NOT flagged, then
-#       cleans up. Proves the gate is load-bearing AND that the narrow
-#       carve-out did not over-widen (pm-v3.2 NO FAIL MISSION closure
-#       discipline; issue #2120 + #2143/#2144/#2145 residual-vector
-#       hardening). Exit 0 on PASS.
+#       a fn-pointer `let f = std::io::stdin;` binding (#2145), and a
+#       GROUPED item-renaming `use std::io::{stdin as input, Write};`
+#       import (#2151)), verifies the gate catches all of them, verifies
+#       the sanctioned helper line and a `.stdin(` builder call are NOT
+#       flagged, verifies the #2152 negative-brace-balance WARN fires on
+#       a multi-line raw string whose body drives the count negative,
+#       then cleans up. Proves the gate is load-bearing AND that the
+#       narrow carve-out did not over-widen (pm-v3.2 NO FAIL MISSION
+#       closure discipline; issue #2120 + #2143/#2144/#2145/#2151/#2152
+#       residual-vector hardening). Exit 0 on PASS.
 
 set -euo pipefail
 
@@ -131,6 +161,24 @@ STDIN_PATTERN='(^|[^A-Za-z0-9_.])stdin[[:space:]]*\('
 # `io::stdin()` / `std::io::stdin()` call is never double-matched here —
 # STDIN_PATTERN alone already covers it.
 STDIN_TOKEN_PATTERN='(^|[^A-Za-z0-9_.])io::stdin([^A-Za-z0-9_(]|$)'
+
+# A third signal (issue #2151): STDIN_TOKEN_PATTERN requires the
+# literal qualified substring `io::stdin` to appear UNBROKEN, but a
+# GROUPED item-renaming import spells it `io::{stdin as <alias>, ...}`
+# — the `{` sits between `io::` and `stdin`, so the substring never
+# appears and the grouped form evades STDIN_TOKEN_PATTERN even though
+# it is the exact same `stdin as` evasion shape #2145 closed for the
+# single-import spelling (`use std::io::stdin as input;` IS caught,
+# because `io::stdin` survives unbroken there). `rustfmt` does not
+# split or rejoin a grouped `use` item's contents, so this evasion
+# survives the CI fmt gate exactly like #2145's other forms. Anchoring
+# directly on the `stdin as` token (preceded by start-of-line, `{`,
+# space, or comma — the positions a `use`-item name can occupy) covers
+# BOTH the plain and grouped spellings in one pattern; `stdin as` has
+# no legitimate non-import use in this codebase (verified against the
+# real tree at authorship — a bare `stdin` identifier being `as`-cast
+# is not a shape this codebase exhibits).
+STDIN_ALIAS_PATTERN='(^|[{ ,])stdin[[:space:]]+as[[:space:]]'
 
 # find_test_boundary <file>
 # Echoes the line number of the first `mod tests {` (or `pub mod tests {`,
@@ -234,6 +282,20 @@ cfg_test_ranges () {
                 sub(/\/\/.*$/, "", counted)
                 o = gsub(/\{/, "{", counted); depth += o; if (o > 0) opened = 1
                 c = gsub(/\}/, "}", counted); depth -= c
+                # Issue #2152 fail-LOUD partial coverage: a per-line
+                # brace count that drives depth NEGATIVE (not merely to
+                # zero) is a single-line-evaluable symptom of a
+                # multi-line string this per-line strip cannot see
+                # (e.g. a stripped line carrying two net `}` with no
+                # matching `{` on that line). WARN to stderr naming the
+                # file+line so the truncation is visible rather than
+                # silently mis-scoping the range -- see the "KNOWN
+                # LIMITATION (issue #2152)" header comment for the
+                # depth==0 residual this cannot distinguish from a
+                # legitimate close.
+                if (depth < 0) {
+                    print "WARN: scripts/check-test-stdin-reads.sh: cfg_test_ranges brace-balance went NEGATIVE at " FILENAME ":" NR " -- likely a multi-line string literal (e.g. r#\"...\"#) whose body carries an unbalanced closing brace this single-line strip cannot see; the enclosing #[cfg(test)] range may be truncated early (issue #2152)." > "/dev/stderr"
+                }
                 if (opened == 1) {
                     if (depth <= 0) { print start":"NR; active = 0 }
                 } else if (line ~ /;[[:space:]]*(\/\/.*)?$/) {
@@ -242,7 +304,13 @@ cfg_test_ranges () {
             }
         }
     }
-    ' "$f" 2>/dev/null
+    ' "$f"
+    # NOTE: unlike the sibling helper_ranges/find_test_boundary
+    # functions, this awk invocation's stderr is deliberately NOT
+    # redirected to /dev/null -- the issue #2152 negative-depth WARN
+    # above is written to stderr and must reach the caller (and, in
+    # --self-test mode, the captured `"$0" 2>&1` gate_output) for the
+    # fail-LOUD contract to hold.
 }
 
 # line_in_ranges <lineno> <ranges-payload>
@@ -281,6 +349,7 @@ scan_test_lines () {
         {
             grep -En "$STDIN_PATTERN" "$f" 2>/dev/null || true
             grep -En "$STDIN_TOKEN_PATTERN" "$f" 2>/dev/null || true
+            grep -En "$STDIN_ALIAS_PATTERN" "$f" 2>/dev/null || true
         } | sort -t: -k1,1n -u
     )"
     [[ -z "$matches" ]] && return 0
@@ -361,7 +430,20 @@ if [[ "${1:-}" == "--self-test" ]]; then
     # std::io::stdin;`) — same evasion shape as case 7, a paren-less
     # `io::stdin` token with no adjacent call.
     probe8="${ROOT}/tests/.stdin_gate_fn_pointer_probe.rs"
-    for p in "$probe1" "$probe2" "$probe3" "$probe4" "$probe5" "$probe6" "$probe7" "$probe8"; do
+    # Case 9 (#2151): a GROUPED item-renaming import
+    # (`use std::io::{stdin as input, Write};`) -- the `{` breaks the
+    # unbroken `io::stdin` substring STDIN_TOKEN_PATTERN anchors on, so
+    # only the new STDIN_ALIAS_PATTERN (anchored on the `stdin as`
+    # token itself) catches the import line.
+    probe9="${ROOT}/tests/.stdin_gate_grouped_alias_import_probe.rs"
+    # Case 10 (#2152): a multi-line raw string whose body drives the
+    # cfg_test_ranges brace-balance NEGATIVE (two net `}` on one
+    # stripped line) -- proves the fail-LOUD WARN path fires. This
+    # probe's own stdin read is NOT asserted caught (the range IS
+    # truncated early, same as the documented #2152 residual) -- only
+    # the WARN text is asserted, which is the honest scope of this fix.
+    probe10="${ROOT}/src/.stdin_gate_multiline_negative_depth_probe.rs"
+    for p in "$probe1" "$probe2" "$probe3" "$probe4" "$probe5" "$probe6" "$probe7" "$probe8" "$probe9" "$probe10"; do
         if [[ -e "$p" ]]; then
             echo "ERROR: self-test scratch file already exists: $p" >&2
             echo "(cleanup may have failed in a prior run — remove manually)" >&2
@@ -478,15 +560,56 @@ fn contrived_fn_pointer_reads_stdin() {
     let _ = f().read_line(&mut buf);
 }
 EOF
+    cat > "$probe9" <<'EOF'
+// CONTRIVED VIOLATION for scripts/check-test-stdin-reads.sh --self-test.
+// Exercises issue #2151: a GROUPED item-renaming import survives
+// `cargo fmt --check` (rustfmt does not split/rejoin a grouped `use`
+// item), so `use std::io::{stdin as input, Write};` then `input()`
+// evades STDIN_TOKEN_PATTERN entirely (the `{` breaks the unbroken
+// `io::stdin` substring it anchors on) even though the single-import
+// sibling form (#2145) is already caught.
+use std::io::{stdin as input, Write};
+#[test]
+fn contrived_grouped_alias_import_reads_stdin() {
+    let mut buf = String::new();
+    let _ = input().read_line(&mut buf);
+    let _ = Write::flush(&mut std::io::stdout());
+}
+EOF
+    cat > "$probe10" <<'EOF'
+// CONTRIVED VIOLATION for scripts/check-test-stdin-reads.sh --self-test.
+// Exercises issue #2152's fail-LOUD path: a multi-line raw string whose
+// body carries a line with two net closing-brace characters drives the
+// cfg_test_ranges brace-balance NEGATIVE (not merely to zero) inside a
+// #[cfg(test)] range -- the single-line-evaluable subset of the
+// per-line-string-strip truncation class this gate can cheaply detect
+// and WARN on (see script header "KNOWN LIMITATION (issue #2152)"). A
+// full multi-line-string parser remains explicitly out of scope for
+// this bash gate; the stdin read below is NOT asserted caught by this
+// probe (the range IS truncated early, same as the documented residual)
+// -- only the loud WARN is asserted.
+#[cfg(test)]
+mod sneaky_ml_negative_probe {
+    const K: &str = r#"
+    }}
+    "#;
+    fn contrived_multiline_negative_depth_reads_stdin() {
+        let mut buf = String::new();
+        let _ = std::io::stdin().read_line(&mut buf);
+    }
+}
+EOF
     set +e
     gate_output="$("$0" 2>&1)"
     gate_exit=$?
     set -e
-    rm -f "$probe1" "$probe2" "$probe3" "$probe4" "$probe5" "$probe6" "$probe7" "$probe8"
+    rm -f "$probe1" "$probe2" "$probe3" "$probe4" "$probe5" "$probe6" "$probe7" "$probe8" "$probe9" "$probe10"
     printf '%s\n' "$gate_output"
-    # PASS requires: non-zero exit, ALL EIGHT probe violations reported,
-    # and the sanctioned helper line + the benign builder call NOT
-    # reported.
+    # PASS requires: non-zero exit, NINE probe violations reported (the
+    # tenth, #2152's negative-depth probe, is asserted via its loud WARN
+    # instead -- its stdin read is deliberately NOT expected caught, see
+    # the probe10 comment above), and the sanctioned helper line + the
+    # benign builder call NOT reported.
     ok=1
     (( gate_exit != 0 )) || ok=0
     printf '%s' "$gate_output" | grep -q '\.stdin_gate_probe\.rs' || ok=0
@@ -497,6 +620,8 @@ EOF
     printf '%s' "$gate_output" | grep -q 'contrived_string_brace_reads_stdin\|\.stdin_gate_string_brace_probe\.rs' || ok=0
     printf '%s' "$gate_output" | grep -q 'use std::io::stdin as input\|\.stdin_gate_alias_import_probe\.rs' || ok=0
     printf '%s' "$gate_output" | grep -q 'let f = std::io::stdin\|\.stdin_gate_fn_pointer_probe\.rs' || ok=0
+    printf '%s' "$gate_output" | grep -q 'stdin as input\|\.stdin_gate_grouped_alias_import_probe\.rs' || ok=0
+    printf '%s' "$gate_output" | grep -q 'brace-balance went NEGATIVE.*stdin_gate_multiline_negative_depth_probe' || ok=0
     if printf '%s' "$gate_output" | grep -q '_sanctioned'; then
         echo "" >&2
         echo "Test-stdin gate self-test: FAIL (carve-out over-widened: the sanctioned helper line was flagged)" >&2
@@ -509,11 +634,11 @@ EOF
     fi
     if (( ok == 1 )); then
         echo ""
-        echo "Test-stdin gate self-test: PASS (caught all eight contrived violations, spared the sanctioned helper + benign builder call; exit=${gate_exit})"
+        echo "Test-stdin gate self-test: PASS (caught nine contrived violations + fired the #2152 negative-depth WARN, spared the sanctioned helper + benign builder call; exit=${gate_exit})"
         exit 0
     else
         echo "" >&2
-        echo "Test-stdin gate self-test: FAIL (gate did not catch a contrived violation; exit=${gate_exit})" >&2
+        echo "Test-stdin gate self-test: FAIL (gate did not catch a contrived violation or fire the #2152 WARN; exit=${gate_exit})" >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary

Fable pre-merge audit residuals filed against PR #2147 (stdin gate) and PR #2149 (env-lock gate) on 2026-07-17. This PR closes all three: #2151, #2152, #2153.

### #2151 — grouped-alias import evasion (`check-test-stdin-reads.sh`)

`use std::io::{stdin as input, Write};` evaded both existing STDIN patterns — the `{` breaks the unbroken `io::stdin` substring `STDIN_TOKEN_PATTERN` anchors on, and `rustfmt` does not split/rejoin a grouped `use` item, so the evasion survives the CI fmt gate. **Fixed**: added `STDIN_ALIAS_PATTERN`, anchored on the `stdin as` token itself (covers both the plain single-import form #2145 already closed and the grouped form). Self-test probe 9 added and asserted caught.

### #2152 — multi-line raw-string truncation (`check-test-stdin-reads.sh`)

`cfg_test_ranges`' per-line string strip has no state for a string spanning multiple lines, so a multi-line raw string whose body carries a net-closing-brace line can truncate a `#[cfg(test)]` range one or more braces early, fail-silent. **This is genuinely beyond a single-line bash strip** — per the orchestrator framing, no multi-line-string state machine was added (explicitly out of scope, matching the "don't chase a perfect parser" directive).

What I DID achieve: `cfg_test_ranges` now emits a loud WARN to stderr naming file+line whenever the per-line brace count drives `depth` **negative** (the single-line-evaluable subset of the truncation class — e.g. a stripped line with two net `}` and no matching `{`). The `2>/dev/null` that was silently swallowing this signal on the awk invocation is removed for that function only.

**Honest scope**: the narrower "depth lands exactly at 0" coincidental-close shape (matching the issue's own canonical repro fixture) is NOT distinguishable from a legitimate range close by brace-count alone, and stays an open, explicitly documented residual in the script header. Self-test probe 10 asserts the WARN fires — it does NOT assert the probe's own stdin read gets caught (that would overclaim; the range IS still truncated in that probe).

### #2153 — env-lock gate comment-insensitivity + missing detector arm (`check-test-env-lock.sh`)

Two parts:

- **(a) Comment-insensitive pairing.** The file-scope `test_env_lock` pairing check matched the token anywhere in the file, including inside a `//` comment. Fixed via a `strip_line_comments` helper (mirrors the sibling stdin gate's per-line strip) applied before the pairing grep.
- **(b) Module-local-lock detector arm** (proposed by #2146, not delivered by PR #2149). Added: independent of whole-file pairing, a file that both mutates `$HOME` and declares its own `static ... Mutex<()>`-style lock within a 50-line adjacency window of that mutation, with no `test_env_lock` reference in the same window, is now flagged — closing the "already-compliant file gains a new hand-rolled lock" residual the #2146 header documented as open. The **window** (not a whole-file "any local lock anywhere" check) is what lets this arm coexist with `src/config.rs`, which legitimately declares several unrelated module-local locks (`GATE_LOCK`, `CAP_LOCK`, `test_env_lock()`'s own internal static) thousands of lines from its `$HOME`-mutating tests — verified no false positive against the live tree.

**Two real bugs surfaced and fixed during this change's own verification** (caught by the mandatory clean-tree false-positive check before merge, not left for CI to find):
1. A `set -euo pipefail` interaction where an empty-result `grep | cut` pipeline killed the whole script on the first file with no local-lock declarations.
2. A `grep -q` piped after a live `sed` process that could SIGPIPE the writer under `pipefail`, false-flagging every `$HOME` line in fully-compliant files (`src/reranker.rs`, `src/cli/rules.rs`, `src/config.rs`, `src/embeddings.rs`). Fixed by materializing comment-stripped content once per file and reading it via here-string instead of a live pipe.

## Self-test probes added

- `check-test-stdin-reads.sh`: probe 9 (grouped-alias import, #2151 — caught), probe 10 (multi-line negative-depth, #2152 — WARN asserted).
- `check-test-env-lock.sh`: comment-only-mention probe (#2153a — caught), module-local-lock-adjacency probe (#2153b — caught, with >50-line padding to isolate the arm-b-only shape from arm-a).

## Verification

- `bash -n` clean on both scripts.
- `--self-test` PASS on both scripts.
- Both gates run clean (`PASS`, zero false positives) against this branch's full `src/` + `tests/` tree — including the six legit `test_env_lock` production sites and the real `#[cfg(test)]` multi-line-raw-string fixtures already in `src/`.

Script-only change; no cargo gates apply. No CHANGELOG entry (matches the precedent of the parent commits 61cf7fae / 3456149e, which are dev-tooling/internal, not user-facing).

Closes #2151
Closes #2152
Closes #2153

## Test plan

- [x] `bash -n scripts/check-test-stdin-reads.sh` / `scripts/check-test-env-lock.sh`
- [x] `scripts/check-test-stdin-reads.sh --self-test` → PASS
- [x] `scripts/check-test-env-lock.sh --self-test` → PASS
- [x] `scripts/check-test-stdin-reads.sh` (clean tree) → PASS
- [x] `scripts/check-test-env-lock.sh` (clean tree) → PASS
- [ ] CI green on the PR (c8-precheck.yml gate jobs)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY