### PR TITLE
docs(cert/#2869): retire the 1M-agent overclaim + capacity-claim gate + reconcile pg-cert scope/versions

### DIFF
--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -301,6 +301,34 @@ jobs:
         # green a no-op.
         run: bash scripts/check-doc-surface-completeness.sh --self-test
 
+  capacity-claim-gate:
+    # CERT GATE (TRUTHFULNESS; #2869, following CERT-GATE-2 #2629/#2492). The
+    # 3x7 claims register finding C-12 caught `docs/zero-touch-trust.html` still
+    # shipping the retired "1 to ~1,000,000 AI agents" figure (#2438) in BOTH
+    # its <meta description> and its tagline — while every other claims gate was
+    # GREEN, because NONE policed agent-count / scale-CAPACITY claims. Gate 4
+    # pins VALUES; gates 9/10/11 pin symbols / SDK paths / CI-job claims; this
+    # pins that no doc publishes a single-fleet agent number above the ratified
+    # 500-1000-agent envelope. Structural exemptions (row/corpus counts never
+    # associate with an `agents` noun; retirement notes; frozen doc trees) keep
+    # it aimed at the defect, and a burn-down allowlist (STALE entry hard-fails)
+    # carries the vetted, explicitly-aspirational vision-tier statements.
+    name: Capacity-claim ceiling gate (#2869)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run capacity-claim gate
+        run: bash scripts/check-capacity-claims.sh
+      - name: Self-test the gate (regression evidence)
+        # Plants the exact #2438 1,000,000-agent overclaim (MUST be flagged) +
+        # near-miss controls that MUST pass (the honest 500-1000 envelope, a
+        # corpus-row "1M+ on Postgres", the MAX_ROWS cap, a retirement note, a
+        # bare year, and an "Ed25519 agent" identifier whose interior digit-run
+        # must not read as an agent count), then exercises allowlist coverage,
+        # the stale-entry hard-fail, and the empty-scan fail-closed.
+        run: bash scripts/check-capacity-claims.sh --self-test
+
   cloud-init-ascii-gate:
     # v0.9.0 (issue #1880): a stray non-ASCII byte (U+2014 em-dash) in a
     # DO cloud-init template made cloud-init reject the config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (published-claims TRUTHFULNESS — CERT-BLOCKING)
+
+- **`docs/zero-touch-trust.html` no longer ships the retired
+  "1 to ~1,000,000 AI agents" overclaim**
+  ([#2869](https://github.com/alphaonedev/ai-memory-mcp/issues/2869), 3x7
+  claims-register finding C-12). The exact figure
+  [#2438](https://github.com/alphaonedev/ai-memory-mcp/issues/2438) retired —
+  three orders of magnitude beyond the documents' own topology envelope
+  (T6 = 1000+ agents/mesh, a ~50-peer federation ceiling) — was still live in
+  BOTH the page's `<meta name="description">` and its hero tagline. Both now
+  state the ratified certified envelope: a **500-1000-agent cluster composed
+  modularly in 500-agent blocks**. Corpus-row "1M+ on Postgres"
+  (`docs/performance.html`) and the `MAX_ROWS = 1,000,000` migration cap are
+  row counts, not agent counts, and are unchanged.
+- **New gate — `scripts/check-capacity-claims.sh` (c8-precheck job
+  "Capacity-claim ceiling gate (#2869)").** No claims gate policed
+  agent-count / scale-CAPACITY claims, so the C-12 overclaim shipped while
+  every gate was green. HARD-BLOCKS any operator-facing doc that publishes a
+  single-fleet agent number above the ratified 1000 ceiling; structural
+  exemptions (row/corpus counts, retirement notes, frozen doc trees) plus a
+  burn-down allowlist (STALE entry hard-fails) that carries the vetted,
+  explicitly-aspirational vision-tier statements. `--self-test` proves it is
+  load-bearing; declared REQUIRED in `required-contexts-release.txt`
+  (gate 7 rule f) and asserted by the `tests/doc_claims_integrity.rs` twin.
+- **`docs/v1.0.0/release-notes.md` — postgres-cert scope + version honesty.**
+  A headline scope banner now states up front that the two backends are not
+  one identical API (**59 of 80 unique HTTP paths served on Postgres, 21
+  fail-closed `501`**; **MCP-stdio is structurally SQLite-only**,
+  [#1675](https://github.com/alphaonedev/ai-memory-mcp/issues/1675)). The
+  "Certified backend versions" section is reconciled to lead with the stack
+  CI actually exercises on every push (**PG 16 + AGE 1.6.0**) and to label the
+  SSOT-pinned **PG 18.4 / AGE 1.7.0 / pgvector 0.8.5** stack as *additionally
+  validated off-CI, not CI-asserted*
+  ([#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512)); an
+  SSOT-internal pgvector pin drift (docker-1461 `0.8.5` vs do-1461 `0.8.2`) is
+  disclosed rather than papered over.
+
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 
 - **Daemon-authored federated consolidations converge at `agent_attested` at

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -61,7 +61,22 @@ v1.0.0 is the **GA of the perfect-endpoint program** — it turns the
 substrate's secure defaults from *opt-in* into *on*, lands the
 crypto-core stage (SubkeyCert instance certification, epistemic memory
 kinds, claim-bitemporal columns), and certifies the postgres + Apache
-AGE + pgvector storage backend on a pinned, live-tested stack.
+AGE + pgvector storage backend.
+
+> **Certified-backend scope — read this before choosing Postgres.** The
+> two backends are **not one identical API**: **59 of the 80 unique
+> production HTTP paths are served on Postgres; the remaining 21 fail
+> closed with a uniform `501 NOT IMPLEMENTED`** (the Agent Skills surface,
+> `/api/v1/share`, the legacy `/api/v1/find_paths` alias, and the
+> `memory_*` MCP-parity routes with no pg SAL trait method yet — pinned by
+> `tests/pg_supported_route_inventory_gate_2799.rs`), and **MCP-stdio is
+> structurally SQLite-only** ([#1675](https://github.com/alphaonedev/ai-memory-mcp/issues/1675)):
+> a Postgres-backed deployment serves MCP clients through the HTTP daemon,
+> not `ai-memory mcp`. The certification evidence rests on the PG 16 / AGE
+> 1.6.0 stack CI tests on every push; the SSOT-pinned PG 18.4 / AGE 1.7.0 /
+> pgvector 0.8.5 stack is **additionally validated off-CI**, not
+> CI-asserted — see §"Certified backend versions" for the exact versions
+> and evidence basis.
 
 The "defaults stop lying" lane (Gate 1′) is the centerpiece: six knobs
 that shipped OFF (or non-functional) through v0.10.0 now resolve to their
@@ -187,22 +202,47 @@ epoch is fail-OPEN, so existing federation is not hard-refused). See
 
 ## Certified backend versions
 
-v1.0.0 is **certified on PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector
-0.8.5** (the pgvector Rust binding is the `pgvector` crate `0.4`,
-`features = ["sqlx"]`). These are the current-stable upstream versions;
-Apache AGE 1.8.0 exists only as `rc0` and is deliberately NOT shipped —
-the certified stack pins the released `release_PG18_1.7.0` line.
+The version story has two honest halves, and it matters which is which:
 
-The single source of truth for the pinned versions is
-`deploy/docker-1461/provision/lib.sh` (`EXPECTED_PG_VERSION=18.4`,
-`EXPECTED_AGE_VERSION=1.7.0`, `PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
-`AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`). The certified stack was
-exercised live on the validation host: the AGE-gated Cypher/KG suites
+**Continuously + reproducibly CI-tested (every PR and push): PostgreSQL 16
++ Apache AGE 1.6.0.** The AGE-gated Cypher/KG suites
 (`age_cte_equivalence`, `g2_postgres_find_paths_age_param_binding`,
 `g4_postgres_link_projects_into_age_graph`, `cov_postgres_kg`,
 `issue_1482_age_cypher_persistent`, `kg_age_fallback`) and the
-pgvector-backed recall-purity suite (`recall_purity_p01_postgres`) ran
-green against it under `--features sal,sal-postgres --include-ignored`.
+pgvector-backed recall-purity suite (`recall_purity_p01_postgres`) run
+green under `--features sal,sal-postgres --include-ignored` against the
+`apache/age:release_PG16_1.6.0` service container in `coverage.yml`, with
+pgvector layered in at service start via the `postgresql-16-pgvector` apt
+package. This PG 16 / AGE 1.6.0 combination is what the substrate's
+Postgres backend has actually, repeatedly, in-repo been exercised on — so
+it is the stack the certification evidence rests on.
+
+**Additionally validated off-CI (SSOT-pinned, NOT CI-asserted):
+PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5.** These are the pins
+the deployment SSOT carries — `deploy/docker-1461/provision/lib.sh`
+(`EXPECTED_PG_VERSION=18.4`, `EXPECTED_AGE_VERSION=1.7.0`,
+`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
+`AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`; the pgvector Rust binding
+is the `pgvector` crate `0.4`, `features = ["sqlx"]`) — and they are the
+current-stable upstream line (Apache AGE 1.8.0 exists only as `rc0` and is
+deliberately not shipped). The same AGE/KG + recall-purity suites were run
+green against this stack on the operator's off-CI validation host, but
+**no CI job builds or version-asserts 18.4 / 1.7.0 / 0.8.5**: the
+dedicated `postgres-age` nightly that once did was RED for its final three
+runs (the vendored `paste` fork rev went unreachable,
+[#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
+1) and was deleted on 2026-07-31 (§"CI posture" below). Treat 18.4 /
+1.7.0 / 0.8.5 as **additionally validated**, not continuously certified;
+the continuously-tested combination is PG 16 / AGE 1.6.0.
+
+> **A separate SSOT-internal pin drift, disclosed rather than papered
+> over:** `deploy/docker-1461/provision/lib.sh` pins pgvector **0.8.5**
+> while the sibling `deploy/do-1461/provision/lib.sh` pins pgvector
+> **0.8.2** (`EXPECTED_PGVECTOR_VERSION=0.8.2`). The two provisioning
+> SSOTs do not agree on the pgvector patch, and the CI-vs-SSOT AGE drift
+> (CI 1.6.0 vs SSOT 1.7.0) is
+> [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
+> 2. Both are tracked, not silently reconciled in prose.
 
 ### What those AGE greens attest — read this before relying on them
 
@@ -239,7 +279,7 @@ per-call fallback WARN that removal left silent). `find_paths` results
 were and remain correct (the CTE reads the durable `memory_links`);
 `kg_query` / `kg_timeline` / `lineage` still use AGE Cypher.
 
-### CI posture for the certified stack — the pins are not CI-asserted
+### CI posture for the SSOT-pinned (18.4) stack — the pins are not CI-asserted
 
 **No CI job builds or version-asserts PG 18.4 + AGE 1.7.0 + pgvector
 0.8.5.** The `postgres-age` job
@@ -262,9 +302,11 @@ and DO run on every PR and push in `coverage.yml` — but against an
 defect 2, held behind
 [#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548)
 (whether any in-PR AGE coverage is wanted at all, to be justified on
-its own merits and with a container image if it ever is). The certified
+its own merits and with a container image if it ever is). The SSOT-pinned
 18.4 / 1.7.0 / 0.8.5 combination itself is exercised on the operator's
-validation host and nowhere else.
+validation host and nowhere else — it is **additionally validated**, not
+continuously CI-certified; the CI-certified combination is PG 16 / AGE
+1.6.0.
 
 ## Additive surfaces
 
@@ -424,9 +466,12 @@ supersedes ROADMAP §11.6's "public security audit by named third-party
 firm" line for this epic). ROADMAP §27 sequences it as a five-step
 program:
 
-1. **DigitalOcean full-spectrum testing + attestation.** The certified
+1. **DigitalOcean full-spectrum testing + attestation.** The SSOT-pinned
    PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack was exercised full-spectrum
-   on DigitalOcean and attested (this also covers the v0.9.0 4-phase
+   on DigitalOcean (the off-CI validation host — this IS the "additionally
+   validated" evidence for those pins; the continuously CI-tested
+   combination is PG 16 / AGE 1.6.0, see §"Certified backend versions")
+   and attested (this also covers the v0.9.0 4-phase
    ship-gate boundary per ROADMAP §17's recorded exception, ruling
    `wf_26d176ac` — the v0.9.0 record re-opens only if this campaign does
    not run).

--- a/docs/zero-touch-trust.html
+++ b/docs/zero-touch-trust.html
@@ -9,7 +9,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ai-memory · Zero-touch trust — CA-rooted federation identity at scale</title>
-<meta name="description" content="CA-rooted, attestation-issued, short-lived credentials replace O(N²) manual key exchange with O(1) trust-the-CA enrollment. Scale a federated AI-memory fleet from 1 to 1,000,000 agents. OS-agnostic: Linux, Windows, macOS.">
+<meta name="description" content="CA-rooted, attestation-issued, short-lived credentials replace O(N²) manual key exchange with O(1) trust-the-CA enrollment. Scale a federated AI-memory fleet of hundreds of agents (certified: 500-1000-agent clusters, composed modularly in 500-agent blocks). OS-agnostic: Linux, Windows, macOS.">
 <meta property="og:title" content="ai-memory · Zero-touch trust (federation identity at scale)">
 <meta property="og:description" content="O(1) CA-rooted trust replaces O(N²) per-peer .pub enrollment. Short-lived auto-rotating credentials, hierarchical trust, GitOps inventory. OS-agnostic.">
 <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/zero-touch-trust.html">
@@ -216,7 +216,7 @@ blockquote strong{color:var(--p1)}
 
 <section class="hero">
   <h1>Zero-touch trust</h1>
-  <p class="tagline">CA-rooted, attestation-issued, short-lived credentials replace O(N²) manual key exchange with O(1) "trust the CA". Scale a federated fleet from 1 to ~1,000,000 AI agents — without touching a single peer to add the next node.</p>
+  <p class="tagline">CA-rooted, attestation-issued, short-lived credentials replace O(N²) manual key exchange with O(1) "trust the CA". Scale a federated fleet of hundreds of AI agents — certified for 500-1000-agent clusters composed modularly in 500-agent blocks (<a href="https://github.com/alphaonedev/ai-memory-mcp/issues/2438">#2438</a>) — without touching a single peer to add the next node.</p>
   <div class="pills">
     <span class="pill">O(1) enrollment</span>
     <span class="pill">first-party CA</span>

--- a/scripts/check-capacity-claims.sh
+++ b/scripts/check-capacity-claims.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# check-capacity-claims.sh — HARD-BLOCK any operator-facing doc that publishes
+# an AGENT-COUNT / fleet-scale capacity claim above the operator-ratified
+# certification ceiling.
+#
+# Why (CERT GATE — TRUTHFULNESS; #2869, follows the CERT-GATE-2 published-claims
+# set #2629/#2492): the 3x7 claims register (`docs/audit/3x7-claims-register-
+# 2026-08-01.md`, finding C-12) caught `docs/zero-touch-trust.html` still
+# shipping "Scale a federated fleet from 1 to ~1,000,000 AI agents" in BOTH its
+# `<meta name="description">` and its page tagline — the exact figure #2438
+# RETIRED as three orders of magnitude beyond the documents' own topology
+# envelope (T6 = 1000+ agents/mesh, a ~50-peer federation ceiling, and an
+# explicit "the peer-to-peer mesh model is the wrong shape past ~50 peers").
+# Gate 4 (docs-vs-SSOT) pins VALUES against Rust consts; gates 9/10/11 pin
+# symbols / SDK paths / CI-job claims — but NOTHING policed agent-count /
+# scale-capacity claims, so this whole class was invisible while every other
+# claims gate was GREEN. That is the #2444 "reports success while doing nothing"
+# shape one axis over, and the register's diagnosis governs it: "the drift
+# direction is consistently toward MORE CLAIMED ENFORCEMENT THAN EXISTS."
+#
+# The ratified certification scope (#2438) is a **500-1000-agent cluster,
+# composed modularly in 500-agent blocks** — scale past one cluster by adding
+# independent clusters, never by growing one mesh. So the per-fleet AGENT
+# ceiling this gate enforces is 1000 (`AGENT_FLEET_CEILING`). A doc may say
+# "hundreds of agents", "500-agent blocks", "500-1000-agent clusters", or
+# "compose independent clusters" freely; it may NOT publish a single-fleet
+# agent number above the ceiling as a live capacity claim.
+#
+# WHAT IS DELIBERATELY NOT FLAGGED (aimed at the defect, not its neighbourhood):
+#   * A row / record / corpus count. `docs/performance.html`'s "1M+ on
+#     Postgres" is a CORPUS-ROW claim ("...on Postgres", no agent noun) and is
+#     defensible; `MAX_ROWS = 1,000,000` (the migration row cap) is not an
+#     agent count. A big number is a violation ONLY when it sits within 40
+#     chars of an `agent(s)` / `AI agents` / `NHI agents` noun on the SAME line
+#     AND the line's ±1 window is not a retirement/historical note.
+#   * A RETIREMENT NOTE that quotes the retired figure to document its
+#     retirement (`docs/federation.md`, `docs/federation-identity.md` both cite
+#     #2438) — recognised by markers like "previous revision", "advertised",
+#     "retired", "three orders of magnitude", "#2438".
+#   * FROZEN doc trees that describe a tree AS IT WAS: `docs/v0.*/`,
+#     `docs/audit/` (the register itself quotes the overclaim), `docs/rfc/`,
+#     `docs/adr*`, `docs/internal/`, `docs/BASELINE-*`.
+#   * A bare 4-digit year (1900-2099) — a date, not a capacity number.
+#
+# Allowlist for any genuinely-legitimate remaining use:
+# `scripts/qc-allowlists/capacity-claims-allow.txt` (`<relpath> <substring>`;
+# a MALFORMED entry HARD-FAILS, a STALE entry that no longer matches HARD-FAILS
+# — the burn-down discipline, so the ledger cannot rot). Empty is the passing
+# state.
+#
+# Scope: docs/**/*.md + docs/**/*.html (override with AI_MEMORY_CAPACITY_DOCS_DIR
+# for --self-test). Exit 0 = clean, 1 = a claim above the ceiling (offender
+# printed), 2 = usage / self-test / malformed-allowlist / empty-scan failure.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCS_DIR="${AI_MEMORY_CAPACITY_DOCS_DIR:-${HERE}/docs}"
+ALLOWLIST="${AI_MEMORY_CAPACITY_ALLOWLIST:-${HERE}/scripts/qc-allowlists/capacity-claims-allow.txt}"
+
+# The scanner. Reads the allowlist path as argv[1], the scan root as argv[2].
+# Emits "<relpath>:<lineno>: <line>" per violation; exit 0 clean, 1 violations,
+# 2 malformed/stale allowlist, 3 empty scan (fail-closed).
+scan() {
+  local root="$1"
+  local allow="${2:-$ALLOWLIST}"
+  python3 - "$allow" "$root" <<'PY'
+import os, re, sys
+
+AGENT_FLEET_CEILING = 1000  # ratified #2438 per-cluster ceiling
+allow_path, root = sys.argv[1], sys.argv[2]
+
+FROZEN = ("docs/v0.", "docs/audit/", "docs/rfc/", "docs/adr",
+          "docs/internal/", "docs/BASELINE-")
+
+HIST = re.compile(
+    r'previous revision|previously published|advertised|retired|no longer'
+    r'|used to (?:say|advertise|claim|read)|three orders of magnitude|was three orders'
+    r'|#2438|deprecated|formerly|claims correction|no .{0,12}scale certification', re.I)
+
+# The overclaim shape is a magnitude token DIRECTLY quantifying agents:
+# "1,000,000 AI agents", "1 to ~1,000,000 agents", "millions of agents",
+# "hundreds of thousands to millions of agents". A big number elsewhere on a
+# line that merely CONTAINS the word "agent" (a byte quota `104857600` beside
+# "per-agent", a row count "1M rows", a context window "1M context") is NOT a
+# claim about fleet size and must NOT match — so the magnitude token has to sit
+# immediately before the `agents` noun, separated only by short connectors
+# (whitespace, `+`, `~`, a dash, `or more`, `to`, `of`, `of the`).
+# Each numeric alternative is \b-anchored so a digit-run INSIDE an identifier
+# ("Ed25519 agent", "SHA256 agent") is not mistaken for an agent count — the
+# only \b in "Ed25519" is at its ends, so `\b\d{4,}\b` cannot latch onto the
+# interior "25519".
+_MAG = (r'\b\d[\d,_]*\s*M\b'          # 1M / 10M
+        r'|\b\d{1,3}(?:[,_]\d{3})+\b'  # 1,000,000
+        r'|\b\d{4,}\b'                 # bare >= 1000
+        r'|\bmillions?\b'              # word-magnitude
+        r'|\bhundreds of thousands\b')
+QUANT = re.compile(
+    r'(?P<num>' + _MAG + r')'
+    r'(?:\s*(?:\+|or more|to|through|[-–—~]|of|of the)\s*)*\s+'
+    r'(?:AI |NHI )?agents?\b', re.I)
+
+def magnitude(tok):
+    t = tok.strip()
+    low = t.lower()
+    if low.startswith('million'):
+        return 1_000_000, False
+    if low.startswith('hundreds of thousands'):
+        return 100_000, False
+    if low.endswith('m') or low.endswith('M'):
+        return int(re.sub(r'[^\d]', '', t)) * 1_000_000, False
+    v = int(t.replace(',', '').replace('_', ''))
+    is_year = re.fullmatch(r'\d{4}', t) is not None and 1900 <= v <= 2099
+    return v, is_year
+
+# ---- load files -----------------------------------------------------------
+files = []
+for dirpath, _dirs, names in os.walk(root):
+    for n in names:
+        if n.endswith(('.md', '.html')):
+            files.append(os.path.join(dirpath, n))
+files.sort()
+if not files:
+    print("check-capacity-claims: no docs scanned (empty scan) — failing CLOSED", file=sys.stderr)
+    sys.exit(3)
+
+# ---- load allowlist (path<space>substring) --------------------------------
+allow = []  # (relpath, substring)
+if os.path.exists(allow_path):
+    for ln in open(allow_path, encoding='utf-8'):
+        s = ln.rstrip('\n')
+        if not s.strip() or s.lstrip().startswith('#'):
+            continue
+        parts = s.split(None, 1)
+        if len(parts) != 2 or not parts[1].strip():
+            print(f"MALFORMED allowlist entry (need '<relpath> <substring>'): {s!r}", file=sys.stderr)
+            sys.exit(2)
+        allow.append((parts[0], parts[1]))
+allow_hit = [False] * len(allow)
+
+violations = []
+
+def relpath(p):
+    r = os.path.relpath(p, root)
+    # normalise so the FROZEN prefixes + allowlist match against docs/... form
+    if not r.startswith('docs' + os.sep) and (os.sep + 'docs' + os.sep) in (os.sep + p):
+        i = p.find(os.sep + 'docs' + os.sep)
+        if i >= 0:
+            r = p[i + 1:]
+    return r.replace(os.sep, '/')
+
+for f in files:
+    rel = relpath(f)
+    if any(rel.startswith(pre) for pre in FROZEN):
+        continue
+    try:
+        lines = open(f, encoding='utf-8').read().splitlines()
+    except (UnicodeDecodeError, OSError):
+        continue
+    for i, line in enumerate(lines):
+        window = "\n".join(lines[max(0, i - 1): i + 2])
+        if HIST.search(window):
+            continue
+        for m in QUANT.finditer(line):
+            val, is_year = magnitude(m.group('num'))
+            if val <= AGENT_FLEET_CEILING or is_year:
+                continue
+            # allowlist?
+            covered = False
+            for idx, (ap, asub) in enumerate(allow):
+                if rel == ap and asub in line:
+                    allow_hit[idx] = True
+                    covered = True
+                    break
+            if covered:
+                continue
+            violations.append(f"{rel}:{i + 1}: {line.strip()}")
+            break  # one report per line is enough
+
+# ---- stale allowlist entries HARD-FAIL (burn-down discipline) --------------
+stale = [f"{allow[i][0]} {allow[i][1]}" for i in range(len(allow)) if not allow_hit[i]]
+if stale:
+    print("STALE allowlist entry (no longer matches any flagged line — remove it):", file=sys.stderr)
+    for s in stale:
+        print(f"  {s}", file=sys.stderr)
+    sys.exit(2)
+
+if violations:
+    for v in violations:
+        print(v)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# --------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+  tmp="${HERE}/.local-runs/capacity-claims-selftest.$$"
+  cleanup() { rm -rf "$tmp"; }
+  trap cleanup EXIT
+  mkdir -p "$tmp/docs"
+
+  # scan() takes the allowlist as its 2nd arg; the self-test uses an empty one
+  # (/dev/null) so the throwaway corpus is judged on the detection rules alone,
+  # never against the production allowlist.
+  mkdir -p "$tmp/bad" "$tmp/good" "$tmp/empty"
+
+  # 1) the exact #2438 overclaim — MUST be flagged (gate exits non-zero).
+  printf '%s\n' '<p class="tagline">Scale a federated fleet from 1 to ~1,000,000 AI agents.</p>' > "$tmp/bad/bad.html"
+  if scan "$tmp/bad" /dev/null >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: gate did not catch the 1,000,000-agent overclaim" >&2
+    exit 2
+  fi
+
+  # 2) the honest fixed claim + legit near-misses — MUST all PASS:
+  #    honest envelope; corpus-row "1M+ on Postgres"; the MAX_ROWS row cap; a
+  #    retirement note that quotes the retired figure; a bare year; and an
+  #    identifier ("Ed25519 agent") whose interior digit-run must not be read
+  #    as an agent count.
+  cat > "$tmp/good/good.html" <<'EOF'
+<p>Scale a federated fleet of hundreds of AI agents (certified: 500-1000-agent
+clusters, composed modularly in 500-agent blocks) - see #2438.</p>
+<p><strong>1M+ on Postgres</strong> - supported via SAL (a corpus-row count).</p>
+<p>The migrator reads one page capped at 1,000,000 rows (MAX_ROWS).</p>
+<p>A previous revision advertised "1 to ~1,000,000 AI agents" - three orders of
+magnitude beyond the envelope; retired per #2438.</p>
+<p>Released in 2026 for AI agents everywhere; enroll Ed25519 agent identities.</p>
+EOF
+  if ! scan "$tmp/good" /dev/null >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: gate flagged an honest / corpus-row / retirement-note / year / identifier line" >&2
+    scan "$tmp/good" /dev/null >&2 || true
+    exit 2
+  fi
+
+  # 3) the allowlist must EXEMPT a vetted line (gate PASSES), and a STALE entry
+  #    that matches nothing must HARD-FAIL (rc 2) — the burn-down discipline.
+  mkdir -p "$tmp/vision"
+  printf '%s\n' '<p>The north star: hundreds of thousands to millions of agents.</p>' > "$tmp/vision/vision.html"
+  printf '%s\n' 'vision.html millions of agents' > "$tmp/allow.txt"
+  if ! scan "$tmp/vision" "$tmp/allow.txt" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: a matching allowlist entry did not exempt a vetted line" >&2
+    exit 2
+  fi
+  printf '%s\n' 'vision.html this-substring-matches-nothing' > "$tmp/stale.txt"
+  strc=0; scan "$tmp/vision" "$tmp/stale.txt" >/dev/null 2>&1 || strc=$?
+  if [ "$strc" -ne 2 ]; then
+    echo "SELF-TEST FAIL: a stale allowlist entry did not hard-fail (burn-down discipline)" >&2
+    exit 2
+  fi
+
+  # 4) empty scan must FAIL CLOSED (rc 3 -> the caller treats it as failure).
+  if scan "$tmp/empty" /dev/null >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: gate passed on an empty scan (must fail closed)" >&2
+    exit 2
+  fi
+
+  echo "check-capacity-claims self-test OK"
+  exit 0
+fi
+
+rc=0
+scan "$DOCS_DIR" || rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "check-capacity-claims: OK (no agent-count capacity claim exceeds the ratified 500-1000-agent envelope, #2438)"
+  exit 0
+elif [ "$rc" -eq 3 ]; then
+  echo "" >&2
+  echo "FAIL (#2869): no docs were scanned — the gate fails CLOSED rather than green a no-op." >&2
+  exit 2
+elif [ "$rc" -eq 2 ]; then
+  echo "" >&2
+  echo "FAIL (#2869): malformed or stale entry in ${ALLOWLIST}." >&2
+  exit 2
+else
+  echo "" >&2
+  echo "FAIL (#2869): a doc publishes an AGENT-COUNT capacity claim above the ratified" >&2
+  echo "500-1000-agent cluster ceiling (#2438). Replace the number with the honest" >&2
+  echo "certified envelope (e.g. \"a fleet of hundreds of agents; certified 500-1000-agent" >&2
+  echo "clusters composed in 500-agent blocks\"), or — for a genuine history/corpus-row use" >&2
+  echo "the structural exemptions miss — add a line to ${ALLOWLIST}." >&2
+  exit 1
+fi

--- a/scripts/qc-allowlists/capacity-claims-allow.txt
+++ b/scripts/qc-allowlists/capacity-claims-allow.txt
@@ -1,0 +1,57 @@
+# capacity-claims-allow.txt — allowlist for `scripts/check-capacity-claims.sh`
+# (#2869). One entry per line: `<relpath> <substring>`, where <relpath> is the
+# doc path relative to the scan root (e.g. `docs/foo.html`) and <substring> is a
+# verbatim fragment of the flagged line.
+#
+# ============================================================================
+# *** THIS FILE IS CURRENTLY EMPTY, AND THAT IS THE PASSING STATE. ***
+# ============================================================================
+# Empty means NO operator-facing doc needs a hand-authored exemption — every
+# legitimate history/corpus-row/retirement use is already covered STRUCTURALLY
+# by the gate (row/corpus nouns never associate with an `agent` noun; the
+# ±1-line HISTORICAL-marker window exempts retirement notes; frozen doc trees
+# under docs/v0.*, docs/audit/, docs/rfc/, docs/adr*, docs/internal/,
+# docs/BASELINE-* are out of scope). Reach for this file only for a genuine
+# case those structural rules miss.
+#
+# DISCIPLINE (burn-down, not pending-fix):
+#   * A MALFORMED entry (not exactly two whitespace-separated fields) HARD-FAILS.
+#   * A STALE entry (one that no longer matches any flagged line) HARD-FAILS —
+#     so the ledger cannot rot into a suppression nobody remembers. If the gate
+#     tells you an entry is stale, DELETE it; do not "fix" it.
+#
+# The ratified envelope is a 500-1000-agent cluster composed in 500-agent
+# blocks (#2438); the correct fix for a real overclaim is to publish that
+# honest number, NOT to allowlist the retired one.
+# ---------------------------------------------------------------------------
+#
+# VETTED EXCEPTIONS — explicitly-aspirational VISION/HORIZON statements.
+# ---------------------------------------------------------------------------
+# Each entry below was read in context (#2869) and is an EXPLICITLY-LABELLED
+# vision-tier / moonshot-horizon / hyperscale-future statement, NOT a claim
+# about a CURRENT or CERTIFIED capability. That is the distinction from the
+# CERT-BLOCKER this gate was built for: `docs/zero-touch-trust.html` presented
+# "1 to ~1,000,000 AI agents" as what the enrollment system DOES today, with no
+# aspiration framing — an overclaim, now FIXED. The lines below are a different
+# speech act (a stated north-star), and a correctly-labelled aspiration is not
+# a false capacity claim. Each substring includes the "millions of agents"
+# clause, so any future edit that changes the claim makes the entry STALE and
+# HARD-FAILS this gate, forcing a re-vet.
+#
+#   * docs/architectures-t5.html — the page IS the vision tier: <title> "T5 —
+#     Global hive ... The vision tier.", tier badge "VISION * v1.0+", section
+#     "The north star". Three vision-tier lines (meta description, hero
+#     tagline, and the T5 Raft-consensus body).
+#   * docs/architectures.html — the "TIER 5 ... VISION v1.0+" card, the highest
+#     (vision) tier of the architectures overview.
+#   * docs/reference-architectures.md — the "Tier 8 — Global hive / hyperscale"
+#     endpoint ("a hyperscale deployment with the hardware footprint of a major
+#     cloud provider ... a sovereign government").
+#   * docs/strategy/moonshot-synthesis.md — "3.3 Hive scale (v0.8.x -> v0.9.x
+#     -> v1.0 horizon)": an explicit forward HORIZON, not a shipped capability.
+docs/architectures-t5.html millions of agents acting as a unified collective
+docs/architectures-t5.html Hundreds of thousands to millions of agents
+docs/architectures-t5.html with millions of agents and cross-jurisdictional rules
+docs/architectures.html millions of agents acting as a unified collective
+docs/reference-architectures.md millions of agents
+docs/strategy/moonshot-synthesis.md thousands-to-millions of agents on shared substrate

--- a/scripts/qc-allowlists/required-contexts-release.txt
+++ b/scripts/qc-allowlists/required-contexts-release.txt
@@ -205,6 +205,17 @@ Named-CI-job existence + enforcement-truthfulness gate (#2629)
 # enforced.
 Doc surface completeness gate (#2839)
 #
+# #2869 — agent-count / scale-CAPACITY claim ceiling gate (CERT TRUTHFULNESS).
+# The accuracy gates above pin cited VALUES / symbols / SDK-paths / CI-jobs;
+# NONE policed a fleet-scale agent-count claim, so `docs/zero-touch-trust.html`
+# shipped the retired "1 to ~1,000,000 AI agents" figure (#2438) while every
+# claims gate was green. Declared REQUIRED per gate 7 rule (f) — a new
+# c8-precheck integrity gate must be declared here (or in the not-required
+# ledger) or it is required-by-nothing (the #2636 class). Mirror-first: this
+# declaration lands before the companion branch-protection API call (KNOWN GAP
+# below), so the gate can prove the context sound before it is enforced.
+Capacity-claim ceiling gate (#2869)
+#
 # ---------------------------------------------------------------------------
 # KNOWN GAPS — declared here so they are not mistaken for oversights.
 # Closing any of them is a branch-protection edit, deliberately NOT done in

--- a/tests/doc_claims_integrity.rs
+++ b/tests/doc_claims_integrity.rs
@@ -516,6 +516,11 @@ fn claims_gates_are_wired_into_ci_with_self_tests_2629() {
         // is MISSING). Same wiring contract: invoked + --self-test in
         // c8-precheck.yml so it cannot silently stop detecting.
         "scripts/check-doc-surface-completeness.sh",
+        // #2869 — the agent-count / scale-CAPACITY claim ceiling gate. No
+        // other claims gate policed a fleet-scale agent number, so the retired
+        // #2438 "1 to ~1,000,000 AI agents" figure shipped on a live page
+        // while every gate was green. Same wiring contract.
+        "scripts/check-capacity-claims.sh",
     ] {
         let path = root.join(script);
         assert!(path.exists(), "claims gate missing from the tree: {script}");


### PR DESCRIPTION
Closes #2869

## CERT-BLOCKER — the 1M-agent overclaim (3x7 register C-12)

`docs/zero-touch-trust.html` still shipped the [#2438](https://github.com/alphaonedev/ai-memory-mcp/issues/2438)-**retired** "1 to ~1,000,000 AI agents" figure in **both** its `<meta name="description">` and its hero tagline — three orders of magnitude beyond the documents' own topology envelope (T6 = 1000+ agents/mesh, ~50-peer federation ceiling). The sibling pages (`docs/federation.md`, `docs/federation-identity.md`) already carried the retirement; this page was missed by that sweep.

Before / after (both spots):

- `<meta description>`: `Scale a federated AI-memory fleet from 1 to 1,000,000 agents.` → `Scale a federated AI-memory fleet of hundreds of agents (certified: 500-1000-agent clusters, composed modularly in 500-agent blocks).`
- tagline: `Scale a federated fleet from 1 to ~1,000,000 AI agents — without touching a single peer…` → `Scale a federated fleet of hundreds of AI agents — certified for 500-1000-agent clusters composed modularly in 500-agent blocks (#2438) — without touching a single peer…`

A full `docs/**` sweep confirms this was the only **current-capability** agent-count overclaim. Corpus-row "1M+ on Postgres" (`performance.html`) and `MAX_ROWS = 1,000,000` are row counts, left untouched. The residual "millions of agents" lines are all explicitly-labelled **vision-tier / moonshot-horizon** statements (page titled "The vision tier", tier badge "VISION · v1.0+", moonshot "v1.0 horizon") — a different speech act, carried as vetted allowlist entries (see below), not fixed away.

## NEW GATE — `scripts/check-capacity-claims.sh`

No claims gate policed agent-count / scale-CAPACITY claims, so the overclaim shipped while every other claims gate (values / symbols / SDK-paths / CI-jobs) was green. This gate HARD-BLOCKS any operator-facing doc that publishes a single-fleet agent number above the ratified 1000 ceiling.

- **Precise detection:** a magnitude token must *directly quantify* the `agents` noun ("1,000,000 AI agents", "millions of agents") — a big number merely near the word "agent" (byte quota `104857600`, "1M rows", "1M context", `Ed25519 agent`) does not match.
- **Structural exemptions:** row/corpus counts (never associate with `agents`), retirement notes (±1-line marker window), frozen doc trees (`docs/v0.*`, `docs/audit/`, `docs/rfc/`, `docs/adr*`, `docs/internal/`, `docs/BASELINE-*`), bare years.
- **Burn-down allowlist** (`scripts/qc-allowlists/capacity-claims-allow.txt`): carries the 6 vetted, explicitly-aspirational vision-tier lines; a **STALE** entry (no longer matching) **hard-fails**, so it cannot rot.
- **`--self-test`** (load-bearing proof): plants the exact 1M overclaim → gate FAILS; the honest 500-1000 envelope + corpus/retirement/year/identifier near-misses → PASS; allowlist coverage + stale-fail + empty-scan-fail-closed all exercised.
- **Wired** into `.github/workflows/c8-precheck.yml` (invoked + `--self-test`, no `needs: classify` / `paths:` / job-level `if:`), **declared REQUIRED** in `required-contexts-release.txt` (gate 7 rule f), and asserted by the `tests/doc_claims_integrity.rs` twin.

## CAVEATS — `docs/v1.0.0/release-notes.md`

- **(a) pg-cert scope → headline.** A scope banner near the cert headline now states up front that the two backends are not one identical API: **59 of 80 unique HTTP paths served on Postgres, 21 fail-closed `501`** (pinned by `tests/pg_supported_route_inventory_gate_2799.rs`), and **MCP-stdio is structurally SQLite-only** ([#1675](https://github.com/alphaonedev/ai-memory-mcp/issues/1675)).
- **(b) version reconciliation.** The "Certified backend versions" section led with a flat "certified on PG 18.4 / AGE 1.7.0 / pgvector 0.8.5" while the honest CI-posture disclosure sat 50+ lines lower. It now leads with the stack CI **actually exercises every PR/push** — **PG 16 + AGE 1.6.0** (`coverage.yml`, `apache/age:release_PG16_1.6.0`, pgvector via `postgresql-16-pgvector` apt) — and labels the SSOT-pinned **PG 18.4 / AGE 1.7.0 / pgvector 0.8.5** stack as **additionally validated off-CI, NOT CI-asserted** (the `postgres-age` nightly that would assert it was RED for its final three runs then deleted 2026-07-31, [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512)). An SSOT-internal pgvector pin drift (docker-1461 `0.8.5` vs do-1461 `0.8.2`) is disclosed rather than papered over.

## Gate results (local)

- `check-capacity-claims.sh` + `--self-test` — PASS
- `check-docs-vs-ssot.sh` — PASS
- `check-ci-job-claims.sh` + `--self-test` — PASS
- `check-required-contexts.sh` — PASS (every c8-precheck job declared required)
- `check-doc-symbol-anchors.sh` — PASS
- `cargo test --test doc_claims_integrity` — 4/4 PASS
- `cargo fmt --check` (edited file) — clean

Docs + CI-gate change only; no product/runtime code touched. **Do not merge — Fable review + audit gate before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY