### PR TITLE
docs(cert): residual §6 only open capacity #2663 #2673

### DIFF
--- a/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
+++ b/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
@@ -42,7 +42,8 @@
 5. **Release.yml / Dockerfile default feature set** may still omit `sal` / `sal-postgres` — certification measured an **asserted** feature build; operators must not tag without verifying release artifact features via `ai-memory features` / assert script.
 
 ### Capacity / follow-on (not gate-blocking for this cert claim set)
-6. Open capacity PRs may remain: #2643, #2644, #2662, #2663, #2673 (security/data integrity capacity — land as capacity allows; not required to assert “ready-to-tag under residual list” if residual list is honest).
+6. **Landed capacity (tip `3bd01c32` and ancestors):** #2643 (`8aa83e6f`, closes #2538/#2633); #2689 signed re-land of #2644 bulk funnel (`9136b5a3`, closes #2550–#2552/#2588/#2594); #2662 delete-lane DLQ (`3bd01c32`, closes #2498).  
+   **Still open (optional before cut):** #2663 (`/sync/since` cursor), #2673 (erasure outbox). Not required to assert ready-to-tag if this residual list is honest.
 
 ### Scale claim residual
 7. **No 1M+ agent scale certification**; modular 500–1000 claim envelope only as previously published after claims corrections.


### PR DESCRIPTION
## Skeptic fix
Cert-note residual §6 listed #2643/#2644/#2662 as open; they are MERGED. Update to:
- Landed: #2643, #2689 (#2644 re-land), #2662
- Still open: **#2663, #2673 only**

Cut SSOT unchanged: b95ad978 or descendant with this file; never d742f331.

Refs: #2682