### PR TITLE
docs(reviews): v1.0.0 GA gap vote, ROADMAP cross-correlation, retractions

### DIFF
--- a/docs/GRAPH_ENGINEERING.md
+++ b/docs/GRAPH_ENGINEERING.md
@@ -401,7 +401,7 @@ provenance decay into folklore:
 | Rule | Incident |
 |---|---|
 | R-101 build daemon | fourteen concurrent lane target trees filled a 912 GB volume to 1.4 GB free |
-| R-202 self-skip ≠ pass | CI postgres has no AGE; every AGE test self-skipped to exit 0 |
+| R-202 self-skip ≠ pass | the PR-gating postgres job runs an AGE-less image, so AGE-gated tests self-skip to exit 0 on that gate (the coverage job does run a live AGE service) |
 | R-203 prove load-bearing | a ghost-node test used a query path that silently falls back, so it passed against unfixed code |
 | R-204 `contains` blind to drift | a span guard passed while broken — `contains` cannot detect a one-byte offset at any distance |
 | R-206 static-guard sweep | five CI jobs lost to a single static guard that targeted test selection could not see |

--- a/docs/reviews/v1.0.0-GA-GAP-VOTE-AND-ROADMAP-CROSS-CORRELATION-OPUS-5.md
+++ b/docs/reviews/v1.0.0-GA-GAP-VOTE-AND-ROADMAP-CROSS-CORRELATION-OPUS-5.md
@@ -1,0 +1,807 @@
+# v1.0.0 GA — gap vote, ROADMAP cross-correlation, and process findings
+
+**Date:** 2026-07-27
+**Reviewer:** Opus 5 (AI NHI), campaign `campaign/v1.0.0-ga`
+**Codebase under review:** `release/v1.0.0` @ `011dd8b9`
+**Codegraph index:** `/home/fate_two/v07/v09-dev/.codegraph` — verified canonical, on
+`release/v1.0.0`, resynced 2026-07-27 19:45
+**Target the assessment is made against:** ai-memory at **1,000,000+ federated AI agent
+deployments in enterprise-class secure configuration** — not a single-user tool, not a
+developer laptop.
+
+> **Status of this document.** Everything in Parts I–V was independently re-verified against
+> the working tree at HEAD on 2026-07-27 before being written down. Every claim carries a
+> `file:line` or an issue number. Part VI records claims made earlier in this campaign that
+> **failed** that verification and are retracted. Wave 2 of the adversarial vote was
+> dispatched but had not reported when this document was committed; §2.4 states exactly what
+> is and is not settled.
+
+---
+
+## Table of contents
+
+1. [Part I — Process finding: codegraph's caller lists are not trustworthy alone](#part-i)
+2. [Part II — The 2×5 adversarial vote](#part-ii)
+3. [Part III — ROADMAP cross-correlation](#part-iii)
+4. [Part IV — Verified findings ledger](#part-iv)
+5. [Part V — ROADMAP commitments with no carrier](#part-v)
+6. [Part VI — Retractions: claims this campaign made that failed verification](#part-vi)
+7. [Part VII — Ranked recommendations](#part-vii)
+8. [Appendix A — verification commands](#appendix-a)
+
+---
+
+<a name="part-i"></a>
+## Part I — Process finding: codegraph's caller lists are not trustworthy alone
+
+This is placed first because it changes how every other finding in this document must be
+produced, and because it contradicts standing written guidance.
+
+### I.1 The standing guidance
+
+Project guidance instructs: *"Trust codegraph results: do NOT re-verify symbol lookups with
+grep."* For **symbol definition lookup** that guidance is correct and remains in force —
+codegraph returns verbatim line-numbered source with call paths in one round-trip, and it is
+strictly better than a grep-and-Read loop.
+
+### I.2 The measurement
+
+For **caller enumeration** the guidance is wrong on this codebase. Two measurements:
+
+| Probe | codegraph result | grep ground truth |
+|---|---|---|
+| `codegraph query blend_and_rank` | `[]` | 1 definition, exists in `src/storage/mod.rs` |
+| callers of `CONTRADICTION_SOFT_LOSER` | **zero callers** | **7 sites across 5 files** |
+
+The `CONTRADICTION_SOFT_LOSER` ground truth, verified at HEAD:
+
+```
+src/autonomy.rs:1106            map.remove(field_names::CONTRADICTION_SOFT_LOSER);
+src/autonomy.rs:2357            .get(field_names::CONTRADICTION_SOFT_LOSER)
+src/models/crdt_merge.rs:455    field_names::CONTRADICTION_SOFT_LOSER,
+src/models/field_names.rs:149   pub const CONTRADICTION_SOFT_LOSER: &str = "contradiction_soft_loser";
+src/storage/mod.rs:3582         field_names::CONTRADICTION_SOFT_LOSER.to_string(),
+src/storage/mod.rs:3648         map.remove(field_names::CONTRADICTION_SOFT_LOSER);
+src/storage/mod.rs:15920        .get(crate::models::field_names::CONTRADICTION_SOFT_LOSER)
+```
+
+The shape of the failure is specific: **private Rust fns and `const` items are under-indexed.**
+Public fns and types resolve correctly.
+
+### I.3 Why this is severe rather than merely inconvenient
+
+The campaign executor runs a completeness gate (G3) whose entire purpose is to catch the
+**#2418 class**: a fix that updates the obvious call sites, passes its own tests, and silently
+leaves other callers on the old contract. That gate was written to consume codegraph caller
+lists.
+
+An empty caller list from an under-indexed symbol makes G3 emit **`PASS` — all callers within
+the touched set**. That is a **false PASS**, and a false PASS is strictly worse than having no
+gate at all, because it carries the authority of verification. The gate would have reported
+green on exactly the class of defect it exists to catch.
+
+### I.4 The fix, as landed
+
+`executor/codegraph.py` no longer trusts a codegraph caller list as complete. It cross-checks
+with grep and takes the **union — never the intersection**:
+
+```python
+def _grep_callers(symbol: str, repo: Path) -> set[str]:
+    r = subprocess.run(
+        ["grep", "-rl", "--include=*.rs", symbol.split("::")[-1], "src/"],
+        cwd=str(repo), capture_output=True, text=True,
+    )
+    return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
+```
+
+```python
+grep_files = _grep_callers(symbol, repo)
+only_grep = sorted(grep_files - callers)
+if only_grep:
+    # Union, never intersection: an under-indexed symbol must WIDEN the
+    # caller set, not narrow it.
+    callers |= grep_files
+```
+
+and the report is annotated so the incompleteness is visible to a human reading the log rather
+than silently absorbed:
+
+```
+COMPLETENESS  CONTRADICTION_SOFT_LOSER
+  FAIL  3 caller file(s) NOT touched: src/autonomy.rs, src/models/crdt_merge.rs, src/models/field_names.rs
+  [INDEX INCOMPLETE: grep found 3 file(s) codegraph missed — src/autonomy.rs,
+   src/models/crdt_merge.rs, src/storage/mod.rs; caller set widened by union]
+  callers: 4
+```
+
+### I.5 The rule this produces
+
+> **Codegraph is a lead generator for blast radius; grep is the confirmation.** Codegraph
+> remains mandatory and remains first — it found the 14-site blast radius on #2418 that a
+> hand-grepped scope had put at 2 funnels. But a codegraph caller list may only ever *widen* a
+> footprint, never bound it. An empty caller list is not evidence of no callers.
+
+This is a process fix, not a code fix, and it is recorded here because the campaign's operating
+principle is: **you do not fix the code, you fix the process that produced the code.**
+
+---
+
+<a name="part-ii"></a>
+## Part II — The 2×5 adversarial vote
+
+### II.1 What was under test
+
+An assessment claimed ai-memory has three gaps relative to a
+"catalogue-and-audit-a-collection" workload:
+
+- **G-A — ranking/retrieval precision.** Measured on a live 2,024-row corpus: the same generic
+  high-priority row is the #1 result for `gh pr merge --squash`, `git push`, **and**
+  `git status`. 522/2024 rows (25.8%) are priority-10 + long-tier carrying an identical `+8.0`
+  additive prior; 93.6% of matches for a representative query score below that prior on BM25.
+  Top-3 for two semantically unrelated queries were byte-identical.
+- **G-B — no external-usage signal.** `access_count` measures *recall* access, not whether a
+  memory is load-bearing for anything outside the substrate. Confidence decay is time-based
+  only (`src/confidence/mod.rs:161-174`, `exp(-age·ln2/half_life)`).
+- **G-C — no collection/filesystem ingest.** No first-class "scan a corpus of external
+  artefacts and maintain a record per artefact" source.
+
+### II.2 Procedural integrity — and a prior failure it corrects
+
+A **prior** vote brief in this campaign was procedurally compromised, and the compromise was
+diagnosed by a later wave. That brief:
+
+1. instructed voters to *"default to REJECT / V1.X if uncertain"* — which manufactures the
+   consensus it then reports;
+2. **pre-labeled the surviving option** before voting; and
+3. instructed *"do not re-derive it"* — which prevented voters from catching an error that was
+   in the brief itself.
+
+The gap-vote brief was written to defeat all three: no instructed default, explicit instruction
+to re-derive anything load-bearing, an explicit warning that shared survey evidence correlates
+voters, and an explicit statement that *"if you conclude the framing itself is wrong, say so —
+that is a valid verdict."*
+
+This is recorded because **a vote is only evidence if its procedure is auditable**, and at 10⁶
+deployments the difference between a real consensus and a manufactured one is not academic.
+
+### II.3 Wave 1 result
+
+| Question | Result |
+|---|---|
+| **Q1 severity** | G-A **CRITICAL** (4/5) · G-B **IMPORTANT** (3/5) · G-C **MARGINAL** (4/5) |
+| **Q2 coverage** | All three **PARTIALLY COVERED** at best |
+| **Q3 missing** | The 1M target is **~3 orders of magnitude past the documented envelope**; the substrate has **no ranking-quality gate at all** |
+| **Q4 ranked** | (1) ranking-quality gate · (2) fleet upgrade/rollback · (3) backend parity |
+
+**All five lenses converged above the gap list.** The dominant Wave-1 finding was not any of
+G-A/G-B/G-C but the observation that closing all three moves the substrate no closer to 10⁶.
+Issues filed from Wave 1: **#2436**, **#2437**, **#2438**.
+
+Wave 1 also **corrected the brief in two places**, which is the behaviour the anti-correlation
+rules were written to produce:
+
+- **"#2066 ≈ G-B" was a false mapping.** #2066 unifies *existing* age/access signals into an
+  eviction gradient. It adds no external usage signal. G-B is about a signal that does not
+  exist in the substrate at all.
+- **"AGE has never executed anywhere" was false.** See §VI.4.
+
+### II.4 What is NOT settled
+
+**Wave 2 was dispatched and had not reported when this document was committed.** Five voters
+with distinct lenses — scale physics, enterprise security review, data-tier integrity,
+measurement validity, and framing skeptic — were tasked to *attack* the Wave-1 consensus rather
+than reproduce it, and were given the three retractions in Part VI as explicit calibration on
+how much of the brief to trust.
+
+Wave 2's central challenge is deliberately aimed at Wave 1's own headline: is
+**#2438** (a) correct and load-bearing, (b) correct but **unactionable** — a restatement of "we
+have not benchmarked" — or (c) **wrong**, because the module/federation architecture means the
+per-node envelope is the only thing that must hold? Until Wave 2 rules, treat §II.3's Q3/Q4 as
+**one wave's finding, not an adjudicated consensus.**
+
+---
+
+<a name="part-iii"></a>
+## Part III — ROADMAP cross-correlation
+
+Every gap was cross-correlated against `ROADMAP.md` at HEAD to establish whether it was
+**adjudicated and deferred**, **adjudicated out of scope**, or simply **absent**. The
+distinction matters: a deferral is a decision that can be revisited; an absence means nobody
+ever framed the question.
+
+### III.1 G-A — ranking/retrieval precision: **ABSENT. Not deferred — never named.**
+
+The ROADMAP names the ranking *mechanism* four times and its *quality* never:
+
+| Line | Content | What it is |
+|---|---|---|
+| `ROADMAP.md:367` | §9.7 — "6-factor recall scoring: FTS relevance · priority · access count · confidence · tier boost · recency decay" | a feature count, not a quality bar |
+| `ROADMAP.md:393` | §10.1 "Real and load-bearing — **use confidently**" — "Hybrid recall — FTS5 + HNSW, content-length-adaptive blend, exponential time decay" | an endorsement |
+| `ROADMAP.md:407` | §10.2 "Real but narrower than the docs imply" | the only recall demotion ever recorded — and it is the post-ANN namespace filter, closed at v0.9.0 |
+| `ROADMAP.md:834` | §11.5 "Cross-encoder reranker default-on" | **not shipped**; see §III.4 |
+
+**There is no §, no gate item, no ruling, and no TRACT gap** (§26.1's 32-gap register at
+`ROADMAP.md:1278`) for retrieval *precision*. The nearest adjacent items are §26.6's G31
+latency actuator (#2068, `[v1.x]`) — latency, not precision — and §27 Gate 2's `index-coverage
+recall reconciliation` (`ROADMAP.md:1333`) — coverage, not ranking.
+
+**No deferral was ever adjudicated because nobody ever framed it as a question.** This is the
+strongest structural finding about G-A: it is not a defer, it is an absence.
+
+#### III.1.1 The 97.0% Recall@5 figure cannot detect the defect it would be cited to refute
+
+`ROADMAP.md:324` (§9.5) publishes:
+
+> `| Recall@5 (keyword, LLM-independent) | **97.0%** (485/500) |`
+
+and `ROADMAP.md:332` sources it: *"ICLR 2025 benchmark, pure SQLite FTS5+BM25."* This is the
+substrate's **only published retrieval-quality claim** — the number that would be produced to
+rebut G-A.
+
+The harness stores **every single corpus row** at identical priority and tier
+(`benchmarks/longmemeval/harness.py:113-120`, verified at HEAD):
+
+```python
+cmd = [
+    binary, "--db", db_path, "store",
+    "--tier", "long",
+    "--namespace", "longmemeval",
+    "--title", title,
+    "--content", f"[{role}]: {content}",
+    "--source", "import",
+    "--tags", f"sid:{sid}",
+    "--priority", "5",
+    "--json",
+]
+```
+
+The additive prior (`src/storage/mod.rs:15279`, verified at HEAD) is:
+
+```sql
+(fts.rank * -1) + (m.priority * 0.5) + (MIN(m.access_count, 50) * 0.1)
++ (m.confidence * 2.0)
++ (CASE m.tier WHEN 'long' THEN 3.0 WHEN 'mid' THEN 1.0 ELSE 0.0 END)
++ (1.0 / (1.0 + (julianday('now') - julianday(m.updated_at)) * 0.1))
+AS fts_score
+```
+
+With uniform `priority=5, tier=long`, the prior evaluates to `5×0.5 + 3.0 = 5.5` for **every
+row** — a constant that **cancels out of the ranking entirely**.
+
+The G-A defect is a `+8.0` prior (`priority 10 × 0.5 + long-tier 3.0`) swamping BM25 on a
+**heterogeneous-priority** corpus. It is therefore **structurally invisible to LongMemEval by
+construction.**
+
+The 97.0% is true-as-measured. The inference an operator will draw from it — "retrieval
+precision is validated" — is false. Filed as **#2437**.
+
+### III.2 G-B — usage/retention economics: **DEFERRED, but the deferral was inherited from a different subject**
+
+- `ROADMAP.md:439` (§10.4) — `| G15 | Stats live-counted | Defer | Watch only |`. This is the
+  only row resembling retention economics, and it is not: it is about `stats.total` being a
+  live `COUNT(*)`. No recorded ruling, no rationale, no scale reasoning. "Watch only" is the
+  entire adjudication.
+- The open carrier **#2066** — `[v1.x] Unified continuous cost-of-access retention model
+  governing eviction (G15)` — attaches to that G15 tag. **The issue's subject and the ROADMAP
+  row's subject are different things.** The retention model has no ROADMAP home; it rides a tag
+  belonging to a stats-counting defect.
+- `ROADMAP.md:835` (§11.5) is the closest *adjudicated* ruling and governs only G-B's ranking
+  half: the live recall-utility term (#1707) is *"**conditional** — wired only if shadow data
+  shows the consume-rate signal diverges from the existing `access_count` proxy."* #1707 is
+  CLOSED and #1706 shadow shipped, so the experiment ran and its answer is recorded somewhere
+  other than the ROADMAP.
+- Retention *machinery* in the ROADMAP is TTL-GC (`:398`) and size-pressure GC (`:603`) — both
+  time- and byte-based.
+
+**Verdict: deferred, deferral never adjudicated.** No ruling exists that considered
+cost-of-access retention and decided against it.
+
+### III.3 G-C — collection ingest: **ADJUDICATED OUT OF SCOPE**
+
+This is the one gap the ROADMAP actually answers. `ROADMAP.md:163` (§4, "What the substrate is
+not"):
+
+> **Not a knowledge base.** Bare propositions about the world ("Tokio's `select!` requires
+> pinned futures") live in sibling repositories. The substrate holds *cognitive artifacts of
+> agent engagement with knowledge* — what an agent learned, when, from what source, with what
+> confidence, attested by whom. The `alphaone-dev-skills` repo is the canonical sibling.
+> **The substrate references knowledge via source-URI; it does not hold knowledge as bare
+> content.**
+
+Reinforced at `ROADMAP.md:153` (§3 scope-test table) and `ROADMAP.md:919` (§13).
+
+"Scan a corpus of external artefacts and maintain a record per artefact" **is** the
+maintain-a-record-per-external-object shape §4 excludes. The nearest shipped things are
+conversation *capture* (§11.3 L1–L4, `ROADMAP.md:470-479`) and `src/mine.rs` (Claude/ChatGPT/
+Slack transcript import) — all agent-engagement artifacts, not external-artefact catalogues.
+
+**Verdict: adjudicated by derivation, never by record.** The ruling is binding but *generic* —
+no line names filesystem/collection ingest and rules on it specifically. Anyone proposing G-C
+must first overturn §4, which is a constitutional amendment requiring the #1171 heterogeneous
+panel per `ROADMAP.md:1336`, not a feature request.
+
+### III.4 Gate structure
+
+**Gate 1** (P0 freeze-critical formats, `ROADMAP.md:1331`) — **contains none of
+G-A/G-B/G-C.** It is exclusively on-disk/wire format freeze: crypto-agility envelope,
+SignableWrite v2, UUID→cid ADR, sub-10kLOC verification spec + CC0 corpus (#1837 CLOSED),
+Portability Spec v2 @ v78, epistemic kinds, claim-bitemporal columns (#1834 CLOSED),
+rollback-evidence anchor, equivocation-proof + checkpoint federation (#1936), quarantine tier,
+custody-class + signed revocation, read-path consumer-binding envelope scope, supply-chain/
+build-integrity.
+
+**Gate 2** (P1 safety machinery, `ROADMAP.md:1333`) — nearest neighbours to the three gaps,
+**none of which is the gap**:
+
+| Gate-2 item | Nearest gap | Why it is not the gap |
+|---|---|---|
+| `verified-path 1M benchmarks` | the 1M target | bears on scale, not on G-A/B/C |
+| `index-coverage recall reconciliation` | G-A | ANN *coverage* (is every row indexed?), not ranking quality |
+| crypto-shred + mandatory tombstones + erasure attestation | G-B | erasure *correctness*, not retention *economics* |
+| capture-completeness lane (L3 SHIPPED v1.0.0 — #1978, #2220) | G-C | conversation capture, not collection ingest |
+
+**The deferred/v1.x set and its rulings:**
+
+| Item | Ruling | Line | Carrier |
+|---|---|---|---|
+| Reranker default-on | *"explicitly REFUSED by the #1867 vote — deferred to v1.0"* | `:828` | **#1969 OPEN, still tagged `[v1.0]` — v1.0.0 shipped without it** |
+| Live recall-utility wire | *"conditional — wired only if shadow data shows divergence"* | `:835` | #1707 CLOSED |
+| 8 coordination hook events | *"DEFERRED to v1.x on carrier #1988 — with a binding SUNSET"* | `:731` | **#1988 CLOSED — the sunset now has no clock** |
+| mDNS · MVCC · OTel · federation E2E | *"ruled DEFERRED to v1.x (recorded, not dropped)"* | `:857` | only E2E has one (#1968) |
+| Distilled hot-path model | *"CUT from v1.0 (Sprint-0 W4 ruling)"* | `:700` | — |
+| TOON v2 (R8) | *"FORMALLY CUT — no §2 property"* | `:851` | — |
+| enforce-as-default decorrelation | *"the enforce-as-default rung… are v1.x, not v1.0.0"* | `:1332` | D3-021→D3-031→D3-060 |
+
+### III.5 ROADMAP-vs-backlog contradictions
+
+The #2416 doc-drift sweep (#2406/#2407/#2408/#2409/#2411) was **not exhaustive.** Live
+contradictions at HEAD:
+
+#### D1 — §25.2/§25.3 claim checkpoint federation "LANDED at v1.0.0"; the outbound leg is dead code
+
+`ROADMAP.md:1226`: *"rides the FED-RQ-01 checkpoint-federation transport — #1936, **LANDED at
+v1.0.0**: resolved commit-checkpoints federate over `/sync/push`…"* Repeated at `:1233`; §27
+Gate 1 lists it as discharged.
+
+Verified at HEAD — the symbol is **defined and never called**:
+
+```
+$ grep -rn "broadcast_checkpoint_resolution_quorum" src/
+src/federation/sync.rs:1548:pub async fn broadcast_checkpoint_resolution_quorum(
+```
+
+One hit. The definition. Zero call sites in `src/`.
+
+The receive leg landed. "Federate" implies both. **Two nodes running this build never exchange
+a checkpoint resolution** — which is the §25.2 epoch-freeze contract's only cross-node
+mechanism. Tracked as **#2391 (OPEN)**.
+
+#### D2 — §10.1 lists hybrid recall under "use confidently"; #2425 says the keyword lane is ~35% collapsed
+
+`ROADMAP.md:393` sits under *"Real and load-bearing (**use confidently**)"*. **#2425 (OPEN)**
+reports that `blend_and_rank` normalises `norm_fts` by a max that **contains** the priority
+prior (`src/storage/mod.rs:15882`, `src/store/postgres.rs:18541`), collapsing ~35% of the
+keyword lane's dynamic range — and that `recall_scoring_parity.rs` is green for the wrong
+reason (the shared prior swamps both backends' relevance terms).
+
+§10.2 exists precisely for "real but narrower than the docs imply". **Hybrid recall is filed in
+the wrong section.**
+
+#### D3 — §11.4 Pillar 2.5 / §12 claim compaction shipped; capabilities still reports it planned
+
+`ROADMAP.md:900` — `| Background curator daemon (R4) | 4 | ✅ shipped v0.8.0 Pillar 2.5 |`.
+**#2400 (OPEN)**: capabilities reports `CapabilityCompaction::planned()` while the destructive
+consolidator shipped (#1749). The §10.3 capabilities-honesty discipline has regressed on this
+surface.
+
+#### D4 — Pillar 1 lease-audit line: doc fixed, tracker stale
+
+`ROADMAP.md:533` now asserts the sweeper emits `coordination.lease_expire_reclaim` audit rows
+*"on both backends — #2371"*. The code **is** present (`src/background/lease_sweep.rs:17,142`;
+`src/store/postgres.rs:10840-10866`), but **#2371 remains OPEN** with the title *"ROADMAP:531
+'Already in baseline' claim is false (both backends)"*. This is the **mirror image** of the
+#2416 class — doc corrected, tracker not.
+
+#### D5 — reranker default-on was promised "deferred to v1.0"; v1.0.0 shipped without it
+
+**#1969 is OPEN and still tagged `[v1.0]`.** Verified at HEAD that the default is off:
+
+```rust
+// src/config.rs:843-845
+fn default_reranker_mode() -> RerankerMode {
+    RerankerMode::Off
+}
+```
+
+An unmet *release* commitment with a live carrier that nothing re-homed. This compounds
+**#2425**: with the reranker off by default, the collapsed keyword lane is the **terminal**
+ordering for the large majority of deployments — there is no second-stage model to repair it.
+
+### III.6 Open issues implying work the ROADMAP does not track at all
+
+| Issue | Substance | ROADMAP coverage |
+|---|---|---|
+| **#2424** `[GA-BLOCKER]` | postgres v83→v84 upgrade is BRICKED. Proven a **class with two live instances**: v67–v73 die on `cid`, v74–v83 on `embedding_space` | **none** — §17's per-release gates (`:1004-1015`) cover ship-gate, A2A-gate, channels, mobile, provenance, GPG tags. **Not one gate is a cross-version upgrade test.** |
+| **#2358** | `recall_observations` pruner is serve-daemon-only ⇒ unbounded ledger growth on MCP-stdio/CLI topologies | unbounded-growth economics appear nowhere |
+| **#2311** | postgres tenant quota is check-then-record TOCTOU across transactions | quotas appear at `:224` as a shipped bullet; fairness under concurrency is untracked |
+| **#2310, #2312, #2313, #2314, #2315, #2317** | six-issue postgres/sqlite divergence cluster | ROADMAP treats the SAL as a solved abstraction (§11.3.1 `:505`); **no backend-parity lane exists** — and postgres is the **only** backend the module model can run on (`:613`) |
+| **#2401** | `CompliancePreset` `encrypt_at_rest` + `pseudonymize_actors` are dead knobs — HIPAA/GDPR config boots silent | §11.4 `:822` commits to "HIPAA-aligned routine templates"; a silently-inert compliance preset is worse than none |
+| **#2169** | `[v1.x][enterprise][hive] Fleet-coordinated rolling reembed orchestration at 1M-instance scale` | the **only** backlog issue that says "1M". **No ROADMAP home at all.** |
+
+For a fleet target, **#2424's class is the single largest untracked commitment**: at 10⁶
+instances you cannot hand-heal a bricked upgrade.
+
+---
+
+<a name="part-iv"></a>
+## Part IV — Verified findings ledger
+
+Every row re-verified against HEAD `011dd8b9` on 2026-07-27.
+
+### IV.1 Filed this cycle
+
+| Issue | Finding | Evidence |
+|---|---|---|
+| **#2436** | contradiction soft-loser penalty is **DEAD on postgres** | see §IV.2 |
+| **#2437** | LongMemEval harness stores every row at identical priority/tier ⇒ the only published relevance benchmark is **structurally blind** | `benchmarks/longmemeval/harness.py:113-120` |
+| **#2438** | stated 1M+ agent target is ~3 orders of magnitude beyond the documented tested envelope | `ROADMAP.md:611`, `:613`, `:659-665` |
+
+### IV.2 #2436 in detail — and it is worse than filed
+
+Postgres **does** carry the priority prior, tier bonus and recency term in SQL. Verified at
+`src/store/postgres.rs:17074-17083`:
+
+```sql
+ts_rank(tsv, to_tsquery('english', $1))
++ (priority * 0.5)
++ (LEAST(access_count, 50) * 0.1)
++ (confidence * 2.0)
++ CASE tier WHEN 'long' THEN 3.0 WHEN 'mid' THEN 1.0 ELSE 0.0 END
++ (1.0 / (1.0 + EXTRACT(EPOCH FROM (NOW() - updated_at)) / 86400.0 * 0.1))
+  AS rank
+```
+
+The divergence is at the **fusion** stage, not the SQL stage:
+
+| Backend | Fusion expression | Location |
+|---|---|---|
+| sqlite | `(mem, blended * decay * penalty)` | `src/storage/mod.rs:15928` |
+| postgres | `(mem, blended)` | `src/store/postgres.rs:18556` |
+
+where sqlite's `penalty` is `SOFT_LOSER_SCORE_FACTOR = 0.5` (`src/storage/mod.rs:6438`) applied
+when the row carries the `contradiction_soft_loser` marker (`src/storage/mod.rs:15918-15928`).
+`grep -c CONTRADICTION_SOFT_LOSER src/store/postgres.rs` returns **0**.
+
+**Postgres applies neither the soft-loser penalty nor the post-fusion confidence-decay
+multiplier** — two ranking terms that sqlite applies.
+
+The aggravating detail: `src/store/postgres.rs:5694` **interpolates `SOFT_LOSER_SCORE_FACTOR`
+into its own rustdoc**, documenting a behaviour the code does not implement. A reader of the
+postgres backend's own API documentation is told the penalty applies. It does not.
+
+Consequence at the target: a conserved contradiction loser recalls at **full rank** on the only
+backend the module model can run on. Stale facts are served at full score to enterprise
+deployments while sqlite endpoints demote them — a **cross-backend truth divergence**, not
+merely a scoring nit.
+
+### IV.3 Verified, previously unfiled
+
+| Finding | Evidence | Status |
+|---|---|---|
+| Reranker default is `Off` for all tiers, making #2425's collapsed keyword lane the **terminal** ordering for most deployments | `src/config.rs:843-845` | needs filing / fold into #1969 |
+| Prior-to-relevance ratio diverges sharply between backends (BM25 and `ts_rank` have different natural scales while sharing an identical additive prior) | `src/storage/mod.rs:15279` vs `src/store/postgres.rs:17074` | needs filing |
+| `#2338`'s sqlite half **is** implemented at HEAD; its postgres half is absent | `src/storage/mod.rs:15920-15928` present; `postgres.rs` count 0 | #2338 OPEN — scope it to postgres |
+
+### IV.4 Issue-state census (verified 2026-07-27)
+
+All fifteen tracked issues re-queried against the live tracker:
+
+```
+#2337  OPEN   contradiction conserve pass unreachable
+#2338  OPEN   G7 conserve_contradiction soft down-weight is inert
+#2339  OPEN   priority is a monotonic ratchet
+#2358  OPEN   recall_observations pruner runs only under the serve daemon
+#2335  OPEN   federation (title,namespace) LWW upsert lets a STALE peer overwrite expires_at
+#2425  OPEN   blend_and_rank normalizes norm_fts by a max that CONTAINS the priority prior
+#2424  OPEN   [GA-BLOCKER] postgres v83→v84 upgrade is BRICKED
+#2391  OPEN   FED-RQ-01 outbound dead
+#2400  OPEN   capabilities reports CapabilityCompaction::planned() but consolidator shipped
+#2371  OPEN   lease sweeper audit — ROADMAP claim (doc since fixed, tracker stale)
+#1969  OPEN   [v1.0] Reranker global default-on flip
+#2066  OPEN   [v1.x] Unified continuous cost-of-access retention model (G15)
+#2436  OPEN   soft-loser penalty DEAD on postgres
+#2437  OPEN   LongMemEval harness verification-integrity
+#2438  OPEN   1M target vs documented envelope
+```
+
+**Correction to an earlier campaign claim:** it was previously asserted that #2337, #2338,
+#2339, #2358 and #2335 were "fixed at HEAD but still open". That claim is **not supported**.
+All five are open, and spot-verification shows the situation is per-issue rather than uniform —
+#2338's sqlite lane is implemented while its postgres lane is not; #2339 has a ceiling guard at
+`src/autonomy.rs:718` (`} else if stale && after > 1 && after <= ceiling {`) whose ability to
+repair an **existing** corpus is unproven. Each of the five requires individual verification
+before any close. See §VI.5.
+
+---
+
+<a name="part-v"></a>
+## Part V — ROADMAP commitments with no carrier
+
+Commitments in `ROADMAP.md` with **no corresponding open issue**:
+
+| # | Commitment | Line | State |
+|---|---|---|---|
+| 1 | **§11.6 mDNS auto-discovery** | `:859` | Ruled *"DEFERRED to v1.x (recorded, not dropped)"*. **Zero issues ever filed, open or closed.** Effectively dropped. |
+| 2 | **§11.6 MVCC strict-consistency mode** | `:861` | Same ruling. **Zero issues ever.** Effectively dropped. |
+| 3 | **§11.6 OpenTelemetry standardization** | `:862` | Same ruling. Only carrier is #2407 — the *docs-drift fix that documented the deferral*. No implementation carrier. |
+| 4 | **§11.4 Pillar4.D — publish measured envelope X** | `:659-665` | #1737 closed as harness-only. `docs/enterprise-deployment.md:1259-1265` still labels 1000/module provisional. |
+| 5 | **§27 Gate 2 — verified-path 1M benchmark numbers + CI gate** | `:1333` | Harness shipped (`src/bench.rs:130 MAX_SCALE = 1_000_000`); `PERFORMANCE.md:231` explicitly refuses to pin numbers; #1987 CLOSED. **A Gate-2 item with no bar.** |
+| 6 | **§11.6 API stability guarantee + strict semver freeze** | `:863`, `:866` | §12 `:905` still reads `🔜 v1.0` after v1.0.0 shipped. No freeze-enforcement issue exists. |
+| 7 | **§25.5 — five of six CUT-invariant CI ratchets** | `:1246` | #1971 CLOSED with only `check-l3-boundary.sh` shipped. The other five are *"enforced TODAY by code review + structural absence."* **Structural absence is not a gate.** |
+| 8 | **§26.1 — the ~20 UNTRACKED TRACT gaps** | `:1278` | Filing them is called a §24 prime-directive obligation. No epic tracks the filing. |
+| 9 | **§11.6 public security audit by a named third-party firm** | `:865` | Superseded for the v1.0.0 epic by AI-NHI review; §12 `:908` still `🔜 v1.0`. No v1.x carrier. |
+| 10 | **§17 — SLSA-style signed build-provenance attestation** | `:1010` | *"tracked for v1.x"* — #1951 CLOSED; no v1.x carrier. |
+| 11 | **§11.4 hook-pipeline SUNSET clock** | `:731` | *"binding SUNSET: if no concrete consumer materializes by v1.x planning, the deferral self-converts to CUT."* **Carrier #1988 is CLOSED — the sunset has no clock and nothing will ever fire it.** |
+| 12 | **§10.4 G3 — HNSW cold-start O(N)** | `:427` | *"OPEN past v1.0.0."* #1860 CLOSED; residual #2223 open but scoped to the vectorlite slice, not cold-start. Partially uncovered. |
+
+### V.1 The highest-severity pair: #4 and #5 together
+
+These are the two items that would convert *"1,000,000+ federated agents"* from an assertion
+into a measured claim, and **both were discharged by shipping the apparatus for measuring
+instead of the measurement.**
+
+`ROADMAP.md:659-665` (§11.4 Pillar4.D) is explicit about the standard it set for itself:
+
+> **Measure — do not guess** — the per-module agent ceiling on the rig… **Publish X**; confirm
+> the 1000-agents/module default sits at ~⅓ of measured X.
+
+**X was never measured.** `infra/pillar4-envelope/` ships only `measure-envelope.sh` and a
+`README.md`; #1737 closed as harness-only. `docs/enterprise-deployment.md:1259-1265` still
+labels the 1000-agents/module figure provisional, to be *"replaced with the measured X once it
+lands."*
+
+The entire 1M story is the arithmetic `1,000,000 ÷ 1000 agents-per-module = 1000 modules`, and
+**the 1000 is a documented guess that the ROADMAP itself instructed nobody to guess.**
+
+Meanwhile `PERFORMANCE.md:231-235` records the parallel disposition for the benchmark numbers,
+verbatim:
+
+> **1M numbers — REPRODUCIBLE-METHODOLOGY, not pinned.** This document deliberately does
+> **not** pin fabricated 1M p95 budgets.
+
+That is an honest refusal to fabricate — but it leaves a Gate-2 line item discharged by a
+methodology document. There is no 1M CI gate and no open carrier for one.
+
+**And every hardened default in the fleet was validated on a 10k-row corpus** (`.github/
+workflows/bench.yml:89-92`) **against a reference platform of "Apple M2, 16 GB, SQLite"**
+(`ROADMAP.md:336-354`) — a laptop. `ROADMAP.md:354` is explicit that these budgets *"are the
+latency contract of being at the endpoint (§2.1)"* — a **single-endpoint** contract, not a
+fleet contract.
+
+### V.2 "Enterprise-class secure configuration" is not a ROADMAP target
+
+The term appears at `:215` (an endpoint type), `:686`/`:824` (procurement framing), and `:640`
+(a docs pointer). It is nowhere stated as an engineering target with acceptance criteria.
+
+§9.8 (`:376-383`) states the honest posture: **third-party compliance held: none** — no SOC 2,
+no ISO 27001, no FedRAMP, no HIPAA certification.
+
+---
+
+<a name="part-vi"></a>
+## Part VI — Retractions: claims this campaign made that failed verification
+
+This section exists because the campaign's own rulebook (R-401 *measure, never inherit*)
+applies to the reviewer. Each claim below was asserted earlier in this campaign, was
+re-verified at HEAD on 2026-07-27, and **failed**. All are retracted.
+
+### VI.1 RETRACTED — "`current_storage_bytes` never decrements"
+
+**False.** It decrements in three places:
+
+```
+src/quotas.rs:647          current_storage_bytes = MAX(current_storage_bytes - ?1, 0),
+src/quotas.rs:777          current_storage_bytes = MAX(current_storage_bytes - ?1, 0),
+src/store/postgres.rs:14326 SET current_storage_bytes = GREATEST(current_storage_bytes - $1, 0),
+```
+
+Both backends clamp at zero. The claim was produced by grepping only for the increment pattern
+and inferring absence — the exact error Part I warns about, committed by the reviewer.
+
+### VI.2 RETRACTED — "`size_gc` is complete and unreachable"
+
+**False framing.** `size_gc` is reachable — `src/curator/mod.rs:291` calls `run_size_gc_pass`,
+which calls `crate::storage::size_gc`. It is **deliberately inert**, and the reason is
+documented in the code (`src/curator/mod.rs:459-480`):
+
+> `#1750` (Pillar-2.5) — **DEFENSIVE GATE**: size-GC byte-cap eviction is a hard-DELETE pass
+> (archive-before-delete, restorable) DISTINCT from consolidation. It must never arm decoupled
+> from the operator's compaction opt-in: the #1749 5-agent vote flagged the
+> `max_corpus_bytes.is_some()`-only gate as a hazard — an operator setting only a byte cap
+> would silently activate a second deletion pass. We additionally require
+> `compaction.enabled`. `max_corpus_bytes` stays OUT of operator config this slice (always
+> compiled-default `None` → still inert in production); this gate is future-proofing.
+> FORWARD-CONSTRAINT (#1750 vote): if `max_corpus_bytes` is ever exposed, it must get its own
+> dedicated `[curator.size_gc].enabled` switch — NOT ride under `[curator.compaction]`.
+
+That is a deliberate safety design with a recorded forward-constraint, not a defect. Calling it
+"unreachable" mischaracterised **conservative gating as a bug**, which — under the north-star
+directive on data integrity — inverts the actual merit of the code.
+
+### VI.3 RETRACTED — "postgres hybrid recall applies neither the soft-loser penalty nor tier decay"
+
+**Half false.** Postgres carries the tier bonus and the recency term in SQL
+(`src/store/postgres.rs:17074-17083`). The accurate, narrower, and still-serious claim is
+§IV.2: the divergence is at the **fusion** stage — sqlite computes `blended * decay * penalty`,
+postgres computes `blended`.
+
+The corrected claim is *more* actionable than the false one, because it names the exact
+expression to fix.
+
+### VI.4 RETRACTED — "CI's postgres carries no Apache AGE; every AGE-gated test has never executed anywhere"
+
+**False.** `.github/workflows/coverage.yml:130-146` runs a **live AGE service on every
+`release/**` PR**:
+
+```yaml
+      pg-age:
+        image: apache/age:release_PG16_1.6.0
+        env:
+          POSTGRES_USER: ai_memory
+          POSTGRES_PASSWORD: ai_memory_test
+          POSTGRES_DB: ai_memory_test
+```
+
+The correct, narrower claim: **the `ci.yml` `postgres-feature` PR gate is AGE-blind**, so
+AGE-gated tests self-skip to exit 0 *on that gate specifically*, while the coverage job does
+exercise them.
+
+This false claim was **committed to `main`** in `docs/GRAPH_ENGINEERING.md` as part of commit
+`e101a698`. The correction ships in the same commit as this document, replacing the R-202
+incident row with the accurate scope.
+
+### VI.5 RETRACTED — "five issues are fixed at HEAD but still open"
+
+**Not supported.** #2337, #2338, #2339, #2358, #2335 are all OPEN, and the situation is
+per-issue rather than uniform. #2338's sqlite lane is implemented while its postgres lane is
+not (§IV.2); #2339 has a ceiling guard at `src/autonomy.rs:718` whose ability to repair an
+existing corpus is unproven. Each requires individual verification before any close, and no
+close should be actioned on the strength of the retracted blanket claim.
+
+### VI.6 The pattern across these five
+
+Four of the five retractions share one root cause: **inferring absence from a grep that did not
+find something.** That is the identical failure mode Part I documents in the tooling — and it
+was committed by the reviewer, using grep, after diagnosing it in codegraph.
+
+The rule generalises beyond either tool:
+
+> **Absence of evidence in a search is not evidence of absence.** A negative claim ("never
+> decrements", "unreachable", "has never executed") requires a *positive* demonstration of the
+> negative — an exhaustive enumeration, a compiler error, an execution trace — not a search
+> that came back empty.
+
+This is proposed as **R-405** for the rulebook.
+
+---
+
+<a name="part-vii"></a>
+## Part VII — Ranked recommendations
+
+Ordered by what the ROADMAP's own gates and rulings make load-bearing for the stated target.
+**Wave 2 may reorder this; see §II.4.**
+
+### 1. Cross-version upgrade/rollback as a first-class release gate
+
+**#2424** proves a *class* — two distinct schema-window bricks (v67–v73 on `cid`, v74–v83 on
+`embedding_space`). §17's release gates (`ROADMAP.md:1004-1015`) contain **zero** cross-version
+upgrade test. At 10⁶ instances a bricked upgrade cannot be hand-healed, and the blast radius is
+the entire fleet at once. This outranks all three gaps and the ROADMAP does not track it.
+
+*Deliverable:* a schema-ladder rehearsal lane in CI that boots every supported prior schema
+version and upgrades it to HEAD, gating on zero-row-loss and `integrity_check=ok`. The local
+PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 substrate built for this campaign already runs this
+rehearsal; it needs to become a gate rather than a local artefact.
+
+### 2. Measure the module envelope X (§11.4 Pillar4.D)
+
+The ROADMAP said *"Measure — do not guess."* It guessed. Every 1M number divides by an
+unvalidated 1000. Until X is measured, the target is unfalsifiable, and an unfalsifiable target
+cannot be engineered toward — it can only be asserted.
+
+*Deliverable:* run `infra/pillar4-envelope/measure-envelope.sh` on real hardware, publish X,
+and either confirm the 1000-agents/module default sits at ~⅓ of X or change the default.
+
+### 3. A ranking-quality gate on a heterogeneous corpus
+
+The finding here is larger than G-A itself. **The substrate has no ranking-quality gate at
+all**, and its one published quality number (97.0% Recall@5) is measured on a corpus that
+**structurally cannot see** the defect it would be cited to refute (§III.1.1). Every ranking
+fix in flight — #2339, #2425, #2436 — is therefore **unfalsifiable**: none can be demonstrated
+to have improved anything.
+
+At 10⁶ agents an unmeasurable ranking is a fleet-wide silent-wrong-answer generator with no
+detector. Nothing in the ROADMAP or backlog proposes such a gate.
+
+*Deliverable:* a LongMemEval variant with heterogeneous priority/tier distribution matching
+observed production corpora (25.8% priority-10 long-tier), wired as a CI gate with a
+regression threshold. Tracked by **#2437**.
+
+### 4. Backend parity as a first-class gate
+
+Six open postgres-divergence issues (#2310–#2317) plus **#2436**, against the **only** backend
+the module model can run on (`ROADMAP.md:613`). The ROADMAP treats the SAL as a solved
+abstraction (§11.3.1 `:505`) and has no parity lane. A truth divergence between backends —
+which #2436 now is — is a data-integrity defect, not a scoring nit.
+
+### 5. FED-RQ-01's dead outbound leg (#2391)
+
+§25.2's epoch-freeze contract — the mechanism by which frozen-within-epoch evaluation binds
+across nodes — **has no send path**. §25.6 already bans the phrase *"epoch closure shipped"*;
+the ROADMAP nonetheless says "LANDED".
+
+### VII.1 What this ranking says about the gap list
+
+The most-defended axis in this substrate is attestation (§2.5), and it is genuinely strong.
+**The least-defended thing in the document is the 1M-agent axis itself: fleet operations —
+upgrade, backend parity, per-tenant blast radius, measured capacity — has no §, no gate, and no
+epic.**
+
+G-C is the wrong worry (§III.3 already adjudicated it). G-A is a genuine, undefended hole whose
+*missing gate* matters more than its bugs. G-B is real, and its deferral was never adjudicated
+because it rode a tag belonging to a different defect.
+
+---
+
+<a name="appendix-a"></a>
+## Appendix A — verification commands
+
+Every claim in this document is reproducible from `release/v1.0.0` @ `011dd8b9`:
+
+```bash
+# §III.1.1 — the benchmark harness stores uniform priority/tier
+sed -n '110,124p' benchmarks/longmemeval/harness.py
+
+# §III.1.1, §IV.2 — the additive prior, sqlite
+sed -n '15274,15284p' src/storage/mod.rs
+
+# §IV.2 — the additive prior, postgres (tier bonus + recency ARE present)
+sed -n '17070,17090p' src/store/postgres.rs
+
+# §IV.2 — the fusion-stage divergence
+grep -n "blended \* decay" src/storage/mod.rs      # -> 15928
+grep -n "(mem, blended)" src/store/postgres.rs      # -> 18556
+grep -c "CONTRADICTION_SOFT_LOSER" src/store/postgres.rs   # -> 0
+
+# §III.5 D1 — FED-RQ-01 outbound leg is defined and never called
+grep -rn "broadcast_checkpoint_resolution_quorum" src/
+
+# §III.5 D5 — reranker default
+sed -n '843,845p' src/config.rs
+
+# §VI.1 — current_storage_bytes DOES decrement
+grep -rn "current_storage_bytes.*MAX(\|current_storage_bytes.*GREATEST(" src/
+
+# §VI.2 — size_gc is gated, not unreachable
+sed -n '459,480p' src/curator/mod.rs
+
+# §VI.4 — coverage.yml runs a live AGE service
+sed -n '130,146p' .github/workflows/coverage.yml
+
+# §I.2 — codegraph under-indexes private fns and consts
+codegraph query blend_and_rank --json          # -> []
+grep -rn "CONTRADICTION_SOFT_LOSER" src/       # -> 7 sites, 5 files
+```
+
+---
+
+## Provenance
+
+- Gap-vote brief (Wave 1): `campaign-executor/logs/gap-vote-brief.md`
+- Gap-vote brief (Wave 2): `campaign-executor/logs/gap-vote-brief-wave2.md`
+- Codegraph gate implementation: `campaign-executor/executor/codegraph.py`
+- Rulebook: `campaign-executor/rules/rulebook.md` (R-405 proposed in §VI.6)
+- Method: `docs/GRAPH_ENGINEERING.md`
+
+**Standing constraint honoured in producing this document:** 100% of analysis and coding in
+this campaign is performed by Opus 5. No Fable, no Sonnet 5.


### PR DESCRIPTION
Records the full v1.0.0 GA gap-coverage review against the stated target of **1,000,000+ federated agent deployments in enterprise-class secure configuration**. Every claim was re-verified against \`release/v1.0.0\` @ \`011dd8b9\` before being written down; Appendix A lists the reproduction command for each.

Adds `docs/reviews/v1.0.0-GA-GAP-VOTE-AND-ROADMAP-CROSS-CORRELATION-OPUS-5.md`.

### Highlights

- **Part I** — codegraph under-indexes private Rust fns and `const` items. `CONTRADICTION_SOFT_LOSER` returned **zero** callers against **7 real sites in 5 files**. The campaign's G3 completeness gate consumed those lists and would have emitted **false PASSes** on exactly the #2418 class it exists to catch. Fixed by unioning grep results and flagging `[INDEX INCOMPLETE]`. A codegraph caller list may only ever *widen* a footprint, never bound it.
- **Part III** — G-A (ranking precision) is **ABSENT** from the ROADMAP, not deferred: nobody ever framed it as a question. The published **97.0% Recall@5** is measured by a harness that stores every row at identical priority/tier (`benchmarks/longmemeval/harness.py:113-120`), so the prior cancels out and the benchmark **structurally cannot detect** the defect it would be cited to refute.
- **Part IV** — #2436 is worse than filed: the postgres/sqlite divergence is at the **fusion** stage (`src/storage/mod.rs:15928` applies `blended * decay * penalty`; `src/store/postgres.rs:18556` applies `blended` alone) while `src/store/postgres.rs:5694` interpolates `SOFT_LOSER_SCORE_FACTOR` into rustdoc it does not implement.
- **Part V** — twelve ROADMAP commitments with no carrier. Highest severity: §11.4 Pillar4.D said *"Measure — do not guess"* the module envelope X; **X was never measured**, and the whole 1M story is `1M ÷ 1000 agents-per-module` where the 1000 is a documented guess.
- **Part VI** — **five claims made earlier in this campaign are retracted**, four sharing one root cause: inferring absence from a search that came back empty. Proposes rulebook **R-405**.

### Also corrects a factual error already on `main`

`docs/GRAPH_ENGINEERING.md` (e101a698) claimed AGE-gated tests "never executed anywhere". False — `.github/workflows/coverage.yml:130-146` runs a live `apache/age:release_PG16_1.6.0` service on every `release/**` PR. The accurate, narrower claim is that the `ci.yml` `postgres-feature` PR gate is AGE-blind. Corrected in the same commit.

### Gates

`check-hardcoded-literals`, `check-vendor-literals`, `check-docs-vs-ssot`, `check-l3-boundary` all pass locally. Docs-only; `[skip ci]` — **no CI release triggered**.

Refs #2436 #2437 #2438 #2424 #2425 #2391 #1969