### PR TITLE
docs+infra(v1.0.0): enterprise-cert campaign PLAN + P0-P11 playbook + AGE 1.6.0 / Grok 4.5 / IronClaw v1.1.0 pins

### DIFF
--- a/docs/v1.0.0/nhi-playbook-P0-P11.md
+++ b/docs/v1.0.0/nhi-playbook-P0-P11.md
@@ -1,0 +1,263 @@
+---
+layout: doc
+---
+# NHI Dogfood Playbook — P0 through P11 (v1.0.0)
+
+**Purpose.** The reproducible, versioned Non-Human-Intelligence (NHI) dogfood
+playbook: twelve phases (P0-P11) an AI NHI agent drives against a running
+ai-memory v1.0.0 binary over MCP / HTTP / CLI to certify the substrate
+end-to-end. This doc closes a reproducibility gap — the playbook previously
+lived only as a stored memory. It is Track A of the
+`test-campaign-2026-08-08-enterprise-cert` (see `PLAN.md`).
+
+**Lineage.** Reconstructed from the v0.7.0 Run-3 result set
+(`docs/v0.7.0/test-campaign-2026-05-18-dogfood/track-a-nhi-results-run3.md`,
+which enumerated P0..P11 with per-assertion evidence and minted SHIP at
+89 PASS / 0 FAIL) and updated to the v1.0.0 SSOT surface. The v0.8.0 dogfood
+evidence in-repo is the IronClaw A2A campaign
+(`docs/v0.8.0/test-campaign-2026-06-24-ironclaw-a2a/`), which is Track B here,
+not the P0-P11 surface.
+
+**How to run.** Drive each phase against a freshly-built binary
+(`cargo build --release --features sal,sal-postgres`), MCP over stdio
+(`printf '<JSON-RPC>' | ./target/release/ai-memory mcp --profile full`), HTTP
+over the daemon (`ai-memory serve`), and CLI directly. Each phase uses an
+isolated namespace / DB so phases do not cross-contaminate. Every phase records
+its PASS/FAIL tally + evidence (row ids, SQL confirmations, error strings).
+
+**v1.0.0 SSOT values used below** (from `CLAUDE.md` / the canonical Rust consts):
+schema **v88**; MCP tools **103** at `--profile full` (102 callable + the
+always-on `memory_capabilities` bootstrap), **7** at `--profile core`;
+capabilities envelope `schema_version` **"3"**; `Memory` **30 fields**;
+`MemoryLinkRelation::COUNT` **9**; HTTP **94** route registrations / **80**
+unique paths; CLI **90** default / **92** sal subcommands; `HookEvent`
+variants **22**. Because these are SSOT-derived, a phase asserts "matches the
+compiled SSOT" rather than a frozen literal — a mismatch is itself a finding.
+
+---
+
+## P0 — Environment & version handshake
+
+**Verifies:** the binary under test is the intended v1.0.0 build, the MCP
+protocol handshake succeeds, and the advertised surface matches the SSOT.
+
+**Pass assertion:**
+- `ai-memory --version` reports `ai-memory 1.0.0` and the binary realpath is the
+  campaign build (not a stale brew/homebrew binary).
+- MCP `initialize` handshake succeeds; `serverInfo.version` = `1.0.0`.
+- `memory_capabilities.schema_version` = `"3"`; `memory_capabilities.version` = `1.0.0`.
+- All tool families load (`loaded:true`).
+- `tools/list` count = **103** at `--profile full` (matches
+  `Profile::full().expected_tool_count()`); `--profile core` = 7.
+
+**Exercised by:** `src/profile.rs::Profile::full().expected_tool_count()`,
+`tests/mcp_tools_list_schema_discovery.rs`, the MCP `initialize` + `memory_capabilities` handshake.
+
+---
+
+## P1 — Core CRUD + DF-1..DF-4 (provenance wire-schema)
+
+**Verifies:** the primitive store/recall/search/list/delete round-trip, plus the
+Form-4 provenance wire-schema fields (`source_uri`, `expected_version`,
+`edit_source`) that must be discoverable AND persist end-to-end.
+
+**Pass assertion:**
+- `memory_store` → `memory_recall` (hybrid + rerank) → `memory_search` (FTS5) →
+  `memory_list` (namespace-scoped) → `memory_delete` all round-trip; `agent_id`
+  is auto-stamped and immutable across update.
+- **DF-1:** MCP `tools/list` exposes `source_uri` in `memory_store.inputSchema.properties`.
+- **DF-2:** `tools/list` exposes `expected_version` + `edit_source` + `source_uri` in `memory_update.inputSchema.properties`.
+- **DF-3:** `memory_store {source_uri:"doc:X"}` persists — `SELECT source_uri FROM memories` equals `"doc:X"` end-to-end (MCP → validation → storage → SQL).
+- **DF-4:** `memory_update {edit_source:"llm"}` triggers archive-and-supersede — an `archived_memories.archive_reason` row plus a new current row carrying `metadata.superseded_id`.
+
+**Exercised by:** `tests/form_4_provenance`, the `source_uri` column tests,
+`http_source_uri_query`; DF-1/DF-2 pin the #892/#893 schema-exposure.
+
+---
+
+## P2 — Lifecycle (tier transitions, archive-before-delete)
+
+**Verifies:** TTL tiers, auto-promotion, explicit promotion, scoped forget, and
+the archive-before-delete data-integrity contract. At v1.0.0 recall is PURE
+(#1869/#1953) — access ladders are applied by the FOLD job, not synchronously —
+so promotion is asserted after a fold, not inline.
+
+**Pass assertion:**
+- Default tier = mid (7d TTL); 5 accesses drive `access_count` to 5 and the row
+  auto-promotes **mid→long** at `PROMOTION_THRESHOLD` after the fold; `expires_at` clears on long.
+- `memory_promote` explicitly jumps mid→long (single call by default; optional `target_tier` stops at mid).
+- `memory_forget` by namespace is EXACT-scoped (a sub-namespace survives a parent-namespace forget).
+- **Archive-before-delete:** every explicit delete/forget writes an
+  `archived_memories` row (`archive_reason='forget'`) BEFORE the row is reaped —
+  the durable text is never destroyed without a restorable archive copy.
+
+**Exercised by:** `tests/recall_purity_p01.rs` (fold-before-gc, purity),
+the promotion-threshold + archive-on-delete storage paths, `memory_gc`.
+
+---
+
+## P3 — Knowledge graph
+
+**Verifies:** entity registration/aliasing, typed links (9-relation closed
+taxonomy), temporal validity, KG traversal, and invalidation propagation. On the
+postgres substrate the AGE Cypher path is exercised; on sqlite the recursive-CTE path.
+
+**Pass assertion:**
+- `memory_entity_register` + `memory_entity_get_by_alias` resolve an alias to its canonical entity.
+- `memory_link` with a valid relation (of the 9 in `MemoryLinkRelation`) creates an edge carrying `valid_from`, `attest_level`.
+- `memory_kg_query` (`max_depth=3`) returns the full traversal path; `memory_kg_timeline` returns events with `valid_from` set.
+- `memory_kg_invalidate` (source_id, target_id, relation) sets `valid_until`; a re-query returns `count:0` (invalidation propagates to the current view) and `attest_level` resets.
+- `memory_find_paths` + `memory_get_taxonomy` + `memory_get_links` (temporal cols exposed) all return.
+
+**Exercised by:** the `kg/` module tests (recursive-CTE + AGE Cypher), the
+`memory_links` closed-taxonomy CHECK, temporal-validity columns.
+
+---
+
+## P4 — Governance & security hardening
+
+**Verifies:** the governance surface, SSRF/HMAC gates, and — under the certified
+config — attestation ON. Fail-closed everywhere.
+
+**Pass assertion:**
+- `memory_pending_list` / `memory_quota_status` / `memory_rule_list` return clean state (system-seeded rules present, `created_by="system:seed"`).
+- `memory_check_agent_action` returns a typed decision for each action kind.
+- `memory_subscribe` SSRF probes (AWS metadata IP / loopback / `file://`) are REJECTED at the HMAC gate (`HMAC secret required`) BEFORE URL validation — defense in depth; no orphan subscription rows created.
+- `memory_notify` → `memory_inbox` round-trips.
+- **Attestation ON:** an unsigned direct HTTP store is `403 ATTESTATION_FAILED`; a signed write lands `attest_level=agent_attested` (the Track E `test-attestation.sh` assertions hold on this binary).
+
+**Exercised by:** the governance rule engine, the subscription HMAC gate,
+`src/identity/attest.rs`, `infra/do-hive/crypto/test-attestation.sh`.
+
+---
+
+## P5 — Power tools (LLM-backed)
+
+**Verifies:** the autonomous-tier LLM tools. Run with a real LLM backend
+(Grok 4.5 via xAI-direct or OpenRouter, per the campaign config) — a
+stub/abstaining backend makes these no-ops.
+
+**Pass assertion:**
+- `memory_check_duplicate` returns a similarity score and a correct `is_duplicate` boolean against the threshold.
+- `memory_expand_query` returns LLM-generated query variants.
+- `memory_auto_tag` (by memory `id`) returns quality tags.
+- `memory_detect_contradiction` correctly flags a genuine contradiction (`contradicts:true`).
+
+**Exercised by:** `src/llm.rs` (provider-agnostic client), the power-tool MCP
+handlers; requires the resolved LLM backend reachable.
+
+---
+
+## P6 — Capabilities v3 shape
+
+**Verifies:** the `memory_capabilities` envelope shape, family routing, and
+optional-param discoverability.
+
+**Pass assertion:**
+- Default response: `schema_version="3"`, all families `loaded:true`, top-level `summary` + `to_describe_to_user` + `tools[]`.
+- Optional params (`source_uri` / `expected_version` / `edit_source`) discoverable in the trimmed wire schemas (ties to P1 DF-1/DF-2).
+- `memory_smart_load` + `memory_load_family` exposed and callable.
+- Tool-count consistency: help-text / capabilities / `tools/list` all reconcile to the SSOT (103 at full).
+
+**Exercised by:** `src/mcp/tools/capabilities.rs`, the capabilities-envelope tests.
+
+---
+
+## P7 — Token-budget ceiling
+
+**Verifies:** the `tools/list` wire payload stays under the token ceiling after
+the schemars expansion, so an NHI host's context budget is respected.
+
+**Pass assertion:**
+- The trimmed full-profile `tools/list` payload is under `TRIMMED_FULL_PROFILE_CEILING_TOKENS` (**11000** cl100k tokens, `tests/token_budget_guard.rs`).
+- The verbose form stays under its own ceiling; the trimmer strips long-form prose (`docs`, nested `description`s, long defaults) while preserving the constructive `inputSchema` shape.
+
+**Exercised by:** `tests/token_budget_guard.rs`,
+`tests/mcp_tools_list_schema_discovery.rs`, `src/mcp/registry::strip_docs_from_tools`.
+
+---
+
+## P8 — Hooks & subscriptions
+
+**Verifies:** the hook lifecycle surface enumeration and the mandatory-HMAC
+subscription dispatch gate.
+
+**Pass assertion:**
+- `capabilities.hooks.webhook_events` enumerates the substrate's webhook event set; `hook_events_count` matches the compiled `HookEvent` SSOT (**22** variants at v1.0.0); `registered_count` = 0 in clean state (no orphan hooks).
+- Subscription dispatch is HMAC-required (unsigned dispatch DISABLED since v0.7.0) — the three dangerous-URL probes from P4 are refused at the HMAC gate before URL validation.
+
+**Exercised by:** `src/hooks/events.rs` (the `HookEvent` enum SSOT),
+`src/subscriptions.rs` (HMAC-signed dispatch, DLQ, replay).
+
+---
+
+## P9 — MCP / HTTP / CLI parity
+
+**Verifies:** the three interfaces agree on source attribution, validation, and
+cross-interface behavior over the shared storage layer.
+
+**Pass assertion:**
+- An MCP-stored memory is retrievable via CLI `list --json` (source stamped `claude`); a CLI-stored memory shows source `cli` with a synthesized durable `agent_id`.
+- Validation parity: an invalid `agent_id` metachar (`$`) and a >128-byte `agent_id` are rejected identically at the CLI and MCP layers.
+- Cross-interface contradiction detection fires (a CLI store flags a `potential_contradictions` id against a prior MCP store).
+- (Postgres deployments serve MCP clients through the HTTP daemon — MCP stdio is structurally sqlite-only, #1675 — so HTTP↔CLI parity is the postgres-substrate assertion.)
+
+**Exercised by:** the validation SSOT (`src/validate.rs`), the source-attribution
+paths, the cross-interface storage layer.
+
+---
+
+## P10 — Performance & scale
+
+**Verifies:** the performance budgets exist and hold, and the substrate reports
+health honestly under sustained load.
+
+**Pass assertion:**
+- `PERFORMANCE.md` budgets exist and the run stays within them (recall p95, rerank budget #2608, recall-embed budget #2577).
+- `memory_stats` returns `by_namespace`, `by_tier`, `db_size_bytes`, `links_count`, `total`.
+- `ai-memory doctor` reports overall INFO with no corruption flagged; `/health` renders the cached FTS-integrity verdict (#2579) and `/metrics` renders the paced corpus gauge (#2583) with zero per-request DB scan cost.
+- Sustained sequential recalls return cleanly with consistent shape (no lock starvation).
+
+**Exercised by:** `PERFORMANCE.md`, `memory_stats`, `ai-memory doctor`,
+`src/background/{fts_integrity,memories_gauge}.rs`.
+
+---
+
+## P11 — Failure & chaos (fail-closed)
+
+**Verifies:** the substrate DEGRADES, never corrupts — under bogus input, chaos,
+and adversarial identities it refuses loudly and self-heals, and the durable text
+survives.
+
+**Pass assertion:**
+- `memory_get` on a bogus UUID returns a sanitized "not found" (no leak).
+- Adversarial `agent_id`s (shell metachar `$`, 200-char overflow, null byte) are rejected at the validation layer.
+- Sequential recalls across distinct contexts return cleanly (no DB-lock errors).
+- **Fail-closed integrity:** `ai-memory doctor` post-chaos is INFO with no residual damage; `verify-audit-trail` is clean; no negative-path write silently succeeded. A power-loss/abort injection (`tests/power_loss_durability.rs`) loses no acknowledged write and leaves `integrity_check` clean.
+
+**Exercised by:** the sanitized error paths, `src/validate.rs`,
+`ai-memory doctor`, `verify-audit-trail`, `tests/power_loss_durability.rs`.
+
+---
+
+## Verdict rubric
+
+At the end of P0-P11 the playbook mints exactly one verdict:
+
+- **SHIP** — every phase's pass assertion GREEN, **0 FAIL**, and every negative /
+  fail-closed assertion was correctly REFUSED. The substrate degraded where it
+  should and never corrupted or lost durable text.
+- **FIX-FIRST** — one or more FIXABLE defects surfaced (a wire-schema drift, a
+  missing tool, a non-fatal parity mismatch). Per the repo prime directive these
+  are NOT deferred: file → fix → retest → re-check, then re-run the affected
+  phase. The verdict cannot be SHIP while any surfaced finding is open.
+- **HOLD** — a data-integrity or fail-closed VIOLATION was observed: a negative
+  assertion that was NOT refused (e.g. an unsigned write accepted while
+  attestation is ON, an SSRF probe reaching the network, a corrupt/ambiguous
+  migration), OR any unintentional data loss / corruption. HOLD blocks the whole
+  campaign verdict until root-caused and closed — data integrity is the
+  highest-order constraint and outranks every convenience.
+
+A campaign-level SHIP requires this playbook to mint SHIP on the certified config
+(encryption + attestation ON, PG16 + AGE 1.6.0 + pgvector, Grok 4.5), reproduced
+on the DO re-host.

--- a/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/PLAN.md
+++ b/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/PLAN.md
@@ -1,0 +1,170 @@
+---
+layout: doc
+---
+# v1.0.0 Enterprise-Certification Test Campaign — PLAN
+
+**Campaign date:** 2026-08-08
+**Base commit (cert tip):** `715cb38f` on `release/v1.0.0`
+**Status:** LOCKED plan. Local-first (free) proves green, then the identical
+config is re-hosted on DigitalOcean for real federated multi-node + capacity.
+
+This document is the clearly-defined, versioned campaign that supersedes the
+earlier narrow "USL probe" framing (operator directive 2026-08-08). The DO
+droplet round is redefined into the **certified-enterprise-federated test**:
+ai-memory v1.0.0 on PostgreSQL 16 + Apache AGE 1.6.0 + pgvector, multi-node
+federated, driven by IronClaw + Grok 4.5, exercising AI NHI + A2A + full-spectrum
+encryption (3 legs) + E2E + 100% regression. **All channels encrypted,
+attestation ON everywhere.** The earlier plaintext + attestation-off round was
+declared INVALID and is not part of this campaign.
+
+---
+
+## 1. Config (LOCKED)
+
+| Facet | Locked value |
+|-------|--------------|
+| Binary | ai-memory **v1.0.0 @ `715cb38f`**, built `cargo build --release --features sal,sal-postgres` |
+| Dim-fix | MUST include **#1882** (the postgres `tier=semantic` 768-vs-384 dim fix; commit `9525f450`). A binary without it opens the postgres schema at the wrong vector dim and every write 503s / recall returns empty. See `infra/do-hive/crypto/README.md` for the exact failure mode. |
+| Store | **PostgreSQL 16** + **Apache AGE 1.6.0** (tag `release_PG16_1.6.0`) + **pgvector** |
+| Schema | **v88** — `CURRENT_SCHEMA_VERSION` SSOT in `src/storage/migrations.rs` + `src/store/postgres.rs::migrate_v88()` at the cert tip. Parity-gated: the sqlite and postgres ladders share the one logical schema number and the campaign asserts sqlite↔postgres schema parity. (This value is the live SSOT at `715cb38f`; the campaign brief's "v81" pre-dated this tip and is superseded — use v88.) |
+| AI NHI brain | **Grok 4.5**. xAI-direct: `XAI_API_KEY`, base URL `https://api.x.ai/v1`, model `grok-4.5`. OpenRouter alt: `OPENROUTER_API_KEY`, model `x-ai/grok-4.5`. Backend selection logic is unchanged from prior rounds — only the model id moved to 4.5. |
+| Encryption | **ON everywhere** — API mTLS (leg 1), federation/quorum mTLS (leg 2), daemon→Postgres `sslmode=verify-full` (leg 3). |
+| Attestation | **ON everywhere** — `AI_MEMORY_REQUIRE_AGENT_ATTESTATION` strict on the store path; federation write-sig (`AI_MEMORY_FED_REQUIRE_WRITE_SIG`) at its v1.0.0 default-ON. |
+
+Two viable encrypted brain-transport paths are both in scope: xAI-direct (the DO
+substrate agent runs `grok-4.5` against `api.x.ai/v1`) and OpenRouter
+(`x-ai/grok-4.5`, the lan-parity IronClaw containers). The ai-memory daemon's own
+LLM/embedder egress is orthogonal to the IronClaw driver's egress.
+
+---
+
+## 2. Tracks
+
+Each track has a concrete pass criterion and is grounded in an existing harness
+in this repository. A track is GREEN only when every listed assertion is GREEN
+against the LOCKED config above.
+
+| Track | Scope | Harness | Pass criterion |
+|-------|-------|---------|----------------|
+| **A** | NHI dogfood P0-P11 | `docs/v1.0.0/nhi-playbook-P0-P11.md` (this campaign's versioned playbook) | Every phase P0-P11 SHIP per its own pass assertion; final verdict rubric = SHIP. Exercised MCP/HTTP/CLI against the v1.0.0 binary. |
+| **B** | A2A multi-agent | IronClaw + Grok 4.5 two-daemon mesh (lan-parity `ic-parity-alice` ↔ `ic-parity-bob`, then DO multi-node) | Two enrolled daemons exchange signed A2A signals/actions across the federation transport; cross-agent memory visible per governance; no unsigned authority-write accepted. |
+| **C** | pg+AGE+pgvector + full regression | `infra/lan-parity-test/run-parity-tests.sh` | `cargo test --features sal,sal-postgres --release` GREEN against the live PG16+AGE 1.6.0+pgvector container on `127.0.0.1:15432`. postgres-backed `live_*` tests are gated on `AI_MEMORY_TEST_POSTGRES_URL` (self-skip when unset); the `#[ignore]`-marked tests require `-- --include-ignored` (see execution note below). Actual live-test count + pass rate recorded in the run log under `.local-runs/`. sqlite↔postgres SAL parity asserted. |
+| **D** | Federation | Enrolled multi-node quorum (lan-parity 2-node → DO N-node) | A W-of-N quorum write commits locally AND replicates to the peer over the mutually-authenticated channel; peer-enrollment + write-sig + nonce + policy-current gates all default-ON and satisfied by REAL enrollment (not an escape hatch). |
+| **E** | Encryption — 3 legs, pos + neg | The 6 scripts in `infra/do-hive/crypto/` (see §2.1) | Every leg's positive assertion PASSES and every negative assertion is REFUSED (fail-closed). `run-all-local.sh` exits 0 (all legs green). |
+| **F** | USL capacity, crypto-ON | DO N-node hive under the encrypted+attested config (`infra/do-hive/`) | Capacity measured on the certified config (encryption + attestation ON) — NOT the earlier invalidated plaintext/attestation-off run. Reported against the defined unit + measured cells (per the operator's 500-1000-agent-cluster / 500-agent-block certification scope). |
+| **E2E** | End-to-end | The full chain: IronClaw(Grok 4.5) → encrypted API → ai-memory daemon → PG16/AGE/pgvector, federated, attested | A store→recall→reflect→consolidate→federate round-trip completes with encryption + attestation ON at every hop and the durable memory TEXT intact on both nodes. |
+
+### 2.1 Track E — the 3 encryption legs (exact pos/neg assertions)
+
+Grounded in `infra/do-hive/crypto/` (read its `README.md` for the per-leg serve
+invocations). Every script prints PASS/FAIL per assertion and exits non-zero if
+any assertion FAILs. `run-all-local.sh` regenerates certs then runs all six legs.
+
+**Leg 1 — API mTLS** (`test-api-mtls.sh`)
+- POS: an allowlisted `client-good` cert GETs `/api/v1/health` → `200`.
+- NEG1: a client presenting NO client cert cannot complete the TLS handshake (mTLS mandatory).
+- NEG2: a valid-but-UNLISTED `client-bad` cert is refused at the rustls `ClientCertVerifier` (daemon logs `not in mTLS allowlist`).
+
+**Leg 2 — federation / quorum mTLS** (`test-federation-mtls.sh`, W-of-N = 2)
+- POS1: peerA's authorised client cert to peerB's federation endpoint over HTTPS → `200`.
+- POS2: a W=2 quorum write to peerA commits locally AND replicates to peerB (`201 quorum_met`, or `202` locally-durable if the ack lands late).
+- NEG1: an UNAUTHORISED peer (`client-bad`, not on the allowlist) is refused at peerB's TLS layer (connection cannot open).
+- NEG2: a PLAINTEXT peer (`http://` to the mTLS port) is refused.
+
+**Leg 3 — daemon→Postgres `sslmode=verify-full`** (`test-pg-verifyfull.sh`)
+- POS: `sslmode=verify-full` + `sslrootcert=ca.crt` against `host=localhost` (matches the cert SAN) CONNECTS with full server-cert verification.
+- NEG1: `sslmode=disable` (plaintext) is REFUSED — `pg_hba` is `hostssl`-only.
+- NEG2: `sslmode=verify-full` against `host=127.0.0.1` (NOT in the cert SAN) is REFUSED on the hostname check.
+- NEG3: `sslmode=verify-full` with an UNRELATED CA as `sslrootcert` is REFUSED on chain verification.
+
+**Attestation** (`test-attestation.sh`, #1751)
+- POS: a signed write (the `attest_sign` example envelope + the bound Ed25519 key) is accepted `201` and the stored row carries `metadata.attest_level = "agent_attested"`.
+- NEG: an UNSIGNED write is rejected `403` with code `ATTESTATION_FAILED`.
+
+**Federation write-signature cross-peer attestation** (`test-fed-write-sig-attestation.sh`, #1801→#1954 default-on flip; #1937 spawn-audit; #1947 FED-RQ-03)
+- POS: a SIGNED write authored as `ai:alice` on peerA federates to peerB and reaches `attest_level=agent_attested` at peerB (queried over peerB's HTTP API) — proves EMIT + cross-peer author enrollment + the strict flip together.
+- NEG: an UNSIGNED third-party relay (author `ai:mallory`, no key enrolled at peerB) is REFUSED at peerB's receiver (fail-closed) — the row never lands, peerB logs the write-sig WARN + DLQ cause `unenrolled_author_strict`.
+- AUD: the daemon emits SIGNED `process.spawn_audited` events (#1937), verified via `ai-memory verify-audit-trail` / a `signed_events` query.
+- POL: FED-RQ-03 (#1947) policy-current gate is default-ON and fail-closed for a DETECTED-stale peer while fail-OPEN for equal/absent policy (both nodes at `policy_seq=0`), so existing federation is not bricked.
+
+**Semantic recall** (`test-semantic-recall.sh`, caveat 2)
+- Stores three topically-distinct memories, then recalls with a PARAPHRASE sharing no salient keywords with the target; asserts the semantic hit ranks first and the response `mode` is `hybrid` (a real embedding vector component was produced). Optional `STORE_URL` points at the pgvector store to prove the real `<=>` operator path on the DO substrate. Uses the in-process MiniLM-L6-v2 (384-dim candle) embedder — no Ollama/nomic dependency.
+
+---
+
+## 3. Execution model
+
+**Local-first, then DO — one observable orchestration.**
+
+1. **Local (free) proves green.**
+   - Crypto legs: `infra/do-hive/crypto/run-all-local.sh` (regenerates certs, runs all six legs, non-zero exit if any leg fails).
+   - pg+AGE+pgvector + regression: bring up `infra/lan-parity-test/docker-compose.yml` (PG+AGE 1.6.0+pgvector container + 2 IronClaw daemons), then `infra/lan-parity-test/run-parity-tests.sh`.
+   - This entire local stage costs $0 (Docker on the local node + in-process MiniLM embedder).
+2. **DO re-hosts the identical config** for the parts local cannot prove: real federated multi-node reachability across droplets, and capacity (Track F) at cluster scale. The DO substrate (`infra/do-hive/`) is provisioned with the byte-identical AGE 1.6.0 pin and Grok 4.5 wiring so a result proven locally is proven on DO.
+3. **One observable orchestration.** Each phase writes a per-phase log under `.local-runs/`; teardown is trap-guarded (`infra/do-hive/teardown.sh` is idempotent; the crypto legs trap-clean their temp dirs). No synchronized-blast defaults; the DO hive is paced and money-gated (operator-triggered spend only).
+
+**Execution notes (surfaced findings, not deferrals):**
+- `run-parity-tests.sh` as shipped runs `cargo test --features sal,sal-postgres --release` WITHOUT `-- --include-ignored`, so the `#[ignore]`-marked postgres tests are NOT exercised by it. The cert run MUST additionally invoke the suite with `-- --include-ignored` (or extend the script) to cover those, and the run log records both invocations. This is a Track C coverage item to close during execution.
+- The DO substrate binary MUST be the #1882-fixed `sal-postgres` build; the memory droplet's `serve` unit only starts once such a binary is present (`infra/do-hive/cloud-init-memory.yaml.tpl`).
+
+---
+
+## 4. Certification gaps being closed (6)
+
+The campaign exists to close six concrete reproducibility / coverage gaps that
+stood between "CI is green" and "enterprise-certified":
+
+1. **Enrolled-federation happy-path never smoke-tested LIVE.** The mechanism to
+   auto-provision peer-key cross-enrollment now EXISTS at this tip
+   (`infra/lan-parity-test/docker-compose.yml` ships the one-shot
+   `ic-parity-peer-key-provisioner` service + `provision-peer-keys.sh`, #1803),
+   so a bare `docker compose up` yields a WORKING enrolled mesh — but the
+   enrolled happy-path had not been exercised end-to-end and recorded as cert
+   evidence. This campaign runs it LIVE (Track D) and captures the evidence.
+2. **P0-P11 playbook was memory-only.** The NHI dogfood playbook lived solely as
+   a stored memory (a reproducibility gap). It is now committed as the versioned
+   doc `docs/v1.0.0/nhi-playbook-P0-P11.md` (Track A).
+3. **AGE version was unpinned on DO.** `infra/do-hive/cloud-init-memory.yaml.tpl`
+   is pinned to the exact tag `release_PG16_1.6.0`, version-identical to
+   `infra/lan-parity-test/Dockerfile.pg-age-vector` (`apache/age:release_PG16_1.6.0`),
+   so DO and lan-parity run the same AGE build.
+4. **Chaos was a manual runbook.** Phase P11 (failure/chaos, fail-closed) is a
+   first-class track phase with concrete pass assertions rather than an ad-hoc
+   manual runbook.
+5. **Production embedder under-exercised over pgvector.** Track E's
+   `test-semantic-recall.sh` with `STORE_URL` set drives the real pgvector `<=>`
+   path; Track C exercises the sal-postgres embedding column end-to-end with the
+   #1882 dim-fix.
+6. **Unified cert-runner being built.** The local-first orchestration
+   (crypto `run-all-local.sh` + lan-parity `run-parity-tests.sh` + the P0-P11
+   playbook) is the seed of the single cert-runner; this PLAN is its
+   specification.
+
+---
+
+## 5. Prerequisites / open dependency
+
+- **IronClaw artifact (operator-provided).** Pinned to **v1.1.0** (`nearai/ironclaw`,
+  tag `ironclaw-v1.1.0`, released 2026-08-06). The previously-pinned
+  `github.com/alphaonedev/ironclaw` v0.28.1 URL is dead/unreachable and has been
+  replaced across the infra (`infra/do-hive/main.tf`, `infra/aws-gpu-burst/main.tf`,
+  and both agent cloud-init Descriptions). IronClaw 1.1.0 is the "Reborn" runtime,
+  a complete re-architecture: the obsolete v0.28.1 `--provider` / `--base-url` /
+  `--model` CLI flags do NOT exist in 1.1.0 (it is config-driven —
+  `ironclaw onboard` + `models set-provider` + `config set` secrets). The
+  DO agent cloud-init `ExecStart` invocation line is therefore left AS-IS for now;
+  the correct 1.1.0 Reborn-runtime invocation replaces the obsolete flags and is
+  being validated separately, wired in a follow-up commit. This is an
+  operator-provided dependency (an authorized, public test-driver artifact), NOT a
+  shirked task.
+
+---
+
+## 6. Verdict gate
+
+The campaign mints **SHIP** only when every track (A-F + E2E) is GREEN under the
+LOCKED config, every crypto leg's pos + neg assertions hold, the DO re-host
+reproduces the local green, and every finding surfaced during execution is
+filed + fixed + retested (per the repo prime directive — no deferrals, no
+surface-level dismissals). Any track RED, or any negative-assertion that is NOT
+refused, blocks the verdict.

--- a/infra/aws-gpu-burst/cloud-init-agent.yaml.tpl
+++ b/infra/aws-gpu-burst/cloud-init-agent.yaml.tpl
@@ -12,7 +12,7 @@ write_files:
     permissions: '0644'
     content: |
       [Unit]
-      Description=IronClaw v0.28.1 agent #${agent_index} (Track E2 burst)
+      Description=IronClaw v1.1.0 agent #${agent_index} (Track E2 burst)
       After=network-online.target
       Wants=network-online.target
 

--- a/infra/aws-gpu-burst/main.tf
+++ b/infra/aws-gpu-burst/main.tf
@@ -89,9 +89,9 @@ variable "ai_memory_image_url" {
 }
 
 variable "ironclaw_image_url" {
-  description = "URL to the IronClaw v0.28.1 runner tarball."
+  description = "URL to the IronClaw v1.1.0 runner tarball."
   type        = string
-  default     = "https://github.com/alphaonedev/ironclaw/releases/download/v0.28.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
+  default     = "https://github.com/nearai/ironclaw/releases/download/ironclaw-v1.1.0/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/do-hive/cloud-init-agent.yaml.tpl
+++ b/infra/do-hive/cloud-init-agent.yaml.tpl
@@ -11,7 +11,7 @@ write_files:
     permissions: '0644'
     content: |
       [Unit]
-      Description=IronClaw v0.29.1 agent #${agent_index} (Track E1 hive)
+      Description=IronClaw v1.1.0 agent #${agent_index} (Track E1 hive)
       After=network-online.target
       Wants=network-online.target
 

--- a/infra/do-hive/cloud-init-memory.yaml.tpl
+++ b/infra/do-hive/cloud-init-memory.yaml.tpl
@@ -75,12 +75,16 @@ write_files:
       fi
 
       # --- build + install Apache AGE from source against pg16 ---
-      # AGE is source-only. master supports PG16; pin the PG16 release branch.
+      # AGE is source-only. Pin the EXACT release tag release_PG16_1.6.0 so the
+      # DO substrate is version-identical to infra/lan-parity-test/Dockerfile.pg-age-vector
+      # (FROM apache/age:release_PG16_1.6.0). An unpinned branch (PG16/master) can
+      # drift the AGE version between the free local parity run and the paid DO
+      # run, so a cert result proven locally would not be proven on DO.
       if [ ! -f "$(/usr/bin/pg_config --pkglibdir)/age.so" ]; then
         rm -rf /opt/age-src
         git clone https://github.com/apache/age.git /opt/age-src
         cd /opt/age-src
-        git checkout PG16 || git checkout master
+        git checkout release_PG16_1.6.0
         make PG_CONFIG=/usr/bin/pg_config
         make install PG_CONFIG=/usr/bin/pg_config
       fi

--- a/infra/do-hive/main.tf
+++ b/infra/do-hive/main.tf
@@ -139,9 +139,9 @@ variable "ai_memory_image_url" {
 }
 
 variable "ironclaw_image_url" {
-  description = "URL to the IronClaw v0.29.1 runner tarball."
+  description = "URL to the IronClaw v1.1.0 runner tarball."
   type        = string
-  default     = "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.29.1/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
+  default     = "https://github.com/nearai/ironclaw/releases/download/ironclaw-v1.1.0/ironclaw-x86_64-unknown-linux-gnu.tar.gz"
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/lan-parity-test/docker-compose.yml
+++ b/infra/lan-parity-test/docker-compose.yml
@@ -138,27 +138,27 @@ services:
       # single-host Docker network used for parity/chaos testing only. Do NOT
       # copy this line into a deployment whose peers cross a real network.
       AI_MEMORY_FED_ALLOW_PLAINTEXT_PEERS: "1"
-      # Operator directive 2026-05-31 (supersedes 2026-05-21 #1067 xAI
-      # Grok 4.3 wiring): IronClaw containers run with OpenRouter
-      # google/gemma-4-26b-a4b-it as the AI NHI brain. Cost+context
-      # rationale: $0.06/M-in + $0.33/M-out (vs $3 + $15 on xAI Grok 4.3,
-      # a 50-95× cost reduction); 262144-token context; 26B sparse-MoE
-      # quality is materially stronger than local 8B gemma4:e4b for
-      # long-context atomise/reflect/calibrate paths. Connectivity
-      # verified 2026-05-31 ~11:23 ET (HTTP 200, 2.2s latency).
+      # Enterprise-cert campaign 2026-08-08 (supersedes the 2026-05-31
+      # OpenRouter Gemma 4 26B cost-optimization for THIS certified
+      # enterprise-federated round): IronClaw containers run Grok 4.5 via
+      # OpenRouter (`x-ai/grok-4.5`) as the AI NHI brain, matching the DO
+      # substrate (infra/do-hive/cloud-init-agent.yaml.tpl runs the xAI-direct
+      # `grok-4.5` model) so the free local lan-parity run and the paid DO run
+      # exercise the SAME model family. Only the model id changes here; the
+      # OpenRouter backend selection is unchanged. Operators who want the prior
+      # cost-optimized Gemma brain override via env
+      # (`AI_MEMORY_LLM_MODEL=google/gemma-4-26b-a4b-it`).
       # `OPENROUTER_API_KEY` comes from `~/.env` on this node;
       # `:?` syntax fails compose with a clear error if the shell env
       # hasn't sourced ~/.env first. Production operators run:
       #   set -a; source ~/.env; set +a
       #   docker compose -f infra/lan-parity-test/docker-compose.yml up -d
       AI_MEMORY_LLM_BACKEND: "openrouter"
-      AI_MEMORY_LLM_MODEL: "${AI_MEMORY_LLM_MODEL:-google/gemma-4-26b-a4b-it}"
-      # auto_tag historically used a separate fast/cheap model
-      # (gemma3:4b on Ollama, then grok-4.3 mini on xAI). On OpenRouter
-      # the same paid Gemma 4 26B model is cheap enough to use uniformly;
-      # operators with extreme cost concerns can override via env to
-      # google/gemma-4-26b-a4b-it:free (rate-limited) or any other model.
-      AI_MEMORY_AUTO_TAG_MODEL: "${AI_MEMORY_AUTO_TAG_MODEL:-google/gemma-4-26b-a4b-it}"
+      AI_MEMORY_LLM_MODEL: "${AI_MEMORY_LLM_MODEL:-x-ai/grok-4.5}"
+      # auto_tag reuses the same paid Grok 4.5 model uniformly; operators with
+      # extreme cost concerns can override via env to a cheaper OpenRouter model
+      # (e.g. google/gemma-4-26b-a4b-it) or any other model.
+      AI_MEMORY_AUTO_TAG_MODEL: "${AI_MEMORY_AUTO_TAG_MODEL:-x-ai/grok-4.5}"
       # Kept for backward compat with anything that still reads OLLAMA_BASE_URL
       # directly (e.g., tier-default fallback when AI_MEMORY_LLM_BACKEND unset
       # in some future config path). Harmless when AI_MEMORY_LLM_BACKEND=openrouter.
@@ -224,11 +224,12 @@ services:
       # single-host Docker network used for parity/chaos testing only. Do NOT
       # copy this line into a deployment whose peers cross a real network.
       AI_MEMORY_FED_ALLOW_PLAINTEXT_PEERS: "1"
-      # See alice's block for the 2026-05-31 OpenRouter Gemma 4 26B
-      # rationale (supersedes the #1067 xAI Grok 4.3 wiring).
+      # See alice's block for the 2026-08-08 enterprise-cert Grok 4.5
+      # rationale (`x-ai/grok-4.5` via OpenRouter; supersedes the
+      # 2026-05-31 Gemma 4 26B cost-optimization for this cert round).
       AI_MEMORY_LLM_BACKEND: "openrouter"
-      AI_MEMORY_LLM_MODEL: "${AI_MEMORY_LLM_MODEL:-google/gemma-4-26b-a4b-it}"
-      AI_MEMORY_AUTO_TAG_MODEL: "${AI_MEMORY_AUTO_TAG_MODEL:-google/gemma-4-26b-a4b-it}"
+      AI_MEMORY_LLM_MODEL: "${AI_MEMORY_LLM_MODEL:-x-ai/grok-4.5}"
+      AI_MEMORY_AUTO_TAG_MODEL: "${AI_MEMORY_AUTO_TAG_MODEL:-x-ai/grok-4.5}"
       OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://host.docker.internal:11434}"
       OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY must be set in shell env — source ~/.env before running docker compose up}"
       AI_MEMORY_API_KEY: "${AI_MEMORY_API_KEY:-${OPENROUTER_API_KEY}}"


### PR DESCRIPTION
Versioned documentation + infra-config pins for the ai-memory v1.0.0 enterprise-certification test campaign (docs + infra-config only; zero src/ behavior change). Base SHA `715cb38f`.

## What landed

**Docs (new, versioned):**
- `docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/PLAN.md` — the LOCKED campaign: config, Tracks A-F + E2E with concrete pass criteria grounded in the existing harness (Track C = `infra/lan-parity-test/run-parity-tests.sh`; Track E = the 6 scripts in `infra/do-hive/crypto/` with exact per-leg pos/neg assertions), local-first then DO re-host execution model, the 6 cert gaps being closed, and the IronClaw v1.1.0 operator-provided dependency.
- `docs/v1.0.0/nhi-playbook-P0-P11.md` — the P0-P11 NHI dogfood playbook as a reproducible versioned doc (previously memory-only), each phase carrying what it verifies + a concrete pass assertion + the repo test/tool that exercises it, plus the SHIP / FIX-FIRST / HOLD verdict rubric.

**Infra-config pins:**
- `infra/do-hive/cloud-init-memory.yaml.tpl` — pin Apache AGE to tag `release_PG16_1.6.0` (was an unpinned `PG16`/`master` branch checkout), version-identical to `infra/lan-parity-test/Dockerfile.pg-age-vector`.
- `infra/lan-parity-test/docker-compose.yml` — ai-memory daemon LLM model -> Grok 4.5 via OpenRouter (`x-ai/grok-4.5`) for both `ic-parity` daemons; backend selection unchanged.
- `infra/do-hive/main.tf` + `infra/aws-gpu-burst/main.tf` — `ironclaw_image_url` -> `nearai/ironclaw` v1.1.0 (dead `alphaonedev` v0.28.1 replaced; value-only edits, no terraform-fmt churn).
- both `cloud-init-agent.yaml.tpl` systemd Descriptions -> `IronClaw v1.1.0 agent`.

The DO agent `ExecStart` `ironclaw --provider/--model` line is intentionally left as-is: IronClaw 1.1.0 ("Reborn") is config-driven and those flags no longer exist; the correct 1.1.0 invocation is validated separately and wired in a follow-up commit.

## Truthfulness note
The campaign brief cited "schema v81"; the live `CURRENT_SCHEMA_VERSION` SSOT at the cert tip `715cb38f` is **v88**. Per correct-and-maximally-truthful discipline the docs use the live SSOT surface (v88, 103 tools at `--profile full`, capabilities `schema_version` "3", 30 `Memory` fields, 9 link relations, 22 `HookEvent` variants). A real finding is recorded in PLAN.md rather than deferred: `run-parity-tests.sh` does not pass `-- --include-ignored`, so the ignore-gated postgres tests need a second invocation to be covered.

## Gates
- `scripts/check-cloud-init-ascii.sh` — PASS (the `.tpl` edits are pure ASCII).
- `scripts/check-docs-vs-ssot.sh` — PASS (no drifting counts; SSOT values used).
- `docker-compose.yml` parses (`yaml.safe_load`).

Both commits are SSH-signed (`%G?` == `G`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY