### PR TITLE
fix(F-L8a): additive in-band recall metadata for embedding-space-mismatch withheld rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (F-L8a — in-band `meta.semantic_withheld` recall signal for embedding-space-mismatch withheld rows; #2167 follow-up)
+
+- **Recall now reports, in-band, how many rows were withheld from SEMANTIC
+  scoring this query** — a new ADDITIVE `meta.semantic_withheld` block on the
+  recall response. The #2167 correctness danger is already CLOSED (a foreign
+  VERIFIED space, an UNVERIFIED `embedding_space IS NULL` space, or a
+  dimensionality mismatch excludes a stored vector from scoring and keeps it
+  keyword-recallable), but the response still reported `mode:"hybrid"` with NO
+  signal that `N` rows were served keyword-only. On MCP stdio there is no
+  `/metrics`, so the daemon's tracing WARN was invisible to a JSON-only NHI —
+  this block is the only introspectable channel. The exclusion counters were
+  ALREADY computed (`RecallTelemetry.{embedding_space_mismatch,
+  embedding_unverified_space,embedding_dim_mismatch}`) and dropped before
+  serialization; the block is populated from them (no recompute). `mode` is
+  UNCHANGED (still `"hybrid"`) — this is purely additive and non-breaking.
+  Shape: `{ measured, space_mismatch, unverified_space, dim_mismatch, total }`
+  (the three cause counters + their sum). **Wired on all three surfaces** — the
+  MCP `memory_recall` tool, the HTTP `/api/v1/recall` sqlite path (which now
+  threads `recall_hybrid_with_telemetry_precomputed_hnsw`), and the
+  `ai-memory recall` CLI (JSON output + a concise stderr note when > 0). K3
+  parity: the sqlite paths are MEASURED (`measured:true`, explicit counts — a
+  `0` is a truthful "nothing withheld"); the postgres SAL recall path excludes
+  foreign-space rows in SQL (`AND embedding_space = $fp`) but does not COUNT
+  them, so it emits `{measured:false}` with the numeric fields OMITTED rather
+  than a fabricated `0` (North Star: DEGRADE, never a WRONG result). Real
+  postgres per-query counting is tracked as a follow-up. Additive to the
+  `RecallMeta` wire shape (`src/models/memory.rs`); crossroads T1 resolved by
+  the 5-agent adversarial vote (`4d3ea1c5`), D-MCP-PRIMARY 4/5. Pinned by
+  `tests/recall_semantic_withheld_fl8a.rs`.
+
 ### Fixed (append-only revision spine was dead code — `AI_MEMORY_APPEND_ONLY` is now live; #1823 / PR-2)
 
 - **`AI_MEMORY_APPEND_ONLY=1` and `[storage].append_only=true` were BOTH inert

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -396,8 +396,11 @@ pub(crate) fn run_with_embedder(
     let resolved_ttl = app_config.effective_ttl();
     let resolved_scoring = app_config.effective_scoring();
 
-    // Perform recall: hybrid if embedder available, keyword otherwise
-    let (results, outcome, mode) = if let Some(emb) = embedder {
+    // Perform recall: hybrid if embedder available, keyword otherwise.
+    // F-L8a — the 4th tuple element is the recall telemetry carrying the
+    // space/unverified/dim rows withheld from semantic scoring; the keyword
+    // branches contribute a zeroed telemetry (no semantic scoring ran).
+    let (results, outcome, mode, telemetry) = if let Some(emb) = embedder {
         // v1.0.0 #2577 — bounded funnel (cache -> wall-clock budget ->
         // degrade-to-keyword), shared with the HTTP + MCP recall surfaces.
         match crate::embeddings::recall_query_embedding(emb, &args.context) {
@@ -422,7 +425,7 @@ pub(crate) fn run_with_embedder(
                     }
                     _ => primary_emb,
                 };
-                let (results, outcome) = db::recall_hybrid(
+                let (results, outcome, telemetry) = db::recall_hybrid_with_telemetry(
                     conn,
                     &args.context,
                     &query_emb,
@@ -454,9 +457,10 @@ pub(crate) fn run_with_embedder(
                         ce.rerank(&args.context, results),
                         outcome,
                         crate::models::RECALL_MODE_HYBRID_RERANK,
+                        telemetry,
                     )
                 } else {
-                    (results, outcome, "hybrid")
+                    (results, outcome, "hybrid", telemetry)
                 }
             }
             None => {
@@ -484,7 +488,12 @@ pub(crate) fn run_with_embedder(
                     vis_caller.as_deref(),
                     args.valid_at.as_deref(),
                 )?;
-                (results, outcome, "keyword")
+                (
+                    results,
+                    outcome,
+                    "keyword",
+                    crate::models::RecallTelemetry::default(),
+                )
             }
         }
     } else {
@@ -505,7 +514,12 @@ pub(crate) fn run_with_embedder(
             vis_caller.as_deref(),
             args.valid_at.as_deref(),
         )?;
-        (results, outcome, "keyword")
+        (
+            results,
+            outcome,
+            "keyword",
+            crate::models::RecallTelemetry::default(),
+        )
     };
 
     // v0.7.0 Form 4 (issue #757) — fact-provenance post-filter.
@@ -588,8 +602,43 @@ pub(crate) fn run_with_embedder(
                 "budget_overflow": outcome.budget_overflow,
             });
         }
+        // F-L8a — fold the MEASURED semantic-withheld block into `meta`
+        // (creating it if the budget sub-block above did not), so a
+        // JSON-consuming CLI caller sees in-band when `mode:"hybrid"`
+        // scored fewer rows than the corpus holds. CLI recall is a
+        // MEASURED sqlite funnel.
+        let sw = crate::models::SemanticWithheld::measured(&telemetry);
+        let sw_value = serde_json::to_value(&sw).unwrap_or(serde_json::Value::Null);
+        let meta = body
+            .as_object_mut()
+            .expect("recall body is always a JSON object")
+            .entry("meta".to_string())
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(obj) = meta.as_object_mut() {
+            obj.insert("semantic_withheld".to_string(), sw_value);
+        }
         writeln!(out.stdout, "{}", serde_json::to_string(&body)?)?;
         return Ok(());
+    }
+    // F-L8a — human-readable path: a concise stderr note when rows were
+    // withheld from semantic scoring this query, so an operator running
+    // `ai-memory recall` sees the same in-band degrade signal the JSON
+    // caller gets (no `/metrics` on a one-shot CLI).
+    {
+        let withheld = telemetry.embedding_space_mismatch
+            + telemetry.embedding_unverified_space
+            + telemetry.embedding_dim_mismatch;
+        if withheld > 0 {
+            writeln!(
+                out.stderr,
+                "ai-memory: {withheld} row(s) withheld from semantic scoring \
+                 (space_mismatch={}, unverified_space={}, dim_mismatch={}); \
+                 kept keyword-recallable. Run `ai-memory reembed` to heal.",
+                telemetry.embedding_space_mismatch,
+                telemetry.embedding_unverified_space,
+                telemetry.embedding_dim_mismatch,
+            )?;
+        }
     }
     if results.is_empty() {
         writeln!(out.stderr, "no memories found for: {}", args.context)?;
@@ -683,6 +732,32 @@ mod tests {
         let stdout = env.stdout_str();
         assert!(stdout.contains("needle title"), "got: {stdout}");
         assert!(stdout.contains("[keyword]"), "got: {stdout}");
+    }
+
+    #[test]
+    fn test_recall_json_emits_semantic_withheld_meta_fl8a() {
+        // F-L8a — the CLI JSON envelope MUST carry the additive
+        // `meta.semantic_withheld` block so a JSON-consuming CLI caller has
+        // the same in-band withheld signal MCP/HTTP gained. Keyword tier
+        // (no embedder) is a MEASURED sqlite funnel with no semantic
+        // scoring, so the block is present, `measured:true`, and a truthful
+        // zero.
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        seed_memory(&db, "test", "needle title", "haystack content");
+        let args = default_args();
+        let cfg = AppConfig::default();
+        {
+            let mut out = env.output();
+            run(&db, &args, true, &cfg, &mut out).unwrap();
+        }
+        let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+        let sw = &v["meta"]["semantic_withheld"];
+        assert_eq!(sw["measured"], serde_json::json!(true), "got: {v}");
+        assert_eq!(sw["total"], serde_json::json!(0), "got: {sw}");
+        assert_eq!(sw["space_mismatch"], serde_json::json!(0));
+        assert_eq!(sw["unverified_space"], serde_json::json!(0));
+        assert_eq!(sw["dim_mismatch"], serde_json::json!(0));
     }
 
     #[test]

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -347,6 +347,26 @@ fn maybe_apply_rerank<'m>(
     }
 }
 
+/// F-L8a — fold the `semantic_withheld` block into the recall response's
+/// `meta` object (creating it if absent), preserving any budget sub-block
+/// already merged. Shared by the sqlite (MEASURED) and postgres
+/// (UNMEASURED) HTTP recall branches so the wire key is present on both
+/// backends. See [`crate::models::SemanticWithheld`].
+fn merge_semantic_withheld_meta(
+    resp: &mut serde_json::Value,
+    sw: &crate::models::SemanticWithheld,
+) {
+    let value = serde_json::to_value(sw).unwrap_or(serde_json::Value::Null);
+    let meta = resp
+        .as_object_mut()
+        .expect("recall response is always a JSON object")
+        .entry("meta".to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(obj) = meta.as_object_mut() {
+        obj.insert("semantic_withheld".to_string(), value);
+    }
+}
+
 async fn recall_response(
     app: &AppState,
     req: &RecallRequest,
@@ -657,6 +677,17 @@ async fn recall_response(
                 if let Some(b) = budget_tokens {
                     resp[field_names::BUDGET_TOKENS] = json!(b);
                 }
+                // F-L8a — the postgres SAL `recall_hybrid` excludes foreign
+                // / unverified-space rows in SQL (`AND embedding_space=$fp`)
+                // but does NOT count them, so no per-query withheld counter
+                // exists on this path today. Emit the block honestly as
+                // UNMEASURED (numeric fields omitted) rather than fabricate a
+                // `0` that could read as "nothing withheld" — the North-Star
+                // "never a WRONG result". Real pg counting is a follow-up.
+                merge_semantic_withheld_meta(
+                    &mut resp,
+                    &crate::models::SemanticWithheld::unmeasured(),
+                );
                 // #1839 G31 — observe recall latency (postgres path), labeled
                 // by the final post-rerank `mode`.
                 crate::metrics::record_recall(mode, recall_started.elapsed().as_secs_f64());
@@ -826,7 +857,11 @@ async fn recall_response(
             let hits = hits_owned
                 .as_deref()
                 .expect("precomputed_hits set when query_emb is Some");
-            let r = db::recall_hybrid_precomputed_hnsw(
+            // F-L8a — telemetry-bearing variant so the recall response can
+            // surface the space/unverified/dim rows withheld from semantic
+            // scoring (the base `recall_hybrid_precomputed_hnsw` wrapper
+            // drops the telemetry). MEASURED sqlite funnel.
+            let r = db::recall_hybrid_with_telemetry_precomputed_hnsw(
                 conn,
                 &ctx_owned,
                 qe,
@@ -856,6 +891,10 @@ async fn recall_response(
             );
             (r, crate::models::RECALL_MODE_HYBRID)
         } else {
+            // Keyword-only: no semantic scoring ran, so nothing was
+            // withheld from it — a zeroed telemetry is the truthful
+            // MEASURED value (F-L8a). Append it so both branches share the
+            // (rows, outcome, telemetry) shape.
             let r = db::recall(
                 conn,
                 &ctx_owned,
@@ -872,7 +911,8 @@ async fn recall_response(
                 source_uri_owned.as_deref(),
                 caller_owned.as_deref(),
                 valid_at_owned.as_deref(),
-            );
+            )
+            .map(|(rows, outcome)| (rows, outcome, crate::models::RecallTelemetry::default()));
             (r, crate::models::RECALL_MODE_KEYWORD)
         }
     })
@@ -881,7 +921,7 @@ async fn recall_response(
     // PHASE 2 (writer) — authoritative touch + recall_observations
     // ledger, batched under one brief writer lock. Mirrors the postgres
     // branch's post-response touch + #1705 ledger.
-    if let Ok((rows, _)) = result.as_ref() {
+    if let Ok((rows, _, _)) = result.as_ref() {
         #[allow(clippy::cast_possible_wrap)]
         let recorded: Vec<(String, i64, f64)> = rows
             .iter()
@@ -923,7 +963,7 @@ async fn recall_response(
     }
 
     match result {
-        Ok((r, outcome)) => {
+        Ok((r, outcome, telemetry)) => {
             // v0.7.0 Form 4 (issue #757) — fact-provenance post-filter.
             // Stage (c) — these post-filters run on OWNED Memory rows;
             // no DB connection needed. The lock is already dropped.
@@ -1032,6 +1072,14 @@ async fn recall_response(
                     "budget_overflow": outcome.budget_overflow,
                 });
             }
+            // F-L8a — always surface the MEASURED semantic-withheld block
+            // (folded into `meta`, alongside any budget sub-block above) so
+            // a JSON-only NHI hitting the sqlite HTTP recall sees in-band
+            // when `mode:"hybrid"` scored fewer rows than the corpus holds.
+            merge_semantic_withheld_meta(
+                &mut resp,
+                &crate::models::SemanticWithheld::measured(&telemetry),
+            );
             // #1839 G31 — observe recall latency (sqlite path), labeled by the
             // final post-rerank `mode`.
             crate::metrics::record_recall(mode, recall_started.elapsed().as_secs_f64());

--- a/src/mcp/tools/recall.rs
+++ b/src/mcp/tools/recall.rs
@@ -9,6 +9,7 @@ use crate::mcp::param_names;
 use crate::mcp::registry::McpTool;
 use crate::models::{
     AttestLevel, CandidateCounts, ConfidenceTier, Memory, MemoryKind, RecallMeta, RecallTelemetry,
+    SemanticWithheld,
 };
 use crate::observations;
 use crate::reranker::BatchedReranker;
@@ -1163,6 +1164,11 @@ pub fn handle_recall_dto(
                 hnsw: telemetry.hnsw_candidates,
             },
             blend_weight,
+            // F-L8a — MCP recall is a MEASURED sqlite funnel: surface the
+            // already-computed space/unverified/dim exclusion counts so a
+            // JSON-only stdio NHI sees in-band that `mode:"hybrid"` scored
+            // fewer rows semantically than the corpus holds.
+            semantic_withheld: SemanticWithheld::measured(telemetry),
         };
         // Merge into existing meta object rather than replacing — P6's
         // decorate_budget may have already populated budget_* keys here.

--- a/src/models/memory.rs
+++ b/src/models/memory.rs
@@ -2021,6 +2021,20 @@ pub struct RecallMeta {
     /// `keyword_only` mode; otherwise the average semantic weight across
     /// the returned candidates (varies 0.50→0.15 with content length).
     pub blend_weight: f64,
+    /// v1.0.0 F-L8a (#2167 follow-up) — rows WITHHELD from SEMANTIC
+    /// scoring this query because their stored vector could not be
+    /// safely compared against the live query vector: a foreign VERIFIED
+    /// space, an UNVERIFIED (`embedding_space IS NULL`) space, or a
+    /// dimensionality mismatch. Such rows stay KEYWORD-recallable
+    /// (degraded, never invisible) — their semantic cosine was forced to
+    /// `0.0` and excluded from the ranking. The correctness danger is
+    /// already CLOSED (a foreign/unverified vector is never scored); this
+    /// block is the missing IN-BAND signal that `mode:"hybrid"` served
+    /// fewer semantically-scored rows than the corpus holds. A JSON-only
+    /// MCP-stdio NHI has no `/metrics`, so the daemon's tracing WARN is
+    /// invisible to it — this block is the only introspectable channel.
+    /// `mode` is UNCHANGED (still `"hybrid"`); this is additive.
+    pub semantic_withheld: SemanticWithheld,
 }
 
 /// v0.6.3.1 (P3): retrieval-stage candidate counts feeding `RecallMeta`.
@@ -2031,6 +2045,87 @@ pub struct CandidateCounts {
     /// Number of candidates retrieved by HNSW (or linear-scan fallback)
     /// semantic search. `0` in keyword-only mode.
     pub hnsw: usize,
+}
+
+/// v1.0.0 F-L8a (#2167 follow-up) — per-query breakdown of rows withheld
+/// from SEMANTIC scoring, populated from the ALREADY-computed
+/// [`RecallTelemetry`] counters (never recomputed). See
+/// [`RecallMeta::semantic_withheld`].
+///
+/// **Honesty contract (North Star: DEGRADE, never report a WRONG value).**
+/// `measured` distinguishes a path that COUNTS per-query exclusions from
+/// one that does not:
+/// - On a MEASURED recall path (the sqlite MCP / HTTP / CLI recall funnels
+///   that thread [`RecallTelemetry`]) `measured` is `true` and the three
+///   cause counters + `total` are present — an explicit `0` here is a
+///   TRUTHFUL "nothing withheld".
+/// - On an UNMEASURED path (the postgres SAL `recall_hybrid`, which
+///   excludes foreign-space rows in SQL via `AND embedding_space = $fp`
+///   but never counts them) `measured` is `false` and the numeric fields
+///   are OMITTED rather than fabricated as `0` — emitting `0` where rows
+///   were excluded uncounted would be a wrong result on the wire, the
+///   exact failure this signal exists to prevent. Postgres per-query
+///   counting is tracked as a follow-up.
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticWithheld {
+    /// `true` when this recall path counts per-query exclusions and the
+    /// numeric fields below are authoritative; `false` on a backend that
+    /// excludes foreign-space rows without counting them (postgres SAL),
+    /// where the numeric fields are absent.
+    pub measured: bool,
+    /// #2167 — rows VERIFIED in a DIFFERENT embedding space than the
+    /// active embedder's fingerprint (a same-dim model swap the dim gate
+    /// cannot catch). Absent on an unmeasured path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space_mismatch: Option<usize>,
+    /// #2167 — rows with NO provenance token (`embedding_space IS NULL`)
+    /// or an ANN hit whose row-side vector could not be re-verified.
+    /// Absent on an unmeasured path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unverified_space: Option<usize>,
+    /// v0.7.0 H7 — rows whose stored embedding dimensionality disagreed
+    /// with the active embedder model. Absent on an unmeasured path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dim_mismatch: Option<usize>,
+    /// Convenience sum of the three causes above. Absent on an unmeasured
+    /// path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<usize>,
+}
+
+impl SemanticWithheld {
+    /// Build the MEASURED block from the already-computed recall
+    /// telemetry counters. Used by every sqlite recall funnel (MCP / HTTP
+    /// / CLI); a keyword-only recall passes a zeroed [`RecallTelemetry`],
+    /// which is a truthful "no semantic scoring ran, nothing withheld".
+    #[must_use]
+    pub fn measured(telemetry: &RecallTelemetry) -> Self {
+        let total = telemetry.embedding_space_mismatch
+            + telemetry.embedding_unverified_space
+            + telemetry.embedding_dim_mismatch;
+        Self {
+            measured: true,
+            space_mismatch: Some(telemetry.embedding_space_mismatch),
+            unverified_space: Some(telemetry.embedding_unverified_space),
+            dim_mismatch: Some(telemetry.embedding_dim_mismatch),
+            total: Some(total),
+        }
+    }
+
+    /// Build the UNMEASURED block for a backend that excludes foreign-space
+    /// rows without counting them (the postgres SAL recall path). The
+    /// numeric fields are omitted so a consumer never mistakes an
+    /// uncounted exclusion for a measured zero.
+    #[must_use]
+    pub fn unmeasured() -> Self {
+        Self {
+            measured: false,
+            space_mismatch: None,
+            unverified_space: None,
+            dim_mismatch: None,
+            total: None,
+        }
+    }
 }
 
 /// v0.6.3.1 (P3): internal telemetry returned alongside recall results.

--- a/tests/cov3_handlers_sqlite.rs
+++ b/tests/cov3_handlers_sqlite.rs
@@ -283,6 +283,31 @@ async fn recall_get_with_context_is_200() {
     assert_eq!(body["mode"], "keyword");
 }
 
+/// F-L8a — the sqlite HTTP recall branch MUST emit the additive
+/// `meta.semantic_withheld` block (never absent), so a JSON-only HTTP NHI
+/// has the same in-band withheld signal the MCP surface gained. This router
+/// has no embedder, so recall is keyword-only: the block is present, MEASURED
+/// (this is a sqlite funnel that threads telemetry), and a truthful zero —
+/// no semantic scoring ran, so nothing was withheld from it.
+#[tokio::test]
+async fn recall_http_sqlite_emits_semantic_withheld_meta_fl8a() {
+    let (r, _t) = sqlite_router();
+    let (status, body) = get(&r, "/api/v1/recall?context=hello%20world&limit=5").await;
+    assert_eq!(status, StatusCode::OK);
+    let sw = &body["meta"]["semantic_withheld"];
+    assert_eq!(
+        sw["measured"], true,
+        "sqlite HTTP recall is a MEASURED funnel; got: {body}"
+    );
+    assert_eq!(
+        sw["total"], 0,
+        "keyword-only recall withholds nothing from semantic scoring; got: {sw}"
+    );
+    assert_eq!(sw["space_mismatch"], 0);
+    assert_eq!(sw["unverified_space"], 0);
+    assert_eq!(sw["dim_mismatch"], 0);
+}
+
 #[tokio::test]
 async fn recall_get_invalid_as_agent_is_400() {
     let (r, _t) = sqlite_router();

--- a/tests/handler_postgres_branches_fake_pg.rs
+++ b/tests/handler_postgres_branches_fake_pg.rs
@@ -641,6 +641,20 @@ async fn pg_recall_get_envelope() {
         v.get("memories").is_some() || v.get("count").is_some(),
         "{v}"
     );
+    // F-L8a K3 parity — the postgres recall branch carries the SAME
+    // `meta.semantic_withheld` KEY as sqlite, but HONESTLY marks it
+    // UNMEASURED (the pg SAL recall excludes foreign-space rows in SQL
+    // without counting them). The numeric fields are OMITTED rather than
+    // fabricated as 0 — never a WRONG result on the wire.
+    let sw = &v["meta"]["semantic_withheld"];
+    assert_eq!(
+        sw["measured"], false,
+        "postgres recall must report semantic_withheld as UNMEASURED; got: {v}"
+    );
+    assert!(
+        sw.get("space_mismatch").is_none() && sw.get("total").is_none(),
+        "unmeasured pg block must OMIT the numeric fields (no fabricated 0); got: {sw}"
+    );
 }
 
 #[tokio::test]

--- a/tests/recall_semantic_withheld_fl8a.rs
+++ b/tests/recall_semantic_withheld_fl8a.rs
@@ -1,0 +1,336 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! F-L8a (#2167 follow-up) — the in-band `meta.semantic_withheld` recall
+//! signal.
+//!
+//! The correctness danger (recall scoring a foreign / unverified / dim-
+//! mismatched vector) is already CLOSED by #2167 — such rows are excluded
+//! from semantic scoring and stay keyword-recallable. What was MISSING is
+//! an in-band signal that `mode:"hybrid"` served fewer semantically-scored
+//! rows than the corpus holds: on MCP stdio there is no `/metrics`, so the
+//! daemon's tracing WARN is invisible to a JSON-only NHI. This test proves
+//! the additive `meta.semantic_withheld` block populates from the already-
+//! computed recall telemetry when a mismatch occurs, and reports a truthful
+//! measured zero otherwise.
+//!
+//! R-203: at the parent commit `RecallMeta` carried no `semantic_withheld`
+//! field, so `resp["meta"]["semantic_withheld"]` was ABSENT — every
+//! assertion below on that path fails pre-fix.
+//!
+//! Run: `AI_MEMORY_NO_CONFIG=1 cargo test --test recall_semantic_withheld_fl8a`
+
+use ai_memory::config::{ResolvedScoring, ResolvedTtl};
+use ai_memory::db;
+use ai_memory::embeddings::{Embed, embedding_space_fingerprint};
+use ai_memory::mcp::handle_recall;
+use ai_memory::models::{
+    ConfidenceSource, Memory, MemoryKind, RecallTelemetry, SemanticWithheld, Tier,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Fixtures — mirror the #2167 acceptance-test seeding so the withheld counts
+// reconcile with a known population.
+// ---------------------------------------------------------------------------
+
+fn fresh_db() -> (rusqlite::Connection, std::path::PathBuf) {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .join(".local-runs")
+        .join("recall-semantic-withheld-fl8a");
+    std::fs::create_dir_all(&root).ok();
+    let path = root.join(format!("ai-memory-fl8a-{}.db", uuid::Uuid::new_v4()));
+    let conn = db::open(&path).expect("open fresh test db");
+    (conn, path)
+}
+
+fn make_memory(title: &str) -> Memory {
+    let now = chrono::Utc::now().to_rfc3339();
+    Memory {
+        id: format!("fl8a-{}", uuid::Uuid::new_v4()),
+        tier: Tier::Long,
+        namespace: "test".to_string(),
+        title: title.to_string(),
+        // Deliberately no overlap with the recall context token below, so
+        // FTS returns nothing and the SEMANTIC phase is the only source —
+        // the returned set is then exactly the scored set.
+        content: "corpus body no-fts-hit-token".to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({}),
+        reflection_depth: 0,
+        memory_kind: MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        ..Memory::default()
+    }
+}
+
+/// Seed a row with a raw embedding stamped to `space` (via the guarded
+/// `set_embedding`). Returns its id.
+fn seed_embedded(conn: &rusqlite::Connection, title: &str, emb: &[f32], space: &str) -> String {
+    let id = db::insert(conn, &make_memory(title)).unwrap();
+    db::set_embedding(conn, &id, emb, space).unwrap();
+    id
+}
+
+/// Seed a cross-dim row via RAW SQL (bypassing `set_embedding`'s per-
+/// namespace dim guard) so a deliberately dim-mismatched row can co-exist.
+fn seed_embedded_raw(conn: &rusqlite::Connection, title: &str, emb: &[f32], space: &str) -> String {
+    let id = db::insert(conn, &make_memory(title)).unwrap();
+    let blob = ai_memory::embeddings::encode_embedding_blob(emb);
+    conn.execute(
+        "UPDATE memories SET embedding = ?1, embedding_dim = ?2, embedding_space = ?3 WHERE id = ?4",
+        rusqlite::params![blob, i64::try_from(emb.len()).unwrap(), space, id],
+    )
+    .unwrap();
+    id
+}
+
+/// Force a row's `embedding_space` to SQL NULL (an unverified row).
+fn null_out_space(conn: &rusqlite::Connection, id: &str) {
+    conn.execute(
+        "UPDATE memories SET embedding_space = NULL WHERE id = ?1",
+        rusqlite::params![id],
+    )
+    .unwrap();
+}
+
+/// A deterministic embedder returning a FIXED 4-dim query vector and a
+/// caller-chosen active space fingerprint. Leaves `query_cache_space` at the
+/// default `None` so the process-global #2577 query-embed cache is NOT
+/// consulted (no cross-test interference).
+struct FixedEmbedder {
+    space: String,
+}
+
+impl Embed for FixedEmbedder {
+    fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        // cosine 1.0 with every active-space seed row → all pass the gate.
+        Ok(vec![1.0, 0.0, 0.0, 0.0])
+    }
+    fn space_fingerprint(&self) -> String {
+        self.space.clone()
+    }
+}
+
+fn ttl() -> ResolvedTtl {
+    ResolvedTtl::default()
+}
+fn scoring() -> ResolvedScoring {
+    ResolvedScoring::default()
+}
+
+// ---------------------------------------------------------------------------
+// The behavioral proof: the field POPULATES on a mismatch corpus.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_recall_meta_reports_semantic_withheld_on_mismatch_corpus() {
+    let (conn, _p) = fresh_db();
+    let active = embedding_space_fingerprint("nomic-embed-text");
+    let foreign = embedding_space_fingerprint("granite-embedding"); // same dim, different space
+    assert_ne!(active, foreign);
+    let qe = [1.0_f32, 0.0, 0.0, 0.0];
+
+    // 3 active-space rows (the ONLY rows that may be semantically scored).
+    seed_embedded(&conn, "active one", &qe, &active);
+    seed_embedded(&conn, "active two", &qe, &active);
+    seed_embedded(&conn, "active three", &qe, &active);
+    // 2 foreign same-dim rows (dim gate passes; SPACE gate must exclude).
+    seed_embedded(&conn, "foreign one", &qe, &foreign);
+    seed_embedded(&conn, "foreign two", &qe, &foreign);
+    // 1 NULL-provenance (unverified) row.
+    let n1 = seed_embedded(&conn, "null one", &qe, &active);
+    null_out_space(&conn, &n1);
+    // 1 cross-dim active-space row (space matches, dim disagrees → dim gate).
+    seed_embedded_raw(&conn, "active cross dim", &[1.0_f32, 0.0], &active);
+
+    let emb = FixedEmbedder {
+        space: active.clone(),
+    };
+    // Context matches no content (no FTS hits) → semantic phase is the ONLY
+    // source, so the returned set is exactly the scored set.
+    let resp = handle_recall(
+        &conn,
+        &json!({ "context": "zzznoftshitzzz", "namespace": "test" }),
+        Some(&emb as &dyn Embed),
+        None,
+        None,
+        false,
+        &ttl(),
+        &scoring(),
+        None,
+    )
+    .expect("recall must succeed");
+
+    // mode is UNCHANGED — still hybrid (this is the additive-not-breaking
+    // contract: the withheld block is a NEW signal, not a mode reinterpret).
+    assert_eq!(
+        resp["mode"].as_str(),
+        Some("hybrid"),
+        "mode must stay hybrid; got: {resp}"
+    );
+
+    let sw = &resp["meta"]["semantic_withheld"];
+    assert_eq!(
+        sw["measured"].as_bool(),
+        Some(true),
+        "sqlite MCP recall is a MEASURED path; got: {resp}"
+    );
+    assert_eq!(
+        sw["space_mismatch"].as_u64(),
+        Some(2),
+        "2 foreign-space rows excluded + counted; got: {sw}"
+    );
+    assert_eq!(
+        sw["unverified_space"].as_u64(),
+        Some(1),
+        "1 NULL-space row excluded + counted; got: {sw}"
+    );
+    assert_eq!(
+        sw["dim_mismatch"].as_u64(),
+        Some(1),
+        "1 cross-dim active row excluded + counted; got: {sw}"
+    );
+    assert_eq!(
+        sw["total"].as_u64(),
+        Some(4),
+        "total is the sum of the three causes; got: {sw}"
+    );
+    // Only the 3 active-space rows made it into the ranking.
+    assert_eq!(
+        resp["count"].as_u64(),
+        Some(3),
+        "only active-space rows scored; got: {resp}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ... and is a truthful measured ZERO on a clean homogeneous corpus.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_recall_meta_reports_zero_withheld_on_clean_corpus() {
+    let (conn, _p) = fresh_db();
+    let active = embedding_space_fingerprint("nomic-embed-text");
+    let qe = [1.0_f32, 0.0, 0.0, 0.0];
+    seed_embedded(&conn, "active one", &qe, &active);
+    seed_embedded(&conn, "active two", &qe, &active);
+
+    let emb = FixedEmbedder {
+        space: active.clone(),
+    };
+    let resp = handle_recall(
+        &conn,
+        &json!({ "context": "zzznoftshitzzz", "namespace": "test" }),
+        Some(&emb as &dyn Embed),
+        None,
+        None,
+        false,
+        &ttl(),
+        &scoring(),
+        None,
+    )
+    .expect("recall must succeed");
+
+    let sw = &resp["meta"]["semantic_withheld"];
+    assert_eq!(sw["measured"].as_bool(), Some(true));
+    assert_eq!(
+        sw["total"].as_u64(),
+        Some(0),
+        "a homogeneous active-space corpus withholds nothing; got: {sw}"
+    );
+    assert_eq!(sw["space_mismatch"].as_u64(), Some(0));
+    assert_eq!(sw["unverified_space"].as_u64(), Some(0));
+    assert_eq!(sw["dim_mismatch"].as_u64(), Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// Keyword-only recall (no embedder) — no semantic scoring ran, so the block
+// is present and a truthful measured zero (never absent, never a lie).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_recall_meta_semantic_withheld_present_and_zero_on_keyword_only() {
+    let (conn, _p) = fresh_db();
+    db::insert(&conn, &make_memory("kw needle title")).unwrap();
+
+    let resp = handle_recall(
+        &conn,
+        &json!({ "context": "no-fts-hit-token", "namespace": "test" }),
+        None, // no embedder → keyword-only path
+        None,
+        None,
+        false,
+        &ttl(),
+        &scoring(),
+        None,
+    )
+    .expect("recall must succeed");
+
+    let sw = &resp["meta"]["semantic_withheld"];
+    assert_eq!(
+        sw["measured"].as_bool(),
+        Some(true),
+        "keyword-only is still a MEASURED sqlite path; got: {resp}"
+    );
+    assert_eq!(
+        sw["total"].as_u64(),
+        Some(0),
+        "no semantic scoring ran → nothing withheld from it; got: {sw}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unit: the honesty contract of the wire shape itself.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn semantic_withheld_measured_maps_telemetry_counters() {
+    let telemetry = RecallTelemetry {
+        embedding_space_mismatch: 2,
+        embedding_unverified_space: 1,
+        embedding_dim_mismatch: 3,
+        ..RecallTelemetry::default()
+    };
+    let v = serde_json::to_value(SemanticWithheld::measured(&telemetry)).unwrap();
+    assert_eq!(v["measured"], json!(true));
+    assert_eq!(v["space_mismatch"], json!(2));
+    assert_eq!(v["unverified_space"], json!(1));
+    assert_eq!(v["dim_mismatch"], json!(3));
+    assert_eq!(v["total"], json!(6), "total = 2 + 1 + 3");
+}
+
+#[test]
+fn semantic_withheld_unmeasured_omits_numeric_fields_never_fabricates_zero() {
+    // The postgres SAL recall path excludes foreign-space rows in SQL but
+    // does not count them; emitting `0` would be a WRONG result on the wire.
+    // The honest shape carries the discriminator and NO numeric keys.
+    let v = serde_json::to_value(SemanticWithheld::unmeasured()).unwrap();
+    assert_eq!(v["measured"], json!(false));
+    let obj = v.as_object().expect("object");
+    assert_eq!(
+        obj.len(),
+        1,
+        "unmeasured block must be exactly {{measured:false}} — no fabricated \
+         counts; got: {v}"
+    );
+    assert!(obj.get("space_mismatch").is_none());
+    assert!(obj.get("total").is_none());
+}


### PR DESCRIPTION
## Summary

Recall reports `mode:"hybrid"` but gave a JSON-only NHI no in-band signal that **N rows were served keyword-only** because their stored vector is in a foreign VERIFIED space, an UNVERIFIED (`embedding_space IS NULL`) space, or dim-mismatched (#2167 / H7). The correctness danger is already **CLOSED** — such rows are excluded from semantic scoring and stay keyword-recallable — but on **MCP stdio there is no `/metrics`**, so the daemon's tracing WARN is invisible. The exclusion counters were **already computed** in `RecallTelemetry` and dropped before serialization.

This adds an **ADDITIVE, non-breaking** `meta.semantic_withheld` block populated from those counters (no recompute). **`mode` is UNCHANGED** (still `"hybrid"`).

### Field shape
```jsonc
"meta": {
  "semantic_withheld": {
    "measured": true,          // false on the postgres path (see K3 parity)
    "space_mismatch": 2,       // #2167 foreign VERIFIED space
    "unverified_space": 1,     // #2167 NULL-provenance / unverifiable
    "dim_mismatch": 1,         // H7 dimension mismatch
    "total": 4
  }
}
```

### Wiring (all three surfaces)
- **MCP `memory_recall`** (`attach_meta`) — MEASURED.
- **HTTP `/api/v1/recall`** sqlite branch — threads `recall_hybrid_with_telemetry_precomputed_hnsw`; MEASURED.
- **`ai-memory recall` CLI** — JSON output + a concise stderr note when >0; MEASURED.

### K3 parity (sqlite + postgres) — honest, never a WRONG value
The postgres SAL `recall_hybrid` excludes foreign-space rows in SQL (`AND embedding_space=$fp`) but does **not COUNT** them, so the pg branch emits `{"measured": false}` with the numeric fields **OMITTED** rather than a fabricated `0` (North Star: DEGRADE, never a wrong result on the wire). Real pg per-query counting is tracked in #2958.

## Crossroads vote
This is a T1 crossroads (new wire field + new public struct field crossing module boundaries). Resolved by the **5-agent adversarial vote (`4d3ea1c5`)**: **D-MCP-PRIMARY 4/5** (the lone D-FULL dissenter's own killer-objection concedes D-MCP-PRIMARY is the guaranteed-honest smaller surface); **unanimous** on the nested shape + explicit-zero on MEASURED sqlite paths + honest-unmeasured on postgres.

## Tests (R-203 — GitHub Actions is halted, so this is the local CI substitute)
- `tests/recall_semantic_withheld_fl8a.rs` — MCP recall over a #2167-style mismatch corpus asserts `space_mismatch=2 / unverified_space=1 / dim_mismatch=1 / total=4`; a clean corpus and the keyword-only path assert a truthful measured `0`; unit tests pin the measured mapping and the unmeasured omit-numerics shape.
- `tests/cov3_handlers_sqlite.rs` — the production HTTP router (sqlite) emits the block.
- `tests/handler_postgres_branches_fake_pg.rs` — the postgres recall branch emits `{measured:false}` with numeric fields omitted.
- CLI JSON-output assertion in `src/cli/recall.rs`.

Local CI-parity green: `cargo fmt --all`; clippy `-D warnings -D clippy::all -D clippy::pedantic` on all four legs (default / sal / sal-postgres / vectorlite); `cargo check --examples`; `qual_10_module_size_ceiling`; `qual_6_7_legacy_error_type_ceiling`; `mcp_input_schema_no_false_strict_1052`; `embedding_space_provenance_2167`; recall_observability / recall_decoration / confidence_tier / form_6 / recall_purity_p01 / cov3 / fake-pg; docs-vs-ssot + hardcoded-literal + vendor-literal gates.

## Follow-up filed
- #2958 — real postgres per-query `semantic_withheld` counting (move the pg path from `measured:false` to measured counts).

No new `security_profile::KNOBS` entry. No MCP tool / HTTP route / CLI subcommand / config knob added, so no tool-count / route / param SSOT pins change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
