### PR TITLE
fix(#2536): namespace_meta requires descendant tree coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (federated `namespace_meta` exact-scope no longer sets descendant defaults)
+
+- **`/sync/push` `namespace_meta[]` / `namespace_meta_clears[]` require tree-scope coverage of descendants** (refs [#2536](https://github.com/alphaonedev/ai-memory-mcp/issues/2536); CWE-284). #2479 confines the row's own namespace (and parent), but `resolve_governance_policy` walks leaf-first and returns the first ancestor with a policy — so a peer enrolled for exact `["secure"]` could set the DEFAULT policy of every `secure/**` child outside its allowlist. Full pattern-vs-pattern subsumption is not in the #239 `glob_match` SSOT; the control requires the same shared `inbound_write_namespace_authorized` verdict against a **concrete deep descendant probe** (`namespace/__ai_memory_2536_desc/deep`). Exact-scope and single-level `prefix/*` fail; `prefix/**` and `**` succeed. Amendment E (`*` global) unchanged. Zero-config meshes unchanged.
+
 ### Fixed (federated `pendings[]` can no longer resurrect a decided governance row)
 
 - **`/sync/push` `pendings[]` refuses to resurrect or clobber a locally-decided pending action** (refs [#2529](https://github.com/alphaonedev/ai-memory-mcp/issues/2529); CWE-284). Pre-fix `upsert_pending_action` was `ON CONFLICT DO UPDATE` over **every** column including `status` / `decided_by` / `approvals`, so an enrolled peer could push `status: "pending"` for an id this node had already rejected and re-arm `execute_pending_action` (which only checks `status == "approved"`), defeating consensus quorum history.

--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -1266,20 +1266,22 @@ pub fn inbound_by_id_namespace_authorized(
 ///   here for uniformity — an operator hitting that refusal should drop the
 ///   redundant field, since the global standard is already in every chain.
 ///
-/// It does NOT and cannot gate:
+/// It also gates (Amendment #2536):
 ///
-/// - **the DESCENDANTS of `namespace`.** `resolve_governance_policy` walks
-///   leaf-first and returns the first level carrying a policy, so a peer scoped
-///   to an ANCESTOR (e.g. exactly `["secure"]`) sets the DEFAULT policy of every
-///   `secure/**` namespace that carries none of its own. Closing that needs
-///   pattern-vs-pattern subsumption, which the shared `glob_match` primitive
-///   structurally cannot express (it matches a pattern against a CONCRETE
-///   target), so a subtree variant was ranked LAST by the #2479 vote and is
-///   tracked separately rather than forked off the one #239 glob SSOT.
-/// - **the namespace the `standard_id` memory LIVES IN.** `set_namespace_standard`
-///   deliberately permits cross-namespace binding ("shared policy"), so gating it
-///   would break a documented feature; the read-amplification that binding a
-///   foreign memory enables is tracked separately.
+/// - **the DESCENDANTS of `namespace` by inheritance.** `resolve_governance_policy`
+///   walks leaf-first and returns the first level carrying a policy, so a peer
+///   scoped to an ANCESTOR (e.g. exactly `["secure"]`) would otherwise set the
+///   DEFAULT policy of every `secure/**` namespace that carries none of its own.
+///   Full pattern-vs-pattern subsumption is not in the #239 `glob_match` SSOT;
+///   instead we require the peer to also be authorized for a **concrete deep
+///   descendant probe** of `namespace` (same `inbound_write_namespace_authorized`
+///   path). Exact-scope and single-level `prefix/*` peers fail that probe;
+///   `prefix/**` and `**` succeed. See #2536.
+/// - **Not gated: the namespace the `standard_id` memory LIVES IN.**
+///   `set_namespace_standard` deliberately permits cross-namespace binding
+///   ("shared policy"), so gating it would break a documented feature; the
+///   read-amplification that binding a foreign memory enables is tracked
+///   separately.
 ///
 /// ## Amendment E — the global standard is not just another namespace
 ///
@@ -1358,8 +1360,45 @@ pub fn inbound_namespace_meta_authorized(
         }
     }
 
+    // #2536 — inheritance reaches descendants. After authorizing `namespace`
+    // itself, require authorization for a concrete deep descendant so an
+    // exact-scope peer cannot set (or clear) a standard that becomes the
+    // default policy of out-of-scope children. Amendment E already gates the
+    // global `*` row; skip the probe there (and there is no meaningful child
+    // of `*`).
+    if namespace != GLOBAL_STANDARD_NAMESPACE {
+        let descendant_probe = format!("{namespace}{NAMESPACE_META_DESCENDANT_PROBE_SUFFIX}");
+        if !inbound_write_namespace_authorized(
+            lane,
+            namespace,
+            &descendant_probe,
+            None,
+            attest_cfg,
+            peer_id,
+            require_push_namespace_scope,
+        ) {
+            tracing::warn!(
+                target: ATTESTATION_TRACE_TARGET,
+                namespace = %namespace,
+                descendant_probe = %descendant_probe,
+                peer_id = %peer_id.unwrap_or(""),
+                "sync_push: refusing federated {lane} entry — peer scope covers \
+                 this namespace but not its descendants (#2536); a governance standard \
+                 (or clear) on an ancestor is the default policy of every child \
+                 without its own. Declare a tree pattern (namespace/** or **) for \
+                 this peer if it is trusted to set hierarchical governance."
+            );
+            return false;
+        }
+    }
+
     true
 }
+
+/// #2536 — suffix appended to `namespace` to form the concrete deep-descendant
+/// probe. Two extra segments so single-level `prefix/*` patterns (which match
+/// exactly one child segment) fail, while `prefix/**` and `**` succeed.
+pub const NAMESPACE_META_DESCENDANT_PROBE_SUFFIX: &str = "/__ai_memory_2536_desc/deep";
 
 #[cfg(test)]
 mod tests {

--- a/tests/federation_namespace_meta_descendant_2536.rs
+++ b/tests/federation_namespace_meta_descendant_2536.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2536 — federated `namespace_meta` must not set hierarchical governance
+//! default for out-of-scope descendants via exact/single-level ancestor scope.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+const REQUIRE_ATTEST_ENV: &str = "AI_MEMORY_REQUIRE_AGENT_ATTESTATION";
+const REQUIRE_ENROLLMENT_ENV: &str = "AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT";
+const TRUST_BODY_AGENT_ID_ENV: &str = "AI_MEMORY_FED_TRUST_BODY_AGENT_ID";
+const PEER_ID: &str = "ai:peer-2536";
+
+/// Exact-scope on the ancestor only — the #2536 exploit posture.
+const EXACT_ANCESTOR: &str = r#"{"ai:peer-2536":{"allowed_namespaces":["secure"],"allowed_sender_agent_ids":["ai:peer-2536"]}}"#;
+
+/// Tree-scope covering secure and all descendants — control.
+const TREE_ANCESTOR: &str = r#"{"ai:peer-2536":{"allowed_namespaces":["secure/**"],"allowed_sender_agent_ids":["ai:peer-2536"]}}"#;
+
+struct PostureGuard;
+impl Drop for PostureGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+            std::env::remove_var(REQUIRE_ATTEST_ENV);
+            std::env::remove_var(REQUIRE_ENROLLMENT_ENV);
+            std::env::remove_var(TRUST_BODY_AGENT_ID_ENV);
+            std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+            std::env::remove_var(
+                ai_memory::federation::receive_auth::REQUIRE_PUSH_NAMESPACE_SCOPE_ENV,
+            );
+        }
+    }
+}
+
+fn set_posture(allowlist: Option<&str>) {
+    unsafe {
+        std::env::set_var(REQUIRE_ATTEST_ENV, "0");
+        std::env::set_var(REQUIRE_ENROLLMENT_ENV, "0");
+        std::env::set_var(TRUST_BODY_AGENT_ID_ENV, "1");
+        std::env::remove_var(ai_memory::federation::peer_attestation::SYNC_TRUST_PEER_ENV);
+        std::env::set_var(
+            ai_memory::federation::receive_auth::REQUIRE_PUSH_NAMESPACE_SCOPE_ENV,
+            "1",
+        );
+        match allowlist {
+            Some(body) => std::env::set_var(
+                ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV,
+                body,
+            ),
+            None => {
+                std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV)
+            }
+        }
+    }
+}
+
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: std::sync::Arc<dyn ai_memory::store::MemoryStore> = {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+        let p = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+        std::sync::Arc::new(ai_memory::store::sqlite::SqliteStore::open(&p).expect("open store"))
+    };
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: std::sync::Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: std::sync::Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: std::sync::Arc::new(None),
+        deferred_audit_queue: std::sync::Arc::new(None),
+        admin_agent_ids: std::sync::Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    (ai_memory::build_router(api_key_state, app_state), db)
+}
+
+async fn seed_standard(router: &axum::Router, ns: &str, title: &str) -> String {
+    let body = json!({
+        "title": title,
+        "content": format!("standard body for {title}"),
+        "namespace": ns,
+        "metadata": {"governance": {"write": "approve", "approver": {"agent": PEER_ID}}}
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/memories")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "seed standard memory failed: {}",
+        resp.status()
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    v["id"].as_str().unwrap().to_string()
+}
+
+async fn push_meta(
+    router: &axum::Router,
+    namespace: &str,
+    standard_id: &str,
+) -> (StatusCode, Value) {
+    let body = json!({
+        "sender_agent_id": PEER_ID,
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "namespace_meta": [{
+            "namespace": namespace,
+            "standard_id": standard_id,
+            "parent_namespace": null
+        }],
+        "dry_run": false,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            PEER_ID,
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, v)
+}
+
+async fn stored_standard(db: &ai_memory::handlers::Db, ns: &str) -> Option<String> {
+    let lock = db.lock().await;
+    ai_memory::db::get_namespace_standard(&lock.0, ns)
+        .ok()
+        .flatten()
+}
+
+async fn resolved_write(
+    db: &ai_memory::handlers::Db,
+    ns: &str,
+) -> Option<ai_memory::models::GovernanceLevel> {
+    let lock = db.lock().await;
+    ai_memory::db::resolve_governance_policy(&lock.0, ns).map(|p| p.core.write)
+}
+
+/// Exact-scope peer sets standard on `secure` → would govern `secure/ops`.
+/// Must refuse (#2536).
+#[tokio::test]
+async fn exact_ancestor_cannot_set_standard_inheriting_to_descendants_2536() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = PostureGuard;
+    set_posture(Some(EXACT_ANCESTOR));
+    let (router, db) = build_router_with_db();
+
+    let sid = seed_standard(&router, "secure", "peer standard").await;
+    let (status, report) = push_meta(&router, "secure", &sid).await;
+    assert_eq!(status, StatusCode::OK, "{report}");
+    assert!(
+        stored_standard(&db, "secure").await.is_none(),
+        "exact-scope must not bind hierarchical standard: {report}"
+    );
+    assert_eq!(
+        report["namespace_meta_applied"].as_u64(),
+        Some(0),
+        "{report}"
+    );
+    assert_eq!(
+        report["namespace_meta_refused"].as_u64(),
+        Some(1),
+        "{report}"
+    );
+    // Descendant remains ungovered by the peer's would-be policy.
+    assert_ne!(
+        resolved_write(&db, "secure/ops").await,
+        Some(ai_memory::models::GovernanceLevel::Approve),
+        "descendant must not inherit peer policy: {report}"
+    );
+}
+
+/// Tree-scope `secure/**` still binds (positive control).
+#[tokio::test]
+async fn tree_scope_still_sets_standard_2536() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = PostureGuard;
+    set_posture(Some(TREE_ANCESTOR));
+    let (router, db) = build_router_with_db();
+
+    let sid = seed_standard(&router, "secure", "peer standard").await;
+    let (status, report) = push_meta(&router, "secure", &sid).await;
+    assert_eq!(status, StatusCode::OK, "{report}");
+    assert_eq!(
+        stored_standard(&db, "secure").await.as_deref(),
+        Some(sid.as_str()),
+        "tree-scope bind must apply: {report}"
+    );
+    assert_eq!(
+        report["namespace_meta_applied"].as_u64(),
+        Some(1),
+        "{report}"
+    );
+    assert_eq!(
+        report["namespace_meta_refused"].as_u64(),
+        Some(0),
+        "{report}"
+    );
+}
+
+#[test]
+fn descendant_probe_suffix_is_two_segments_2536() {
+    let s = ai_memory::federation::receive_auth::NAMESPACE_META_DESCENDANT_PROBE_SUFFIX;
+    assert!(s.starts_with('/'));
+    assert_eq!(s.matches('/').count(), 2, "two extra segments: {s}");
+}

--- a/tests/federation_namespace_meta_descendant_2536.rs
+++ b/tests/federation_namespace_meta_descendant_2536.rs
@@ -55,7 +55,7 @@ fn set_posture(allowlist: Option<&str>) {
                 body,
             ),
             None => {
-                std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV)
+                std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
             }
         }
     }

--- a/tests/federation_ns_meta_scope_2479.rs
+++ b/tests/federation_ns_meta_scope_2479.rs
@@ -84,20 +84,26 @@ const PEER_ID: &str = "ai:evil";
 const VICTIM_NS: &str = "secure/ops";
 const IN_SCOPE_NS: &str = "public/ok";
 
-/// `ai:evil` may act inside `public/*` only.
+/// `ai:evil` may act inside the `public/**` tree only.
+/// Tree pattern (not `public/*`) so in-scope `namespace_meta` controls still
+/// pass the #2536 descendant-coverage probe on `public/ok`.
 const SCOPED_ALLOWLIST: &str =
-    r#"{"ai:evil":{"allowed_namespaces":["public/*"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
+    r#"{"ai:evil":{"allowed_namespaces":["public/**"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
 
-/// The CONTROL posture: the same peer, scoped to reach the victim namespace too.
-const SCOPED_ALLOWLIST_WITH_VICTIM: &str = r#"{"ai:evil":{"allowed_namespaces":["public/*","secure/*"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
+/// The CONTROL posture: the same peer, scoped to reach the victim namespace tree.
+/// #2536 requires tree coverage (`/**`) — a single-level `secure/*` matches
+/// `secure/ops` but not its descendants, so it may not set/clear hierarchical
+/// governance on that node.
+const SCOPED_ALLOWLIST_WITH_VICTIM: &str = r#"{"ai:evil":{"allowed_namespaces":["public/*","secure/**"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
 
 /// Root-namespace posture for the parent cell: the peer owns `alpha` but NOT the
 /// namespace it tries to attach as `alpha`'s inheritance parent.
 const SCOPED_ALLOWLIST_ROOT: &str =
     r#"{"ai:evil":{"allowed_namespaces":["alpha"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
 
-/// The control for the parent cell: both ends of the link are in scope.
-const SCOPED_ALLOWLIST_ROOT_AND_PARENT: &str = r#"{"ai:evil":{"allowed_namespaces":["alpha","victim"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
+/// The control for the parent cell: both ends of the link are in scope with
+/// tree coverage (#2536 descendant probe on `alpha`).
+const SCOPED_ALLOWLIST_ROOT_AND_PARENT: &str = r#"{"ai:evil":{"allowed_namespaces":["alpha/**","victim/**"],"allowed_sender_agent_ids":["ai:evil"]}}"#;
 
 /// Amendment E: `["*"]` reads as "any top-level namespace" but glob-matches the
 /// literal global-standard key `*`.


### PR DESCRIPTION
## Summary
Gate1 residual **#2536**: federated `namespace_meta` / `namespace_meta_clears` can no longer let an exact-scope (or single-level) peer set hierarchical governance defaults for out-of-scope descendants.

### Control
After #2479 authorizes the row's own namespace (and parent), require the same shared `inbound_write_namespace_authorized` verdict against a **concrete deep descendant probe**  
`namespace/__ai_memory_2536_desc/deep` (#2536).

| Peer allowlist | Result on meta for `secure` |
|----------------|-----------------------------|
| `["secure"]` exact | **refuse** |
| `["secure/*"]` one-level | **refuse** |
| `["secure/**"]` tree | allow |
| `["**"]` | allow |
| zero-config (no allowlist) | unchanged byte-identical |

No new glob SSOT / pattern-vs-pattern subsumption — dual concrete probe only. Amendment E (`*` global) unchanged.

### Tests
- `tests/federation_namespace_meta_descendant_2536.rs` — 3/3
- `tests/federation_ns_meta_scope_2479.rs` — 11/11 (controls updated to tree patterns where hierarchical governance is intentional)

### Code + security review (control)
- **Threat:** exact-scope ancestor binds standard → `resolve_governance_policy` leaf-first inheritance rewrites rules for every child without its own policy (authz-config takeover of out-of-scope tenants).
- **Mitigation:** fail closed unless peer scope also matches a deep descendant concrete path; reuses Layer-1/Layer-2 + knob 147.
- **Clear lane:** same function — cannot disarm descendants by clearing an exact-scope ancestor.
- **Residual:** `standard_id` memory may still live in a foreign namespace (documented #2479 non-goal).

Refs: #2536 #2682 #2479