### PR TITLE
docs(#2922): retire the FedRAMP/IL5 path + Q3 2026 GA claim from for-everyone.html

### DIFF
--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -291,12 +291,12 @@ footer a{color:var(--text-muted)}
   <div class="container">
     <span class="eyebrow">Certification</span>
     <h2>Current certification status.</h2>
-    <p>ai-memory v0.9.0 holds the following internal certifications. External (third-party) audits and compliance attestations are <strong>not yet held</strong> for any release; do not represent ai-memory as SOC 2, ISO 27001, FedRAMP, or HIPAA-compliant.</p>
+    <p>ai-memory v1.0.0 holds the following internal certifications, carried forward under the currency caveats noted below. External (third-party) audits and compliance attestations are <strong>not yet held</strong> for any release; do not represent ai-memory as SOC 2, ISO 27001, FedRAMP, or HIPAA-compliant. No FedRAMP or IL5 authorization is held or claimed &mdash; obtaining one would be a separate, unstarted process.</p>
     <table class="facts">
       <thead><tr><th>Certification</th><th>Status</th><th>Authority</th></tr></thead>
       <tbody>
-        <tr><td>A2A-Certified (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ai2ai-gate">A2A gate</a> (repo, Pages site retired per #2034) · v0.6.2 + v0.6.3 — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
-        <tr><td>Ship-Gate (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ship-gate">Ship gate</a> (repo, Pages site retired per #2034) · 9/9 cert + 5/5 channels green at v0.6.2 cut — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0, see currency note below</td></tr>
+        <tr><td>A2A-Certified (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ai2ai-gate">A2A gate</a> (repo, Pages site retired per #2034) · v0.6.2 + v0.6.3 — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0/v1.0.0, see currency note below</td></tr>
+        <tr><td>Ship-Gate (internal)</td><td class="num">Yes</td><td class="src"><a href="https://github.com/alphaonedev/ai-memory-ship-gate">Ship gate</a> (repo, Pages site retired per #2034) · 9/9 cert + 5/5 channels green at v0.6.2 cut — last full 4-phase cell run; not re-run at v0.7.0/v0.8.x/v0.9.0/v1.0.0, see currency note below</td></tr>
         <tr><td>SOC 2</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
         <tr><td>ISO 27001</td><td class="num">No</td><td class="src">No third-party audit. Do not represent.</td></tr>
         <tr><td>FedRAMP</td><td class="num">No</td><td class="src">No authorization. Do not represent.</td></tr>
@@ -313,7 +313,7 @@ footer a{color:var(--text-muted)}
       (#2034) — the certification rows above now cite the source repos
       directly instead of the retired Pages URLs. Their
       last full 4-phase cell run is the v0.6.2/v0.6.3 cut cited above — neither was
-      re-run as a full 4-phase cell for v0.7.0, v0.8.0, v0.8.1, or v0.9.0.
+      re-run as a full 4-phase cell for v0.7.0, v0.8.0, v0.8.1, v0.9.0, or v1.0.0.
       <strong>v0.9.0 shipped under a one-time recorded descope of the 4-phase
       ship-gate/A2A-gate re-run</strong> (ruling <code>wf_26d176ac</code>, 10/10,
       tracked on <a href="https://github.com/alphaonedev/ai-memory-mcp/issues/1938">#1938</a>).

--- a/docs/for-everyone.html
+++ b/docs/for-everyone.html
@@ -417,7 +417,7 @@ ai-memory mcp --tier autonomous</pre>
           <li><strong>Per-BU policy enforcement</strong> via governance + hooks; one platform, N policies</li>
           <li><strong>Hooks for DLP integration</strong> — your existing data-loss-prevention pipeline plugs in</li>
           <li><strong>Vendor-risk-zero</strong> — Apache 2.0, full source, single binary, no SaaS dependency</li>
-          <li><strong>FIPS path</strong> via v0.7.0 attested identity (Ed25519 shipped; HSM-backed via AgenticMem Attest)</li>
+          <li><strong>Attested identity</strong> via v0.7.0 (Ed25519 shipped; HSM-backed custody via AgenticMem Attest) — <em>targets</em> FIPS-grade key handling; this is not a FIPS validation and none is held</li>
         </ul>
       </div>
       <div class="aud-stack">
@@ -441,7 +441,7 @@ ai-memory mcp --tier autonomous</pre>
       <div class="scale-tag">SCALE · GOVERNMENT</div>
       <h2>Federal · State · Local · Municipal.</h2>
       <p>AI mandate is real. Cloud ban is real. Foreign vendor scrutiny is real. Audit trail is mandatory.</p>
-      <div class="scale-pop">Sovereign · Air-gapped · FIPS / IL5 path</div>
+      <div class="scale-pop">Sovereign · Air-gapped · No FedRAMP / IL5 authorization</div>
     </div>
     <div class="right">
       <div class="aud-pain">
@@ -450,7 +450,7 @@ ai-memory mcp --tier autonomous</pre>
       </div>
       <div class="aud-fix">
         <h3>▲ The Fix</h3>
-        <p><strong>Apache 2.0 OSS</strong>. Single Rust binary. Zero outbound calls. Public source code, auditable from <code>git clone</code>. Attested keys (Ed25519 at v0.7.0; HSM / TPM / Secure Enclave custody via AgenticMem Attest). FedRAMP / IL5 path via the AgenticMem Sovereign tier. <strong>Domestic supplier (US-based AlphaOne LLC) for procurement.</strong></p>
+        <p><strong>Apache 2.0 OSS</strong>. Single Rust binary. Zero outbound calls. Public source code, auditable from <code>git clone</code>. Attested keys (Ed25519 at v0.7.0; HSM / TPM / Secure Enclave custody via AgenticMem Attest). <strong>No FedRAMP or IL5 authorization is held or claimed</strong> — obtaining one would be a separate, unstarted process, and the AgenticMem Sovereign tier is a forward-looking commercial offering, not an authorization. See <a href="evidence.html">evidence.html</a>. <strong>Domestic supplier (US-based AlphaOne LLC) for procurement.</strong></p>
       </div>
       <div class="aud-roi">
         <h3>▼ The ROI</h3>
@@ -458,7 +458,7 @@ ai-memory mcp --tier autonomous</pre>
           <li><strong>100% air-gap operable</strong> — no exceptions, no special "offline mode" — just doesn't make outbound calls</li>
           <li><strong>Public source-code audit</strong> — your security team reads the entire codebase in a week</li>
           <li><strong>No vendor lock-in</strong> — single Rust binary, single SQLite file, copy is backup</li>
-          <li><strong>FedRAMP / IL5 path</strong> via AgenticMem Sovereign commercial tier (Q3 2026 GA)</li>
+          <li><strong>No FedRAMP / IL5 authorization</strong> — none is held or claimed for any release; an authorization would be a separate, unstarted process. Do not represent ai-memory or AgenticMem as FedRAMP- or IL5-authorized</li>
           <li><strong>Domestic supplier</strong> — US-incorporated, no foreign-ownership concerns</li>
           <li><strong>SBOM clean</strong> — Cargo.toml is the SBOM; <code>cargo audit</code> runs in CI</li>
         </ul>
@@ -467,7 +467,7 @@ ai-memory mcp --tier autonomous</pre>
         <h3>▼ Deployment Pattern</h3>
         <div class="aud-stack-row"><span class="badge">air-gap</span> Build from source on the secure subnet; no internet</div>
         <div class="aud-stack-row"><span class="badge">SQLCipher</span> Encryption-at-rest via <code>--features sqlcipher</code></div>
-        <div class="aud-stack-row"><span class="badge">FIPS</span> v0.7.0 attested-identity for FIPS 140-3 path</div>
+        <div class="aud-stack-row"><span class="badge">keys</span> v0.7.0 attested-identity targets FIPS-grade key handling; no FIPS 140-3 validation is held</div>
         <div class="aud-stack-row"><span class="badge">HSM</span> Hardware key custody via AgenticMem Attest commercial tier</div>
         <div class="aud-stack-row"><span class="badge">audit</span> Append-only signed event log; no operator can rewrite history</div>
         <div class="aud-stack-row"><span class="badge">domestic</span> AlphaOne LLC (US, Delaware) is the sole responsible party</div>


### PR DESCRIPTION
Fixes the contradiction tracked in #2922. (`Closes` is deliberately not used — auto-close does not fire on a non-default base branch.)

## What was claimed vs what is true

| Site | Claimed | True |
|---|---|---|
| `docs/for-everyone.html:453` | "FedRAMP / IL5 path via the AgenticMem Sovereign tier" | No FedRAMP or IL5 authorization is held or claimed. Obtaining one would be a separate, unstarted process. The Sovereign tier is a forward-looking commercial offering, not an authorization. |
| `docs/for-everyone.html:461` | "**FedRAMP / IL5 path** via AgenticMem Sovereign commercial tier **(Q3 2026 GA)**" | Same — and there is no dated GA commitment. The date is DROPPED, not re-dated. |
| `docs/for-everyone.html:444` | "Sovereign · Air-gapped · FIPS / IL5 path" | Same class of authorization overclaim; now states no FedRAMP / IL5 authorization. |
| `docs/for-everyone.html:420` | "**FIPS path** via v0.7.0 attested identity" | The v0.7.0 attested-identity work *targets* FIPS-grade key handling. It is not a FIPS validation, and none is held. |
| `docs/for-everyone.html:470` | "v0.7.0 attested-identity for FIPS 140-3 path" | Same — restated as "targets FIPS-grade key handling; no FIPS 140-3 validation is held". |
| `docs/evidence.html:294` | "ai-memory **v0.9.0** holds the following internal certifications" | `Cargo.toml` is `1.0.0` (verified in-tree). Updated to v1.0.0 and pointed at the currency caveat immediately below it. |
| `docs/evidence.html:298,299,316` | "not re-run at v0.7.0/v0.8.x/v0.9.0" | No v1.0.0 4-phase ship-gate / A2A-gate cell run exists either. Once line 294 says v1.0.0, omitting v1.0.0 from those enumerations would imply a v1.0.0 cell HAD been run — so v1.0.0 is added to both. |

The corrected `docs/at-a-glance.html` (#2913 / PR #2920) states plainly that no FedRAMP authorization is held and that an ATO is a separate, unstarted process. Two live pages on the same site disagreed about the exact claim #2913 exists to retire; the dated `(Q3 2026 GA)` line was the sharpest form of that contradiction. Both sites now also link to `evidence.html`, whose certification table has always read `FedRAMP | No | No authorization. Do not represent.`

**Direction is claim-retiring only.** No new capability, timeline, or authorization claim is added anywhere in this diff. Every edit either deletes a claim or replaces it with an explicit negation.

## Deliberately NOT touched

- **`docs/for-everyone.html:449`** — the government pain-quote ("Every offering needs FedRAMP authorization") is a customer voicing their own procurement problem, not a product claim. Left verbatim.
- **`docs/at-a-glance.html` lines 1556 / 1568 / 1732 / 1765** — four remaining FedRAMP overclaims ("FedRAMP / IL5 / Sovereign" persona label, "FedRAMP-certified deployments", "Five steps from laptop to FedRAMP", the "FedRAMP / IL5" step title). **PR #2920 is open and already corrects all four**; editing them in this branch would conflict with it. Reported, not duplicated.
- **`docs/evidence.html` frozen-v0.9.0 markers** — the page `<title>`, the `FROZEN · v0.9.0` badge, the "Current release: v0.9.0" row, and the footer. Those are statements about a *measured, frozen* code surface and about the last cut tag (the v1.0.0 tag-cut is operator-gated and has not fired). Re-pointing them at v1.0.0 would assert numbers nobody re-derived — that would add claims, which is the opposite of this PR's direction.
- **`docs/CONFIG_SCHEMA.md:270`** — "audit log suitable for SIEM ingestion and SOC2 / HIPAA / GDPR / FedRAMP evidence" is a suitability claim about a log format, not an authorization or a path/timeline. `docs/BASELINE-v0.6.3.1.md:227` names a config preset and is a frozen baseline doc. Neither asserts a path as fact; both reviewed, no change.
- `docs/v0.*/` frozen trees — out of scope by the same reasoning that keeps them out of the docs-vs-SSOT gate.

## Gates

Run in the worktree at `eb4dd0b7`:

```
scripts/check-docs-vs-ssot.sh        PASS  (schema=89, full_tools=103, routes=94, release=1.0.0)
scripts/check-doc-symbol-anchors.sh  PASS
scripts/check-ci-job-claims.sh       PASS  (18 workflows parsed)
```

Docs-only; no Rust source, no SSOT pin, no CHANGELOG-eligible user-facing behaviour change.

## AI involvement

Authored by an AI agent (Claude) under Fable 5 orchestration; operator-delegated authority. Every claim in the table above was verified against the in-tree file at the cited line and against `Cargo.toml`; the at-a-glance disposition was verified against the live `gh pr diff 2920`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
