### PR TITLE
fix(federation/#2860): converge tenant-attributed consolidation under strict write-sig (5-agent vote 4d3ea1c5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (federation data-integrity — CERT-BLOCKING)
+
+- **Tenant-attributed federated consolidation now CONVERGES under strict
+  write-sig** (#2860, follow-up to #2856/#2861; 5-agent adversarial vote
+  `4d3ea1c5`, Option A). `POST /api/v1/consolidate` minted a NEW
+  substrate-DERIVED memory (LLM summary / deterministic concat produced by the
+  origin DAEMON) stamped `metadata.agent_id=<tenant>` with NO
+  `write_signature`; the daemon cannot sign as the tenant, so under the
+  v1.0.0-default `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1` the receiver refused it as
+  an unsigned honored third-party relay (`unenrolled_author_strict`) — it
+  committed on the origin but never reached peers (silent inter-node
+  divergence, forbidden by the North Star). **The fix, send-path/mint-site
+  only (no receiver-twin, wire-schema, or `SignableWrite` change):** on the
+  FEDERATED path the consolidation is now authored as the daemon's federation
+  identity (`FederationConfig::sender_agent_id`) — the substrate that ACTUALLY
+  derived the bytes and HOLDS the signing key — so it SELF-RELAYS past the
+  strict gate (`require = strict && attribute != sender` is structurally
+  false) and converges at EVERY peer regardless of key enrollment, and a
+  best-effort daemon `write_signature` over the standard 6-field
+  `SignableWrite` upgrades it to `attest_level=agent_attested` where the daemon
+  key is enrolled (required for a VISIBLE, non-quarantined convergence under
+  the hardened `asi-hard` profile, which pins
+  `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1`). Crypto-honest (`agent_id ==
+  signer == sender`, no CWE-346 decoupling); matches the already-converging
+  curator `ConsolidationPass`. The invoking tenant + source authors are
+  retained as **UNTRUSTED provenance** (`metadata.consolidator_tenant` +
+  `consolidated_from_agents`; nothing authorizes off them), and the
+  content-authorship truth of a caller-SUPPLIED summary is recorded in
+  `metadata.summary_source` (`caller` | `substrate`).
+- **The consolidation's `derived_from` lineage edges + source disposition now
+  replicate too** (#2860) — previously `broadcast_consolidate_quorum` shipped
+  only `deletions:[source_ids]` (a hard-DELETE), so under the v1.0.0-default
+  `AI_MEMORY_CONSOLIDATE_TOMBSTONE_SOURCES` disposition the origin TOMBSTONED +
+  retained its sources while peers HARD-DELETED them and never received the
+  navigable edges — a second divergence. The broadcast now carries the
+  navigable `C -> source` `derived_from` edges on the existing `links[]` lane
+  and, under the tombstone disposition, re-broadcasts the RETAINED tombstoned
+  source rows on the `memories[]` lane (converging their `lifecycle_state` via
+  the receiver's normal LWW merge, their original `write_signature` still
+  valid) instead of hard-deleting them; the legacy hard-delete disposition
+  keeps the `deletions[]` list unchanged. Backend-parity pinned by a live-pg
+  test; cross-backend authorship/finalize logic covered by unit tests.
+- **New `MemoryStore::set_row_metadata`** SAL primitive (both adapters;
+  additive) — an in-place `metadata` replace (no `updated_at`/`version` bump)
+  used by the federated-consolidate finalize so the stored origin row
+  byte-matches the broadcast copy (a catch-up re-send of a signature-less row
+  would otherwise flip a peer's `agent_attested` row back to `claimed` and
+  re-quarantine it under `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED`).
+
 ### Docs / gates (perfection wave 2 — post-#2844 remainder; #2837 #2838 #2839 #2834)
 
 - **New reference-doc COMPLETENESS gate** `scripts/check-doc-surface-completeness.sh`

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -1018,7 +1018,7 @@ mod tests {
         let cfg = build_config(vec![url1, url2], 2, 2000);
         let new_mem = sample_memory();
         let sources = vec!["src-a".to_string(), "src-b".to_string()];
-        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &sources)
+        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &sources, &[], &[])
             .await
             .unwrap();
         assert!(finalise_quorum(&tracker).is_ok());
@@ -1038,7 +1038,7 @@ mod tests {
         let (url2, _) = spawn_mock_peer(MockBehaviour::Fail).await;
         let cfg = build_config(vec![url1, url2], 3, 500);
         let new_mem = sample_memory();
-        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &[])
+        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &[], &[], &[])
             .await
             .unwrap();
         let err = finalise_quorum(&tracker).unwrap_err();
@@ -3083,7 +3083,7 @@ mod tests {
         let url1 = spawn_id_drift_peer().await;
         let cfg = build_config(vec![url1], 2, 1000);
         let new_mem = sample_memory();
-        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &[])
+        let tracker = broadcast_consolidate_quorum(&cfg, &new_mem, &[], &[], &[])
             .await
             .unwrap();
         let err = finalise_quorum(&tracker).unwrap_err();
@@ -3299,7 +3299,7 @@ mod tests {
         let cfg = build_config(vec![url1, url2], 2, 2000);
         let mem = sample_memory();
         let sources = vec!["src-1".to_string(), "src-2".to_string()];
-        let _tracker = broadcast_consolidate_quorum(&cfg, &mem, &sources)
+        let _tracker = broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[])
             .await
             .unwrap();
         for _ in 0..200 {

--- a/src/federation/sync.rs
+++ b/src/federation/sync.rs
@@ -1203,10 +1203,24 @@ pub async fn broadcast_link_quorum(
     Ok(tracker)
 }
 
-/// v0.6.2 (#326): fan out a consolidation in a single `sync_push` — the new
-/// consolidated memory + the source ids being deleted. Mirrors the local
-/// semantics of `db::consolidate` (insert new + delete sources) so peers
-/// end up in the same terminal state as the originator.
+/// v0.6.2 (#326): fan out a consolidation in a single `sync_push` so peers
+/// reach the SAME terminal state as the originator. Mirrors the local
+/// disposition of `db::consolidate`:
+///
+/// - **`deletions`** — the legacy hard-DELETE disposition: source ids the peer
+///   must reap (populated only when `consolidate_tombstone_sources` is OFF).
+/// - **`tombstoned_sources`** — #2860: the RETAINED, `lifecycle_state`-flipped
+///   source rows under the v1.0.0-default TOMBSTONE disposition. Riding the
+///   normal `memories[]` lane, they converge via the receiver's LWW
+///   `insert_if_newer`/`merge_inbound` (the `SignableWrite` envelope excludes
+///   `lifecycle_state` + `content` is unchanged, so each source's original
+///   `write_signature` still verifies). Peers thus RETAIN + tombstone the
+///   sources instead of hard-deleting them — closing the divergence where the
+///   origin tombstoned while the `deletions[]` lane made peers hard-delete.
+/// - **`derived_edges`** — #2860: the navigable `C -> source` `derived_from`
+///   lineage edges, riding the existing `links[]` lane so the lineage DAG
+///   converges (the `deletions[]` legacy path emits none — cascade would reap
+///   them; `metadata.derived_from` carries provenance there instead).
 ///
 /// # Errors
 ///
@@ -1214,16 +1228,26 @@ pub async fn broadcast_link_quorum(
 pub async fn broadcast_consolidate_quorum(
     config: &FederationConfig,
     new_mem: &Memory,
-    source_ids: &[String],
+    deletions: &[String],
+    tombstoned_sources: &[Memory],
+    derived_edges: &[MemoryLink],
 ) -> Result<AckTracker, QuorumError> {
     let now = Instant::now();
     let tracker = Arc::new(Mutex::new(AckTracker::new(config.policy.clone(), now)));
     tracker.lock().await.record_local();
 
+    // #2860 — the consolidated row FIRST, then any tombstoned source rows, so a
+    // strict-write-sig peer applies the (self-relayed, agent-attested)
+    // consolidation and converges the sources' tombstone state in one push.
+    let mut memories: Vec<&Memory> = Vec::with_capacity(1 + tombstoned_sources.len());
+    memories.push(new_mem);
+    memories.extend(tombstoned_sources.iter());
+
     let body = serde_json::json!({
         (field_names::SENDER_AGENT_ID): config.sender_agent_id,
-        "memories": [new_mem],
-        "deletions": source_ids,
+        "memories": memories,
+        "deletions": deletions,
+        "links": derived_edges,
         "dry_run": false,
     });
 

--- a/src/handlers/consolidate_federation.rs
+++ b/src/handlers/consolidate_federation.rs
@@ -1,0 +1,353 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2860 (federation data-integrity, 5-agent vote `4d3ea1c5`, decision memory
+//! `8b428944`) — helpers that make a TENANT-facing federated consolidation
+//! CONVERGE across a strict-write-sig mesh.
+//!
+//! **The gap.** `POST /api/v1/consolidate` mints a NEW substrate-derived memory
+//! (an LLM summary or a deterministic title-concat produced by the origin
+//! DAEMON) and — pre-#2860 — stamped `metadata.agent_id = <tenant>` with NO
+//! `metadata.write_signature`. The origin daemon CANNOT produce the tenant's
+//! Ed25519 signature, so under the v1.0.0-default strict
+//! `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1` the receiver's per-write attestation gate
+//! refused it as an unsigned HONORED third-party relay (`attribute != sender`)
+//! → it committed on the origin but NEVER converged to peers (#2856 filed the
+//! silent divergence; #2861 shipped the loud-202 floor; THIS closes the gap).
+//!
+//! **The fix (Option A — substrate-authored self-relay + emit-sig).** On the
+//! FEDERATED path the consolidated row is authored as the origin daemon's
+//! federation identity ([`crate::federation::FederationConfig::sender_agent_id`])
+//! — the substrate node that ACTUALLY derived the bytes and that HOLDS the key
+//! it signs with. That makes the receive gate's `require = require_write_sig &&
+//! (attribute != sender)` structurally FALSE (self-relay), so the row converges
+//! at EVERY peer regardless of key enrollment; and a best-effort daemon
+//! `write_signature` over the standard 6-field `SignableWrite` envelope upgrades
+//! it to `attest_level=agent_attested` wherever the daemon key is enrolled (the
+//! posture the hardened `asi-hard` profile, which pins
+//! `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1`, requires for a VISIBLE, non-
+//! quarantined convergence). Authoring as the sender is crypto-honest
+//! (`agent_id == signer == sender`, no CWE-346 decoupling) and matches the
+//! already-converging curator `ConsolidationPass` (author = `AI_CURATOR`
+//! substrate sentinel). The invoking tenant + source authors are retained as
+//! UNTRUSTED provenance ([`META_CONSOLIDATOR_TENANT`] + the existing
+//! `consolidated_from_agents`), and the content-authorship truth of a
+//! caller-SUPPLIED summary is preserved in [`META_SUMMARY_SOURCE`].
+
+use crate::models::{Memory, MemoryLink, MemoryLinkRelation, field_names};
+
+/// `metadata.consolidator_tenant` — the tenant that INVOKED a substrate-authored
+/// federated consolidation. **UNTRUSTED provenance** (rides unsigned metadata):
+/// nothing may authorize, isolate, quota, bill, or delete off this key (the
+/// #2860 security-lens ruling — the instant something does, the CWE-345 honesty
+/// guarantee lapses). The signed authorship (`metadata.agent_id`) is the
+/// substrate; this only records "on whose behalf".
+pub(crate) const META_CONSOLIDATOR_TENANT: &str = "consolidator_tenant";
+
+/// `metadata.summary_source` — `"caller"` when the consolidation's `content` is
+/// the VERBATIM tenant-supplied summary (genuinely tenant-authored bytes) or
+/// `"substrate"` when the daemon derived it (LLM / deterministic concat). Keeps
+/// the row's authorship record truthful even though `agent_id` names the
+/// substrate that assembled + signs the row (#2860 truthfulness lens).
+pub(crate) const META_SUMMARY_SOURCE: &str = "summary_source";
+/// [`META_SUMMARY_SOURCE`] value: caller supplied the summary bytes verbatim.
+pub(crate) const SUMMARY_SOURCE_CALLER: &str = "caller";
+/// [`META_SUMMARY_SOURCE`] value: the substrate (daemon) derived the summary.
+pub(crate) const SUMMARY_SOURCE_SUBSTRATE: &str = "substrate";
+
+/// Classify the consolidation's content authorship from the request's raw
+/// `summary` field: a non-empty caller-supplied summary is genuinely
+/// tenant-authored CONTENT ([`SUMMARY_SOURCE_CALLER`]); an absent / empty one
+/// means the daemon derived it (LLM or deterministic concat,
+/// [`SUMMARY_SOURCE_SUBSTRATE`]). Keeps the row's authorship record truthful
+/// even though `agent_id` names the substrate that assembled + signs the row.
+#[must_use]
+pub(crate) fn summary_source_of(raw_summary: Option<&str>) -> &'static str {
+    if raw_summary.is_some_and(|s| !s.trim().is_empty()) {
+        SUMMARY_SOURCE_CALLER
+    } else {
+        SUMMARY_SOURCE_SUBSTRATE
+    }
+}
+
+/// Finalize a substrate-authored consolidated row's metadata for federation:
+/// take the read-back row's metadata (whose `agent_id` is already the substrate
+/// author == `author_agent_id`) and additively stamp the [`META_CONSOLIDATOR_TENANT`]
+/// + [`META_SUMMARY_SOURCE`] provenance keys, then BEST-EFFORT sign the row with
+/// the daemon's `author_agent_id` keypair, persisting `metadata.write_signature`
+/// + `metadata.attest_level = agent_attested`.
+///
+/// Returns the FULL replacement metadata `Value` and whether a signature was
+/// emitted. When no daemon signing key is enrolled the row converges as
+/// `claimed` (still fixes the divergence); no fields other than the two
+/// provenance keys are added in that case. The signature commits ONLY to the
+/// 6-field `SignableWrite` envelope (`agent_id + namespace + title + kind +
+/// created_at + sha256(content)`), which excludes `metadata`, so stamping the
+/// provenance keys never invalidates it, and it is computed over the PLAINTEXT
+/// `content` the broadcast + receiver see (never an at-rest ciphertext).
+#[must_use]
+pub(crate) fn finalize_consolidation_metadata(
+    mem: &Memory,
+    author_agent_id: &str,
+    signing_keypair: Option<&crate::identity::keypair::AgentKeypair>,
+    consolidator_tenant: &str,
+    summary_source: &str,
+) -> (serde_json::Value, bool) {
+    let mut meta = mem.metadata.clone();
+    if let Some(obj) = meta.as_object_mut() {
+        if !consolidator_tenant.is_empty() {
+            obj.insert(
+                META_CONSOLIDATOR_TENANT.to_string(),
+                serde_json::Value::String(consolidator_tenant.to_string()),
+            );
+        }
+        obj.insert(
+            META_SUMMARY_SOURCE.to_string(),
+            serde_json::Value::String(summary_source.to_string()),
+        );
+    }
+    let signed = match signing_keypair {
+        Some(kp) => sign_into_metadata(&mut meta, mem, author_agent_id, kp),
+        None => false,
+    };
+    (meta, signed)
+}
+
+/// Best-effort load of the daemon's signing keypair for the federation identity
+/// that will AUTHOR (and self-attest) a consolidated row. Returns `None` when no
+/// private key is enrolled on disk — the consolidation then converges `claimed`
+/// (still fixed; only the `agent_attested` upgrade is skipped). The daemon HOLDS
+/// this key (it is the same identity it signs the `/sync/push` envelope with),
+/// so signing as it is honest self-attestation, never a CWE-346 decoupling.
+#[must_use]
+pub(crate) fn load_author_signing_keypair(
+    author_agent_id: &str,
+) -> Option<crate::identity::keypair::AgentKeypair> {
+    let dir = crate::identity::keypair::default_key_dir().ok()?;
+    let kp = crate::identity::keypair::load(author_agent_id, &dir).ok()?;
+    if kp.private.is_none() {
+        return None;
+    }
+    Some(kp)
+}
+
+/// Sign `mem`'s 6-field `SignableWrite` with `keypair` (whose identity is
+/// `author_agent_id == mem.metadata.agent_id`) and stamp
+/// `metadata.write_signature` (base64) + `metadata.attest_level=agent_attested`.
+/// The envelope excludes `metadata`, so stamping these keys never invalidates
+/// the signature, and it commits over the PLAINTEXT `content` the broadcast +
+/// receiver see. Returns `false` on a signing failure (e.g. a public-only key).
+fn sign_into_metadata(
+    meta: &mut serde_json::Value,
+    mem: &Memory,
+    author_agent_id: &str,
+    keypair: &crate::identity::keypair::AgentKeypair,
+) -> bool {
+    use base64::Engine as _;
+    let Ok(sig) = crate::identity::attest::sign_memory_write(keypair, mem, author_agent_id) else {
+        return false;
+    };
+    let Some(obj) = meta.as_object_mut() else {
+        return false;
+    };
+    obj.insert(
+        field_names::WRITE_SIGNATURE.to_string(),
+        serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(&sig)),
+    );
+    obj.insert(
+        field_names::ATTEST_LEVEL.to_string(),
+        serde_json::Value::String(
+            crate::identity::verify::AttestLevel::AgentAttested
+                .as_str()
+                .to_string(),
+        ),
+    );
+    true
+}
+
+/// Build the navigable `derived_from` edges (`C -> source`, one per source)
+/// that must converge to peers alongside the consolidated row when the sources
+/// are TOMBSTONED (retained) rather than hard-deleted — mirroring the origin's
+/// `db::consolidate` edge writes. Unsigned advisory provenance edges (the
+/// `source_cid`/`target_cid` mirror is repopulated by the receiver's link-apply
+/// path). Empty under the legacy hard-delete disposition (the edges would be
+/// cascade-deleted on both ends, so `metadata.derived_from` carries provenance
+/// instead).
+#[must_use]
+pub(crate) fn derived_from_edges(consolidated: &Memory, source_ids: &[String]) -> Vec<MemoryLink> {
+    source_ids
+        .iter()
+        .map(|source_id| MemoryLink {
+            source_id: consolidated.id.clone(),
+            target_id: source_id.clone(),
+            relation: MemoryLinkRelation::DerivedFrom,
+            created_at: consolidated.created_at.clone(),
+            signature: None,
+            observed_by: None,
+            valid_from: None,
+            valid_until: None,
+            attest_level: None,
+            source_cid: None,
+            target_cid: None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    //! #2860 regression — pins that a substrate-authored (self-relayed)
+    //! consolidation CONVERGES under the v1.0.0-default strict
+    //! `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1`, both as a signed `agent_attested`
+    //! row (daemon key enrolled) and as an unsigned `claimed` self-relay
+    //! (structurally accepted because `attribute == sender`) — the exact gap
+    //! #2856/#2860 filed. Complements the live 2-node pg+AGE convergence repro.
+    use super::*;
+    use crate::identity::verify::AttestLevel;
+    use crate::identity::{attest, keypair};
+    use crate::models::Memory;
+
+    /// The daemon federation identity that authors a federated consolidation.
+    const SENDER: &str = "ai:node1";
+    /// The invoking tenant (retained only as untrusted provenance).
+    const TENANT: &str = "tenant:alice";
+
+    fn pk_b64(kp: &keypair::AgentKeypair) -> String {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(kp.public.to_bytes())
+    }
+
+    /// A consolidated row as `db::consolidate` mints it on the FEDERATED path:
+    /// `metadata.agent_id` already the substrate sender.
+    fn consolidated_mem() -> Memory {
+        Memory {
+            id: "c-2860".to_string(),
+            namespace: "team/alpha".to_string(),
+            title: "merged deployment notes".to_string(),
+            content: "scale to three replicas; use the blue-green rollout".to_string(),
+            created_at: "2026-08-10T12:00:00+00:00".to_string(),
+            metadata: serde_json::json!({
+                "agent_id": SENDER,
+                "consolidated_from_agents": ["tenant:alice", "tenant:bob"],
+            }),
+            ..Memory::default()
+        }
+    }
+
+    #[test]
+    fn finalize_with_daemon_key_lands_agent_attested_and_verifies() {
+        let kp = keypair::generate(SENDER).expect("gen daemon key");
+        let mem = consolidated_mem();
+        let (meta, signed) = finalize_consolidation_metadata(
+            &mem,
+            SENDER,
+            Some(&kp),
+            TENANT,
+            SUMMARY_SOURCE_SUBSTRATE,
+        );
+        assert!(signed, "a daemon key must produce a write_signature");
+        let obj = meta.as_object().unwrap();
+        // Provenance stamped.
+        assert_eq!(obj[META_CONSOLIDATOR_TENANT], serde_json::json!(TENANT));
+        assert_eq!(
+            obj[META_SUMMARY_SOURCE],
+            serde_json::json!(SUMMARY_SOURCE_SUBSTRATE)
+        );
+        assert_eq!(
+            obj[field_names::ATTEST_LEVEL],
+            serde_json::json!(AttestLevel::AgentAttested.as_str())
+        );
+        // The emitted signature must actually VERIFY at a receiver: recompute
+        // the attestation over the SAME row + the sender's enrolled pubkey.
+        use base64::Engine as _;
+        let sig = base64::engine::general_purpose::STANDARD
+            .decode(obj[field_names::WRITE_SIGNATURE].as_str().unwrap())
+            .expect("decode write_signature");
+        let mut verify_mem = consolidated_mem();
+        let level = attest::stamp_attestation(
+            &mut verify_mem,
+            SENDER,
+            Some(&pk_b64(&kp)),
+            Some(&sig),
+            true, // strict — this is the honored self-relay lane's verify
+        )
+        .expect("substrate-signed consolidation must verify under strict");
+        assert_eq!(
+            level,
+            AttestLevel::AgentAttested,
+            "a daemon-signed consolidation converges agent_attested where the key is enrolled"
+        );
+    }
+
+    #[test]
+    fn self_relay_converges_claimed_without_a_key() {
+        // No daemon key on disk: finalize adds only provenance, no signature.
+        let mem = consolidated_mem();
+        let (meta, signed) =
+            finalize_consolidation_metadata(&mem, SENDER, None, TENANT, SUMMARY_SOURCE_CALLER);
+        assert!(!signed);
+        let obj = meta.as_object().unwrap();
+        assert!(!obj.contains_key(field_names::WRITE_SIGNATURE));
+        assert_eq!(
+            obj[META_SUMMARY_SOURCE],
+            serde_json::json!(SUMMARY_SOURCE_CALLER)
+        );
+        // The receiver gate computes `require = strict && (attribute != sender)`;
+        // for a self-relay (author == sender) that is FALSE, so an UNSIGNED
+        // consolidation is still ACCEPTED (lands `claimed`) — the structural
+        // reason authoring-as-sender converges at EVERY peer regardless of key
+        // enrollment. Mirror that self-relay verify here (require = false).
+        let mut verify_mem = consolidated_mem();
+        let level = attest::stamp_attestation(&mut verify_mem, SENDER, None, None, false)
+            .expect("self-relay accepts unsigned");
+        assert_eq!(level, AttestLevel::Claimed);
+    }
+
+    #[test]
+    fn tenant_authored_unsigned_is_refused_under_strict_honored_relay() {
+        // The PRE-#2860 shape: a TENANT-attributed consolidation relayed by the
+        // daemon (attribute=tenant != sender) with no verifiable signature is
+        // REFUSED under strict — the exact divergence #2860 closes by moving
+        // authorship to the sender (above).
+        let mut mem = consolidated_mem();
+        mem.metadata
+            .as_object_mut()
+            .unwrap()
+            .insert("agent_id".to_string(), serde_json::json!("tenant:alice"));
+        // Honored third-party relay verify: no bound key, no signature, strict.
+        let err = attest::stamp_attestation(&mut mem, "tenant:alice", None, None, true);
+        assert!(
+            err.is_err(),
+            "an unsigned honored third-party (tenant) relay must be refused under strict"
+        );
+    }
+
+    #[test]
+    fn summary_source_classification() {
+        assert_eq!(
+            summary_source_of(Some("a real summary")),
+            SUMMARY_SOURCE_CALLER
+        );
+        assert_eq!(summary_source_of(Some("   ")), SUMMARY_SOURCE_SUBSTRATE);
+        assert_eq!(summary_source_of(None), SUMMARY_SOURCE_SUBSTRATE);
+    }
+
+    #[test]
+    fn derived_from_edges_point_from_consolidation_to_each_source() {
+        let mem = consolidated_mem();
+        let sources = vec!["src-a".to_string(), "src-b".to_string()];
+        let edges = derived_from_edges(&mem, &sources);
+        assert_eq!(edges.len(), 2);
+        for (edge, src) in edges.iter().zip(sources.iter()) {
+            assert_eq!(
+                edge.source_id, mem.id,
+                "edge originates at the consolidation"
+            );
+            assert_eq!(&edge.target_id, src, "edge targets the source");
+            assert_eq!(
+                edge.relation,
+                crate::models::MemoryLinkRelation::DerivedFrom
+            );
+            assert_eq!(edge.created_at, mem.created_at);
+        }
+    }
+}

--- a/src/handlers/consolidate_federation.rs
+++ b/src/handlers/consolidate_federation.rs
@@ -193,6 +193,126 @@ pub(crate) fn derived_from_edges(consolidated: &Memory, source_ids: &[String]) -
         .collect()
 }
 
+/// The broadcast disposition for a federated consolidation: the source ids to
+/// hard-DELETE at peers (legacy), the RETAINED tombstoned source rows to
+/// re-broadcast (tombstone disposition), and the `derived_from` edges to ship.
+pub(crate) struct FanoutDisposition {
+    pub deletions: Vec<String>,
+    pub tombstoned_sources: Vec<Memory>,
+    pub derived_edges: Vec<MemoryLink>,
+}
+
+/// SQLITE federated-consolidate finalize + disposition (shared, testable). On
+/// the read-back consolidated row `mem` (already authored as `author_id` == the
+/// federation sender): stamp the substrate `write_signature` + tenant/summary
+/// provenance (persisting it in place so the stored origin row byte-matches the
+/// broadcast copy), mutate `mem.metadata` to the finalized value, then compute
+/// the source disposition — under the v1.0.0-default tombstone posture the
+/// RETAINED tombstoned source rows are re-broadcast (no `deletions`) alongside
+/// the navigable `derived_from` edges; otherwise the legacy `deletions` list is
+/// returned. All reads/writes go through the caller's already-open connection.
+pub(crate) fn sqlite_finalize_and_disposition(
+    conn: &rusqlite::Connection,
+    mem: &mut Memory,
+    source_ids: &[String],
+    author_id: &str,
+    consolidator_tenant: &str,
+    raw_summary: Option<&str>,
+) -> FanoutDisposition {
+    let summary_source = summary_source_of(raw_summary);
+    let author_kp = load_author_signing_keypair(author_id);
+    let (final_meta, _signed) = finalize_consolidation_metadata(
+        mem,
+        author_id,
+        author_kp.as_ref(),
+        consolidator_tenant,
+        summary_source,
+    );
+    if let Ok(js) = serde_json::to_string(&final_meta) {
+        if let Err(e) = crate::db::set_row_metadata(conn, &mem.id, &js) {
+            tracing::warn!(
+                "consolidate: failed to persist federated attestation metadata for {}: {e}",
+                mem.id
+            );
+        }
+    }
+    mem.metadata = final_meta;
+    if crate::config::consolidate_tombstone_sources_enabled() {
+        let tombstoned_sources = source_ids
+            .iter()
+            .filter_map(|id| crate::db::get(conn, id).ok().flatten())
+            .collect();
+        let derived_edges = derived_from_edges(mem, source_ids);
+        FanoutDisposition {
+            deletions: Vec::new(),
+            tombstoned_sources,
+            derived_edges,
+        }
+    } else {
+        FanoutDisposition {
+            deletions: source_ids.to_vec(),
+            tombstoned_sources: Vec::new(),
+            derived_edges: Vec::new(),
+        }
+    }
+}
+
+/// SAL-store (postgres) twin of [`sqlite_finalize_and_disposition`] — identical
+/// finalize + disposition logic routed through the `MemoryStore` trait so the
+/// two backends cannot drift. `ctx` is the SOURCE-read context (the invoking
+/// tenant, who owns the sources); `set_row_metadata` ignores it (in-place
+/// by-id). `mem` is the read-back consolidated row (already authored as
+/// `author_id`).
+#[cfg(feature = "sal")]
+pub(crate) async fn store_finalize_and_disposition(
+    store: &dyn crate::store::MemoryStore,
+    ctx: &crate::store::CallerContext,
+    mem: &mut Memory,
+    source_ids: &[String],
+    author_id: &str,
+    consolidator_tenant: &str,
+    raw_summary: Option<&str>,
+) -> FanoutDisposition {
+    let summary_source = summary_source_of(raw_summary);
+    let author_kp = load_author_signing_keypair(author_id);
+    let (final_meta, _signed) = finalize_consolidation_metadata(
+        mem,
+        author_id,
+        author_kp.as_ref(),
+        consolidator_tenant,
+        summary_source,
+    );
+    if let Ok(js) = serde_json::to_string(&final_meta) {
+        if let Err(e) = store.set_row_metadata(ctx, &mem.id, &js).await {
+            tracing::warn!(
+                "consolidate(pg): failed to persist federated attestation metadata for {}: {e}",
+                mem.id
+            );
+        }
+    }
+    mem.metadata = final_meta;
+    if crate::config::consolidate_tombstone_sources_enabled() {
+        let mut tombstoned_sources = Vec::with_capacity(source_ids.len());
+        for id in source_ids {
+            if let Ok(src) = store.get(ctx, id).await {
+                tombstoned_sources.push(src);
+            }
+        }
+        let derived_edges = derived_from_edges(mem, source_ids);
+        FanoutDisposition {
+            deletions: Vec::new(),
+            tombstoned_sources,
+            derived_edges,
+        }
+    } else {
+        FanoutDisposition {
+            deletions: source_ids.to_vec(),
+            tombstoned_sources: Vec::new(),
+            derived_edges: Vec::new(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! #2860 regression — pins that a substrate-authored (self-relayed)
@@ -349,5 +469,180 @@ mod tests {
             );
             assert_eq!(edge.created_at, mem.created_at);
         }
+    }
+
+    // ---- finalize+disposition helper coverage (both backend twins) ----
+
+    use std::sync::Mutex;
+    /// Serializes the tombstone/lineage process-global flag flips.
+    static FLAG_LOCK: Mutex<()> = Mutex::new(());
+
+    fn seed_mem(id: &str, ns: &str, title: &str, author: &str) -> Memory {
+        Memory {
+            id: id.to_string(),
+            namespace: ns.to_string(),
+            title: title.to_string(),
+            content: format!("content for {title} alpha beta gamma"),
+            created_at: "2026-08-10T12:00:00+00:00".to_string(),
+            updated_at: "2026-08-10T12:00:00+00:00".to_string(),
+            metadata: serde_json::json!({ "agent_id": author }),
+            ..Memory::default()
+        }
+    }
+
+    /// SQLITE twin: `sqlite_finalize_and_disposition` under the tombstone
+    /// disposition stamps the provenance, persists it in place, and returns the
+    /// retained tombstoned sources + navigable edges (no `deletions`).
+    #[test]
+    fn sqlite_finalize_and_disposition_tombstone_disposition() {
+        let _g = FLAG_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::config::set_lineage_dag(true);
+        crate::config::set_consolidate_tombstone_sources(true);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conn = crate::db::open(&dir.path().join("t.db")).expect("open");
+        let ns = "fed-consolidate-2860";
+        crate::db::insert(&conn, &seed_mem("src-a", ns, "A", "tenant:alice")).expect("a");
+        crate::db::insert(&conn, &seed_mem("src-b", ns, "B", "tenant:alice")).expect("b");
+        let mut consolidated = seed_mem("c-2860", ns, "merged", SENDER);
+        crate::db::insert(&conn, &consolidated).expect("c");
+
+        let disp = sqlite_finalize_and_disposition(
+            &conn,
+            &mut consolidated,
+            &["src-a".to_string(), "src-b".to_string()],
+            SENDER,
+            TENANT,
+            Some("a caller summary"),
+        );
+
+        crate::config::set_lineage_dag(false);
+        crate::config::set_consolidate_tombstone_sources(false);
+
+        assert!(
+            disp.deletions.is_empty(),
+            "tombstone mode ships no hard deletions"
+        );
+        assert_eq!(
+            disp.tombstoned_sources.len(),
+            2,
+            "both retained sources re-broadcast"
+        );
+        assert_eq!(
+            disp.derived_edges.len(),
+            2,
+            "one derived_from edge per source"
+        );
+        // Provenance stamped on the in-memory row AND persisted.
+        assert_eq!(
+            consolidated.metadata[META_CONSOLIDATOR_TENANT],
+            serde_json::json!(TENANT)
+        );
+        assert_eq!(
+            consolidated.metadata[META_SUMMARY_SOURCE],
+            serde_json::json!(SUMMARY_SOURCE_CALLER)
+        );
+        let persisted = crate::db::get(&conn, "c-2860")
+            .expect("get")
+            .expect("present");
+        assert_eq!(
+            persisted.metadata[META_CONSOLIDATOR_TENANT],
+            serde_json::json!(TENANT),
+            "finalize metadata persisted to the origin row (byte-matches broadcast)"
+        );
+    }
+
+    /// SQLITE twin, legacy hard-delete disposition: `deletions` carries the
+    /// source ids and no tombstoned rows / edges are shipped.
+    #[test]
+    fn sqlite_finalize_and_disposition_legacy_delete_disposition() {
+        let _g = FLAG_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::config::set_lineage_dag(false);
+        crate::config::set_consolidate_tombstone_sources(false);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conn = crate::db::open(&dir.path().join("t.db")).expect("open");
+        let mut consolidated = seed_mem("c-legacy", "ns", "merged", SENDER);
+        crate::db::insert(&conn, &consolidated).expect("c");
+        let disp = sqlite_finalize_and_disposition(
+            &conn,
+            &mut consolidated,
+            &["src-a".to_string(), "src-b".to_string()],
+            SENDER,
+            TENANT,
+            None,
+        );
+        assert_eq!(
+            disp.deletions.len(),
+            2,
+            "legacy disposition hard-deletes sources"
+        );
+        assert!(disp.tombstoned_sources.is_empty());
+        assert!(disp.derived_edges.is_empty());
+        assert_eq!(
+            consolidated.metadata[META_SUMMARY_SOURCE],
+            serde_json::json!(SUMMARY_SOURCE_SUBSTRATE)
+        );
+    }
+
+    /// SAL twin: `store_finalize_and_disposition` runs the IDENTICAL body
+    /// through the `MemoryStore` trait — exercised here with a `SqliteStore`
+    /// (so the postgres branch's finalize logic is covered without a live pg).
+    #[cfg(feature = "sal")]
+    #[tokio::test]
+    async fn store_finalize_and_disposition_matches_sqlite_twin() {
+        use crate::store::{CallerContext, MemoryStore};
+        let _g = FLAG_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::config::set_lineage_dag(true);
+        crate::config::set_consolidate_tombstone_sources(true);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = crate::store::sqlite::SqliteStore::open(dir.path().join("s.db")).expect("open");
+        let tenant_ctx = CallerContext::for_agent(TENANT);
+        store
+            .store(&tenant_ctx, &seed_mem("s-a", "ns", "A", TENANT))
+            .await
+            .expect("a");
+        store
+            .store(&tenant_ctx, &seed_mem("s-b", "ns", "B", TENANT))
+            .await
+            .expect("b");
+        let mut consolidated = seed_mem("s-c", "ns", "merged", SENDER);
+        store
+            .store(&CallerContext::for_agent(SENDER), &consolidated)
+            .await
+            .expect("c");
+
+        let disp = store_finalize_and_disposition(
+            &store,
+            &tenant_ctx,
+            &mut consolidated,
+            &["s-a".to_string(), "s-b".to_string()],
+            SENDER,
+            TENANT,
+            Some("caller text"),
+        )
+        .await;
+
+        crate::config::set_lineage_dag(false);
+        crate::config::set_consolidate_tombstone_sources(false);
+
+        assert!(disp.deletions.is_empty());
+        assert_eq!(disp.tombstoned_sources.len(), 2);
+        assert_eq!(disp.derived_edges.len(), 2);
+        assert_eq!(
+            consolidated.metadata[META_CONSOLIDATOR_TENANT],
+            serde_json::json!(TENANT)
+        );
+        assert_eq!(
+            consolidated.metadata[META_SUMMARY_SOURCE],
+            serde_json::json!(SUMMARY_SOURCE_CALLER)
+        );
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -103,6 +103,7 @@ pub mod approvals;
 pub mod archive;
 pub mod bulk;
 pub mod capture_turn;
+pub mod consolidate_federation;
 pub mod coordination;
 pub mod create;
 pub mod errors;

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -225,11 +225,14 @@ async fn fetch_consolidate_source_pairs(
     Ok(out)
 }
 
-/// #1552 / #326 — shared federation fanout for the consolidate write path,
-/// called by both the postgres SAL branch and the sqlite branch of
-/// [`consolidate_memories`]. Broadcasts the merged memory + the source-id
-/// deletions to the W-quorum so peers converge `metadata.consolidated_from_agents`
-/// + the deleted sources synchronously instead of waiting on async catch-up.
+/// #1552 / #326 / #2860 — shared federation fanout for the consolidate write
+/// path, called by both the postgres SAL branch and the sqlite branch of
+/// [`consolidate_memories`]. Broadcasts the substrate-authored merged memory to
+/// the W-quorum plus its source disposition — either the legacy `deletions`
+/// (hard-DELETE) list OR the RETAINED `tombstoned_sources` rows + navigable
+/// `derived_edges` (`derived_from`) under the v1.0.0-default tombstone
+/// disposition (#2860) — so peers converge the consolidation, the source state,
+/// AND the lineage DAG synchronously instead of waiting on async catch-up.
 ///
 /// Returns `Some(response)` when the quorum is NOT met (a typed 503 the caller
 /// must return verbatim), or `None` on success / when federation is disabled
@@ -237,13 +240,27 @@ async fn fetch_consolidate_source_pairs(
 async fn consolidate_fanout(
     fed: Option<&crate::federation::FederationConfig>,
     mem: &crate::models::Memory,
-    source_ids: &[String],
+    deletions: &[String],
+    tombstoned_sources: &[crate::models::Memory],
+    derived_edges: &[crate::models::MemoryLink],
 ) -> Option<axum::response::Response> {
     let fed = fed?;
-    match crate::federation::broadcast_consolidate_quorum(fed, mem, source_ids).await {
+    match crate::federation::broadcast_consolidate_quorum(
+        fed,
+        mem,
+        deletions,
+        tombstoned_sources,
+        derived_edges,
+    )
+    .await
+    {
         Ok(tracker) => {
             if let Err(err) = crate::federation::finalise_quorum(&tracker) {
-                // #869 — typed 503 envelope via the shared helper.
+                // #869 — typed 503 envelope via the shared helper. (#2861 in the
+                // merge queue enhances this to an id-bearing 202 via
+                // `under_replicated_consolidate_response`; overlap noted — this
+                // convergence fix makes the quorum SUCCEED, so the miss path is
+                // now the residual peer-down case, where the loud floor matters.)
                 let payload = crate::federation::QuorumNotMetPayload::from_err(&err);
                 return Some(super::under_replicated_response(&payload));
             }
@@ -393,6 +410,15 @@ pub async fn consolidate_memories(
         {
             return store_err_to_response(e);
         }
+        // #2860 (5-agent vote `4d3ea1c5`) — federated path: author the
+        // substrate-DERIVED row as the daemon's federation identity so it
+        // self-relays past strict write-sig (postgres twin of the sqlite
+        // branch's `author_id`). The `for_agent` ctx (source-read visibility /
+        // IDOR) is UNCHANGED — only the recorded author moves.
+        let pg_author_id = match app.federation.as_ref().as_ref() {
+            Some(f) => f.sender_agent_id.clone(),
+            None => consolidator_agent_id.clone(),
+        };
         let new_id = match app
             .store
             .consolidate(
@@ -403,26 +429,81 @@ pub async fn consolidate_memories(
                 &body.namespace,
                 &tier,
                 crate::db::CONSOLIDATION_SOURCE,
-                &consolidator_agent_id,
+                &pg_author_id,
             )
             .await
         {
             Ok(new_id) => new_id,
             Err(e) => return store_err_to_response(e),
         };
-        // #1552 — federation fanout parity (shared `consolidate_fanout` helper,
-        // covered by the sqlite-branch fanout test). The SAL-ported postgres
-        // branch previously returned here WITHOUT broadcasting, so on a
-        // postgres-backed federated hive a consolidation only reached
-        // cross-region peers via async catch-up (`/sync/since`) rather than the
-        // synchronous W-quorum. Read the merged row back through the trait, then
-        // broadcast it + the source-id deletions; a quorum miss surfaces a typed
-        // 503 exactly like the regular create path. A read-back failure logs +
-        // falls through to the success envelope (catch-up reconciles peers).
+        // #1552 / #2860 — federation fanout parity (shared `consolidate_fanout`
+        // helper). The SAL-ported postgres branch previously returned here
+        // WITHOUT broadcasting; now it reads the substrate-authored row back
+        // through the trait, FINALIZES it (best-effort daemon `write_signature`
+        // + tenant/summary provenance, persisted via `set_row_metadata` so the
+        // stored row byte-matches the broadcast copy), and broadcasts it + its
+        // source disposition + `derived_from` lineage — the postgres twin of the
+        // sqlite branch below. A read-back failure logs + falls through to the
+        // success envelope (catch-up reconciles peers).
         if app.federation.is_some() {
-            if let Ok(mem) = app.store.get(&ctx, &new_id).await {
-                if let Some(resp) =
-                    consolidate_fanout(app.federation.as_ref().as_ref(), &mem, &source_ids).await
+            // #2860 — the consolidated row is now owned by `pg_author_id` (the
+            // substrate sender), so read it back AS the author: the `for_agent`
+            // tenant `ctx` would visibility-filter the sender-owned row to
+            // NotFound and silently skip the fanout. The source reads below stay
+            // on the tenant `ctx` (the tenant owns the sources).
+            let author_ctx = crate::store::CallerContext::for_agent(&pg_author_id);
+            if let Ok(mut mem) = app.store.get(&author_ctx, &new_id).await {
+                let summary_source = crate::handlers::consolidate_federation::summary_source_of(
+                    body.summary.as_deref(),
+                );
+                let author_kp =
+                    crate::handlers::consolidate_federation::load_author_signing_keypair(
+                        &pg_author_id,
+                    );
+                let (final_meta, _signed) =
+                    crate::handlers::consolidate_federation::finalize_consolidation_metadata(
+                        &mem,
+                        &pg_author_id,
+                        author_kp.as_ref(),
+                        &consolidator_agent_id,
+                        summary_source,
+                    );
+                if let Ok(js) = serde_json::to_string(&final_meta) {
+                    if let Err(e) = app.store.set_row_metadata(&ctx, &new_id, &js).await {
+                        tracing::warn!(
+                            "consolidate(pg): failed to persist federated attestation metadata for {new_id}: {e}"
+                        );
+                    }
+                }
+                mem.metadata = final_meta;
+                // Source disposition: TOMBSTONE (v1.0.0 default) re-broadcasts the
+                // retained tombstoned source rows via memories[] + ships the
+                // navigable derived_from edges; legacy hard-delete keeps the
+                // deletions[] list.
+                let (deletions, tombstoned_sources, derived_edges) =
+                    if crate::config::consolidate_tombstone_sources_enabled() {
+                        let mut sources: Vec<Memory> = Vec::with_capacity(source_ids.len());
+                        for id in &source_ids {
+                            if let Ok(src) = app.store.get(&ctx, id).await {
+                                sources.push(src);
+                            }
+                        }
+                        let edges = crate::handlers::consolidate_federation::derived_from_edges(
+                            &mem,
+                            &source_ids,
+                        );
+                        (Vec::new(), sources, edges)
+                    } else {
+                        (source_ids.clone(), Vec::new(), Vec::new())
+                    };
+                if let Some(resp) = consolidate_fanout(
+                    app.federation.as_ref().as_ref(),
+                    &mem,
+                    &deletions,
+                    &tombstoned_sources,
+                    &derived_edges,
+                )
+                .await
                 {
                     return resp;
                 }
@@ -498,9 +579,29 @@ pub async fn consolidate_memories(
             };
         }
     }
-    // #2121 — tenant HTTP surface: never substrate-authored (parity with the
-    // postgres branch above, whose `for_agent` ctx has
-    // `bypass_visibility = false`).
+    // #2121 / #2860 — a NON-federated tenant HTTP consolidate stays tenant-
+    // authored + never substrate-authored (byte-identical single-node
+    // behaviour). On the FEDERATED path (#2860, 5-agent vote `4d3ea1c5`,
+    // decision memory `8b428944`) the substrate-DERIVED row is authored as the
+    // daemon's federation identity (`fed.sender_agent_id`) — the substrate that
+    // ran the derivation and HOLDS the signing key — so it SELF-RELAYS past the
+    // strict per-write attestation gate (`require = strict && attribute !=
+    // sender` is false) and can land `agent_attested` where the daemon key is
+    // enrolled. Quota is still charged to the INVOKING tenant above; the tenant
+    // is retained as provenance by the federated finalize below. This mirrors
+    // the already-converging curator `ConsolidationPass` (author = `AI_CURATOR`
+    // substrate sentinel). `substrate_authored` stays `false` for cross-backend
+    // parity: the postgres SAL `consolidate` derives it from
+    // `ctx.bypass_visibility` (`false` for the `for_agent` tenant ctx we must
+    // NOT relax — it gates the source-read visibility / IDOR), so the sqlite
+    // path mirrors that, and the `AI_MEMORY_REQUIRE_WHY_TRACE=1` gate applies
+    // IDENTICALLY on both backends (a why_trace-less federated consolidation is
+    // refused on both, never stamped-and-passed on one).
+    let fed_enabled = app.federation.is_some();
+    let author_id = match app.federation.as_ref().as_ref() {
+        Some(f) => f.sender_agent_id.clone(),
+        None => consolidator_agent_id.clone(),
+    };
     let consolidate_result = db::consolidate(
         &lock.0,
         &body.ids,
@@ -509,7 +610,7 @@ pub async fn consolidate_memories(
         &body.namespace,
         &tier,
         crate::db::CONSOLIDATION_SOURCE,
-        &consolidator_agent_id,
+        &author_id,
         false,
     );
     // #1788 — refund the quota charge if the consolidate write failed (mirrors
@@ -525,9 +626,10 @@ pub async fn consolidate_memories(
         }
     }
     // Read the newly consolidated memory back so we can fanout — must do
-    // this inside the same lock window because db::consolidate deletes
-    // the source rows as part of its transaction.
-    let new_mem = match &consolidate_result {
+    // this inside the same lock window because db::consolidate deletes (or,
+    // under the tombstone disposition, retains) the source rows as part of
+    // its transaction.
+    let mut new_mem = match &consolidate_result {
         Ok(new_id) => db::get(&lock.0, new_id).ok().flatten(),
         Err(_) => None,
     };
@@ -550,17 +652,71 @@ pub async fn consolidate_memories(
             details,
         );
     }
+    // #2860 — on the FEDERATED path, finalize the substrate-authored row
+    // (best-effort daemon `write_signature` + tenant/summary provenance) and
+    // prepare the lineage disposition to broadcast, all while the lock is held
+    // so the tombstoned source rows + `derived_from` edges are read
+    // consistently. `fanout_deletions` defaults to the legacy hard-DELETE list
+    // and is emptied only under the tombstone disposition (where the sources
+    // are re-broadcast as tombstoned rows instead).
+    let mut fanout_deletions: Vec<String> = source_ids.clone();
+    let mut tombstoned_sources: Vec<Memory> = Vec::new();
+    let mut derived_edges: Vec<crate::models::MemoryLink> = Vec::new();
+    if fed_enabled {
+        if let Some(mem) = new_mem.as_mut() {
+            let summary_source =
+                crate::handlers::consolidate_federation::summary_source_of(body.summary.as_deref());
+            let author_kp =
+                crate::handlers::consolidate_federation::load_author_signing_keypair(&author_id);
+            let (final_meta, _signed) =
+                crate::handlers::consolidate_federation::finalize_consolidation_metadata(
+                    mem,
+                    &author_id,
+                    author_kp.as_ref(),
+                    &consolidator_agent_id,
+                    summary_source,
+                );
+            if let Ok(js) = serde_json::to_string(&final_meta) {
+                if let Err(e) = db::set_row_metadata(&lock.0, &mem.id, &js) {
+                    tracing::warn!(
+                        "consolidate: failed to persist federated attestation metadata for {}: {e}",
+                        mem.id
+                    );
+                }
+            }
+            mem.metadata = final_meta;
+            if crate::config::consolidate_tombstone_sources_enabled() {
+                // TOMBSTONE disposition (v1.0.0 default): peers RETAIN + tombstone
+                // the sources (converged via the memories[] LWW lane) and receive
+                // the navigable `derived_from` edges — no hard-delete, so lineage
+                // + source-state converge instead of diverging.
+                fanout_deletions = Vec::new();
+                tombstoned_sources = source_ids
+                    .iter()
+                    .filter_map(|id| db::get(&lock.0, id).ok().flatten())
+                    .collect();
+                derived_edges =
+                    crate::handlers::consolidate_federation::derived_from_edges(mem, &source_ids);
+            }
+        }
+    }
     // Drop DB lock before fanning out — peers POST back to our sync_push
     // and we'd deadlock on the shared Mutex if we held it.
     drop(lock);
     match consolidate_result {
         Ok(new_id) => {
-            // v0.6.2 (#326) / #1552: propagate consolidation to peers so
-            // `metadata.consolidated_from_agents` and the deleted sources
-            // are in sync across the mesh (shared `consolidate_fanout` helper).
+            // v0.6.2 (#326) / #1552 / #2860: propagate the consolidation + its
+            // source disposition + `derived_from` lineage to peers so the mesh
+            // reaches the same terminal state (shared `consolidate_fanout`).
             if let Some(mem) = new_mem {
-                if let Some(resp) =
-                    consolidate_fanout(app.federation.as_ref().as_ref(), &mem, &source_ids).await
+                if let Some(resp) = consolidate_fanout(
+                    app.federation.as_ref().as_ref(),
+                    &mem,
+                    &fanout_deletions,
+                    &tombstoned_sources,
+                    &derived_edges,
+                )
+                .await
                 {
                     return resp;
                 }

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -453,55 +453,26 @@ pub async fn consolidate_memories(
             // on the tenant `ctx` (the tenant owns the sources).
             let author_ctx = crate::store::CallerContext::for_agent(&pg_author_id);
             if let Ok(mut mem) = app.store.get(&author_ctx, &new_id).await {
-                let summary_source = crate::handlers::consolidate_federation::summary_source_of(
+                // Shared, unit-tested finalize+disposition (SAL twin of the sqlite
+                // branch's `sqlite_finalize_and_disposition`). Source reads stay on
+                // the tenant `ctx` (the tenant owns the sources); `set_row_metadata`
+                // is by-id and ctx-agnostic.
+                let disp = crate::handlers::consolidate_federation::store_finalize_and_disposition(
+                    app.store.as_ref(),
+                    &ctx,
+                    &mut mem,
+                    &source_ids,
+                    &pg_author_id,
+                    &consolidator_agent_id,
                     body.summary.as_deref(),
-                );
-                let author_kp =
-                    crate::handlers::consolidate_federation::load_author_signing_keypair(
-                        &pg_author_id,
-                    );
-                let (final_meta, _signed) =
-                    crate::handlers::consolidate_federation::finalize_consolidation_metadata(
-                        &mem,
-                        &pg_author_id,
-                        author_kp.as_ref(),
-                        &consolidator_agent_id,
-                        summary_source,
-                    );
-                if let Ok(js) = serde_json::to_string(&final_meta) {
-                    if let Err(e) = app.store.set_row_metadata(&ctx, &new_id, &js).await {
-                        tracing::warn!(
-                            "consolidate(pg): failed to persist federated attestation metadata for {new_id}: {e}"
-                        );
-                    }
-                }
-                mem.metadata = final_meta;
-                // Source disposition: TOMBSTONE (v1.0.0 default) re-broadcasts the
-                // retained tombstoned source rows via memories[] + ships the
-                // navigable derived_from edges; legacy hard-delete keeps the
-                // deletions[] list.
-                let (deletions, tombstoned_sources, derived_edges) =
-                    if crate::config::consolidate_tombstone_sources_enabled() {
-                        let mut sources: Vec<Memory> = Vec::with_capacity(source_ids.len());
-                        for id in &source_ids {
-                            if let Ok(src) = app.store.get(&ctx, id).await {
-                                sources.push(src);
-                            }
-                        }
-                        let edges = crate::handlers::consolidate_federation::derived_from_edges(
-                            &mem,
-                            &source_ids,
-                        );
-                        (Vec::new(), sources, edges)
-                    } else {
-                        (source_ids.clone(), Vec::new(), Vec::new())
-                    };
+                )
+                .await;
                 if let Some(resp) = consolidate_fanout(
                     app.federation.as_ref().as_ref(),
                     &mem,
-                    &deletions,
-                    &tombstoned_sources,
-                    &derived_edges,
+                    &disp.deletions,
+                    &disp.tombstoned_sources,
+                    &disp.derived_edges,
                 )
                 .await
                 {
@@ -655,51 +626,24 @@ pub async fn consolidate_memories(
     // #2860 — on the FEDERATED path, finalize the substrate-authored row
     // (best-effort daemon `write_signature` + tenant/summary provenance) and
     // prepare the lineage disposition to broadcast, all while the lock is held
-    // so the tombstoned source rows + `derived_from` edges are read
-    // consistently. `fanout_deletions` defaults to the legacy hard-DELETE list
-    // and is emptied only under the tombstone disposition (where the sources
-    // are re-broadcast as tombstoned rows instead).
-    let mut fanout_deletions: Vec<String> = source_ids.clone();
-    let mut tombstoned_sources: Vec<Memory> = Vec::new();
-    let mut derived_edges: Vec<crate::models::MemoryLink> = Vec::new();
-    if fed_enabled {
-        if let Some(mem) = new_mem.as_mut() {
-            let summary_source =
-                crate::handlers::consolidate_federation::summary_source_of(body.summary.as_deref());
-            let author_kp =
-                crate::handlers::consolidate_federation::load_author_signing_keypair(&author_id);
-            let (final_meta, _signed) =
-                crate::handlers::consolidate_federation::finalize_consolidation_metadata(
-                    mem,
-                    &author_id,
-                    author_kp.as_ref(),
-                    &consolidator_agent_id,
-                    summary_source,
-                );
-            if let Ok(js) = serde_json::to_string(&final_meta) {
-                if let Err(e) = db::set_row_metadata(&lock.0, &mem.id, &js) {
-                    tracing::warn!(
-                        "consolidate: failed to persist federated attestation metadata for {}: {e}",
-                        mem.id
-                    );
-                }
-            }
-            mem.metadata = final_meta;
-            if crate::config::consolidate_tombstone_sources_enabled() {
-                // TOMBSTONE disposition (v1.0.0 default): peers RETAIN + tombstone
-                // the sources (converged via the memories[] LWW lane) and receive
-                // the navigable `derived_from` edges — no hard-delete, so lineage
-                // + source-state converge instead of diverging.
-                fanout_deletions = Vec::new();
-                tombstoned_sources = source_ids
-                    .iter()
-                    .filter_map(|id| db::get(&lock.0, id).ok().flatten())
-                    .collect();
-                derived_edges =
-                    crate::handlers::consolidate_federation::derived_from_edges(mem, &source_ids);
-            }
-        }
-    }
+    // so the tombstoned source rows + `derived_from` edges are read consistently.
+    // The finalize+disposition logic is the shared, unit-tested helper (its
+    // postgres twin `store_finalize_and_disposition` runs the identical body
+    // through the SAL trait, so the two backends cannot drift).
+    let disposition = if fed_enabled {
+        new_mem.as_mut().map(|mem| {
+            crate::handlers::consolidate_federation::sqlite_finalize_and_disposition(
+                &lock.0,
+                mem,
+                &source_ids,
+                &author_id,
+                &consolidator_agent_id,
+                body.summary.as_deref(),
+            )
+        })
+    } else {
+        None
+    };
     // Drop DB lock before fanning out — peers POST back to our sync_push
     // and we'd deadlock on the shared Mutex if we held it.
     drop(lock);
@@ -709,12 +653,19 @@ pub async fn consolidate_memories(
             // source disposition + `derived_from` lineage to peers so the mesh
             // reaches the same terminal state (shared `consolidate_fanout`).
             if let Some(mem) = new_mem {
+                let disp = disposition.unwrap_or_else(|| {
+                    crate::handlers::consolidate_federation::FanoutDisposition {
+                        deletions: source_ids.clone(),
+                        tombstoned_sources: Vec::new(),
+                        derived_edges: Vec::new(),
+                    }
+                });
                 if let Some(resp) = consolidate_fanout(
                     app.federation.as_ref().as_ref(),
                     &mem,
-                    &fanout_deletions,
-                    &tombstoned_sources,
-                    &derived_edges,
+                    &disp.deletions,
+                    &disp.tombstoned_sources,
+                    &disp.derived_edges,
                 )
                 .await
                 {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8483,6 +8483,31 @@ pub fn consolidate(
     }
 }
 
+/// #2860 (federation data-integrity, 5-agent vote `4d3ea1c5`) — replace a
+/// single row's `metadata` JSON in place. Used ONLY by the federated-
+/// consolidate finalize (`handlers::consolidate_federation`) to additively
+/// stamp the substrate `write_signature` + `attest_level=agent_attested` +
+/// `consolidator_tenant`/`summary_source` provenance onto a freshly-minted
+/// consolidated row so the STORED origin row byte-matches the broadcast copy
+/// (a catch-up re-send of a row missing the signature would otherwise flip a
+/// peer's `agent_attested` row back to `claimed` — and re-quarantine it under
+/// `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED`). Deliberately does NOT touch
+/// `updated_at` / `version`: the caller stamps the SAME metadata onto the
+/// broadcast object, so the federation LWW timestamp stays the mint instant on
+/// every replica. The `write_signature` commits to the 6-field `SignableWrite`
+/// envelope only (never `metadata`), so replacing `metadata` here cannot
+/// invalidate it.
+///
+/// # Errors
+/// Propagates the `rusqlite` UPDATE error.
+pub fn set_row_metadata(conn: &Connection, id: &str, metadata_json: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE memories SET metadata = ?1 WHERE id = ?2",
+        params![metadata_json, id],
+    )?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Reflection (v0.7.0 recursive-learning Task 4/8, issue #655).
 // ---------------------------------------------------------------------------

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2312,6 +2312,26 @@ pub trait MemoryStore: Send + Sync {
         })
     }
 
+    /// #2860 (federation data-integrity, 5-agent vote `4d3ea1c5`) — replace a
+    /// single row's `metadata` JSON in place. Used ONLY by the federated
+    /// consolidate finalize on the postgres branch (the sqlite branch calls the
+    /// `db::set_row_metadata` free function directly on its open connection) to
+    /// stamp the substrate `write_signature` + `attest_level=agent_attested` +
+    /// `consolidator_tenant`/`summary_source` provenance onto a freshly-minted
+    /// consolidated row so the STORED origin row byte-matches the broadcast copy.
+    /// Deliberately does NOT touch `updated_at`/`version` — see the sqlite
+    /// twin's doc. Default returns `UnsupportedCapability`.
+    async fn set_row_metadata(
+        &self,
+        _ctx: &CallerContext,
+        _id: &str,
+        _metadata_json: &str,
+    ) -> StoreResult<()> {
+        Err(StoreError::UnsupportedCapability {
+            capability: "SET_ROW_METADATA".to_string(),
+        })
+    }
+
     /// Recursive-learning primitive (#655 Task 4/8): mint a reflection
     /// memory over `input.source_ids`, computing
     /// `reflection_depth = max(source depths) + 1`, refusing with

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -21785,6 +21785,29 @@ impl MemoryStore for PostgresStore {
         Ok(new_id)
     }
 
+    /// #2860 (federation data-integrity, 5-agent vote `4d3ea1c5`) — postgres
+    /// twin of `db::set_row_metadata` / `SqliteStore::set_row_metadata`.
+    /// Replace one row's `metadata` jsonb in place (no `updated_at`/`version`
+    /// bump) so the federated-consolidate finalize can stamp the substrate
+    /// `write_signature` + provenance onto the freshly-minted row identically
+    /// on both backends. `metadata` is `jsonb NOT NULL` with a
+    /// `jsonb_typeof = 'object'` CHECK, so the input is cast `$1::jsonb`.
+    async fn set_row_metadata(
+        &self,
+        _ctx: &CallerContext,
+        id: &str,
+        metadata_json: &str,
+    ) -> StoreResult<()> {
+        self.gate_record_stop()?;
+        sqlx::query("UPDATE memories SET metadata = $1::jsonb WHERE id = $2")
+            .bind(metadata_json)
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| to_store_err("set_row_metadata", e))?;
+        Ok(())
+    }
+
     async fn reflect(
         &self,
         ctx: &CallerContext,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1173,6 +1173,17 @@ impl MemoryStore for SqliteStore {
         .map_err(box_err)
     }
 
+    async fn set_row_metadata(
+        &self,
+        _ctx: &CallerContext,
+        id: &str,
+        metadata_json: &str,
+    ) -> StoreResult<()> {
+        self.gate_record_stop()?;
+        let conn = self.state.lock().await;
+        db::set_row_metadata(&conn, id, metadata_json).map_err(box_err)
+    }
+
     async fn reflect(
         &self,
         ctx: &CallerContext,

--- a/tests/cov_federation_sync_quorum_arms.rs
+++ b/tests/cov_federation_sync_quorum_arms.rs
@@ -734,7 +734,13 @@ async fn restore_quorum_ack_and_fail_arms() {
 async fn consolidate_quorum_ack_and_fail_arms() {
     let mem = fixture_memory("consol-var-1");
     let sources = vec!["src-1".to_string(), "src-2".to_string()];
-    assert_variant_quorum_arms!(|cfg| sync::broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[]));
+    assert_variant_quorum_arms!(|cfg| sync::broadcast_consolidate_quorum(
+        &cfg,
+        &mem,
+        &sources,
+        &[],
+        &[]
+    ));
 }
 
 #[tokio::test]

--- a/tests/cov_federation_sync_quorum_arms.rs
+++ b/tests/cov_federation_sync_quorum_arms.rs
@@ -734,7 +734,7 @@ async fn restore_quorum_ack_and_fail_arms() {
 async fn consolidate_quorum_ack_and_fail_arms() {
     let mem = fixture_memory("consol-var-1");
     let sources = vec!["src-1".to_string(), "src-2".to_string()];
-    assert_variant_quorum_arms!(|cfg| sync::broadcast_consolidate_quorum(&cfg, &mem, &sources));
+    assert_variant_quorum_arms!(|cfg| sync::broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[]));
 }
 
 #[tokio::test]

--- a/tests/cov_ga2_federation.rs
+++ b/tests/cov_ga2_federation.rs
@@ -1189,7 +1189,7 @@ async fn broadcast_consolidate_quorum_no_peers_ok() {
     let cfg = quorum_config(Vec::new());
     let mem = ga2_memory("consol-new");
     let sources = vec!["src-a".to_string(), "src-b".to_string()];
-    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &mem, &sources)
+    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[])
         .await
         .expect("consolidate quorum returns tracker");
     assert!(tracker.finalise(std::time::Instant::now()).is_ok());

--- a/tests/cov_ga2_federation.rs
+++ b/tests/cov_ga2_federation.rs
@@ -1189,9 +1189,10 @@ async fn broadcast_consolidate_quorum_no_peers_ok() {
     let cfg = quorum_config(Vec::new());
     let mem = ga2_memory("consol-new");
     let sources = vec!["src-a".to_string(), "src-b".to_string()];
-    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[])
-        .await
-        .expect("consolidate quorum returns tracker");
+    let tracker =
+        ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &mem, &sources, &[], &[])
+            .await
+            .expect("consolidate quorum returns tracker");
     assert!(tracker.finalise(std::time::Instant::now()).is_ok());
 }
 

--- a/tests/cov_ga2_pg_adapter2.rs
+++ b/tests/cov_ga2_pg_adapter2.rs
@@ -726,9 +726,10 @@ async fn broadcast_consolidate_quorum_peer_ack_meets_quorum() {
     let cfg = quorum_config_w2(vec![peer("peer-ack", url)]);
     let m = ga2_memory("consol-ack");
     let sources = vec!["src-x".to_string(), "src-y".to_string()];
-    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &m, &sources, &[], &[])
-        .await
-        .expect("consolidate quorum returns tracker");
+    let tracker =
+        ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &m, &sources, &[], &[])
+            .await
+            .expect("consolidate quorum returns tracker");
     assert!(tracker.finalise(std::time::Instant::now()).is_ok());
 }
 

--- a/tests/cov_ga2_pg_adapter2.rs
+++ b/tests/cov_ga2_pg_adapter2.rs
@@ -726,7 +726,7 @@ async fn broadcast_consolidate_quorum_peer_ack_meets_quorum() {
     let cfg = quorum_config_w2(vec![peer("peer-ack", url)]);
     let m = ga2_memory("consol-ack");
     let sources = vec!["src-x".to_string(), "src-y".to_string()];
-    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &m, &sources)
+    let tracker = ai_memory::federation::sync::broadcast_consolidate_quorum(&cfg, &m, &sources, &[], &[])
         .await
         .expect("consolidate quorum returns tracker");
     assert!(tracker.finalise(std::time::Instant::now()).is_ok());

--- a/tests/fed_consolidate_converges_2860_pg.rs
+++ b/tests/fed_consolidate_converges_2860_pg.rs
@@ -1,0 +1,151 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2860 (federation data-integrity, 5-agent vote `4d3ea1c5`) — live-Postgres
+//! parity for the tenant-facing federated-consolidation CONVERGENCE fix.
+//!
+//! The fix (Option A) authors a substrate-DERIVED consolidation as the daemon's
+//! federation identity (so it self-relays past strict write-sig) and stamps the
+//! best-effort daemon `write_signature` + tenant/summary provenance via the new
+//! `MemoryStore::set_row_metadata` primitive. This file pins the two
+//! backend-specific pieces on the LIVE postgres adapter so they cannot diverge
+//! from the sqlite twin (whose logic is covered by the unit tests in
+//! `handlers::consolidate_federation`):
+//!
+//!   1. `PostgresStore::consolidate` stamps the passed author id as the row's
+//!      `metadata.agent_id` — i.e. authoring the row as the SENDER (not the
+//!      tenant) works identically to sqlite, which is the whole convergence
+//!      mechanism.
+//!   2. `PostgresStore::set_row_metadata` replaces the row's `metadata` jsonb in
+//!      place (the finalize step that persists the substrate signature +
+//!      provenance so the STORED origin row byte-matches the broadcast copy).
+//!
+//! Gated on `AI_MEMORY_TEST_POSTGRES_URL`; skips cleanly when unset.
+
+#![cfg(feature = "sal-postgres")]
+#![allow(clippy::missing_panics_doc, clippy::doc_markdown)]
+
+use ai_memory::models::{Memory, Tier};
+use ai_memory::store::postgres::PostgresStore;
+use ai_memory::store::{CallerContext, MemoryStore};
+
+fn postgres_url() -> Option<String> {
+    std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
+}
+
+async fn connect() -> Option<PostgresStore> {
+    let url = postgres_url()?;
+    Some(
+        PostgresStore::connect(&url)
+            .await
+            .expect("connect postgres"),
+    )
+}
+
+fn mem(id: &str, ns: &str, title: &str, content: &str, author: &str) -> Memory {
+    Memory {
+        id: id.to_string(),
+        namespace: ns.to_string(),
+        title: title.to_string(),
+        content: content.to_string(),
+        created_at: "2026-08-10T12:00:00+00:00".to_string(),
+        updated_at: "2026-08-10T12:00:00+00:00".to_string(),
+        metadata: serde_json::json!({ "agent_id": author }),
+        ..Memory::default()
+    }
+}
+
+/// #2860 — on postgres, consolidating with the SENDER id as the author stamps
+/// `metadata.agent_id = <sender>` (the self-relay authorship), and
+/// `set_row_metadata` then persists the substrate `write_signature` +
+/// provenance in place without disturbing the authorship — mirroring the
+/// sqlite finalize.
+#[tokio::test]
+async fn pg_federated_consolidation_authors_as_sender_and_finalize_persists_2860() {
+    let Some(store) = connect().await else {
+        return;
+    };
+    let sender = "ai:node-sender";
+    let tenant = "tenant:alice";
+    let ns = format!("fed-consolidate-2860-{}", uuid::Uuid::new_v4());
+    let ctx = CallerContext::for_agent(tenant);
+
+    let a = uuid::Uuid::new_v4().to_string();
+    let b = uuid::Uuid::new_v4().to_string();
+    store
+        .store(&ctx, &mem(&a, &ns, "A", "alpha one two three", tenant))
+        .await
+        .expect("store source a");
+    store
+        .store(&ctx, &mem(&b, &ns, "B", "beta four five six", tenant))
+        .await
+        .expect("store source b");
+
+    // Author the consolidation as the SENDER (the #2860 convergence mechanism).
+    let new_id = store
+        .consolidate(
+            &ctx,
+            &[a.clone(), b.clone()],
+            "merged",
+            "merged summary content",
+            &ns,
+            &Tier::Long,
+            "consolidation",
+            sender,
+        )
+        .await
+        .expect("pg consolidate authored as sender");
+
+    // The consolidated row is owned by the SENDER now, so read it back as the
+    // author (the tenant ctx would visibility-filter it out — the documented
+    // ownership consequence of substrate authorship).
+    let author_ctx = CallerContext::for_agent(sender);
+    let row = store
+        .get(&author_ctx, &new_id)
+        .await
+        .expect("get consolidated");
+    assert_eq!(
+        row.metadata.get("agent_id").and_then(|v| v.as_str()),
+        Some(sender),
+        "pg consolidate must author the row as the passed sender id (self-relay authorship)"
+    );
+
+    // Finalize: replace metadata jsonb in place (write_signature + provenance).
+    let mut finalized = row.metadata.clone();
+    let obj = finalized.as_object_mut().unwrap();
+    obj.insert(
+        "write_signature".to_string(),
+        serde_json::json!("AAAA-not-a-real-sig-just-a-roundtrip-probe"),
+    );
+    obj.insert("consolidator_tenant".to_string(), serde_json::json!(tenant));
+    obj.insert("summary_source".to_string(), serde_json::json!("substrate"));
+    let js = serde_json::to_string(&finalized).unwrap();
+    store
+        .set_row_metadata(&ctx, &new_id, &js)
+        .await
+        .expect("pg set_row_metadata");
+
+    let after = store
+        .get(&author_ctx, &new_id)
+        .await
+        .expect("get after finalize");
+    let am = after.metadata.as_object().unwrap();
+    assert_eq!(
+        am.get("agent_id").and_then(|v| v.as_str()),
+        Some(sender),
+        "finalize must NOT disturb the substrate authorship"
+    );
+    assert_eq!(
+        am.get("consolidator_tenant").and_then(|v| v.as_str()),
+        Some(tenant),
+        "finalize persists the untrusted tenant provenance"
+    );
+    assert_eq!(
+        am.get("summary_source").and_then(|v| v.as_str()),
+        Some("substrate")
+    );
+    assert!(
+        am.contains_key("write_signature"),
+        "finalize persists the substrate write_signature in place (jsonb replace)"
+    );
+}

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -453,7 +453,7 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // what it now refuses, why the disposition is surface-keyed rather than
     // unconditional (3x3 vote 7-2), and which residual is deliberate.
     // MEASURED post-change: 28_047. Ceiling 27_900 -> 28_120 (+73 headroom).
-    ("src/storage/mod.rs", 28_200), /* 2026-08-04 #2718/CB-14 QUAL-10: `memories_updated_since_counted` (raw pre-drop row count for the F7 tie-group guard) + `sync_state_merge_authorized` (per-key-authorized #2670-class fold) + 2 unit tests. Measured 28_160; ceiling 28_120 -> 28_200 (+40 headroom). */
+    ("src/storage/mod.rs", 28_300), /* 2026-08-04 #2718/CB-14 QUAL-10: `memories_updated_since_counted` (raw pre-drop row count for the F7 tie-group guard) + `sync_state_merge_authorized` (per-key-authorized #2670-class fold) + 2 unit tests. Measured 28_160; ceiling 28_120 -> 28_200 (+40 headroom). 2026-08-10 (#2860, 5-agent vote 4d3ea1c5): the `set_row_metadata` free fn (federated-consolidate finalize metadata persist). Measured 28_211; ceiling 28_200 -> 28_300 (+89 headroom). */
     // 2026-07-21 (#1802 R-05 S1) — NEW submodule extracted from
     // storage/mod.rs (doctor / observability probes). Measured 698;
     // ceiling 800 (+102).


### PR DESCRIPTION
Closes #2860

## Problem

A tenant-facing `POST /api/v1/consolidate` mints a NEW substrate-DERIVED memory (an LLM summary or a deterministic title-concat produced by the origin **daemon**) stamped `metadata.agent_id=<tenant>` with **no** `write_signature`. The daemon cannot produce the tenant's Ed25519 signature, so under the v1.0.0-default strict `AI_MEMORY_FED_REQUIRE_WRITE_SIG=1` the receiver refuses it as an unsigned honored third-party relay (`unenrolled_author_strict`) — it commits on the origin but **never converges to peers** (silent inter-node divergence, forbidden by the North Star). #2856 filed it; #2861 shipped the loud-202 floor; this makes it **converge**.

The consolidation also **tombstoned + retained** its sources locally (v1.0.0-default `AI_MEMORY_CONSOLIDATE_TOMBSTONE_SOURCES`) and wrote navigable `derived_from` edges, but the broadcast shipped only `deletions:[source_ids]` — so peers **hard-deleted** the sources and never received the edges: a second divergence.

## Decision — 5-agent adversarial vote (`4d3ea1c5`)

This is a genuine T3 (security posture) + T4 (signed-bytes/authorship) crossroads. Five distinct adversarial lenses (data-integrity/North-Star · federation-convergence · attestation-security/CWE-346 · tenant-vs-substrate-truthfulness · blast-radius-under-cert-freeze) all ranked **Option A first** (Condorcet winner; **B last in 4/5**; A2 rejected — reintroduces the bug; D honest-but-doesn't-fix). Decision memory `8b428944`.

- **A (chosen)** — author the federated consolidation as the daemon's federation identity (`FederationConfig::sender_agent_id`), the substrate that ACTUALLY derived the bytes and HOLDS the signing key. It self-relays past the strict gate (`require = strict && attribute != sender` is structurally false) and converges at **every** peer regardless of key enrollment; a best-effort daemon `write_signature` over the standard 6-field `SignableWrite` upgrades it to `agent_attested` where the daemon key is enrolled (required for **visible, non-quarantined** convergence under `asi-hard`, which pins `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1`). Crypto-honest (`agent_id == signer == sender`, no CWE-346 decoupling); matches the already-converging curator `ConsolidationPass`. **Send-path/mint-site only** — no receiver-twin, wire-schema, or `SignableWrite` change.
- **B (rejected)** — keep `agent_id=tenant`, sign with the daemon key, verify against the sender key: a CWE-346 universal-impersonation primitive; touches both receiver twins on the frozen signed-bytes path.
- **A2 (rejected)** — a dedicated non-sender substrate identity re-refuses at un-enrolled peers (reintroduces the bug + orphans source deletions).
- **D (rejected)** — documented non-convergence leaves permanent divergence.

## What changed

- **Authorship convergence** (`src/handlers/power_consolidation.rs` — both the sqlite branch and the postgres SAL branch): on the federated path the consolidation is authored as `sender_agent_id`; the read-back row is finalized (`src/handlers/consolidate_federation.rs`) with a best-effort daemon `write_signature` + `attest_level=agent_attested` + untrusted `consolidator_tenant` / `summary_source` provenance, persisted to the stored origin row so it byte-matches the broadcast copy.
- **Lineage/tombstone convergence** (`src/federation/sync.rs::broadcast_consolidate_quorum`): ships the `C -> source` `derived_from` edges on the existing `links[]` lane and, under the tombstone disposition, re-broadcasts the retained tombstoned source rows on `memories[]` (converging their `lifecycle_state` via the receiver's normal LWW merge — their original `write_signature` stays valid) instead of hard-deleting via `deletions[]`. Legacy hard-delete disposition unchanged.
- **New additive `MemoryStore::set_row_metadata`** (both adapters + `db::set_row_metadata` free fn) — in-place `metadata` replace (no `updated_at`/`version` bump) used only by the finalize.

**SSOT-clean:** no MCP-tool / HTTP-route / CLI-verb / schema-version / env-var change; no new wire field. `qual_10` ceiling bumped for `storage/mod.rs` (dated). CHANGELOG updated.

## Documented consequence

On the federated path the consolidation is now **owned by the substrate** (`agent_id=sender`), so under enforced-multi-agent reads (`AI_MEMORY_AGENT_ID` set) the invoking tenant does not see it via `scope=private` recall. Inert under the default trust-all posture, and identical to the shipped curator consolidation behavior. A tenant read-grant is a future enhancement outside cert-freeze scope. The vote accepted this trade-off (all five lenses ranked A first *with* this cost — divergence is the worse North-Star violation).

## Tests / gates

- 5 unit tests in `handlers::consolidate_federation`: signed→`agent_attested` verifies; unsigned self-relay→`claimed` accepted; **pre-#2860 tenant-unsigned honored relay→refused under strict** (proves the gap); `summary_source`; `derived_from` edges.
- Live-pg parity test `tests/fed_consolidate_converges_2860_pg.rs`: postgres authoring-as-sender + `set_row_metadata` round-trip.
- `cargo fmt` clean; **clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` green on all four legs** (default / sal / sal-postgres / vectorlite); `cargo audit`; `qual_10` + `qual_6_7` ceilings.

## Overlap note (merge order)

Based on `origin/release/v1.0.0`; #2861 (`fix/2856-fed-consolidate-replicate`, in the merge queue) also edits `consolidate_fanout` + `parity.rs` (its id-bearing 202). This PR keeps the existing loud-202 floor and now makes the quorum *succeed*, so the miss path is the residual peer-down case. A trivial merge-order conflict on `consolidate_fanout` is expected; both changes compose.

## Recommended DO re-verify

The convergence invariants are pinned at the unit + live-pg-adapter level. A **DO 2-node pg+AGE federated mesh re-verify** (consolidate at node1 → assert the consolidated memory + `derived_from` edges + tombstoned sources converge to node2, `attest_level` correct, no silent skip) is recommended for final end-to-end cert confirmation on the validated DO harness.

## AI involvement

Authored by Claude Opus 5 (hard-coder) under the autonomous v1.0.0 loop. Design resolved by the mandatory 5-agent adversarial vote (`4d3ea1c5`); decision + vote tally recorded in ai-memory (`8b428944`). Expect a multi-agent code + security review to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
