### PR TITLE
fix(#2874): bulk-create error-mode is atomically fail-closed (no probe-then-upsert lost-update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `version` dispositions are unchanged (they keep the upsert / rename).
   Regression: `tests/create_conflict_2771.rs` (single-connection deterministic +
   a genuine two-connection sqlite race + a live-pg two-task race).
+- **The BULK create surface (`POST /api/v1/memories/bulk`) now closes the SAME
+  probe-then-upsert lost-update under the default `on_conflict=error`, on BOTH
+  backends** ([#2874](https://github.com/alphaonedev/ai-memory-mcp/issues/2874);
+  5-agent adversarial vote `4d3ea1c5`, 3-2 for reusing the certified per-row
+  no-overwrite primitive — option B, minimal new surface). Pre-fix the bulk
+  `error` rows were snapshot-probed (`#2725` pre-existing-collision reject) then
+  WRITTEN via an upsert (sqlite `db::insert` / postgres `store_batch`'s
+  `ON CONFLICT DO UPDATE`), so a row racing into the same `(title, namespace)`
+  BETWEEN the probe and the write was silently upsert-overwritten under `error`
+  mode — the identical North-Star lost-update `#2771` closed on single-create,
+  reachable on the pooled-parallel postgres and multi-process sqlite surfaces.
+  Now each `error`-mode bulk row is ATOMICALLY fail-closed: sqlite routes the
+  FIRST occurrence of a key through the certified `db::insert_no_overwrite`
+  (`INSERT … ON CONFLICT DO NOTHING` → typed `ConflictError`), and postgres
+  routes `error` rows per-row through the certified
+  `MemoryStore::store_with_embedding_no_overwrite` (`#2771`); a race-detected
+  collision is surfaced as the SAME typed `409 CONFLICT` (with `existing_id`)
+  the pre-existing probe raises, NEVER an overwrite. `merge`/`version` keep the
+  upsert, and the `#2725` in-batch last-wins dedup is preserved (a later
+  same-key sibling that already landed this batch keeps the upsert, never a
+  self-conflict). No new SAL surface — the fix reuses the just-certified
+  single-create no-overwrite methods (`src/handlers/bulk.rs`). Regression:
+  `tests/bulk_create_conflict_2874.rs` (two-connection sqlite race + `merge`
+  control + in-batch-dedup guard + a live-pg two-task handler race, all keyed on
+  the schema-v45 `version` column so an upsert-overwrite is a hard failure).
 ### Fixed (published-claims TRUTHFULNESS — CERT-BLOCKING)
 
 - **`docs/zero-touch-trust.html` no longer ships the retired

--- a/src/handlers/bulk.rs
+++ b/src/handlers/bulk.rs
@@ -996,6 +996,14 @@ async fn bulk_create_sqlite(
 
     let mut outcomes: Vec<(usize, String, String)> = Vec::new();
     let mut committed: Vec<(Memory, Option<Vec<f32>>)> = Vec::new();
+    // #2874 — keys that have DURABLY LANDED earlier in THIS batch. Drives the
+    // fail-closed write routing below: the FIRST occurrence of an `error`-mode
+    // key writes through `db::insert_no_overwrite` (fail-closed against a row
+    // that raced past the Stage-2 pre-existing probe), while a later in-batch
+    // SIBLING whose key already landed here keeps the legacy upsert so the
+    // #2725 last-wins in-batch dedup is preserved (never a self-conflict).
+    let mut landed_this_batch: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
     {
         let lock = app.db.lock().await;
         // #2725 (CB-23) — snapshot each `error`-mode row's PRE-EXISTING
@@ -1177,8 +1185,28 @@ async fn bulk_create_sqlite(
                 continue;
             }
 
-            match db::insert(&lock.0, &row.mem) {
+            // #2874 — under the default `on_conflict=error` disposition the
+            // write must be ATOMICALLY fail-closed so a row racing into
+            // `(title, namespace)` BETWEEN the Stage-2 pre-existing probe and
+            // this write can no longer be silently upsert-overwritten (the
+            // North-Star lost-update the single-create #2771 fix already closed
+            // on the create funnel). The FIRST occurrence of a key routes
+            // through `db::insert_no_overwrite` (`INSERT … ON CONFLICT DO
+            // NOTHING` → typed `ConflictError`); an in-batch SIBLING whose key
+            // already LANDED in this batch keeps the legacy upsert so the #2725
+            // last-wins in-batch dedup is preserved (NOT turned into a
+            // self-conflict). `merge`/`version` always keep the upsert.
+            let key = (row.mem.title.clone(), row.mem.namespace.clone());
+            let fail_closed =
+                row.on_conflict == OnConflictMode::Error && !landed_this_batch.contains(&key);
+            let insert_result = if fail_closed {
+                db::insert_no_overwrite(&lock.0, &row.mem)
+            } else {
+                db::insert(&lock.0, &row.mem)
+            };
+            match insert_result {
                 Ok(returned_id) => {
+                    landed_this_batch.insert(key);
                     // Issue #219 parity — persist the vector so semantic recall
                     // can find this row immediately (#2594).
                     if let (Some(vec), Some(space)) = (row.embedding.as_ref(), &embedding_space)
@@ -1205,7 +1233,10 @@ async fn bulk_create_sqlite(
                     committed.push((row.mem, row.embedding));
                 }
                 Err(e) => {
-                    // #1788 — refund the quota charge since the insert failed.
+                    // #1788 — refund the quota charge since the insert failed
+                    // (a fail-closed conflict never landed a row, so the
+                    // per-row charge above must be returned, exactly as any
+                    // other write failure).
                     if !caller.is_empty()
                         && let Err(re) = crate::quotas::refund_op(
                             &lock.0,
@@ -1218,7 +1249,17 @@ async fn bulk_create_sqlite(
                     {
                         crate::quotas::log_refund_op_failed(caller, &re);
                     }
-                    ledger.reject(row.index, "store", &e.to_string());
+                    // #2874 — the fail-closed `db::insert_no_overwrite` refused
+                    // a `(title, namespace)` collision that raced past Stage-2's
+                    // probe. Surface it as the SAME typed 409-class conflict
+                    // (carrying `existing_id`) the pre-existing-collision arm
+                    // emits — NEVER a silent overwrite, and distinct from a
+                    // generic store error. Mirrors single-create #2771.
+                    if let Some(conflict) = e.downcast_ref::<crate::storage::ConflictError>() {
+                        ledger.reject_conflict(row.index, &conflict.existing_id);
+                    } else {
+                        ledger.reject(row.index, "store", &e.to_string());
+                    }
                 }
             }
         }
@@ -1448,35 +1489,100 @@ async fn bulk_create_postgres(
 
     let mut outcomes: Vec<(usize, String, String)> = Vec::new();
     // #2724 (F3) — the memories that durably committed, each carrying the
-    // PERSISTED id `store_batch` returned, so the post-commit stages below
+    // PERSISTED id the write returned, so the post-commit stages below
     // (audit / dispatch / federation fanout) key on the same id every other
-    // consumer keys on. Populated only on the atomic-success arm.
+    // consumer keys on.
     let mut committed_mems: Vec<Memory> = Vec::new();
-    if !allowed.is_empty() {
-        let memories: Vec<Memory> = allowed.iter().map(|r| r.mem.clone()).collect();
+
+    // #2874 — partition the surviving rows by conflict disposition. Under the
+    // default `on_conflict=error` the write MUST be ATOMICALLY fail-closed so a
+    // row racing into `(title, namespace)` BETWEEN the Stage-2 probe and the
+    // write can no longer be silently upsert-overwritten by `store_batch`'s
+    // `ON CONFLICT DO UPDATE` arm — the North-Star lost-update the single-create
+    // #2771 fix already closed on the create funnel. `error` rows route per-row
+    // through the certified `store_with_embedding_no_overwrite` twin (#2771);
+    // `merge`/`version` keep the batched upsert (task-mandated). The per-row
+    // `error` lane trades `store_batch`'s single round-trip for reuse of the
+    // just-certified no-overwrite primitive — 5-agent vote `4d3ea1c5`, option B
+    // (a batched `store_batch_no_overwrite` is the tracked throughput
+    // optimisation if error-mode bulk volume is measured to warrant it). Only a
+    // batch that mixes `error` with `merge`/`version` on the SAME key (a
+    // self-contradictory request no sane loader sends) splits atomicity across
+    // the two lanes; the reconciling envelope invariant holds either way.
+    let space = embedding_space.as_deref();
+    let (error_rows, batch_rows): (Vec<PreparedRow>, Vec<PreparedRow>) = allowed
+        .into_iter()
+        .partition(|r| r.on_conflict == OnConflictMode::Error);
+
+    // --- error lane: per-row fail-closed, IN INPUT ORDER. `partition`
+    // preserves relative order within the lane, so the FIRST occurrence of a
+    // key writes through the no-overwrite twin (a raced / pre-existing
+    // collision => typed `StoreError::Conflict` => `reject_conflict`, NEVER an
+    // overwrite) while a later in-batch SIBLING whose key already landed here
+    // keeps the upsert so its content wins LAST exactly as #2725 pins — never a
+    // self-conflict.
+    let mut landed: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::with_capacity(error_rows.len());
+    for row in error_rows {
+        let key = (row.mem.title.clone(), row.mem.namespace.clone());
+        let store_res = if landed.contains(&key) {
+            app.store
+                .store_with_embedding(&ctx, &row.mem, row.embedding.as_deref(), space)
+                .await
+        } else {
+            app.store
+                .store_with_embedding_no_overwrite(&ctx, &row.mem, row.embedding.as_deref(), space)
+                .await
+        };
+        match store_res {
+            Ok(id) => {
+                landed.insert(key);
+                outcomes.push((row.index, row.mem.id.clone(), id.clone()));
+                let mut mem = row.mem.clone();
+                mem.id = id;
+                committed_mems.push(mem);
+            }
+            Err(crate::store::StoreError::Conflict { id }) => {
+                // The no-overwrite write refused a `(title, namespace)`
+                // collision that raced past Stage-2's probe. Surface the SAME
+                // typed 409-class conflict (carrying `existing_id`) the
+                // pre-existing arm emits — NEVER a silent overwrite. Mirrors
+                // single-create #2771 (`store_with_embedding_no_overwrite`
+                // charges no quota on the DO-NOTHING arm — the tx never
+                // commits — so there is no charge to refund here).
+                ledger.reject_conflict(row.index, &id);
+            }
+            Err(e) => {
+                ledger.reject_class(row.index, "store", classify_store_err(&e), &e.to_string());
+            }
+        }
+    }
+
+    // --- merge/version lane: the existing atomic batched upsert (#1481),
+    // semantics UNCHANGED, plus the post-commit vector stamp for the rows that
+    // landed.
+    if !batch_rows.is_empty() {
+        let memories: Vec<Memory> = batch_rows.iter().map(|r| r.mem.clone()).collect();
         match app.store.store_batch(&ctx, &memories).await {
-            Ok(ids) if ids.len() == allowed.len() => {
-                for (row, returned) in allowed.iter().zip(ids.iter()) {
+            Ok(ids) if ids.len() == batch_rows.len() => {
+                for (row, returned) in batch_rows.iter().zip(ids.iter()) {
                     outcomes.push((row.index, row.mem.id.clone(), returned.clone()));
                     let mut mem = row.mem.clone();
                     mem.id = returned.clone();
                     committed_mems.push(mem);
                 }
-                // #2594 — stamp the vectors for the rows that actually landed.
-                // The batch is atomic, so this runs only on a committed batch.
+                // #2594 — one entry per PERSISTED id, LAST-wins (the same rule
+                // the upsert used to pick the surviving content). Several input
+                // rows can share a returned id (in-batch `(title, namespace)`
+                // collapse), and duplicate ids in one multi-row UPDATE are the
+                // shape postgres refuses with "cannot affect row a second time";
+                // pairing surviving CONTENT with an earlier row's VECTOR would
+                // also score a row against text it does not hold (a wrong
+                // result, which outranks a missing one).
                 if let Some(space) = embedding_space.as_deref() {
-                    // One entry per PERSISTED id, LAST-wins — the same rule
-                    // the upsert used to pick the surviving content. Several
-                    // input rows can share a returned id (in-batch
-                    // `(title, namespace)` collapse), and duplicate ids in one
-                    // multi-row UPDATE are the shape postgres refuses with
-                    // "cannot affect row a second time". Pairing the surviving
-                    // CONTENT with an earlier row's VECTOR would also make
-                    // semantic recall score a row against text it does not
-                    // hold — a wrong result, which outranks a missing one.
                     let mut by_id: std::collections::HashMap<&str, &Vec<f32>> =
                         std::collections::HashMap::new();
-                    for (row, id) in allowed.iter().zip(ids.iter()) {
+                    for (row, id) in batch_rows.iter().zip(ids.iter()) {
                         if let Some(v) = row.embedding.as_ref() {
                             by_id.insert(id.as_str(), v);
                         }
@@ -1502,26 +1608,24 @@ async fn bulk_create_postgres(
                 let detail = format!(
                     "store_batch returned {} ids for {} rows",
                     ids.len(),
-                    allowed.len()
+                    batch_rows.len()
                 );
                 tracing::error!("bulk_create(postgres): {detail}");
-                for row in &allowed {
+                for row in &batch_rows {
                     ledger.reject(row.index, "store", &detail);
                 }
             }
             Err(e) => {
                 // #2588 — the batch is ATOMIC: a quota breach (or any other
                 // failure) inside `store_batch` rolls the WHOLE transaction
-                // back, so EVERY allowed row was lost. Pre-#2588 this pushed
-                // ONE opaque `"internal error"` string and still returned
-                // HTTP 200 — 31,000 rows were dropped behind exactly that
-                // shape. Every lost row now gets its own typed, indexed
-                // rejection, and `BulkLedger::status` turns the total loss
-                // into the dominant cause's status (429 for quota).
+                // back, so EVERY merge/version row in the batch was lost. Every
+                // lost row gets its own typed, indexed rejection, and
+                // `BulkLedger::status` turns the total loss into the dominant
+                // cause's status (429 for quota).
                 let class = classify_store_err(&e);
                 let detail = e.to_string();
                 tracing::warn!("bulk_create(postgres): store_batch failed: {detail}");
-                for row in &allowed {
+                for row in &batch_rows {
                     ledger.reject_class(row.index, "store", class, &detail);
                 }
             }

--- a/tests/bulk_create_conflict_2874.rs
+++ b/tests/bulk_create_conflict_2874.rs
@@ -1,0 +1,569 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// clippy allows (test scaffolding): pedantic lints with no behavioral impact.
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown,
+    clippy::items_after_statements
+)]
+//! #2874 — the default `on_conflict=error` disposition on the BULK create
+//! surface (`POST /api/v1/memories/bulk`) must be ATOMICALLY fail-closed, the
+//! same guarantee #2771 gave single-create: a row racing into the same
+//! `(title, namespace)` key BETWEEN the Stage-2 pre-existing probe and the
+//! write is REFUSED (typed 409-class conflict, carrying `existing_id`), never
+//! allowed to silently upsert-overwrite the first writer's durable content.
+//!
+//! Pre-#2874 the bulk `error` rows probed then WROTE via an upsert (sqlite
+//! `db::insert` / postgres `store_batch`'s `ON CONFLICT DO UPDATE`), so a
+//! writer that slipped in between the probe and the write had its content
+//! clobbered with no 409 and no snapshot — the IDENTICAL North-Star
+//! lost-update #2771 closed on the single-create path, but on the bulk path.
+//!
+//! The load-bearing no-overwrite assertion is the schema-v45 `version` column:
+//! a fresh insert lands `version = 1`, and an upsert-MERGE bumps it (`#1632`).
+//! So `version == 1` on the surviving row PROVES the loser hit the fail-closed
+//! `DO NOTHING` arm and never upsert-merged — the pre-#2874 bug would leave
+//! `version == 2`. Counter assertions are ALWAYS paired with an out-of-band
+//! read of the stored row (a self-consistent envelope is how the class hides).
+//!
+//! sqlite is covered by a genuine TWO-CONNECTION race (two routers on ONE db
+//! file — each holds its own `app.db` mutex, so they serialise on the SQLite
+//! file lock, not the tokio mutex) plus a `merge` CONTROL and the #2725
+//! in-batch last-wins dedup guard; postgres is covered by a real TWO-TASK race
+//! through the actual `bulk_create_postgres` handler (gated on
+//! `AI_MEMORY_TEST_POSTGRES_URL`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use rusqlite::{Connection, params};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::handlers::{ApiKeyState, AppState, Db};
+
+const AGENT: &str = "bulk-conflict-2874-agent";
+
+/// #1985 — pin this binary to the explicit permissive agent-attestation
+/// opt-out; the v1.0 HTTP-direct default is REQUIRED and would reject these
+/// unsigned store fixtures before the accounting under test runs. Mirrors
+/// `tests/bulk_on_conflict_2725.rs::permissive_attestation_for_tests`.
+fn permissive_attestation_for_tests() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    // SAFETY: `Once`-gated process-global env write, one stable value for the
+    // process lifetime, set before the caller issues any gated store.
+    ONCE.call_once(|| unsafe { std::env::set_var("AI_MEMORY_REQUIRE_AGENT_ATTESTATION", "0") });
+}
+
+/// A router backed by the sqlite file at `db_path`. Two routers on the SAME
+/// path share the durable file but hold DISTINCT `app.db` mutexes, so two
+/// concurrent bulk posts genuinely race on the SQLite write lock.
+fn build_router_on(db_path: &Path) -> axum::Router {
+    permissive_attestation_for_tests();
+    // Materialise the schema once, then open the router's own connection.
+    let _ = ai_memory::db::open(db_path).expect("db::open seed schema");
+    let conn = ai_memory::db::open(db_path).expect("reopen for AppState");
+    let db: Db = Arc::new(Mutex::new((
+        conn,
+        db_path.to_path_buf(),
+        ResolvedTtl::default(),
+        true,
+    )));
+    #[cfg(feature = "sal")]
+    let store: Arc<dyn ai_memory::store::MemoryStore> =
+        Arc::new(ai_memory::store::sqlite::SqliteStore::open(db_path).expect("open SqliteStore"));
+    let app_state = AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: ai_memory::handlers::StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store,
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: std::sync::Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    ai_memory::build_router(api_key_state, app_state)
+}
+
+fn row(namespace: &str, title: &str, content: &str) -> Value {
+    json!({
+        "tier": "long", "namespace": namespace, "title": title, "content": content,
+        "tags": [], "priority": 5, "confidence": 1.0, "source": "api", "metadata": {},
+    })
+}
+
+fn row_merge(namespace: &str, title: &str, content: &str) -> Value {
+    let mut r = row(namespace, title, content);
+    r["on_conflict"] = json!("merge");
+    r
+}
+
+async fn post(router: &axum::Router, body: &Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/memories/bulk")
+        .header("content-type", "application/json")
+        .header("x-agent-id", AGENT)
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed = serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null);
+    (status, parsed)
+}
+
+// Out-of-band ground truth — never the response's own counters.
+fn db_row_count(db_path: &Path, namespace: &str, title: &str) -> i64 {
+    Connection::open(db_path)
+        .expect("open")
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = ?1 AND title = ?2",
+            params![namespace, title],
+            |r| r.get(0),
+        )
+        .expect("count")
+}
+
+fn db_content_id_version(db_path: &Path, namespace: &str, title: &str) -> (String, String, i64) {
+    Connection::open(db_path)
+        .expect("open")
+        .query_row(
+            "SELECT content, id, version FROM memories WHERE namespace = ?1 AND title = ?2",
+            params![namespace, title],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .expect("row")
+}
+
+fn u64_of(v: &Value, k: &str) -> u64 {
+    v[k].as_u64().unwrap_or_else(|| panic!("missing {k}: {v}"))
+}
+
+// ───────────────────────────────────────────────────────────────────
+// sqlite — genuine two-connection race (multi-process-shaped)
+// ───────────────────────────────────────────────────────────────────
+
+/// Two routers on ONE db file race a bulk `error`-mode create of the SAME
+/// `(title, namespace)`. The `(title, namespace)` UNIQUE index guarantees
+/// exactly one winner; the loser is REJECTED as a 409-class conflict carrying
+/// the winner's `existing_id` — NEVER a silent overwrite, NEVER two rows. The
+/// surviving row's `version == 1` proves the loser hit the fail-closed
+/// `DO NOTHING` arm (an upsert-merge would have bumped it to 2), whether it
+/// was refused by the write arm (true race) or the up-front probe (the writers
+/// happened to serialise).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bulk_error_mode_race_exactly_one_winner_no_overwrite_sqlite_2874() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("m.db");
+    let ns = "race-2874";
+    let title = "raced-title";
+
+    let router_a = build_router_on(&db_path);
+    let router_b = build_router_on(&db_path);
+
+    let ba = json!([row(ns, title, "content-from-A")]);
+    let bb = json!([row(ns, title, "content-from-B")]);
+    let (ra, rb) = tokio::join!(post(&router_a, &ba), post(&router_b, &bb));
+
+    let (status_a, va) = ra;
+    let (status_b, vb) = rb;
+
+    let created_total = u64_of(&va, "created") + u64_of(&vb, "created");
+    let rejected_total = u64_of(&va, "rejected") + u64_of(&vb, "rejected");
+    assert_eq!(
+        created_total, 1,
+        "exactly one bulk create must win the race: A={va} B={vb}"
+    );
+    assert_eq!(
+        rejected_total, 1,
+        "exactly one bulk create must be refused as a conflict: A={va} B={vb}"
+    );
+
+    // Exactly one durable row, never overwritten (version == 1).
+    assert_eq!(
+        db_row_count(&db_path, ns, title),
+        1,
+        "the race must leave exactly one row"
+    );
+    let (content, id, version) = db_content_id_version(&db_path, ns, title);
+    assert!(
+        content == "content-from-A" || content == "content-from-B",
+        "the durable content must be an unmodified writer's, not a merge: {content}"
+    );
+    assert_eq!(
+        version, 1,
+        "#2874: the surviving row must NOT have been upsert-merged (version stays 1)"
+    );
+
+    // The loser's response carries the typed 409 conflict + the winner's id.
+    let (loser_status, loser) = if u64_of(&va, "rejected") == 1 {
+        (status_a, &va)
+    } else {
+        (status_b, &vb)
+    };
+    assert_eq!(
+        loser_status,
+        StatusCode::CONFLICT,
+        "an all-rejected bulk is a dominant 409: {loser}"
+    );
+    assert_eq!(loser["errors"][0]["code"], json!("CONFLICT"), "{loser}");
+    assert_eq!(
+        loser["errors"][0]["existing_id"],
+        json!(id),
+        "the conflict must carry the surviving row's id so a loader can reconcile: {loser}"
+    );
+    // Whichever won answered 200 with created:1.
+    let winner_status = if u64_of(&va, "created") == 1 {
+        status_a
+    } else {
+        status_b
+    };
+    assert_eq!(winner_status, StatusCode::OK, "the winner is a clean 200");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// sqlite — CONTROL: the `merge` disposition still upserts (unchanged).
+// ───────────────────────────────────────────────────────────────────
+
+/// The `merge` disposition keeps the LEGACY upsert — it overwrites the stored
+/// content AND bumps `version` to 2 — proving #2874 changed ONLY the `error`
+/// disposition and the fix is load-bearing (the same op under `error` refuses).
+#[tokio::test]
+async fn bulk_merge_mode_still_upserts_content_sqlite_2874() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("m.db");
+    let ns = "merge-2874";
+    let title = "dup";
+    let router = build_router_on(&db_path);
+
+    let (status, v) = post(&router, &json!([row(ns, title, "original")])).await;
+    assert_eq!(status, StatusCode::OK, "seed lands: {v}");
+    assert_eq!(v["created"], json!(1), "{v}");
+    let (_, _, v_before) = db_content_id_version(&db_path, ns, title);
+    assert_eq!(v_before, 1, "fresh insert is version 1");
+
+    let (status, v) = post(&router, &json!([row_merge(ns, title, "merged content")])).await;
+    assert_eq!(status, StatusCode::OK, "clean merge-update is 200: {v}");
+    assert_eq!(v["created"], json!(0), "{v}");
+    assert_eq!(v["updated"], json!(1), "{v}");
+
+    let (content, _, v_after) = db_content_id_version(&db_path, ns, title);
+    assert_eq!(
+        content, "merged content",
+        "the merge disposition DOES overwrite (legacy upsert, unchanged by #2874)"
+    );
+    assert_eq!(
+        v_after, 2,
+        "the merge upsert bumps version — proving the error-mode version==1 check is load-bearing"
+    );
+    assert_eq!(db_row_count(&db_path, ns, title), 1, "still one row: {v}");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// sqlite — GUARD: in-batch last-wins dedup is preserved (#2725) under the
+// new fail-closed routing (a later same-key sibling must NOT self-conflict).
+// ───────────────────────────────────────────────────────────────────
+
+/// Two `error`-mode rows sharing `(title, namespace)` in the SAME batch, no
+/// pre-existing row: the FIRST occurrence lands via the fail-closed no-overwrite
+/// write, and the LATER sibling collapses onto it (last-wins content) as an
+/// in-batch dedup — NOT a self-conflict. This pins that the #2874 `landed`-set
+/// routing preserves the #2725 in-batch semantics.
+#[tokio::test]
+async fn bulk_in_batch_error_dedup_last_wins_preserved_sqlite_2874() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("m.db");
+    let ns = "dedup-2874";
+    let title = "same";
+    let router = build_router_on(&db_path);
+
+    let (status, v) = post(
+        &router,
+        &json!([row(ns, title, "first"), row(ns, title, "second")]),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::MULTI_STATUS,
+        "partial-fill dedup is 207: {v}"
+    );
+    assert_eq!(v["created"], json!(1), "one survivor created: {v}");
+    assert_eq!(
+        v["rejected"],
+        json!(0),
+        "an in-batch sibling must NOT be a conflict under fail-closed routing: {v}"
+    );
+    assert_eq!(
+        v["deduped"],
+        json!(1),
+        "the earlier sibling is deduped: {v}"
+    );
+    let deduped = v["deduped_rows"].as_array().expect("deduped_rows[]");
+    assert_eq!(
+        deduped[0]["superseded_by"],
+        json!(1),
+        "LAST input wins: {v}"
+    );
+
+    let (content, _, version) = db_content_id_version(&db_path, ns, title);
+    assert_eq!(content, "second", "the LAST row's content is durable");
+    assert_eq!(db_row_count(&db_path, ns, title), 1, "{v}");
+    // The sibling collapse rides the upsert arm, so version is bumped (as it
+    // was pre-#2874) — the in-batch path is deliberately unchanged.
+    assert_eq!(version, 2, "in-batch collapse upserts (unchanged): {v}");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// postgres — real TWO-TASK race through the actual handler (gated on live pg)
+// ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "sal-postgres")]
+mod pg {
+    use super::{AGENT, permissive_attestation_for_tests, row, row_merge, u64_of};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, RwLock};
+    use tower::ServiceExt as _;
+
+    use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+    use ai_memory::handlers::{ApiKeyState, AppState, Db, StorageBackend};
+    use ai_memory::store::postgres::PostgresStore;
+    use ai_memory::store::{CallerContext, MemoryStore};
+
+    fn postgres_url() -> Option<String> {
+        std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
+    }
+
+    fn uid(prefix: &str) -> String {
+        format!("{prefix}-{}", uuid::Uuid::new_v4())
+    }
+
+    fn build_pg_router(store: Arc<dyn MemoryStore>) -> axum::Router {
+        permissive_attestation_for_tests();
+        let conn = ai_memory::db::open(std::path::Path::new(":memory:")).expect("scratch sqlite");
+        let db: Db = Arc::new(Mutex::new((
+            conn,
+            std::path::PathBuf::from(":memory:"),
+            ResolvedTtl::default(),
+            true,
+        )));
+        let app_state = AppState {
+            db,
+            embedder: Arc::new(None),
+            vector_index: Arc::new(Mutex::new(None)),
+            federation: Arc::new(None),
+            tier_config: Arc::new(FeatureTier::Keyword.config()),
+            scoring: Arc::new(ResolvedScoring::default()),
+            profile: Arc::new(ai_memory::profile::Profile::core()),
+            mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
+            family_embeddings: Arc::new(RwLock::new(Some(Vec::new()))),
+            storage_backend: StorageBackend::Postgres,
+            store,
+            llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+            auto_tag_model: Arc::new(None),
+            llm_call_timeout: std::time::Duration::from_secs(30),
+            replay_cache: std::sync::Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+            verify_require_nonce: false,
+            federation_nonce_cache: std::sync::Arc::new(
+                ai_memory::identity::replay::FederationNonceCache::default(),
+            ),
+            autonomous_hooks: false,
+            recall_scope: Arc::new(None),
+            deferred_audit_queue: Arc::new(None),
+            admin_agent_ids: Arc::new(Vec::new()),
+            rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+            resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+                ai_memory::config::ResolvedModels::default(),
+            )),
+            runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+            max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+            enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+            http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+        };
+        let api_key_state = ApiKeyState {
+            key: None,
+            mtls_enforced: false,
+            enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+            identity_mode: ai_memory::config::HttpIdentityMode::default(),
+        };
+        ai_memory::build_router(api_key_state, app_state)
+    }
+
+    async fn post(router: &axum::Router, body: &Value) -> (StatusCode, Value) {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/memories/bulk")
+            .header("content-type", "application/json")
+            .header("x-agent-id", AGENT)
+            .body(Body::from(serde_json::to_vec(body).unwrap()))
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed = serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null);
+        (status, parsed)
+    }
+
+    /// Two concurrent `bulk_create_postgres` invocations (separate pooled
+    /// connections, one shared router) race a fresh `(title, namespace)` under
+    /// the default `error` disposition. Exactly one wins; the other is refused
+    /// as a 409-class conflict carrying the winner's id — NEVER a silent upsert
+    /// (`store_with_embedding`'s `ON CONFLICT DO UPDATE`) over the durable
+    /// content. `version == 1` proves fail-closed on the survivor.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn bulk_error_mode_race_exactly_one_winner_no_overwrite_pg_2874() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store: Arc<dyn MemoryStore> = Arc::new(
+            PostgresStore::connect(&url)
+                .await
+                .expect("connect postgres"),
+        );
+        let router = build_pg_router(Arc::clone(&store));
+        let ns = uid("race-ns");
+        let title = "pg-raced-title";
+
+        let ba = json!([row(&ns, title, "content-A")]);
+        let bb = json!([row(&ns, title, "content-B")]);
+        let (ra, rb) = tokio::join!(post(&router, &ba), post(&router, &bb));
+        let (status_a, va) = ra;
+        let (status_b, vb) = rb;
+
+        assert_eq!(
+            u64_of(&va, "created") + u64_of(&vb, "created"),
+            1,
+            "exactly one pg bulk create must win: A={va} B={vb}"
+        );
+        assert_eq!(
+            u64_of(&va, "rejected") + u64_of(&vb, "rejected"),
+            1,
+            "exactly one pg bulk create must be refused: A={va} B={vb}"
+        );
+
+        // Out-of-band durability check via an admin (visibility-bypass) read.
+        // The `(title, namespace)` UNIQUE index guarantees at most one row, so
+        // resolving the id by key is also the "exactly one row" proof.
+        let ctx = CallerContext::for_admin("ai:reader-2874");
+        let winner_id = store
+            .find_by_title_namespace(title, &ns)
+            .await
+            .expect("probe survivor")
+            .expect("exactly one durable row for the raced key");
+        let winner = store.get(&ctx, &winner_id).await.expect("get survivor");
+        assert!(
+            winner.content == "content-A" || winner.content == "content-B",
+            "the durable pg content must be an unmodified writer's: {}",
+            winner.content
+        );
+        assert_eq!(
+            winner.version, 1,
+            "#2874: the surviving pg row must NOT have been upsert-merged (version stays 1)"
+        );
+
+        let (loser_status, loser) = if u64_of(&va, "rejected") == 1 {
+            (status_a, &va)
+        } else {
+            (status_b, &vb)
+        };
+        assert_eq!(
+            loser_status,
+            StatusCode::CONFLICT,
+            "loser is a 409: {loser}"
+        );
+        assert_eq!(loser["errors"][0]["code"], json!("CONFLICT"), "{loser}");
+        assert_eq!(
+            loser["errors"][0]["existing_id"],
+            json!(winner.id),
+            "{loser}"
+        );
+    }
+
+    /// CONTROL: the `merge` disposition still upserts on postgres (content
+    /// replaced, `version` bumped) — proving #2874 changed only `error`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bulk_merge_mode_still_upserts_pg_2874() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+            return;
+        };
+        let store: Arc<dyn MemoryStore> = Arc::new(
+            PostgresStore::connect(&url)
+                .await
+                .expect("connect postgres"),
+        );
+        let router = build_pg_router(Arc::clone(&store));
+        let ns = uid("merge-ns");
+        let title = "pg-merge-title";
+
+        let (status, v) = post(&router, &json!([row(&ns, title, "original")])).await;
+        assert_eq!(status, StatusCode::OK, "seed lands: {v}");
+        assert_eq!(v["created"], json!(1), "{v}");
+
+        let (status, v) = post(&router, &json!([row_merge(&ns, title, "merged content")])).await;
+        assert_eq!(status, StatusCode::OK, "clean merge is 200: {v}");
+        assert_eq!(v["updated"], json!(1), "{v}");
+
+        let ctx = CallerContext::for_admin("ai:reader-2874");
+        let row_id = store
+            .find_by_title_namespace(title, &ns)
+            .await
+            .expect("probe row")
+            .expect("still one row (id preserved on upsert)");
+        let row_after = store.get(&ctx, &row_id).await.expect("get");
+        assert_eq!(
+            row_after.content, "merged content",
+            "the merge disposition DOES overwrite on pg (legacy, unchanged by #2874)"
+        );
+        assert_eq!(
+            row_after.version, 2,
+            "the merge upsert bumps version — the error-mode version==1 check is load-bearing"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2874. The default `on_conflict=error` disposition on the BULK create surface (`POST /api/v1/memories/bulk`) carried the **IDENTICAL probe-then-upsert lost-update race** that the just-merged #2771 (PR #2873) closed on single-create — but on the bulk path. This is effectively cert-blocking: we just certified the single-create fix; the bulk path must not still silently overwrite.

### The defect (North-Star silent data loss)

#2725's pre-loop probe rejects an *already-stored* `(title, namespace)` collision, but the surviving rows were then **written via an upsert** — sqlite `db::insert` / postgres `store_batch`'s `ON CONFLICT (title, namespace) DO UPDATE`. So a row racing into the same key **between the probe and the write** (a concurrent writer — pooled-parallel Axum handlers on postgres, or a second process on sqlite) was **silently upsert-overwritten under `error` mode** — no 409, no snapshot, the first writer's durable content clobbered.

### The fix — reuse the certified #2771 no-overwrite primitives (no new SAL surface)

`error`-mode bulk rows are now **atomically fail-closed on BOTH backends**:

- **sqlite** — the FIRST occurrence of a key routes through the certified `db::insert_no_overwrite` (`INSERT … ON CONFLICT DO NOTHING` → typed `ConflictError`); a race/pre-existing collision is surfaced as the SAME typed `409 CONFLICT` (with `existing_id`) via `ledger.reject_conflict`, never an overwrite.
- **postgres** — `error` rows route per-row through the certified `MemoryStore::store_with_embedding_no_overwrite`; `StoreError::Conflict` maps to the same `reject_conflict`. `merge`/`version` keep the batched `store_batch` upsert.

`merge`/`version` keep the upsert (task-mandated). The **#2725 in-batch last-wins dedup is preserved** on both backends: a later same-key sibling that already landed this batch keeps the upsert, so it is a `deduped_rows[]` collapse, **never a self-conflict** — the pinned #2725 semantics (`tests/bulk_on_conflict_2725.rs`) are unchanged (re-run green).

Chosen per the mandated **5-agent adversarial decision vote (`4d3ea1c5`, T1 new-surface + T3 fail-open→fail-closed)**, 3-2 for **option B** (reuse the just-certified single-create no-overwrite methods, minimal new attestable surface / cross-backend symmetry / deterministic testability) over option A (a new batched `store_batch_no_overwrite`). A batched no-overwrite variant is documented as the tracked throughput optimisation if error-mode bulk volume is measured to warrant it.

### Files
- `src/handlers/bulk.rs` — `bulk_create_sqlite` fail-closed write routing + `ConflictError`→`reject_conflict`; `bulk_create_postgres` per-disposition partition + per-row no-overwrite error lane.
- `tests/bulk_create_conflict_2874.rs` — new regression suite.
- `CHANGELOG.md` — `[Unreleased]` entry.

### Tests (local)
```
test result: ok. 5 passed  (tests/bulk_create_conflict_2874.rs — incl. live-PG two-task handler race)
test result: ok. 4 passed  (tests/bulk_on_conflict_2725.rs — no regression)
```
All keyed on the schema-v45 `version` column so an upsert-overwrite is a hard failure (fail-closed refusal → survivor stays `version==1`; a `merge` bumps to `2`). The pg legs ran against a live PG16 via `AI_MEMORY_TEST_POSTGRES_URL`.

CI-parity run locally: `cargo fmt --check`; clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` on **default / sal / sal-postgres / vectorlite** (all clean); `cargo check --examples`; `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` (unchanged — no new symbols, `src/storage/mod.rs` untouched); hardcoded-literal + vendor-literal gates PASS. No SSOT pins move (no new MCP tool / HTTP route / CLI verb / schema version / SAL trait method).

## AI involvement
Authored by Claude (Opus 5, hard-coder tier) under operator authority for the v1.0.0 certification loop. Design decision made via the deterministic 5-agent adversarial vote (`4d3ea1c5`), synthesized and recorded to ai-memory before implementation. Not merged by the author — Fable gates the merge after code + security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY