### PR TITLE
ci: cert-evidence unblocker cluster — in-PR pg+AGE tier, one-decl-source gate, release supply-chain (#2548 #2512 #2534 #2895)

### DIFF
--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -570,6 +570,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run required-contexts gate
         run: bash scripts/check-required-contexts.sh
+      - name: One-declaration-source gate (#2534 — branch-protection.yml)
+        # HARD-FAIL if .github/branch-protection.yml re-declares a bare
+        # `required_checks` key. The required-status-check set has ONE
+        # declaration source (required-contexts-release.txt, verified by the
+        # gate above); a second hand-maintained list in branch-protection.yml
+        # is exactly the #2443 defect. Runs as a step of THIS already-required
+        # job (no new required context to add to the mirror).
+        run: bash scripts/check-branch-protection.sh
+      - name: Self-test the one-declaration-source gate (#2534)
+        run: bash scripts/check-branch-protection.sh --self-test
       - name: Self-test the gate (regression evidence)
         # --self-test plants each historical shape in a throwaway copy UNDER
         # the repo (never system /tmp): the (b1) matrix+`if:` wedge, an (a)

--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -13,20 +13,44 @@
 # the AGE-backed cells (with the AGE url set, so they stop self-skipping)
 # against a LIVE stack pinned to the ONE TRUE certified triple.
 #
-# THE ONE TRUE CERTIFIED TRIPLE (SSOT: docs/postgres-age-guide.md §"Certified
-# versions" + deploy/docker-1461/provision/lib.sh):
+# ONE DECLARATION SOURCE (#B1 cert-review fix, 2026-08-11). Earlier revisions
+# of this job started the STOCK `apache/age:release_PG18_1.7.0` service image
+# unmodified (which ships PostgreSQL 18.1, not 18.4) and installed pgvector
+# UNPINNED (resolves to whatever the pgdg snapshot currently carries, e.g.
+# 0.8.6) — so the docs claiming "the exact triple 18.4/1.7.0/0.8.5 is
+# CI-asserted in-PR" OVERCLAIMED what this job actually proved. The fix is to
+# make CI run the ACTUAL certified minors rather than weaken the docs: this
+# job now BUILDS the real deploy artifact —
+# `deploy/docker-1461/Dockerfile.pg-age-vector`, the SAME recipe the
+# docker-1461 mesh ships — with build-args resolved from the ONE SSOT,
+# `deploy/docker-1461/provision/lib.sh` (`PG_APT_VERSION`,
+# `PGVECTOR_APT_VERSION`, `AGE_BASE_IMAGE`, `EXPECTED_PG_VERSION`,
+# `EXPECTED_AGE_VERSION`), and RUNS that built image as the postgres under
+# test — not a `services:` block pointed at the unmodified base image. No
+# version literal is re-typed in this file: every pin is read from the
+# deploy SSOT by the "Resolve certified stack pins" step below and threaded
+# through `$GITHUB_ENV` to the build + assert steps. This is the maximal
+# "extend prior art, do not fork it" path (CLAUDE.md): the CI evidence and
+# the shipped deploy image are now the SAME artifact, so a future SSOT pin
+# bump moves both in lockstep with zero drift by construction.
+#
+# THE ONE TRUE CERTIFIED TRIPLE (SSOT: deploy/docker-1461/provision/lib.sh —
+# see also docs/postgres-age-guide.md §"Certified versions"):
 #
 #   * PostgreSQL   18.4   (EXPECTED_PG_VERSION=18.4)
-#   * Apache AGE   1.7.0  (EXPECTED_AGE_VERSION=1.7.0; image apache/age:release_PG18_1.7.0)
+#   * Apache AGE   1.7.0  (EXPECTED_AGE_VERSION=1.7.0; base image apache/age:release_PG18_1.7.0)
 #   * pgvector     0.8.5  (PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1)
 #
-# The service image `apache/age:release_PG18_1.7.0` ships AGE 1.7.0 compiled
-# into the PG18 tree; pgvector is layered in at service-start via the pgdg
-# `postgresql-18-pgvector` apt package (the upstream apache/age image does not
-# ship pgvector), mirroring deploy/docker-1461/Dockerfile.pg-age-vector. The
-# `Assert certified stack versions` step below hard-fails if the running stack
-# is not AGE 1.7.0 on PG 18 with pgvector >= 0.8.5 — so this job is EVIDENCE,
-# not a claim: a base-image drift that silently moved AGE off 1.7.0 reds here.
+# `deploy/docker-1461/Dockerfile.pg-age-vector` bumps the apache/age base
+# image's server to the exact pinned minor via a pgdg `apt --only-upgrade`
+# (ABI-safe within PG major 18 — AGE's compiled extension loads unchanged
+# across PG minors) and layers in the exact pinned pgvector .deb (the
+# upstream apache/age image does not ship pgvector). The
+# `Assert certified stack versions` step below hard-fails on ANY drift from
+# the exact pinned minors — so this job is EVIDENCE, not a claim: a base-image
+# or apt-snapshot drift that silently moved a version off the SSOT pin reds
+# here, and the printed `PostgreSQL=… Apache AGE=… pgvector=…` notice in the
+# executed run is the proof.
 #
 # Modelled on postgres-parity-nightly.yml (mold + trimmed dev debug to hold the
 # heavy sal-postgres build under the runner RSS/disk ceilings) and coverage.yml
@@ -67,21 +91,12 @@ jobs:
     name: "Certified pg+AGE cells (live PG 18.4 + AGE 1.7.0 + pgvector 0.8.5)"
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    services:
-      pg-age:
-        # CANONICAL certified triple — Apache AGE 1.7.0 on PostgreSQL 18.
-        image: apache/age:release_PG18_1.7.0
-        env:
-          POSTGRES_USER: ai_memory
-          POSTGRES_PASSWORD: ai_memory_ci
-          POSTGRES_DB: ai_memory_ci
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U ai_memory -d ai_memory_ci"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 12
+    # NOTE: deliberately NO `services:` block. A GitHub Actions `services:`
+    # entry can only start a bare image — it cannot pass `--build-arg`s — so
+    # it structurally cannot run the pinned-minor deploy image below. The
+    # postgres+AGE+pgvector container is built and run explicitly in the
+    # steps below instead, from the SAME Dockerfile the docker-1461 mesh
+    # ships (see the "ONE DECLARATION SOURCE" header note above).
     steps:
       - uses: actions/checkout@v4
 
@@ -102,7 +117,7 @@ jobs:
         with:
           components: clippy
 
-      - name: Install mold linker
+      - name: Install mold linker + postgresql-client
         run: |
           sudo apt-get update
           sudo apt-get install -y mold postgresql-client
@@ -110,34 +125,75 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Resolve certified stack pins from deploy SSOT
+        run: |
+          set -euo pipefail
+          # ONE declaration source (#B1): every version literal this job
+          # exercises comes from deploy/docker-1461/provision/lib.sh — the
+          # SAME file the docker-1461 mesh + its validate harness consume.
+          # Nothing below is re-typed as a bare literal; a future SSOT pin
+          # bump (e.g. a PG 18.5 point release) moves this job automatically.
+          source deploy/docker-1461/provision/lib.sh
+          {
+            echo "CERT_AGE_BASE_IMAGE=${AGE_BASE_IMAGE}"
+            echo "CERT_PG_MAJOR=${PG_MAJOR}"
+            echo "CERT_PG_APT_VERSION=${PG_APT_VERSION}"
+            echo "CERT_PGVECTOR_APT_VERSION=${PGVECTOR_APT_VERSION}"
+            echo "CERT_EXPECTED_PG_VERSION=${EXPECTED_PG_VERSION}"
+            echo "CERT_EXPECTED_AGE_VERSION=${EXPECTED_AGE_VERSION}"
+            # pg_extension.extversion for pgvector reports the bare semver
+            # (e.g. "0.8.5"), never the pgdg package suffix — strip it here
+            # once so the assert step below has no literal of its own.
+            echo "CERT_EXPECTED_PGVECTOR_VERSION=${PGVECTOR_APT_VERSION%%-*}"
+          } >> "$GITHUB_ENV"
+          echo "::notice::certified pins resolved from deploy/docker-1461/provision/lib.sh — PG ${PG_APT_VERSION} (server ${EXPECTED_PG_VERSION}), AGE base ${AGE_BASE_IMAGE} (server ${EXPECTED_AGE_VERSION}), pgvector ${PGVECTOR_APT_VERSION}"
+
+      - name: Build certified pg+AGE+pgvector image (deploy/docker-1461/Dockerfile.pg-age-vector)
+        run: |
+          set -euo pipefail
+          # Builds the SAME artifact the docker-1461 mesh ships — extending
+          # prior art rather than forking a second recipe. Every ARG comes
+          # from the previous step's resolved SSOT env, never a literal here.
+          docker build \
+            --build-arg AGE_BASE_IMAGE="${CERT_AGE_BASE_IMAGE}" \
+            --build-arg PG_MAJOR="${CERT_PG_MAJOR}" \
+            --build-arg PG_APT_VERSION="${CERT_PG_APT_VERSION}" \
+            --build-arg PGVECTOR_APT_VERSION="${CERT_PGVECTOR_APT_VERSION}" \
+            -t cert-pg-age-vector:ci \
+            -f deploy/docker-1461/Dockerfile.pg-age-vector \
+            deploy/docker-1461
+
+      - name: Run certified pg+AGE+pgvector container
+        run: |
+          set -euo pipefail
+          docker run -d --name cert-pg-age \
+            -e POSTGRES_USER=ai_memory \
+            -e POSTGRES_PASSWORD=ai_memory_ci \
+            -e POSTGRES_DB=ai_memory_ci \
+            -p 5432:5432 \
+            cert-pg-age-vector:ci
+
       - name: Wait for postgres readiness
         run: |
           set -euo pipefail
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if pg_isready -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci >/dev/null 2>&1; then
               echo "::notice::postgres is up"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::postgres did not become ready within 60s"
+          echo "::error::postgres did not become ready within 120s"
+          docker logs cert-pg-age || true
           exit 1
 
-      - name: Install pgvector + provision AGE/vector extensions (certified stack)
+      - name: Provision AGE + vector extensions (certified stack)
         env:
           PGPASSWORD: ai_memory_ci
         run: |
           set -euo pipefail
-          # Locate the pg-age service container so we can apt-get install
-          # pgvector against the same Debian-based image (apache/age PG18
-          # inherits the pgdg apt sources via the official postgres:18 base).
-          PG_CONTAINER=$(docker ps --filter "ancestor=apache/age:release_PG18_1.7.0" --format '{{.ID}}' | head -1)
-          echo "pg container: $PG_CONTAINER"
-          docker exec "$PG_CONTAINER" apt-get update
-          # pgvector for PG18. Unpinned deb (the pgdg snapshot codename can move)
-          # — the exact resolved version is ASSERTED >= 0.8.5 in the next step,
-          # which is the certification-grade check, not the apt version string.
-          docker exec "$PG_CONTAINER" apt-get install -y postgresql-18-pgvector
+          # pgvector is already baked into the image at the pinned version
+          # by Dockerfile.pg-age-vector (built above) — no apt-get here.
           # Provision extensions + the memory_graph AGE graph the SAL postgres
           # adapter expects. Mirrors coverage.yml + infra/lan-parity-test/init-age.sql.
           psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -c "CREATE EXTENSION IF NOT EXISTS vector;"
@@ -159,25 +215,31 @@ jobs:
             echo ""
             echo "| component | running | certified (SSOT) |"
             echo "| --- | --- | --- |"
-            echo "| PostgreSQL | $pg_ver | 18.4 |"
-            echo "| Apache AGE | $age_ver | 1.7.0 |"
-            echo "| pgvector | $vec_ver | 0.8.5 |"
+            echo "| PostgreSQL | $pg_ver | ${CERT_EXPECTED_PG_VERSION} |"
+            echo "| Apache AGE | $age_ver | ${CERT_EXPECTED_AGE_VERSION} |"
+            echo "| pgvector | $vec_ver | ${CERT_EXPECTED_PGVECTOR_VERSION} |"
           } >> "$GITHUB_STEP_SUMMARY"
-          # AGE is the certification subject (#2512): a base-image drift off
-          # 1.7.0 must RED, never silently certify the wrong version.
-          case "$pg_ver" in 18*) : ;; *) echo "::error::expected PostgreSQL 18.x, got $pg_ver"; exit 1 ;; esac
-          # Certified AGE minor is 1.7 (accept the '1.7' and '1.7.0' renderings
-          # of the same extension version; reject 1.6.x and anything else — the
-          # whole point of #2512 is that CI must run the certified 1.7, not 1.6).
-          case "$age_ver" in
-            1.7|1.7.*) echo "Apache AGE $age_ver == certified 1.7 OK" ;;
-            *) echo "::error::expected Apache AGE 1.7 (certified), got '$age_ver' — CI must not certify a version it does not run (§5.4(3))"; exit 1 ;;
+          # EXACT-minor assertion (#B1) — the SSOT-pinned minor, not merely
+          # the major. A base-image drift off the exact pinned minor (an apt
+          # snapshot moving, a base-image digest update) must RED, never
+          # silently certify a different version than the one the docs cite.
+          case "$pg_ver" in
+            "$CERT_EXPECTED_PG_VERSION") echo "PostgreSQL $pg_ver == certified $CERT_EXPECTED_PG_VERSION OK" ;;
+            *) echo "::error::expected PostgreSQL exactly $CERT_EXPECTED_PG_VERSION (certified, deploy/docker-1461/provision/lib.sh EXPECTED_PG_VERSION), got '$pg_ver' — CI must not certify a version it does not run (§5.4(3))"; exit 1 ;;
           esac
-          # pgvector >= 0.8.5 (certified). Fail on absence or an older minor.
+          # Certified AGE is exactly 1.7.0. Reject 1.6.x and anything else —
+          # the whole point of #2512 is that CI must run the certified 1.7.0,
+          # not merely a 1.7.* rendering of a different point release.
+          case "$age_ver" in
+            "$CERT_EXPECTED_AGE_VERSION") echo "Apache AGE $age_ver == certified $CERT_EXPECTED_AGE_VERSION OK" ;;
+            *) echo "::error::expected Apache AGE exactly $CERT_EXPECTED_AGE_VERSION (certified, deploy/docker-1461/provision/lib.sh EXPECTED_AGE_VERSION), got '$age_ver' — CI must not certify a version it does not run (§5.4(3))"; exit 1 ;;
+          esac
+          # pgvector must match the SSOT-pinned semver exactly (allowing only
+          # for a trailing suffix the extversion column itself might carry).
           case "$vec_ver" in
             "") echo "::error::pgvector extension not present"; exit 1 ;;
-            0.8.[5-9]*|0.9.*|0.[1-9][0-9]*|[1-9]*) echo "pgvector $vec_ver >= 0.8.5 OK" ;;
-            *) echo "::error::expected pgvector >= 0.8.5 (certified), got '$vec_ver'"; exit 1 ;;
+            ${CERT_EXPECTED_PGVECTOR_VERSION}*) echo "pgvector $vec_ver == certified ${CERT_EXPECTED_PGVECTOR_VERSION} OK" ;;
+            *) echo "::error::expected pgvector exactly ${CERT_EXPECTED_PGVECTOR_VERSION} (certified, deploy/docker-1461/provision/lib.sh PGVECTOR_APT_VERSION), got '$vec_ver' — CI must not certify a version it does not run (§5.4(3))"; exit 1 ;;
           esac
 
       - name: Run #[ignore]-gated pg + AGE cells against the certified stack

--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -27,7 +27,7 @@
 # `PGVECTOR_APT_VERSION`, `AGE_BASE_IMAGE`, `EXPECTED_PG_VERSION`,
 # `EXPECTED_AGE_VERSION`), and RUNS that built image as the postgres under
 # test — not a `services:` block pointed at the unmodified base image. No
-# version literal is re-typed in this file: every pin is read from the
+# operative version literal is re-typed in this file: every pin is read from the
 # deploy SSOT by the "Resolve certified stack pins" step below and threaded
 # through `$GITHUB_ENV` to the build + assert steps. This is the maximal
 # "extend prior art, do not fork it" path (CLAUDE.md): the CI evidence and

--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -206,7 +206,13 @@ jobs:
         run: |
           set -euo pipefail
           PSQL="psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -tAX"
-          pg_ver=$($PSQL -c "SHOW server_version;" | tr -d '[:space:]')
+          # split_part(...,' ',1) strips the "(Debian 18.4-1.pgdg13+1)" build
+          # metadata SHOW server_version / current_setting append after the
+          # bare version — without this, tr -d '[:space:]' collapses that
+          # into "18.4(Debian18.4-1.pgdg13+1)", which never equals the exact
+          # SSOT string and false-reds the assert below even when the
+          # server IS the certified 18.4.
+          pg_ver=$($PSQL -c "SELECT split_part(current_setting('server_version'), ' ', 1);" | tr -d '[:space:]')
           age_ver=$($PSQL -c "SELECT extversion FROM pg_extension WHERE extname='age';" | tr -d '[:space:]')
           vec_ver=$($PSQL -c "SELECT extversion FROM pg_extension WHERE extname='vector';" | tr -d '[:space:]')
           echo "::notice::certified stack — PostgreSQL=$pg_ver  Apache AGE=$age_ver  pgvector=$vec_ver"

--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -1,0 +1,211 @@
+# Certified Postgres + Apache AGE + pgvector tier — IN-PR cert evidence (#2548).
+#
+# WHY THIS WORKFLOW EXISTS. Before #2548 the certified pg+AGE tier was NEVER
+# exercised in-PR. The `#[ignore]`-gated postgres/AGE cells ran ONLY in
+# `postgres-parity-nightly.yml` (a `schedule:` workflow that fires from the
+# DEFAULT branch, not from a PR into `release/**`), and the AGE-backed cells
+# self-skip unless `AI_MEMORY_TEST_AGE_URL` is set — so on the certification
+# branch nothing proved the certified tier actually works. The 2026-08-01
+# cutline ruling §5.4(3) requires EXECUTED evidence on real Postgres + AGE +
+# pgvector, at the CERTIFIED versions, on the cert branch. "You cannot certify
+# a tier CI does not run", and the ruling forbids "CI-on-16-while-certifying-18".
+# This job is what makes §5.4(3) executable: it runs the ignored pg cells AND
+# the AGE-backed cells (with the AGE url set, so they stop self-skipping)
+# against a LIVE stack pinned to the ONE TRUE certified triple.
+#
+# THE ONE TRUE CERTIFIED TRIPLE (SSOT: docs/postgres-age-guide.md §"Certified
+# versions" + deploy/docker-1461/provision/lib.sh):
+#
+#   * PostgreSQL   18.4   (EXPECTED_PG_VERSION=18.4)
+#   * Apache AGE   1.7.0  (EXPECTED_AGE_VERSION=1.7.0; image apache/age:release_PG18_1.7.0)
+#   * pgvector     0.8.5  (PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1)
+#
+# The service image `apache/age:release_PG18_1.7.0` ships AGE 1.7.0 compiled
+# into the PG18 tree; pgvector is layered in at service-start via the pgdg
+# `postgresql-18-pgvector` apt package (the upstream apache/age image does not
+# ship pgvector), mirroring deploy/docker-1461/Dockerfile.pg-age-vector. The
+# `Assert certified stack versions` step below hard-fails if the running stack
+# is not AGE 1.7.0 on PG 18 with pgvector >= 0.8.5 — so this job is EVIDENCE,
+# not a claim: a base-image drift that silently moved AGE off 1.7.0 reds here.
+#
+# Modelled on postgres-parity-nightly.yml (mold + trimmed dev debug to hold the
+# heavy sal-postgres build under the runner RSS/disk ceilings) and coverage.yml
+# (the pg-age service + AGE/pgvector extension provisioning). coverage.yml keeps
+# running the DOCUMENTED ALTERNATE matrix (PG16 + AGE 1.6.0); this job is the
+# CANONICAL certified-triple evidence. Both are honest and both are in the SSOT.
+name: "Certified Postgres + AGE + pgvector tier (#2548)"
+
+on:
+  pull_request:
+    branches: ["release/**"]
+  push:
+    branches: ["release/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Event-distinct key (includes github.event_name) so a same-sha push +
+  # pull_request pair never collide into one cancel-in-progress group — the
+  # rule-(d) CANCELLED-DUPLICATE class scripts/check-required-contexts.sh
+  # guards against. Fork-PR-safe: isolates fork PRs by number.
+  group: cert-pg-age-${{ github.event_name }}-${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Match postgres-feature / postgres-parity-nightly: mold linker + no dev debug
+  # info to keep the heavy sal-postgres build under the runner ceilings.
+  RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  AI_MEMORY_TEST_POSTGRES_URL: "postgres://ai_memory:ai_memory_ci@127.0.0.1:5432/ai_memory_ci"
+  AI_MEMORY_TEST_AGE_URL: "postgres://ai_memory:ai_memory_ci@127.0.0.1:5432/ai_memory_ci"
+
+jobs:
+  cert-postgres-age:
+    name: "Certified pg+AGE cells (live PG 18.4 + AGE 1.7.0 + pgvector 0.8.5)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      pg-age:
+        # CANONICAL certified triple — Apache AGE 1.7.0 on PostgreSQL 18.
+        image: apache/age:release_PG18_1.7.0
+        env:
+          POSTGRES_USER: ai_memory
+          POSTGRES_PASSWORD: ai_memory_ci
+          POSTGRES_DB: ai_memory_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ai_memory -d ai_memory_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk (heavy sal-postgres build headroom)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup \
+                      /usr/local/share/powershell /usr/local/share/chromium \
+                      /usr/local/share/boost /usr/local/lib/node_modules \
+                      /opt/google /usr/lib/jvm /opt/microsoft \
+                      /usr/share/swift /usr/share/miniconda || true
+          sudo apt-get autoremove --purge -y || true
+          sudo apt-get clean || true
+          df -h /
+
+      - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: clippy
+
+      - name: Install mold linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold postgresql-client
+          mold --version
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Wait for postgres readiness
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci >/dev/null 2>&1; then
+              echo "::notice::postgres is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::postgres did not become ready within 60s"
+          exit 1
+
+      - name: Install pgvector + provision AGE/vector extensions (certified stack)
+        env:
+          PGPASSWORD: ai_memory_ci
+        run: |
+          set -euo pipefail
+          # Locate the pg-age service container so we can apt-get install
+          # pgvector against the same Debian-based image (apache/age PG18
+          # inherits the pgdg apt sources via the official postgres:18 base).
+          PG_CONTAINER=$(docker ps --filter "ancestor=apache/age:release_PG18_1.7.0" --format '{{.ID}}' | head -1)
+          echo "pg container: $PG_CONTAINER"
+          docker exec "$PG_CONTAINER" apt-get update
+          # pgvector for PG18. Unpinned deb (the pgdg snapshot codename can move)
+          # — the exact resolved version is ASSERTED >= 0.8.5 in the next step,
+          # which is the certification-grade check, not the apt version string.
+          docker exec "$PG_CONTAINER" apt-get install -y postgresql-18-pgvector
+          # Provision extensions + the memory_graph AGE graph the SAL postgres
+          # adapter expects. Mirrors coverage.yml + infra/lan-parity-test/init-age.sql.
+          psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -c "CREATE EXTENSION IF NOT EXISTS age;"
+          psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -c "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public; SELECT ag_catalog.create_graph('memory_graph');" || echo "memory_graph already exists or AGE init handled by ladder"
+
+      - name: Assert certified stack versions (cert evidence, hard-fail on drift)
+        env:
+          PGPASSWORD: ai_memory_ci
+        run: |
+          set -euo pipefail
+          PSQL="psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_ci -tAX"
+          pg_ver=$($PSQL -c "SHOW server_version;" | tr -d '[:space:]')
+          age_ver=$($PSQL -c "SELECT extversion FROM pg_extension WHERE extname='age';" | tr -d '[:space:]')
+          vec_ver=$($PSQL -c "SELECT extversion FROM pg_extension WHERE extname='vector';" | tr -d '[:space:]')
+          echo "::notice::certified stack — PostgreSQL=$pg_ver  Apache AGE=$age_ver  pgvector=$vec_ver"
+          {
+            echo "### Certified Postgres + AGE + pgvector tier"
+            echo ""
+            echo "| component | running | certified (SSOT) |"
+            echo "| --- | --- | --- |"
+            echo "| PostgreSQL | $pg_ver | 18.4 |"
+            echo "| Apache AGE | $age_ver | 1.7.0 |"
+            echo "| pgvector | $vec_ver | 0.8.5 |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # AGE is the certification subject (#2512): a base-image drift off
+          # 1.7.0 must RED, never silently certify the wrong version.
+          case "$pg_ver" in 18*) : ;; *) echo "::error::expected PostgreSQL 18.x, got $pg_ver"; exit 1 ;; esac
+          # Certified AGE minor is 1.7 (accept the '1.7' and '1.7.0' renderings
+          # of the same extension version; reject 1.6.x and anything else — the
+          # whole point of #2512 is that CI must run the certified 1.7, not 1.6).
+          case "$age_ver" in
+            1.7|1.7.*) echo "Apache AGE $age_ver == certified 1.7 OK" ;;
+            *) echo "::error::expected Apache AGE 1.7 (certified), got '$age_ver' — CI must not certify a version it does not run (§5.4(3))"; exit 1 ;;
+          esac
+          # pgvector >= 0.8.5 (certified). Fail on absence or an older minor.
+          case "$vec_ver" in
+            "") echo "::error::pgvector extension not present"; exit 1 ;;
+            0.8.[5-9]*|0.9.*|0.[1-9][0-9]*|[1-9]*) echo "pgvector $vec_ver >= 0.8.5 OK" ;;
+            *) echo "::error::expected pgvector >= 0.8.5 (certified), got '$vec_ver'"; exit 1 ;;
+          esac
+
+      - name: Run #[ignore]-gated pg + AGE cells against the certified stack
+        run: |
+          set -euo pipefail
+          # The pg-parity binaries mirror postgres-parity-nightly.yml (they do
+          # not touch AGE). The AGE-backed binaries self-skip unless
+          # AI_MEMORY_TEST_AGE_URL is set (it is, in env: above), so they run
+          # here — this is the in-PR cert evidence that was missing (#2548).
+          # `--include-ignored` also runs the explicitly #[ignore]-gated cells
+          # (e.g. age_cypher_param_binding_2511). --test-threads=1 because the
+          # sal-postgres suite shares one database with no per-test isolation.
+          cargo test --features sal-postgres \
+            --test secret_screen_postgres_parity_g29 \
+            --test postgres_l2_rehydration_1693 \
+            --test erasure_fanout_postgres_g30 \
+            --test recall_purity_p01_postgres \
+            --test qual_pg_write_funnel_parity_2393_2397 \
+            --test store_parity_gaps \
+            --test age_cypher_param_binding_2511 \
+            --test kg_query_relation_parity_2792 \
+            --test g2_postgres_find_paths_age_param_binding \
+            --test g4_postgres_link_projects_into_age_graph \
+            --test g5_find_paths_cte_served_on_age \
+            --test kg_age_fallback \
+            --test age_cte_equivalence \
+            --test issue_1482_age_cypher_persistent \
+            --test pillar4_4c_deferred_age_cold_path_1735 \
+            --test pillar4_4d_age_unprojection_on_delete_1783 \
+            --test age_deferred_projection_cluster_2375_2376_2377 \
+            -- --include-ignored --test-threads=1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,17 @@
 # base image has AGE+postgres; pgvector is installed at service-start via
 # the runtime `postgresql-16-pgvector` apt package. Mirror of the
 # `infra/lan-parity-test/` Docker stack the Tier 4 cov audit used.
+#
+# STACK PROVENANCE (#2512). This job runs the DOCUMENTED ALTERNATE matrix —
+# PostgreSQL 16 + Apache AGE 1.6.0 + pgvector — which docs/postgres-age-guide.md
+# §"Certified versions" retains as a "tested alternate matrix
+# (`infra/lan-parity-test/`)". It is NOT the certified triple and does not
+# certify one: coverage is a Rust line-coverage measurement, not cert evidence.
+# The ONE TRUE CERTIFIED triple — PostgreSQL 18.4 + Apache AGE 1.7.0 +
+# pgvector 0.8.5 — is exercised in-PR by `.github/workflows/cert-postgres-age.yml`
+# (#2548), so CI runs BOTH stacks the SSOT documents and neither is drift:
+# canonical here would risk this required coverage gate on a PG-major flip it
+# does not measure, while the cert job proves the canonical tier separately.
 
 name: Per-Module Coverage Thresholds
 
@@ -142,7 +153,10 @@ jobs:
       contents: read
       pull-requests: write
     services:
-      # Live PG + Apache AGE 1.6.0 (graph extension on PostgreSQL 16).
+      # Live PG + Apache AGE 1.6.0 (graph extension on PostgreSQL 16) — the
+      # DOCUMENTED ALTERNATE matrix (#2512; see the header note above). The
+      # certified triple (PG 18.4 + AGE 1.7.0 + pgvector 0.8.5) is exercised
+      # by `.github/workflows/cert-postgres-age.yml`, not here.
       # The pgvector extension is layered in via the
       # `Install pgvector + provision AGE/vector extensions` step below
       # because the upstream `apache/age` image doesn't ship pgvector

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,12 +82,62 @@ jobs:
           fi
 
   # --------------------------------------------------------------------
+  # #2895 (§3C release-pipeline supply-chain) — run the SAME supply-chain
+  # gates the PR-time CI runs, INSIDE the release pipeline, BEFORE any build
+  # or publish. A gate that only guards PRs does not guard the artifact a
+  # `workflow_dispatch` release mints: `release.yml` builds + publishes from a
+  # tag ref, and nothing forced that tag's tree through the gates. This job
+  # is a `needs:` of every build/publish job, so a git-sourced dependency
+  # (#2050 / #2512) or an un-ledgered custom build script (#2635) blocks the
+  # release rather than shipping to crates.io / GHCR / Homebrew / COPR.
+  # §6.6: treat current knowledge as a floor — extend this job as gates land.
+  # --------------------------------------------------------------------
+  supply-chain:
+    name: Supply-chain gates (before build + publish)
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.tag }}
+
+      - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Git-dependency-source gate (#2050 / #2512)
+        # No cargo dependency may resolve from a git source (a deleted/rewritten
+        # git repo is an unfetchable, unpinnable supply-chain hole). Pure
+        # bash/grep over Cargo.toml + Cargo.lock; no toolchain needed.
+        run: bash scripts/check-git-dependency-sources.sh
+
+      - name: Git-dependency-source gate self-test (#2050 / #2512)
+        run: bash scripts/check-git-dependency-sources.sh --self-test
+
+      - name: Fetch the locked dependency graph (#2635)
+        # cargo metadata --offline resolves the complete cross-platform graph;
+        # fetch first so the verifier runs offline + content-pinned.
+        run: cargo fetch --locked
+
+      - name: Build-script custom-build ledger gate (#2635)
+        # Every custom-build package in the resolved graph must be ledgered in
+        # supply-chain/build-script-vetting.json — a build script executes with
+        # the builder's authority at compile time, and a release build runs
+        # every one of them.
+        run: python3 scripts/check-build-script-vetting.py
+
+      - name: Build-script ledger gate self-test (#2635)
+        run: python3 scripts/check-build-script-vetting.py --self-test
+
+  # --------------------------------------------------------------------
   # Cross-platform binary builds + GitHub Release page.
   # 5 targets: linux x86_64 + aarch64, macOS x86_64 + aarch64, windows x86_64.
   # --------------------------------------------------------------------
   release:
     name: Release (${{ matrix.target }})
-    needs: preflight
+    needs: [preflight, supply-chain]
     runs-on: ${{ matrix.os }}
     # #2487 supply-chain: OIDC-bound Sigstore build provenance for the
     # release binaries + deb/rpm, mirroring the OIDC pattern the SDK
@@ -148,7 +198,10 @@ jobs:
       # deps on every matrix OS); operators needing PG use an asserted
       # sal-postgres build or the plan-c image. Agents never workflow_dispatch.
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} --features sal
+        # --locked (#2895): build against the COMMITTED Cargo.lock exactly.
+        # A release must never silently resolve a newer transitive dependency
+        # than the one that was reviewed/audited on the branch.
+        run: cargo build --locked --release --target ${{ matrix.target }} --features sal
 
       - name: Assert compiled features (#2676, #2728)
         shell: bash
@@ -387,7 +440,7 @@ jobs:
   # --------------------------------------------------------------------
   sbom:
     name: SBOM (CycloneDX)
-    needs: [preflight]
+    needs: [preflight, supply-chain]
     runs-on: ubuntu-latest
     # #2487 — OIDC-bound Sigstore provenance for the CycloneDX SBOM
     # artifact (same mechanism as the release-binary job above).
@@ -484,7 +537,7 @@ jobs:
   # --------------------------------------------------------------------
   mobile-ios:
     name: Mobile artifact (iOS xcframework)
-    needs: [preflight]
+    needs: [preflight, supply-chain]
     if: needs.preflight.outputs.is_prerelease == 'false'
     runs-on: macos-latest
     # #2487 — OIDC-bound Sigstore provenance for the iOS xcframework
@@ -519,6 +572,7 @@ jobs:
           for TARGET in aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios; do
             echo "::group::cargo build --target $TARGET"
             cargo build \
+              --locked \
               --release \
               --target "$TARGET" \
               --no-default-features \
@@ -623,7 +677,7 @@ jobs:
   # --------------------------------------------------------------------
   mobile-android:
     name: Mobile artifact (Android AAR-compatible)
-    needs: [preflight]
+    needs: [preflight, supply-chain]
     if: needs.preflight.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     # #2487 — OIDC-bound Sigstore provenance for the Android JNI tarball
@@ -697,6 +751,7 @@ jobs:
             ABI="${ABI_OF[$TARGET]}"
             echo "::group::cargo build --target $TARGET ($ABI)"
             cargo build \
+              --locked \
               --release \
               --target "$TARGET" \
               --no-default-features \
@@ -776,16 +831,24 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.tag }}
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
+        # #2895 — pin the publish toolchain to the same 1.96.0 every other
+        # release + verification job uses (was bare `@stable`, an unpinned,
+        # moving compiler on the one job that mints the crates.io artifact).
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Publish to crates.io (with retry)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
+          # #2895 — `--locked` (build the crate against the COMMITTED Cargo.lock)
+          # and NO `--allow-dirty`. The checkout is at the release tag, so the
+          # tree is already clean; `--allow-dirty` only ever masked a tree that
+          # DIVERGED from the committed source, which is exactly what a
+          # supply-chain gate must not paper over on the publish path.
           for attempt in 1 2 3; do
-            if output=$(cargo publish --allow-dirty 2>&1); then
+            if output=$(cargo publish --locked 2>&1); then
               echo "::notice::crates.io publish succeeded on attempt $attempt"
               echo "$output" | tail -10
               exit 0
@@ -945,7 +1008,7 @@ jobs:
   # --------------------------------------------------------------------
   docker:
     name: Docker (GHCR)
-    needs: [preflight]
+    needs: [preflight, supply-chain]
     if: needs.preflight.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,13 +143,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.github/workflows/cert-postgres-age.yml` triggers on `pull_request` +
   `push` to `release/**` and runs the `#[ignore]`-gated postgres cells AND
   the AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
-  self-skipping) against a live `apache/age:release_PG18_1.7.0` service with
-  pgvector layered in, `--include-ignored --test-threads=1`. Makes the
+  self-skipping) against the certified image CI builds from
+  `deploy/docker-1461/Dockerfile.pg-age-vector` (the same recipe the
+  docker-1461 mesh ships, SSOT-pinned from `deploy/docker-1461/provision/lib.sh`),
+  `--include-ignored --test-threads=1`. Makes the
   2026-08-01 cutline ruling §5.4(3) EXECUTABLE — the certified tier is proven
   by execution on the cert branch, not merely claimed. A version-assert step
-  hard-fails if the running stack is not AGE **1.7.0** on PG **18** with
-  pgvector **>= 0.8.5**, so a base-image drift reds instead of silently
-  certifying the wrong version.
+  hard-fails if the running stack is not the EXACT certified minors —
+  PostgreSQL **18.4**, AGE **1.7.0**, pgvector **0.8.5** — so any drift reds
+  instead of silently certifying the wrong version.
 - **#2512 — AGE pin drift reconciled.** The **one true certified triple** is
   standardized and documented: **PostgreSQL 18.4 + Apache AGE 1.7.0 +
   pgvector 0.8.5** (SSOT: `deploy/docker-1461/provision/lib.sh` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measurement, not cert evidence) with a cross-reference to the cert job, so
   CI and the certified-version SSOT AGREE and neither is drift. The release
   branch already vendors `paste` in-tree (`path = "vendor/paste"`, #2050), so
-  there is no dead git pin to fix here.
+  there is no dead git pin to fix here. `docs/v1.0.0/release-notes.md` is
+  reconciled in lockstep (§"Certified backend versions" + §"CI posture"): the
+  passages that said the 18.4/1.7.0/0.8.5 stack was "additionally validated
+  off-CI, not CI-asserted" now state it is exercised in-PR by the new cert
+  job, with PG 16/AGE 1.6.0 relabelled as the documented alternate — closing
+  the §0 cross-doc contradiction that would otherwise ship.
 - **#2534 — one declaration source for required checks.** New gate
   `scripts/check-branch-protection.sh` (with `--self-test`) HARD-FAILS if
   `.github/branch-protection.yml` re-declares a bare `required_checks` key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `store.list` invariant holding. Live-postgres regression coverage:
   `tests/ordering_determinism_2602_2615_pg.rs` (`#[ignore]`,
   `--features sal,sal-postgres`, `AI_MEMORY_TEST_POSTGRES_URL`).
+### CI / supply-chain (cert-evidence unblocker cluster — CERT-BLOCKING; #2548 #2512 #2534 #2895)
+
+- **#2548 — certified pg+AGE tier now runs IN-PR.** New workflow
+  `.github/workflows/cert-postgres-age.yml` triggers on `pull_request` +
+  `push` to `release/**` and runs the `#[ignore]`-gated postgres cells AND
+  the AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
+  self-skipping) against a live `apache/age:release_PG18_1.7.0` service with
+  pgvector layered in, `--include-ignored --test-threads=1`. Makes the
+  2026-08-01 cutline ruling §5.4(3) EXECUTABLE — the certified tier is proven
+  by execution on the cert branch, not merely claimed. A version-assert step
+  hard-fails if the running stack is not AGE **1.7.0** on PG **18** with
+  pgvector **>= 0.8.5**, so a base-image drift reds instead of silently
+  certifying the wrong version.
+- **#2512 — AGE pin drift reconciled.** The **one true certified triple** is
+  standardized and documented: **PostgreSQL 18.4 + Apache AGE 1.7.0 +
+  pgvector 0.8.5** (SSOT: `deploy/docker-1461/provision/lib.sh` +
+  `docs/postgres-age-guide.md`). The new cert job exercises that canonical
+  triple; `coverage.yml` (which pins the PG16 + AGE 1.6.0 alternate) is now
+  explicitly labelled as the DOCUMENTED ALTERNATE matrix (a line-coverage
+  measurement, not cert evidence) with a cross-reference to the cert job, so
+  CI and the certified-version SSOT AGREE and neither is drift. The release
+  branch already vendors `paste` in-tree (`path = "vendor/paste"`, #2050), so
+  there is no dead git pin to fix here.
+- **#2534 — one declaration source for required checks.** New gate
+  `scripts/check-branch-protection.sh` (with `--self-test`) HARD-FAILS if
+  `.github/branch-protection.yml` re-declares a bare `required_checks` key
+  (the #2443 regression), while correctly NOT tripping on the intended
+  `required_checks_declaration` pointer. Wired as steps of the already-required
+  `required-contexts-gate` job in `.github/workflows/c8-precheck.yml`.
+- **#2895 — release pipeline supply-chain hardening.**
+  `.github/workflows/release.yml`: every `cargo build` and `cargo publish`
+  now passes `--locked`; `--allow-dirty` is dropped from `cargo publish`; the
+  crates.io publish toolchain is pinned to **1.96.0** (was bare `@stable`);
+  and a new `supply-chain` job runs the git-dependency-source (#2050/#2512)
+  and build-script-vetting (#2635) gates BEFORE any build or publish, wired
+  as a `needs:` of every build/publish job so a supply-chain finding blocks
+  the release rather than shipping to crates.io / GHCR / Homebrew / COPR.
 
 ### Fixed (data integrity — import round-trip)
 

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -56,10 +56,14 @@ works on postgres.
 > **CI evidence (#2548 / #2512).** The **one true certified triple** —
 > PostgreSQL **18.4** + Apache AGE **1.7.0** + pgvector **0.8.5** — is
 > exercised **in-PR on `release/**`** by
-> `.github/workflows/cert-postgres-age.yml`, which runs the `#[ignore]`-gated
-> postgres cells AND the AGE-backed cells against a live
-> `apache/age:release_PG18_1.7.0` service and **hard-fails if the running AGE
-> is not 1.7.0** — so the certified tier is proven by execution, never merely
+> `.github/workflows/cert-postgres-age.yml`, which BUILDS the bundled
+> [`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector)
+> to the exact pins declared in `deploy/docker-1461/provision/lib.sh` (the ONE
+> declaration source — no literal is re-typed in the workflow), runs the
+> `#[ignore]`-gated postgres cells AND the AGE-backed cells against that built
+> image, and **hard-fails on ANY drift from the exact pinned minors** —
+> PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.5, not merely "PG 18" or
+> "AGE 1.7.x" — so the certified tier is proven by execution, never merely
 > claimed (2026-08-01 cutline ruling §5.4(3): "you cannot certify a tier CI
 > does not run"). The `infra/lan-parity-test/` alternate matrix (PG 16 + AGE
 > 1.6.0) is what the `coverage.yml` line-coverage measurement runs; that is a

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -53,6 +53,18 @@ works on postgres.
 | pgvector | **0.8.5** (canonical) | Faster HNSW; 0.8.3 fixed HNSW-vacuuming index corruption. SSOT: `PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`. **Required**: the `sal-postgres` Cargo feature pulls `dep:pgvector` (Rust binding crate `pgvector = "0.4"`) which maps Rust vectors to the Postgres `vector` column type. |
 | ai-memory | v0.9.0 with `--features sal-postgres` | The `sal-postgres` feature is **off by default** to keep the no-postgres build hermetic. |
 
+> **CI evidence (#2548 / #2512).** The **one true certified triple** —
+> PostgreSQL **18.4** + Apache AGE **1.7.0** + pgvector **0.8.5** — is
+> exercised **in-PR on `release/**`** by
+> `.github/workflows/cert-postgres-age.yml`, which runs the `#[ignore]`-gated
+> postgres cells AND the AGE-backed cells against a live
+> `apache/age:release_PG18_1.7.0` service and **hard-fails if the running AGE
+> is not 1.7.0** — so the certified tier is proven by execution, never merely
+> claimed (2026-08-01 cutline ruling §5.4(3): "you cannot certify a tier CI
+> does not run"). The `infra/lan-parity-test/` alternate matrix (PG 16 + AGE
+> 1.6.0) is what the `coverage.yml` line-coverage measurement runs; that is a
+> coverage measurement, not cert evidence.
+
 ### Bundled Dockerfile (Apache AGE + pgvector on PG18, #1065)
 
 The upstream `apache/age:release_PG18_1.7.0` image ships AGE but **not**

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -72,11 +72,14 @@ AGE + pgvector storage backend.
 > `tests/pg_supported_route_inventory_gate_2799.rs`), and **MCP-stdio is
 > structurally SQLite-only** ([#1675](https://github.com/alphaonedev/ai-memory-mcp/issues/1675)):
 > a Postgres-backed deployment serves MCP clients through the HTTP daemon,
-> not `ai-memory mcp`. The certification evidence rests on the PG 16 / AGE
-> 1.6.0 stack CI tests on every push; the SSOT-pinned PG 18.4 / AGE 1.7.0 /
-> pgvector 0.8.5 stack is **additionally validated off-CI**, not
-> CI-asserted — see §"Certified backend versions" for the exact versions
-> and evidence basis.
+> not `ai-memory mcp`. The certified **PG 18.4 / AGE 1.7.0 / pgvector
+> 0.8.5** stack is now exercised in-PR on every `release/**` PR by
+> `.github/workflows/cert-postgres-age.yml`, which runs the pg-parity and
+> AGE cells `--include-ignored` against the live
+> `apache/age:release_PG18_1.7.0` image and hard-fails on version drift;
+> the PG 16 / AGE 1.6.0 combination in `coverage.yml` is the documented
+> **alternate** matrix (a line-coverage measurement). See §"Certified
+> backend versions" for the exact versions and evidence basis.
 
 The "defaults stop lying" lane (Gate 1′) is the centerpiece: six knobs
 that shipped OFF (or non-functional) through v0.10.0 now resolve to their
@@ -214,27 +217,30 @@ pgvector-backed recall-purity suite (`recall_purity_p01_postgres`) run
 green under `--features sal,sal-postgres --include-ignored` against the
 `apache/age:release_PG16_1.6.0` service container in `coverage.yml`, with
 pgvector layered in at service start via the `postgresql-16-pgvector` apt
-package. This PG 16 / AGE 1.6.0 combination is what the substrate's
-Postgres backend has actually, repeatedly, in-repo been exercised on — so
-it is the stack the certification evidence rests on.
+package. This PG 16 / AGE 1.6.0 combination is the documented **alternate**
+matrix — the stack `coverage.yml` measures line coverage against; the
+certified PG 18.4 / AGE 1.7.0 / pgvector 0.8.5 stack is exercised in-PR
+separately by `.github/workflows/cert-postgres-age.yml` (next paragraph).
 
-**Additionally validated off-CI (SSOT-pinned, NOT CI-asserted):
-PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5.** These are the pins
+**CI-asserted in-PR on `release/**` (SSOT-pinned): PostgreSQL 18.4 + Apache
+AGE 1.7.0 + pgvector 0.8.5.** These are the pins
 the deployment SSOT carries — `deploy/docker-1461/provision/lib.sh`
 (`EXPECTED_PG_VERSION=18.4`, `EXPECTED_AGE_VERSION=1.7.0`,
 `PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
 `AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`; the pgvector Rust binding
 is the `pgvector` crate `0.4`, `features = ["sqlx"]`) — and they are the
 current-stable upstream line (Apache AGE 1.8.0 exists only as `rc0` and is
-deliberately not shipped). The same AGE/KG + recall-purity suites were run
-green against this stack on the operator's off-CI validation host, but
-**no CI job builds or version-asserts 18.4 / 1.7.0 / 0.8.5**: the
-dedicated `postgres-age` nightly that once did was RED for its final three
-runs (the vendored `paste` fork rev went unreachable,
-[#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
-1) and was deleted on 2026-07-31 (§"CI posture" below). Treat 18.4 /
-1.7.0 / 0.8.5 as **additionally validated**, not continuously certified;
-the continuously-tested combination is PG 16 / AGE 1.6.0.
+deliberately not shipped). As of
+[#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548) /
+[#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) the
+AGE/KG + recall-purity suites run against this exact stack in-PR:
+`.github/workflows/cert-postgres-age.yml` stands up a live
+`apache/age:release_PG18_1.7.0` service (pgvector layered in via
+`postgresql-18-pgvector`), runs the pg-parity and AGE cells
+`--include-ignored`, and hard-fails if the running stack is not AGE 1.7.0
+on PG 18 with pgvector >= 0.8.5 — so the certified tier is proven by
+execution on the cert branch, not merely claimed. The PG 16 / AGE 1.6.0
+combination in `coverage.yml` remains as the documented alternate matrix.
 
 > **Cross-lane pgvector pin — reconciled ([#2872](https://github.com/alphaonedev/ai-memory-mcp/issues/2872)).**
 > Both certified provisioning SSOTs now pin pgvector **0.8.5**:
@@ -248,9 +254,13 @@ the continuously-tested combination is PG 16 / AGE 1.6.0.
 > was additionally no longer resolvable (pgdg keeps only a rolling window,
 > so `0.8.2-1.pgdg24.04+1` is absent from noble-pgdg). Cross-lane parity is
 > now asserted mechanically by `tests/provisioning_pgvector_pin_parity.rs`,
-> so a future accidental divergence fails loudly. The remaining CI-vs-SSOT
-> AGE drift (CI 1.6.0 vs SSOT 1.7.0) is separate and still tracked as
-> [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect 2.
+> so a future accidental divergence fails loudly. The former CI-vs-SSOT
+> AGE drift (CI 1.6.0 vs SSOT 1.7.0) is **resolved** by
+> [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) /
+> [#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548): the
+> certified AGE 1.7.0 / PG 18 canonical stack is now exercised in-PR by
+> `.github/workflows/cert-postgres-age.yml`, while `coverage.yml`'s
+> PG 16 / AGE 1.6.0 run is the documented alternate matrix.
 
 ### What those AGE greens attest — read this before relying on them
 
@@ -287,34 +297,36 @@ per-call fallback WARN that removal left silent). `find_paths` results
 were and remain correct (the CTE reads the durable `memory_links`);
 `kg_query` / `kg_timeline` / `lineage` still use AGE Cypher.
 
-### CI posture for the SSOT-pinned (18.4) stack — the pins are not CI-asserted
+### CI posture for the SSOT-pinned (18.4) stack — exercised in-PR on `release/**`
 
-**No CI job builds or version-asserts PG 18.4 + AGE 1.7.0 + pgvector
-0.8.5.** The `postgres-age` job
+**The certified PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack is now
+exercised in-PR.** `.github/workflows/cert-postgres-age.yml`
+([#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548))
+triggers on `pull_request` + `push` to `release/**`, stands up a live
+`apache/age:release_PG18_1.7.0` service with pgvector layered in via
+`postgresql-18-pgvector`, runs the `#[ignore]`-gated pg-parity binaries
+AND the AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
+self-skipping) under `--features sal-postgres --include-ignored`, and a
+version-assert step hard-fails if the running stack is not AGE 1.7.0 on
+PG 18 with pgvector >= 0.8.5. This is what makes the 2026-08-01 cutline
+ruling §5.4(3) executable — the certified tier is proven by execution on
+the cert branch.
+
+The historical `postgres-age` nightly
 ([#2012](https://github.com/alphaonedev/ai-memory-mcp/issues/2012)) that
-did was **deleted on 2026-07-31 by operator directive** (`2b85ba38`),
-not repaired: it rebuilt the certified stack from source on the runner
-every night purely to reproduce a stack that already exists
-continuously as the `ai-memory-pg:18.4-age1.7.0-vec0.8.5` container on
-the validation host. What survives in
-`.github/workflows/postgres-parity-nightly.yml` is the
-`postgres-parity` job, which runs four `#[ignore]`-gated cross-backend
-parity binaries against a `pgvector/pgvector:pg16` service container —
-**PG 16, no AGE, not the certified stack.**
-
-The AGE-gated Cypher/KG suites listed above are not `#[ignore]`-gated
-and DO run on every PR and push in `coverage.yml` — but against an
-`apache/age:release_PG16_1.6.0` service container, i.e. **PG 16 + AGE
-1.6.0, not the certified pins.** That CI-vs-SSOT version drift is
-[#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512)
-defect 2, held behind
-[#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548)
-(whether any in-PR AGE coverage is wanted at all, to be justified on
-its own merits and with a container image if it ever is). The SSOT-pinned
-18.4 / 1.7.0 / 0.8.5 combination itself is exercised on the operator's
-validation host and nowhere else — it is **additionally validated**, not
-continuously CI-certified; the CI-certified combination is PG 16 / AGE
-1.6.0.
+once rebuilt the stack from source every night was **deleted on
+2026-07-31 by operator directive** (`2b85ba38`), and is NOT what
+provides this coverage — the new in-PR job above does.
+`.github/workflows/postgres-parity-nightly.yml` retains the
+`postgres-parity` job (four cross-backend parity binaries against a
+`pgvector/pgvector:pg16` service container, no AGE). `coverage.yml`
+continues to run the AGE-gated Cypher/KG suites on every PR and push
+against an `apache/age:release_PG16_1.6.0` service container — **PG 16 +
+AGE 1.6.0**, retained as the documented alternate matrix (a line-coverage
+measurement, not the certified tier). The former CI-vs-SSOT AGE drift
+([#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
+2) is **resolved**: CI now exercises the certified AGE 1.7.0 canonical
+tier via `cert-postgres-age.yml` and honestly labels the PG 16 alternate.
 
 ## Additive surfaces
 

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -75,8 +75,10 @@ AGE + pgvector storage backend.
 > not `ai-memory mcp`. The certified **PG 18.4 / AGE 1.7.0 / pgvector
 > 0.8.5** stack is now exercised in-PR on every `release/**` PR by
 > `.github/workflows/cert-postgres-age.yml`, which runs the pg-parity and
-> AGE cells `--include-ignored` against the live
-> `apache/age:release_PG18_1.7.0` image and hard-fails on version drift;
+> AGE cells `--include-ignored` against the certified image CI builds from
+> `deploy/docker-1461/Dockerfile.pg-age-vector` (SSOT-pinned PG 18.4 / AGE
+> 1.7.0 / pgvector 0.8.5) and hard-fails on any drift from the exact pinned
+> minors;
 > the PG 16 / AGE 1.6.0 combination in `coverage.yml` is the documented
 > **alternate** matrix (a line-coverage measurement). See §"Certified
 > backend versions" for the exact versions and evidence basis.

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -234,13 +234,17 @@ deliberately not shipped). As of
 [#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548) /
 [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) the
 AGE/KG + recall-purity suites run against this exact stack in-PR:
-`.github/workflows/cert-postgres-age.yml` stands up a live
-`apache/age:release_PG18_1.7.0` service (pgvector layered in via
-`postgresql-18-pgvector`), runs the pg-parity and AGE cells
-`--include-ignored`, and hard-fails if the running stack is not AGE 1.7.0
-on PG 18 with pgvector >= 0.8.5 — so the certified tier is proven by
-execution on the cert branch, not merely claimed. The PG 16 / AGE 1.6.0
-combination in `coverage.yml` remains as the documented alternate matrix.
+`.github/workflows/cert-postgres-age.yml` BUILDS
+`deploy/docker-1461/Dockerfile.pg-age-vector` — the same recipe the
+docker-1461 mesh ships — with build-args resolved straight from this SSOT
+(`deploy/docker-1461/provision/lib.sh`), runs the resulting image as the
+postgres under test, runs the pg-parity and AGE cells `--include-ignored`,
+and version-asserts the EXACT pinned minors (PostgreSQL 18.4, Apache AGE
+1.7.0, pgvector 0.8.5 — not merely "PG 18" or "pgvector >= 0.8.5") — so the
+certified tier is proven by execution on the cert branch, not merely
+claimed, and CI's build artifact is the SAME artifact the deploy SSOT
+ships (zero drift by construction). The PG 16 / AGE 1.6.0 combination in
+`coverage.yml` remains as the documented alternate matrix.
 
 > **Cross-lane pgvector pin — reconciled ([#2872](https://github.com/alphaonedev/ai-memory-mcp/issues/2872)).**
 > Both certified provisioning SSOTs now pin pgvector **0.8.5**:
@@ -302,15 +306,20 @@ were and remain correct (the CTE reads the durable `memory_links`);
 **The certified PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack is now
 exercised in-PR.** `.github/workflows/cert-postgres-age.yml`
 ([#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548))
-triggers on `pull_request` + `push` to `release/**`, stands up a live
-`apache/age:release_PG18_1.7.0` service with pgvector layered in via
-`postgresql-18-pgvector`, runs the `#[ignore]`-gated pg-parity binaries
-AND the AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
+triggers on `pull_request` + `push` to `release/**`, resolves every
+version pin from the ONE declaration source
+(`deploy/docker-1461/provision/lib.sh`), BUILDS
+`deploy/docker-1461/Dockerfile.pg-age-vector` with those pins as
+build-args (the same recipe the docker-1461 mesh ships — no second,
+drift-prone copy of the pins), runs the resulting image as the postgres
+under test, runs the `#[ignore]`-gated pg-parity binaries AND the
+AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
 self-skipping) under `--features sal-postgres --include-ignored`, and a
-version-assert step hard-fails if the running stack is not AGE 1.7.0 on
-PG 18 with pgvector >= 0.8.5. This is what makes the 2026-08-01 cutline
+version-assert step hard-fails on ANY drift from the exact pinned minors
+— PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.5, not a looser "PG 18"
+/ "pgvector >= 0.8.5" match. This is what makes the 2026-08-01 cutline
 ruling §5.4(3) executable — the certified tier is proven by execution on
-the cert branch.
+the cert branch, at the exact certified minors the docs cite.
 
 The historical `postgres-age` nightly
 ([#2012](https://github.com/alphaonedev/ai-memory-mcp/issues/2012)) that
@@ -488,9 +497,12 @@ program:
 
 1. **DigitalOcean full-spectrum testing + attestation.** The SSOT-pinned
    PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack was exercised full-spectrum
-   on DigitalOcean (the off-CI validation host — this IS the "additionally
-   validated" evidence for those pins; the continuously CI-tested
-   combination is PG 16 / AGE 1.6.0, see §"Certified backend versions")
+   on DigitalOcean (the off-CI validation host — at the time this campaign
+   ran, DO was the only place that exact triple had been exercised end to
+   end; CI has since begun exercising the same certified triple in-PR on
+   `release/**`, runs `deploy/docker-1461/Dockerfile.pg-age-vector` built
+   to the SSOT-pinned minors, and version-asserts the exact result — see
+   §"Certified backend versions" for the current in-PR posture)
    and attested (this also covers the v0.9.0 4-phase
    ship-gate boundary per ROADMAP §17's recorded exception, ruling
    `wf_26d176ac` — the v0.9.0 record re-opens only if this campaign does

--- a/scripts/check-branch-protection.sh
+++ b/scripts/check-branch-protection.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check-branch-protection.sh — one-declaration-source gate for the required
+# status-check set (#2534).
+#
+# THE RULE. `.github/branch-protection.yml` MUST NOT declare a `required_checks`
+# key. Live branch protection lives on the GitHub API and is the authoritative
+# artefact; the in-repo DECLARATION of the required-status-check set is
+# `scripts/qc-allowlists/required-contexts-release.txt` (verified by
+# scripts/check-required-contexts.sh). A second, hand-maintained list of check
+# names inside branch-protection.yml is EXACTLY how #2443 happened: that file
+# once carried per-branch `required_checks:` lists that were wrong in both
+# directions (over-declared unrequireable `<workflow> / <job>` strings AND
+# omitting 22 live-required contexts), while asserting `enforce_admins: true`
+# over them — a committed policy file MANUFACTURING assurance an enterprise
+# reviewer reads instead of the API.
+#
+# #2443 reconciled the file to a single POINTER (`required_checks_declaration:`)
+# at the one true declaration. This gate keeps the regressive `required_checks:`
+# key from ever re-landing. It fails CLOSED if the file is missing.
+#
+# WHAT IS NOT A VIOLATION. The pointer key `required_checks_declaration:` is the
+# intended shape and MUST pass — the match is anchored so `required_checks`
+# followed by `_declaration` (or any other identifier character) is not a hit;
+# only a bare `required_checks:` key (optionally a `- required_checks:` list
+# item) fails.
+#
+# Exit codes: 0 clean · 1 violation · 2 usage / self-test failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BP_FILE_DEFAULT="$REPO_ROOT/.github/branch-protection.yml"
+
+# A YAML key `required_checks:` — optionally a `- required_checks:` list item —
+# at any indentation. `[^_[:alnum:]]`-style boundary after the name is enforced
+# by requiring optional whitespace then `:` IMMEDIATELY, so
+# `required_checks_declaration:` (next char `_`) can never match.
+VIOLATION_RE='^[[:space:]]*(-[[:space:]]+)?required_checks[[:space:]]*:'
+
+check_file() {
+  local f="$1"
+  if [ ! -f "$f" ]; then
+    echo "check-branch-protection: ERROR — $f not found (fail-closed)" >&2
+    return 1
+  fi
+  local hits
+  # -v skips YAML comments so a `# ... required_checks: ...` prose line never
+  # trips the gate; the declaration itself is never a comment.
+  hits="$(grep -nE "$VIOLATION_RE" "$f" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [ -n "$hits" ]; then
+    echo "check-branch-protection: VIOLATION — $f declares a bare 'required_checks' key:" >&2
+    echo "$hits" | sed 's/^/    /' >&2
+    echo "" >&2
+    echo "  The required-status-check set has ONE declaration source:" >&2
+    echo "    scripts/qc-allowlists/required-contexts-release.txt" >&2
+    echo "  (verified by scripts/check-required-contexts.sh). Do NOT list check" >&2
+    echo "  names in branch-protection.yml — see #2443 / #2534." >&2
+    return 1
+  fi
+  return 0
+}
+
+self_test() {
+  local tmp
+  tmp="$REPO_ROOT/.local-runs/check-branch-protection-selftest.$$"
+  mkdir -p "$tmp"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT
+
+  # (1) The pointer-only shape (the reconciled #2443 form) MUST PASS.
+  cat > "$tmp/clean.yml" <<'YML'
+version: 2
+required_checks_declaration:
+  release_branches:
+    file: scripts/qc-allowlists/required-contexts-release.txt
+branches:
+  - pattern: release/**
+    enforce_admins: true
+# A prose mention of required_checks: in a comment must not trip the gate.
+YML
+  if ! check_file "$tmp/clean.yml" >/dev/null 2>&1; then
+    echo "self-test FAILED: clean pointer-only file was rejected" >&2
+    exit 2
+  fi
+
+  # (2) A bare per-branch `required_checks:` key MUST FAIL (the #2443 regression).
+  cat > "$tmp/dirty.yml" <<'YML'
+version: 2
+branches:
+  - pattern: release/**
+    required_checks:
+      - "Check (ubuntu-latest)"
+YML
+  if check_file "$tmp/dirty.yml" >/dev/null 2>&1; then
+    echo "self-test FAILED: a bare required_checks key was NOT rejected" >&2
+    exit 2
+  fi
+
+  # (3) A `- required_checks:` list-item form MUST FAIL too.
+  cat > "$tmp/dirty2.yml" <<'YML'
+version: 2
+- required_checks: []
+YML
+  if check_file "$tmp/dirty2.yml" >/dev/null 2>&1; then
+    echo "self-test FAILED: a '- required_checks:' list item was NOT rejected" >&2
+    exit 2
+  fi
+
+  # (4) A missing file MUST FAIL closed.
+  if check_file "$tmp/does-not-exist.yml" >/dev/null 2>&1; then
+    echo "self-test FAILED: a missing file passed (should fail closed)" >&2
+    exit 2
+  fi
+
+  echo "check-branch-protection self-test OK (pointer passes; bare key, list-item, and missing file all fail)"
+}
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    ;;
+  "")
+    if check_file "$BP_FILE_DEFAULT"; then
+      echo "check-branch-protection: OK — .github/branch-protection.yml declares no bare 'required_checks' key"
+    else
+      exit 1
+    fi
+    ;;
+  *)
+    echo "usage: $(basename "$0") [--self-test]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/qc-allowlists/ci-job-claims-pending.txt
+++ b/scripts/qc-allowlists/ci-job-claims-pending.txt
@@ -58,7 +58,9 @@ ROADMAP.md Code Coverage          #2629 C-24
 ROADMAP.md ci.yml:Code Coverage   #2629 C-24 the possessive citation on the same line
 
 # --- C-23 -------------------------------------------------------------
-docs/v1.0.0/release-notes.md postgres-age  #2629 C-23 job deleted in da3fb9cc
+# (resolved #2512/#2548) release-notes.md §"CI posture" now describes the
+# postgres-age deletion + the new in-PR cert-postgres-age.yml coverage with
+# no false enforcement claim, so no suppression entry is needed here.
 
 # --- C-21 — BURNED DOWN 2026-08-01 ------------------------------------
 # The PERFORMANCE.md correction lane removed the AGE-job citation, so the


### PR DESCRIPTION
CRITICAL-PATH cert-evidence unblocker cluster. The 2026-08-01 cutline ruling §5.4(3) requires EXECUTED evidence on real Postgres+AGE+pgvector in CI at the CERTIFIED versions; today the certified pg+AGE tier never runs in-PR and the AGE pin drifts. This closes that so the §5.4 evidence harness can be produced truthfully.

## The one true certified triple
**PostgreSQL 18.4 + Apache AGE 1.7.0 + pgvector 0.8.5** — SSOT `deploy/docker-1461/provision/lib.sh` (`EXPECTED_PG_VERSION=18.4`, `EXPECTED_AGE_VERSION=1.7.0`, `PGVECTOR_APT_VERSION=0.8.5`) + `docs/postgres-age-guide.md` §Prerequisites. Image: `apache/age:release_PG18_1.7.0`.

## #2548 — certified pg+AGE tier now runs IN-PR
New `.github/workflows/cert-postgres-age.yml` (`pull_request` + `push` on `release/**`, `workflow_dispatch`) runs the `#[ignore]`-gated postgres cells AND the AGE-backed cells against a live `apache/age:release_PG18_1.7.0` service (pgvector layered in via `postgresql-18-pgvector`), `--include-ignored --test-threads=1`. The AGE cells self-skip unless `AI_MEMORY_TEST_AGE_URL` is set (it is), so they actually execute — the missing in-PR cert evidence. A version-assert step **hard-fails** if the running stack is not AGE 1.7 on PG 18 with pgvector >= 0.8.5, so a base-image drift reds instead of silently certifying the wrong version. Modelled on `postgres-parity-nightly.yml` (mold + trimmed dev debug) + `coverage.yml` (AGE/vector provisioning). This job runs on THIS PR — its result IS the cert evidence.

## #2512 — AGE pin drift reconciled
`coverage.yml` pins the PG16 + AGE 1.6.0 alternate. Rather than risk the required coverage gate on a PG-major flip it does not measure, it is now **explicitly labelled the DOCUMENTED ALTERNATE matrix** (a line-coverage measurement, not cert evidence) with a cross-reference to the cert job; the canonical triple is exercised by the new cert job. So CI runs BOTH stacks the SSOT documents and neither is drift, and §5.4(3)'s "CI-on-16-while-certifying-18" is resolved because the cert evidence runs on 18/1.7.0. `docs/postgres-age-guide.md` gains a CI-evidence cross-reference. **Verified:** the release branch already vendors `paste` in-tree (`paste = { path = "vendor/paste" }`, #2050) — no dead git pin to fix here.

## #2534 — one declaration source for required checks
New `scripts/check-branch-protection.sh` (`--self-test`) HARD-FAILS if `.github/branch-protection.yml` re-declares a bare `required_checks` key (the #2443 regression), while correctly NOT tripping on the intended `required_checks_declaration` pointer. Wired as steps of the already-required `required-contexts-gate` job in `c8-precheck.yml` — no new required context to add to the mirror.

## #2895 — release-pipeline supply-chain hardening (§3C)
`.github/workflows/release.yml`: `--locked` on every `cargo build` + `cargo publish`; `--allow-dirty` dropped from publish; crates.io publish toolchain pinned to **1.96.0** (was bare `@stable`); new `supply-chain` job runs the git-dependency-source (#2050/#2512) + build-script-vetting (#2635) gates BEFORE any build/publish, wired as a `needs:` of every build/publish job.

## Local validation
- `actionlint -shellcheck=` clean on all changed/new workflows
- `check-branch-protection.sh` + `--self-test`: PASS
- `check-required-contexts.sh` + `--self-test`: PASS (new cert workflow + release `supply-chain` job accepted; rule (d) exempt via event-distinct concurrency key, rule (e) no unquoted `#`, rule (f) covers only ci/c8/coverage jobs — none added there)
- `check-git-dependency-sources.sh` + `--self-test`: PASS
- `check-docs-vs-ssot.sh`, `check-doc-symbol-anchors.sh`, `check-ci-job-claims.sh`: PASS (18 workflows parsed)

## AI involvement
Authored by Claude Opus 5 (coder tier) under operator delegation on the ENTERPRISE FEDERATION CERTIFICATION campaign. Not self-merged — Fable review+audit gate before merge.

Closes #2548 #2512 #2534 #2895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY