### PR TITLE
test(#2285): serialize synthesis prompt-telemetry tests behind a shared lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tests/form_1_synthesis.rs` test-isolation flake on the synthesis prompt-size telemetry counter** ([#2285](https://github.com/alphaonedev/ai-memory-mcp/issues/2285), observed on [#2283](https://github.com/alphaonedev/ai-memory-mcp/pull/2283) CI run 29852909319). `run_synthesis_pass` (`src/mcp/tools/store/synthesis.rs`) calls `build_prompt_with_cap` — which records the process-global `SYNTHESIS_PROMPT_MAX_CHARS` running-max telemetry counter — unconditionally whenever a store engages synthesis, BEFORE any K9 recheck / delete-cap / failure-mode disposition. Only the two dedicated PERF tests that assert an exact count on that counter held the pre-existing `prompt_max_chars_lock()` guard; every other synthesis-engaging test in the file (14 of them) wrote the same global counter without holding it, so under cargo's default parallel test runner one of those writer tests could land a larger max between an asserting test's prompt build and its `assert_eq!`, producing an intermittent failure. Test-only fix: every test whose `run_store`/`run_store_with_embedder` call reaches `run_synthesis_pass` now takes the same shared `prompt_max_chars_lock()` guard for the duration of the test. No production code changed.
+
 ### CI
 
 - **Build-script vetting claims are now mechanically pinned** ([#2259](https://github.com/alphaonedev/ai-memory-mcp/issues/2259); pre-ship 3x7 Wave-B). The formal supply-chain record now covers the actual `reed-solomon-simd` 3.1.0 `build.rs` and its `readme-rustdocifier` 0.1.1 build dependency (including that helper's own build script and full source): both are documentation-only `README.md` → `OUT_DIR` transforms with no network/process/unsafe/native-probe behavior. `scripts/check-build-script-vetting.py`, run in CI, fails on checksum, custom-build-target, or exact build-dependency-closure drift so a future "no build scripts"-style claim cannot rest on an unchecked assumption.

--- a/tests/form_1_synthesis.rs
+++ b/tests/form_1_synthesis.rs
@@ -212,6 +212,15 @@ const BASE_CONTENT: &str = "This is a substantial body so the AUTONOMY_MIN_CONTE
 /// insert; the new row exists alongside the existing candidate.
 #[test]
 fn verb_add_proceeds_with_insert() {
+    // #2285 — `run_store` below engages real synthesis (a candidate is
+    // seeded), which calls `build_prompt_with_cap` and writes the
+    // process-global `SYNTHESIS_PROMPT_MAX_CHARS` running-max counter.
+    // Serialize against the tests that assert an exact count on that
+    // counter so this test's write can't land mid-assert.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     // Seed and incoming share keyword tokens so the FTS pre-filter
     // surfaces the seeded row as a candidate. Titles differ enough
@@ -259,6 +268,13 @@ fn verb_add_proceeds_with_insert() {
 /// candidate with `merged_content` and SKIPs the new-row insert.
 #[test]
 fn verb_update_rewrites_existing_and_skips_insert() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let existing_id = seed_existing(
         &conn,
@@ -333,6 +349,13 @@ fn verb_update_rewrites_existing_and_skips_insert() {
 /// proceeds with the standard insert.
 #[test]
 fn verb_delete_removes_candidate_and_inserts_new() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let existing_id = seed_existing(
         &conn,
@@ -378,6 +401,13 @@ fn verb_delete_removes_candidate_and_inserts_new() {
 /// insert; both rows survive.
 #[test]
 fn verb_no_op_keeps_candidate_and_inserts_new() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let existing_id = seed_existing(
         &conn,
@@ -597,6 +627,12 @@ fn synthesis_delete_verdict_consults_k9_per_candidate() {
     let _g = k9_synthesis_rules_lock()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // #2285 — `run_store` below engages real synthesis and writes the
+    // process-global `SYNTHESIS_PROMPT_MAX_CHARS` running-max counter;
+    // serialize against the tests that assert an exact count on it.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
 
     let (conn, db_path) = open_db();
     let ns = "ns-k9-recheck";
@@ -665,6 +701,14 @@ fn synthesis_delete_verdict_consults_k9_per_candidate() {
 /// `GOVERNANCE_REFUSED` envelope. No candidate is deleted.
 #[test]
 fn synthesis_unbounded_delete_refused_without_k10_approval() {
+    // #2285 — `run_store` below builds the synthesis prompt (and thus
+    // writes the process-global prompt-size telemetry counter) before
+    // the per-call delete cap is checked on the returned verdict, even
+    // though this test expects the write to ultimately refuse.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-unbounded-delete";
     // No policy installed → default cap of 1 applies.
@@ -727,6 +771,13 @@ fn synthesis_unbounded_delete_refused_without_k10_approval() {
 /// the legacy fall-through.
 #[test]
 fn synthesis_response_carries_synthesis_failed_on_llm_error() {
+    // #2285 — the prompt is built (and the process-global prompt-size
+    // telemetry counter written) before the mocked LLM call fails, so
+    // this test still needs to serialize against the asserting tests.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-failed-flag";
     // Default policy: fall_through.
@@ -832,6 +883,13 @@ fn synthesis_prompt_truncates_candidate_content_at_cap() {
 /// error instead of silently falling through.
 #[test]
 fn synthesis_block_write_namespace_refuses_on_curator_down() {
+    // #2285 — the prompt is built (and the process-global prompt-size
+    // telemetry counter written) before the mocked LLM call fails, so
+    // this test still needs to serialize against the asserting tests.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-block-write";
     install_synthesis_policy(
@@ -884,6 +942,13 @@ fn synthesis_block_write_namespace_refuses_on_curator_down() {
 /// the substrate-state assertion is the load-bearing check.
 #[test]
 fn synthesis_multi_update_verdict_honors_all_updates() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-multi-update";
 
@@ -1121,6 +1186,12 @@ fn synthesis_delete_verdict_k9_ask_skips_candidate() {
     let _g = k9_synthesis_rules_lock()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // #2285 — `run_store` below engages real synthesis and writes the
+    // process-global `SYNTHESIS_PROMPT_MAX_CHARS` running-max counter;
+    // serialize against the tests that assert an exact count on it.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
 
     let (conn, db_path) = open_db();
     let ns = "ns-k9-ask-synthesis";
@@ -1179,6 +1250,13 @@ fn synthesis_delete_verdict_k9_ask_skips_candidate() {
 /// (lines 670-679).
 #[test]
 fn synthesis_update_plus_delete_combined_applies_both() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-update-plus-delete";
     let id_update = seed_existing(
@@ -1302,6 +1380,12 @@ impl ai_memory::embeddings::Embed for IntegrationMockEmbedder {
 fn synthesis_update_with_embedder_re_embeds_merged_content() {
     use ai_memory::hnsw::VectorIndex;
 
+    // #2285 — `run_store_with_embedder` below engages real synthesis and
+    // writes the process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-update-embed";
     let id_update = seed_existing(
@@ -1367,6 +1451,13 @@ fn synthesis_update_with_embedder_re_embeds_merged_content() {
 /// row with relation='supersedes' from the new memory id → target id.
 #[test]
 fn issue_1239_synthesis_update_emits_supersedes_link() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-1239-update";
     let target_id = seed_existing(
@@ -1450,6 +1541,13 @@ fn issue_1239_synthesis_update_emits_supersedes_link() {
 ///      never have run, leaving the candidate alive).
 #[test]
 fn issue_1239_synthesis_delete_reinsert_emits_supersedes_link() {
+    // #2285 — see `verb_add_proceeds_with_insert` for why this guard is
+    // needed: `run_store` engages real synthesis and writes the
+    // process-global prompt-size telemetry counter.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-1239-delete-reinsert";
     let target_id = seed_existing(
@@ -1602,6 +1700,14 @@ fn issue_1240_synthesis_depth_guard_refuses_at_depth_4() {
 /// confirm the counter starts at 0 in the absence of a parent scope.
 #[test]
 fn issue_1240_synthesis_depth_guard_admits_depth_under_cap() {
+    // #2285 — unlike its depth=4-refusal sibling above, this test runs
+    // the synthesis pass to completion (depth=1, under the cap), so
+    // `run_store` writes the process-global prompt-size telemetry
+    // counter and must serialize against the asserting tests.
+    let _prompt_telemetry_guard = prompt_max_chars_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     let (conn, db_path) = open_db();
     let ns = "ns-1240-under-cap";
     let _seed = seed_existing(&conn, "kubernetes deployment notes", "prior body", ns);


### PR DESCRIPTION
## Summary

Fixes the `tests/form_1_synthesis.rs` test-isolation flake reported in #2285, observed on PR #2283 CI run [29852909319](https://github.com/alphaonedev/ai-memory-mcp/actions/runs/29852909319) (a docs-only diff — nothing in that PR's own change caused this).

**Root cause.** `run_synthesis_pass` (`src/mcp/tools/store/synthesis.rs:102`) calls `synthesise_with_cap` → `build_prompt_with_cap` **unconditionally** whenever a store call engages synthesis (a matching candidate exists), and `build_prompt_with_cap` records the process-global `SYNTHESIS_PROMPT_MAX_CHARS` running-max telemetry counter. This happens **before** any K9 delete-recheck, per-call delete-cap refusal, or curator-failure-mode disposition — so even a test whose store call ultimately *refuses* or *fails* still writes the global counter.

Only the two dedicated PERF tests that assert an exact count on that counter (`synthesis_prompt_truncates_candidate_content_at_cap`, `synthesis_prompt_format_reuse_byte_identical`) held the pre-existing `prompt_max_chars_lock()` guard (added in #788/PERF-16). The other 14 synthesis-engaging tests in the same file wrote the same global counter **without** holding that lock, so under cargo's default parallel test runner one of those tests could land a bigger max between an asserting test's prompt build and its `assert_eq!`, producing an intermittent failure that never reproduces in isolation.

## Fix (test-only)

Every test whose `run_store` / `run_store_with_embedder` call reaches `run_synthesis_pass` now takes the same shared `prompt_max_chars_lock()` guard (`.lock().unwrap_or_else(|p| p.into_inner())`, poison-tolerant so a panicked test can't cascade-poison the lock for the rest of the suite) for the duration of the test:

- `verb_add_proceeds_with_insert`
- `verb_update_rewrites_existing_and_skips_insert`
- `verb_delete_removes_candidate_and_inserts_new`
- `verb_no_op_keeps_candidate_and_inserts_new`
- `synthesis_delete_verdict_consults_k9_per_candidate` (also holds `k9_synthesis_rules_lock()`, consistent acquire order — no deadlock)
- `synthesis_unbounded_delete_refused_without_k10_approval`
- `synthesis_response_carries_synthesis_failed_on_llm_error`
- `synthesis_block_write_namespace_refuses_on_curator_down`
- `synthesis_multi_update_verdict_honors_all_updates`
- `synthesis_delete_verdict_k9_ask_skips_candidate` (also holds `k9_synthesis_rules_lock()`, same order)
- `synthesis_update_plus_delete_combined_applies_both`
- `synthesis_update_with_embedder_re_embeds_merged_content`
- `issue_1239_synthesis_update_emits_supersedes_link`
- `issue_1239_synthesis_delete_reinsert_emits_supersedes_link`
- `issue_1240_synthesis_depth_guard_admits_depth_under_cap` (runs synthesis to completion at depth=1)

Two tests were confirmed to NOT need the lock (verified against source): `synthesis_parse_response_round_trips` never calls `run_store`, and `issue_1240_synthesis_depth_guard_refuses_at_depth_4` refuses `SYNTHESIS_DEPTH_EXCEEDED` **before** `run_synthesis_pass` is ever invoked (`src/mcp/tools/store/mod.rs:613`).

No production code changed — only `tests/form_1_synthesis.rs` and a `CHANGELOG.md` entry.

## Evidence

`AI_MEMORY_NO_CONFIG=1 cargo test --test form_1_synthesis` at default parallelism, 10 loop iterations — 19/19 passed every run, zero `LOOP-FAIL`:

```
LOOP 1: test result: ok. 19 passed; 0 failed
LOOP 2: test result: ok. 19 passed; 0 failed
LOOP 3: test result: ok. 19 passed; 0 failed
LOOP 4: test result: ok. 19 passed; 0 failed
LOOP 5: test result: ok. 19 passed; 0 failed
LOOP 6: test result: ok. 19 passed; 0 failed
LOOP 7: test result: ok. 19 passed; 0 failed
LOOP 8: test result: ok. 19 passed; 0 failed
LOOP 9: test result: ok. 19 passed; 0 failed
LOOP 10: test result: ok. 19 passed; 0 failed
```

Also ran once with `-- --test-threads=8` explicitly — 19/19 passed.

Gates: `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` clean (default features); `cargo clippy --all-targets --features sal -- -D warnings -D clippy::pedantic` clean; `cargo check --examples --all-targets` clean; `cargo check --all-targets --features sal` clean; `cargo check --all-targets --features sal-postgres` clean; `scripts/check-docs-vs-ssot.sh` PASS.

## AI involvement

This PR was authored by an AI agent (Sonnet 5, easy-coder tier) under the ai-memory-mcp v1.0.0 GA campaign, dispatched to investigate and fix a pre-diagnosed test-isolation flake. The root-cause analysis (lock coverage gap in `run_synthesis_pass`'s unconditional prompt-build) was independently re-verified by reading `src/mcp/tools/store/synthesis.rs` and `src/mcp/tools/store/mod.rs` before making changes, rather than taken on faith from the dispatch brief. Test plan: 10x default-parallelism loop + 1x explicit `--test-threads=8` (see Evidence above), plus the full local gate suite.

Closes #2285

🤖 Generated with [Claude Code](https://claude.com/claude-code)