### PR TITLE
fix(#2545): refuse clear_namespace_standard when standard is unresolvable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (clear_namespace_standard cannot disarm unresolvable governance)
+
+- **Claimed callers can no longer clear a namespace standard when the bound memory is severed or dangling** (refs [#2545](https://github.com/alphaonedev/ai-memory-mcp/issues/2545); CWE-284). Pre-fix the #1777 owner gate short-circuited when the standard was unresolvable, so any claimed agent could `DELETE` the last governance evidence and restore allow-on-silence. MCP/sqlite and PostgresStore refuse unresolvable clears with a re-point remedy; healthy #1777 contracts unchanged.
+
 ### Fixed (plaintext peer gate: loopback exactness is now suite-enforced)
 
 - **Regression pins for `host_is_loopback` exactness** (refs [#2677](https://github.com/alphaonedev/ai-memory-mcp/issues/2677); CWE-319 class). Behaviour was already correct after #2477; the suite only covered happy-path loopback. Spoof hosts (`127.0.0.1.evil.com`, `localhost.evil.com`, query-embedded loopback strings, `127.0.0.2`) are refused by unit + `FederationConfig::build` tests so a future `starts_with`/`contains` "tidy" cannot silently re-open cleartext federation. Decimal/hex IPv4 forms normalise to `127.0.0.1` in the URL parser and remain correctly exempt (pinned).

--- a/src/mcp/tools/namespace.rs
+++ b/src/mcp/tools/namespace.rs
@@ -539,26 +539,60 @@ pub(crate) fn handle_namespace_clear_standard(
     // non-owner could disarm protections others rely on, and a non-admin owner
     // could set-but-never-clear). Gate ONLY when identity is claimed
     // (params.agent_id present); daemon-internal + unclaimed callers pass, same
-    // as SET. The bare DELETE carries no owner, but the standard memory's
-    // metadata.agent_id is recoverable via get_namespace_standard → db::get.
+    // as SET.
+    //
+    // #2545 — when the standard is UNRESOLVABLE (severed `standard_id` NULL
+    // post-#2503, or dangling id after memory reap), the pre-fix `&&`-chain
+    // short-circuited and skipped the gate entirely — any claimed caller could
+    // DELETE the last evidence of governance and restore allow-on-silence.
+    // Unresolvable + claimed identity → refuse with a re-point remedy.
     let identity_claimed = params
         .get(param_names::AGENT_ID)
         .and_then(|v| v.as_str())
         .is_some_and(|s| !s.is_empty());
-    if identity_claimed
-        && let Ok(Some(standard_id)) = db::get_namespace_standard(conn, namespace)
-        && let Ok(Some(existing_mem)) = db::get(conn, &standard_id)
-    {
-        let recorded_owner = existing_mem
-            .metadata
-            .get(param_names::AGENT_ID)
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let is_unowned = recorded_owner.is_empty() || recorded_owner == "system";
-        if !is_unowned && recorded_owner != caller && caller != sentinels::DAEMON_PRINCIPAL {
-            return Err(format!(
-                "caller does not own this namespace standard (caller={caller}, owner={recorded_owner})"
-            ));
+    if identity_claimed {
+        let meta_row_exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM namespace_meta WHERE namespace = ?1",
+                rusqlite::params![namespace],
+                |_| Ok(1i32),
+            )
+            .is_ok();
+        if meta_row_exists {
+            let resolved = match db::get_namespace_standard(conn, namespace) {
+                Ok(Some(standard_id)) => db::get(conn, &standard_id).map_err(|e| e.to_string())?,
+                Ok(None) => None,
+                Err(e) => return Err(e.to_string()),
+            };
+            match resolved {
+                Some(existing_mem) => {
+                    let recorded_owner = existing_mem
+                        .metadata
+                        .get(param_names::AGENT_ID)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let is_unowned = recorded_owner.is_empty() || recorded_owner == "system";
+                    if !is_unowned
+                        && recorded_owner != caller
+                        && caller != sentinels::DAEMON_PRINCIPAL
+                    {
+                        return Err(format!(
+                            "caller does not own this namespace standard (caller={caller}, owner={recorded_owner})"
+                        ));
+                    }
+                }
+                None => {
+                    if caller != sentinels::DAEMON_PRINCIPAL {
+                        return Err(
+                            "cannot clear namespace standard: the bound standard memory is \
+                             unresolvable (severed or dangling). Re-point the standard with \
+                             memory_namespace_set_standard first, then clear — or use a \
+                             daemon/admin surface."
+                                .to_string(),
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -787,6 +821,37 @@ mod tests {
                 .is_none(),
             "owner clear removes the standard"
         );
+    }
+
+    /// #2545 — claimed non-owner must not clear a SEVERED/dangling binding.
+    #[test]
+    fn clear_standard_refuses_unresolvable_binding_2545() {
+        let conn = fresh_conn();
+        let id = insert_owned(&conn, "ns-clear-2545", "standard", "ai:alice");
+        handle_namespace_set_standard(
+            &conn,
+            &json!({"namespace": "ns-clear-2545", "id": id, "agent_id": "ai:alice"}),
+        )
+        .expect("alice sets");
+        db::delete(&conn, &id).expect("delete standard memory");
+
+        let err = handle_namespace_clear_standard(
+            &conn,
+            &json!({"namespace": "ns-clear-2545", "agent_id": "ai:bob"}),
+        )
+        .expect_err("claimed non-owner clear of unresolvable binding must refuse");
+        assert!(
+            err.contains("unresolvable") || err.contains("does not own"),
+            "got: {err}"
+        );
+        let still: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM namespace_meta WHERE namespace = ?1",
+                ["ns-clear-2545"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(still, 1, "namespace_meta row must survive refused clear");
     }
 
     // set_standard: happy path without governance.

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -19945,26 +19945,56 @@ impl MemoryStore for PostgresStore {
         // protecting every memory in the namespace, so it must be owner-gated
         // like SET. The standard memory's owner is `metadata->>'agent_id'`;
         // refuse a clear by a different named agent (admin/bypass + unowned pass).
+        //
+        // #2545 — INNER JOIN through standard_id yielded no row for severed
+        // (NULL) or dangling standard_ids, which skipped the gate. When a
+        // namespace_meta row exists but the standard is unresolvable, refuse
+        // (non-bypass) so clear cannot disarm fail-closed governance.
         if !ctx.bypass_visibility {
-            let recorded_owner: Option<String> = sqlx::query_scalar(
-                "SELECT m.metadata->>'agent_id' FROM namespace_meta nm \
-                 JOIN memories m ON m.id = nm.standard_id WHERE nm.namespace = $1",
+            let meta_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM namespace_meta WHERE namespace = $1)",
             )
             .bind(namespace)
-            .fetch_optional(&self.pool)
+            .fetch_one(&self.pool)
             .await
-            .map_err(|e| to_store_err("clear_namespace_standard owner pre-fetch", e))?
-            .flatten();
-            if let Some(owner) = recorded_owner
-                && !owner.is_empty()
-                && owner != "system"
-                && owner != ctx.effective_principal()
-            {
-                return Err(StoreError::PermissionDenied {
-                    action: crate::OP_CLEAR_NAMESPACE_STANDARD.to_string(),
-                    target: namespace.to_string(),
-                    reason: format!("caller does not own this namespace standard (owner: {owner})"),
-                });
+            .map_err(|e| to_store_err("clear_namespace_standard meta-exists", e))?;
+            if meta_exists {
+                let recorded_owner: Option<String> = sqlx::query_scalar(
+                    "SELECT m.metadata->>'agent_id' FROM namespace_meta nm \
+                     JOIN memories m ON m.id = nm.standard_id WHERE nm.namespace = $1",
+                )
+                .bind(namespace)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| to_store_err("clear_namespace_standard owner pre-fetch", e))?
+                .flatten();
+                match recorded_owner {
+                    Some(owner)
+                        if !owner.is_empty()
+                            && owner != "system"
+                            && owner != ctx.effective_principal() =>
+                    {
+                        return Err(StoreError::PermissionDenied {
+                            action: crate::OP_CLEAR_NAMESPACE_STANDARD.to_string(),
+                            target: namespace.to_string(),
+                            reason: format!(
+                                "caller does not own this namespace standard (owner: {owner})"
+                            ),
+                        });
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(StoreError::PermissionDenied {
+                            action: crate::OP_CLEAR_NAMESPACE_STANDARD.to_string(),
+                            target: namespace.to_string(),
+                            reason:
+                                "cannot clear namespace standard: the bound standard memory is \
+                                     unresolvable (severed or dangling). Re-point the standard \
+                                     first, then clear — or use an admin/bypass surface."
+                                    .to_string(),
+                        });
+                    }
+                }
             }
         }
         let rows_affected = sqlx::query("DELETE FROM namespace_meta WHERE namespace = $1")


### PR DESCRIPTION
## Summary
Post-tag security **#2545** (CWE-284): claimed callers could clear a namespace standard when the bound memory was severed/dangling because the #1777 owner gate short-circuited.

### Control
1. **MCP/sqlite** — if `namespace_meta` exists and standard is unresolvable → refuse (daemon principal exempt)
2. **PostgresStore** — meta EXISTS + no resolvable owner → `PermissionDenied`
3. Healthy #1777 owner/non-owner contracts unchanged

### Tests
`clear_standard_refuses_unresolvable_binding_2545` + `clear_standard_owner_gate_1777`

Refs: #2545 #1777 #2503 #2682