### PR TITLE
fix(#2569,#2570): idempotent import round-trip for an edited/existing corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (data integrity — import round-trip)
+
+- **An edited corpus can now re-import its own backup, and the default
+  `--on-conflict version` re-imports losslessly onto an EXISTING corpus**
+  ([#2570](https://github.com/alphaonedev/ai-memory-mcp/issues/2570) +
+  [#2569](https://github.com/alphaonedev/ai-memory-mcp/issues/2569); 5-agent
+  vote `4d3ea1c5`; data-integrity North Star). Two coupled defects on the
+  import-admission path, both landed via ONE shared archive-lifecycle
+  predicate + ONE shared divergence predicate so the v1 (`src/cli/io.rs`) and
+  v2 (`src/portability/import.rs`) funnels cannot drift (#2488 lesson).
+  **(#2570)** the import archive gate skipped a row keyed on mere PRESENCE in
+  `archived_memories`, but #1725 snapshots the prior content of a STILL-LIVE
+  row there under `archive_reason='in_place_edit'` on every in-place edit — so
+  an edited-but-live row failed the re-import of its OWN backup
+  (`covenant_skipped`), progressively and silently making an edited corpus
+  un-re-importable. The new `db::memory_is_genuinely_archived` predicate
+  discriminates `archive_reason`: it blocks re-admission ONLY for a GENUINE
+  archival (gc / `ttl_expired` / `size_gc` / offload / `superseded` / `forget`
+  / operator archive / NULL reason, via the NULL-safe `IS NOT`) and admits an
+  `in_place_edit` revision snapshot of a live row. **(#2569)** the default
+  `ConflictMode::Version` REUSES the payload `id`, so re-importing a row whose
+  id already existed hit `UNIQUE constraint failed: memories.id` → counted
+  `refused`, exit non-zero — so the documented lossless restore imported
+  NOTHING onto a non-empty corpus. A same-`id` row is now an IDEMPOTENT no-op
+  (counted under a new `idempotent_skipped` disposition, excluded from the
+  exit-code sum): the durable row is the source of truth and is NEVER
+  overwritten (mirrors the #2878 never-clobber contract and the v2 funnel's
+  existing idempotent skip). Both idempotent skips run AFTER the forget /
+  archive covenant gates, so they can never resurrect a forgotten or
+  genuinely-archived id. A per-row WARNING is surfaced when a same-`id`
+  backup row's DURABLE content (title / content — never restamped metadata)
+  diverges from the live row it would replace, so a divergent backup is not
+  silently swallowed; overwriting a diverged row is the explicit
+  `--on-conflict merge` opt-in. The `import --help`, `docs/USER_GUIDE.md`
+  §"Export and Backup", and `docs/TROUBLESHOOTING.md` split-brain restore
+  procedure are reconciled to the true behavior (the split-brain fix cited a
+  bare `import --trust-source` overwriting via upsert, but `--trust-source`
+  does not change the conflict disposition and the default `version` never
+  overwrites — the real overwrite path is `--on-conflict merge`).
+
 ### Fixed (cert truthfulness — published-claims reconciliation)
 
 - **The published LongMemEval keyword headline figures are now MEASURED on

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -323,9 +323,14 @@ disagree on `(title, namespace)` content.
 
 **Fix**: Decide which side is authoritative. On that side, run
 `ai-memory export > snapshot.json`. On the other side,
-`ai-memory import --trust-source < snapshot.json`. The upsert on
-`(title, namespace)` will overwrite the divergent copies with the
-authoritative ones.
+`ai-memory import --trust-source --on-conflict merge < snapshot.json`.
+`--on-conflict merge` is the disposition that OVERWRITES a divergent
+copy: the default `version` never clobbers — it keeps the existing row,
+and for a same-`id` row it is an idempotent no-op (so the default would
+leave the divergent copies untouched). `--trust-source` only preserves
+the embedded `agent_id`; it does not change the conflict disposition.
+The `merge` upsert on `(title, namespace)` overwrites the divergent
+copies with the authoritative ones.
 
 Per-namespace conflict resolution is an open work item (sync-phase
 Layer 2b).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2120,6 +2120,14 @@ Restore (preserves links):
 ai-memory import < memories-backup.json
 ```
 
+Re-importing a backup is idempotent and safe to run onto an existing
+corpus: rows already present (same `id`) are kept unchanged and reported
+as `idempotent_skipped`, missing rows are added, and nothing is
+duplicated or clobbered — the default `--on-conflict version` never
+overwrites a live row. A per-row warning is emitted where a backup row's
+content diverges from the live row it would replace; to overwrite diverged
+rows with the backup copy, add `--on-conflict merge`.
+
 ## Priority Guide
 
 | Priority | When to Use |

--- a/src/cli/io.rs
+++ b/src/cli/io.rs
@@ -36,10 +36,14 @@ pub enum OnConflict {
     /// idempotent behaviour — opt into it explicitly to re-import a
     /// backup without creating suffixed duplicates.
     Merge,
-    /// Auto-suffix the title (`title (2)`, `title (3)`, …) until a free
-    /// `(title, namespace)` slot is found, then insert a new row.
-    /// Never clobbers; both old and new rows persist. The #1780 default
-    /// — completes the import losslessly and is recoverable.
+    /// A `(title, namespace)` collision with a DIFFERENT existing row is
+    /// auto-suffixed (`title (2)`, `title (3)`, …) into a free slot, then
+    /// inserted — never clobbers; both rows persist. A row whose `id` is
+    /// ALREADY present (re-importing the corpus's own export onto an existing
+    /// corpus) is an IDEMPOTENT no-op: the durable row is kept, never
+    /// re-inserted or overwritten (#2569). The #1780 default — re-importing a
+    /// backup adds the missing rows and keeps the existing ones, without
+    /// duplicating or clobbering; use `merge` to overwrite a diverged row.
     #[default]
     Version,
 }
@@ -101,10 +105,12 @@ pub struct ImportArgs {
     /// — see [`crate::cli::backup::StoreDisagreement`].
     #[arg(long)]
     pub store_url: Option<String>,
-    /// Disposition on a `(title, namespace)` collision with an existing
-    /// memory: `version` (default — auto-suffix `title (N)`, never
-    /// clobber), `merge` (legacy silent idempotent upsert), or `error`
-    /// (refuse + skip the colliding row, continue the import).
+    /// Disposition on a `(title, namespace)` collision with a DIFFERENT
+    /// existing memory: `version` (default — auto-suffix `title (N)`, never
+    /// clobber), `merge` (legacy silent upsert — the way to OVERWRITE a
+    /// diverged row on restore), or `error` (refuse + skip the colliding row,
+    /// continue). A row whose `id` already exists is always an idempotent
+    /// no-op under `version`/`error` (kept, never overwritten; #2569).
     #[arg(long, value_enum, default_value_t = OnConflict::Version)]
     pub on_conflict: OnConflict,
 }
@@ -489,17 +495,26 @@ pub(crate) fn import_from_str(
     // BOTH kinds and the command exited 0 regardless; the counters below are
     // what the exit code is computed from.
     //
-    // `covenant_skipped` = a destination forget tombstone or a dest-archived
-    // id refused re-admission. These are the substrate HONOURING an erasure /
-    // archival decision, they are steady-state on any repeat restore, and
-    // #1725 puts every in-place-edited row into `archived_memories` — so
-    // treating them as failures would make a re-import forever-red and the
-    // alarm would be `|| true`-ed away (objection O9).
+    // `covenant_skipped` = a destination forget tombstone or a GENUINELY
+    // archived id refused re-admission. These are the substrate HONOURING an
+    // erasure / archival decision; they are steady-state on any repeat
+    // restore, so treating them as failures would make a re-import forever-red
+    // and the alarm would be `|| true`-ed away (objection O9). v1.0.0 #2570 —
+    // an `archive_reason='in_place_edit'` snapshot is a backup of a row that
+    // is STILL LIVE (#1725), NOT a genuine archival, so it no longer lands
+    // here: the gate below discriminates via `memory_is_genuinely_archived`
+    // and the live row is admitted (then idempotent-skipped just below).
     let mut covenant_skipped = 0usize;
     let mut covenant_skipped_ids: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     // `refused` = the bundle could NOT be faithfully reconstructed here.
     let mut refused = 0usize;
+    // v1.0.0 #2569 — `idempotent_skipped` = a row whose id is ALREADY LIVE at
+    // the destination (re-importing the corpus's own export onto an existing
+    // corpus). A NO-OP, NOT a failure and NOT counted in `imported` (no write
+    // happened); the durable row is kept, never overwritten. Deliberately
+    // excluded from the exit-code sum so an idempotent restore exits 0.
+    let mut idempotent_skipped = 0usize;
     for mut mem in memories {
         // #2208 re-audit N1 — the v1 wire-form must honour the SAME forget
         // covenant as the v2 route: stripping `spec_version` from a bundle
@@ -517,7 +532,16 @@ pub(crate) fn import_from_str(
         }
         // #2208 N1 mirror — a dest-ARCHIVED id must not be re-admitted live
         // (dual residency); the sanctioned way back is memory_archive_restore.
-        if db::memory_is_archived(&conn, &mem.id)? {
+        //
+        // v1.0.0 #2570 — DISCRIMINATE the archive_reason via the shared
+        // `memory_is_genuinely_archived` predicate (identical to the v2
+        // `portability::import` funnel): skip ONLY a GENUINE archival. #1725
+        // snapshots the prior content of a STILL-LIVE row into
+        // `archived_memories` under `archive_reason='in_place_edit'` on every
+        // in-place edit, so keying on mere presence made an edited-but-live
+        // row fail the re-import of its OWN backup. This admits the
+        // in_place_edit snapshot and blocks only a real archival.
+        if db::memory_is_genuinely_archived(&conn, &mem.id)? {
             errors.push(format!(
                 "{}: skipped — the id is archived at the destination \
                  (restore via memory_archive_restore, not import)",
@@ -525,6 +549,33 @@ pub(crate) fn import_from_str(
             ));
             covenant_skipped += 1;
             covenant_skipped_ids.insert(mem.id.clone());
+            continue;
+        }
+        // v1.0.0 #2569 — IDEMPOTENT same-id re-import. A row whose id is
+        // ALREADY LIVE at the destination (re-importing the corpus's own
+        // export onto an existing corpus — the documented restore path) is a
+        // NO-OP, not a `UNIQUE constraint failed: memories.id` refusal (the
+        // default `ConflictMode::Version` reuses the payload id, so it cannot
+        // re-insert an existing id). The durable row is the source of truth
+        // and is NEVER overwritten (mirrors #2878 never-clobber + the v2
+        // idempotent skip). This runs AFTER the forget/archive covenant gates
+        // above, so it can never resurrect a forgotten/archived id (5-agent
+        // vote 4d3ea1c5). A per-row WARNING is surfaced when the incoming
+        // DURABLE content diverges from the stored row (title/content only —
+        // never restamped metadata) so a divergent backup is not silently
+        // swallowed; to overwrite a diverged row the operator opts into
+        // `--on-conflict merge`.
+        if db::memory_exists(&conn, &mem.id)? {
+            if let Ok(Some(existing)) = db::get(&conn, &mem.id)
+                && db::imported_row_diverges(&existing, &mem)
+            {
+                errors.push(format!(
+                    "{}: already present — durable row kept; incoming content \
+                     differs (use --on-conflict merge to overwrite)",
+                    mem.id
+                ));
+            }
+            idempotent_skipped += 1;
             continue;
         }
         // v1.0.0 #2490 — REDACTION-OVERWRITE REFUSAL.
@@ -682,14 +733,19 @@ pub(crate) fn import_from_str(
                 "links_skipped_by_covenant": links_skipped_by_covenant,
                 "refused": refused,
                 "skipped_by_covenant": covenant_skipped,
+                // v1.0.0 #2569 — rows whose id was ALREADY present (idempotent
+                // re-import onto an existing corpus). A success, NOT a refusal:
+                // excluded from the exit-code sum so a restore of an unchanged
+                // corpus exits 0.
+                "idempotent_skipped": idempotent_skipped,
                 "errors": errors
             })
         )?;
     } else {
         writeln!(
             out.stdout,
-            "imported: {imported} (restamped agent_id on {restamped}), \
-             links: {links_imported}"
+            "imported: {imported} (restamped agent_id on {restamped}, \
+             already-present {idempotent_skipped}), links: {links_imported}"
         )?;
         if args.trust_source {
             writeln!(
@@ -1480,6 +1536,204 @@ mod tests {
             errs.iter()
                 .any(|e| e.as_str().unwrap_or_default().contains("archived")),
             "the archive skip is reported, got: {errs:?}"
+        );
+    }
+
+    /// ★ #2569 — the DEFAULT `--on-conflict version` re-imports the corpus's
+    /// own export onto an EXISTING corpus idempotently (pre-fix every row was
+    /// `refused` with `UNIQUE constraint failed: memories.id`).
+    #[test]
+    fn v1_reimport_onto_existing_corpus_is_idempotent_2569() {
+        let src = TestEnv::fresh();
+        let src_db = src.db_path.clone();
+        let _ = seed_memory(&src_db, "ns", "a-title", "a-content");
+        let _ = seed_memory(&src_db, "ns", "b-title", "b-content");
+        let payload = export_payload_at(&src_db);
+
+        let mut dst = TestEnv::fresh();
+        let dst_db = dst.db_path.clone();
+        let args = ImportArgs {
+            trust_source: false,
+            store_url: None,
+            on_conflict: OnConflict::Version,
+        };
+        // First import lands both rows.
+        {
+            let mut out = dst.output();
+            import_from_str(&payload, &dst_db, &args, true, Some("caller"), &mut out).unwrap();
+        }
+        // Re-import the SAME payload onto the now-existing corpus.
+        let code = {
+            let mut out = dst.output();
+            import_from_str(&payload, &dst_db, &args, true, Some("caller"), &mut out).unwrap()
+        };
+        assert_eq!(
+            code, 0,
+            "#2569: an idempotent re-import exits 0, not incomplete"
+        );
+
+        let v: serde_json::Value =
+            serde_json::from_str(dst.stdout_str().lines().last().unwrap()).unwrap();
+        assert_eq!(v["imported"], 0, "nothing was newly written");
+        assert_eq!(v["refused"], 0, "#2569: no UNIQUE-id refusal");
+        assert_eq!(
+            v["idempotent_skipped"], 2,
+            "both already-present rows are no-ops"
+        );
+        assert_eq!(
+            v["skipped_by_covenant"], 0,
+            "neither row hit a covenant gate"
+        );
+
+        // No duplicates manufactured under suffixed titles.
+        let conn = db::open(&dst_db).unwrap();
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 2, "#2569: an idempotent re-import creates zero new rows");
+    }
+
+    /// ★ #2570 — an EDITED (still-live) row's in_place_edit snapshot must NOT
+    /// make the row's own backup covenant-skipped; the re-import is idempotent.
+    #[test]
+    fn v1_reimport_of_edited_corpus_is_idempotent_2570() {
+        let src = TestEnv::fresh();
+        let src_db = src.db_path.clone();
+        let id = seed_memory(&src_db, "ns", "edit-me", "v1-content");
+        let _ = seed_memory(&src_db, "ns", "stable", "stable-content");
+        let payload1 = export_payload_at(&src_db);
+
+        let mut dst = TestEnv::fresh();
+        let dst_db = dst.db_path.clone();
+        let args = ImportArgs {
+            trust_source: false,
+            store_url: None,
+            on_conflict: OnConflict::Version,
+        };
+        {
+            let mut out = dst.output();
+            import_from_str(&payload1, &dst_db, &args, true, Some("caller"), &mut out).unwrap();
+        }
+        // Edit the row IN PLACE at the destination → #1725 in_place_edit snapshot.
+        {
+            let conn = db::open(&dst_db).unwrap();
+            let (changed, _) = db::update(
+                &conn,
+                &id,
+                None,
+                Some("v2-content"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+            assert!(changed, "the in-place edit landed");
+            assert!(
+                db::memory_is_archived(&conn, &id).unwrap(),
+                "precondition: the edit created an in_place_edit snapshot",
+            );
+        }
+        // Re-export the (edited) destination and re-import onto itself.
+        let payload2 = export_payload_at(&dst_db);
+        let code = {
+            let mut out = dst.output();
+            import_from_str(&payload2, &dst_db, &args, true, Some("caller"), &mut out).unwrap()
+        };
+        assert_eq!(
+            code, 0,
+            "#2570: the edited corpus re-imports its own backup cleanly"
+        );
+
+        let v: serde_json::Value =
+            serde_json::from_str(dst.stdout_str().lines().last().unwrap()).unwrap();
+        assert_eq!(
+            v["skipped_by_covenant"], 0,
+            "#2570: the edited-but-live row is NOT covenant-skipped as archived",
+        );
+        assert_eq!(
+            v["idempotent_skipped"], 2,
+            "both live rows are idempotent no-ops"
+        );
+        assert_eq!(v["refused"], 0);
+
+        // The durable edited row survives (never clobbered).
+        let conn = db::open(&dst_db).unwrap();
+        assert_eq!(
+            db::get(&conn, &id).unwrap().unwrap().content,
+            "v2-content",
+            "#2878: the durable live row is never clobbered on re-import",
+        );
+    }
+
+    /// ★ #2569 — a same-id re-import whose DURABLE content diverges from the
+    /// live row is still an idempotent no-op (never a clobber), but surfaces a
+    /// per-row WARNING so the divergent backup is not silently swallowed
+    /// (5-agent vote 4d3ea1c5, A-with-reporting).
+    #[test]
+    fn v1_divergent_same_id_reimport_warns_and_never_clobbers_2569() {
+        let src = TestEnv::fresh();
+        let src_db = src.db_path.clone();
+        let id = seed_memory(&src_db, "ns", "z-title", "OLD backup content");
+        let payload_old = export_payload_at(&src_db); // carries the OLD content
+
+        let mut dst = TestEnv::fresh();
+        let dst_db = dst.db_path.clone();
+        let args = ImportArgs {
+            trust_source: false,
+            store_url: None,
+            on_conflict: OnConflict::Version,
+        };
+        {
+            let mut out = dst.output();
+            import_from_str(&payload_old, &dst_db, &args, true, Some("caller"), &mut out).unwrap();
+        }
+        // The live row drifts (edited after the backup was taken).
+        {
+            let conn = db::open(&dst_db).unwrap();
+            db::update(
+                &conn,
+                &id,
+                None,
+                Some("LIVE newer content"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        }
+        // Re-import the OLD backup: same id, DIFFERENT content.
+        {
+            let mut out = dst.output();
+            import_from_str(&payload_old, &dst_db, &args, true, Some("caller"), &mut out).unwrap();
+        }
+        let v: serde_json::Value =
+            serde_json::from_str(dst.stdout_str().lines().last().unwrap()).unwrap();
+        assert_eq!(
+            v["idempotent_skipped"], 1,
+            "#2569: a diverged same-id row is still a no-op"
+        );
+        assert_eq!(v["refused"], 0);
+        let errs = v["errors"].as_array().unwrap();
+        assert!(
+            errs.iter()
+                .any(|e| e.as_str().unwrap_or_default().contains("content differs")),
+            "#2569: a divergent backup must warn, got: {errs:?}",
+        );
+
+        // The durable NEWER live row is never overwritten by the OLD backup.
+        let conn = db::open(&dst_db).unwrap();
+        assert_eq!(
+            db::get(&conn, &id).unwrap().unwrap().content,
+            "LIVE newer content",
+            "#2878: the older backup never clobbers the durable live row",
         );
     }
 

--- a/src/portability/import.rs
+++ b/src/portability/import.rs
@@ -152,10 +152,20 @@ pub struct ImportReport {
     /// future admission; only the destination's own forget funnel erases).
     pub tombstones_skipped_live: usize,
     /// Memory rows skipped because the DESTINATION holds the id in
-    /// `archived_memories` (#2208 adjacent: re-admitting it live would
-    /// leave the id in BOTH tables; the sanctioned way back to live is
-    /// `memory_archive_restore`).
+    /// `archived_memories` under a GENUINE archival reason (#2208 adjacent:
+    /// re-admitting it live would leave the id in BOTH tables; the sanctioned
+    /// way back to live is `memory_archive_restore`). v1.0.0 #2570 — an
+    /// `archive_reason='in_place_edit'` snapshot of a STILL-LIVE row is NOT a
+    /// genuine archival and is NOT counted here; it is admitted (then
+    /// idempotent-skipped as a same-id re-import).
     pub archived_skipped: usize,
+    /// Memory rows skipped because the id is ALREADY LIVE at the destination —
+    /// an idempotent same-id re-import (the corpus's own export re-applied
+    /// onto an existing corpus). NOT a failure and NOT counted in `memories`
+    /// (no write happened): the durable row is kept, never overwritten
+    /// (#2569, 5-agent vote 4d3ea1c5). A divergent incoming copy adds a
+    /// `warnings` entry but is still not applied.
+    pub idempotent_skipped: usize,
     /// Memory rows whose `metadata.agent_id` was restamped with the
     /// caller's id (the L1-parity default; `--trust-source` disables).
     pub restamped: usize,
@@ -445,18 +455,40 @@ fn apply_all_classes(
         // on `storage::get`; re-admitting it live would leave the id in
         // BOTH `memories` and `archived_memories` (dual residency). The
         // sanctioned way back to live is `memory_archive_restore`.
-        if crate::storage::memory_is_archived(conn, &mem.id)
+        //
+        // v1.0.0 #2570 — DISCRIMINATE the archive_reason via the shared
+        // `memory_is_genuinely_archived` predicate (identical to the v1
+        // `cli::io` funnel): skip ONLY a GENUINE archival. #1725 snapshots the
+        // prior content of a STILL-LIVE row into `archived_memories` under
+        // `archive_reason='in_place_edit'` on every in-place edit, so keying on
+        // mere presence made an edited-but-live row fail the re-import of its
+        // OWN backup. This admits the in_place_edit snapshot and blocks only a
+        // real archival.
+        if crate::storage::memory_is_genuinely_archived(conn, &mem.id)
             .with_context(|| format!("import: archive probe for memory {}", mem.id))?
         {
             report.archived_skipped += 1;
             continue;
         }
-        // Idempotent: skip a memory already present (a re-import is a no-op).
-        if crate::storage::get(conn, &mem.id)
+        // v1.0.0 #2569 — IDEMPOTENT same-id re-import: a row already LIVE at
+        // the destination is a NO-OP (counted `idempotent_skipped`, NOT
+        // `memories` — no write happened), never a refusal. The durable row is
+        // the source of truth and is NEVER overwritten (#2878 never-clobber).
+        // A WARNING is surfaced when the incoming DURABLE content (title /
+        // content, never restamped metadata) diverges from the stored row, so
+        // a divergent backup is not silently swallowed (5-agent vote
+        // 4d3ea1c5). Runs AFTER the forget/archive covenant gates, so it never
+        // resurrects a forgotten/archived id.
+        if let Some(existing) = crate::storage::get(conn, &mem.id)
             .with_context(|| format!("import: probing existing memory {}", mem.id))?
-            .is_some()
         {
-            report.memories += 1;
+            if crate::storage::imported_row_diverges(&existing, mem) {
+                report.warnings.push(format!(
+                    "memory {} already present — durable row kept; incoming content differs",
+                    mem.id
+                ));
+            }
+            report.idempotent_skipped += 1;
             continue;
         }
         let mut staged = mem.clone();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4955,6 +4955,80 @@ pub fn memory_is_archived(conn: &Connection, memory_id: &str) -> Result<bool> {
     Ok(exists)
 }
 
+/// v1.0.0 #2570 — does a GENUINE archival exist for `memory_id`, i.e. an
+/// `archived_memories` row the operator intends to STAY gone?
+///
+/// This is the DISCRIMINATING form of [`memory_is_archived`] and the shared
+/// predicate BOTH import-admission funnels (the v1 `cli::io` wire form and
+/// the v2 `portability::import` envelope) consult, so the two backends
+/// cannot drift (#2488 lesson). Plain `memory_is_archived` keys on mere
+/// PRESENCE in `archived_memories` — but #1725
+/// ([`archive_memory_insert_only`]) snapshots the PRIOR content of a
+/// STILL-LIVE row into `archived_memories` under
+/// `archive_reason='in_place_edit'` (SAME id, single slot) on EVERY in-place
+/// edit, while the edited row keeps living in `memories`. Keying re-admission
+/// on presence therefore made an edited-but-live row fail the re-import of
+/// its OWN backup — progressive, silent un-re-importability of an edited
+/// corpus (#2570).
+///
+/// So the covenant gate skips re-admission ONLY for a GENUINE archival — a
+/// gc / `ttl_expired` / `size_gc` / offload / `superseded` / `forget` /
+/// operator archive (`explicit` / `archive` / a caller-supplied reason), or a
+/// NULL reason — NOT for an `in_place_edit` revision snapshot of a row that
+/// is still live. `archive_reason IS NOT ?2` is the NULL-SAFE `IS NOT`
+/// operator (a NULL reason is DISTINCT from `'in_place_edit'` ⇒ counted as a
+/// genuine archival ⇒ still blocks), never the three-valued `<>`. An id that
+/// carries BOTH an `in_place_edit` snapshot AND a genuine archival (edited,
+/// then later gc-archived so the live row is gone) still returns `true`, so a
+/// truly-archived id is never re-admitted.
+///
+/// # Errors
+///
+/// Returns `Err` only on hard SQLite failures.
+pub fn memory_is_genuinely_archived(conn: &Connection, memory_id: &str) -> Result<bool> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM archived_memories \
+         WHERE id = ?1 AND archive_reason IS NOT ?2)",
+        params![memory_id, field_names::ARCHIVE_REASON_IN_PLACE_EDIT],
+        |r| r.get(0),
+    )?;
+    Ok(exists)
+}
+
+/// v1.0.0 #2569 — is `memory_id` currently a LIVE row in `memories`?
+///
+/// A cheap existence probe (no decrypt, unlike [`get`]) the import funnels
+/// consult to make a re-import of a row that is ALREADY present an idempotent
+/// NO-OP instead of a `UNIQUE constraint failed: memories.id` refusal: the
+/// default `ConflictMode::Version` reuses the payload id, so it cannot
+/// re-insert an existing id. Runs AFTER the forget/archive covenant gates, so
+/// it never governs a forgotten/archived id.
+///
+/// # Errors
+///
+/// Returns `Err` only on hard SQLite failures.
+pub fn memory_exists(conn: &Connection, memory_id: &str) -> Result<bool> {
+    let exists: bool = conn.query_row(SQL_MEMORY_EXISTS, params![memory_id], |r| r.get(0))?;
+    Ok(exists)
+}
+
+/// v1.0.0 #2569 — does an incoming import row DIVERGE from the row already
+/// stored under the same id, in the DURABLE source-of-truth fields?
+///
+/// Compares ONLY `title` + `content` — NEVER `metadata`: the default import
+/// restamp rewrites `metadata.agent_id` (and adds `imported_from_agent_id`),
+/// so a metadata compare would report divergence on EVERY faithful
+/// self-restore and train operators to ignore the warning (5-agent vote
+/// 4d3ea1c5). A `true` result drives a per-row WARNING that the durable row
+/// was KEPT and the incoming (differing) copy was NOT applied — the substrate
+/// never silently overwrites a live row on the default disposition, and never
+/// silently swallows a divergent backup either. To overwrite a diverged row
+/// the operator opts into `--on-conflict merge`.
+#[must_use]
+pub fn imported_row_diverges(existing: &Memory, incoming: &Memory) -> bool {
+    existing.title != incoming.title || existing.content != incoming.content
+}
+
 /// #1832 (TRACT-gap G18) — a read-only projection of a persisted v71
 /// `forget_tombstones` row: the SIGNED ERASURE ATTESTATION the substrate
 /// ALREADY computes at forget time (`purge_and_tombstone_forget`) and stores,

--- a/tests/import_roundtrip_2569_2570.rs
+++ b/tests/import_roundtrip_2569_2570.rs
@@ -1,0 +1,355 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #2570 + #2569 — the import round-trip must survive an EDITED corpus and a
+//! re-import onto an EXISTING corpus.
+//!
+//! - #2570: the import archive-admission gate must DISCRIMINATE
+//!   `archive_reason`. #1725 snapshots the prior content of a STILL-LIVE row
+//!   into `archived_memories` under `archive_reason='in_place_edit'` on every
+//!   in-place edit, so a gate keyed on mere PRESENCE wrongly covenant-skipped
+//!   an edited-but-live row's own backup. `db::memory_is_genuinely_archived`
+//!   admits the `in_place_edit` snapshot and blocks only a genuine archival.
+//! - #2569: the default `ConflictMode::Version` reuses the payload `id`, so a
+//!   same-`id` re-import onto an existing corpus hit `UNIQUE constraint
+//!   failed: memories.id` → `refused`. It is now an IDEMPOTENT no-op
+//!   (`idempotent_skipped`), never overwriting the durable row (#2878).
+//!
+//! Both dispositions were chosen by the 5-agent adversarial vote `4d3ea1c5`
+//! (A-with-reporting, unanimous). The GATING invariant (vote lens 5): the
+//! forget/archive covenant gates run BEFORE the same-id idempotent skip, so it
+//! can never resurrect a forgotten / genuinely-archived id — pinned below.
+
+#![allow(clippy::missing_panics_doc, clippy::uninlined_format_args)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ai_memory::models::{Memory, MemoryKind, Tier};
+use ai_memory::portability::emit::{ExportEnvelope, SPEC_VERSION_V2};
+use ai_memory::portability::import::{ImportOptions, import_full_envelope};
+use rusqlite::Connection;
+
+const AUTHOR: &str = "ai:bundle-author";
+
+fn scratch_root(tag: &str) -> PathBuf {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-2569-2570-roundtrip")
+        .join(tag);
+    std::fs::create_dir_all(&root).ok();
+    root
+}
+
+fn fresh_db(tag: &str) -> (PathBuf, Connection) {
+    let dir = tempfile::Builder::new()
+        .prefix(tag)
+        .tempdir_in(scratch_root(tag))
+        .expect("tempdir under .local-runs");
+    let path = dir.path().join("db.sqlite");
+    let conn = ai_memory::db::open(&path).expect("init db");
+    std::mem::forget(dir); // keep the file alive for the test's connection
+    (path, conn)
+}
+
+fn mem(id: &str, title: &str, ns: &str, content: &str) -> Memory {
+    let now = "2026-07-20T00:00:00Z".to_string();
+    Memory {
+        id: id.into(),
+        tier: Tier::Mid,
+        namespace: ns.into(),
+        title: title.into(),
+        content: content.into(),
+        priority: 5,
+        confidence: 1.0,
+        source: "system".into(),
+        created_at: now.clone(),
+        updated_at: now,
+        expires_at: Some("2099-01-01T00:00:00Z".into()),
+        memory_kind: MemoryKind::Observation,
+        metadata: serde_json::json!({ "agent_id": AUTHOR }),
+        ..Memory::default()
+    }
+}
+
+fn envelope_with(memories: Vec<Memory>) -> ExportEnvelope {
+    let count = memories.len();
+    ExportEnvelope {
+        spec_version: SPEC_VERSION_V2.to_string(),
+        db_schema_version: 0, // 0 <= any dst schema, so the newer-producer gate never fires
+        source: "issue-2569-2570-test".into(),
+        exported_at: "2026-07-20T00:00:00Z".into(),
+        memories,
+        links: Vec::new(),
+        signed_events: Vec::new(),
+        memory_revisions: Vec::new(),
+        forget_tombstones: Vec::new(),
+        agent_lineage: Vec::new(),
+        model_attestations: Vec::new(),
+        governance_rules: Vec::new(),
+        trust_anchors: Vec::new(),
+        portability_complete: false,
+        conformance_level: "L1".into(),
+        conformance_by_class: BTreeMap::new(),
+        count,
+    }
+}
+
+fn opts() -> ImportOptions {
+    ImportOptions {
+        caller_agent_id: "ai:importer".into(),
+        ..ImportOptions::default()
+    }
+}
+
+/// v1.0.0 #2570 — the SHARED archive-lifecycle predicate. An `in_place_edit`
+/// snapshot of a STILL-LIVE row is NOT a genuine archival; a real archival is.
+#[test]
+fn memory_is_genuinely_archived_discriminates_in_place_edit_2570() {
+    let (_path, conn) = fresh_db("predicate");
+
+    // (a) An edited-but-live row: insert, then edit in place → #1725 snapshots
+    // the prior content under archive_reason='in_place_edit' while the live row
+    // survives in `memories`.
+    ai_memory::db::insert(&conn, &mem("edited", "t-edit", "ns", "v1")).expect("insert");
+    let (changed, _) = ai_memory::db::update(
+        &conn,
+        "edited",
+        None,
+        Some("v2"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("in-place edit");
+    assert!(changed, "the in-place content edit landed");
+
+    // The snapshot exists (so the un-discriminating `memory_is_archived` is
+    // true), but it is NOT a genuine archival, and the live row is still there.
+    assert!(
+        ai_memory::db::memory_is_archived(&conn, "edited").expect("probe"),
+        "the in_place_edit snapshot is present in archived_memories",
+    );
+    assert!(
+        !ai_memory::db::memory_is_genuinely_archived(&conn, "edited").expect("probe"),
+        "#2570: an in_place_edit snapshot must NOT count as a genuine archival",
+    );
+    assert!(
+        ai_memory::db::memory_exists(&conn, "edited").expect("probe"),
+        "the edited row is still LIVE",
+    );
+
+    // (b) A genuinely-archived row: insert then archive (operator reason).
+    ai_memory::db::insert(&conn, &mem("archived", "t-arch", "ns", "c")).expect("insert");
+    assert!(
+        ai_memory::db::archive_memory(&conn, "archived", Some("explicit")).expect("archive"),
+        "operator archive",
+    );
+    assert!(
+        ai_memory::db::memory_is_genuinely_archived(&conn, "archived").expect("probe"),
+        "#2570: a real archival (reason != in_place_edit) still blocks re-admission",
+    );
+    assert!(
+        !ai_memory::db::memory_exists(&conn, "archived").expect("probe"),
+        "a genuinely-archived row is no longer live",
+    );
+}
+
+/// v1.0.0 #2569 — the durable-divergence predicate keys on title/content only,
+/// never metadata (the restamp mutates `metadata.agent_id` on every self-restore).
+#[test]
+fn imported_row_diverges_ignores_metadata_2569() {
+    let a = mem("id", "T", "ns", "same content");
+    let mut b = mem("id", "T", "ns", "same content");
+    // A different agent_id in metadata (what the default restamp produces) is
+    // NOT divergence.
+    b.metadata =
+        serde_json::json!({ "agent_id": "ai:someone-else", "imported_from_agent_id": AUTHOR });
+    assert!(
+        !ai_memory::db::imported_row_diverges(&a, &b),
+        "#2569: differing metadata must not read as content divergence",
+    );
+
+    let c = mem("id", "T", "ns", "DIFFERENT content");
+    assert!(
+        ai_memory::db::imported_row_diverges(&a, &c),
+        "#2569: differing durable content IS divergence",
+    );
+    let d = mem("id", "DIFFERENT title", "ns", "same content");
+    assert!(
+        ai_memory::db::imported_row_diverges(&a, &d),
+        "#2569: differing title IS divergence",
+    );
+}
+
+/// ★ #2570 + #2569 end-to-end (v2 funnel): export a corpus, EDIT a row in
+/// place, then re-import its own export onto the SAME corpus. The edited row is
+/// ADMITTED (not covenant-skipped) and is an idempotent no-op — never a
+/// UNIQUE-id refusal, never a clobber.
+#[test]
+fn v2_reimport_of_edited_corpus_is_idempotent_2569_2570() {
+    let (_path, conn) = fresh_db("v2-edited");
+
+    // Seed a corpus of 3 rows, then edit ONE in place (in_place_edit snapshot).
+    for i in 0..3 {
+        ai_memory::db::insert(
+            &conn,
+            &mem(&format!("m{i}"), &format!("t{i}"), "ns", &format!("c{i}")),
+        )
+        .expect("seed");
+    }
+    let (changed, _) = ai_memory::db::update(
+        &conn,
+        "m1",
+        None,
+        Some("c1-edited"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("edit");
+    assert!(changed);
+    assert!(
+        ai_memory::db::memory_is_archived(&conn, "m1").expect("probe"),
+        "precondition: the edit created an in_place_edit snapshot",
+    );
+
+    // The "current export": every live row, m1 carrying its EDITED content.
+    let env = envelope_with(vec![
+        mem("m0", "t0", "ns", "c0"),
+        mem("m1", "t1", "ns", "c1-edited"),
+        mem("m2", "t2", "ns", "c2"),
+    ]);
+
+    let report = import_full_envelope(&conn, &env, &opts()).expect("re-import");
+
+    assert_eq!(
+        report.archived_skipped, 0,
+        "#2570: the edited-but-live row is NOT covenant-skipped as archived",
+    );
+    assert_eq!(
+        report.memories, 0,
+        "#2569: nothing was newly written — every id already exists",
+    );
+    assert_eq!(
+        report.idempotent_skipped, 3,
+        "#2569: all three already-present rows are idempotent no-ops",
+    );
+    assert!(report.committed);
+
+    // The durable rows are untouched (never overwritten): m1 keeps its edit.
+    assert_eq!(
+        ai_memory::db::get(&conn, "m1")
+            .expect("get")
+            .expect("row")
+            .content,
+        "c1-edited",
+        "#2878: the durable live row is never clobbered on re-import",
+    );
+    // No duplicate rows were manufactured under suffixed titles.
+    let n: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .expect("count");
+    assert_eq!(n, 3, "#2569: an idempotent re-import creates zero new rows");
+}
+
+/// A genuinely gc/operator-archived id stays covenant-skipped on re-import
+/// (the #2570 fix narrows the gate WITHOUT re-opening resurrection), and a
+/// dest-forgotten id stays refused — both covenant gates run BEFORE the
+/// same-id idempotent skip (vote lens 5 gating invariant).
+#[test]
+fn v2_covenant_gates_precede_idempotent_skip_2569_2570() {
+    let (_path, conn) = fresh_db("v2-covenant");
+
+    // (a) genuinely archived id.
+    ai_memory::db::insert(&conn, &mem("arch", "t-arch", "ns", "c")).expect("insert");
+    assert!(ai_memory::db::archive_memory(&conn, "arch", Some("explicit")).expect("archive"));
+
+    // (b) dest-forgotten id (tombstone).
+    ai_memory::db::insert(&conn, &mem("forg", "t-forg", "ns-forget", "c")).expect("insert");
+    assert_eq!(
+        ai_memory::db::forget(&conn, Some("ns-forget"), None, None, false).expect("forget"),
+        1,
+    );
+
+    let env = envelope_with(vec![
+        mem("arch", "t-arch", "ns", "c"),
+        mem("forg", "t-forg", "ns-forget", "c"),
+    ]);
+    let report = import_full_envelope(&conn, &env, &opts()).expect("re-import");
+
+    assert_eq!(
+        report.archived_skipped, 1,
+        "#2570: a REAL archival still blocks re-admission"
+    );
+    assert_eq!(
+        report.tombstoned_skipped, 1,
+        "the forget tombstone still forbids resurrection"
+    );
+    assert_eq!(
+        report.idempotent_skipped, 0,
+        "neither reached the same-id idempotent path"
+    );
+    assert_eq!(report.memories, 0, "no covenant-gated id was re-admitted");
+
+    assert!(
+        ai_memory::db::get(&conn, "arch").expect("get").is_none(),
+        "the archived id did not come back live",
+    );
+    assert!(
+        ai_memory::db::get(&conn, "forg").expect("get").is_none(),
+        "the forgotten id did not resurrect",
+    );
+}
+
+/// A same-id re-import whose DURABLE content diverges from the live row is
+/// still an idempotent no-op (never a clobber), but surfaces a WARNING so the
+/// divergent backup is not silently swallowed (vote: A-with-reporting).
+#[test]
+fn v2_divergent_same_id_reimport_warns_and_never_clobbers_2569() {
+    let (_path, conn) = fresh_db("v2-divergent");
+
+    ai_memory::db::insert(&conn, &mem("z", "tz", "ns", "LIVE content")).expect("insert");
+
+    // Byte-identical re-import → clean no-op, NO divergence warning.
+    let env_same = envelope_with(vec![mem("z", "tz", "ns", "LIVE content")]);
+    let r1 = import_full_envelope(&conn, &env_same, &opts()).expect("re-import same");
+    assert_eq!(r1.idempotent_skipped, 1);
+    assert!(
+        !r1.warnings.iter().any(|w| w.contains("content differs")),
+        "a byte-identical re-import must NOT warn: {:?}",
+        r1.warnings,
+    );
+
+    // A DIVERGENT backup (older content) → still idempotent-skipped, but warned.
+    let env_diff = envelope_with(vec![mem("z", "tz", "ns", "OLD backup content")]);
+    let r2 = import_full_envelope(&conn, &env_diff, &opts()).expect("re-import diverged");
+    assert_eq!(
+        r2.idempotent_skipped, 1,
+        "#2569: a diverged same-id row is still a no-op"
+    );
+    assert!(
+        r2.warnings.iter().any(|w| w.contains("content differs")),
+        "#2569: a divergent backup must surface a warning: {:?}",
+        r2.warnings,
+    );
+
+    // The durable live row is NEVER overwritten by the older backup.
+    assert_eq!(
+        ai_memory::db::get(&conn, "z")
+            .expect("get")
+            .expect("row")
+            .content,
+        "LIVE content",
+        "#2878: the durable row wins — the older backup never clobbers it",
+    );
+}


### PR DESCRIPTION
## Summary

Two coupled data-integrity defects on the import-admission path, landed via **ONE shared archive-lifecycle predicate + ONE shared divergence predicate** so the v1 (`src/cli/io.rs`) and v2 (`src/portability/import.rs`) funnels cannot drift (#2488 lesson).

### #2570 — an edited corpus silently rejected its own backup
The import archive gate skipped a row keyed on mere **presence** in `archived_memories`. But #1725 snapshots the prior content of a **still-live** row there under `archive_reason='in_place_edit'` on every in-place edit, so an edited-but-live row failed the re-import of its **own** backup (`covenant_skipped`) — progressive, silent un-re-importability of an edited corpus.

New `db::memory_is_genuinely_archived` discriminates `archive_reason` via the NULL-safe `IS NOT`: it blocks re-admission **only** for a genuine archival (gc / `ttl_expired` / `size_gc` / offload / `superseded` / `forget` / operator / NULL reason) and **admits** an `in_place_edit` revision snapshot of a live row.

### #2569 — the default `--on-conflict version` couldn't re-import onto an existing corpus
`ConflictMode::Version` **reuses the payload `id`**, so re-importing a row whose id already exists hit `UNIQUE constraint failed: memories.id` → `refused`, exit non-zero — the documented lossless restore imported **nothing** onto a non-empty corpus.

A same-`id` row is now an **idempotent no-op** (new `idempotent_skipped` disposition, excluded from the exit-code sum): the durable row is the source of truth and is **never overwritten** (mirrors the #2878 never-clobber contract + the v2 funnel's existing idempotent skip). Both idempotent skips run **after** the forget/archive covenant gates, so they can never resurrect a forgotten or genuinely-archived id. A per-row **warning** is surfaced when a same-`id` backup's durable content (title/content — never restamped metadata) diverges from the live row it would replace, so a divergent backup is not silently swallowed; overwriting a diverged row is the explicit `--on-conflict merge` opt-in.

## AI involvement

Implemented autonomously by Claude Opus 5 (hard-coder). The #2569 disposition is a public-contract + posture + spec-deviation crossroads (T1/T3/T5), so it was decided by the mandated **5-agent adversarial vote (`4d3ea1c5`)** — **UNANIMOUS A-with-reporting** (idempotent no-op skip + mandatory content-divergence warning). Rejected B (route same-id to Merge: reopens the #2878 clobber and enables a stale-content rollback/lost-update oracle) and C (typed refusal: leaves re-import red, keeps the docs a lie).

## Docs reconciled
`import --help` (`OnConflict::Version` + `ImportArgs.on_conflict`), `docs/USER_GUIDE.md` §"Export and Backup", and `docs/TROUBLESHOOTING.md` split-brain restore procedure — the latter cited a bare `import --trust-source` overwriting via upsert, but `--trust-source` does not change the conflict disposition and the default `version` never overwrites; the real overwrite path is `--on-conflict merge`.

## Tests
- `tests/import_roundtrip_2569_2570.rs` (v2 funnel + shared predicates) — **5/5**
- `src/cli/io.rs` internal v1 tests — **6/6** (incl. the covenant-precedence pin `v1_form_import_does_not_resurrect_dest_forgotten_or_archived_2208`)
- Covered: edited-corpus re-import admitted + idempotent; genuinely-archived id stays `covenant_skipped`; forgotten id stays refused; byte-identical re-import is a clean exit-0 no-op; a divergent same-id backup warns and never clobbers.
- Regression: `import_conflict_2878`, `export_import_false_success_2490`, `portability::import` lib tests (25/0), qual module-size + legacy-error ceilings — all green.

## CI parity (local)
`cargo fmt --all --check` clean; `cargo check --examples` clean; clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` green on **default / sal / sal-postgres / vectorlite**; vendor-literal + hardcoded-literal gates PASS.

Closes #2569 #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY