### PR TITLE
docs(config): correct stale memory_kinds doc-comment (D4 fix-now doc-drift)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2145,19 +2145,24 @@ pub struct CapabilitiesV3 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kg_backend: Option<String>,
 
-    /// L1-1 (v0.7.0) — typed memory-kind set. Forwarded from the v2
-    /// projection's `memory_kinds` field. Always
-    /// `["observation", "reflection"]` for v0.7.0.
+    /// L1-1 (v0.7.0) — the FROZEN LEGACY 2-element memory-kind hint,
+    /// always `["observation", "reflection"]` (from
+    /// [`default_memory_kinds`]). Forwarded verbatim from the v2
+    /// projection's `memory_kinds` field and kept for back-compat with
+    /// v1 / v2 capabilities consumers.
     ///
-    /// **L3-5 honesty note.** The grand-slam spec called for a third
-    /// `"goal"` kind here, but the [`crate::models::memory::MemoryKind`]
-    /// enum in this binary only carries `Observation` and `Reflection`.
-    /// Per the operator's "every reported field maps to real
-    /// implementation" directive, the v3 surface reports exactly what
-    /// the substrate enforces — the `goal` kind is deferred to the
-    /// tracker (`a4f8d465`) for a v0.8.0 wave that lands the enum
-    /// variant + migration + write-path coverage. Reporting it here
-    /// today would be theatrical.
+    /// This field is NOT the accepted vocabulary. The
+    /// [`crate::models::memory::MemoryKind`] enum carries **16 variants
+    /// at v1.0.0** ([`crate::models::MemoryKind::all`]: the 10 Form-6
+    /// kinds plus Goal/Plan/Step from v0.8.0 Pillar-2 typed-cognition
+    /// (#1709) plus Told/Instruction/Intervention from v1.0.0 epistemic
+    /// typing (#1945)), and the substrate accepts all 16 on write. The
+    /// authoritative, complete accepted vocabulary is carried on the
+    /// Form-6 [`CapabilityMemoryKindVocab`] `memory_kind_vocab` block
+    /// (compile-anchored to [`crate::models::MemoryKind::all`]); callers
+    /// should consult that block rather than this legacy two-element
+    /// list. Widening or removing this frozen field is a separate voted
+    /// wire-shape change, not a doc fix.
     #[serde(default = "default_memory_kinds")]
     pub memory_kinds: Vec<String>,
 


### PR DESCRIPTION
## Summary

Wave-2 **D4 fix-now doc-drift** loose end. The doc-comment on the v3
`Capabilities.memory_kinds` wire field in `src/config.rs` (~line 2148)
falsely stated the `MemoryKind` enum "only carries `Observation` and
`Reflection`". That is stale: at v1.0.0 `MemoryKind::all()`
(`src/models/memory.rs`) carries **16 variants** — the 10 Form-6 kinds
plus Goal/Plan/Step (#1709) plus Told/Instruction/Intervention (#1945) —
and the substrate accepts all 16 on write.

This is the **twin of #2952**, which already corrected the identical stale
comment in `tests/capabilities_v3_l3_5.rs` (now reads "carries 16 variants
at v1.0.0"). This PR closes the remaining source-side loose end.

## Change (DOC-COMMENT ONLY — no behavior change)

The prose now truthfully describes the field: `memory_kinds` is a **FROZEN
LEGACY 2-element** back-compat hint (`["observation","reflection"]`, from
`default_memory_kinds()`), kept for v1/v2 capabilities consumers, while the
**authoritative full 16-kind vocabulary** is carried on the Form-6
`memory_kind_vocab` block (compile-anchored to `MemoryKind::all`). No wire
value or `default_memory_kinds()` behavior changed — the legacy field stays
frozen; widening/removing it is a separate voted wire-shape change, not this
task.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` clean (default)
- `cargo clippy --all-targets --features sal -- -D warnings -D clippy::all -D clippy::pedantic` clean (sal)
- `scripts/check-docs-vs-ssot.sh` PASS

## AI involvement

Authored by Claude Opus 5 (light-tier coder) under operator authority.
Mechanical T6-exempt doc-correction — no 5-agent vote required. Commit
signed as AlphaOne (`%G? %an` = `G AlphaOne`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY