### PR TITLE
infra(#2872): unify pgvector pin across both certified provisioning lanes to 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   apply to them. The classifier decision table is CI-provable via
   `pg-hostssl-healthcheck.sh --self-test` (no live PostgreSQL required). The
   Ed25519-CA channel-binding half of #2658 remains tracked as residual.
+- **The two certified provisioning SSOTs now pin the SAME pgvector patch
+  (0.8.5), and a cross-lane parity test keeps them from silently diverging**
+  ([#2872](https://github.com/alphaonedev/ai-memory-mcp/issues/2872)). The
+  container lane `deploy/docker-1461/provision/lib.sh` pinned pgvector 0.8.5
+  (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`) while the sibling NATIVE lane
+  `deploy/do-1461/provision/lib.sh` pinned 0.8.2
+  (`EXPECTED_PGVECTOR_VERSION=0.8.2`) — a bet-the-farm consistency defect
+  disclosed but not reconciled at v1.0.0. Investigation against the live pgdg
+  apt repo found the divergence was accidental drift, not a distro constraint:
+  `0.8.5` is published for BOTH lanes' distros (`0.8.5-1.pgdg24.04+1` for
+  Ubuntu 24.04 / noble, `0.8.5-1.pgdg13+1` for Debian 13 / trixie), AND the
+  do-1461 `0.8.2-1.pgdg24.04+1` pin was no longer resolvable at all (pgdg keeps
+  only a rolling window — 0.8.4/0.8.5/0.8.6 for postgresql-18 — so an apt
+  install of 0.8.2 would fail, the #2658 nonexistent-pin class). Fix: unify
+  do-1461 to `PGVECTOR_APT_VERSION=0.8.5-1.pgdg24.04+1` /
+  `EXPECTED_PGVECTOR_VERSION=0.8.5` (matching docker-1461 and the canonical
+  v1.0.0 GA stack), reconcile every dependent narrative literal across both
+  lanes' provisioning scripts / Dockerfiles / Terraform / README, replace the
+  release-notes "the two provisioning SSOTs do not agree" caveat with the
+  reconciled truth, and add `tests/provisioning_pgvector_pin_parity.rs` — a
+  mechanical cross-lane pin-parity gate (only the pgdg distro suffix may differ;
+  the upstream patch must match and equal the canonical 0.8.5) so a future
+  accidental re-divergence fails loud.
 
 ### Fixed (federation data-integrity — CERT-BLOCKING)
 

--- a/deploy/do-1461/README.md
+++ b/deploy/do-1461/README.md
@@ -14,7 +14,7 @@ verification harness proves it.
 
 The fleet is **12 nodes across 3 regions** (nyc3 US-East, fra1 EU-Central, sgp1
 Asia-SE). Each region is a self-contained substrate cluster: **one regional
-PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2 node + 3 ai-memory daemon
+PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5 node + 3 ai-memory daemon
 peers**. A region's peers key to their own `search_path` schema (`ic_peer_1..K`,
 within-region) on **their region's** pg node and dial it on **that region's
 private VPC IP under TLS verify-full**. The 9 peers federate into ONE cross-region
@@ -36,15 +36,15 @@ Hostnames encode each node's function: `do-1461-<function>-<region>-<NN>`.
 | `do-1461-peer-nyc3-01`| peer  | nyc3   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-nyc3-02`| peer  | nyc3   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-nyc3-03`| peer  | nyc3   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
-| `do-1461-pg-nyc3-01`  | pg    | nyc3   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2|
+| `do-1461-pg-nyc3-01`  | pg    | nyc3   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5|
 | `do-1461-peer-fra1-01`| peer  | fra1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-fra1-02`| peer  | fra1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-fra1-03`| peer  | fra1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
-| `do-1461-pg-fra1-01`  | pg    | fra1   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2|
+| `do-1461-pg-fra1-01`  | pg    | fra1   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5|
 | `do-1461-peer-sgp1-01`| peer  | sgp1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-sgp1-02`| peer  | sgp1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
 | `do-1461-peer-sgp1-03`| peer  | sgp1   | s-4vcpu-8gb   | federated `ai-memory serve` + CPU Ollama embedder sidecar  |
-| `do-1461-pg-sgp1-01`  | pg    | sgp1   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2|
+| `do-1461-pg-sgp1-01`  | pg    | sgp1   | s-4vcpu-8gb   | regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5|
 
 The **9 peers** (3 per region) form ONE cross-region federation mesh. ai-memory
 federation is **primarily EVENTUAL**: every HTTP write commits **locally**, then
@@ -196,7 +196,7 @@ SSH command line.
 - **Pinned artifacts** (`provision/lib.sh`): binary `sha256`, version `0.7.0`,
   schema `v57`, the pinned native Ollama release (`$OLLAMA_VERSION`), and the
   pinned pgdg apt `.deb`s — **PostgreSQL 18.4** (`$PG_APT_VERSION`), **Apache AGE
-  1.7.0** (`$AGE_APT_VERSION`), **pgvector 0.8.2** (`$PGVECTOR_APT_VERSION`),
+  1.7.0** (`$AGE_APT_VERSION`), **pgvector 0.8.5** (`$PGVECTOR_APT_VERSION`),
   installed NATIVELY (no Docker anywhere on the fleet) — plus embedder/LLM model
   ids, the synchronous write quorum (auto `W=$FED_SYNC_QUORUM_W` clamped to the
   node count, or `$QUORUM_WRITES`), and the zero-touch credential TTL
@@ -242,7 +242,7 @@ runs on every peer. These controls are asserted LIVE over the wire by the
 Checks: binary `sha256` + `--version` (every node); `/api/v1/health`,
 `storage_backend == postgres`, `db_schema_version == 57`, single-instance, and
 systemd-active (every peer); **pg-node upstream-stack assertions** (the live
-server reports PostgreSQL `18.4`, Apache AGE `1.7.0`, pgvector `0.8.2`; the AGE
+server reports PostgreSQL `18.4`, Apache AGE `1.7.0`, pgvector `0.8.5`; the AGE
 graph is present; and every daemon→PG backend is TLS — `>=1 ssl, 0 plaintext`);
 and a fleet **federation-convergence** probe that writes a collective-scope
 marker to one peer and reads it back by id on another over the encrypted path.

--- a/deploy/do-1461/provision/20_pg_age.sh
+++ b/deploy/do-1461/provision/20_pg_age.sh
@@ -2,7 +2,7 @@
 # Copyright 2026 AlphaOne LLC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Stand up the per-REGION PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2
+# Stand up the per-REGION PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5
 # substrate droplets (role=pg, ONE per region) — NATIVE, no Docker (operator
 # decision: zero Docker anywhere on the DO fleet). Within each region every peer
 # keys to its own search_path schema (ic_peer_<K>) on THAT region's pg node and
@@ -14,7 +14,7 @@
 #
 # Install vector (verified against the live pgdg noble repo — see lib.sh):
 #   * postgresql-18          18.4   exact pgdg .deb
-#   * postgresql-18-pgvector 0.8.2  exact pgdg .deb
+#   * postgresql-18-pgvector 0.8.5  exact pgdg .deb
 #   * postgresql-18-age      age.control default_version='1.7.0' (extversion
 #     1.7.0) — same commit as the apache/age:release_PG18_1.7.0 image; the
 #     pgdg "~rc0" is only a Debian revision label. No source build.
@@ -284,7 +284,7 @@ EOS
   scp_to "$ROLE_SQL"   "$pg_pub" "$PG_STAGE_DIR/role.sql"
   ssh_node "$pg_pub" "chmod 0600 $PG_STAGE_DIR/role.sql"
 
-  log "[$pg_host] running native PG18.4 + AGE1.7.0 + pgvector0.8.2 install (this builds nothing — pinned .debs)"
+  log "[$pg_host] running native PG18.4 + AGE1.7.0 + pgvector0.8.5 install (this builds nothing — pinned .debs)"
   ssh_node "$pg_pub" "bash $PG_STAGE_DIR/pg-install.sh"
 
   log "[$pg_host] waiting for postgres ready"

--- a/deploy/do-1461/provision/lib.sh
+++ b/deploy/do-1461/provision/lib.sh
@@ -188,13 +188,13 @@ BATMAN_CURATOR_MAX_OPS="${BATMAN_CURATOR_MAX_OPS:-100}"
 CURATOR_HEALTH_MAX_RESTARTS="${CURATOR_HEALTH_MAX_RESTARTS:-3}"
 
 # ---------------------------------------------------------------------------
-# Pinned PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2 substrate — NATIVE
+# Pinned PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5 substrate — NATIVE
 # (NO Docker anywhere on the DO fleet, per operator decision). Installed from
 # the official PostgreSQL apt repository (pgdg) on the droplet's own distro.
 # Assessment (verified against the live pgdg noble repo): apt is a complete,
 # pinned install vector for all three —
 #   * postgresql-18         18.4   (exact)
-#   * postgresql-18-pgvector 0.8.2 (exact)
+#   * postgresql-18-pgvector 0.8.5 (exact)
 #   * postgresql-18-age      ships age.control default_version='1.7.0' and
 #     age--1.7.0.sql, built from the SAME commit (806fa2eb) as the
 #     apache/age:release_PG18_1.7.0 image docker-1461 used — the pgdg "~rc0"
@@ -204,13 +204,24 @@ CURATOR_HEALTH_MAX_RESTARTS="${CURATOR_HEALTH_MAX_RESTARTS:-3}"
 PG_MAJOR="${PG_MAJOR:-18}"                                          # server major (apt pkg suffix)
 PGDG_CODENAME="${PGDG_CODENAME:-noble}"                            # droplet distro codename (Ubuntu 24.04)
 PG_APT_VERSION="${PG_APT_VERSION:-18.4-1.pgdg24.04+1}"             # pinned exact pgdg server .deb
-PGVECTOR_APT_VERSION="${PGVECTOR_APT_VERSION:-0.8.2-1.pgdg24.04+1}" # pinned pgvector 0.8.2
+# pgvector patch is UNIFIED with the docker-1461 lane (#2872): both certified
+# provisioning SSOTs pin pgvector 0.8.5 — the canonical v1.0.0 GA stack
+# (docs/v1.0.0/release-notes.md). Only the pgdg distro suffix differs by lane
+# (this NATIVE lane is Ubuntu 24.04 = noble = pgdg24.04; the docker-1461
+# container lane is Debian 13 = pgdg13). Both `0.8.5-1.pgdg24.04+1` (noble) and
+# `0.8.5-1.pgdg13+1` (trixie) exist in the live pgdg apt repo, so the patch is
+# genuinely common across the two distros. The prior 0.8.2 pin here was
+# accidental drift AND no longer resolvable: pgdg keeps only a rolling window
+# (0.8.4/0.8.5/0.8.6 for postgresql-18) so `0.8.2-1.pgdg24.04+1` is absent from
+# noble-pgdg — an apt install of it would fail (the #2658 nonexistent-pin class).
+# Cross-lane parity is asserted by tests/provisioning_pgvector_pin_parity.rs.
+PGVECTOR_APT_VERSION="${PGVECTOR_APT_VERSION:-0.8.5-1.pgdg24.04+1}" # pinned pgvector 0.8.5
 AGE_APT_VERSION="${AGE_APT_VERSION:-1.7.0~rc0-1.pgdg24.04+1}"      # AGE 1.7.0 (extversion 1.7.0)
 # Reproducibility assertion anchors — the validate harness asserts these exact
 # upstream-reported versions (directive: results must reflect 18.4 + AGE 1.7.0).
 EXPECTED_PG_VERSION="${EXPECTED_PG_VERSION:-18.4}"
 EXPECTED_AGE_VERSION="${EXPECTED_AGE_VERSION:-1.7.0}"
-EXPECTED_PGVECTOR_VERSION="${EXPECTED_PGVECTOR_VERSION:-0.8.2}"
+EXPECTED_PGVECTOR_VERSION="${EXPECTED_PGVECTOR_VERSION:-0.8.5}"
 
 # Native cluster identity (Debian/Ubuntu postgresql-common layout). Applied
 # identically on EACH region's pg droplet; the daemon-owned TLS material is

--- a/deploy/do-1461/provision/pg-age/Dockerfile
+++ b/deploy/do-1461/provision/pg-age/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2026 AlphaOne LLC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Reproducible PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2 image for the
+# Reproducible PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5 image for the
 # do-1461 SHARED substrate (one pg droplet; every peer keyed to its own
 # search_path schema ic_peer_<N>). Mirrors deploy/docker-1461/Dockerfile.pg-age-vector
 # EXACTLY so the DO fleet and the local Docker mesh assert the SAME upstream

--- a/deploy/do-1461/terraform/variables.tf
+++ b/deploy/do-1461/terraform/variables.tf
@@ -65,7 +65,7 @@ variable "pg_port" {
 # do-1461 GRAND SLAM topology (15 nodes) — the Secure Enterprise Federated
 # Reference Architecture: a 3-region AI Agent Hive. Each region is a
 # self-contained substrate cluster of 1 regional PostgreSQL 18.4 + Apache
-# AGE 1.7.0 + pgvector 0.8.2 node, 3 ai-memory daemon peers, and 1 agent (an
+# AGE 1.7.0 + pgvector 0.8.5 node, 3 ai-memory daemon peers, and 1 agent (an
 # NHI client driver). A region's peers reach THEIR regional pg over that
 # region's private VPC under sslmode=verify-full (daemon->PG leg); the 9 peers
 # federate into ONE mesh across all three regions over public IPs secured by
@@ -74,7 +74,7 @@ variable "pg_port" {
 #
 #   per region (x3: nyc3 US-East, fra1 EU-Central, sgp1 Asia-SE):
 #     - 3 peers (ai-memory daemon, sal,sal-postgres) -> federation mesh members
-#     - 1 pg    (regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.2)
+#     - 1 pg    (regional PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5)
 #     - 1 agent (NHI client: xAI grok-4.3 driver; pure mTLS client, NOT a mesh
 #                member) -> exercises the a2a + ai_nhi full-spectrum groups
 #   => 9 peers + 3 regional pg + 3 agents = 15 nodes. Federation is EVENTUAL

--- a/deploy/do-1461/validate/run.sh
+++ b/deploy/do-1461/validate/run.sh
@@ -140,7 +140,7 @@ inv_all | while IFS="$(printf '\t')" read -r host role region pub priv; do
                      || record "$host" "single_instance" 1 "${nproc:-0}" FAIL
 done
 
-# ---- pg nodes: pinned upstream stack (PG 18.4 + AGE 1.7.0 + pgvector 0.8.2) --
+# ---- pg nodes: pinned upstream stack (PG 18.4 + AGE 1.7.0 + pgvector 0.8.5) --
 # ONE regional PG droplet per region runs the pinned NATIVE stack (no container
 # anywhere on the DO fleet). Every published result must be peer-verifiable
 # against the EXACT upstream stack, so assert the LIVE server reports those

--- a/deploy/docker-1461/bench/embed_bench.py
+++ b/deploy/docker-1461/bench/embed_bench.py
@@ -43,7 +43,7 @@ CORPUS = [
     "The federation quorum uses W=2-of-3 mTLS with /sync/* bypassing the api_key "
     "under client-cert auth, so peer health gates and quorum POSTs succeed without "
     "presenting the daemon HTTP api_key.",
-    "pgvector 0.8.2 HNSW index over the 768-dim nomic-embed-text vectors stored in "
+    "pgvector 0.8.5 HNSW index over the 768-dim nomic-embed-text vectors stored in "
     "PostgreSQL 18.4; the daemon connects over TLS verify-full and the ANN search "
     "honors hnsw.ef_search at query time.",
     "Reflection: across the do-1461 provisioning run the role.sql application site "

--- a/deploy/docker-1461/bench/store_bench.py
+++ b/deploy/docker-1461/bench/store_bench.py
@@ -50,7 +50,7 @@ CORPUS = [
      "api_key under client-cert auth, so peer health gates and quorum POSTs "
      "succeed without presenting the daemon HTTP api_key."),
     ("pgvector hnsw",
-     "pgvector 0.8.2 HNSW index over the 768-dim nomic-embed-text vectors "
+     "pgvector 0.8.5 HNSW index over the 768-dim nomic-embed-text vectors "
      "stored in PostgreSQL 18.4; the daemon connects over TLS verify-full and "
      "the ANN search honors hnsw.ef_search at query time."),
     ("provisioning reflection",

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -235,14 +235,21 @@ runs (the vendored `paste` fork rev went unreachable,
 1.7.0 / 0.8.5 as **additionally validated**, not continuously certified;
 the continuously-tested combination is PG 16 / AGE 1.6.0.
 
-> **A separate SSOT-internal pin drift, disclosed rather than papered
-> over:** `deploy/docker-1461/provision/lib.sh` pins pgvector **0.8.5**
-> while the sibling `deploy/do-1461/provision/lib.sh` pins pgvector
-> **0.8.2** (`EXPECTED_PGVECTOR_VERSION=0.8.2`). The two provisioning
-> SSOTs do not agree on the pgvector patch, and the CI-vs-SSOT AGE drift
-> (CI 1.6.0 vs SSOT 1.7.0) is
-> [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
-> 2. Both are tracked, not silently reconciled in prose.
+> **Cross-lane pgvector pin — reconciled ([#2872](https://github.com/alphaonedev/ai-memory-mcp/issues/2872)).**
+> Both certified provisioning SSOTs now pin pgvector **0.8.5**:
+> `deploy/docker-1461/provision/lib.sh` (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
+> the container lane on Debian 13) and `deploy/do-1461/provision/lib.sh`
+> (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg24.04+1`,
+> `EXPECTED_PGVECTOR_VERSION=0.8.5`, the NATIVE lane on Ubuntu 24.04). Only
+> the pgdg distro suffix differs by lane (`pgdg13` vs `pgdg24.04`); the
+> patch version is identical and both distro builds exist in the live pgdg
+> apt repo. The earlier `do-1461` pin of `0.8.2` was accidental drift and
+> was additionally no longer resolvable (pgdg keeps only a rolling window,
+> so `0.8.2-1.pgdg24.04+1` is absent from noble-pgdg). Cross-lane parity is
+> now asserted mechanically by `tests/provisioning_pgvector_pin_parity.rs`,
+> so a future accidental divergence fails loudly. The remaining CI-vs-SSOT
+> AGE drift (CI 1.6.0 vs SSOT 1.7.0) is separate and still tracked as
+> [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect 2.
 
 ### What those AGE greens attest — read this before relying on them
 

--- a/tests/provisioning_pgvector_pin_parity.rs
+++ b/tests/provisioning_pgvector_pin_parity.rs
@@ -1,0 +1,130 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-lane pgvector pin parity (#2872) — mechanical pin.
+//!
+//! The two certified provisioning SSOTs — the docker-1461 container lane
+//! (`deploy/docker-1461/provision/lib.sh`, Debian 13 / `pgdg13`) and the
+//! do-1461 NATIVE lane (`deploy/do-1461/provision/lib.sh`, Ubuntu 24.04 /
+//! `pgdg24.04`) — MUST agree on the pgvector PATCH they pin. They deliberately
+//! differ only in the pgdg distro suffix baked into the apt version string,
+//! because they provision on different distros; the `x.y.z` patch itself is a
+//! fleet-wide contract (the canonical v1.0.0 GA stack, pinned to pgvector
+//! 0.8.5 in `docs/v1.0.0/release-notes.md`).
+//!
+//! Before #2872 the two lanes silently disagreed (docker-1461 pinned 0.8.5
+//! while do-1461 pinned 0.8.2) — a bet-the-farm consistency defect, and the
+//! do-1461 pin was additionally no longer resolvable in the live pgdg repo
+//! (the #2658 nonexistent-pin class). This test fails LOUD on any future
+//! accidental re-divergence, so the reconciliation cannot silently rot.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_lib_sh(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read provisioning SSOT {}: {e}", path.display()))
+}
+
+/// Extract the default from the first live `${var:-<default>}` shell
+/// parameter-expansion whose inner variable is `var`.
+///
+/// Keyed on the INNER `${var:-` token, not the LHS assignment name, because a
+/// lane may assign through an override indirection whose LHS differs from the
+/// inner default var (docker-1461:
+/// `PGVECTOR_APT_VERSION="${DOCKER_1461_PGVECTOR_APT_VERSION:-…}"`). Comment
+/// lines are skipped so a `#`-prefixed narrative mention never shadows the
+/// live pin.
+fn shell_default(source: &str, var: &str) -> String {
+    let needle = format!("${{{var}:-");
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = trimmed.split_once(&needle).map(|(_, r)| r) {
+            let value = rest.split_once('}').map_or(rest, |(v, _)| v);
+            return value.to_string();
+        }
+    }
+    panic!("no live `{var}` default expansion found in provisioning SSOT");
+}
+
+/// Reduce a pgdg apt version string (`0.8.5-1.pgdg24.04+1`) to its bare
+/// upstream patch (`0.8.5`). A bare patch (`0.8.5`) is returned unchanged.
+fn upstream_patch(apt_version: &str) -> String {
+    apt_version
+        .split_once('-')
+        .map_or(apt_version, |(patch, _)| patch)
+        .to_string()
+}
+
+/// The canonical v1.0.0 GA pgvector patch both lanes must pin.
+const EXPECTED_PGVECTOR_PATCH: &str = "0.8.5";
+
+const DOCKER_LANE: &str = "deploy/docker-1461/provision/lib.sh";
+const DO_LANE: &str = "deploy/do-1461/provision/lib.sh";
+
+#[test]
+fn docker_and_do_lanes_pin_the_same_pgvector_patch_2872() {
+    let docker = read_lib_sh(DOCKER_LANE);
+    let dolane = read_lib_sh(DO_LANE);
+
+    let docker_patch = upstream_patch(&shell_default(&docker, "DOCKER_1461_PGVECTOR_APT_VERSION"));
+    let do_patch = upstream_patch(&shell_default(&dolane, "PGVECTOR_APT_VERSION"));
+
+    assert_eq!(
+        docker_patch, do_patch,
+        "cross-lane pgvector patch drift (#2872): docker-1461 pins {docker_patch}, \
+         do-1461 pins {do_patch} — both certified SSOTs must pin the same patch"
+    );
+    assert_eq!(
+        docker_patch, EXPECTED_PGVECTOR_PATCH,
+        "docker-1461 pgvector patch {docker_patch} != canonical v1.0.0 stack \
+         {EXPECTED_PGVECTOR_PATCH}"
+    );
+}
+
+#[test]
+fn do_lane_expected_matches_its_apt_pin_2872() {
+    let dolane = read_lib_sh(DO_LANE);
+    let apt_patch = upstream_patch(&shell_default(&dolane, "PGVECTOR_APT_VERSION"));
+    let expected = shell_default(&dolane, "EXPECTED_PGVECTOR_VERSION");
+
+    assert_eq!(
+        apt_patch, expected,
+        "do-1461 self-consistency (#2872): the validate harness asserts the \
+         installed pgvector equals EXPECTED_PGVECTOR_VERSION ({expected}), but \
+         the apt pin installs {apt_patch}"
+    );
+    assert_eq!(
+        expected, EXPECTED_PGVECTOR_PATCH,
+        "do-1461 EXPECTED_PGVECTOR_VERSION {expected} != canonical v1.0.0 stack \
+         {EXPECTED_PGVECTOR_PATCH}"
+    );
+}
+
+#[test]
+fn each_lane_carries_its_own_pgdg_distro_suffix_2872() {
+    // The lanes MUST keep distinct distro suffixes (they provision different
+    // distros); unifying the suffix would be a false unification that breaks
+    // one lane's apt resolution.
+    let docker = shell_default(
+        &read_lib_sh(DOCKER_LANE),
+        "DOCKER_1461_PGVECTOR_APT_VERSION",
+    );
+    let dolane = shell_default(&read_lib_sh(DO_LANE), "PGVECTOR_APT_VERSION");
+
+    assert!(
+        docker.contains("pgdg13"),
+        "docker-1461 (Debian 13) pgvector pin should carry the pgdg13 suffix: {docker}"
+    );
+    assert!(
+        dolane.contains("pgdg24.04"),
+        "do-1461 (Ubuntu 24.04) pgvector pin should carry the pgdg24.04 suffix: {dolane}"
+    );
+}


### PR DESCRIPTION
Closes #2872

## Problem

The two certified provisioning SSOTs disagreed on the pgvector patch — a bet-the-farm consistency defect disclosed (honestly) in `docs/v1.0.0/release-notes.md` but never reconciled:

- `deploy/docker-1461/provision/lib.sh` (container lane, Debian 13) pinned **0.8.5** (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`)
- `deploy/do-1461/provision/lib.sh` (NATIVE lane, Ubuntu 24.04) pinned **0.8.2** (`PGVECTOR_APT_VERSION=0.8.2-1.pgdg24.04+1`, `EXPECTED_PGVECTOR_VERSION=0.8.2`)

## Investigation finding — accidental drift, NOT a distro constraint

Verified against the **live pgdg apt repo** (`apt.postgresql.org`) for both distros:

| distro | `postgresql-18-pgvector` versions available |
|---|---|
| noble (Ubuntu 24.04) | `0.8.6-1.pgdg24.04+1`, **`0.8.5-1.pgdg24.04+1`**, `0.8.4-1.pgdg24.04+1` |
| trixie (Debian 13) | `0.8.6-1.pgdg13+1`, **`0.8.5-1.pgdg13+1`**, `0.8.4-1.pgdg13+1` |

Two decisive facts:

1. **`0.8.5-1.pgdg24.04+1` exists** for noble — so do-1461 CAN pin 0.8.5. The divergence was accidental drift (do-1461 was never bumped when the canonical stack / docker-1461 moved to 0.8.5), **not** a genuine pgdg/distro constraint. → unify to 0.8.5, don't document a false divergence.
2. **`0.8.2-1.pgdg24.04+1` is ABSENT** from the current noble-pgdg repo (pgdg keeps only a rolling window: 0.8.4/0.8.5/0.8.6). So do-1461's existing pin was **already unresolvable** — an `apt install postgresql-18-pgvector=0.8.2-1.pgdg24.04+1` would fail: the #2658 cloud-init-silent-failure / nonexistent-pin class, not merely cosmetic drift.

0.8.5 (not 0.8.6) is the reconciliation target because it is the canonical certified v1.0.0 GA stack (`docs/v1.0.0/release-notes.md`) and what docker-1461 already pins; jumping to 0.8.6 would create NEW drift.

## What changed

- **`deploy/do-1461/provision/lib.sh`** — `PGVECTOR_APT_VERSION` → `0.8.5-1.pgdg24.04+1`, `EXPECTED_PGVECTOR_VERSION` → `0.8.5`, plus an inline rationale comment (why the lanes share the patch but differ in pgdg suffix; why the old 0.8.2 was drift + unresolvable).
- Every dependent narrative literal across both lanes reconciled: `deploy/do-1461/{provision/20_pg_age.sh, provision/pg-age/Dockerfile, terraform/variables.tf, validate/run.sh, README.md}` and the stale docker-1461 bench prose (`bench/{embed_bench,store_bench}.py`, which said 0.8.2 while that lane pins 0.8.5).
- **`docs/v1.0.0/release-notes.md`** — replaced the "the two provisioning SSOTs do not agree" caveat with the reconciled truth (both lanes pin 0.8.5; only the pgdg distro suffix differs; cross-checked by the new test). The separate AGE CI-vs-SSOT drift (#2512 defect 2) is preserved.
- **`tests/provisioning_pgvector_pin_parity.rs`** (new) — mechanical cross-lane pin-parity gate: the two lanes' upstream patch must match and equal the canonical 0.8.5, do-1461's `EXPECTED_` must match its own apt pin, and each lane keeps its own distinct pgdg distro suffix. Fails loud on future accidental re-divergence.
- **`CHANGELOG.md`** `[Unreleased]` entry under the existing certified-provisioning section.

Out of scope and correctly left untouched: the separate CI-tested `infra/lan-parity-test/` PG16 + AGE 1.6.0 + pgvector 0.8.2 matrix (a legitimately-distinct, factual tested combination) and the frozen `docs/v0.7.0/**` campaign artifacts.

## Local gate results

- `cargo test --test provisioning_pgvector_pin_parity` — **3 passed** (0 failed)
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` — **clean** (exit 0)
- `cargo fmt --check` (new test) — OK
- `scripts/check-docs-vs-ssot.sh` — PASS
- `scripts/check-cloud-init-ascii.sh` — OK
- `scripts/check-doc-symbol-anchors.sh` — PASS

## AI involvement

Implemented by Claude Opus 5 (autonomous v1.0.0 certification loop). Investigation cross-checked the pgvector version availability against the live pgdg apt `Packages` indices for both `noble-pgdg` and `trixie-pgdg`. Not a 5-agent-vote crossroads: reconciling a version pin with one correct value (0.8.5, published for both distros) is single-correct-answer, mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY