### PR TITLE
infra(do-hive): Track D DO-substrate cert round EXECUTED — 6 harness fixes + 2 substrate findings (#2850-#2857)

### DIFF
--- a/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-d-f-e2e-do-results.md
+++ b/docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-d-f-e2e-do-results.md
@@ -3,142 +3,166 @@ layout: doc
 ---
 # v1.0.0 Enterprise-Cert — DigitalOcean round (Track D / F / E2E / P5) results
 
-**Round date:** 2026-08-09
-**Base:** `release/v1.0.0` @ `fa73a7bf` (DO federation infra #2813 + IronClaw 1.1.0
-cloud-init #2819 merged; PLAN.md cert tip lineage).
-**Orchestrator:** Opus 5 (`hard-coder` tier), DO cert round.
-**Disposition:** **STAGED — NOT EXECUTED.** Blocked fail-closed on two
-operator-reserved inputs (see §Blocker). No droplets were spawned; no spend
-incurred; baseline `doctl compute droplet list` was and remains EMPTY of
-`ai-memory-hive`.
+**Round date:** 2026-08-10 (EXECUTED — supersedes the 2026-08-09 STAGED record)
+**Base:** `release/v1.0.0` @ `67883f8d`
+**Orchestrator:** Opus 5 (`hard-coder`), DO cert round. Spend operator-authorized 2026-08-10.
+**Disposition:** **EXECUTED on a real 2-node federated DO mesh (pg16 + AGE 1.6.0 + pgvector,
+mTLS, W=2, attestation ON).** Track D substrate assertions **PROVEN PASS** (by direct
+probe); E2E + P5 driven with **Grok 4.5** over the encrypted/attested path; Track F a bounded
+crypto-ON read sample. **8 findings filed 1:1** (#2850–#2857). Hive **torn down; zero droplets**.
 
-This document is intentionally honest per the campaign's truthfulness
-discipline: it records exactly what was PROVEN on this host, what is STAGED and
-runnable, and what is DEFERRED pending an operator action — with no assertion
-dressed up as a pass it did not earn.
+This document is honest per the campaign truthfulness discipline: every row is labelled
+PROVEN / PARTIAL / DEFERRED, harness bugs are distinguished from substrate behaviour, and no
+assertion is reported as a pass it did not earn.
 
----
+## Provisioned topology (as-run)
 
-## Config pins (LOCKED, verified staged)
+| item | value |
+|------|-------|
+| spawn | `TF_VAR_memory_count=2 TF_VAR_agent_count=1 TF_VAR_quorum_writes=2` (via `TF_VAR_*` — the `-var` CLI channel is broken, #2850) |
+| memory nodes | `ai:hive-memory-1` 165.227.98.195 (priv 10.20.0.2), `ai:hive-memory-2` 138.197.27.145 (priv 10.20.0.3) |
+| agent | `ai-memory-hive-agent-1` 157.245.1.226 (IronClaw 1.1.0) |
+| store | PostgreSQL 16 + Apache AGE **1.6.0** + pgvector **0.8.4** (both built from source on-node; `kg_backend=age` confirmed) |
+| crypto | mTLS everywhere (per-node leaves, `--mtls-allowlist`); W=2 quorum over mutual TLS |
+| attestation | v1.0.0 default-ON (`AI_MEMORY_REQUIRE_AGENT_ATTESTATION` HTTP-direct required; `AI_MEMORY_FED_REQUIRE_WRITE_SIG` default-ON) |
+| AI NHI brain | **Grok 4.5** via OpenRouter (`x-ai/grok-4.5`) wired into each node daemon |
+| runtime / spend | ~48 min droplet uptime; teardown **2026-08-10T13:38:46Z**; spend ~**$0.05** (of the $100 budget) |
 
-| Facet | Value | Status |
-|-------|-------|--------|
-| Binary | `ai-memory` v1.0.0 built `cargo build --release --features sal,sal-postgres` on the orchestrator host | BUILT |
-| #1882 dim-fix | proxy check: `ai-memory verify-audit-trail --help` carries `--store-url` | SEE §#1882 |
-| Signer | `target/release/examples/attest_sign` (federate.sh A4 write-sig leg) | BUILT |
-| Store | PostgreSQL 16 + Apache AGE `release_PG16_1.6.0` + pgvector (memory cloud-init) | STAGED (cloud-init) |
-| Topology | `memory_count=2 agent_count=1 quorum_writes=2` | STAGED (`terraform validate` = Success) |
-| Encryption | mTLS everywhere (federate.sh mints per-node leaves via `crypto/gen-certs.sh` HIVE_NODE_IPS mode) | STAGED |
-| Attestation | v1.0.0 default-on write-sig; A4 cross-peer `agent_attested` leg | STAGED |
-| AI NHI brain | Grok 4.5 (`XAI_API_KEY` / `OPENROUTER_API_KEY`) | **MISSING (blocker)** |
+## Substrate bring-up required three infra fixes (all validated live, all filed + fixed in this PR)
 
-Terraform: `terraform init` OK, `terraform validate` = **Success!** against
-`infra/do-hive` at this tip. Vars (`memory_count`, `agent_count`,
-`quorum_writes`, `agent_workload`) and the `memory_nodes` output that
-`federate.sh` consumes are present and shape-correct. IronClaw pinned to
-`ironclaw-v1.1.0` (`ironclaw_image_url`).
+The DO Track-D substrate had **never actually been executed** (prior rounds STAGED on the money
+gate), so this round is the first to boot it — and it did not boot cleanly. Three provisioning
+defects were root-caused, fixed live, and are corrected in `infra/do-hive/` in this PR:
 
----
+1. **#2851** — AGE `git checkout release_PG16_1.6.0` ref does not exist (that is the *Docker* tag;
+   the git branch is `release/PG16/1.6.0`). Under `set -e` it aborted the entire provision → bare
+   substrate. **Fixed** (`cloud-init-memory.yaml.tpl`).
+2. **#2852** — fed-bootstrap writes the minted `api_key` config to `$XDG_CONFIG_HOME/...`, but
+   `AppConfig::config_path()` (`src/config.rs:7072`) reads `$HOME/.config/...` and **ignores XDG**,
+   so the api_key was unread → serve fail-closed on the `0.0.0.0` bind (exit 75, 114 restarts).
+   **Fixed** — write to the daemon-read path.
+3. **#2853** — base unit has no `WorkingDirectory`; the daemon's local sqlite `ai-memory.db`
+   (deferred-audit journal + nonce cache, opened even in pg mode) defaults to `/` which
+   `User=aimemory` cannot write → `SQLITE_CANTOPEN` (exit 75). **Fixed** — `WorkingDirectory=/opt/ai-memory`.
 
-## §#1882 — binary provenance (PROVEN on this host)
+With those three fixes the mesh reached MESH-READY on both nodes (serve active, :9077 mTLS, peer
+reachable, author key cross-enrolled).
 
-The #1882 postgres `tier=semantic` 768-vs-384 dim fix is the load-bearing pin:
-a binary without it opens the pg schema at the wrong vector dim and every write
-503s / recall returns empty. Proxy verification (PLAN §3 execution note): the
-built binary's `verify-audit-trail` subcommand carries `--store-url`.
+## Track D — federation (PROVEN PASS)
+
+`./federate.sh verify` verbatim (6 PASS / 2 FAIL — **both FAILs are harness bugs, not substrate**):
 
 ```
-$ cargo build --release --features sal,sal-postgres      # Finished in 15m 18s
-$ cargo build --release --features sal,sal-postgres --example attest_sign
-$ ./target/release/ai-memory --version
-ai-memory 1.0.0
-$ ./target/release/ai-memory verify-audit-trail --help | grep -- --store-url
-      --store-url <URL>   v1.0.0 pg-parity PR-B — verify the audit chain against
-                          a POSTGRES store ... Postgres requires a binary built
-                          with --features sal-postgres
-1882-PROXY: PASS
+PASS: node 1 /health over mTLS (200)
+PASS: node 1 refuses a client presenting no cert
+PASS: node 2 /health over mTLS (200)
+PASS: node 2 refuses a client presenting no cert
+PASS: CROSS-HOST: node 1 reaches node 2 at https://10.20.0.3:9077 over mutual TLS (200)
+FAIL: quorum write at node 1 got '403' ({"code":"ATTESTATION_FAILED",...})   # harness: unsigned probe, #2854
+PASS: signed write accepted at node 1 (201 id=027995dc-...)
+FAIL: signed write never reached node 2 (...)                                 # harness: wrong jq path, #2855
+----
+federate verify: 6 PASS / 2 FAIL
 ```
 
-Both artifacts built: `target/release/ai-memory` (sal + sal-postgres) and
-`target/release/examples/attest_sign` (the write-sig signer federate.sh A4
-needs). This is a necessary-but-not-sufficient proxy: it proves the CLI carries
-the pg-parity surface, not that a live pg write commits at 768-dim — the latter
-is a runtime assertion that only the DO substrate (or the local lan-parity
-Track C) exercises, and is part of the STAGED/DEFERRED set below.
+**Direct-probe confirmation (C5 fresh-subprocess re-check) proves the substrate PASSES all Track D
+assertions:**
 
----
+| Track D assertion | result | evidence |
+|---|---|---|
+| each node `/health` over mTLS → 200 | **PROVEN PASS** | federate.sh A1 |
+| no-cert client refused (mTLS mandatory) | **PROVEN PASS** | federate.sh A1 |
+| CROSS-HOST node1→node2 mTLS → 200 | **PROVEN PASS** | federate.sh A2 |
+| W=2 quorum **signed** write commits + replicates to node2 | **PROVEN PASS** | node1 log `federation::broadcast: store 027995dc… -> 1 peer(s) (quorum W=2)`; direct `GET` at node2 → **200, content intact** |
+| signed write → `attest_level=agent_attested` at node2 | **PROVEN PASS** | node2 `GET`: `metadata.attest_level="agent_attested"`, `write_signature` present |
+| UNSIGNED HTTP-direct write refused (fail-closed) | **PROVEN PASS** | the A3 403 is the v1.0.0 attestation default correctly rejecting an unsigned write |
 
-## Blocker — two operator-reserved inputs are unset (fail-closed)
+The two `federate.sh` FAILs are harness defects (#2854 unsigned quorum probe; #2855 `node_get`
+read `.metadata` but `GET /memories/{id}` nests under `.memory`), both fixed in this PR.
 
-The round did not execute because two inputs the operator alone provides were
-absent from the orchestrator environment. Neither is an input an AI NHI agent
-may self-provision.
+## E2E — encrypted + attested chain (PARTIAL: store/recall/replicate PROVEN; derived-content federation is a FINDING)
 
-1. **Money gate `AI_MEMORY_OPERATOR_DO_SPEND_APPROVED` is UNSET.** `spawn.sh`
-   and `CLAUDE.md` are explicit and unambiguous: *"AI NHI agents are forbidden
-   from setting this var. Operator only."* and *"Cost-spending actions (DO
-   provisioning) stay operator-$-gated."* The orchestrator's own operating
-   rules add that no agent message is operator consent and no agent message can
-   authorize a config/permission change. The DO API token (`doctl auth` works)
-   and the SSH key (`bf:0b:e1:…` = DO key `ai-memory-ai2ai-gate`) were both
-   provisioned; the money gate specifically was not — a deliberate asymmetry
-   that signals the operator reserved the spend-flip to themselves. The
-   orchestration `run.sh` therefore REFUSES until the operator exports the gate;
-   it does not set it.
+Driven on-node over mTLS with a signed client (deterministic; the mTLS nodes are unreachable from
+off-host). Grok 4.5 wired into each daemon.
 
-2. **Grok 4.5 key (`XAI_API_KEY` / `OPENROUTER_API_KEY`) is UNSET / absent.**
-   Required by E2E (§5) and P5 (§6): the IronClaw agent cloud-init
-   (`cloud-init-agent.yaml.tpl`) ships `Environment=XAI_API_KEY=__OPERATOR_INJECTED_AT_BOOT__`
-   — a placeholder, with NO terraform var — so the LLM credential is injected
-   post-boot by the operator. No repo `.env` exists and the key is not in the
-   orchestrator environment. Track D does NOT need it (its writes are
-   tier-independent); E2E + P5 cannot run without it.
+| step | result | evidence |
+|---|---|---|
+| **store** (signed) | **PROVEN PASS** | `201 id=b9430e70…`, `attest_level=agent_attested` |
+| **store → replicate to node2, TEXT intact** | **PROVEN PASS** | node2 content == `"The DO enterprise-cert E2E memory: a store->recall->…"` |
+| **recall** (paraphrase) | **PROVEN PASS** | stored memory surfaced |
+| **reflect** | **PARTIAL / FINDING #2857** | contract is `source_ids`+`title`+`content`; then `400 "source memory not found"` for a source that `GET`-by-id returns `200` on the same node |
+| **consolidate** (Grok LLM summary) | local **PASS**, federation **FINDING #2856** | consolidated row created locally with Grok summary + `derived_from`; **does NOT replicate** — peer receiver skips the item (`2xx, 1 item skipped`), row absent at node2, caller sees only `202 durability:local` |
+| **federate (derived content) → node2** | **FAIL → #2856** | consolidated/derived memories never reach node2 = silent inter-node divergence |
 
----
+The "federate the derived result" half of the E2E chain is blocked by **#2856** (the round's most
+important substrate finding): LLM-consolidated (and, by the same receiver path, likely other
+daemon-derived) memories are refused by the peer receiver **regardless of `AI_MEMORY_FED_REQUIRE_WRITE_SIG`**
+(reproduced with it default-ON and explicitly `=0`), producing silent divergence between federated
+nodes on a core operation. The two consolidation *sources* replicate fine; only the derived result
+is skipped.
 
-## Per-assertion ledger (PROVEN vs STAGED vs DEFERRED)
+## P5 — LLM power tools vs pg with real Grok 4.5 (PROVEN for the LLM-backed HTTP tools)
 
-| Track | Assertion | Result |
-|-------|-----------|--------|
-| pre | `cargo build --release --features sal,sal-postgres` + `attest_sign` | **PROVEN** (built on host) |
-| pre | #1882 proxy: `verify-audit-trail --store-url` | **PROVEN** (see §#1882) |
-| pre | `terraform init` + `validate` on `infra/do-hive` | **PROVEN** (Success) |
-| pre | trap-guarded `run.sh` (teardown armed BEFORE first spawn) | **PROVEN** (authored, `.local-runs/do-round-2026-08-09/run.sh`) |
-| D | each node `/health` over mTLS 200; no-cert refused | STAGED (blocked on spend gate) |
-| D | CROSS-HOST node1→node2 mTLS 200 | STAGED (blocked on spend gate) |
-| D | W=2 quorum write commits + replicates to node 2 | STAGED (blocked on spend gate) |
-| D | signed write authored node1 → `attest_level=agent_attested` at node2 | STAGED (blocked on spend gate) |
-| E2E | store→recall→reflect→consolidate→federate, TEXT intact both nodes | DEFERRED (spend gate **and** Grok key) |
-| P5 | reflect / auto_tag / consolidate / contradiction w/ Grok 4.5 | DEFERRED (spend gate **and** Grok key) |
-| F | USL capacity ramp, crypto+attestation ON (stretch) | DEFERRED (spend gate; stretch only) |
+| tool | result | evidence |
+|---|---|---|
+| **auto_tag** (Grok) | **PROVEN PASS** | `-> ["e2e","memory","enterprise","mesh","federation"]` |
+| **consolidate summary** (Grok) | **PROVEN PASS** | consolidated row carries a real LLM summary (`app.llm.summarize_memories`) |
+| **expand_query** (Grok) | **PROVEN PASS** | `-> ["federated service mesh attestation","distributed mesh data replication", …]` |
+| **contradiction detection** | **PARTIAL (by design)** | `POST /api/v1/contradictions` is **heuristic-only**; LLM contradiction detection is MCP-stdio-scoped and NOT on the pg HTTP surface — recorded honestly, not a defect of this round |
 
-No assertion is reported as a pass that was not executed. The four `pre` rows
-are genuinely proven on the orchestrator host; every DO-substrate row is
-honestly STAGED/DEFERRED, not silently greened.
+Real Grok 4.5 inference over the pg+AGE substrate is proven for every LLM-backed HTTP tool.
 
----
+## Track F — capacity, crypto ON (bounded sample; full USL DEFERRED)
 
-## How to execute (operator, one command)
+Recall-throughput ramp on node1 over mTLS loopback (crypto + attestation ON):
 
-Everything else is staged. The operator flips the one reserved gate (and,
-for E2E/P5, provides the Grok key), then runs the trap-guarded orchestration:
-
-```bash
-export AI_MEMORY_OPERATOR_DO_SPEND_APPROVED=1          # operator only
-export XAI_API_KEY=<grok-4.5-key>                      # optional, for E2E/P5
-/home/fate_two/v07/v09-dev/.local-runs/do-round-2026-08-09/run.sh
+```
+concurrency,duration_s,total_ops,ops_per_s
+1,8,220,27.5
+2,8,228,28.5
+4,8,241,30.1
+8,8,237,29.6
 ```
 
-`run.sh` arms `trap teardown EXIT INT TERM` BEFORE the first spawn, verifies
-the #1882 binary, `spawn.sh apply -var memory_count=2 -var agent_count=1 -var
-quorum_writes=2`, waits for cloud-init, scp's the #1882 binary onto each node,
-runs `federate.sh` (Track D wire + verify), drives E2E/P5 if the Grok key is
-present, and tears the hive down on ANY exit path — verifying
-`doctl compute droplet list --tag-name ai-memory-hive` is EMPTY as its last act.
+Flat ~28–30 ops/s across 1→8 concurrency — **handshake-dominated** (each `curl` pays a fresh mTLS
+handshake), so this measures per-request TLS+recall latency (~35 ms), not a substrate scaling law.
+**PROVEN:** the certified crypto-ON config serves reads. **DEFERRED:** a real USL knee/projection —
+that needs the `agent_workload=loadgen` measurement topology (5 loadgen + 1 substrate) with a
+connection-reusing instrument, not this 2-node federation cert topology, and the ramp harness is
+not mTLS-client-cert-aware. Out of scope for this bounded correctness round ("not a scale burn").
 
----
+## Findings filed — 1:1 (8)
+
+| # | issue | class |
+|---|---|---|
+| 1 | [#2850](https://github.com/alphaonedev/ai-memory-mcp/issues/2850) `spawn.sh apply/plan` drop `-var` CLI args (wrong topology + 10x spend hazard) | infra harness — **fixed in PR** |
+| 2 | [#2851](https://github.com/alphaonedev/ai-memory-mcp/issues/2851) AGE git ref `release_PG16_1.6.0` does not exist → total provision failure | infra — **fixed in PR** |
+| 3 | [#2852](https://github.com/alphaonedev/ai-memory-mcp/issues/2852) api_key written to XDG path the daemon never reads (`config_path` ignores XDG) → serve fail-closed | infra — **fixed in PR** |
+| 4 | [#2853](https://github.com/alphaonedev/ai-memory-mcp/issues/2853) no writable `WorkingDirectory` → local sqlite `SQLITE_CANTOPEN` in pg mode | infra — **fixed in PR** |
+| 5 | [#2854](https://github.com/alphaonedev/ai-memory-mcp/issues/2854) `federate.sh` A3 quorum probe UNSIGNED → false 403 FAIL under v1.0.0 attestation default | infra harness — **fixed in PR** |
+| 6 | [#2855](https://github.com/alphaonedev/ai-memory-mcp/issues/2855) `federate.sh` `node_get` reads `.metadata` but GET-by-id nests under `.memory` → false "never reached node2" | infra harness — **fixed in PR** |
+| 7 | [#2856](https://github.com/alphaonedev/ai-memory-mcp/issues/2856) LLM-consolidated memories never federate — peer receiver skips the item; silent inter-node divergence (write-sig-independent) | **substrate — remediation wave** |
+| 8 | [#2857](https://github.com/alphaonedev/ai-memory-mcp/issues/2857) `POST /memory_reflect` `400 source memory not found` for a memory GET-by-id returns 200 (pg) | **substrate — remediation wave** |
+
+Findings 1–6 are infra/harness defects, fixed inline in this PR (validated live; the template was
+not re-rendered/re-spawned — a confirming spawn is recommended at review). Findings 7–8 are
+substrate (`src/`) defects requiring investigation + a local pg repro (per C5) and are left for the
+Fable-orchestrated remediation wave.
+
+## Verdict
+
+- **Track D (federation):** GREEN — every mTLS / cross-host / quorum-replication / cross-peer
+  attestation assertion PROVEN on a real 2-node DO mesh.
+- **E2E:** GREEN for store → recall → replicate (attested, TEXT intact both nodes); **RED for
+  federating derived content** (#2856) — a genuine data-integrity finding.
+- **P5:** GREEN for every LLM-backed HTTP tool with real Grok 4.5 over pg+AGE.
+- **Track F:** bounded crypto-ON read sample proven; full USL projection DEFERRED (topology).
+
+Cert cannot mint SHIP for the DO round until #2856 (and #2857) are fixed + retested, per the prime
+directive. The federation transport, mTLS, quorum, and cross-peer attestation core is proven.
 
 ## Teardown confirmation
 
-No droplets were spawned. `doctl compute droplet list --tag-name ai-memory-hive`
-was EMPTY at baseline and remains EMPTY. Spend incurred: **$0.00**.
+`infra/do-hive/teardown.sh` destroyed 5 resources (2 memory + 1 agent + VPC + firewall).
+`doctl compute droplet list --tag-name ai-memory-hive` → **EMPTY**; full-list grep → **zero
+ai-memory-hive droplets**. Timestamp **2026-08-10T13:38:46Z**. Spend ~**$0.05**.

--- a/infra/do-hive/cloud-init-memory.yaml.tpl
+++ b/infra/do-hive/cloud-init-memory.yaml.tpl
@@ -41,6 +41,12 @@ write_files:
       Type=simple
       User=aimemory
       Group=aimemory
+      # #2853: even in postgres-store mode the daemon opens a local sqlite
+      # ai-memory.db (deferred-audit journal + federation nonce cache). With no
+      # WorkingDirectory systemd's default CWD is /, which User=aimemory cannot
+      # write, so the open fails SQLITE_CANTOPEN (exit 75). Give it the aimemory
+      # home (writable) as CWD so the relative ai-memory.db lands there.
+      WorkingDirectory=/opt/ai-memory
       Environment=AI_MEMORY_PERMISSIONS_MODE=enforce
       Environment=AI_MEMORY_AUTONOMOUS_HOOKS=0
       Environment=RUST_LOG=ai_memory=info,store::postgres=info
@@ -265,8 +271,16 @@ write_files:
       API_KEY="$(cat /etc/ai-memory/api-key)"
       # The umask subshell matters: config.toml carries the api_key, so it must
       # never exist even momentarily at the inherited 0644.
+      # #2852: the daemon's config resolver (AppConfig::config_path,
+      # src/config.rs) reads $HOME/.config/ai-memory/config.toml and IGNORES
+      # XDG_CONFIG_HOME. In the serve drop-in $HOME=/opt/ai-memory, so the daemon
+      # loads /opt/ai-memory/.config/ai-memory/config.toml. Writing the api_key
+      # config to $XDG_DIR left it UNREAD and serve fail-closed on the 0.0.0.0
+      # bind ("api_key is unset", exit 75). Write to the path the daemon loads.
+      DAEMON_CFG_DIR=/opt/ai-memory/.config/ai-memory
+      install -d -o aimemory -g aimemory -m 0750 "$DAEMON_CFG_DIR"
       ( umask 077
-        cat > "$XDG_DIR/ai-memory/config.toml" <<CFG
+        cat > "$DAEMON_CFG_DIR/config.toml" <<CFG
       schema_version = 2
       api_key = "$API_KEY"
 
@@ -274,8 +288,8 @@ write_files:
       agent_ids = ["$ADMIN_ID"]
       CFG
       ) || fail "could not write the daemon config"
-      chown root:aimemory "$XDG_DIR/ai-memory/config.toml"
-      chmod 0640 "$XDG_DIR/ai-memory/config.toml"
+      chown root:aimemory "$DAEMON_CFG_DIR/config.toml"
+      chmod 0640 "$DAEMON_CFG_DIR/config.toml"
       # NOTE: tier is left unset, so the daemon keeps its compiled default
       # (semantic). A Track-D-only run that does not need the embedder can
       # add `tier = "keyword"` to that file and restart -- the same
@@ -423,16 +437,22 @@ write_files:
       fi
 
       # --- build + install Apache AGE from source against pg16 ---
-      # AGE is source-only. Pin the EXACT release tag release_PG16_1.6.0 so the
-      # DO substrate is version-identical to infra/lan-parity-test/Dockerfile.pg-age-vector
-      # (FROM apache/age:release_PG16_1.6.0). An unpinned branch (PG16/master) can
-      # drift the AGE version between the free local parity run and the paid DO
-      # run, so a cert result proven locally would not be proven on DO.
+      # AGE is source-only. Pin the EXACT 1.6.0/PG16 release so the DO substrate
+      # is version-identical to infra/lan-parity-test/Dockerfile.pg-age-vector
+      # (FROM apache/age:release_PG16_1.6.0). NOTE the git ref and the docker tag
+      # DIFFER: the apache/age GitHub repo has NO ref named `release_PG16_1.6.0`
+      # (that underscore form is the DOCKER tag). The git branch/tag are
+      # slash-delimited -- `release/PG16/1.6.0` (== tag `PG16/v1.6.0-rc0`,
+      # commit 2db2f060), the same 1.6.0 code the docker image ships. An
+      # unpinned branch (PG16/master) can drift the AGE version between the free
+      # local parity run and the paid DO run, so a cert result proven locally
+      # would not be proven on DO. (#2851 -- the underscore ref failed
+      # `git checkout` under `set -e` and aborted the whole provision.)
       if [ ! -f "$(/usr/bin/pg_config --pkglibdir)/age.so" ]; then
         rm -rf /opt/age-src
         git clone https://github.com/apache/age.git /opt/age-src
         cd /opt/age-src
-        git checkout release_PG16_1.6.0
+        git checkout release/PG16/1.6.0
         make PG_CONFIG=/usr/bin/pg_config
         make install PG_CONFIG=/usr/bin/pg_config
       fi

--- a/infra/do-hive/federate.sh
+++ b/infra/do-hive/federate.sh
@@ -298,8 +298,18 @@ EOS
   #       201 = quorum_met; 202 = locally durable with a late ack. Both prove
   #       the mutually authenticated peer channel carried it; the replication
   #       itself is asserted separately by READING node 2.
-  body=$(jq -nc --arg t "hive-quorum-probe-$$" --arg ns "$NS" \
-    '{title:$t,content:"a federated write that must replicate across the DO mTLS quorum mesh",namespace:$ns,tier:"mid"}')
+  # #2854: v1.0.0 fail-closes UNSIGNED HTTP-direct writes (POST /api/v1/memories)
+  # with 403 ATTESTATION_FAILED, so the quorum probe MUST be signed (like A4)
+  # or it never reaches the fanout it is meant to assert.
+  QTITLE="hive-quorum-probe-$$"
+  QCONTENT="a federated write that must replicate across the DO mTLS quorum mesh"
+  QCREATED="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+  QSIG=""
+  [ -x "$SIGNER" ] && QSIG="$("$SIGNER" --agent-id "$AUTHOR_ID" --namespace "$NS" \
+    --title "$QTITLE" --kind observation --created-at "$QCREATED" --content "$QCONTENT" \
+    --priv-file "$AUTHOR_KEY_DIR/$AUTHOR_ID.priv" 2>/dev/null)"
+  body=$(jq -nc --arg t "$QTITLE" --arg c "$QCONTENT" --arg ns "$NS" --arg s "$QSIG" --arg ca "$QCREATED" \
+    '{title:$t,content:$c,namespace:$ns,tier:"mid"} + (if $s != "" then {signature:$s,created_at:$ca} else {} end)')
   resp=$(node_post 0 "$(b64 "$body")")
   qcode=$(echo "$resp" | tail -1)
   qjson=$(echo "$resp" | sed '$d')
@@ -312,7 +322,7 @@ EOS
   if [ -n "$QID" ]; then
     landed=""
     for _ in $(seq 1 20); do
-      landed=$(node_get 1 "$QID" | jq -r '.id // empty' 2>/dev/null)
+      landed=$(node_get 1 "$QID" | jq -r '(.memory.id // .id) // empty' 2>/dev/null)
       [ -n "$landed" ] && break
       sleep 2
     done
@@ -356,7 +366,7 @@ EOS
       if [ -n "$SID" ]; then
         lvl=""
         for _ in $(seq 1 20); do
-          lvl=$(node_get 1 "$SID" | jq -r '.metadata.attest_level // empty' 2>/dev/null)
+          lvl=$(node_get 1 "$SID" | jq -r '(.memory.metadata.attest_level // .metadata.attest_level) // empty' 2>/dev/null)
           [ -n "$lvl" ] && break
           sleep 2
         done

--- a/infra/do-hive/spawn.sh
+++ b/infra/do-hive/spawn.sh
@@ -91,14 +91,19 @@ case "${cmd}" in
   plan)
     print_cost
     terraform init -input=false
-    terraform plan -input=false
+    # #2850: forward extra CLI args (e.g. -var memory_count=2) to terraform.
+    # Without this the documented recipe `spawn.sh apply -var memory_count=2`
+    # silently dropped every -var and provisioned the DEFAULT topology
+    # (memory_count=1 -> Track D impossible; agent_count=10 -> ~10x spend).
+    terraform plan -input=false "${@:2}"
     ;;
   apply)
     print_cost
     require_money_gate
     terraform init -input=false
     mkdir -p "${SCRATCH_ROOT}/${NOW}"
-    terraform apply -input=false -auto-approve
+    # #2850: forward extra CLI args (e.g. -var memory_count=2) — see plan case.
+    terraform apply -input=false -auto-approve "${@:2}"
     terraform output -json > "${SCRATCH_ROOT}/${NOW}/outputs.json"
     cp terraform.tfstate "${SCRATCH_ROOT}/${NOW}/terraform.tfstate"
     echo "[spawn.sh] Apply complete. Audit dump: ${SCRATCH_ROOT}/${NOW}/"


### PR DESCRIPTION
## DO Track-D enterprise-cert round — EXECUTED (2026-08-10, spend operator-authorized)

First real execution of the DigitalOcean Track-D federated round (prior rounds STAGED on the money gate). Provisioned a 2-node **pg16 + Apache AGE 1.6.0 + pgvector** mesh with **mTLS everywhere, W=2 quorum, attestation ON**, driven by **Grok 4.5**. Full per-assertion ledger + verbatim evidence: `docs/v1.0.0/test-campaign-2026-08-08-enterprise-cert/track-d-f-e2e-do-results.md`.

### What passed (PROVEN by direct probe)
- **Track D federation:** mTLS `/health` both nodes, no-cert refused, **cross-host node1→node2 mTLS 200**, **W=2 signed quorum write commits + replicates to node2 with `attest_level=agent_attested`, content intact**. (The two `federate.sh` FAILs were harness bugs — #2854/#2855 — fixed here; the substrate passes.)
- **E2E:** signed store → recall → replicate to node2 with durable TEXT intact.
- **P5 (Grok 4.5 over pg+AGE):** `auto_tag`, consolidate LLM-summary, `expand_query` all real Grok output.

### What this PR changes (6 infra/harness fixes, validated live)
Six defects blocked a clean DO Track-D bring-up; each root-caused, fixed live on the running mesh, and corrected here in `infra/do-hive/`:

| # | fix |
|---|-----|
| #2851 | AGE git ref `release_PG16_1.6.0` (docker tag) → `release/PG16/1.6.0` (git branch) — the wrong ref aborted the whole provision |
| #2852 | write the api_key config to the **daemon-read** `$HOME/.config` path (`config_path()` ignores `XDG_CONFIG_HOME`) — was fail-closing serve on the bind |
| #2853 | add `WorkingDirectory=/opt/ai-memory` — the local sqlite (deferred-audit/nonce, opened even in pg mode) was `SQLITE_CANTOPEN` at `/` |
| #2850 | `spawn.sh` forward `"${@:2}"` — `-var` was silently dropped (wrong topology + 10x agent-droplet spend hazard) |
| #2854 | `federate.sh` A3 signs the quorum probe (v1.0.0 fail-closes unsigned HTTP-direct writes) |
| #2855 | `federate.sh` reads the `.memory.*` GET-by-id envelope, not top-level |

Caveat: fixes mirror live-validated behaviour but the template was **not re-rendered/re-spawned** — a confirming spawn at review is recommended.

### Left for the reviewed remediation wave (substrate `src/`, need local pg repro per C5)
- **#2856** — LLM-consolidated / daemon-derived memories **never federate**: the peer receiver skips the item (`2xx, 1 item skipped`), producing **silent inter-node divergence**. Reproduced 3x, write-sig-independent (default-ON and `=0`). Data-integrity finding.
- **#2857** — `POST /api/v1/memory_reflect` returns `400 "source memory not found"` for a memory that `GET`-by-id returns `200` on the same pg node.

### Findings 1:1 (8): #2850–#2857.

### Teardown
5 resources destroyed; `doctl compute droplet list` EMPTY at **2026-08-10T13:38:46Z**; spend ~$0.05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
