### PR TITLE
fix(federation): consolidate under-replication 202 returns created id + fails loud (#2856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Federated consolidation no longer returns a success-shaped response while
+  silently diverging (#2856, data-integrity, 5-agent vote `4d3ea1c5`).** A
+  `POST /api/v1/consolidate` mints a NEW substrate-derived memory attributed to
+  the tenant consolidator, but the origin daemon cannot produce that tenant's
+  Ed25519 signature — so under the v1.0.0-default strict
+  `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1` a peer refuses the unsigned honored-
+  third-party relay (`unenrolled_author_strict`) and buckets it into `skipped`
+  inside its own 2xx, missing the W-of-N quorum. The origin then returned a
+  `202 durability:"local"` body that OMITTED the created memory's `id`, so a
+  caller saw a success-shaped 2xx with no way to discover the row that
+  committed locally but did not replicate. The consolidate under-replication
+  `202` now carries the created `id` (plus the `consolidated` / `summary` /
+  `content` / `memory` fields the `201` success body emits) alongside
+  `quorum_met:false` / `durability:"local"`, so the under-replication is LOUD
+  and RECONCILABLE (the North-Star "degrade, never diverge silently" floor).
+  The `202`-not-`5xx` status is preserved (the local row is durable — W3/gap
+  G12). Applies to both the sqlite and postgres consolidate branches via the
+  shared `consolidate_fanout` helper. Regression:
+  `handlers::tests::http_consolidate_under_replicated_returns_created_id_2856`.
+  Convergent replication of a tenant-attributed consolidation (which requires
+  resolving the tenant-vs-substrate authorship model) is tracked as a
+  follow-up (#2860).
+
 ### Docs / gates (perfection wave 2 — post-#2844 remainder; #2837 #2838 #2839 #2834)
 
 - **New reference-doc COMPLETENESS gate** `scripts/check-doc-surface-completeness.sh`

--- a/src/handlers/parity.rs
+++ b/src/handlers/parity.rs
@@ -79,6 +79,61 @@ pub(crate) fn under_replicated_response(payload: &QuorumNotMetPayload) -> axum::
     (StatusCode::ACCEPTED, Json(body)).into_response()
 }
 
+/// #2856 (federation data-integrity) — the consolidate-specific
+/// under-replication response. Sibling of [`under_replicated_response`]
+/// that ADDITIONALLY carries the created consolidated memory's `id` (and
+/// the same `{id, consolidated, summary, content, memory}` fields the
+/// success `201` body emits), so a caller whose consolidation committed
+/// LOCALLY but did not reach quorum can DISCOVER the row it must reconcile.
+///
+/// **Why a distinct helper.** `consolidate` mints a NEW substrate-derived
+/// memory attributed to the tenant consolidator, but the origin daemon
+/// cannot produce that tenant's Ed25519 signature — so under the
+/// v1.0.0-default strict `AI_MEMORY_FED_REQUIRE_WRITE_SIG` the receiver
+/// refuses the unsigned honored-third-party relay and buckets it into
+/// `skipped` inside its own 2xx. The origin then finalises a quorum MISS
+/// and returns THIS 202. Pre-#2856 the bare [`under_replicated_response`]
+/// omitted the `id`, so the caller saw a success-shaped 2xx with NO way to
+/// tell WHAT was written-locally-but-not-replicated — the "success-shaped
+/// while silently diverging" defect the North Star forbids. Emitting the
+/// `id` + the `quorum_met:false` / `durability:"local"` state makes the
+/// under-replication LOUD and RECONCILABLE (5-agent vote `4d3ea1c5`,
+/// Option A). The `202`-not-`5xx` status is preserved (W3 / gap G12): the
+/// local row IS durable.
+///
+/// True convergent replication of a tenant-attributed consolidation is a
+/// separate authorship-model decision tracked as a follow-up; this helper
+/// closes the silent-divergence + missing-`id` defect without changing the
+/// receiver gate or the row's attribution.
+pub(crate) fn under_replicated_consolidate_response(
+    payload: &QuorumNotMetPayload,
+    mem: &Memory,
+    source_count: usize,
+) -> axum::response::Response {
+    use crate::models::field_names;
+    let body = json!({
+        "id": mem.id,
+        (field_names::CONSOLIDATED): source_count,
+        "summary": mem.content,
+        // v0.7.0 L7-followup — mirror `content` + a nested `memory` dict so
+        // the caller reads the same shape as the `201` success body.
+        "content": mem.content,
+        "memory": {
+            "id": mem.id,
+            "title": mem.title,
+            "content": mem.content,
+            "namespace": mem.namespace,
+        },
+        // Replication state — LOUD + honest (never a bare success body).
+        "quorum_met": false,
+        "acks": payload.got,
+        "needed": payload.needed,
+        "reason": payload.reason,
+        "durability": "local",
+    });
+    (StatusCode::ACCEPTED, Json(body)).into_response()
+}
+
 /// Fan out a locally-committed memory to peers via quorum store. On full
 /// quorum, returns `None` (caller returns its normal 2xx success). On a
 /// quorum MISS, returns `Some(202_response)` carrying the replication

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -243,9 +243,20 @@ async fn consolidate_fanout(
     match crate::federation::broadcast_consolidate_quorum(fed, mem, source_ids).await {
         Ok(tracker) => {
             if let Err(err) = crate::federation::finalise_quorum(&tracker) {
-                // #869 — typed 503 envelope via the shared helper.
+                // #2856 (federation data-integrity, 5-agent vote `4d3ea1c5`,
+                // Option A) — a consolidation is a substrate-derived write the
+                // origin daemon cannot sign as the tenant consolidator, so a
+                // strict-write-sig peer refuses it and the quorum misses. Return
+                // the id-bearing under-replication 202 (was the bare
+                // `under_replicated_response`, which omitted the created `id`)
+                // so the caller can DISCOVER + reconcile the local-only row
+                // instead of seeing a success-shaped 2xx with nothing to act on.
                 let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
-                return Some(super::under_replicated_response(&payload));
+                return Some(super::under_replicated_consolidate_response(
+                    &payload,
+                    mem,
+                    source_ids.len(),
+                ));
             }
         }
         Err(e) => {

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -9928,6 +9928,121 @@ async fn http_consolidate_fans_out_to_peer_1552() {
 }
 
 #[tokio::test]
+async fn http_consolidate_under_replicated_returns_created_id_2856() {
+    // #2856 (federation data-integrity, 5-agent vote `4d3ea1c5`, Option A) —
+    // a consolidation is a substrate-derived write the origin daemon cannot
+    // sign as the tenant consolidator, so a strict-write-sig peer refuses it
+    // (returns 2xx but `skipped:1`) and the W=2 quorum MISSES. The origin must
+    // then fail LOUD, NOT return a success-shaped 2xx that hides what diverged:
+    // the `202` under-replication body MUST carry the created memory `id` (+
+    // `quorum_met:false` / `durability:"local"`) so the caller can DISCOVER +
+    // reconcile the local-only row. Pre-#2856 the bare under-replication body
+    // omitted the `id` — the North-Star "success-shaped while silently
+    // diverging" defect. The local write stays durable (202, not 5xx: W3/G12).
+    use std::sync::atomic::Ordering;
+    let state = test_state();
+    let now = Utc::now().to_rfc3339();
+    let (id_a, id_b) = {
+        let lock = state.lock().await;
+        let mk = |title: &str| Memory {
+            cid: None,
+            valid_from: None,
+            valid_until: None,
+            id: Uuid::new_v4().to_string(),
+            tier: Tier::Long,
+            namespace: "merge-fed-skip-ns".into(),
+            title: title.into(),
+            content: format!("body for {title}"),
+            tags: vec![],
+            priority: 5,
+            confidence: 1.0,
+            source: "test".into(),
+            access_count: 0,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            last_accessed_at: None,
+            expires_at: None,
+            metadata: serde_json::json!({"agent_id": "consolidator"}),
+            reflection_depth: 0,
+            memory_kind: crate::models::MemoryKind::Observation,
+            entity_id: None,
+            persona_version: None,
+            citations: Vec::new(),
+            source_uri: None,
+            source_span: None,
+            confidence_source: crate::models::ConfidenceSource::CallerProvided,
+            confidence_signals: None,
+            confidence_decayed_at: None,
+            version: 1,
+            lifecycle_state: crate::models::LifecycleState::Open,
+        };
+        let a = db::insert(&lock.0, &mk("fed-skip-draft-a")).unwrap();
+        let b = db::insert(&lock.0, &mk("fed-skip-draft-b")).unwrap();
+        (a, b)
+    };
+    // The peer returns 2xx but SKIPS the item (the strict-write-sig refusal) →
+    // NON-ack → W=2 quorum miss.
+    let (peer_url, count) = h8d_spawn_mock_peer(H8dPeerBehaviour::Skip).await;
+    let app_state = h8d_app_state_with_fed(state.clone(), vec![peer_url], 2, 1500);
+    let app = Router::new()
+        .route("/api/v1/consolidate", axum_post(consolidate_memories))
+        .with_state(app_state);
+    let body = serde_json::json!({
+        "ids": [id_a, id_b],
+        "title": "fed-skip-merged-result",
+        "summary": "a merge that a strict peer refuses to replicate",
+        "namespace": "merge-fed-skip-ns",
+        "tier": Tier::Long.as_str()
+    });
+    let resp = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/consolidate")
+                .method("POST")
+                .header(crate::HEADER_CONTENT_TYPE, crate::MIME_JSON)
+                .header("x-agent-id", "consolidator")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Durable-but-under-replicated: 202, never a 5xx (W3/G12), never a bare
+    // success that hides the divergence.
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "a refused-by-peer consolidation must surface as 202 under-replicated"
+    );
+    assert!(
+        count.load(Ordering::Relaxed) >= 1,
+        "consolidate must have attempted the fanout to the refusing peer"
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    // North-Star: the response is LOUD (quorum not met) AND RECONCILABLE (the
+    // created id is returned so the caller can find the local-only row).
+    assert_eq!(v["quorum_met"], serde_json::json!(false), "body={v}");
+    assert_eq!(v["durability"], serde_json::json!("local"), "body={v}");
+    let created_id = v["id"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            panic!("consolidate 202 must return the created memory id (#2856); body={v}")
+        });
+    // The returned id must resolve to the durably-committed local row.
+    {
+        let lock = state.lock().await;
+        let got = db::get(&lock.0, created_id).unwrap();
+        assert!(
+            got.is_some(),
+            "the returned consolidate id must be a durable local row (#2856)"
+        );
+    }
+}
+
+#[tokio::test]
 async fn http_reflect_fans_out_to_peer_1552() {
     // #1552 — the reflect write path must broadcast the new reflection memory
     // (and its `reflects_on` edges) to the federation quorum (shared
@@ -10513,6 +10628,15 @@ async fn h8d_spawn_mock_peer(
                 StatusCode::OK,
                 Json(json!({"applied": 1, "noop": 0, "skipped": 0})),
             ),
+            // #2856 — a receiver that returns 2xx but reports the item
+            // SKIPPED (refused/not applied), exactly what a strict-write-sig
+            // peer does to an unsigned consolidated relay. `post_and_classify`
+            // classifies `skipped > 0` as a NON-ack, so the origin's quorum
+            // misses.
+            H8dPeerBehaviour::Skip => (
+                StatusCode::OK,
+                Json(json!({"applied": 0, "noop": 0, "skipped": 1})),
+            ),
             H8dPeerBehaviour::Fail500 => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "stub failure"})),
@@ -10549,6 +10673,10 @@ async fn h8d_spawn_mock_peer(
 enum H8dPeerBehaviour {
     /// Always returns 200 OK with the standard ack envelope.
     Ack,
+    /// #2856 — returns 200 OK but reports the item `skipped` (refused /
+    /// not applied), the exact strict-write-sig receiver disposition for
+    /// an unsigned consolidated relay. Counts as a NON-ack at the origin.
+    Skip,
     /// Always returns 500 Internal Server Error.
     Fail500,
     /// Always returns 503 Service Unavailable.


### PR DESCRIPTION
## Summary

Fixes #2856 — a federation **data-integrity** defect where a federated consolidation returned a **success-shaped response while silently diverging** replicas.

### Root cause (pinned by a live-postgres reproduction)

`POST /api/v1/consolidate` mints a NEW substrate-derived memory attributed to the **tenant consolidator**, but the origin daemon cannot produce that tenant's Ed25519 signature, so it emits **no `metadata.write_signature`**. On broadcast (`broadcast_consolidate_quorum`), the receiver's per-write content-attestation gate (`apply_inbound_write_attestation` → `stamp_attestation`) computes `require = require_write_sig_env && (attribute_agent != sender)`. The consolidated memory is an unsigned **HONORED third-party relay** (author = tenant ≠ sender = origin-daemon), so under the v1.0.0-default strict `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1` the receiver **refuses it** (`unenrolled_author_strict`) and buckets it into `skipped` inside its own `2xx`, missing the W-of-N quorum. The signed *sources* replicate because they carried a valid `--sign` `write_signature`; the substrate-created consolidation output structurally cannot.

The origin then returned a `202 durability:"local"` body that **omitted the created memory's `id`** — a caller saw a success-shaped `2xx` with no way to discover the row that committed locally but never replicated.

Verified `applied:0, skipped:1` on the live pg mesh with the exact WARN `honored third-party relay refused — ... unenrolled_author_strict`.

### Fix (5-agent adversarial vote `4d3ea1c5`, Option A — the Condorcet winner)

The vote (data-integrity / federation-correctness / security-posture / blast-radius / pg-SAL-parity lenses) split 3–2 on the *convergence* mechanism and rejected both convergence options for a cert fix: **daemon self-attribution** changes tenant→daemon ownership (rejected by data-integrity + federation-correctness); **daemon-attested substrate-derived write** is a CWE-346 decoupling touching the T4 signed-bytes contract + both receiver twins under cert freeze (rejected by security + blast-radius + pg-parity). **Option A** — origin fails LOUD + returns the created `id` — is the only option in every lens's top-3 and no lens's bottom, and fully closes the filed silent-divergence + missing-`id` defect with zero new integrity/security/ownership/parity risk.

- The consolidate under-replication `202` now carries the created memory `id` (plus the `consolidated` / `summary` / `content` / `memory` fields the `201` success body emits) alongside `quorum_met:false` / `durability:"local"`, so the under-replication is **LOUD and RECONCILABLE**.
- `202`-not-`5xx` preserved (the local row is durable — W3 / gap G12).
- Applies to **both** the sqlite and postgres consolidate branches via the shared `consolidate_fanout` helper (identical response shape).

Convergent replication of a tenant-attributed consolidation (which requires resolving the tenant-vs-substrate authorship model, and also replicating the `derived_from` lineage edges + source-tombstone disposition the broadcast currently drops) is tracked as follow-up **#2860** — a genuine authorship-model crossroads the vote shows is unsafe to rush under cert freeze.

### Files

- `src/handlers/parity.rs` — new `under_replicated_consolidate_response` (id-bearing sibling of `under_replicated_response`).
- `src/handlers/power_consolidation.rs` — `consolidate_fanout` uses the id-bearing helper on quorum-miss.
- `src/handlers/tests.rs` — new `Skip` mock-peer behaviour (2xx-but-skipped) + regression `http_consolidate_under_replicated_returns_created_id_2856`.
- `CHANGELOG.md`.

### Tests / gates

- Regression `handlers::tests::http_consolidate_under_replicated_returns_created_id_2856` — green (asserts `202` + returned `id` resolves to a durable local row + `quorum_met:false`).
- Live-pg reproduction confirmed the pre-fix `skipped:1` refusal (scaffolding removed post-diagnosis).
- `cargo fmt --all --check`; clippy `-D warnings -D clippy::all -D clippy::pedantic` on default / `sal` / `sal-postgres` / `vectorlite`; `AI_MEMORY_NO_CONFIG=1 cargo test` (touched paths); `cargo audit`.

## AI involvement

Authored by Claude Opus 5 (hard-coder tier). Root cause pinned by a live-postgres reproduction against the strict-default write-sig posture; design decided by the deterministic 5-agent adversarial vote (memory `4d3ea1c5`). No external code adopted.

Closes #2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
