### PR TITLE
test(backup): serialize process-global STORE_URL_ENV tests to fix flake (#2970)

### DIFF
--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -819,6 +819,10 @@ mod tests {
 
     #[test]
     fn test_backup_happy_path_creates_snapshot_and_manifest() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -852,6 +856,10 @@ mod tests {
 
     #[test]
     fn test_backup_json_emits_manifest_with_sha256() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -873,6 +881,10 @@ mod tests {
 
     #[test]
     fn test_restore_from_directory_picks_newest() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "before-backup", "stuff");
@@ -902,6 +914,10 @@ mod tests {
 
     #[test]
     fn test_restore_from_explicit_file_path() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -934,6 +950,10 @@ mod tests {
 
     #[test]
     fn test_restore_with_skip_verify_succeeds_without_manifest() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -971,6 +991,10 @@ mod tests {
 
     #[test]
     fn test_restore_bad_sha256_errors() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1010,6 +1034,10 @@ mod tests {
 
     #[test]
     fn test_backup_retention_prunes_old_snapshots() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1055,6 +1083,10 @@ mod tests {
     /// the supported path. The credential in the DSN is redacted.
     #[test]
     fn backup_refuses_a_postgres_store_url_argument_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1074,6 +1106,10 @@ mod tests {
     /// `restore` refuses the same store — the false-assurance half of #2444.
     #[test]
     fn restore_refuses_a_postgres_store_url_argument_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         let args = RestoreArgs {
@@ -1094,6 +1130,10 @@ mod tests {
     /// valid manifest.
     #[test]
     fn backup_refuses_an_unrecognised_store_url_scheme_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1123,6 +1163,10 @@ mod tests {
     /// check has to happen first.
     #[test]
     fn backup_refuses_to_create_a_missing_source_database_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         let missing = db.parent().unwrap().join("never-created-2444.db");
@@ -1147,6 +1191,10 @@ mod tests {
     /// the row count actually captured.
     #[test]
     fn backup_manifest_records_backend_schema_and_memory_count_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1173,6 +1221,10 @@ mod tests {
     /// refusing would strand the sqlite governance sidecar on a pg host.
     #[test]
     fn backup_warns_but_succeeds_on_an_empty_corpus_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         // Bring the database into existence WITHOUT storing any memory.
@@ -1197,6 +1249,10 @@ mod tests {
     /// rather than copied onto a SQLite path.
     #[test]
     fn restore_refuses_a_cross_backend_manifest_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1225,6 +1281,10 @@ mod tests {
     /// Refuse instead.
     #[test]
     fn restore_refuses_a_forward_schema_snapshot_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1253,6 +1313,10 @@ mod tests {
     /// operator already holds would be its own data-loss event.
     #[test]
     fn restore_accepts_a_legacy_manifest_without_the_new_fields_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");
@@ -1285,6 +1349,10 @@ mod tests {
     /// moved aside.
     #[test]
     fn restore_refuses_a_snapshot_that_is_not_an_ai_memory_database_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "survivor", "must not be clobbered");
@@ -1321,6 +1389,10 @@ mod tests {
     /// SQLite can replay stale frames INTO the restored corpus.
     #[test]
     fn restore_moves_the_wal_and_shm_sidecars_aside_2444() {
+        // #2970 — serialize the process-global store-url env read (resolve_store_url).
+        let _g = crate::store_url::store_url_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "ns", "t", "c");


### PR DESCRIPTION
## Summary
- `src/cli/backup.rs`'s test module drives `run_backup`/`run_restore`/`refuse_pg_store`, all of which read the **process-global** store-url env (`AI_MEMORY_STORE_URL` / `_FILE`) via `crate::daemon_runtime::resolve_store_url`. One test (`refuse_pg_store_typed_refusal_on_postgres_url_2572`) **mutates** those vars under `store_url_env_lock`, but the other 18 tests read them **without** any lock. Multi-threaded `cargo test` lets a reader observe the mutating test's in-flight `postgres://` value → a spurious refusal (the intermittent `backup_manifest_records_backend_schema_and_memory_count_2444` flake, #2970).
- Fix: acquire the **shared, already-canonical** `crate::store_url::store_url_env_lock` at the top of every test in the module that crosses `resolve_store_url` (all 19). Pure test-serialization — no production code, no assertions changed.

**Design note (deviation from the literal task spec):** the dispatch asked for a new per-module `STORE_URL_ENV_TEST_LOCK` static. That would **not** fix the flake — `store_url.rs`'s own doc-comment states the shared `store_url_env_lock` is the ONE lock every store-url env test must take, precisely because "a per-test local mutex does NOT serialise against a sibling test using its own mutex." The mutating `#2572` test already holds `store_url_env_lock`, so a separate mutex on the reader tests would leave the race open. Reusing the existing shared lock is the only correct serialization here (T6 exempt — a documented precedent is being copied).

## AI involvement
- Agent: Claude Opus 4.8
- Authority class: Trivial (test-only serialization guard)
- Human approver(s) for Sensitive items: n/a
- Memory entries created/updated: none

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` on default AND `sal` AND `sal-postgres` AND `vectorlite` (all exit 0)
- [x] `( umask 022; AI_MEMORY_NO_CONFIG=1 cargo test --lib cli::backup:: )` — 19 passed, run 3× (all green)
- [x] `cargo audit` (exit 0)
- [x] `cargo test --test qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` (green; `src/cli/backup.rs` not in the qual_10 allowlist)

## Linked issues
Closes #2970

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY