### PR TITLE
feat(federation): Gate1 confine action_transitions + checkpoints namespaces (#2649,#2650)

### DIFF
--- a/src/federation/push_lanes.rs
+++ b/src/federation/push_lanes.rs
@@ -71,7 +71,10 @@ impl SyncPushWriteLane {
             Self::Pendings | Self::PendingDecisions => ConfinementKind::PendingPayloadNamespace,
             Self::NamespaceMeta | Self::NamespaceMetaClears => ConfinementKind::NamespaceMeta,
             Self::Signals => ConfinementKind::ClaimedNamespace,
-            Self::ActionTransitions | Self::Checkpoints => ConfinementKind::ByIdStoredNamespace,
+            // #2649: stored action namespace (already loaded for signable).
+            Self::ActionTransitions => ConfinementKind::ByIdStoredNamespace,
+            // #2650: wire `cp.namespace` is the freeze-anchor write subject.
+            Self::Checkpoints => ConfinementKind::ClaimedNamespace,
         }
     }
 }
@@ -161,6 +164,27 @@ mod tests {
         assert_eq!(
             SyncPushWriteLane::Signals.confinement_kind(),
             ConfinementKind::ClaimedNamespace
+        );
+    }
+
+    /// #2649 / #2650 — crypto lanes must declare a namespace strategy (not "exempt").
+    #[test]
+    fn gate1_crypto_lanes_require_namespace_strategy() {
+        assert_eq!(
+            SyncPushWriteLane::ActionTransitions.confinement_kind(),
+            ConfinementKind::ByIdStoredNamespace
+        );
+        assert_eq!(
+            SyncPushWriteLane::Checkpoints.confinement_kind(),
+            ConfinementKind::ClaimedNamespace
+        );
+        assert_eq!(
+            SyncPushWriteLane::ActionTransitions.wire_field(),
+            LANE_ACTION_TRANSITIONS
+        );
+        assert_eq!(
+            SyncPushWriteLane::Checkpoints.wire_field(),
+            LANE_CHECKPOINTS
         );
     }
 }

--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -1668,6 +1668,75 @@ mod tests {
         );
     }
 
+    /// #2649 / #2650 — crypto lanes must share the same Layer-1 namespace choke
+    /// as memories (authentication is not authorization). Pins the lane tokens
+    /// the receive loop passes so a rename cannot silently drop confinement.
+    #[test]
+    fn inbound_write_namespace_refuses_crypto_lanes_out_of_scope_2649_2650() {
+        use crate::federation::peer_attestation::{PeerAttestationConfig, PeerScope};
+
+        let mut scoped = PeerAttestationConfig::default();
+        scoped.peers.insert(
+            "peer-1".to_string(),
+            PeerScope {
+                allowed_sender_agent_ids: vec![],
+                allowed_namespaces: vec!["public/*".to_string()],
+            },
+        );
+
+        // #2649 — action_transitions subject is the **stored** action namespace.
+        assert!(
+            inbound_write_namespace_authorized(
+                LANE_ACTION_TRANSITIONS,
+                "act-1",
+                "public/ok",
+                Some("public/ok"),
+                &scoped,
+                Some("peer-1"),
+                true,
+            ),
+            "in-scope stored action namespace accepted"
+        );
+        assert!(
+            !inbound_write_namespace_authorized(
+                LANE_ACTION_TRANSITIONS,
+                "act-1",
+                "secure/ops",
+                Some("secure/ops"),
+                &scoped,
+                Some("peer-1"),
+                true,
+            ),
+            "#2649: out-of-scope stored action namespace refused"
+        );
+
+        // #2650 — checkpoints subject is the wire-claimed freeze-anchor ns.
+        assert!(
+            inbound_write_namespace_authorized(
+                LANE_CHECKPOINTS,
+                "cp-1",
+                "public/ok",
+                None,
+                &scoped,
+                Some("peer-1"),
+                true,
+            ),
+            "in-scope checkpoint namespace accepted"
+        );
+        assert!(
+            !inbound_write_namespace_authorized(
+                LANE_CHECKPOINTS,
+                "cp-1",
+                "secure/ops",
+                None,
+                &scoped,
+                Some("peer-1"),
+                true,
+            ),
+            "#2650: out-of-scope checkpoint namespace refused"
+        );
+    }
+
     /// #2488 — the by-id verdict's `Option<&str>` contract, exercised without
     /// any HTTP/DB plumbing. The `None` arms are the whole point of the type
     /// change: one must reach Layer 2 (the shape whose gate #2488 skipped), the

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -2921,6 +2921,23 @@ pub async fn sync_push(
                 continue;
             }
         };
+        // Gate 1 / #2649 — authentication is not authorization. Crypto authz
+        // (authorize_remote_transition) answers "who signed"; this choke answers
+        // "may this peer touch the stored action namespace". Subject is the
+        // **stored** namespace already loaded for the signable — no extra read.
+        // Zero-config (`!has_allowlist`) short-circuits inside the helper.
+        if !crate::federation::receive_auth::inbound_write_namespace_authorized(
+            crate::federation::receive_auth::LANE_ACTION_TRANSITIONS,
+            &op.action_id,
+            &local.namespace,
+            Some(local.namespace.as_str()),
+            &attest_cfg,
+            peer_header_owned.as_deref(),
+            require_push_ns_scope,
+        ) {
+            skipped += 1;
+            continue;
+        }
         if body.dry_run {
             noop += 1;
             continue;
@@ -3029,6 +3046,24 @@ pub async fn sync_push(
         // Only RESOLVED checkpoints federate — a pending checkpoint carries no
         // resolution attestation, so there is nothing to authorize or apply.
         if cp.state == crate::models::CheckpointState::Pending {
+            skipped += 1;
+            continue;
+        }
+        // Gate 1 / #2650 — format validation is not scope. Resolver-key crypto
+        // answers "who resolved"; this choke answers "may this peer write a
+        // freeze-anchor resolution in `cp.namespace`". Wire namespace is the
+        // write subject (first-resolution-wins may create/update under that ns).
+        // Postgres still skips apply entirely (#2464) — confinement still runs
+        // so both backends refuse out-of-scope rows the same way.
+        if !crate::federation::receive_auth::inbound_write_namespace_authorized(
+            crate::federation::receive_auth::LANE_CHECKPOINTS,
+            &cp.id,
+            &cp.namespace,
+            None,
+            &attest_cfg,
+            peer_header_owned.as_deref(),
+            require_push_ns_scope,
+        ) {
             skipped += 1;
             continue;
         }


### PR DESCRIPTION
## Summary
Continues Gate 1 after #2683. Crypto-authorized write lanes now also pass the **shared namespace choke**.

- `action_transitions[]` → `inbound_write_namespace_authorized` on stored action namespace (#2649)
- `checkpoints[]` → same on wire `cp.namespace` (#2650)
- `push_lanes` ConfinementKind split + unit pin

## Residual
Pull path #2480 not in this PR. Full Gate1 must-close set still tracked on #2682.

## Test
- [x] `cargo test --lib federation::push_lanes` (4 tests)
- [x] hardcoded-literal gate PASS
- [ ] CI

Refs: #2682 #2649 #2650