### PR TITLE
fix(federation/#2865): daemon-authored consolidations converge at agent_attested out-of-box (push write-sig key-dir fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 
+- **Daemon-authored federated consolidations converge at `agent_attested` at
+  peers OUT-OF-BOX for a normally-enrolled mesh — no manual DB-bind step**
+  ([#2865](https://github.com/alphaonedev/ai-memory-mcp/issues/2865); 5-agent
+  adversarial vote `4d3ea1c5`, UNANIMOUS). A consolidation authored as the
+  daemon's FEDERATION identity (e.g. `ai:hive-memory-1`, #2860/#2862) carries a
+  valid propagated `metadata.write_signature`, but the `/sync/push` receive lane
+  resolved the attributed author's verification key from the DB `agent_pubkey`
+  registry ONLY. `fed-bootstrap.sh` (and mesh enrollment generally) cross-enrolls
+  a peer's federation public key into the on-disk key store (the key-dir) — the
+  SAME source the PULL author lane (#2715), the signal-author lane, and the
+  transition-author lane already trust — but does NOT bind it into the per-node
+  DB registry, so the signature could not be verified and the row landed
+  `attest_level=claimed` (and was QUARANTINED at peers under
+  `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1` / `asi-hard`). The push lane's
+  author-key resolution now falls back to the enrolled key-dir
+  (`crate::identity::verify::lookup_peer_public_key`) as a MISS-ONLY layer after
+  the DB registry (`handlers::federation_receive::resolve_author_bound_key`),
+  bringing it to parity with the pull lane on BOTH backends and closing the gap
+  with no manual bind. **No weakening of attestation:** the key-dir is
+  operator/enrollment-controlled and not writable over the wire; the fallback is
+  miss-only so a DB-bound key always wins; and the presented signature is still
+  VERIFIED against whichever key resolves, so a forged/absent key can only
+  DEGRADE a row to `claimed`, never mis-attest it (a forged signature is rejected
+  unconditionally). Pinned by `tests/federation_writesig_keydir_fallback_2865.rs`.
 - **Re-broadcast tombstoned consolidation SOURCE rows no longer DIVERGE in
   `attest_level` across nodes** (#2863, residual of #2860 surfaced by the DO
   2-node re-verify; two 5-agent adversarial votes `4d3ea1c5`). A consolidation

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -615,6 +615,72 @@ pub(super) fn signal_author_authorized(
     true
 }
 
+/// #2865 — resolve the attributed author's bound Ed25519 public key (base64)
+/// for the `/sync/push` per-write CONTENT-attestation lane
+/// ([`apply_inbound_write_attestation`]): the DB `agent_pubkey` registry FIRST,
+/// then the on-disk ENROLLED key store ([`crate::identity::verify::lookup_peer_public_key`],
+/// the key-dir) as a MISS-ONLY fallback.
+///
+/// **Why the fallback (the #2865 gap).** A daemon authors a federated
+/// consolidation as its FEDERATION identity (e.g. `ai:hive-memory-1`,
+/// #2860/#2862). A normally-enrolled mesh cross-enrolls a peer's federation
+/// public key into the key-dir — the SAME source the PULL author lane
+/// ([`attest_inbound_pull_memory`]), the signal-author lane
+/// ([`signal_author_authorized`]), and the transition-author lane already
+/// trust — but does NOT bind it into the per-node DB `agent_pubkey` registry.
+/// Pre-#2865 the push lane resolved the author key from the DB registry ONLY,
+/// so the propagated `metadata.write_signature` could not be verified and the
+/// row landed `attest_level=claimed` — quarantined at peers under
+/// `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED` (asi-hard). Consulting the key-dir
+/// as a fallback brings the push lane to parity with the pull lane and makes
+/// daemon-authored derived content converge at `agent_attested` OUT-OF-BOX,
+/// with no manual DB-bind step. 5-agent vote (`4d3ea1c5`), unanimous.
+///
+/// **Trust (why this is not a new grant).** The key-dir is
+/// operator/enrollment-controlled and is NOT writable over the wire — no
+/// `/sync/*` receive handler writes it — so reading it grants no new trust; it
+/// is the identical source three inbound author lanes already use. The fallback
+/// is MISS-ONLY (`registry_key.or_else(...)`): a key bound into the DB registry
+/// (e.g. the cert-round author via the admin `PUT /api/v1/agents/{id}/pubkey`
+/// route, or `ai-memory agents bind-key`) ALWAYS wins, so a stale/rotated
+/// key-dir entry can never shadow the authoritative registry key. And
+/// [`apply_inbound_write_attestation`] VERIFIES the presented signature against
+/// whichever key resolves — a wrong/absent key can only DEGRADE the row to
+/// `claimed`, never mis-attest it (a forged signature is rejected
+/// unconditionally). The key-dir [`ed25519_dalek::VerifyingKey`] is encoded
+/// URL-safe-no-pad exactly as the pull lane encodes it;
+/// [`crate::identity::keypair::decode_public_base64`] accepts both that and the
+/// STANDARD form the DB registry stores.
+#[must_use]
+pub fn resolve_author_bound_key(
+    registry_key: Option<String>,
+    attribute_agent: &str,
+) -> Option<String> {
+    use base64::Engine as _;
+    registry_key.or_else(|| {
+        crate::identity::verify::lookup_peer_public_key(attribute_agent)
+            .map(|vk| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.to_bytes()))
+    })
+}
+
+/// Test seam for [`resolve_author_bound_key`] taking an explicit key
+/// directory (mirrors the [`crate::identity::verify::lookup_peer_public_key`]
+/// / `lookup_peer_public_key_in` pairing) so a regression test can populate a
+/// tempdir key-dir without touching the operator's real key store or mutating
+/// `AI_MEMORY_KEY_DIR`.
+#[must_use]
+pub fn resolve_author_bound_key_in(
+    registry_key: Option<String>,
+    attribute_agent: &str,
+    key_dir: &std::path::Path,
+) -> Option<String> {
+    use base64::Engine as _;
+    registry_key.or_else(|| {
+        crate::identity::verify::lookup_peer_public_key_in(attribute_agent, key_dir)
+            .map(|vk| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.to_bytes()))
+    })
+}
+
 /// #1464 (v0.8.0) — per-write CONTENT attestation on the federation receive
 /// path. The ATTRIBUTION lane ([`resolve_inbound_attribution`]) resolves
 /// WHO a relayed memory is attributed to; this resolves WHETHER the relayed
@@ -741,7 +807,6 @@ pub(super) fn apply_inbound_write_attestation(
 /// must be skipped.
 #[must_use]
 pub(crate) fn attest_inbound_pull_memory(mem: &mut Memory) -> bool {
-    use base64::Engine;
     let Some(author) = mem
         .metadata
         .get(crate::META_KEY_AGENT_ID)
@@ -756,8 +821,12 @@ pub(crate) fn attest_inbound_pull_memory(mem: &mut Memory) -> bool {
     // #2340 — redact BEFORE verify/stamp so the attestation commits over the
     // persisted bytes (see fn docs).
     crate::federation::receive_auth::redact_inbound_before_attestation(mem);
-    let author_bound_key = crate::identity::verify::lookup_peer_public_key(&author)
-        .map(|vk| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.to_bytes()));
+    // #2865 — single-source the author-key resolution through the shared
+    // helper. The pull lane has no DB-registry source (it is backend-uniform by
+    // design), so it passes `None` and the helper resolves the enrolled key-dir
+    // key exactly as before (byte-identical) — the same resolver the push lane
+    // now falls back to.
+    let author_bound_key = resolve_author_bound_key(None, &author);
     match apply_inbound_write_attestation(
         mem,
         &author,
@@ -1996,9 +2065,13 @@ pub async fn sync_push(
         // write_signature) is HONORED rather than re-attributed to the daemon
         // relay sender (the #2860 re-broadcast divergence). Reused below as the
         // attestation bound key when the claim is honored (attribute == claimed).
-        let claim_bound_key = original_claim
-            .as_deref()
-            .and_then(|c| db::agent_pubkey(&lock.0, c).ok().flatten());
+        let claim_bound_key = original_claim.as_deref().and_then(|c| {
+            // #2865 — DB registry FIRST, enrolled key-dir as a MISS-ONLY
+            // fallback, so a third-party author whose FEDERATION identity key
+            // is cross-enrolled in the key-dir (not DB-bound) is HONORED
+            // rather than re-attributed to the relay sender.
+            resolve_author_bound_key(db::agent_pubkey(&lock.0, c).ok().flatten(), c)
+        });
         let claim_write_attested = original_claim.as_deref().is_some_and(|c| {
             inbound_claim_is_write_attested(&to_insert, c, claim_bound_key.as_deref())
         });
@@ -2022,7 +2095,15 @@ pub async fn sync_push(
         let author_bound_key = if Some(attribute_agent.as_str()) == original_claim.as_deref() {
             claim_bound_key.clone()
         } else {
-            db::agent_pubkey(&lock.0, &attribute_agent).ok().flatten()
+            // #2865 — same DB-first, enrolled-key-dir MISS-ONLY fallback as the
+            // claim key above (the honored branch already carries it via
+            // `claim_bound_key`). Lets a peer's cross-enrolled FEDERATION
+            // identity key verify a propagated write_signature and reach
+            // agent_attested out-of-box, with no manual DB-bind step.
+            resolve_author_bound_key(
+                db::agent_pubkey(&lock.0, &attribute_agent).ok().flatten(),
+                &attribute_agent,
+            )
         };
         if let Err(e) = apply_inbound_write_attestation(
             &mut to_insert,

--- a/src/handlers/federation_signing_check.rs
+++ b/src/handlers/federation_signing_check.rs
@@ -300,7 +300,14 @@ pub(super) async fn sync_push_via_store(
         // honored (attribute == claimed). The enrolled-key lookup resolves
         // through the SAL `agent_pubkey` trait method so both backends match.
         let claim_bound_key = match original_claim.as_deref() {
-            Some(c) => app.store.agent_pubkey(c).await.ok().flatten(),
+            // #2865 — DB registry FIRST, enrolled key-dir as a MISS-ONLY
+            // fallback (postgres twin of the sqlite path), so a third-party
+            // author whose FEDERATION identity key is cross-enrolled in the
+            // key-dir (not DB-bound) is HONORED rather than re-attributed.
+            Some(c) => crate::handlers::federation_receive::resolve_author_bound_key(
+                app.store.agent_pubkey(c).await.ok().flatten(),
+                c,
+            ),
             None => None,
         };
         let claim_write_attested = original_claim.as_deref().is_some_and(|c| {
@@ -327,11 +334,18 @@ pub(super) async fn sync_push_via_store(
         let bound_pubkey = if Some(attribute_agent.as_str()) == original_claim.as_deref() {
             claim_bound_key.clone()
         } else {
-            app.store
-                .agent_pubkey(&attribute_agent)
-                .await
-                .ok()
-                .flatten()
+            // #2865 — same DB-first, enrolled-key-dir MISS-ONLY fallback as the
+            // claim key above (postgres twin), so a peer's cross-enrolled
+            // FEDERATION identity key verifies a propagated write_signature and
+            // reaches agent_attested out-of-box, backend-uniform with sqlite.
+            crate::handlers::federation_receive::resolve_author_bound_key(
+                app.store
+                    .agent_pubkey(&attribute_agent)
+                    .await
+                    .ok()
+                    .flatten(),
+                &attribute_agent,
+            )
         };
         if let Err(e) = apply_inbound_write_attestation(
             &mut to_insert,

--- a/tests/federation_writesig_keydir_fallback_2865.rs
+++ b/tests/federation_writesig_keydir_fallback_2865.rs
@@ -1,0 +1,212 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2865 — the FINAL federation-convergence enrollment fix.
+//!
+//! A daemon authors a federated consolidation as its FEDERATION identity
+//! (e.g. `ai:hive-memory-1`). A normally-enrolled mesh cross-enrolls a peer's
+//! federation public key into the on-disk key store (the key-dir) — the SAME
+//! source the PULL author lane, the signal-author lane, and the
+//! transition-author lane already trust — but does NOT bind it into the per-node
+//! DB `agent_pubkey` registry. Pre-#2865 the `/sync/push` receive lane resolved
+//! the author's write-signature verification key from the DB registry ONLY, so
+//! a daemon-authored consolidation's propagated `metadata.write_signature` could
+//! not be verified and the row landed `attest_level=claimed` — quarantined at
+//! peers under `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED` (asi-hard).
+//!
+//! The fix (5-agent vote `4d3ea1c5`, unanimous) makes the push lane's
+//! author-key resolution consult the enrolled key-dir as a MISS-ONLY fallback
+//! after the DB registry — `handlers::federation_receive::resolve_author_bound_key`
+//! — bringing it to parity with the pull lane and closing the gap OUT-OF-BOX,
+//! with NO manual DB-bind step.
+//!
+//! These tests pin the RESOLUTION SEAM directly (not merely `stamp_attestation`,
+//! which would be a tautology since it already accepts the key as a param): a
+//! DB-miss falls back to the key-dir, an unenrolled author yields `None`, and a
+//! DB-registry key ALWAYS wins over the key-dir (miss-only precedence). The
+//! end-to-end legs then reproduce the before/after — a key-dir-enrolled author
+//! reaches `agent_attested` with NO DB bind, while an unenrolled author stays
+//! `claimed`.
+
+use base64::Engine as _;
+
+use ai_memory::handlers::federation_receive::{
+    resolve_author_bound_key, resolve_author_bound_key_in,
+};
+use ai_memory::identity::attest::{sign_memory_write, stamp_attestation};
+use ai_memory::identity::keypair;
+use ai_memory::identity::verify::AttestLevel;
+use ai_memory::models::Memory;
+
+const AUTHOR: &str = "ai:hive-memory-1";
+
+fn url_safe(kp: &keypair::AgentKeypair) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(kp.public.to_bytes())
+}
+
+fn standard(kp: &keypair::AgentKeypair) -> String {
+    base64::engine::general_purpose::STANDARD.encode(kp.public.to_bytes())
+}
+
+/// A memory shaped like a daemon-authored consolidation, authored as the
+/// FEDERATION identity — the #2865 subject.
+fn consolidation_mem() -> Memory {
+    Memory {
+        id: "m-2865".to_string(),
+        namespace: "hive/ops".to_string(),
+        title: "consolidated deployment guide".to_string(),
+        content: "scale the deployment to three replicas across the mesh".to_string(),
+        created_at: "2026-08-10T12:00:00+00:00".to_string(),
+        metadata: serde_json::json!({ "agent_id": AUTHOR }),
+        ..Memory::default()
+    }
+}
+
+// ---- resolution seam (the load-bearing fix; NOT a stamp_attestation tautology)
+
+#[test]
+fn resolve_seam_db_miss_falls_back_to_keydir_2865() {
+    // The peer's FEDERATION identity key is cross-enrolled into the key-dir
+    // (mesh cross-enrollment) but NOT DB-bound → registry miss.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let kp = keypair::generate(AUTHOR).expect("generate");
+    keypair::save(&kp, dir.path()).expect("save keypair");
+
+    let resolved = resolve_author_bound_key_in(None, AUTHOR, dir.path());
+    assert_eq!(
+        resolved.as_deref(),
+        Some(url_safe(&kp).as_str()),
+        "a DB-registry miss must fall back to the enrolled key-dir key (URL-safe-no-pad)"
+    );
+}
+
+#[test]
+fn resolve_seam_unenrolled_author_yields_none_2865() {
+    // No DB registry key AND no key-dir entry → None (the row will stay claimed,
+    // and the honored-third-party WARN can still name missing-author-key).
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let resolved = resolve_author_bound_key_in(None, AUTHOR, dir.path());
+    assert_eq!(
+        resolved, None,
+        "an author enrolled NEITHER in the DB registry NOR the key-dir must resolve to None"
+    );
+}
+
+#[test]
+fn resolve_seam_db_registry_wins_over_keydir_2865() {
+    // MISS-ONLY precedence: a key bound into the DB registry (e.g. the cert-round
+    // author via the admin PUT route / `agents bind-key`) ALWAYS wins, so a
+    // stale/rotated key-dir entry can never shadow the authoritative registry key.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let keydir_kp = keypair::generate(AUTHOR).expect("generate keydir");
+    keypair::save(&keydir_kp, dir.path()).expect("save keydir keypair");
+
+    // A DIFFERENT key present in the DB registry.
+    let registry_kp = keypair::generate("ai:registry-bound").expect("generate registry");
+    let registry_b64 = standard(&registry_kp);
+
+    let resolved = resolve_author_bound_key_in(Some(registry_b64.clone()), AUTHOR, dir.path());
+    assert_eq!(
+        resolved,
+        Some(registry_b64),
+        "the DB-registry key must win outright (key-dir is consulted ONLY on a registry miss)"
+    );
+    assert_ne!(
+        resolved.as_deref(),
+        Some(url_safe(&keydir_kp).as_str()),
+        "the key-dir key must NOT be consulted when the registry already resolved a key"
+    );
+}
+
+#[test]
+fn resolve_default_helper_no_keydir_hit_is_none_2865() {
+    // The production wrapper (default key-dir) resolves `None` for an author with
+    // no DB key and no key-dir entry under the process default dir — a byte for
+    // the pull-lane parity (pull passes `None` and expects the same helper).
+    // Uses a randomised author so the process key-dir cannot coincidentally hold it.
+    let unknown = format!("ai:unenrolled-{}", uuid::Uuid::new_v4());
+    assert_eq!(resolve_author_bound_key(None, &unknown), None);
+}
+
+// ---- end-to-end before/after (no manual DB bind) --------------------------
+
+#[test]
+fn end_to_end_keydir_enrolled_author_reaches_agent_attested_2865() {
+    // AFTER: the daemon authored + signed the consolidation as its FED identity;
+    // the peer cross-enrolled that key into the key-dir (no DB bind). The push
+    // lane resolves the key from the key-dir and the propagated write_signature
+    // verifies → agent_attested, OUT-OF-BOX.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let kp = keypair::generate(AUTHOR).expect("generate");
+    keypair::save(&kp, dir.path()).expect("save keypair");
+
+    let mut mem = consolidation_mem();
+    let sig = sign_memory_write(&kp, &mem, AUTHOR).expect("sign write");
+
+    // The receive lane resolves the bound key with NO DB registry entry.
+    let bound = resolve_author_bound_key_in(None, AUTHOR, dir.path());
+    assert!(
+        bound.is_some(),
+        "key-dir fallback must resolve the enrolled key"
+    );
+
+    let level = stamp_attestation(&mut mem, AUTHOR, bound.as_deref(), Some(&sig), false)
+        .expect("attestation must not error for a valid signature");
+    assert_eq!(
+        level,
+        AttestLevel::AgentAttested,
+        "a valid write_signature verified against the key-dir-resolved key must reach agent_attested"
+    );
+    assert_eq!(mem.metadata["attest_level"], "agent_attested");
+}
+
+#[test]
+fn end_to_end_unenrolled_author_stays_claimed_2865() {
+    // BEFORE (reproduced): with the author enrolled in NEITHER the DB registry
+    // NOR the key-dir, the presented signature cannot be verified against any
+    // key, so under the permissive default the row DEGRADES to claimed (never a
+    // wrong result). This is the state the fix upgrades once the key is enrolled.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let kp = keypair::generate(AUTHOR).expect("generate");
+    // Deliberately do NOT save the key anywhere.
+
+    let mut mem = consolidation_mem();
+    let sig = sign_memory_write(&kp, &mem, AUTHOR).expect("sign write");
+
+    let bound = resolve_author_bound_key_in(None, AUTHOR, dir.path());
+    assert_eq!(bound, None, "unenrolled author has no resolvable key");
+
+    let level = stamp_attestation(&mut mem, AUTHOR, bound.as_deref(), Some(&sig), false)
+        .expect("permissive unsigned-or-unresolvable path must not error");
+    assert_eq!(
+        level,
+        AttestLevel::Claimed,
+        "a presented signature with NO resolvable key must land claimed under the permissive default"
+    );
+}
+
+#[test]
+fn end_to_end_forged_signature_rejected_regardless_of_key_source_2865() {
+    // The key-dir fallback NEVER weakens verification: a forged signature against
+    // the key-dir-resolved key is rejected UNCONDITIONALLY (never downgraded to
+    // claimed) — the fix widens the KEY SOURCE, never the accept criterion.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let kp = keypair::generate(AUTHOR).expect("generate");
+    keypair::save(&kp, dir.path()).expect("save keypair");
+
+    let mut mem = consolidation_mem();
+    let mut sig = sign_memory_write(&kp, &mem, AUTHOR).expect("sign write");
+    sig[0] ^= 0xFF; // flip a byte → forged
+
+    let bound = resolve_author_bound_key_in(None, AUTHOR, dir.path());
+    assert!(
+        bound.is_some(),
+        "key-dir fallback must resolve the enrolled key"
+    );
+
+    let err = stamp_attestation(&mut mem, AUTHOR, bound.as_deref(), Some(&sig), false);
+    assert!(
+        err.is_err(),
+        "a forged signature must be rejected even when the key resolved via the key-dir fallback"
+    );
+}


### PR DESCRIPTION
## The gap (#2865) — final federation-convergence enrollment fix

A federated consolidation is authored as the daemon's **FEDERATION identity** (e.g. `ai:hive-memory-1`, #2860/#2862) and carries a valid propagated `metadata.write_signature`. But the `/sync/push` receive lane resolved the attributed author's verification key from the DB `agent_pubkey` **registry ONLY** (sqlite `db::agent_pubkey`, postgres `store.agent_pubkey`).

Mesh enrollment — `fed-bootstrap.sh` stage E, and cross-enrollment generally — installs a peer's federation public key into the on-disk **key-dir**, the SAME source the PULL author lane (#2715 `attest_inbound_pull_memory`), the signal-author lane, and the transition-author lane already trust — but does **not** DB-bind it into the per-node registry. So the propagated signature could not be verified, the row landed `attest_level=claimed`, and under `AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED=1` (`asi-hard`) it was **QUARANTINED (hidden)** at peers out-of-the-box.

Convergence itself held (durable text present/visible/not-skipped); this is an **attestation-visibility gap**, not data loss. The push lane also diverged from the pull lane, which already reached `agent_attested` on the same content via the key-dir.

## Root cause (file:line, at base 5806e9b9)

- sqlite push: `src/handlers/federation_receive.rs` — `claim_bound_key` (was `db::agent_pubkey` only) and `author_bound_key` (was `db::agent_pubkey` only).
- postgres push: `src/handlers/federation_signing_check.rs` — `claim_bound_key` / `bound_pubkey` (both `store.agent_pubkey` only).
- pull lane (`attest_inbound_pull_memory`) already resolved from the key-dir (`lookup_peer_public_key`) — the precedent this fix brings the push lane into parity with.

## Decision — 5-agent adversarial vote `4d3ea1c5` (UNANIMOUS 5/5 for option c)

Three loci considered: (a) infra-only fed-bootstrap DB-bind; (b) runtime enrollment auto-registers into the DB registry; (c) **runtime resolution parity** — push lane consults the key-dir as a MISS-ONLY fallback after the DB registry, mirroring the pull lane. Lenses: precedent / security-trust-boundary / blast-radius / North-Star data-integrity / testability. (a) rejected: do-hive-only, only provable by a live run. (b) rejected: second authoritative key store (rekey/revoke incompatible-state risk) + contaminates the local direct-write attestation lane.

## The fix

New shared helper `handlers::federation_receive::resolve_author_bound_key` (+ `_in` test seam): `registry_key.or_else(|| lookup_peer_public_key(author) …)`. Wired into **both keys** (claim-honoring + final attestation) on **both backends**, and the pull lane is routed through it too (`resolve_author_bound_key(None, author)`, byte-identical) to single-source the resolver.

**No weakening of attestation.** The key-dir is operator/enrollment-controlled and not writable over the wire (no `/sync/*` handler writes it). The fallback is **miss-only**, so a DB-bound key always wins — a stale/rotated key-dir entry can never shadow the authoritative registry key. The presented signature is still VERIFIED against whichever key resolves, so a wrong/absent key can only DEGRADE a row to `claimed`, never mis-attest it (forged signatures are rejected unconditionally). The local store-path attestation (`stamp_attestation_sync`/`_async`) is deliberately untouched — a local write attests the local agent, not a peer.

## Before/after verification (no manual bind step)

`tests/federation_writesig_keydir_fallback_2865.rs` (7 cases, all green):
- resolution seam: DB-miss falls back to key-dir; unenrolled author → `None`; DB-registry key **wins** over key-dir (miss-only precedence).
- end-to-end: a key-dir-enrolled author reaches **`agent_attested` with NO DB bind** (the fix); an unenrolled author stays `claimed` (reproduces the before-state); a forged signature is rejected regardless of key source.

## Gates (all green, run under `AI_MEMORY_NO_CONFIG=1`, `umask 022`)

- `cargo fmt --all`; `cargo check --all-targets` (default) + `--examples`
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` on **default / sal / sal-postgres / vectorlite**
- `cargo test --test federation_writesig_keydir_fallback_2865` (7/7) + `federation_inbound_verify` + `federation_write_sig_emit_1801` + `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling`
- `cargo audit`

No MCP tools / HTTP routes / CLI verbs / schema versions / env vars added — no SSOT pins affected. CHANGELOG `[Unreleased]` updated.

## DO re-verify implication

Because this closes the gap in the runtime (not infra), the final DO 2-node re-verify should **remove any manual bind of the peer FEDERATION identity** into the receiver's DB registry — daemon-authored consolidations must reach `agent_attested` at the peer with only the normal key-dir cross-enrollment, proving out-of-box convergence.

Closes #2865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY