### PR TITLE
hardening(pr-4): L7 verifier exoneration-asymmetry — authenticated watermark exonerates, unauthenticated only convicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (L7 — audit-trail verifier exoneration asymmetry; forensic-audit-trail PR-4)
+
+- **The audit-trail verifier no longer EXONERATES on an unauthenticated forensic
+  watermark, while it still CONVICTS on one.** `verify_audit_trail`'s off-table
+  `#1850` watermark feeds BOTH directions — `TruncationCheck::{Detected,NotDetected}`
+  and the forensic-watermark `HeadHashCheck::{Mismatch,NotDetected}`. On an
+  UNSIGNED daemon (a hostile host that strips the daemon signature) that anchor is
+  unauthenticated, so trusting it to render `NotDetected` / a clean bill of health
+  is a forged all-clear. PR-4 adds the guard
+  `governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey)` +
+  the pure `signed_events::exoneration_gated_head_hash`, which gate ONLY the
+  EXONERATING direction: a clean truncation/head-hash verdict now renders only
+  when a non-empty watermark signature + its prev_hash chain verify against the
+  OUT-OF-BAND `AI_MEMORY_AUDIT_PUBKEY` pin (whole-chain `verify_since` under the
+  pin — no reimplemented crypto). The CONVICTING direction keeps reading the raw
+  unauthenticated `last_audit_watermark`, so a stripped signature can only
+  DEGRADE a clean verdict to WITHHELD (`Unknown`) — never SUPPRESS a
+  truncation/rewrite conviction.
+- **Enrollment-gated (mirrors the L4 `compute_signature_verdict` posture):** with
+  NO pin enrolled there is no authority to authenticate against, so the verifier
+  keeps its legacy trust-the-anchor behaviour and a default deployment is
+  byte-identical (the `audit_truncation_anchor_1850` regression passes UNMODIFIED).
+  Both backends call the SAME backend-neutral guard + the SAME pure gate over the
+  on-host forensic sink, so the sqlite and PostgreSQL verdicts are IDENTICAL (K3
+  parity). No new `security_profile` knob. Registered as a §5.4.5 removal-proof
+  control (`scripts/check-cert-removal-proof.sh`): mutating the guard to
+  `return true` flips an unauthenticated-watermark verdict clean and reds
+  `tests/audit_exoneration_asymmetry_l7.rs`.
+
 ### Fixed (append-only revision spine was dead code — `AI_MEMORY_APPEND_ONLY` is now live; #1823 / PR-2)
 
 - **`AI_MEMORY_APPEND_ONLY=1` and `[storage].append_only=true` were BOTH inert

--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -78,6 +78,14 @@ MAP=(
   # not merely that the code is reached. Neutralization => is_clean stays true
   # under the pin => the guard test's dirty assertion goes RED.
   "compute_signature_verdict|body|SignatureCheck::Unenforced { checked: 0, unverified: 0 }|src/signed_events.rs|audit_signature_pin_l4|downgraded_lineage_row_under_pin_dirties_l4"
+  # L7 (PR-4, forensic-audit-trail wave) — the EXONERATION-authenticity gate.
+  # `return true` (the always-allow disposition) lets an UNAUTHENTICATED forensic
+  # watermark exonerate, defeating the L7 asymmetry. GUARD FIXTURE is the
+  # CLOSED GAP CLASS itself: a pin enrolled + an UNSIGNED watermark + a CLEAN
+  # chain (which a watermark-trusting verifier WOULD render NotDetected on both
+  # lanes). Honest guard => Unknown withheld on both lanes; mutated `return true`
+  # => NotDetected => the guard test's `assert_eq!(…, Unknown)` goes RED.
+  "audit_watermark_exoneration_authenticated|return|return true;|src/governance/audit.rs|audit_exoneration_asymmetry_l7|unauthenticated_watermark_under_pin_withholds_exoneration_l7"
 )
 
 # Apply MUTATION to function CTL in TARGET, per SHAPE.

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -1067,19 +1067,31 @@ pub fn last_audit_watermark() -> Option<(i64, String)> {
     let dir = live_sink_dir()?;
     let files = list_forensic_files(&dir).ok()?;
     // Newest first; "current + previous daily file" per the daily rotation.
+    // The `signed` bit is dropped here — the CONVICTING lanes read this raw
+    // (unauthenticated) anchor. The L7 exonerating lanes gate on
+    // [`audit_watermark_exoneration_authenticated`] instead.
     for file in files.iter().rev().take(2) {
-        if let Some(found) = scan_file_last_watermark(file) {
-            return Some(found);
+        if let Some((seq, hash, _signed)) = scan_file_last_watermark(file) {
+            return Some((seq, hash));
         }
     }
     None
 }
 
-/// Return the LAST (most-recent) watermark row in a single forensic file,
-/// or `None` if it carries none. Malformed / wrong-version rows are skipped.
-fn scan_file_last_watermark(path: &Path) -> Option<(i64, String)> {
+/// The most-recent watermark row in a single forensic file:
+/// `(head_sequence, head_canonical_hash, signed)` where `signed` is `true`
+/// iff that row carried a non-empty Ed25519 `sig`. `None` if the file carries
+/// no watermark. Malformed / wrong-version rows are skipped.
+///
+/// The `signed` bit is what the L7
+/// [`audit_watermark_exoneration_authenticated`] gate consumes: `verify_since`
+/// tolerates an unsigned row (counts it, never fails on it), so the exonerating
+/// lanes must additionally confirm the exact watermark they trust is itself
+/// signed. [`last_audit_watermark`] ignores the bit (the CONVICTING lanes read
+/// the raw unauthenticated anchor).
+fn scan_file_last_watermark(path: &Path) -> Option<(i64, String, bool)> {
     let f = File::open(path).ok()?;
-    let mut found: Option<(i64, String)> = None;
+    let mut found: Option<(i64, String, bool)> = None;
     for line in BufReader::new(f).lines() {
         let Ok(line) = line else { continue };
         if line.trim().is_empty() {
@@ -1105,10 +1117,82 @@ fn scan_file_last_watermark(path: &Path) -> Option<(i64, String)> {
             .get("head_canonical_hash")
             .and_then(serde_json::Value::as_str);
         if let (Some(seq), Some(hash)) = (seq, hash) {
-            found = Some((seq, hash.to_string()));
+            found = Some((seq, hash.to_string(), !row.sig.is_empty()));
         }
     }
     found
+}
+
+/// L7 (PR-4, forensic-audit-trail wave) — earliest `--since` sentinel the
+/// [`audit_watermark_exoneration_authenticated`] gate feeds [`verify_since`] so
+/// the WHOLE forensic chain (every daily file) is authenticated under the pin.
+/// Any real forensic file (dated `>= v1.0.0`) sorts at/after it, so the seed
+/// loop skips none and the verify loop walks all of them from genesis.
+const EARLIEST_FORENSIC_SINCE: &str = "1970-01-01";
+
+/// L7 (PR-4, forensic-audit-trail wave) — EXONERATION-authenticity gate for the
+/// audit-trail verifier ([`crate::signed_events::verify_audit_trail`] + its
+/// postgres twin). Returns `true` when the exonerating verdict lanes
+/// (`TruncationCheck::NotDetected`, and `HeadHashCheck::NotDetected` on the
+/// forensic-watermark anchor) are PERMITTED to render a clean bill of health on
+/// the current forensic watermark; `false` withholds them to the safe
+/// `Unknown`.
+///
+/// The L7 asymmetry: a hostile host can STRIP the daemon signature off a
+/// forensic watermark row, but the exonerating lanes must not trust an
+/// unauthenticated anchor to mint "clean". The CONVICTING lanes (`Detected` /
+/// `Mismatch`) ignore this gate and keep reading the raw
+/// [`last_audit_watermark`], so a stripped signature can only DEGRADE a clean
+/// verdict to WITHHELD (`Unknown`) — never SUPPRESS a truncation/rewrite
+/// conviction.
+///
+/// Enrollment-gated, mirroring the L4 `compute_signature_verdict` posture: with
+/// NO out-of-band [`AUDIT_PUBKEY_ENV`] pin there is no authority to authenticate
+/// against, so the verifier keeps its legacy trust-the-anchor behaviour
+/// (`true`). Once a pin IS enrolled, exoneration is permitted ONLY when the
+/// forensic watermark row carries a non-empty Ed25519 signature that verifies
+/// against the pin AND the prev_hash chain up to it is intact — whole-chain
+/// [`verify_since`] under the pin (no reimplemented crypto; `verify_strict`
+/// rejects malleable signatures). Backend-neutral (the forensic sink is
+/// on-host), so both backends' `verify_audit_trail` call THIS fn and agree (K3
+/// parity).
+///
+/// Constant-`true` here (the §5.4.5 removal-proof mutation) lets an
+/// unauthenticated watermark exonerate — the L7 asymmetry defeated.
+#[must_use]
+pub fn audit_watermark_exoneration_authenticated(audit_pubkey: Option<&VerifyingKey>) -> bool {
+    // Enrollment gate: no out-of-band pin → no authority → legacy behaviour.
+    let Some(pubkey) = audit_pubkey else {
+        return true;
+    };
+    // A pin IS enrolled: the exonerating lanes may render clean ONLY on an
+    // authenticated watermark. No live sink → no anchor to authenticate →
+    // nothing for the exonerating lanes to render anyway; withhold.
+    let Some(dir) = live_sink_dir() else {
+        return false;
+    };
+    // The whole forensic chain must verify under the pin: a broken prev_hash
+    // link OR a signature that does not verify → withhold exoneration.
+    match verify_since(&dir, EARLIEST_FORENSIC_SINCE, Some(pubkey)) {
+        Ok(report) if report.first_failure.is_none() => {}
+        _ => return false,
+    }
+    // The chain is intact and every SIGNED row verified — but verify_since
+    // TOLERATES unsigned rows. The watermark the value lanes will actually
+    // consume is the LAST watermark row in the NEWEST forensic file that
+    // carries one (mirrors `last_audit_watermark`'s newest-first scan over the
+    // current + previous daily file). Lock onto that same row and require IT to
+    // be signed, else a hostile host that appends an UNSIGNED watermark onto an
+    // otherwise-verifying chain could still mint exoneration.
+    let Ok(files) = list_forensic_files(&dir) else {
+        return false;
+    };
+    for file in files.iter().rev().take(2) {
+        if let Some((_, _, signed)) = scan_file_last_watermark(file) {
+            return signed;
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -1800,6 +1800,29 @@ pub fn fold_head_hash_verdicts(verdicts: Vec<HeadHashCheck>) -> HeadHashCheck {
     HeadHashCheck::Unknown
 }
 
+/// v1.0.0 L7 (PR-4, forensic-audit-trail wave) — apply the exoneration
+/// asymmetry to ONE forensic-watermark [`HeadHashCheck`] verdict.
+///
+/// A `Mismatch` (CONVICTION) always stands: a stripped daemon signature must
+/// never SUPPRESS a same-length-rewrite conviction. A `NotDetected`
+/// (EXONERATION) is DOWNGRADED to `Unknown` (withheld) unless `exonerate_ok`, so
+/// an UNAUTHENTICATED anchor can never mint a clean head-hash bill of health.
+/// `Unknown` passes through. `exonerate_ok` is
+/// [`crate::governance::audit::audit_watermark_exoneration_authenticated`],
+/// which is `true` when no out-of-band audit pin is enrolled (legacy
+/// trust-the-anchor) OR the forensic watermark authenticates against the pin.
+/// Pure so BOTH backends' `verify_audit_trail` gate the forensic-watermark
+/// sub-lane identically (K3 parity). The witness dual-head sub-lane is NOT
+/// routed through here — it is already consumed only via its own K1 pin +
+/// signature gate (`verified_witness_dual_head`).
+#[must_use]
+pub fn exoneration_gated_head_hash(verdict: HeadHashCheck, exonerate_ok: bool) -> HeadHashCheck {
+    match verdict {
+        HeadHashCheck::NotDetected if !exonerate_ok => HeadHashCheck::Unknown,
+        other => other,
+    }
+}
+
 /// v0.9.0 G9 (#1826) — verdict of the three-key Recorder/Judge/Stopper
 /// signing-layer SEPARATION check, computed by
 /// [`compute_role_separation_verdict`]. Additive/opt-in: with no role keys
@@ -2386,15 +2409,30 @@ pub fn verify_audit_trail(
     // No SIEM/syslog call here (the report is the surface); the off-host
     // `AI_MEMORY_LOG_SINK=syslog` tier is the residual-closing control for
     // the hostile-host / unsigned-daemon posture (see fn-level docs).
+    // v1.0.0 L7 (PR-4) — EXONERATION-authenticity gate. The exonerating verdict
+    // lanes (`TruncationCheck::NotDetected`, `HeadHashCheck::NotDetected` on the
+    // forensic watermark) may render clean ONLY when this holds; the CONVICTING
+    // lanes ignore it and keep reading the raw unauthenticated watermark.
+    // Enrollment-gated on the out-of-band `AI_MEMORY_AUDIT_PUBKEY` pin (no pin →
+    // legacy trust-the-anchor). SHARED with the postgres twin (K3 parity).
+    let exonerate_ok =
+        crate::governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey);
     let truncation = match crate::governance::audit::last_audit_watermark() {
         Some((anchored_head, _head_canonical_hash)) => {
             if head_sequence < anchored_head {
+                // CONVICT on the raw (unauthenticated) anchor — a stripped
+                // signature must never SUPPRESS a truncation conviction.
                 TruncationCheck::Detected {
                     anchored_head,
                     db_head: head_sequence,
                 }
-            } else {
+            } else if exonerate_ok {
                 TruncationCheck::NotDetected
+            } else {
+                // L7 — a pin is enrolled but the anchor did not authenticate:
+                // WITHHOLD the clean bill of health rather than exonerate on
+                // unauthenticated evidence.
+                TruncationCheck::Unknown
             }
         }
         None => TruncationCheck::Unknown,
@@ -2577,6 +2615,8 @@ pub fn verify_audit_trail(
             verified_witness_dual_head(latest_witness.as_ref(), enrolled_pubkey.as_ref());
         let mut verdicts: Vec<HeadHashCheck> = Vec::new();
         // (a) forensic watermark → signed_events row AT the anchored sequence.
+        // v1.0.0 L7 (PR-4) — CONVICT (Mismatch) on the raw anchor, but EXONERATE
+        // (NotDetected) only behind the authenticity gate (`exonerate_ok`).
         if let Some((anchored_head, anchored_hash)) =
             crate::governance::audit::last_audit_watermark()
             && anchored_head > 0
@@ -2585,10 +2625,13 @@ pub fn verify_audit_trail(
             let recomputed = recompute_signed_row_hash_at(conn, anchored_head)
                 .ok()
                 .flatten();
-            verdicts.push(compute_head_hash_verdict(
-                Some(&anchored_hash),
-                recomputed.as_deref(),
-                CHAIN_SIGNED_EVENTS,
+            verdicts.push(exoneration_gated_head_hash(
+                compute_head_hash_verdict(
+                    Some(&anchored_hash),
+                    recomputed.as_deref(),
+                    CHAIN_SIGNED_EVENTS,
+                ),
+                exonerate_ok,
             ));
         }
         // (b) witness dual anchor → signed_events + memory_revisions rows AT the

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -12221,17 +12221,28 @@ impl PostgresStore {
             .await
             .map_err(|e| to_store_err("verify_audit_trail.head", e))?;
 
+        // v1.0.0 L7 (PR-4) — EXONERATION-authenticity gate (SHARED with the
+        // sqlite twin; K3 parity). Enrollment-gated on the out-of-band
+        // `AI_MEMORY_AUDIT_PUBKEY` pin: no pin → legacy trust-the-anchor;
+        // pin enrolled → exonerate only on an authenticated forensic watermark.
+        let exonerate_ok =
+            crate::governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey);
+
         // Off-table tail-truncation verdict — the SAME shared forensic reader
         // the sqlite path uses (item 7 wired the pg chokepoint to stamp it).
         let truncation = match crate::governance::audit::last_audit_watermark() {
             Some((anchored_head, _)) => {
                 if head_sequence < anchored_head {
+                    // CONVICT on the raw (unauthenticated) anchor.
                     TruncationCheck::Detected {
                         anchored_head,
                         db_head: head_sequence,
                     }
-                } else {
+                } else if exonerate_ok {
                     TruncationCheck::NotDetected
+                } else {
+                    // L7 — pin enrolled + anchor unauthenticated → WITHHOLD.
+                    TruncationCheck::Unknown
                 }
             }
             None => TruncationCheck::Unknown,
@@ -12537,16 +12548,22 @@ impl PostgresStore {
                 enrolled.as_ref(),
             );
             let mut verdicts: Vec<crate::signed_events::HeadHashCheck> = Vec::new();
+            // v1.0.0 L7 (PR-4) — CONVICT (Mismatch) on the raw anchor, EXONERATE
+            // (NotDetected) only behind the authenticity gate (`exonerate_ok`).
+            // SHARED pure gate with the sqlite twin (K3 parity).
             if let Some((anchored_head, anchored_hash)) =
                 crate::governance::audit::last_audit_watermark()
                 && anchored_head > 0
                 && anchored_head <= head_sequence
             {
                 let recomputed = pg_recompute_signed_row_hash_at(&self.pool, anchored_head).await;
-                verdicts.push(crate::signed_events::compute_head_hash_verdict(
-                    Some(&anchored_hash),
-                    recomputed.as_deref(),
-                    crate::signed_events::CHAIN_SIGNED_EVENTS,
+                verdicts.push(crate::signed_events::exoneration_gated_head_hash(
+                    crate::signed_events::compute_head_hash_verdict(
+                        Some(&anchored_hash),
+                        recomputed.as_deref(),
+                        crate::signed_events::CHAIN_SIGNED_EVENTS,
+                    ),
+                    exonerate_ok,
                 ));
             }
             if let Some(dual) = witness_dual {

--- a/tests/audit_exoneration_asymmetry_l7.rs
+++ b/tests/audit_exoneration_asymmetry_l7.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 L7 (PR-4, forensic-audit-trail wave) — the audit-trail verifier's
+//! EXONERATION-asymmetry rule: it must STOP EXONERATING on an UNAUTHENTICATED
+//! forensic watermark while still CONVICTING on it.
+//!
+//! Context: `verify_audit_trail`'s off-table watermark feeds BOTH directions —
+//! `TruncationCheck::{Detected,NotDetected}` and the forensic-watermark
+//! `HeadHashCheck::{Mismatch,NotDetected}`. On an UNSIGNED daemon (a hostile
+//! host that strips the daemon signature) the watermark is unauthenticated, so
+//! trusting it to render `NotDetected` / a clean bill of health is a forged
+//! all-clear. The L7 control
+//! ([`ai_memory::governance::audit::audit_watermark_exoneration_authenticated`]
+//! + the pure [`ai_memory::signed_events::exoneration_gated_head_hash`]) gates
+//! ONLY the exonerating direction on an out-of-band-pinned, signature+chain
+//! authenticated watermark, while the convicting direction keeps reading the
+//! raw unauthenticated anchor.
+//!
+//! Pins:
+//! - (auth)     pin enrolled + watermark signed by the pin + clean chain →
+//!              `NotDetected` (the control does NOT over-withhold).
+//! - (withhold) pin enrolled + UNSIGNED watermark + clean chain → `Unknown`
+//!              (BOTH lanes withheld). This is the §5.4.5 removal-proof lane
+//!              test: mutating the guard to `return true` flips it to
+//!              `NotDetected` (RED).
+//! - (convict1) pin enrolled + UNSIGNED watermark + truncated DB → `Detected`
+//!              (a stripped signature can NEVER suppress a truncation
+//!              conviction).
+//! - (convict2) pin enrolled + UNSIGNED watermark + same-length head rewrite →
+//!              `Mismatch` (conviction survives on unauthenticated evidence).
+//! - (legacy)   NO pin + UNSIGNED watermark + clean chain → `NotDetected`
+//!              (enrollment-gated: with no authority the pre-L7 trust-the-anchor
+//!              behaviour is byte-preserved — the `audit_truncation_anchor_1850`
+//!              acceptance posture).
+//!
+//! The forensic sink is process-global, so these tests serialise via a
+//! module-local lock (the `audit_truncation_anchor_1850` discipline).
+
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use ai_memory::governance::audit as forensic;
+use ai_memory::signed_events::{
+    HeadHashCheck, SignedEvent, TruncationCheck, append_signed_event, canonical_chain_bytes,
+    payload_hash, verify_audit_trail,
+};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand_core::OsRng;
+use rusqlite::{Connection, params};
+use sha2::{Digest, Sha256};
+
+/// Process-global serialisation for the shared forensic SINK.
+fn forensic_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Tempdirs under `.local-runs/` (project no-`/tmp` HARD RULE).
+fn local_runs_root() -> PathBuf {
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("l7-exoneration-asymmetry")
+}
+
+fn fresh_dir(label: &str) -> tempfile::TempDir {
+    let root = local_runs_root();
+    std::fs::create_dir_all(&root).ok();
+    tempfile::Builder::new()
+        .prefix(&format!("{label}-"))
+        .tempdir_in(&root)
+        .expect("tempdir under .local-runs")
+}
+
+fn open_db(dir: &Path) -> (PathBuf, Connection) {
+    let path = dir.join("audit.db");
+    drop(ai_memory::db::open(&path).expect("init db"));
+    let conn = ai_memory::db::open(&path).expect("open db");
+    (path, conn)
+}
+
+fn append_row(conn: &Connection, payload: &[u8]) {
+    let ev = SignedEvent {
+        id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "alice".to_string(),
+        event_type: "memory_link.created".to_string(),
+        payload_hash: payload_hash(payload),
+        signature: None,
+        attest_level: "unsigned".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        ..SignedEvent::default()
+    };
+    append_signed_event(conn, &ev).expect("append");
+}
+
+/// Recompute the surviving head row's canonical hash EXACTLY as the verifier
+/// does and anchor that REAL hash into the off-table forensic watermark
+/// (mirrors `audit_truncation_anchor_1850::anchor_real_head`). Returns the head
+/// sequence. Signs with whatever key `forensic::init` installed on the sink.
+fn anchor_real_head(conn: &Connection) -> i64 {
+    let (seq, hash_hex) = conn
+        .query_row(
+            "SELECT id, agent_id, event_type, payload_hash, signature, attest_level, \
+                    timestamp, sequence, cause_hash \
+             FROM signed_events ORDER BY sequence DESC LIMIT 1",
+            [],
+            |row| {
+                let ev = SignedEvent {
+                    id: row.get(0)?,
+                    agent_id: row.get(1)?,
+                    event_type: row.get(2)?,
+                    payload_hash: row.get(3)?,
+                    signature: row.get(4)?,
+                    attest_level: row.get(5)?,
+                    timestamp: row.get(6)?,
+                    sequence: row.get(7)?,
+                    cause_hash: row.get::<_, Option<Vec<u8>>>(8)?,
+                    prev_hash: Vec::new(),
+                };
+                let mut h = Sha256::new();
+                h.update(canonical_chain_bytes(&ev));
+                Ok((ev.sequence, hex::encode(h.finalize())))
+            },
+        )
+        .expect("read head row");
+    forensic::record_audit_watermark(seq, &hash_hex);
+    forensic::flush_blocking();
+    seq
+}
+
+fn fresh_pin() -> (SigningKey, VerifyingKey) {
+    let key = SigningKey::generate(&mut OsRng);
+    let vk = key.verifying_key();
+    (key, vk)
+}
+
+// -----------------------------------------------------------------
+// (auth) pin + SIGNED watermark + clean chain → NotDetected.
+// Proves the control does NOT over-withhold: an authenticated anchor still
+// exonerates. The sink is signed by the SAME key the pin verifies against.
+// -----------------------------------------------------------------
+
+#[test]
+fn authenticated_watermark_under_pin_exonerates_l7() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("auth-forensic");
+    let ddir = fresh_dir("auth-db");
+    let (sink_key, pin) = fresh_pin();
+    // The forensic sink signs its watermark rows with `sink_key`; the verifier
+    // is handed `pin` = its public half → the watermark AUTHENTICATES.
+    forensic::init(fdir.path(), Some(sink_key)).expect("forensic init");
+
+    let (_path, conn) = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    anchor_real_head(&conn);
+
+    let report = verify_audit_trail(&conn, None, Some(&pin)).expect("verify");
+    assert_eq!(report.head_sequence, 5);
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::NotDetected,
+        "an AUTHENTICATED watermark (signed by the pinned key) must still \
+         exonerate the truncation lane; report={report:?}"
+    );
+    assert_eq!(
+        report.head_hash,
+        HeadHashCheck::NotDetected,
+        "an AUTHENTICATED watermark must still exonerate the head-hash lane; \
+         report={report:?}"
+    );
+
+    forensic::shutdown();
+}
+
+// -----------------------------------------------------------------
+// (withhold) pin + UNSIGNED watermark + clean chain → Unknown (BOTH lanes).
+// §5.4.5 REMOVAL-PROOF LANE TEST — registered in check-cert-removal-proof.sh.
+// Mutating `audit_watermark_exoneration_authenticated` to `return true` flips
+// both verdicts to NotDetected → this test goes RED.
+// -----------------------------------------------------------------
+
+#[test]
+fn unauthenticated_watermark_under_pin_withholds_exoneration_l7() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("withhold-forensic");
+    let ddir = fresh_dir("withhold-db");
+    let (_unused_key, pin) = fresh_pin();
+    // Sink is UNSIGNED (None) → the watermark row carries no signature, so it
+    // cannot authenticate against the enrolled `pin`.
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let (_path, conn) = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    // Anchor the REAL head hash: the DB is CLEAN, so a watermark-trusting
+    // verifier WOULD render NotDetected on both lanes — the exact forged
+    // all-clear the L7 control refuses on unauthenticated evidence.
+    anchor_real_head(&conn);
+
+    let report = verify_audit_trail(&conn, None, Some(&pin)).expect("verify");
+    assert_eq!(report.head_sequence, 5);
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Unknown,
+        "a pin is enrolled but the watermark is UNAUTHENTICATED — the \
+         truncation lane must WITHHOLD (Unknown), never exonerate on \
+         unauthenticated evidence; report={report:?}"
+    );
+    assert_eq!(
+        report.head_hash,
+        HeadHashCheck::Unknown,
+        "a pin is enrolled but the watermark is UNAUTHENTICATED — the \
+         head-hash lane must WITHHOLD (Unknown), never render a clean \
+         head-hash bill of health; report={report:?}"
+    );
+
+    forensic::shutdown();
+}
+
+// -----------------------------------------------------------------
+// (convict1) pin + UNSIGNED watermark + truncated DB → Detected.
+// A stripped signature must NEVER suppress a truncation conviction.
+// -----------------------------------------------------------------
+
+#[test]
+fn unauthenticated_watermark_still_convicts_truncation_l7() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("convict1-forensic");
+    let ddir = fresh_dir("convict1-db");
+    let (_unused_key, pin) = fresh_pin();
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let (_path, conn) = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    forensic::record_audit_watermark(5, "anchor-hash-head-5");
+    forensic::flush_blocking();
+
+    // Truncate the trailing two rows — surviving 1..=3 stays contiguous.
+    conn.execute("DELETE FROM signed_events WHERE sequence IN (4, 5)", [])
+        .expect("truncate tail");
+
+    let report = verify_audit_trail(&conn, None, Some(&pin)).expect("verify");
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Detected {
+            anchored_head: 5,
+            db_head: 3,
+        },
+        "conviction must fire on the UNAUTHENTICATED anchor — the L7 asymmetry \
+         gates only the exonerating direction; report={report:?}"
+    );
+    assert!(
+        !report.is_clean(),
+        "a detected truncation is NOT clean regardless of authentication; \
+         report={report:?}"
+    );
+
+    forensic::shutdown();
+}
+
+// -----------------------------------------------------------------
+// (convict2) pin + UNSIGNED watermark + same-length head rewrite → Mismatch.
+// The head-hash conviction survives on unauthenticated evidence too.
+// -----------------------------------------------------------------
+
+#[test]
+fn unauthenticated_watermark_still_convicts_head_rewrite_l7() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("convict2-forensic");
+    let ddir = fresh_dir("convict2-db");
+    let (_unused_key, pin) = fresh_pin();
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let (_path, conn) = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    let head_seq = anchor_real_head(&conn);
+
+    // SAME-LENGTH rewrite of the head row's payload_hash — chain stays intact,
+    // seq-only truncation reads clean, only the head-hash anchor catches it.
+    conn.execute(
+        "UPDATE signed_events SET payload_hash = ?1 WHERE sequence = ?2",
+        params![vec![0xFFu8; 32], head_seq],
+    )
+    .expect("rewrite head payload in place");
+
+    let report = verify_audit_trail(&conn, None, Some(&pin)).expect("verify");
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Unknown,
+        "the seq-only truncation lane cannot see a same-length rewrite, and the \
+         UNAUTHENTICATED anchor cannot exonerate it → Unknown; report={report:?}"
+    );
+    match &report.head_hash {
+        HeadHashCheck::Mismatch { chain, .. } => assert_eq!(chain, "signed_events"),
+        other => panic!(
+            "head-hash conviction must fire on the UNAUTHENTICATED anchor, \
+             got {other:?}; report={report:?}"
+        ),
+    }
+    assert!(
+        !report.is_clean(),
+        "a head-hash mismatch is NOT clean regardless of authentication; \
+         report={report:?}"
+    );
+
+    forensic::shutdown();
+}
+
+// -----------------------------------------------------------------
+// (legacy) NO pin + UNSIGNED watermark + clean chain → NotDetected.
+// Enrollment-gated: with no out-of-band authority the pre-L7 trust-the-anchor
+// behaviour is byte-preserved (the audit_truncation_anchor_1850 posture).
+// -----------------------------------------------------------------
+
+#[test]
+fn no_pin_preserves_legacy_exoneration_l7() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("legacy-forensic");
+    let ddir = fresh_dir("legacy-db");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let (_path, conn) = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    anchor_real_head(&conn);
+
+    // No pin threaded (`None`) → the asymmetry does not engage; an unsigned
+    // watermark on a clean chain exonerates exactly as it did pre-L7.
+    let report = verify_audit_trail(&conn, None, None).expect("verify");
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::NotDetected,
+        "no pin → legacy trust-the-anchor exoneration preserved; report={report:?}"
+    );
+    assert_eq!(
+        report.head_hash,
+        HeadHashCheck::NotDetected,
+        "no pin → legacy head-hash exoneration preserved; report={report:?}"
+    );
+    assert!(
+        report.is_clean(),
+        "no pin + clean chain + matching anchor is a clean all-clear; report={report:?}"
+    );
+
+    forensic::shutdown();
+}


### PR DESCRIPTION
## What this does

L7 of the forensic-audit-trail hardening wave: the audit-trail verifier now STOPS EXONERATING on an unauthenticated forensic watermark while it still CONVICTS on one.

`verify_audit_trail`'s off-table #1850 watermark (`last_audit_watermark`) fed BOTH directions — `TruncationCheck::{Detected,NotDetected}` and the forensic-watermark `HeadHashCheck::{Mismatch,NotDetected}`. On an UNSIGNED daemon (a hostile host that strips the daemon signature) that anchor is unauthenticated, so trusting it to render `NotDetected` / a clean bill of health is a forged all-clear.

New control:
- `governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey)` — the guard fn. Returns `true` only when the exonerating lanes may render clean: no out-of-band `AI_MEMORY_AUDIT_PUBKEY` pin enrolled (legacy trust-the-anchor), OR the forensic watermark row carries a non-empty Ed25519 signature that verifies against the pin AND its prev_hash chain is intact (whole-chain `verify_since` under the pin — no reimplemented crypto; `verify_strict` rejects malleable sigs). Expressed as a guard fn so a `return true` mutation flips the lane clean (removal-proof-able).
- `signed_events::exoneration_gated_head_hash(verdict, exonerate_ok)` — pure gate that downgrades a forensic-watermark `HeadHashCheck::NotDetected` to `Unknown` when exoneration is not authenticated; `Mismatch`/`Unknown` pass through unchanged.

The CONVICTING direction keeps reading the raw unauthenticated `last_audit_watermark`, so a stripped signature can only DEGRADE a clean verdict to WITHHELD (`Unknown`) — never SUPPRESS a truncation/rewrite conviction.

## The four repointed watermark-reader sites (same PR)

The prompt's line anchors had shifted after PR-3; the watermark-reader consumer sites are:
- `src/signed_events.rs` `verify_audit_trail` — truncation lane (was ~:2180, now ~:2421) → gated exoneration.
- `src/signed_events.rs` `verify_audit_trail` — forensic head-hash sub-lane (was ~:2369, now ~:2627) → `exoneration_gated_head_hash`.
- `src/store/postgres.rs` `PostgresStore::verify_audit_trail` — truncation lane (was ~:12181, now ~:12233).
- `src/store/postgres.rs` `PostgresStore::verify_audit_trail` — forensic head-hash sub-lane (was ~:12486, now ~:12559).

Both backends call the SAME backend-neutral guard + SAME pure gate over the on-host forensic sink → identical verdicts (K3 parity). The witness dual-head sub-lane is untouched (already K1-pin + signature gated via `verified_witness_dual_head`). No new `security_profile::KNOBS` entry.

## Acceptance criterion

`tests/audit_truncation_anchor_1850.rs` is **byte-unmodified** (not in this changeset — `git status` shows no entry for it). It inits the sink UNSIGNED with no pin and asserts `Detected` / `NotDetected`; because the control is enrollment-gated (no pin → legacy behaviour) the convicting path and the no-pin exonerating path are byte-preserved, so it passes unchanged.

## Tests

New `tests/audit_exoneration_asymmetry_l7.rs`:
- `authenticated_watermark_under_pin_exonerates_l7` — pin + watermark signed by the pinned key → `NotDetected` (control does not over-withhold).
- `unauthenticated_watermark_under_pin_withholds_exoneration_l7` — pin + UNSIGNED watermark + clean chain → both lanes `Unknown` (the §5.4.5 removal-proof lane test).
- `unauthenticated_watermark_still_convicts_truncation_l7` — pin + UNSIGNED watermark + truncated DB → `Detected`.
- `unauthenticated_watermark_still_convicts_head_rewrite_l7` — pin + UNSIGNED watermark + same-length head rewrite → `Mismatch`.
- `no_pin_preserves_legacy_exoneration_l7` — no pin + UNSIGNED watermark + clean chain → `NotDetected` (legacy preserved).

Removal-proof row added to `scripts/check-cert-removal-proof.sh` (`return`-shape, `return true;`): mutating the guard reds the withhold lane test.

## CI note

GitHub Actions is HALTED repo-wide, so CI will not run on this PR. Per the wave protocol, Fable validates locally (full suite `--features sal` + `--features sal-postgres` under `umask 022`, the `audit_truncation_anchor_1850` regression unmodified, `cargo check --examples`, clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` across all feature legs, the removal-proof RED-on-mutate/GREEN-on-revert transcript, and K3 parity). Local `cargo check --all-targets --features sal` is green in the worktree.

Closes #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
