### PR TITLE
fix(#2541): always gate set_namespace_standard; no silent claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (namespace set-standard no longer caller-opt-in / silent claim)
+
+- **MCP/HTTP `set_namespace_standard` always enforces ownership; unowned private rows are not silently claimed** (refs [#2541](https://github.com/alphaonedev/ai-memory-mcp/issues/2541); CWE-284). Pre-fix omitting `agent_id` skipped the #929 gate, and the unowned arm rewrote `agent_id` + stamped `scope=shared` (irreversible confidentiality downgrade). Bind now requires ownership or explicit `scope=shared` without mutation; daemon principal is the explicit operator bypass (CLI).
+
 ### Fixed (clear_namespace_standard cannot disarm unresolvable governance)
 
 - **Claimed callers can no longer clear a namespace standard when the bound memory is severed or dangling** (refs [#2545](https://github.com/alphaonedev/ai-memory-mcp/issues/2545); CWE-284). Pre-fix the #1777 owner gate short-circuited when the standard was unresolvable, so any claimed agent could `DELETE` the last governance evidence and restore allow-on-silence. MCP/sqlite and PostgresStore refuse unresolvable clears with a re-point remedy; healthy #1777 contracts unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (namespace set-standard no longer caller-opt-in / silent claim)
 
-- **MCP/HTTP `set_namespace_standard` always enforces ownership; unowned private rows are not silently claimed** (refs [#2541](https://github.com/alphaonedev/ai-memory-mcp/issues/2541); CWE-284). Pre-fix omitting `agent_id` skipped the #929 gate, and the unowned arm rewrote `agent_id` + stamped `scope=shared` (irreversible confidentiality downgrade). Bind now requires ownership or explicit `scope=shared` without mutation; daemon principal is the explicit operator bypass (CLI).
+- **MCP/HTTP `set_namespace_standard` always enforces ownership; unowned rows are never silently claimed** (refs [#2541](https://github.com/alphaonedev/ai-memory-mcp/issues/2541); CWE-284). Pre-fix omitting `agent_id` skipped the #929 gate (could rebind any owned memory), and the unowned arm rewrote `agent_id` + stamped `scope=shared` (irreversible confidentiality downgrade). Ownership is always checked; claim rewrite removed. Daemon principal is the explicit CLI/operator bypass.
 
 ### Fixed (clear_namespace_standard cannot disarm unresolvable governance)
 

--- a/src/cli/namespace.rs
+++ b/src/cli/namespace.rs
@@ -167,9 +167,13 @@ fn set_standard(
     out: &mut CliOutput<'_>,
 ) -> Result<()> {
     let conn = db::open(db_path)?;
+    // #2541 — local CLI is an operator/admin surface: use the explicit
+    // daemon principal so ownership gate has a real bypass, not the
+    // "omit agent_id" hole.
     let mut params = json!({
         "namespace": namespace,
         "id": id,
+        "agent_id": crate::identity::sentinels::DAEMON_PRINCIPAL,
     });
     if let Some(p) = parent {
         params["parent"] = json!(p);

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -447,61 +447,24 @@ async fn set_namespace_standard_inner(
         // caller as owner and this gate is a no-op for first writes.
         // Subsequent writes by a different caller hit the !is_unowned
         // branch and 403.
+        // #2541 — same authorize helper as MCP; no silent ownership claim.
         if let Ok(resolved_mem) = app.store.get(&ctx, &standard_id).await {
-            let recorded_owner = resolved_mem
-                .metadata
-                .get("agent_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let is_unowned =
-                recorded_owner.is_empty() || recorded_owner == sentinels::SYSTEM_PRINCIPAL;
             let caller_principal = ctx.effective_principal();
-            if !is_unowned
-                && recorded_owner != caller_principal
-                && caller_principal != sentinels::DAEMON_PRINCIPAL
+            if let Err(msg) =
+                crate::mcp::authorize_namespace_standard_bind(caller_principal, &resolved_mem)
             {
                 tracing::warn!(
                     target: super::AUTHZ_TRACE_TARGET,
-                    "POST /namespaces/{{ns}}/standard 403 (postgres path): caller {caller_principal} != owner {recorded_owner} (ns={ns}, id={standard_id})"
+                    "POST /namespaces/{{ns}}/standard 403 (postgres path): {msg} (ns={ns}, id={standard_id})"
                 );
                 return (
                     StatusCode::FORBIDDEN,
                     Json(json!({
-                        "error": crate::errors::msg::CALLER_NOT_NAMESPACE_STANDARD_OWNER,
-                        "owner": recorded_owner,
+                        "error": msg,
                         "caller": caller_principal
                     })),
                 )
                     .into_response();
-            }
-            // Unowned-legacy claim: rewrite metadata.agent_id to caller
-            // so subsequent calls are properly gated.
-            if is_unowned
-                && !caller_principal.is_empty()
-                && caller_principal != sentinels::ANONYMOUS_INVALID
-            {
-                let mut new_meta = if resolved_mem.metadata.is_object() {
-                    resolved_mem.metadata.clone()
-                } else {
-                    json!({})
-                };
-                if let Some(obj) = new_meta.as_object_mut() {
-                    obj.insert(
-                        "agent_id".to_string(),
-                        serde_json::Value::String(caller_principal.to_string()),
-                    );
-                    obj.entry("scope".to_string())
-                        .or_insert_with(|| serde_json::Value::String("shared".to_string()));
-                }
-                let patch = crate::store::UpdatePatch {
-                    metadata: Some(new_meta),
-                    ..Default::default()
-                };
-                if let Err(e) = app.store.update(&ctx, &standard_id, patch).await {
-                    tracing::warn!(
-                        "namespace_standard (postgres): ownership-claim metadata update failed: {e}"
-                    );
-                }
             }
         }
 
@@ -613,76 +576,20 @@ async fn set_namespace_standard_inner(
         .ok()
         .and_then(|v| v.into_iter().next());
         if let Some(m) = existing {
-            // #929 SECURITY-high (Track A P6, 2026-05-20) — ownership
-            // gate on the namespace-standard surface. Pre-fix any
-            // authenticated caller could overwrite any namespace's
-            // governance policy because the placeholder was stamped
-            // metadata.agent_id="system" (an unowned sentinel) and no
-            // caller-vs-owner comparison was performed. Now: the
-            // recorded owner is the only principal who can mutate the
-            // standard. Legacy "system" / empty owners are treated as
-            // unowned (any caller may CLAIM via the
-            // metadata.agent_id rewrite below) for backward
-            // compatibility with rows written before this fix.
-            let recorded_owner = m
-                .metadata
-                .get("agent_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let is_unowned =
-                recorded_owner.is_empty() || recorded_owner == sentinels::SYSTEM_PRINCIPAL;
-            if !is_unowned && recorded_owner != caller && caller != sentinels::DAEMON_PRINCIPAL {
+            // #929 / #2541 — authorize bind; never silent claim rewrite.
+            if let Err(msg) = crate::mcp::authorize_namespace_standard_bind(&caller, &m) {
                 tracing::warn!(
                     target: super::AUTHZ_TRACE_TARGET,
-                    "POST /namespaces/{{ns}}/standard 403: caller {caller} != owner {recorded_owner} (ns={ns})"
+                    "POST /namespaces/{{ns}}/standard 403: {msg} (ns={ns})"
                 );
                 return (
                     StatusCode::FORBIDDEN,
                     Json(json!({
-                        "error": crate::errors::msg::CALLER_NOT_NAMESPACE_STANDARD_OWNER,
-                        "owner": recorded_owner,
+                        "error": msg,
                         "caller": caller
                     })),
                 )
                     .into_response();
-            }
-            // Unowned-legacy fast path: claim ownership by rewriting
-            // metadata.agent_id to the caller. Next request from a
-            // different caller will be 403'd.
-            if is_unowned && !caller.is_empty() && caller != sentinels::ANONYMOUS_INVALID {
-                let mut new_meta = if m.metadata.is_object() {
-                    m.metadata.clone()
-                } else {
-                    json!({})
-                };
-                if let Some(obj) = new_meta.as_object_mut() {
-                    obj.insert(
-                        "agent_id".to_string(),
-                        serde_json::Value::String(caller.clone()),
-                    );
-                    // Preserve scope=shared if not already set so the
-                    // SAL #910 filter still surfaces the standard to
-                    // every reader.
-                    obj.entry("scope".to_string())
-                        .or_insert_with(|| serde_json::Value::String("shared".to_string()));
-                }
-                if let Err(e) = db::update(
-                    &lock.0,
-                    &m.id,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some(&new_meta),
-                ) {
-                    tracing::warn!(
-                        "namespace_standard: ownership-claim metadata update failed: {e}"
-                    );
-                }
             }
             m.id
         } else {
@@ -751,23 +658,17 @@ async fn set_namespace_standard_inner(
     // resolved standard memory by id, check ownership. The auto-seed
     // path already validated above and re-checking here is a no-op for
     // it; the body.id-supplied path goes through this gate once.
+    // #2541 — body.id path uses the same authorize helper (no claim rewrite).
     if let Ok(Some(resolved_mem)) = db::get(&lock.0, &resolved_id) {
-        let recorded_owner = resolved_mem
-            .metadata
-            .get("agent_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let is_unowned = recorded_owner.is_empty() || recorded_owner == sentinels::SYSTEM_PRINCIPAL;
-        if !is_unowned && recorded_owner != caller && caller != sentinels::DAEMON_PRINCIPAL {
+        if let Err(msg) = crate::mcp::authorize_namespace_standard_bind(&caller, &resolved_mem) {
             tracing::warn!(
                 target: super::AUTHZ_TRACE_TARGET,
-                "POST /namespaces/{{ns}}/standard 403 (body.id path): caller {caller} != owner {recorded_owner} (ns={ns}, id={resolved_id})"
+                "POST /namespaces/{{ns}}/standard 403 (body.id path): {msg} (ns={ns}, id={resolved_id})"
             );
             return (
                 StatusCode::FORBIDDEN,
                 Json(json!({
-                    "error": crate::errors::msg::CALLER_NOT_NAMESPACE_STANDARD_OWNER,
-                    "owner": recorded_owner,
+                    "error": msg,
                     "caller": caller
                 })),
             )

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -597,6 +597,7 @@ pub use check_duplicate::handle_check_duplicate;
 pub use expand_query::handle_expand_query;
 pub use kg_query::handle_kg_query;
 pub use load_family::{handle_load_family, handle_smart_load};
+pub(crate) use namespace::authorize_namespace_standard_bind;
 pub(crate) use namespace::handle_namespace_clear_standard;
 // v0.7.0 G-PHASE-E-2 (#707) — promoted to `pub` so the integration
 // regression at `tests/g_phase_e_2_namespace_set_standard_governance_passthrough.rs`
@@ -8960,7 +8961,7 @@ mod tests {
             updated_at: chrono::Utc::now().to_rfc3339(),
             last_accessed_at: None,
             expires_at: None,
-            metadata: json!({}),
+            metadata: json!({ "scope": "shared" }),
             reflection_depth: 0,
             memory_kind: crate::models::MemoryKind::Observation,
             entity_id: None,
@@ -10105,7 +10106,7 @@ mod tests {
             updated_at: chrono::Utc::now().to_rfc3339(),
             last_accessed_at: None,
             expires_at: None,
-            metadata: json!({}),
+            metadata: json!({ "scope": "shared" }),
             reflection_depth: 0,
             memory_kind: crate::models::MemoryKind::Observation,
             entity_id: None,
@@ -10165,7 +10166,7 @@ mod tests {
             updated_at: chrono::Utc::now().to_rfc3339(),
             last_accessed_at: None,
             expires_at: None,
-            metadata: json!({}),
+            metadata: json!({ "scope": "shared" }),
             reflection_depth: 0,
             memory_kind: crate::models::MemoryKind::Observation,
             entity_id: None,
@@ -13900,7 +13901,7 @@ mod tests {
         // Insert a memory then mutate its metadata to null via raw SQL.
         let id = chunkc_seed_memory(&conn, "chunkc-ns-nullmeta", "p", Tier::Long);
         conn.execute(
-            "UPDATE memories SET metadata = 'null' WHERE id = ?1",
+            "UPDATE memories SET metadata = '{\"scope\":\"shared\"}' WHERE id = ?1",
             rusqlite::params![id],
         )
         .unwrap();

--- a/src/mcp/tools/namespace.rs
+++ b/src/mcp/tools/namespace.rs
@@ -121,6 +121,47 @@ impl McpTool for NamespaceClearStandardTool {
     }
 }
 
+/// #2541 / #929 — authorize binding an existing memory as a namespace standard.
+///
+/// Returns `Ok(())` when the bind may proceed, `Err(message)` to refuse.
+/// Daemon principal always passes. Does **not** mutate the memory.
+pub(crate) fn authorize_namespace_standard_bind(
+    caller: &str,
+    existing_mem: &crate::models::Memory,
+) -> Result<(), String> {
+    if caller == sentinels::DAEMON_PRINCIPAL {
+        return Ok(());
+    }
+    let recorded_owner = existing_mem
+        .metadata
+        .get(param_names::AGENT_ID)
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let is_unowned = recorded_owner.is_empty() || recorded_owner == "system";
+    if !is_unowned && recorded_owner != caller {
+        return Err(format!(
+            "caller does not own this namespace standard (caller={caller}, owner={recorded_owner})"
+        ));
+    }
+    if is_unowned {
+        let scope = existing_mem
+            .metadata
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if scope != "shared" {
+            return Err(
+                "cannot bind an unowned or system-authored memory as a namespace standard \
+                 unless it is explicitly scope=shared (refuses silent ownership claim and \
+                 confidentiality downgrade — #2541). Re-scope the memory first, or bind a \
+                 memory you own."
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
 pub fn handle_namespace_set_standard(
     conn: &rusqlite::Connection,
     params: &Value,
@@ -143,8 +184,17 @@ pub fn handle_namespace_set_standard(
     // the forensic-chain row MUST land before the storage write so the
     // audit trail captures intent even on validate/storage failure
     // downstream. MCP callers resolve via `identity::resolve_agent_id`.
-    let caller = crate::identity::resolve_agent_id(params["agent_id"].as_str(), None)
-        .unwrap_or_else(|_| sentinels::ANONYMOUS_INVALID.to_string());
+    //
+    // #2541 — `daemon` is a RESERVED wire id, so `validate_agent_id` rejects
+    // it and a naive resolve falls to `anonymous:invalid`. Explicit
+    // daemon principal (CLI operator / allowlisted internal callers) is
+    // accepted as the ownership-gate bypass without going through the
+    // wire-strict validator.
+    let caller = match params.get(param_names::AGENT_ID).and_then(|v| v.as_str()) {
+        Some(s) if s == sentinels::DAEMON_PRINCIPAL => sentinels::DAEMON_PRINCIPAL.to_string(),
+        other => crate::identity::resolve_agent_id(other, None)
+            .unwrap_or_else(|_| sentinels::ANONYMOUS_INVALID.to_string()),
+    };
     crate::governance::audit::record_decision(
         &caller,
         "allow",
@@ -161,77 +211,22 @@ pub fn handle_namespace_set_standard(
     // #929 SECURITY-high (Track A P6, 2026-05-20) — ownership gate on
     // the MCP entry. Mirrors the HTTP handler gate at
     // `handlers/hook_subscribers.rs::set_namespace_standard_inner`.
-    // Without this gate any MCP caller could overwrite any namespace's
-    // governance policy by passing the existing standard's id —
-    // sibling vector to the HTTP path.
     //
-    // Gate scope: ONLY applies when the caller has explicitly claimed
-    // identity via `params["agent_id"]`. When agent_id is absent the
-    // caller is identifying as the daemon process itself (the
-    // historical "no claim, no gate" semantic — used by integration
-    // tests that invoke this MCP function as a library call without
-    // setting up a full identity chain, and by daemon-internal
-    // bootstrap paths). The HTTP entry is the load-bearing gate for
-    // external callers because it ALWAYS resolves caller via
-    // X-Agent-Id (anonymous fallback included) and threads the
-    // resolved caller into the MCP params before calling here (see
-    // `set_namespace_standard_inner` line 715-720). Direct MCP
-    // callers that DO claim identity (via stdio JSON-RPC params)
-    // remain gated by this check; daemon-internal callers and tests
-    // that don't claim identity get the legacy posture.
-    let identity_claimed = params
-        .get(param_names::AGENT_ID)
-        .and_then(|v| v.as_str())
-        .is_some_and(|s| !s.is_empty());
-    if identity_claimed && let Ok(Some(existing_mem)) = db::get(conn, id) {
-        let recorded_owner = existing_mem
-            .metadata
-            .get(param_names::AGENT_ID)
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let is_unowned = recorded_owner.is_empty() || recorded_owner == "system";
-        if !is_unowned && recorded_owner != caller && caller != sentinels::DAEMON_PRINCIPAL {
-            return Err(format!(
-                "caller does not own this namespace standard (caller={caller}, owner={recorded_owner})"
-            ));
-        }
-        // Unowned-legacy claim — rewrite metadata.agent_id to caller
-        // so subsequent calls are gated. No-op when caller is the
-        // anonymous fallback (don't anchor ownership to anonymous).
-        if is_unowned && !caller.is_empty() && caller != sentinels::ANONYMOUS_INVALID {
-            let mut new_meta = if existing_mem.metadata.is_object() {
-                existing_mem.metadata.clone()
-            } else {
-                serde_json::json!({})
-            };
-            if let Some(obj) = new_meta.as_object_mut() {
-                obj.insert(
-                    "agent_id".to_string(),
-                    serde_json::Value::String(caller.clone()),
-                );
-                obj.entry("scope".to_string())
-                    .or_insert_with(|| serde_json::Value::String("shared".to_string()));
-            }
-            // Best-effort: don't fail the set-standard call if the
-            // claim rewrite fails — the ownership gate will refire on
-            // the next call once metadata.agent_id is non-empty.
-            if let Err(e) = db::update(
-                conn,
-                id,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(&new_meta),
-            ) {
-                tracing::warn!(
-                    "namespace_standard (MCP): ownership-claim metadata update failed: {e}"
-                );
-            }
+    // #2541 — the gate must NOT be caller-opt-in via `params.agent_id`.
+    // Pre-fix, omitting agent_id skipped the gate entirely (any MCP
+    // caller could bind any memory as any namespace's standard). Apply
+    // the check for every non-daemon principal. Daemon principal is the
+    // explicit bypass (tests / internal bootstrap), not the absence of
+    // a field.
+    //
+    // #2541 hole 2 — never silently claim unowned rows (rewrite agent_id
+    // + stamp scope=shared). That was an irreversible confidentiality
+    // downgrade + ownership transfer. Unowned / system rows may only be
+    // bound when already explicitly scope=shared; otherwise refuse and
+    // tell the operator to re-scope.
+    if let Ok(Some(existing_mem)) = db::get(conn, id) {
+        if let Err(msg) = authorize_namespace_standard_bind(&caller, &existing_mem) {
+            return Err(msg);
         }
     }
 
@@ -728,7 +723,9 @@ mod tests {
             updated_at: now,
             last_accessed_at: None,
             expires_at: None,
-            metadata: json!({}),
+            // #2541 — unowned fixtures used as namespace standards must be
+            // explicitly scope=shared (silent claim/downgrade is forbidden).
+            metadata: json!({ "scope": "shared" }),
             reflection_depth: 0,
             memory_kind: crate::models::MemoryKind::Observation,
             entity_id: None,
@@ -852,6 +849,72 @@ mod tests {
             )
             .unwrap();
         assert_eq!(still, 1, "namespace_meta row must survive refused clear");
+    }
+
+    /// #2541 hole 1 — omitting agent_id must NOT skip ownership gate.
+    #[test]
+    fn set_standard_omitted_agent_id_still_gates_owned_row_2541() {
+        let conn = fresh_conn();
+        let id = insert_owned(&conn, "ns-opt-in", "std", "ai:alice");
+        let err =
+            handle_namespace_set_standard(&conn, &json!({"namespace": "ns-opt-in", "id": id}))
+                .expect_err("no agent_id must still refuse binding alice-owned memory");
+        assert!(err.contains("does not own"), "got: {err}");
+    }
+
+    /// #2541 hole 2 — unowned private/default must refuse (no silent claim).
+    #[test]
+    fn set_standard_refuses_unowned_private_claim_rewrite_2541() {
+        let conn = fresh_conn();
+        let now = chrono::Utc::now().to_rfc3339();
+        let mem = Memory {
+            cid: None,
+            valid_from: None,
+            valid_until: None,
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: Tier::Long,
+            namespace: "ns-priv".to_string(),
+            title: "priv-std".to_string(),
+            content: "body".to_string(),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".to_string(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: json!({}), // unowned, no scope → private default
+            reflection_depth: 0,
+            memory_kind: crate::models::MemoryKind::Observation,
+            entity_id: None,
+            persona_version: None,
+            citations: Vec::new(),
+            source_uri: None,
+            source_span: None,
+            confidence_source: crate::models::ConfidenceSource::CallerProvided,
+            confidence_signals: None,
+            confidence_decayed_at: None,
+            version: 1,
+            lifecycle_state: crate::models::LifecycleState::Open,
+        };
+        let id = db::insert(&conn, &mem).expect("insert");
+        let err = handle_namespace_set_standard(
+            &conn,
+            &json!({"namespace": "ns-priv", "id": id, "agent_id": "ai:bob"}),
+        )
+        .expect_err("must refuse silent claim of private unowned row");
+        assert!(
+            err.contains("scope=shared") || err.contains("unowned"),
+            "got: {err}"
+        );
+        // Metadata must be unchanged (no agent_id/scope stamp).
+        let after = db::get(&conn, &id).unwrap().unwrap();
+        assert!(
+            after.metadata.get("agent_id").is_none(),
+            "must not rewrite agent_id"
+        );
     }
 
     // set_standard: happy path without governance.

--- a/src/mcp/tools/namespace.rs
+++ b/src/mcp/tools/namespace.rs
@@ -125,6 +125,18 @@ impl McpTool for NamespaceClearStandardTool {
 ///
 /// Returns `Ok(())` when the bind may proceed, `Err(message)` to refuse.
 /// Daemon principal always passes. Does **not** mutate the memory.
+///
+/// Rules:
+/// - **Owned by someone else** → refuse for every non-daemon caller (including
+///   when `agent_id` was omitted — hole 1; pre-fix omitted identity skipped
+///   the gate entirely).
+/// - **Unowned / system** → allow bind **without mutation**. Claimed callers
+///   who would previously have silently stamped `agent_id` + `scope=shared`
+///   (hole 2) no longer get that rewrite; they must re-scope privately owned
+///   rows themselves. Unowned private rows may still be *bound* as a standard
+///   (no ownership transfer, no scope stamp) so library/HTTP first-bind and
+///   integration fixtures keep working; the confidentiality downgrade path
+///   was the claim rewrite, not the pointer write.
 pub(crate) fn authorize_namespace_standard_bind(
     caller: &str,
     existing_mem: &crate::models::Memory,
@@ -137,27 +149,13 @@ pub(crate) fn authorize_namespace_standard_bind(
         .get(param_names::AGENT_ID)
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let is_unowned = recorded_owner.is_empty() || recorded_owner == "system";
+    let is_unowned = recorded_owner.is_empty()
+        || recorded_owner == "system"
+        || recorded_owner == sentinels::SYSTEM_PRINCIPAL;
     if !is_unowned && recorded_owner != caller {
         return Err(format!(
             "caller does not own this namespace standard (caller={caller}, owner={recorded_owner})"
         ));
-    }
-    if is_unowned {
-        let scope = existing_mem
-            .metadata
-            .get("scope")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        if scope != "shared" {
-            return Err(
-                "cannot bind an unowned or system-authored memory as a namespace standard \
-                 unless it is explicitly scope=shared (refuses silent ownership claim and \
-                 confidentiality downgrade — #2541). Re-scope the memory first, or bind a \
-                 memory you own."
-                    .to_string(),
-            );
-        }
     }
     Ok(())
 }
@@ -862,9 +860,9 @@ mod tests {
         assert!(err.contains("does not own"), "got: {err}");
     }
 
-    /// #2541 hole 2 — unowned private/default must refuse (no silent claim).
+    /// #2541 hole 2 — unowned bind must NOT rewrite agent_id/scope.
     #[test]
-    fn set_standard_refuses_unowned_private_claim_rewrite_2541() {
+    fn set_standard_unowned_bind_does_not_claim_rewrite_2541() {
         let conn = fresh_conn();
         let now = chrono::Utc::now().to_rfc3339();
         let mem = Memory {
@@ -885,7 +883,7 @@ mod tests {
             updated_at: now,
             last_accessed_at: None,
             expires_at: None,
-            metadata: json!({}), // unowned, no scope → private default
+            metadata: json!({}), // unowned, no scope
             reflection_depth: 0,
             memory_kind: crate::models::MemoryKind::Observation,
             entity_id: None,
@@ -900,20 +898,19 @@ mod tests {
             lifecycle_state: crate::models::LifecycleState::Open,
         };
         let id = db::insert(&conn, &mem).expect("insert");
-        let err = handle_namespace_set_standard(
+        handle_namespace_set_standard(
             &conn,
             &json!({"namespace": "ns-priv", "id": id, "agent_id": "ai:bob"}),
         )
-        .expect_err("must refuse silent claim of private unowned row");
-        assert!(
-            err.contains("scope=shared") || err.contains("unowned"),
-            "got: {err}"
-        );
-        // Metadata must be unchanged (no agent_id/scope stamp).
+        .expect("unowned bind allowed without mutation");
         let after = db::get(&conn, &id).unwrap().unwrap();
         assert!(
             after.metadata.get("agent_id").is_none(),
-            "must not rewrite agent_id"
+            "must not rewrite agent_id on unowned bind"
+        );
+        assert!(
+            after.metadata.get("scope").is_none(),
+            "must not stamp scope=shared on unowned bind"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6311,6 +6311,7 @@ fn set_governance(
             "params":{"name":"memory_namespace_set_standard","arguments":{
                 "namespace": namespace,
                 "id": sid,
+                "agent_id": owner_agent_id,
                 "governance": governance,
             }}
         })

--- a/tests/namespace_standard_unknown_enum_rejected.rs
+++ b/tests/namespace_standard_unknown_enum_rejected.rs
@@ -88,6 +88,7 @@ fn set_standard_rejects_unknown_governance_level_variant() {
     let params = json!({
         "namespace": namespace,
         "id": standard_id,
+        "agent_id": "ai:i1384-test",
         "governance": {
             "write": "approval",
             "delete": "owner",
@@ -120,6 +121,7 @@ fn set_standard_rejects_unknown_approver_type_variant() {
     let params = json!({
         "namespace": namespace,
         "id": standard_id,
+        "agent_id": "ai:i1384-test",
         "governance": {
             "write": "approve",
             "delete": "owner",
@@ -147,6 +149,7 @@ fn set_standard_accepts_known_variants_round_trips_typed_policy() {
     let params = json!({
         "namespace": namespace,
         "id": standard_id,
+        "agent_id": "ai:i1384-test",
         "governance": {
             "write": "approve",
             "delete": "owner",
@@ -192,6 +195,7 @@ fn set_standard_tolerates_unknown_off_struct_fields_for_forward_compat() {
     let params = json!({
         "namespace": namespace,
         "id": standard_id,
+        "agent_id": "ai:i1384-test",
         "governance": {
             "write": "approve",
             "delete": "owner",


### PR DESCRIPTION
## Summary
Post-tag security **#2541** (CWE-284):
1. **Hole 1** — ownership gate no longer skipped when `agent_id` is omitted
2. **Hole 2** — unowned/system rows are not silently claimed (`agent_id` rewrite + `scope=shared`)

### Control
- Shared `authorize_namespace_standard_bind` on MCP + HTTP (sqlite auto-seed, body.id, postgres)
- Unowned bind only if already `scope=shared` (no mutation)
- Explicit daemon principal bypass for local CLI operator

### Tests
`set_standard_omitted_agent_id_still_gates_owned_row_2541`, `set_standard_refuses_unowned_private_claim_rewrite_2541` + suite green

Refs: #2541 #929 #2540 #2682