### PR TITLE
fix(do-hive): RSA cert chain for pg scram channel binding + scram test leg (Progresses #2658)

### DIFF
--- a/infra/do-hive/crypto/README.md
+++ b/infra/do-hive/crypto/README.md
@@ -18,7 +18,7 @@ first; the DO step re-hosts the identical config onto droplets.
 | `gen-certs.sh` | CA + server/client/peer/pg leaf certs, SANs, allowlists, fingerprints |
 | `test-api-mtls.sh` | **Leg 1** API mTLS: allowlisted client operates API / no-cert + unlisted-cert refused |
 | `test-federation-mtls.sh` | **Leg 2** federation quorum mTLS across 2 local daemons: authorised peer replicates / unauthorised + plaintext refused |
-| `test-pg-verifyfull.sh` | **Leg 3** daemon→Postgres `sslmode=verify-full`: pinned-CA connect / plaintext + host-mismatch + unpinned-CA refused |
+| `test-pg-verifyfull.sh` | **Leg 3** daemon→Postgres `sslmode=verify-full`: pinned-CA connect / scram-sha-256 + `channel_binding=require` connect (guards the RSA cert chain — Ed25519 aborts channel binding) / plaintext + host-mismatch + unpinned-CA refused |
 | `test-attestation.sh` | attestation ON (`#1751`): signed write (real bound keypair) accepted / unsigned rejected 403 |
 | `test-semantic-recall.sh` | caveat 2: in-process MiniLM-384 vectors + semantic recall ranking (no Ollama/nomic) |
 | `run-all-local.sh` | regenerates certs + runs every leg; non-zero exit if any fails |

--- a/infra/do-hive/crypto/gen-certs.sh
+++ b/infra/do-hive/crypto/gen-certs.sh
@@ -26,7 +26,18 @@
 # Postgres verify-full DOES use the CA chain + hostname, so pg-server is CA-
 # signed and its SAN must match the host the daemon connects to ($PG_HOST).
 #
-# Ed25519 leaf keys (fast, small). Postgres/rustls both accept them.
+# Key algorithm: RSA (CA 4096 / leaf 2048), matching the certified pg-TLS lane
+# deploy/do-1461/provision/15_tls.sh. This is NOT a "fast/small" nicety — it is
+# REQUIRED for the Postgres leg. Under sslmode=verify-full + scram-sha-256 with
+# channel binding (tls-server-end-point, RFC 5929), libpq hashes the server
+# certificate using the digest named in its signatureAlgorithm. An Ed25519
+# certificate has NO such digest (its signatureAlgorithm carries no separate
+# hash OID), so libpq aborts the handshake with
+#   "could not find digest for NID UNDEF"
+# before it ever authenticates. RSA/SHA-256 (and EC/P-256/SHA-256) carry a real
+# digest and bind cleanly. rustls (the API/federation mTLS legs) accepts RSA
+# leaves just as it did Ed25519, so one RSA chain serves every leg. See
+# test-pg-verifyfull.sh's scram+channel-binding leg for the guarding regression.
 # Usage:
 #   ./gen-certs.sh                        # localhost-only material
 #   EXTRA_SAN_IP=167.71.175.191 EXTRA_SAN_DNS=hive-substrate \
@@ -46,20 +57,22 @@ cd "$OUT_DIR"
 fp() { openssl x509 -in "$1" -outform DER | openssl dgst -sha256 | awk '{print $NF}'; }
 
 # --- Root CA -----------------------------------------------------------------
-openssl genpkey -algorithm ed25519 -out ca.key
-openssl req -x509 -new -key ca.key -days "$DAYS" -out ca.crt \
+# RSA/SHA-256 chain (see header): required for the pg scram + channel-binding
+# leg, accepted by rustls for the mTLS legs.
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -key ca.key -sha256 -days "$DAYS" -out ca.crt \
   -subj "/CN=ai-memory-do-round-CA"
 
 # helper: mint a leaf cert <name> <CN> <SAN-extfile-body>
 mint() {
   local name="$1" cn="$2" san="$3"
-  openssl genpkey -algorithm ed25519 -out "${name}.key"
+  openssl genrsa -out "${name}.key" 2048
   openssl req -new -key "${name}.key" -out "${name}.csr" -subj "/CN=${cn}"
   cat > "${name}.ext" <<EOF
 subjectAltName=${san}
 EOF
   openssl x509 -req -in "${name}.csr" -CA ca.crt -CAkey ca.key -CAcreateserial \
-    -days "$DAYS" -out "${name}.crt" -extfile "${name}.ext"
+    -days "$DAYS" -sha256 -out "${name}.crt" -extfile "${name}.ext"
   rm -f "${name}.csr" "${name}.ext"
   chmod 600 "${name}.key"
 }

--- a/infra/do-hive/crypto/test-pg-verifyfull.sh
+++ b/infra/do-hive/crypto/test-pg-verifyfull.sh
@@ -8,6 +8,16 @@
 #
 #   POS  sslmode=verify-full + sslrootcert=ca.crt against host=localhost (matches
 #        the cert SAN) CONNECTS with full server-cert verification.
+#   POS2 the SAME connect under scram-sha-256 auth with channel_binding=require
+#        succeeds. This is the leg that guards the cert KEY ALGORITHM: libpq's
+#        tls-server-end-point channel binding hashes the server cert with the
+#        digest in its signatureAlgorithm, so an Ed25519 chain aborts here with
+#        "could not find digest for NID UNDEF" while the RSA/SHA-256 chain
+#        gen-certs.sh now mints binds cleanly (regression for #2658 / the
+#        misleading "Postgres accepts Ed25519" claim). The certified pg-TLS lane
+#        (deploy/do-1461) and 20_pg_age.sh's pg_hba are scram-sha-256; this
+#        mirrors that auth method so the local pre-flight exercises the real
+#        channel-binding path, not just trust auth.
 #   NEG1 sslmode=disable (plaintext) is REFUSED — pg_hba is hostssl-only.
 #   NEG2 sslmode=verify-full against host=127.0.0.1 (NOT in the cert SAN) is
 #        REFUSED on the hostname check ("server certificate for ... does not
@@ -49,12 +59,19 @@ unix_socket_directories = '$PGDATA'
 ssl = on
 ssl_cert_file = 'server.crt'
 ssl_key_file = 'server.key'
+password_encryption = 'scram-sha-256'
 EOF
-# hostssl-only for the app user => a plaintext connection is refused at the HBA.
+# hostssl-only => a plaintext connection is refused at the HBA. The APP user
+# ($PGUSER) authenticates with scram-sha-256 — mirroring the certified lane
+# (deploy/do-1461 20_pg_age.sh) — so the POS2 leg below exercises the real
+# scram channel-binding path (the one that trips over an Ed25519 server cert).
+# The postgres superuser stays trust so the bootstrap probes below stay simple.
 cat > "$PGDATA/pg_hba.conf" <<EOF
-local   all all                 trust
-hostssl all all 127.0.0.1/32    trust
-hostssl all all ::1/128         trust
+local   all all                       trust
+hostssl all postgres 127.0.0.1/32     trust
+hostssl all postgres ::1/128          trust
+hostssl all all      127.0.0.1/32     scram-sha-256
+hostssl all all      ::1/128          scram-sha-256
 EOF
 "$PGBIN/pg_ctl" -D "$PGDATA" -l "$PGDATA/pg.log" -w start >/dev/null 2>&1 || { echo "pg start failed"; tail -20 "$PGDATA/pg.log"; exit 1; }
 "$PGBIN/psql" -h localhost -p "$PGPORT" -U postgres -d postgres -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<SQL
@@ -73,6 +90,17 @@ if "$PGBIN/psql" "host=localhost port=$PGPORT user=$PGUSER dbname=$PGDB sslmode=
      -tAc "SELECT 'tls-ok';" 2>"$OUT/../pg.pos.err" | grep -q tls-ok; then
   ok "leg3 POS: sslmode=verify-full + pinned CA + host=localhost connected"
 else no "leg3 POS: verify-full connect failed ($(cat "$OUT/../pg.pos.err"))"; fi
+
+# --- POSITIVE 2: scram-sha-256 auth + verify-full + channel_binding=require ---
+# tls-server-end-point channel binding hashes the server cert using the digest
+# named in its signatureAlgorithm. An Ed25519 chain has none => libpq aborts
+# with "could not find digest for NID UNDEF"; the RSA/SHA-256 chain binds. This
+# is the leg that would have caught the #2658 Ed25519 breakage — the older
+# trust-auth-only suite never negotiated scram, so it never reached this path.
+if "$PGBIN/psql" "host=localhost port=$PGPORT user=$PGUSER dbname=$PGDB sslmode=verify-full sslrootcert=$CA channel_binding=require" \
+     -tAc "SELECT 'cb-ok';" 2>"$OUT/../pg.pos2.err" | grep -q cb-ok; then
+  ok "leg3 POS2: scram-sha-256 + verify-full + channel_binding=require connected (RSA chain binds)"
+else no "leg3 POS2: scram channel-binding connect failed ($(cat "$OUT/../pg.pos2.err"))"; fi
 
 # --- NEGATIVE 1: plaintext (sslmode=disable) refused by hostssl-only HBA -----
 if "$PGBIN/psql" "host=localhost port=$PGPORT user=$PGUSER dbname=$PGDB sslmode=disable" \


### PR DESCRIPTION
## Summary

Closes the truthfulness/coverage residual of #2658 in the localhost-only `infra/do-hive` pg-TLS lane. (The hostssl fail-open half was fixed in #2870; the certified lane `deploy/do-1461` already uses RSA + verify-full + scram, which works.)

`infra/do-hive/crypto/gen-certs.sh` minted an **Ed25519** CA + leaf certs under a header comment claiming *"Postgres/rustls both accept them"* — false for the Postgres leg. Under `sslmode=verify-full` + `scram-sha-256` with channel binding (tls-server-end-point, RFC 5929), libpq hashes the server certificate using the digest named in its `signatureAlgorithm`; an Ed25519 certificate has **no such digest**, so libpq aborts the handshake with `could not find digest for NID UNDEF` before it authenticates.

Reproduced locally against PG16 before fixing:
- Ed25519 CA-signed pg cert → `RESULT[ed25519]: CHANNEL-BINDING CONNECT FAILED: ... could not find digest for NID UNDEF`
- RSA/SHA-256 chain → `RESULT[rsa]: CHANNEL-BINDING CONNECT SUCCEEDED`

## Changes

**Fix 1 — `gen-certs.sh`:** re-algorithm the CA (RSA 4096) and every leaf (RSA 2048, `-sha256`), mirroring the certified pg-TLS lane `deploy/do-1461/provision/15_tls.sh` (read first per "always look for prior code first"). Correct the misleading header comment to state the real channel-binding constraint (why RSA/EC, not Ed25519). rustls still accepts RSA leaves for the API/federation mTLS legs, so one RSA chain serves every leg.

**Fix 2 — `test-pg-verifyfull.sh`:** the suite used **trust** auth, so it never negotiated scram and never exercised the channel-binding path — it could not have caught the Ed25519 breakage. The app user is now configured for `scram-sha-256` (`password_encryption` + `hostssl` scram HBA; postgres superuser stays `trust` for the bootstrap probes), mirroring `deploy/do-1461/provision/20_pg_age.sh`. New **POS2** leg asserts `verify-full` + `channel_binding=require` connects — the regression that fails on an Ed25519 chain and passes on RSA.

**Docs — `README.md`:** the leg-3 table row now names the scram + channel-binding coverage.

## Local verification (PG16, `umask 022`)

Certs regenerate as RSA/SHA-256:
```
ca / server / pg-server / client-good / peerA: Signature Algorithm: sha256WithRSAEncryption
pg-server Public Key Algorithm: rsaEncryption (2048 bit)
```

`test-pg-verifyfull.sh` (in the built `sal-postgres` tree — includes the real-daemon EXTRA leg):
```
PASS: leg3 POS: sslmode=verify-full + pinned CA + host=localhost connected
PASS: leg3 POS2: scram-sha-256 + verify-full + channel_binding=require connected (RSA chain binds)
PASS: leg3 NEG1: plaintext (sslmode=disable) refused (no pg_hba)
PASS: leg3 NEG2: verify-full host mismatch refused
PASS: leg3 NEG3: verify-full unpinned/invalid CA refused (certificate verify)
PASS: leg3 EXTRA: daemon connected over verify-full TLS and served /health
leg3 summary: 6 PASS / 0 FAIL
```
`bash -n` clean on both scripts. No `.tpl` touched (cloud-init-ascii gate not implicated).

## Scope / posture

infra/test only. `infra/do-hive` pg is **localhost-only**, so this is **not** a live-security-blocking fix — it closes a latent trap (an Ed25519 chain would break the moment scram + channel binding is enabled) plus a truthfulness/coverage gap. Progresses #2658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY