### PR TITLE
fix(d1): pin pg consolidation invariants + removal-proof; correct stale capabilities kind-count comment

### DIFF
--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -34,6 +34,20 @@
 #                  <mutation-payload> — neutralizes a control expressed as a
 #                  multi-term `&&` guard or a multi-branch verdict fn, where a
 #                  single injected first statement cannot bypass every arm.
+#   shape=subst  : literal find/replace ONE unique occurrence of <OLD> with
+#                  <NEW>, where <mutation-payload> = "<OLD>>>><NEW>" (the `>>>`
+#                  delimiter never appears in Rust). Neutralizes a control that
+#                  is a SINGLE FIELD BINDING / expression buried mid-function
+#                  (not a whole guard fn) — e.g. the consolidate builder's
+#                  `confidence` floor or `memory_kind` stamp, where neither a
+#                  first-statement return nor a whole-body swap can target the
+#                  one binding without breaking the surrounding function. <NEW>
+#                  MUST embed the `// CERT-REMOVAL-PROOF-MUTATION` marker (the
+#                  harness greps it to confirm the edit landed + a clean
+#                  revert). The `<ctl>` column is a descriptive control LABEL
+#                  (the function locator is not used for this shape). A payload
+#                  whose <OLD> matches 0 or >1 sites is a hard error (exit 3) so
+#                  a subst can never silently over-mutate.
 #
 # SAFETY: mutations are applied in-place then reverted via `git checkout --`.
 # The dirty-working-tree guard is PER ROW — each row refuses only when ITS OWN
@@ -78,6 +92,18 @@ MAP=(
   # not merely that the code is reached. Neutralization => is_clean stays true
   # under the pin => the guard test's dirty assertion goes RED.
   "compute_signature_verdict|body|SignatureCheck::Unenforced { checked: 0, unverified: 0 }|src/signed_events.rs|audit_signature_pin_l4|downgraded_lineage_row_under_pin_dirties_l4"
+  # D1 (2x7 re-audit) — consolidation-laundering closure (#2935/#2936). The
+  # controls are two SINGLE BINDINGS in the sqlite `db::consolidate` builder,
+  # not guard fns, so they use the `subst` shape (return/body cannot target one
+  # field without breaking the function). Row 1 neutralizes the confidence
+  # FLOOR (relaxes the running min back to a hardcoded 1.0 => the laundering
+  # regression); row 2 neutralizes the derived-KIND stamp (Claim => Observation).
+  # The lane test (`trust_propagation_1958_1959.rs`, SQLite in-memory — no live
+  # PG needed) asserts BOTH invariants, so either mutation reds it. The pg twin
+  # (`src/store/postgres.rs`) is END-TO-END pinned by
+  # cov_postgres_governance.rs::consolidate_merges_sources against a live PG.
+  "consolidate_confidence_floor_2935|subst|min_confidence = min_confidence.min(mem.confidence);>>>min_confidence = min_confidence.min(1.0); // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
+  "consolidate_derived_kind_2935|subst|memory_kind: crate::models::MemoryKind::Claim,>>>memory_kind: crate::models::MemoryKind::Observation, // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
 )
 
 # Apply MUTATION to function CTL in TARGET, per SHAPE.
@@ -98,6 +124,23 @@ payload = os.environ["CERT_PAYLOAD"]
 MARK    = " // CERT-REMOVAL-PROOF-MUTATION"
 
 lines = open(path).read().splitlines(keepends=True)
+
+# subst — literal find/replace of ONE unique <OLD> with <NEW>. The function
+# locator below is not used for this shape (the control is a mid-function
+# binding, not a `pub fn`). A payload matching 0 or >1 sites is a hard error so
+# a subst can never silently over-mutate.
+if shape == 'subst':
+    old, sep, new = payload.partition('>>>')
+    if not sep:
+        sys.stderr.write("subst payload missing '>>>' delimiter\n")
+        sys.exit(3)
+    text = ''.join(lines)
+    n = text.count(old)
+    if n != 1:
+        sys.stderr.write("subst OLD matched %d sites (want exactly 1)\n" % n)
+        sys.exit(3)
+    open(path, 'w').write(text.replace(old, new, 1))
+    sys.exit(0)
 
 # Locate `[pub] fn <ctl>` signature line.
 sig = re.compile(r'^\s*(?:pub(?:\([^)]*\))?\s+)?fn %s\b' % re.escape(ctl))
@@ -221,6 +264,25 @@ RS
     echo "  [ok] body-shape: whole body replaced, braces balanced"
   else
     echo "  [FAIL] body-shape did not rewrite as expected"; rc=1
+  fi
+
+  # subst shape — one unique OLD replaced with NEW (marker embedded).
+  cp "$fx" "$dir/subst.rs"
+  apply_mutation subst_label subst "return false;>>>return true; // CERT-REMOVAL-PROOF-MUTATION" "$dir/subst.rs"
+  if grep -q "return true; // CERT-REMOVAL-PROOF-MUTATION" "$dir/subst.rs" \
+     && ! grep -q "return false;" "$dir/subst.rs"; then
+    echo "  [ok] subst-shape: unique OLD replaced, marker embedded"
+  else
+    echo "  [FAIL] subst-shape did not rewrite as expected"; rc=1
+  fi
+
+  # subst shape — a non-unique OLD (2 sites) MUST hard-error (never over-mutate).
+  cp "$fx" "$dir/subst-dup.rs"
+  printf 'pub fn a() { let x = 1; }\npub fn b() { let x = 1; }\n' >"$dir/subst-dup.rs"
+  if apply_mutation subst_label subst "let x = 1;>>>let x = 2;" "$dir/subst-dup.rs" 2>/dev/null; then
+    echo "  [FAIL] subst-shape accepted a non-unique OLD (should exit 3)"; rc=1
+  else
+    echo "  [ok] subst-shape: non-unique OLD rejected (exit 3)"
   fi
 
   echo

--- a/tests/capabilities_v3_l3_5.rs
+++ b/tests/capabilities_v3_l3_5.rs
@@ -314,13 +314,21 @@ fn cap_v3_l3_5_memory_kinds_reports_real_implemented_set_only() {
         .as_array()
         .expect("memory_kinds must be an array under v3");
     let kinds: Vec<&str> = kinds.iter().filter_map(Value::as_str).collect();
-    // Substrate truth — MemoryKind enum carries only these two variants
-    // as of v0.7.0. The grand-slam spec called for a third "goal" kind
-    // but the enum doesn't define it; honest reporting omits it.
+    // Substrate truth — the `MemoryKind` enum carries 16 variants at v1.0.0
+    // (`MemoryKind::all()`: the 10 Form-6 kinds + Goal/Plan/Step from v0.8.0
+    // Pillar-2 typed-cognition #1709 + Told/Instruction/Intervention from
+    // v1.0.0 epistemic typing #1945 — `goal` IS defined). This `memory_kinds`
+    // field, however, is a LEGACY back-compat wire element that reports only
+    // the original two kinds the v3 envelope froze; it is deliberately NOT the
+    // full enum. The pinned `["observation", "reflection"]` value below is that
+    // frozen two-kind wire contract — widening it to the full 16-kind set is a
+    // separate voted wire-shape change (T1), not a comment fix. This test pins
+    // the frozen field so an accidental widen (or a regression to a
+    // theatrical/nonexistent kind) reds here.
     assert_eq!(
         kinds,
         vec!["observation", "reflection"],
-        "memory_kinds must enumerate the actual MemoryKind variants, not theatrical ones"
+        "memory_kinds must enumerate the frozen legacy wire kinds, not theatrical ones"
     );
 }
 

--- a/tests/cov_postgres_governance.rs
+++ b/tests/cov_postgres_governance.rs
@@ -313,14 +313,14 @@ async fn consolidate_merges_sources() {
     let ns = uid("cov-consol");
     let a = uid("ca");
     let b = uid("cb");
-    store
-        .store(&ctx, &mem(&a, &ns, "source a", "abody", "ai:cov4"))
-        .await
-        .unwrap();
-    store
-        .store(&ctx, &mem(&b, &ns, "source b", "bbody", "ai:cov4"))
-        .await
-        .unwrap();
+    // v1.0.0 #2935 — DISTINCT source confidences so the min (0.6) is
+    // DISTINGUISHABLE from the pre-#2935 hardcoded-1.0 laundering regression.
+    let mut ma = mem(&a, &ns, "source a", "abody", "ai:cov4");
+    ma.confidence = 0.6;
+    let mut mb = mem(&b, &ns, "source b", "bbody", "ai:cov4");
+    mb.confidence = 0.7;
+    store.store(&ctx, &ma).await.unwrap();
+    store.store(&ctx, &mb).await.unwrap();
     let new_id = store
         .consolidate(
             &ctx,
@@ -336,6 +336,29 @@ async fn consolidate_merges_sources() {
         .expect("consolidate");
     let got = store.get(&ctx, &new_id).await.expect("get consolidated");
     assert_eq!(got.title, "consolidated");
+    // v1.0.0 #2935 (R20 residual) — pg parity with the sqlite consolidate
+    // builder (`storage::consolidate_confidence_is_min_of_sources_2935`): a
+    // derived synthesis must NOT launder low-confidence sources into a
+    // maximally-certain 1.0 summary. Without these asserts a future refactor
+    // could silently regress the pg builder to `confidence = 1.0` /
+    // `memory_kind = Observation` while the sqlite unit test alone stayed
+    // green. confidence == min(0.6, 0.7) == 0.6 (NOT 1.0); `<= 0.6` so a
+    // future policy deriving an even lower value still passes (never inflates)
+    // and strictly-below-1.0 so a hardcoded-1.0 builder reds here.
+    assert!(
+        got.confidence <= 0.6 + f64::EPSILON,
+        "consolidated confidence {} exceeded min(source)=0.6 (pg laundering regression)",
+        got.confidence
+    );
+    assert!((got.confidence - 0.6).abs() < 1e-9);
+    // A consolidation is a DERIVED synthesis — `Claim` (vote 4d3ea1c5), never
+    // a first-hand `Observation` (the laundering defect).
+    assert_eq!(
+        got.memory_kind,
+        MemoryKind::Claim,
+        "consolidated memory_kind should be Claim (derived), got {:?}",
+        got.memory_kind
+    );
 }
 
 #[tokio::test]

--- a/tests/trust_propagation_1958_1959.rs
+++ b/tests/trust_propagation_1958_1959.rs
@@ -200,6 +200,67 @@ fn consolidate_sibling_merge_takes_the_min() {
     lineage_off();
 }
 
+/// v1.0.0 #2935 (R20 residual) — the confidence-VALUE + derived-KIND
+/// laundering closure, pinned on the SQLite `db::consolidate` builder and
+/// GUARDED by the removal-proof harness
+/// (`scripts/check-cert-removal-proof.sh` rows `consolidate_confidence_floor_2935`
+/// / `consolidate_derived_kind_2935`). Distinct from
+/// `consolidate_stamps_min_propagated_trust` above, which pins the orthogonal
+/// trust-TIER floor: this pins the confidence-FLOAT floor + the memory-kind
+/// stamp. A consolidated (derived) memory must NOT launder low-confidence
+/// source claims into a maximally-certain 1.0 summary — its confidence ==
+/// min(source confidences), NEVER a hardcoded 1.0 — and its memory_kind is
+/// `Claim` (a derived synthesis), NEVER a first-hand `Observation`. Distinct
+/// source confidences (0.6, 0.7) make the min (0.6) DISTINGUISHABLE from the
+/// 1.0 regression: a hardcoded-1.0 builder reds this test.
+#[test]
+fn consolidate_floors_confidence_and_stamps_claim_2935() {
+    let _g = flag_guard();
+    lineage_on();
+    let conn = open_mem_db();
+
+    let a = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+    let b = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    let mut lo = mem_with_attest(a, "A", "2026-01-01T00:00:00+00:00", None);
+    lo.confidence = 0.6;
+    let mut hi = mem_with_attest(b, "B", "2026-01-02T00:00:00+00:00", None);
+    hi.confidence = 0.7;
+    db::insert(&conn, &lo).unwrap();
+    db::insert(&conn, &hi).unwrap();
+
+    let cid = db::consolidate(
+        &conn,
+        &[a.to_string(), b.to_string()],
+        "merged-2935",
+        "merged summary",
+        "ns",
+        &Tier::Long,
+        "test",
+        "ai:consolidator",
+        false,
+    )
+    .expect("consolidate");
+
+    let merged = db::get(&conn, &cid).unwrap().expect("consolidated row");
+    // confidence == min(0.6, 0.7) == 0.6; `<= 0.6` so a future policy deriving
+    // an even lower value still passes (never inflates), and strictly below
+    // 1.0 so a hardcoded-1.0 laundering builder reds here.
+    assert!(
+        merged.confidence <= 0.6 + f64::EPSILON,
+        "consolidated confidence {} exceeded min(source)=0.6 (laundering regression)",
+        merged.confidence
+    );
+    assert!((merged.confidence - 0.6).abs() < 1e-9);
+    // A derived synthesis is `Claim`, never a first-hand `Observation`.
+    assert_eq!(
+        merged.memory_kind,
+        ai_memory::models::MemoryKind::Claim,
+        "consolidated memory_kind should be Claim (derived), got {:?}",
+        merged.memory_kind
+    );
+    lineage_off();
+}
+
 #[test]
 fn propagated_trust_tier_bounds_by_low_ancestor() {
     let _g = flag_guard();


### PR DESCRIPTION
## Summary

Two small hardening fixes from the 2×7 re-audit. **GitHub Actions is HALTED repo-wide**, so CI does not run here — the evidence below is first-hand local validation (R-203) substituting for CI.

### FIX 1 — D1: mechanically pin the pg side of the #2935/#2936 consolidation-laundering closure

The postgres test `consolidate_merges_sources` (`tests/cov_postgres_governance.rs`) asserted **only** `title == "consolidated"`. It did **not** assert the #2935/#2936 data-integrity invariants on postgres, so a future refactor could silently regress the pg builder to a hardcoded `confidence = 1.0` / `memory_kind = Observation` (the exact laundering vector #2935 closed) while the sqlite unit test alone stayed green.

- **`tests/cov_postgres_governance.rs::consolidate_merges_sources`** — now stores two sources with **distinct** confidences (0.6, 0.7) and asserts the consolidated row has `confidence == min(sources) == 0.6` (**not** 1.0) and `memory_kind == Claim` (**not** Observation). This is the live-PG end-to-end pg parity to the sqlite `storage::consolidate_confidence_is_min_of_sources_2935` invariant. Distinct confidences make the min (0.6) *distinguishable* from the 1.0 regression. The pg builder (`src/store/postgres.rs`) already binds these correctly (`confidence: min_confidence`, `memory_kind: Claim`); this test pins them.
- **`tests/trust_propagation_1958_1959.rs::consolidate_floors_confidence_and_stamps_claim_2935`** — a new SQLite in-memory lane test (distinct 0.6/0.7 source confidences) asserting both invariants, so the removal-proof harness (which runs guards via `cargo test --test`) has a reachable guard. The existing #2935 assert is a lib **unit** test, unreachable via `--test`.
- **`scripts/check-cert-removal-proof.sh`** — adds a `subst` mutation shape (literal find/replace of **one** unique binding; hard-errors on 0 or >1 matches so it can never silently over-mutate) plus two rows that neutralize the sqlite `db::consolidate` confidence floor (`min(mem.confidence)` → `min(1.0)`) and the derived-kind stamp (`Claim` → `Observation`), proving the lane test goes RED. Consolidation-laundering is now a **load-bearing, removal-proof-guarded** control. `--self-test` exercises the new shape (rewrite + non-unique rejection), no cargo.

### FIX 2 — D4 doc-drift: correct a stale/false pinning-test comment

`tests/capabilities_v3_l3_5.rs` claimed the `MemoryKind` enum *"carries only these two variants"* and *"doesn't define goal"*. Both are false: `MemoryKind::all()` enumerates **16** variants and `Goal` **is** defined. The comment now explains that the `memory_kinds` capabilities field is a **legacy back-compat wire element** (`default_memory_kinds()` returns a fixed `["observation", "reflection"]`), not a projection of the enum.

**Pure comment/doc change** — the pinned value `vec!["observation", "reflection"]` is **unchanged**; the 2→16 wire-shape widen is a separate voted PR.

## Data-integrity note

No product-behavior or security surface is touched (test files + a test-harness script + one comment). The change strengthens a data-integrity invariant (never launder low-confidence sources into a maximally-certain derived summary) by making it removal-proof-guarded on the postgres backend as well as sqlite. No `security_profile::KNOBS` change.

## R-203 local evidence (Actions down — CI substitute)

- **New sqlite lane test GREEN**: `cargo test --features sal --test trust_propagation_1958_1959 consolidate_floors_confidence_and_stamps_claim_2935 -- --exact` → `test result: ok. 1 passed`.
- **Removal-proof RED/GREEN** (both new rows), under `( umask 022; … )`:
  - `consolidate_confidence_floor_2935` → `[PROVEN] control is load-bearing: broken→RED (rc=101), restored→GREEN (rc=0)`
  - `consolidate_derived_kind_2935` → `[PROVEN] control is load-bearing: broken→RED (rc=101), restored→GREEN (rc=0)`
  - Tree clean after the proof (no leftover mutation; per-row dirty-guard verified working).
- **Harness `--self-test`**: PASS — return/body/subst shapes all rewrite as intended; non-unique `subst` OLD correctly rejected (exit 3).
- **clippy** (exact CI flags `-D warnings -D clippy::all -D clippy::pedantic`), `--all-targets`: **default leg** clean (exit 0); **sal-postgres leg** clean (exit 0). Both cover the touched test files (`capabilities_v3_l3_5`, `trust_propagation_1958_1959` on default; `cov_postgres_governance` on sal-postgres).
- **fmt**: `cargo fmt --all` clean.
- `cargo check --examples` unaffected: this PR changes only test files, one comment, and a bash script — no library/example source.

> The pg assertion path (`consolidate_merges_sources`) is `#[ignore]` + `sal-postgres` and runs only against a live PG (`AI_MEMORY_TEST_POSTGRES_URL`); it compiles clean under the sal-postgres clippy leg here. The pg builder was read directly to confirm the expected values (`confidence: min_confidence`, `memory_kind: Claim`).

**Do not merge** — Fable review + audit gate. No tag-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY