### PR TITLE
ci(#2657): hoist the sal-postgres test compile out of the 2100s watchdog window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -952,6 +952,39 @@ jobs:
           pg_test() {
             local label="$1"; shift
             local rc=0
+            # #2657: COMPILE the test binaries OUTSIDE the watchdog first, so the
+            # 2100s per-invocation cap times test RUNTIME (the hang-detection
+            # purpose) rather than compile+run wall-time. This is the same fix
+            # #1989 applied to `run_tests` in the `check` job above; that issue
+            # fixed one of the two near-identical runners and left this twin
+            # untouched, so the postgres gate kept timing compile+run.
+            #
+            # MEASURED on run 30718303500 attempt 2: the timed invocation began
+            # 22:16:43 and the first `Running tests/...` line did not appear
+            # until 22:24:41 — 478s (23% of the 2100s cap) spent compiling 316
+            # crates INSIDE the window. Tests then ran 1605s before the kill;
+            # 478 + 1605 = 2083s against the 2100s cap, and the SIGTERM landed
+            # 99% of the way through (547 of 550 binaries had run; only
+            # wire_check_sole_path_pin, wt_1_a_schema_migration, wt1c_mcp_atomise
+            # and zeroize_secret_holders_1258 never started). Nothing hung — the
+            # watchdog was measuring the build.
+            #
+            # The failure mode this closes is a silent, GROWING one: compile time
+            # rises with every test file added, so each new binary shrinks the
+            # runtime budget the cap actually grants. Hoisting the build is the
+            # correct fix rather than raising the cap, which would only reset the
+            # same curve and have to be raised again; the cap must keep timing
+            # hang-detection alone. The job-level `timeout-minutes` still bounds
+            # the build, and a genuine runtime hang still trips the 2100s below.
+            #
+            # `|| return "$?"` is load-bearing: a compile failure must fail the
+            # job here, not fall through into a `timeout` run that would report a
+            # confusing second error. `cargo test --no-run` accepts (and ignores)
+            # the trailing `-- --test-threads=1` that every call site passes —
+            # verified on cargo 1.96.0 for all three arg shapes used below
+            # (bare, `--lib`, and repeated `--test <name>`): exit 0, zero tests
+            # executed.
+            cargo test --no-run "$@" || return "$?"
             # `--no-fail-fast` (#2500) — DIAGNOSTIC COMPLETENESS. Without it,
             # cargo exits after the FIRST failing test executable and every
             # later binary is never run. That is not hypothetical: on PR

--- a/scripts/test/test-ci-workflow-invariants.sh
+++ b/scripts/test/test-ci-workflow-invariants.sh
@@ -558,6 +558,103 @@ else
     fi
 fi
 
+# ===========================================================================
+# SECTION D — #2657: the watchdog must time test RUNTIME, not compile+run.
+#
+# THE DEFECT. `ci.yml` carries TWO near-identical test-runner shell functions:
+# `run_tests` in the `check` job and `pg_test` in the `Postgres feature gate`
+# job. #1989 hoisted compilation OUT of the timed window in `run_tests` and
+# never touched its twin, so for the whole of the v1.0.0 epic the postgres
+# gate's 2100s cap measured compile+run.
+#
+# MEASURED on run 30718303500 attempt 2: the timed invocation began 22:16:43
+# and the first `Running tests/...` line appeared at 22:24:41 — 478s (23% of
+# the cap) spent compiling 316 crates INSIDE the window. Tests then ran 1605s
+# before the SIGTERM; 478 + 1605 = 2083s against a 2100s cap, and the kill
+# landed 99% of the way through (547 of 550 binaries had run). Nothing hung.
+#
+# WHY IT IS A SEPARATE INVARIANT FROM SECTION B. B is about diagnostic
+# completeness — a run that DID report should reach the binary carrying the
+# proof. This is about a MEASUREMENT being of the wrong quantity: the cap is
+# hang-detection, and a hang is a property of the RUN. Worse, the error it
+# produces is a `::error::[#1492 watchdog] ... exceeded the timeout` naming a
+# hang that did not occur, so the misfire actively misdirects triage.
+#
+# WHY IT MUST BE A GATE RATHER THAN A FIX. The failure mode is TWIN DRIFT: two
+# copies of one discipline, one fixed and one silently left behind. Fixing
+# `pg_test` alone would leave the class open the next time a runner is added.
+# So this rule is stated over EVERY watchdog-wrapped invocation, not over the
+# two functions that exist today.
+#
+# WHY THE SHORT-CIRCUIT IS PART OF THE RULE. The prebuild must be
+# `... || return "$?"`: a compile failure has to fail the job at the prebuild,
+# not fall through into a `timeout` run that reports a second, confusing error.
+# ===========================================================================
+echo "  --- Section D: #2657 watchdog measures RUNTIME, not compile+run ---"
+
+# d_scan <ci.yml-path> — prints "<bad>/<total>" over the watchdog-wrapped
+# `cargo test` invocations in that file. A wrapped invocation is COVERED when a
+# short-circuiting `--no-run` prebuild appears between the opener of its own
+# enclosing shell function and the invocation itself. Factored out so the R-203
+# regression leg below can run the IDENTICAL logic against a mutated copy.
+d_scan() {
+    local file="$1" total=0 bad=0 line w opener prebuild
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        total=$((total + 1))
+        w="${line%%:*}"
+        # Nearest enclosing `name() {` opener above the invocation.
+        opener="$(awk -v w="$w" '
+            NR < w && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_]*\(\)[[:space:]]*\{[[:space:]]*$/ { n = NR }
+            END { print n + 0 }' "$file")"
+        if [ "$opener" -eq 0 ]; then
+            bad=$((bad + 1))
+            printf '         watchdog line %s is not inside a shell function\n' "$w" >&2
+            continue
+        fi
+        prebuild="$(awk -v a="$opener" -v b="$w" '
+            NR > a && NR < b && /cargo test --no-run "\$@" \|\| return "\$\?"/ { n = NR }
+            END { print n + 0 }' "$file")"
+        if [ "$prebuild" -eq 0 ]; then
+            bad=$((bad + 1))
+            printf '         no short-circuiting `cargo test --no-run "$@" || return "$?"` between the function opener (line %s) and the timed invocation (line %s)\n' \
+                "$opener" "$w" >&2
+        fi
+    done <<< "$(grep -nE '(TIMEOUT_BIN|--kill-after=60)[^|]*cargo test' "$file" || true)"
+    printf '%s/%s' "$bad" "$total"
+}
+
+d_result="$(d_scan "$CI_YML")"
+d_bad="${d_result%%/*}"
+d_total="${d_result##*/}"
+if [ "$d_total" -eq 0 ]; then
+    bad "D: found no watchdog-wrapped 'cargo test' invocation in $CI_YML" \
+        "the #1492 watchdog wrapper was removed or renamed — this guard has gone blind"
+elif [ "$d_bad" -eq 0 ]; then
+    ok "D: all $d_total watchdog-wrapped 'cargo test' invocations hoist compilation out of the timed window"
+else
+    bad "D: $d_bad of $d_total watchdog-wrapped 'cargo test' invocations compile INSIDE the timed window" \
+        "the per-invocation cap then measures compile+run and shrinks as test files are added, and its ::error:: names a hang that did not occur (#2657; #1989 fixed only the check-job twin)"
+fi
+
+# R-203 regression leg: strip the prebuild from a throwaway copy and require
+# the scan to CATCH it. Without this, a scan whose regex silently stopped
+# matching would report 0/0-clean forever — the same vacuous-assertion hazard
+# Sections A and C each carry a frozen-fixture leg against. Scratch lives under
+# the repo (never system /tmp), trap-cleaned by the SCRATCH dir above.
+if [ "$d_total" -gt 0 ]; then
+    D_MUT="$SCRATCH/ci-2657-mutant.yml"
+    grep -v 'cargo test --no-run "\$@" || return "\$?"' "$CI_YML" > "$D_MUT"
+    d_mut_result="$(d_scan "$D_MUT" 2>/dev/null)"
+    d_mut_bad="${d_mut_result%%/*}"
+    if [ "$d_mut_bad" -eq "$d_total" ]; then
+        ok "D regression: stripping every --no-run prebuild makes ALL $d_total invocations fail the scan — the rule is load-bearing"
+    else
+        bad "D regression: the prebuild-stripped mutant did not fail the scan ($d_mut_result)" \
+            "the scan has gone blind — every assertion above is vacuous"
+    fi
+fi
+
 echo ""
 if [ "$FAIL" -eq 0 ]; then
     echo "ci.yml invariants: $PASS/$PASS PASS"


### PR DESCRIPTION
## What

`.github/workflows/ci.yml` carries two near-identical test-runner shell functions: `run_tests` in the `check` job and `pg_test` in the `Postgres feature gate` job. #1989 hoisted compilation OUT of the timed window in `run_tests` — citing exactly this reasoning in its comment — and never touched its twin. The postgres gate's 2100s cap has therefore been measuring `compile + run` rather than `run`.

This adds `cargo test --no-run "$@" || return "$?"` as the first statement of `pg_test`, mirroring `run_tests`.

## The measurement

Run `30718303500` attempt 2:

| | |
|---|---|
| timed invocation begins | `22:16:43` |
| first `Running tests/…` | `22:24:41` |
| **compile inside the window** | **478s — 23% of the 2100s cap, 316 crates** |
| tests then ran | 1605s before SIGTERM |
| total | 478 + 1605 = 2083s vs the 2100s cap |
| binaries that ran | **547 of 550** |

The kill landed 99% of the way through. Only `wire_check_sole_path_pin`, `wt_1_a_schema_migration`, `wt1c_mcp_atomise` and `zeroize_secret_holders_1258` never started. Nothing hung — and the watchdog reported it as a hang, so the misfire actively misdirects triage.

The failure mode is silent and **growing**: compile time rises with every test file added, so each new binary shrinks the runtime budget the cap actually grants.

## What is deliberately NOT changed

The 2100s cap is untouched. Raising it would mask the growth curve and need raising again; the cap must keep timing hang-detection only. `--no-fail-fast` (#2500) and the exit-124 `::error::` branch are also untouched. The `ci.yml` diff is a pure insertion — 33 added lines, 0 removed, 0 modified.

## Evidence

**1. YAML validity.** `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → parses, 11 jobs. Structural assertions off the parsed tree: the `postgres-feature` step contains the prebuild; `2100` still occurs 8×; `--no-fail-fast` still occurs 4×.

**2. Shell-function proof.** The step body was extracted **verbatim from the parsed YAML** (not hand-copied) and driven over a stub `cargo` on `PATH` under `.local-runs/`:

```
CASE allpass (TEST_IMPACT=__ALL__)                    -> step exit 0
  cargo test --no-run      --features sal-postgres -- --test-threads=1
  cargo test --no-fail-fast --features sal-postgres -- --test-threads=1

CASE allfail (stub exits 101 on --no-run)             -> step exit 101
  cargo test --no-run      --features sal-postgres -- --test-threads=1
  (stub: exiting 101)
  << no second invocation — short-circuited >>

CASE impact (TEST_IMPACT=<two binaries>)              -> step exit 0
  cargo test --no-run      --features sal-postgres --lib -- --test-threads=1
  cargo test --no-fail-fast --features sal-postgres --lib -- --test-threads=1
  cargo test --no-run      --features sal-postgres --test A --test B -- --test-threads=1
  cargo test --no-fail-fast --features sal-postgres --test A --test B -- --test-threads=1
```

`--no-run` fires **first** in every branch, receives the identical `"$@"`, and a non-zero prebuild short-circuits before the timed invocation — so a compile failure still fails the job rather than falling through to a `timeout` run. A second pass had the stub log its parent process, confirming the prebuild's parent is the shell while the timed run's parent is `timeout --signal=TERM --kill-after=60 2100 cargo test --no-fail-fast …`: the wrapper is intact and now wraps only the run.

**3. `"$@"` expansion — verified, not assumed.** On cargo 1.96.0 against a throwaway 3-binary crate, all three pg call-site arg shapes:

| invocation | exit | tests executed |
|---|---|---|
| `--no-run --features sal-postgres -- --test-threads=1` | 0 | 0 |
| `--no-run --features sal-postgres --lib -- --test-threads=1` | 0 | 0 |
| `--no-run --features sal-postgres --test a --test b -- --test-threads=1` | 0 | 0 |
| same, with a deliberate compile error | **101** | — |

`cargo test --no-run` accepts and ignores the trailing harness args; `grep -cE '^(running\|test result)'` on its output is `0`, so the flag is genuinely inert rather than silently running anything.

**4. `scripts/check-required-contexts.sh`** — exact output:

```
check-required-contexts: OK (release/v1.0.0: every mirrored required context maps to a reporting job; no matrix+if wedge; no decider with a job-level if; no path-filtered carrier; every needs-classify step guarded; no dual-trigger cancelled-duplicate carrier; every job in ci.yml c8-precheck.yml coverage.yml declared required or dated-and-tracked as not-required)
```

Exit 0 — no job names, `if:` conditions, or concurrency keys were touched.

## The gate (Section D)

The defect class is **twin drift**: two copies of one discipline, one fixed and one silently left behind. Fixing `pg_test` alone leaves that class open the next time a runner is added, so the rule is stated over **every** watchdog-wrapped `cargo test` invocation rather than over the two functions that exist today — each must be preceded, *inside its own shell function*, by a short-circuiting `--no-run` prebuild.

Run against the **pre-fix** `ci.yml` it fails correctly and names the culprit:

```
FAIL  D: 1 of 2 watchdog-wrapped 'cargo test' invocations compile INSIDE the timed window
      no short-circuiting `cargo test --no-run "$@" || return "$?"` between the
      function opener (line 952) and the timed invocation (line 983)
```

An R-203 leg strips every prebuild from a throwaway copy and requires the scan to catch all of them, so a regex that silently stopped matching cannot leave the rule vacuously green. Suite: **31/31 PASS** (was 29/29).

## What this evidence does and does not establish

**Established.** The prebuild is invoked first, with identical arguments, outside the `timeout` wrapper; a failing prebuild aborts the step; `cargo test --no-run` tolerates the trailing harness args at every call site; the workflow still parses; no other control in `pg_test` changed.

**Not established.** That the postgres gate now completes within 2100s of *runtime*. That is a claim about a live CI run, and the run that would validate it **is the postgres gate on this PR** — which is exactly the gate being changed. The measurement above says the tests themselves ran 1605s of the 2100s budget with 3 binaries left, so recovering the 478s should leave real headroom; but until this PR's own Postgres gate reports green, that is a projection from one attempt's timings, not a verified result. It is also a projection from *one* run: compile time varies with cache state, and the 478s figure is a single sample, not a distribution.

**Deliberately out of scope.** This does not reduce total job wall-time — the compile still happens, just outside the timed window, still bounded by the job-level `timeout-minutes: 45`. If the suite's genuine *runtime* later approaches 2100s on its own, that is a real signal about test growth and should be met with test-level work, not a cap bump. Keeping the cap fixed is what preserves that signal.

Closes #2657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
