### PR TITLE
docs(cert): align ready-to-tag tip SHA to b95ad978 (never cut d742f331)

### DIFF
--- a/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
+++ b/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
@@ -1,11 +1,14 @@
 # Ready-to-tag certification note — ai-memory v1.0.0
 
 **Status:** READY-TO-TAG (operator-gated)  
-**Tip SHA:** `d742f3314860e199a75c257c554835dabddef1b0`  
+**Tip SHA (cut target):** `b95ad9780585e6a7354f9ae994e0d95829913567` — first tip that **includes this cert note**.  
+**Also valid to cut:** any later `release/v1.0.0` tip that is a **descendant of `b95ad978`** and still contains this file (e.g. tip-alignment edits).  
+**Do not cut:** `d742f331` — measure-binary parent; **omits** this cert note.  
+**Measure binary (Gate3):** `d742f331` (asserted `sal-postgres` build).  
 **Branch:** `release/v1.0.0`  
-**Date:** 2026-08-04T01:43:35Z  
+**Date:** 2026-08-04T01:50:00Z  
 **Epic:** [#2682](https://github.com/alphaonedev/ai-memory-mcp/issues/2682)  
-**Authority:** AI NHI 100% engineering; **operator only** for tag cut + publish  
+**Authority:** AI NHI 100% engineering; **operator only** for tag cut + publish
 
 ## Gates
 
@@ -14,8 +17,8 @@
 | **1 Structural confinement** | PASS with residuals | `push_lanes` exhaustiveness + shared `inbound_*`; links/signals/crypto lanes; pull path #2480 via #2685 `a9b77b24` |
 | **2 Claims** | PASS | Merge order **#2655 → #2656 → #2668 → #2659 LAST** (… `f95d889e`) |
 | **Packaging #2676** | PASS with residual | #2686 `d742f331` — `ai-memory features` + `assert-compiled-features.sh` |
-| **3 Measured evidence** | PASS | DO do-perf: asserted sal-postgres binary; PG18+AGE+pgvector; hostssl cleartext REFUSED; TLS1.3 verify-full; 20 stores; droplets torn down |
-| **4 Agreement vote** | PASS | `{SCRATCH}/gate4-vote.md` — 3/3 AGREE with residuals |
+| **3 Measured evidence** | PASS | DO do-perf: asserted sal-postgres binary @ `d742f331`; PG18+AGE+pgvector; hostssl cleartext REFUSED; TLS1.3 verify-full; 20 stores; droplets torn down |
+| **4 Agreement vote** | PASS | 3/3 AGREE with residuals (package tip `b95ad978`) |
 
 ## Merge train (selected)
 
@@ -25,6 +28,7 @@
 | #2685 | Gate1 pull #2480 |
 | #2655 → #2656 → #2668 → #2659 | Claims train (2659 last) |
 | #2686 | Feature self-report |
+| #2687 | Ready-to-tag cert note (tip becomes `b95ad978`) |
 
 ## Explicit residual list (must appear on any tag checklist)
 
@@ -47,7 +51,7 @@
 
 1. Review this note + residual list  
 2. Optionally land residual security issues or accept as post-tag  
-3. **Cut** `v1.0.0` tag on tip `d742f331` if satisfied  
+3. **Cut** `v1.0.0` on tip **`b95ad978` or any descendant on `release/v1.0.0` that still contains this document** — **never** on `d742f331`  
 4. **Dispatch** publish workflows  
 5. Agents **must not** create tags or dispatch release/publish
 
@@ -55,10 +59,12 @@
 
 ```bash
 git fetch origin && git log -1 --oneline origin/release/v1.0.0
-# expect d742f331
+# tip must be b95ad978 or a descendant that includes this file (never cut d742f331)
+git merge-base --is-ancestor b95ad978 origin/release/v1.0.0 && echo "cert-note tip is ancestor of HEAD: OK"
 git tag -l 'v1.0.0*'   # expect empty until operator cuts
 cargo build --release --features sal-postgres
 ./target/release/ai-memory features
+# expect features list to include sal-postgres (and sal, sqlite-bundled on default+sal-postgres builds)
 scripts/assert-compiled-features.sh ./target/release/ai-memory --require sal-postgres
 ```
 


### PR DESCRIPTION
## Skeptic fix (#2682 ready-to-tag package)

Cert note Tip SHA / operator cut instructions named measure-binary parent `d742f331`, which **omits** this cert note. Operator must cut **`b95ad978` or a descendant that includes this document** — never `d742f331`.

Gate3 measure binary remains `d742f331` (asserted sal-postgres); documented separately.

## Control
Docs-only. No runtime change.

Refs: #2682