### PR TITLE
infra(lan-parity): serialize sal-postgres parity run + cover #[ignore] live-pg tests (#2784)

### DIFF
--- a/infra/lan-parity-test/run-parity-tests.sh
+++ b/infra/lan-parity-test/run-parity-tests.sh
@@ -6,6 +6,21 @@
 # LAN-parity PG+AGE container exposed on 127.0.0.1:15432. Captures the
 # full log under .local-runs/ for ship-gate audit trail.
 #
+# WHY `-- --test-threads=1` IS MANDATORY (do not remove):
+#   The sal-postgres suite shares ONE `ai_memory_test` database with NO
+#   per-test schema isolation (see CLAUDE.md §"Local coverage"). Running
+#   it WITHOUT serialising threads lets two postgres-backed tests grab the
+#   same advisory-lock key (`SELECT pg_advisory_lock($1)`) and DEADLOCK on
+#   shared Postgres locks. This actually happened during the v1.0.0 cert
+#   campaign: a parallel run wedged after 7007 passing tests, with a stack
+#   of sessions blocked on `pg_advisory_lock` (the oldest stuck 6h27m),
+#   until the run had to be killed. Serialising with `--test-threads=1`
+#   is the same posture CI's coverage.yml already uses.
+#
+# The suite runs in TWO serialized passes: the default pass, then a second
+# pass with `--include-ignored` so the `#[ignore]`-gated live-pg tests are
+# exercised too. The script exits non-zero if EITHER pass fails.
+#
 # Pre-flight:
 #   docker compose -f infra/lan-parity-test/docker-compose.yml up -d pg-age
 #   (wait for pg-age healthcheck → healthy)
@@ -32,12 +47,34 @@ PGPASSWORD=ai_memory_test psql -h 127.0.0.1 -p 15432 -U ai_memory -d ai_memory_t
 echo "[lan-parity] PG+AGE reachable. Running cargo SAL-postgres tests..."
 echo ""
 
+# Pass 1 — default suite, serialized (--test-threads=1 mandatory; see header).
+echo "[lan-parity] Pass 1/2: default suite (serialized)..."
 AI_MEMORY_TEST_POSTGRES_URL="$PG_URL" \
 AI_MEMORY_NO_CONFIG=1 \
-cargo test --features sal,sal-postgres --release 2>&1 | tee "$LOG"
-
-EXIT=${PIPESTATUS[0]}
+cargo test --features sal,sal-postgres --release -- --test-threads=1 2>&1 | tee "$LOG"
+EXIT_DEFAULT=${PIPESTATUS[0]}
 echo ""
-echo "[lan-parity] cargo exit code: $EXIT"
+echo "[lan-parity] Pass 1/2 cargo exit code: $EXIT_DEFAULT"
+
+# Pass 2 — #[ignore]-gated live-pg tests, serialized. Appended to the same log.
+echo ""
+echo "[lan-parity] Pass 2/2: #[ignore]-gated live-pg tests (serialized)..."
+AI_MEMORY_TEST_POSTGRES_URL="$PG_URL" \
+AI_MEMORY_NO_CONFIG=1 \
+cargo test --features sal,sal-postgres --release -- --include-ignored --test-threads=1 2>&1 | tee -a "$LOG"
+EXIT_IGNORED=${PIPESTATUS[0]}
+echo ""
+echo "[lan-parity] Pass 2/2 cargo exit code: $EXIT_IGNORED"
+
+# Propagate failure from EITHER pass (non-zero if either did not pass).
+EXIT=0
+if [ "$EXIT_DEFAULT" -ne 0 ]; then
+    EXIT="$EXIT_DEFAULT"
+elif [ "$EXIT_IGNORED" -ne 0 ]; then
+    EXIT="$EXIT_IGNORED"
+fi
+
+echo ""
+echo "[lan-parity] Overall exit code: $EXIT (default=$EXIT_DEFAULT, ignored=$EXIT_IGNORED)"
 echo "[lan-parity] Log preserved at: $LOG"
 exit "$EXIT"


### PR DESCRIPTION
## Summary
Test-infra fix: `infra/lan-parity-test/run-parity-tests.sh` ran the sal-postgres suite WITHOUT `-- --test-threads=1`. That suite shares ONE `ai_memory_test` DB with no per-test schema isolation (CLAUDE.md §"Local coverage"), so parallel test threads grab the same `pg_advisory_lock` key and DEADLOCK. During the v1.0.0 enterprise-cert campaign this wedged a full run after 7007 passing tests — `pg_stat_activity` showed 14 sessions stacked on `SELECT pg_advisory_lock($1)`, the oldest stuck 6h27m — until the run had to be killed.

## Changes (`infra/lan-parity-test/run-parity-tests.sh` only)
- Append `-- --test-threads=1` to serialize the run (matches CI's `coverage.yml`).
- Add a SECOND serialized pass `-- --include-ignored --test-threads=1` so the `#[ignore]`-gated live-pg tests are exercised (the second gap noted in `docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/PLAN.md` §3).
- Preserve the PG-reachability preflight + log-capture/tee; propagate failure from EITHER pass (script exits non-zero if either fails).
- Header comment now records WHY `--test-threads=1` is mandatory (shared-DB advisory-lock deadlock).

No `src/` change, no cargo build required. `bash -n` passes.

## AI involvement
Authored by Claude Opus 5 (light-tier coder) under operator authorization. Test-infra/mechanical scope. SSH-signed commit (`%G?` = `G`).

Fixes #2784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
