### PR TITLE
fix(#2543): gate HTTP get-standard through is_visible_to_caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (HTTP get-standard no longer serves private standard bodies)
+
+- **`GET /api/v1/namespaces?namespace=` and path-form `…/{ns}/standard` gate the standard body through `visibility::is_visible_to_caller`** (refs [#2543](https://github.com/alphaonedev/ai-memory-mcp/issues/2543); #959 residual; CWE-284). Pre-fix the sqlite arm passed `caller=None` into `handle_namespace_get_standard` and the postgres arm used `CallerContext::for_admin`, so any caller who could name a namespace received title + content + governance of a default-private standard (the last unfiltered read of that body after #2537 closed the injection path). Both arms now resolve `X-Agent-Id` and share the MCP honesty shape: count-only `standards_withheld`, no id/owner leak. Shared-scope and owner reads unchanged. CLI/MCP stdio `None` trust-all posture unchanged.
+
 ### Fixed (namespace set-standard no longer caller-opt-in / silent claim)
 
 - **MCP/HTTP `set_namespace_standard` always enforces ownership; unowned rows are never silently claimed** (refs [#2541](https://github.com/alphaonedev/ai-memory-mcp/issues/2541); CWE-284). Pre-fix omitting `agent_id` skipped the #929 gate (could rebind any owned memory), and the unowned arm rewrote `agent_id` + stamped `scope=shared` (irreversible confidentiality downgrade). Ownership is always checked; claim rewrite removed. Daemon principal is the explicit CLI/operator bypass.

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -811,10 +811,22 @@ pub async fn get_namespace_standard_qs(
         // thread headers through so the gate sees the X-Agent-Id.
         return list_namespaces(State(app), headers).await.into_response();
     };
-    // #945-sibling — when ns IS supplied, this becomes a per-namespace
-    // standard fetch. Currently no caller-vs-owner gate on this read
-    // path (filed as a follow-up under #959).
-    let _ = &headers;
+
+    // v1.0.0 #2543 / #959 residual — explicit HTTP fetch of a namespace
+    // standard is gated through the SAME canonical
+    // `visibility::is_visible_to_caller` predicate as #2537 injection and
+    // MCP `memory_namespace_get_standard`. Pre-fix this route passed
+    // `None` (sqlite) / `CallerContext::for_admin` (postgres), so any
+    // caller who could name a namespace received title + content + the
+    // full governance blob of a default-private standard. Withholding
+    // matches the MCP honesty shape: count-only `standards_withheld`,
+    // never the withheld id / owner / namespace (existence-oracle pin).
+    let visibility_caller = match resolve_caller_agent_id(None, &headers, None) {
+        Ok(id) => id,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response();
+        }
+    };
 
     // v0.7.0 Wave-3 Continuation 5 (Bucket C / S35) — postgres-backed
     // daemons resolve the namespace standard via the SAL trait. When
@@ -824,12 +836,10 @@ pub async fn get_namespace_standard_qs(
     // the exact namespace.
     #[cfg(feature = "sal")]
     if matches!(app.storage_backend, StorageBackend::Postgres) {
-        // v0.7.0 ship-hardening (2026-05-19): namespace standards are
-        // governance POLICY — readable by any caller that can query
-        // the namespace itself. Use for_admin so the SAL #910
-        // scope=private visibility filter doesn't drop the standard
-        // memory when the requester is not the policy author.
-        let ctx = crate::store::CallerContext::for_admin(sentinels::AI_HTTP_INTERNAL);
+        // Binding lookup is namespace_meta (not a visibility-scoped memory
+        // row). Admin context keeps the binding probe stable; body bytes
+        // still go through `is_visible_to_caller` after a separate get.
+        let bind_ctx = crate::store::CallerContext::for_admin(sentinels::AI_HTTP_INTERNAL);
         let inherit = q.inherit.unwrap_or(false);
         // Build chain leaf → root (most-specific first) by trimming
         // `/segment` until empty. The chain matches the SQLite
@@ -854,61 +864,98 @@ pub async fn get_namespace_standard_qs(
             // `handle_namespace_get_standard` inherit branch which
             // returns `chain` + `standards` arrays.
             let mut standards: Vec<serde_json::Value> = Vec::new();
+            let mut withheld: usize = 0;
             for candidate in &chain {
                 if let Ok(Some((standard_id, parent))) =
-                    app.store.get_namespace_standard(&ctx, candidate).await
+                    app.store.get_namespace_standard(&bind_ctx, candidate).await
                 {
-                    // Pull the standard memory body so the caller can
-                    // see governance + content layered through.
-                    let mem_doc = match app.store.get(&ctx, &standard_id).await {
-                        Ok(m) => json!({
-                            "namespace": candidate,
-                            (field_names::STANDARD_ID): standard_id,
-                            "id": standard_id,
-                            "title": m.title,
-                            "content": m.content,
-                            "priority": m.priority,
-                            (field_names::PARENT_NAMESPACE): parent,
-                            (field_names::GOVERNANCE): m.metadata.get(crate::META_KEY_GOVERNANCE).cloned()
-                                .unwrap_or(serde_json::Value::Null),
-                        }),
-                        Err(_) => json!({
-                            "namespace": candidate,
-                            (field_names::STANDARD_ID): standard_id,
-                            "id": standard_id,
-                            (field_names::PARENT_NAMESPACE): parent,
-                        }),
-                    };
-                    standards.push(mem_doc);
+                    // #2543 — fetch the body under admin (so SAL private
+                    // filter does not collapse Withheld into Absent), then
+                    // apply the canonical predicate before any title /
+                    // content / governance bytes enter the response.
+                    match app.store.get(&bind_ctx, &standard_id).await {
+                        Ok(m)
+                            if crate::visibility::is_visible_to_caller(&m, &visibility_caller) =>
+                        {
+                            standards.push(json!({
+                                "namespace": candidate,
+                                (field_names::STANDARD_ID): standard_id,
+                                "id": standard_id,
+                                "title": m.title,
+                                "content": m.content,
+                                "priority": m.priority,
+                                (field_names::PARENT_NAMESPACE): parent,
+                                (field_names::GOVERNANCE): m.metadata
+                                    .get(crate::META_KEY_GOVERNANCE)
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::Null),
+                            }));
+                        }
+                        Ok(_) => {
+                            // Binding exists; body not visible — honesty
+                            // count only (never the namespace name of a
+                            // withheld chain link).
+                            withheld += 1;
+                        }
+                        Err(_) => {
+                            // Dangling binding: surface id without body
+                            // (matches pre-fix dangling shape).
+                            standards.push(json!({
+                                "namespace": candidate,
+                                (field_names::STANDARD_ID): standard_id,
+                                "id": standard_id,
+                                (field_names::PARENT_NAMESPACE): parent,
+                            }));
+                        }
+                    }
                 }
             }
-            // Pick the closest (leaf-most) entry as the resolved
+            // Pick the closest (leaf-most) *visible* entry as the resolved
             // standard for the response root level so existing
             // single-standard consumers still see the expected
-            // `standard_id`.
+            // `standard_id` when the caller may read it.
             let closest = standards.first().cloned().unwrap_or(json!({}));
-            return (
-                StatusCode::OK,
-                Json(json!({
-                    "namespace": ns,
-                    "chain": chain,
-                    "standards": standards,
-                    "resolved_namespace": closest.get("namespace").cloned()
-                        .unwrap_or(serde_json::Value::Null),
-                    (field_names::STANDARD_ID): closest.get(field_names::STANDARD_ID).cloned()
-                        .unwrap_or(serde_json::Value::Null),
-                    "id": closest.get("id").cloned()
-                        .unwrap_or(serde_json::Value::Null),
-                    (field_names::PARENT_NAMESPACE): closest.get(field_names::PARENT_NAMESPACE).cloned()
-                        .unwrap_or(serde_json::Value::Null),
-                    (field_names::STORAGE_BACKEND): "postgres",
-                })),
-            )
-                .into_response();
+            let mut body = json!({
+                "namespace": ns,
+                "chain": chain,
+                "standards": standards,
+                "count": standards.len(),
+                "resolved_namespace": closest.get("namespace").cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                (field_names::STANDARD_ID): closest.get(field_names::STANDARD_ID).cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                "id": closest.get("id").cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                (field_names::PARENT_NAMESPACE): closest.get(field_names::PARENT_NAMESPACE).cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                (field_names::STORAGE_BACKEND): "postgres",
+            });
+            if withheld > 0 {
+                body[field_names::STANDARDS_WITHHELD] = json!(withheld);
+            }
+            return (StatusCode::OK, Json(body)).into_response();
         }
         // Non-inherit form — single exact-match lookup.
-        match app.store.get_namespace_standard(&ctx, &ns).await {
+        match app.store.get_namespace_standard(&bind_ctx, &ns).await {
             Ok(Some((standard_id, parent))) => {
+                // #2543 — if the bound memory exists and is not visible,
+                // do not leak its id (MCP honesty shape).
+                match app.store.get(&bind_ctx, &standard_id).await {
+                    Ok(m) if !crate::visibility::is_visible_to_caller(&m, &visibility_caller) => {
+                        return (
+                            StatusCode::OK,
+                            Json(json!({
+                                "namespace": ns,
+                                (field_names::STANDARD_ID): serde_json::Value::Null,
+                                "id": serde_json::Value::Null,
+                                (field_names::STANDARDS_WITHHELD): 1,
+                                (field_names::STORAGE_BACKEND): "postgres",
+                            })),
+                        )
+                            .into_response();
+                    }
+                    _ => {}
+                }
                 return (
                     StatusCode::OK,
                     Json(json!({
@@ -943,17 +990,10 @@ pub async fn get_namespace_standard_qs(
         params["inherit"] = json!(inh);
     }
     let lock = app.db.lock().await;
-    // v1.0.0 #2537 — `None` visibility caller, DELIBERATE and scope-bounded.
-    // #2537 closes the UNSOLICITED injection of a standard body into every
-    // recall / session_start response. This route is the EXPLICIT
-    // per-namespace standard fetch, whose no-caller-gate posture is a
-    // pre-existing, in-tree, documented product decision with its own filed
-    // follow-up: see the `#945-sibling` note above and the postgres arm's
-    // `CallerContext::for_admin` ("namespace standards are governance POLICY
-    // — readable by any caller that can query the namespace itself"). Gating
-    // only the sqlite arm here would ALSO fork sqlite/postgres behaviour on
-    // one route. Tracked as its own issue against #959.
-    let result = crate::mcp::handle_namespace_get_standard(&lock.0, &params, None);
+    // #2543 — pass the HTTP principal into the shared MCP choke so the
+    // sqlite arm cannot diverge from postgres / injection / tool surfaces.
+    let result =
+        crate::mcp::handle_namespace_get_standard(&lock.0, &params, Some(&visibility_caller));
     drop(lock);
     match result {
         Ok(v) => (StatusCode::OK, Json(v)).into_response(),

--- a/tests/ns_standard_http_read_2543.rs
+++ b/tests/ns_standard_http_read_2543.rs
@@ -1,0 +1,288 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::doc_markdown, clippy::too_many_lines, clippy::needless_update)]
+
+//! v1.0.0 #2543 — HTTP GET namespace-standard explicit-fetch visibility gate.
+//!
+//! Residual of #959 / #2537: MCP injection and `memory_namespace_get_standard`
+//! route through `lookup_namespace_standard` + `is_visible_to_caller`, but the
+//! HTTP surfaces
+//!
+//! - `GET /api/v1/namespaces?namespace=`
+//! - `GET /api/v1/namespaces/{ns}/standard`
+//!
+//! previously passed `caller=None` (sqlite) / `CallerContext::for_admin`
+//! (postgres), so any agent who could name a namespace received title +
+//! content of a default-private standard body.
+//!
+//! Pins:
+//! - bob cannot read alice's private cross-namespace-bound standard body
+//! - honesty marker is count-only (`standards_withheld`), no id/owner leak
+//! - CONTROL: shared-scope standard remains fetchable
+//! - CONTROL: owner can still read their own private standard
+
+use std::sync::Arc;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::handlers::{ApiKeyState, AppState, Db};
+use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::NamedTempFile;
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+const SECRET: &str = "CLASSIFIED-ALICE-HTTP-2543";
+const ALICE: &str = "ai:alice";
+const BOB: &str = "ai:bob";
+const VICTIM_NS: &str = "t2543-victim";
+const TENANT_NS: &str = "t2543-tenant";
+
+fn seed_memory(
+    conn: &rusqlite::Connection,
+    id: &str,
+    namespace: &str,
+    owner: &str,
+    scope: Option<&str>,
+    content: &str,
+) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        ai_memory::META_KEY_AGENT_ID.to_string(),
+        json!(owner.to_string()),
+    );
+    if let Some(s) = scope {
+        metadata.insert(ai_memory::META_KEY_SCOPE.to_string(), json!(s.to_string()));
+    }
+    let mem = Memory {
+        id: id.to_string(),
+        tier: Tier::Long,
+        namespace: namespace.to_string(),
+        title: id.to_string(),
+        content: content.to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test-2543".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::Value::Object(metadata),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: vec![],
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        ..Memory::default()
+    };
+    ai_memory::db::insert(conn, &mem).expect("insert");
+}
+
+fn seed_cross_namespace_bind(conn: &rusqlite::Connection, scope: Option<&str>) {
+    seed_memory(
+        conn,
+        "alice-std-2543",
+        VICTIM_NS,
+        ALICE,
+        scope,
+        &format!("needle {SECRET}"),
+    );
+    ai_memory::db::set_namespace_standard(conn, TENANT_NS, "alice-std-2543", None)
+        .expect("bind standard");
+}
+
+fn build_router(db_path: &std::path::Path) -> axum::Router {
+    let conn = ai_memory::db::open(db_path).expect("reopen for AppState");
+    let db: Db = Arc::new(Mutex::new((
+        conn,
+        db_path.to_path_buf(),
+        ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: Arc<dyn ai_memory::store::MemoryStore> =
+        Arc::new(ai_memory::store::sqlite::SqliteStore::open(db_path).expect("open SqliteStore"));
+    let app_state = AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    ai_memory::build_router(api_key_state, app_state)
+}
+
+async fn get_standard_qs(router: &axum::Router, ns: &str, agent: &str) -> (StatusCode, String) {
+    let uri = format!("/api/v1/namespaces?namespace={ns}");
+    let req = Request::builder()
+        .method("GET")
+        .uri(&uri)
+        .header("X-Agent-Id", agent)
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+        .await
+        .unwrap();
+    (status, String::from_utf8_lossy(&bytes).to_string())
+}
+
+async fn get_standard_path(router: &axum::Router, ns: &str, agent: &str) -> (StatusCode, String) {
+    let uri = format!("/api/v1/namespaces/{ns}/standard");
+    let req = Request::builder()
+        .method("GET")
+        .uri(&uri)
+        .header("X-Agent-Id", agent)
+        .body(Body::empty())
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+        .await
+        .unwrap();
+    (status, String::from_utf8_lossy(&bytes).to_string())
+}
+
+#[tokio::test]
+async fn http_qs_withholds_private_cross_namespace_standard_2543() {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    {
+        let conn = ai_memory::db::open(tmp.path()).expect("open");
+        seed_cross_namespace_bind(&conn, None);
+    }
+    let router = build_router(tmp.path());
+
+    let (status, body) = get_standard_qs(&router, TENANT_NS, BOB).await;
+    assert_eq!(status, StatusCode::OK, "got {status}: {body}");
+    assert!(
+        !body.contains(SECRET),
+        "#2543 LEAK (HTTP qs): bob received alice's private standard body. response={body}"
+    );
+    assert!(
+        !body.contains("alice-std-2543"),
+        "#2543 existence oracle: withheld id must not appear. response={body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["standards_withheld"].as_u64(), Some(1), "got {body}");
+    assert!(
+        parsed.get("standard_id").is_none()
+            || parsed["standard_id"].is_null()
+            || parsed["standard_id"] == json!(null),
+        "standard_id must be null when withheld; got {body}"
+    );
+}
+
+#[tokio::test]
+async fn http_path_withholds_private_cross_namespace_standard_2543() {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    {
+        let conn = ai_memory::db::open(tmp.path()).expect("open");
+        seed_cross_namespace_bind(&conn, None);
+    }
+    let router = build_router(tmp.path());
+
+    let (status, body) = get_standard_path(&router, TENANT_NS, BOB).await;
+    assert_eq!(status, StatusCode::OK, "got {status}: {body}");
+    assert!(
+        !body.contains(SECRET),
+        "#2543 LEAK (HTTP path): bob received alice's private standard body. response={body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["standards_withheld"].as_u64(), Some(1), "got {body}");
+}
+
+#[tokio::test]
+async fn http_qs_shared_standard_still_readable_2543() {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    {
+        let conn = ai_memory::db::open(tmp.path()).expect("open");
+        seed_cross_namespace_bind(&conn, Some("shared"));
+    }
+    let router = build_router(tmp.path());
+
+    let (status, body) = get_standard_qs(&router, TENANT_NS, BOB).await;
+    assert_eq!(status, StatusCode::OK, "got {status}: {body}");
+    assert!(
+        body.contains(SECRET),
+        "CONTROL: shared-policy standard must remain fetchable; got {body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(
+        parsed["standard_id"].as_str(),
+        Some("alice-std-2543"),
+        "got {body}"
+    );
+    assert!(
+        parsed.get("standards_withheld").is_none(),
+        "nothing withheld for shared; got {body}"
+    );
+}
+
+#[tokio::test]
+async fn http_qs_owner_can_read_own_private_standard_2543() {
+    let tmp = NamedTempFile::new().expect("tempfile");
+    {
+        let conn = ai_memory::db::open(tmp.path()).expect("open");
+        seed_cross_namespace_bind(&conn, None);
+    }
+    let router = build_router(tmp.path());
+
+    let (status, body) = get_standard_qs(&router, TENANT_NS, ALICE).await;
+    assert_eq!(status, StatusCode::OK, "got {status}: {body}");
+    assert!(
+        body.contains(SECRET),
+        "CONTROL: owner must still read their private standard; got {body}"
+    );
+    let parsed: Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(
+        parsed["standard_id"].as_str(),
+        Some("alice-std-2543"),
+        "got {body}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the #959 residual tracked as **#2543**: explicit HTTP fetch of a namespace standard no longer serves default-private title/content/governance to arbitrary callers.

### Control
- **sqlite:** `get_namespace_standard_qs` resolves `X-Agent-Id` and passes `Some(caller)` into `handle_namespace_get_standard` (same choke as #2537 MCP).
- **postgres:** binding lookup may use admin (namespace_meta is not a visibility-scoped row); memory body is fetched then filtered with `visibility::is_visible_to_caller`.
- **Honesty shape:** count-only `standards_withheld`; never the withheld id/owner/namespace (existence-oracle pin).
- **Unchanged:** shared-scope standards readable; owner can read own private; CLI/MCP stdio `None` trust-all; non-inherit PG envelope when visible.

### Decision
Issue listed three options. Chose **gate like #2540** (option 3) for enterprise consistency with #2537 injection/MCP — not document-as-public, not typed-allowlist-only projection (raw blob is the hazard; full body gate is cleaner).

### Tests
- New `tests/ns_standard_http_read_2543.rs` (qs + path withhold, shared control, owner control)
- Related: `ns_standard_read_leak_2537`, `cov_ga2_handlers_b`, `handler_postgres_branches_fake_pg` pg_get_namespace_*, `issue_1326_*`, `l07_3` http_get_namespace

### Review gates
- Code review of control path
- Security: CWE-284 residual; no silent privilege; dual-backend parity

Refs: #2543, #959, #2537/#2540