### PR TITLE
fix(ci): restore line-ending .gitattributes clobbered by the CHANGELOG union commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,34 @@
+# Cross-platform line-ending policy.
+#
+# Default: auto-detect text, leave binary as-is.
+* text=auto
+
+# JSON/JSONL snapshots used by the test suite must use LF on every
+# checkout — Windows otherwise rewrites them as CRLF and the byte-for-byte
+# snapshot tests (e.g. tests/longmemeval_reflection_bench.rs::snapshot_matches_generator)
+# fail with a phantom drift.
+*.jsonl text eol=lf
+*.json  text eol=lf
+
+# Shell scripts always LF (POSIX-only consumers).
+*.sh    text eol=lf
+
+# Rust + TOML + Markdown — let git auto-detect but never normalise binaries.
+*.rs    text
+*.toml  text
+*.md    text
+
+# Migrations are SQL — LF always (deterministic hashing inputs).
+*.sql   text eol=lf
+
+# Test fixture binaries + model weights — never touch.
+*.bin   binary
+*.gz    binary
+*.zst   binary
+*.tar   binary
+*.png   binary
+*.jpg   binary
+*.parquet binary
+
+# CHANGELOG append-conflict auto-resolution (both [Unreleased] entries kept).
 CHANGELOG.md merge=union


### PR DESCRIPTION
**Blocks the whole PR queue.** #2751's `printf > .gitattributes` overwrote the repo's cross-platform line-ending policy, keeping only `CHANGELOG.md merge=union`. The lost `*.json/*.jsonl eol=lf` rules are what stop Windows from checking out the JSON snapshot goldens as CRLF; without them the Windows Check leg fails the conformance + tools-list snapshot tests with phantom drift (ubuntu/macos green). Restores the full original .gitattributes + re-appends the union line. No golden regen needed. Merge first, then all queued PRs rebase onto this and go Windows-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)