### PR TITLE
docs(#2318): retire the last "tracked follow-up" claims about postgres archive-link wiring

### DIFF
--- a/docs/design/Grok-TRACT-v0.8.0-Development-Gaps.md
+++ b/docs/design/Grok-TRACT-v0.8.0-Development-Gaps.md
@@ -277,7 +277,7 @@ FED-RQ-02..05 OPEN: epoch manifest federation, `/sync/since` checkpoint catch-up
 
 ### G-P2-13 · Postgres snapshot/restore link edges (v70)
 
-`archived_memory_links` table exists; postgres snapshot/restore wiring tracked follow-up.
+`archived_memory_links` table exists; postgres snapshot/restore wiring tracked follow-up. **[Superseded 2026-07-30, #2318: the postgres wiring had in fact already shipped — `forget` / `archive_by_ids` snapshot and `archive_restore` re-inserts, pinned by `archive_restore_preserves_links_pg_1771`. Finding left verbatim: this document is a dated 2026-06-28 assessment of `release/v0.8.0 @ 14a34566` and is not retroactively edited.]**
 
 ### G-P2-14 · Capability honesty (#1672–#1674)
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12479,6 +12479,7 @@ pub fn list_archived(
 /// preserved edge whose endpoints still exist, and the behaviour is pinned
 /// by `archive_restore_preserves_links_pg_1771`. Both backends wire
 /// snapshot/restore.
+///
 /// v1.0.0 #2418 (L-EXPIRY-CANON) — read `archived_memories.original_expires_at`
 /// and return it in the ONE canonical fixed-UTC rendering.
 ///

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12470,8 +12470,15 @@ pub fn list_archived(
 /// empty edge graph. Other `ON DELETE CASCADE` provenance
 /// (`recall_observations`, confidence-calibration rows,
 /// `memory_transcript_links`) is regenerable telemetry and is NOT
-/// preserved by design. POSTGRES edge restore is a tracked follow-up
-/// (this commit wires sqlite only).
+/// preserved by design.
+///
+/// #2318 truth-fix: this comment long read "POSTGRES edge restore is a
+/// tracked follow-up (this commit wires sqlite only)". That is FALSE and
+/// has been since v70 shipped — `PostgresStore::forget` and
+/// `archive_by_ids` snapshot edges, `archive_restore` re-inserts every
+/// preserved edge whose endpoints still exist, and the behaviour is pinned
+/// by `archive_restore_preserves_links_pg_1771`. Both backends wire
+/// snapshot/restore.
 /// v1.0.0 #2418 (L-EXPIRY-CANON) — read `archived_memories.original_expires_at`
 /// and return it in the ONE canonical fixed-UTC rendering.
 ///

--- a/src/store/postgres_schema.sql
+++ b/src/store/postgres_schema.sql
@@ -537,9 +537,11 @@ CREATE INDEX IF NOT EXISTS archived_memories_archived_at_idx ON archived_memorie
 -- FK (it is an archive table, like archived_memories itself) plus an
 -- `archived_at` stamp. The explicit/recovery-expected delete paths
 -- snapshot a memory's edges here BEFORE the cascade DELETE so restore can
--- re-insert them. SQLite wires snapshot/restore this commit; the postgres
--- snapshot/restore wiring is a tracked follow-up — this table is created
--- on both backends now for adapter-schema consistency. Fresh installs get
+-- re-insert them. BOTH backends wire snapshot/restore: `PostgresStore::forget`
+-- and `archive_by_ids` snapshot, `archive_restore` re-inserts, pinned by
+-- `archive_restore_preserves_links_pg_1771`. (#2318 truth-fix — this comment
+-- long called the postgres wiring "a tracked follow-up" after it had
+-- shipped.) The table is created on both backends. Fresh installs get
 -- it inline here; upgraded installs via PostgresStore::migrate_v70.
 -- ─────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS archived_memory_links (


### PR DESCRIPTION
## What was still false

#2318 closed after correcting two sites. A **repo-wide** grep found two more live claims that the postgres archive-link snapshot/restore wiring is unfinished:

| site | claim |
|---|---|
| `src/storage/mod.rs` (doc comment on `restore_archived*`) | *"POSTGRES edge restore is a tracked follow-up (this commit wires sqlite only)"* |
| `src/store/postgres_schema.sql` (v70 table comment) | *"the postgres snapshot/restore wiring is a tracked follow-up"* |

Both are false, and have been since v70 shipped: `PostgresStore::forget` and `archive_by_ids` snapshot edges, `archive_restore` re-inserts every preserved edge whose endpoints still exist, and the behaviour is pinned by `archive_restore_preserves_links_pg_1771`.

Corrected in the pattern already used at `src/store/postgres.rs:711` — state that it **shipped** *and* name the prior false claim. A reader who finds a comment contradicting the code should be able to tell which one moved, rather than guessing whether the comment or the implementation is stale.

## The dated artifact is annotated, not rewritten

`docs/design/Grok-TRACT-v0.8.0-Development-Gaps.md:280` carries the same claim. It is **not** corrected, because it is a dated point-in-time assessment (`Assessment date: 2026-06-28`, against `release/v0.8.0 @ 14a34566`). Its finding is left **verbatim** with a dated supersession annotation.

The distinction is deliberate and worth stating as a convention: **live source comments describe current behaviour and must be true; dated assessments describe a moment and must not be retroactively edited.** Silently "fixing" a historical audit would make the record agree with the present at the cost of no longer recording what was actually believed then — which is the opposite of what an audit trail is for.

`CHANGELOG.md:146` needs no change — it *records the correction* rather than repeating the claim.

## Method note

The shard audit that surfaced this reported **two** sites. Searching repo-wide rather than trusting that count found the **third**. Absence of evidence in a bounded search is not evidence of absence (**R-405**) — a rule I violated earlier today on #2500 by concluding "no issue tracks this" from a `--limit 200` search, so it is applied deliberately here.

## Verification

- `cargo fmt -- --check src/storage/mod.rs` clean (rustfmt parses the file, so a malformed doc block would fail here without needing a full build)
- Changes are one Rust **doc comment**, one **SQL comment**, and one **markdown annotation** — no codegen surface, no schema change, no behaviour change
- Post-fix grep confirms the only surviving `"tracked follow-up"` string near this wiring is `src/store/postgres.rs:711`, which is the acknowledgement of the prior false claim rather than a claim itself

Closes #2318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY