### PR TITLE
fix(pg): recall_hybrid author-filter parity + isolation-safe live-pg parity tests (7 cert tests)

### DIFF
--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -19421,7 +19421,17 @@ impl MemoryStore for PostgresStore {
         .bind(filter.namespace.as_ref())
         .bind(filter.tier.as_ref().map(Tier::as_str))
         .bind(tags_first)
-        .bind(filter.agent_id.as_ref().or(ctx.as_agent.as_ref()))
+        // #1720 A7 PARITY: the `$5` author filter binds ONLY the explicit
+        // `filter.agent_id` — never `ctx.as_agent`. `as_agent` is the
+        // impersonation / visibility principal (it feeds `$9` = `caller_opt`
+        // for the scope=private + target_agent_id carve-out), NOT an author
+        // restriction. Folding it into the author filter here diverged from
+        // both `PostgresStore::search` (which binds `filter.agent_id` only)
+        // and every sqlite recall path (which passes the author filter as
+        // `None` and threads `as_agent` only into the visibility clause) —
+        // silently dropping rows the caller may legitimately see (e.g. an
+        // inbox row authored by another agent but `target_agent_id`=caller).
+        .bind(filter.agent_id.as_ref())
         .bind(filter.since)
         .bind(filter.until)
         .bind(fts_pool)
@@ -19512,7 +19522,10 @@ impl MemoryStore for PostgresStore {
             .bind(filter.namespace.as_ref())
             .bind(filter.tier.as_ref().map(Tier::as_str))
             .bind(tags_first)
-            .bind(filter.agent_id.as_ref().or(ctx.as_agent.as_ref()))
+            // #1720 A7 PARITY (semantic pool): bind ONLY the explicit author
+            // filter here; `ctx.as_agent` drives visibility via `$9`, never
+            // authorship. See the matching comment on the FTS pool bind above.
+            .bind(filter.agent_id.as_ref())
             .bind(filter.since)
             .bind(filter.until)
             .bind(ann_pool)

--- a/tests/append_only_spine_flagon_g6.rs
+++ b/tests/append_only_spine_flagon_g6.rs
@@ -791,7 +791,13 @@ mod postgres_twins {
             return;
         };
         ai_memory::config::set_append_only(true);
-        let ctx = CallerContext::for_agent("g6-flagon");
+        // The pg trait `update` enforces the #1412/#1628 caller-owns gate:
+        // `metadata->>'agent_id'` (the owner stamped at store time from
+        // `sample()`, i.e. "ai:g6-flagon") must equal `ctx.effective_principal()`.
+        // The caller principal MUST therefore match the stamped owner, or the
+        // update is correctly refused with `PermissionDenied` (a real security
+        // control, NOT a bug). `sample()` stamps `metadata.agent_id="ai:g6-flagon"`.
+        let ctx = CallerContext::for_agent("ai:g6-flagon");
         let id = uuid::Uuid::new_v4().to_string();
         let mem = sample(&id, "ns-pg-put", "pg-v1");
         MemoryStore::store(&pg, &ctx, &mem)

--- a/tests/audit_cause_binding_1822.rs
+++ b/tests/audit_cause_binding_1822.rs
@@ -328,6 +328,17 @@ mod postgres_parity {
         let ts = chrono::Utc::now();
         let cause = compute_cause_hash(&agent, "memory.reclassified", &id, "pg|obs|decision");
 
+        // ISOLATION-SAFETY: `signed_events.sequence` carries a UNIQUE index and
+        // the shared postgres DB accumulates real audit rows from every other
+        // test in the suite (the nightly runs the whole `sal-postgres` suite
+        // serially against ONE DB), so a hardcoded `sequence = 1` collides.
+        // Compute the next free sequence from the live head instead.
+        let base_seq: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(sequence), 0) FROM signed_events")
+                .fetch_one(pg.pool())
+                .await
+                .expect("read signed_events head");
+
         // INSERT a cause-bearing row directly (no pg writer binds a cause
         // in G5a — this exercises the COLUMN round-trip + shared fold).
         sqlx::query(
@@ -344,7 +355,7 @@ mod postgres_parity {
         .bind("unsigned")
         .bind(ts)
         .bind(ZERO_HASH.to_vec())
-        .bind(1_i64)
+        .bind(base_seq + 1)
         .bind(&cause)
         .execute(pg.pool())
         .await

--- a/tests/audit_witness_truncation_1822.rs
+++ b/tests/audit_witness_truncation_1822.rs
@@ -640,6 +640,14 @@ mod postgres_parity {
         let id = uuid::Uuid::new_v4().to_string();
         let agent = format!("ai:1822-{}", uuid::Uuid::new_v4());
         let ts = chrono::Utc::now();
+        // ISOLATION-SAFETY: `sequence` is UNIQUE and the shared postgres DB
+        // accumulates audit rows across the whole suite, so a hardcoded
+        // `sequence = 1` collides. Compute the next free sequence from the head.
+        let base_seq: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(sequence), 0) FROM signed_events")
+                .fetch_one(pg.pool())
+                .await
+                .expect("read signed_events head");
         sqlx::query(
             "INSERT INTO signed_events \
                 (id, agent_id, event_type, payload_hash, signature, attest_level, timestamp, \
@@ -654,7 +662,7 @@ mod postgres_parity {
         .bind("unsigned")
         .bind(ts)
         .bind(ai_memory::signed_events::ZERO_HASH.to_vec())
-        .bind(1_i64)
+        .bind(base_seq + 1)
         .bind(Option::<Vec<u8>>::None)
         .execute(pg.pool())
         .await

--- a/tests/expiry_canonical_ingress_2418.rs
+++ b/tests/expiry_canonical_ingress_2418.rs
@@ -390,6 +390,13 @@ async fn postgres_expiry_parity_2418() {
         "2027-03-01T21:00:00+09:00",
     ];
     let canonical = canonicalize_valid_time(spellings[0]).expect("canonical");
+    // The pg store fail-CLOSES on a malformed transaction-time stamp
+    // (`parse_rfc3339_required(&memory.created_at)` — the North-Star
+    // "never store corrupt data" posture); `Memory::default()` leaves
+    // created_at / updated_at EMPTY, which is not valid RFC3339. Stamp
+    // them so the fixture exercises the `expires_at` canonicalization it
+    // means to test, not the empty-timestamp reject path.
+    let now = chrono::Utc::now().to_rfc3339();
     for (i, spelling) in spellings.iter().enumerate() {
         let id = format!("canon-parity-pg-{i}");
         let mem = Memory {
@@ -398,6 +405,8 @@ async fn postgres_expiry_parity_2418() {
             title: format!("parity-{i}"),
             content: "parity body".to_string(),
             tier: Tier::Mid,
+            created_at: now.clone(),
+            updated_at: now.clone(),
             expires_at: Some((*spelling).to_string()),
             ..Memory::default()
         };

--- a/tests/role_separation_1826.rs
+++ b/tests/role_separation_1826.rs
@@ -636,6 +636,14 @@ mod postgres_parity {
         let agent = format!("ai:1826-{}", uuid::Uuid::new_v4());
         let ph = payload_hash(b"pg-forged");
         let ts = chrono::Utc::now();
+        // ISOLATION-SAFETY: `sequence` is UNIQUE and the shared postgres DB
+        // accumulates audit rows across the whole suite, so a hardcoded
+        // `sequence = 1` collides. Compute the next free sequence from the head.
+        let base_seq: i64 =
+            sqlx::query_scalar("SELECT COALESCE(MAX(sequence), 0) FROM signed_events")
+                .fetch_one(pg.pool())
+                .await
+                .expect("read signed_events head");
         sqlx::query(
             "INSERT INTO signed_events \
                 (id, agent_id, event_type, payload_hash, signature, attest_level, timestamp, \
@@ -650,7 +658,7 @@ mod postgres_parity {
         .bind("recorder_signed")
         .bind(ts)
         .bind(ai_memory::signed_events::ZERO_HASH.to_vec())
-        .bind(1_i64)
+        .bind(base_seq + 1)
         .bind(Option::<Vec<u8>>::None)
         .execute(pg.pool())
         .await


### PR DESCRIPTION
## What

Root-causes and fixes the 7 `#[ignore]` live-Postgres parity tests that fail on the shared postgres DB, for the v1.0.0 enterprise cert. One is a real PRODUCT bug on the postgres recall path; the other six are test-side (owner/fixture bugs + hardcoded-sequence isolation collisions).

Closes #2789
Closes #2790

## Per-test determination table

| # | Test (file) | Class | Root cause | Fix |
|---|---|---|---|---|
| 1 | `pg_content_update_writes_one_supersede_leaf` (`append_only_spine_flagon_g6.rs`) | TEST bug | `sample()` stamps owner `ai:g6-flagon` but caller is `for_agent("g6-flagon")`; the pg #1412/#1628 owner gate correctly refuses `update` with `PermissionDenied`. | caller → `for_agent("ai:g6-flagon")` |
| 2 | `cause_hash_column_round_trips_and_fold_is_identical` (`audit_cause_binding_1822.rs`) | TEST-ISOLATION | hardcoded `signed_events.sequence = 1` (UNIQUE) collides on the shared DB | `MAX(sequence)+1` |
| 3 | `pg_head_hash_clean_chain_not_detected_and_rewrite_mismatch` (`audit_witness_truncation_1822.rs`) | TEST-ISOLATION | `verify_audit_trail(None)` asserts global-chain cleanliness; polluted by the sibling collisions | self-heals once siblings insert cleanly (no code change; verified serial fresh-DB) |
| 4 | `pg_verify_audit_trail_surfaces_witness_and_cause_verdicts` (`audit_witness_truncation_1822.rs`) | TEST-ISOLATION | hardcoded `sequence = 1` | `MAX(sequence)+1` |
| 5 | `postgres_expiry_parity_2418` (`expiry_canonical_ingress_2418.rs`) | TEST bug | `Memory::default()` empty `created_at`/`updated_at`; pg `store` fail-CLOSES on a malformed RFC3339 stamp (North-Star posture; sqlite tolerant) | stamp valid `created_at`/`updated_at` |
| 6 | `backend_parity_role_separation` (`role_separation_1826.rs`) | TEST-ISOLATION | hardcoded `sequence = 1` | `MAX(sequence)+1` |
| 7 | `pg_parity_private_leak_and_bypass_a7_1720` (`store_parity_gaps.rs`) | **PRODUCT bug (postgres)** | `recall_hybrid` bound the `$5` author filter to `filter.agent_id.or(ctx.as_agent)`, conflating impersonation principal with authorship; dropped rows visible to the caller (inbox `target_agent_id=caller`); diverged from pg `search` + sqlite recall | bind `$5` = `filter.agent_id` only (both FTS + semantic pools) — the test itself was already correct |

## The product bug (#7 / #2789)

`src/store/postgres.rs::PostgresStore::recall_hybrid` used `ctx.as_agent` (the impersonation / visibility principal, which correctly powers the `$9` scope=private + `target_agent_id` carve-out) ALSO as a fallback for the `$5` SQL author predicate. That silently restricted recall to self-authored rows whenever `as_agent` was set, breaking the #1720 inbox carve-out. Fails **closed** (fewer results, never a leak). Not reachable via the HTTP recall handler today (it uses `for_agent(...)`, leaving `ctx.as_agent = None`), but a real parity/correctness defect that a live-pg parity test correctly caught.

## Evidence

- All 7 pass on a **genuinely volume-wiped** DB, run serially (`--test-threads=1`).
- The three sequence tests pass against a DB pre-seeded with a `sequence = 1` row (the original collision condition).
- sqlite/default suites of every touched file (66 tests) + the sqlite A7 twin (`sqlite_admin_bypass_visibility_a7_1720`) + the four pg recall-visibility parity files (`cov_postgres_core`, `claim_bitemporal_1834_pg`, `scope_private_sal_level_visibility`, `visibility_private_leak_1720`) stay green.
- `clippy --release --all-targets --features sal,sal-postgres -- -D warnings -D clippy::all -D clippy::pedantic`: 0 warnings. `fmt --check`: clean. `qual_10_module_size_ceiling`: green. My changes are entirely `sal-postgres`-gated, so the default/sal/vectorlite legs compile identically to origin.

## Environment gotcha (verified, documented)

The reset command `docker compose rm -sf pg-age && up -d pg-age` recreates only the CONTAINER; the compose uses a named volume `pg-age-data`, so DB rows survive "resets" and accumulate. A true wipe needs `docker compose down -v` / `docker volume rm ai-memory-lan-parity_pg-age-data`. This is why the failures appeared to reproduce "on a fresh DB" — the volume was never fresh.

## postgres-parity-nightly

These 7 tests are NOT in the nightly's current binary set (`secret_screen_postgres_parity_g29`, `postgres_l2_rehydration_1693`, `erasure_fanout_postgres_g30`, `recall_purity_p01_postgres`), and the required PR `postgres-feature` job runs without `--ignored`, so no CI job runs them today — exactly why they failed unnoticed. This PR does NOT by itself flip the nightly green (the nightly is red for its own reasons in its own set). Wiring these fixed binaries into the nightly is recommended in #2790 and should be done only after auditing every `#[ignore]` test in those binaries for shared-DB isolation-safety.

## AI involvement

Authored by Claude Opus 5 (hard-coder). Root-cause + fixes + all validation runs performed against the live PG16 + AGE + pgvector parity stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
