### PR TITLE
fix(federation): inventory require_sig tri-state — omission no longer downgrades the fail-closed signing default (#2975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (federation inventory — omitting `enforcement.require_sig` no longer silently downgrades the fail-closed signing default; #2975)
+
+- **A federation inventory that simply OMITTED `enforcement.require_sig`
+  planned `DisableStrictEnforcement`, turning the v1.0.0 fail-closed signing
+  gate OFF.** `EnforcementSpec::require_sig` was a plain `bool` with a serde
+  struct-default of `false`, and the reconciler read that desired state
+  literally (`reconcile.rs`: `if want_strict && … else if !want_strict &&
+  observed.strict_enforced { DisableStrictEnforcement }`). Because the runtime
+  gate `AI_MEMORY_FED_REQUIRE_SIG` (env #29) is default-ON since v0.7.0, the
+  live posture IS `strict_enforced` — so an operator who wrote an inventory and
+  left the field out got an automatic downgrade of the secure default, and the
+  pre-secure-default rollout guidance ("flip `require_sig: true` last") had
+  silently inverted into an instruction to disable it. **A control that a
+  DELETED line switches off is the wrong shape.**
+- **`require_sig` is now a TRI-STATE `Option<bool>`**, consumed by an
+  exhaustive `match` (no `unwrap_or` collapse anywhere): `None` (omitted, or
+  the whole `enforcement:` block omitted — both spellings of silence agree) =
+  **unmanaged**, and the reconciler plans NO enforcement action in either
+  direction; `Some(true)` = `EnableStrictEnforcement`, still gated on every
+  desired node being observed sign-capable; `Some(false)` =
+  `DisableStrictEnforcement`. Deleting the line is a no-op; weakening the
+  fleet requires ADDING greppable lines.
+- **A deliberate downgrade takes a two-key turn.** An explicit
+  `require_sig: false` MUST carry a non-empty sibling `disable_reason` or the
+  inventory FAILS TO LOAD (`inventory_enforcement_disable_reason_missing`), and
+  a `disable_reason` present WITHOUT an explicit `require_sig: false` is also a
+  load error (`inventory_enforcement_disable_reason_without_disable`) so a
+  stale acknowledgement cannot rot into a standing pre-authorization for the
+  next downgrade. Both checks live at inventory load/validate — the reconciler
+  NEVER suppresses a planned action, because a suppressed action would make
+  `ReconcilePlan::is_noop()` falsely report convergence.
+- **New non-action advisory channel** `ReconcilePlan::advisories`, with
+  `ReconcileAdvisory::EnforcementUnmanagedDrift`, emitted when desired is
+  `None` AND the fleet is observed permissive — so an unmanaged-permissive
+  fleet is VISIBLE rather than silently reported as converged. `is_noop()`
+  stays actions-only (unchanged semantics): an advisory is an observation, not
+  work, and does not block convergence.
+- Option 1 ("just default the struct to `true`") was killed on grounds:
+  `desired.nodes().all(…)` is VACUOUSLY true on an empty node list, so the
+  minimal documented inventory would immediately plan `EnableStrictEnforcement`
+  and 401-partition every unlisted legacy sender — pinned by
+  `empty_node_list_does_not_vacuously_enable_strict_2975`.
+- `reconcile()` / `ReconcileAction` have zero callers outside the module, so
+  the API-shape change is free now and semver-breaking after Phase-4 wiring.
+  `docs/federation-identity.md` §3/§6/§7.6/§9 rewritten to the new contract
+  (the "omission keeps the permissive rollout posture" language is gone).
+  Covering unit tests in `reconcile.rs` (omitted+strict ⇒ no Disable — the
+  regression pin; omitted+permissive ⇒ advisory; both explicit-true gated
+  paths; explicit-false ⇒ Disable; idempotence in all three desired states) and
+  `inventory.rs` (both two-key-turn error directions, the happy path, and the
+  two-spellings-of-silence pin). 5-agent T3 adversarial vote, 4-1 (Option 2 +
+  hardened Option 3).
+
 ### Security (append-only spine — the primary create funnel's upsert no longer bypasses the signed ledger; #2948 / PR-3)
 
 - **`db::insert` — the hottest write path — rewrote durable authored `content`

--- a/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
+++ b/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
@@ -600,6 +600,35 @@ for the changed wire surface — the posture is UNCHANGED from `e22bc93c`
 except that a formerly-silent quarantine is now operator-visible (strictly
 MORE observable, never weaker).
 
+**Re-cert trigger — FIRED, pending re-affirmation (PR #2979, #2975
+inventory `require_sig` tri-state).** The §7-watched federation surface
+changed: `src/federation/identity/inventory.rs` (`EnforcementSpec`) and
+`src/federation/identity/reconcile.rs` (the Phase-4 declarative
+reconciler planner). The change is **planner/config-plane ONLY — no
+wire, no schema, no runtime-gate change**: `reconcile()` /
+`ReconcileAction` have ZERO production callers (Phase-4 scaffolding), so
+no shipped execution path changes behavior; the runtime signing gate
+(`AI_MEMORY_FED_REQUIRE_SIG`, env #29) and every receive-path check are
+byte-identical. What changed is the declarative contract:
+`EnforcementSpec::require_sig` became a tri-state `Option<bool>` so an
+inventory that OMITS the field can no longer plan
+`DisableStrictEnforcement` against the fail-closed runtime default (the
+#2975 footgun — a deleted line silently downgrading the certified
+posture); an explicit downgrade now requires a two-key turn
+(`require_sig: false` + non-empty `disable_reason`, enforced at
+inventory load), and unmanaged-permissive drift surfaces as a non-action
+`ReconcileAdvisory`. It adds **NO new `AI_MEMORY_FED_*` identifier**
+(the existing env #29 mapping is unchanged) and REMOVES **no** certified
+control (the removal-proof set is unchanged; the cert gate's 18 checks
+reference none of the changed symbols). Ratified by a 5-agent T3
+adversarial vote (4–1, recorded on #2975). **This PR does NOT re-mint
+the certification:** re-running §5.4(2)–(5) at the new SHA and
+re-affirming this document against it is the operator/reviewer gate.
+Until that re-affirmation lands, treat the certification as EXPIRED per
+this clause for the changed surface — the posture is strictly STRONGER,
+never weaker, than at `e22bc93c` (a silent-downgrade path in the
+declarative operator flow was closed).
+
 **Named signer.** The determination at `580d8427` is a **GitHub
 squash-merge** of PR #2910, committed by `GitHub` on behalf of the
 operator account (`alphaonedev`). GitHub signature verification is

--- a/docs/federation-identity.md
+++ b/docs/federation-identity.md
@@ -299,7 +299,10 @@ quorum:
   width: 2                           # W-of-N; >= MIN_QUORUM_WIDTH (1)
 
 enforcement:
-  require_sig: true                  # maps to AI_MEMORY_FED_REQUIRE_SIG
+  require_sig: true                  # tri-state; OMIT = unmanaged, not
+                                     # permissive. Maps to
+                                     # AI_MEMORY_FED_REQUIRE_SIG.
+  # disable_reason: <why>            # REQUIRED with `require_sig: false`
 ```
 
 Field reference:
@@ -329,12 +332,38 @@ Field reference:
 - **`enforcement.require_sig`** — the reconciler's DESIRED strict-enforcement
   state (whether receivers reject unsigned posts); maps to the runtime gate
   `AI_MEMORY_FED_REQUIRE_SIG`, which is **fail-closed / ON by default at
-  v1.0.0** (env #29). This inventory field's struct-default is `false`, so an
-  inventory that OMITS it declares *desired = permissive* — and the reconciler
-  then emits `DisableStrictEnforcement`, **actively downgrading the fail-closed
-  default** rather than "keeping" it. Set `require_sig: true` to match the
-  secure default; leave it `false` only inside a deliberate staged-enrollment
-  window (see §9). The struct-default footgun is tracked in #2975.
+  v1.0.0** (env #29). It is a **tri-state** (`Option<bool>`, #2975):
+
+  | value | meaning | reconciler plans |
+  |---|---|---|
+  | *omitted* | **unmanaged** — the inventory declines to govern enforcement | NOTHING, in either direction |
+  | `true` | desired strict | `EnableStrictEnforcement`, gated on all nodes observed sign-capable |
+  | `false` | desired permissive (requires `disable_reason`) | `DisableStrictEnforcement`, immediately |
+
+  Omission is **not** "desired permissive". Deleting the line is a no-op, so
+  an inventory that says nothing can never downgrade the fail-closed runtime
+  default. Omitting the whole `enforcement:` block and writing
+  `enforcement: {}` are the same state.
+
+- **`enforcement.disable_reason`** — the second key of the two-key turn. An
+  explicit `require_sig: false` MUST be accompanied by a non-empty
+  `disable_reason` or the inventory **fails to load** with
+  `inventory_enforcement_disable_reason_missing`. The reverse is also a load
+  error (`inventory_enforcement_disable_reason_without_disable`): a
+  `disable_reason` left behind after the downgrade was reverted would silently
+  pre-authorize the next one, so stale acknowledgements are rejected. Both
+  checks live at inventory load/validate — the reconciler never suppresses a
+  planned action, because a suppressed action would make
+  `ReconcilePlan::is_noop()` falsely report convergence.
+
+  Net effect: weakening the fleet requires **adding two greppable lines**,
+  never deleting one.
+
+  ```yaml
+  enforcement:
+    require_sig: false
+    disable_reason: staged peer key enrollment window, ticket OPS-42
+  ```
 
 ---
 
@@ -437,6 +466,21 @@ state is a no-op (`ReconcilePlan::is_noop()`). The plan is
 emitted **last**, gated on observed sign-capability, so the reconciler
 can never recreate the manual "enroll-before-sign" footgun.
 
+The enforcement arm is an exhaustive `match` on the `require_sig`
+tri-state (§6), so an inventory that omits the field plans **no**
+enforcement action in either direction — it can neither tighten nor
+downgrade the live gate. Because "unmanaged" is not the same as "fine",
+the plan also carries a **non-action advisory** channel,
+`ReconcilePlan::advisories`. A fleet observed permissive while the
+inventory declines to manage enforcement yields
+`ReconcileAdvisory::EnforcementUnmanagedDrift`, so an unmanaged-permissive
+fleet is visible rather than silently reported as converged. Advisories
+are excluded from `is_noop()` **by design** — they are observations, not
+work, and **do not block convergence**; the applier never "applies" one.
+Resolve one by declaring intent: `require_sig: true` to have the
+reconciler flip enforcement on, or an explicit `require_sig: false` +
+`disable_reason` to record that permissive is deliberate.
+
 The side-effecting "Apply" half is
 [`scripts/federation-rollout.sh`](../scripts/federation-rollout.sh) — the
 generalized `deploy-rebuild.sh`: capture argv+environ (secrets
@@ -515,12 +559,28 @@ These are the load-bearing checks, each pinned end-to-end in
    auto-rollback). Watch the signed-vs-unsigned ratio climb toward 1.0.
 5. **Only after every node presents signed credentials**, set
    `enforcement.require_sig: true` (partition-safe; the reconciler flips
-   enforcement on **last**). Note: the runtime gate is already fail-closed by
-   default at v1.0.0, so this staged model applies only when you have
-   *deliberately* set `require_sig: false` (or `AI_MEMORY_FED_REQUIRE_SIG=0`)
-   for the enrollment window — a downgrade the reconciler honours by emitting
-   `DisableStrictEnforcement`. A greenfield v1.0.0 fleet that enrolls keys
-   before its first strict boot needs no downgrade at all.
+   enforcement on **last**). The runtime gate is already fail-closed by
+   default at v1.0.0, so a greenfield fleet that enrolls keys before its
+   first strict boot needs no downgrade at all — and an inventory that
+   simply **omits** `require_sig` leaves the secure default alone
+   (unmanaged, §6), it does not turn it off.
+
+   The staged model below applies only when you *deliberately* open an
+   enrollment window. Doing so takes both keys — an explicit
+   `require_sig: false` **and** a non-empty `disable_reason`, or the
+   inventory will not load:
+
+   ```yaml
+   enforcement:
+     require_sig: false
+     disable_reason: enrolling region/sfo peer keys, ticket OPS-42
+   ```
+
+   The reconciler honours that by emitting `DisableStrictEnforcement`.
+   Close the window by restoring `require_sig: true` **and deleting the
+   `disable_reason`** — a leftover reason is itself a load error, so the
+   acknowledgement cannot rot into a standing pre-authorization for the
+   next downgrade.
 6. **For regional scale**, mint intermediate CAs per region (§7.4) and
    move receivers to a **root-only** bundle.
 

--- a/src/federation/identity/inventory.rs
+++ b/src/federation/identity/inventory.rs
@@ -14,14 +14,22 @@
 //!
 //! Unlike an MCP tool-request struct (which stays permissive per #1052 so
 //! the wire schema is truthful for heterogeneous hosts), this is an
-//! operator-authored *trust* config. A silently-dropped typo —
-//! `requir_sig:` parsing as the default `require_sig: false` — would
-//! quietly weaken enforcement. So every struct here carries
-//! `#[serde(deny_unknown_fields)]`: an unrecognised key is a hard parse
-//! error the operator sees at load time, mirroring the inline-API-key
-//! rejection in [`crate::config`]. (The #1052 honesty pin only scans the
-//! MCP `tool_definitions()` payload, so this strictness is out of its
-//! scope.)
+//! operator-authored *trust* config. Every struct here carries
+//! `#[serde(deny_unknown_fields)]`, so an unrecognised key is a hard
+//! parse error the operator sees at load time, mirroring the
+//! inline-API-key rejection in [`crate::config`]. (The #1052 honesty pin
+//! only scans the MCP `tool_definitions()` payload, so this strictness is
+//! out of its scope.)
+//!
+//! That strictness is load-bearing for the enforcement block (#2975).
+//! WITHOUT it, a typo would be silently dropped and the surviving struct
+//! would still parse: `requir_sig: false` would leave
+//! [`EnforcementSpec::require_sig`] at its serde default `None`, silently
+//! demoting an intended explicit downgrade to *unmanaged*; and
+//! `disable_resaon:` would strip the two-key acknowledgement out of an
+//! explicit `require_sig: false`, defeating the very validation that
+//! makes a downgrade deliberate. With `deny_unknown_fields` both are
+//! parse errors, not silent posture changes.
 //!
 //! ## Reuse, not reinvention
 //!
@@ -105,15 +113,81 @@ pub struct QuorumSpec {
     pub width: u32,
 }
 
-/// Fleet enforcement posture.
+/// Fleet enforcement posture — a **tri-state** desired declaration (#2975).
+///
+/// The runtime gate this maps to (`AI_MEMORY_FED_REQUIRE_SIG`, env #29) is
+/// fail-closed / ON by default at v1.0.0. A two-valued `bool` desired-state
+/// could not distinguish "the operator wants permissive" from "the operator
+/// said nothing", so an inventory that merely omitted the block declared
+/// *desired = permissive* and the reconciler dutifully planned
+/// [`super::reconcile::ReconcileAction::DisableStrictEnforcement`] —
+/// silently downgrading the secure default. Hence the `Option`:
+///
+/// - `None` (field omitted, or the whole `enforcement:` block omitted) —
+///   enforcement is **unmanaged**. The reconciler plans NO enforcement
+///   action in either direction; deleting the line is a no-op, never a
+///   downgrade.
+/// - `Some(true)` — desired strict. The reconciler emits
+///   `EnableStrictEnforcement`, still gated on every desired node being
+///   observed sign-capable.
+/// - `Some(false)` — desired permissive. The reconciler emits
+///   `DisableStrictEnforcement`, and the inventory MUST carry a non-empty
+///   [`disable_reason`](Self::disable_reason) or it fails validation at
+///   load time. Weakening the fleet therefore requires ADDING two
+///   greppable lines, not deleting one.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnforcementSpec {
-    /// Whether receivers reject unsigned posts. Maps to
-    /// `AI_MEMORY_FED_REQUIRE_SIG`. Defaults to `false` so an inventory
-    /// that omits the block keeps the permissive rollout posture.
+    /// Desired strict-enforcement state (whether receivers reject unsigned
+    /// posts). Maps to `AI_MEMORY_FED_REQUIRE_SIG`. **Omitted = `None` =
+    /// unmanaged**, NOT permissive — see the type docs. Consumed with an
+    /// exhaustive `match`; never collapse it with `unwrap_or`.
     #[serde(default)]
-    pub require_sig: bool,
+    pub require_sig: Option<bool>,
+    /// Operator acknowledgement accompanying an explicit
+    /// `require_sig: false` — the second key of the two-key turn.
+    ///
+    /// Enforcement of this pairing lives entirely at inventory
+    /// load/validate ([`FederationInventory::validate`]), never in the
+    /// reconciler: suppressing a planned action would make
+    /// [`super::reconcile::ReconcilePlan::is_noop`] falsely report
+    /// convergence. Both directions are validation errors — a downgrade
+    /// without a reason, and a reason left behind after the downgrade was
+    /// reverted (stale-ack rot).
+    #[serde(default)]
+    pub disable_reason: Option<String>,
+}
+
+impl EnforcementSpec {
+    /// Validate the two-key turn on an explicit strict-enforcement
+    /// downgrade.
+    ///
+    /// # Errors
+    /// [`InventoryError::EnforcementDisableReasonMissing`] when
+    /// `require_sig: false` carries no non-empty `disable_reason`;
+    /// [`InventoryError::EnforcementDisableReasonWithoutDisable`] when a
+    /// `disable_reason` is present without an explicit `require_sig: false`.
+    fn validate(&self) -> Result<(), InventoryError> {
+        match self.require_sig {
+            // Explicit downgrade: demand a non-empty acknowledgement.
+            Some(false) => {
+                if !self
+                    .disable_reason
+                    .as_deref()
+                    .is_some_and(|r| !r.trim().is_empty())
+                {
+                    return Err(InventoryError::EnforcementDisableReasonMissing);
+                }
+            }
+            // Strict or unmanaged: a lingering acknowledgement is rot.
+            Some(true) | None => {
+                if self.disable_reason.is_some() {
+                    return Err(InventoryError::EnforcementDisableReasonWithoutDisable);
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 /// The declarative inventory: desired fleet membership + trust topology +
@@ -132,7 +206,9 @@ pub struct FederationInventory {
     pub regions: Vec<RegionSpec>,
     /// Quorum width.
     pub quorum: QuorumSpec,
-    /// Enforcement posture (defaults to permissive when omitted).
+    /// Enforcement posture. Omitting the whole block is the SAME desired
+    /// state as omitting `require_sig` inside it — both spellings of
+    /// silence yield `require_sig: None` (**unmanaged**, not permissive).
     #[serde(default)]
     pub enforcement: EnforcementSpec,
 }
@@ -165,6 +241,15 @@ pub enum InventoryError {
     DuplicateNodeId { id: String },
     /// `quorum.width` is below [`MIN_QUORUM_WIDTH`].
     InvalidQuorumWidth { width: u32 },
+    /// `enforcement.require_sig: false` (an explicit strict-enforcement
+    /// downgrade) carried no non-empty `enforcement.disable_reason` — the
+    /// second key of the two-key turn (#2975).
+    EnforcementDisableReasonMissing,
+    /// `enforcement.disable_reason` is present without an explicit
+    /// `enforcement.require_sig: false`. A stale acknowledgement left
+    /// behind after a downgrade was reverted would silently pre-authorize
+    /// the next one, so it is rejected at load time (#2975).
+    EnforcementDisableReasonWithoutDisable,
 }
 
 impl InventoryError {
@@ -181,6 +266,10 @@ impl InventoryError {
             Self::RenewBeforeNotShorterThanTtl { .. } => "inventory_renew_before_not_shorter",
             Self::DuplicateNodeId { .. } => "inventory_duplicate_node_id",
             Self::InvalidQuorumWidth { .. } => "inventory_invalid_quorum_width",
+            Self::EnforcementDisableReasonMissing => "inventory_enforcement_disable_reason_missing",
+            Self::EnforcementDisableReasonWithoutDisable => {
+                "inventory_enforcement_disable_reason_without_disable"
+            }
         }
     }
 }
@@ -252,7 +341,8 @@ impl FederationInventory {
 
     /// Semantic validation beyond what serde shape-checks: non-empty
     /// trust domain + region names, valid node ids, parsable + sane
-    /// durations, unique ids, and a sane quorum width.
+    /// durations, unique ids, a sane quorum width, and the #2975 two-key
+    /// turn on an explicit strict-enforcement downgrade.
     ///
     /// # Errors
     /// One of the semantic [`InventoryError`] variants on the first
@@ -266,6 +356,9 @@ impl FederationInventory {
                 width: self.quorum.width,
             });
         }
+        // #2975 — the ack for an explicit downgrade is enforced HERE, at
+        // load, and never by suppressing a reconciler action.
+        self.enforcement.validate()?;
         let mut seen_ids: BTreeSet<&str> = BTreeSet::new();
         for region in &self.regions {
             if region.name.trim().is_empty() {
@@ -373,7 +466,8 @@ enforcement:
         assert_eq!(inv.root_ca.as_deref(), Some("root.pub"));
         assert_eq!(inv.regions.len(), 2);
         assert_eq!(inv.quorum.width, 2);
-        assert!(inv.enforcement.require_sig);
+        assert_eq!(inv.enforcement.require_sig, Some(true));
+        assert_eq!(inv.enforcement.disable_reason, None);
         assert_eq!(inv.nodes().count(), 3);
         let first = inv.nodes().next().expect("a node");
         assert_eq!(first.id, "region/nyc/node-1");
@@ -386,16 +480,116 @@ enforcement:
         );
     }
 
+    /// #2975 — the two spellings of silence. An absent `enforcement:`
+    /// block and a present-but-empty `enforcement: {}` MUST both yield
+    /// `require_sig: None` (unmanaged), never `Some(false)`. serde
+    /// field-`default` and struct-`Default` are different mechanisms, so
+    /// this pins that they cannot diverge.
     #[test]
-    fn enforcement_defaults_to_permissive_when_omitted() {
-        let yaml = "\
+    fn enforcement_is_unmanaged_when_omitted_or_empty() {
+        let block_absent = "\
 trust_domain: d
 quorum:
   width: 1
 ";
-        let inv = FederationInventory::from_yaml_str(yaml).expect("valid");
-        assert!(!inv.enforcement.require_sig);
+        let inv = FederationInventory::from_yaml_str(block_absent).expect("valid");
+        assert_eq!(
+            inv.enforcement.require_sig, None,
+            "an omitted enforcement block is UNMANAGED, not permissive"
+        );
+        assert_eq!(inv.enforcement.disable_reason, None);
         assert_eq!(inv.nodes().count(), 0);
+
+        let block_empty = "\
+trust_domain: d
+quorum:
+  width: 1
+enforcement: {}
+";
+        let inv_empty = FederationInventory::from_yaml_str(block_empty).expect("valid");
+        assert_eq!(
+            inv_empty.enforcement, inv.enforcement,
+            "`enforcement: {{}}` must be identical to an omitted block"
+        );
+        assert_eq!(inv_empty.enforcement.require_sig, None);
+    }
+
+    /// #2975 two-key turn, key 1 missing: an explicit downgrade with no
+    /// acknowledgement is a load-time validation error.
+    #[test]
+    fn explicit_disable_without_reason_is_rejected() {
+        let yaml = "\
+trust_domain: d
+quorum:
+  width: 1
+enforcement:
+  require_sig: false
+";
+        let err = FederationInventory::from_yaml_str(yaml).expect_err("needs a reason");
+        assert_eq!(err, InventoryError::EnforcementDisableReasonMissing);
+        assert_eq!(err.tag(), "inventory_enforcement_disable_reason_missing");
+    }
+
+    /// A whitespace-only reason is not an acknowledgement.
+    #[test]
+    fn explicit_disable_with_blank_reason_is_rejected() {
+        let yaml = "\
+trust_domain: d
+quorum:
+  width: 1
+enforcement:
+  require_sig: false
+  disable_reason: '   '
+";
+        let err = FederationInventory::from_yaml_str(yaml).expect_err("blank is not a reason");
+        assert_eq!(err, InventoryError::EnforcementDisableReasonMissing);
+    }
+
+    /// #2975 stale-ack rot: a `disable_reason` left behind after the
+    /// downgrade was reverted (or never made) is a validation error in
+    /// BOTH surviving states — unmanaged and explicit-strict.
+    #[test]
+    fn disable_reason_without_explicit_disable_is_rejected() {
+        for enforcement in [
+            "enforcement:\n  disable_reason: leftover\n",
+            "enforcement:\n  require_sig: true\n  disable_reason: leftover\n",
+            // Even an EMPTY reason is rot: its presence is the signal.
+            "enforcement:\n  disable_reason: ''\n",
+        ] {
+            let yaml = format!("trust_domain: d\nquorum:\n  width: 1\n{enforcement}");
+            let Err(err) = FederationInventory::from_yaml_str(&yaml) else {
+                panic!("stale ack must be rejected: {enforcement}");
+            };
+            assert_eq!(
+                err,
+                InventoryError::EnforcementDisableReasonWithoutDisable,
+                "wrong error for: {enforcement}"
+            );
+            assert_eq!(
+                err.tag(),
+                "inventory_enforcement_disable_reason_without_disable"
+            );
+        }
+    }
+
+    /// The happy path of the two-key turn: an explicit downgrade WITH a
+    /// non-empty reason parses and validates.
+    #[test]
+    fn explicit_disable_with_reason_parses() {
+        let yaml = "\
+trust_domain: d
+quorum:
+  width: 1
+enforcement:
+  require_sig: false
+  disable_reason: staged peer key enrollment window, ticket OPS-42
+";
+        let inv = FederationInventory::from_yaml_str(yaml).expect("valid two-key downgrade");
+        assert_eq!(inv.enforcement.require_sig, Some(false));
+        assert_eq!(
+            inv.enforcement.disable_reason.as_deref(),
+            Some("staged peer key enrollment window, ticket OPS-42")
+        );
     }
 
     #[test]

--- a/src/federation/identity/reconcile.rs
+++ b/src/federation/identity/reconcile.rs
@@ -23,11 +23,43 @@
 //! that this pass's enroll/issue actions will succeed. Relaxing enforcement is
 //! always safe and is emitted immediately.
 //!
+//! ## The enforcement tri-state (#2975) — omission is UNMANAGED
+//!
+//! The mirror-image footgun is a downgrade nobody asked for. The runtime gate
+//! (`AI_MEMORY_FED_REQUIRE_SIG`, env #29) is fail-closed / ON by default at
+//! v1.0.0, so while
+//! [`EnforcementSpec::require_sig`](super::inventory::EnforcementSpec::require_sig)
+//! was a plain `bool`, an inventory that simply OMITTED the field declared
+//! *desired = permissive* and this function planned `DisableStrictEnforcement`
+//! — silently turning the secure default OFF. `require_sig` is now
+//! `Option<bool>` and consumed by an exhaustive `match`:
+//!
+//! | desired `require_sig` | meaning | enforcement action planned |
+//! |---|---|---|
+//! | `None` (omitted) | **unmanaged** | NONE, in either direction |
+//! | `Some(true)` | desired strict | `EnableStrictEnforcement`, gated on all-sign-capable |
+//! | `Some(false)` | desired permissive | `DisableStrictEnforcement`, immediately |
+//!
+//! Deleting the line is therefore a no-op; weakening the fleet requires
+//! ADDING an explicit `require_sig: false` **and** a non-empty
+//! `disable_reason`. That acknowledgement is enforced entirely at inventory
+//! load/validate — this module NEVER suppresses a planned action, because a
+//! suppressed action would make [`ReconcilePlan::is_noop`] falsely report
+//! convergence.
+//!
+//! Unmanaged is not the same as *fine*, so the plan carries a non-action
+//! [`ReconcileAdvisory`] channel: a fleet observed permissive while the
+//! inventory declines to manage enforcement emits
+//! [`ReconcileAdvisory::EnforcementUnmanagedDrift`], so an
+//! unmanaged-permissive fleet is VISIBLE rather than silently "converged".
+//!
 //! ## Idempotence
 //!
-//! A converged fleet yields an empty plan ([`ReconcilePlan::is_noop`]). Re-running
-//! the reconciler against state it already produced is a no-op — the controller
-//! loop can call it on a timer without thrashing.
+//! A converged fleet yields an empty ACTION list ([`ReconcilePlan::is_noop`]).
+//! Re-running the reconciler against state it already produced is a no-op —
+//! the controller loop can call it on a timer without thrashing. `is_noop` is
+//! deliberately **actions-only**: an advisory is an observation, not work, and
+//! does NOT block convergence.
 
 use std::collections::BTreeMap;
 
@@ -86,28 +118,61 @@ pub enum ReconcileAction {
     IssueCredential { id: String },
     /// An observed node is not in the inventory — decommission it.
     DecommissionNode { id: String },
-    /// Flip the fleet to reject unsigned posts. Emitted ONLY when every
-    /// desired node is observed sign-capable, and always ordered LAST so a
-    /// plan that also enrolls/issues never strict-enforces ahead of
-    /// capability.
+    /// Flip the fleet to reject unsigned posts. Emitted ONLY when the
+    /// inventory declares `require_sig: Some(true)` AND every desired node is
+    /// observed sign-capable, and always ordered LAST so a plan that also
+    /// enrolls/issues never strict-enforces ahead of capability.
     EnableStrictEnforcement,
     /// Relax the fleet to accept unsigned posts. Always partition-safe;
-    /// emitted immediately when the inventory wants permissive but the fleet
-    /// is observed strict.
+    /// emitted immediately when the inventory declares an EXPLICIT
+    /// `require_sig: Some(false)` (which validation required a
+    /// `disable_reason` for) but the fleet is observed strict. An inventory
+    /// that merely omits `require_sig` NEVER produces this action (#2975).
     DisableStrictEnforcement,
 }
 
+/// A non-action observation the reconciler surfaces alongside the plan
+/// (#2975).
+///
+/// An advisory reports a state an operator probably wants to know about but
+/// that the inventory has NOT asked the reconciler to change. It is
+/// deliberately excluded from [`ReconcilePlan::is_noop`] and from the applier
+/// contract: an advisory NEVER blocks convergence and is never "applied".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcileAdvisory {
+    /// The inventory declines to manage enforcement
+    /// (`require_sig` omitted ⇒ `None`) AND the fleet is observed permissive
+    /// (`strict_enforced == false`).
+    ///
+    /// This is the visibility mitigation for omission-is-unmanaged: without
+    /// it, an unmanaged fleet sitting permissive would report as cleanly
+    /// converged and nobody would learn that the highest-value posture field
+    /// is going ungoverned. Resolve it by declaring intent —
+    /// `require_sig: true` to have the reconciler flip it on, or an explicit
+    /// `require_sig: false` + `disable_reason` to record that permissive is
+    /// deliberate.
+    EnforcementUnmanagedDrift,
+}
+
 /// The ordered set of actions that converges the observed fleet toward the
-/// desired inventory.
+/// desired inventory, plus any non-action advisories.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReconcilePlan {
     /// Actions in apply order: enrollments → credential issuance →
     /// decommissions → enforcement relaxation → enforcement tightening (last).
     pub actions: Vec<ReconcileAction>,
+    /// Non-action observations (#2975). Carrying an advisory does NOT make a
+    /// plan non-converged — see [`Self::is_noop`].
+    pub advisories: Vec<ReconcileAdvisory>,
 }
 
 impl ReconcilePlan {
     /// A converged fleet needs no actions.
+    ///
+    /// **Actions-only, by design.** Advisories are observations, not work: a
+    /// plan carrying only an advisory IS converged and the controller loop
+    /// must not thrash on it. Report advisories separately via
+    /// [`Self::advisories`].
     #[must_use]
     pub fn is_noop(&self) -> bool {
         self.actions.is_empty()
@@ -121,16 +186,25 @@ impl ReconcilePlan {
 /// 1. `EnrollNode` for every desired node absent from the observed fleet.
 /// 2. `IssueCredential` for every desired node present-but-not-sign-capable.
 /// 3. `DecommissionNode` for every observed node not in the inventory.
-/// 4. `DisableStrictEnforcement` when the inventory wants permissive but the
-///    fleet is strict (always safe).
-/// 5. `EnableStrictEnforcement` — LAST, and ONLY when the inventory wants
-///    strict, the fleet is not yet strict, AND every desired node is observed
-///    sign-capable. If any desired node still lacks signing capability this
-///    pass only does the enroll/issue work; a later pass (after credentials
-///    propagate) emits the enforcement flip.
+/// 4. `DisableStrictEnforcement` when the inventory declares an EXPLICIT
+///    `require_sig: Some(false)` but the fleet is strict (always safe).
+/// 5. `EnableStrictEnforcement` — LAST, and ONLY when the inventory declares
+///    `require_sig: Some(true)`, the fleet is not yet strict, AND every
+///    desired node is observed sign-capable. If any desired node still lacks
+///    signing capability this pass only does the enroll/issue work; a later
+///    pass (after credentials propagate) emits the enforcement flip.
+///
+/// Steps 4 and 5 are mutually exclusive arms of ONE exhaustive `match` on the
+/// tri-state desired value, so at most one enforcement action is ever planned
+/// and `require_sig: None` (unmanaged) plans neither (#2975). An unmanaged
+/// fleet observed permissive instead yields
+/// [`ReconcileAdvisory::EnforcementUnmanagedDrift`] on
+/// [`ReconcilePlan::advisories`], which does not affect
+/// [`ReconcilePlan::is_noop`].
 #[must_use]
 pub fn reconcile(desired: &FederationInventory, observed: &ObservedState) -> ReconcilePlan {
     let mut actions = Vec::new();
+    let mut advisories = Vec::new();
 
     let desired_ids: BTreeMap<&str, ()> = desired.nodes().map(|n| (n.id.as_str(), ())).collect();
 
@@ -157,18 +231,40 @@ pub fn reconcile(desired: &FederationInventory, observed: &ObservedState) -> Rec
         }
     }
 
-    // 4+5 — enforcement transition, gated on observed capability.
-    let want_strict = desired.enforcement.require_sig;
-    if want_strict && !observed.strict_enforced {
-        let all_sign_capable = desired.nodes().all(|n| observed.is_sign_capable(&n.id));
-        if all_sign_capable {
-            actions.push(ReconcileAction::EnableStrictEnforcement);
+    // 4+5 — enforcement transition. EXHAUSTIVE match on the #2975 tri-state:
+    // an omitted `require_sig` is UNMANAGED and must never be collapsed to
+    // `false` by an `unwrap_or`, which is exactly the bug this closes.
+    match desired.enforcement.require_sig {
+        // Desired strict — tighten LAST, and only grounded in observed
+        // capability, never in the optimism that this pass's enroll/issue
+        // actions will succeed.
+        Some(true) => {
+            if !observed.strict_enforced && desired.nodes().all(|n| observed.is_sign_capable(&n.id))
+            {
+                actions.push(ReconcileAction::EnableStrictEnforcement);
+            }
         }
-    } else if !want_strict && observed.strict_enforced {
-        actions.push(ReconcileAction::DisableStrictEnforcement);
+        // Desired permissive, EXPLICITLY (validation already required a
+        // non-empty `disable_reason`). Relaxing is always partition-safe.
+        Some(false) => {
+            if observed.strict_enforced {
+                actions.push(ReconcileAction::DisableStrictEnforcement);
+            }
+        }
+        // Unmanaged — plan NOTHING in either direction. Surface the drift so
+        // an unmanaged-permissive fleet is visible rather than silently
+        // "converged".
+        None => {
+            if !observed.strict_enforced {
+                advisories.push(ReconcileAdvisory::EnforcementUnmanagedDrift);
+            }
+        }
     }
 
-    ReconcilePlan { actions }
+    ReconcilePlan {
+        actions,
+        advisories,
+    }
 }
 
 #[cfg(test)]
@@ -197,6 +293,46 @@ quorum:
   width: 2
 enforcement:
   require_sig: true
+";
+
+    /// The SAME two nodes, but the inventory says nothing about
+    /// enforcement — the #2975 unmanaged state (`require_sig: None`).
+    const TWO_NODE_UNMANAGED: &str = "\
+trust_domain: fleet
+regions:
+  - name: r
+    nodes:
+      - id: node-1
+        attestor: mtls-cert
+        cred_ttl: 1h
+        renew_before: 5m
+      - id: node-2
+        attestor: mtls-cert
+        cred_ttl: 1h
+        renew_before: 5m
+quorum:
+  width: 2
+";
+
+    /// The SAME two nodes with an EXPLICIT, acknowledged downgrade.
+    const TWO_NODE_EXPLICIT_DISABLE: &str = "\
+trust_domain: fleet
+regions:
+  - name: r
+    nodes:
+      - id: node-1
+        attestor: mtls-cert
+        cred_ttl: 1h
+        renew_before: 5m
+      - id: node-2
+        attestor: mtls-cert
+        cred_ttl: 1h
+        renew_before: 5m
+quorum:
+  width: 2
+enforcement:
+  require_sig: false
+  disable_reason: staged peer key enrollment, ticket OPS-42
 ";
 
     fn signing(id: &str) -> ObservedNode {
@@ -376,6 +512,7 @@ quorum:
   width: 1
 enforcement:
   require_sig: false
+  disable_reason: staged peer key enrollment, ticket OPS-42
 ");
         let observed = ObservedState {
             nodes: vec![signing("node-1")],
@@ -386,17 +523,218 @@ enforcement:
             plan.actions,
             vec![ReconcileAction::DisableStrictEnforcement]
         );
+        assert!(
+            plan.advisories.is_empty(),
+            "an explicitly-managed downgrade is not unmanaged drift"
+        );
     }
 
+    // ---------------------------------------------------------------
+    // #2975 — enforcement is a TRI-STATE; omission is UNMANAGED.
+    // ---------------------------------------------------------------
+
+    /// **The regression test for the footgun.** Under the v1.0.0 secure
+    /// default the live posture IS strict. An inventory that simply OMITS
+    /// `require_sig` must NOT plan `DisableStrictEnforcement` — before
+    /// #2975 it did, silently downgrading the fail-closed default.
     #[test]
-    fn already_permissive_desired_permissive_is_noop() {
-        let permissive = inv("\
+    fn omitted_enforcement_never_disables_observed_strict_2975() {
+        let desired = inv(TWO_NODE_UNMANAGED);
+        let observed = ObservedState {
+            nodes: vec![signing("node-1"), signing("node-2")],
+            strict_enforced: true,
+        };
+        let plan = reconcile(&desired, &observed);
+        assert!(
+            !plan
+                .actions
+                .contains(&ReconcileAction::DisableStrictEnforcement),
+            "omission is UNMANAGED — it must never plan a downgrade: {:?}",
+            plan.actions
+        );
+        assert!(
+            plan.actions.is_empty(),
+            "an unmanaged, otherwise-converged fleet plans nothing at all: {:?}",
+            plan.actions
+        );
+        assert!(
+            plan.advisories.is_empty(),
+            "an unmanaged fleet observed STRICT is not permissive drift"
+        );
+        assert!(plan.is_noop());
+    }
+
+    /// Omitted + observed permissive: still no action in either direction,
+    /// but the plan carries the visibility advisory so an
+    /// unmanaged-permissive fleet is not silently "converged".
+    #[test]
+    fn omitted_enforcement_permissive_fleet_emits_drift_advisory_2975() {
+        let desired = inv(TWO_NODE_UNMANAGED);
+        let observed = ObservedState {
+            nodes: vec![signing("node-1"), signing("node-2")],
+            strict_enforced: false,
+        };
+        let plan = reconcile(&desired, &observed);
+        assert!(
+            plan.actions.is_empty(),
+            "unmanaged plans NO enforcement action in either direction: {:?}",
+            plan.actions
+        );
+        assert_eq!(
+            plan.advisories,
+            vec![ReconcileAdvisory::EnforcementUnmanagedDrift]
+        );
+        assert!(
+            plan.is_noop(),
+            "an advisory must NOT block convergence — is_noop stays actions-only"
+        );
+    }
+
+    /// Explicit `Some(false)` (with its mandatory `disable_reason`) still
+    /// downgrades an observed-strict fleet — the deliberate staged-rollout
+    /// path is preserved, only the ACCIDENTAL one is closed.
+    #[test]
+    fn explicit_disable_still_downgrades_observed_strict_2975() {
+        let desired = inv(TWO_NODE_EXPLICIT_DISABLE);
+        let observed = ObservedState {
+            nodes: vec![signing("node-1"), signing("node-2")],
+            strict_enforced: true,
+        };
+        let plan = reconcile(&desired, &observed);
+        assert_eq!(
+            plan.actions,
+            vec![ReconcileAction::DisableStrictEnforcement]
+        );
+        assert!(plan.advisories.is_empty());
+    }
+
+    /// Idempotence across ALL THREE desired states: a fleet already at its
+    /// declared posture yields an empty action list every time.
+    #[test]
+    fn converged_fleet_is_a_noop_in_every_desired_state_2975() {
+        // Some(true) converged: fleet strict.
+        let strict_plan = reconcile(
+            &inv(TWO_NODE_STRICT),
+            &ObservedState {
+                nodes: vec![signing("node-1"), signing("node-2")],
+                strict_enforced: true,
+            },
+        );
+        assert!(strict_plan.is_noop(), "{:?}", strict_plan.actions);
+
+        // Some(false) converged: fleet permissive.
+        let disable_plan = reconcile(
+            &inv(TWO_NODE_EXPLICIT_DISABLE),
+            &ObservedState {
+                nodes: vec![signing("node-1"), signing("node-2")],
+                strict_enforced: false,
+            },
+        );
+        assert!(disable_plan.is_noop(), "{:?}", disable_plan.actions);
+
+        // None: converged by definition — BOTH observed postures are no-ops.
+        for strict_enforced in [true, false] {
+            let plan = reconcile(
+                &inv(TWO_NODE_UNMANAGED),
+                &ObservedState {
+                    nodes: vec![signing("node-1"), signing("node-2")],
+                    strict_enforced,
+                },
+            );
+            assert!(
+                plan.is_noop(),
+                "unmanaged must be a no-op at strict_enforced={strict_enforced}: {:?}",
+                plan.actions
+            );
+        }
+    }
+
+    /// Re-running the reconciler against the state its own plan produced
+    /// must converge to a no-op — the controller-loop-on-a-timer contract.
+    #[test]
+    fn replanning_after_applying_the_enable_action_converges_2975() {
+        let desired = inv(TWO_NODE_STRICT);
+        let before = ObservedState {
+            nodes: vec![signing("node-1"), signing("node-2")],
+            strict_enforced: false,
+        };
+        let first = reconcile(&desired, &before);
+        assert_eq!(
+            first.actions.last(),
+            Some(&ReconcileAction::EnableStrictEnforcement)
+        );
+        // Apply it, then replan.
+        let after = ObservedState {
+            strict_enforced: true,
+            ..before
+        };
+        assert!(reconcile(&desired, &after).is_noop());
+    }
+
+    /// An empty inventory that omits enforcement is unmanaged, not
+    /// permissive. (Renamed from `already_permissive_desired_permissive_is_noop`
+    /// — the old name asserted the semantics #2975 removed.)
+    #[test]
+    fn empty_inventory_is_unmanaged_and_a_noop_2975() {
+        let unmanaged = inv("\
 trust_domain: fleet
 quorum:
   width: 1
 ");
+        assert_eq!(unmanaged.enforcement.require_sig, None);
         let observed = ObservedState::default();
-        let plan = reconcile(&permissive, &observed);
+        let plan = reconcile(&unmanaged, &observed);
         assert!(plan.is_noop());
+        assert!(plan.actions.is_empty());
+        // Empty node list + observed permissive ⇒ the drift advisory fires.
+        assert_eq!(
+            plan.advisories,
+            vec![ReconcileAdvisory::EnforcementUnmanagedDrift]
+        );
+    }
+
+    /// The #2975 vote's grounded kill of "just default it to `true`": an
+    /// empty desired node list makes `.all(..)` VACUOUSLY true, so a
+    /// default-true inventory would immediately plan
+    /// `EnableStrictEnforcement` and 401-partition every unlisted legacy
+    /// sender. Under the tri-state, the minimal inventory plans nothing.
+    #[test]
+    fn empty_node_list_does_not_vacuously_enable_strict_2975() {
+        let unmanaged = inv("\
+trust_domain: fleet
+quorum:
+  width: 1
+");
+        let plan = reconcile(
+            &unmanaged,
+            &ObservedState {
+                nodes: Vec::new(),
+                strict_enforced: false,
+            },
+        );
+        assert!(
+            !plan
+                .actions
+                .contains(&ReconcileAction::EnableStrictEnforcement),
+            "a node-less unmanaged inventory must not vacuously strict-enforce"
+        );
+
+        // Contrast: an EXPLICIT `require_sig: true` on a node-less inventory
+        // DOES flip — that is the operator asking for it, in writing.
+        let explicit_strict = inv("\
+trust_domain: fleet
+quorum:
+  width: 1
+enforcement:
+  require_sig: true
+");
+        let plan = reconcile(
+            &explicit_strict,
+            &ObservedState {
+                nodes: Vec::new(),
+                strict_enforced: false,
+            },
+        );
+        assert_eq!(plan.actions, vec![ReconcileAction::EnableStrictEnforcement]);
     }
 }


### PR DESCRIPTION
Implements the ratified 5-agent T3 adversarial vote verdict on #2975 (Option 2 + hardened Option 3, 4–1) — see the verdict comment on the issue for the full record.

## What
- `EnforcementSpec::require_sig`: `bool` → `Option<bool>`, consumed by an exhaustive `match` (no `unwrap_or` collapse). **Omitted = unmanaged** (both spellings: absent block ≡ `enforcement: {}`): the reconciler plans NO enforcement action in either direction, so deleting a line can never emit `DisableStrictEnforcement` against the v1.0.0 fail-closed runtime default.
- **Two-key turn at inventory load** (never action suppression): explicit `require_sig: false` requires a non-empty `disable_reason`; a stale `disable_reason` without the explicit false is equally a load error. Weakening the fleet = adding two greppable lines, never deleting one.
- **Advisory channel**: `ReconcilePlan::advisories` + `EnforcementUnmanagedDrift` when desired is `None` and the fleet is observed permissive. `is_noop()` stays actions-only.
- docs/federation-identity.md §3/§6/§7.6/§9 rewritten to the new contract; CHANGELOG entry.

## Evidence (independently re-verified by Fable in the worktree)
- `cargo test --lib federation::identity`: **115/115** (under umask 022); full `federation::` 357/357 per implementer
- clippy `-D warnings -D clippy::all -D clippy::pedantic`: clean (all 4 legs per implementer; default leg re-verified)
- `cargo fmt --check`, `cargo check --examples`, docs-vs-ssot + doc-symbol-anchors gates: green
- Footgun regression pin: `omitted_enforcement_never_disables_observed_strict_2975`; the vote's Option-1 kill mechanized in `empty_node_list_does_not_vacuously_enable_strict_2975`
- Sweep: zero `EnforcementSpec::require_sig` consumers outside inventory.rs/reconcile.rs/docs (runtime `federation::signing::require_sig()` family untouched)

## Notes
- API-shape change is free now: `reconcile()`/`ReconcileAction`/`ReconcilePlan` have zero callers outside the module (Phase-4 scaffolding); semver-breaking after wiring.
- Known follow-up: `ReconcileAdvisory` has no production consumer yet (no reconciler caller exists at all) — will file so the visibility mitigation doesn't ship as an unenforced claim.
- Behavior break (intended, fail-closed): an existing on-disk inventory with bare `require_sig: false` now refuses to load until a `disable_reason` is added; §9 documents the two-line remedy. No such inventory in-tree.

Closes #2975 (manual close needed — non-default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)