### PR TITLE
fix(#2955): scope forensic watermark high-water read to genesis_db_id

### DIFF
--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -112,6 +112,16 @@ MAP=(
   # cov_postgres_governance.rs::consolidate_merges_sources against a live PG.
   "consolidate_confidence_floor_2935|subst|min_confidence = min_confidence.min(mem.confidence);>>>min_confidence = min_confidence.min(1.0); // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
   "consolidate_derived_kind_2935|subst|memory_kind: crate::models::MemoryKind::Claim,>>>memory_kind: crate::models::MemoryKind::Observation, // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
+  # #2955 — forensic watermark PER-DATABASE scoping. The control is a SINGLE
+  # branch in `scan_file_last_watermark` (not a guard fn), so it uses `subst`:
+  # neutralizing `if line_id != mine {` to `if false {` stops the cross-DB skip,
+  # so a SIBLING database's watermark (a different genesis `db_id`) is honored as
+  # THIS db's high-water — the exact cross-DB watermark bleed #2955 closes. The
+  # lane test asserts a foreign-`db_id` watermark is NOT returned to a scoped
+  # reader; the mutation makes it returned => RED. Both backends read through
+  # this ONE shared reader (`last_audit_watermark`), so the pg twin is
+  # composite-covered by the same proof.
+  "scan_file_last_watermark_db_id_scope_2955|subst|) && line_id != mine>>>) && false // CERT-REMOVAL-PROOF-MUTATION|src/governance/audit.rs|audit_watermark_db_id_scope_2955|foreign_db_watermark_not_honored_as_this_db_high_water"
 )
 
 # Apply MUTATION to function CTL in TARGET, per SHAPE.

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -997,12 +997,24 @@ static LAST_WATERMARKED_SEQ: AtomicI64 = AtomicI64::new(0);
 ///
 /// Fire-and-forget through [`record_decision`]: a no-op when the forensic
 /// sink is not initialised, errors logged + swallowed otherwise.
-pub fn record_audit_watermark(head_sequence: i64, head_canonical_hash: &str) {
-    let payload = serde_json::json!({
+pub fn record_audit_watermark(head_sequence: i64, head_canonical_hash: &str, db_id: Option<&str>) {
+    let mut payload = serde_json::json!({
         "v": AUDIT_WATERMARK_PAYLOAD_VERSION,
         "head_sequence": head_sequence,
         "head_canonical_hash": head_canonical_hash,
     });
+    // v1.0.0 #2955 — bind this database's genesis-derived identity so the SHARED
+    // on-host forensic watermark file filters PER DATABASE, mirroring the #2370
+    // witness (`witness_resolution_json`) + head-anchor (`scan_head_anchor_log`)
+    // db_id-scoping siblings. PRESENT-ONLY (never a new `ForensicDecision`
+    // field — the T4 note): a db_id-less row stays byte-identical to a legacy
+    // watermark and older readers ignore the extra key, so the `v` gate is
+    // unchanged (no version bump). A watermark carrying a DIFFERENT db_id
+    // anchors a sibling DB sharing this sink and must never be read as THIS
+    // db's high-water (the cross-DB watermark bleed #2955 closes).
+    if let Some(id) = db_id {
+        payload["db_id"] = serde_json::Value::String(id.to_string());
+    }
     record_decision(
         AUDIT_WATERMARK_ACTOR,
         AUDIT_WATERMARK_DECISION,
@@ -1010,6 +1022,22 @@ pub fn record_audit_watermark(head_sequence: i64, head_canonical_hash: &str) {
         "",
         payload,
     );
+}
+
+/// #1850 — cheap, non-claiming peek at the [`WATERMARK_INTERVAL`] throttle so a
+/// backend can resolve the (query-bearing) `db_id` ONLY when an emission is
+/// actually due. Mirrors the witness lane's "cheap pre-check keeps key I/O off
+/// every append" discipline (`try_emit_audit_head_witness`): the authoritative
+/// single-emitter guarantee still lives in the CAS inside
+/// [`maybe_record_audit_watermark`], so a lost race here at most wastes one
+/// genesis read — never a double emission.
+#[must_use]
+pub fn watermark_emission_due(head_sequence: i64) -> bool {
+    if head_sequence <= 0 {
+        return false;
+    }
+    let last = LAST_WATERMARKED_SEQ.load(Ordering::Relaxed);
+    head_sequence.saturating_sub(last) >= WATERMARK_INTERVAL
 }
 
 /// #1850 — throttled emitter for the signed-events append hot path.
@@ -1022,7 +1050,11 @@ pub fn record_audit_watermark(head_sequence: i64, head_canonical_hash: &str) {
 /// Lock-free throttle via a compare-and-swap on [`LAST_WATERMARKED_SEQ`];
 /// concurrent callers crossing the same interval boundary collapse to a
 /// single emission.
-pub fn maybe_record_audit_watermark(head_sequence: i64, head_canonical_hash: &str) {
+pub fn maybe_record_audit_watermark(
+    head_sequence: i64,
+    head_canonical_hash: &str,
+    db_id: Option<&str>,
+) {
     if head_sequence <= 0 {
         return;
     }
@@ -1038,7 +1070,7 @@ pub fn maybe_record_audit_watermark(head_sequence: i64, head_canonical_hash: &st
     {
         return;
     }
-    record_audit_watermark(head_sequence, head_canonical_hash);
+    record_audit_watermark(head_sequence, head_canonical_hash, db_id);
 }
 
 /// Forensic directory of the live sink, if [`init`] has run.
@@ -1063,15 +1095,22 @@ fn live_sink_dir() -> Option<PathBuf> {
 /// `verify-audit-trail` surface; a raw-library caller that never called
 /// [`init`] sees `None` (Unknown), which is the safe default.
 #[must_use]
-pub fn last_audit_watermark() -> Option<(i64, String)> {
+pub fn last_audit_watermark(db_id: Option<&str>) -> Option<(i64, String)> {
     let dir = live_sink_dir()?;
     let files = list_forensic_files(&dir).ok()?;
     // Newest first; "current + previous daily file" per the daily rotation.
     // The `signed` bit is dropped here — the CONVICTING lanes read this raw
     // (unauthenticated) anchor. The L7 exonerating lanes gate on
     // [`audit_watermark_exoneration_authenticated`] instead.
+    //
+    // v1.0.0 #2955 — `db_id` scopes the SHARED on-host forensic sink PER
+    // DATABASE (mirrors [`read_head_anchor_high_water`]): a watermark carrying a
+    // DIFFERENT db_id anchors a sibling DB on this mount and is skipped, so a
+    // restored / rotated / co-located DB's head can never be read as THIS db's
+    // high-water. `db_id = None` (an opener with no genesis / empty chain) reads
+    // every watermark — the conservative pre-#2955 posture.
     for file in files.iter().rev().take(2) {
-        if let Some((seq, hash, _signed)) = scan_file_last_watermark(file) {
+        if let Some((seq, hash, _signed)) = scan_file_last_watermark(file, db_id) {
             return Some((seq, hash));
         }
     }
@@ -1089,7 +1128,7 @@ pub fn last_audit_watermark() -> Option<(i64, String)> {
 /// lanes must additionally confirm the exact watermark they trust is itself
 /// signed. [`last_audit_watermark`] ignores the bit (the CONVICTING lanes read
 /// the raw unauthenticated anchor).
-fn scan_file_last_watermark(path: &Path) -> Option<(i64, String, bool)> {
+fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, String, bool)> {
     let f = File::open(path).ok()?;
     let mut found: Option<(i64, String, bool)> = None;
     for line in BufReader::new(f).lines() {
@@ -1105,6 +1144,19 @@ fn scan_file_last_watermark(path: &Path) -> Option<(i64, String, bool)> {
         }
         if row.payload.get("v").and_then(serde_json::Value::as_i64)
             != Some(AUDIT_WATERMARK_PAYLOAD_VERSION)
+        {
+            continue;
+        }
+        // v1.0.0 #2955 — per-database scoping (mirrors `scan_head_anchor_log`'s
+        // #2370 match): a watermark carrying a DIFFERENT db_id anchors a sibling
+        // DB sharing this on-host sink and must NEVER become this opener's
+        // high-water. A db_id-less (legacy) watermark is counted conservatively
+        // for every opener; `db_id = None` (no genesis / empty chain) counts
+        // every watermark. Only the cross-DB (foreign-id) row is skipped.
+        if let (Some(line_id), Some(mine)) = (
+            row.payload.get("db_id").and_then(serde_json::Value::as_str),
+            db_id,
+        ) && line_id != mine
         {
             continue;
         }
@@ -1160,7 +1212,10 @@ const EARLIEST_FORENSIC_SINCE: &str = "1970-01-01";
 /// Constant-`true` here (the §5.4.5 removal-proof mutation) lets an
 /// unauthenticated watermark exonerate — the L7 asymmetry defeated.
 #[must_use]
-pub fn audit_watermark_exoneration_authenticated(audit_pubkey: Option<&VerifyingKey>) -> bool {
+pub fn audit_watermark_exoneration_authenticated(
+    audit_pubkey: Option<&VerifyingKey>,
+    db_id: Option<&str>,
+) -> bool {
     // Enrollment gate: no out-of-band pin → no authority → legacy behaviour.
     let Some(pubkey) = audit_pubkey else {
         return true;
@@ -1184,11 +1239,16 @@ pub fn audit_watermark_exoneration_authenticated(audit_pubkey: Option<&Verifying
     // current + previous daily file). Lock onto that same row and require IT to
     // be signed, else a hostile host that appends an UNSIGNED watermark onto an
     // otherwise-verifying chain could still mint exoneration.
+    //
+    // v1.0.0 #2955 — lock onto the SAME db_id-scoped row [`last_audit_watermark`]
+    // consumes: authenticating a SIBLING DB's watermark would let a foreign
+    // (still-signed) anchor exonerate this db, so the exoneration lane threads
+    // the opener's db_id through the identical per-database filter.
     let Ok(files) = list_forensic_files(&dir) else {
         return false;
     };
     for file in files.iter().rev().take(2) {
-        if let Some((_, _, signed)) = scan_file_last_watermark(file) {
+        if let Some((_, _, signed)) = scan_file_last_watermark(file, db_id) {
             return signed;
         }
     }

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -2415,28 +2415,37 @@ pub fn verify_audit_trail(
     // lanes ignore it and keep reading the raw unauthenticated watermark.
     // Enrollment-gated on the out-of-band `AI_MEMORY_AUDIT_PUBKEY` pin (no pin →
     // legacy trust-the-anchor). SHARED with the postgres twin (K3 parity).
-    let exonerate_ok =
-        crate::governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey);
-    let truncation = match crate::governance::audit::last_audit_watermark() {
-        Some((anchored_head, _head_canonical_hash)) => {
-            if head_sequence < anchored_head {
-                // CONVICT on the raw (unauthenticated) anchor — a stripped
-                // signature must never SUPPRESS a truncation conviction.
-                TruncationCheck::Detected {
-                    anchored_head,
-                    db_head: head_sequence,
+    // v1.0.0 #2955 — this database's genesis-derived identity scopes the SHARED
+    // on-host forensic watermark reads below (both the truncation lane and the
+    // #1873 head-hash lane), so a sibling DB sharing this sink can never bleed
+    // its head into THIS db's verdict. `None` on an empty chain / read fault =
+    // the conservative count-every-watermark posture.
+    let watermark_db_id = genesis_db_id(conn).ok().flatten();
+    let exonerate_ok = crate::governance::audit::audit_watermark_exoneration_authenticated(
+        audit_pubkey,
+        watermark_db_id.as_deref(),
+    );
+    let truncation =
+        match crate::governance::audit::last_audit_watermark(watermark_db_id.as_deref()) {
+            Some((anchored_head, _head_canonical_hash)) => {
+                if head_sequence < anchored_head {
+                    // CONVICT on the raw (unauthenticated) anchor — a stripped
+                    // signature must never SUPPRESS a truncation conviction.
+                    TruncationCheck::Detected {
+                        anchored_head,
+                        db_head: head_sequence,
+                    }
+                } else if exonerate_ok {
+                    TruncationCheck::NotDetected
+                } else {
+                    // L7 — a pin is enrolled but the anchor did not authenticate:
+                    // WITHHOLD the clean bill of health rather than exonerate on
+                    // unauthenticated evidence.
+                    TruncationCheck::Unknown
                 }
-            } else if exonerate_ok {
-                TruncationCheck::NotDetected
-            } else {
-                // L7 — a pin is enrolled but the anchor did not authenticate:
-                // WITHHOLD the clean bill of health rather than exonerate on
-                // unauthenticated evidence.
-                TruncationCheck::Unknown
             }
-        }
-        None => TruncationCheck::Unknown,
-    };
+            None => TruncationCheck::Unknown,
+        };
 
     // Resolve the RFC3339 `since` timestamp to a sequence FLOOR: the
     // max sequence of any row strictly BEFORE the window. `verify_chain`
@@ -2618,7 +2627,7 @@ pub fn verify_audit_trail(
         // v1.0.0 L7 (PR-4) — CONVICT (Mismatch) on the raw anchor, but EXONERATE
         // (NotDetected) only behind the authenticity gate (`exonerate_ok`).
         if let Some((anchored_head, anchored_hash)) =
-            crate::governance::audit::last_audit_watermark()
+            crate::governance::audit::last_audit_watermark(watermark_db_id.as_deref())
             && anchored_head > 0
             && anchored_head <= head_sequence
         {
@@ -2957,7 +2966,20 @@ pub fn append_signed_event_no_tx(conn: &Connection, event: &SignedEvent) -> Resu
     let mut hasher = Sha256::new();
     hasher.update(canonical_chain_bytes(&head_view));
     let head_hash_hex = hex_lower(hasher.finalize().as_slice());
-    crate::governance::audit::maybe_record_audit_watermark(next_seq, &head_hash_hex);
+    // v1.0.0 #2955 — stamp this database's genesis-derived identity into the
+    // shared on-host watermark so a restored / rotated / co-located sibling DB's
+    // anchor can never be read back as THIS db's high-water. Resolve the
+    // (query-bearing) db_id ONLY when an emission is actually due — the cheap
+    // peek keeps the genesis read off the 63-of-64 non-emitting appends,
+    // mirroring the witness lane's interval pre-check.
+    if crate::governance::audit::watermark_emission_due(next_seq) {
+        let db_id = genesis_db_id(conn).ok().flatten();
+        crate::governance::audit::maybe_record_audit_watermark(
+            next_seq,
+            &head_hash_hex,
+            db_id.as_deref(),
+        );
+    }
 
     // v0.9.0 G5b (#1822) — INDEPENDENT dual-chain audit-head witness anchor.
     // Emitted on the SAME `WATERMARK_INTERVAL` cadence (throttled), in the

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -11925,7 +11925,26 @@ async fn pg_append_signed_event_with_chain_in_tx(
     // permanently `Unknown`; wiring it here closes that gap. The forensic
     // write is a FILE write (never touches this pg tx), so it is safe
     // fire-and-forget.
-    crate::governance::audit::maybe_record_audit_watermark(next_seq, &head_hash_hex);
+    //
+    // v1.0.0 #2955 — stamp this database's genesis-derived identity (the SAME
+    // stable stored columns as the witness lane below, never a TIMESTAMPTZ
+    // readback) so the shared on-host watermark filters per database. The
+    // (query-bearing) genesis fetch is gated behind the cheap emission-due peek
+    // so it stays off the 63-of-64 non-emitting appends (K3 parity with sqlite).
+    if crate::governance::audit::watermark_emission_due(next_seq) {
+        let genesis: Option<(String, String, Vec<u8>)> =
+            sqlx::query_as(crate::signed_events::GENESIS_ROW_SQL)
+                .fetch_optional(&mut **tx)
+                .await?;
+        let db_id = genesis.map(|(gid, gagent, gpayload)| {
+            crate::signed_events::db_id_from_genesis_parts(&gid, &gagent, &gpayload)
+        });
+        crate::governance::audit::maybe_record_audit_watermark(
+            next_seq,
+            &head_hash_hex,
+            db_id.as_deref(),
+        );
+    }
 
     // v0.9.0 G5b (#1822, item 6) — INDEPENDENT dual-chain audit-head witness
     // anchor at the postgres chokepoint (parity with sqlite). Emitted in THIS
@@ -12221,32 +12240,56 @@ impl PostgresStore {
             .await
             .map_err(|e| to_store_err("verify_audit_trail.head", e))?;
 
+        // v1.0.0 #2955 — this database's genesis-derived identity scopes the
+        // SHARED on-host forensic watermark reads below, so a sibling DB sharing
+        // the sink can never bleed its head into THIS db's verdict. Derived from
+        // the SAME stable stored columns as the sqlite twin + the pg witness
+        // emission (id/agent_id/payload_hash, never a TIMESTAMPTZ readback), so
+        // both backends resolve the identical db_id (K3 parity). Unlike the
+        // #2373-deferred rollback lane (which threads into a SYNC verdict fn),
+        // the watermark reader is called directly in this async fn, so the pg
+        // CHECK side can + does scope it. `None` on an empty chain = the
+        // conservative count-every-watermark posture.
+        let watermark_db_id: Option<String> = {
+            let genesis: Option<(String, String, Vec<u8>)> =
+                sqlx::query_as(crate::signed_events::GENESIS_ROW_SQL)
+                    .fetch_optional(&self.pool)
+                    .await
+                    .map_err(|e| to_store_err("verify_audit_trail.genesis", e))?;
+            genesis.map(|(gid, gagent, gpayload)| {
+                crate::signed_events::db_id_from_genesis_parts(&gid, &gagent, &gpayload)
+            })
+        };
+
         // v1.0.0 L7 (PR-4) — EXONERATION-authenticity gate (SHARED with the
         // sqlite twin; K3 parity). Enrollment-gated on the out-of-band
         // `AI_MEMORY_AUDIT_PUBKEY` pin: no pin → legacy trust-the-anchor;
         // pin enrolled → exonerate only on an authenticated forensic watermark.
-        let exonerate_ok =
-            crate::governance::audit::audit_watermark_exoneration_authenticated(audit_pubkey);
+        let exonerate_ok = crate::governance::audit::audit_watermark_exoneration_authenticated(
+            audit_pubkey,
+            watermark_db_id.as_deref(),
+        );
 
         // Off-table tail-truncation verdict — the SAME shared forensic reader
         // the sqlite path uses (item 7 wired the pg chokepoint to stamp it).
-        let truncation = match crate::governance::audit::last_audit_watermark() {
-            Some((anchored_head, _)) => {
-                if head_sequence < anchored_head {
-                    // CONVICT on the raw (unauthenticated) anchor.
-                    TruncationCheck::Detected {
-                        anchored_head,
-                        db_head: head_sequence,
+        let truncation =
+            match crate::governance::audit::last_audit_watermark(watermark_db_id.as_deref()) {
+                Some((anchored_head, _)) => {
+                    if head_sequence < anchored_head {
+                        // CONVICT on the raw (unauthenticated) anchor.
+                        TruncationCheck::Detected {
+                            anchored_head,
+                            db_head: head_sequence,
+                        }
+                    } else if exonerate_ok {
+                        TruncationCheck::NotDetected
+                    } else {
+                        // L7 — pin enrolled + anchor unauthenticated → WITHHOLD.
+                        TruncationCheck::Unknown
                     }
-                } else if exonerate_ok {
-                    TruncationCheck::NotDetected
-                } else {
-                    // L7 — pin enrolled + anchor unauthenticated → WITHHOLD.
-                    TruncationCheck::Unknown
                 }
-            }
-            None => TruncationCheck::Unknown,
-        };
+                None => TruncationCheck::Unknown,
+            };
 
         // Resolve the RFC3339 `since` to a sequence FLOOR (mirrors sqlite).
         let floor: i64 = match since {
@@ -12552,7 +12595,7 @@ impl PostgresStore {
             // (NotDetected) only behind the authenticity gate (`exonerate_ok`).
             // SHARED pure gate with the sqlite twin (K3 parity).
             if let Some((anchored_head, anchored_hash)) =
-                crate::governance::audit::last_audit_watermark()
+                crate::governance::audit::last_audit_watermark(watermark_db_id.as_deref())
                 && anchored_head > 0
                 && anchored_head <= head_sequence
             {

--- a/tests/audit_exoneration_asymmetry_l7.rs
+++ b/tests/audit_exoneration_asymmetry_l7.rs
@@ -127,7 +127,7 @@ fn anchor_real_head(conn: &Connection) -> i64 {
             },
         )
         .expect("read head row");
-    forensic::record_audit_watermark(seq, &hash_hex);
+    forensic::record_audit_watermark(seq, &hash_hex, None);
     forensic::flush_blocking();
     seq
 }
@@ -247,7 +247,7 @@ fn unauthenticated_watermark_still_convicts_truncation_l7() {
     for i in 0..5 {
         append_row(&conn, format!("payload-{i}").as_bytes());
     }
-    forensic::record_audit_watermark(5, "anchor-hash-head-5");
+    forensic::record_audit_watermark(5, "anchor-hash-head-5", None);
     forensic::flush_blocking();
 
     // Truncate the trailing two rows — surviving 1..=3 stays contiguous.

--- a/tests/audit_truncation_anchor_1850.rs
+++ b/tests/audit_truncation_anchor_1850.rs
@@ -102,7 +102,7 @@ fn trailing_delete_after_watermark_is_detected() {
         append_row(&conn, format!("payload-{i}").as_bytes());
     }
     // Anchor the head (5) into the off-table forensic chain.
-    forensic::record_audit_watermark(5, "anchor-hash-head-5");
+    forensic::record_audit_watermark(5, "anchor-hash-head-5", None);
     forensic::flush_blocking();
 
     // Truncate the trailing two rows (sequences 4,5) — the surviving
@@ -335,7 +335,7 @@ fn anchor_real_head(conn: &Connection) -> i64 {
             },
         )
         .expect("read head row");
-    forensic::record_audit_watermark(seq, &hash_hex);
+    forensic::record_audit_watermark(seq, &hash_hex, None);
     forensic::flush_blocking();
     seq
 }

--- a/tests/audit_watermark_db_id_scope_2955.rs
+++ b/tests/audit_watermark_db_id_scope_2955.rs
@@ -1,0 +1,236 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 #2955 — the forensic audit-trail watermark high-water read
+//! ([`ai_memory::governance::audit::last_audit_watermark`], via
+//! `scan_file_last_watermark`) must be scoped to the resolving database's
+//! `genesis_db_id`, EXACTLY as its two sibling controls already are — the
+//! WITNESS anchor (`witness_resolution_json`) and the ROLLBACK head-anchor
+//! (`scan_head_anchor_log`), both #2370.
+//!
+//! The defect: the watermark file sink is process/host-global, so a watermark
+//! written by a DIFFERENT database instance sharing the same on-host sink (a
+//! restored / rotated / re-genesis'd DB, or a co-located test/prod mixup) was
+//! read back as THIS db's high-water — a cross-DB watermark bleed that can
+//! forge a wrong truncation/rollback verdict in `verify_audit_trail`.
+//!
+//! Pins (broken → wrong verdict, fixed → correct):
+//! - a SIBLING-db watermark (foreign `db_id`) is NOT honored as this db's
+//!   high-water (the removal-proof lane — mutating the scope filter off makes
+//!   the foreign row honored → this test RED);
+//! - THIS db's own watermark IS still honored (the fix does not over-block);
+//! - a legacy id-less watermark is counted CONSERVATIVELY for every opener;
+//! - `db_id = None` (empty chain) reads every watermark (pre-#2955 posture);
+//! - END-TO-END: a foreign watermark can no longer forge a `Detected`
+//!   truncation verdict against a chain that was never truncated.
+//!
+//! The forensic sink is process-global, so these tests serialise via a
+//! module-local lock (the `tests/audit_truncation_anchor_1850.rs` discipline).
+
+#![allow(clippy::missing_panics_doc)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use ai_memory::governance::audit as forensic;
+use ai_memory::signed_events::{
+    SignedEvent, TruncationCheck, append_signed_event, genesis_db_id, payload_hash,
+    verify_audit_trail,
+};
+use rusqlite::Connection;
+
+/// Process-global serialisation for the shared forensic SINK.
+fn forensic_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Tempdirs under `.local-runs/` (project no-`/tmp` HARD RULE).
+fn fresh_dir(label: &str) -> tempfile::TempDir {
+    let root = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("issue-2955-watermark-db-id-scope");
+    std::fs::create_dir_all(&root).ok();
+    tempfile::Builder::new()
+        .prefix(&format!("{label}-"))
+        .tempdir_in(&root)
+        .expect("tempdir under .local-runs")
+}
+
+fn open_db(dir: &Path) -> Connection {
+    let path = dir.join("audit.db");
+    drop(ai_memory::db::open(&path).expect("init db"));
+    ai_memory::db::open(&path).expect("open db")
+}
+
+fn append_row(conn: &Connection, payload: &[u8]) {
+    let ev = SignedEvent {
+        id: uuid::Uuid::new_v4().to_string(),
+        agent_id: "alice".to_string(),
+        event_type: "memory_link.created".to_string(),
+        payload_hash: payload_hash(payload),
+        signature: None,
+        attest_level: "unsigned".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        ..SignedEvent::default()
+    };
+    append_signed_event(conn, &ev).expect("append");
+}
+
+// ---------------------------------------------------------------------------
+// Removal-proof lane (scripts/check-cert-removal-proof.sh row
+// `scan_file_last_watermark_db_id_scope_2955`): a foreign-db watermark must
+// NOT be honored as this db's high-water. Mutating the scope filter off makes
+// it honored → this test RED.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn foreign_db_watermark_not_honored_as_this_db_high_water() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("a-forensic");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // A SIBLING database (a different genesis identity) stamped its head=100
+    // into the SHARED on-host sink. `db-alpha`/`db-beta` stand in for two
+    // genesis-derived `db_id`s sharing one watermark file.
+    forensic::record_audit_watermark(100, "sibling-head-hash", Some("db-alpha"));
+    forensic::flush_blocking();
+
+    // FIX: an opener whose db_id is `db-beta` must NOT read the `db-alpha`
+    // sibling's watermark as its own high-water.
+    assert_eq!(
+        forensic::last_audit_watermark(Some("db-beta")),
+        None,
+        "a foreign-db_id watermark bled into this db's high-water (cross-DB bleed #2955)"
+    );
+
+    // The OWNING database still reads its own watermark (no over-block).
+    assert_eq!(
+        forensic::last_audit_watermark(Some("db-alpha")),
+        Some((100, "sibling-head-hash".to_string())),
+        "own-db watermark must still be honored"
+    );
+
+    // `db_id = None` (an opener with no genesis / empty chain) reads every
+    // watermark — the conservative pre-#2955 posture.
+    assert_eq!(
+        forensic::last_audit_watermark(None),
+        Some((100, "sibling-head-hash".to_string())),
+        "None (no genesis) must read every watermark (conservative posture)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy id-less watermark: counted conservatively for every opener (the
+// one-release compat window, mirroring scan_head_anchor_log's legacy arm).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_id_less_watermark_counted_for_every_scoped_reader() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("b-forensic");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // A pre-#2955 (id-less) watermark — no `db_id` in its payload.
+    forensic::record_audit_watermark(42, "legacy-head-hash", None);
+    forensic::flush_blocking();
+
+    // A scoped opener still counts the legacy row (conservative: over-detect
+    // toward truncation, never suppress).
+    assert_eq!(
+        forensic::last_audit_watermark(Some("db-gamma")),
+        Some((42, "legacy-head-hash".to_string())),
+        "a legacy id-less watermark must be counted for every scoped opener"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// END-TO-END: a foreign-db watermark can no longer forge a `Detected`
+// truncation verdict against a chain that was never truncated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn foreign_watermark_does_not_forge_truncation_verdict() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("c-forensic");
+    let ddir = fresh_dir("c-db");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let conn = open_db(ddir.path());
+    for i in 0..3 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    // This db's real genesis-derived identity (64-hex) can never equal the
+    // literal sibling label below, so the anchor is unambiguously foreign.
+    let this_db_id = genesis_db_id(&conn)
+        .expect("genesis db_id")
+        .expect("chain has a genesis row");
+    assert_ne!(this_db_id, "sibling-db-not-this-one");
+
+    // A SIBLING DB (sharing this on-host sink) anchored head=100 — far above
+    // this db's real head of 3. Pre-#2955 the unscoped read honored it and
+    // forged `Detected { anchored_head: 100, db_head: 3 }`.
+    forensic::record_audit_watermark(100, "sibling-head-hash", Some("sibling-db-not-this-one"));
+    forensic::flush_blocking();
+
+    let report = verify_audit_trail(&conn, None, None).expect("verify");
+    assert_eq!(
+        report.head_sequence, 3,
+        "in-DB head is 3; report={report:?}"
+    );
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Unknown,
+        "a SIBLING db's watermark must not forge a truncation verdict for THIS db; report={report:?}"
+    );
+    assert!(
+        report.is_clean(),
+        "an untruncated chain with only a foreign watermark stays clean; report={report:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Own-db watermark still convicts a real truncation (the fix does not blind
+// the CONVICTING lane for the resolving database).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn own_db_watermark_still_detects_truncation() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("d-forensic");
+    let ddir = fresh_dir("d-db");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    let conn = open_db(ddir.path());
+    for i in 0..5 {
+        append_row(&conn, format!("payload-{i}").as_bytes());
+    }
+    let this_db_id = genesis_db_id(&conn)
+        .expect("genesis db_id")
+        .expect("chain has a genesis row");
+
+    // Anchor head=5 under THIS db's own identity, then truncate the tail.
+    forensic::record_audit_watermark(5, "own-head-hash", Some(&this_db_id));
+    forensic::flush_blocking();
+    conn.execute("DELETE FROM signed_events WHERE sequence IN (4, 5)", [])
+        .expect("truncate tail");
+
+    let report = verify_audit_trail(&conn, None, None).expect("verify");
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Detected {
+            anchored_head: 5,
+            db_head: 3,
+        },
+        "own-db watermark must still convict a real tail truncation; report={report:?}"
+    );
+}

--- a/tests/audit_witness_truncation_1822.rs
+++ b/tests/audit_witness_truncation_1822.rs
@@ -776,7 +776,7 @@ mod postgres_parity {
         for i in 0..300 {
             pg.emit_spawn_audit(&format!("argv0-{i}"), "1822-f2-headhash")
                 .await;
-            if let Some((seq, _)) = witness::last_audit_watermark() {
+            if let Some((seq, _)) = witness::last_audit_watermark(None) {
                 anchored = Some(seq); // fired on the just-appended head → anchored == head
                 break;
             }


### PR DESCRIPTION
## What

`last_audit_watermark()` (`src/governance/audit.rs`) resolved the forensic
truncation-anchor high-water via `scan_file_last_watermark` WITHOUT scoping to
the resolving database's `genesis_db_id`, while its two sibling controls are
db_id-scoped:

- the WITNESS anchor lane (`witness_resolution_json`, #2370, `v: 3`)
- the ROLLBACK head-anchor lane (`scan_head_anchor_log`, #2370)

The forensic watermark file sink is process/host-global, so a watermark written
by a DIFFERENT database instance sharing the same on-host sink (a restored /
rotated / re-genesis'd DB, or a co-located test/prod mixup) could be read back
as THIS db's high-water — a cross-DB watermark bleed that can forge a wrong
`TruncationCheck` / `HeadHashCheck` verdict in `verify_audit_trail`.

## Fix (copy the sibling precedent, no new scheme)

- **Write**: `record_audit_watermark` stamps this DB's genesis-derived `db_id`
  into the watermark payload PRESENT-ONLY. Older readers ignore the extra key
  and the `v` gate is unchanged (no version bump, mixed-version-fleet safe).
- **Read**: `scan_file_last_watermark(db_id)` / `last_audit_watermark(db_id)`
  filter exactly as `scan_head_anchor_log`: a watermark carrying a DIFFERENT
  db_id is skipped, a legacy id-less watermark is counted conservatively for
  every opener, `db_id = None` (empty chain) reads every watermark.
- **Hot path**: the write-side genesis resolution is gated behind a cheap
  `watermark_emission_due` peek so the genesis query stays off the 63-of-64
  non-emitting appends (mirrors the witness lane's interval pre-check).
- **L7 exoneration**: `audit_watermark_exoneration_authenticated` threads the
  same db_id so it locks onto THIS db's watermark, never a sibling's.
- **K3 parity**: the postgres twin resolves db_id via the shared
  `GENESIS_ROW_SQL` on both the append and the two verify read paths.

Single-correct-answer parity fix copying an in-repo precedent (T6 exempt).

## R-203 evidence (local parity — GitHub Actions may be halted)

Removal-proof (`scripts/check-cert-removal-proof.sh scan_file_last_watermark_db_id_scope_2955`):

```
[PROVEN] control is load-bearing: broken→RED (rc=101), restored→GREEN (rc=0)
```

Regression suite `cargo test --features sal --test audit_watermark_db_id_scope_2955` — 4 passed:
- `foreign_db_watermark_not_honored_as_this_db_high_water`
- `foreign_watermark_does_not_forge_truncation_verdict`
- `legacy_id_less_watermark_counted_for_every_scoped_reader`
- `own_db_watermark_still_detects_truncation`

Sibling audit-trail suites re-run green (unmodified behavior under legacy `None`):
- `audit_truncation_anchor_1850` — 8 passed
- `audit_witness_truncation_1822` — 17 passed
- `audit_exoneration_asymmetry_l7` — passed (co-run, exit 0)

Four-leg clippy (`-D warnings -D clippy::all -D clippy::pedantic`, `--all-targets`)
all EXIT=0: default, `sal`, `sal-postgres`, `vectorlite`. `cargo fmt --check`
clean; `cargo check --examples` EXIT=0.

## AI involvement

Implemented by Claude Opus 5 (hard-coder) under AlphaOne operator authority.
Commit is SSH-signed as AlphaOne (`git log -1 --format='%G?'` = `G`).

Refs #2955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
