### PR TITLE
docs(v1.0.0): re-mint Track A verdict FIX-FIRST -> SHIP after re-running P3/P4/P10/P11 on the fixed tip

### DIFF
--- a/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-a-nhi-results.md
+++ b/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-a-nhi-results.md
@@ -10,6 +10,15 @@ against the **certified enterprise config** — encryption + attestation ON,
 PostgreSQL 16 + Apache AGE 1.6.0 + pgvector, over the HTTPS + mTLS REST surface
 and the CLI/MCP surfaces. Run date **2026-08-09**.
 
+> **⚠️ The FIX-FIRST verdict below is the FIRST-PASS record (2026-08-09 @
+> `25329b2b`) and has been SUPERSEDED.** The fixes landed and the affected
+> phases were re-run against the fixed tip. The current Track A verdict is
+> **SHIP (Track A local scope)** — see
+> [Re-mint 2026-08-09 @ `5ceab18b`](#re-mint-2026-08-09--5ceab18b) at the end
+> of this document. The first-pass sections are preserved verbatim rather
+> than rewritten: they describe the substrate **as it was**, and re-pointing
+> them at the fixed tip would falsify the record.
+
 ## Config banner (certified)
 
 | Fact | Value |
@@ -24,7 +33,7 @@ and the CLI/MCP surfaces. Run date **2026-08-09**.
 | Auth | top-level `api_key` (admin gate), `AI_MEMORY_ADMIN_AGENT_IDS=ai:admin`, tier=semantic (MiniLM 384-dim embedder loaded) |
 | Drive surfaces | pg substrate via HTTPS REST (signed writes via `attest_sign`) + CLI; MCP-stdio (sqlite) for wire-schema + parity per playbook §"How to run" |
 
-## Phase summary
+## Phase summary (FIRST PASS, 2026-08-09 @ `25329b2b`)
 
 | Phase | Status | Verdict | Notes |
 |-------|--------|---------|-------|
@@ -40,7 +49,7 @@ and the CLI/MCP surfaces. Run date **2026-08-09**.
 | P9  MCP/HTTP/CLI parity | ✅ | **PASS** | per-interface source stamp; identical validation refusals |
 | P10 Performance & scale | ✅ | **PASS** | stats/health/metrics shapes; doctor pg-direct gap (#2795) |
 | P11 Failure & chaos (fail-closed) | ✅ | **PASS** | sanitized errors, adversarial refusals, sustained recalls; audit-tool pg gap (#2795) |
-| **Overall** | — | **FIX-FIRST** | 2 fixable pg defects (P3) block a campaign SHIP; no data-integrity / fail-closed VIOLATION observed |
+| **Overall** | — | **FIX-FIRST** (first pass — SUPERSEDED, see the re-mint) | 2 fixable pg defects (P3) block a campaign SHIP; no data-integrity / fail-closed VIOLATION observed |
 
 Issues filed: **#2792, #2793, #2794, #2795, #2796**.
 
@@ -198,3 +207,211 @@ P3 kg_query/kg_invalidate are **PROVEN-BROKEN on pg**. P5 LLM tools are
 **BLOCKED-BY-NO-LLM** (not tested). `doctor`/`verify-audit-trail` pg paths are
 **BLOCKED-BY-TOOLING** (sqlite-only), with the pg audit chain verified out-of-band
 by direct SQL.
+
+---
+
+# Re-mint 2026-08-09 @ `5ceab18b`
+
+The first-pass verdict was **FIX-FIRST**. The fixes landed
+([PR #2798](https://github.com/alphaonedev/ai-memory-mcp/pull/2798) for
+#2792/#2793 + the coupled #2800,
+[PR #2802](https://github.com/alphaonedev/ai-memory-mcp/pull/2802) for #2795's
+`verify-audit-trail --store-url`, and
+[PR #2811](https://github.com/alphaonedev/ai-memory-mcp/pull/2811) for the
+Phase-2 truthfulness floor that re-scoped #2794 to v1.x
+[#2807](https://github.com/alphaonedev/ai-memory-mcp/issues/2807)). Per the
+playbook rubric ("file → fix → retest → re-check, then re-run the affected
+phase") the RED / BLOCKED assertions were re-run against the fixed tip on a
+**fresh database**.
+
+**Scope of this re-mint.** ONLY the assertions that were RED or BLOCKED in the
+first pass: **P3** (all), the **P4** governance-inspection gap plus an
+enforcement control, and the **P10/P11** integrity-tooling gap. P0/P1/P2/P6/P7/
+P8/P9 and the P4 security core are NOT re-run — they were green on the first
+pass and none of the three merged PRs touches them. P5 remains
+BLOCKED-BY-NO-LLM.
+
+## Config banner (re-mint)
+
+| Fact | Value |
+|------|-------|
+| Binary | `ai-memory 1.0.0` (frozen copy of the tip `target/release/ai-memory` — a concurrent agent shares `target/`, so the SUT was copied aside before the run) |
+| Binary sha256 | `38b2d944ce5449ddeda710e969db3afaa61615f7667757f9df5c4fa970accf2a` |
+| Git commit | `5ceab18bf37ecc1fd00a3576b10fbb4d6c99fde7` (release/v1.0.0; incl. #2798, #2802, #2811) |
+| Build features | `sal, sal-postgres` |
+| Tip-binary proof | `ai-memory verify-audit-trail --help` advertises `--store-url` (the #2802 flag) — a direct behavioural check, not an mtime |
+| Backend | **PostgreSQL 16 + Apache AGE 1.6.0 + pgvector**, **FRESH** DB `tracka_remint`, schema **v88**, 37 tables, AGE `memory_graph` projection created, `embedding_dim=384` |
+| Encryption / transport | **TLS ON** (rustls) + **mTLS ON** (client-cert allowlist), port **19666** |
+| Attestation | **ON** — `AI_MEMORY_REQUIRE_AGENT_ATTESTATION=1`; `ai:alice` Ed25519 key registered + bound over the admin HTTP route |
+| Auth | top-level `api_key`, `AI_MEMORY_ADMIN_AGENT_IDS=ai:admin`, tier=semantic (MiniLM 384-dim) |
+| Evidence log | `.local-runs/cert-campaign/tracka/remint-2026-08-09/evidence.log` (raw, unedited command output) |
+
+## P3 — Knowledge graph — **PASS** (was FAIL)
+
+Driven over the AGE Cypher path on pg. All nine `MemoryLinkRelation` variants
+are exercised with a real edge each.
+
+| # | Assertion | Result | Evidence |
+|---|-----------|--------|----------|
+| P3-0 | one edge per relation created (9/9) | **PASS** | all nine `POST /links` return `linked:true`, `attest_level=self_signed` |
+| P3-A | `kg_query(max_depth=3)` traverses **ALL 9** relations (#2792) | **PASS** | `count:9`; `relations_returned=advances,contradicts,decomposes_into,depends_on,derived_from,derives_from,reflects_on,related_to,supersedes` |
+| P3-A2 | the AGE projection itself carries all 9 | **PASS** | untyped Cypher `MATCH (a)-[r]->(b) WHERE a.id=<hub>` → 9 rows, one per relation |
+| P3-A3 | fail-closed control: the #1859 lineage guard still refuses a BACKWARDS provenance edge | **PASS** | `derived_from` older→newer → **409** `link refused: reflection cycle` |
+| P3-B | `kg_timeline` carries all 9 relations (#2800 sibling) | **PASS** | `timeline_relations` = the same 9 |
+| P3-C | `kg_invalidate` on an OWNED pg row is **200 found:true**, not 404 (#2793) | **PASS** | `http_code=200`, `{"found":true,"valid_until":"2026-08-09T…"}` |
+| P3-C2 | invalidation visible in the relational row | **PASS** | `SELECT relation, valid_until FROM memory_links` → `supersedes` / `valid_until=2026-08-09 …` |
+| P3-C3 | invalidated edge EXCLUDED from the kg_query current view | **PASS** | re-query `count:8`, `supersedes` absent |
+| P3-C4 | `include_invalidated:true` returns it — history preserved, **no data loss** | **PASS** | `count:9`, `supersedes` present |
+| P3-C5 | the AGE edge carries `valid_until` too (the #2793 coupled AGE-stamp fix) | **PASS** | Cypher returns `"supersedes"` with `valid_until = "2026-08-09T…"` |
+| P3-D | ownership still enforced — NON-owner `kg_invalidate` refused, **no IDOR** | **PASS** | `ai:mallory` → **404** `source memory not found`; the targeted edge's `valid_until` stays **NULL** (unmodified) |
+| P3-E | `kg/find_paths` + `taxonomy` + `get_links` temporal/attest columns | **PASS** | find_paths returns a path; taxonomy `200`; get_links exposes `valid_from`/`valid_until`/`attest_level` |
+
+**Chronology note (harness, not substrate).** The provenance subset
+P = {`derived_from`, `reflects_on`, `derives_from`} is governed by the #1859
+lineage-DAG acyclicity guard (postgres Pass 0 of
+`src/store/postgres.rs::validate_link_pre_create_pg`), which refuses a
+provenance edge whose TARGET is newer than its SOURCE. A first attempt seeded
+the hub BEFORE its provenance targets, so those three edges were correctly
+REFUSED at creation and `kg_query` returned 6 relations — the three missing
+ones had no edge to traverse. Re-seeding the three provenance ancestors before
+the hub produced all nine edges and the 9/9 result above. Recorded because the
+6-of-9 reading would otherwise look like a partial #2792 regression; it was a
+test-ordering error, and P3-A3 pins the guard still fires.
+
+**Observation (not a defect, not filed):** the refusal message for a
+`derived_from` / `derives_from` edge reads `… --reflects_on--> … would close a
+cycle`. The relation name is hard-coded in the shared
+`StorageError::LinkReflectionCycle` Display, deliberately, so the wire body is
+byte-identical across sqlite and postgres. It is accurate about the guard and
+imprecise about which relation the caller used.
+
+## P4 — Governance & security — **PASS**
+
+#2794 was RESCOPED to v1.x ([#2807](https://github.com/alphaonedev/ai-memory-mcp/issues/2807))
+by the frozen 59/21 pg-supported partition (PLAN.md §2.0, PR #2811). Both
+routes are in the **21 fully-501** set, so the cert-scope assertion is that the
+501 is HONEST and TYPED — a fail-closed refusal, never wrong data — and that
+governance ENFORCEMENT still works on pg.
+
+| # | Assertion | Result | Evidence |
+|---|-----------|--------|----------|
+| P4-A | `memory_rule_list` on pg is an honest, TYPED 501 | **PASS** | `501` + `{"error":"endpoint not yet implemented for postgres-backed daemon","endpoint":"/api/v1/memory_rule_list","method":"POST","storage_backend":"postgres","remediation":"…"}` |
+| P4-B | `memory_check_agent_action` on pg is an honest, TYPED 501 | **PASS** | same typed envelope, `endpoint=/api/v1/memory_check_agent_action` |
+| P4-B2 | the 501 is STRUCTURALLY honest — nothing to read | **PASS** | `SELECT to_regclass('public.governance_rules')` → **NULL** (no such table on pg). The 501 is a refusal, not a silent read of the empty sqlite scratch |
+| P4-C | attestation ON — UNSIGNED direct HTTP store refused | **PASS** | **403** `ATTESTATION_FAILED` |
+| P4-D | SIGNED write lands `agent_attested` (verified in pg, not the response echo) | **PASS** | `SELECT metadata->>'attest_level'` → `agent_attested`, `write_signature` persisted (`has_write_sig=t`) |
+| P4-E | governance ENFORCEMENT on pg — a `write=approve` namespace standard is persisted | **PASS** | `metadata->'governance'` on pg = `{"write":"approve","delete":"owner","inherit":true,"promote":"owner"}`; `namespace_meta` binds it |
+| P4-E2 | a signed+attested governed write is **GATED**, not accepted | **PASS** | response `{"status":"pending","pending_id":"89362545-…"}`; `SELECT count(*) … WHERE title='p4enf governed write probe'` → **0 landed**; `pending_actions` → one row: `action_type=store`, `status=pending`, `requested_by=ai:alice`, `namespace=p4enf` |
+| P4-E3 | control — the same write into an UNGOVERNED namespace lands | **PASS** | `201`, `attest_level=agent_attested` |
+| P4-F | SSRF probes refused at the HMAC gate BEFORE URL validation | **PASS** | AWS-metadata `169.254.169.254`, loopback `127.0.0.1:22`, `file:///etc/passwd` — all three → `HMAC secret required`; `SELECT count(*) FROM subscriptions` → **0** orphan rows |
+| P4-G | pending + quota surfaces on pg | **PASS** | `/pending` `{count:…, storage_backend:"postgres"}`; `quota/status` returns per-agent/per-namespace rows |
+
+P4-E is the load-bearing one: because the probe write is signed AND attested, it
+clears the attestation gate, so the refusal can only come from governance. The
+approve-gated write is routed to `pending_actions` and zero rows land — the
+inspection API 501s, the ENFORCEMENT does not.
+
+## P10 / P11 — Perf, tooling, chaos, fail-closed — **PASS**
+
+| # | Assertion | Result | Evidence |
+|---|-----------|--------|----------|
+| P10/11-A0 | a REAL pg audit chain is seeded | **PASS** | `POST /capture_turn` ×5 → 5×`201`; `signed_events` sequences 1-5 with linked `prev_hash`/`this_hash` |
+| P10/11-A | `verify-audit-trail --store-url postgres://…` verifies FIRST-PARTY against the pg chain (#2795 → PR #2802) | **PASS** | `exit_code=0`, `chain_intact:true`, 5 events checked |
+| P10/11-A2 | human-readable render (shared verdict fns, GATE K3) | **PASS** | same verdict, exit 0 |
+| P10/11-A3 | flag-absent invocation is UNCHANGED (local sqlite `--db`) | **PASS** | exit 0 on the local scratch DB |
+| P10/11-A5 | **TAMPER DETECTION** — delete a true MIDDLE row (sequence-ordered offset 2 of 5) | **PASS** | `exit_code=1`, `chain_intact:false` — the break is DETECTED and the tool fails loudly |
+| P10/11-A6 | **TAIL truncation** — a different detection mechanism, tested deliberately | **PASS (honest degrade)** | with no witness anchor enrolled: `truncation:{status:"unknown"}`, `witness:{status:"unknown"}`, exit 0 — the verifier WITHHOLDS judgement, it never claims the chain is verified-untruncated. With `AI_MEMORY_REQUIRE_WITNESS=1`: `witness:{status:"missing"}`, **exit 1** — fail-closed. This matches the documented `signed_events` tamper-evidence scope (tail truncation is caught by the #1850 off-table watermark, which is opt-in custody) |
+| P10/11-B1 | `doctor --store-url <pg>` REFUSED at argv parse — cannot silently open the wrong store | **PASS** | `error: unexpected argument '--store-url' found`, exit 2 |
+| P10/11-B2 | `doctor --help` does not advertise `--store-url` | **PASS** | `store_url_occurrences_in_doctor_help=0` |
+| P10/11-B3 | `doctor --db` does NOT falsely claim pg health | **PASS** | report names its own scope: `"mode":"local"`, `"source":"<the sqlite path>"`, `total_memories 0` — while the pg corpus holds **20**. It reports on the store it opened and says which one that is |
+| P10/11-B4 | `doctor --remote` against the certified daemon | **FAIL-LOUD, new finding** | `Capabilities` section `severity:"critical"`, `note:"could not reach https://127.0.0.1:19666/api/v1/capabilities"` → **[#2815](https://github.com/alphaonedev/ai-memory-mcp/issues/2815)** (below). No false health claim |
+| P10 | stats / health / metrics shapes on pg | **PASS** | `stats` → `total_memories:20, links_count:9, by_tier{long:7,mid:13}`; `/api/v1/health` → `status:ok, version:1.0.0`; `/metrics` → `ai_memory_memories 20` + `ai_memory_memories_refreshed_at_seconds` |
+| P11 | sanitized not-found on a bogus UUID | **PASS** | `{"error":"not found"}` `404`, no leak |
+| P11 | adversarial `agent_id` (shell metachar / 200-char overflow) | **PASS** | both `400`: `invalid character '$'` / `exceeds max length of 128 bytes` |
+| P11 | sustained sequential recalls on pg | **PASS** | 10/10 `200`, 19-27 ms, no lock starvation |
+
+## New finding — [#2815](https://github.com/alphaonedev/ai-memory-mcp/issues/2815)
+
+`doctor --remote` exposes **no** `--ca-cert` / `--client-cert` / `--api-key`
+flags (`doctor --help` grep count = 0), so it cannot authenticate to a
+TLS + mTLS + api-key daemon. Isolated against the **same** pg store: the same
+command succeeds over plain HTTP on `:19667` (all sections `info`) and fails
+against the certified daemon on `:19666`. Postgres is therefore held constant
+and the transport posture is the only variable.
+
+The consequence is that on the certified enterprise config a pg deployment has
+**no working first-party `doctor` path at all**: `--store-url` does not exist
+(#2810, deferred to v1.x) and `--remote` — the remediation #2810 and PR #2802's
+commit message both name — cannot authenticate.
+
+It is **not** a data-integrity defect and **not** a false-health claim: doctor
+renders the section `critical` with `could not reach <url>` and names the
+`source` it queried. It is a missing capability plus a claims-truthfulness gap
+in #2810's stated remediation, so it does not move the verdict to HOLD.
+
+## Claims-parity spot check
+
+`tests/pg_supported_route_inventory_gate_2799.rs` — the Phase-1 anti-regression
+gate that freezes the 59-supported / 21-fully-501 partition — run against this
+fresh database. Result recorded in
+`.local-runs/cert-campaign/tracka/remint-2026-08-09/gate2799.log`.
+
+## Harness corrections made during this re-mint (disclosed)
+
+Three errors were mine, not the substrate's. They are recorded because each one
+initially LOOKED like a defect:
+
+1. **Provenance chronology** (P3) — seeding the hub before its provenance
+   ancestors made the #1859 guard refuse three edges; `kg_query` then honestly
+   returned 6 of 9. Fixed by seeding ancestors first; the guard is pinned by
+   P3-A3.
+2. **`namespace_standard` wire shape** (P4) — the body field is `id`, not
+   `memory_id`. With the invented field the handler synthesised a default
+   standard carrying no `governance` blob, so the governed write was correctly
+   ungated. With the real shape (`{"governance":{…}}`) enforcement fires.
+3. **Evidence-log truncation** — `curl -o /dev/stdout` re-opens the
+   already-redirected evidence file with `O_TRUNC` and destroys it. The whole
+   sequence was re-run on a fresh database after removing that flag, so the
+   committed `evidence.log` is one coherent artifact rather than a repaired one.
+
+## Re-minted Track A verdict — **SHIP (Track A local scope)**
+
+Per the playbook rubric:
+
+- **Every re-run assertion is GREEN.** P3 went FAIL → PASS (all 9 relations
+  traverse on pg/AGE; `kg_invalidate` works on an owned row and the
+  invalidation is visible relationally, in the current view, and on the AGE
+  edge). P4's 501s are honest and typed, and governance ENFORCEMENT is proven
+  on pg by an approve-gated write that lands zero rows. P10/P11's
+  `verify-audit-trail --store-url` verifies the pg chain first-party and
+  DETECTS a middle-row tamper with exit 1.
+- **Every negative / fail-closed assertion was correctly REFUSED**: unsigned
+  write `403`, non-owner `kg_invalidate` refused with the edge left untouched,
+  backwards provenance edge `409`, three SSRF probes stopped at the HMAC gate
+  with zero orphan rows, adversarial identities `400`, `doctor --store-url`
+  refused at argv parse.
+- **No data-integrity or fail-closed VIOLATION was observed**, so HOLD does not
+  apply. Invalidation is reversible (`include_invalidated` returns the edge);
+  no durable text was destroyed by any operation in this run.
+- **No in-scope finding remains open.** #2792, #2793, #2800 and #2795 are FIXED
+  and re-verified here. #2794 → #2807 and the `doctor` pg-direct gap → #2810 are
+  RESCOPED to v1.x by the frozen 59/21 cert boundary and are DISCLOSED, not
+  hidden — both surfaces refuse honestly rather than returning wrong data.
+
+**Honesty ledger (what this verdict does and does not cover).**
+
+- **PROVEN on the certified pg stack, this re-mint:** P3 in full, the P4
+  governance 501-honesty + ENFORCEMENT + attestation + SSRF assertions, and the
+  P10/P11 audit-chain, tamper-detection, doctor-disclosure and chaos
+  assertions.
+- **PROVEN on the first pass and not re-run** (no merged PR touches them):
+  P0/P1/P2/P6/P7/P8/P9.
+- **BLOCKED-BY-NO-LLM:** P5 `expand_query` / `auto_tag` / `detect_contradiction`
+  are **not certifiable in this $0 local env** and are NOT claimed. They must be
+  certified on the DO round with a real Grok 4.5 backend. `check_duplicate`
+  (embeddings, no LLM) passed on the first pass.
+- **DISCLOSED GAPS, deliberately outside the cert boundary:** the 21 fully-501
+  pg routes (#2803), `doctor` pg-direct (#2810), and `doctor --remote` on a
+  hardened daemon (#2815, filed by this re-mint).
+- **SCOPE:** this verdict is Track A, LOCAL. A campaign-level SHIP additionally
+  requires reproduction on the DO re-host with a real LLM, per PLAN.md.

--- a/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-a-nhi-results.md
+++ b/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-a-nhi-results.md
@@ -352,8 +352,23 @@ in #2810's stated remediation, so it does not move the verdict to HOLD.
 ## Claims-parity spot check
 
 `tests/pg_supported_route_inventory_gate_2799.rs` — the Phase-1 anti-regression
-gate that freezes the 59-supported / 21-fully-501 partition — run against this
-fresh database. Result recorded in
+gate that freezes the 59-supported / 21-fully-501 partition — run in release
+against this fresh database:
+
+```
+AI_MEMORY_TEST_POSTGRES_URL=postgres://…/tracka_remint \
+  cargo test --features sal,sal-postgres --release \
+             --test pg_supported_route_inventory_gate_2799
+
+test already_open_sal_route_1111_routes_stay_supported ... ok
+test pg_supported_inventory_and_counts_are_pinned ... ok
+test allowlist_membership_is_frozen_at_source ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored
+```
+
+**PASS (3/3)** — the pg-supported inventory and the source-level allow-list
+membership are unchanged, so the 59/21 partition this re-mint certifies against
+is the one the gate pins. Log:
 `.local-runs/cert-campaign/tracka/remint-2026-08-09/gate2799.log`.
 
 ## Harness corrections made during this re-mint (disclosed)


### PR DESCRIPTION
Re-mints the Track A verdict of the v1.0.0 enterprise-cert campaign from **FIX-FIRST** to **SHIP (Track A, local scope)** after re-running the RED / BLOCKED phases against the fixed tip.

Docs-only — one file, `docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-a-nhi-results.md`.

## Why now

The first pass minted FIX-FIRST on two postgres defects. The fixes have landed:

- #2798 — #2792 (`kg_query` traversed only `related_to` on pg) + #2793 (`kg_invalidate` always-404 on pg) + the coupled #2800 (`kg_timeline`)
- #2802 — #2795's `verify-audit-trail --store-url` for first-party pg audit-chain verification
- #2811 — the Phase-2 truthfulness floor, which RE-SCOPED #2794 to v1.x #2807 under the frozen 59/21 pg-supported partition (PLAN.md §2.0)

Per the playbook rubric ("file → fix → retest → re-check, then re-run the affected phase"), P3 / P4 / P10 / P11 were re-run at `5ceab18b` on a **fresh** PG16 + AGE 1.6.0 + pgvector database with TLS + mTLS + attestation ON.

## Scope discipline

Only what was RED or BLOCKED is re-run and re-claimed: P3 in full, the P4 governance-inspection gap plus an enforcement control, and the P10/P11 integrity-tooling gap. **P0/P1/P2/P6/P7/P8/P9 and the P4 security core are NOT re-run and NOT re-claimed** — no merged PR touches them; they stand on the first-pass record. **P5 remains BLOCKED-BY-NO-LLM** and is explicitly not certified locally (DO round with a real Grok 4.5 backend).

The first-pass sections are preserved verbatim behind a superseded banner rather than rewritten — they describe the substrate as it was, and re-pointing them at the fixed tip would falsify the record (the CHANGELOG reasoning the docs-vs-SSOT gate already encodes).

## Results

| Phase | Was | Now | Load-bearing evidence |
|---|---|---|---|
| P3 | FAIL | **PASS** | `kg_query` returns `count:9` over all nine `MemoryLinkRelation` variants; the AGE projection itself carries all 9; `kg_timeline` carries all 9; `kg_invalidate` on an owned pg row is `200 found:true` with `valid_until` stamped relationally AND on the AGE edge; the edge leaves the current view and returns under `include_invalidated` (history preserved) |
| P4 | pg gap | **PASS** | both 501s are TYPED (`{error,endpoint,method,storage_backend,remediation}`) and structurally honest (`to_regclass('governance_rules')` is NULL on pg); ENFORCEMENT proven — a `write=approve` standard routes a signed+attested write to `pending_actions` with **0 rows landed**, while the same write into an ungoverned namespace lands |
| P10/P11 | tooling gap | **PASS** | `verify-audit-trail --store-url` verifies the pg chain first-party (exit 0, `chain_intact:true`) and **detects a middle-row tamper** (exit 1, `chain_intact:false`) |

Negative / fail-closed assertions all correctly refused: unsigned write `403 ATTESTATION_FAILED`; non-owner `kg_invalidate` refused with the edge left untouched (no IDOR); backwards provenance edge `409` (the #1859 lineage guard); three SSRF probes stopped at the HMAC gate with **zero** orphan subscription rows; adversarial `agent_id`s `400`; `doctor --store-url` refused at argv parse.

**Tail truncation was tested deliberately** because it is a different detection mechanism from the middle-row chain walk. Without an enrolled witness anchor the verifier reports `truncation:{status:"unknown"}` / `witness:{status:"unknown"}` — it WITHHOLDS judgement rather than falsely claiming verified — and `AI_MEMORY_REQUIRE_WITNESS=1` makes it fail closed (exit 1). That matches the documented `signed_events` tamper-evidence scope.

Claims-parity spot check: `tests/pg_supported_route_inventory_gate_2799.rs` **3/3 PASS** in release against the fresh database, so the 59/21 partition this re-mint certifies against is the one the gate pins.

## New finding filed

**#2815** — `doctor --remote` exposes no `--ca-cert` / `--client-cert` / `--api-key` flags, so it cannot authenticate to a TLS + mTLS + api-key daemon. Isolated against the **same** pg store (works over plain HTTP on `:19667`, fails over TLS+mTLS on `:19666`), so postgres is held constant and the transport posture is the only variable. Consequence: on the certified config a pg deployment has **no working first-party `doctor` path at all** — `--store-url` does not exist (#2810) and `--remote` cannot authenticate, which makes #2810's stated remediation untrue for that posture.

It is **not** a data-integrity defect and **not** a false-health claim (doctor renders `critical` + `could not reach <url>` and names the `source` it queried), so it does not move the verdict to HOLD.

## Harness errors disclosed in the doc

Three were mine, not the substrate's, and each initially looked like a defect:

1. Seeding the hub before its provenance ancestors made the #1859 acyclicity guard refuse three edges, so `kg_query` honestly returned 6 of 9. Re-seeded in the correct order; P3-A3 pins that the guard still fires.
2. The `namespace_standard` body field is `id`, not `memory_id` — the invented field was ignored, the handler synthesized a standard with no governance blob, and the governed write was correctly ungated.
3. `curl -o /dev/stdout` re-opens the already-redirected evidence file with `O_TRUNC` and destroyed it; the whole sequence was re-run on a fresh database so the committed evidence log is one coherent artifact rather than a repaired one.

## Verification

Raw, unedited command output: `.local-runs/cert-campaign/tracka/remint-2026-08-09/evidence.log`.

Docs gates run in the worktree, all PASS: `check-doc-symbol-anchors.sh`, `check-docs-vs-ssot.sh`, `check-ci-job-claims.sh`, `check-sdk-route-paths.sh`.

## AI involvement

Authored by Claude Opus 5 under the v1.0.0 autonomous loop, acting as the delegated authority of the `alphaonedev` operator. Re-run executed against a frozen copy of the tip `sal,sal-postgres` release binary (sha256 `38b2d944…`, tip-proof: `verify-audit-trail --help` advertises the #2802 `--store-url` flag) on a dedicated port and database so the concurrent Track B agent was not disturbed. Not merged — held for the Fable 5 review gate.

Closes #2796 is NOT claimed here (the playbook doc drift is another agent's lane); this PR touches only `track-a-nhi-results.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
