### PR TITLE
fix(#2529): refuse federated pendings[] resurrection of decided rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (federated `pendings[]` can no longer resurrect a decided governance row)
+
+- **`/sync/push` `pendings[]` refuses to resurrect or clobber a locally-decided pending action** (refs [#2529](https://github.com/alphaonedev/ai-memory-mcp/issues/2529); CWE-284). Pre-fix `upsert_pending_action` was `ON CONFLICT DO UPDATE` over **every** column including `status` / `decided_by` / `approvals`, so an enrolled peer could push `status: "pending"` for an id this node had already rejected and re-arm `execute_pending_action` (which only checks `status == "approved"`), defeating consensus quorum history.
+  - Receive loop: refuse wire rows with `status != "pending"` (decisions converge via `pending_decisions[]`); refuse when the **local** row is already terminal.
+  - Storage: on conflict, only refresh request body fields, and only while local `status = 'pending'`; decision columns are never wire-writable on conflict.
+  - Fresh undecided pendings still apply (zero-config + enrolled).
+
 ### Fixed (a typo in `AI_MEMORY_FED_PEER_ATTESTATION` no longer wide-opens federated DELETE)
 
 - **Malformed or empty-present peer-attestation config no longer degrades to zero-config faith replication** (refs [#2504](https://github.com/alphaonedev/ai-memory-mcp/issues/2504); CWE-284). Pre-fix `from_env` treated parse error like env-absent: `has_allowlist() == false`, which turns **off** the federated-delete namespace gate and the #1056 TOFU 401 while the WARN claimed "default-deny". Read `/sync/since` and destructive DELETE took opposite postures from the same broken value.

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -2527,6 +2527,21 @@ pub async fn sync_push(
             noop += 1;
             continue;
         }
+        // #2529 (CWE-284) — `pendings[]` is the injection lane for UNDECIDED
+        // governance rows. Decisions converge through `pending_decisions[]`.
+        // Refuse wire rows that already claim a terminal status, so a peer
+        // cannot inject a pre-approved/rejected row and skip the decision path.
+        if pa.status != "pending" {
+            tracing::warn!(
+                target: ATTESTATION_TRACE_TARGET,
+                pending_id = %pa.id,
+                status = %pa.status,
+                "sync_push: refusing federated pendings entry with non-pending status \
+                 (#2529) — use pending_decisions[] to converge decisions"
+            );
+            skipped += 1;
+            continue;
+        }
         // #1920 (CWE-862) — gate the pending upsert behind the per-peer
         // authorship allowlist so a hostile peer cannot inject a pending
         // action attributed to an arbitrary `requested_by` (or a forged
@@ -2549,6 +2564,37 @@ pub async fn sync_push(
             skipped += 1;
             continue;
         }
+        // Probe local row once for #2529 terminal-status refuse + #2478 ns.
+        let local_pending = match db::get_pending_action(&lock.0, &pa.id) {
+            Ok(row) => row,
+            Err(e) => {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    pending_id = %pa.id,
+                    cause = crate::federation::receive_auth::CAUSE_NAMESPACE_PROBE_UNRESOLVABLE,
+                    error = %e,
+                    "sync_push: refusing federated pendings entry — local governance row \
+                     unresolvable (#2478/#2529 fail-closed)"
+                );
+                skipped += 1;
+                continue;
+            }
+        };
+        // #2529 — a locally DECIDED pending is terminal from the wire's view.
+        // Refuse resurrection / clobber of decided_by / approvals / status.
+        if let Some(ref existing) = local_pending {
+            if existing.status != "pending" {
+                tracing::warn!(
+                    target: ATTESTATION_TRACE_TARGET,
+                    pending_id = %pa.id,
+                    local_status = %existing.status,
+                    "sync_push: refusing federated pendings upsert — local row is already \
+                     decided (#2529); decisions converge via pending_decisions[]"
+                );
+                skipped += 1;
+                continue;
+            }
+        }
         // #2478 (CWE-284) — #1920 gates WHO a pending may be attributed to; it
         // never consults a namespace. Confine the injection to the peer's scope
         // through the SAME shared verdict the memories/deletions lanes use, so
@@ -2563,22 +2609,7 @@ pub async fn sync_push(
         // oversight — but this lane's sink is strictly more destructive than
         // `memories[]`, so it is named here and in the PR body.
         if ns_gate_enrolled {
-            let stored_pending_ns = match db::get_pending_action(&lock.0, &pa.id) {
-                Ok(existing) => existing.map(|row| row.namespace),
-                Err(e) => {
-                    tracing::warn!(
-                        target: ATTESTATION_TRACE_TARGET,
-                        pending_id = %pa.id,
-                        cause = crate::federation::receive_auth::CAUSE_NAMESPACE_PROBE_UNRESOLVABLE,
-                        error = %e,
-                        "sync_push: refusing federated pendings entry — the governance row \
-                         this upsert would overwrite is UNRESOLVABLE on this node, so the \
-                         scope gate cannot decide (#2478 fail-closed)."
-                    );
-                    skipped += 1;
-                    continue;
-                }
-            };
+            let stored_pending_ns = local_pending.as_ref().map(|row| row.namespace.clone());
             if !pending_namespaces_authorized(
                 &lock.0,
                 crate::federation::receive_auth::LANE_PENDINGS,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18014,11 +18014,17 @@ pub fn queue_pending_action(
 
 /// v0.6.2 (S34): upsert a `pending_actions` row from a canonical `PendingAction`
 /// struct — used by `sync_push` to apply a peer-originated pending row so
-/// governance state is cluster-consistent. Preserves `approvals` and
-/// decision fields verbatim so re-plays converge. Uses `INSERT ... ON
-/// CONFLICT(id) DO UPDATE` because the originator's id is stable across
-/// peers (unlike `queue_pending_action` which mints a fresh UUID per
-/// queue call).
+/// governance state is cluster-consistent. Uses `INSERT ... ON CONFLICT(id)
+/// DO UPDATE` because the originator's id is stable across peers (unlike
+/// `queue_pending_action` which mints a fresh UUID per queue call).
+///
+/// #2529 — **decision columns are never wire-writable on conflict.**
+/// Pre-fix `ON CONFLICT DO UPDATE` rewrote `status` / `decided_by` /
+/// `decided_at` / `approvals` from the peer, so an enrolled peer could
+/// resurrect a locally-decided row back to `pending` and wipe quorum
+/// history. On conflict we only refresh the request body fields, and only
+/// while the local row is still `pending` (`WHERE` clause). Terminal
+/// decisions converge via `pending_decisions[]`, not `pendings[]`.
 pub fn upsert_pending_action(conn: &Connection, pa: &PendingAction) -> Result<()> {
     let payload_json = serde_json::to_string(&pa.payload)?;
     let approvals_json = serde_json::to_string(&pa.approvals)?;
@@ -18033,11 +18039,8 @@ pub fn upsert_pending_action(conn: &Connection, pa: &PendingAction) -> Result<()
             namespace    = excluded.namespace,
             payload      = excluded.payload,
             requested_by = excluded.requested_by,
-            requested_at = excluded.requested_at,
-            status       = excluded.status,
-            decided_by   = excluded.decided_by,
-            decided_at   = excluded.decided_at,
-            approvals    = excluded.approvals",
+            requested_at = excluded.requested_at
+         WHERE pending_actions.status = 'pending'",
         params![
             pa.id,
             pa.action_type,

--- a/tests/federation_pending_resurrection_2529.rs
+++ b/tests/federation_pending_resurrection_2529.rs
@@ -131,7 +131,7 @@ async fn push_pendings(router: &axum::Router, pendings: Vec<Value>) -> (StatusCo
     (status, report)
 }
 
-fn pending_wire(id: &str, status: &str, approvals: Value) -> Value {
+fn pending_wire(id: &str, status: &str, approvals: &Value) -> Value {
     json!({
         "id": id,
         "action_type": "store",
@@ -199,7 +199,7 @@ async fn federated_pending_cannot_resurrect_rejected_row_2529() {
         vec![pending_wire(
             "pa-2529-rej",
             "pending",
-            json!([{"agent_id": "ai:attacker", "approved_at": chrono::Utc::now().to_rfc3339()}]),
+            &json!([{"agent_id": "ai:attacker", "approved_at": chrono::Utc::now().to_rfc3339()}]),
         )],
     )
     .await;
@@ -239,7 +239,7 @@ async fn federated_pending_rejects_wire_non_pending_status_2529() {
 
     let (st, report) = push_pendings(
         &router,
-        vec![pending_wire("pa-2529-pre", "approved", json!([]))],
+        vec![pending_wire("pa-2529-pre", "approved", &json!([]))],
     )
     .await;
     assert_eq!(st, StatusCode::OK);
@@ -259,7 +259,7 @@ async fn control_fresh_pending_still_applies_2529() {
 
     let (st, report) = push_pendings(
         &router,
-        vec![pending_wire("pa-2529-ok", "pending", json!([]))],
+        vec![pending_wire("pa-2529-ok", "pending", &json!([]))],
     )
     .await;
     assert_eq!(st, StatusCode::OK, "{report}");

--- a/tests/federation_pending_resurrection_2529.rs
+++ b/tests/federation_pending_resurrection_2529.rs
@@ -1,0 +1,313 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2529 — federated `pendings[]` must not resurrect a locally-decided pending
+//! or land a pre-decided wire row.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+const PEER_ID: &str = "ai:peer-2529";
+const REQUIRE_ATTEST_ENV: &str = "AI_MEMORY_REQUIRE_AGENT_ATTESTATION";
+const REQUIRE_ENROLLMENT_ENV: &str = "AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT";
+const TRUST_BODY_AGENT_ID_ENV: &str = "AI_MEMORY_FED_TRUST_BODY_AGENT_ID";
+
+struct PostureGuard;
+impl Drop for PostureGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+            std::env::remove_var(REQUIRE_ATTEST_ENV);
+            std::env::remove_var(REQUIRE_ENROLLMENT_ENV);
+            std::env::remove_var(TRUST_BODY_AGENT_ID_ENV);
+            std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+            std::env::remove_var(
+                ai_memory::federation::receive_auth::REQUIRE_PUSH_NAMESPACE_SCOPE_ENV,
+            );
+        }
+    }
+}
+
+fn clear_and_zero_config() {
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+        std::env::set_var(REQUIRE_ATTEST_ENV, "0");
+        std::env::set_var(REQUIRE_ENROLLMENT_ENV, "0");
+        std::env::set_var(TRUST_BODY_AGENT_ID_ENV, "1");
+        std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+        std::env::remove_var(ai_memory::federation::receive_auth::REQUIRE_PUSH_NAMESPACE_SCOPE_ENV);
+    }
+}
+
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: std::sync::Arc<dyn ai_memory::store::MemoryStore> = {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+        let p = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+        std::sync::Arc::new(ai_memory::store::sqlite::SqliteStore::open(&p).expect("open store"))
+    };
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: std::sync::Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: std::sync::Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: std::sync::Arc::new(None),
+        deferred_audit_queue: std::sync::Arc::new(None),
+        admin_agent_ids: std::sync::Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    (ai_memory::build_router(api_key_state, app_state), db)
+}
+
+async fn push_pendings(router: &axum::Router, pendings: Vec<Value>) -> (StatusCode, Value) {
+    let body = json!({
+        "sender_agent_id": PEER_ID,
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "pendings": pendings,
+        "dry_run": false,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            PEER_ID,
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let report: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, report)
+}
+
+fn pending_wire(id: &str, status: &str, approvals: Value) -> Value {
+    json!({
+        "id": id,
+        "action_type": "store",
+        "memory_id": null,
+        "namespace": "public/ok",
+        "payload": {
+            "title": "t",
+            "content": "c",
+            "namespace": "public/ok",
+            "metadata": {"agent_id": PEER_ID}
+        },
+        "requested_by": PEER_ID,
+        "requested_at": chrono::Utc::now().to_rfc3339(),
+        "status": status,
+        "decided_by": if status == "pending" { Value::Null } else { json!("ai:local") },
+        "decided_at": if status == "pending" {
+            Value::Null
+        } else {
+            json!(chrono::Utc::now().to_rfc3339())
+        },
+        "approvals": approvals
+    })
+}
+
+#[tokio::test]
+async fn federated_pending_cannot_resurrect_rejected_row_2529() {
+    let _lock = ENV_LOCK.lock().await;
+    let _g = PostureGuard;
+    clear_and_zero_config();
+    let (router, db) = build_router_with_db();
+
+    {
+        let guard = db.lock().await;
+        let pa = ai_memory::models::PendingAction {
+            id: "pa-2529-rej".into(),
+            action_type: "store".into(),
+            memory_id: None,
+            namespace: "public/ok".into(),
+            payload: json!({
+                "title": "orig",
+                "content": "orig",
+                "namespace": "public/ok",
+                "metadata": {"agent_id": PEER_ID}
+            }),
+            requested_by: PEER_ID.into(),
+            requested_at: chrono::Utc::now().to_rfc3339(),
+            status: "pending".into(),
+            decided_by: None,
+            decided_at: None,
+            approvals: vec![],
+        };
+        ai_memory::db::upsert_pending_action(&guard.0, &pa).unwrap();
+        guard
+            .0
+            .execute(
+                "UPDATE pending_actions SET status='rejected', decided_by='ai:local', \
+                 decided_at=?1, approvals='[]' WHERE id=?2",
+                rusqlite::params![chrono::Utc::now().to_rfc3339(), "pa-2529-rej"],
+            )
+            .unwrap();
+    }
+
+    let (st, report) = push_pendings(
+        &router,
+        vec![pending_wire(
+            "pa-2529-rej",
+            "pending",
+            json!([{"agent_id": "ai:attacker", "approved_at": chrono::Utc::now().to_rfc3339()}]),
+        )],
+    )
+    .await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "push should 200 with per-item skip: {report}"
+    );
+    assert_eq!(
+        report["pendings_applied"].as_u64().unwrap_or(99),
+        0,
+        "resurrection must not apply: {report}"
+    );
+    assert!(
+        report["skipped"].as_u64().unwrap_or(0) >= 1,
+        "must skip: {report}"
+    );
+
+    let guard = db.lock().await;
+    let row = ai_memory::db::get_pending_action(&guard.0, "pa-2529-rej")
+        .unwrap()
+        .expect("row survives");
+    assert_eq!(row.status, "rejected", "status must stay decided");
+    assert_eq!(row.decided_by.as_deref(), Some("ai:local"));
+    assert!(
+        row.approvals.is_empty(),
+        "approvals must not be wire-clobbered"
+    );
+}
+
+#[tokio::test]
+async fn federated_pending_rejects_wire_non_pending_status_2529() {
+    let _lock = ENV_LOCK.lock().await;
+    let _g = PostureGuard;
+    clear_and_zero_config();
+    let (router, db) = build_router_with_db();
+
+    let (st, report) = push_pendings(
+        &router,
+        vec![pending_wire("pa-2529-pre", "approved", json!([]))],
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(report["pendings_applied"].as_u64().unwrap_or(99), 0);
+
+    let guard = db.lock().await;
+    let row = ai_memory::db::get_pending_action(&guard.0, "pa-2529-pre").unwrap();
+    assert!(row.is_none(), "pre-approved wire row must not land");
+}
+
+#[tokio::test]
+async fn control_fresh_pending_still_applies_2529() {
+    let _lock = ENV_LOCK.lock().await;
+    let _g = PostureGuard;
+    clear_and_zero_config();
+    let (router, db) = build_router_with_db();
+
+    let (st, report) = push_pendings(
+        &router,
+        vec![pending_wire("pa-2529-ok", "pending", json!([]))],
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK, "{report}");
+    assert_eq!(
+        report["pendings_applied"].as_u64().unwrap_or(0),
+        1,
+        "fresh pending must still apply: {report}"
+    );
+    let guard = db.lock().await;
+    let row = ai_memory::db::get_pending_action(&guard.0, "pa-2529-ok")
+        .unwrap()
+        .expect("landed");
+    assert_eq!(row.status, "pending");
+}
+
+#[test]
+fn upsert_sql_does_not_clobber_decided_status_2529() {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let mut pa = ai_memory::models::PendingAction {
+        id: "pa-sql-2529".into(),
+        action_type: "store".into(),
+        memory_id: None,
+        namespace: "public/ok".into(),
+        payload: json!({"title": "a", "content": "b"}),
+        requested_by: "ai:x".into(),
+        requested_at: chrono::Utc::now().to_rfc3339(),
+        status: "pending".into(),
+        decided_by: None,
+        decided_at: None,
+        approvals: vec![],
+    };
+    ai_memory::db::upsert_pending_action(&conn, &pa).unwrap();
+    conn.execute(
+        "UPDATE pending_actions SET status='rejected', decided_by='ai:local' WHERE id=?1",
+        ["pa-sql-2529"],
+    )
+    .unwrap();
+    pa.status = "pending".into();
+    pa.decided_by = None;
+    pa.payload = json!({"title": "evil", "content": "evil"});
+    ai_memory::db::upsert_pending_action(&conn, &pa).unwrap();
+    let got = ai_memory::db::get_pending_action(&conn, "pa-sql-2529")
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.status, "rejected");
+    assert_eq!(got.decided_by.as_deref(), Some("ai:local"));
+    assert_eq!(
+        got.payload["title"], "a",
+        "payload must not update on decided"
+    );
+}


### PR DESCRIPTION
## Summary
Gate1 residual **#2529**: federated `pendings[]` can no longer resurrect a locally-decided pending or inject a pre-approved wire row.

### Control
1. **Receive:** refuse `status != "pending"` on wire; refuse when local status is terminal
2. **Storage:** `ON CONFLICT` only updates request body fields while local is still `pending`; never overwrites `status`/`decided_*`/`approvals` from wire
3. **Decisions** still converge via `pending_decisions[]`

### Tests
`tests/federation_pending_resurrection_2529.rs` — 4/4 (resurrection refuse, wire non-pending refuse, fresh apply control, SQL no-clobber)

### Security
CWE-284: durable governance decision + consensus quorum integrity.

Refs: #2529 #2682 #2478