### PR TITLE
fix(#2436): correct postgres soft-loser penalty predicate (dead code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed (HTTP get-standard no longer serves private standard bodies)
+### Fixed (postgres soft-loser recall penalty was dead code)
+
+- **`PostgresStore::search_with_source_uri` now matches the G7 soft-loser marker's real JSON shape** (refs [#2436](https://github.com/alphaonedev/ai-memory-mcp/issues/2436), CB-16). `conserve_contradiction` stamps `metadata.contradiction_soft_loser` as a JSON boolean `true` (`serde_json::Value::Bool`), so postgres' `->>` operator renders it as the TEXT `'true'`. The predicate compared `(m.metadata->>'contradiction_soft_loser') = '1'`, which is ALWAYS false — the multiplicative recall down-weight never applied on postgres, so an LLM-confirmed-contradicted loser kept outranking its fresh winner at full score (a cross-backend divergence: the sqlite twins `json_extract(...) = 1` worked, the postgres mirror did not). Predicate corrected to `= 'true'`; an absent marker still yields `NULL` → factor 1.0 (no penalty, no error). The false in-code comment claiming the penalty applied is corrected. Regression: `tests/pg_soft_loser_penalty_2436.rs` (always-run sqlite value-shape + penalty pins; `#[ignore]`+`sal-postgres` live-PG parity proof).
 
 - **`GET /api/v1/namespaces?namespace=` and path-form `…/{ns}/standard` gate the standard body through `visibility::is_visible_to_caller`** (refs [#2543](https://github.com/alphaonedev/ai-memory-mcp/issues/2543); #959 residual; CWE-284). Pre-fix the sqlite arm passed `caller=None` into `handle_namespace_get_standard` and the postgres arm used `CallerContext::for_admin`, so any caller who could name a namespace received title + content + governance of a default-private standard (the last unfiltered read of that body after #2537 closed the injection path). Both arms now resolve `X-Agent-Id` and share the MCP honesty shape: count-only `standards_withheld`, no id/owner leak. Shared-scope and owner reads unchanged. CLI/MCP stdio `None` trust-all posture unchanged.
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -6269,7 +6269,16 @@ impl PostgresStore {
                     -- multiplicatively penalized so it cannot outrank its
                     -- winner at full score (reversible — clearing the
                     -- marker restores rank; sqlite twin in db::recall).
-                    * (CASE WHEN (m.metadata->>'contradiction_soft_loser') = '1'
+                    -- #2436 (CB-16) — `conserve_contradiction` stamps the
+                    -- marker as JSON boolean `true` (serde `Value::Bool`),
+                    -- so `->>` yields the TEXT 'true', NOT '1'. The prior
+                    -- `= '1'` never matched on postgres (dead penalty); the
+                    -- sqlite twins compare `json_extract(...) = 1` because
+                    -- SQLite's json_extract of a JSON true yields integer 1.
+                    -- An absent marker makes `->>` NULL, so `NULL = 'true'`
+                    -- is NULL → the CASE ELSE arm applies factor 1.0 (no
+                    -- penalty, no error).
+                    * (CASE WHEN (m.metadata->>'contradiction_soft_loser') = 'true'
                             THEN {soft_loser_factor} ELSE 1.0 END) AS rank
              FROM memories m
              WHERE m.tsv @@ plainto_tsquery('english', $1)

--- a/tests/pg_soft_loser_penalty_2436.rs
+++ b/tests/pg_soft_loser_penalty_2436.rs
@@ -1,0 +1,290 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2436 (CB-16) — postgres soft-loser recall penalty was DEAD CODE.
+//!
+//! `conserve_contradiction` (`src/storage/mod.rs`) stamps the G7 #1824
+//! marker `metadata.contradiction_soft_loser` as a JSON boolean `true`
+//! (`serde_json::Value::Bool(true)`). The sqlite recall twins
+//! (`db::recall` + `db::search_with_source_uri`) read it with
+//! `json_extract(m.metadata, '$.contradiction_soft_loser') = 1` — correct,
+//! because `SQLite`'s `json_extract` of a JSON `true` yields the INTEGER 1.
+//!
+//! The postgres mirror in `PostgresStore::search_with_source_uri` read it
+//! with `(m.metadata->>'contradiction_soft_loser') = '1'`. The `->>`
+//! operator returns the JSON value AS TEXT, so a JSON boolean `true`
+//! renders as the TEXT `'true'`, and `'true' = '1'` is ALWAYS false — the
+//! multiplicative down-weight never applied on postgres. A stale
+//! LLM-confirmed-contradicted loser kept outranking its fresh winner at
+//! full score on any postgres-backed daemon: a cross-backend correctness
+//! divergence (the sqlite penalty worked, the postgres one did not).
+//!
+//! This harness pins BOTH halves:
+//!
+//! * The always-run sqlite guard `writer_stamps_soft_loser_as_json_bool`
+//!   pins the WRITER'S VALUE SHAPE — the exact contract the postgres
+//!   predicate depends on. If the marker were ever stamped as the string
+//!   `"1"` / `"true"` or the integer `1` instead of the JSON boolean, this
+//!   guard fails alongside the postgres predicate, so the two can never
+//!   silently drift apart again.
+//! * The `#[ignore]`-gated `pg_soft_loser_penalty_applies_2436` (compiled
+//!   only under `--features sal-postgres`) drives the real predicate
+//!   against a live postgres and proves the penalty is APPLIED for a
+//!   soft-loser row and NOT applied for a normal row. Run it with
+//!   `AI_MEMORY_TEST_POSTGRES_URL` set:
+//!   `cargo test --features sal-postgres --test pg_soft_loser_penalty_2436 -- --ignored`.
+
+#![allow(clippy::missing_panics_doc)]
+
+use ai_memory::db;
+use ai_memory::models::field_names;
+use ai_memory::models::{Memory, Tier};
+use rusqlite::Connection;
+use serde_json::{Value, json};
+
+fn fresh_sqlite() -> Connection {
+    db::open(std::path::Path::new(":memory:")).expect("open in-memory sqlite")
+}
+
+/// Distinct `title` per id so the `(title, namespace)` upsert keeps the
+/// loser and winner as SEPARATE rows (both still match a `deploy target`
+/// keyword recall).
+fn seed(conn: &Connection, id: &str, priority: i32) {
+    let mem = Memory {
+        id: id.to_string(),
+        tier: Tier::Long,
+        namespace: "cb16".to_string(),
+        title: format!("deploy target directive {id}"),
+        content: "the canonical deploy target".to_string(),
+        priority,
+        confidence: 1.0,
+        source: "test".to_string(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        metadata: json!({}),
+        ..Memory::default()
+    };
+    db::insert(conn, &mem).expect("seed");
+}
+
+/// The load-bearing value-shape pin for the postgres predicate fix:
+/// `conserve_contradiction` MUST stamp `metadata.contradiction_soft_loser`
+/// as a JSON boolean `true`, because the postgres recall predicate reads
+/// `(m.metadata->>'contradiction_soft_loser') = 'true'` (the `->>` text
+/// rendering of a JSON boolean). A string `"1"` / `"true"` or an integer
+/// `1` here would silently re-break the postgres penalty.
+#[test]
+fn writer_stamps_soft_loser_as_json_bool() {
+    let conn = fresh_sqlite();
+    seed(&conn, "cb16-loser", 8);
+    seed(&conn, "cb16-winner", 5);
+    let loser = db::get(&conn, "cb16-loser")
+        .expect("get")
+        .expect("loser exists");
+
+    db::conserve_contradiction(&conn, &loser, "cb16-winner", None).expect("conserve");
+
+    let reread = db::get(&conn, "cb16-loser")
+        .expect("get")
+        .expect("loser exists");
+    let marker = reread
+        .metadata
+        .get(field_names::CONTRADICTION_SOFT_LOSER)
+        .expect("soft-loser marker present after conserve");
+    assert_eq!(
+        marker,
+        &Value::Bool(true),
+        "the marker MUST be the JSON boolean `true` (not \"1\"/\"true\"/1) — \
+         the postgres predicate `->>'…' = 'true'` depends on this exact shape (#2436)"
+    );
+    assert!(
+        marker.is_boolean(),
+        "a non-boolean marker would render as a different `->>` text and re-break pg"
+    );
+}
+
+/// sqlite reference: the penalty ranks the conserved soft-loser BELOW its
+/// winner even though the loser carries the higher base score. This is the
+/// contract the postgres twin must match (proven live below).
+#[test]
+fn sqlite_soft_loser_ranks_below_winner() {
+    let conn = fresh_sqlite();
+    seed(&conn, "cb16-loser", 8);
+    seed(&conn, "cb16-winner", 5);
+    let loser = db::get(&conn, "cb16-loser")
+        .expect("get")
+        .expect("loser exists");
+
+    let rank = |conn: &Connection| -> Vec<String> {
+        let (rows, _) = db::recall(
+            conn,
+            "deploy target",
+            Some("cb16"),
+            10,
+            None,
+            None,
+            None,
+            ai_memory::SECS_PER_HOUR,
+            ai_memory::SECS_PER_DAY,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+        )
+        .expect("recall");
+        rows.into_iter().map(|(m, _)| m.id).collect()
+    };
+
+    assert_eq!(
+        rank(&conn).first().map(String::as_str),
+        Some("cb16-loser"),
+        "pre-conserve the higher-priority/long-tier loser dominates"
+    );
+    db::conserve_contradiction(&conn, &loser, "cb16-winner", None).expect("conserve");
+    assert_eq!(
+        rank(&conn).first().map(String::as_str),
+        Some("cb16-winner"),
+        "the soft down-weight must rank the conserved loser below its winner"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Postgres-side regression — compiles under `sal-postgres`; skipped on a
+// plain `cargo test` by `#[ignore]` so a node with no live PG stays green.
+// ─────────────────────────────────────────────────────────────────────
+#[cfg(feature = "sal-postgres")]
+mod postgres_side {
+    use ai_memory::models::field_names;
+    use ai_memory::models::{Memory, Tier};
+    use ai_memory::store::postgres::PostgresStore;
+    use ai_memory::store::{CallerContext, Filter, MemoryStore};
+    use serde_json::json;
+
+    async fn live_pg() -> Option<PostgresStore> {
+        let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        match PostgresStore::connect(&url).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!(
+                    "skipping postgres soft-loser verify: PostgresStore::connect failed: {e}\n\
+                     (test-infra blocker per issue #79 — 192.168.50.100 ↔ 192.168.1.50 routing)"
+                );
+                None
+            }
+        }
+    }
+
+    /// Identical `title` + `content` (so `to_tsvector` — and therefore
+    /// `ts_rank` — is IDENTICAL for the two rows), placed in DISTINCT
+    /// namespaces so the `(title, namespace)` upsert keeps them as separate
+    /// rows. Searched with `namespace = None`, so both compete in one
+    /// ranking where the soft-loser penalty is the ONLY differentiator.
+    fn sample(id: &str, namespace: &str, token: &str, priority: i32, soft_loser: bool) -> Memory {
+        let metadata = if soft_loser {
+            // The EXACT value shape `conserve_contradiction` stamps: a JSON
+            // boolean `true`. This is what the fixed pg predicate matches.
+            json!({ (field_names::CONTRADICTION_SOFT_LOSER): true })
+        } else {
+            json!({})
+        };
+        Memory {
+            id: id.to_string(),
+            tier: Tier::Long,
+            namespace: namespace.to_string(),
+            title: format!("directive {token}"),
+            content: format!("the canonical {token}"),
+            priority,
+            confidence: 1.0,
+            source: "test".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            metadata,
+            ..Memory::default()
+        }
+    }
+
+    /// #2436 — the postgres soft-loser penalty is APPLIED for a marked row
+    /// and NOT applied for a normal row.
+    #[tokio::test]
+    #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL — Track C blocker per issue #79"]
+    async fn pg_soft_loser_penalty_applies_2436() {
+        let Some(pg) = live_pg().await else {
+            return;
+        };
+        let ctx = CallerContext::for_agent("cb16-parity");
+
+        // Distinctive tokens keep the namespace-less search from colliding
+        // with any co-resident row in the shared test DB.
+        let tok = "cb16softloserdeploytoken";
+        // loser carries the marker AND the higher priority; winner is a
+        // normal row with a LOWER priority. Identical tsv ⇒ equal ts_rank,
+        // so post-fix the 0.5× penalty must sink the loser below the winner
+        // despite the `priority DESC` tiebreak (which is what made the loser
+        // wrongly win pre-fix, when the penalty never matched).
+        let loser = sample("pg-cb16-loser", "cb16-pg-loser", tok, 8, true);
+        let winner = sample("pg-cb16-winner", "cb16-pg-winner", tok, 3, false);
+        let _ = MemoryStore::store(&pg, &ctx, &loser).await;
+        let _ = MemoryStore::store(&pg, &ctx, &winner).await;
+
+        let filter = Filter {
+            limit: 10,
+            ..Filter::default()
+        };
+        let ranked = pg
+            .search_with_source_uri(tok, &filter, None)
+            .await
+            .expect("search_with_source_uri");
+
+        // Teardown BEFORE asserting (#2287) so a failed assertion never
+        // leaves fixture rows behind for the next run.
+        for id in ["pg-cb16-loser", "pg-cb16-winner"] {
+            let _ = sqlx::query("DELETE FROM memories WHERE id = $1")
+                .bind(id)
+                .execute(pg.pool())
+                .await;
+        }
+
+        let order: Vec<String> = ranked.iter().map(|m| m.id.clone()).collect();
+        let lp = order.iter().position(|id| id == "pg-cb16-loser");
+        let wp = order.iter().position(|id| id == "pg-cb16-winner");
+        assert!(
+            wp.is_some() && lp.is_some(),
+            "both fixture rows must be recalled. order={order:?}"
+        );
+        assert!(
+            wp < lp,
+            "#2436: the penalty must be LIVE on postgres — the marked loser \
+             (pre-fix: won on the priority tiebreak at equal ts_rank) now ranks \
+             below its winner. order={order:?}"
+        );
+
+        // Control: two NORMAL (unmarked) rows with identical tsv fall to the
+        // priority tiebreak, so the higher-priority one wins — proving factor
+        // 1.0 for an absent marker (and that an absent marker never errors).
+        let tok2 = "cb16normaldeploytoken";
+        let hi = sample("pg-cb16-normal-hi", "cb16-pg-hi", tok2, 9, false);
+        let lo = sample("pg-cb16-normal-lo", "cb16-pg-lo", tok2, 2, false);
+        let _ = MemoryStore::store(&pg, &ctx, &hi).await;
+        let _ = MemoryStore::store(&pg, &ctx, &lo).await;
+        let ranked2 = pg
+            .search_with_source_uri(tok2, &filter, None)
+            .await
+            .expect("search_with_source_uri");
+        for id in ["pg-cb16-normal-hi", "pg-cb16-normal-lo"] {
+            let _ = sqlx::query("DELETE FROM memories WHERE id = $1")
+                .bind(id)
+                .execute(pg.pool())
+                .await;
+        }
+        let order2: Vec<String> = ranked2.iter().map(|m| m.id.clone()).collect();
+        let hi_pos = order2.iter().position(|id| id == "pg-cb16-normal-hi");
+        let lo_pos = order2.iter().position(|id| id == "pg-cb16-normal-lo");
+        assert!(
+            hi_pos.is_some() && lo_pos.is_some() && hi_pos < lo_pos,
+            "unmarked rows are NOT penalized — the higher-priority one wins the \
+             equal-rank tiebreak. order={order2:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2436

## Root cause (CB-16 — confirmed postgres correctness defect)

The G7 (#1824) contradiction **soft-loser** recall down-weight was **dead code on postgres**.

`conserve_contradiction` (`src/storage/mod.rs:3771`) stamps the marker as a **JSON boolean `true`** (`serde_json::Value::Bool(true)`). Postgres' `->>` operator returns the JSON value **as TEXT**, so a JSON boolean `true` renders as the string `'true'`. The recall predicate in `PostgresStore::search_with_source_uri` compared:

```sql
-- before (src/store/postgres.rs)
* (CASE WHEN (m.metadata->>'contradiction_soft_loser') = '1'
        THEN {soft_loser_factor} ELSE 1.0 END) AS rank
```

`'true' = '1'` is **always false**, so the multiplicative penalty never applied — an LLM-confirmed-contradicted loser kept outranking its fresh winner at full score on any postgres-backed daemon. The sqlite twins (`src/storage/mod.rs:6202` and `:6807`) use `json_extract(m.metadata, '$.contradiction_soft_loser') = 1`, which matches correctly because SQLite's `json_extract` of a JSON `true` yields the **integer 1**. A cross-backend correctness divergence: sqlite penalized, postgres did not.

## Fix

```sql
-- after
* (CASE WHEN (m.metadata->>'contradiction_soft_loser') = 'true'
        THEN {soft_loser_factor} ELSE 1.0 END) AS rank
```

- Matches the exact value the writer stamps (JSON boolean → `->>` text `'true'`).
- **Robust to an absent marker**: `->>` returns `NULL`, `NULL = 'true'` is `NULL`, so the `CASE ELSE` arm applies factor **1.0** (no penalty, no error) — never a wrong result. (North Star: degrade, never corrupt.)
- The false in-code comment that described the (non-working) behavior is corrected to document the real JSON-boolean shape and the absent-marker semantics.

## Test evidence

New `tests/pg_soft_loser_penalty_2436.rs`:

- **`writer_stamps_soft_loser_as_json_bool`** (always-run, sqlite) — pins the load-bearing contract: `conserve_contradiction` writes the marker as a JSON boolean `true` (not `"1"`/`"true"`/`1`). If the writer ever drifts, this fails alongside the pg predicate so they can't silently diverge again.
- **`sqlite_soft_loser_ranks_below_winner`** (always-run, sqlite) — the reference ordering contract the postgres twin must match.
- **`pg_soft_loser_penalty_applies_2436`** (`#[ignore]` + `sal-postgres`, live-PG) — mirrors the repo's `AI_MEMORY_TEST_POSTGRES_URL` harness: proves the penalty is **applied** for a soft-loser row (ranks below its winner at equal `ts_rank`) and **not applied** for a normal row. Run with `cargo test --features sal-postgres --test pg_soft_loser_penalty_2436 -- --ignored`.

Local verification: `cargo fmt --all --check` clean; clippy green on all four CI legs (default / `sal` / `sal-postgres` / `vectorlite`, `-D warnings -D clippy::all -D clippy::pedantic`); the two always-run sqlite tests pass. `src/store/postgres.rs` stays under its `qual_10` module-size ceiling (33,013 ≤ 33,050). CHANGELOG `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY