### PR TITLE
fix(#2878): close probe-then-upsert lost-update on MCP store + import error/no-overwrite funnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/bulk_create_conflict_2874.rs` (two-connection sqlite race + `merge`
   control + in-batch-dedup guard + a live-pg two-task handler race, all keyed on
   the schema-v45 `version` column so an upsert-overwrite is a hard failure).
+- **The FLAGSHIP MCP agent write surface (`memory_store`) and the Portability-v2
+  importer now close the SAME probe-then-upsert lost-update on their
+  error/no-overwrite dispositions — the funnels the `#2771`/`#2874` fixes did
+  not reach** ([#2878](https://github.com/alphaonedev/ai-memory-mcp/issues/2878),
+  final 5-agent cert re-vote; applies the certified `#2771`/`#2874` precedent to
+  the remaining funnels, so no new vote). Pre-fix both probed then WROTE via
+  `db::insert`'s `ON CONFLICT (title, namespace) DO UPDATE`, so a concurrent
+  writer racing into the key BETWEEN the probe and the write was silently
+  upsert-overwritten despite the caller's error / never-clobber intent — the
+  identical North-Star unintentional-data-loss defect. Now:
+  - **MCP `memory_store` `on_conflict=error`** (the default for v2-aware
+    clients; MCP stdio is sqlite-only per `#1675`) routes the write through the
+    certified `db::insert_no_overwrite` (`INSERT … ON CONFLICT DO NOTHING` →
+    typed `ConflictError`); a race-detected collision is surfaced as the SAME
+    typed `CONFLICT:` string the up-front probe raises (single-sourced via
+    `validation::conflict_error_message`), NEVER an overwrite
+    (`src/mcp/tools/store/{mod,validation}.rs`).
+  - **Portability-v2 import** routes every non-`Merge` disposition's write
+    through the new remote-admission twin `db::insert_imported_no_overwrite`
+    (`insert_inner(.., stamp_local_clock=false, fail_on_conflict=true)`), so a
+    probe-miss that races a colliding writer is REFUSED (per-row
+    `conflicts_skipped` skip, mirroring the probe-hit `Error` disposition),
+    never a silent clobber (`src/portability/import.rs`, `src/storage/mod.rs`).
+    The importer wraps its apply in one `BEGIN IMMEDIATE` transaction, so this
+    is structural defense-in-depth that makes "never clobber the destination's
+    durable text" hold by construction regardless of isolation level.
+  `merge` (opt-in silent upsert) and `version` (title-suffix) semantics are
+  unchanged; the non-race path is byte-identical (`DO NOTHING` and `DO UPDATE`
+  behave the same absent a conflict). Regression:
+  `tests/import_conflict_2878.rs` (single-connection deterministic +
+  two-connection sqlite race on the no-overwrite primitive + `Version`/`Error`
+  funnel non-clobber contract) and the MCP-store two-connection race + `merge`
+  control in `src/mcp/tools/store/tests.rs`, all keyed on the schema-v45
+  `version` column so an upsert-overwrite is a hard failure.
 ### Fixed (published-claims TRUTHFULNESS — CERT-BLOCKING)
 
 - **`docs/zero-touch-trust.html` no longer ships the retired

--- a/src/mcp/tools/store/mod.rs
+++ b/src/mcp/tools/store/mod.rs
@@ -862,13 +862,29 @@ pub(crate) fn handle_store(
         return Err(e.to_string());
     }
 
-    let actual_id = match db::insert(conn, &mem) {
+    // #2878 — under `on_conflict=error` the write must be ATOMICALLY
+    // fail-closed: a concurrent writer racing into `(title, namespace)`
+    // BETWEEN validation.rs's up-front existence probe (`OnConflict::Error`)
+    // and this write can no longer silently upsert-overwrite the first
+    // writer's durable content (the North-Star lost-update #2771 closed on the
+    // HTTP create funnel, closed here on the flagship MCP store surface — MCP
+    // stdio is sqlite-only per #1675, so `db::insert_no_overwrite` is the
+    // path). `merge`/`version` keep the legacy `db::insert` upsert (merge =
+    // opt-in upsert; version already suffixed the title to a free slot above).
+    let insert_result = if matches!(on_conflict, OnConflict::Error) {
+        db::insert_no_overwrite(conn, &mem)
+    } else {
+        db::insert(conn, &mem)
+    };
+    let actual_id = match insert_result {
         Ok(id) => id,
         Err(e) => {
             // Insert failed AFTER we committed quota — refund so the
             // counter reflects only successful stores. Refund lands on
             // the same `(agent_id, namespace)` row the check_and_record
-            // above incremented (v50, #1156).
+            // above incremented (v50, #1156). A fail-closed conflict never
+            // landed a row, so the charge is refunded exactly as any other
+            // write failure.
             if let Err(re) = crate::quotas::refund_op(
                 conn,
                 &agent_id,
@@ -878,6 +894,19 @@ pub(crate) fn handle_store(
                 },
             ) {
                 crate::quotas::log_refund_op_failed(&agent_id, &re);
+            }
+            // #2878 — the fail-closed `db::insert_no_overwrite` refused a
+            // `(title, namespace)` collision that raced past validation.rs's
+            // `OnConflict::Error` probe. Surface the SAME typed `CONFLICT:`
+            // string the probe raises (single-sourced via
+            // `validation::conflict_error_message`) — NEVER a silent overwrite,
+            // and distinct from a generic database error. Mirrors HTTP #2771.
+            if let Some(conflict) = e.downcast_ref::<crate::storage::ConflictError>() {
+                return Err(validation::conflict_error_message(
+                    &conflict.title,
+                    &conflict.namespace,
+                    &conflict.existing_id,
+                ));
             }
             // v0.7.0 L1-6 Deliverable E — surface the substrate
             // governance pre-write hook's refusal with a clearly-

--- a/src/mcp/tools/store/tests.rs
+++ b/src/mcp/tools/store/tests.rs
@@ -2509,3 +2509,227 @@ fn a1_1579_force_store_embeds_exactly_once() {
         "#1579 A1: force=true path must embed exactly once (source embed only)"
     );
 }
+
+// ───────────────────────────────────────────────────────────────────
+// #2878 — MCP `memory_store` `on_conflict=error` must be ATOMICALLY
+// fail-closed on the FLAGSHIP agent write surface: a concurrent writer
+// racing into the same `(title, namespace)` between validation.rs's
+// existence probe and `handle_store`'s write can no longer silently
+// upsert-overwrite the first writer's durable content. The load-bearing
+// no-overwrite assertion is the schema-v45 `version` column: a fresh
+// insert lands `version = 1`, an upsert-MERGE bumps it (#1632) — so a
+// surviving `version = 1` PROVES no upsert clobbered the winner.
+// ───────────────────────────────────────────────────────────────────
+
+fn error_mode_params(title: &str, ns: &str, tag: &str) -> Value {
+    json!({
+        "title": title,
+        "content": format!("durable content from {tag}, long enough to be meaningful prose."),
+        "namespace": ns,
+        "tier": Tier::Mid.as_str(),
+        "priority": 5,
+        "confidence": 0.9,
+        "source": "nhi",
+        "agent_id": format!("ai:racer-{tag}"),
+        "on_conflict": "error",
+    })
+}
+
+/// Deterministic single-connection contract: the FIRST `error`-mode store
+/// lands `version = 1`; a SECOND `error`-mode store on the same
+/// `(title, namespace)` is REFUSED with the typed `CONFLICT:` string and
+/// NEVER overwrites — the durable row stays the first writer's content at
+/// `version = 1`. (Here the up-front probe catches it; the race test below
+/// exercises the write-path no-overwrite arm.)
+#[test]
+fn issue_2878_mcp_store_error_mode_refuses_and_preserves_content() {
+    crate::identity::attest::permissive_attestation_for_lib_tests();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("m.db");
+    let conn = db::open(&path).expect("open");
+    let ttl = ResolvedTtl::default();
+
+    let first = handle_store(
+        &conn,
+        &path,
+        &error_mode_params("shared-mcp-title", "mcp/ops", "winner"),
+        None,
+        None,
+        None,
+        &ttl,
+        false,
+        None,
+        None,
+        None,
+    )
+    .expect("first error-mode store ok");
+    let winner_id = first["id"].as_str().expect("id").to_string();
+    let row = db::get(&conn, &winner_id).expect("get").expect("row");
+    assert_eq!(row.version, 1, "fresh insert lands version=1");
+
+    let err = handle_store(
+        &conn,
+        &path,
+        &error_mode_params("shared-mcp-title", "mcp/ops", "loser"),
+        None,
+        None,
+        None,
+        &ttl,
+        false,
+        None,
+        None,
+        None,
+    )
+    .expect_err("second error-mode store MUST be refused, never overwrite");
+    assert!(err.contains("CONFLICT"), "got: {err}");
+    assert!(
+        err.contains(&winner_id),
+        "conflict names the winner id: {err}"
+    );
+
+    // Durable content untouched — the winner's, at version=1 (no upsert bump).
+    let row = db::get(&conn, &winner_id)
+        .expect("get")
+        .expect("row present");
+    assert!(
+        row.content.contains("from winner"),
+        "winner content must be durable, got: {}",
+        row.content
+    );
+    assert_eq!(
+        row.version, 1,
+        "#2878: no upsert-merge ever bumped the version"
+    );
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE title = ?1 AND namespace = ?2",
+            rusqlite::params!["shared-mcp-title", "mcp/ops"],
+            |r| r.get(0),
+        )
+        .expect("count");
+    assert_eq!(count, 1, "error mode must leave exactly one row");
+}
+
+/// Genuine two-connection race (multi-process-shaped: MCP stdio is
+/// single-threaded per process, so two racers are two OS processes / two
+/// connections to the same DB file). Exactly one `error`-mode store wins;
+/// the loser is refused with the typed `CONFLICT` string — decided by the
+/// `(title, namespace)` UNIQUE index, never by a silent upsert. The
+/// surviving row is the winner's content at `version = 1`. WAL + a generous
+/// busy-timeout keep the loser off the lock-contention path so the outcome
+/// is decided by the index, not lock timing.
+#[test]
+fn issue_2878_mcp_store_error_mode_two_connection_race_one_winner() {
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    crate::identity::attest::permissive_attestation_for_lib_tests();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("m.db");
+    // Materialise the schema once so both racers open an already-migrated
+    // file (avoids a migration/DDL race unrelated to this test).
+    drop(db::open(&path).expect("seed schema"));
+
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = Vec::new();
+    for tag in ["a", "b"] {
+        let path = path.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            let conn = db::open(&path).expect("open");
+            conn.busy_timeout(Duration::from_secs(10))
+                .expect("busy_timeout");
+            let ttl = ResolvedTtl::default();
+            let params = error_mode_params("raced-mcp-title", "race/mcp", tag);
+            barrier.wait();
+            handle_store(
+                &conn, &path, &params, None, None, None, &ttl, false, None, None, None,
+            )
+        }));
+    }
+    let results: Vec<Result<Value, String>> = handles
+        .into_iter()
+        .map(|h| h.join().expect("join"))
+        .collect();
+
+    let winners: Vec<&Value> = results.iter().filter_map(|r| r.as_ref().ok()).collect();
+    assert_eq!(
+        winners.len(),
+        1,
+        "exactly one error-mode store must win the race"
+    );
+    for r in &results {
+        if let Err(e) = r {
+            assert!(
+                e.contains("CONFLICT"),
+                "loser must get the typed CONFLICT refusal, not a silent overwrite / other error: {e}"
+            );
+        }
+    }
+
+    // Exactly one row; its content is the winner's, at version=1 (never upserted).
+    let conn = db::open(&path).expect("reopen");
+    let winner_id = winners[0]["id"].as_str().expect("id").to_string();
+    let row = db::get(&conn, &winner_id)
+        .expect("get")
+        .expect("winner row");
+    assert!(
+        row.content.contains("durable content from"),
+        "winner content must be durable: {}",
+        row.content
+    );
+    assert_eq!(
+        row.version, 1,
+        "#2878: the race must never upsert-overwrite (version stays 1)"
+    );
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE title = ?1 AND namespace = ?2",
+            rusqlite::params!["raced-mcp-title", "race/mcp"],
+            |r| r.get(0),
+        )
+        .expect("count");
+    assert_eq!(count, 1, "the race must leave exactly one row");
+}
+
+/// Control: `on_conflict=merge` (the operator's opt-in silent upsert) is
+/// UNCHANGED by #2878 — a second merge store on the same key upserts the
+/// content and bumps `version`, proving the no-overwrite fix touched ONLY
+/// the `error` disposition.
+#[test]
+fn issue_2878_mcp_store_merge_mode_still_upserts_unchanged() {
+    crate::identity::attest::permissive_attestation_for_lib_tests();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("m.db");
+    let conn = db::open(&path).expect("open");
+    let ttl = ResolvedTtl::default();
+
+    let mut first = error_mode_params("merge-mcp-title", "mcp/merge", "one");
+    first["on_conflict"] = json!("merge");
+    let id = handle_store(
+        &conn, &path, &first, None, None, None, &ttl, false, None, None, None,
+    )
+    .expect("first merge store")["id"]
+        .as_str()
+        .expect("id")
+        .to_string();
+
+    let mut second = error_mode_params("merge-mcp-title", "mcp/merge", "two");
+    second["on_conflict"] = json!("merge");
+    handle_store(
+        &conn, &path, &second, None, None, None, &ttl, false, None, None, None,
+    )
+    .expect("second merge store upserts (unchanged by #2878)");
+
+    let row = db::get(&conn, &id).expect("get").expect("row");
+    assert!(
+        row.content.contains("from two"),
+        "merge disposition upserts the incoming content (unchanged): {}",
+        row.content
+    );
+    assert!(
+        row.version >= 2,
+        "#1632: merge upsert bumps version (proves #2878 changed only error mode), got {}",
+        row.version
+    );
+}

--- a/src/mcp/tools/store/validation.rs
+++ b/src/mcp/tools/store/validation.rs
@@ -77,6 +77,22 @@ pub(super) fn default_on_conflict_for_client(mcp_client: Option<&str>) -> OnConf
     OnConflict::Merge
 }
 
+/// v1.0.0 #2878 — the ONE builder for the typed `CONFLICT:` string a
+/// `(title, namespace)` collision returns on the MCP `memory_store`
+/// `on_conflict=error` path, whether the collision is PROBE-detected (an
+/// existing row seen up front, in [`parse_and_build_memory`]) or WRITE-detected
+/// (the fail-closed `db::insert_no_overwrite` refused a racer, in
+/// `super::handle_store`). Single-sources the wire shape — the message literal
+/// lives at exactly one site — so a race-detected conflict is byte-identical to
+/// a probe-detected one.
+pub(super) fn conflict_error_message(title: &str, namespace: &str, existing_id: &str) -> String {
+    format!(
+        "CONFLICT: memory with title '{title}' already exists in namespace \
+         '{namespace}' (existing id: {existing_id}). Pass \
+         on_conflict='merge' to update in place or 'version' to suffix the title."
+    )
+}
+
 /// #881 — input-parse + validation + memory-construction extracted
 /// from the monolithic `handle_store`. Returns the parsed
 /// `(memory, on_conflict, agent_id, explicit_scope)` tuple ready for
@@ -229,11 +245,7 @@ pub(super) fn parse_and_build_memory(
             if let Some(existing_id) =
                 db::find_by_title_namespace(conn, title, &namespace).map_err(|e| e.to_string())?
             {
-                return Err(format!(
-                    "CONFLICT: memory with title '{title}' already exists in namespace \
-                     '{namespace}' (existing id: {existing_id}). Pass \
-                     on_conflict='merge' to update in place or 'version' to suffix the title."
-                ));
+                return Err(conflict_error_message(title, &namespace, &existing_id));
             }
             title.to_string()
         }

--- a/src/portability/import.rs
+++ b/src/portability/import.rs
@@ -550,10 +550,24 @@ fn apply_all_classes(
         // path always took `storage::insert`'s silent upsert-merge, which
         // CLOBBERED an existing destination row's content whenever an
         // imported memory (different id) collided on `(title, namespace)`.
-        if let Some(existing_id) =
+        let collision =
             crate::storage::find_by_title_namespace(conn, &staged.title, &staged.namespace)
-                .with_context(|| format!("import: collision probe for memory {}", staged.id))?
-        {
+                .with_context(|| format!("import: collision probe for memory {}", staged.id))?;
+        // #2878 — whether the write below must be ATOMICALLY fail-closed
+        // (`insert_imported_no_overwrite`, `INSERT … ON CONFLICT DO NOTHING`).
+        // Every non-`Merge` disposition promises "never clobber the
+        // destination's durable text", so a concurrent writer that raced into
+        // `(title, namespace)` BETWEEN the probe above and the write must be
+        // REFUSED, not upsert-merged — the North-Star lost-update #2771 closed
+        // on the create funnel, here on the Portability-v2 importer. Only
+        // `Merge` (the operator's opt-in silent upsert-merge) keeps the upsert;
+        // the non-race path is byte-identical under both writes (`DO NOTHING`
+        // and `DO UPDATE` behave the same when there is no conflict), so
+        // `Version`'s suffix semantics and `Merge`'s upsert semantics are
+        // unchanged — only the raced-collision outcome flips from a silent
+        // clobber to a skip.
+        let fail_closed = opts.on_conflict != ConflictMode::Merge;
+        if let Some(existing_id) = collision {
             match opts.on_conflict {
                 // Legacy silent upsert-merge — the operator opted in.
                 ConflictMode::Merge => {}
@@ -583,10 +597,40 @@ fn apply_all_classes(
         // `storage::insert`, but WITHOUT advancing this node's vector-clock
         // component — remote-admission semantics mirroring `insert_if_newer`,
         // #2211: the destination did not author these rows). It opens no
-        // inner transaction.
-        crate::storage::insert_imported(conn, &staged)
-            .with_context(|| format!("import memory {}", staged.id))?;
-        report.memories += 1;
+        // inner transaction. #2878 — under the non-`Merge` dispositions the
+        // write is the fail-closed `insert_imported_no_overwrite`, so a racer
+        // that took the key AFTER the probe cannot be silently clobbered.
+        let write_result = if fail_closed {
+            crate::storage::insert_imported_no_overwrite(conn, &staged)
+        } else {
+            crate::storage::insert_imported(conn, &staged)
+        };
+        match write_result {
+            Ok(_) => {
+                report.memories += 1;
+            }
+            // #2878 — the fail-closed write refused a `(title, namespace)`
+            // collision that raced past the probe above. Skip the row with the
+            // SAME disposition as the probe-hit `Error` arm (count + WARN +
+            // continue), never a silent overwrite and never a bundle abort — a
+            // conflict has always been a per-row skip on this funnel, not an
+            // all-or-nothing failure.
+            Err(e) if e.downcast_ref::<crate::storage::ConflictError>().is_some() => {
+                let existing_id = e
+                    .downcast_ref::<crate::storage::ConflictError>()
+                    .map_or_else(String::new, |c| c.existing_id.clone());
+                report.conflicts_skipped += 1;
+                report.warnings.push(format!(
+                    "memory {} skipped: (title, namespace) collision with existing {existing_id} \
+                     (raced past the collision probe)",
+                    staged.id
+                ));
+                continue;
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("import memory {}", staged.id));
+            }
+        }
     }
     for link in &env.links {
         // Pre-ship 3x7 HIGH-2 (link lane) — L1 parity with the `cli::io`

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1475,6 +1475,27 @@ pub fn insert_imported(conn: &Connection, mem: &Memory) -> Result<String> {
     insert_inner(conn, mem, false, false)
 }
 
+/// v1.0.0 #2878 — FAIL-CLOSED remote-admission insert: the no-overwrite twin
+/// of [`insert_imported`] (same remote-admission funnel — vector-clock crosses
+/// verbatim, NOT stamped locally) EXCEPT a `(title, namespace)` collision is
+/// `DO NOTHING` instead of `DO UPDATE`: a row that already holds the key is NOT
+/// overwritten. Instead the write returns a typed [`ConflictError`] (the same
+/// shape the up-front existence probe raises). Closes the Portability-v2
+/// probe-then-upsert lost-update: on a PROBE MISS under the non-`Merge`
+/// dispositions the importer routes here so a concurrent writer that raced into
+/// the key BETWEEN the collision probe and the write can never be silently
+/// upsert-overwritten. `Merge` (the operator's opt-in silent upsert) keeps
+/// calling [`insert_imported`].
+///
+/// # Errors
+///
+/// * [`ConflictError`] (via `anyhow`) when `(mem.title, mem.namespace)`
+///   already exists — the existing row is left byte-identical.
+/// * Otherwise identical to [`insert_imported`].
+pub fn insert_imported_no_overwrite(conn: &Connection, mem: &Memory) -> Result<String> {
+    insert_inner(conn, mem, false, true)
+}
+
 /// Shared body of [`insert`] / [`insert_imported`] / [`insert_no_overwrite`].
 /// `stamp_local_clock` selects whether this node's vector-clock component is
 /// advanced (local authorship) or the metadata crosses verbatim (remote

--- a/tests/import_conflict_2878.rs
+++ b/tests/import_conflict_2878.rs
@@ -1,0 +1,409 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2878 — the Portability-v2 importer must be ATOMICALLY fail-closed on a
+//! `(title, namespace)` collision under every non-`Merge` disposition: a row
+//! that raced into the key BETWEEN the collision probe and the write is
+//! REFUSED (typed `ConflictError` → per-row skip), never allowed to silently
+//! upsert-overwrite the destination's durable content.
+//!
+//! Pre-#2878 a probe MISS fell through to `storage::insert_imported`
+//! (`insert_inner(.., false, false)` = `INSERT … ON CONFLICT DO UPDATE`), so a
+//! writer that slipped into the key after the probe had the destination row's
+//! content clobbered with no warning — the identical North-Star lost-update
+//! #2771 closed on the create funnel, on the import funnel. `Merge` (the
+//! operator's opt-in silent upsert) is unchanged.
+//!
+//! The importer wraps every apply in ONE `BEGIN IMMEDIATE` transaction, so two
+//! concurrent imports SERIALIZE and the second's probe always SEES the first's
+//! committed row (the collision is probe-visible, never a mid-transaction
+//! race). The no-overwrite write arm is therefore STRUCTURAL defense-in-depth
+//! — it makes "never clobber" hold by construction regardless of isolation
+//! level or backend, rather than resting on the IMMEDIATE-transaction argument.
+//! These tests pin BOTH halves: the certified `insert_imported_no_overwrite`
+//! primitive the funnel now wires in (single-connection deterministic + a
+//! genuine two-connection race), and the funnel's end-to-end non-clobber
+//! contract under the `Version` (default) and `Error` dispositions.
+//!
+//! The load-bearing no-overwrite assertion is the schema-v45 `version` column:
+//! a fresh insert lands `version = 1`, an upsert-MERGE bumps it (#1632).
+
+#![allow(clippy::missing_panics_doc, clippy::uninlined_format_args)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ai_memory::models::{Memory, MemoryKind, Tier};
+use ai_memory::portability::emit::{ExportEnvelope, SPEC_VERSION_V2};
+use ai_memory::portability::import::{ImportOptions, import_full_envelope};
+use rusqlite::Connection;
+
+const AUTHOR: &str = "ai:bundle-author";
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-2878-import-conflict")
+        .join(tag);
+    std::fs::create_dir_all(&root).ok();
+    root
+}
+
+/// A migrated DB file that outlives the returned connection (the file is
+/// leaked, not the connection — the two-connection race re-opens it).
+fn fresh_db_path(tag: &str) -> PathBuf {
+    let dir = tempfile::Builder::new()
+        .prefix(tag)
+        .tempdir_in(scratch_root(tag))
+        .expect("tempdir under .local-runs");
+    let path = dir.path().join("db.sqlite");
+    drop(ai_memory::db::open(&path).expect("init db"));
+    std::mem::forget(dir); // keep the file alive for the test's connections
+    path
+}
+
+fn mem(id: &str, title: &str, ns: &str, content: &str) -> Memory {
+    let now = "2026-07-20T00:00:00Z".to_string();
+    Memory {
+        id: id.into(),
+        tier: Tier::Mid,
+        namespace: ns.into(),
+        title: title.into(),
+        content: content.into(),
+        priority: 5,
+        confidence: 1.0,
+        source: "system".into(),
+        created_at: now.clone(),
+        updated_at: now,
+        expires_at: Some("2099-01-01T00:00:00Z".into()),
+        memory_kind: MemoryKind::Observation,
+        metadata: serde_json::json!({ "agent_id": AUTHOR }),
+        ..Memory::default()
+    }
+}
+
+fn envelope_with(memories: Vec<Memory>) -> ExportEnvelope {
+    let count = memories.len();
+    ExportEnvelope {
+        spec_version: SPEC_VERSION_V2.to_string(),
+        // 0 <= any migrated destination schema, so the fail-closed
+        // newer-producer gate never fires for this hand-built bundle.
+        db_schema_version: 0,
+        source: "issue-2878-test".into(),
+        exported_at: "2026-07-20T00:00:00Z".into(),
+        memories,
+        links: Vec::new(),
+        signed_events: Vec::new(),
+        memory_revisions: Vec::new(),
+        forget_tombstones: Vec::new(),
+        agent_lineage: Vec::new(),
+        model_attestations: Vec::new(),
+        governance_rules: Vec::new(),
+        trust_anchors: Vec::new(),
+        portability_complete: false,
+        conformance_level: "L1".into(),
+        conformance_by_class: BTreeMap::new(),
+        count,
+    }
+}
+
+/// Default (secure) importer options — restamp identity, `Version` on
+/// collision (never clobber).
+fn default_opts() -> ImportOptions {
+    ImportOptions {
+        caller_agent_id: "ai:importer".into(),
+        ..ImportOptions::default()
+    }
+}
+
+fn error_opts() -> ImportOptions {
+    ImportOptions {
+        caller_agent_id: "ai:importer".into(),
+        on_conflict: ai_memory::storage::ConflictMode::Error,
+        ..ImportOptions::default()
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// primitive — `insert_imported_no_overwrite` (the funnel's write arm)
+// ───────────────────────────────────────────────────────────────────
+
+/// The remote-admission no-overwrite insert REFUSES a `(title, namespace)`
+/// collision with the typed `ConflictError` carrying the incumbent's id, and
+/// leaves the durable row byte-identical (winner's content, `version = 1`).
+#[test]
+fn insert_imported_no_overwrite_refuses_and_preserves_content_2878() {
+    let path = fresh_db_path("primitive");
+    let conn = ai_memory::db::open(&path).expect("open");
+
+    let winner = mem(
+        "id-winner",
+        "shared-title",
+        "team/ops",
+        "WINNER durable content",
+    );
+    let winner_id = ai_memory::db::insert_imported_no_overwrite(&conn, &winner).expect("first ok");
+    assert_eq!(winner_id, "id-winner");
+
+    let loser = mem(
+        "id-loser",
+        "shared-title",
+        "team/ops",
+        "LOSER content MUST NOT land",
+    );
+    let err = ai_memory::db::insert_imported_no_overwrite(&conn, &loser)
+        .expect_err("second import MUST be refused, never overwrite");
+    let conflict = err
+        .downcast_ref::<ai_memory::storage::ConflictError>()
+        .expect("typed ConflictError");
+    assert_eq!(conflict.existing_id, "id-winner");
+    assert_eq!(conflict.title, "shared-title");
+    assert_eq!(conflict.namespace, "team/ops");
+
+    let row = ai_memory::db::get(&conn, "id-winner")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.content, "WINNER durable content");
+    assert_eq!(row.version, 1, "no upsert-merge ever bumped the version");
+    assert!(
+        ai_memory::db::get(&conn, "id-loser")
+            .expect("get")
+            .is_none(),
+        "loser id must not exist"
+    );
+}
+
+/// Control: the legacy `insert_imported` (the `Merge`/upsert path #2878 leaves
+/// unchanged) DOES clobber — proving the no-overwrite fix changed only the
+/// non-`Merge` write, and that the assertion above is load-bearing.
+#[test]
+fn insert_imported_still_upserts_on_merge_2878() {
+    let path = fresh_db_path("merge-control");
+    let conn = ai_memory::db::open(&path).expect("open");
+
+    ai_memory::db::insert_imported(&conn, &mem("id-1", "shared-title", "team/ops", "first"))
+        .expect("first");
+    ai_memory::db::insert_imported(
+        &conn,
+        &mem("id-2", "shared-title", "team/ops", "second wins on merge"),
+    )
+    .expect("merge upsert");
+    let row = ai_memory::db::get(&conn, "id-1")
+        .expect("get")
+        .expect("surviving row");
+    assert_eq!(row.content, "second wins on merge");
+    assert!(
+        row.version >= 2,
+        "merge upsert bumps version (#1632), got {}",
+        row.version
+    );
+}
+
+/// Genuine two-connection race on the no-overwrite primitive: the
+/// `(title, namespace)` UNIQUE index guarantees exactly one winner; the loser
+/// gets the typed `ConflictError` (never a silent overwrite, never two rows),
+/// and the surviving content is the winner's at `version = 1`.
+#[test]
+fn insert_imported_no_overwrite_two_connection_race_one_winner_2878() {
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    let path = fresh_db_path("race");
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = Vec::new();
+    for tag in ["a", "b"] {
+        let path = path.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            let conn = ai_memory::db::open(&path).expect("open");
+            conn.busy_timeout(Duration::from_secs(10))
+                .expect("busy_timeout");
+            let m = mem(
+                &format!("id-{tag}"),
+                "raced-title",
+                "race/ns",
+                &format!("content-from-{tag}"),
+            );
+            barrier.wait();
+            ai_memory::db::insert_imported_no_overwrite(&conn, &m)
+        }));
+    }
+    let results: Vec<_> = handles
+        .into_iter()
+        .map(|h| h.join().expect("join"))
+        .collect();
+
+    let winners: Vec<&String> = results.iter().filter_map(|r| r.as_ref().ok()).collect();
+    assert_eq!(winners.len(), 1, "exactly one import must win the race");
+    for r in &results {
+        if let Err(e) = r {
+            e.downcast_ref::<ai_memory::storage::ConflictError>()
+                .expect("loser must get the typed ConflictError, not a lock/other error");
+        }
+    }
+
+    let conn = ai_memory::db::open(&path).expect("reopen");
+    let winner_id = winners[0].clone();
+    let row = ai_memory::db::get(&conn, &winner_id)
+        .expect("get")
+        .expect("winner row");
+    let expected = format!("content-from-{}", winner_id.trim_start_matches("id-"));
+    assert_eq!(row.content, expected, "winner content must be durable");
+    assert_eq!(
+        row.version, 1,
+        "the race must never upsert-overwrite (version stays 1)"
+    );
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE title = ?1 AND namespace = ?2",
+            rusqlite::params!["raced-title", "race/ns"],
+            |r| r.get(0),
+        )
+        .expect("count");
+    assert_eq!(count, 1, "the race must leave exactly one row");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// funnel — `import_full_envelope` end-to-end non-clobber contract
+// ───────────────────────────────────────────────────────────────────
+
+/// A fresh import lands the row at `version = 1` (baseline), and a SECOND
+/// import of a DIFFERENT-id memory colliding on `(title, namespace)` under the
+/// default `Version` disposition SUFFIXES the incoming title so BOTH rows
+/// persist — the destination's original row is NEVER clobbered (content intact,
+/// `version = 1`). Semantics unchanged by #2878; the no-overwrite write arm is
+/// a structural no-op on this (probe-visible) collision.
+#[test]
+fn import_version_disposition_never_clobbers_destination_2878() {
+    let path = fresh_db_path("funnel-version");
+    let conn = Connection::open(&path).expect("open raw");
+    // Re-run migrations/pragmas through the canonical opener on a fresh handle.
+    drop(conn);
+    let conn = ai_memory::db::open(&path).expect("open");
+
+    let first = import_full_envelope(
+        &conn,
+        &envelope_with(vec![mem(
+            "id-a",
+            "runbook",
+            "portability",
+            "ORIGINAL destination text",
+        )]),
+        &default_opts(),
+    )
+    .expect("first import");
+    assert_eq!(first.memories, 1);
+    let row = ai_memory::db::get(&conn, "id-a")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.version, 1, "fresh import lands version=1");
+
+    // Second import: different id, SAME (title, namespace).
+    let second = import_full_envelope(
+        &conn,
+        &envelope_with(vec![mem(
+            "id-b",
+            "runbook",
+            "portability",
+            "INCOMING different text",
+        )]),
+        &default_opts(),
+    )
+    .expect("second import");
+    assert_eq!(
+        second.memories, 1,
+        "Version suffixes the incoming title so it also persists"
+    );
+
+    // The destination's ORIGINAL row is untouched — content + version.
+    let original = ai_memory::db::get(&conn, "id-a")
+        .expect("get")
+        .expect("original row");
+    assert_eq!(
+        original.content, "ORIGINAL destination text",
+        "#2878: the destination's durable content must never be clobbered"
+    );
+    assert_eq!(
+        original.version, 1,
+        "#2878: no upsert-merge ever bumped the original"
+    );
+    // The incoming row landed under a suffixed title.
+    let incoming = ai_memory::db::get(&conn, "id-b")
+        .expect("get")
+        .expect("incoming row");
+    assert_ne!(
+        incoming.title, "runbook",
+        "Version suffixes the colliding title"
+    );
+    assert!(
+        incoming.title.starts_with("runbook"),
+        "suffix keeps the base: {}",
+        incoming.title
+    );
+}
+
+/// Under the `Error` disposition a colliding import is SKIPPED
+/// (`conflicts_skipped = 1`), the destination's original row is left intact
+/// (content + `version = 1`), and no second row is created.
+#[test]
+fn import_error_disposition_skips_and_preserves_destination_2878() {
+    let path = fresh_db_path("funnel-error");
+    let conn = ai_memory::db::open(&path).expect("open");
+
+    import_full_envelope(
+        &conn,
+        &envelope_with(vec![mem(
+            "id-a",
+            "runbook",
+            "portability",
+            "ORIGINAL destination text",
+        )]),
+        &error_opts(),
+    )
+    .expect("first import");
+
+    let report = import_full_envelope(
+        &conn,
+        &envelope_with(vec![mem(
+            "id-b",
+            "runbook",
+            "portability",
+            "INCOMING must be refused",
+        )]),
+        &error_opts(),
+    )
+    .expect("second import (bundle still lands, colliding row skipped)");
+    assert_eq!(
+        report.memories, 0,
+        "the colliding row is not admitted under Error"
+    );
+    assert_eq!(
+        report.conflicts_skipped, 1,
+        "the collision is counted, not clobbered"
+    );
+
+    let original = ai_memory::db::get(&conn, "id-a")
+        .expect("get")
+        .expect("original row");
+    assert_eq!(original.content, "ORIGINAL destination text");
+    assert_eq!(
+        original.version, 1,
+        "#2878: original never upsert-overwritten"
+    );
+    assert!(
+        ai_memory::db::get(&conn, "id-b").expect("get").is_none(),
+        "the refused row must not exist"
+    );
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE title = ?1 AND namespace = ?2",
+            rusqlite::params!["runbook", "portability"],
+            |r| r.get(0),
+        )
+        .expect("count");
+    assert_eq!(
+        count, 1,
+        "Error disposition leaves exactly the original row"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the headline cert-BLOCKER #2878 (final 5-agent cert re-vote): the probe-then-upsert **lost-update** (North-Star silent-data-loss) was still live on the error/no-overwrite write funnels the #2771 (create) / #2874 (bulk) fixes did **not** reach — including the FLAGSHIP MCP agent write surface.

Both funnels probed `find_by_title_namespace` then WROTE via `db::insert`'s `ON CONFLICT (title, namespace) DO UPDATE`, so a concurrent writer racing into the key BETWEEN the probe and the write was silently upsert-overwritten despite the caller's error / never-clobber intent — the identical North-Star unintentional-data-loss defect #2771/#2874 closed elsewhere.

## Funnels fixed

- **MCP `memory_store` `on_conflict=error`** (the v2-aware-client default; MCP stdio is sqlite-only per #1675) now routes the write through the certified `db::insert_no_overwrite` (`INSERT … ON CONFLICT DO NOTHING` → typed `ConflictError`). A race-detected collision surfaces the **same** typed `CONFLICT:` string the up-front probe raises — single-sourced via a new `validation::conflict_error_message` helper — never an overwrite. `src/mcp/tools/store/{mod,validation}.rs`.
- **Portability-v2 import** routes every non-`Merge` disposition's probe-miss write through the new remote-admission twin `db::insert_imported_no_overwrite` (`insert_inner(.., stamp_local_clock=false, fail_on_conflict=true)`). A raced collision is refused as a per-row `conflicts_skipped` skip (mirroring the probe-hit `Error` disposition), never a silent clobber. The importer wraps its apply in one `BEGIN IMMEDIATE` transaction, so this is **structural defense-in-depth** that makes "never clobber the destination's durable text" hold by construction. `src/portability/import.rs`, `src/storage/mod.rs`.

`merge` (opt-in silent upsert) and `version` (title-suffix) semantics are **unchanged**; the non-race path is byte-identical (`DO NOTHING` and `DO UPDATE` behave the same absent a conflict).

Both funnels are **sqlite-only** (MCP stdio per #1675; `import_full_envelope` takes a `rusqlite::Connection`), so there is no new postgres/SAL surface — the pg-serve-MCP-over-HTTP create path already routes through the SAL and was fixed by #2771.

## Disposition finding — autonomy / curator rollback restores (NOT fixed, by design)

`autonomy::reverse_rollback_entry_store` and `curator::compaction::rollback_consolidation` are **guarded RESTORE** paths: probe → refuse-if-a-**different**-id owns the key → `store.store` restore-by-id. The certified create no-overwrite primitive does **not** fit them — it refuses **any** `(title, namespace)` collision, including the legitimate **same-id idempotent restore**. Their residual non-atomic window is narrow (single curator daemon / serial `curator --rollback`) and already documented (guardrail G4, "EXACT PARITY with the rusqlite twin"). Closing it properly needs a **new restore-safe atomic primitive** (a T1 trait-shape change requiring its own 5-agent vote), not this precedent — tracked separately, outside the #2771 lost-update class.

## Decision provenance

Applies the certified #2771/#2874 precedent to the remaining funnels — **T6 does not fire** (copying an existing precedent IS the decision), so no new 5-agent vote.

## Tests (all run locally, green)

- `tests/import_conflict_2878.rs` — 5 tests: `insert_imported_no_overwrite` single-connection deterministic refuse + `merge` control + genuine two-connection sqlite race, and the `Version`/`Error` funnel end-to-end non-clobber contract. **5 passed.**
- `src/mcp/tools/store/tests.rs` — 3 tests: `on_conflict=error` deterministic refuse + two-connection race one-winner + `merge`-mode-unchanged control. **3 passed.**

All keyed on the schema-v45 `version` column so an upsert-overwrite (which bumps `version` per #1632) is a hard failure.

CI-parity run locally: `cargo fmt --all`; clippy `--all-targets -D warnings -D clippy::all -D clippy::pedantic` on **default + sal + sal-postgres + vectorlite** (all clean); `cargo check --examples`; `cargo check --lib` on default + `sal,sal-postgres`; `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling`; hardcoded-literal + vendor-literal gates — all green. No live-PG leg applies (both funnels are sqlite-only).

## AI involvement

Authored by Claude Opus 5 (hard-coder) on the v1.0.0 cert loop. Not merged — Fable review + security-audit gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY