### PR TITLE
fix(#2602,#2615): final total-order tiebreak on list/load_family + recall-observations ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no stopword removal) — a smaller, pre-existing tokenizer-asymmetry class
   already true for title/content, and a DEGRADE (fewer Postgres results),
   never a wrong result.
+### Fixed (data integrity — deterministic wire-visible ordering)
+
+- **`list` / `memory_load_family` and the `recall_observations` audit ledger
+  now carry a FINAL total-order tiebreak, so which rows page under LIMIT and
+  in what order the ledger reads back are no longer plan-/backend-dependent**
+  ([#2602](https://github.com/alphaonedev/ai-memory-mcp/issues/2602) +
+  [#2615](https://github.com/alphaonedev/ai-memory-mcp/issues/2615);
+  data-integrity North Star). Both surfaces ordered by a non-unique key set
+  with no tiebreak, so ties — which are COMMON — left the row at rank *k*
+  among the ties (and therefore which rows page vs fall off under LIMIT/OFFSET)
+  an arbitrary, plan-dependent choice, a wire-visible non-determinism.
+  **(#2602)** `list` (`storage::build_list_query`), `PostgresStore::list`, and
+  `memory_load_family` (always-on core profile) ordered by
+  `priority DESC, updated_at DESC` only — priority is 1-10 and bulk/federated
+  rows share an `updated_at` ms, so ties abound. All three sites now append
+  `, id ASC` (the UUID primary key — unique, NOT NULL) as the final key,
+  identical across sqlite + postgres. On sqlite the composite index
+  `idx_memories_ns_list_order` still serves the `(priority, updated_at)` walk
+  order and only block-sorts each tie group by `id` (EXPLAIN QUERY PLAN: "USE
+  TEMP B-TREE FOR RIGHT PART OF ORDER BY", a bounded per-tie sort — NOT a full
+  "FOR ORDER BY" sort), so early-stop under LIMIT is preserved and no index
+  migration is required. **(#2615)** `list_recall_observations` (both backends)
+  ordered by `observed_at DESC` only — every row a single recall appends shares
+  `observed_at` (= the tx timestamp), leaving an arbitrary permutation within
+  each `recall_id` on the append-only P0-1 AUDIT ledger. It now appends
+  `, rank ASC, memory_id ASC` for a strict total order. Regression coverage:
+  `tests/ordering_determinism_2602_2615.rs`.
 
 ### Fixed (data integrity — import round-trip)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each `recall_id` on the append-only P0-1 AUDIT ledger. It now appends
   `, rank ASC, memory_id ASC` for a strict total order. Regression coverage:
   `tests/ordering_determinism_2602_2615.rs`.
+- **Collation-stable postgres tiebreaks (#1724 collation-byte-range class),
+  closing a residual where the new tiebreaks themselves ordered differently
+  across backends.** `memories.id` and `recall_observations.recall_id` /
+  `.memory_id` are `TEXT`, NOT `uuid`, on postgres, and the corpus is not
+  guaranteed canonical lowercase UUIDs — `portability::import` preserves
+  ids verbatim and federation receive applies a peer's `mem.id` verbatim
+  with no UUID-format validation — so a mixed-case id (`mem-a` vs `MEM-B`)
+  sorted under postgres' default (non-`C`) collation while sqlite always
+  sorts `id`/`recall_id`/`memory_id` BINARY, silently reintroducing
+  backend-dependent order on the very tiebreak meant to close #2602/#2615.
+  `PostgresStore::list`'s `id` tiebreak and `PostgresStore::list_recall_observations`'s
+  `memory_id`/`recall_id` tiebreaks are now `COLLATE "C"`, byte-ordering
+  identically to sqlite on both surfaces. `list_recall_observations` (both
+  backends) also gained a final `recall_id` key — the ledger's actual
+  PRIMARY KEY is `(recall_id, memory_id)`, so `memory_id` alone is unique
+  only WITHIN one `recall_id`, and this listing surface accepts
+  `recall_id = None` (unfiltered). Also gave the HTTP postgres
+  `load_family` path (`handlers::power_consolidation::load_family_handler`)
+  an explicit `id ASC` in-process tiebreak so its ordering is
+  self-contained rather than depending implicitly on the upstream
+  `store.list` invariant holding. Live-postgres regression coverage:
+  `tests/ordering_determinism_2602_2615_pg.rs` (`#[ignore]`,
+  `--features sal,sal-postgres`, `AI_MEMORY_TEST_POSTGRES_URL`).
 
 ### Fixed (data integrity — import round-trip)
 

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -1118,11 +1118,17 @@ pub async fn load_family_handler(
         let ctx = crate::handlers::parity::http_caller_ctx(&headers, None);
         let narrow = |rows: Vec<Memory>| -> Vec<Memory> {
             let mut kept: Vec<Memory> = rows.into_iter().filter(|m| family_eq.matches(m)).collect();
-            // priority DESC, updated_at DESC (mirrors handle_load_family).
+            // priority DESC, updated_at DESC, id ASC (mirrors handle_load_family
+            // + the #2602/#2615 `store::list` tiebreak). `sort_by` is stable, so
+            // this in-process sort inherits determinism only IMPLICITLY from the
+            // already-ordered `store.list` result; an explicit `id` tiebreak
+            // makes this call site a self-contained total order rather than one
+            // that silently depends on an upstream invariant holding.
             kept.sort_by(|a, b| {
                 b.priority
                     .cmp(&a.priority)
                     .then_with(|| b.updated_at.cmp(&a.updated_at))
+                    .then_with(|| a.id.cmp(&b.id))
             });
             kept
         };

--- a/src/mcp/tools/load_family.rs
+++ b/src/mcp/tools/load_family.rs
@@ -336,7 +336,7 @@ pub fn handle_load_family(
            AND json_extract(metadata, '$.family') = ?2 \
            AND (expires_at IS NULL OR expires_at > ?3) \
            {lifecycle_vis} \
-         ORDER BY priority DESC, updated_at DESC \
+         ORDER BY priority DESC, updated_at DESC, id ASC \
          LIMIT ?4"
     );
 

--- a/src/observations/mod.rs
+++ b/src/observations/mod.rs
@@ -284,7 +284,14 @@ pub fn list_observations(
         sql.push_str(" AND observed_at <= ?");
         binds.push(Box::new(u.to_string()));
     }
-    sql.push_str(" ORDER BY observed_at DESC LIMIT ?");
+    // v1.0.0 #2615 — total order on the append-only P0-1 AUDIT ledger. Every
+    // row a single recall appends shares `observed_at` (= the tx timestamp), so
+    // `ORDER BY observed_at DESC` alone left an ARBITRARY permutation within each
+    // recall_id — a wire-visible non-determinism on an audit surface. `rank`
+    // (the retriever's returned position) then `memory_id` (unique per recall_id)
+    // make the order strict and total, byte-identical to the postgres twin
+    // (`PostgresStore::list_recall_observations`).
+    sql.push_str(" ORDER BY observed_at DESC, rank ASC, memory_id ASC LIMIT ?");
     let lim_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     binds.push(Box::new(lim_i64));
 

--- a/src/observations/mod.rs
+++ b/src/observations/mod.rs
@@ -288,10 +288,16 @@ pub fn list_observations(
     // row a single recall appends shares `observed_at` (= the tx timestamp), so
     // `ORDER BY observed_at DESC` alone left an ARBITRARY permutation within each
     // recall_id — a wire-visible non-determinism on an audit surface. `rank`
-    // (the retriever's returned position) then `memory_id` (unique per recall_id)
-    // make the order strict and total, byte-identical to the postgres twin
-    // (`PostgresStore::list_recall_observations`).
-    sql.push_str(" ORDER BY observed_at DESC, rank ASC, memory_id ASC LIMIT ?");
+    // (the retriever's returned position) then `memory_id` narrow ties within a
+    // single recall_id, but this listing surface also accepts `recall_id =
+    // None` (unfiltered), and the table's actual PRIMARY KEY is
+    // `(recall_id, memory_id)` — `memory_id` is unique only WITHIN a
+    // recall_id partition, so TWO recalls that observe the same memory at the
+    // same rank in the same `observed_at` instant (ms-precision text on
+    // sqlite) leave a residual tie. `recall_id ASC` as the FINAL key gives the
+    // full PK and makes the order genuinely total, byte-identical to the
+    // postgres twin (`PostgresStore::list_recall_observations`).
+    sql.push_str(" ORDER BY observed_at DESC, rank ASC, memory_id ASC, recall_id ASC LIMIT ?");
     let lim_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     binds.push(Box::new(lim_i64));
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -74,7 +74,19 @@ pub(crate) const SQL_UPDATE_METADATA_AND_UPDATED_AT_BY_ID: &str =
 // drive through `idx_memories_list_order` / `idx_memories_ns_list_order`
 // instead of the formerly non-sargable `(?N IS NULL OR col = ?N)` arms.
 const SQL_LIST_BASE: &str = "SELECT * FROM memories WHERE (expires_at IS NULL OR expires_at > ?)";
-const SQL_LIST_ORDER_LIMIT: &str = " ORDER BY priority DESC, updated_at DESC LIMIT ? OFFSET ?";
+// v1.0.0 #2602 — `id ASC` is the FINAL total-order tiebreak. `(priority,
+// updated_at)` ties are common (priority is 1-10; bulk/federated rows share an
+// `updated_at` ms), so WITHOUT it the row at rank k among ties — which rows page
+// vs fall off under LIMIT/OFFSET — is plan-/backend-dependent, a wire-visible
+// non-determinism. `id` is the UUID primary key (unique, NOT NULL), so the sort
+// is now a strict total order, byte-identical to the postgres twin
+// (`PostgresStore::list`) and the `memory_load_family` loader. See the v56
+// `idx_memories_ns_list_order` note: SQLite serves the `(priority, updated_at)`
+// prefix from the index and block-sorts each tie group by `id`, so early-stop
+// under LIMIT is preserved (EXPLAIN QUERY PLAN: "USE TEMP B-TREE FOR RIGHT PART
+// OF ORDER BY" — a bounded per-tie-block sort, NOT a full "FOR ORDER BY" sort).
+const SQL_LIST_ORDER_LIMIT: &str =
+    " ORDER BY priority DESC, updated_at DESC, id ASC LIMIT ? OFFSET ?";
 
 /// v0.7.0 H6 (round-2) — truncate a `DateTime<Utc>` to microsecond
 /// precision. Companion of the same-named helper in

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -17839,8 +17839,16 @@ impl MemoryStore for PostgresStore {
         // to the sqlite twin (`storage::build_list_query`) + the
         // `memory_load_family` loader: `(priority, updated_at)` ties are common,
         // so without it which rows page vs fall off under LIMIT was
-        // plan-/backend-dependent. `id` is the UUID primary key (unique, NOT
-        // NULL) so the sort is a strict total order on both backends.
+        // plan-/backend-dependent. `id` is `TEXT PRIMARY KEY` on postgres (NOT
+        // `uuid`), and ids are NOT guaranteed to be canonical lowercase UUIDs —
+        // `portability::import` preserves corpus ids verbatim and federation
+        // receive applies a peer's `mem.id` verbatim with no UUID-format
+        // validation, so e.g. `mem-a` vs `MEM-B` can appear. Postgres' default
+        // (non-"C") collation orders such strings DIFFERENTLY from sqlite's
+        // BINARY comparison, which would silently reintroduce cross-backend
+        // ordering drift on the very tiebreak meant to close it (#1724
+        // collation-byte-range lesson). `COLLATE "C"` pins the postgres sort to
+        // byte order, identical to sqlite BINARY, on BOTH backends.
         let list_sql = format!(
             "SELECT {cols} FROM memories
              WHERE {ns_predicate}
@@ -17862,7 +17870,7 @@ impl MemoryStore for PostgresStore {
                )
                {metadata_eq_predicate}
                {lifecycle_vis}
-             ORDER BY priority DESC, updated_at DESC, id ASC
+             ORDER BY priority DESC, updated_at DESC, id COLLATE \"C\" ASC
              LIMIT $5",
             // v1.0.0 R19/A3 (#1948) — fail-closed lifecycle allow-list. Also
             // covers the export egress: `export_memories` delegates to `list`.
@@ -21834,8 +21842,15 @@ impl MemoryStore for PostgresStore {
         // v1.0.0 #2615 — total order on the audit ledger, identical to the
         // sqlite twin (`crate::observations::list_observations`): all rows a
         // single recall appends share `observed_at`, so `rank` then `memory_id`
-        // make the within-recall order strict and deterministic.
-        qb.push(" ORDER BY observed_at DESC, rank ASC, memory_id ASC LIMIT ")
+        // narrow ties within one recall_id — but this surface also accepts
+        // `recall_id = None` (unfiltered) and the table's PRIMARY KEY is
+        // `(recall_id, memory_id)`, so `recall_id ASC` is the FINAL key needed
+        // for a genuinely total order across recall_ids. `memory_id` and
+        // `recall_id` are TEXT on postgres and not guaranteed canonical UUIDs
+        // (same #1724-class risk as the `memories.id` tiebreak in `list`), so
+        // both are pinned `COLLATE "C"` to byte-order identically to sqlite
+        // BINARY.
+        qb.push(" ORDER BY observed_at DESC, rank ASC, memory_id COLLATE \"C\" ASC, recall_id COLLATE \"C\" ASC LIMIT ")
             .push_bind(lim_i64);
         let rows = qb
             .build()

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -17835,6 +17835,12 @@ impl MemoryStore for PostgresStore {
         } else {
             ""
         };
+        // v1.0.0 #2602 — `id ASC` is the FINAL total-order tiebreak, IDENTICAL
+        // to the sqlite twin (`storage::build_list_query`) + the
+        // `memory_load_family` loader: `(priority, updated_at)` ties are common,
+        // so without it which rows page vs fall off under LIMIT was
+        // plan-/backend-dependent. `id` is the UUID primary key (unique, NOT
+        // NULL) so the sort is a strict total order on both backends.
         let list_sql = format!(
             "SELECT {cols} FROM memories
              WHERE {ns_predicate}
@@ -17856,7 +17862,7 @@ impl MemoryStore for PostgresStore {
                )
                {metadata_eq_predicate}
                {lifecycle_vis}
-             ORDER BY priority DESC, updated_at DESC
+             ORDER BY priority DESC, updated_at DESC, id ASC
              LIMIT $5",
             // v1.0.0 R19/A3 (#1948) — fail-closed lifecycle allow-list. Also
             // covers the export egress: `export_memories` delegates to `list`.
@@ -21825,7 +21831,11 @@ impl MemoryStore for PostgresStore {
             qb.push(" AND observed_at <= ").push_bind(u.to_string());
         }
         let lim_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-        qb.push(" ORDER BY observed_at DESC LIMIT ")
+        // v1.0.0 #2615 — total order on the audit ledger, identical to the
+        // sqlite twin (`crate::observations::list_observations`): all rows a
+        // single recall appends share `observed_at`, so `rank` then `memory_id`
+        // make the within-recall order strict and deterministic.
+        qb.push(" ORDER BY observed_at DESC, rank ASC, memory_id ASC LIMIT ")
             .push_bind(lim_i64);
         let rows = qb
             .build()

--- a/tests/ordering_determinism_2602_2615.rs
+++ b/tests/ordering_determinism_2602_2615.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #2602 + #2615 — total-order tiebreak regression suite for the
+//! two non-deterministic wire-visible `ORDER BY` surfaces.
+//!
+//! #2602 — `storage::list` (`build_list_query`) + `memory_load_family`
+//! ordered by `priority DESC, updated_at DESC` with NO final tiebreak.
+//! `(priority, updated_at)` ties are common (priority is 1-10; bulk /
+//! federated rows share an `updated_at` ms), so which rows page vs fall
+//! off under LIMIT/OFFSET was plan-dependent. The fix appends `id ASC`
+//! (the UUID primary key) as the final total-order key on ALL THREE
+//! sites (sqlite `build_list_query`, `PostgresStore::list`,
+//! `memory_load_family`), so the sort is now a STRICT total order.
+//!
+//! #2615 — `list_recall_observations` ordered by `observed_at DESC`
+//! only; every row a single recall appends shares `observed_at`, so the
+//! within-`recall_id` permutation was arbitrary on the append-only P0-1
+//! AUDIT ledger. The fix appends `rank ASC, memory_id ASC`.
+//!
+//! These tests exercise the sqlite path (the MCP-stdio / CLI backend +
+//! the sqlite half of the SAL). The postgres twins carry byte-identical
+//! `ORDER BY` clauses (verified by inspection + the shared comment
+//! anchors) and are covered under the live-PG suites.
+
+use ai_memory::observations;
+use rusqlite::{Connection, params};
+
+fn fresh_db() -> Connection {
+    ai_memory::storage::open(std::path::Path::new(":memory:")).expect("open in-memory db")
+}
+
+/// Seed a memory with an explicit `priority` + `updated_at` + optional
+/// `metadata.family`, so ties can be forced deterministically.
+fn seed_mem(conn: &Connection, id: &str, ns: &str, priority: i64, updated_at: &str, family: &str) {
+    let metadata = format!(r#"{{"family":"{family}"}}"#);
+    conn.execute(
+        "INSERT INTO memories \
+            (id, tier, namespace, title, content, priority, metadata, created_at, updated_at) \
+         VALUES (?1, 'long', ?2, ?3, 'content', ?4, ?5, '2025-01-01T00:00:00Z', ?6)",
+        params![
+            id,
+            ns,
+            format!("title-{id}"),
+            priority,
+            metadata,
+            updated_at
+        ],
+    )
+    .expect("seed memory");
+}
+
+// --------------------------------------------------------------------
+// #2602 — storage::list total order
+// --------------------------------------------------------------------
+
+/// All six rows share `(priority, updated_at)`. The tiebreak makes the
+/// returned order STRICTLY `id ASC`, and identical across two calls.
+#[test]
+fn list_ties_resolve_to_id_ascending_stably_2602() {
+    let conn = fresh_db();
+    let ns = "detns";
+    let tied_at = "2026-01-01T00:00:00.000Z";
+    // Insert deliberately OUT of id order so a naive plan could echo the
+    // insertion / rowid order instead of the id order.
+    for id in [
+        "mem-id-03",
+        "mem-id-01",
+        "mem-id-05",
+        "mem-id-02",
+        "mem-id-06",
+        "mem-id-04",
+    ] {
+        seed_mem(&conn, id, ns, 5, tied_at, "core");
+    }
+
+    let ids = |limit: usize, offset: usize| -> Vec<String> {
+        ai_memory::storage::list(
+            &conn,
+            Some(ns),
+            None,
+            limit,
+            offset,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("list")
+        .into_iter()
+        .map(|m| m.id)
+        .collect()
+    };
+
+    let run1 = ids(100, 0);
+    let run2 = ids(100, 0);
+    assert_eq!(
+        run1, run2,
+        "two identical list calls must return identical order"
+    );
+    assert_eq!(
+        run1,
+        vec![
+            "mem-id-01",
+            "mem-id-02",
+            "mem-id-03",
+            "mem-id-04",
+            "mem-id-05",
+            "mem-id-06",
+        ],
+        "ties must resolve to strict id-ascending order"
+    );
+
+    // Which rows PAGE under LIMIT/OFFSET is now well-defined: the first
+    // page is the three lowest ids, the second page the next three — no
+    // row is dropped or duplicated across the boundary.
+    assert_eq!(ids(3, 0), vec!["mem-id-01", "mem-id-02", "mem-id-03"]);
+    assert_eq!(ids(3, 3), vec!["mem-id-04", "mem-id-05", "mem-id-06"]);
+}
+
+/// The tiebreak is subordinate to `priority DESC, updated_at DESC` — it
+/// only orders WITHIN a tie group, never overrides the primary keys.
+#[test]
+fn list_id_tiebreak_is_subordinate_to_priority_and_updated_at_2602() {
+    let conn = fresh_db();
+    let ns = "ordns";
+    // Higher priority wins regardless of id; newer updated_at wins within
+    // a priority; id only breaks a full (priority, updated_at) tie.
+    seed_mem(&conn, "zzz-hi", ns, 9, "2020-01-01T00:00:00.000Z", "core"); // pri 9 → first
+    seed_mem(
+        &conn,
+        "aaa-mid-new",
+        ns,
+        5,
+        "2026-01-01T00:00:00.000Z",
+        "core",
+    );
+    seed_mem(
+        &conn,
+        "aaa-mid-old-b",
+        ns,
+        5,
+        "2020-01-01T00:00:00.000Z",
+        "core",
+    );
+    seed_mem(
+        &conn,
+        "aaa-mid-old-a",
+        ns,
+        5,
+        "2020-01-01T00:00:00.000Z",
+        "core",
+    );
+
+    let got: Vec<String> = ai_memory::storage::list(
+        &conn,
+        Some(ns),
+        None,
+        100,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("list")
+    .into_iter()
+    .map(|m| m.id)
+    .collect();
+
+    assert_eq!(
+        got,
+        vec![
+            "zzz-hi",        // priority 9
+            "aaa-mid-new",   // priority 5, newest updated_at
+            "aaa-mid-old-a", // priority 5, tied updated_at, id ASC
+            "aaa-mid-old-b",
+        ],
+    );
+}
+
+// --------------------------------------------------------------------
+// #2602 — memory_load_family total order (always-on core-profile loader)
+// --------------------------------------------------------------------
+
+#[test]
+fn load_family_ties_resolve_to_id_ascending_stably_2602() {
+    let conn = fresh_db();
+    let ns = "famns";
+    let tied_at = "2026-03-03T00:00:00.000Z";
+    for id in ["fam-03", "fam-01", "fam-05", "fam-02", "fam-06", "fam-04"] {
+        seed_mem(&conn, id, ns, 5, tied_at, "core");
+    }
+
+    let ids = |k: u64| -> Vec<String> {
+        let resp = ai_memory::mcp::handle_load_family(
+            &conn,
+            &serde_json::json!({"family": "core", "namespace": ns, "k": k}),
+            None,
+        )
+        .expect("load_family");
+        resp["memories"]
+            .as_array()
+            .expect("memories array")
+            .iter()
+            .map(|m| m["id"].as_str().expect("id").to_string())
+            .collect()
+    };
+
+    let run1 = ids(100);
+    let run2 = ids(100);
+    assert_eq!(run1, run2, "two identical load_family calls must match");
+    assert_eq!(
+        run1,
+        vec!["fam-01", "fam-02", "fam-03", "fam-04", "fam-05", "fam-06"],
+    );
+    // Under the k budget the SAME lowest-id prefix is served.
+    assert_eq!(ids(3), vec!["fam-01", "fam-02", "fam-03"]);
+}
+
+// --------------------------------------------------------------------
+// #2615 — list_recall_observations total order (audit ledger)
+// --------------------------------------------------------------------
+
+/// Insert observations that share `observed_at` (the single-recall
+/// case). The tiebreak makes the order `rank ASC, memory_id ASC`,
+/// stable across two reads.
+#[test]
+fn recall_observations_tiebreak_is_rank_then_memory_id_2615() {
+    let conn = fresh_db();
+    for id in ["mA", "mB", "mC", "mD"] {
+        seed_mem(&conn, id, "obs", 5, "2025-01-01T00:00:00Z", "core");
+    }
+
+    let tied_at = "2026-02-02T00:00:00.000Z";
+    // Same recall_id, all rows share observed_at. Insert out of order.
+    // Two rows share rank=2 (mB, mA) → memory_id ASC breaks it (mA<mB).
+    let insert = |memory_id: &str, rank: i64, observed_at: &str| {
+        conn.execute(
+            "INSERT INTO recall_observations \
+                (recall_id, memory_id, retriever, rank, score, observed_at, folded) \
+             VALUES ('rid', ?1, 'hybrid', ?2, 0.5, ?3, 0)",
+            params![memory_id, rank, observed_at],
+        )
+        .expect("insert observation");
+    };
+    insert("mB", 2, tied_at);
+    insert("mA", 2, tied_at);
+    insert("mC", 1, tied_at);
+    // A row with a strictly NEWER observed_at must still sort FIRST — the
+    // tiebreak is subordinate to the primary `observed_at DESC` key.
+    insert("mD", 9, "2026-02-02T00:00:01.000Z");
+
+    let order = |conn: &Connection| -> Vec<(String, i64)> {
+        observations::list_observations(conn, Some("rid"), None, None, None, 100)
+            .expect("list_observations")
+            .into_iter()
+            .map(|o| (o.memory_id, o.rank))
+            .collect()
+    };
+
+    let run1 = order(&conn);
+    let run2 = order(&conn);
+    assert_eq!(
+        run1, run2,
+        "two identical ledger reads must return identical order"
+    );
+    assert_eq!(
+        run1,
+        vec![
+            ("mD".to_string(), 9), // newest observed_at → first
+            ("mC".to_string(), 1), // then rank ASC within the tied observed_at
+            ("mA".to_string(), 2), // rank tie → memory_id ASC
+            ("mB".to_string(), 2),
+        ],
+    );
+}

--- a/tests/ordering_determinism_2602_2615_pg.rs
+++ b/tests/ordering_determinism_2602_2615_pg.rs
@@ -1,0 +1,363 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #2602 + #2615 (postgres collation-stability twin) — this is the
+//! #1724 collation-byte-range lesson class applied to the #2602/#2615
+//! total-order tiebreaks: a TEXT column compared/ordered under a non-`C`
+//! postgres collation orders DIFFERENTLY from sqlite's BINARY comparison,
+//! so a tiebreak added to make ordering *cross-backend identical* can
+//! itself silently reintroduce backend-dependent order if it isn't pinned
+//! `COLLATE "C"`.
+//!
+//! `memories.id` is `TEXT PRIMARY KEY` on postgres (NOT `uuid`), and the
+//! corpus is not guaranteed canonical lowercase UUIDs —
+//! `portability::import` preserves ids verbatim and federation receive
+//! applies a peer's `mem.id` verbatim with no UUID-format validation — so
+//! a mixed-case id (`mem-a` vs `MEM-B`) is a live shape, not a
+//! hypothetical. Likewise `recall_observations.recall_id` /
+//! `.memory_id` are `TEXT`.
+//!
+//! This file proves, against a LIVE postgres instance:
+//!
+//! 1. `PostgresStore::list`'s `id ASC` tiebreak (#2602) is `COLLATE "C"`
+//!    and produces the SAME order sqlite's BINARY comparison produces for
+//!    mixed-case, non-canonical-UUID ids tied on `(priority, updated_at)`.
+//! 2. `PostgresStore::list_recall_observations`'s `memory_id` / `recall_id`
+//!    tiebreaks (#2615) are `COLLATE "C"` and produce the SAME order
+//!    sqlite produces for rows tied on `(observed_at, rank)` that span
+//!    TWO different `recall_id`s observing the SAME `memory_id` (the
+//!    residual tie B2 closes: the ledger's actual PRIMARY KEY is
+//!    `(recall_id, memory_id)`, so `memory_id` alone is unique only
+//!    WITHIN one `recall_id`, and `recall_id = None` is a supported
+//!    unfiltered read).
+//!
+//! Confirmed against the live reference instance
+//! (`en_US.UTF-8` — the stock non-`C` default on the CI/dev postgres):
+//!
+//! ```text
+//! default collation:  mem-a, MEM-B, mem-C   |  mem-x-<suf>, MEM-Y-<suf>  |  rid-a-<suf>, RID-B-<suf>
+//! COLLATE "C":         MEM-B, mem-C, mem-a  |  MEM-Y-<suf>, mem-x-<suf>  |  RID-B-<suf>, rid-a-<suf>
+//! ```
+//!
+//! i.e. the default-collation order and the `COLLATE "C"` order are
+//! DIFFERENT orderings of the SAME rows for every id family this test
+//! seeds — so `COLLATE "C"` is load-bearing, not decorative: reverting
+//! either `postgres.rs` `ORDER BY` clause back to a bare (non-collated)
+//! tiebreak makes `pg_list_id_tiebreak_matches_sqlite_binary_order_2602`
+//! / `pg_recall_observations_tiebreak_matches_sqlite_across_recall_ids_2615`
+//! FAIL (verified manually pre-commit by reverting the `COLLATE "C"`
+//! clauses and re-running this file against the same live instance; the
+//! `en_US.UTF-8` collation is a live property of the connected database,
+//! not a compile-time constant, so it cannot be asserted in Rust without
+//! coupling the test to postgres' locale internals — the PASS/FAIL
+//! contrast against the documented pre-fix behavior above is the
+//! R-203 evidence).
+//!
+//! Gated on `feature = "sal-postgres"` + `#[ignore]` (this repo's
+//! `--include-ignored` live-PG convention — see e.g.
+//! `tests/age_cypher_param_binding_2511.rs`); soft-skips with a printed
+//! reason when `AI_MEMORY_TEST_POSTGRES_URL` is unset, so `cargo test
+//! --features sal,sal-postgres` (without `--include-ignored`) never
+//! attempts a live connection.
+
+#![cfg(feature = "sal-postgres")]
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use ai_memory::models::{Memory, Tier};
+use ai_memory::store::postgres::PostgresStore;
+use ai_memory::store::{CallerContext, Filter, MemoryStore};
+
+fn pg_url() -> Option<String> {
+    std::env::var("AI_MEMORY_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+fn uniq(prefix: &str) -> String {
+    format!("{prefix}-{}", &uuid::Uuid::new_v4().to_string()[..8])
+}
+
+/// Bypass-visibility admin ctx — this test's seeded rows are its own, so
+/// visibility filtering (an orthogonal concern to ORDER BY determinism)
+/// is deliberately taken out of scope.
+fn admin_ctx() -> CallerContext {
+    let mut ctx = CallerContext::for_agent("ai:test-2602-2615-pg");
+    ctx.bypass_visibility = true;
+    ctx
+}
+
+async fn raw_pool(url: &str) -> sqlx::PgPool {
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(url)
+        .await
+        .expect("raw pool for recall_observations seeding")
+}
+
+/// Seed a memory tied on `(priority, updated_at)` so only the `id`
+/// tiebreak can distinguish it from its siblings.
+async fn seed_tied_memory(store: &Arc<dyn MemoryStore>, id: &str, ns: &str) {
+    let mem = Memory {
+        id: id.to_string(),
+        // `Tier::Long` never expires (`discrete_ttl_secs() == None`) — the
+        // default `Tier::Mid` backfills `expires_at` to `created_at + 7
+        // days` (#1466), which the fixed 2025-01-01 `created_at` below
+        // would already be well past by the time this test runs, silently
+        // dropping every seeded row from `list`'s
+        // `expires_at IS NULL OR expires_at > NOW()` predicate. Matches
+        // the sqlite twin's `seed_mem` helper, which inserts `'long'`.
+        tier: Tier::Long,
+        namespace: ns.to_string(),
+        title: format!("title-{id}"),
+        content: "ordering_determinism_2602_2615_pg fixture".to_string(),
+        priority: 5,
+        created_at: "2025-01-01T00:00:00+00:00".to_string(),
+        updated_at: "2026-01-01T00:00:00+00:00".to_string(),
+        metadata: json!({"agent_id": "ai:test-2602-2615-pg"}),
+        ..Default::default()
+    };
+    store
+        .store(&admin_ctx(), &mem)
+        .await
+        .expect("seed tied memory");
+}
+
+// ---------------------------------------------------------------------
+// #2602 (B1) — `PostgresStore::list`'s `id COLLATE "C"` tiebreak matches
+// sqlite BINARY order for mixed-case, non-canonical-UUID ids.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires a live postgres (AI_MEMORY_TEST_POSTGRES_URL); run with --include-ignored"]
+async fn pg_list_id_tiebreak_matches_sqlite_binary_order_2602() {
+    let Some(url) = pg_url() else {
+        eprintln!(
+            "SKIP pg_list_id_tiebreak_matches_sqlite_binary_order_2602: \
+             no AI_MEMORY_TEST_POSTGRES_URL"
+        );
+        return;
+    };
+    let suf = &uuid::Uuid::new_v4().to_string()[..8];
+    let ns = uniq("list-order-2602-pg");
+    // Mixed-case, non-canonical-UUID ids — the live shape `portability::
+    // import` / federation receive can produce verbatim. Case differs at
+    // the FIRST byte ('M' vs 'm') and, for the two lowercase-first ids,
+    // at the 5th byte ('C' vs 'a') — the exact positions where postgres'
+    // stock `en_US.UTF-8` collation and `COLLATE "C"` / sqlite BINARY
+    // disagree (verified live: default → mem-a, MEM-B, mem-C; `C` →
+    // MEM-B, mem-C, mem-a).
+    let id_mem_a = format!("mem-a-{suf}");
+    let id_mem_b = format!("MEM-B-{suf}");
+    let id_mem_c = format!("mem-C-{suf}");
+
+    let store: Arc<dyn MemoryStore> = Arc::new(
+        PostgresStore::connect(&url)
+            .await
+            .expect("connect postgres"),
+    );
+    // Insert deliberately out of the expected order.
+    seed_tied_memory(&store, &id_mem_a, &ns).await;
+    seed_tied_memory(&store, &id_mem_b, &ns).await;
+    seed_tied_memory(&store, &id_mem_c, &ns).await;
+
+    let filter = Filter {
+        namespace: Some(ns.clone()),
+        limit: 100,
+        ..Default::default()
+    };
+    let pg_ids: Vec<String> = store
+        .list(&admin_ctx(), &filter)
+        .await
+        .expect("pg list")
+        .into_iter()
+        .map(|m| m.id)
+        .collect();
+
+    // The sqlite twin, seeded with the SAME ids/priority/updated_at via
+    // the raw storage funnel (mirrors
+    // tests/ordering_determinism_2602_2615.rs's `seed_mem`).
+    let sconn: rusqlite::Connection =
+        ai_memory::storage::open(std::path::Path::new(":memory:")).expect("open sqlite");
+    for id in [&id_mem_a, &id_mem_b, &id_mem_c] {
+        sconn
+            .execute(
+                "INSERT INTO memories \
+                    (id, tier, namespace, title, content, priority, metadata, \
+                     created_at, updated_at) \
+                 VALUES (?1, 'long', ?2, ?3, 'content', 5, '{}', \
+                         '2025-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+                rusqlite::params![id, ns, format!("title-{id}")],
+            )
+            .expect("seed sqlite memory");
+    }
+    let sqlite_ids: Vec<String> = ai_memory::storage::list(
+        &sconn,
+        Some(&ns),
+        None,
+        100,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("sqlite list")
+    .into_iter()
+    .map(|m| m.id)
+    .collect();
+
+    assert_eq!(
+        sqlite_ids,
+        vec![id_mem_b.clone(), id_mem_c.clone(), id_mem_a.clone()],
+        "sqlite BINARY order sanity check (byte order: 'M' < 'm', then 'C' < 'a')"
+    );
+    assert_eq!(
+        pg_ids, sqlite_ids,
+        "#2602/#1724: postgres `id COLLATE \"C\"` tiebreak must produce the \
+         SAME order as sqlite BINARY for mixed-case ids tied on \
+         (priority, updated_at) — without COLLATE \"C\" postgres' default \
+         collation returns [{id_mem_a}, {id_mem_b}, {id_mem_c}] instead"
+    );
+}
+
+// ---------------------------------------------------------------------
+// #2615 (B2) — `PostgresStore::list_recall_observations`'s
+// `memory_id COLLATE "C"` + `recall_id COLLATE "C"` tiebreaks match
+// sqlite BINARY order, including the residual cross-`recall_id` tie
+// (same `memory_id`, same `rank`, same `observed_at`, different
+// `recall_id`) that only a FULL-PK tiebreak resolves.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires a live postgres (AI_MEMORY_TEST_POSTGRES_URL); run with --include-ignored"]
+async fn pg_recall_observations_tiebreak_matches_sqlite_across_recall_ids_2615() {
+    let Some(url) = pg_url() else {
+        eprintln!(
+            "SKIP pg_recall_observations_tiebreak_matches_sqlite_across_recall_ids_2615: \
+             no AI_MEMORY_TEST_POSTGRES_URL"
+        );
+        return;
+    };
+    let suf = &uuid::Uuid::new_v4().to_string()[..8];
+    let ns = uniq("obs-order-2615-pg");
+    let mem_x = format!("mem-x-{suf}"); // referenced by BOTH recall_ids
+    let mem_y = format!("MEM-Y-{suf}"); // referenced only by rid_a
+
+    // Mixed-case recall_ids — same live-shape argument as the memory ids
+    // above; recall_id is caller-supplied, never format-validated.
+    let rid_a = format!("rid-a-{suf}");
+    let rid_b = format!("RID-B-{suf}");
+
+    let store: Arc<dyn MemoryStore> = Arc::new(
+        PostgresStore::connect(&url)
+            .await
+            .expect("connect postgres"),
+    );
+    seed_tied_memory(&store, &mem_x, &ns).await;
+    seed_tied_memory(&store, &mem_y, &ns).await;
+
+    let pool = raw_pool(&url).await;
+    let tied_at = chrono::DateTime::parse_from_rfc3339("2026-02-02T00:00:00Z")
+        .expect("parse tied_at")
+        .with_timezone(&chrono::Utc);
+    // All THREE rows share (rank=1, observed_at=tied_at) — a full tie the
+    // #2615 `rank`+`memory_id` fix narrowed to (memory_id, recall_id)
+    // pairs, and the B2 fix is what makes THAT residual tie total.
+    // (recall_id, memory_id) pairs: (rid_a, mem_x), (RID_B, mem_x),
+    // (rid_a, mem_y) — all distinct under the table's real PRIMARY KEY.
+    let insert = |recall_id: String, memory_id: String| {
+        let pool = pool.clone();
+        let observed_at = tied_at;
+        async move {
+            sqlx::query(
+                "INSERT INTO recall_observations \
+                    (recall_id, memory_id, retriever, rank, score, observed_at) \
+                 VALUES ($1, $2, 'hybrid', 1, 0.5, $3)",
+            )
+            .bind(recall_id)
+            .bind(memory_id)
+            .bind(observed_at)
+            .execute(&pool)
+            .await
+            .expect("insert recall_observations row");
+        }
+    };
+    // Insert deliberately out of the expected order.
+    insert(rid_a.clone(), mem_x.clone()).await;
+    insert(rid_a.clone(), mem_y.clone()).await;
+    insert(rid_b.clone(), mem_x.clone()).await;
+
+    // Unfiltered read (`recall_id = None`) — the surface B2 targets.
+    let pg_order: Vec<(String, String)> = store
+        .list_recall_observations(None, None, None, None, 100)
+        .await
+        .expect("pg list_recall_observations")
+        .into_iter()
+        .filter(|o| o.memory_id == mem_x || o.memory_id == mem_y)
+        .map(|o| (o.memory_id, o.recall_id))
+        .collect();
+
+    // sqlite twin: same memories + same observation rows via the raw
+    // storage/observations funnels.
+    let sconn: rusqlite::Connection =
+        ai_memory::storage::open(std::path::Path::new(":memory:")).expect("open sqlite");
+    for id in [&mem_x, &mem_y] {
+        sconn
+            .execute(
+                "INSERT INTO memories \
+                    (id, tier, namespace, title, content, priority, metadata, \
+                     created_at, updated_at) \
+                 VALUES (?1, 'long', ?2, ?3, 'content', 5, '{}', \
+                         '2025-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+                rusqlite::params![id, ns, format!("title-{id}")],
+            )
+            .expect("seed sqlite memory");
+    }
+    let tied_at_text = "2026-02-02T00:00:00.000Z";
+    for (recall_id, memory_id) in [
+        (rid_a.as_str(), mem_x.as_str()),
+        (rid_a.as_str(), mem_y.as_str()),
+        (rid_b.as_str(), mem_x.as_str()),
+    ] {
+        sconn
+            .execute(
+                "INSERT INTO recall_observations \
+                    (recall_id, memory_id, retriever, rank, score, observed_at, folded) \
+                 VALUES (?1, ?2, 'hybrid', 1, 0.5, ?3, 0)",
+                rusqlite::params![recall_id, memory_id, tied_at_text],
+            )
+            .expect("seed sqlite observation");
+    }
+    let sqlite_order: Vec<(String, String)> =
+        ai_memory::observations::list_observations(&sconn, None, None, None, None, 100)
+            .expect("sqlite list_observations")
+            .into_iter()
+            .map(|o| (o.memory_id, o.recall_id))
+            .collect();
+
+    assert_eq!(
+        sqlite_order,
+        vec![
+            (mem_y.clone(), rid_a.clone()),
+            (mem_x.clone(), rid_b.clone()),
+            (mem_x.clone(), rid_a.clone()),
+        ],
+        "sqlite BINARY order sanity check: memory_id ASC first \
+         ('M' < 'm'), then recall_id ASC within the tied memory_id \
+         ('R' < 'r')"
+    );
+    assert_eq!(
+        pg_order, sqlite_order,
+        "#2615/#1724: postgres `memory_id COLLATE \"C\"` + \
+         `recall_id COLLATE \"C\"` tiebreaks must produce the SAME order \
+         as sqlite BINARY across two recall_ids observing the same \
+         memory_id at the same rank/observed_at — without COLLATE \"C\" \
+         postgres' default collation orders memory_id/recall_id \
+         differently"
+    );
+}


### PR DESCRIPTION
Closes #2602 #2615

## Problem
Two non-deterministic `ORDER BY` defects on wire-visible surfaces — both order by a non-unique key set with **no final tiebreak**, so ties (which are common) left which rows page vs fall off, and the audit-ledger read-back order, plan-/backend-dependent.

## Fix — one total-order tiebreak per surface, identical across sqlite + postgres
**#2602** — `list` (`storage::build_list_query`), `PostgresStore::list`, and `memory_load_family` ordered by `priority DESC, updated_at DESC` only. Priority is 1-10 and bulk/federated rows share an `updated_at` ms, so ties abound. All three sites now append `, id ASC` (the UUID primary key — unique, NOT NULL).

**#2615** — `list_recall_observations` (sqlite + postgres) ordered by `observed_at DESC` only; every row a single recall appends shares `observed_at`, leaving an arbitrary permutation within each `recall_id` on the append-only P0-1 AUDIT ledger. Now appends `, rank ASC, memory_id ASC`.

## EXPLAIN before/after (#2602, sqlite, `idx_memories_ns_list_order`)
```
BEFORE:  SEARCH memories USING INDEX idx_memories_ns_list_order (namespace=?)
AFTER:   SEARCH memories USING INDEX idx_memories_ns_list_order (namespace=?)
         USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```
`RIGHT PART OF ORDER BY` is a **bounded per-tie-block sort**, not a full `FOR ORDER BY` sort: the index still serves the `(priority, updated_at)` walk order and only orders each tie group by `id`, so **early-stop under LIMIT is preserved** and no index migration is required.

## Tests
`tests/ordering_determinism_2602_2615.rs` (4 sqlite tests): stable id-ascending tie resolution + well-defined LIMIT/OFFSET paging for `list` and `load_family`; `rank`-then-`memory_id` order for the recall ledger; each stable across two reads and subordinate to the primary keys.

## AI involvement
Authored by the Opus 5 coder. Single-correct total-order append (issue-prescribed `id ASC`) → decide-and-build with EXPLAIN evidence recorded; **no 5-agent vote** required per the crossroads protocol single-correct-answer bug-fix exemption. Cites the #2488 both-backends parity lesson.

## Gates
`cargo check` (default / sal / sal-postgres / examples), `cargo clippy --all-targets -D warnings -D clippy::all -D clippy::pedantic` (default / sal / sal-postgres / vectorlite), `cargo fmt --all --check`, `qual_10_module_size_ceiling` (postgres.rs ceiling bumped 33_150 → 33_250 in lockstep), `qual_6_7_legacy_error_type_ceiling`, docs-vs-ssot + migration-ladder gates — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY