### PR TITLE
docs: enterprise-federation A+ turnkey consolidation (close verifier gaps)

### DIFF
--- a/docs/deploy/enterprise-federation.env
+++ b/docs/deploy/enterprise-federation.env
@@ -10,10 +10,33 @@
 # administered peers within ONE accountable organisation — see
 # federation.md's certified trust-boundary text before deploying this).
 #
-# Load before launching the daemon, e.g.:
+# Load before launching the daemon, e.g. (FULL CERTIFIED LAUNCH):
 #
 #   set -a; . /etc/ai-memory/enterprise-federation.env; set +a
-#   ai-memory serve --quorum-peers https://peer-a.example.org:9077,...
+#   ai-memory serve \
+#     --tls-cert       /etc/ai-memory/server.crt \
+#     --tls-key        /etc/ai-memory/server.key \
+#     --mtls-allowlist /etc/ai-memory/peer-fingerprints.allow \
+#     --quorum-peers   https://peer-a.example.org:9077,https://peer-b.example.org:9077
+#
+# The three --tls-cert / --tls-key / --mtls-allowlist flags and the
+# config.toml `api_key` are NOT env-settable and NOT pinned by the profile
+# below — they are the transport + application auth layers (federation.md
+# "The three auth layers", Layer 1 mTLS + Layer 2 X-API-Key) that the
+# certified posture requires but that this env file cannot carry. A
+# paste-and-run WITHOUT them is asi-hard-clean at the crypto/attestation
+# layer yet has NO transport confinement. Set them explicitly, and set the
+# shared API key in config.toml (there is NO --api-key CLI flag):
+#
+#   # /etc/ai-memory/config.toml
+#   api_key = "…"        # e.g. contents of /etc/ai-memory/api.key
+#
+# BEFORE first sync, enroll every peer's Ed25519 public key on THIS daemon
+# (default AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT is strict → an un-enrolled
+# x-peer-id is refused 401 peer_not_enrolled), per federation.md
+# "Operator checklist" step 3 / enterprise-deployment.md §8.6:
+#
+#   ai-memory identity import --agent-id peer-a@host --pub peer-a@host.pub
 #
 # Verify BEFORE relying on it — never infer from the flags alone (the
 # embedding-guard-gap lesson: verify the banner / doctor report, never
@@ -83,6 +106,19 @@ AI_MEMORY_PERMISSIONS_MODE=enforce
 # replication (#2504). No peer scope's `allowed_namespaces` may contain a
 # bare `**` (a deliberate per-peer allow-all) — the certified posture
 # forbids it; scope every peer to its real namespace set.
+#
+# ── Which identity lane is this? (legacy fingerprint + attestation) ──────
+# The CERTIFIED enterprise-federation posture stands up the LEGACY
+# transport/identity lane: the mTLS fingerprint allowlist
+# (--mtls-allowlist) + AI_MEMORY_FED_PEER_FINGERPRINTS outbound pinning +
+# per-peer AI_MEMORY_FED_PEER_ATTESTATION JSON + per-peer `.pub` Ed25519
+# enrollment (`ai-memory identity import`, federation.md "Operator
+# checklist" step 3). It does NOT require the zero-touch CA-rooted
+# credential system (AI_MEMORY_FED_TRUST_BUNDLE_DIR / _CRED_PATH /
+# _CRED_CHAIN_PATH / _INVENTORY_PATH, docs/federation-identity.md).
+# The zero-touch layer composes ON TOP and removes O(N^2) manual `.pub`
+# exchange as a fleet grows, but it is OPTIONAL — do not set those vars
+# unless you are adopting it. Stand up this lane first.
 
 # ── Peer URLs — REQUIRED. ─────────────────────────────────────────────────
 # https:// only for every non-loopback peer. The asi-hard pin above already
@@ -100,11 +136,44 @@ AI_MEMORY_PERMISSIONS_MODE=enforce
 # See docs/deploy/asi-hard.env for the full explanation.
 AI_MEMORY_INFERENCE_EGRESS=loopback-only
 
-# ── Optional operator key custody — recommended. ──────────────────────────
-# See docs/deploy/asi-hard.env for the full explanation.
-# AI_MEMORY_WITNESS_KEY_DIR=/etc/ai-memory/witness-keys
-# AI_MEMORY_WITNESS_PUBKEY=<base64-url-nopad-32-bytes>
-# AI_MEMORY_RECORDER_KEY_DIR=/etc/ai-memory/recorder-keys
-# AI_MEMORY_JUDGE_KEY_DIR=/etc/ai-memory/judge-keys
-# AI_MEMORY_STOPPER_KEY_DIR=/etc/ai-memory/stopper-keys
-# AI_MEMORY_OPERATOR_PUBKEY=<base64-32-bytes>
+# ── Audit-custody key enrollment — REQUIRED for a clean verify-audit-trail
+#    under asi-hard. ─────────────────────────────────────────────────────
+# The asi-hard profile (SSOT src/security_profile.rs::KNOBS) PINS four
+# require-modes ON:
+#   AI_MEMORY_REQUIRE_WITNESS          — dual-chain audit-head witness anchor
+#   AI_MEMORY_REQUIRE_ROLE_SEPARATION  — three-key Recorder/Judge/Stopper sep.
+#   AI_MEMORY_REQUIRE_IDENTITY_LINEAGE — identity-lineage succession chain
+#   AI_MEMORY_REQUIRE_ROLLBACK_CHECK   — open-time rollback-evidence head check
+# Those pins only BECOME cryptographically load-bearing once the matching
+# custody KEY material is enrolled. A require-mode with NO enrolled key is
+# DIRTY (exit 1), not withheld — so under asi-hard these are REQUIRED, not
+# merely recommended, to get a clean `ai-memory verify-audit-trail`.
+# Point each dir at a mount the daemon can READ but a compromised daemon
+# process cannot OVERWRITE:
+#
+#   AI_MEMORY_WITNESS_KEY_DIR=/etc/ai-memory/witness-keys       # signer (audit-witness.priv)
+#   AI_MEMORY_WITNESS_PUBKEY=<base64-url-nopad-32-bytes>        # K1 pin (verify-side)
+#   AI_MEMORY_RECORDER_KEY_DIR=/etc/ai-memory/recorder-keys     # role: Recorder signer
+#   AI_MEMORY_RECORDER_PUBKEY=<base64-url-nopad-32-bytes>       # Recorder pin
+#   AI_MEMORY_JUDGE_KEY_DIR=/etc/ai-memory/judge-keys           # role: Judge signer
+#   AI_MEMORY_JUDGE_PUBKEY=<base64-url-nopad-32-bytes>          # Judge pin
+#   AI_MEMORY_STOPPER_KEY_DIR=/etc/ai-memory/stopper-keys       # role: Stopper signer
+#   AI_MEMORY_STOPPER_PUBKEY=<base64-url-nopad-32-bytes>        # Stopper pin
+#   AI_MEMORY_OPERATOR_PUBKEY=<base64-32-bytes>                 # governance operator key
+# (The enrolled recorder/judge/stopper pubkeys MUST be pairwise-distinct.)
+# Identity lineage additionally needs an enrolled genesis succession record
+# (`agent_lineage`); rollback-check needs the off-table head-anchor.log on
+# the witness mount.
+#
+# ── doctor --posture is NOT verify-audit-trail — an HONEST distinction. ───
+# `ai-memory doctor --posture enterprise-federation` machine-checks the
+# 18 BOOT-time federation controls (enrollment / sig / nonce / scope /
+# fingerprints / attestation JSON / at-rest / plaintext-peer refusal, etc.
+# — src/enterprise_federation_posture.rs). It does NOT check the four
+# audit-custody require-modes above; those are consumed by a SEPARATE
+# command, `ai-memory verify-audit-trail` (src/governance/audit.rs, both
+# backends). CONSEQUENCE: a node can BOOT clean and PASS
+# `doctor --posture enterprise-federation` while `verify-audit-trail`
+# reports DIRTY — precisely because the pinned require-modes have no
+# enrolled key yet. Run BOTH as part of the certified stand-up; do not
+# read a green `doctor --posture` as proof the audit spine is anchored.

--- a/docs/federation-identity.md
+++ b/docs/federation-identity.md
@@ -36,6 +36,21 @@ layout: doc
 > [`docs/federation.md`](federation.html). The two layers compose: mTLS is
 > the transport boundary, zero-touch credentials are the application
 > identity carried *inside* it.
+>
+> **Which lane does the certified enterprise-federation profile use?**
+> The [`docs/deploy/enterprise-federation.env`](deploy/enterprise-federation.env)
+> CERTIFIED stand-up
+> (`AI_MEMORY_REQUIRE_ENTERPRISE_FEDERATION_POSTURE=1`) engages the
+> **legacy transport/identity lane** — the mTLS fingerprint allowlist +
+> `X-API-Key` + per-peer attestation JSON + per-peer `.pub` Ed25519
+> enrollment described in [`docs/federation.md`](federation.html). It
+> does **NOT** require the zero-touch CA-rooted credential system
+> documented below (`AI_MEMORY_FED_TRUST_BUNDLE_DIR` / `_CRED_PATH` /
+> `_CRED_CHAIN_PATH` / `_INVENTORY_PATH`). The zero-touch layer composes
+> cleanly ON TOP of the certified lane and removes O(N²) manual `.pub`
+> exchange as a fleet grows, but it is **optional** — stand up the legacy
+> lane first, then adopt zero-touch when peer count makes manual
+> enrollment the operational bottleneck.
 
 ---
 
@@ -216,6 +231,7 @@ This is a **pure de-hardcode**: a node that sets nothing presents the
 | `AI_MEMORY_FED_SYNC_TRUST_PEER` / `AI_MEMORY_FED_TRUST_BODY_AGENT_ID` | Legacy attestation bypass flags — leave unset under default-deny. |
 | `AI_MEMORY_FED_REQUIRE_TRANSITION_SIG` | **v0.8.0 (#1718), default `1` fail-closed.** Inner per-transition Ed25519 signature gate on inbound federated action-state transitions (an authority-granting write). A forged signature is rejected unconditionally regardless of this knob. See `docs/federation.md`. |
 | `AI_MEMORY_FED_REQUIRE_WRITE_SIG` | **v0.8.0 (#1464); default flipped to `1` fail-closed at v1.0.0 (#1801/#1954).** Per-write CONTENT attestation on inbound relayed memories (data, not authority): a valid `metadata.write_signature` over the #626 `SignableWrite` envelope upgrades the row to `attest_level=agent_attested`; truthy refuses an unsigned honored third-party claim. See `docs/federation.md`. |
+| `AI_MEMORY_FED_REQUIRE_SIGNAL_SIG` | **v0.8.1 (#1843); default flipped to `1` fail-closed at v1.0.0 (#1801/#1954).** Per-signal AUTHOR attestation on inbound relayed SIGNALS (the signal-subcollection sibling of `AI_MEMORY_FED_REQUIRE_WRITE_SIG`): truthy requires the signal to verify against `from_agent`'s locally-enrolled Ed25519 key, closing the CWE-346 forge-any-author gap. See `docs/federation.md`. |
 | `AI_MEMORY_FED_PEER_FINGERPRINTS` | **v0.8.0 (#1678), unset = pinning off.** Outbound peer SERVER-cert SHA-256 pinning (`known_hosts` model). **BOTH the daemon quorum client AND the `ai-memory sync` CLI call one builder (`tls::build_rustls_pinning_client_config`) that hardcodes `UnpinnedHostPolicy::Reject`, so an unpinned host is fail-closed on either path** — setting a partial pin file is a fail-closed outage, not a rollout, and `--ca-cert` is not consulted on a pinned run. Earlier revisions of this row called the CLI path the looser half ("accept-any", then "CA validation"); both were wrong (the `AcceptAny` variant has no production construction site since #1794). See `docs/federation.md`. |
 | `AI_MEMORY_FED_REQUIRE_SERVER_VERIFY` | **v1.0.0 (#2448), default `1` fail-closed.** Outbound federation TLS must verify the peer's SERVER certificate. `--insecure-skip-server-verify` is refused unless this is explicitly falsy AND `--client-cert`/`--client-key` are both supplied; pinned to `1` under `AI_MEMORY_SECURITY_PROFILE=asi-hard`. Federation replicates plaintext content, so an unverified peer server is a direct disclosure surface. See `docs/federation.md`. |
 | `AI_MEMORY_FED_DLQ_DEPTH_WARN_THRESHOLD` | **v0.8.0 (#1544), default `1000`.** Edge-triggered push-DLQ-depth WARN. See `docs/federation.md`. |

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -435,6 +435,42 @@ independently — these are layered on top.
   ([#1544](https://github.com/alphaonedev/ai-memory-mcp/issues/1544)).**
   See the DLQ paragraph in the runbook below.
 
+## v1.0.0 federation knobs (additional)
+
+Three more federation knobs ship at v1.0.0 beyond the v0.7/v0.8 set
+above. The certified `docs/deploy/enterprise-federation.env` profile
+leaves all three at their secure defaults:
+
+- **`AI_MEMORY_FED_REQUIRE_SIGNAL_SIG`** (**default `1`** at v1.0.0) —
+  per-signal AUTHOR attestation on inbound relayed signals, the
+  signal-subcollection sibling of `AI_MEMORY_FED_REQUIRE_WRITE_SIG`. An
+  enrolled peer may otherwise relay a signal forged as any agent
+  (CWE-346); truthy requires the signal to verify against `from_agent`'s
+  locally-enrolled Ed25519 key. Also in
+  [`federation-identity.md` §4](federation-identity.html) and
+  [`docs/enterprise-deployment.md` §14.3](enterprise-deployment.html).
+- **`AI_MEMORY_FED_REQUIRE_POLICY_CURRENT`** (**default `1`**) —
+  cross-node governance-policy freshness gate: refuses an inbound push
+  whose advertised `sender_policy_seq` is STRICTLY behind the local
+  committed policy with `409 stale_policy_version`. Fail-closed only for
+  a *detected*-stale epoch; an absent / undeterminable epoch is accepted
+  (fail-open by design), so it never hard-refuses a peer that does not
+  advertise. See [`docs/enterprise-deployment.md`
+  §14.3](enterprise-deployment.html). The certified
+  `enterprise-federation.env` pins it explicitly (#2911) so an
+  operator's `=0` cannot silently escape the certified set.
+- **`AI_MEMORY_FED_CERT_PEER_BINDING`** (default `warn`) +
+  **`AI_MEMORY_FED_CERT_PEER_BINDING_MAP`** (path; unset) — the INBOUND
+  mTLS client-cert ↔ `x-peer-id` cross-check, the compensating control
+  for an `AI_MEMORY_FED_REQUIRE_SIG=0` window. The map file binds each
+  pinned client-cert SHA-256 fingerprint to the one `x-peer-id` it may
+  assert (`<sha256-hex> <peer-id>` per line, same operator-declares-the-pin
+  model as the outbound `AI_MEMORY_FED_PEER_FINGERPRINTS`); `warn` logs a
+  mismatch, `enforce` refuses it `401 peer_id_cert_mismatch`. Inert until
+  the map is configured. Distinct from the OUTBOUND server-cert pinning
+  `AI_MEMORY_FED_PEER_FINGERPRINTS` above — this binds the peer's CLIENT
+  cert to its claimed identity.
+
 ## Quorum + vector clocks
 
 v0.6.x quorum semantics are unchanged: W-of-N writes (default majority),
@@ -456,12 +492,36 @@ local namespace cap, even if the sending peer's local cap is higher.
    `openssl x509 -in peer.crt -noout -fingerprint -sha256`.
 2. **Populate `peer-fingerprints.allow`.** One fingerprint per line.
    Inline comments (`# label`) and `:` separators tolerated.
-3. **Author the peer attestation JSON** and stage it in your secrets
-   manager. Treat the file like a config blob, not a credential — the
-   contents are operator-configured authorization, not authentication
-   material.
-4. **Set `AI_MEMORY_FED_PEER_ATTESTATION`** on the receiving daemon's
-   environment.
+3. **Enroll each peer's Ed25519 signing key — REQUIRED under the
+   default posture.** `AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT` defaults
+   to **strict** at v0.8.0+: an inbound `/sync/push` or `/sync/since`
+   that carries an `x-peer-id` with **no locally-enrolled Ed25519 public
+   key is rejected `401 peer_not_enrolled`** — the mTLS cert and the
+   attestation JSON alone are NOT sufficient. Exchange each peer's public
+   key out-of-band and import it into THIS daemon's key directory
+   (`AI_MEMORY_KEY_DIR`), the same `identity import` step
+   [`docs/enterprise-deployment.md` §8.4 / §8.6](enterprise-deployment.html)
+   prescribe for a swarm — restated here so this checklist is a complete
+   single turnkey path:
+   ```bash
+   # On the peer (one-time, if it has no keypair): writes bob@host2.pub
+   # under its key dir.
+   ai-memory identity generate --agent-id bob@host2
+   # Exchange bob@host2.pub out-of-band, then on THIS receiving daemon:
+   ai-memory identity import --agent-id bob@host2 --pub bob@host2.pub
+   ```
+   `import` writes a public-only `<agent_id>.pub` (no private half); the
+   receive path resolves it via
+   [`identity::verify::lookup_peer_public_key`](../src/identity/verify.rs).
+   The claimed `x-peer-id` MUST equal the enrolled `--agent-id`. During
+   the key-exchange window the rollout escape hatch
+   `AI_MEMORY_FED_ALLOW_UNENROLLED_PEERS=1` temporarily accepts
+   unenrolled peers — flip it back to unset once every peer is enrolled.
+4. **Author the peer attestation JSON and set
+   `AI_MEMORY_FED_PEER_ATTESTATION`** on the receiving daemon's
+   environment. Treat the file like a config blob, not a credential —
+   the contents are operator-configured authorization, not
+   authentication material.
 5. **Leave the two `TRUST_*` flags unset** unless your peer mesh is
    under operator-level control (e.g., the in-tree integration tests
    set both — see


### PR DESCRIPTION
Post-campaign last-mile: lifts the enterprise-federation config docs from the C7 adversarial verifier's **A− (turnkey-with-gaps)** to **A+** by consolidating the certified stand-up into one paste-and-run path. **Doc-only, 3 files.** Closes verifier gaps F3 (peer-key enrollment step), F4 (certified-lane clarity), F5 (full certified launch flags), F8 (knob-table completeness), F9 (custody-key enrollment + the honest doctor-vs-verify-audit-trail limitation — Fable-confirmed the 18-check posture gate references those audit knobs 0 times). No factual claim changed; anti-overclaim held (500–1000/≤50-peer, not-E2E). Doc gates green. Reviewed+signed by Fable. No tag-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)