### PR TITLE
infra(#2298): point do-hive IronClaw at nearai/ironclaw v0.29.1 + grok-4.5

### DIFF
--- a/infra/do-hive/cloud-init-agent.yaml.tpl
+++ b/infra/do-hive/cloud-init-agent.yaml.tpl
@@ -11,7 +11,7 @@ write_files:
     permissions: '0644'
     content: |
       [Unit]
-      Description=IronClaw v0.28.1 agent #${agent_index} (Track E1 hive)
+      Description=IronClaw v0.29.1 agent #${agent_index} (Track E1 hive)
       After=network-online.target
       Wants=network-online.target
 
@@ -22,7 +22,7 @@ write_files:
       Environment=AI_MEMORY_AGENT_ID=hive-e1-agent-${agent_index}
       Environment=AI_MEMORY_HTTP=http://${memory_private_ip}:9077
       Environment=XAI_API_KEY=__OPERATOR_INJECTED_AT_BOOT__
-      ExecStart=/opt/ironclaw/bin/ironclaw --provider openai-compatible --base-url https://api.x.ai/v1 --model grok-4.3
+      ExecStart=/opt/ironclaw/bin/ironclaw --provider openai-compatible --base-url https://api.x.ai/v1 --model grok-4.5
       Restart=on-failure
       RestartSec=5
 

--- a/infra/do-hive/main.tf
+++ b/infra/do-hive/main.tf
@@ -128,9 +128,9 @@ variable "ai_memory_image_url" {
 }
 
 variable "ironclaw_image_url" {
-  description = "URL to the IronClaw v0.28.1 runner tarball."
+  description = "URL to the IronClaw v0.29.1 runner tarball."
   type        = string
-  default     = "https://github.com/alphaonedev/ironclaw/releases/download/v0.28.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
+  default     = "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.29.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `infra/do-hive/main.tf` `ironclaw_image_url` default pointed at `github.com/alphaonedev/ironclaw`, a repo that **does not exist** (`gh repo view` -> could not resolve to a Repository). Cloud-init's `curl -fsSL` at boot would 404 and silently provision a bare agent droplet with no IronClaw installed -- the same silent-failure class as #1880.
- Repoints the default tarball URL to the canonical NearAI distribution `github.com/nearai/ironclaw` at the current stable release tag `ironclaw-v0.29.1` (note the tag segment is `ironclaw-v0.29.1`, not `v0.29.1` -- both org and tag format were wrong).
- Bumps the `ironclaw_image_url` variable description and the cloud-init systemd unit's `Description=` comment from `v0.28.1` to `v0.29.1` for cosmetic consistency.
- Switches the IronClaw `ExecStart` xAI model flag from `--model grok-4.3` to `--model grok-4.5` per operator directive (DO A2A uses Grok 4.5).

`infra/aws-gpu-burst/` carries the identical nonexistent-org URL (`main.tf:94`) and the same stale `v0.28.1` description/comment, but per the issue body it is explicitly out of scope for this fix (flagged only; E2 track is withdrawn from active scope per CLAUDE.md).

## Files changed

- `infra/do-hive/main.tf` (lines 131, 133)
- `infra/do-hive/cloud-init-agent.yaml.tpl` (lines 14, 25)

## Exact strings changed

| File:line | Before | After |
|---|---|---|
| `main.tf:131` | `"URL to the IronClaw v0.28.1 runner tarball."` | `"URL to the IronClaw v0.29.1 runner tarball."` |
| `main.tf:133` | `https://github.com/alphaonedev/ironclaw/releases/download/v0.28.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz` | `https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.29.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz` |
| `cloud-init-agent.yaml.tpl:14` | `Description=IronClaw v0.28.1 agent #${agent_index} (Track E1 hive)` | `Description=IronClaw v0.29.1 agent #${agent_index} (Track E1 hive)` |
| `cloud-init-agent.yaml.tpl:25` | `--model grok-4.3` | `--model grok-4.5` |

Grep-confirmed no other `alphaonedev/ironclaw`, `v0.28.1`, or `grok-4.3` occurrences remain in either file.

## AI involvement

Implemented end-to-end by the Sonnet 5 easy-coder tier in the ai-memory-mcp v1.0.0 autonomous loop, dispatched to fix issue #2298. All edits are plain-text literal swaps (URL, tag, model id, comment) with no logic changes; verified via `scripts/check-cloud-init-ascii.sh`, `terraform validate`, and a Python YAML re-parse of the templated cloud-init file. No code review beyond the automated gates below was performed by this agent; human/downstream review requested before merge.

## Test plan

- [x] `bash scripts/check-cloud-init-ascii.sh` -- PASS (`check-cloud-init-ascii: OK (all cloud-init templates are pure ASCII)`)
- [x] `terraform -chdir=infra/do-hive validate` -- `Success! The configuration is valid.`
- [x] `terraform -chdir=infra/do-hive fmt -check -diff` -- pre-existing formatting diffs on unrelated lines (138, 215-217) confirmed present on `release/v1.0.0` HEAD before this change (not introduced by this PR)
- [x] `python3 -c "import yaml; yaml.safe_load(open('infra/do-hive/cloud-init-agent.yaml.tpl').read())"` -- parses cleanly
- [x] `bash scripts/check-vendor-literals.sh` -- PASS
- [x] `git status --short` -- confirms only the two intended files modified, no `.terraform/`/lock-file leakage (both gitignored)

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY