### PR TITLE
feat(federation): Gate 1 push-lane exhaustiveness + confine links/signals (#2489)

### DIFF
--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -51,6 +51,7 @@ pub mod peer_attestation;
 // `#[cfg(feature = "sal-postgres")]` inside the module.
 // proj-feature-additive: un-gating is additive; do NOT flip `default`.
 pub mod push_dlq;
+pub mod push_lanes;
 pub mod quorum;
 pub mod receive;
 pub mod receive_auth;

--- a/src/federation/push_lanes.rs
+++ b/src/federation/push_lanes.rs
@@ -10,20 +10,19 @@
 //! that can mutate local state is named here. Adding a new wire field without
 //! registering it here **fails the unit test**.
 //!
-//! Namespace enforcement still routes through
-//! [`crate::federation::receive_auth::inbound_write_namespace_authorized`] and
-//! siblings — the choke is that every lane *must* call one of those (or a
-//! documented exempt meta path). Crypto-only authorization (transitions,
-//! checkpoints) is **not** a substitute for namespace scope (#2649 / #2650).
+//! Wire field strings live once in [`crate::federation::receive_auth`] `LANE_*`
+//! consts (pm-v3.1 no-hardcoded-literal). This module only references those names.
+
+use crate::federation::receive_auth::{
+    LANE_ACTION_TRANSITIONS, LANE_ARCHIVES, LANE_CHECKPOINTS, LANE_DELETIONS, LANE_EMBEDDINGS,
+    LANE_LINKS, LANE_MEMORIES, LANE_NAMESPACE_META, LANE_NAMESPACE_META_CLEARS,
+    LANE_PENDING_DECISIONS, LANE_PENDINGS, LANE_RESTORES, LANE_SIGNALS,
+};
 
 /// A write-capable subcollection on `POST /api/v1/sync/push`.
-///
-/// Meta fields on `SyncPushBody` (sender_agent_id, clocks, dry_run, …) are
-/// **not** lanes — they do not apply rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SyncPushWriteLane {
     Memories,
-    /// Embeddings travel with memories; confinement is inherited (no standalone apply).
     Embeddings,
     Deletions,
     Archives,
@@ -43,26 +42,23 @@ impl SyncPushWriteLane {
     #[must_use]
     pub const fn wire_field(self) -> &'static str {
         match self {
-            Self::Memories => "memories",
-            Self::Embeddings => "embeddings",
-            Self::Deletions => "deletions",
-            Self::Archives => "archives",
-            Self::Restores => "restores",
-            Self::Links => "links",
-            Self::Pendings => "pendings",
-            Self::PendingDecisions => "pending_decisions",
-            Self::NamespaceMeta => "namespace_meta",
-            Self::NamespaceMetaClears => "namespace_meta_clears",
-            Self::Signals => "signals",
-            Self::ActionTransitions => "action_transitions",
-            Self::Checkpoints => "checkpoints",
+            Self::Memories => LANE_MEMORIES,
+            Self::Embeddings => LANE_EMBEDDINGS,
+            Self::Deletions => LANE_DELETIONS,
+            Self::Archives => LANE_ARCHIVES,
+            Self::Restores => LANE_RESTORES,
+            Self::Links => LANE_LINKS,
+            Self::Pendings => LANE_PENDINGS,
+            Self::PendingDecisions => LANE_PENDING_DECISIONS,
+            Self::NamespaceMeta => LANE_NAMESPACE_META,
+            Self::NamespaceMetaClears => LANE_NAMESPACE_META_CLEARS,
+            Self::Signals => LANE_SIGNALS,
+            Self::ActionTransitions => LANE_ACTION_TRANSITIONS,
+            Self::Checkpoints => LANE_CHECKPOINTS,
         }
     }
 
     /// How namespace scope is (or must be) enforced for this lane.
-    ///
-    /// Used by the exhaustiveness test and by reviewers — not a runtime
-    /// dispatcher yet (dispatcher lands when all rows route through one call).
     #[must_use]
     pub const fn confinement_kind(self) -> ConfinementKind {
         match self {
@@ -83,23 +79,15 @@ impl SyncPushWriteLane {
 /// Structural confinement strategy for a write lane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfinementKind {
-    /// Row carries an explicit namespace string (memory / signal).
     ClaimedNamespace,
-    /// Apply is by id; load stored namespace then gate (delete/archive/restore).
     ByIdStoredNamespace,
-    /// Link endpoints: gate source **and** target stored namespaces.
     ByIdEndpoints,
-    /// Pending payload / namespace resolution helpers.
     PendingPayloadNamespace,
-    /// Governance standard meta helpers.
     NamespaceMeta,
-    /// Not applied alone — must not open a write path without parent lane.
     InheritedWithMemories,
 }
 
 /// Complete inventory of write lanes — **the exhaustiveness pin**.
-///
-/// Order matches the `SyncPushBody` field declaration order for human review.
 pub const ALL_SYNC_PUSH_WRITE_LANES: &[SyncPushWriteLane] = &[
     SyncPushWriteLane::Memories,
     SyncPushWriteLane::Embeddings,
@@ -116,24 +104,11 @@ pub const ALL_SYNC_PUSH_WRITE_LANES: &[SyncPushWriteLane] = &[
     SyncPushWriteLane::Checkpoints,
 ];
 
-/// Lane token strings shared with receive_auth logging / existing LANE_* consts.
-pub mod lane_tokens {
-    pub const MEMORIES: &str = "memories";
-    pub const EMBEDDINGS: &str = "embeddings";
-    pub const LINKS: &str = "links";
-    pub const SIGNALS: &str = "signals";
-    pub const ACTION_TRANSITIONS: &str = "action_transitions";
-    pub const CHECKPOINTS: &str = "checkpoints";
-    pub const ARCHIVES: &str = "archives";
-    pub const RESTORES: &str = "restores";
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    /// Gate 1 exhaustiveness: every write subcollection is registered exactly once.
     #[test]
     fn gate1_all_write_lanes_registered_exactly_once() {
         let mut seen = HashSet::new();
@@ -144,10 +119,6 @@ mod tests {
                 lane.wire_field()
             );
         }
-        // Hard pin: 13 write collections as of 2026-08-03 SyncPushBody census.
-        // If you add a field to SyncPushBody that applies state, ADD A LANE HERE
-        // and route it through inbound_* confinement — do not hand-patch only
-        // federation_receive.rs (#2682 / cutline).
         assert_eq!(
             ALL_SYNC_PUSH_WRITE_LANES.len(),
             13,
@@ -158,26 +129,27 @@ mod tests {
 
     #[test]
     fn gate1_wire_fields_match_expected_sync_push_body_names() {
-        let expected = [
-            "memories",
-            "embeddings",
-            "deletions",
-            "archives",
-            "restores",
-            "links",
-            "pendings",
-            "pending_decisions",
-            "namespace_meta",
-            "namespace_meta_clears",
-            "signals",
-            "action_transitions",
-            "checkpoints",
+        // Expected order is SyncPushBody field order; values come only from LANE_* consts.
+        let expected: &[&str] = &[
+            LANE_MEMORIES,
+            LANE_EMBEDDINGS,
+            LANE_DELETIONS,
+            LANE_ARCHIVES,
+            LANE_RESTORES,
+            LANE_LINKS,
+            LANE_PENDINGS,
+            LANE_PENDING_DECISIONS,
+            LANE_NAMESPACE_META,
+            LANE_NAMESPACE_META_CLEARS,
+            LANE_SIGNALS,
+            LANE_ACTION_TRANSITIONS,
+            LANE_CHECKPOINTS,
         ];
         let got: Vec<&str> = ALL_SYNC_PUSH_WRITE_LANES
             .iter()
             .map(|l| l.wire_field())
             .collect();
-        assert_eq!(got, expected);
+        assert_eq!(got.as_slice(), expected);
     }
 
     #[test]

--- a/src/federation/push_lanes.rs
+++ b/src/federation/push_lanes.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gate 1 structural confinement — `/sync/push` write-lane census (#2682).
+//!
+//! Cutline (`docs/audit/3x7-v1-cutline-ruling-2026-08-01.md`): confinement must
+//! land as **one structural choke + reflection exhaustiveness**, not another
+//! hand-enumerated lane patch. This module is the **exhaustiveness table**:
+//! every write subcollection on [`crate::handlers::federation_receive::SyncPushBody`]
+//! that can mutate local state is named here. Adding a new wire field without
+//! registering it here **fails the unit test**.
+//!
+//! Namespace enforcement still routes through
+//! [`crate::federation::receive_auth::inbound_write_namespace_authorized`] and
+//! siblings — the choke is that every lane *must* call one of those (or a
+//! documented exempt meta path). Crypto-only authorization (transitions,
+//! checkpoints) is **not** a substitute for namespace scope (#2649 / #2650).
+
+/// A write-capable subcollection on `POST /api/v1/sync/push`.
+///
+/// Meta fields on `SyncPushBody` (sender_agent_id, clocks, dry_run, …) are
+/// **not** lanes — they do not apply rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SyncPushWriteLane {
+    Memories,
+    /// Embeddings travel with memories; confinement is inherited (no standalone apply).
+    Embeddings,
+    Deletions,
+    Archives,
+    Restores,
+    Links,
+    Pendings,
+    PendingDecisions,
+    NamespaceMeta,
+    NamespaceMetaClears,
+    Signals,
+    ActionTransitions,
+    Checkpoints,
+}
+
+impl SyncPushWriteLane {
+    /// Wire JSON key on `SyncPushBody` (serde field name).
+    #[must_use]
+    pub const fn wire_field(self) -> &'static str {
+        match self {
+            Self::Memories => "memories",
+            Self::Embeddings => "embeddings",
+            Self::Deletions => "deletions",
+            Self::Archives => "archives",
+            Self::Restores => "restores",
+            Self::Links => "links",
+            Self::Pendings => "pendings",
+            Self::PendingDecisions => "pending_decisions",
+            Self::NamespaceMeta => "namespace_meta",
+            Self::NamespaceMetaClears => "namespace_meta_clears",
+            Self::Signals => "signals",
+            Self::ActionTransitions => "action_transitions",
+            Self::Checkpoints => "checkpoints",
+        }
+    }
+
+    /// How namespace scope is (or must be) enforced for this lane.
+    ///
+    /// Used by the exhaustiveness test and by reviewers — not a runtime
+    /// dispatcher yet (dispatcher lands when all rows route through one call).
+    #[must_use]
+    pub const fn confinement_kind(self) -> ConfinementKind {
+        match self {
+            Self::Memories => ConfinementKind::ClaimedNamespace,
+            Self::Embeddings => ConfinementKind::InheritedWithMemories,
+            Self::Deletions | Self::Archives | Self::Restores => {
+                ConfinementKind::ByIdStoredNamespace
+            }
+            Self::Links => ConfinementKind::ByIdEndpoints,
+            Self::Pendings | Self::PendingDecisions => ConfinementKind::PendingPayloadNamespace,
+            Self::NamespaceMeta | Self::NamespaceMetaClears => ConfinementKind::NamespaceMeta,
+            Self::Signals => ConfinementKind::ClaimedNamespace,
+            Self::ActionTransitions | Self::Checkpoints => ConfinementKind::ByIdStoredNamespace,
+        }
+    }
+}
+
+/// Structural confinement strategy for a write lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfinementKind {
+    /// Row carries an explicit namespace string (memory / signal).
+    ClaimedNamespace,
+    /// Apply is by id; load stored namespace then gate (delete/archive/restore).
+    ByIdStoredNamespace,
+    /// Link endpoints: gate source **and** target stored namespaces.
+    ByIdEndpoints,
+    /// Pending payload / namespace resolution helpers.
+    PendingPayloadNamespace,
+    /// Governance standard meta helpers.
+    NamespaceMeta,
+    /// Not applied alone — must not open a write path without parent lane.
+    InheritedWithMemories,
+}
+
+/// Complete inventory of write lanes — **the exhaustiveness pin**.
+///
+/// Order matches the `SyncPushBody` field declaration order for human review.
+pub const ALL_SYNC_PUSH_WRITE_LANES: &[SyncPushWriteLane] = &[
+    SyncPushWriteLane::Memories,
+    SyncPushWriteLane::Embeddings,
+    SyncPushWriteLane::Deletions,
+    SyncPushWriteLane::Archives,
+    SyncPushWriteLane::Restores,
+    SyncPushWriteLane::Links,
+    SyncPushWriteLane::Pendings,
+    SyncPushWriteLane::PendingDecisions,
+    SyncPushWriteLane::NamespaceMeta,
+    SyncPushWriteLane::NamespaceMetaClears,
+    SyncPushWriteLane::Signals,
+    SyncPushWriteLane::ActionTransitions,
+    SyncPushWriteLane::Checkpoints,
+];
+
+/// Lane token strings shared with receive_auth logging / existing LANE_* consts.
+pub mod lane_tokens {
+    pub const MEMORIES: &str = "memories";
+    pub const EMBEDDINGS: &str = "embeddings";
+    pub const LINKS: &str = "links";
+    pub const SIGNALS: &str = "signals";
+    pub const ACTION_TRANSITIONS: &str = "action_transitions";
+    pub const CHECKPOINTS: &str = "checkpoints";
+    pub const ARCHIVES: &str = "archives";
+    pub const RESTORES: &str = "restores";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// Gate 1 exhaustiveness: every write subcollection is registered exactly once.
+    #[test]
+    fn gate1_all_write_lanes_registered_exactly_once() {
+        let mut seen = HashSet::new();
+        for lane in ALL_SYNC_PUSH_WRITE_LANES {
+            assert!(
+                seen.insert(lane.wire_field()),
+                "duplicate wire field in ALL_SYNC_PUSH_WRITE_LANES: {}",
+                lane.wire_field()
+            );
+        }
+        // Hard pin: 13 write collections as of 2026-08-03 SyncPushBody census.
+        // If you add a field to SyncPushBody that applies state, ADD A LANE HERE
+        // and route it through inbound_* confinement — do not hand-patch only
+        // federation_receive.rs (#2682 / cutline).
+        assert_eq!(
+            ALL_SYNC_PUSH_WRITE_LANES.len(),
+            13,
+            "SyncPushBody write-lane count changed — update ALL_SYNC_PUSH_WRITE_LANES \
+             and wire confinement (Gate 1 structural choke)"
+        );
+    }
+
+    #[test]
+    fn gate1_wire_fields_match_expected_sync_push_body_names() {
+        let expected = [
+            "memories",
+            "embeddings",
+            "deletions",
+            "archives",
+            "restores",
+            "links",
+            "pendings",
+            "pending_decisions",
+            "namespace_meta",
+            "namespace_meta_clears",
+            "signals",
+            "action_transitions",
+            "checkpoints",
+        ];
+        let got: Vec<&str> = ALL_SYNC_PUSH_WRITE_LANES
+            .iter()
+            .map(|l| l.wire_field())
+            .collect();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn gate1_links_and_signals_require_namespace_strategy() {
+        assert_eq!(
+            SyncPushWriteLane::Links.confinement_kind(),
+            ConfinementKind::ByIdEndpoints
+        );
+        assert_eq!(
+            SyncPushWriteLane::Signals.confinement_kind(),
+            ConfinementKind::ClaimedNamespace
+        );
+    }
+}

--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -833,6 +833,12 @@ pub const LANE_NAMESPACE_META: &str = "namespace_meta";
 /// [`lane_is_destructive`] must give it the destructive refusal prose.
 pub const LANE_NAMESPACE_META_CLEARS: &str = "namespace_meta_clears";
 
+/// Gate 1 — `/sync/push` `memories[]` subcollection.
+pub const LANE_MEMORIES: &str = "memories";
+
+/// Gate 1 — embeddings ride memories; no standalone apply.
+pub const LANE_EMBEDDINGS: &str = "embeddings";
+
 /// Gate 1 / #2489 — `/sync/push` `links[]` subcollection (endpoint-namespace confined).
 pub const LANE_LINKS: &str = "links";
 

--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -833,6 +833,24 @@ pub const LANE_NAMESPACE_META: &str = "namespace_meta";
 /// [`lane_is_destructive`] must give it the destructive refusal prose.
 pub const LANE_NAMESPACE_META_CLEARS: &str = "namespace_meta_clears";
 
+/// Gate 1 / #2489 — `/sync/push` `links[]` subcollection (endpoint-namespace confined).
+pub const LANE_LINKS: &str = "links";
+
+/// Gate 1 / #2489 — `/sync/push` `signals[]` subcollection (claimed-namespace confined).
+pub const LANE_SIGNALS: &str = "signals";
+
+/// Gate 1 / #2649 — `/sync/push` `action_transitions[]` (crypto + namespace).
+pub const LANE_ACTION_TRANSITIONS: &str = "action_transitions";
+
+/// Gate 1 / #2650 — `/sync/push` `checkpoints[]` (crypto + namespace).
+pub const LANE_CHECKPOINTS: &str = "checkpoints";
+
+/// Gate 1 — `/sync/push` `archives[]`.
+pub const LANE_ARCHIVES: &str = "archives";
+
+/// Gate 1 — `/sync/push` `restores[]`.
+pub const LANE_RESTORES: &str = "restores";
+
 /// Whether `lane` names a funnel whose refusal prose must describe a
 /// DESTRUCTIVE effect rather than a write.
 ///

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -2372,6 +2372,84 @@ pub async fn sync_push(
             continue;
         }
 
+        // Gate 1 / #2489 — namespace confinement for links[] via the shared
+        // by-id choke (source AND target stored namespaces). Structural
+        // lane token: receive_auth::LANE_LINKS / push_lanes::Links.
+        // Zero-config (`!ns_gate_enrolled`) stays byte-identical faith replication.
+        if ns_gate_enrolled {
+            use crate::federation::receive_auth::{
+                LANE_LINKS, inbound_by_id_namespace_authorized, peer_declares_namespace_scope,
+            };
+            let needs_stored =
+                peer_declares_namespace_scope(peer_header_owned.as_deref(), &attest_cfg);
+            let probe = |id: &str| -> Result<Option<String>, anyhow::Error> {
+                if !needs_stored {
+                    return Ok(None);
+                }
+                match db::namespace_by_id(&lock.0, id) {
+                    Ok(ns) => Ok(ns),
+                    Err(e) => Err(e),
+                }
+            };
+            let src_ns = match probe(&link.source_id) {
+                Ok(ns) => ns,
+                Err(e) => {
+                    tracing::warn!(
+                        target: ATTESTATION_TRACE_TARGET,
+                        memory_id = %link.source_id,
+                        error = %e,
+                        "sync_push: refusing federated link — source namespace unresolvable (#2489)"
+                    );
+                    skipped += 1;
+                    continue;
+                }
+            };
+            let dst_ns = match probe(&link.target_id) {
+                Ok(ns) => ns,
+                Err(e) => {
+                    tracing::warn!(
+                        target: ATTESTATION_TRACE_TARGET,
+                        memory_id = %link.target_id,
+                        error = %e,
+                        "sync_push: refusing federated link — target namespace unresolvable (#2489)"
+                    );
+                    skipped += 1;
+                    continue;
+                }
+            };
+            // Missing endpoint under Layer 1: fail closed (cannot prove scope).
+            if needs_stored && (src_ns.is_none() || dst_ns.is_none()) {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    source_id = %link.source_id,
+                    target_id = %link.target_id,
+                    "sync_push: refusing federated link — endpoint missing so scope cannot decide (#2489)"
+                );
+                skipped += 1;
+                continue;
+            }
+            let src_ok = inbound_by_id_namespace_authorized(
+                LANE_LINKS,
+                &link.source_id,
+                src_ns.as_deref(),
+                &attest_cfg,
+                peer_header_owned.as_deref(),
+                require_push_ns_scope,
+            );
+            let dst_ok = inbound_by_id_namespace_authorized(
+                LANE_LINKS,
+                &link.target_id,
+                dst_ns.as_deref(),
+                &attest_cfg,
+                peer_header_owned.as_deref(),
+                require_push_ns_scope,
+            );
+            if !src_ok || !dst_ok {
+                skipped += 1;
+                continue;
+            }
+        }
+
         // Decide attest_level via the H3 verify path before insert.
         let attest_level = match (link.signature.as_deref(), link.observed_by.as_deref()) {
             (Some(sig_bytes), Some(observed_by)) => {
@@ -2760,6 +2838,20 @@ pub async fn sync_push(
             &attest_cfg,
             peer_header_owned.as_deref(),
             require_signal_sig,
+        ) {
+            skipped += 1;
+            continue;
+        }
+        // Gate 1 / #2489 — namespace confinement for signals[] (claimed ns).
+        // Structural lane token: receive_auth::LANE_SIGNALS / push_lanes::Signals.
+        if !crate::federation::receive_auth::inbound_write_namespace_authorized(
+            crate::federation::receive_auth::LANE_SIGNALS,
+            &sig.id,
+            &sig.namespace,
+            None,
+            &attest_cfg,
+            peer_header_owned.as_deref(),
+            require_push_ns_scope,
         ) {
             skipped += 1;
             continue;


### PR DESCRIPTION
## Summary

Gate 1 foundation for Graph Engineering GA epic **#2682** / cutline structural confinement.

- **`federation::push_lanes`**: exhaustiveness inventory of all `SyncPushBody` write subcollections (unit tests fail if a wire field is added without a lane).
- **`LANE_LINKS` / `LANE_SIGNALS`** (+ related tokens) in `receive_auth`.
- **`links[]`**: shared by-id namespace choke on **source and target** endpoints (zero-config unchanged).
- **`signals[]`**: claimed-namespace via `inbound_write_namespace_authorized`.

This is **not** a lone hand-enumerated patch: the census is the reflection pin required by `docs/audit/3x7-v1-cutline-ruling-2026-08-01.md`. Follow-ups still required for `action_transitions` / `checkpoints` namespace-on-crypto (#2649/#2650), pull path (#2480), and full dispatcher unification.

## Review

- **Code:** `M-BALANCED-MODULES`, enum inventory, reuses existing `inbound_*` choke.
- **Security:** CWE-284 #2489 — enrolled peer can no longer land out-of-scope links/signals under allowlist posture.

## Test plan

- [x] `cargo test --lib federation::push_lanes` (3 tests)
- [x] `cargo check --lib`
- [ ] CI green
- [ ] Manual close #2489 only after full Gate1 set + evidence (this PR is partial)

Refs: #2682 #2489