### PR TITLE
test(pg): claims-parity anti-regression gate + router-mirror completeness (Phase-1 PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (Phase-1 pg-parity remediation — claims-parity anti-regression gate; vote `4d3ea1c5`)
+
+- **`tests/pg_supported_route_inventory_gate_2799.rs`** — the durable
+  control the v1.0 pg-parity remediation (Option B+) mandated. The
+  postgres surface allow-list (`postgres_endpoint_supported`) is
+  hand-maintained; when it silently lags the router, an un-migrated
+  handler can 501-vs-corrupt (a route opened onto the empty scratch
+  sqlite reads/writes the WRONG DB on a pg daemon). The gate (a)
+  freezes the allow-list membership at SOURCE level (the exact
+  route-const + path-matcher set), (b) pins the AUTHORITATIVE
+  pg-supported inventory — **59 of 80 unique production paths are
+  pg-supported; 21 are fully fail-closed 501** (the register's "56" and
+  the audit's "73" were both wrong) — and the exact fully-501 list, and
+  (c) asserts every pg-supported path is a registered route. Any future
+  allow-list/router edit now forces a reviewed inventory update +
+  proof-of-dispatch, closing the omission class that produced these 501s.
+
+### Fixed (router-mirror completeness — `path_is_registered_route`)
+
+- `path_is_registered_route` was missing three registered + pg-supported
+  routes (`POST /api/v1/signals` #1718, `POST /api/v1/actions/{id}/transition`
+  #1718, `POST /api/v1/checkpoints/{id}/resolve` #2391) and the
+  `POST /api/v1/skill/{id}/retire` arm — a latent 404-vs-501
+  wire-truthfulness drift (masked because a pg-supported route never
+  reaches that branch). Surfaced by the anti-regression gate above and
+  reconciled so the router mirror is complete.
+
 <!-- wave-2 GA cert (#2705): entries restored after conflict-free batch merge (#2768/#2770/#2774) -->
 <!-- PR #2768 (fix/2758-unfired-governance-hooks) -->
 <!-- #2758 (fix/2758-unfired-governance-hooks) -->

--- a/src/handlers/postgres_gate.rs
+++ b/src/handlers/postgres_gate.rs
@@ -479,6 +479,12 @@ pub fn path_is_registered_route(method: &axum::http::Method, path: &str) -> bool
         ("DELETE", super::routes::SUBSCRIPTIONS) => true,
         ("GET", super::routes::SUBSCRIPTIONS) => true,
         ("POST", super::routes::SESSION_START) => true,
+        // #1718 — Commit-C2 signal send-path (was missing from this
+        // router mirror even though the route is registered + pg-supported;
+        // the omission was masked because a pg-supported route never
+        // reaches the 404-vs-501 branch this table feeds — caught by the
+        // Phase-1 anti-regression gate `pg_supported_route_inventory_gate`).
+        ("POST", super::routes::SIGNALS) => true,
         // Cluster E API-2 — Agent Skills (parameterless variants).
         ("POST", super::routes::SKILL_REGISTER) => true,
         ("GET", super::routes::SKILL_LIST) => true,
@@ -524,17 +530,23 @@ pub fn path_is_registered_route(method: &axum::http::Method, path: &str) -> bool
         ("POST", p) if archive_restore_path(p) => true,
         // /api/v1/pending/{id}/approve|reject
         ("POST", p) if pending_decide_path(p) => true,
+        // /api/v1/actions/{id}/transition (#1718) + /api/v1/checkpoints/{id}/resolve
+        // (#2391) — registered + pg-supported, previously absent from this
+        // router mirror (Phase-1 anti-regression-gate finding).
+        ("POST", p) if actions_transition_path(p) => true,
+        ("POST", p) if checkpoints_resolve_path(p) => true,
         // /api/v1/approvals/{pending_id}
         ("POST", p) if approvals_decide_path(p) => true,
         // /api/v1/skill/{id} (GET)
         ("GET", p) if skill_id_path(p) => true,
         // /api/v1/skill/{id}/resource (GET)
         ("GET", p) if skill_id_sub_path(p, "resource") => true,
-        // /api/v1/skill/{id}/export | /promote | /compose (POST)
+        // /api/v1/skill/{id}/export | /promote | /compose | /retire (POST)
         ("POST", p)
             if skill_id_sub_path(p, "export")
                 || skill_id_sub_path(p, "promote")
-                || skill_id_sub_path(p, "compose") =>
+                || skill_id_sub_path(p, "compose")
+                || skill_id_sub_path(p, "retire") =>
         {
             true
         }

--- a/tests/pg_supported_route_inventory_gate_2799.rs
+++ b/tests/pg_supported_route_inventory_gate_2799.rs
@@ -1,0 +1,480 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Phase-1 pg-parity remediation (5-agent vote `4d3ea1c5`, Option B+) —
+//! the CLAIMS-PARITY ANTI-REGRESSION GATE.
+//!
+//! ## Why this test exists
+//!
+//! The postgres surface gate (`postgres_endpoint_supported`,
+//! `src/handlers/postgres_gate.rs`) is a HAND-MAINTAINED allow-list. A
+//! route reaches a postgres-backed daemon's handler ONLY if it appears
+//! there; everything else is shielded by a fail-closed 501 so an
+//! un-migrated handler can never silently fall through to the empty
+//! in-memory scratch SQLite `app.db` and read/write the WRONG database
+//! (data corruption / loss, invisible to green CI).
+//!
+//! The v1.0 cert audit found the register's advertised pg-supported
+//! count (56), the audit's count (73), and the SSOT total (94/80) all
+//! disagreed — because a hand-maintained allow-list drifts silently
+//! against the router. **That silent drift IS the omission class this
+//! gate closes.** It converts every future edit to the allow-list (or
+//! to the router) into a change this test flags, forcing an explicit,
+//! reviewed update to the pinned inventory below — at which point a
+//! reviewer must confirm the opened route's handler genuinely dispatches
+//! to `app.store` (the pg SAL) and never `app.db.lock()`, per the
+//! BINDING SAFETY INVARIANT.
+//!
+//! ## What it pins
+//!
+//! 1. **Source-level membership freeze** — the exact set of route-const
+//!    and path-matcher names the allow-list references. A silent
+//!    add/remove of a match arm fails here.
+//! 2. **Runtime inventory + count** — over every registered production
+//!    route, the authoritative pg-supported count and the exact
+//!    fully-501 inventory. A route that gains/loses pg support fails
+//!    here.
+//! 3. **Structural subset** — every pg-supported (method, path) is a
+//!    registered route (a supported-but-unregistered tuple would be a
+//!    501-vs-404 wire-truthfulness violation).
+//!
+//! ## Companion control
+//!
+//! Freezing membership is HALF the control. The other half is the
+//! per-opened-route PROOF-OF-DISPATCH integration test (drive the route
+//! against a live pg daemon whose scratch sqlite is empty; assert a row
+//! written via pg is returned — proving SAL dispatch, not a scratch
+//! read). See `tests/serve_postgres_extended.rs` and the reflect /
+//! reflection_origin / recall_observations proof tests. This gate makes
+//! the inventory reviewable; those tests make each entry behaviourally
+//! true.
+
+#![cfg(feature = "sal")]
+// This gate's value is the prose: the doc comments ARE the reviewable,
+// authoritative pg-supported inventory + the binding-safety rationale.
+// Relax the doc-STYLE pedantic lints (identifier backticks / list
+// indentation) here — the prose is intentional and human-facing.
+#![allow(
+    clippy::doc_markdown,
+    clippy::doc_overindented_list_items,
+    clippy::doc_lazy_continuation
+)]
+
+use axum::http::Method;
+use std::collections::BTreeSet;
+
+use ai_memory::handlers::routes;
+use ai_memory::handlers::{path_is_registered_route, postgres_endpoint_supported};
+
+/// Every production `/api/v1` URL-path const, referenced by name so a
+/// renamed/removed const breaks compilation here (router SSOT binding).
+/// This IS the 80-unique-path inventory the CLAUDE.md architecture note
+/// pins; keep it in lockstep with `src/handlers/routes.rs`.
+fn all_registered_paths() -> Vec<&'static str> {
+    vec![
+        routes::ACTIONS_ID_TRANSITION,
+        routes::AGENTS,
+        routes::AGENTS_ID_PUBKEY,
+        routes::APPROVALS_PENDING_ID,
+        routes::APPROVALS_STREAM,
+        routes::ARCHIVE,
+        routes::ARCHIVE_ID_RESTORE,
+        routes::ARCHIVE_STATS,
+        routes::AUTO_TAG,
+        routes::CAPABILITIES,
+        routes::CAPTURE_TURN,
+        routes::CHECK_DUPLICATE,
+        routes::CHECKPOINTS_ID_RESOLVE,
+        routes::CONSOLIDATE,
+        routes::CONTRADICTIONS,
+        routes::ENTITIES,
+        routes::ENTITIES_BY_ALIAS,
+        routes::EXPAND_QUERY,
+        routes::EXPORT,
+        routes::FIND_PATHS,
+        routes::FORGET,
+        routes::GC,
+        routes::HEALTH,
+        routes::IMPORT,
+        routes::INBOX,
+        routes::KG_FIND_PATHS,
+        routes::KG_INVALIDATE,
+        routes::KG_QUERY,
+        routes::KG_TIMELINE,
+        routes::LINKS,
+        routes::LINKS_ID,
+        routes::LINKS_VERIFY,
+        routes::MEMORIES,
+        routes::MEMORIES_BULK,
+        routes::MEMORIES_ID,
+        routes::MEMORIES_ID_LINEAGE,
+        routes::MEMORIES_ID_PROMOTE,
+        routes::MEMORY_ATOMISE,
+        routes::MEMORY_CALIBRATE_CONFIDENCE,
+        routes::MEMORY_CHECK_AGENT_ACTION,
+        routes::MEMORY_DEPENDENTS_OF_INVALIDATED,
+        routes::MEMORY_EXPORT_REFLECTION,
+        routes::MEMORY_LOAD_FAMILY,
+        routes::MEMORY_RECALL_OBSERVATIONS,
+        routes::MEMORY_REFLECT,
+        routes::MEMORY_REFLECTION_ORIGIN,
+        routes::MEMORY_REPLAY,
+        routes::MEMORY_RULE_LIST,
+        routes::MEMORY_SMART_LOAD,
+        routes::MEMORY_SUBSCRIPTION_DLQ_LIST,
+        routes::MEMORY_SUBSCRIPTION_REPLAY,
+        routes::MEMORY_VERIFY,
+        routes::METRICS,
+        routes::METRICS_BARE,
+        routes::NAMESPACES,
+        routes::NAMESPACES_NS_STANDARD,
+        routes::NOTIFY,
+        routes::PENDING,
+        routes::PENDING_ID_APPROVE,
+        routes::PENDING_ID_REJECT,
+        routes::QUOTA_STATUS,
+        routes::RECALL,
+        routes::SEARCH,
+        routes::SESSION_START,
+        routes::SHARE,
+        routes::SIGNALS,
+        routes::SKILL_ID,
+        routes::SKILL_ID_COMPOSE,
+        routes::SKILL_ID_EXPORT,
+        routes::SKILL_ID_PROMOTE,
+        routes::SKILL_ID_RESOURCE,
+        routes::SKILL_ID_RETIRE,
+        routes::SKILL_LIST,
+        routes::SKILL_REGISTER,
+        routes::STATS,
+        routes::SUBSCRIPTIONS,
+        routes::SYNC_PUSH,
+        routes::SYNC_SINCE,
+        routes::TAXONOMY,
+        routes::TOOLS_LIST,
+    ]
+}
+
+const METHODS: [Method; 4] = [Method::GET, Method::POST, Method::PUT, Method::DELETE];
+
+/// The AUTHORITATIVE pg-supported inventory (2026-08-09, Phase-1 vote
+/// `4d3ea1c5`): of the 80 unique production URL paths, exactly these 21
+/// are FULLY fail-closed (no HTTP method reaches a postgres-backed
+/// handler). Each is honest-v1.x-rescoped OR verified app.db-bound /
+/// SAL-less:
+///   - 8 skill routes — no pg skills table (`migrate_v82` no-op).
+///   - `/api/v1/find_paths` — bare alias; operators use `/api/v1/kg/find_paths`.
+///   - `/api/v1/share` — openable via SAL get+store, but the pg source-read
+///     CallerContext is a T3 authz posture choice (deferred to a vote).
+///   - route_1111 family that is verified app.db-bound (calls `app.db.lock()`
+///     with no pg branch) or has NO SAL trait method:
+///       memory_atomise, memory_calibrate_confidence, memory_smart_load,
+///       memory_export_reflection, memory_replay, memory_subscription_replay,
+///       memory_subscription_dlq_list  (do-not-touch honest-v1.x set);
+///       memory_verify (compact link-verify; `signed_at` not reproducible
+///         from the `verify_link` SAL — `/api/v1/links/verify` IS the
+///         pg-supported link-verify surface);
+///       memory_dependents_of_invalidated (NO SAL trait method);
+///       memory_rule_list + memory_check_agent_action (postgres ships NO
+///         `governance_rules` table — a ~300+ LOC new-table gap the vote
+///         explicitly refused to rush into the cert window).
+/// Opening ANY of these requires proving SAL dispatch first (see the
+/// module doc) and updating this list with justification.
+fn expected_fully_501_paths() -> BTreeSet<&'static str> {
+    [
+        routes::FIND_PATHS,
+        routes::SHARE,
+        routes::MEMORY_ATOMISE,
+        routes::MEMORY_CALIBRATE_CONFIDENCE,
+        routes::MEMORY_CHECK_AGENT_ACTION,
+        routes::MEMORY_DEPENDENTS_OF_INVALIDATED,
+        routes::MEMORY_EXPORT_REFLECTION,
+        routes::MEMORY_REPLAY,
+        routes::MEMORY_RULE_LIST,
+        routes::MEMORY_SMART_LOAD,
+        routes::MEMORY_SUBSCRIPTION_DLQ_LIST,
+        routes::MEMORY_SUBSCRIPTION_REPLAY,
+        routes::MEMORY_VERIFY,
+        routes::SKILL_ID,
+        routes::SKILL_ID_COMPOSE,
+        routes::SKILL_ID_EXPORT,
+        routes::SKILL_ID_PROMOTE,
+        routes::SKILL_ID_RESOURCE,
+        routes::SKILL_ID_RETIRE,
+        routes::SKILL_LIST,
+        routes::SKILL_REGISTER,
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Authoritative counts pinned 2026-08-09 (Phase-1). Bump in lockstep
+/// with a dated justification when the allow-list legitimately changes.
+const EXPECTED_PG_SUPPORTED_UNIQUE_PATHS: usize = 59;
+const EXPECTED_FULLY_501_PATHS: usize = 21;
+const EXPECTED_TOTAL_UNIQUE_PATHS: usize = 80;
+
+/// Source-level membership freeze: the exact route-const + path-matcher
+/// names the allow-list body references. A silent match-arm add/remove
+/// (the drift class that produced the audit's count disagreement) fails
+/// here until this SSOT is updated — forcing a reviewed edit.
+const EXPECTED_ALLOWLIST_CONSTS: &[&str] = &[
+    "AGENTS",
+    "APPROVALS_STREAM",
+    "ARCHIVE",
+    "ARCHIVE_STATS",
+    "AUTO_TAG",
+    "CAPABILITIES",
+    "CAPTURE_TURN",
+    "CHECK_DUPLICATE",
+    "CONSOLIDATE",
+    "CONTRADICTIONS",
+    "ENTITIES",
+    "ENTITIES_BY_ALIAS",
+    "EXPAND_QUERY",
+    "EXPORT",
+    "FORGET",
+    "GC",
+    "HEALTH",
+    "IMPORT",
+    "INBOX",
+    "KG_FIND_PATHS",
+    "KG_INVALIDATE",
+    "KG_QUERY",
+    "KG_TIMELINE",
+    "LINKS",
+    "LINKS_VERIFY",
+    "MEMORIES",
+    "MEMORIES_BULK",
+    "MEMORY_LOAD_FAMILY",
+    "MEMORY_RECALL_OBSERVATIONS",
+    "MEMORY_REFLECT",
+    "MEMORY_REFLECTION_ORIGIN",
+    "METRICS",
+    "METRICS_BARE",
+    "NAMESPACES",
+    "NOTIFY",
+    "PENDING",
+    "QUOTA_STATUS",
+    "RECALL",
+    "SEARCH",
+    "SESSION_START",
+    "SIGNALS",
+    "STATS",
+    "SUBSCRIPTIONS",
+    "SYNC_PUSH",
+    "SYNC_SINCE",
+    "TAXONOMY",
+    "TOOLS_LIST",
+];
+
+const EXPECTED_ALLOWLIST_HELPERS: &[&str] = &[
+    "actions_transition_path",
+    "agents_pubkey_path",
+    "approvals_decide_path",
+    "archive_restore_path",
+    "checkpoints_resolve_path",
+    "links_id_path",
+    "memory_id_path",
+    "memory_lineage_path",
+    "memory_promote_path",
+    "namespace_standard_delete_path",
+    "namespace_standard_post_path",
+    "pending_decide_path",
+];
+
+/// Extract the body of `postgres_endpoint_supported` from the on-disk
+/// source and return the sets of route-const + path-matcher names it
+/// references.
+fn allowlist_referenced_names() -> (BTreeSet<String>, BTreeSet<String>) {
+    let src = include_str!("../src/handlers/postgres_gate.rs");
+    let start = src
+        .find("pub fn postgres_endpoint_supported")
+        .expect("postgres_endpoint_supported present");
+    // The fn body ends at the next top-level `\npub fn ` after the start.
+    let rest = &src[start..];
+    let end = rest[1..].find("\npub fn ").map_or(rest.len(), |i| i + 1);
+    let body = &rest[..end];
+
+    let mut consts = BTreeSet::new();
+    let mut helpers = BTreeSet::new();
+    // routes::CONST references.
+    let bytes = body.as_bytes();
+    let needle = b"routes::";
+    let mut i = 0;
+    while let Some(p) = find_sub(&bytes[i..], needle) {
+        let s = i + p + needle.len();
+        let mut e = s;
+        while e < bytes.len() && (bytes[e].is_ascii_alphanumeric() || bytes[e] == b'_') {
+            e += 1;
+        }
+        if e > s {
+            consts.insert(body[s..e].to_string());
+        }
+        i = e;
+    }
+    // `foo_path(` matcher references.
+    for (idx, _) in body.match_indices("_path(") {
+        // walk backwards to the start of the identifier
+        let mut s = idx;
+        while s > 0 {
+            let c = bytes[s - 1];
+            if c.is_ascii_alphanumeric() || c == b'_' {
+                s -= 1;
+            } else {
+                break;
+            }
+        }
+        let ident = &body[s..idx + "_path".len()];
+        // Only accept a plain call (identifier immediately followed by
+        // "_path("); exclude any `::`-qualified path helper (there are
+        // none, but be defensive).
+        if !ident.is_empty() && ident.ends_with("_path") {
+            helpers.insert(ident.to_string());
+        }
+    }
+    (consts, helpers)
+}
+
+fn find_sub(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+#[test]
+fn allowlist_membership_is_frozen_at_source() {
+    let (consts, helpers) = allowlist_referenced_names();
+    let expected_consts: BTreeSet<String> = EXPECTED_ALLOWLIST_CONSTS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    let expected_helpers: BTreeSet<String> = EXPECTED_ALLOWLIST_HELPERS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+    assert_eq!(
+        consts,
+        expected_consts,
+        "postgres_endpoint_supported allow-list route-const membership drifted.\n\
+         The hand-maintained gate lagging the router IS the omission class that \
+         produced the v1.0 pg-parity 501s. If you INTENTIONALLY opened/closed a \
+         route, update EXPECTED_ALLOWLIST_CONSTS + the pinned counts below WITH a \
+         dated justification, and prove the opened handler dispatches to app.store \
+         (never app.db.lock()) via a proof-of-dispatch test.\n\
+         added-in-source: {:?}\nremoved-from-source: {:?}",
+        consts.difference(&expected_consts).collect::<Vec<_>>(),
+        expected_consts.difference(&consts).collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        helpers,
+        expected_helpers,
+        "postgres_endpoint_supported path-matcher membership drifted; \
+         see the message above.\nadded: {:?}\nremoved: {:?}",
+        helpers.difference(&expected_helpers).collect::<Vec<_>>(),
+        expected_helpers.difference(&helpers).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn pg_supported_inventory_and_counts_are_pinned() {
+    let paths = all_registered_paths();
+    assert_eq!(
+        paths.len(),
+        EXPECTED_TOTAL_UNIQUE_PATHS,
+        "unique production path count drifted from the routes.rs SSOT"
+    );
+
+    let mut supported_paths: BTreeSet<&'static str> = BTreeSet::new();
+    let mut fully_501: BTreeSet<&'static str> = BTreeSet::new();
+
+    for &path in &paths {
+        let any_supported = METHODS.iter().any(|m| postgres_endpoint_supported(m, path));
+        // Structural subset: a pg-supported PATH must be a registered route
+        // (under some method), else the gate would fabricate a 501 for an
+        // unrouted path — a 404-vs-501 wire-truthfulness violation (#1410).
+        // Checked at the PATH level because the metadata early-returns
+        // (health/capabilities/metrics) are intentionally method-agnostic
+        // while only their GET form is registered.
+        if any_supported {
+            assert!(
+                METHODS.iter().any(|m| path_is_registered_route(m, path)),
+                "{path} is pg-supported but is NOT a registered route under any \
+                 method (postgres_endpoint_supported / path_is_registered_route drift)"
+            );
+            supported_paths.insert(path);
+        } else {
+            fully_501.insert(path);
+        }
+    }
+
+    assert_eq!(
+        fully_501,
+        expected_fully_501_paths(),
+        "the fully-501 (not pg-supported) path inventory drifted.\n\
+         unexpectedly-501: {:?}\nunexpectedly-supported: {:?}\n\
+         Update expected_fully_501_paths() + the counts WITH justification, and \
+         prove SAL dispatch for any newly-opened route.",
+        fully_501
+            .difference(&expected_fully_501_paths())
+            .collect::<Vec<_>>(),
+        expected_fully_501_paths()
+            .difference(&fully_501)
+            .collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        fully_501.len(),
+        EXPECTED_FULLY_501_PATHS,
+        "fully-501 path count drifted"
+    );
+    assert_eq!(
+        supported_paths.len(),
+        EXPECTED_PG_SUPPORTED_UNIQUE_PATHS,
+        "pg-supported unique-path count drifted"
+    );
+    assert_eq!(
+        supported_paths.len() + fully_501.len(),
+        EXPECTED_TOTAL_UNIQUE_PATHS,
+        "supported + fully-501 must partition the full path set"
+    );
+}
+
+/// The three route_1111 routes that ARE pg-supported (SAL-backed with a
+/// verified `StorageBackend::Postgres` branch dispatching to
+/// `app.store.{reflect,get_reflection_origin,list_recall_observations}`)
+/// must stay supported — a regression that dropped them would silently
+/// 501 a working pg surface.
+#[test]
+fn already_open_sal_route_1111_routes_stay_supported() {
+    assert!(postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_REFLECT
+    ));
+    assert!(postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_REFLECTION_ORIGIN
+    ));
+    assert!(postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_RECALL_OBSERVATIONS
+    ));
+    // Conversely, the verified app.db-bound / SAL-less siblings must stay
+    // fail-closed (opening them would convert a safe 501 into a silent
+    // scratch-sqlite read/write on a pg daemon).
+    assert!(!postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_VERIFY
+    ));
+    assert!(!postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_DEPENDENTS_OF_INVALIDATED
+    ));
+    assert!(!postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_RULE_LIST
+    ));
+    assert!(!postgres_endpoint_supported(
+        &Method::POST,
+        routes::MEMORY_CHECK_AGENT_ACTION
+    ));
+    assert!(!postgres_endpoint_supported(&Method::POST, routes::SHARE));
+}

--- a/tests/pg_supported_route_inventory_gate_2799.rs
+++ b/tests/pg_supported_route_inventory_gate_2799.rs
@@ -49,16 +49,20 @@
 //! the inventory reviewable; those tests make each entry behaviourally
 //! true.
 
-#![cfg(feature = "sal")]
 // This gate's value is the prose: the doc comments ARE the reviewable,
 // authoritative pg-supported inventory + the binding-safety rationale.
 // Relax the doc-STYLE pedantic lints (identifier backticks / list
-// indentation) here — the prose is intentional and human-facing.
+// indentation) here — the prose is intentional and human-facing. These
+// allows sit BEFORE the `#![cfg]` so they still apply to the crate-level
+// `//!` module docs on a non-sal build (e.g. the vectorlite CI leg),
+// where `#![cfg(feature = "sal")]` empties the crate but the module docs
+// are still linted.
 #![allow(
     clippy::doc_markdown,
     clippy::doc_overindented_list_items,
     clippy::doc_lazy_continuation
 )]
+#![cfg(feature = "sal")]
 
 use axum::http::Method;
 use std::collections::BTreeSet;


### PR DESCRIPTION
## Phase-1 pg-parity remediation — PR-A (the durable control)

Phase-1 of the v1.0 pg-parity remediation (5-agent vote `4d3ea1c5`, refined Option B+). This PR lands the **CLAIMS-PARITY ANTI-REGRESSION GATE** — the durable control the vote mandated — plus a router-mirror completeness fix it surfaced. **No route is opened** (see "Truthful classification" below).

### The omission class this closes
`postgres_endpoint_supported` (`src/handlers/postgres_gate.rs`) is a hand-maintained allow-list. A route reaches a postgres-backed daemon's handler only if it appears there; everything else is a fail-closed 501 so an un-migrated handler can't fall through to the empty scratch sqlite `app.db` and read/write the WRONG database. When that hand-maintained list silently lags the router, the advertised pg-surface drifts — the audit found the register (56), the audit (73) and the SSOT (80/94) all disagreed.

### What lands
- **`tests/pg_supported_route_inventory_gate_2799.rs`** — three mechanical assertions:
  1. **Source-level membership freeze** — the exact route-const (47) + path-matcher (12) set the allow-list references. A silent match-arm add/remove fails here.
  2. **Authoritative inventory + count** — **59 of 80 unique production paths are pg-supported; 21 are fully fail-closed 501**, with the exact fully-501 list pinned. (The "56"/"73" claims were both wrong.)
  3. **Structural subset** — every pg-supported path is a registered route (404-vs-501 truthfulness, #1410).
- **`path_is_registered_route` mirror completeness** — it was missing `POST /signals` (#1718), `POST /actions/{id}/transition` (#1718), `POST /checkpoints/{id}/resolve` (#2391) and the `skill/{id}/retire` arm. Latent 404-vs-501 drift (masked because a pg-supported route never reaches that branch); surfaced by the new gate and reconciled.

### Truthful per-candidate classification (verified against HEAD)
Every currently-501 candidate the task named was verified; **none is cleanly openable in Phase-1**, so opening any would violate the binding safety invariant:

| Route | Verdict |
|---|---|
| `memory_reflect`, `memory_reflection_origin`, `memory_recall_observations` | **already open + SAL-backed** (verified pg branch → `app.store.*`); pinned as regressions here |
| `memory_verify` (#1111) | **app.db-bound**; its compact shape's `signed_at` is NOT reproducible from the `verify_link` SAL (`VerifyLinkReport` lacks `valid_from`). `POST /api/v1/links/verify` IS the pg-supported link-verify surface. Stays 501. |
| `memory_dependents_of_invalidated` | **no SAL trait method** exists (app.db-bound). Genuine gap → 501. |
| `memory_rule_list`, `memory_check_agent_action` | postgres ships **no `governance_rules` table** (`src/store/postgres.rs` migrate_v66 comment). A ~300+ LOC new-table gap the vote explicitly refused to rush into the cert window → honest-v1.x, 501. |
| `/api/v1/share` | openable via `app.store.get` + `app.store.store`, **but the pg source-read `CallerContext` is a T3 security-posture choice** (crossroads protocol) — deferred to a 5-agent vote, not decided unilaterally here. |
| `memory_atomise`, `memory_smart_load`, `memory_export_reflection`, `memory_replay`, `memory_subscription_replay`, `memory_subscription_dlq_list`, `memory_calibrate_confidence`, skills/* | do-not-touch honest-v1.x rescope (app.db-bound). |

### CI-parity run locally
- `cargo test --features sal --test pg_supported_route_inventory_gate_2799` — 3/3 green
- clippy `-D warnings -D clippy::all -D clippy::pedantic` on `sal` + `sal-postgres` (`--all-targets`) — clean
- `cargo fmt --all --check` — clean; qual_10 + qual_6_7 ceilings — green
- All src changes are `#[cfg(feature = "sal")]`-gated, so the default + vectorlite legs are byte-identical to base (relying on CI for those two legs).

### AI involvement
Authored by Claude Opus 5 (hard-coder) under the Phase-1 pg-parity remediation directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY