### PR TITLE
fix(#2676): ship --features sal on release and Docker binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,22 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # #2676 packaging residual — release channel must not ship default-only
+      # binaries that omit `sal` (federation/SAL surface). Assert via the same
+      # pin Gate3 provision uses (`scripts/assert-compiled-features.sh`).
+      # Note: `sal-postgres` is NOT enabled here (sqlx/pgvector weight + native
+      # deps on every matrix OS); operators needing PG use an asserted
+      # sal-postgres build or the plan-c image. Agents never workflow_dispatch.
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features sal
+
+      - name: Assert compiled features (#2676)
+        shell: bash
+        run: |
+          bin="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          # Windows artifact is .exe; run via path. Script uses `features` subcommand.
+          bash scripts/assert-compiled-features.sh "$bin" \
+            --require sqlite-bundled --require sal
 
       - name: Package binary (unix)
         if: ${{ !contains(matrix.target, 'windows') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (release/Docker binaries ship federation `sal` feature)
+
+- **Dockerfile and `release.yml` build with `--features sal` and assert the compiled feature set** (refs [#2676](https://github.com/alphaonedev/ai-memory-mcp/issues/2676) packaging residual). Pre-fix default cargo features were only `sqlite-bundled`, so GHCR/deb/tarball artifacts could omit the SAL/federation surface Gate3 measured with an asserted build. `scripts/assert-compiled-features.sh` now runs in the image build and on each release matrix binary (`sqlite-bundled` + `sal`). `sal-postgres` remains opt-in for PG-native deployments (plan-c / explicit build), not forced onto every multi-OS release target.
+
 ### Fixed (federated REJECT cannot veto foreign-namespace pendings)
 
 - **`/sync/push` `pending_decisions[]` REJECT is namespace-confined** (refs [#2532](https://github.com/alphaonedev/ai-memory-mcp/issues/2532); CWE-284). #2478 gated APPROVE but deliberately left REJECT ungated; an enrolled peer scoped to `public/*` could permanently set `status=rejected` on another tenant's queue. REJECT now uses the same local-row probe + shared `pending_namespaces_authorized` gate as APPROVE. Out-of-scope refuse leaves the row pending (still approvable by legitimate in-scope actors — the correct multi-tenant outcome). In-scope reject still converges. Zero-config unchanged.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,15 @@ COPY migrations/ migrations/
 # alphaonedev/paste fork was deleted. The build context MUST include it
 # or `cargo build` fails: "failed to read /build/vendor/paste/Cargo.toml".
 COPY vendor/ vendor/
-
-RUN cargo build --release && strip target/release/ai-memory
+# #2676 packaging residual — ship the federation surface operators expect.
+# Default cargo features are only `sqlite-bundled`; without `sal`, SAL store
+# paths and several daemon federation workers stay compiled out. Gate3 cert
+# measured an asserted feature build; GHCR/deb must not silently ship less.
+COPY scripts/assert-compiled-features.sh scripts/assert-compiled-features.sh
+RUN cargo build --release --features sal \
+    && strip target/release/ai-memory \
+    && bash scripts/assert-compiled-features.sh target/release/ai-memory \
+         --require sqlite-bundled --require sal
 
 # ---- Runtime stage ----
 FROM debian:bookworm-slim

--- a/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
+++ b/docs/handoff/READY-TO-TAG-v1.0.0-CERT-NOTE.md
@@ -16,7 +16,7 @@
 |------|--------|----------|
 | **1 Structural confinement** | PASS | `push_lanes` exhaustiveness + shared `inbound_*`; links/signals/crypto lanes; pull path #2480 via #2685 `a9b77b24`; residuals #2529/#2536/#2532 closed (#2694/#2696/#2698) |
 | **2 Claims** | PASS | Merge order **#2655 → #2656 → #2668 → #2659 LAST** (… `f95d889e`) |
-| **Packaging #2676** | PASS with residual | #2686 `d742f331` — `ai-memory features` + `assert-compiled-features.sh` |
+| **Packaging #2676** | PASS | #2686 `d742f331` — `ai-memory features` + `assert-compiled-features.sh`; release/Dockerfile ship `--features sal` + assert |
 | **3 Measured evidence** | PASS | DO do-perf: asserted sal-postgres binary @ `d742f331`; PG18+AGE+pgvector; hostssl cleartext REFUSED; TLS1.3 verify-full; 20 stores; droplets torn down |
 | **4 Agreement vote** | PASS | 3/3 AGREE with residuals (package tip `b95ad978`) |
 
@@ -40,7 +40,7 @@
 - **#2532** via #2698 (`1c12c988`) — REJECT namespace-confined same as APPROVE (closes unauthorized foreign veto)
 
 ### Packaging / release-channel residual
-5. **Release.yml / Dockerfile default feature set** may still omit `sal` / `sal-postgres` — certification measured an **asserted** feature build; operators must not tag without verifying release artifact features via `ai-memory features` / assert script.
+5. **Release channel ships `--features sal`** (Dockerfile + `release.yml` matrix) and asserts via `scripts/assert-compiled-features.sh` (`sqlite-bundled` + `sal`). **`sal-postgres` is not** on every multi-OS release binary (native sqlx weight); PG deployments use an asserted `sal-postgres` build (Gate3 measure tip `d742f331` / plan-c image). Operators still verify cut artifacts with `ai-memory features` / assert script before publish.
 
 ### Capacity / follow-on (not gate-blocking for this cert claim set)
 6. **Landed capacity (inventory at tip):** #2643 (`8aa83e6fe989`, authz #2538/#2633); #2689 (`9136b5a33259`, signed re-land of #2644 bulk funnel); #2662 (`3bd01c329e65`, delete-lane DLQ #2498); #2663 (`b3096c156373`, /sync/since cursor #2441); #2673 (`0d50789b`, erasure outbox #2446).


### PR DESCRIPTION
## Summary
Packaging residual from Gate3 cert note: release/Docker channel no longer ships default-only (`sqlite-bundled`) binaries that omit `sal`.

### Control
1. **Dockerfile** — `cargo build --release --features sal` + `assert-compiled-features.sh --require sqlite-bundled --require sal`
2. **release.yml** — matrix binaries built with `--features sal` + same assert after build
3. **Cert note** — packaging residual updated; Gate packaging → PASS

### Not in this PR
- `sal-postgres` on every multi-OS release target (sqlx/pgvector weight) — remains plan-c / explicit asserted build (Gate3 measure tip)
- Tag cut / `workflow_dispatch` release.yml — **never** (operator only)

### Security / review
Fail-closed packaging: wrong feature set fails the image build and release job rather than shipping a silent false-success artifact.

Refs: #2676 #2682 #2686