### PR TITLE
fix(#2371): lease sweeper emits signed_events coordination audit per reclaimed lease (both backends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (COORDINATION-AUDIT lane, roadmap-3x7 findings)
+
+- **Lease sweeper now emits a `signed_events` coordination-audit entry per reclaimed lease on both backends** ([#2371](https://github.com/alphaonedev/ai-memory-mcp/issues/2371)) — the FORCED reclamation of an expired coordination lease was the ONE lease op with no forensic trace (the voluntary acquire/renew/release ops all append signed-chain rows), so the ROADMAP "sweeper … emits `signed_events` audit entry" claim was false. The sqlite `sweep_expired_leases` now returns the reclaimed `(action_id, holder)` pairs via an atomic `DELETE … RETURNING`, and the new `sweep_expired_leases_audited` wrapper (driven by `background::lease_sweep` + the `SqliteStore` SAL path) appends one `coordination.lease_expire_reclaim` row per reclaimed lease attributed to the reclaimed holder; the postgres `lease_sweep_expired` twin does the same via `DELETE … RETURNING` + a byte-parity `signed_events` append (shared `coordination_audit::coordination_payload_hash`). Pinned by `actions::tests::sweep_expired_leases_audited_emits_one_row_per_reclaimed_lease`, `background::lease_sweep::tests::run_lease_sweep_emits_coordination_audit_per_reclaimed_lease`, and the sal-postgres `lease_sweep_expired_emits_coordination_audit_2371`.
+
 ### Fixed (STORAGE-CHAIN lane, fable-3x7 findings)
 
 - **sqlite `memory_update` tier→long now clears the stale short/mid `expires_at`** ([#2331](https://github.com/alphaonedev/ai-memory-mcp/issues/2331), FBL-01) — the #1626 tier→long ⇒ `expires_at = NULL` coupling, previously postgres-only, landed on the sqlite `update_with_expected_version` + supersede funnels so the tier-blind GC can no longer archive (or hard-delete + crypto-erase under `archive_on_gc=false`) an explicitly-promoted permanent row at its leftover TTL deadline. Pinned by `tests/storage_chain_fbl.rs`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -528,7 +528,7 @@ L4 is the architecturally clean removal of the entire problem class: hosts volun
 - `memory_action_create / update / transition / delete / query / dag` MCP tools.
 - Action state machine (pending → claimed → in_progress → done | failed | abandoned).
 - Dependency DAG with typed edges (`requires` / `unlocks` / `blocks` / `gated_by` / `sibling`).
-- Lease + heartbeat for resilience (sweeper releases expired leases, emits `signed_events` audit entry).
+- Lease + heartbeat for resilience (sweeper releases expired leases, emitting one `coordination.lease_expire_reclaim` `signed_events` audit entry per reclaimed lease on both backends — #2371).
 - Federation-aware quorum claiming (W-of-N agreement on transitions).
 - Vector clock per `action_id` for federation merge.
 - `memory_lease_acquire / renew / release / query` MCP tools.

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -562,12 +562,52 @@ pub fn lease_get(
 }
 
 /// Reclaim (delete) every lease whose `expires_at <= now`, releasing the
-/// action for a fresh holder. Returns the number of leases reclaimed.
+/// action for a fresh holder. Returns the reclaimed `(action_id, holder)`
+/// pairs so the caller can emit one coordination-audit `signed_events` row per
+/// FORCED reclamation (#2371) — the asymmetric twin of the voluntary
+/// [`lease_release`], which is the ONE lease op that previously left no
+/// forensic trace. The `DELETE ... RETURNING` is atomic, so the returned set is
+/// EXACTLY the rows removed (no SELECT-then-DELETE TOCTOU where a concurrently
+/// renewed lease could be audited as reclaimed without being deleted).
 ///
 /// # Errors
-/// Propagates the `rusqlite` delete error.
-pub fn sweep_expired_leases(conn: &Connection, now: i64) -> rusqlite::Result<usize> {
-    conn.execute("DELETE FROM leases WHERE expires_at <= ?1", params![now])
+/// Propagates the `rusqlite` delete/query error.
+pub fn sweep_expired_leases(
+    conn: &Connection,
+    now: i64,
+) -> rusqlite::Result<Vec<(String, String)>> {
+    let mut stmt =
+        conn.prepare("DELETE FROM leases WHERE expires_at <= ?1 RETURNING action_id, holder")?;
+    let reclaimed = stmt
+        .query_map(params![now], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<(String, String)>>>()?;
+    Ok(reclaimed)
+}
+
+/// Reclaim expired leases via [`sweep_expired_leases`] AND emit one
+/// coordination-audit `signed_events` row per reclaimed lease
+/// ([`crate::coordination_audit::LEASE_SWEEP_RECLAIM`]), attributed to the
+/// reclaimed `holder` (the entity losing coordination authority) with the same
+/// `[action_id, holder]` identity the voluntary lease ops use. Returns the
+/// reclaimed count. The audit append is best-effort (#1722): the DELETE has
+/// already committed, so a rare append failure is WARN-logged inside
+/// [`crate::coordination_audit::emit`], never propagated.
+///
+/// # Errors
+/// Propagates the `rusqlite` delete/query error from [`sweep_expired_leases`].
+pub fn sweep_expired_leases_audited(conn: &Connection, now: i64) -> rusqlite::Result<usize> {
+    let reclaimed = sweep_expired_leases(conn, now)?;
+    for (action_id, holder) in &reclaimed {
+        crate::coordination_audit::emit(
+            conn,
+            crate::coordination_audit::LEASE_SWEEP_RECLAIM,
+            holder,
+            &[action_id.as_str(), holder.as_str()],
+        );
+    }
+    Ok(reclaimed.len())
 }
 
 #[cfg(test)]
@@ -987,8 +1027,13 @@ mod tests {
             LeaseAcquire::Conflict => panic!("expected Acquired"),
         }
 
-        // The sweep reclaims exactly the one expired lease.
-        assert_eq!(sweep_expired_leases(&conn, now).unwrap(), 1);
+        // The sweep reclaims exactly the one expired lease and RETURNS the
+        // (action_id, holder) pair so the caller can audit the reclamation.
+        let reclaimed = sweep_expired_leases(&conn, now).unwrap();
+        assert_eq!(
+            reclaimed,
+            vec![("sweep-1".to_string(), "holder".to_string())]
+        );
         assert!(lease_get(&conn, "sweep-1").unwrap().is_none());
 
         // A non-expired lease (expires_at = now + 1000) is NOT swept.
@@ -996,8 +1041,51 @@ mod tests {
             LeaseAcquire::Acquired(_) => {}
             LeaseAcquire::Conflict => panic!("expected Acquired"),
         }
-        assert_eq!(sweep_expired_leases(&conn, now).unwrap(), 0);
+        assert!(sweep_expired_leases(&conn, now).unwrap().is_empty());
         assert!(lease_get(&conn, "sweep-1").unwrap().is_some());
+    }
+
+    #[test]
+    fn sweep_expired_leases_audited_emits_one_row_per_reclaimed_lease() {
+        let conn = fresh();
+        let now = 1_700_000_000;
+        create(&conn, &sample("audited-1")).unwrap();
+        create(&conn, &sample("audited-2")).unwrap();
+        // Two expired leases held by distinct holders.
+        lease_acquire(&conn, "audited-1", "holder-a", now, now - 1).unwrap();
+        lease_acquire(&conn, "audited-2", "holder-b", now, now - 1).unwrap();
+
+        assert_eq!(sweep_expired_leases_audited(&conn, now).unwrap(), 2);
+
+        // Exactly one LEASE_SWEEP_RECLAIM row per reclaimed lease, each
+        // attributed to the reclaimed holder.
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+                params![crate::coordination_audit::LEASE_SWEEP_RECLAIM],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2, "one audit row per reclaimed lease");
+        let holders: i64 = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT agent_id) FROM signed_events WHERE event_type = ?1",
+                params![crate::coordination_audit::LEASE_SWEEP_RECLAIM],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(holders, 2, "rows attributed to each reclaimed holder");
+
+        // An idempotent re-sweep reclaims nothing and appends no new rows.
+        assert_eq!(sweep_expired_leases_audited(&conn, now).unwrap(), 0);
+        let count2: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM signed_events WHERE event_type = ?1",
+                params![crate::coordination_audit::LEASE_SWEEP_RECLAIM],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count2, 2, "no-op sweep appends no audit rows");
     }
 
     // v1.0.0 FBL-05/FBL-06 regression: `lease_acquire` must be atomic across

--- a/src/background/lease_sweep.rs
+++ b/src/background/lease_sweep.rs
@@ -11,6 +11,13 @@
 //! ([`crate::background::offload_ttl_sweep`]) structurally; the cadence is
 //! tighter (hourly, not daily) because leases are short-lived.
 //!
+//! #2371 — a reclaim is a FORCED revocation of coordination authority (the
+//! holder did not voluntarily surrender the lease), so the sweep drives the
+//! audited primitive [`crate::actions::sweep_expired_leases_audited`], which
+//! appends one `coordination.lease_expire_reclaim` `signed_events` row per
+//! reclaimed lease — the tamper-evident twin of the voluntary
+//! acquire/renew/release audit rows.
+//!
 //! Spawned by `daemon_runtime::bootstrap_serve` alongside the GC, TTL, and
 //! transcript-lifecycle loops; aborted on shutdown.
 
@@ -48,7 +55,7 @@ impl LeaseSweepAdapter
     )
 {
     fn run_lease_sweep(&self, now_unix: i64) -> anyhow::Result<usize> {
-        crate::actions::sweep_expired_leases(&self.0, now_unix).map_err(anyhow::Error::from)
+        crate::actions::sweep_expired_leases_audited(&self.0, now_unix).map_err(anyhow::Error::from)
     }
 }
 
@@ -90,7 +97,8 @@ mod tests {
     struct ConnAdapter(rusqlite::Connection);
     impl LeaseSweepAdapter for ConnAdapter {
         fn run_lease_sweep(&self, now_unix: i64) -> anyhow::Result<usize> {
-            crate::actions::sweep_expired_leases(&self.0, now_unix).map_err(anyhow::Error::from)
+            crate::actions::sweep_expired_leases_audited(&self.0, now_unix)
+                .map_err(anyhow::Error::from)
         }
     }
 
@@ -127,6 +135,49 @@ mod tests {
         crate::actions::lease_acquire(&conn, "ls-1", "holder", now, now - 1).unwrap();
         let adapter = ConnAdapter(conn);
         assert_eq!(adapter.run_lease_sweep(now).unwrap(), 1);
+    }
+
+    /// #2371 — the sweep is a FORCED lease revocation, so it must leave the
+    /// same coordination-audit trace the voluntary ops do: exactly one
+    /// `coordination.lease_expire_reclaim` `signed_events` row per reclaimed
+    /// lease, attributed to the reclaimed holder. Mirrors the voluntary
+    /// lease-op audit test in `coordination_audit::tests`.
+    #[test]
+    fn run_lease_sweep_emits_coordination_audit_per_reclaimed_lease() {
+        let conn = crate::storage::open(std::path::Path::new(":memory:")).unwrap();
+        let now = 1_700_000_000;
+        let action = crate::models::Action {
+            id: "audit-ls-1".to_string(),
+            namespace: "_act".to_string(),
+            kind: "test.kind".to_string(),
+            state: crate::models::ActionState::Pending,
+            title: "t".to_string(),
+            payload: serde_json::json!({}),
+            priority: 5,
+            agent_id: None,
+            claimed_by: None,
+            vector_clock: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        };
+        crate::actions::create(&conn, &action).unwrap();
+        crate::actions::lease_acquire(&conn, "audit-ls-1", "holder-x", now, now - 1).unwrap();
+
+        let adapter = ConnAdapter(conn);
+        assert_eq!(adapter.run_lease_sweep(now).unwrap(), 1);
+
+        let (count, agent): (i64, String) = adapter
+            .0
+            .query_row(
+                "SELECT COUNT(*), COALESCE(MAX(agent_id), '') FROM signed_events \
+                 WHERE event_type = ?1",
+                rusqlite::params![crate::coordination_audit::LEASE_SWEEP_RECLAIM],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "exactly one lease-sweep reclaim audit row");
+        assert_eq!(agent, "holder-x", "attributed to the reclaimed holder");
     }
 
     /// Default-const sanity: the cadence resolves to the documented value so a

--- a/src/coordination_audit.rs
+++ b/src/coordination_audit.rs
@@ -62,6 +62,13 @@ pub const LEASE_ACQUIRE: &str = "coordination.lease_acquire";
 pub const LEASE_RENEW: &str = "coordination.lease_renew";
 /// Lease release (`memory_lease_release`).
 pub const LEASE_RELEASE: &str = "coordination.lease_release";
+/// Forced lease reclamation by the background expiry sweeper
+/// (`background::lease_sweep` / the postgres maintenance loop). The
+/// asymmetric twin of the VOLUNTARY [`LEASE_RELEASE`]: the sweeper reclaims
+/// coordination authority a holder did NOT voluntarily surrender, so — as the
+/// only FORCED revocation of a lease — it MUST leave the same tamper-evident
+/// forensic trace the voluntary ops do (#2371).
+pub const LEASE_SWEEP_RECLAIM: &str = "coordination.lease_expire_reclaim";
 /// Attested-checkpoint creation (`memory_checkpoint_create`).
 pub const CHECKPOINT_CREATE: &str = "coordination.checkpoint_create";
 /// Attested-checkpoint resolution (`memory_checkpoint_resolve`).
@@ -72,6 +79,23 @@ pub const ROUTINE_CREATE: &str = "coordination.routine_create";
 pub const ROUTINE_FREEZE: &str = "coordination.routine_freeze";
 /// Routine run / materialisation (`memory_routine_run`).
 pub const ROUTINE_RUN: &str = "coordination.routine_run";
+
+/// Build the coordination-audit `payload_hash`: SHA-256 over `identity_parts`
+/// joined by the 0x1F unit separator (the module's canonical bounded-identity
+/// digest). Shared by [`emit`] (the sqlite append) and the postgres
+/// coordination-audit append so a given `identity_parts` hashes byte-identically
+/// on both backends (#2371 lease-sweep parity).
+#[must_use]
+pub fn coordination_payload_hash(identity_parts: &[&str]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    for (i, part) in identity_parts.iter().enumerate() {
+        if i > 0 {
+            hasher.update([FIELD_SEP]);
+        }
+        hasher.update(part.as_bytes());
+    }
+    hasher.finalize().to_vec()
+}
 
 /// Emit one `signed_events` audit row for a coordination state-mutation.
 ///
@@ -87,17 +111,8 @@ pub const ROUTINE_RUN: &str = "coordination.routine_run";
 /// already succeeded, so an audit-append failure must not surface to the
 /// caller. See the module docs for the rationale.
 pub fn emit(conn: &rusqlite::Connection, event_type: &str, actor: &str, identity_parts: &[&str]) {
-    let mut hasher = Sha256::new();
-    for (i, part) in identity_parts.iter().enumerate() {
-        if i > 0 {
-            hasher.update([FIELD_SEP]);
-        }
-        hasher.update(part.as_bytes());
-    }
-    let payload_hash = hasher.finalize().to_vec();
-
     let event = crate::signed_events::SignedEvent::with_daemon_signature(
-        payload_hash,
+        coordination_payload_hash(identity_parts),
         actor.to_string(),
         event_type.to_string(),
         chrono::Utc::now().to_rfc3339(),

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -10667,6 +10667,42 @@ impl PostgresStore {
             );
         }
     }
+
+    /// #2371 — postgres twin of the sqlite `crate::coordination_audit::emit`
+    /// for a FORCED lease reclamation. Builds the row from the SAME
+    /// [`crate::coordination_audit::coordination_payload_hash`] pre-image
+    /// (`[action_id, holder]` joined by 0x1F) and the SAME `with_daemon_signature`
+    /// idiom, attributed to the reclaimed `holder`, so the
+    /// `coordination.lease_expire_reclaim` row persists + verifies identically
+    /// on both backends (K3 parity). Best-effort: an append failure is
+    /// WARN-logged and swallowed — the sweep DELETE already committed.
+    async fn emit_lease_sweep_reclaim_audit(&self, action_id: &str, holder: &str) {
+        let ts = Utc::now();
+        let event = crate::signed_events::SignedEvent::with_daemon_signature(
+            crate::coordination_audit::coordination_payload_hash(&[action_id, holder]),
+            holder.to_string(),
+            crate::coordination_audit::LEASE_SWEEP_RECLAIM.to_string(),
+            ts.to_rfc3339(),
+            None,
+        );
+        let insert_row = PgSignedEventInsert {
+            id: &event.id,
+            agent_id: &event.agent_id,
+            event_type: &event.event_type,
+            payload_hash: &event.payload_hash,
+            signature: event.signature.as_deref(),
+            attest_level: &event.attest_level,
+            timestamp: ts,
+            cause_hash: None,
+        };
+        if let Err(e) = pg_append_signed_event_with_chain(&self.pool, insert_row).await {
+            tracing::warn!(
+                target: crate::signed_events::SIGNED_EVENTS_TRACE_TARGET,
+                action_id, holder,
+                "failed to append coordination.lease_expire_reclaim audit row: {e}"
+            );
+        }
+    }
 }
 
 /// Caller-supplied fields for [`pg_append_signed_event_with_chain`].
@@ -20496,12 +20532,34 @@ impl MemoryStore for PostgresStore {
     }
 
     async fn lease_sweep_expired(&self, now: i64) -> StoreResult<usize> {
-        let res = sqlx::query("DELETE FROM leases WHERE expires_at <= $1")
-            .bind(now)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| to_store_err("lease_sweep_expired", e))?;
-        Ok(usize::try_from(res.rows_affected()).unwrap_or(0))
+        use sqlx::Row;
+        // #2371 — `RETURNING` makes the reclaimed set EXACTLY the rows deleted
+        // (atomic; no SELECT-then-DELETE TOCTOU), so the FORCED reclamation
+        // leaves the same tamper-evident coordination-audit trace the voluntary
+        // lease ops do — the backend-parity twin of the sqlite
+        // `crate::actions::sweep_expired_leases_audited` path.
+        let rows =
+            sqlx::query("DELETE FROM leases WHERE expires_at <= $1 RETURNING action_id, holder")
+                .bind(now)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| to_store_err("lease_sweep_expired", e))?;
+        let mut reclaimed: Vec<(String, String)> = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let action_id: String = r
+                .try_get("action_id")
+                .map_err(|e| to_store_err("lease_sweep_expired.action_id", e))?;
+            let holder: String = r
+                .try_get("holder")
+                .map_err(|e| to_store_err("lease_sweep_expired.holder", e))?;
+            reclaimed.push((action_id, holder));
+        }
+        // Best-effort audit append per reclaimed lease (the DELETE already
+        // committed): a failure is WARN-logged, never cratering the sweep.
+        for (action_id, holder) in &reclaimed {
+            self.emit_lease_sweep_reclaim_audit(action_id, holder).await;
+        }
+        Ok(reclaimed.len())
     }
 
     async fn signal_send(
@@ -28695,6 +28753,76 @@ mod tests {
             holder_row, winners[0],
             "the surviving leases row must belong to the single winner"
         );
+        // Cleanup — cascade removes the lease row with the action.
+        let _ = sqlx::query("DELETE FROM actions WHERE id = $1")
+            .bind(&aid)
+            .execute(&store.pool)
+            .await;
+    }
+
+    /// #2371 — postgres `lease_sweep_expired` must emit one
+    /// `coordination.lease_expire_reclaim` `signed_events` row per reclaimed
+    /// lease, attributed to the reclaimed holder — the backend-parity twin of
+    /// the sqlite `sweep_expired_leases_audited` path (K3). Acquires an expired
+    /// lease, sweeps, and asserts exactly one audit row. Skips cleanly without
+    /// `AI_MEMORY_TEST_POSTGRES_URL`.
+    #[tokio::test]
+    async fn lease_sweep_expired_emits_coordination_audit_2371() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store = PostgresStore::connect(&url).await.expect("connect");
+        let ctx = CallerContext::for_agent("ai:sal-test");
+        let unique = uuid::Uuid::new_v4();
+        let ns = format!("lease-sweep-2371-{unique}");
+        let aid = format!("lease-sweep-2371-act-{unique}");
+        let holder = format!("holder-2371-{unique}");
+        let action = crate::models::Action {
+            id: aid.clone(),
+            namespace: ns,
+            kind: "test.lease-sweep".to_string(),
+            state: crate::models::ActionState::Pending,
+            title: "lease 2371 sweep target".to_string(),
+            payload: serde_json::json!({}),
+            priority: 5,
+            agent_id: Some("ai:sal-test".to_string()),
+            claimed_by: None,
+            vector_clock: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            created_at: 1_700_000_000,
+            updated_at: 1_700_000_000,
+        };
+        store
+            .action_create(&ctx, &action)
+            .await
+            .expect("action_create");
+        // Acquire a lease whose deadline is already in the past.
+        let now = 1_700_100_000_i64;
+        store
+            .lease_acquire(&ctx, &aid, &holder, now, now - 1)
+            .await
+            .expect("lease_acquire");
+
+        assert_eq!(
+            store.lease_sweep_expired(now).await.expect("sweep"),
+            1,
+            "exactly one expired lease reclaimed"
+        );
+
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM signed_events WHERE event_type = $1 AND agent_id = $2",
+        )
+        .bind(crate::coordination_audit::LEASE_SWEEP_RECLAIM)
+        .bind(&holder)
+        .fetch_one(&store.pool)
+        .await
+        .expect("query audit rows");
+        assert_eq!(
+            count, 1,
+            "one lease-sweep reclaim audit row attributed to the holder"
+        );
+
         // Cleanup — cascade removes the lease row with the action.
         let _ = sqlx::query("DELETE FROM actions WHERE id = $1")
             .bind(&aid)

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1378,7 +1378,9 @@ impl MemoryStore for SqliteStore {
 
     async fn lease_sweep_expired(&self, now: i64) -> StoreResult<usize> {
         let conn = self.state.lock().await;
-        crate::actions::sweep_expired_leases(&conn, now).map_err(box_err)
+        // #2371 — emit one coordination-audit `signed_events` row per reclaimed
+        // lease (the FORCED-revocation twin of the voluntary lease-op audit).
+        crate::actions::sweep_expired_leases_audited(&conn, now).map_err(box_err)
     }
 
     async fn signal_send(

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -892,7 +892,12 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // (#2310-#2318) + the v87 anchor merge + the FBL-20/33/03 pg mirrors
     // land the file at 29_869. Ceiling 29_020 -> 29_900 (+31 headroom).
     // The module-split relief remains tracked under #650-class follow-ups.
-    ("src/store/postgres.rs", 29_900),
+    // 2026-07-24 (#2371 lease-sweep-audit) — `lease_sweep_expired` gains a
+    // `DELETE ... RETURNING` + per-pair emit loop, the
+    // `emit_lease_sweep_reclaim_audit` helper, and the sal-postgres
+    // `lease_sweep_expired_emits_coordination_audit_2371` regression test;
+    // land the file at 29_997. Ceiling 29_900 -> 30_040 (+43 headroom).
+    ("src/store/postgres.rs", 30_040),
     // 2026-06-10 (#1579 B7) — bumped 9_000 → 9_150: the
     // `db_mmap_size_bytes` knob (ENV_DB_MMAP_SIZE const +
     // StorageSection/ResolvedStorage fields + the resolve_storage env >


### PR DESCRIPTION
Closes #2371

## Problem
The FORCED reclamation of an expired coordination lease was the ONE lease op with **no forensic trace**. The voluntary `acquire`/`renew`/`release` ops all append signed-chain rows via `coordination_audit::emit` (#1722), so the shipped bare `DELETE` sweeper left the only forced revocation of coordination authority untraceable — and ROADMAP.md:531's "Already in baseline" claim (*"sweeper releases expired leases, emits `signed_events` audit entry"*) was **false** on both backends.

Evidence: sqlite `sweep_expired_leases` (`src/actions/mod.rs`), postgres `lease_sweep_expired` (`src/store/postgres.rs`), and the `background::lease_sweep` loop all did a bare DELETE + `tracing` log, no emit.

## Fix (~35 LOC + tests)
- **`src/coordination_audit.rs`** — new `LEASE_SWEEP_RECLAIM = "coordination.lease_expire_reclaim"` const alongside the existing lease consts; extracted `coordination_payload_hash` (0x1F-joined SHA-256) so both backends hash a given identity byte-identically.
- **`src/actions/mod.rs`** — `sweep_expired_leases` now returns the reclaimed `(action_id, holder)` pairs via an **atomic `DELETE … RETURNING`** (no SELECT-then-DELETE TOCTOU); new `sweep_expired_leases_audited` wrapper emits one row per reclaimed lease attributed to the reclaimed holder.
- **`src/background/lease_sweep.rs`** + **`src/store/sqlite.rs`** — drive the audited wrapper.
- **`src/store/postgres.rs`** — twin `DELETE … RETURNING action_id, holder` + `emit_lease_sweep_reclaim_audit` per pair via `pg_append_signed_event_with_chain` (same `with_daemon_signature` idiom + shared payload-hash → K3 cross-backend parity).
- **`ROADMAP.md:531`** — reworded to name the exact event type; the claim is now TRUE.
- All emits are **best-effort** (#1722 posture): the DELETE has already committed, so an audit-append failure is WARN-logged, never craters the sweep — degrade, never corrupt.

## Tests
- `actions::tests::sweep_expired_leases_audited_emits_one_row_per_reclaimed_lease` — 2 expired leases, distinct holders → exactly 2 rows, each attributed to its holder; idempotent re-sweep appends nothing.
- `background::lease_sweep::tests::run_lease_sweep_emits_coordination_audit_per_reclaimed_lease` — exercises the adapter path end-to-end.
- `store::postgres::tests::lease_sweep_expired_emits_coordination_audit_2371` — sal-postgres, self-skips without `AI_MEMORY_TEST_POSTGRES_URL`.

## Gates (local, green)
`fmt --check` · `clippy --all-targets` (default **and** `--features sal-postgres`) `-D warnings -D clippy::all -D clippy::pedantic` · `cargo check --all-targets` (default / `sal` / `sal-postgres`) · `cargo check --examples` · targeted lib tests (actions / background::lease_sweep / coordination_audit) · `qual_10_module_size_ceiling` (postgres.rs ceiling bumped 29_900 → 30_040 in lockstep, dated comment) · `qual_6_7_legacy_error_type_ceiling` · `check-hardcoded-literals.sh` · `check-docs-vs-ssot.sh` · `check-vendor-literals.sh`.

## AI involvement
Authored by an autonomous Sonnet-5 implementation worker under an Opus-4.8 orchestrator, per the repo's AI Developer Workflow. This is a **precedent-copy** of the existing #1722 `coordination_audit::emit` pattern (T6 does not fire — copying the precedent IS the decision), so no crossroads 5-agent vote was required. Base SHA: `af6bc460`. **DRAFT — held for Fable review; do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY