### PR TITLE
docs: graph-engineering development process and standard

### DIFF
--- a/docs/GRAPH_ENGINEERING.md
+++ b/docs/GRAPH_ENGINEERING.md
@@ -1,0 +1,429 @@
+# Graph Engineering — ai-memory development process & standard
+
+**Status:** active — governs AI-NHI development on this repository
+**Adopted:** 2026-07-27 (v1.0.0 GA campaign)
+**Supersedes:** the loop-in-head orchestration described in `.local-runs/HANDOFF-NEW-ACCOUNT.md`
+
+---
+
+## 0. The principle everything follows from
+
+> **You do not fix the code. You fix the process that produced the code.**
+
+When a reviewer catches the same mistake in a third file, the wrong move is to fix three
+files. The right move is to add one sentence to the rulebook and regenerate the batch.
+Individual failures are the loop's job. Attention belongs on the patterns.
+
+Corollary: **if you are hand-patching agent output, you are working inside the agent's job
+instead of building the thing that does it.**
+
+Two standards sit alongside it:
+
+> **Data tier: absolute perfection.** A fix is not done when its own test passes. It is done
+> when the full data-tier matrix passes against it. (Operator standard, 2026-07-26 —
+> enterprise customers are the bar.)
+
+> **A self-skipping test is NOT a pass.** A test that skips because an extension or feature
+> is absent is an untested surface, not coverage.
+
+---
+
+## 1. Loops vs graphs, and why this repo uses a graph
+
+Most agents are **loops**: the model thinks, calls a tool, reads the result, thinks again,
+until it decides it is done. Control lives inside the model. You see the input and the
+output and almost nothing in between — so when it fails at minute forty, you do not know
+which minute went wrong.
+
+A **graph** moves control outside the model. Steps are named, edges are declared, state
+lives on disk. The model still does the thinking, but inside nodes that were drawn in
+advance. Some nodes use no model at all — a script, a compiler, a test suite.
+
+Four properties follow:
+
+| Property | Why it matters here |
+|---|---|
+| **Failure is located** | it happens at a named node, not "somewhere in a long run" |
+| **Runs are resumable** | state is on disk, so a killed run restarts where it stopped |
+| **Branches parallelise** | independent nodes run concurrently, conflict-checked by computation |
+| **Boring parts are deterministic** | a script decides, instead of paying a model to guess |
+
+### When NOT to use a graph
+
+A graph requires knowing the shape of the work in advance. That is the whole trade.
+Skip it when:
+
+- **The task runs once.** Setup cost amortises across repetitions; building a judge and a
+  rulebook to process eleven files is slower than doing the eleven files.
+- **The steps are unknown.** Research, unfamiliar debugging, exploring a new codebase.
+  A loop will find a path you would not have drawn; locking topology early locks in a wrong
+  guess.
+- **No mechanical judge exists and none can.** If correctness genuinely needs human taste on
+  every item, reviewer nodes become theatre.
+
+**Middle path:** run a loop first to learn the shape, keep notes on every correction, and
+those notes become the first rulebook. Build the graph for the second run.
+
+**This repo qualifies** because the v1.0.0 fix campaign is ~30 lanes of repeating shape
+(find defect → fix → test → review → merge → close) with a mechanical judge available (CI,
+plus the checks below).
+
+---
+
+## 2. The eight steps
+
+### Step 1 — Build the judge before anything else
+
+An agent without an exit condition never finishes. It stops when it *feels* done, which is
+a mood, not a condition.
+
+Before writing any instruction about the work itself, decide **how a machine tells you the
+work is correct**. Not a human reading the output. A machine.
+
+**Artefact:** `scripts/judge.sh <pr-number>` → exit `0` pass / `1` fail, printing why.
+
+Six mechanical checks, each citing a rulebook ID:
+
+| ID | Check | Rule |
+|---|---|---|
+| J1 | 0 *genuine* CI failures on a settled head | R-403 |
+| J2 | src changed ⇒ a test file was touched | R-203 |
+| J3 | sqlite changed ⇒ postgres twin, or a stated reason | R-303 |
+| J4 | size-ceilinged file grew ⇒ ceiling re-measured | R-401/402 |
+| J5 | no `/tmp` path introduced | HARD-RULE |
+| J6 | PR body cites `Closes #N` | R-502 |
+
+J1 is deliberately not "did `gh pr checks` say pass" — it queries the check-runs API for
+`conclusion=="failure"`, because the rendered label reports a *cancelled* concurrency-twin
+as `fail`.
+
+### Step 2 — Break the judge on purpose
+
+A judge that never fails is decoration, and every green result downstream of a blind judge
+is meaningless.
+
+**Artefact:** `scripts/judge-selftest.sh` — validates in **both** directions:
+
+- **Positive:** three real merged PRs must PASS. A judge that rejects known-good work is too
+  strict and will block real progress.
+- **Negative:** four synthetic breakages must FAIL, **and must trip the correct rule**. A
+  check that fires accidentally is not a check.
+- **Control:** the sqlite-only-*with-rationale* case must be **allowed** — this distinguishes
+  a working judge from one that rejects everything.
+
+Run this before generating anything at scale.
+
+### Step 3 — Write the rulebook, and never patch around it
+
+**Artefact:** `rules/rulebook.md` — read by every lane before it touches anything.
+
+Two properties make it work:
+
+1. **It grows.** Every reviewer catch the rules did not cover becomes a new sentence.
+2. **Nothing bypasses it.** The moment output is hand-edited to match what the rulebook
+   *should* have said, there are two sources of truth and one is in someone's head.
+
+Every rule has a **stable ID** so reviewers can cite it. Rules are grouped:
+
+| Series | Concern | Examples |
+|---|---|---|
+| R-100 | build & resources | R-101 never compile in a lane · R-103 `cargo clean`, not `rm -rf` |
+| R-200 | verification | R-202 self-skip ≠ pass · R-203 prove tests load-bearing · R-204 `contains` cannot detect drift |
+| R-300 | completeness | R-301 footprint from codegraph not grep · R-303 both backends |
+| R-400 | measurement | R-401 measure, never inherit a number · R-402 max-wins insufficient when changes stack |
+| R-500 | process | R-501 check backlog before filing · R-502 close the audit trail |
+
+Every rule carries **provenance** — the specific incident that produced it. These are not
+generic best practices; they are the recorded ways this campaign broke.
+
+### Step 4 — Stress-test the rules on three items, then delete the work
+
+**Artefact:** `scripts/rule-stresstest.sh <task1> <task2> <task3>`
+
+Run three items twice — **with** the rulebook and **without** it — and diff. Every
+difference is a place where the rules are missing, wrong, or *worse than the model's
+default*. Fix the rulebook, not the files.
+
+Then **delete everything produced**. The goal was never the three artefacts; it was the
+rules. Keeping the output is how the first three items follow one convention and everything
+after follows another.
+
+### Step 5 — Put state on disk, not in the context window
+
+**Artefact:** the ai-memory coordination substrate itself (`actions`, `action_edges`,
+`leases` — schema v59), namespace `campaign/v1.0.0-ga`.
+
+The work queue is **rebuilt from durable state on every run**. Nothing about it lives in a
+conversation. The consequence: the process is **resumable by construction** — kill it at 60%,
+restart, and it resumes at 60% because the substrate remembers.
+
+This is also deliberate dogfooding: the campaign's control graph runs on the product's own
+coordination primitives.
+
+### Step 6 — Two reviewers who cannot see each other, citing rule IDs
+
+One reviewer sharing context with the worker will agree with the worker — it has seen the
+reasoning and is primed to accept it.
+
+**Artefact:** `scripts/review.sh <pr-number>` — two fresh sessions, each seeing **only** the
+diff and the rulebook.
+
+Required output shape:
+
+```
+RULE: <rule-id> | ISSUE: <what is wrong, with file:line>
+RULE: GAP | ISSUE: <problem> | SUGGESTED-RULE: <the sentence that should be added>
+PASS
+```
+
+The **citation is what closes the loop**:
+
+- A citation turns a vague complaint into a queue item.
+- **A rule cited three times across different lanes is not three problems — it is one badly
+  written rule.** Rewrite that line and re-run the affected batch.
+- A `GAP` finding makes a rulebook hole as reportable as a code defect.
+- **Reviewer disagreement usually means the rulebook is ambiguous at that spot.** That is an
+  edit, not a coin flip.
+
+The script rolls up citation frequency across *all* reviews so patterns are visible.
+
+### Step 7 — Make the boring checks deterministic, and place them by cost
+
+Anything a script can verify must never be verified by a model — faster, cheaper, no
+opinions.
+
+**The rule is not "check often". It is: match check frequency to check cost.**
+
+**Artefact:** `scripts/checks.sh fast|slow`
+
+| Placement | Contents | Cost |
+|---|---|---|
+| **FAST — in-loop** | `cargo fmt --check`, six shell gates (hardcoded-literals, vendor-literals, docs-vs-SSOT, l3-boundary, cloud-init-ascii, migration-ladder), implicated static-guard enumeration, `/tmp` scan | seconds |
+| **SLOW — batched** | full `cargo test --features sal-postgres` compile + suite | ~40 min, 180–200 GB |
+
+The slow path **categorises** its errors rather than listing them:
+
+```bash
+grep -oE '^error(\[E[0-9]+\])?' build.log | sort | uniq -c | sort -rn | head
+```
+
+Thousands of individual errors are usually one classification problem. A category is fixable
+with one rule; instances are not.
+
+### Step 8 — Serialize the expensive operation
+
+If one operation dominates cost or time, do not let every agent trigger it.
+
+**Artefact:** `scripts/build-daemon.sh` (systemd user unit `campaign-build-daemon.service`)
+
+- Lanes **append a request** to `queue/build_requests` — they never invoke a heavy build.
+- The daemon drains the queue, builds **once** into **one shared `CARGO_TARGET_DIR`**, runs
+  the affected tests, and fans results back to `logs/build_results/<lane>`.
+- A **120 GB disk floor** is enforced before every build; below it the daemon reclaims by
+  `cargo clean` on worktrees whose HEAD is safely on a remote, and **refuses to build** if it
+  still cannot clear the floor.
+
+N agents each triggering a rebuild pays N times for work that batches into one.
+
+---
+
+## 3. The control graph
+
+### Typed state
+
+Mirrors `src/models/action.rs::ActionState`:
+
+```
+pending ──► claimed ──► in_progress ──► done | failed | abandoned
+   │           │
+   │           └──► pending          (claim release)
+   └──► abandoned                    (early abandon)
+```
+
+Terminal states accept no outbound transition. **`claimed → done` is illegal** — the legal
+route is `claimed → in_progress → done`. Callers request a destination and the executor walks
+the legal path.
+
+The mirror is **verified against the Rust source** at preflight, parsing the actual enum. A
+mirror that drifts silently is worse than no mirror.
+
+### Routing (deterministic, no model)
+
+A node is dispatchable **only if** all hold:
+
+1. state is `pending`
+2. no `blocks` predecessor is un-`done`
+3. its file footprint does not intersect any node currently held
+
+An **undeclared footprint is treated as conflicting** — unproven-safe is not safe.
+
+### Gates — BLOCK stops routing
+
+| Gate | Blocks when |
+|---|---|
+| `state-mirror` | the typed mirror has drifted from `action.rs` |
+| `disk` | ≥90% used or <120 GB free |
+| `codegraph-id` | the index is not the canonical repo on `release/v1.0.0` |
+| `codegraph` | the index is older than HEAD |
+| `pg-substrate` | the PG+AGE test stack is not healthy |
+| `stale-holds` | a node has been held with no progress beyond the threshold |
+
+**The executor never "proceeds anyway."** That judgement is precisely what is being removed
+from the loop.
+
+---
+
+## 4. Codegraph — integral, not incidental
+
+Codegraph is wired as three gates the process cannot route around.
+
+| Gate | Purpose |
+|---|---|
+| **G1 identity** | the index must belong to the **canonical** codebase. Verified by resolved path **and** git branch **and** index presence — not a path string. Codegraph resolves the nearest `.codegraph` at or *above* a query path, so a worktree can silently resolve into a different repo's index. A fresh index of the *wrong* codebase is more dangerous than a stale index of the right one, so identity gates **before** freshness. |
+| **G2 footprint** | a node's file footprint is **derived from its symbols**, never trusted from a hand-written list. |
+| **G3 completeness** | after a change, every caller of a changed symbol must be touched or explicitly excluded with a reason. |
+
+**Freshness is automated**, not remembered: a systemd timer runs every 15 minutes —
+`git fetch` → `merge --ff-only` → `codegraph sync`, at `Nice=10` with idle I/O.
+
+**Caveat encoded in the tooling:** codegraph caller lists on common symbol names
+(`resolve`, `get`, `new`, `insert`, `validate`, …) collide across modules. Results for those
+names are returned **flagged for verification** — they are leads, not facts.
+
+---
+
+## 5. Verification substrate
+
+A permanent local stack, because the shipped CI cannot exercise these surfaces.
+
+| Component | Version |
+|---|---|
+| PostgreSQL | **18.4** |
+| Apache AGE | **1.7.0** |
+| pgvector | **0.8.5** |
+
+- **TLS 1.3 enforced** — `pg_hba.conf` contains **no plain `host` lines**, so a cleartext
+  connection is refused rather than silently downgraded. A client cert exists for mTLS work.
+- **Two instances:** a working instance, and a deliberately **bare** instance whose only
+  purpose is migration rehearsal — it must be able to start from an empty database so an
+  upgrade run creates the extensions itself, as a real upgrade would.
+- Extensions are **built from pinned commit SHAs** against the official PG image, because the
+  upstream AGE image ships a different PostgreSQL patch level. The SHAs are baked into the
+  image so a rebuild is reproducible.
+
+**Why this exists:** the CI postgres service carries pgvector but **no AGE**. Every AGE-gated
+test detects the missing extension, logs a skip, and exits 0. Those tests had never executed
+anywhere. Their green was the absence of evidence.
+
+---
+
+## 6. Data-tier matrix
+
+Eighteen lanes, run in full after **every** merged data-tier fix — not just the touched lane.
+
+Ladder (forward + bootstrap-replay + idempotence) · archive round-trip losslessness ·
+encryption at rest · concurrency & isolation · crash/power-loss durability · AGE projection
+consistency · AGE deferred drain · pgvector correctness · cross-backend parity · federation
+convergence · collation & encoding · FK/cascade integrity · quota enforcement · audit-chain
+tamper evidence · backup/restore · TLS enforcement.
+
+**Protocol:** baseline → fix → **retest the FULL matrix** → compare. Any lane that changed
+state, *including `PASS → SKIPPED`*, is a finding.
+
+Results are reported `PASS / FAIL / **SKIPPED**` separately. A `SKIPPED` lane blocks any
+"full spectrum" claim.
+
+---
+
+## 7. Post-fix dogfood install
+
+Each fixed iteration is installed on the development node and exercised against the real
+memory substrate — a migration rehearsal on production data, which the synthetic stack
+cannot provide.
+
+Order is deliberate; do not reorder:
+
+1. build release from HEAD
+2. **snapshot** the live DB (sqlite backup API — consistent under concurrent readers)
+3. run the ladder against the **snapshot** with the new binary
+4. assert: **no rows lost**, `integrity_check = ok`, version **monotonic**
+5. only then install (symlink-versioned, so rollback is a symlink flip)
+6. report what must restart — never kill a live MCP, which would self-DOS the session
+
+If step 3 or 4 fails, nothing is installed and the live database was never exposed.
+
+---
+
+## 8. Crossroads protocol
+
+Genuine architecture inflection points (`T1`–`T6`: public-contract shape change · sync↔async
+boundary · security posture · hard-to-reverse representation · spec deviation · ≥2
+mutually-exclusive paths with no precedent) require an **adversarial vote before building**,
+with the verdict cited in the commit.
+
+**Lessons learned about running votes:**
+
+- **Lenses must be genuinely distinct**, or five voters produce one argument in five
+  vocabularies. Measure effective panel size, not headcount.
+- **Do not instruct a default.** A brief that says "default to REJECT if uncertain"
+  manufactures the consensus it then reports.
+- **Do not forbid re-derivation.** A brief that says "do not re-derive, vote on it" prevents
+  voters from catching an error in the brief itself.
+- **Shared evidence correlates voters.** Independence in *reasoning* is not independence in
+  *evidence* — if a fact in the brief is wrong, every voter inherits it.
+- **Unanimity is where groupthink hides.** Point a second wave at the consensus, not at the
+  rejected options.
+
+---
+
+## 9. Non-negotiables
+
+- **No agent scratch under `/tmp`** — use the project-local scratch directory.
+- **`cargo clean`, never `rm -rf`** (operator hard rule R005).
+- **Measure, never inherit a number** — ceilings, sizes, counts are read from the artefact,
+  not copied from a brief, an issue body, or another branch.
+- **MAX-WINS is insufficient when changes stack.** Two lanes editing one file produce a
+  combined size above *both* candidate ceilings. Re-measure after rebase.
+- **Verify a red before believing it** — genuine failure vs cancelled concurrency-twin vs
+  watchdog timeout. Query the API, not the rendered label.
+- **Never blame a red on the most recent merge** without reverting to base and re-running.
+- **Close the audit trail** — merged work closes its issues with evidence and transitions its
+  node. Stale-open issues and merged-but-held nodes are process defects.
+- **A deferral needs a tracked carrier.** Silence is not a disposition.
+
+---
+
+## 10. Provenance
+
+Every rule above was produced by a specific failure. A partial record, because rules without
+provenance decay into folklore:
+
+| Rule | Incident |
+|---|---|
+| R-101 build daemon | fourteen concurrent lane target trees filled a 912 GB volume to 1.4 GB free |
+| R-202 self-skip ≠ pass | CI postgres has no AGE; every AGE test self-skipped to exit 0 |
+| R-203 prove load-bearing | a ghost-node test used a query path that silently falls back, so it passed against unfixed code |
+| R-204 `contains` blind to drift | a span guard passed while broken — `contains` cannot detect a one-byte offset at any distance |
+| R-206 static-guard sweep | five CI jobs lost to a single static guard that targeted test selection could not see |
+| R-301 codegraph footprint | an issue was filed with a 2-funnel scope; codegraph showed 14 call sites |
+| R-401/402 measure | an orchestrator brief carried three wrong ceiling numbers; a lane caught them by measuring |
+| R-403 classify the red | a rendered `fail` was a cancelled concurrency twin; a separate red was a watchdog timeout on a passing run |
+| R-404 revert before blaming | fixture residue produced failures that pointed convincingly at a just-merged PR |
+| R-501 check the backlog | an issue was filed as a duplicate of an existing one |
+| R-502 close the trail | three stale-open issues and two merged-but-held nodes found in one session |
+| state mirror | nodes were transitioned to a state named `fixing`, which does not exist — the handoff doc said so in prose and nothing caught it |
+
+---
+
+## 11. The actual shift
+
+The question was never whether the model is smart enough. It is **who decides what happens
+next.**
+
+In a loop, the model decides and you find out at the end. In a graph, you decided in advance
+and the model executes inside the boundaries you drew.
+
+What remains model work is what is irreducibly judgement: reading a codebase, writing a fix,
+adversarial review. Everything around it — precondition checking, routing, conflict
+detection, footprint derivation, completeness verification, build serialisation, merge and
+close-out — is deterministic, inspectable, and outside the prompt.


### PR DESCRIPTION
Adds `docs/GRAPH_ENGINEERING.md` — the development process and standard the v1.0.0 GA campaign now runs on.

**Docs-only.** No `src/`, no tests, no workflows. Commit carries `[skip ci]`.

## What it records

The shift from a loop (control inside the model) to a graph (control in code, state on disk). Core principle: **fix the process that produced the code, not the code** — a rule cited three times is one badly-written rule, not three defects.

- **The eight steps** with their artefacts: judge-first · break-the-judge · rulebook · rule stress-test · state-on-disk · blind reviewers *citing rule IDs* · checks placed by cost · serialised expensive operation
- **The control graph** — typed state mirrored from `src/models/action.rs` and mechanically verified against it, deterministic routing (a node dispatches only if pending + unblocked + file-disjoint; an undeclared footprint counts as conflicting), and six BLOCK gates
- **Codegraph as three non-skippable gates** — identity / footprint / completeness — plus automated 15-minute index freshness. Identity gates *before* freshness, because a fresh index of the wrong codebase is more dangerous than a stale index of the right one
- **The verification substrate** — PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5, TLS enforced, with a deliberately bare second instance for migration rehearsal
- **The 18-lane data-tier matrix** and the retest-in-full protocol
- **Post-fix dogfood ordering** — prove the migration on a snapshot before the live database is ever exposed
- **Crossroads voting**, including how a brief can manufacture its own consensus
- **A provenance table** mapping each rule to the incident that produced it

## Why it is worth committing

Two findings in it are load-bearing beyond process documentation:

1. **CI's postgres service carries pgvector but no Apache AGE.** Every AGE-gated test detects the missing extension, logs a skip, and exits 0 — so those tests have never executed anywhere. Their green is the absence of evidence. This is why the local substrate exists.
2. **The expensive check was on the hot path.** Lanes each ran a full `--features sal-postgres` build (~40 min, 180–200 GB). Fourteen target trees filled a 912 GB volume to 1.4 GB free. The build is now serialised behind a daemon with a shared target dir and a disk floor.

## Release safety

No release or publish path is reachable from a push to `main`:

| workflow | trigger |
|---|---|
| `release.yml` | `workflow_dispatch` only (requires an existing tag as input) |
| `publish-sdk-shims.yml` | `workflow_dispatch` only |
| `yank.yml` | `workflow_dispatch` only |
| `publish-sdks.yml` | tags `v*` only |

Verified by enumerating every workflow's push triggers. `[skip ci]` additionally suppresses the routine matrix on a docs-only change.

## AI involvement

Authored by Claude Opus 5 under operator direction, per `docs/AI_DEVELOPER_WORKFLOW.md` §8.2. Operator explicitly authorised a commit to `main` for this document. Merging via the REST squash endpoint so GitHub creates and signs the commit, satisfying the `signed-attested-branches` ruleset.