### PR TITLE
fix(#2240): correct tr reverse-range in ci-test-impact.sh tokenise

### DIFF
--- a/scripts/ci-test-impact.sh
+++ b/scripts/ci-test-impact.sh
@@ -139,7 +139,7 @@ tokenise() {
     {
         printf '%s\n' "$stem"
         printf '%s\n' "$full"
-    } | tr '_-./' '\n' | awk '
+    } | tr '_./-' '\n' | awk '
         length($0) >= 3 \
         && $0 !~ /^(rs|src|lib|mod|tests|test|the|and|for|use|with|core|util|utils|main)$/ {
             print tolower($0)


### PR DESCRIPTION
## Summary

`scripts/ci-test-impact.sh:142` tokenised paths with `tr '_-./' '\n'`. Inside
a `tr` SET, `_-.` is parsed as a character RANGE from `_` (0x5F) to `.`
(0x2E), which is REVERSE in ASCII collating order. GNU coreutils `tr`
(every Linux dev host and the ubuntu CI runners) errors out on this:

```
tr: range-endpoints of '_-.' are in reverse collating sequence order
```

**Effect:** `tokenise()` silently produced empty output on every call, so
`compute_impact()` always saw an empty impact set for any non-foundational
diff and fell back to `__ALL__` (safe but wasteful — every CI Check job ran
the full 495-test suite instead of the targeted subset). Separately,
`--self-test` died mid-run at the first tokenise self-test case and exited
1 without printing the pass/fail summary, so the self-test could not be
wired into CI as a load-bearing gate (pm-v3.2 discipline).

**Fix:** reorder the character class so `-` is not interpretable as a range
operator — `tr '_./-' '\n'` places the hyphen last (POSIX-portable
literal-hyphen-last discipline). One-line change; no other behavior change.

## Evidence

Before (reproduced against `release/v1.0.0` HEAD, matches the issue's
repro exactly):

```
$ bash scripts/ci-test-impact.sh --self-test
  PASS  Cargo.toml is foundational
  ... (8 PASS lines)
tr: range-endpoints of '_-.' are in reverse collating sequence order
$ echo $?
1
```

After:

```
$ bash scripts/ci-test-impact.sh --self-test
  PASS  Cargo.toml is foundational
  PASS  src/lib.rs is foundational
  PASS  src/validate.rs is foundational
  PASS  migrations.rs is foundational
  PASS  handlers/memories.rs is NOT foundational
  PASS  handlers/admin.rs is NOT foundational
  PASS  tests/foo.rs is NOT foundational
  PASS  .github/workflows/ci.yml IS foundational
  PASS  tokenise(memories_query) → split + denoised
  PASS  tokenise(admin) → denoised
  PASS  compute_impact(handlers/admin.rs) includes admin_*
  PASS  compute_impact always includes route_count_invariant

[self-test] 12 passed / 0 failed
$ echo $?
0
```

Representative-path tokenise checks (manual, no tr errors):
- `src/storage/mod.rs` → `storage`
- `tests/foo_bar.rs` → `foo`, `bar`

Sample selection behavior — real diff against `src/handlers/admin.rs`
(non-foundational):

- Before: `tokenise` crashes → empty impact set → `test_impact=__ALL__`,
  `test_impact_reason=empty-impact-fallback`
- After: `test_impact_count=27`, `test_impact_total=495`,
  `test_impact_reason=impact-selected:27/495 (94%-skip)` — a real targeted
  subset instead of the full suite.

Fallback-path sanity (still safe): a foundational-file diff (`src/lib.rs`)
still correctly forces `test_impact=__ALL__`,
`test_impact_reason=foundational:src/lib.rs` — the fail-safe direction is
unchanged, only the previously-dead selector now actually selects.

## AI involvement
- Agent: Claude Sonnet 5 (easy-coder tier)
- Authority class: Trivial (CI-infra script fix, no Rust/production surface)
- Human approver(s) for Sensitive items: n/a
- Memory entries created/updated: `3ff498df-ab41-4280-b0fa-b91956649548` (ai-memory-mcp namespace, operator-directive record)

## Test plan
- [x] `bash scripts/ci-test-impact.sh --self-test` — 12 passed / 0 failed, exit 0
- [x] shellcheck — not available in this environment; no dedicated CI shellcheck job gates `scripts/*.sh` (actionlint runs with `-shellcheck=` disabled per `.github/workflows/ci.yml`)
- [x] Manual tokenise() spot-checks against representative paths
- [x] End-to-end sample selection behavior (before/after) verified against real diffs
- [x] Fallback-to-`__ALL__` path re-verified safe on a foundational-file diff
- N/A cargo fmt/clippy/test/audit — this PR touches only `scripts/ci-test-impact.sh` (bash), no Rust surface

## Linked issues
Closes #2240