### PR TITLE
infra(#2658): fail-CLOSED hostssl arming in the certified provisioning lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (certified provisioning fail-OPEN — CERT-BLOCKING)
+
+- **A failing TLS/hostssl arming step can no longer bring PostgreSQL up
+  ACCEPTING CLEARTEXT while the provisioning lane reports healthy**
+  ([#2658](https://github.com/alphaonedev/ai-memory-mcp/issues/2658)). In the
+  certified provisioning lanes the PostgreSQL substrate is meant to enforce
+  hostssl (a non-TLS TCP connection refused pre-auth), but the readiness signal
+  did not PROVE it: the `deploy/docker-1461` compose healthcheck was
+  `pg_isready -U … -d …`, which speaks over the LOCAL unix socket
+  (`local … trust`) and reports healthy whenever the postmaster is up —
+  REGARDLESS of whether hostssl was actually armed on the TCP listener. A run in
+  which the arming silently did not take effect (a lost `pg_hba.conf` bind-mount,
+  an `ssl` GUC that never applied, PGDATA non-empty so init was skipped) would
+  therefore come up accepting cleartext on TCP, report healthy, and let
+  provisioning proceed — a silent security disarm. Fix: the healthcheck now
+  requires BOTH `pg_isready` AND proof that a plaintext (`sslmode=disable`) TCP
+  connection to the loopback listener is REFUSED PRE-AUTH by `pg_hba.conf`
+  (`deploy/docker-1461/pg-hostssl-healthcheck.sh`, baked into
+  `Dockerfile.pg-age-vector`), so "healthy" now MEANS "hostssl armed"; the
+  `provision/50_up.sh` gate re-probes and aborts LOUD (non-zero, named cause)
+  rather than declaring a cleartext-accepting mesh ready; and the native
+  `deploy/do-1461/provision/20_pg_age.sh` lane fails CLOSED (`die`) after the
+  extension verify if a plaintext connection over the region VPC IP is not
+  refused pre-auth. The `deploy/hive-1461` + `infra/do-hive` lanes bind
+  PostgreSQL localhost-only (no hostssl arming), so the fail-open class does not
+  apply to them. The classifier decision table is CI-provable via
+  `pg-hostssl-healthcheck.sh --self-test` (no live PostgreSQL required). The
+  Ed25519-CA channel-binding half of #2658 remains tracked as residual.
+
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 
 - **Daemon-authored federated consolidations converge at `agent_attested` at

--- a/deploy/do-1461/provision/20_pg_age.sh
+++ b/deploy/do-1461/provision/20_pg_age.sh
@@ -297,6 +297,28 @@ EOS
   echo "$exts" | grep -q vector || die "[$pg_host] vector (pgvector) extension missing"
   log "[$pg_host] extensions OK: $(echo $exts | tr '\n' ' ')"
 
+  # ------------------------------------------------------------------------
+  # #2658 fail-CLOSED hostssl proof. Everything above (pg_isready, extension
+  # verify) speaks over the LOCAL unix socket (`local ... trust`) and passes
+  # even if the hostssl arming silently did not take effect (ssl GUC not
+  # applied, a lost pg_hba, ...). A run that reports "ready" while the TCP
+  # listener accepts CLEARTEXT is a silent security disarm in the certified
+  # provisioning lane. PROVE hostssl is armed before declaring the substrate
+  # ready: a plaintext (sslmode=disable) TCP connection over the region VPC
+  # IP MUST be refused PRE-AUTH by the hostssl-only pg_hba ("no pg_hba.conf
+  # entry ... no encryption"). Any other outcome -- a query that runs
+  # (trust), or one that reaches authentication (transport admitted in
+  # cleartext) -- aborts provisioning LOUD.
+  log "[$pg_host] proving hostssl armed (plaintext sslmode=disable on $pg_priv:$PG_PORT must be REFUSED pre-auth)"
+  local plain_out
+  plain_out="$(ssh_node "$pg_pub" "psql 'host=$pg_priv port=$PG_PORT user=$PG_USER dbname=$PG_DB sslmode=disable connect_timeout=5' -w -tAc 'SELECT 1' 2>&1; true")"
+  case "$plain_out" in
+    *"no pg_hba.conf entry"*|*"no encryption"*)
+      log "[$pg_host] hostssl armed: plaintext refused pre-auth" ;;
+    *)
+      die "[$pg_host] FAIL-CLOSED (#2658): hostssl is NOT provably armed -- a plaintext (sslmode=disable) TCP connection to $pg_priv:$PG_PORT was NOT refused pre-auth. REFUSING to declare this pg substrate ready (a cleartext-accepting postgres reporting healthy is the silent disarm this gate exists to prevent). probe: ${plain_out}" ;;
+  esac
+
   log "region $region PG18.4/AGE1.7.0/pgvector substrate ready ($pg_host @ $pg_priv:$PG_PORT, $peer_n peer schemas, NATIVE/no-docker)"
 }
 

--- a/deploy/docker-1461/Dockerfile.pg-age-vector
+++ b/deploy/docker-1461/Dockerfile.pg-age-vector
@@ -40,5 +40,12 @@ RUN apt-get update \
       "postgresql-${PG_MAJOR}-pgvector=${PGVECTOR_APT_VERSION}" \
  && rm -rf /var/lib/apt/lists/*
 
+# Fail-closed hostssl healthcheck (#2658). Baked in so "healthy" means
+# "hostssl PROVABLY armed" (a plaintext sslmode=disable TCP connection is
+# refused pre-auth), not merely "postmaster up on the local socket". The
+# compose healthcheck invokes this; provision/50_up.sh blocks on healthy.
+COPY pg-hostssl-healthcheck.sh /usr/local/bin/pg-hostssl-healthcheck.sh
+RUN chmod 0755 /usr/local/bin/pg-hostssl-healthcheck.sh
+
 # Base image entrypoint + USER state preserved; AGE auto-installs via
 # its own /docker-entrypoint-initdb.d/00-create-extension-age.sql.

--- a/deploy/docker-1461/docker-compose.yml
+++ b/deploy/docker-1461/docker-compose.yml
@@ -95,9 +95,14 @@ services:
       # hostssl-only client-auth map — rejects non-TLS TCP pre-auth.
       - ${PG_HBA_FILE:?PG_HBA_FILE must be set}:/etc/postgresql/pg_hba.conf:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DB}"]
+      # #2658 fail-CLOSED: "healthy" requires BOTH pg_isready (local socket)
+      # AND proof that hostssl is armed -- a plaintext sslmode=disable TCP
+      # connection is refused pre-auth. `pg_isready` alone (local `trust`
+      # socket) reported healthy even when the TCP listener accepted
+      # cleartext, a silent security disarm; the baked-in script closes it.
+      test: ["CMD", "/usr/local/bin/pg-hostssl-healthcheck.sh"]
       interval: 3s
-      timeout: 5s
+      timeout: 8s
       retries: 20
       start_period: 20s
     networks:

--- a/deploy/docker-1461/pg-hostssl-healthcheck.sh
+++ b/deploy/docker-1461/pg-hostssl-healthcheck.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# docker-1461 PostgreSQL healthcheck (#2658) -- fail-CLOSED hostssl proof.
+#
+# THE FAIL-OPEN THIS CLOSES. The prior compose healthcheck was
+# `pg_isready -U <user> -d <db>`, which speaks over the LOCAL unix socket
+# (pg_hba `local ... trust`). That probe reports "healthy" whenever the
+# postmaster is up -- REGARDLESS of whether hostssl enforcement was armed
+# on the TCP listener. So a run in which the TLS/hostssl arming silently
+# did not take effect (a lost bind-mount of pg_hba.conf, an ssl GUC that
+# never applied, PGDATA non-empty so init was skipped, ...) would bring
+# PostgreSQL up ACCEPTING CLEARTEXT on TCP while the container reported
+# healthy and provisioning proceeded. That is a silent security disarm in
+# the certified provisioning lane (issue #2658).
+#
+# THE GUARD. This script reports healthy ONLY when BOTH hold:
+#   (1) the server is ready (pg_isready over the local socket), AND
+#   (2) hostssl is PROVABLY armed -- a plaintext (sslmode=disable) TCP
+#       connection to the loopback listener is REFUSED PRE-AUTH by
+#       pg_hba.conf ("no pg_hba.conf entry ... no encryption").
+# Any outcome in which the cleartext TCP connection is ACCEPTED (it
+# succeeds, or it reaches authentication -- proving the transport was
+# admitted in cleartext) FAILS the healthcheck. The container therefore
+# never reports healthy while cleartext is accepted, and the provisioning
+# gate (provision/50_up.sh) that blocks on `healthy` fails LOUD instead of
+# declaring a cleartext-accepting mesh ready.
+#
+# DEGRADE-NEVER-DISARM. Fail-closed by construction: any probe outcome
+# other than a proven pre-auth refusal is treated as "hostssl NOT proven"
+# and the healthcheck fails. Worst case is a mesh that will not come up
+# (loud), never a mesh that comes up cleartext (silent).
+#
+# `--self-test` exercises the classifier over simulated psql outputs with
+# NO live PostgreSQL (mirrors scripts/check-*.sh --self-test), so the
+# decision logic is CI-provable.
+
+set -u
+
+PGUSER_EFF="${POSTGRES_USER:-${PGUSER:-postgres}}"
+PGDB_EFF="${POSTGRES_DB:-${PGDATABASE:-$PGUSER_EFF}}"
+PGPORT_EFF="${PGPORT:-5432}"
+PGHOST_PLAINTEXT="127.0.0.1"
+
+# classify_plaintext_probe <combined-psql-output>
+#   -> stdout one of: armed | cleartext_accepted | unknown
+#   armed              : plaintext TCP refused PRE-AUTH by hostssl pg_hba
+#                        ("no pg_hba.conf entry ... no encryption").
+#   cleartext_accepted : the non-TLS transport was admitted -- either the
+#                        query ran (trust) or it reached authentication
+#                        (a password/auth error is proof the cleartext
+#                        connection was accepted at the transport layer).
+#   unknown            : neither signature -- treated as NOT proven
+#                        (fail-closed) by the caller.
+classify_plaintext_probe() {
+  local out="$1"
+  case "$out" in
+    *"no pg_hba.conf entry"*|*"no encryption"*)
+      printf 'armed\n'; return 0 ;;
+  esac
+  case "$out" in
+    *"password"*|*"authentication"*|*"fe_sendauth"*|*"no password supplied"*)
+      printf 'cleartext_accepted\n'; return 0 ;;
+  esac
+  # A successful scalar result (the query RAN over cleartext) is the worst
+  # case. `$(...)` strips trailing newlines, so a clean `SELECT 1` collapses
+  # to the exact string "1"; guard the last-line form too.
+  case "$out" in
+    1) printf 'cleartext_accepted\n'; return 0 ;;
+  esac
+  case "$out" in
+    *"
+1") printf 'cleartext_accepted\n'; return 0 ;;
+  esac
+  printf 'unknown\n'
+}
+
+run_healthcheck() {
+  # (1) readiness over the local socket.
+  if ! pg_isready -U "$PGUSER_EFF" -d "$PGDB_EFF" >/dev/null 2>&1; then
+    echo "[hostssl-healthcheck] not ready: pg_isready failed" >&2
+    return 1
+  fi
+
+  # (2) plaintext TCP probe -- MUST be refused pre-auth by the hostssl pg_hba.
+  # `-w` so a stock (non-hostssl) pg_hba that reaches auth fails without a
+  # password prompt rather than hanging; the point is that reaching auth AT
+  # ALL proves the cleartext transport was admitted.
+  local conn probe_out verdict
+  conn="host=${PGHOST_PLAINTEXT} port=${PGPORT_EFF} user=${PGUSER_EFF} dbname=${PGDB_EFF} sslmode=disable connect_timeout=5"
+  probe_out="$(psql "$conn" -w -tAc 'SELECT 1' 2>&1)"
+  verdict="$(classify_plaintext_probe "$probe_out")"
+
+  case "$verdict" in
+    armed)
+      return 0 ;;
+    cleartext_accepted)
+      echo "[hostssl-healthcheck] FAIL-CLOSED (#2658): a plaintext sslmode=disable TCP connection to ${PGHOST_PLAINTEXT}:${PGPORT_EFF} was ACCEPTED -- hostssl is NOT armed. Refusing to report healthy. probe: ${probe_out}" >&2
+      return 1 ;;
+    *)
+      echo "[hostssl-healthcheck] FAIL-CLOSED (#2658): could not PROVE the plaintext sslmode=disable TCP connection to ${PGHOST_PLAINTEXT}:${PGPORT_EFF} was refused pre-auth -- treating hostssl as NOT proven. probe: ${probe_out}" >&2
+      return 1 ;;
+  esac
+}
+
+self_test() {
+  local fails=0 got
+  check() { # <label> <expected> <probe-output>
+    got="$(classify_plaintext_probe "$3")"
+    if [ "$got" = "$2" ]; then
+      echo "  ok   $1 -> $got"
+    else
+      echo "  FAIL $1 -> got '$got', want '$2'"; fails=$((fails + 1))
+    fi
+  }
+  echo "[hostssl-healthcheck --self-test] classifier decision table:"
+  # hostssl armed: canonical pre-auth refusal.
+  check hostssl_refusal armed \
+    'psql: error: connection to server at "127.0.0.1", port 5432 failed: FATAL:  no pg_hba.conf entry for host "127.0.0.1", user "ai_memory", database "ai_memory", no encryption'
+  check no_encryption_only armed 'FATAL:  no encryption'
+  # cleartext accepted: reached auth (transport admitted) or ran the query.
+  check stock_no_password cleartext_accepted 'psql: error: connection ... failed: fe_sendauth: no password supplied'
+  check stock_auth_failed cleartext_accepted 'psql: error: FATAL:  password authentication failed for user "ai_memory"'
+  check trust_query_ran cleartext_accepted '1'
+  # ambiguous -> fail-closed (unknown).
+  check tcp_refused unknown 'psql: error: connection to server at "127.0.0.1", port 5432 failed: Connection refused'
+  check timeout unknown 'psql: error: connection ... failed: timeout expired'
+  if [ "$fails" -eq 0 ]; then
+    echo "[hostssl-healthcheck --self-test] PASS"
+    return 0
+  fi
+  echo "[hostssl-healthcheck --self-test] FAIL ($fails)"
+  return 1
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  *)           run_healthcheck ;;
+esac

--- a/deploy/docker-1461/provision/50_up.sh
+++ b/deploy/docker-1461/provision/50_up.sh
@@ -29,8 +29,17 @@ dc up -d --remove-orphans
 # Gate: PG first (peers depend_on it healthy, but assert explicitly).
 log "up: waiting for $PG_CONTAINER"
 wait_healthy "$PG_CONTAINER" "${DOCKER_1461_PG_WAIT_TICKS:-40}" \
-  || die "up: $PG_CONTAINER did not become healthy"
+  || die "up: $PG_CONTAINER did not become healthy (its healthcheck now PROVES hostssl is armed -- a plaintext sslmode=disable TCP connection must be refused pre-auth, #2658; check 'docker logs $PG_CONTAINER' + the healthcheck output for a cleartext-accepted disarm)"
 log "up: $PG_CONTAINER healthy"
+
+# #2658 explicit fail-CLOSED re-probe. The healthcheck already gates
+# `healthy` on hostssl being armed, but re-run it here so a disarm aborts
+# provisioning with a NAMED security cause (not a generic wait timeout),
+# and so the gate survives a future revert of the compose healthcheck.
+log "up: proving hostssl armed on $PG_CONTAINER (plaintext sslmode=disable must be REFUSED pre-auth)"
+node_exec "$PG_CONTAINER" /usr/local/bin/pg-hostssl-healthcheck.sh \
+  || die "up: REFUSING to declare the mesh ready -- $PG_CONTAINER is up but hostssl is NOT provably armed; a plaintext (sslmode=disable) TCP connection was not refused pre-auth (silent cleartext disarm, #2658)"
+log "up: hostssl armed on $PG_CONTAINER (cleartext refused pre-auth)"
 
 # Gate: each peer over the real mTLS HTTPS healthcheck.
 i=1


### PR DESCRIPTION
## Summary

Closes the **fail-OPEN half** of cert-BLOCKER #2658: a failing TLS/hostssl arming step could bring PostgreSQL up **accepting cleartext** on its TCP listener while the certified provisioning lane reported **healthy** — a silent security disarm.

### The fail-open (file:line)

`deploy/docker-1461/docker-compose.yml` (pre-fix, `pg-age.healthcheck`):
```yaml
test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DB}"]
```
`pg_isready` speaks over the **local unix socket** (`local all all trust` in the rendered `pg_hba.conf`), so it reports healthy whenever the postmaster is up — **regardless of whether hostssl was armed on the TCP listener**. If the arming silently did not take effect (a lost `pg_hba.conf` bind-mount, an `ssl` GUC that never applied, PGDATA non-empty so init was skipped) the container comes up accepting cleartext on TCP, reports healthy, and `provision/50_up.sh` (which blocks on `wait_healthy`) proceeds. The native lane `deploy/do-1461/provision/20_pg_age.sh` had the same shape: `pg_isready` + extension verify over the trust socket, never a cleartext-refused probe.

The existing cleartext-refused checks were only in the **post-hoc TEST phase** (`deploy/docker-1461/test/run.sh` check #9, `deploy/do-1461/test/encrypted_legs.sh` LEG-3 negative) — they run *after* the mesh is already declared ready.

### The loud-fail guard

- **`deploy/docker-1461/pg-hostssl-healthcheck.sh`** (new, baked into `Dockerfile.pg-age-vector`): "healthy" now requires **both** `pg_isready` **and** proof that a plaintext `sslmode=disable` TCP connection to the loopback listener is **REFUSED PRE-AUTH** by `pg_hba.conf` (`no pg_hba.conf entry ... no encryption`). A cleartext connection that *succeeds* (trust) or *reaches authentication* (a password/auth error — proof the transport was admitted in cleartext) FAILS the healthcheck. Fail-closed by construction: any non-refusal outcome is treated as "hostssl NOT proven". The compose healthcheck invokes it; since peers `depend_on: service_healthy` and `50_up.sh` blocks on `wait_healthy`, a disarm now fail-closes the whole mesh.
- **`deploy/docker-1461/provision/50_up.sh`**: re-probes after `healthy` and aborts LOUD (`die`, non-zero) with a **named security cause** rather than a generic wait timeout, and survives a future revert of the compose healthcheck.
- **`deploy/do-1461/provision/20_pg_age.sh`**: after the extension verify, a plaintext `sslmode=disable` connection over the region VPC IP must be refused pre-auth or provisioning `die`s.

`deploy/hive-1461` + `infra/do-hive` bind PostgreSQL **localhost-only** (no hostssl arming — a different, accepted posture), so the fail-open class does not apply there.

### Verification

The arming-step-failure simulation is the classifier decision table, CI-provable with **no live PostgreSQL**:

```
$ deploy/docker-1461/pg-hostssl-healthcheck.sh --self-test
  ok   hostssl_refusal -> armed                 # "no pg_hba.conf entry ... no encryption" => healthy
  ok   no_encryption_only -> armed
  ok   stock_no_password -> cleartext_accepted  # reached auth => UNHEALTHY (disarm)
  ok   stock_auth_failed -> cleartext_accepted
  ok   trust_query_ran -> cleartext_accepted    # query ran over cleartext => UNHEALTHY
  ok   tcp_refused -> unknown                    # fail-closed
  ok   timeout -> unknown                        # fail-closed
PASS
```
A simulated arming failure (stock `host all all scram` / trust) is classified `cleartext_accepted` → healthcheck exits non-zero → `50_up.sh`/`wait_healthy` `die`s loud instead of declaring a cleartext-accepting mesh ready.

### Gates
- `bash -n` clean on all touched scripts.
- `pg-hostssl-healthcheck.sh --self-test` PASS.
- Cloud-init ASCII gate PASS (no `.tpl` touched; added lines are ASCII-clean).
- Migration-ladder gate PASS (untouched).

### Residual (tracked, not this PR)
The Ed25519-CA libpq channel-binding half of #2658 (`could not find digest for NID UNDEF` under `sslmode=verify-full`) — the `infra/do-hive/crypto/gen-certs.sh` CA/PG-key-algorithm change — remains a tracked residual of #2658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY