### PR TITLE
test(export-reflections): checkpoint WAL before subprocess read to deflake #2764

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- #2764 (test/2764-flaky-export-isolation) -->
+### Fixed (`export_reflections::test_memory_export_reflection_mcp_tool` no longer intermittently fails with `memory not found` on macOS)
+
+- **The reflection-export MCP integration test is now deterministic across a process boundary** (refs [#2764](https://github.com/alphaonedev/ai-memory-mcp/issues/2764); epic [#2705](https://github.com/alphaonedev/ai-memory-mcp/issues/2705)). `tests/cli/export_reflections.rs::test_memory_export_reflection_mcp_tool` is the ONLY test in the module that reads the seeded database from a SEPARATE process — it seeds the reflection with an in-process `rusqlite::Connection`, drops it, then spawns an `ai-memory mcp` subprocess that reads the row back by id. `db::open` opens the DB in WAL mode with `synchronous=NORMAL`, and rusqlite's `Drop` -> `sqlite3_close` checkpoint-on-close is best-effort, so on macOS (APFS + WAL) the just-committed reflection row could still be sitting in the `-wal` sidecar when the subprocess opened the DB — surfacing as an intermittent `memory not found` (a test-isolation/durability defect in the harness, NOT a substrate defect; the on-disk row was always correct). **Fix:** the test now forces `PRAGMA wal_checkpoint(TRUNCATE)` via the existing `db::checkpoint` on the writer connection BEFORE dropping it, guaranteeing the committed row is durably in the main DB file the reader process opens. This is a durability barrier, not a timing hack — no `sleep` was added and no assertion was weakened. Each test already runs against its own `tempfile::TempDir` DB with a per-test namespace, so no cross-test state is shared.
+
 <!-- v1.0.0 GA cert drain (#2705): entries restored after the conflict-free batch-merge strip -->
 <!-- #2747 (cb19-2721-reserved-sentinel-wire) -->
 ### Fixed (reserved `daemon` principal can no longer be self-asserted from the MCP wire in `namespace_set_standard`)

--- a/tests/cli/export_reflections.rs
+++ b/tests/cli/export_reflections.rs
@@ -273,6 +273,18 @@ fn test_memory_export_reflection_mcp_tool() {
     let conn = open(&db_path);
     let src = seed_observation(&conn, "mcp-ns", "obs");
     let rfl_id = drive_reflect(&conn, &db_path, "mcp-ns", &src, "lesson");
+    // This is the only test in the module that reads the seeded DB from a
+    // SEPARATE process (the spawned `ai-memory mcp` subprocess below) rather
+    // than an in-process `db::open`. `db::open` opens WAL with
+    // `synchronous=NORMAL`, and rusqlite's `Drop`->`sqlite3_close`
+    // checkpoint-on-close is best-effort — so on macOS (APFS + WAL) the
+    // reflection row can still be sitting in the `-wal` sidecar when the
+    // subprocess opens the DB, surfacing as an intermittent
+    // `memory not found` (issue #2764). Force a full checkpoint into the
+    // main DB file BEFORE dropping the writer so the reader process is
+    // guaranteed to see the committed row. This is a durability barrier,
+    // not a timing hack.
+    db::checkpoint(&conn).expect("wal checkpoint before subprocess read");
     drop(conn);
 
     let request = format!(


### PR DESCRIPTION
## Summary

`export_reflections::test_memory_export_reflection_mcp_tool` fails intermittently on macOS CI with `memory not found` (issue #2764, epic #2705). It is the ONLY test in `tests/cli/export_reflections.rs` that reads the seeded DB across a **process boundary**: it seeds a reflection with an in-process `rusqlite::Connection`, drops it, then spawns an `ai-memory mcp` subprocess that reads the row back by id.

### Root cause (test-isolation / durability, NOT a substrate defect)

`db::open` opens the DB in WAL mode with `synchronous=NORMAL`, and rusqlite's `Drop` -> `sqlite3_close` checkpoint-on-close is best-effort. On macOS (APFS + WAL) the just-committed reflection row can still be sitting in the `-wal` sidecar when the subprocess opens the DB, so `db::get` in the `memory_export_reflection` handler returns `None` -> `memory not found`. The on-disk row was always correct; only the cross-process WAL visibility timing was racy. Every sibling test reads via an in-process `db::open` in `run_cli`, so WAL visibility is trivially satisfied there — which is why only this one test flaked.

### Fix

Force `PRAGMA wal_checkpoint(TRUNCATE)` via the existing `db::checkpoint` on the writer connection **before** dropping it, guaranteeing the committed row is durably in the main DB file the reader process opens. This is a durability barrier, **not** a timing hack — **no `sleep` added, no assertion weakened**. Each test already runs against its own `tempfile::TempDir` DB with a per-test namespace, so no cross-test state is shared.

Files:
- `tests/cli/export_reflections.rs` — checkpoint before `drop(conn)` in `test_memory_export_reflection_mcp_tool`
- `CHANGELOG.md` — `[Unreleased]` `### Fixed` entry

### Gates / evidence

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` — clean (default AND `--features sal-postgres`)
- Determinism: the single test **20/20 green** under a repeat loop (`umask 022`, `AI_MEMORY_NO_CONFIG=1`)
- Full `export_reflections` module — **7/7 green**, no sibling breakage

## AI involvement

Authored by an Opus 5 coder agent in the autonomous v1.0.0 GA cert loop (#2705), dispatched by the Fable-5 orchestrator. Root-cause analysis via codegraph; fix implemented, gated, and verified per the project's testing-loop discipline.

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY