### PR TITLE
test(#2176,#2177,#2055): pin fingerprint-gate degenerate/model-implied axes + link-relation footgun docs

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -107,6 +107,27 @@ const PREFIX_SCHEME_NOMIC_TASK_V1: &str = "nomic-task-v1";
 /// NEVER collide, so the gate can produce a false MISMATCH (→ a safe
 /// local re-embed) but NEVER a false MATCH (→ corruption): degrade, never
 /// corrupt (#2168 CORE INVARIANT). M-STRONG-TYPES-GUARD.
+///
+/// **[#2177] The `#<prefix_scheme>` axis is MODEL-IMPLIED, not an
+/// independently transmitted wire value.** Both sides (the receiver's own
+/// fingerprint AND its canonicalisation of the shipped `model` string) call
+/// the SAME [`Embedder::model_requires_nomic_prefix`] predicate against the
+/// (folded) model id — the scheme is a pure function of the id, computed
+/// locally, never read off the wire. This is intentional and is what keeps
+/// the gate wire-back-compat with zero wire changes across DIFFERENT model
+/// ids. The residual: it CANNOT discriminate two peers on the SAME model id
+/// whose binaries apply DIFFERENT prefix behaviour (e.g. a future release
+/// that starts sending `task_type` for a role-asymmetric model this
+/// predicate doesn't yet know about, or any future edit to the
+/// `model_requires_nomic_prefix` table) — such a divergence would silently
+/// mint the SAME fingerprint on both sides today. Promoting an explicit
+/// `prefix_scheme` field onto the wire (`ShippedEmbedding`, additive +
+/// `#[serde(default)]`) so a sender can assert its scheme independently of
+/// the receiver's local derivation is DEFERRED to v1.x (tracked by #2177);
+/// until then, this function is the SSOT for the implication and
+/// `space_fingerprint_2168_tests::prefix_scheme_is_derived_from_model_id_2177`
+/// pins it so a future change to the predicate can't silently drift this
+/// axis without the test catching it.
 //
 // #2167 GENERALISATION (shared SSOT for federation-gate + per-row write-stamp +
 // recall-gate + adoption): the body below keeps #2168's prose-strip AND adds
@@ -248,6 +269,55 @@ mod space_fingerprint_2168_tests {
             embedding_space_fingerprint("  Nomic-Embed-Text (768-dim, remote)  "),
             embedding_space_fingerprint("nomic-embed-text"),
         );
+    }
+
+    /// **[#2177]** Pins the model→prefix-scheme implication explicitly:
+    /// the `#<scheme>` half of the fingerprint is NOT an independently
+    /// transmitted axis — it is always exactly
+    /// `super::Embedder::model_requires_nomic_prefix(<canonical id>)`
+    /// re-derived from the fingerprint's own id half. This test fails the
+    /// moment a future change makes the fingerprint compute the scheme via
+    /// a DIFFERENT code path than the local embed-prefix decision (the
+    /// prose in [`super::embedding_space_fingerprint`] documents WHY this
+    /// coupling exists and what the deferred v1.x explicit-field follow-up
+    /// looks like).
+    #[test]
+    fn prefix_scheme_is_derived_from_model_id_2177() {
+        let cases = [
+            // (input, expect nomic-task-v1 scheme)
+            ("nomic-embed-text", true),
+            ("nomic-embed-text-v1.5", true),
+            ("nomic-ai/nomic-embed-text-v1.5", true),
+            ("granite-embedding", false),
+            ("bge-base-en-v1.5", false),
+            ("all-MiniLM-L6-v2", false),
+            ("sentence-transformers/all-MiniLM-L6-v2", false),
+        ];
+        for (model, expect_nomic_scheme) in cases {
+            let fp = embedding_space_fingerprint(model);
+            let (id, scheme) = fp
+                .split_once('#')
+                .unwrap_or_else(|| panic!("fingerprint {fp:?} missing '#' separator"));
+            // The scheme axis must equal a FRESH call of the same
+            // #1520 predicate against the fingerprint's own (canonical,
+            // post-fold) id — i.e. the scheme is model-IMPLIED, never an
+            // independently-set value.
+            let recomputed = super::Embedder::model_requires_nomic_prefix(id);
+            assert_eq!(
+                recomputed, expect_nomic_scheme,
+                "model={model} id={id} scheme={scheme}"
+            );
+            let expected_scheme = if recomputed {
+                super::PREFIX_SCHEME_NOMIC_TASK_V1
+            } else {
+                super::PREFIX_SCHEME_NONE
+            };
+            assert_eq!(
+                scheme, expected_scheme,
+                "model={model}: fingerprint scheme must equal \
+                 model_requires_nomic_prefix(id) — the axis is model-implied (#2177)"
+            );
+        }
     }
 }
 

--- a/src/models/link.rs
+++ b/src/models/link.rs
@@ -148,6 +148,41 @@ impl std::fmt::Display for AttestLevel {
 /// helpers exist because the column is read as a `String` in many
 /// call sites that are not deserialising through serde (e.g.
 /// `rusqlite::Row::get`).
+///
+/// # ⚠️ FOOTGUN: `DerivedFrom` (`derived_from`) vs `DerivesFrom`
+/// (`derives_from`) — NOT duplicates, OPPOSITE directions ([#2055])
+///
+/// These two variants differ by a single character (`derived` vs
+/// `derives`) and are trivially confused by anyone authoring links,
+/// reading a KG traversal, or reasoning about the [`Self::LINEAGE`]
+/// trio — but they carry **opposite cardinalities and opposite
+/// authorship**:
+///
+/// | Variant | Wire slug | Cardinality | Produced by | Direction |
+/// |---|---|---|---|---|
+/// | [`Self::DerivedFrom`] | `derived_from` | **N → 1** (many sources, one result) | consolidation-merge | `source_id` = the merged memory, `target_id` = a source it absorbed |
+/// | [`Self::DerivesFrom`] | `derives_from` | **1 → N** (one source, many results) | atomisation-split | `source_id` = an atom, `target_id` = the parent it was split from |
+///
+/// Worked example — consolidating memories A + B into C, then
+/// atomising C into atoms X + Y, emits exactly these four edges:
+///
+/// ```text
+/// C --derived_from--> A     (consolidation: C ABSORBED A)
+/// C --derived_from--> B     (consolidation: C ABSORBED B)
+/// X --derives_from--> C     (atomisation: X was SPLIT OUT of C)
+/// Y --derives_from--> C     (atomisation: Y was SPLIT OUT of C)
+/// ```
+///
+/// Neither variant is a duplicate of the other and **NEITHER MAY BE
+/// RENAMED**: both wire slugs are persisted in `memory_links.relation`,
+/// enumerated in the SQL-side CHECK constraint
+/// (`crate::validate::VALID_RELATIONS`), and serialized over the wire —
+/// a rename is a breaking migration + wire change (tracked separately;
+/// coordinate with any future v1.x follow-up before touching either
+/// spelling). When authoring a link, read the table above rather than
+/// pattern-matching on the variant name's prefix.
+///
+/// [#2055]: https://github.com/alphaonedev/ai-memory-mcp/issues/2055
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryLinkRelation {
@@ -213,6 +248,13 @@ impl MemoryLinkRelation {
     /// to reject with a typed error or fall back to a default. The
     /// canonical strings are the SQL-side CHECK constraint membership
     /// list — keep this list in sync with the migration.
+    ///
+    /// ⚠️ Authoring a link by hand (e.g. `MemoryLinkRelation::from_str("derived_from")`)?
+    /// Double-check you want `"derived_from"` and not `"derives_from"` —
+    /// see the FOOTGUN section of [`MemoryLinkRelation`]'s type-level doc
+    /// comment before picking one; the names differ by a single character
+    /// but point in OPPOSITE directions (`derived_from` = N→1
+    /// consolidation-merge, `derives_from` = 1→N atomisation-split).
     #[must_use]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {

--- a/tests/federation_2168_embed_fingerprint.rs
+++ b/tests/federation_2168_embed_fingerprint.rs
@@ -322,6 +322,81 @@ async fn foreign_model_shipped_vector_not_stored_verbatim_deferred_2168() {
 }
 
 // ---------------------------------------------------------------------------
+// 1b. Empty/degenerate model string, SAME dim → deferred local re-embed;
+//     the empty-string wire value NEVER short-circuits into a false MATCH
+//     (#2176, [#2168 Fable audit] regression-hardening follow-up).
+//
+//     `embedding_space_fingerprint("")` canonicalises to `"#none"`, which
+//     can never equal the receiver's own fingerprint (its `id` half is
+//     always non-empty — `model_description()` always names a real model),
+//     so the only accepting path is exact equality with the receiver's
+//     derived fingerprint. This pins that degenerate-wire-value disposition
+//     as a regression proof rather than leaving it to code-reading: a
+//     future refactor that special-cases an absent/empty model string as
+//     "legacy sender, accept" would be caught here.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_model_string_shipped_vector_not_stored_verbatim_deferred_2176() {
+    let _g = env_lock();
+    // SAFETY: env mutation under env_lock for the test's duration.
+    unsafe {
+        std::env::set_var(REQUIRE_SIG_ENV, "0");
+    }
+    // Receiver runs nomic-768; its local re-embed returns the distinctive
+    // LOCAL_REEMBED_FILL vector.
+    let ollama = mock_ollama_embed(768, LOCAL_REEMBED_FILL, Duration::ZERO).await;
+    let embedder = build_nomic_embedder(&ollama.uri());
+    let dim = embedder.dim();
+    let rx = build_receiver(Some(embedder));
+
+    let mem = sample_memory("empty-model-1");
+    // A SAME-DIMENSION (768) unit-norm vector shipped with an EMPTY
+    // `model` string — the degenerate/absent-fingerprint wire value.
+    // Passes the dim + #1584 norm gates; must still fail the #2168
+    // fingerprint gate (fingerprint("") = "#none" != the receiver's
+    // non-empty nomic fingerprint).
+    let empty_model_vec = unit_norm_fill(dim);
+    let shipped = vec![ShippedEmbedding::new(
+        mem.id.clone(),
+        String::new(),
+        empty_model_vec.clone(),
+    )];
+    let body = push_body(std::slice::from_ref(&mem), &shipped);
+    let (status, v) = post_push(&rx.router, serde_json::to_vec(&body).unwrap()).await;
+    assert_eq!(status, StatusCode::OK, "push must be acked: {v}");
+    // CRDT-safe: the row still lands even though its degenerate-model
+    // vector is refused.
+    assert_eq!(v["applied"], 1, "row must land (CRDT convergence): {v}");
+
+    // The deferred local re-embed lands the receiver's OWN vector.
+    let stored = wait_for_embedding(&rx.db, &mem.id, Duration::from_secs(10))
+        .await
+        .expect("deferred local re-embed must populate the row");
+    assert_eq!(stored.len(), dim, "stored vector is receiver-dim");
+
+    // INVARIANT: the stored embedding is the LOCAL re-embed, never the
+    // empty-model shipped vector.
+    assert!(
+        (stored[0] - LOCAL_REEMBED_FILL).abs() < 1e-6,
+        "stored[0] must be the LOCAL re-embed fill, got {}",
+        stored[0]
+    );
+    assert_ne!(
+        stored, empty_model_vec,
+        "an empty-model-string shipped vector must NEVER be stored verbatim (#2176/#2168)"
+    );
+    assert!(
+        embed_calls(&ollama).await >= 1,
+        "empty-model fingerprint mismatch must trigger the deferred local re-embed"
+    );
+
+    unsafe {
+        std::env::remove_var(REQUIRE_SIG_ENV);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 2. Matching model → stored verbatim (no #1566 perf regression).
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three small, non-blocking follow-ups (docs + test-only, no production behavior change):

- **Closes #2176** — [#2168 Fable audit] adds an empty-model-string regression test (`empty_model_string_shipped_vector_not_stored_verbatim_deferred_2176`) to `tests/federation_2168_embed_fingerprint.rs`, cloned from the existing foreign-model test. Pins that `embedding_space_fingerprint("")` (`"#none"`) can never false-MATCH a real receiver's fingerprint, so a same-dim vector shipped with an empty/degenerate `model` string still routes to the deferred local re-embed and the foreign vector is never stored verbatim (CRDT-safe row landing preserved).

- **Closes #2177** — [#2168 Fable audit] adds an explicit doc-comment to `embedding_space_fingerprint` (`src/embeddings.rs`) pinning that the `#<prefix_scheme>` axis is **model-implied**, not an independently transmitted wire value: both sides derive it by calling `Embedder::model_requires_nomic_prefix` on the (folded) model id. Documents the residual (same model id, divergent binary prefix behavior, cannot be discriminated today) and notes the promoted-typed-field fix is DEFERRED to v1.x per the issue. Adds `prefix_scheme_is_derived_from_model_id_2177`, a test that fails if a future change routes the fingerprint's scheme computation through a different code path than the local embed-prefix decision.

- **Closes #2055** — [#1833 finding] adds a type-level FOOTGUN doc-comment on `MemoryLinkRelation` (`src/models/link.rs`) contrasting `DerivedFrom`/`derived_from` (N→1 consolidation-merge) against `DerivesFrom`/`derives_from` (1→N atomisation-split) with a worked 4-edge example, plus a doc-warning on `from_str` pointing authors at the distinction before they pick a relation string. Neither wire slug is renamed (both are persisted/CHECK-constrained/serialized — a rename would be a breaking migration); this is purely additive clarification.

## Files
- `src/embeddings.rs` — doc-comment + `prefix_scheme_is_derived_from_model_id_2177` test
- `src/models/link.rs` — `MemoryLinkRelation` type-level FOOTGUN doc + `from_str` doc-warning
- `tests/federation_2168_embed_fingerprint.rs` — `empty_model_string_shipped_vector_not_stored_verbatim_deferred_2176` test

## Test plan
- [x] `cargo test --lib embeddings::space_fingerprint_2168_tests` — 6/6 pass (incl. new `prefix_scheme_is_derived_from_model_id_2177`)
- [x] `cargo test --lib link::` — 65/65 pass (no regressions to `models::link` unit tests)
- [x] `cargo test --test federation_2168_embed_fingerprint` — 5/5 pass (incl. new `empty_model_string_shipped_vector_not_stored_verbatim_deferred_2176`)
- [x] `cargo check --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo clippy --all-targets --features sal -- -D warnings -D clippy::pedantic` — clean
- [x] No `qual_10`/`qual_6_7` ceiling table entries reference the touched files — no lockstep bump needed
- [ ] CI full gate matrix (watching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182xSSVeBxMzhqGaBgH4MVz