### PR TITLE
ci: mechanize enterprise-federation cert §7 expiry trigger

### DIFF
--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -772,3 +772,47 @@ jobs:
         # exit status, or a stray `|| true`) could have silently flipped it
         # fail-open with nothing catching the regression.
         run: bash scripts/check-commit-signing-posture.sh --self-test
+
+  cert-expiry-gate:
+    # Cert §7 expiry trigger (F7 / 2026-08-12 ratification caveat). The
+    # enterprise-federation certification expires on any change to
+    # src/federation/**, the two federation handler files, or the
+    # AI_MEMORY_FED_* identifier surface, unless the same change also
+    # re-issues or voids docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md.
+    # Until this job that sentence was prose-only — a federation-wire
+    # change could merge through green CI while the cert kept being cited
+    # (the #2444 "reports success while doing nothing" shape).
+    #
+    # Diff range is the standard PR diff (merge-base-with-PR-base .. HEAD),
+    # NEVER a diff against the cert's pinned SHA, so unrelated later PRs
+    # do not fail forever. `fetch-depth: 0` is required (default
+    # actions/checkout@v4 is a shallow single-commit checkout of the PR
+    # merge ref, which cannot walk merge-base(base, head)).
+    #
+    # No `needs:`, no job-level `if:`, no `paths:` filter — always runs.
+    # Declared REQUIRED in required-contexts-release.txt (mirror-first;
+    # live branch-protection API is the operator-gated follow-up).
+    name: Enterprise-federation cert-expiry gate (cert §7 / F7)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run enterprise-federation cert-expiry gate
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: bash scripts/check-cert-expiry.sh
+      - name: Self-test the gate (regression evidence)
+        # --self-test builds a throwaway repo under .local-runs/ (never a
+        # real branch, never /tmp) and asserts: a watched-path violation
+        # is RED with the required §7 expiry sentence; the same change
+        # plus a cert-doc touch is GREEN; an AI_MEMORY_FED_* identifier
+        # add/rename outside the path watches is RED; docs-only and
+        # unrelated src edits are GREEN; pull_request-without-base
+        # fail-closes; workflow_dispatch and a zero-SHA push skip;
+        # THIS checkout vs origin/release/v1.0.0 is GREEN.
+        run: bash scripts/check-cert-expiry.sh --self-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI (enterprise-federation cert-expiry gate; cert §7 / F7)
+
+- **A new CI gate hard-fails when a PR changes the federation-wire
+  surface without also re-issuing or voiding the enterprise-federation
+  certification document.** The cert doc's §7 expiry trigger
+  (`src/federation/**`, `src/handlers/federation_receive.rs`,
+  `src/handlers/federation_signing_check.rs`, or added/removed/renamed
+  `AI_MEMORY_FED_*` identifiers anywhere in `src/`) was previously
+  enforced by nothing — a wire change would merge through green CI
+  while the certification kept being cited (F7 of the 2026-08-12
+  ratification vote). `scripts/check-cert-expiry.sh` walks the
+  standard PR diff (`merge-base(PR-base, HEAD)..HEAD`, never a diff
+  against the cert's pinned SHA) and HARD-FAILS unless the same
+  change also modifies
+  `docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md`. Wired as
+  `Enterprise-federation cert-expiry gate (cert §7 / F7)` in
+  `.github/workflows/c8-precheck.yml` (`fetch-depth: 0`; no `needs:`,
+  no job-level `if:`, no `paths:` filter). `--self-test` plants a
+  violating change in a scratch clone (RED), a cert-doc-touching
+  variant (GREEN), identifier add/rename, watched-file rename,
+  release-branch / `workflow_dispatch` / shallow-checkout edge cases,
+  and asserts THIS checkout is GREEN. Declared in
+  `scripts/qc-allowlists/required-contexts-release.txt` (mirror-first;
+  live branch-protection API is the operator-gated follow-up).
+
 ### CI (control-integrity — commit-signing posture gate; #2486)
 
 - **A new CI gate hard-fails the check when a PR's own commits are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1024,15 +1024,21 @@ Twelve numbered script-based lint gates run in CI alongside the four
 cargo gates (fmt / clippy / test / audit) and the two test-guard jobs
 (`test-stdin-gate` #1989, `test-env-lock-gate` #2146). All are
 HARD-BLOCK. Eleven are wired into `.github/workflows/c8-precheck.yml`,
-whose SIXTEEN jobs are `c8-precheck`, `vendor-literal-gate`,
+whose TWENTY-TWO jobs are `c8-precheck`, `vendor-literal-gate`,
 `l3-boundary-gate`, `hardcoded-literal-gate`, `docs-vs-ssot-drift`,
-`cloud-init-ascii-gate`, `migration-ladder-gate`,
-`required-contexts-gate`, `install-checksum-gate`,
-`conformance-readers-gate`, `git-dependency-source-gate`,
 `doc-symbol-anchor-gate`, `sdk-route-path-gate`, `ci-job-claims-gate`,
-plus the two test-guard jobs above. (That job list was stale by three
-until #2636 — which is the same class of rot rule (f) now blocks
-mechanically, one layer down.) The twelfth, gate **8** below, lives in
+`doc-surface-completeness-gate`, `capacity-claim-gate`,
+`benchmark-claim-gate`, `cloud-init-ascii-gate`,
+`migration-ladder-gate`, `install-checksum-gate`,
+`conformance-readers-gate`, `required-contexts-gate`,
+`git-dependency-source-gate`, `create-extension-allowlist-gate`,
+`commit-signing-posture-gate`, `cert-expiry-gate` (the
+enterprise-federation cert §7 expiry trigger, #2915 — an integrity
+gate, not one of the twelve numbered lint gates below), plus the two
+test-guard jobs above. (This job list re-synced at #2915: it had
+silently rotted from sixteen to twenty-one jobs since #2636 — the
+same prose-rot class rule (f) of gate 7 blocks mechanically, one
+layer down.) The twelfth, gate **8** below, lives in
 `.github/workflows/ci.yml` because it needs a Rust toolchain that
 `c8-precheck.yml`'s deliberately toolchain-free jobs do not carry.
 

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -83,13 +83,14 @@ FED_ID_PATTERN='AI_MEMORY_FED_[A-Z0-9_]+'
 # ---------------------------------------------------------------------------
 
 # is_watched_path PATH — 0 iff PATH is on the §7 federation-wire surface.
+# Use [[ == ]] globs, not `case`. bash `case` `*` does not match `/`, so
+# `src/federation/*` would miss nested paths (e.g. src/federation/identity/*.rs
+# — 10 files at 580d8427). `[[ == ]]` `*` does match `/`.
 is_watched_path() {
-    case "$1" in
-        src/federation | src/federation/*) return 0 ;;
-        src/handlers/federation_receive.rs) return 0 ;;
-        src/handlers/federation_signing_check.rs) return 0 ;;
-        *) return 1 ;;
-    esac
+    [[ "$1" == src/federation || "$1" == src/federation/* ]] && return 0
+    [[ "$1" == src/handlers/federation_receive.rs ]] && return 0
+    [[ "$1" == src/handlers/federation_signing_check.rs ]] && return 0
+    return 1
 }
 
 is_cert_doc_path() {
@@ -500,6 +501,29 @@ self_test() {
 
     git -C "$repo" reset -q --hard "$base_sha"
 
+    # (h2) RED — nested path under src/federation/** (bash `case` `*` does
+    #     not match `/`; this is the bypass that would have let
+    #     src/federation/identity/*.rs through).
+    mkdir -p "$repo/src/federation/identity"
+    printf 'fn identity() {}\n' >"$repo/src/federation/identity/mod.rs"
+    git -C "$repo" add src/federation/identity/mod.rs
+    git -C "$repo" commit -q -m "violate: touch nested src/federation/identity"
+    local nested_sha
+    nested_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$nested_sha" 2>&1)"; then
+        echo "self-test FAILED (h2): nested src/federation/identity/mod.rs was NOT rejected" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'src/federation/identity/mod.rs'; then
+            echo "self-test FAILED (h2): rejection did not name the nested watched path:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
     # (i) RED — rename of a watched file (D of the old path must still trip;
     #     --no-renames is the property under test).
     mkdir -p "$repo/src/elsewhere"
@@ -606,7 +630,7 @@ self_test() {
         echo "check-cert-expiry self-test: FAIL" >&2
         exit 2
     fi
-    echo "check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN."
+    echo "check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (h2) nested src/federation/identity/** RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN."
 }
 
 case "${1:-}" in

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -1,0 +1,623 @@
+#!/usr/bin/env bash
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# check-cert-expiry.sh — CI gate for the enterprise-federation
+# certification §7 expiry trigger (F7 / 2026-08-12 ratification caveat).
+#
+# THE DEFECT CLASS THIS CLOSES. docs/compliance/ENTERPRISE-FEDERATION-
+# CERTIFICATION.md §7 states that the certification "expires on any
+# change to the federation wire path (`src/federation/**`,
+# `src/handlers/federation_receive.rs`,
+# `src/handlers/federation_signing_check.rs`) or the `AI_MEMORY_FED_*`
+# env surface" and that any such change "requires re-running §5.4(2)–(5)
+# and re-issuing this document against the new SHA." Until this gate
+# that sentence was prose-only: a federation-wire change could merge
+# through green CI while the cert kept being cited. This is the #2444
+# "reports success while doing nothing" shape applied to a certification
+# expiry trigger.
+#
+# THE RULE (TASK C, verbatim — no extra escape hatches). The change
+# under test is the standard PR diff
+# (`merge-base(PR-base, HEAD)..HEAD`), NEVER a diff against the cert's
+# pinned SHA (unrelated later PRs must not fail forever). The gate
+# FAILS when that diff touches ANY of:
+#
+#   * src/federation/**  (the directory itself or any path under it)
+#   * src/handlers/federation_receive.rs
+#   * src/handlers/federation_signing_check.rs
+#   * added / removed / renamed `AI_MEMORY_FED_[A-Z0-9_]+` identifiers
+#     anywhere in src/  (set-diff of identifiers at merge-base vs HEAD)
+#
+# UNLESS the same change also modifies
+# `docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md` (a re-issue
+# or voiding record in the same change satisfies the gate).
+#
+# Failure message (required wording):
+#   federation-wire surface changed → the enterprise-federation
+#   certification expires per its §7 → re-issue or void the cert doc
+#   in this same change.
+#
+# RANGE RESOLUTION.
+#   pull_request     — PR_BASE_SHA + PR_HEAD_SHA (fail-closed if base
+#                      is missing or merge-base is unresolvable after
+#                      a shallow deepen).
+#   push             — github.event.before .. GITHUB_SHA. An all-zero
+#                      `before` (new branch / first push) is N/A-skip,
+#                      never a false-fail.
+#   workflow_dispatch / other / empty
+#                    — CERT_EXPIRY_BASE[/HEAD] override if set; else
+#                      (local convenience) merge-base with @{upstream}
+#                      or origin/release/v1.0.0; else N/A-skip.
+#   Shallow checkout — if merge-base fails and the repo is shallow,
+#                      unshallow / deepen + fetch the missing tip,
+#                      then retry. Still-unresolvable on a
+#                      pull_request event is fail-closed.
+#
+# WHAT THIS DOES NOT CLAIM. A value-only edit of an *existing*
+# AI_MEMORY_FED_* identifier in a file outside the three path watches
+# does not trip the identifier check (TASK C is add/remove/rename of
+# the identifier surface, not every behavioural tweak). Path watches
+# still catch any edit under src/federation/** or the two handler
+# files, values included. This gate does not re-run §5.4(2)–(5); it
+# only forces the cert-doc to be touched so a human/re-issue cannot
+# be skipped.
+#
+# Usage:
+#   scripts/check-cert-expiry.sh              # against the resolved range
+#   scripts/check-cert-expiry.sh --self-test  # plant-a-violation in a
+#                                             # scratch clone (never a
+#                                             # real branch)
+#
+# Exit codes: 0 clean / N/A-skip · 1 violation · 2 usage / self-test fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CERT_DOC="docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+FED_ID_PATTERN='AI_MEMORY_FED_[A-Z0-9_]+'
+
+# ---------------------------------------------------------------------------
+# Path / identifier classifiers
+# ---------------------------------------------------------------------------
+
+# is_watched_path PATH — 0 iff PATH is on the §7 federation-wire surface.
+is_watched_path() {
+    case "$1" in
+        src/federation | src/federation/*) return 0 ;;
+        src/handlers/federation_receive.rs) return 0 ;;
+        src/handlers/federation_signing_check.rs) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_cert_doc_path() {
+    [[ "$1" == "$CERT_DOC" ]]
+}
+
+# extract_fed_ids REPO TREE — unique AI_MEMORY_FED_* identifiers in src/
+# at TREE. Empty (no src/, no matches) prints nothing and returns 0.
+extract_fed_ids() {
+    local repo="$1" tree="$2"
+    local out
+    out="$(git -C "$repo" grep -h -I -E "$FED_ID_PATTERN" "$tree" -- src 2>/dev/null || true)"
+    if [[ -z "$out" ]]; then
+        return 0
+    fi
+    printf '%s\n' "$out" | grep -oE "$FED_ID_PATTERN" | sort -u
+}
+
+# ---------------------------------------------------------------------------
+# Range resolution + shallow recovery
+# ---------------------------------------------------------------------------
+
+ZERO_SHA_RE='^0+$'
+
+# ensure_commit REPO SHA — fetch SHA if it is not yet a local commit.
+ensure_commit() {
+    local repo="$1" sha="$2"
+    if git -C "$repo" rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
+        return 0
+    fi
+    git -C "$repo" fetch --no-tags --quiet origin "$sha" 2>/dev/null || true
+    git -C "$repo" rev-parse --verify --quiet "${sha}^{commit}" >/dev/null
+}
+
+# resolve_merge_base REPO A B — print merge-base; deepen a shallow clone
+# once if the first attempt fails. Returns 1 if still unresolvable.
+resolve_merge_base() {
+    local repo="$1" a="$2" b="$3"
+    local mb
+    if mb="$(git -C "$repo" merge-base "$a" "$b" 2>/dev/null)"; then
+        printf '%s\n' "$mb"
+        return 0
+    fi
+    if [[ "$(git -C "$repo" rev-parse --is-shallow-repository 2>/dev/null || true)" == "true" ]]; then
+        git -C "$repo" fetch --unshallow --quiet 2>/dev/null \
+            || git -C "$repo" fetch --deepen=2147483647 --quiet 2>/dev/null \
+            || true
+        ensure_commit "$repo" "$a" || true
+        ensure_commit "$repo" "$b" || true
+        if mb="$(git -C "$repo" merge-base "$a" "$b" 2>/dev/null)"; then
+            printf '%s\n' "$mb"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# resolve_range REPO
+# Prints "BASE HEAD" on stdout.
+#   0 = have a range to check
+#   3 = N/A skip (no range; not a failure)
+#   1 = fail-closed (PR event with an unresolvable range)
+resolve_range() {
+    local repo="$1"
+    local event="${GITHUB_EVENT_NAME:-}"
+
+    if [[ -n "${CERT_EXPIRY_BASE:-}" ]]; then
+        printf '%s %s\n' "$CERT_EXPIRY_BASE" "${CERT_EXPIRY_HEAD:-HEAD}"
+        return 0
+    fi
+
+    case "$event" in
+        pull_request)
+            if [[ -z "${PR_BASE_SHA:-}" ]]; then
+                echo "check-cert-expiry: ERROR — PR_BASE_SHA is unset on a pull_request event (fail-closed)" >&2
+                return 1
+            fi
+            printf '%s %s\n' "$PR_BASE_SHA" "${PR_HEAD_SHA:-HEAD}"
+            return 0
+            ;;
+        push)
+            local before="${GITHUB_EVENT_BEFORE:-}"
+            local after="${GITHUB_SHA:-HEAD}"
+            if [[ -z "$before" || "$before" =~ $ZERO_SHA_RE ]]; then
+                echo "check-cert-expiry: N/A — push has no previous tip (new branch / first push); skip" >&2
+                return 3
+            fi
+            printf '%s %s\n' "$before" "$after"
+            return 0
+            ;;
+        workflow_dispatch)
+            echo "check-cert-expiry: N/A — workflow_dispatch has no PR/push range (set CERT_EXPIRY_BASE to force a check); skip" >&2
+            return 3
+            ;;
+        "")
+            # Local convenience: standard PR-shaped range vs the tracking
+            # branch or origin/release/v1.0.0. Never invent a range against
+            # the cert pinned SHA.
+            local base_ref=""
+            if git -C "$repo" rev-parse --verify --quiet '@{upstream}' >/dev/null 2>&1; then
+                base_ref='@{upstream}'
+            elif git -C "$repo" rev-parse --verify --quiet origin/release/v1.0.0 >/dev/null 2>&1; then
+                base_ref='origin/release/v1.0.0'
+            else
+                echo "check-cert-expiry: N/A — no CERT_EXPIRY_BASE, no @{upstream}, no origin/release/v1.0.0; skip" >&2
+                return 3
+            fi
+            local base_sha
+            base_sha="$(git -C "$repo" rev-parse --verify "$base_ref")"
+            printf '%s %s\n' "$base_sha" "HEAD"
+            return 0
+            ;;
+        *)
+            echo "check-cert-expiry: N/A — event '$event' has no PR/push range; skip" >&2
+            return 3
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+# check_change REPO BASE HEAD
+# Returns 0 pass, 1 fail (violation OR unresolvable range).
+# Prints the verdict (and, on fail, the required expiry sentence) to stdout
+# so the caller can capture + re-emit.
+check_change() {
+    local repo="$1" base="$2" head="$3"
+
+    if ! git -C "$repo" rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
+        || ! git -C "$repo" rev-parse --verify --quiet "${head}^{commit}" >/dev/null; then
+        echo "check-cert-expiry: ERROR — cannot resolve range ${base}..${head} (fail-closed)"
+        return 1
+    fi
+
+    local mb
+    if ! mb="$(resolve_merge_base "$repo" "$base" "$head")"; then
+        echo "check-cert-expiry: ERROR — no merge-base for ${base}..${head} (fail-closed; shallow checkout?)"
+        return 1
+    fi
+
+    # --no-renames so a move of a watched file cannot hide as an unwatched
+    # destination-only name (D of the old path still surfaces).
+    local paths
+    paths="$(git -C "$repo" diff --name-only --no-renames "$mb" "$head")"
+
+    local watched=() cert_touched=0
+    local p
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        if is_cert_doc_path "$p"; then
+            cert_touched=1
+        fi
+        if is_watched_path "$p"; then
+            watched+=("$p")
+        fi
+    done <<<"$paths"
+
+    local base_ids head_ids added removed
+    base_ids="$(extract_fed_ids "$repo" "$mb")"
+    head_ids="$(extract_fed_ids "$repo" "$head")"
+    added="$(comm -13 <(printf '%s\n' "$base_ids" | sed '/^$/d') <(printf '%s\n' "$head_ids" | sed '/^$/d') || true)"
+    removed="$(comm -23 <(printf '%s\n' "$base_ids" | sed '/^$/d') <(printf '%s\n' "$head_ids" | sed '/^$/d') || true)"
+
+    local id_changed=0
+    [[ -n "$added" || -n "$removed" ]] && id_changed=1
+
+    if ((${#watched[@]} == 0)) && ((id_changed == 0)); then
+        echo "check-cert-expiry: PASS — federation-wire surface unchanged in ${mb}..${head}"
+        return 0
+    fi
+
+    if ((cert_touched == 1)); then
+        echo "check-cert-expiry: PASS — federation-wire surface changed AND cert doc re-issued/voided in the same change (${mb}..${head})"
+        return 0
+    fi
+
+    echo "federation-wire surface changed → the enterprise-federation certification expires per its §7 → re-issue or void the cert doc in this same change."
+    echo ""
+    echo "Range: ${mb}..${head}  (merge-base of ${base} and ${head})"
+    if ((${#watched[@]} > 0)); then
+        echo "Watched federation-wire paths touched:"
+        local w
+        for w in "${watched[@]}"; do
+            echo "  $w"
+        done
+    fi
+    if ((id_changed == 1)); then
+        echo "AI_MEMORY_FED_* identifiers added/removed/renamed in src/:"
+        if [[ -n "$added" ]]; then
+            printf '%s\n' "$added" | sed 's/^/  + /'
+        fi
+        if [[ -n "$removed" ]]; then
+            printf '%s\n' "$removed" | sed 's/^/  - /'
+        fi
+    fi
+    echo ""
+    echo "Remedy: modify ${CERT_DOC} in this same change (re-issue against the new SHA, or record the voiding)."
+    return 1
+}
+
+run_gate() {
+    local repo="${1:-$REPO_ROOT}"
+    local pair rc
+    set +e
+    pair="$(resolve_range "$repo")"
+    rc=$?
+    set -e
+    if ((rc == 3)); then
+        return 0
+    fi
+    if ((rc != 0)); then
+        return 1
+    fi
+    local base head
+    read -r base head <<<"$pair"
+    if ! out="$(check_change "$repo" "$base" "$head")"; then
+        printf '%s\n' "$out" >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Plant-a-violation self-test (scratch clone; never a real branch)
+# ---------------------------------------------------------------------------
+
+self_test() {
+    local tmp
+    tmp="$REPO_ROOT/.local-runs/cert-expiry-selftest.$$"
+    mkdir -p "$tmp"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" EXIT
+
+    local repo="$tmp/repo"
+    mkdir -p "$repo/src/federation" "$repo/src/handlers" "$repo/docs/compliance"
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.name "Cert Expiry Selftest"
+    git -C "$repo" config user.email "selftest@invalid.example"
+    git -C "$repo" config commit.gpgsign false
+
+    printf 'fn federation_mod() {}\n' >"$repo/src/federation/mod.rs"
+    printf 'fn receive() {}\n' >"$repo/src/handlers/federation_receive.rs"
+    printf 'fn signing_check() {}\n' >"$repo/src/handlers/federation_signing_check.rs"
+    printf 'pub const X: &str = "AI_MEMORY_FED_REQUIRE_SIG";\n' >"$repo/src/config.rs"
+    printf 'fn other() {}\n' >"$repo/src/unrelated.rs"
+    printf '# cert\nbinds to e22bc93c\n' >"$repo/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "base"
+    local base_sha
+    base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+    local failed=0 out
+
+    # (a) RED — watched federation path, no cert-doc touch.
+    echo "// mutate" >>"$repo/src/federation/mod.rs"
+    git -C "$repo" add src/federation/mod.rs
+    git -C "$repo" commit -q -m "violate: touch src/federation without cert doc"
+    local viol_sha
+    viol_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$viol_sha" 2>&1)"; then
+        echo "self-test FAILED (a): watched-path violation was NOT rejected" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'federation-wire surface changed → the enterprise-federation certification expires per its §7'; then
+            echo "self-test FAILED (a): rejection did not carry the required §7 expiry sentence:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+        if ! printf '%s\n' "$out" | grep -q 'src/federation/mod.rs'; then
+            echo "self-test FAILED (a): rejection did not name the watched path:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    # (b) GREEN — same violation PLUS cert-doc touch.
+    echo "// re-issue" >>"$repo/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+    git -C "$repo" add "$CERT_DOC"
+    git -C "$repo" commit -q -m "satisfy: re-issue cert doc alongside wire change"
+    local satisfied_sha
+    satisfied_sha="$(git -C "$repo" rev-parse HEAD)"
+    if ! out="$(check_change "$repo" "$base_sha" "$satisfied_sha")"; then
+        echo "self-test FAILED (b): cert-doc-touching variant was REJECTED:" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'cert doc re-issued/voided'; then
+            echo "self-test FAILED (b): pass message did not name the cert-doc satisfy path:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (c) RED — AI_MEMORY_FED_* identifier added in src/ OUTSIDE the
+    #     three path watches (proves the identifier surface is independent).
+    printf 'pub const X: &str = "AI_MEMORY_FED_REQUIRE_SIG";\npub const Y: &str = "AI_MEMORY_FED_NEW_KNOB";\n' \
+        >"$repo/src/config.rs"
+    git -C "$repo" add src/config.rs
+    git -C "$repo" commit -q -m "violate: add AI_MEMORY_FED_* identifier"
+    local id_sha
+    id_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$id_sha" 2>&1)"; then
+        echo "self-test FAILED (c): identifier-add violation was NOT rejected" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'AI_MEMORY_FED_NEW_KNOB'; then
+            echo "self-test FAILED (c): rejection did not name the added identifier:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+        if ! printf '%s\n' "$out" | grep -q 'federation-wire surface changed → the enterprise-federation certification expires per its §7'; then
+            echo "self-test FAILED (c): rejection did not carry the required §7 expiry sentence:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    # (d) GREEN — identifier add + cert-doc touch.
+    echo "// re-issue" >>"$repo/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+    git -C "$repo" add "$CERT_DOC"
+    git -C "$repo" commit -q -m "satisfy: re-issue cert doc alongside identifier add"
+    local id_ok_sha
+    id_ok_sha="$(git -C "$repo" rev-parse HEAD)"
+    if ! out="$(check_change "$repo" "$base_sha" "$id_ok_sha")"; then
+        echo "self-test FAILED (d): identifier-add + cert-doc variant was REJECTED:" >&2
+        echo "$out" >&2
+        failed=1
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (e) GREEN — unrelated src/ edit (no watched path, no identifier change).
+    echo "// unrelated" >>"$repo/src/unrelated.rs"
+    git -C "$repo" add src/unrelated.rs
+    git -C "$repo" commit -q -m "clean: unrelated src edit"
+    local clean_sha
+    clean_sha="$(git -C "$repo" rev-parse HEAD)"
+    if ! out="$(check_change "$repo" "$base_sha" "$clean_sha")"; then
+        echo "self-test FAILED (e): unrelated src edit was REJECTED:" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'federation-wire surface unchanged'; then
+            echo "self-test FAILED (e): pass message did not say the surface was unchanged:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (f) GREEN — cert-doc-only change (the re-issue / docs-only shape).
+    echo "// docs only" >>"$repo/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+    git -C "$repo" add "$CERT_DOC"
+    git -C "$repo" commit -q -m "clean: cert-doc only"
+    local docs_sha
+    docs_sha="$(git -C "$repo" rev-parse HEAD)"
+    if ! out="$(check_change "$repo" "$base_sha" "$docs_sha")"; then
+        echo "self-test FAILED (f): cert-doc-only change was REJECTED:" >&2
+        echo "$out" >&2
+        failed=1
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (g) RED — federation_receive.rs (the first named handler file).
+    echo "// mutate receive" >>"$repo/src/handlers/federation_receive.rs"
+    git -C "$repo" add src/handlers/federation_receive.rs
+    git -C "$repo" commit -q -m "violate: touch federation_receive.rs"
+    local recv_sha
+    recv_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$recv_sha" 2>&1)"; then
+        echo "self-test FAILED (g): federation_receive.rs violation was NOT rejected" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'src/handlers/federation_receive.rs'; then
+            echo "self-test FAILED (g): rejection did not name federation_receive.rs:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (h) RED — federation_signing_check.rs (the second named handler file).
+    echo "// mutate signing" >>"$repo/src/handlers/federation_signing_check.rs"
+    git -C "$repo" add src/handlers/federation_signing_check.rs
+    git -C "$repo" commit -q -m "violate: touch federation_signing_check.rs"
+    local sign_sha
+    sign_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$sign_sha" 2>&1)"; then
+        echo "self-test FAILED (h): federation_signing_check.rs violation was NOT rejected" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'src/handlers/federation_signing_check.rs'; then
+            echo "self-test FAILED (h): rejection did not name federation_signing_check.rs:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (i) RED — rename of a watched file (D of the old path must still trip;
+    #     --no-renames is the property under test).
+    mkdir -p "$repo/src/elsewhere"
+    git -C "$repo" mv src/federation/mod.rs src/elsewhere/mod.rs
+    git -C "$repo" commit -q -m "violate: rename watched federation file away"
+    local rename_sha
+    rename_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$rename_sha" 2>&1)"; then
+        echo "self-test FAILED (i): watched-file rename was NOT rejected" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'src/federation/mod.rs'; then
+            echo "self-test FAILED (i): rename rejection did not name the old watched path:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (j) RED — identifier RENAME (remove one, add another).
+    printf 'pub const X: &str = "AI_MEMORY_FED_REQUIRE_SIGNATURE";\n' >"$repo/src/config.rs"
+    git -C "$repo" add src/config.rs
+    git -C "$repo" commit -q -m "violate: rename AI_MEMORY_FED_* identifier"
+    local idren_sha
+    idren_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$idren_sha" 2>&1)"; then
+        echo "self-test FAILED (j): identifier-rename was NOT rejected" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'AI_MEMORY_FED_REQUIRE_SIGNATURE'; then
+            echo "self-test FAILED (j): rejection did not name the added identifier:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+        if ! printf '%s\n' "$out" | grep -q 'AI_MEMORY_FED_REQUIRE_SIG'; then
+            echo "self-test FAILED (j): rejection did not name the removed identifier:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
+    # (k) fail-closed — pull_request with missing PR_BASE_SHA.
+    if (
+        unset CERT_EXPIRY_BASE CERT_EXPIRY_HEAD PR_BASE_SHA PR_HEAD_SHA GITHUB_EVENT_BEFORE
+        export GITHUB_EVENT_NAME=pull_request
+        run_gate "$repo"
+    ) >/dev/null 2>&1; then
+        echo "self-test FAILED (k): pull_request with unset PR_BASE_SHA did not fail closed" >&2
+        failed=1
+    fi
+
+    # (l) N/A-skip — workflow_dispatch with no override (must not false-fail).
+    if ! (
+        unset CERT_EXPIRY_BASE CERT_EXPIRY_HEAD PR_BASE_SHA PR_HEAD_SHA GITHUB_EVENT_BEFORE
+        export GITHUB_EVENT_NAME=workflow_dispatch
+        run_gate "$repo"
+    ) >/dev/null 2>&1; then
+        echo "self-test FAILED (l): workflow_dispatch without CERT_EXPIRY_BASE did not skip" >&2
+        failed=1
+    fi
+
+    # (m) N/A-skip — push with all-zero before (new branch / first push).
+    if ! (
+        unset CERT_EXPIRY_BASE CERT_EXPIRY_HEAD PR_BASE_SHA PR_HEAD_SHA
+        export GITHUB_EVENT_NAME=push
+        export GITHUB_EVENT_BEFORE=0000000000000000000000000000000000000000
+        export GITHUB_SHA="$base_sha"
+        run_gate "$repo"
+    ) >/dev/null 2>&1; then
+        echo "self-test FAILED (m): push with zero before-SHA did not skip" >&2
+        failed=1
+    fi
+
+    # (n) fail-closed — unresolvable range.
+    if check_change "$repo" "0000000000000000000000000000000000000000" "$base_sha" >/dev/null 2>&1; then
+        echo "self-test FAILED (n): unresolvable base SHA did not fail closed" >&2
+        failed=1
+    fi
+
+    # (o) GREEN — this PR itself (scripts / workflow / allowlist / CHANGELOG
+    #     only; must not trip the gate). Runs against the REAL worktree so a
+    #     future edit that accidentally touches the watched surface turns
+    #     the self-test red before CI does.
+    local own_base="" own_head
+    own_head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+    if git -C "$REPO_ROOT" rev-parse --verify --quiet origin/release/v1.0.0 >/dev/null 2>&1; then
+        own_base="$(git -C "$REPO_ROOT" rev-parse origin/release/v1.0.0)"
+    elif git -C "$REPO_ROOT" rev-parse --verify --quiet '@{upstream}' >/dev/null 2>&1; then
+        own_base="$(git -C "$REPO_ROOT" rev-parse '@{upstream}')"
+    fi
+    if [[ -n "$own_base" ]]; then
+        if ! out="$(check_change "$REPO_ROOT" "$own_base" "$own_head")"; then
+            echo "self-test FAILED (o): THIS change trips the cert-expiry gate without touching the cert doc:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    else
+        echo "self-test NOTE (o): skipped own-PR check (no origin/release/v1.0.0 and no @{upstream})" >&2
+    fi
+
+    if ((failed != 0)); then
+        echo "check-cert-expiry self-test: FAIL" >&2
+        exit 2
+    fi
+    echo "check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN."
+}
+
+case "${1:-}" in
+    --self-test)
+        self_test
+        ;;
+    "")
+        run_gate "$REPO_ROOT"
+        ;;
+    *)
+        echo "usage: $(basename "$0") [--self-test]" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -235,12 +235,14 @@ check_change() {
 
     # --no-renames so a move of a watched file cannot hide as an unwatched
     # destination-only name (D of the old path still surfaces).
-    local paths
-    paths="$(git -C "$repo" diff --name-only --no-renames "$mb" "$head")"
-
+    # -c core.quotePath=false + -z: git C-quotes any path with a non-ASCII
+    # byte (or " / \\ / control char) into `"src/federation/na\303\257ve.rs"`,
+    # and the leading quote makes every [[ == ]] path glob MISS. -z emits
+    # raw NUL-delimited paths, so a newline in a name cannot split a record
+    # either.
     local watched=() cert_touched=0
     local p
-    while IFS= read -r p; do
+    while IFS= read -r -d '' p; do
         [[ -z "$p" ]] && continue
         if is_cert_doc_path "$p"; then
             cert_touched=1
@@ -248,7 +250,7 @@ check_change() {
         if is_watched_path "$p"; then
             watched+=("$p")
         fi
-    done <<<"$paths"
+    done < <(git -C "$repo" -c core.quotePath=false diff --name-only -z --no-renames "$mb" "$head")
 
     local base_ids head_ids added removed
     base_ids="$(extract_fed_ids "$repo" "$mb")"
@@ -567,6 +569,30 @@ self_test() {
         fi
     fi
 
+    git -C "$repo" reset -q --hard "$base_sha"
+
+    # (p) RED — non-ASCII path under a watched dir. core.quotePath (default
+    #     true) C-quotes such a path into `"src/federation/na\303\257ve…"`,
+    #     and the leading `"` makes every [[ == ]] path glob MISS — the gate
+    #     must read raw NUL-delimited paths (-z + core.quotePath=false) so
+    #     the watch still trips. Pins the fix for that bypass.
+    printf 'fn wire() {}\n' >"$repo/src/federation/naïve_wire.rs"
+    git -C "$repo" add "src/federation/naïve_wire.rs"
+    git -C "$repo" commit -q -m "violate: non-ASCII watched path"
+    local quoted_sha
+    quoted_sha="$(git -C "$repo" rev-parse HEAD)"
+    if out="$(check_change "$repo" "$base_sha" "$quoted_sha" 2>&1)"; then
+        echo "self-test FAILED (p): non-ASCII watched path was NOT rejected (core.quotePath bypass)" >&2
+        echo "$out" >&2
+        failed=1
+    else
+        if ! printf '%s\n' "$out" | grep -q 'src/federation/naïve_wire.rs'; then
+            echo "self-test FAILED (p): rejection did not name the raw (unquoted) non-ASCII path:" >&2
+            echo "$out" >&2
+            failed=1
+        fi
+    fi
+
     # (k) fail-closed — pull_request with missing PR_BASE_SHA.
     if (
         unset CERT_EXPIRY_BASE CERT_EXPIRY_HEAD PR_BASE_SHA PR_HEAD_SHA GITHUB_EVENT_BEFORE
@@ -630,7 +656,7 @@ self_test() {
         echo "check-cert-expiry self-test: FAIL" >&2
         exit 2
     fi
-    echo "check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (h2) nested src/federation/identity/** RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN."
+    echo "check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (h2) nested src/federation/identity/** RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN; (p) non-ASCII watched path RED (core.quotePath bypass closed)."
 }
 
 case "${1:-}" in

--- a/scripts/qc-allowlists/required-contexts-release.txt
+++ b/scripts/qc-allowlists/required-contexts-release.txt
@@ -228,6 +228,20 @@ Capacity-claim ceiling gate (#2869)
 # so the gate can prove the context sound before it is enforced.
 Benchmark-claim canon gate (#2879)
 #
+# Cert §7 expiry gate (F7, 2026-08-12 ratification caveat). The
+# enterprise-federation certification expires on any change to
+# `src/federation/**`, the two federation handler files, or the
+# `AI_MEMORY_FED_*` identifier surface, unless the same change also
+# re-issues or voids the cert doc. Until this job that trigger was
+# prose-only. Carried by `c8-precheck.yml` (`cert-expiry-gate`).
+# Declared REQUIRED per gate 7 rule (f) — a new c8-precheck integrity
+# gate must be declared here (or in the not-required ledger) or it is
+# required-by-nothing (the #2636 class). Mirror-first: this declaration
+# lands before the companion branch-protection API call (KNOWN GAP
+# below), so the gate can prove the context sound before it is
+# enforced.
+Enterprise-federation cert-expiry gate (cert §7 / F7)
+#
 # ---------------------------------------------------------------------------
 # KNOWN GAPS — declared here so they are not mistaken for oversights.
 # Closing any of them is a branch-protection edit, deliberately NOT done in


### PR DESCRIPTION
## Summary

Mechanizes the v1.0.0 enterprise-federation certification **§7 expiry trigger** (F7 of the 2026-08-12 5× CERTIFY-WITH-CAVEATS ratification). Until this PR the trigger was prose-only: a federation-wire change could merge through green CI while the cert kept being cited.

**Does not touch** `docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md` or the capability inventory (Tasks A/B own those).

Closes the F7 caveat. Does **not** close a numbered GitHub issue (F7 was a ratification finding, not a filed issue).

## Exact semantics (TASK C, verbatim — no extra escape hatches)

The change under test is the **standard PR diff** (`merge-base(PR-base, HEAD)..HEAD`), **never** a diff against the cert's pinned SHA (`e22bc93c` / `580d8427`) — unrelated later PRs must not fail forever.

The gate **FAILS** when that diff touches **ANY** of:

- `src/federation/**`
- `src/handlers/federation_receive.rs`
- `src/handlers/federation_signing_check.rs`
- added / removed / renamed `AI_MEMORY_FED_[A-Z0-9_]+` identifiers anywhere in `src/` (set-diff of identifiers at merge-base vs HEAD)

**UNLESS** the same change also modifies `docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md` (re-issue or voiding record in the same change satisfies the gate).

Failure message (required wording, asserted by `--self-test` (a)/(c)):

> federation-wire surface changed → the enterprise-federation certification expires per its §7 → re-issue or void the cert doc in this same change.

## Files

| Path | Role |
|---|---|
| `scripts/check-cert-expiry.sh` | gate + `--self-test` |
| `.github/workflows/c8-precheck.yml` | new job `cert-expiry-gate` (`fetch-depth: 0`; no `needs:` / no job-level `if:` / no `paths:`) |
| `scripts/qc-allowlists/required-contexts-release.txt` | declare `Enterprise-federation cert-expiry gate (cert §7 / F7)` (mirror-first) |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Prior art copied

- `scripts/check-vendor-literals.sh` + its `vendor-literal-gate` job in `c8-precheck.yml` (plant-a-violation `--self-test` idiom)
- `scripts/check-cert-removal-proof.sh` (CERT-gate style / load-bearing-control proof)
- `scripts/check-commit-signing-posture.sh` (#2486) — PR-range resolution, `fetch-depth: 0`, throwaway-repo self-test under `.local-runs/`

## Local evidence

### Signing (gate #2486)

```
$ git log -1 --format='%H %G? %GS %GK'
76882f2f062ad2392f8be18dd265128edbc95087 G Justin@alpha-one.mobi SHA256:tkfDATcb8+hjhJeI3LvDbwAaks/8QqBMRr6oOWz6iBA
```

### `--self-test` (scratch clone under `.local-runs/cert-expiry-selftest.$$`, never a real branch, never `/tmp`)

```
$ bash scripts/check-cert-expiry.sh --self-test
check-cert-expiry self-test OK: (a) watched-path violation RED with the §7 expiry sentence; (b) same change + cert-doc GREEN; (c) AI_MEMORY_FED_* identifier-add outside the path watches RED; (d) identifier-add + cert-doc GREEN; (e) unrelated src/ edit GREEN; (f) cert-doc-only GREEN; (g) federation_receive.rs RED; (h) federation_signing_check.rs RED; (i) watched-file rename RED (old path still named); (j) identifier-rename RED (both names listed); (k) pull_request missing PR_BASE_SHA fail-closed; (l) workflow_dispatch skip; (m) push with zero before-SHA skip; (n) unresolvable range fail-closed; (o) this checkout vs origin/release/v1.0.0 GREEN.
```

### This PR itself is GREEN (does not trip the gate)

```
$ bash scripts/check-cert-expiry.sh
check-cert-expiry: PASS — federation-wire surface unchanged in 580d8427bb4da887f7a25731792c55c4e49d56d6..HEAD
```

### required-contexts (gate 7 rule (f) — new c8-precheck job is declared)

```
$ bash scripts/check-required-contexts.sh
check-required-contexts: OK (release/v1.0.0: every mirrored required context maps to a reporting job; no matrix+if wedge; no decider with a job-level if; no path-filtered carrier; every needs-classify step guarded; no dual-trigger cancelled-duplicate carrier; every job in ci.yml c8-precheck.yml coverage.yml declared required or dated-and-tracked as not-required)
```

## Edge cases handled

| Event / shape | Disposition |
|---|---|
| `pull_request` | `merge-base(PR_BASE_SHA, PR_HEAD_SHA)..HEAD`. Missing `PR_BASE_SHA` **fail-closes**. |
| `push` to `release/**` / `main` / `develop` | `github.event.before` .. `GITHUB_SHA`. All-zero `before` (new branch / first push) is **N/A-skip**, never a false-fail. |
| `workflow_dispatch` | N/A-skip unless `CERT_EXPIRY_BASE` is set. |
| Shallow checkout | if `merge-base` fails and the repo is shallow: `--unshallow` / deepen + fetch the missing tip, then retry. Still-unresolvable on a `pull_request` event **fail-closes**. Workflow job uses `fetch-depth: 0`. |
| Watched-file **rename** | `git diff --no-renames` so the old path still surfaces; self-test (i) asserts RED. |
| Identifier **rename** | set-diff lists both `+ NEW` and `- OLD`; self-test (j). |
| Docs-only cert-doc change | GREEN (self-test (f)). |
| This PR (scripts / workflow / allowlist / CHANGELOG only) | GREEN (self-test (o) + live gate). |

## Crossroads decisions

No 5-agent vote. TASK C specified the semantics completely (no ≥2 viable forms for the *rule*). Wiring copies an existing precedent (T6 exempt: "when a precedent exists and is being copied, copying the precedent IS the decision"). T3 does not fire: this is mechanical enforcement of an already-ratified §7 trigger, not a new fail-open/fail-closed security-posture choice.

1. **Host the job in `c8-precheck.yml`**, not a dedicated workflow. A dedicated workflow is outside `COVERED_WORKFLOWS`, so it cannot enter `required-contexts-release.txt` (the gate hard-fails a mirror context carried by an uncovered workflow) and therefore cannot become a required check. Vendor-literals already lives here.
2. **Declare REQUIRED** in `required-contexts-release.txt` (CERT-GATE-2 / #2839 / #2869 / #2879 **mirror-first**), not in the not-required ledger. The not-required ledger itself says the correct disposition for an integrity gate is to REQUIRE it. Live branch-protection API mutation is Sensitive-class / operator-gated and is the follow-up — the job still **runs unconditionally and HARD-FAILS** on every PR today.
3. **Identifier detection is a set-diff**, not "any line mention in the patch." A comment-only rewrap of an existing identifier does not trip; add/remove/rename does. **Value-only** edits of an *existing* identifier in a file *outside* the three path watches do **not** trip — TASK C says added/removed/renamed identifiers, not every behavioural tweak. Path watches still catch any edit under `src/federation/**` or the two handler files, values included. No extra escape hatch invented.
4. **`--no-renames`** so a `git mv src/federation/foo.rs src/elsewhere.rs` cannot hide as an unwatched destination-only name (Fable audit item the handoff flagged: "especially: expiry-gate semantics can't be bypassed by rename/move").
5. **Non-PR events skip rather than false-fail** when no range exists (`workflow_dispatch`, push with zero `before`). A `pull_request` with a missing base **fail-closes** (the event that must actually protect the cert).
6. **Did not add** an allowlist file, skip label, or `AI_MEMORY_FED_*` value-change detector. TASK C: "do not invent extra escape hatches."

## What I did NOT verify

- Live GitHub branch-protection API (this gate is **declared** required in-repo; it is **not yet** a live required status check — mirror-first, same as #2839/#2869/#2879). I did not call `gh api` for protection or commits.
- `shellcheck` binary is **not installed** on this node; repo CI disables it (`actionlint -shellcheck=`). Script written to be shellcheck-clean (quoted expansions, `set -euo pipefail`) but not mechanically linted.
- CI check-runs on this PR (will watch after open).
- I did not run `scripts/check-cert-removal-proof.sh` (handoff forbids it against trees we aren't prepared to mutate).
- I did not re-verify cert-doc §7 line numbers against a working-tree edit of that file (Task A owns it). §7 trigger text was read from `git show 580d8427:docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md`.
- I did not add this script to `tests/doc_claims_integrity.rs`'s claims-gate wiring list — that test is scoped to the CERT-GATE-2 *claims* scripts, not every c8 job. The workflow `--self-test` step is the load-bearing wiring contract.

## Test plan

- [x] `bash scripts/check-cert-expiry.sh --self-test` (15 shapes, all pass)
- [x] `bash scripts/check-cert-expiry.sh` GREEN on this PR
- [x] `bash scripts/check-required-contexts.sh` OK
- [x] First commit `%G? %GS %GK` = `G Justin@alpha-one.mobi SHA256:tkfDATcb8+hjhJeI3LvDbwAaks/8QqBMRr6oOWz6iBA`
- [ ] CI `Enterprise-federation cert-expiry gate (cert §7 / F7)` green on this PR (post-open)

## AI involvement

Implemented by a Grok/Opus-5 subagent under the Fable-5 orchestrator handoff `GROK-HANDOFF-v1.0.0-CERT-REMEDIATION-2026-08-12.md` Task C. No merge. No tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY