### PR TITLE
test(#2165,#2159): serialize env/permissions test races onto crate-canonical locks

### DIFF
--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -404,6 +404,17 @@ mod tests {
     use super::*;
 
     fn fresh() -> Connection {
+        // #2159 — `db::open` reads process-global env (e.g.
+        // `AI_MEMORY_REQUIRE_ROLLBACK_CHECK`, consulted by the open-time
+        // rollback-evidence check). Another test in the same `--lib`
+        // process (e.g. `security_profile::tests::asi_hard_*`) mutates
+        // that var under the shared `crate::config::test_env_lock`
+        // cohort; without also holding it here, a parallel-scheduled open
+        // can observe the var mid-mutation and spuriously refuse to open
+        // an in-memory DB (no pinnable off-table head anchor). Serialise
+        // against every env-mutating test in the crate, not just this
+        // module's own tests.
+        let _guard = crate::config::test_env_lock();
         crate::storage::open(std::path::Path::new(":memory:")).expect("open in-memory db")
     }
 

--- a/src/security_profile.rs
+++ b/src/security_profile.rs
@@ -339,11 +339,20 @@ pub fn enforce_at_boot() -> Result<(SecurityPosture, Vec<PinReport>)> {
 mod tests {
     use super::*;
 
-    /// Process-wide guard: these tests mutate `AI_MEMORY_*` env vars, which
-    /// races with any other test that reads them. Serialise them.
-    fn env_lock() -> &'static std::sync::Mutex<()> {
-        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    /// Serialize env mutations against every other `AI_MEMORY_*`-mutating
+    /// test in the crate, not just this module's own tests (#2159, residual
+    /// of the #1998→#2115→#2127 env-isolation class). A module-local mutex
+    /// only covers this module's own `--test-threads>1` races; it still
+    /// races the shared `test_env_lock` cohort in `src/embeddings.rs` /
+    /// `src/reranker.rs` / `src/config.rs` / `src/cli/commands/config.rs` /
+    /// `src/cli/rules.rs` / `src/recover/transcript_paths.rs`, so this
+    /// delegates to the single crate-canonical
+    /// [`crate::config::test_env_lock`]. Every knob this module pins
+    /// (including `AI_MEMORY_REQUIRE_ROLLBACK_CHECK`) is a process-global
+    /// env var a concurrently-running test elsewhere in the `--lib` binary
+    /// (e.g. `routines::tests`) can observe mid-mutation without this.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::config::test_env_lock()
     }
 
     /// Clear every knob env var + the profile selector so a test starts
@@ -357,6 +366,22 @@ mod tests {
             for (env, _) in pinned_knobs() {
                 std::env::remove_var(env);
             }
+        }
+    }
+
+    /// RAII guard: on drop, clears every knob + the profile selector.
+    /// Installed immediately after the entry-state `clear_all()` in every
+    /// test below so a mid-test panic (an `assert!`/`unwrap()` failure)
+    /// still restores the baseline instead of leaking a pinned knob (e.g.
+    /// `AI_MEMORY_REQUIRE_ROLLBACK_CHECK=1`) into whatever test runs next
+    /// in the same `--lib` process (#2159). Must be declared AFTER the
+    /// `env_lock()` guard in each test so it drops (and clears) BEFORE the
+    /// lock releases.
+    struct KnobsGuard;
+    impl Drop for KnobsGuard {
+        fn drop(&mut self) {
+            // SAFETY: constructed only while the caller holds `env_lock()`.
+            unsafe { clear_all() };
         }
     }
 
@@ -383,8 +408,9 @@ mod tests {
 
     #[test]
     fn standard_posture_is_a_noop() {
-        let _g = env_lock().lock().unwrap();
+        let _g = env_lock();
         unsafe { clear_all() };
+        let _cleanup = KnobsGuard;
         let (posture, reports) = enforce_at_boot().unwrap();
         assert_eq!(posture, SecurityPosture::Standard);
         assert!(reports.is_empty(), "standard posture must pin nothing");
@@ -392,14 +418,16 @@ mod tests {
         for (env, _) in pinned_knobs() {
             assert!(std::env::var(env).is_err(), "{env} must remain unset");
         }
-        unsafe { clear_all() };
     }
 
     #[test]
     fn asi_hard_pins_every_unset_knob() {
-        let _g = env_lock().lock().unwrap();
+        let _g = env_lock();
         unsafe {
             clear_all();
+        }
+        let _cleanup = KnobsGuard;
+        unsafe {
             std::env::set_var(ENV_SECURITY_PROFILE, "asi-hard");
         }
         let (posture, reports) = enforce_at_boot().unwrap();
@@ -419,14 +447,16 @@ mod tests {
             "asi-hard must pin PRAGMA synchronous to FULL"
         );
         assert!(is_asi_hard());
-        unsafe { clear_all() };
     }
 
     #[test]
     fn asi_hard_accepts_already_compliant_values() {
-        let _g = env_lock().lock().unwrap();
+        let _g = env_lock();
         unsafe {
             clear_all();
+        }
+        let _cleanup = KnobsGuard;
+        unsafe {
             std::env::set_var(ENV_SECURITY_PROFILE, "asi-hard");
             // Operator already set the hard value (and a STRONGER one for
             // synchronous) — must be accepted, not refused.
@@ -446,14 +476,16 @@ mod tests {
         assert_eq!(sync.action, PinAction::AlreadyCompliant);
         // EXTRA (stronger than FULL) is preserved, not overwritten.
         assert_eq!(std::env::var("AI_MEMORY_DB_SYNCHRONOUS").unwrap(), "EXTRA");
-        unsafe { clear_all() };
     }
 
     #[test]
     fn asi_hard_refuses_a_loosening_override() {
-        let _g = env_lock().lock().unwrap();
+        let _g = env_lock();
         unsafe {
             clear_all();
+        }
+        let _cleanup = KnobsGuard;
+        unsafe {
             std::env::set_var(ENV_SECURITY_PROFILE, "asi-hard");
             // Attempt to DISABLE the credential screen under asi-hard.
             std::env::set_var("AI_MEMORY_SECRET_SCREEN_MODE", "off");
@@ -464,20 +496,21 @@ mod tests {
             msg.contains("asi-hard") && msg.contains("AI_MEMORY_SECRET_SCREEN_MODE"),
             "refusal must name the posture + knob: {msg}"
         );
-        unsafe { clear_all() };
     }
 
     #[test]
     fn asi_hard_refuses_a_falsy_boolean_override() {
-        let _g = env_lock().lock().unwrap();
+        let _g = env_lock();
         unsafe {
             clear_all();
+        }
+        let _cleanup = KnobsGuard;
+        unsafe {
             std::env::set_var(ENV_SECURITY_PROFILE, "asi-hard");
             std::env::set_var("AI_MEMORY_REQUIRE_WITNESS", "0");
         }
         let err = enforce_at_boot().unwrap_err();
         assert!(format!("{err}").contains("AI_MEMORY_REQUIRE_WITNESS"));
-        unsafe { clear_all() };
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -22102,8 +22102,19 @@ mod tests {
         let _gate = lock_permissions_mode_for_test();
         override_active_permissions_mode_for_test(PermissionsMode::Enforce);
         clear_active_permission_rules_for_test();
+        // #2165 — this rule used to be namespace_pattern "**" (matching
+        // EVERY namespace). Since `_gate` only serialises against other
+        // `lock_permissions_mode_for_test()` holders, a sibling test that
+        // does NOT take that lock (e.g. storage::tests::ck_trigger_* /
+        // create_link_* success-path tests) could interleave with THIS
+        // test's live Enforce+Deny window under parallel `cargo test --lib`
+        // scheduling and see its own unrelated link create wrongly refused.
+        // Scoping the pattern to this test's own "a3-fed" namespace (the
+        // only namespace this test writes into) preserves full coverage —
+        // peer_attested still bypasses a namespace-matching Deny — while
+        // eliminating collateral denial of every other storage test.
         set_active_permission_rules(vec![PermissionRule {
-            namespace_pattern: "**".to_string(),
+            namespace_pattern: "a3-fed".to_string(),
             op: "memory_link".to_string(),
             agent_pattern: "*".to_string(),
             decision: RuleDecision::Deny,
@@ -25136,6 +25147,18 @@ mod tests {
         // The CHECK trigger fires on UPDATE as well as INSERT — a
         // post-hoc UPDATE that flips an unsigned row to self_signed
         // without supplying signature bytes must be refused.
+        //
+        // #2165 — same shared-state race as
+        // `ck_trigger_admits_unsigned_with_null_signature`: this test's
+        // `create_link_signed(...).unwrap()` seed-write is equally exposed
+        // to `a3_create_link_inbound_peer_attested_bypasses_governance`'s
+        // transient global deny-all-links rule. Hold the same gate.
+        let _gate = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Off,
+        );
+        crate::permissions::clear_active_permission_rules_for_test();
+
         let conn = test_db();
         let s = make_memory("ck-upd-src", "test", Tier::Long, 5);
         let t = make_memory("ck-upd-tgt", "test", Tier::Long, 5);
@@ -25159,6 +25182,21 @@ mod tests {
         // peer_attested — the unsigned path with NULL signature
         // (the v0.6.4 default) must still admit. Negative-control
         // test pinning the trigger's narrow scope.
+        //
+        // #2165 — `a3_create_link_inbound_peer_attested_bypasses_governance`
+        // installs a process-wide `**`/`memory_link`/Deny rule under
+        // `lock_permissions_mode_for_test()` for the duration of its body.
+        // Without holding the same gate here, a parallel `cargo test --lib`
+        // scheduler can interleave this test's `create_link_signed` call
+        // inside that window and see the unsigned create wrongly refused.
+        // Pin mode to Off + clear rules so we observe a clean baseline
+        // (either pre- or post-a3, never mid-a3).
+        let _gate = crate::config::lock_permissions_mode_for_test();
+        crate::config::override_active_permissions_mode_for_test(
+            crate::config::PermissionsMode::Off,
+        );
+        crate::permissions::clear_active_permission_rules_for_test();
+
         let conn = test_db();
         let s = make_memory("ck-unsigned-src", "test", Tier::Long, 5);
         let t = make_memory("ck-unsigned-tgt", "test", Tier::Long, 5);

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -330,7 +330,7 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // space/unverified counters + aggregated WARN) + the §5 boot adoption /
     // §6 census / embedding_space_boot_maintenance helpers land
     // storage/mod.rs at 25_504; ceiling 25_650 (+146 headroom).
-    ("src/storage/mod.rs", 25_650),
+    ("src/storage/mod.rs", 25_750), /* 2026-07-18 #2165 test-isolation comments on the ck_trigger_* / a3-fed permissions-race fix (25_686) */
     // 2026-06-10 (#1579 B6/F5.6, storage lane) — the embed-backfill
     // sweep converted from whole-backlog materialisation to a bounded
     // drain loop over `get_unembedded_ids_batch` (+ the no-progress


### PR DESCRIPTION
Closes #2165
Closes #2159

Fixes two `--lib` parallel-scheduling test races.

- **#2159** — unify `routines::tests` + `security_profile::tests` env locking onto the crate-canonical `crate::config::test_env_lock()`; add a panic-safe `KnobsGuard` RAII so a failing test can't leak a pinned integrity knob (`AI_MEMORY_REQUIRE_ROLLBACK_CHECK`) into the next test.
- **#2165** — scope `a3_create_link_...`'s global `"**"`/`memory_link`/Deny rule to its own `"a3-fed"` namespace, and make the `ck_trigger_*` tests hold `lock_permissions_mode_for_test()` + pin mode Off so they see a clean baseline.

Test-only (3 test modules). `storage/mod.rs` qual_10 ceiling bumped 25_650→25_750 in lockstep. Gates green locally (fmt, clippy sal/pedantic, check --all-targets sal, qual_10, qual_6_7).

## AI involvement
Authored by an AI NHI agent (Sonnet 5 fix, Opus 4.8 orchestrator finish + review) under the v1.0.0 autonomous loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182xSSVeBxMzhqGaBgH4MVz