### PR TITLE
fix(federation/#2667): durable push-DLQ landing on every fanout lane (no more silent divergence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 
+- **Every federation fanout lane now lands a durable push-DLQ row on a
+  non-acking peer — a failed fanout is recoverable, not a silent divergence**
+  ([#2667](https://github.com/alphaonedev/ai-memory-mcp/issues/2667); 5-agent
+  adversarial vote `4d3ea1c5`). Pre-fix only the store (#933) and delete (#2498)
+  lanes enqueued a `federation_push_dlq` row when a peer did not ack; the other
+  11 `broadcast_*_quorum` lanes — `archive`, `restore`, `link`, `consolidate`,
+  `pending`, `pending_decision`, `action_transition`, `checkpoint_resolution`,
+  `signal_create`, `namespace_meta`, `namespace_meta_clear` — emitted a lone
+  `tracing::warn!` and dropped the failure, so a peer that was down,
+  deadline-evicted, or that refused an item inside an HTTP 200 (`skipped > 0`,
+  #2341) diverged PERMANENTLY and SILENTLY. This included governance
+  (`namespace_meta`) and authority (`pending` / `pending_decision` /
+  checkpoint-resolution / action-transition) state that the anti-entropy
+  catch-up loop — which pulls MEMORY rows only — never reconciles. All 13 lanes
+  now route their non-ack failures through one shared `land_push_failures`
+  helper so the `replay_federation_push_dlq` worker re-drives them on peer
+  recovery (default build AND both backends). DLQ keys are LANE-PREFIXED
+  (`archive:{id}`, `link:{src}:{tgt}:{rel}`, `namespace_meta:{ns}`,
+  `action_transition:{action_id}:{to_state}:{updated_at}` per-transition, …) so
+  distinct pending ops on the same subject never collide, and — load-bearing —
+  so a legacy-mode `consolidate` body (which carries `deletions[]`) does not
+  trip the replay restore-race guard against the live consolidated row; `store`
+  and `delete` keep the bare memory-id key their guard and documented
+  last-wins collision require. Follow-up (tracked, not silent-loss): a
+  subcollection anti-entropy reconciler as the convergence backstop past the
+  100-attempt quarantine ceiling, and a DLQ landing for the non-quorum
+  `bulk_catchup_push` bulk sender (its memory-row payload is already self-healed
+  by the `/sync/since` catch-up loop).
 - **Daemon-authored federated consolidations converge at `agent_attested` at
   peers OUT-OF-BOX for a normally-enrolled mesh — no manual DB-bind step**
   ([#2865](https://github.com/alphaonedev/ai-memory-mcp/issues/2865); 5-agent

--- a/src/federation/sync.rs
+++ b/src/federation/sync.rs
@@ -382,6 +382,98 @@ pub(super) async fn post_and_classify(
     }
 }
 
+/// #2667 — reason stamped on a `federation_push_dlq` row when a peer never
+/// acked inside the deadline and no explicit per-peer failure was observed
+/// (the task was deadline-evicted before it reported an outcome).
+pub(super) const DEADLINE_EXCEEDED_REASON: &str = "deadline_exceeded";
+
+/// #2667 — the SINGLE implementation of the federation push-DLQ landing pass,
+/// the #933 (store) / #2498 (delete) pattern now applied to EVERY fanout lane.
+/// For each dispatched peer that did NOT ack inside the deadline (explicit
+/// `Fail`/`Throttled` outcomes AND deadline-evicted tasks whose outcome was
+/// never observed), enqueue a `federation_push_dlq` row keyed on `dlq_key` so
+/// `replay_federation_push_dlq` re-POSTs `body` when the peer recovers.
+///
+/// Pre-#2667 ONLY the store + delete lanes did this; the other 11
+/// `broadcast_*_quorum` lanes emitted a lone `tracing::warn!` and then dropped
+/// the failure — permanent, silent replica divergence, including governance
+/// (`namespace_meta`) and authority (`pending` / `pending_decision` /
+/// checkpoint-resolution / action-transition) state that the anti-entropy
+/// catch-up loop — which pulls MEMORY rows only — never reconciles.
+///
+/// ## DLQ key contract (`dlq_key` → `federation_push_dlq.memory_id`)
+///
+/// The DLQ row upserts on `(memory_id, peer_id)` (last-failure-wins) and the
+/// replay worker's #2716 restore-race guard consults `row.memory_id` as a
+/// LIVE-memory lookup ONLY for delete-shaped payloads (`payload_is_delete`):
+///
+/// - `store` + `delete` pass the BARE memory id: the delete lane's guard needs
+///   the real id, and their documented store-then-delete last-wins collision is
+///   deliberate (the newer delete supersedes a superseded pending store).
+/// - every OTHER lane passes a LANE-PREFIXED key (`archive:{id}`,
+///   `link:{s}:{t}:{rel}`, `namespace_meta:{ns}`,
+///   `action_transition:{id}:{to}:{ts}`, …). The `:`-bearing prefix can NEVER
+///   collide with a bare memory UUID (a store/delete row) nor with another
+///   lane's rows, so distinct pending ops on the same subject never clobber
+///   each other's `payload_json`. It is also load-bearing for `consolidate`:
+///   its legacy-mode body carries `deletions[]`, so a BARE `new_mem.id` key
+///   would trip `payload_is_delete`, the guard would find `new_mem.id` LIVE,
+///   and the whole consolidation would be SUPERSEDED (never replayed). The
+///   prefix makes the guard's lookup miss → the replay proceeds.
+///
+/// Best-effort: a sink error NEVER propagates — the local write already
+/// committed and the quorum verdict is already computed. `expected_id` on the
+/// replay POST is inert for these subcollection lanes (a `sync_push` 200 body
+/// carries no per-item `ids` echo), so a synthetic `dlq_key` is safe there.
+pub(super) async fn land_push_failures(
+    config: &FederationConfig,
+    tracker: &AckTracker,
+    dispatched_peer_ids: &[String],
+    explicit_failures: Vec<(String, String)>,
+    dlq_key: &str,
+    body: &serde_json::Value,
+    lane: &str,
+) {
+    let Some(sink) = config.dlq_sink.as_ref() else {
+        return;
+    };
+    let acked = tracker.acked_peer_ids();
+    let explicit_map: std::collections::HashMap<String, String> =
+        explicit_failures.into_iter().collect();
+    for peer_id in dispatched_peer_ids {
+        if acked.contains(peer_id) {
+            continue;
+        }
+        let reason = explicit_map
+            .get(peer_id)
+            .cloned()
+            .unwrap_or_else(|| DEADLINE_EXCEEDED_REASON.to_string());
+        if let Err(e) = sink
+            .enqueue_push_failure(dlq_key, peer_id, body, &reason)
+            .await
+        {
+            tracing::warn!(
+                target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
+                dlq_key = %dlq_key,
+                peer_id = %peer_id,
+                lane = %lane,
+                "federation: failed to enqueue {lane} push-failure DLQ row for peer \
+                 {peer_id} on {dlq_key}: {e}",
+            );
+        } else {
+            tracing::info!(
+                target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
+                dlq_key = %dlq_key,
+                peer_id = %peer_id,
+                reason = %reason,
+                lane = %lane,
+                "federation: enqueued {lane} push-failure DLQ row for peer {peer_id} \
+                 on {dlq_key} (reason: {reason})",
+            );
+        }
+    }
+}
+
 /// Fan out a just-committed memory to every configured peer. Returns
 /// an `AckTracker` whose `finalise()` you then call against the
 /// deadline to get the quorum outcome.
@@ -640,43 +732,18 @@ pub async fn broadcast_store_quorum_with_embedding(
     // #2678 — ungated. Pre-#2678 this branch was sal-only, so the default
     // shipped binary preserved pre-#933 "silently lost" behaviour while
     // migrations created the table and metrics advertised depth=0 healthy.
-    if let Some(sink) = config.dlq_sink.as_ref() {
-        let acked = tracker.acked_peer_ids();
-        let explicit_map: std::collections::HashMap<String, String> =
-            explicit_failures.into_iter().collect();
-        for peer_id in &dispatched_peer_ids {
-            if acked.contains(peer_id) {
-                continue;
-            }
-            let reason = explicit_map
-                .get(peer_id)
-                .cloned()
-                .unwrap_or_else(|| "deadline_exceeded".to_string());
-            if let Err(e) = sink
-                .enqueue_push_failure(&mem.id, peer_id, &body, &reason)
-                .await
-            {
-                tracing::warn!(
-                    target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
-                    memory_id = %mem.id,
-                    peer_id = %peer_id,
-                    "federation: failed to enqueue push-failure DLQ row \
-                     for peer {peer_id} on memory {}: {e}",
-                    mem.id,
-                );
-            } else {
-                tracing::info!(
-                    target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
-                    memory_id = %mem.id,
-                    peer_id = %peer_id,
-                    reason = %reason,
-                    "federation: enqueued push-failure DLQ row for peer {peer_id} \
-                     on memory {} (reason: {reason})",
-                    mem.id,
-                );
-            }
-        }
-    }
+    // #2667 — via the shared landing pass. Store keeps the BARE memory-id key
+    // (documented store-then-delete last-wins collision with the delete lane).
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &mem.id,
+        &body,
+        "store",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -874,38 +941,20 @@ pub async fn broadcast_delete_quorum(
     // the peer never applied the delete, so it holds no tombstone for that
     // id, and an operator-initiated `restore_archived` deliberately
     // bypasses the tombstone gate as an authorized un-forget.
-    if let Some(sink) = config.dlq_sink.as_ref() {
-        let acked = tracker.acked_peer_ids();
-        let explicit_map: std::collections::HashMap<String, String> =
-            explicit_failures.into_iter().collect();
-        for peer_id in &dispatched_peer_ids {
-            if acked.contains(peer_id) {
-                continue;
-            }
-            let reason = explicit_map
-                .get(peer_id)
-                .cloned()
-                .unwrap_or_else(|| "deadline_exceeded".to_string());
-            if let Err(e) = sink.enqueue_push_failure(id, peer_id, &body, &reason).await {
-                tracing::warn!(
-                    target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
-                    memory_id = %id,
-                    peer_id = %peer_id,
-                    "federation: failed to enqueue delete push-failure DLQ row \
-                     for peer {peer_id} on memory {id}: {e}",
-                );
-            } else {
-                tracing::info!(
-                    target: super::push_dlq::PUSH_DLQ_TRACE_TARGET,
-                    memory_id = %id,
-                    peer_id = %peer_id,
-                    reason = %reason,
-                    "federation: enqueued delete push-failure DLQ row for peer \
-                     {peer_id} on memory {id} (reason: {reason})",
-                );
-            }
-        }
-    }
+    // #2667 — via the shared landing pass. Delete keeps the BARE memory-id key
+    // (the #2716 restore-race guard reads `row.memory_id` as a live-memory
+    // lookup for delete-shaped payloads; the store-then-delete last-wins
+    // collision analysis above is unchanged).
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        id,
+        &body,
+        "delete",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -936,6 +985,10 @@ pub async fn broadcast_archive_quorum(
         "archives": [id],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -976,6 +1029,7 @@ pub async fn broadcast_archive_quorum(
             }
             Ok(Some(Ok((peer_id, AckOutcome::Fail(reason) | AckOutcome::Throttled(reason))))) => {
                 tracing::warn!("federation: archive peer {peer_id} failed for {id}: {reason}");
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: archive peer join error: {e}");
@@ -1005,6 +1059,16 @@ pub async fn broadcast_archive_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("archive:{id}"),
+        &body,
+        "archive",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1036,6 +1100,10 @@ pub async fn broadcast_restore_quorum(
         "restores": [id],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1076,6 +1144,7 @@ pub async fn broadcast_restore_quorum(
             }
             Ok(Some(Ok((peer_id, AckOutcome::Fail(reason) | AckOutcome::Throttled(reason))))) => {
                 tracing::warn!("federation: restore peer {peer_id} failed for {id}: {reason}");
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: restore peer join error: {e}");
@@ -1105,6 +1174,16 @@ pub async fn broadcast_restore_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("restore:{id}"),
+        &body,
+        "restore",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1131,6 +1210,10 @@ pub async fn broadcast_link_quorum(
         "dry_run": false,
     });
     let log_id = format!("{}→{}", link.source_id, link.target_id);
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1171,6 +1254,7 @@ pub async fn broadcast_link_quorum(
             }
             Ok(Some(Ok((peer_id, AckOutcome::Fail(reason) | AckOutcome::Throttled(reason))))) => {
                 tracing::warn!("federation: link peer {peer_id} failed for {log_id}: {reason}");
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: link peer join error: {e}");
@@ -1200,6 +1284,21 @@ pub async fn broadcast_link_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!(
+            "link:{}:{}:{}",
+            link.source_id,
+            link.target_id,
+            link.relation.as_str()
+        ),
+        &body,
+        "link",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1251,6 +1350,10 @@ pub async fn broadcast_consolidate_quorum(
         "dry_run": false,
     });
 
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
+
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
         let client = config.client.clone();
@@ -1293,6 +1396,7 @@ pub async fn broadcast_consolidate_quorum(
                     "federation: consolidate peer {peer_id} failed for {}: {reason}",
                     new_mem.id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: consolidate peer join error: {e}");
@@ -1322,6 +1426,20 @@ pub async fn broadcast_consolidate_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    // #2667 — PREFIXED key: the legacy-mode body carries `deletions[]`, so a
+    // bare `new_mem.id` key would trip `payload_is_delete` and the replay
+    // restore-race guard would supersede the whole consolidation (new_mem is
+    // live). The `consolidate:` prefix makes the guard's lookup miss → replay.
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("{}:{}", crate::audit::OP_CONSOLIDATE, new_mem.id),
+        &body,
+        crate::audit::OP_CONSOLIDATE,
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1350,6 +1468,10 @@ pub async fn broadcast_pending_quorum(
         "pendings": [pending],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1393,6 +1515,7 @@ pub async fn broadcast_pending_quorum(
                     "federation: pending peer {peer_id} failed for {}: {reason}",
                     pending.id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: pending peer join error: {e}");
@@ -1422,6 +1545,16 @@ pub async fn broadcast_pending_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("pending:{}", pending.id),
+        &body,
+        "pending",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1449,6 +1582,10 @@ pub async fn broadcast_pending_decision_quorum(
         "pending_decisions": [decision],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1492,6 +1629,7 @@ pub async fn broadcast_pending_decision_quorum(
                     "federation: pending-decision peer {peer_id} failed for {}: {reason}",
                     decision.id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: pending-decision peer join error: {e}");
@@ -1521,6 +1659,16 @@ pub async fn broadcast_pending_decision_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("pending_decision:{}", decision.id),
+        &body,
+        "pending_decision",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1604,6 +1752,10 @@ pub async fn broadcast_action_transition_quorum(
         "dry_run": false,
     });
 
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
+
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
         let client = config.client.clone();
@@ -1646,6 +1798,7 @@ pub async fn broadcast_action_transition_quorum(
                     "federation: action-transition peer {peer_id} failed for {}: {reason}",
                     op.action_id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: action-transition peer join error: {e}");
@@ -1675,6 +1828,26 @@ pub async fn broadcast_action_transition_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    // #2667 — PER-TRANSITION key: the action state machine is NON-monotonic
+    // (CAS-guarded on `from_state`), so a last-wins `action_id` key would drop
+    // an intermediate transition and strand a peer whose CAS then never matches.
+    // Keying on (action_id, to_state, updated_at) preserves every distinct
+    // transition while idempotently coalescing retries of the same one.
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!(
+            "action_transition:{}:{}:{}",
+            op.action_id,
+            op.to_state.as_str(),
+            op.updated_at
+        ),
+        &body,
+        "action_transition",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1709,6 +1882,10 @@ pub async fn broadcast_checkpoint_resolution_quorum(
         "checkpoints": [checkpoint],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1752,6 +1929,7 @@ pub async fn broadcast_checkpoint_resolution_quorum(
                     "federation: checkpoint-resolution peer {peer_id} failed for {}: {reason}",
                     checkpoint.id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: checkpoint-resolution peer join error: {e}");
@@ -1781,6 +1959,16 @@ pub async fn broadcast_checkpoint_resolution_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("checkpoint:{}", checkpoint.id),
+        &body,
+        "checkpoint_resolution",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1809,6 +1997,10 @@ pub async fn broadcast_signal_create_quorum(
         "signals": [signal],
         "dry_run": false,
     });
+
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
 
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
@@ -1852,6 +2044,7 @@ pub async fn broadcast_signal_create_quorum(
                     "federation: signal peer {peer_id} failed for {}: {reason}",
                     signal.id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: signal peer join error: {e}");
@@ -1881,6 +2074,16 @@ pub async fn broadcast_signal_create_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("signal:{}", signal.id),
+        &body,
+        "signal",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -1911,6 +2114,10 @@ pub async fn broadcast_namespace_meta_quorum(
     });
 
     let target_id = entry.namespace.clone();
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
+
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
         let client = config.client.clone();
@@ -1953,6 +2160,7 @@ pub async fn broadcast_namespace_meta_quorum(
                     "federation: namespace_meta peer {peer_id} failed for {}: {reason}",
                     entry.namespace
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: namespace_meta peer join error: {e}");
@@ -1982,6 +2190,16 @@ pub async fn broadcast_namespace_meta_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("namespace_meta:{}", entry.namespace),
+        &body,
+        "namespace_meta",
+    )
+    .await;
     Ok(tracker)
 }
 
@@ -2016,6 +2234,10 @@ pub async fn broadcast_namespace_meta_clear_quorum(
     // Use the joined namespace list as the ack-classifier's `target_id` so
     // post-quorum logs carry enough context to trace back to the operation.
     let target_id = namespaces.join(",");
+    // #2667 — DLQ landing bookkeeping (mirrors the store/delete lanes).
+    let dispatched_peer_ids: Vec<String> = config.peers.iter().map(|p| p.id.clone()).collect();
+    let mut explicit_failures: Vec<(String, String)> = Vec::new();
+
     let mut joins: JoinSet<(String, AckOutcome)> = JoinSet::new();
     for peer in &config.peers {
         let client = config.client.clone();
@@ -2058,6 +2280,7 @@ pub async fn broadcast_namespace_meta_clear_quorum(
                     "federation: namespace_meta_clear peer {peer_id} failed for [{}]: {reason}",
                     target_id
                 );
+                explicit_failures.push((peer_id, reason));
             }
             Ok(Some(Err(e))) => {
                 tracing::warn!("federation: namespace_meta_clear peer join error: {e}");
@@ -2087,6 +2310,16 @@ pub async fn broadcast_namespace_meta_clear_quorum(
             detail: TRACKER_ARC_STILL_REFERENCED.to_string(),
         })?
         .into_inner();
+    land_push_failures(
+        config,
+        &tracker,
+        &dispatched_peer_ids,
+        explicit_failures,
+        &format!("namespace_meta_clear:{target_id}"),
+        &body,
+        "namespace_meta_clear",
+    )
+    .await;
     Ok(tracker)
 }
 

--- a/tests/federation_lane_dlq_2667.rs
+++ b/tests/federation_lane_dlq_2667.rs
@@ -1,0 +1,614 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2667 regression suite — EVERY federation fanout lane MUST land a
+//! `federation_push_dlq` row for a dispatched peer that does not ack, so a
+//! failed fanout is durably retried by the replay worker instead of a lost
+//! `tracing::warn!`.
+//!
+//! ## Why this test exists
+//!
+//! Pre-#2667 only `broadcast_store_quorum` (#933) and `broadcast_delete_quorum`
+//! (#2498) enqueued a DLQ row on a non-acking peer. The other 11
+//! `broadcast_*_quorum` lanes emitted a lone `tracing::warn!` and then dropped
+//! the failure — permanent, silent replica divergence, INCLUDING governance
+//! (`namespace_meta`) and authority (`pending` / `pending_decision` /
+//! checkpoint-resolution / action-transition) state that the anti-entropy
+//! catch-up loop — which pulls MEMORY rows only — never reconciles.
+//!
+//! ## Coverage
+//!
+//! - one `*_lands_prefixed_dlq_row_2667` test per lane: a peer returning 500
+//!   leaves exactly ONE pending row carrying the lane-PREFIXED DLQ key
+//!   (`archive:{id}`, `link:{s}:{t}:{rel}`, `namespace_meta:{ns}`,
+//!   `action_transition:{id}:{to}:{ts}`, …) and the verbatim subcollection
+//!   body. The exact-key assertion is the load-bearing regression guard — a
+//!   copy-paste that keyed the wrong lane, or reverted a prefix to a bare
+//!   memory id, still lands exactly one row and would pass a count-only test.
+//! - `namespace_meta_lane_replays_and_clears_2667` — a governance lane row is
+//!   re-driven by `replay_once` once the peer recovers, and the `sync_push`
+//!   200 (no `ids` echo) acks it (never a spurious `id_drift`).
+//! - `consolidate_prefixed_key_replays_and_never_supersedes_2667` — the
+//!   load-bearing prefix proof: a legacy-mode consolidate body carries
+//!   `deletions[]`, so it is delete-shaped and the replay restore-race guard
+//!   fires on the KEY. The `consolidate:` prefix makes the guard's live-memory
+//!   lookup MISS, so the consolidation replays; a BARE `new_mem.id` key would
+//!   trip the guard against the LIVE consolidated row (inserted here with a
+//!   FUTURE `updated_at` so `restore_supersedes` returns true) and SUPERSEDE
+//!   the replay — never re-POSTing.
+
+#![cfg(feature = "sal")]
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::post;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use ai_memory::federation::push_dlq::{
+    FederationDlqSink, FederationPushDlqRow, SqliteDlqSink, replay_once,
+};
+use ai_memory::federation::{
+    ActionTransitionOp, FederationConfig, PeerEndpoint, broadcast_action_transition_quorum,
+    broadcast_archive_quorum, broadcast_checkpoint_resolution_quorum, broadcast_consolidate_quorum,
+    broadcast_link_quorum, broadcast_namespace_meta_clear_quorum, broadcast_namespace_meta_quorum,
+    broadcast_pending_decision_quorum, broadcast_pending_quorum, broadcast_restore_quorum,
+    broadcast_signal_create_quorum,
+};
+use ai_memory::models::action::ActionState;
+use ai_memory::models::checkpoint::{CheckpointState, ConditionType};
+use ai_memory::models::signal::{Signal, SignalType};
+use ai_memory::models::{
+    Checkpoint, ConfidenceSource, LifecycleState, Memory, MemoryKind, MemoryLink,
+    MemoryLinkRelation, NamespaceMetaEntry, PendingAction, PendingDecision, Tier,
+};
+use ai_memory::replication::QuorumPolicy;
+
+/// Peer is DOWN — every POST answers 500.
+const MODE_FAIL: usize = 1;
+/// Peer answers HTTP 200 with a clean apply report (used after recovery).
+const MODE_OK: usize = 0;
+
+#[derive(Clone, Default)]
+struct PeerState {
+    mode: Arc<AtomicUsize>,
+    hit_count: Arc<AtomicUsize>,
+    last_body: Arc<Mutex<Option<serde_json::Value>>>,
+}
+
+impl PeerState {
+    fn with_mode(mode: usize) -> Self {
+        Self {
+            mode: Arc::new(AtomicUsize::new(mode)),
+            ..Default::default()
+        }
+    }
+    fn set_mode(&self, mode: usize) {
+        self.mode.store(mode, Ordering::Relaxed);
+    }
+    fn hits(&self) -> usize {
+        self.hit_count.load(Ordering::Relaxed)
+    }
+}
+
+async fn push_handler(
+    State(state): State<PeerState>,
+    axum::extract::Json(body): axum::extract::Json<serde_json::Value>,
+) -> (StatusCode, axum::Json<serde_json::Value>) {
+    state.hit_count.fetch_add(1, Ordering::Relaxed);
+    *state.last_body.lock().await = Some(body);
+    match state.mode.load(Ordering::Relaxed) {
+        MODE_FAIL => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({"error": "stub down"})),
+        ),
+        // A clean apply report with NO `ids` array — the shape every
+        // sync_push receiver returns, so `post_once` acks (lens-2 killer:
+        // a synthetic DLQ key can never mint a spurious `id_drift`).
+        _ => (
+            StatusCode::OK,
+            axum::Json(serde_json::json!({"applied": 1, "noop": 0, "skipped": 0})),
+        ),
+    }
+}
+
+async fn spawn_mock_peer(state: PeerState) -> String {
+    let app = Router::new()
+        .route("/api/v1/sync/push", post(push_handler))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    format!("http://{addr}")
+}
+
+/// On-disk sqlite `Db` migrated past v48 so `federation_push_dlq` exists.
+/// Scratch lives under `.local-runs/` per the project no-`/tmp` hard rule.
+fn fresh_dlq_db() -> (tempfile::TempDir, ai_memory::handlers::Db) {
+    let tmp = tempfile::Builder::new()
+        .prefix("v100-2667-lane-dlq-")
+        .tempdir_in(concat!(env!("CARGO_MANIFEST_DIR"), "/.local-runs"))
+        .expect("create local-runs tempdir");
+    let db_path = tmp.path().join("dlq.db");
+    let conn = ai_memory::storage::open(&db_path).expect("open sqlite");
+    let ttl = ai_memory::config::ResolvedTtl::default();
+    let handle = Arc::new(tokio::sync::Mutex::new((conn, db_path, ttl, true)));
+    (tmp, handle)
+}
+
+/// Build a config whose quorum W equals N so every configured peer is
+/// required — the fanout can never early-exit before the failing peer is
+/// observed.
+fn build_cfg(peer_url: &str, sink: Arc<dyn FederationDlqSink>) -> FederationConfig {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("build reqwest client");
+    FederationConfig {
+        policy: QuorumPolicy::new(2, 2, Duration::from_secs(2), Duration::from_secs(30)).unwrap(),
+        peers: vec![PeerEndpoint {
+            id: "peer-down".to_string(),
+            sync_push_url: format!("{peer_url}/api/v1/sync/push"),
+        }],
+        client,
+        sender_agent_id: "ai:lane-dlq-2667".to_string(),
+        api_key: None,
+        signing_key: None,
+        dlq_sink: Some(sink),
+    }
+}
+
+/// Stand up a single DOWN peer + a fresh sqlite DLQ sink + a W=N config.
+async fn down_peer() -> (
+    tempfile::TempDir,
+    PeerState,
+    Arc<dyn FederationDlqSink>,
+    FederationConfig,
+) {
+    let peer = PeerState::with_mode(MODE_FAIL);
+    let peer_url = spawn_mock_peer(peer.clone()).await;
+    let (tmp, db) = fresh_dlq_db();
+    let sink: Arc<dyn FederationDlqSink> = Arc::new(SqliteDlqSink::new(db).await.unwrap());
+    let cfg = build_cfg(&peer_url, sink.clone());
+    (tmp, peer, sink, cfg)
+}
+
+/// Assert exactly one pending DLQ row exists, keyed by the EXACT lane-prefixed
+/// `expected_key`, belonging to the down peer, carrying a non-empty failure
+/// reason. Returns the row so the caller can assert its subcollection payload.
+async fn assert_single_row(
+    sink: &Arc<dyn FederationDlqSink>,
+    expected_key: &str,
+) -> FederationPushDlqRow {
+    let pending = sink.take_pending_dlq_rows(64).await.expect("take pending");
+    assert_eq!(
+        pending.len(),
+        1,
+        "#2667: a failed fanout must land exactly ONE DLQ row keyed {expected_key}; got {:?}",
+        pending
+            .iter()
+            .map(|r| r.memory_id.clone())
+            .collect::<Vec<_>>()
+    );
+    let row = pending.into_iter().next().unwrap();
+    assert_eq!(
+        row.memory_id, expected_key,
+        "#2667: the DLQ key must be the lane-prefixed key (a bare-id or wrong-lane \
+         regression still lands one row and would pass a count-only test)"
+    );
+    assert_eq!(row.peer_id, "peer-down");
+    assert_eq!(row.attempt_count, 1);
+    assert!(
+        !row.last_error.is_empty(),
+        "last_error MUST capture the peer's failure reason"
+    );
+    row
+}
+
+// --- fixtures (mirrors of the `src/federation/mod.rs` unit-test samples) ---
+
+fn sample_memory() -> Memory {
+    let now = chrono::Utc::now().to_rfc3339();
+    Memory {
+        cid: None,
+        valid_from: None,
+        valid_until: None,
+        id: "fed-test".to_string(),
+        tier: Tier::Mid,
+        namespace: "app".to_string(),
+        title: "hello".to_string(),
+        content: "world for federation test".to_string(),
+        tags: vec!["t".to_string()],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({"agent_id":"ai:test"}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        lifecycle_state: LifecycleState::Open,
+    }
+}
+
+fn sample_link() -> MemoryLink {
+    MemoryLink {
+        source_id: "mem-a".to_string(),
+        target_id: "mem-b".to_string(),
+        relation: MemoryLinkRelation::RelatedTo,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        signature: None,
+        observed_by: None,
+        valid_from: None,
+        valid_until: None,
+        attest_level: None,
+        source_cid: None,
+        target_cid: None,
+    }
+}
+
+fn sample_pending() -> PendingAction {
+    PendingAction {
+        id: "pa-1".to_string(),
+        action_type: "delete".to_string(),
+        memory_id: Some("mem-x".to_string()),
+        namespace: "app".to_string(),
+        payload: serde_json::json!({}),
+        requested_by: "ai:test".to_string(),
+        requested_at: chrono::Utc::now().to_rfc3339(),
+        status: "pending".to_string(),
+        decided_by: None,
+        decided_at: None,
+        approvals: vec![],
+    }
+}
+
+fn sample_decision() -> PendingDecision {
+    PendingDecision {
+        id: "pa-1".to_string(),
+        approved: true,
+        decider: "ai:approver".to_string(),
+    }
+}
+
+fn sample_action_transition() -> ActionTransitionOp {
+    ActionTransitionOp {
+        action_id: "act-1".to_string(),
+        from_state: ActionState::Pending,
+        to_state: ActionState::Claimed,
+        claimed_by: Some("ai:worker".to_string()),
+        vector_clock: serde_json::json!({}),
+        updated_at: 0,
+        signature: Vec::new(),
+        signer_pubkey: Vec::new(),
+        nonce: Vec::new(),
+    }
+}
+
+fn sample_checkpoint() -> Checkpoint {
+    Checkpoint {
+        id: "cp-1".to_string(),
+        namespace: "_cp".to_string(),
+        title: "needs approval".to_string(),
+        condition_type: ConditionType::Approval,
+        condition: serde_json::json!({}),
+        state: CheckpointState::Pending,
+        created_by: "agent-creator".to_string(),
+        resolved_by: None,
+        resolution: None,
+        resolution_note: None,
+        signature: vec![],
+        resolver_pubkey: vec![],
+        created_at: 1_700_000_000,
+        deadline_at: None,
+        resolved_at: None,
+        metadata: serde_json::json!({}),
+    }
+}
+
+fn sample_signal() -> Signal {
+    Signal {
+        id: "sig-1".to_string(),
+        namespace: "app".to_string(),
+        from_agent: "ai:sender".to_string(),
+        to_agent: None,
+        subject: "s".to_string(),
+        body: serde_json::json!({}),
+        signal_type: SignalType::Notify,
+        in_reply_to: None,
+        correlation_id: None,
+        reference_ids: serde_json::json!([]),
+        created_at: 0,
+        expires_at: None,
+        delivered_at: None,
+        read_at: None,
+        acknowledged_at: None,
+        signature: vec![],
+        sender_pubkey: vec![],
+    }
+}
+
+fn sample_namespace_meta() -> NamespaceMetaEntry {
+    NamespaceMetaEntry {
+        namespace: "app/team".to_string(),
+        standard_id: "mem-std-1".to_string(),
+        parent_namespace: Some("app".to_string()),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+// --- per-lane "peer down -> exactly one prefixed DLQ row" tests ---
+
+#[tokio::test]
+async fn archive_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_archive_quorum(&cfg, "mem-arch").await.unwrap();
+    let row = assert_single_row(&sink, "archive:mem-arch").await;
+    assert_eq!(
+        row.payload_json["archives"],
+        serde_json::json!(["mem-arch"])
+    );
+}
+
+#[tokio::test]
+async fn restore_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_restore_quorum(&cfg, "mem-rest").await.unwrap();
+    let row = assert_single_row(&sink, "restore:mem-rest").await;
+    assert_eq!(
+        row.payload_json["restores"],
+        serde_json::json!(["mem-rest"])
+    );
+}
+
+#[tokio::test]
+async fn link_lane_lands_composite_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_link_quorum(&cfg, &sample_link()).await.unwrap();
+    // Composite key includes the relation so two links between the same pair
+    // with different relations do not collide (last-wins) in the DLQ.
+    let row = assert_single_row(&sink, "link:mem-a:mem-b:related_to").await;
+    assert_eq!(row.payload_json["links"][0]["source_id"], "mem-a");
+    assert_eq!(row.payload_json["links"][0]["target_id"], "mem-b");
+}
+
+#[tokio::test]
+async fn pending_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_pending_quorum(&cfg, &sample_pending())
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "pending:pa-1").await;
+    assert_eq!(row.payload_json["pendings"][0]["id"], "pa-1");
+}
+
+#[tokio::test]
+async fn pending_decision_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_pending_decision_quorum(&cfg, &sample_decision())
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "pending_decision:pa-1").await;
+    assert_eq!(row.payload_json["pending_decisions"][0]["id"], "pa-1");
+}
+
+#[tokio::test]
+async fn action_transition_lane_lands_per_transition_key_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_action_transition_quorum(&cfg, &sample_action_transition())
+        .await
+        .unwrap();
+    // Per-transition key (action_id:to_state:updated_at) — a last-wins
+    // action_id key would drop an intermediate CAS transition and strand a peer.
+    let row = assert_single_row(&sink, "action_transition:act-1:claimed:0").await;
+    assert_eq!(
+        row.payload_json["action_transitions"][0]["action_id"],
+        "act-1"
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_resolution_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_checkpoint_resolution_quorum(&cfg, &sample_checkpoint())
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "checkpoint:cp-1").await;
+    assert_eq!(row.payload_json["checkpoints"][0]["id"], "cp-1");
+}
+
+#[tokio::test]
+async fn signal_create_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_signal_create_quorum(&cfg, &sample_signal())
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "signal:sig-1").await;
+    assert_eq!(row.payload_json["signals"][0]["id"], "sig-1");
+}
+
+#[tokio::test]
+async fn namespace_meta_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_namespace_meta_quorum(&cfg, &sample_namespace_meta())
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "namespace_meta:app/team").await;
+    assert_eq!(
+        row.payload_json["namespace_meta"][0]["namespace"],
+        "app/team"
+    );
+}
+
+#[tokio::test]
+async fn namespace_meta_clear_lane_lands_prefixed_dlq_row_2667() {
+    let (_tmp, _peer, sink, cfg) = down_peer().await;
+    broadcast_namespace_meta_clear_quorum(&cfg, &["app/team".to_string(), "app/ops".to_string()])
+        .await
+        .unwrap();
+    let row = assert_single_row(&sink, "namespace_meta_clear:app/team,app/ops").await;
+    assert_eq!(
+        row.payload_json["namespace_meta_clears"],
+        serde_json::json!(["app/team", "app/ops"])
+    );
+}
+
+// --- replay re-drive (governance lane) ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn namespace_meta_lane_replays_and_clears_2667() {
+    let (_tmp, peer, sink, cfg) = down_peer().await;
+    broadcast_namespace_meta_quorum(&cfg, &sample_namespace_meta())
+        .await
+        .unwrap();
+    assert_eq!(sink.pending_dlq_count().await.unwrap(), 1);
+    let hits_before = peer.hits();
+
+    peer.set_mode(MODE_OK);
+    replay_once(&cfg, sink.as_ref()).await;
+
+    assert_eq!(
+        sink.pending_dlq_count().await.unwrap(),
+        0,
+        "the governance namespace_meta row must drain once the peer recovers"
+    );
+    assert_eq!(
+        peer.hits(),
+        hits_before + 1,
+        "replay re-POSTs the namespace_meta body once — the 200 has no `ids` echo, \
+         so it acks (never a spurious id_drift)"
+    );
+}
+
+// --- the load-bearing prefix proof: consolidate must NOT self-supersede ---
+
+#[tokio::test(flavor = "multi_thread")]
+async fn consolidate_prefixed_key_replays_and_never_supersedes_2667() {
+    let peer = PeerState::with_mode(MODE_FAIL);
+    let peer_url = spawn_mock_peer(peer.clone()).await;
+    let (_tmp, db) = fresh_dlq_db();
+
+    // Make the consolidated row LIVE with a FAR-FUTURE updated_at: under a bare
+    // `new_mem.id` key the replay restore-race guard would find it live-and-
+    // newer (`restore_supersedes(future, failed_at) == true`) and SUPERSEDE the
+    // replay. The `consolidate:` prefix makes the guard's lookup miss.
+    let mut new_mem = sample_memory();
+    new_mem.id = "cons-new".to_string();
+    new_mem.updated_at = "2099-01-01T00:00:00+00:00".to_string();
+    {
+        let guard = db.lock().await;
+        ai_memory::storage::insert(&guard.0, &new_mem).expect("seed live consolidated row");
+    }
+
+    let sink: Arc<dyn FederationDlqSink> = Arc::new(SqliteDlqSink::new(db.clone()).await.unwrap());
+    let cfg = build_cfg(&peer_url, sink.clone());
+
+    // Legacy-mode consolidate: non-empty `deletions[]` makes the payload
+    // delete-shaped, which is exactly what arms the replay restore-race guard.
+    broadcast_consolidate_quorum(&cfg, &new_mem, &["src-1".to_string()], &[], &[])
+        .await
+        .unwrap();
+
+    let row = assert_single_row(&sink, "consolidate:cons-new").await;
+    assert!(
+        row.payload_json["deletions"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()),
+        "legacy consolidate carries a non-empty deletions[] (arms the guard)"
+    );
+
+    let hits_before = peer.hits();
+    peer.set_mode(MODE_OK);
+    replay_once(&cfg, sink.as_ref()).await;
+
+    assert_eq!(
+        sink.pending_dlq_count().await.unwrap(),
+        0,
+        "the consolidation must DRAIN (not be superseded) once the peer is healthy"
+    );
+    assert_eq!(
+        peer.hits(),
+        hits_before + 1,
+        "#2667: replay MUST re-POST the consolidation — a bare-`new_mem.id` key \
+         regression would supersede it against the live row and never re-POST"
+    );
+}
+
+// --- postgres parity (both backends) ---
+
+/// The landing pass is TRAIT dispatch through `FederationDlqSink`, so it is
+/// backend-blind by construction. This drives a GOVERNANCE lane
+/// (`broadcast_namespace_meta_quorum`) through `PostgresDlqSink` and asserts the
+/// identical lane-prefixed row lands on the postgres sink. Ignored by default;
+/// run against a SCRATCH database with `AI_MEMORY_TEST_POSTGRES_URL` set:
+/// `cargo test --features sal-postgres --test federation_lane_dlq_2667 -- --ignored`.
+#[cfg(feature = "sal-postgres")]
+#[tokio::test]
+#[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL pointing at a live scratch instance"]
+async fn pg_namespace_meta_lane_dlq_parity_2667() {
+    use ai_memory::federation::push_dlq::PostgresDlqSink;
+    use ai_memory::store::postgres::PostgresStore;
+
+    let Ok(url) = std::env::var("AI_MEMORY_TEST_POSTGRES_URL") else {
+        eprintln!("test skipped: AI_MEMORY_TEST_POSTGRES_URL not set");
+        return;
+    };
+    let store = match PostgresStore::connect(&url).await {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            eprintln!("test skipped: PostgresStore::connect failed: {e}");
+            return;
+        }
+    };
+    let sink: Arc<dyn FederationDlqSink> = Arc::new(PostgresDlqSink::new(store));
+
+    let peer = PeerState::with_mode(MODE_FAIL);
+    let peer_url = spawn_mock_peer(peer).await;
+    let cfg = build_cfg(&peer_url, sink.clone());
+    // Unique namespace so re-runs against a shared DB cannot collide.
+    let ns = format!("pg-2667/{}", uuid::Uuid::new_v4());
+    let entry = NamespaceMetaEntry {
+        namespace: ns.clone(),
+        standard_id: "mem-std-pg".to_string(),
+        parent_namespace: None,
+        updated_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    broadcast_namespace_meta_quorum(&cfg, &entry).await.unwrap();
+
+    let expected_key = format!("namespace_meta:{ns}");
+    let pending = sink.take_pending_dlq_rows(256).await.expect("pg take");
+    let row = pending
+        .iter()
+        .find(|r| r.memory_id == expected_key)
+        .expect("#2667: the namespace_meta lane must land a DLQ row on the postgres sink too");
+    assert_eq!(row.peer_id, "peer-down");
+    assert!(!row.last_error.is_empty());
+    assert_eq!(row.payload_json["namespace_meta"][0]["namespace"], ns);
+
+    // Leave zero residue: clear the row we created.
+    assert!(
+        sink.mark_dlq_row_replayed(row.id, row.attempt_count)
+            .await
+            .expect("pg clear"),
+        "the parity row must clear cleanly"
+    );
+}


### PR DESCRIPTION
Progresses #2667 (cert-BLOCKER — federation silent divergence).

## The gap

Only `broadcast_store_quorum` (#933) and `broadcast_delete_quorum` (#2498) enqueued a `federation_push_dlq` row when a peer did not ack. The other **11** `broadcast_*_quorum` lanes — `archive`, `restore`, `link`, `consolidate`, `pending`, `pending_decision`, `action_transition`, `checkpoint_resolution`, `signal_create`, `namespace_meta`, `namespace_meta_clear` — emitted a lone `tracing::warn!` and dropped the failure. A peer that was down, deadline-evicted, or that refused an item inside an HTTP 200 (`skipped>0`, #2341) diverged **permanently and silently**, including governance (`namespace_meta`) and authority (`pending`/`pending_decision`/checkpoint/action-transition) state — none of which the anti-entropy catch-up loop (MEMORY rows only) reconciles.

## The fix

All 13 lanes now route non-ack failures through **one shared `land_push_failures` helper** so `replay_federation_push_dlq` re-drives them on peer recovery — default build **and** both backends (the pg serve path already wires `PostgresDlqSink`, `daemon_runtime.rs:5694/5724`).

**DLQ keys are lane-prefixed** (`archive:{id}`, `link:{src}:{tgt}:{rel}`, `namespace_meta:{ns}`, `action_transition:{action_id}:{to_state}:{updated_at}` per-transition, …):
- `:`-bearing prefixes can never collide with a bare memory UUID (store/delete rows) nor with each other on the `(memory_id, peer_id)` upsert key, so distinct pending ops on one subject never clobber each other.
- **load-bearing for `consolidate`**: its legacy-mode body carries `deletions[]`, so a bare `new_mem.id` key would trip the #2716 replay restore-race guard against the *live* consolidated row and supersede the whole consolidation (never replay). The prefix makes the guard's lookup miss.
- `action_transition` keys per-transition because the state machine is non-monotonic (CAS-guarded) — a last-wins `action_id` key would drop an intermediate transition and strand a peer.
- `store` + `delete` keep the **bare** memory-id key their guard and documented last-wins collision require.
- `replay`'s `expected_id` is inert for these subcollections (no `ids` echo), so a synthetic key is safe (confirmed against `post_once`).

## Decision — 5-agent adversarial vote (`4d3ea1c5`)

Data-integrity / replay-machinery / precedent / blast-radius / scope lenses. Verdicts: PREFIXED-EXCEPT-STORE-DELETE keying, shared helper across all 13 lanes, **Progresses** (not Closes).

## Scope + tracked follow-up

The DLQ landing is the *recoverable-not-lost* floor. Two items remain follow-up (why this is "Progresses", not "Closes"): `bulk_catchup_push` (not a quorum lane; its memory-row payload is already self-healed by the `/sync/since` catch-up loop) and a subcollection anti-entropy reconciler as the convergence backstop past the 100-attempt quarantine ceiling. Postgres receivers report several of these lanes `unsupported_on_postgres` (#2341) → those rows quarantine as `permanent` by design (honest count, not loss).

## Tests

`tests/federation_lane_dlq_2667.rs` — one exact-prefixed-key row assertion per lane (a wrong-lane / bare-id regression fails it), a governance `namespace_meta` replay re-drive (also proves no spurious `id_drift`), the `consolidate` no-self-supersede prefix proof (seeds a future-`updated_at` live row so a bare-key regression would supersede), and a `#[ignore]` pg parity test. 12 pass; both DLQ-refactored store/delete suites (`federation_dlq_replay`, `federation_delete_dlq_2498`, `federation_delete_dlq_default_build_2717`) stay green.

## Gates

`cargo check` (default + sal + sal-postgres + examples); clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` on default / sal / sal-postgres / vectorlite; `cargo fmt --all`; `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling`; hardcoded-literal + vendor-literal gates — all green.

## AI involvement

Authored by Claude Opus 5 (hard-coder) under the v1.0.0 GA loop. Keying + shared-helper + scope resolved by the 5-agent adversarial vote (`4d3ea1c5`); no external code adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY