### PR TITLE
docs(#2034): consolidate GitHub Pages to v0.8.1-v1.0.0 + retire legacy test-campaign Pages links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
 [![Tests](https://img.shields.io/badge/tests-2%2C400%2B_%E2%80%A2_%E2%89%A592%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
-[![Test Hub](https://img.shields.io/badge/test--hub-live_results-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-test-hub/)
-[![Discovery Gate](https://img.shields.io/badge/discovery--gate-6%2F6_PASS_%E2%80%A2_GATE_GREEN-2ea043?logo=githubpages)](https://alphaonedev.github.io/ai-memory-discovery-gate/)
-[![v0.6.4 Cert](https://img.shields.io/badge/v0.6.4_cert-CERT_GREEN-2ea043?logo=githubpages)](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md)
+[![Evidence Hub](https://img.shields.io/badge/evidence--hub-campaigns-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-mcp/evidence/)
+[![v0.6.4 Cert](https://img.shields.io/badge/v0.6.4_cert-CERT_GREEN-2ea043?logo=github)](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md)
 [![MCP](https://img.shields.io/badge/MCP-7_default_%E2%80%A2_103_full-blueviolet)]()
 [![NSA CSI](https://img.shields.io/badge/NSA_CSI_MCP-10%2F10_concerns_%E2%80%A2_7%2F7_recs-2ea043)](https://alphaonedev.github.io/ai-memory-mcp/compliance/nsa-csi-mcp.html)
 [![Evidence v0.6.4](https://img.shields.io/badge/claims-frozen_v0.6.4-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
@@ -767,7 +766,7 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (93 route registrations 
 - **Color CLI output** -- ANSI tier labels (red/yellow/green), priority bars, bold titles, cyan namespaces
 
 ### Quality
-- **~10,000 tests across the full surface** -- roughly 6,712 `#[test]`/`#[tokio::test]` attributes under `src/` (5,759 `#[test]` + 953 `#[tokio::test]`) plus roughly 3,362 under `tests/` (2,138 `#[test]` + 1,224 `#[tokio::test]`), grown from the v0.6.4-era ~2,400-test baseline (1,960 lib + 211 integration + 16 mcp_integration + 4 webhook_http_parity + 16 recipe_contract + ~150 across other binary targets). Line coverage held above the **≥92% project bar**; net-new v0.6.4 modules at 100% (`sizes.rs`), 99.50% (`profile.rs`), 97.58% (`cli/audit.rs`), 97.05% (`cli/doctor.rs`), 92.56% (`handlers.rs`), 92.26% (`cli/install.rs`). v0.6.3.x baselines (1,809 / 93.08% and 1,886 / 93.84%) remain frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.4 metrics in the release notes and on the [test-hub campaign](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md). Empirical NHI discovery acceptance proven separately by the [Discovery Gate](https://alphaonedev.github.io/ai-memory-discovery-gate/) (T1–T4 matrix vs. live xAI Grok 4.3, 6/6 PASS, **GATE GREEN**).
+- **~10,000 tests across the full surface** -- roughly 6,712 `#[test]`/`#[tokio::test]` attributes under `src/` (5,759 `#[test]` + 953 `#[tokio::test]`) plus roughly 3,362 under `tests/` (2,138 `#[test]` + 1,224 `#[tokio::test]`), grown from the v0.6.4-era ~2,400-test baseline (1,960 lib + 211 integration + 16 mcp_integration + 4 webhook_http_parity + 16 recipe_contract + ~150 across other binary targets). Line coverage held above the **≥92% project bar**; net-new v0.6.4 modules at 100% (`sizes.rs`), 99.50% (`profile.rs`), 97.58% (`cli/audit.rs`), 97.05% (`cli/doctor.rs`), 92.56% (`handlers.rs`), 92.26% (`cli/install.rs`). v0.6.3.x baselines (1,809 / 93.08% and 1,886 / 93.84%) remain frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.4 metrics in the release notes and on the [test-hub campaign](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md). Empirical NHI discovery acceptance proven separately by the Discovery Gate (T1–T4 matrix vs. live xAI Grok 4.3, 6/6 PASS, **GATE GREEN**) — see the [Evidence Hub](https://alphaonedev.github.io/ai-memory-mcp/evidence/) (the `ai-memory-discovery-gate` Pages site is retired per #2034).
 - **LongMemEval benchmark** -- **97.0% R@5** pure FTS5 keyword (LLM-independent, 2.2 seconds, 232 q/s, zero API costs) on the ICLR 2025 LongMemEval-S dataset; LLM query expansion with the current-generation Gemma 4 model measures **97.2% R@5 / 99.6% R@10 / 99.8% R@20** (cloud-API venue; the historical `gemma3:4b` 97.8% figure is retired as headline per [#1975](https://github.com/alphaonedev/ai-memory-mcp/issues/1975)). See [benchmark details](benchmarks/longmemeval/).
 - **MCP Prompts** -- `recall-first` and `memory-workflow` prompts teach AI clients to use memory proactively
 - **TOON-default** -- recall/list/search responses use TOON compact by default (79% smaller than JSON)
@@ -842,7 +841,7 @@ ai-memory bench                      # human-readable table
 ai-memory bench --json               # machine-parseable
 ```
 
-Substrate is unchanged across v0.6.3.x → v0.6.4 (the `quiet-tools` release ships a smaller default tool surface, not a different hot-path). p99 targets here remain informational pending the next dedicated soak window; latest soak evidence is on the [test hub](https://alphaonedev.github.io/ai-memory-test-hub/).
+Substrate is unchanged across v0.6.3.x → v0.6.4 (the `quiet-tools` release ships a smaller default tool surface, not a different hot-path). p99 targets here remain informational pending the next dedicated soak window; latest soak evidence is on the [Evidence Hub](https://alphaonedev.github.io/ai-memory-mcp/evidence/) (the `ai-memory-test-hub` Pages site is retired per #2034).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,17 +8,17 @@ layout: doc
 ## 🎯 Current release · **v0.9.0** (`secure-default hardening`) · ≥92% line coverage (ratchet pinned in [`.coverage-baseline`](../.coverage-baseline))
 
 [![Release](https://img.shields.io/badge/release-v0.9.0-brightgreen?logo=github)](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.9.0)
-[![A2A Gate](https://img.shields.io/badge/A2A_gate-9%2F9_green-brightgreen)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)
-[![Ship Gate](https://img.shields.io/badge/ship_gate-green-brightgreen)](https://alphaonedev.github.io/ai-memory-ship-gate/)
 [![crates.io](https://img.shields.io/crates/v/ai-memory)](https://crates.io/crates/ai-memory)
 
 **v0.6.3** cleared the a2a-gate certification bar (three consecutive full-testbook green runs across three agent frameworks and three transport modes — **324 passing scenarios**, zero partial greens); **v0.7.0** layers on the attested-cortex epic (Ed25519 attestation, 25-event hook pipeline, postgres+AGE first-class backend, schema v57). Full release notes: [`v0.7.0/release-notes.md`](v0.7.0/release-notes.html).
 
 **📦 [Release v0.9.0](https://github.com/alphaonedev/ai-memory-mcp/releases/tag/v0.9.0)** ·
-**📊 [A2A gate (umbrella spec)](https://alphaonedev.github.io/ai-memory-ai2ai-gate/)** ·
-**🚢 [Ship gate](https://alphaonedev.github.io/ai-memory-ship-gate/)** ·
-**📖 [AI-NHI insights](https://alphaonedev.github.io/ai-memory-ai2ai-gate/insights/)** ·
-**🐳 [Reproduce locally](https://alphaonedev.github.io/ai-memory-ai2ai-gate/local-docker-mesh/)**
+**🧪 [Evidence Hub (campaigns)](evidence/)** ·
+**📊 [Frozen Claims](evidence.html)**
+
+> The v0.6.x-era A2A-gate / Ship-gate GitHub Pages sites (`ai-memory-ai2ai-gate`,
+> `ai-memory-ship-gate`) are retired as of the v1.0.0 docs consolidation
+> (#2034) — their evidence is indexed on the [Evidence Hub](evidence/) above.
 
 </div>
 

--- a/docs/a2a-messaging.html
+++ b/docs/a2a-messaging.html
@@ -163,11 +163,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -226,11 +221,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/agent-identity.html
+++ b/docs/agent-identity.html
@@ -150,11 +150,6 @@ blockquote strong{color:var(--p1)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -213,11 +208,6 @@ blockquote strong{color:var(--p1)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures-t1.html
+++ b/docs/architectures-t1.html
@@ -180,11 +180,6 @@ table tr:last-child td{border-bottom:none}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -243,11 +238,6 @@ table tr:last-child td{border-bottom:none}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures-t2.html
+++ b/docs/architectures-t2.html
@@ -179,11 +179,6 @@ table tr:last-child td{border-bottom:none}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -242,11 +237,6 @@ table tr:last-child td{border-bottom:none}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures-t3.html
+++ b/docs/architectures-t3.html
@@ -179,11 +179,6 @@ table tr:last-child td{border-bottom:none}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -242,11 +237,6 @@ table tr:last-child td{border-bottom:none}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures-t4.html
+++ b/docs/architectures-t4.html
@@ -176,11 +176,6 @@ table tr:last-child td{border-bottom:none}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -239,11 +234,6 @@ table tr:last-child td{border-bottom:none}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures-t5.html
+++ b/docs/architectures-t5.html
@@ -176,11 +176,6 @@ table tr:last-child td{border-bottom:none}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -239,11 +234,6 @@ table tr:last-child td{border-bottom:none}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/architectures.html
+++ b/docs/architectures.html
@@ -170,11 +170,6 @@ section p{margin-bottom:.85rem}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -233,11 +228,6 @@ section p{margin-bottom:.85rem}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/archival.html
+++ b/docs/archival.html
@@ -167,11 +167,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -230,11 +225,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -827,11 +827,6 @@ footer.site-foot a { color: var(--text-muted); }
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>

--- a/docs/autonomous.html
+++ b/docs/autonomous.html
@@ -183,11 +183,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -246,11 +241,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/batman-active-mode.html
+++ b/docs/batman-active-mode.html
@@ -171,11 +171,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -234,11 +229,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/compliance/_inventory/mcp-registry-submission.json
+++ b/docs/compliance/_inventory/mcp-registry-submission.json
@@ -104,7 +104,7 @@
     "longmemeval_r_at_20_smart": 0.998,
     "longmemeval_dataset": "ICLR 2025 LongMemEval-S (500 questions, 6 categories)",
     "ship_gate_evidence_url": "https://alphaonedev.github.io/ai-memory-mcp/evidence.html",
-    "discovery_gate_url": "https://alphaonedev.github.io/ai-memory-discovery-gate/",
+    "discovery_gate_url": "https://alphaonedev.github.io/ai-memory-mcp/evidence/",
     "a2a_gate_status": "48/48 PASS across 4 channels (mTLS verified)"
   },
   "compliance_evidence": {

--- a/docs/credits.html
+++ b/docs/credits.html
@@ -148,11 +148,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -211,11 +206,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/data-flow.html
+++ b/docs/data-flow.html
@@ -167,11 +167,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -230,11 +225,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/encryption.html
+++ b/docs/encryption.html
@@ -174,11 +174,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -237,11 +232,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/engineering-discipline.html
+++ b/docs/engineering-discipline.html
@@ -181,11 +181,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -244,11 +239,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -158,11 +158,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html" class="current">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -182,10 +177,8 @@ footer a{color:var(--text-muted)}
       No other page invents its own counts. If a number on another page disagrees with this page, this page is correct and the other is a bug — please <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/new">file an issue</a>.
     </p>
     <div style="display:flex;justify-content:center;gap:.75rem;flex-wrap:wrap;margin-top:1.75rem">
-      <a href="https://alphaonedev.github.io/ai-memory-test-hub/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--p1);color:var(--p1);background:rgba(110,231,255,.06);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;font-weight:600;text-decoration:none">🧪 Live test-hub →</a>
-      <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--p2);color:var(--p2);background:rgba(255,184,107,.06);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;font-weight:600;text-decoration:none">📊 v0.6.3 release evidence (historical) →</a>
-      <a href="https://alphaonedev.github.io/ai-memory-ship-gate/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--text-muted);color:var(--text-muted);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;text-decoration:none">🚢 ship-gate</a>
-      <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--text-muted);color:var(--text-muted);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;text-decoration:none">🤝 A2A-gate</a>
+      <a href="evidence/" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--p1);color:var(--p1);background:rgba(110,231,255,.06);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;font-weight:600;text-decoration:none">🧪 Evidence Hub (campaigns) →</a>
+      <a href="performance.html" style="display:inline-block;padding:.65rem 1.25rem;border:1px solid var(--text-muted);color:var(--text-muted);border-radius:6px;font-family:var(--font-mono);font-size:.9rem;text-decoration:none">📊 Performance budgets</a>
     </div>
   </div>
 </section>
@@ -302,8 +295,8 @@ footer a{color:var(--text-muted)}
     <table class="facts">
       <thead><tr><th>Certification</th><th>Status</th><th>Authority</th></tr></thead>
       <tbody>
-        <tr><td>A2A-Certified (internal)</td><td class="num">Yes</td><td class="src"><a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A gate</a> · v0.6.2 + v0.6.3 — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
-        <tr><td>Ship-Gate (internal)</td><td class="num">Yes</td><td class="src"><a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship gate</a> · 9/9 cert + 5/5 channels green at v0.6.2 cut — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
+        <tr><td>A2A-Certified (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ai2ai-gate">A2A gate</a> (repo, Pages site retired per #2034) · v0.6.2 + v0.6.3 — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
+        <tr><td>Ship-Gate (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ship-gate">Ship gate</a> (repo, Pages site retired per #2034) · 9/9 cert + 5/5 channels green at v0.6.2 cut — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
         <tr><td>SOC 2</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
         <tr><td>ISO 27001</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
         <tr><td>FedRAMP</td><td class="num">No</td><td class="src">No authorization. Do not represent.</td></tr>
@@ -312,9 +305,13 @@ footer a{color:var(--text-muted)}
     </table>
 
     <div class="callout">
-      <strong>Ship-Gate / A2A-Gate currency note (#1938 Gate-0 W3, 2026-07-11).</strong>
-      The linked Ship-Gate and A2A-Gate pages are separate GitHub Pages sites
-      (<code>ai-memory-ship-gate</code>, <code>ai-memory-ai2ai-gate</code> repos) whose
+      <strong>Ship-Gate / A2A-Gate currency note (#1938 Gate-0 W3, 2026-07-11;
+      Pages-retirement update #2034).</strong>
+      Ship-Gate and A2A-Gate were previously separate GitHub Pages sites
+      (<code>ai-memory-ship-gate</code>, <code>ai-memory-ai2ai-gate</code> repos);
+      those Pages sites are retired as of the v1.0.0 docs consolidation
+      (#2034) — the certification rows above now cite the source repos
+      directly instead of the retired Pages URLs. Their
       last full 4-phase cell run is the v0.6.2/v0.6.3 cut cited above — neither was
       re-run as a full 4-phase cell for v0.7.0, v0.8.0, v0.8.1, or v0.9.0.
       <strong>v0.9.0 shipped under a one-time recorded descope of the 4-phase

--- a/docs/evidence/index.html
+++ b/docs/evidence/index.html
@@ -72,9 +72,6 @@ footer{padding:2rem 1.5rem;text-align:center;color:var(--text-dim);font-size:.85
     <div class="right">
       <a href="../evidence.html">Frozen Claims</a>
       <a href="./" style="color:var(--text);font-weight:600">Evidence Hub</a>
-      <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-      <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-      <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub →</a>
     </div>
   </div>

--- a/docs/feature-matrix.html
+++ b/docs/feature-matrix.html
@@ -248,11 +248,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -312,11 +307,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/for-everyone.html
+++ b/docs/for-everyone.html
@@ -181,11 +181,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -245,11 +240,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/governance.html
+++ b/docs/governance.html
@@ -194,11 +194,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -257,11 +252,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/hierarchies.html
+++ b/docs/hierarchies.html
@@ -168,11 +168,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -231,11 +226,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/import-history.html
+++ b/docs/import-history.html
@@ -150,11 +150,6 @@ blockquote strong{color:var(--p2)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -213,11 +208,6 @@ blockquote strong{color:var(--p2)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,11 +284,6 @@ footer .legal{margin-top:.5rem;font-size:.78rem;color:var(--text-dim)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -356,11 +351,6 @@ footer .legal{margin-top:.5rem;font-size:.78rem;color:var(--text-dim)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -163,11 +163,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -227,11 +222,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/knowledge-graph.html
+++ b/docs/knowledge-graph.html
@@ -170,11 +170,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -233,11 +228,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/lifecycle.html
+++ b/docs/lifecycle.html
@@ -159,11 +159,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -222,11 +217,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/memory-rules.html
+++ b/docs/memory-rules.html
@@ -168,11 +168,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -231,11 +226,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/memory-tiers.html
+++ b/docs/memory-tiers.html
@@ -182,11 +182,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -245,11 +240,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -161,11 +161,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -224,11 +219,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/release-pipeline.html
+++ b/docs/release-pipeline.html
@@ -189,11 +189,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -252,11 +247,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/release-v0.7.1.html
+++ b/docs/release-v0.7.1.html
@@ -81,6 +81,9 @@ footer a:hover{color:var(--accent)}
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="inner">

--- a/docs/schema.html
+++ b/docs/schema.html
@@ -168,11 +168,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -231,11 +226,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/tracing.html
+++ b/docs/tracing.html
@@ -174,11 +174,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -237,11 +232,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/ttl-controls.html
+++ b/docs/ttl-controls.html
@@ -163,11 +163,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -226,11 +221,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/types.html
+++ b/docs/types.html
@@ -173,11 +173,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -236,11 +231,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/v070-architecture.html
+++ b/docs/v070-architecture.html
@@ -71,6 +71,9 @@ footer a{color:var(--muted)}
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="row">

--- a/docs/v070-changelog.html
+++ b/docs/v070-changelog.html
@@ -67,6 +67,9 @@ footer a{color:var(--muted)}
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="row">

--- a/docs/validators.html
+++ b/docs/validators.html
@@ -164,11 +164,6 @@ footer a{color:var(--text-muted)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -227,11 +222,6 @@ footer a{color:var(--text-muted)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/whats-new-v063.html
+++ b/docs/whats-new-v063.html
@@ -132,6 +132,9 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="inner">
@@ -202,11 +205,6 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -265,11 +263,6 @@ footer{padding:3rem 1.5rem;text-align:center;font-size:.85rem;color:var(--text-d
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>

--- a/docs/whats-new-v064.html
+++ b/docs/whats-new-v064.html
@@ -88,6 +88,9 @@ footer{padding:2.5rem 1.5rem;text-align:center;color:var(--text-dim);font-size:.
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="inner">

--- a/docs/whats-new-v07.html
+++ b/docs/whats-new-v07.html
@@ -104,6 +104,9 @@ footer a:hover{color:var(--accent)}
 </style>
 </head>
 <body>
+<div style="background:#3a2a0a;border-bottom:2px solid #ffb86b;color:#ffe4b5;padding:.85rem 1.25rem;text-align:center;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:.88rem;line-height:1.5">
+  <strong>&#9888; Archived release page.</strong> This page documents a pre-v0.8.1 release and is kept for historical reference only (retirement per <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2034" style="color:#ffe4b5;text-decoration:underline">#2034</a>). For the current v0.8.1&nbsp;&rarr;&nbsp;v1.0.0 documentation, see <a href="whats-new-v09.html" style="color:#ffe4b5;text-decoration:underline">what's new in v0.9.0</a> or the <a href="index.html" style="color:#ffe4b5;text-decoration:underline">documentation home</a>.
+</div>
 
 <nav class="topnav">
   <div class="inner">

--- a/docs/whats-new-v08.html
+++ b/docs/whats-new-v08.html
@@ -115,7 +115,7 @@ footer a:hover{color:var(--accent)}
       <a href="whats-new-v08.html" class="active">v0.8.0</a>
       <a href="whats-new-v07.html">v0.7.0 (prior release)</a>
       <a href="coordination.html" style="color:#c8a2ff">Coordination</a>
-      <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:#2ea043">Discovery Gate</a>
+      <a href="evidence/" style="color:#2ea043">Evidence Hub</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
     </div>
   </div>
@@ -480,7 +480,7 @@ ai-memory doctor</pre>
         <span class="tag">Quality gate</span>
         <h3>Validated end-to-end</h3>
         <p>Full CI matrix green on the release commit &mdash; Linux/macOS/Windows, the SQLite <strong>and</strong> PostgreSQL+AGE feature gates, <code>clippy -D pedantic</code> + <code>fmt</code>, per-module coverage, iOS/Android cross-compile, MSRV (Rust 1.96), Docker build, <code>cargo audit</code> clean. Validated by a P0&ndash;P11 multi-agent validation, a 2-round external-model security review (every finding fixed), and a live agent-to-agent campaign across heterogeneous models &mdash; zero defects.</p>
-        <p><a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:var(--good)">Discovery Gate &rarr;</a></p>
+        <p><a href="evidence/" style="color:var(--good)">Evidence Hub &rarr;</a></p>
       </div>
     </div>
   </div>

--- a/docs/whats-new-v09.html
+++ b/docs/whats-new-v09.html
@@ -124,7 +124,7 @@ footer a:hover{color:var(--accent)}
       <a href="whats-new-v09.html" class="active">v0.9.0</a>
       <a href="whats-new-v08.html">v0.8.0 (prior release)</a>
       <a href="governance.html" style="color:#2ea043">Governance</a>
-      <a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:#2ea043">Discovery Gate</a>
+      <a href="evidence/" style="color:#2ea043">Evidence Hub</a>
       <a href="https://github.com/alphaonedev/ai-memory-mcp">GitHub</a>
     </div>
   </div>
@@ -482,7 +482,7 @@ footer a:hover{color:var(--accent)}
         <span class="tag">Quality gate</span>
         <h3>Reviewed &amp; validated end-to-end</h3>
         <p>Full CI matrix green on the release commit &mdash; Linux/macOS/Windows, the SQLite <strong>and</strong> PostgreSQL+AGE feature gates, <code>clippy -D pedantic</code> + <code>fmt</code>, per-module coverage, iOS/Android cross-compile, MSRV, Docker build, <code>cargo audit</code> clean. Hardened by a five-lane adversarial code + security review whose 49 findings were each fixed and pinned by a regression test.</p>
-        <p><a href="https://alphaonedev.github.io/ai-memory-discovery-gate/" style="color:var(--good)">Discovery Gate &rarr;</a></p>
+        <p><a href="evidence/" style="color:var(--good)">Evidence Hub &rarr;</a></p>
       </div>
     </div>
   </div>

--- a/docs/zero-touch-trust.html
+++ b/docs/zero-touch-trust.html
@@ -146,11 +146,6 @@ blockquote strong{color:var(--p1)}
         <div class="menu-pane">
           <a href="evidence.html">Frozen Claims</a>
           <a href="evidence/">Evidence Hub (campaigns)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-          <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-          <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
           <a href="performance.html">Performance budgets</a>
           <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         </div>
@@ -209,11 +204,6 @@ blockquote strong{color:var(--p1)}
         <div class="mnav-group">Evidence</div>
         <a href="evidence.html">Frozen Claims</a>
         <a href="evidence/">Evidence Hub (campaigns)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/">Test Hub</a>
-        <a href="https://alphaonedev.github.io/ai-memory-a2a-v0.6.3.1/">v0.6.3.1 A2A (live)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-test-hub/releases/v0.6.3/">v0.6.3 evidence (historical)</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ship-gate/">Ship Gate</a>
-        <a href="https://alphaonedev.github.io/ai-memory-ai2ai-gate/">A2A Gate</a>
         <a href="performance.html">Performance budgets</a>
         <a href="https://github.com/alphaonedev/ai-memory-mcp/blob/main/benchmarks/longmemeval/results.md">LongMemEval variants</a>
         <div class="mnav-group">More</div>


### PR DESCRIPTION
## Summary

Docs-only PR (`docs/` GitHub Pages site content). No Rust/product changes.

- **Site-wide "Evidence" nav** — stripped the direct links to the legacy per-release test-campaign GitHub Pages sites (`ai-memory-test-hub`, `ai-memory-ship-gate`, `ai-memory-ai2ai-gate`, `ai-memory-a2a-v0.6.3.1`) from the recurring nav dropdown across every currently-live `docs/*.html` page (37 pages × desktop+mobile nav). Replaced with the internal Evidence Hub (`docs/evidence/`), which already indexes v0.7.0 → v0.9.0 campaign evidence. Same treatment applied to `docs/evidence.html`'s CTA buttons and `docs/evidence/index.html`'s own topnav.
- **`docs/evidence.html` certification citations** (A2A-gate / Ship-Gate rows + currency-note callout) now link the source GitHub repos instead of the retiring Pages sites, with an explicit "Pages site retired per #2034" note — the underlying self-attested-security claims and honest currency caveats are preserved verbatim.
- **`whats-new-v08.html` / `whats-new-v09.html`** (the currently-live v0.8.1→v1.0.0-span pages) had their one remaining Discovery Gate Pages link repointed to the Evidence Hub.
- **Top-level `README.md` and `docs/README.md`** — badges/links to the legacy test-hub/discovery-gate/ai2ai-gate/ship-gate Pages sites replaced with internal Evidence Hub links (or GitHub repo links for inline citations), each noting the retirement.
- **`docs/compliance/_inventory/mcp-registry-submission.json`** — `discovery_gate_url` now points at the internal Evidence Hub instead of the retiring Pages URL (compliance-evidence integrity preserved, JSON validated).
- **Six pre-v0.8.1 per-version pages retired-in-place** (`whats-new-v063.html`, `whats-new-v064.html`, `whats-new-v07.html`, `release-v0.7.1.html`, `v070-architecture.html`, `v070-changelog.html`): added a visible "Archived release page" banner linking forward to the current docs, per the issue's archive-over-delete policy. Their historical links to the legacy Pages sites are left intact as part of the archived record — rewriting them would misrepresent when/how the historical claims were made.

## Deliberately out of scope

- **Legacy per-release test-campaign *repos*** (`ai-memory-test-hub`, `ai-memory-ai2ai-gate`, `ai-memory-ship-gate`, `ai-memory-a2a-v0.6.3.1`, `ai-memory-discovery-gate`, `ai-memory-a2a-v0.7.0`, `ai-memory-curator-soak`) are **not** archived/deleted by this PR — per the issue's hard sequencing constraint, Pages cleanup must land first; repo archival/deletion is an operator-actioned follow-up.
- Deep versioned dev-process subdirectories (`docs/v0.6.4/`, `docs/v0.7/`, `docs/v0.7.0/`, migration guides, `RUNBOOK-*.md`) are untouched — not reachable from the live site nav; their references are historical dev-process artifacts, mostly already GitHub-repo (not Pages) links.
- Hero headline wording and "current release" version badges are untouched — v1.0.0 has not tagged yet, so the site correctly still shows v0.9.0 as current.

## Verification

- Relative-href resolver pass over every changed file — no internal links broken by this change.
- `scripts/check-docs-vs-ssot.sh` — PASS (no numeric-claim drift; this PR cites no SSOT counts).
- `scripts/check-vendor-literals.sh` — PASS.
- `scripts/check-hardcoded-literals.sh` — PASS.
- `docs/compliance/_inventory/mcp-registry-submission.json` — validated as parseable JSON post-edit.

## Test plan

- [x] Grep-verified zero remaining `alphaonedev.github.io/ai-memory-{test-hub,discovery-gate,ship-gate,ai2ai-gate,a2a-v0.6.3.1}` references outside the six intentionally-archived legacy pages.
- [x] No dead internal links introduced (href resolver check).
- [ ] CI green on this branch (watching).

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182xSSVeBxMzhqGaBgH4MVz