### PR TITLE
test(crypto): boot test-attestation.sh at tier=keyword to kill the semantic-boot health-poll race

### DIFF
--- a/infra/do-hive/crypto/test-attestation.sh
+++ b/infra/do-hive/crypto/test-attestation.sh
@@ -41,13 +41,29 @@ AI_MEMORY_NO_CONFIG=1 "$BIN" agents bind-key --agent-id "$AGENT" --pubkey "$PUB"
 echo "INFO: bound pubkey $PUB for $AGENT"
 
 # --- 2. launch daemon: HTTPS + mTLS + attestation REQUIRED --------------------
-AI_MEMORY_NO_CONFIG=1 AI_MEMORY_REQUIRE_AGENT_ATTESTATION=1 \
+# Attestation is tier-independent — it needs NO embedder. Boot the daemon at
+# tier=keyword via an ISOLATED XDG config so a fresh host with no MiniLM cache
+# neither logs EMBEDDER LOAD FAILED nor pays a semantic-tier boot delay that
+# RACES the health-poll window. Historically this leg booted the compiled-default
+# tier=semantic (AI_MEMORY_NO_CONFIG=1; serve has NO --tier flag — tier resolves
+# from config.toml only), whose MiniLM-at-boot load exceeded the poll window under
+# machine load, so every subsequent request returned HTTP 000 and the POS/NEG
+# assertions failed spuriously (KNOWN-DO-STAGING.md §2 boot-race — failed 0/2 with
+# got-000 under load, passed 2/2 isolated). Fix mirrors the sibling
+# test-fed-write-sig-attestation.sh: drop AI_MEMORY_NO_CONFIG on the serve line and
+# point XDG_CONFIG_HOME/HOME at an isolated tier=keyword config (same isolation
+# NO_CONFIG gives the offline CLI ops above, but WITH a tier override).
+CFG="$WORK/xdg"; mkdir -p "$CFG/ai-memory"
+printf 'schema_version = 2\ntier = "keyword"\n' > "$CFG/ai-memory/config.toml"
+XDG_CONFIG_HOME="$CFG" HOME="$WORK" AI_MEMORY_REQUIRE_AGENT_ATTESTATION=1 \
 "$BIN" serve --host 127.0.0.1 --port "$PORT" --db "$DB" \
   --tls-cert "$OUT/server.crt" --tls-key "$OUT/server.key" \
   --mtls-allowlist "$OUT/allowlist.txt" >"$LOG" 2>&1 &
 DPID=$!
 CC=(--cert "$OUT/client-good.crt" --key "$OUT/client-good.key")
-for i in $(seq 1 40); do
+# Belt-and-suspenders: a 60 s poll window (matching the sibling leg) on top of the
+# real fix, so a heavily-loaded host still clears the fast keyword-tier boot.
+for i in $(seq 1 120); do
   curl -sk "${CC[@]}" "https://127.0.0.1:$PORT/api/v1/health" -o /dev/null && break; sleep 0.5; done
 BASE="https://127.0.0.1:$PORT/api/v1"
 


### PR DESCRIPTION
## Summary

Fixes a test-harness boot-race in `infra/do-hive/crypto/test-attestation.sh`. The leg booted its `ai-memory serve` daemon at the compiled-DEFAULT `tier=semantic` (`AI_MEMORY_NO_CONFIG=1`; `serve` has **no** `--tier` flag — tier resolves from `config.toml` only), loading the MiniLM embedder **at boot**. On a loaded host that boot exceeded the 20 s health-poll window (`seq 1 40; sleep 0.5`), the poll gave up, and every subsequent request returned HTTP `000` → the POS (201) and NEG (403) assertions both failed spuriously.

This is a boot-race in the harness, **not** a product/attestation defect — the same class documented in `KNOWN-DO-STAGING.md` §2, already solved for the sibling `test-fed-write-sig-attestation.sh`.

## Fix

Mirror the sibling leg: boot the daemon at `tier=keyword` via an isolated `XDG_CONFIG_HOME` config so **no embedder is loaded** and boot is fast (attestation is tier-independent). Drop `AI_MEMORY_NO_CONFIG` on the `serve` line so the isolated `config.toml` (`schema_version = 2` + `tier = "keyword"`) is read; keep TLS + mTLS (`--tls-cert`/`--tls-key`/`--mtls-allowlist`) and the SAME pos/neg assertions (signed→201 `agent_attested`, unsigned→403 `ATTESTATION_FAILED`). Belt-and-suspenders bump the poll to a 60 s bound.

**No assertion weakened. Test-infra only** — bash script under `infra/do-hive/crypto/`; no `src/` change, no product behavior change.

## Verification

- `bash -n infra/do-hive/crypto/test-attestation.sh` — clean.
- Isolated run (`BIN=…/measure-wt/target/release/ai-memory`, `SIGNER=…/examples/attest_sign`):

```
PASS: attest POS: signed write accepted 201 (id=457e7b2f-…)
PASS: attest NEG: unsigned write rejected 403 ATTESTATION_FAILED
----
attestation summary: 2 PASS / 0 FAIL
===EXIT 0===
```

## AI involvement

Authored by Claude (Opus 5 easy-tier coder) under operator authority for the v1.0.0 loop. Root-cause + fix pattern taken directly from the sibling `test-fed-write-sig-attestation.sh` isolated-config idiom and `KNOWN-DO-STAGING.md` §2.

Fixes #2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
