### PR TITLE
fix(federation/#2863): converge re-broadcast tombstoned consolidation source attest_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 
+- **Re-broadcast tombstoned consolidation SOURCE rows no longer DIVERGE in
+  `attest_level` across nodes** (#2863, residual of #2860 surfaced by the DO
+  2-node re-verify; two 5-agent adversarial votes `4d3ea1c5`). A consolidation
+  SOURCE that landed `agent_attested` at a peer (fresh push, self-relayed by its
+  author) was DOWNGRADED to `claimed` at that peer when the #2860 lineage path
+  RE-BROADCAST it under the daemon federation identity — same byte-identical
+  valid `write_signature`, same content, divergent `attest_level` (origin
+  `agent_attested` vs peer `claimed`; under `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1`
+  a visibility divergence). Two independent mechanisms, both closed **without
+  weakening attestation** (an unsigned/forged/unenrolled-author row still lands
+  `claimed`): **(1)** `resolve_inbound_attribution` now HONORS a third-party
+  claim whose `write_signature` VERIFIES against the CLAIMED author's
+  locally-enrolled key (a valid Ed25519 signature over the 6-field
+  `SignableWrite` is unforgeable proof of authorship independent of the relaying
+  peer — strictly stronger than the operational `allowed_sender_agent_ids`
+  allowlist, which governs UNSIGNED bare claims), rather than re-attributing it
+  to the daemon relay; **(2)** the re-broadcast MERGES over the peer's existing
+  row, where `db::merge_inbound`'s `sanitize_inbound_attestation` (which
+  correctly neutralizes an UNTRUSTED wire-asserted level for the LWW tiebreak)
+  also wiped the receiver's OWN just-verified level and LWW-newer persisted
+  `claimed` — so `merge_inbound` now re-asserts `agent_attested` ATOMICALLY (in
+  the merge transaction, before the content-sealing write, so it holds under
+  at-rest encryption and leaves no crash window that could strand a terminal
+  tombstone) when, and only when, the merged row's full `SignableWrite` surface
+  + `write_signature` is byte-identical to the row THIS node just verified
+  (`receiver_verified` — never a peer self-assertion). Convergence is
+  enrollment-bounded: a peer without the origin author's key legitimately
+  stays `claimed` (fail-closed degrade; TOFU key distribution deferred to v1.x).
+  Both backends (sqlite + postgres) edited identically; the receive-loop wiring
+  is pinned end-to-end by `tests/fed_consolidate_source_attest_parity_2863.rs`
+  (sqlite `/sync/push`) and `tests/fed_consolidate_converges_2860_pg.rs` (live
+  postgres), plus unit arms for the attribution honor path
+  (`handlers::federation_receive`), the pure re-assert
+  (`models::crdt_merge::reassert_verified_attestation`), and the real merge path
+  (`storage::merge_inbound`). New pure fn
+  `identity::attest::resolve_write_attest_level` factored out of
+  `stamp_attestation` so the honor decision and the stamped level share ONE
+  verification.
 - **Tenant-attributed federated consolidation now CONVERGES under strict
   write-sig** (#2860, follow-up to #2856/#2861; 5-agent adversarial vote
   `4d3ea1c5`, Option A). `POST /api/v1/consolidate` minted a NEW

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -342,11 +342,28 @@ pub(super) fn check_sender_clock_skew(sender_agent_id: &str, body: &SyncPushBody
 /// This preserves legitimate multi-author relay provenance (a hub/curator
 /// relaying a fleet of agents the operator allowlisted) while closing the
 /// forge hole for unauthorized claims.
+///
+/// #2863 — `claim_write_attested` is an INDEPENDENT honor path: when the row
+/// carries a `metadata.write_signature` that VERIFIES against the CLAIMED
+/// author's locally-enrolled key (computed caller-side over the POST-redaction
+/// bytes via [`inbound_claim_is_write_attested`], because the enrolled-key
+/// lookup straddles the sync-sqlite / async-pg boundary), the claim is honored
+/// regardless of the allowlist. A valid Ed25519 signature over the 6-field
+/// `SignableWrite` is unforgeable proof of authorship independent of which peer
+/// relayed it — strictly stronger than the operational `allowed_sender_agent_ids`
+/// allowlist, which is the authorization for UNSIGNED bare claims. This closes
+/// the #2860 re-broadcast divergence where a tombstoned consolidation SOURCE
+/// authored by A but relayed under the daemon federation identity was
+/// re-attributed to the daemon and downgraded from `agent_attested` to
+/// `claimed` at the peer. An unsigned / forged / unenrolled-author claim still
+/// re-attributes exactly as before (the honor path requires a VERIFIED enrolled
+/// signature, never mere presence).
 pub(super) fn resolve_inbound_attribution(
     to_insert: &mut Memory,
     sender_agent_id: &str,
     attest_cfg: &PeerAttestationConfig,
     peer_id: Option<&str>,
+    claim_write_attested: bool,
 ) -> String {
     let Some(claimed) = to_insert
         .metadata
@@ -360,16 +377,19 @@ pub(super) fn resolve_inbound_attribution(
     if claimed == sender_agent_id {
         return claimed;
     }
-    // Enrolled posture: a relayed third-party claim is trusted ONLY if the
-    // operator authorized this peer to author as that agent. Zero-config
-    // (no allowlist) preserves the faith-based posture.
-    let authorized = if attest_cfg.has_allowlist() {
-        peer_id
-            .and_then(|p| attest_cfg.scope_for(p))
-            .is_some_and(|scope| scope.allowed_sender_agent_ids.iter().any(|a| a == &claimed))
-    } else {
-        true
-    };
+    // A relayed third-party claim is honored when EITHER (#2863) it carries a
+    // write_signature that cryptographically verifies against the claimed
+    // author's enrolled key, OR (enrolled posture) the operator authorized this
+    // peer to author as that agent. Zero-config (no allowlist) preserves the
+    // faith-based posture.
+    let authorized = claim_write_attested
+        || if attest_cfg.has_allowlist() {
+            peer_id
+                .and_then(|p| attest_cfg.scope_for(p))
+                .is_some_and(|scope| scope.allowed_sender_agent_ids.iter().any(|a| a == &claimed))
+        } else {
+            true
+        };
     if authorized {
         return claimed;
     }
@@ -398,6 +418,44 @@ pub(super) fn resolve_inbound_attribution(
         );
     }
     sender_agent_id.to_string()
+}
+
+/// #2863 — does this inbound row's presented `metadata.write_signature` VERIFY
+/// against `claimed_author`'s locally-enrolled key over the 6-field
+/// `SignableWrite`? Reuses the EXACT `attest_write` path the write-sig lane
+/// stamps with (over the POST-redaction persisted bytes — call this AFTER
+/// [`crate::federation::receive_auth::redact_inbound_before_attestation`]), so
+/// the honor decision [`resolve_inbound_attribution`] makes and the level
+/// [`apply_inbound_write_attestation`] stamps cannot disagree. A valid Ed25519
+/// signature is unforgeable proof of authorship independent of which peer
+/// relayed it; `claimed_bound_key` MUST come from the LOCAL enrolled keystore
+/// (`agent_pubkey`), never a wire-presented key. Returns `false` on any absent
+/// signature / unenrolled key / verification failure (fail-closed).
+pub(super) fn inbound_claim_is_write_attested(
+    mem: &Memory,
+    claimed_author: &str,
+    claimed_bound_key: Option<&str>,
+) -> bool {
+    let presented_sig = mem
+        .metadata
+        .get(crate::models::field_names::WRITE_SIGNATURE)
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(s.trim())
+                .ok()
+        });
+    matches!(
+        crate::identity::attest::resolve_write_attest_level(
+            mem,
+            claimed_author,
+            claimed_bound_key,
+            presented_sig.as_deref(),
+            false,
+        ),
+        Ok(crate::identity::verify::AttestLevel::AgentAttested)
+    )
 }
 
 /// #2720 F-12 (CWE-346) — bind the DECIDER of an inbound federated pending
@@ -1924,11 +1982,32 @@ pub async fn sync_push(
             .get(crate::META_KEY_AGENT_ID)
             .and_then(serde_json::Value::as_str)
             .map(str::to_string);
+        // #2340 (FBL-32) — redact to the TO-BE-PERSISTED form FIRST. Moved
+        // AHEAD of attribution for #2863 so BOTH the crypto-attest HONOR check
+        // and the attestation stamp below verify over exactly the bytes
+        // `db::merge_inbound` will persist (the funnel's own redact is then an
+        // idempotent no-op). The reorder is behavior-preserving: redact touches
+        // only content/title/write_signature while attribution reads/writes only
+        // agent_id/attest_level. A cross-mode raw-signed row has its stale
+        // write_signature dropped inside the helper and lands honestly `claimed`.
+        crate::federation::receive_auth::redact_inbound_before_attestation(&mut to_insert);
+        // #2863 — resolve the CLAIMED author's enrolled key up front so a
+        // cryptographically-attested third-party claim (a valid propagated
+        // write_signature) is HONORED rather than re-attributed to the daemon
+        // relay sender (the #2860 re-broadcast divergence). Reused below as the
+        // attestation bound key when the claim is honored (attribute == claimed).
+        let claim_bound_key = original_claim
+            .as_deref()
+            .and_then(|c| db::agent_pubkey(&lock.0, c).ok().flatten());
+        let claim_write_attested = original_claim.as_deref().is_some_and(|c| {
+            inbound_claim_is_write_attested(&to_insert, c, claim_bound_key.as_deref())
+        });
         let attribute_agent = resolve_inbound_attribution(
             &mut to_insert,
             &body.sender_agent_id,
             &attest_cfg,
             peer_header_owned.as_deref(),
+            claim_write_attested,
         );
         // #1464 (v0.8.0) — per-write CONTENT attestation. Verify any
         // presented `metadata.write_signature` against the attributed
@@ -1937,16 +2016,14 @@ pub async fn sync_push(
         // third-party relayed claim. Skips re-attributed rows internally.
         // Hoist the author's bound key so the refusal WARN can distinguish
         // missing-author-key from missing-signature (item 7 observability —
-        // the manual substitute for the deferred TOFU key distribution).
-        //
-        // #2340 (FBL-32) — redact to the TO-BE-PERSISTED form FIRST, so the
-        // attestation below verifies + stamps over exactly the bytes
-        // `db::merge_inbound`'s storage funnel will persist (the funnel's own
-        // redact becomes an idempotent no-op). A cross-mode raw-signed row
-        // has its stale write_signature dropped inside the helper and lands
-        // honestly `claimed` instead of a false `agent_attested`.
-        crate::federation::receive_auth::redact_inbound_before_attestation(&mut to_insert);
-        let author_bound_key = db::agent_pubkey(&lock.0, &attribute_agent).ok().flatten();
+        // the manual substitute for the deferred TOFU key distribution). When
+        // the claim was honored, `attribute_agent == original_claim`, so reuse
+        // the key already looked up above (avoids a second lookup, #2863).
+        let author_bound_key = if Some(attribute_agent.as_str()) == original_claim.as_deref() {
+            claim_bound_key.clone()
+        } else {
+            db::agent_pubkey(&lock.0, &attribute_agent).ok().flatten()
+        };
         if let Err(e) = apply_inbound_write_attestation(
             &mut to_insert,
             &attribute_agent,
@@ -2098,7 +2175,13 @@ pub async fn sync_push(
         // operates on the exact row — with any re-attribution applied —
         // that is persisted here. `stamp_reflection_origin` carried the
         // `peer_origin` / `original_depth` / local-cap metadata.)
-        match db::merge_inbound(&lock.0, &to_insert) {
+        // #2863 — pass the receiver's VERIFIED verdict so the merge-over-existing
+        // path re-asserts `agent_attested` atomically when the persisted row is
+        // byte-identical to the signed unit this node just verified (the merge's
+        // `sanitize` otherwise demotes it to `claimed`). `row_is_agent_attested`
+        // reads the post-`apply` `to_insert` (THIS node's verdict, never a peer
+        // self-assertion).
+        match db::merge_inbound(&lock.0, &to_insert, row_is_agent_attested(&to_insert)) {
             Ok(actual_id) => {
                 applied += 1;
                 // v1.0.0 R19/A3 (#1948) — route-OUT dequarantine-on-attest.
@@ -4074,7 +4157,7 @@ mod tests {
         // verbatim and NOT rewritten (preserve #1056/#238 behaviour).
         let mut m = claiming("alice");
         assert_eq!(
-            resolve_inbound_attribution(&mut m, "ai:relay", &zero, Some("ai:relay")),
+            resolve_inbound_attribution(&mut m, "ai:relay", &zero, Some("ai:relay"), false),
             "alice"
         );
         assert_eq!(m.metadata["agent_id"], "alice");
@@ -4083,7 +4166,7 @@ mod tests {
         // to the sender AND rewrite ownership; stamp the bare-claim level.
         let mut m2 = claiming("alice");
         assert_eq!(
-            resolve_inbound_attribution(&mut m2, "ai:relay", &cfg, Some("ai:relay")),
+            resolve_inbound_attribution(&mut m2, "ai:relay", &cfg, Some("ai:relay"), false),
             "ai:relay"
         );
         assert_eq!(
@@ -4095,7 +4178,7 @@ mod tests {
         // (3) Enrolled, peer authorized to author as "bob" → trusted, preserved.
         let mut m3 = claiming("bob");
         assert_eq!(
-            resolve_inbound_attribution(&mut m3, "ai:relay", &cfg, Some("ai:relay")),
+            resolve_inbound_attribution(&mut m3, "ai:relay", &cfg, Some("ai:relay"), false),
             "bob"
         );
         assert_eq!(m3.metadata["agent_id"], "bob");
@@ -4104,7 +4187,7 @@ mod tests {
         // → trusted regardless of the allowlist.
         let mut m4 = claiming("ai:relay");
         assert_eq!(
-            resolve_inbound_attribution(&mut m4, "ai:relay", &cfg, Some("ai:relay")),
+            resolve_inbound_attribution(&mut m4, "ai:relay", &cfg, Some("ai:relay"), false),
             "ai:relay"
         );
 
@@ -4115,9 +4198,131 @@ mod tests {
             ..Memory::default()
         };
         assert_eq!(
-            resolve_inbound_attribution(&mut m5, "ai:relay", &cfg, Some("ai:relay")),
+            resolve_inbound_attribution(&mut m5, "ai:relay", &cfg, Some("ai:relay"), false),
             "ai:relay"
         );
+    }
+
+    /// #2863 — fed-consolidate-source-attest-parity (fix #1: attribution).
+    /// Drives the receive loop's attribution + apply sequence for a re-broadcast
+    /// tombstoned SOURCE relayed under the daemon federation identity (sender !=
+    /// the source's author). A third-party claim carrying a write_signature that
+    /// VERIFIES against the CLAIMED author's ENROLLED key is HONORED (lands
+    /// `agent_attested`); an unsigned / forged / unenrolled-author claim still
+    /// re-attributes to the sender and lands `claimed`.
+    #[test]
+    fn rebroadcast_source_honors_crypto_attested_claim_2863() {
+        use crate::federation::peer_attestation::PeerScope;
+        use std::collections::HashMap;
+
+        // Mirror of the receive-loop sequence (redact omitted — no secret in the
+        // fixture): compute the crypto-attest signal, resolve attribution,
+        // resolve the bound key exactly as the caller does, stamp.
+        fn drive(
+            mem: &mut Memory,
+            sender: &str,
+            cfg: &PeerAttestationConfig,
+            peer: Option<&str>,
+            claimed_key: Option<&str>,
+            require: bool,
+        ) -> String {
+            let original_claim = mem
+                .metadata
+                .get(crate::META_KEY_AGENT_ID)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let claim_write_attested = original_claim
+                .as_deref()
+                .is_some_and(|c| inbound_claim_is_write_attested(mem, c, claimed_key));
+            let attribute =
+                resolve_inbound_attribution(mem, sender, cfg, peer, claim_write_attested);
+            // Caller key-reuse: when the claim was honored (attribute == claim),
+            // the bound key is the claimed author's; otherwise the re-attributed
+            // sender's key (unenrolled in this fixture → None).
+            let bound = if Some(attribute.as_str()) == original_claim.as_deref() {
+                claimed_key
+            } else {
+                None
+            };
+            apply_inbound_write_attestation(
+                mem,
+                &attribute,
+                sender,
+                original_claim.as_deref(),
+                bound,
+                require,
+            )
+            .expect("apply must not reject (honored verifies; re-attributed skips)");
+            attribute
+        }
+
+        let author = "ai:hive-author";
+        let daemon = "ai:hive-memory-1"; // #2860 re-broadcast sender (fed identity)
+        let kp = keypair::generate(author).unwrap();
+        let author_pk = pk_b64(&kp);
+        // Enrolled peer authorized ONLY as itself — hive-author is a third party.
+        let mut peers = HashMap::new();
+        peers.insert(daemon.to_string(), PeerScope::default());
+        let cfg = PeerAttestationConfig::from_peers(peers);
+
+        let signed = |author_id: &str| -> Memory {
+            let mut m = wsig_mem(author_id);
+            let sig = attest::sign_memory_write(&kp, &m, author_id).unwrap();
+            put_write_sig(&mut m, &sig);
+            m
+        };
+
+        // (a) Self-relay signed (sender == author) → agent_attested [control].
+        let mut a = signed(author);
+        assert_eq!(
+            drive(&mut a, author, &cfg, Some(author), Some(&author_pk), true),
+            author
+        );
+        assert_eq!(a.metadata["attest_level"], "agent_attested");
+
+        // (b) THE FIX: third-party signed, enrolled peer NOT authorized as
+        // hive-author, author key enrolled → HONORED → agent_attested. (Pre-fix
+        // this re-attributed to `daemon` and landed `claimed`.)
+        let mut b = signed(author);
+        assert_eq!(
+            drive(&mut b, daemon, &cfg, Some(daemon), Some(&author_pk), true),
+            author,
+            "#2863: a crypto-attested third-party claim must be honored, not re-attributed"
+        );
+        assert_eq!(b.metadata["attest_level"], "agent_attested");
+        assert_eq!(
+            b.metadata["agent_id"], author,
+            "authorship preserved as the true author"
+        );
+
+        // (c) Third-party UNSIGNED → re-attributed → claimed.
+        let mut c = wsig_mem(author);
+        assert_eq!(
+            drive(&mut c, daemon, &cfg, Some(daemon), Some(&author_pk), false),
+            daemon
+        );
+        assert_eq!(c.metadata["attest_level"], "claimed");
+
+        // (d) Third-party FORGED sig (present but invalid) → NOT honored (verify,
+        // not presence) → re-attributed → claimed.
+        let mut d = wsig_mem(author);
+        let mut sig = attest::sign_memory_write(&kp, &d, author).unwrap();
+        sig[0] ^= 0xFF;
+        put_write_sig(&mut d, &sig);
+        assert_eq!(
+            drive(&mut d, daemon, &cfg, Some(daemon), Some(&author_pk), false),
+            daemon
+        );
+        assert_eq!(d.metadata["attest_level"], "claimed");
+
+        // (e) Third-party signed but author key NOT enrolled (bound_key=None) →
+        // cannot verify → not honored → re-attributed → claimed (fail-closed).
+        let mut e = signed(author);
+        assert_eq!(
+            drive(&mut e, daemon, &cfg, Some(daemon), None, false),
+            daemon
+        );
+        assert_eq!(e.metadata["attest_level"], "claimed");
     }
 
     /// #1920 ADVERSARIAL — a hostile-but-enrolled peer must not be able to

--- a/src/handlers/federation_signing_check.rs
+++ b/src/handlers/federation_signing_check.rs
@@ -286,32 +286,53 @@ pub(super) async fn sync_push_via_store(
             .get(crate::META_KEY_AGENT_ID)
             .and_then(serde_json::Value::as_str)
             .map(str::to_string);
+        // #2340 (FBL-32) — redact to the TO-BE-PERSISTED form FIRST (postgres
+        // twin of the sqlite receive path). Moved AHEAD of attribution for #2863
+        // so BOTH the crypto-attest HONOR check and the attestation stamp verify
+        // over exactly the bytes `PostgresStore::merge_inbound` persists. Redact
+        // touches only content/title/write_signature; attribution reads/writes
+        // only agent_id/attest_level, so the reorder is behavior-preserving.
+        crate::federation::receive_auth::redact_inbound_before_attestation(&mut to_insert);
+        // #2863 — resolve the CLAIMED author's enrolled key up front so a
+        // cryptographically-attested third-party claim (a valid propagated
+        // write_signature) is HONORED rather than re-attributed to the daemon
+        // relay sender. Reused as the attestation bound key when the claim is
+        // honored (attribute == claimed). The enrolled-key lookup resolves
+        // through the SAL `agent_pubkey` trait method so both backends match.
+        let claim_bound_key = match original_claim.as_deref() {
+            Some(c) => app.store.agent_pubkey(c).await.ok().flatten(),
+            None => None,
+        };
+        let claim_write_attested = original_claim.as_deref().is_some_and(|c| {
+            crate::handlers::federation_receive::inbound_claim_is_write_attested(
+                &to_insert,
+                c,
+                claim_bound_key.as_deref(),
+            )
+        });
         let attribute_agent = resolve_inbound_attribution(
             &mut to_insert,
             &body.sender_agent_id,
             &attest_cfg,
             peer_header_owned.as_deref(),
+            claim_write_attested,
         );
         // #1464 (v0.8.0) — per-write CONTENT attestation (postgres twin of
         // the sqlite receive path). Verify any presented
         // `metadata.write_signature` against the attributed author's enrolled
         // key → `agent_attested` vs `claimed`; reject forged, or (strict,
-        // opt-in) an unsigned honored third-party claim. The enrolled-key
-        // lookup resolves through the SAL `agent_pubkey` trait method so both
-        // backends behave identically.
-        // #2340 (FBL-32) — redact to the TO-BE-PERSISTED form FIRST (postgres
-        // twin of the sqlite receive path): the attestation below verifies +
-        // stamps over exactly the bytes `PostgresStore::merge_inbound`'s
-        // screen will persist. A cross-mode raw-signed row has its stale
-        // write_signature dropped inside the helper and lands honestly
-        // `claimed` instead of a false `agent_attested`.
-        crate::federation::receive_auth::redact_inbound_before_attestation(&mut to_insert);
-        let bound_pubkey = app
-            .store
-            .agent_pubkey(&attribute_agent)
-            .await
-            .ok()
-            .flatten();
+        // opt-in) an unsigned honored third-party claim. When the claim was
+        // honored, `attribute_agent == original_claim`, so reuse the key already
+        // looked up above (avoids a second lookup, #2863).
+        let bound_pubkey = if Some(attribute_agent.as_str()) == original_claim.as_deref() {
+            claim_bound_key.clone()
+        } else {
+            app.store
+                .agent_pubkey(&attribute_agent)
+                .await
+                .ok()
+                .flatten()
+        };
         if let Err(e) = apply_inbound_write_attestation(
             &mut to_insert,
             &attribute_agent,
@@ -459,7 +480,19 @@ pub(super) async fn sync_push_via_store(
         // Pre-fix this called `apply_remote_memory`, which had NONE of the
         // receive-lane guards (a stale peer could resurrect a forgotten
         // row; a same-id/different-title push error-skipped forever).
-        match app.store.merge_inbound(&ctx, &to_insert).await {
+        // #2863 — pass the receiver's VERIFIED verdict (postgres twin) so the
+        // merge-over-existing path re-asserts `agent_attested` atomically when the
+        // persisted row is byte-identical to the signed unit this node verified;
+        // `row_is_agent_attested` reads the post-`apply` `to_insert`.
+        match app
+            .store
+            .merge_inbound(
+                &ctx,
+                &to_insert,
+                crate::handlers::federation_receive::row_is_agent_attested(&to_insert),
+            )
+            .await
+        {
             Ok(applied_id) => {
                 applied += 1;
                 // v1.0.0 R19/A3 (#1948) — route-OUT dequarantine-on-attest

--- a/src/identity/attest.rs
+++ b/src/identity/attest.rs
@@ -315,22 +315,28 @@ pub fn redact_before_sign(mem: &mut Memory) {
 }
 
 /// I/O-free core: resolve the [`AttestLevel`] for `mem` written by
-/// `agent_id` (given the agent's bound key + an optional presented
-/// signature) and, on success, stamp `metadata.attest_level`.
+/// `agent_id`, given the agent's bound key + an optional presented signature.
+/// Does NOT mutate `mem` (the sibling [`stamp_attestation`] writes the level).
 ///
 /// The signed surface is built from the memory itself —
 /// `agent_id + namespace + title + kind + created_at + sha256(content)` —
-/// so the signature commits to the row's identity-bearing fields. The
-/// caller supplies `agent_id` explicitly (every write surface already
-/// resolved it) rather than re-deriving it from metadata.
+/// recomputing `sha256(content)` over the PERSISTED bytes (never a presented
+/// digest) so the signature commits to the row's identity-bearing fields. The
+/// caller supplies `agent_id` explicitly (every write surface already resolved
+/// it) rather than re-deriving it from metadata.
+///
+/// #2863 — factored out of [`stamp_attestation`] so the federation receive path
+/// can reuse the EXACT same verification to decide whether to HONOR a
+/// cryptographically-attested third-party claim; sharing this one function
+/// guarantees the honor decision and the stamped `attest_level` cannot disagree.
 ///
 /// # Errors
 ///
 /// Surfaces [`crate::identity::verify::AttestError`] (forged signature,
 /// attestation required but absent, malformed signature, corrupt bound
 /// key) as an `anyhow::Error` so the write path rejects the store.
-pub fn stamp_attestation(
-    mem: &mut Memory,
+pub fn resolve_write_attest_level(
+    mem: &Memory,
     agent_id: &str,
     bound_pubkey_b64: Option<&str>,
     signature: Option<&[u8]>,
@@ -345,8 +351,27 @@ pub fn stamp_attestation(
         created_at: &mem.created_at,
         content_sha256: &content_hash,
     };
-    let level = crate::identity::verify::attest_write(&write, bound_pubkey_b64, signature, require)
-        .map_err(|e| anyhow::anyhow!("agent attestation failed: {e}"))?;
+    crate::identity::verify::attest_write(&write, bound_pubkey_b64, signature, require)
+        .map_err(|e| anyhow::anyhow!("agent attestation failed: {e}"))
+}
+
+/// Resolve the [`AttestLevel`] for `mem` written by `agent_id` (via
+/// [`resolve_write_attest_level`]) and, on success, stamp
+/// `metadata.attest_level`.
+///
+/// # Errors
+///
+/// Surfaces [`crate::identity::verify::AttestError`] (forged signature,
+/// attestation required but absent, malformed signature, corrupt bound
+/// key) as an `anyhow::Error` so the write path rejects the store.
+pub fn stamp_attestation(
+    mem: &mut Memory,
+    agent_id: &str,
+    bound_pubkey_b64: Option<&str>,
+    signature: Option<&[u8]>,
+    require: bool,
+) -> Result<AttestLevel> {
+    let level = resolve_write_attest_level(mem, agent_id, bound_pubkey_b64, signature, require)?;
 
     if let Some(obj) = mem.metadata.as_object_mut() {
         obj.insert(

--- a/src/models/crdt_merge.rs
+++ b/src/models/crdt_merge.rs
@@ -170,6 +170,78 @@ pub fn sanitize_inbound_attestation(inbound: &Memory) -> Memory {
     sanitized
 }
 
+/// #2863 — re-assert the RECEIVER-VERIFIED `agent_attested` level onto a merged
+/// row when `receiver_verified` is set AND the merged row's `SignableWrite`
+/// surface + `write_signature` is byte-identical to `verified_inbound` (the row
+/// the federation receive path already verified against the origin author's
+/// LOCALLY-ENROLLED key). [`sanitize_inbound_attestation`] correctly neutralizes
+/// the inbound level for the LWW TIEBREAK — a peer must never win by
+/// self-asserting `agent_attested` — but that must not DEMOTE a level THIS node
+/// INDEPENDENTLY verified over the persisted bytes (env #94). Applied on the
+/// merged row INSIDE the merge transaction and BEFORE the content-sealing write,
+/// so the plaintext surface compare holds on at-rest-encrypted deployments too
+/// (the `content` column becomes ciphertext only AFTER the write) and there is
+/// no non-atomic crash window that could strand a TERMINAL tombstone at
+/// `claimed`. `receiver_verified` is the caller's trust signal
+/// (`row_is_agent_attested` of the row AFTER `apply_inbound_write_attestation`,
+/// which always overwrites `attest_level` with THIS node's verdict); every
+/// NON-receive caller passes `false` for a byte-identical legacy merge.
+#[must_use]
+pub fn reassert_verified_attestation(
+    mut merged: Memory,
+    verified_inbound: &Memory,
+    receiver_verified: bool,
+) -> Memory {
+    if receiver_verified && signed_surface_matches(&merged, verified_inbound) {
+        if let Some(obj) = merged.metadata.as_object_mut() {
+            obj.insert(
+                field_names::ATTEST_LEVEL.to_string(),
+                Value::String(AttestLevel::AgentAttested.as_str().to_string()),
+            );
+        }
+    }
+    merged
+}
+
+/// #2863 — do two rows carry a byte-identical 6-field `SignableWrite` surface
+/// (`agent_id` + `namespace` + `title` + `memory_kind` + `created_at` +
+/// `content`) AND the same non-empty `write_signature`? The signature commits to
+/// `sha256(content)` + the other five fields, so an identical signature over an
+/// identical surface proves the persisted merged row IS the exact coherent
+/// signed unit the receiver verified — never a field-wise CRDT accretion
+/// (a "Frankenstein" row) nor a distinct signed unit. A missing/empty signature
+/// or agent_id on either side is a non-match (fail-closed).
+fn signed_surface_matches(a: &Memory, b: &Memory) -> bool {
+    fn meta_str<'m>(m: &'m Memory, key: &str) -> Option<&'m str> {
+        m.metadata.get(key).and_then(Value::as_str)
+    }
+    // `created_at` compared by INSTANT, not bytes: a lossless RFC3339
+    // re-rendering (e.g. postgres round-tripping `TIMESTAMPTZ` back to the wire,
+    // or `Z` vs `+00:00`) represents the SAME signed instant and must still
+    // match, while a genuinely different `created_at` (a Frankenstein whose
+    // timestamp came from a distinct row) is rejected — so the two backends
+    // cannot drift on the rendering seam. Unparseable values fall back to byte
+    // equality (fail-closed on the pathological case).
+    let created_at_eq = match (
+        chrono::DateTime::parse_from_rfc3339(&a.created_at),
+        chrono::DateTime::parse_from_rfc3339(&b.created_at),
+    ) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => a.created_at == b.created_at,
+    };
+    let sig_a = meta_str(a, field_names::WRITE_SIGNATURE);
+    let agent_a = meta_str(a, param_names::AGENT_ID);
+    a.content == b.content
+        && a.title == b.title
+        && a.namespace == b.namespace
+        && created_at_eq
+        && a.memory_kind == b.memory_kind
+        && agent_a == meta_str(b, param_names::AGENT_ID)
+        && agent_a.is_some_and(|s| !s.is_empty())
+        && sig_a == meta_str(b, field_names::WRITE_SIGNATURE)
+        && sig_a.is_some_and(|s| !s.is_empty())
+}
+
 /// #1755 item 3b — cap an UNTRUSTED inbound row's `updated_at` to a
 /// freshness ceiling (`now + skew_secs`) before it is merged, so a
 /// federated relay cannot post-date `updated_at` — the PRIMARY LWW
@@ -952,6 +1024,74 @@ mod tests {
         let sanitized = sanitize_inbound_attestation(&no_level);
         assert!(sanitized.metadata.get("attest_level").is_none());
         assert_eq!(attest_rank(&sanitized), 0);
+    }
+
+    // ---- #2863 reassert_verified_attestation --------------------------------
+
+    /// A `base`-shaped row carrying `agent_id` + `write_signature` + a given
+    /// `attest_level` (the six signed-surface fields come from `base`).
+    fn signed_row_2863(sig: &str, level: &str) -> Memory {
+        let mut m = base("a", "2026-06-16T00:00:00+00:00");
+        m.metadata = json!({
+            "agent_id": "ai:hive-author",
+            "write_signature": sig,
+            "attest_level": level,
+        });
+        m
+    }
+
+    fn level_of(m: &Memory) -> Option<&str> {
+        m.metadata.get("attest_level").and_then(Value::as_str)
+    }
+
+    #[test]
+    fn reassert_restores_agent_attested_on_matching_surface_2863() {
+        // sanitize demoted the merged row to `claimed`, but its full SignableWrite
+        // surface + write_signature equals the receiver-verified inbound → restore.
+        let verified = signed_row_2863("SIG", "agent_attested");
+        let merged = signed_row_2863("SIG", "claimed");
+        let out = reassert_verified_attestation(merged, &verified, true);
+        assert_eq!(level_of(&out), Some("agent_attested"));
+    }
+
+    #[test]
+    fn reassert_noop_when_not_receiver_verified_2863() {
+        // Non-receive callers pass false → byte-identical legacy merge (claimed).
+        let verified = signed_row_2863("SIG", "agent_attested");
+        let merged = signed_row_2863("SIG", "claimed");
+        let out = reassert_verified_attestation(merged, &verified, false);
+        assert_eq!(level_of(&out), Some("claimed"));
+    }
+
+    #[test]
+    fn reassert_noop_on_content_surface_mismatch_2863() {
+        // A Frankenstein / local-won row (different content) must stay claimed.
+        let verified = signed_row_2863("SIG", "agent_attested");
+        let mut merged = signed_row_2863("SIG", "claimed");
+        merged.content = "DIFFERENT-CONTENT".into();
+        let out = reassert_verified_attestation(merged, &verified, true);
+        assert_eq!(level_of(&out), Some("claimed"));
+    }
+
+    #[test]
+    fn reassert_noop_on_signature_mismatch_2863() {
+        // A DIFFERENT write_signature (a distinct signed unit) must not be laundered.
+        let verified = signed_row_2863("SIG-A", "agent_attested");
+        let merged = signed_row_2863("SIG-B", "claimed");
+        let out = reassert_verified_attestation(merged, &verified, true);
+        assert_eq!(level_of(&out), Some("claimed"));
+    }
+
+    #[test]
+    fn reassert_noop_when_signature_absent_2863() {
+        // No write_signature on either side → fail-closed (never re-assert).
+        let mut verified = base("a", "2026-06-16T00:00:00+00:00");
+        verified.metadata =
+            json!({ "agent_id": "ai:hive-author", "attest_level": "agent_attested" });
+        let mut merged = base("a", "2026-06-16T00:00:00+00:00");
+        merged.metadata = json!({ "agent_id": "ai:hive-author", "attest_level": "claimed" });
+        let out = reassert_verified_attestation(merged, &verified, true);
+        assert_eq!(level_of(&out), Some("claimed"));
     }
 
     /// Set `metadata.version_vector` from `(peer, ts)` pairs (test helper).

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -28,7 +28,8 @@ pub use capture_turn::*;
 #[allow(unused_imports)]
 pub use checkpoint::*;
 pub use crdt_merge::{
-    clamp_inbound_updated_at, merge_memory, sanitize_inbound_attestation, stamp_version_vector,
+    clamp_inbound_updated_at, merge_memory, reassert_verified_attestation,
+    sanitize_inbound_attestation, stamp_version_vector,
 };
 #[allow(unused_imports)]
 pub use crdt_primitives::{OrSet, PnCounter};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13976,7 +13976,11 @@ pub fn archived_namespace_by_id(conn: &Connection, id: &str) -> Result<Option<St
 /// Bubbles up rusqlite / serde errors from the read, the merge-write, or
 /// the `insert_if_newer` fall-through. On any error inside the merge
 /// transaction the partial write is rolled back.
-pub fn merge_inbound(conn: &Connection, inbound: &Memory) -> Result<String> {
+pub fn merge_inbound(
+    conn: &Connection,
+    inbound: &Memory,
+    receiver_verified: bool,
+) -> Result<String> {
     // Take the write lock up front so the read-merge-write is atomic
     // against a concurrent peer push (BEGIN IMMEDIATE — same idiom as
     // `consolidate` / `size_gc`).
@@ -14020,6 +14024,21 @@ pub fn merge_inbound(conn: &Connection, inbound: &Memory) -> Result<String> {
                 // #224 field-wise merge — the SAME pure reconciler the
                 // postgres adapter calls in Rust (no per-backend drift).
                 let merged = crate::models::merge_memory(&existing, &prepared);
+                // #2863 — re-assert the receiver-VERIFIED `agent_attested` level
+                // ATOMICALLY (inside this BEGIN IMMEDIATE tx, before the
+                // content-sealing `overwrite_full_row_by_id`). `sanitize` above
+                // demoted the inbound level to `claimed` for the LWW tiebreak
+                // (correct — a peer must not self-assert), but that must not
+                // DEMOTE a level THIS node verified over the persisted bytes:
+                // when the merged row's full SignableWrite surface + signature is
+                // byte-identical to the verified inbound, restore `agent_attested`.
+                // No-op when `receiver_verified` is false (every non-receive
+                // caller) — byte-identical legacy merge.
+                let merged = crate::models::reassert_verified_attestation(
+                    merged,
+                    inbound,
+                    receiver_verified,
+                );
                 overwrite_full_row_by_id(conn, &merged)?;
                 Ok(Some(merged.id))
             }
@@ -22362,7 +22381,7 @@ mod tests {
         });
         inbound.updated_at = "2026-06-16T09:00:00+00:00".to_string();
 
-        let result_id = merge_inbound(&conn, &inbound).unwrap();
+        let result_id = merge_inbound(&conn, &inbound, false).unwrap();
         assert_eq!(result_id, id, "merge returns the existing row id");
 
         let got = get(&conn, &id).unwrap().unwrap();
@@ -22388,6 +22407,64 @@ mod tests {
         );
     }
 
+    /// #2863 — the REAL merge-over-existing path re-asserts a RECEIVER-VERIFIED
+    /// `agent_attested` atomically (the `sanitize` + LWW-newer demotion of a
+    /// re-broadcast tombstoned SOURCE that the receiver just verified is the
+    /// bug). Pins: (1) `receiver_verified=true` + matching signed surface →
+    /// persisted `agent_attested` (RED before the fix — sanitize+LWW → claimed);
+    /// (2) `receiver_verified=false` → legacy `claimed`. The forge-negative (a
+    /// merged row whose signed surface DIFFERS from the verified inbound stays
+    /// `claimed`) is pinned backend-agnostically by
+    /// `crate::models::crdt_merge::tests::reassert_noop_on_{content,signature}_*_2863`.
+    #[test]
+    fn merge_inbound_reasserts_receiver_verified_agent_attested_2863() {
+        // Persist an existing agent_attested signed source, then merge a NEWER
+        // re-broadcast of the same signed unit; return the persisted attest_level.
+        let run = |receiver_verified: bool| -> String {
+            let conn = test_db();
+            let mut existing = make_memory("src-2863", "team/alpha", Tier::Long, 5);
+            existing.content = "scale the deployment to three replicas".to_string();
+            existing.title = "kubernetes deployment guide".to_string();
+            existing.created_at = "2026-08-10T12:00:00+00:00".to_string();
+            existing.updated_at = "2026-08-10T12:00:00+00:00".to_string();
+            existing.metadata = serde_json::json!({
+                "agent_id": "ai:hive-author",
+                "write_signature": "JjiHIu1K887waRYKYvSO-roundtrip-b64",
+                "attest_level": "agent_attested",
+            });
+            let id = insert(&conn, &existing).unwrap();
+
+            // Re-broadcast tombstoned SOURCE: SAME signed surface + signature,
+            // NEWER updated_at (wins LWW), wire attest_level `agent_attested`
+            // (sanitize demotes it inside merge_inbound).
+            let mut inbound = existing.clone();
+            inbound.id = id.clone();
+            inbound.updated_at = "2026-08-10T19:14:31+00:00".to_string();
+
+            let rid = merge_inbound(&conn, &inbound, receiver_verified).unwrap();
+            assert_eq!(rid, id, "merge returns the existing row id");
+            get(&conn, &id)
+                .unwrap()
+                .unwrap()
+                .metadata
+                .get("attest_level")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<absent>")
+                .to_string()
+        };
+
+        assert_eq!(
+            run(true),
+            "agent_attested",
+            "#2863: a receiver-verified level survives the merge (not demoted to claimed)"
+        );
+        assert_eq!(
+            run(false),
+            "claimed",
+            "non-receive callers pass false → byte-identical legacy sanitize+LWW demotion"
+        );
+    }
+
     /// A brand-new id (no existing row) falls through to `insert_if_newer`
     /// and creates the row fresh (OLD behaviour preserved).
     #[test]
@@ -22395,7 +22472,7 @@ mod tests {
         let conn = test_db();
         let mem = make_memory("merge-fresh", "test", Tier::Mid, 5);
         let inbound_id = mem.id.clone();
-        let result_id = merge_inbound(&conn, &mem).unwrap();
+        let result_id = merge_inbound(&conn, &mem, false).unwrap();
         assert_eq!(result_id, inbound_id, "fresh insert returns the row id");
         let got = get(&conn, &inbound_id).unwrap().unwrap();
         assert_eq!(got.title, "merge-fresh");
@@ -22428,7 +22505,7 @@ mod tests {
         inbound.tags = vec!["b".to_string()];
         inbound.updated_at = "2026-06-16T09:00:00+00:00".to_string();
 
-        let result_id = merge_inbound(&conn, &inbound).unwrap();
+        let result_id = merge_inbound(&conn, &inbound, false).unwrap();
 
         // Deduped onto the existing row (kept its id); the new id never
         // became a separate row.
@@ -22473,7 +22550,7 @@ mod tests {
         inbound.expires_at = None;
         inbound.updated_at = "2026-06-16T09:00:00+00:00".to_string();
 
-        merge_inbound(&conn, &inbound).unwrap();
+        merge_inbound(&conn, &inbound, false).unwrap();
         let got = get(&conn, &id).unwrap().unwrap();
         // LWW content (inbound newer) + max-durability tier + max depth —
         // all consistent in the single persisted row.
@@ -22515,7 +22592,7 @@ mod tests {
         inbound.version = 4;
         inbound.updated_at = "2026-06-16T00:00:00+00:00".to_string();
 
-        merge_inbound(&conn, &inbound).unwrap();
+        merge_inbound(&conn, &inbound, false).unwrap();
         let got = get(&conn, &id).unwrap().unwrap();
         assert_eq!(got.version, 12, "version is max(12, 4)");
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1851,7 +1851,20 @@ pub trait MemoryStore: Send + Sync {
     ///
     /// Returns `InvalidInput` when `inbound` fails validation. Returns
     /// `Backend` for storage errors.
-    async fn merge_inbound(&self, _ctx: &CallerContext, _inbound: &Memory) -> StoreResult<String> {
+    /// #2863 — `receiver_verified` is THIS node's own attestation verdict for
+    /// `inbound` (`row_is_agent_attested` of the row AFTER the receive path's
+    /// `apply_inbound_write_attestation`, never a peer self-assertion). When set,
+    /// the merge-over-existing path re-asserts `agent_attested` on the persisted
+    /// row iff its full `SignableWrite` surface + `write_signature` is
+    /// byte-identical to `inbound` — so the CRDT `sanitize` (which neutralizes an
+    /// UNTRUSTED level for the LWW tiebreak) cannot demote a level this node
+    /// independently verified. Non-receive callers pass `false` (legacy merge).
+    async fn merge_inbound(
+        &self,
+        _ctx: &CallerContext,
+        _inbound: &Memory,
+        _receiver_verified: bool,
+    ) -> StoreResult<String> {
         Err(StoreError::UnsupportedCapability {
             capability: "FEDERATION_MERGE_INBOUND".to_string(),
         })

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -19109,7 +19109,12 @@ impl MemoryStore for PostgresStore {
         Ok(applied_id)
     }
 
-    async fn merge_inbound(&self, ctx: &CallerContext, inbound: &Memory) -> StoreResult<String> {
+    async fn merge_inbound(
+        &self,
+        ctx: &CallerContext,
+        inbound: &Memory,
+        receiver_verified: bool,
+    ) -> StoreResult<String> {
         self.gate_record_stop()?;
         // v0.8.1 W2.3 (#1821 / gap G30) — resurrection guard (postgres parity
         // with the sqlite insert_if_newer gate). DROP an inbound write for a
@@ -19185,6 +19190,17 @@ impl MemoryStore for PostgresStore {
             crate::identity::attest::ATTEST_CREATED_AT_SKEW_SECS,
         );
         let merged = crate::models::merge_memory(&existing, &prepared);
+        // #2863 — atomic `agent_attested` re-assert (postgres twin of the sqlite
+        // `db::merge_inbound` path): `sanitize` above demoted the inbound level
+        // to `claimed` for the LWW tiebreak, but that must not DEMOTE a level
+        // THIS node verified over the persisted bytes. When the merged row's full
+        // SignableWrite surface + `write_signature` is byte-identical to the
+        // (post-redaction) verified `inbound`, restore `agent_attested`. The
+        // restored level flows into the `metadata` column encoded below, so it is
+        // written in the SAME UPDATE (atomic, no crash window). No-op when
+        // `receiver_verified` is false.
+        let merged =
+            crate::models::reassert_verified_attestation(merged, inbound, receiver_verified);
 
         // Encode the JSON-shaped columns the same way the
         // `apply_remote_memory` insert path does.
@@ -32145,7 +32161,7 @@ mod tests {
             .expect("apply_remote_memory is an idempotent no-op on a tombstoned id");
         assert_eq!(id, vid);
         let id2 = store
-            .merge_inbound(&ctx, &replay)
+            .merge_inbound(&ctx, &replay, false)
             .await
             .expect("merge_inbound is an idempotent no-op on a tombstoned id");
         assert_eq!(id2, vid);
@@ -32407,7 +32423,7 @@ mod tests {
         m2.content = "content-v2".to_string();
         m2.updated_at = (chrono::Utc::now() + chrono::Duration::seconds(5)).to_rfc3339();
         store
-            .merge_inbound(&ctx, &m2)
+            .merge_inbound(&ctx, &m2, false)
             .await
             .expect("merge_inbound v2");
 
@@ -32906,11 +32922,11 @@ mod tests {
         );
         // merge_inbound persists an inbound peer memory and returns its id.
         let a_id = store
-            .merge_inbound(&ctx, &a)
+            .merge_inbound(&ctx, &a, false)
             .await
             .expect("merge_inbound a");
         let b_id = store
-            .merge_inbound(&ctx, &b)
+            .merge_inbound(&ctx, &b, false)
             .await
             .expect("merge_inbound b");
         assert!(!a_id.is_empty() && !b_id.is_empty());

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -801,13 +801,19 @@ impl MemoryStore for SqliteStore {
         db::insert_if_newer(&conn, memory).map_err(box_err)
     }
 
-    async fn merge_inbound(&self, _ctx: &CallerContext, inbound: &Memory) -> StoreResult<String> {
+    async fn merge_inbound(
+        &self,
+        _ctx: &CallerContext,
+        inbound: &Memory,
+        receiver_verified: bool,
+    ) -> StoreResult<String> {
         self.gate_record_stop()?;
         // v0.8.0 Pillar-3 (#1709 / #224) — delegate to the sqlite
         // free-fn, which does the atomic read-by-id → `merge_memory` →
-        // full-row write (else `insert_if_newer` fall-through).
+        // full-row write (else `insert_if_newer` fall-through). #2863 — thread
+        // the receiver-verified verdict for the atomic agent_attested re-assert.
         let conn = self.state.lock().await;
-        db::merge_inbound(&conn, inbound).map_err(box_err)
+        db::merge_inbound(&conn, inbound, receiver_verified).map_err(box_err)
     }
 
     async fn apply_remote_link(
@@ -3767,7 +3773,7 @@ mod tests {
         m2.content = "content-v2".to_string();
         m2.updated_at = (chrono::Utc::now() + chrono::Duration::seconds(5)).to_rfc3339();
         store
-            .merge_inbound(&ctx, &m2)
+            .merge_inbound(&ctx, &m2, false)
             .await
             .expect("merge_inbound v2");
 

--- a/tests/claim_bitemporal_federation_convergence_2207.rs
+++ b/tests/claim_bitemporal_federation_convergence_2207.rs
@@ -124,7 +124,7 @@ fn remote_newer_close_replicates_by_id_and_valid_at_excludes() {
 
     // A peer CLOSED the claim: same id, NEWER updated_at, valid_until set.
     let closed = claim(&id, T1_CLOSE_UPD, Some(CLOSE_AT));
-    let merged_id = storage::merge_inbound(&conn, &closed).expect("merge inbound close");
+    let merged_id = storage::merge_inbound(&conn, &closed, false).expect("merge inbound close");
     assert_eq!(merged_id, id, "merge_inbound reconciles the existing id");
 
     // The receiver ADOPTED the close (newer-wins LWW on valid_until).
@@ -168,7 +168,7 @@ fn both_merge_orders_converge_to_identical_rows() {
     // Node 1 holds A (open), receives B (closed).
     let (_tmp1, conn1) = fresh_db();
     let id1 = storage::insert(&conn1, &a_open).expect("node1 seed A");
-    storage::merge_inbound(&conn1, &b_closed).expect("node1 merge B");
+    storage::merge_inbound(&conn1, &b_closed, false).expect("node1 merge B");
     let row1 = db::get(&conn1, &id1)
         .expect("node1 get")
         .expect("node1 row");
@@ -176,7 +176,7 @@ fn both_merge_orders_converge_to_identical_rows() {
     // Node 2 holds B (closed), receives A (open) — the REVERSE order.
     let (_tmp2, conn2) = fresh_db();
     let id2 = storage::insert(&conn2, &b_closed).expect("node2 seed B");
-    storage::merge_inbound(&conn2, &a_open).expect("node2 merge A");
+    storage::merge_inbound(&conn2, &a_open, false).expect("node2 merge A");
     let row2 = db::get(&conn2, &id2)
         .expect("node2 get")
         .expect("node2 row");
@@ -222,7 +222,7 @@ fn stale_remote_reopen_does_not_clobber_local_close() {
 
     // A STALE peer row: same id, OLDER updated_at, still OPEN (valid_until=None).
     let stale_open = claim(&id, T0_OPEN, None);
-    storage::merge_inbound(&conn, &stale_open).expect("merge stale open");
+    storage::merge_inbound(&conn, &stale_open, false).expect("merge stale open");
 
     // The local close survives (prefer-non-null / LWW keeps the close).
     let got = db::get(&conn, &id).expect("get").expect("row present");

--- a/tests/encryption_at_rest.rs
+++ b/tests/encryption_at_rest.rs
@@ -619,7 +619,7 @@ fn federation_merge_seals_content_and_snapshots_1773() {
     let mut inbound = existing.clone();
     inbound.content = "merged via federation".to_string();
     inbound.updated_at = "2026-06-01T00:00:00+00:00".to_string();
-    db::merge_inbound(&conn, &inbound).expect("merge_inbound");
+    db::merge_inbound(&conn, &inbound, false).expect("merge_inbound");
 
     // HIGH: read must return the MERGED content (re-sealed), not stale.
     let fetched = db::get(&conn, &id).expect("get").expect("exists");

--- a/tests/erasure_fanout_postgres_g30.rs
+++ b/tests/erasure_fanout_postgres_g30.rs
@@ -110,7 +110,7 @@ async fn postgres_forget_tombstone_blocks_resurrection_g30() {
         ..mem(&ns, "rnote", "original secret content")
     };
     let returned = pg
-        .merge_inbound(&admin, &revived)
+        .merge_inbound(&admin, &revived, false)
         .await
         .expect("merge_inbound");
     assert_eq!(

--- a/tests/fed_consolidate_converges_2860_pg.rs
+++ b/tests/fed_consolidate_converges_2860_pg.rs
@@ -149,3 +149,78 @@ async fn pg_federated_consolidation_authors_as_sender_and_finalize_persists_2860
         "finalize persists the substrate write_signature in place (jsonb replace)"
     );
 }
+
+/// #2863 — live-postgres parity for the merge-path `agent_attested` re-assert.
+/// A re-broadcast of a source that landed `agent_attested` merges OVER the
+/// existing row; `PostgresStore::merge_inbound` runs the shared `sanitize` +
+/// LWW-newer (which would demote the receiver-verified level to `claimed`), then
+/// atomically re-asserts `agent_attested` when the merged row's SignableWrite
+/// surface + `write_signature` matches the verified inbound. Pins that the pg
+/// twin behaves IDENTICALLY to the sqlite `db::merge_inbound` unit test
+/// (`storage::tests::merge_inbound_reasserts_receiver_verified_agent_attested_2863`)
+/// — including the `created_at` TIMESTAMPTZ round-trip (matched by instant, not
+/// bytes). `receiver_verified=false` reproduces the legacy demotion.
+#[tokio::test]
+async fn pg_merge_inbound_reasserts_receiver_verified_agent_attested_2863() {
+    // Fresh existing agent_attested signed source; merge a NEWER re-broadcast of
+    // the same signed unit; return the persisted attest_level. (Declared before
+    // any statement to satisfy `clippy::items_after_statements`.)
+    async fn scenario(store: &PostgresStore, receiver_verified: bool) -> String {
+        let ns = format!("fed-2863-{}", uuid::Uuid::new_v4());
+        let id = uuid::Uuid::new_v4().to_string();
+        let author = "ai:hive-author";
+        let ctx = CallerContext::for_agent(author);
+
+        store
+            .store(
+                &ctx,
+                &mem(&id, &ns, "k8s guide", "scale to three replicas", author),
+            )
+            .await
+            .expect("store existing source");
+        // Force the persisted row to the finalized agent_attested + signature
+        // shape (mirrors the origin's finalize), bypassing store()'s own gate.
+        let meta = serde_json::json!({
+            "agent_id": author,
+            "write_signature": "JjiHIu-2863-roundtrip-b64",
+            "attest_level": "agent_attested",
+        });
+        store
+            .set_row_metadata(&ctx, &id, &serde_json::to_string(&meta).unwrap())
+            .await
+            .expect("finalize existing to agent_attested");
+
+        // Inbound = the PERSISTED row (so its signed surface — incl. the pg
+        // TIMESTAMPTZ-rendered created_at — matches byte-for-byte / by-instant),
+        // NEWER updated_at, carrying the same write_signature + wire level.
+        let stored = store.get(&ctx, &id).await.expect("get finalized");
+        let mut inbound = stored.clone();
+        inbound.updated_at = "2026-08-11T00:00:00+00:00".to_string();
+        inbound.metadata = meta.clone();
+
+        store
+            .merge_inbound(&ctx, &inbound, receiver_verified)
+            .await
+            .expect("pg merge_inbound");
+        let got = store.get(&ctx, &id).await.expect("get after merge");
+        got.metadata
+            .get("attest_level")
+            .and_then(|v| v.as_str())
+            .unwrap_or("<absent>")
+            .to_string()
+    }
+
+    let Some(store) = connect().await else {
+        return;
+    };
+    assert_eq!(
+        scenario(&store, true).await,
+        "agent_attested",
+        "#2863 pg: a receiver-verified level survives the merge (parity with sqlite)"
+    );
+    assert_eq!(
+        scenario(&store, false).await,
+        "claimed",
+        "#2863 pg: receiver_verified=false → legacy sanitize+LWW demotion"
+    );
+}

--- a/tests/fed_consolidate_source_attest_parity_2863.rs
+++ b/tests/fed_consolidate_source_attest_parity_2863.rs
@@ -1,0 +1,249 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// clippy allows (test scaffolding): pedantic lints with no behavioural
+// impact on the regression we pin.
+#![allow(clippy::redundant_closure_for_method_calls, clippy::too_many_lines)]
+
+//! #2863 (federation data-integrity) — fed-consolidate-source-attest-parity.
+//!
+//! End-to-end `/sync/push` pin for the #2860 re-broadcast divergence: a
+//! consolidation SOURCE row that landed `agent_attested` on the peer (fresh
+//! push, self-relayed by its author) must STAY `agent_attested` when the same
+//! row is RE-BROADCAST under the daemon federation identity (a newer
+//! `updated_at`, as the tombstone disposition emits). Pre-fix the re-broadcast
+//! MERGED over the existing row and `db::merge_inbound`'s `sanitize` + LWW-newer
+//! demoted the receiver's own just-verified level to `claimed` — a divergence
+//! from the origin's `agent_attested`.
+//!
+//! This drives the REAL `/sync/push` receive loop (not `db::merge_inbound`
+//! alone), so it pins the receive-loop WIRING: that the loop passes
+//! `row_is_agent_attested(&to_insert)` into `merge_inbound` so the atomic
+//! `reassert_verified_attestation` restores the verified level. Zero-config
+//! posture (the DO-mesh shape); the enrolled-unauthorized honor branch (fix #1
+//! in `resolve_inbound_attribution`) is unit-covered in
+//! `handlers::federation_receive::tests::rebroadcast_source_honors_crypto_attested_claim_2863`.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use base64::Engine as _;
+use serde_json::{Value, json};
+use tower::ServiceExt as _;
+
+/// Process-global async lock — these tests mutate federation env vars.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn build_router_with_db() -> (axum::Router, ai_memory::handlers::Db) {
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).unwrap();
+    let path = std::path::PathBuf::from(":memory:");
+    let db: ai_memory::handlers::Db = std::sync::Arc::new(tokio::sync::Mutex::new((
+        conn,
+        path,
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: std::sync::Arc<dyn ai_memory::store::MemoryStore> = {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+        let p = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+        std::sync::Arc::new(
+            ai_memory::store::sqlite::SqliteStore::open(&p).expect("open SqliteStore"),
+        )
+    };
+    let app_state = ai_memory::handlers::AppState {
+        db: db.clone(),
+        embedder: std::sync::Arc::new(None),
+        vector_index: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+        federation: std::sync::Arc::new(None),
+        tier_config: std::sync::Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: std::sync::Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: std::sync::Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: std::sync::Arc::new(None),
+        active_keypair: std::sync::Arc::new(None),
+        family_embeddings: std::sync::Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: std::sync::Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: std::sync::Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: std::sync::Arc::new(None),
+        deferred_audit_queue: std::sync::Arc::new(None),
+        admin_agent_ids: std::sync::Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ai_memory::handlers::ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let router = ai_memory::build_router(api_key_state, app_state);
+    (router, db)
+}
+
+/// Relax the ENVELOPE-level federation gates so the per-write attestation lane
+/// under test is reached, and clear the allowlist (zero-config posture).
+fn reset_env_zero_config() {
+    unsafe {
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+        std::env::remove_var(ai_memory::federation::peer_attestation::TRUST_BODY_AGENT_ID_ENV);
+        std::env::set_var("AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT", "0");
+        std::env::set_var("AI_MEMORY_FED_REQUIRE_SIG", "0");
+        std::env::set_var("AI_MEMORY_FED_REQUIRE_NONCE", "0");
+        // Strict per-write sig stays at its v1.0.0 default (unset) — the signed
+        // source verifies, so strict never bricks it.
+        std::env::remove_var("AI_MEMORY_FED_REQUIRE_WRITE_SIG");
+        std::env::remove_var("AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED");
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn memory_json(
+    id: &str,
+    ns: &str,
+    title: &str,
+    content: &str,
+    created_at: &str,
+    updated_at: &str,
+    author: &str,
+    write_sig_b64: &str,
+) -> Value {
+    json!({
+        "id": id,
+        "tier": "long",
+        "namespace": ns,
+        "title": title,
+        "content": content,
+        "tags": [],
+        "priority": 5,
+        "confidence": 1.0,
+        "source": "user",
+        "access_count": 0,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "metadata": { "agent_id": author, "write_signature": write_sig_b64 },
+        "reflection_depth": 0,
+        "memory_kind": "observation",
+    })
+}
+
+async fn post_sync_push(router: &axum::Router, sender: &str, memory: Value) -> StatusCode {
+    let body = json!({
+        "sender_agent_id": sender,
+        "sender_clock": {"entries": {}},
+        "memories": [memory],
+        "dry_run": false,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            sender,
+        )
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    router.clone().oneshot(req).await.unwrap().status()
+}
+
+async fn row_attest(db: &ai_memory::handlers::Db, id: &str) -> (String, String) {
+    let lock = db.lock().await;
+    lock.0
+        .query_row(
+            "SELECT json_extract(metadata,'$.attest_level'), json_extract(metadata,'$.agent_id') \
+             FROM memories WHERE id = ?1",
+            rusqlite::params![id],
+            |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+        )
+        .unwrap()
+}
+
+#[tokio::test]
+async fn rebroadcast_tombstoned_source_stays_agent_attested_2863() {
+    let _g = ENV_LOCK.lock().await;
+    reset_env_zero_config();
+
+    let (router, db) = build_router_with_db();
+    let author = "ai:hive-author";
+    let daemon = "ai:hive-memory-1"; // #2860 re-broadcast sender (fed identity)
+
+    // Enroll the origin author's key at this receiver so the write_signature
+    // verifies (both DO nodes had it enrolled).
+    let kp = ai_memory::identity::keypair::generate(author).unwrap();
+    let pk_b64 = base64::engine::general_purpose::STANDARD.encode(kp.public.to_bytes());
+    {
+        let lock = db.lock().await;
+        ai_memory::db::register_agent(&lock.0, author, "nhi", &[]).unwrap();
+        ai_memory::db::bind_agent_pubkey(&lock.0, author, &pk_b64).unwrap();
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let ns = "team/alpha";
+    let title = "kubernetes deployment guide";
+    let content = "scale the deployment to three replicas";
+    let created = "2026-08-10T12:00:00+00:00";
+
+    // Sign the 6-field SignableWrite exactly as the AUTHORING node would.
+    let to_sign = ai_memory::models::Memory {
+        id: id.clone(),
+        namespace: ns.to_string(),
+        title: title.to_string(),
+        content: content.to_string(),
+        created_at: created.to_string(),
+        metadata: json!({ "agent_id": author }),
+        ..ai_memory::models::Memory::default()
+    };
+    let sig = ai_memory::identity::attest::sign_memory_write(&kp, &to_sign, author).unwrap();
+    let sig_b64 = base64::engine::general_purpose::STANDARD.encode(&sig);
+
+    // POST 1 — fresh push, SELF-RELAYED by the author → lands agent_attested.
+    let status1 = post_sync_push(
+        &router,
+        author,
+        memory_json(&id, ns, title, content, created, created, author, &sig_b64),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::OK, "fresh signed self-relay push");
+    let (lvl1, owner1) = row_attest(&db, &id).await;
+    assert_eq!(
+        lvl1, "agent_attested",
+        "fresh signed source lands agent_attested"
+    );
+    assert_eq!(owner1, author);
+
+    // POST 2 — the #2860 RE-BROADCAST: same source (same id + write_signature),
+    // NEWER updated_at (the tombstone disposition), relayed under the DAEMON
+    // federation identity (a third-party relay from the receiver's view).
+    let newer = "2026-08-10T19:14:31+00:00";
+    let status2 = post_sync_push(
+        &router,
+        daemon,
+        memory_json(&id, ns, title, content, created, newer, author, &sig_b64),
+    )
+    .await;
+    assert_eq!(status2, StatusCode::OK, "re-broadcast push accepted");
+
+    let (lvl2, owner2) = row_attest(&db, &id).await;
+    assert_eq!(
+        lvl2, "agent_attested",
+        "#2863: the re-broadcast merge-over-existing must NOT demote the \
+         receiver-verified level to `claimed` (origin stays agent_attested)"
+    );
+    assert_eq!(owner2, author, "authorship preserved as the true author");
+}

--- a/tests/issue_2059_2060_covenant_write_gates.rs
+++ b/tests/issue_2059_2060_covenant_write_gates.rs
@@ -511,7 +511,7 @@ fn merge_inbound_same_id_consults_governance_pre_write_2123() {
     let mut refused = seed.clone();
     refused.title = format!("now {GOV_MARKER_2123} laundered");
     refused.updated_at = chrono::Utc::now().to_rfc3339();
-    let err = db::merge_inbound(&conn, &refused)
+    let err = db::merge_inbound(&conn, &refused, false)
         .expect_err("a same-id merge into a governance-refused shape must be refused");
     assert!(
         err.downcast_ref::<GovernanceRefusal>().is_some(),
@@ -547,7 +547,7 @@ fn merge_inbound_same_id_never_refuses_missing_why_trace_under_enforce_2123() {
     no_wt.title = "benign merged title".to_string();
     no_wt.metadata = serde_json::json!({"agent_id": "alice"});
     no_wt.updated_at = chrono::Utc::now().to_rfc3339();
-    let id = db::merge_inbound(&conn, &no_wt)
+    let id = db::merge_inbound(&conn, &no_wt, false)
         .expect("a why_trace-less same-id inbound merge must NEVER be refused");
     assert_eq!(id, seed.id, "the merge resolves to the existing id");
     unsafe { std::env::remove_var(REQUIRE_WHY_TRACE_ENV) };

--- a/tests/issue_2121_2122_2123_covenant_funnels.rs
+++ b/tests/issue_2121_2122_2123_covenant_funnels.rs
@@ -513,7 +513,7 @@ fn merge_inbound_same_id_never_refuses_missing_why_trace_under_enforce_2123() {
     inbound.content = "remote merged content".to_string();
     inbound.updated_at = (chrono::Utc::now() + chrono::Duration::seconds(2)).to_rfc3339();
     inbound.version = 2;
-    let merged_id = db::merge_inbound(&conn, &inbound)
+    let merged_id = db::merge_inbound(&conn, &inbound, false)
         .expect("merge_inbound must accept a why_trace-less inbound write under enforce");
     assert_eq!(merged_id, id);
     let got = db::get(&conn, &id).unwrap().unwrap();

--- a/tests/record_stop_r45_1955.rs
+++ b/tests/record_stop_r45_1955.rs
@@ -208,7 +208,7 @@ async fn federation_receive_is_stopped() {
     let merge = mk_memory("merge-inbound", "peer merge under stop");
     assert!(
         matches!(
-            store.merge_inbound(&c, &merge).await,
+            store.merge_inbound(&c, &merge, false).await,
             Err(StoreError::Stopped { .. })
         ),
         "merge_inbound must refuse under stop"

--- a/tests/recursive_sal_coverage.rs
+++ b/tests/recursive_sal_coverage.rs
@@ -928,7 +928,7 @@ async fn exercise_sal_surface(store: &dyn MemoryStore) {
     mi_local.priority = 3;
     mi_local.updated_at = "2026-06-16T00:00:00+00:00".to_string();
     let stored_id = store
-        .merge_inbound(&ctx, &mi_local)
+        .merge_inbound(&ctx, &mi_local, false)
         .await
         .expect("merge_inbound fresh-insert ok");
     assert_eq!(stored_id, mi_id, "fresh merge_inbound returns the row id");
@@ -938,7 +938,7 @@ async fn exercise_sal_surface(store: &dyn MemoryStore) {
     mi_inbound.priority = 5;
     mi_inbound.updated_at = "2026-06-16T09:00:00+00:00".to_string();
     let merged_id = store
-        .merge_inbound(&ctx, &mi_inbound)
+        .merge_inbound(&ctx, &mi_inbound, false)
         .await
         .expect("merge_inbound divergent same-id ok");
     assert_eq!(merged_id, mi_id, "merge returns the existing row id");

--- a/tests/store_parity_gaps.rs
+++ b/tests/store_parity_gaps.rs
@@ -2101,7 +2101,7 @@ mod postgres_side {
         inbound.id = id.clone();
         inbound.content = plaintext.to_string();
         inbound.updated_at = (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
-        let merged_id = MemoryStore::merge_inbound(&pg, &admin_ctx, &inbound)
+        let merged_id = MemoryStore::merge_inbound(&pg, &admin_ctx, &inbound, false)
             .await
             .expect("merge_inbound under encryption");
         assert_eq!(merged_id, id, "merge resolves the same-id UPDATE path");


### PR DESCRIPTION
## Summary

Closes #2863 — a federation attestation-metadata divergence surfaced by the #2860 DO 2-node re-verify (the #2860 CORE convergence, PR #2862, is merged and PROVEN; this is the residual).

A consolidation **SOURCE** row that landed `attest_level=agent_attested` at a peer (fresh push, self-relayed by its author) was **DOWNGRADED to `claimed`** when the #2860 lineage path **RE-BROADCAST** it under the daemon federation identity — same byte-identical valid `write_signature`, same content (len 140), same version, divergent `attest_level` (origin `agent_attested` vs peer `claimed`), reproduced verbatim on the live DO mesh (source `38b83c5f`, sig `JjiHIu…`). Under `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1` this is a visibility divergence (`claimed` inbound is quarantined). North-Star "never diverge" violation.

## Pinned root cause — two independent mechanisms (the issue's SignableWrite field-form hypothesis was not the cause)

**(1) Attribution.** On the re-broadcast the push `sender_agent_id` is the daemon federation identity, so the source (authored by another agent) is a THIRD-PARTY claim. `resolve_inbound_attribution` (`src/handlers/federation_receive.rs`) re-attributed it to the daemon and stamped `claimed` when the author was not in the peer's `allowed_sender_agent_ids` allowlist.

**(2) Merge (the deeper cause, fires regardless of allowlist).** The re-broadcast MERGES over the peer's existing row; `db::merge_inbound` (`src/storage/mod.rs:13979`) runs `sanitize_inbound_attestation` (`src/models/crdt_merge.rs:160`) — which correctly neutralizes an UNTRUSTED wire-asserted level for the LWW tiebreak — but it ALSO wiped the receiver's OWN just-verified `agent_attested`, and `merge_metadata`'s LWW-newer (the tombstone) then persisted `claimed`, while `agent_id` was preserved local (the true author) by the immutable sub-rule — exactly the observed `agent_id=author` + `attest_level=claimed`.

## Fix (both closed WITHOUT weakening attestation — unsigned/forged/unenrolled-author still lands `claimed`)

1. `resolve_inbound_attribution` HONORS a third-party claim whose `write_signature` VERIFIES against the CLAIMED author's locally-enrolled key (a valid Ed25519 signature over the 6-field `SignableWrite` is unforgeable proof of authorship independent of the relaying peer, strictly stronger than the operational allowlist), threaded via a new `claim_write_attested` bool so the whole attribution decision stays centralized.
2. `merge_inbound` re-asserts `agent_attested` **ATOMICALLY** (in the merge transaction, before the content-sealing write — holds under at-rest encryption, no crash window that could strand a terminal tombstone) when, and only when, the merged row's full SignableWrite surface + `write_signature` is byte-identical to the row THIS node just verified (`receiver_verified` bool, never a peer self-assertion; `created_at` matched by instant so the two backends can't drift on the TIMESTAMPTZ round-trip). Both backends edited identically.

Convergence is enrollment-bounded (a peer without the origin author's key stays `claimed` — fail-closed degrade; TOFU deferred to v1.x). New pure `identity::attest::resolve_write_attest_level` (shared verification) + `models::crdt_merge::reassert_verified_attestation`.

## Decisions (deterministic 5-agent adversarial vote, memory `4d3ea1c5`)

- **Fix #1** (T3 attestation-semantics + T1 pub-fn shape): 5/5 approve; honor-crypto-attested-claim in the centralized attribution fn.
- **Fix #2** (T3 posture + T1 new merge param + T6): 5/5 approve; the ATOMIC merge-transaction form chosen on the convergent condition from the data-integrity + backend-parity lenses (rejects the non-atomic separate-UPDATE, which had a terminal-tombstone crash window and an encryption content-match seam).

## Tests

- `tests/fed_consolidate_source_attest_parity_2863.rs` — sqlite `/sync/push` end-to-end wiring pin (fresh signed self-relay → `agent_attested`; re-broadcast under the daemon identity → STAYS `agent_attested`).
- `tests/fed_consolidate_converges_2860_pg.rs` — live-postgres parity for the merge-path re-assert (gated on `AI_MEMORY_TEST_POSTGRES_URL`).
- Unit arms: attribution honor path (`handlers::federation_receive`, arms self-relay / crypto-attested third-party / unsigned / forged / unenrolled), the pure re-assert (`models::crdt_merge`, incl. forge-negatives), the real merge path (`storage::merge_inbound`).

## Gates (all green locally)

fmt · clippy pedantic (default + sal + sal-postgres + vectorlite, `--all-targets`) · `AI_MEMORY_NO_CONFIG=1` targeted tests (7 lib + e2e + 41 regression) · cargo audit · qual_10 + qual_6_7 ceilings · cargo check --examples.

A DO 2-node re-verify is warranted as a final confirmation, but the local sqlite e2e + live-pg parity are the primary gates.

## AI involvement

Authored by Claude Opus 5 under operator delegation; two 5-agent adversarial votes drove the crossroads decisions. Do not merge — Fable review + security-audit gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY