### PR TITLE
test(#2677): pin host_is_loopback exactness against spoof shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (plaintext peer gate: loopback exactness is now suite-enforced)
+
+- **Regression pins for `host_is_loopback` exactness** (refs [#2677](https://github.com/alphaonedev/ai-memory-mcp/issues/2677); CWE-319 class). Behaviour was already correct after #2477; the suite only covered happy-path loopback. Spoof hosts (`127.0.0.1.evil.com`, `localhost.evil.com`, query-embedded loopback strings, `127.0.0.2`) are refused by unit + `FederationConfig::build` tests so a future `starts_with`/`contains` "tidy" cannot silently re-open cleartext federation. Decimal/hex IPv4 forms normalise to `127.0.0.1` in the URL parser and remain correctly exempt (pinned).
+
 ### Fixed (release/Docker binaries ship federation `sal` feature)
 
 - **Dockerfile and `release.yml` build with `--features sal` and assert the compiled feature set** (refs [#2676](https://github.com/alphaonedev/ai-memory-mcp/issues/2676) packaging residual). Pre-fix default cargo features were only `sqlite-bundled`, so GHCR/deb/tarball artifacts could omit the SAL/federation surface Gate3 measured with an asserted build. `scripts/assert-compiled-features.sh` now runs in the image build and on each release matrix binary (`sqlite-bundled` + `sal`). `sal-postgres` remains opt-in for PG-native deployments (plan-c / explicit build), not forced onto every multi-OS release target.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -2415,4 +2415,70 @@ mod tests {
                 .contains("exactly two")
         );
     }
+
+    /// #2677 — `host_is_loopback` exactness is load-bearing for the #2477
+    /// plaintext exemption. A future refactor to `starts_with("127.")` or
+    /// `contains("localhost")` would accept spoof hosts while every happy-
+    /// path test still passed (false-success class).
+    #[test]
+    fn host_is_loopback_exact_only_refuses_spoof_shapes_2677() {
+        for good in ["127.0.0.1", "::1", "localhost", "0:0:0:0:0:0:0:1", "[::1]"] {
+            assert!(
+                host_is_loopback(good),
+                "literal loopback must match: {good}"
+            );
+        }
+        for bad in [
+            "127.0.0.1.evil.com",
+            "localhost.evil.com",
+            "127.0.0.2",
+            "127.1",
+            "0.0.0.0",
+            "evil-localhost",
+            "localhostx",
+            "2130706433",
+            "0x7f000001",
+            "",
+            "example.com",
+        ] {
+            assert!(
+                !host_is_loopback(bad),
+                "spoof/encoded host must NOT be loopback: {bad}"
+            );
+        }
+    }
+
+    /// #2677 — scheme guard refuses spoofed "loopback" HTTP peers (hatch off).
+    #[test]
+    fn validate_peer_url_refuses_loopback_spoof_http_2677() {
+        let _g = fed_pin_env_lock();
+        // Ensure hatch is off for this process while we hold the pin lock.
+        // SAFETY: single-threaded unit test under process-wide pin lock.
+        unsafe {
+            std::env::remove_var(FED_ALLOW_PLAINTEXT_PEERS_ENV);
+        }
+        for peer in [
+            "http://127.0.0.1.evil.com:9077",
+            "http://localhost.evil.com:9077",
+            "http://evil.com/?x=127.0.0.1",
+            "http://127.0.0.2:9077",
+        ] {
+            assert!(
+                validate_peer_url_scheme(peer).is_err(),
+                "#2677: spoof loopback HTTP peer must be REFUSED: {peer}"
+            );
+        }
+        // Positive control: literal loopback still exempt.
+        assert!(validate_peer_url_scheme("http://127.0.0.1:9077").is_ok());
+        // url/reqwest normalises decimal/hex IPv4 forms to 127.0.0.1 before
+        // host_str(); they ARE loopback. Pin accept so a silent behaviour
+        // flip is reviewed (not a silent widen of a non-loopback host).
+        for peer in ["http://2130706433/", "http://0x7f000001/"] {
+            assert!(
+                validate_peer_url_scheme(peer).is_ok(),
+                "#2677: decimal/hex IPv4 loopback forms normalise to 127.0.0.1 \
+                 and must stay exempt: {peer}"
+            );
+        }
+    }
 }

--- a/tests/federation_plaintext_peer_2477.rs
+++ b/tests/federation_plaintext_peer_2477.rs
@@ -204,6 +204,36 @@ async fn container_hostname_is_not_treated_as_loopback_2477() {
     );
 }
 
+/// #2677 — pin EXACTNESS of the loopback exemption. Happy-path loopback tests
+/// would still pass if `host_is_loopback` were weakened to `starts_with("127.")`
+/// or `contains("localhost")`, which would accept plaintext peers on attacker
+/// hosts. Spoof shapes must stay refused without the hatch.
+#[tokio::test]
+async fn loopback_spoof_shapes_are_refused_not_exempt_2677() {
+    let _g = ENV_LOCK.lock().await;
+    clear_hatch();
+    for peer in [
+        "http://127.0.0.1.evil.com:9077",
+        "http://localhost.evil.com:9077",
+        "http://evil.com/?x=127.0.0.1",
+        "http://127.0.0.2:9077",
+    ] {
+        assert!(
+            build_one(peer).is_err(),
+            "#2677: spoof loopback peer must be REFUSED (exact host match only): {peer}"
+        );
+    }
+    // url crate normalises decimal/hex IPv4 to 127.0.0.1 — true loopback;
+    // pin acceptance so a behaviour flip is deliberate.
+    for peer in ["http://2130706433:9077", "http://0x7f000001:9077"] {
+        assert!(
+            build_one(peer).is_ok(),
+            "#2677: decimal/hex IPv4 loopback forms must stay exempt after URL \
+             normalisation: {peer}"
+        );
+    }
+}
+
 /// GUARD. The staged-rollout hatch works, and only on an explicit truthy
 /// token: an unrecognised value must never silently widen the control
 /// (the FBL-14 rule).


### PR DESCRIPTION
## Summary
Post-tag residual **#2677**: suite now enforces exactness of `host_is_loopback` used by the #2477 plaintext-peer gate.

### Control
- Unit: spoof hosts refused; literal loopback accepted
- Unit + integration: `127.0.0.1.evil.com`, `localhost.evil.com`, query-embedded loopback, `127.0.0.2` refused without hatch
- Decimal/hex IPv4 (`2130706433`, `0x7f000001`) normalise via URL parser to `127.0.0.1` — pin **accept** (true loopback)

### Security
False-success class: happy-path tests alone would not notice a weakened predicate. No behaviour change for production control.

Refs: #2677 #2477 #2682