### PR TITLE
fix(gates): widen the doc-drift gates to the GitHub Pages (.html) surface (#2977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `inventory.rs` (both two-key-turn error directions, the happy path, and the
   two-spellings-of-silence pin). 5-agent T3 adversarial vote, 4-1 (Option 2 +
   hardened Option 3).
+### Fixed (doc-drift gates now cover the GitHub Pages `.html` surface; #2977)
+
+- **~70 hand-authored Jekyll pages under `docs/` were UNGATED, and that is why
+  the published site drifted invisibly while every claims gate stayed green.**
+  `scripts/check-docs-vs-ssot.sh` walked exactly ONE `.html` file
+  (`docs/compliance/nsa-csi-mcp.html`) and `scripts/check-ci-job-claims.sh`
+  walked three; every other published page could carry a stale schema version, a
+  stale tool/route/CLI count, a stale sitewide chrome stamp, or a
+  bench-as-merge-blocker claim with no gate able to see it. The v1.0.0 doc-drift
+  campaign (Waves 1-3) fixed the CURRENT drift by hand; without gate coverage the
+  surface would simply rot again.
+  - The html scan set is now **ENROLL-BY-DEFAULT** over `docs/**/*.html`, minus
+    the frozen pages named in the new
+    `scripts/qc-allowlists/html-doc-frozen-exempt.txt` — ONE exemption SSOT read
+    by BOTH gates, so they cannot disagree about where the frozen boundary sits.
+    An enumerated INCLUDE list cannot close this class: the rot IS that a new
+    page lands ungated. Frozen = per-release trees (`docs/v0.7.0/`, `docs/v0.7/`),
+    `whats-new-v*` / `v070-*` / `release-v0.7.1` release narratives, the frozen
+    v0.7.0-era AI-NHI page, and the two dated security assessments — each entry
+    carries its rationale in that file's header. Resolved set at this commit: 53
+    pages. A missing exemption file or an empty resolved set FAILS CLOSED.
+  - Both gates learned the **HTML markup dialect**: `<strong>`/`<b>` where
+    markdown writes `**`, `<code>` where it writes a backtick, `&nbsp;` where it
+    writes a space. ONE rule table serves both dialects rather than a second
+    html table that could silently disagree. Adding the pages WITHOUT this would
+    have been a widening that scans 53 more files and can see nothing on them.
+  - Two html-specific HISTORICAL guards keep TRUE history out of the violation
+    set: the guard is evaluated over a **tag-stripped, whitespace-collapsed**
+    view (so `schema <strong>v67</strong> added …` is still recognised as a
+    ladder statement), and the release-card markers (`PRIOR RELEASE`,
+    `What's New in vX.Y.Z`) are evaluated over a **3-line preceding window**,
+    because an html release card puts its attribution in the divs ABOVE the
+    numbers. The self-test asserts BOTH directions — the same numbers with the
+    card markers removed are REJECTED, so the window is a guard, not a blanket.
+  - **NEW RULE — sitewide chrome version stamp.** The footer stamp
+    (`ai-memory vX.Y.Z`, scoped to the text inside `<footer>`) and the hero/nav
+    release badge (`<span class="badge">vX.Y.Z`) must equal the `Cargo.toml`
+    version. The campaign found `v0.9.0` chrome on 38 pages with every gate
+    green. Body prose is never read (a page may narrate v0.7.0 history all day),
+    frozen pages keep their own stamp, and **published-install / download
+    references are SKIPPED by name** — the v1.0.0 tag-cut is operator-gated, so
+    an install line pinned at the last PUBLISHED tag is CORRECT.
+  - **Residual drift found + fixed** (docs corrected to match code, never the
+    reverse): `docs/evidence/index.html` chrome + meta still stamped `v0.9.0` on
+    a LIVE hub; `docs/at-a-glance.html` called advisory `bench.yml` a "CI guard"
+    (the C6 finding, and the same page already says two sections earlier that
+    bench is deliberately not a required status check);
+    `docs/reproducible-baselines.html` cited a `Bench · bench` CI job that
+    resolves to no declared job name or key.
+  - R-203: 10 new `--self-test` legs across the two gates, each proving RED on an
+    injected violation and GREEN on the corrected page, plus the frozen-exemption
+    boundary in both directions and fail-closed on a missing exemption SSOT.
 
 ### Security (append-only spine — the primary create funnel's upsert no longer bypasses the signed ledger; #2948 / PR-3)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1242,6 +1242,50 @@ historical control (a prior-release paragraph, a frozen baseline and
 ladder mentions must still PASS), rule N1, and all three ledger
 directions. Scratch lives under `.local-runs/`, never `mktemp -d`.
 
+**#2977 — the GitHub-Pages `.html` surface.** #2492 widened the PATTERN
+set; the scan SET stayed markdown-plus-one-file, so ~70 hand-authored
+Jekyll pages under `docs/` were ungated and the published site drifted
+invisibly through the whole v1.0.0 campaign (stale schema versions, a
+sitewide `v0.9.0` chrome stamp, a false sub-10ms recall claim, a
+bench-as-merge-blocker claim, a kind-count 10-vs-16) with this gate
+GREEN. The html scan set is now **enroll-by-default** over
+`docs/**/*.html` minus the frozen pages named in
+`scripts/qc-allowlists/html-doc-frozen-exempt.txt` — ONE exemption SSOT,
+shared with gate 11 so the two cannot disagree about the boundary. That
+INVERTS the `.md` argument above deliberately: an enumerated INCLUDE list
+cannot close a class whose whole shape is "a new page lands ungated", and
+the `.html` tree's frozen surfaces are a small, named, structurally
+obvious set (per-release trees, `whats-new-v*`, release narratives, dated
+assessments) where a `.md` glob would drag in the whole
+reviews/design/audit sprawl. A missing exemption file, or an empty
+resolved set outside the fixture, FAILS CLOSED.
+
+The SAME rule table serves both dialects (`<strong>`/`<b>` for `**`,
+`<code>` for a backtick, `&nbsp;` for a space) rather than a second html
+table that could silently disagree — and without that, adding the pages
+would have been a widening that scans them and can see nothing. Two
+html-specific HISTORICAL guards keep TRUE history out of the violation
+set: the guard runs over a **tag-stripped, whitespace-collapsed** view
+(so `schema <strong>vNN</strong> added …` is still recognised as a ladder
+statement — spelled with a placeholder here because the dialect-agnostic
+anchor reads this file too, and an example carrying a real number would
+BE the drift it describes), and the release-card markers (`PRIOR RELEASE`, `What's New in
+vX.Y.Z`) run over a **3-line preceding window**, because an html release
+card puts its attribution in the divs ABOVE the numbers. `--self-test`
+asserts both directions: the same numbers with the card markers REMOVED
+are rejected, so the window is a guard and not a blanket exemption.
+
+**New rule in the same gate — sitewide CHROME version stamp.** The footer
+stamp (`ai-memory vX.Y.Z`, scoped to text inside `<footer>`) and the
+hero/nav release badge (`<span class="badge">vX.Y.Z`) must equal the
+`Cargo.toml` version. Chrome is the version an operator reads on EVERY
+page and was the one claim nothing checked. Body prose is never read (a
+page may narrate v0.7.0 history all day); frozen pages keep their own
+stamp; and **published-install / download references are skipped by
+name** — the tag-cut is operator-gated, so an install line pinned at the
+last PUBLISHED tag is CORRECT, and flagging it would push a doc author to
+publish an install command for a tag that does not exist.
+
 **5. Cloud-init ASCII gate** (#1880) — `scripts/check-cloud-init-ascii.sh`.
 A stray non-ASCII byte (a U+2014 em-dash) in a DigitalOcean
 cloud-init template made cloud-init silently discard the config
@@ -1682,6 +1726,20 @@ plants all four claims; the C-31 leg asserts the rejection comes from
 the ENFORCEMENT rule specifically, and its paired near-miss — the same
 workflow described WITHOUT an enforcement verb — must PASS so the rule
 does not ban mentioning an advisory workflow at all.
+
+**#2977 — the html corpus.** The DOCS corpus's html half was a THREE-FILE
+allowlist AND every citation regex required a MARKDOWN code span, so a
+bench / CI-enforcement claim on any of the other ~70 published Jekyll
+pages was invisible for TWO independent reasons — campaign finding C6
+(`at-a-glance.html`'s bench claim) is exactly that shape. The html half is
+now enroll-by-default over `docs/**/*.html` minus
+`scripts/qc-allowlists/html-doc-frozen-exempt.txt` (the SAME exemption
+SSOT gate 4 reads), and the citation shapes admit `<code>` alongside the
+backtick. Fixing only the corpus, or only the regexes, would have been a
+widening that scans 53 more pages and reports success while doing nothing
+— the #2444 shape, in the gate built to catch it. Two live claims fell
+out on first run: an advisory workflow called a "CI guard" and a
+`Bench · bench` composite that resolves to no declared job.
 
 **`cargo test` twin for gates 4 / 9 / 10 / 11:**
 `tests/doc_claims_integrity.rs` (the

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -1600,7 +1600,7 @@ footer.site-foot a { color: var(--text-muted); }
           <ul class="rmt-bullets">
             <li>Hierarchical namespace paths (<code>projects/alpha/decisions</code>)</li>
             <li>Temporal-validity knowledge graph (recursive CTE today, AGE-ready for v0.7)</li>
-            <li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>
+            <li>Published p95/p99 budgets + advisory bench regression check (<code>bench.yml</code>)</li>
             <li>92.59% test coverage (4,699 lib + integration tests, across the ubuntu/macos/windows CI matrix; v0.7.0)</li>
             <li>Two SSRF defects discovered during campaign — fixed before tag</li>
           </ul>

--- a/docs/evidence/index.html
+++ b/docs/evidence/index.html
@@ -18,7 +18,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ai-memory · Evidence Hub — testing, baseline env, results</title>
-<meta name="description" content="Evidence hub for ai-memory v0.9.0: per-campaign testing records, baseline test environments, and full pass/fail results with commit SHAs and test-result lines. The running record behind the frozen public claims.">
+<meta name="description" content="Evidence hub for ai-memory v1.0.0: per-campaign testing records, baseline test environments, and full pass/fail results with commit SHAs and test-result lines. The running record behind the frozen public claims.">
 <meta name="theme-color" content="#0d1117">
 <link rel="canonical" href="https://alphaonedev.github.io/ai-memory-mcp/evidence/">
 <style>
@@ -303,7 +303,7 @@ footer{padding:2rem 1.5rem;text-align:center;color:var(--text-dim);font-size:.85
 </section>
 
 <footer>
-  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.9.0 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="../evidence.html">Frozen Claims</a> · <a href="../">home</a></p>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v1.0.0 — <a href="https://github.com/alphaonedev/ai-memory-mcp">source on GitHub</a> · <a href="../evidence.html">Frozen Claims</a> · <a href="../">home</a></p>
 </footer>
 
 </body>

--- a/docs/reproducible-baselines.html
+++ b/docs/reproducible-baselines.html
@@ -287,7 +287,7 @@ ai-memory bench --baseline baseline-&lt;sha&gt;.json --regression-threshold 10</
         <tr>
           <td class="col-name">Bench</td>
           <td>"Is this build still inside its published latency contract, and has it drifted against a known-good run?"</td>
-          <td><code>PERFORMANCE.md</code>, <code>src/bench.rs</code> (<code>P95_TOLERANCE</code>, <code>DEFAULT_REGRESSION_THRESHOLD_PCT</code>), the advisory <code>Bench · bench</code> CI job, <a href="BASELINE-v0.6.3.1.html">BASELINE-v0.6.3.1.md</a></td>
+          <td><code>PERFORMANCE.md</code>, <code>src/bench.rs</code> (<code>P95_TOLERANCE</code>, <code>DEFAULT_REGRESSION_THRESHOLD_PCT</code>), the advisory <code>bench</code> CI job in <code>bench.yml</code>, <a href="BASELINE-v0.6.3.1.html">BASELINE-v0.6.3.1.md</a></td>
         </tr>
         <tr>
           <td class="col-name">Full suite</td>

--- a/scripts/check-ci-job-claims.sh
+++ b/scripts/check-ci-job-claims.sh
@@ -101,6 +101,12 @@ jobs:
       - run: true
 WFEOF
     printf 'Lint (fmt + clippy)\n' > "$FIX/scripts/qc-allowlists/required-contexts-release.txt"
+    # #2977 — the frozen-page exemption SSOT. The fixture carries a REAL
+    # one (not an empty stub) so the html legs below can prove BOTH
+    # directions of the boundary: an enroll-by-default live page is
+    # scanned, a listed frozen page is not.
+    printf '# fixture\ndocs/whats-new-v\n' \
+        > "$FIX/scripts/qc-allowlists/html-doc-frozen-exempt.txt"
 
     run_fixture() { ( AI_MEMORY_CIJOB_GATE_ROOT="$FIX" "$SELF" >/dev/null 2>&1; echo "$?" ); }
     run_fixture_out() { AI_MEMORY_CIJOB_GATE_ROOT="$FIX" "$SELF" 2>&1 || true; }
@@ -108,6 +114,7 @@ WFEOF
     write_clean() {
         rm -f "$FIX"/README.md "$FIX"/ROADMAP.md "$FIX"/PERFORMANCE.md \
               "$FIX"/docs/v1.0.0/release-notes.md \
+              "$FIX"/docs/at-a-glance.html "$FIX"/docs/whats-new-v09.html \
               "$FIX"/scripts/qc-allowlists/ci-job-claims-pending.txt
         # NEAR-MISS CONTROLS — every one must PASS:
         #  * a job cited by its real name that IS in the required set,
@@ -269,6 +276,78 @@ MDEOF
         echo "FAIL: self-test #2713 — engine fault did not produce the distinct fail-closed message" >&2; exit 1; }
     echo "PASS: self-test #2713 — an analysis-engine error FAILS CLOSED (exit $fault_rc, distinct message, no PASS banner)"
 
+    # ================================================================
+    # #2977 — the GitHub-Pages (.html) surface
+    # ================================================================
+    # THE DEFECT: the html half of DOCS was a THREE-FILE allowlist AND
+    # every citation regex required a MARKDOWN code span, so a bench /
+    # CI-enforcement claim on any of the other ~70 published Jekyll pages
+    # was invisible for TWO independent reasons. Campaign finding C6 is
+    # the verbatim shape planted below.
+
+    # ---- RED: an enforcement claim on a page that was NOT in the old
+    # three-file html allowlist, written in the HTML code-span dialect.
+    write_clean
+    printf '<li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>\n' \
+        > "$FIX/docs/at-a-glance.html"
+    [[ "$(run_fixture)" != "0" ]] || {
+        echo "FAIL: self-test #2977 — an html-dialect enforcement claim on an enroll-by-default page was ACCEPTED." >&2
+        echo "       bench.yml is advisory; this is the C6 shape and the gate must see it." >&2
+        exit 1; }
+    out="$(run_fixture_out)"
+    grep -q 'WORKFLOW_ENFORCEMENT' <<<"$out" || {
+        echo "FAIL: self-test #2977 — rejected, but NOT by the enforcement rule (wrong reason)" >&2; exit 1; }
+    grep -q 'docs/at-a-glance.html' <<<"$out" || {
+        echo "FAIL: self-test #2977 — the violation did not name the html page" >&2; exit 1; }
+    echo "PASS: self-test #2977 RED — an html <code>-span enforcement claim on an enroll-by-default page is REJECTED"
+
+    # ---- GREEN-on-fixed: the corrected advisory phrasing PASSES, so the
+    # rule is not a blanket ban on naming bench.yml from an html page.
+    write_clean
+    printf '<li>Published p95/p99 budgets + advisory bench regression check (<code>bench.yml</code>)</li>\n' \
+        > "$FIX/docs/at-a-glance.html"
+    [[ "$(run_fixture)" = "0" ]] || {
+        echo "FAIL: self-test #2977 GREEN — the CORRECTED advisory phrasing was still rejected" >&2
+        run_fixture_out | sed 's/^/       /' >&2
+        exit 1; }
+    echo "PASS: self-test #2977 GREEN — the corrected advisory phrasing on the same html page PASSES"
+
+    # ---- RED: html-dialect JOB_EXISTS. The verbatim
+    # docs/reproducible-baselines.html shape — a `<workflow> · <job-key>`
+    # composite display name that resolves to no declared job.
+    write_clean
+    printf 'the advisory <code>Bench &middot; bench</code> CI job\n' \
+        > "$FIX/docs/at-a-glance.html"
+    [[ "$(run_fixture)" != "0" ]] || {
+        echo "FAIL: self-test #2977 — an html-dialect citation of a non-existent CI job was ACCEPTED" >&2; exit 1; }
+    run_fixture_out | grep -q 'JOB_EXISTS' || {
+        echo "FAIL: self-test #2977 — rejected, but NOT by the existence rule (wrong reason)" >&2; exit 1; }
+    echo "PASS: self-test #2977 RED — an html-dialect citation of a job that resolves to nothing is REJECTED"
+
+    # ---- FROZEN EXEMPTION is load-bearing, in BOTH directions. The very
+    # same claim on a page listed in html-doc-frozen-exempt.txt must PASS:
+    # a "what's new in vN" page is, by construction, a statement about vN.
+    write_clean
+    printf '<li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>\n' \
+        > "$FIX/docs/whats-new-v09.html"
+    [[ "$(run_fixture)" = "0" ]] || {
+        echo "FAIL: self-test #2977 — a FROZEN page (html-doc-frozen-exempt.txt) was scanned" >&2
+        run_fixture_out | sed 's/^/       /' >&2
+        exit 1; }
+    echo "PASS: self-test #2977 — a page named in html-doc-frozen-exempt.txt is EXEMPT (the same claim passes there)"
+
+    # ---- the exemption SSOT is REQUIRED: resolving the html scan set
+    # without its frozen boundary would either red every frozen page or
+    # silently drop the widening. Refuse instead.
+    write_clean
+    mv "$FIX/scripts/qc-allowlists/html-doc-frozen-exempt.txt" "$FIX/exempt.bak"
+    [[ "$(run_fixture)" != "0" ]] || {
+        echo "FAIL: self-test #2977 — a MISSING frozen-exemption SSOT did not fail the gate" >&2; exit 1; }
+    run_fixture_out | grep -q 'html-doc-frozen-exempt.txt' || {
+        echo "FAIL: self-test #2977 — the missing-SSOT failure did not name the file" >&2; exit 1; }
+    mv "$FIX/exempt.bak" "$FIX/scripts/qc-allowlists/html-doc-frozen-exempt.txt"
+    echo "PASS: self-test #2977 — a missing frozen-exemption SSOT FAILS CLOSED"
+
     # ---- never a silent no-op ----------------------------------------
     rm -rf "$FIX/.github/workflows"
     mkdir -p "$FIX/.github/workflows"
@@ -413,11 +492,42 @@ def job_is_required(token):
     return any(r.startswith(token + " (") for r in required)
 
 
+# #2977 — the html half of this corpus was a THREE-FILE allowlist, so the
+# bench / CI-enforcement claims on the other ~70 published Jekyll pages
+# were unscanned (campaign finding C6: at-a-glance.html's bench claim).
+# The html set is now ENROLL-BY-DEFAULT over `docs/**/*.html` minus the
+# frozen pages named in scripts/qc-allowlists/html-doc-frozen-exempt.txt —
+# the SAME exemption SSOT scripts/check-docs-vs-ssot.sh reads, so the two
+# gates cannot disagree about where the frozen boundary sits. An
+# enumerated INCLUDE list cannot close this class: the rot is exactly that
+# a NEW page lands unscanned.
+#
+# FAIL-CLOSED on a missing exemption file: resolving the scan set without
+# its boundary would either red every frozen page or silently drop the
+# widening, and both are worse than refusing.
+exempt_path = os.path.join(root, "scripts/qc-allowlists/html-doc-frozen-exempt.txt")
+html_frozen = []
+if os.path.exists(exempt_path):
+    for line in open(exempt_path, encoding="utf-8"):
+        line = line.split("#", 1)[0].strip()
+        if line:
+            html_frozen.append(line)
+elif os.path.exists(os.path.join(root, "docs")):
+    raise RuntimeError(
+        "check-ci-job-claims: missing scripts/qc-allowlists/html-doc-frozen-exempt.txt "
+        "— refusing to resolve the html scan set without its frozen-page exemption SSOT (#2977)"
+    )
+
+html_docs = sorted(
+    p[len(root) + 1:]
+    for p in glob.glob(os.path.join(root, "docs/**/*.html"), recursive=True)
+    if not any(frozen in p[len(root) + 1:] for frozen in html_frozen)
+)
+
 DOCS = ["README.md", "ROADMAP.md", "PERFORMANCE.md",
         "docs/DEVELOPER_GUIDE.md", "docs/ENGINEERING_STANDARDS.md",
         "docs/CLI_REFERENCE.md", "docs/CONFIG_SCHEMA.md",
-        "docs/reproducible-baselines.html", "docs/for-everyone.html",
-        "docs/audience/developer.html"] + sorted(glob.glob(
+        ] + html_docs + sorted(glob.glob(
     os.path.join(root, "docs/v1.0.0/*.md")))
 
 # YAML trigger / structural keywords are not job names.
@@ -469,10 +579,27 @@ def enforcement_near(line, start, end):
     hi = min(len(line), end + ENFORCE_PROXIMITY)
     return bool(ENFORCE.search(line[lo:hi]))
 
+# MARKUP DIALECT (#2977). The citation shapes below were written against
+# MARKDOWN code spans. Adding the .html corpus to DOCS without teaching
+# them the html spelling would have been a widening that scans 53 more
+# pages and can see NOTHING on them — the #2444 "reports success while
+# doing nothing" shape, in the very gate built to catch that class.
+# `CO`/`CC` therefore admit BOTH `` ` `` and `<code>`/`</code>`; a .md
+# file never contains `<code>` and a .html file never contains a code
+# backtick, so neither dialect widens the other's match set.
+#
+# Measured effect on the tree at 57b7fe35: the citation
+# `<li>Published p95/p99 budgets + CI guard (<code>bench.yml</code>)</li>`
+# in docs/at-a-glance.html is invisible to a backtick-only WF_TICK and is
+# an ENFORCEMENT claim about an advisory workflow once seen.
+CO = r"(?:`|<code>)"
+CC = r"(?:`|</code>)"
+
 WF_PATH = re.compile(r"\.github/workflows/([A-Za-z0-9_.-]+\.ya?ml)")
-WF_TICK = re.compile(r"`([A-Za-z0-9_.-]+\.ya?ml)`")
+WF_TICK = re.compile(CO + r"([A-Za-z0-9_.-]+\.ya?ml)" + CC)
 POSSESSIVE = re.compile(
-    r"`([A-Za-z0-9_.-]+\.ya?ml)`'s\s+(?:\"([^\"]+)\"|`([^`]+)`)\s+job")
+    CO + r"([A-Za-z0-9_.-]+\.ya?ml)" + CC + r"'s\s+(?:\"([^\"]+)\"|"
+    + CO + r"([^`<]+)" + CC + r")\s+job")
 # `<stem>` workflow -- the bare-stem citation shape (3x7 lane-3,
 # 2026-08-09). README said "The `token-budget` workflow is a **required
 # status check**" while `token-budget` appears NOWHERE in
@@ -481,11 +608,12 @@ POSSESSIVE = re.compile(
 # ENFORCEMENT rule -- the rule built for exactly that false claim --
 # was structurally blind to the single most-quoted enforcement
 # sentence in the tier-1 doc. Resolves the stem to <stem>.yml.
-WF_WORD = re.compile(r"`([A-Za-z0-9_.-]{2,40})`\s+workflow\b")
+WF_WORD = re.compile(CO + r"([A-Za-z0-9_.-]{2,40})" + CC + r"\s+workflow\b")
 JOB_CITE = re.compile(
-    r"(?:`([^`\n]{2,60})`|\"([^\"\n]{2,60})\")\s+(?:CI\s+|nightly\s+)?job\b")
+    r"(?:" + CO + r"([^`<\n]{2,60})" + CC + r"|\"([^\"\n]{2,60})\")"
+    r"\s+(?:CI\s+|nightly\s+)?job\b")
 JOB_IN_WF = re.compile(
-    r"`(?:\.github/workflows/)?([A-Za-z0-9_.-]+\.ya?ml)`\s*[,)]?\s*"
+    CO + r"(?:\.github/workflows/)?([A-Za-z0-9_.-]+\.ya?ml)" + CC + r"\s*[,)]?\s*"
     r"(?:the\s+)?([A-Za-z0-9_][A-Za-z0-9_ -]{0,28}?)\s+job\b")
 
 

--- a/scripts/check-docs-vs-ssot.sh
+++ b/scripts/check-docs-vs-ssot.sh
@@ -231,20 +231,86 @@ do
     [[ "$_dup" == 0 ]] && DOC_FILES+=("$_wf")
 done
 
-# Operator-facing HTML surfaces (rendered compliance pages). Markdown is
-# the primary narrative form, but procurement-facing .html pages restate
-# the same mechanically-pinned SSOT counts and drift INDEPENDENTLY of
-# their .md siblings when an SSOT moves — #2729 / CB-32: nsa-csi-mcp.html
-# shipped stale 89/91 CLI counts vs SSOT 90/92 while
+# Operator-facing HTML surfaces (rendered GitHub Pages). Markdown is the
+# primary narrative form, but the published .html pages restate the same
+# mechanically-pinned SSOT counts and drift INDEPENDENTLY of their .md
+# siblings when an SSOT moves — #2729 / CB-32: nsa-csi-mcp.html shipped
+# stale 89/91 CLI counts vs SSOT 90/92 while
 # nsa-csi-mcp-security-mapping.md was already correct at 90/92. The gate
 # had ZERO html references (same class as #2668 E-20 for benchmark.svg),
-# so the rendered surface was invisible. These files are walked by the
-# html-aware CLI-count rules in run_all_rules below. Kept as an explicit
-# allowlist (not a `**/*.html` glob) so a historical/archived HTML page
-# cannot silently enroll a legitimate past-release count into the gate.
-HTML_DOC_FILES=(
-    docs/compliance/nsa-csi-mcp.html
-)
+# so the rendered surface was invisible.
+#
+# #2977 — WIDENED from the one-file allowlist to the whole operator-facing
+# `docs/**/*.html` surface. The one-file allowlist was itself the defect:
+# ~70 hand-authored Jekyll pages were ungated, and the v1.0.0 doc-drift
+# campaign (Waves 1-3) found stale schema versions, a sitewide v0.9.0
+# chrome stamp, a false sub-10ms recall claim, a bench-as-merge-blocker
+# claim and a kind-count 10-vs-16 across them WHILE THIS GATE STAYED
+# GREEN. An enumerated allowlist cannot close that class: the rot is
+# exactly that a NEW page lands ungated, so the scan set has to be
+# ENROLL-BY-DEFAULT and the EXEMPTIONS have to be the enumerated thing.
+#
+# That inverts the #2839 `.md` argument, and deliberately so. The `.md`
+# side stayed an additive list because a blanket `docs/**/*.md` glob drags
+# in the historical ladder references, the frozen per-release summaries,
+# and the analysis/adjudication artefacts under docs/reviews|design|audit
+# — surfaces whose numbers are TRUE STATEMENTS ABOUT A PAST RELEASE. The
+# .html tree has no such sprawl: its frozen surfaces are a small, named,
+# structurally-obvious set (per-release trees, whats-new pages, release
+# narratives, dated assessments), which is precisely the shape an
+# exemption list can carry honestly. Every exemption below names WHY the
+# page is frozen, so a reviewer can audit the boundary in one read.
+#
+# The exemption set is NOT declared here. It lives ONCE, in
+# scripts/qc-allowlists/html-doc-frozen-exempt.txt, because
+# scripts/check-ci-job-claims.sh walks the SAME html surface and two
+# copies of a frozen-vs-live boundary would silently disagree the first
+# time one is edited. That file's header carries the per-entry rationale
+# and the test for admitting an entry.
+#
+# FAIL-CLOSED: a missing exemption file, or an EMPTY resolved set outside
+# the --self-test fixture, is a hard failure — never a silent green
+# (#2444 "reports success while doing nothing").
+HTML_FROZEN_EXEMPT_FILE="$REPO_ROOT/scripts/qc-allowlists/html-doc-frozen-exempt.txt"
+HTML_FROZEN_EXEMPT=()
+if [[ -f "$HTML_FROZEN_EXEMPT_FILE" ]]; then
+    while IFS= read -r _fx; do
+        _fx="${_fx%%#*}"
+        _fx="$(printf '%s' "$_fx" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        [[ -z "$_fx" ]] && continue
+        HTML_FROZEN_EXEMPT+=("$_fx")
+    done < "$HTML_FROZEN_EXEMPT_FILE"
+else
+    # Unconditional, fixture included: resolving the html scan set without
+    # its frozen boundary would either red every frozen page or silently
+    # drop the widening. Both are worse than refusing, and a check that is
+    # waived under --self-test is a check the self-test cannot prove.
+    printf 'FAIL: check-docs-vs-ssot: missing %s — refusing to resolve the html scan set without its frozen-page exemption SSOT (#2977 fail-closed)\n' \
+        "$HTML_FROZEN_EXEMPT_FILE" >&2
+    exit 1
+fi
+
+html_is_frozen() {
+    local f="$1" pat
+    for pat in "${HTML_FROZEN_EXEMPT[@]:-}"; do
+        [[ -z "$pat" ]] && continue
+        [[ "$f" == *"$pat"* ]] && return 0
+    done
+    return 1
+}
+
+HTML_DOC_FILES=()
+while IFS= read -r _hf; do
+    [[ -z "$_hf" ]] && continue
+    _hf="${_hf#./}"
+    html_is_frozen "$_hf" && continue
+    HTML_DOC_FILES+=("$_hf")
+done < <(find docs -name '*.html' -type f 2>/dev/null | sort)
+
+if [[ ${#HTML_DOC_FILES[@]} -eq 0 && -z "${AI_MEMORY_DOCS_GATE_ROOT:-}" ]]; then
+    printf 'FAIL: check-docs-vs-ssot: resolved ZERO operator-facing docs/**/*.html pages — the html rules would be a silent no-op (#2444)\n' >&2
+    exit 1
+fi
 
 # Additional surfaces walked ONLY by the HookEvent rule (3x7 lane-3,
 # 2026-08-09). The HookEvent rule was the last legacy hand-regex left
@@ -260,14 +326,23 @@ HTML_DOC_FILES=(
 # rules, and widening them here would enroll pages whose OTHER counts
 # belong to a different correction lane, redding this gate on drift it
 # is not the subject of. One rule, one scan set.
-HOOK_DOC_FILES=(
-    "${DOC_FILES[@]}"
-    "${HTML_DOC_FILES[@]}"
-    docs/production-deployment.md
-    docs/strategy/coala-mapping.md
-    docs/audience/developer.html
+# De-duped (#2977): docs/audience/developer.html and
+# docs/essays/brass-tacks-3-why.html were hand-added here when
+# HTML_DOC_FILES held one file; the widened glob now already carries
+# them, and a duplicate entry would report the same drift twice.
+HOOK_DOC_FILES=()
+for _hd in \
+    "${DOC_FILES[@]}" \
+    "${HTML_DOC_FILES[@]}" \
+    docs/production-deployment.md \
+    docs/strategy/coala-mapping.md \
+    docs/audience/developer.html \
     docs/essays/brass-tacks-3-why.html
-)
+do
+    _dup=0
+    for _e in "${HOOK_DOC_FILES[@]:-}"; do [[ "$_e" == "$_hd" ]] && { _dup=1; break; }; done
+    [[ "$_dup" == 0 ]] && HOOK_DOC_FILES+=("$_hd")
+done
 
 # Doc surfaces the pgvector-certified-patch rule walks. Its own EXPLICIT
 # allowlist (the "one rule, one scan set" discipline the HookEvent /
@@ -397,18 +472,34 @@ check_narrative_count_rule() {
     if [[ $# -gt 0 ]]; then
         files=("$@")
     fi
-    for f in "${files[@]}"; do
-        [[ -f "$f" ]] || continue
-        # Use python for robust regex with capture groups. Capture-then-
-        # check, not `done < <(python3 …)`: a process-substitution's exit
-        # status is unobserved under `set -euo pipefail`, so a crashing
-        # engine (a non-UTF-8 byte → the unguarded `open('$f')`) silently
-        # yielded no rows and the rule passed — the #2713 fail-open shape.
-        local narrative_rows
-        narrative_rows="$(
-            python3 -c "
-import re, sys
-pat = re.compile(r'''$pattern''')
+    # ONE python per RULE, not per FILE (#2977). The scan sets grew from a
+    # handful of curated .md files to ~90 (the widened html surface), and a
+    # per-file spawn made the gate's cost linear in interpreter startups
+    # rather than in work. Batching is also why the fail-closed contract is
+    # stated per-RULE below: a crash anywhere in the batch refuses the
+    # whole rule, which is strictly safer than refusing one file.
+    #
+    # Capture-then-check, never `done < <(python3 …)`: a process
+    # substitution's exit status is unobserved under `set -euo pipefail`,
+    # so a crashing engine (a non-UTF-8 byte reaching an unguarded
+    # `open()`) silently yields no rows and the rule PASSES — the #2713
+    # fail-open shape.
+    local narrative_rows
+    narrative_rows="$(
+        GATE_NC_FILES="${files[*]}" \
+        GATE_NC_PATTERN="$pattern" \
+        GATE_NC_RELEASE="$CANONICAL_RELEASE_VERSION" \
+        python3 - <<'NCPY'
+import html as htmlmod
+import os
+import re
+
+pat = re.compile(os.environ["GATE_NC_PATTERN"])
+release = os.environ["GATE_NC_RELEASE"]
+
+if os.environ.get("AI_MEMORY_DOCS_GATE_SELFTEST_FAULT"):
+    raise RuntimeError("check-docs-vs-ssot self-test: injected analysis-engine fault (#2713)")
+
 # HISTORICAL GUARD -- 3x7 lane-3, 2026-08-09. Mirrors is_historical in
 # the #2492 generalised scanner below. Principle: a TRUE statement about
 # a PAST release must never be re-pointed at the canonical, or the gate
@@ -417,46 +508,94 @@ pat = re.compile(r'''$pattern''')
 # enough to miss history by accident. Generalising the HookEvent anchors
 # made that accident stop holding: the README prior-release paragraph and
 # the ROADMAP frozen v0.7.1 baseline both legitimately say 25.
-# NOTE: single-quoted regexes only -- this python is embedded in a
-# double-quoted shell string, so a double quote here closes it.
-_PARA_LEAD = re.compile(r'^\s*\*\*v([0-9]+\.[0-9]+\.[0-9]+)')
-_HIST = [
-    re.compile(r'^\s*#{1,6}\s'),
-    re.compile(r'\b[Aa]t the v[0-9]+\.[0-9]+\.[0-9]+ release\b'),
-    re.compile(r'\brelease, surface was\b'),
-    re.compile(r'\bv[0-9]+ added\b'),
-    re.compile(r'\bwas [0-9]+ at v[0-9]'),
-    re.compile(r'\bShip state at v[0-9]+\.[0-9]+'),
-    re.compile(r'\bFrozen v[0-9]+\.[0-9]+[^ ]* baseline\b'),
+PARA_LEAD = re.compile(r"^\s*\*\*v([0-9]+\.[0-9]+\.[0-9]+)")
+HIST = [
+    re.compile(r"^\s*#{1,6}\s"),
+    re.compile(r"\b[Aa]t the v[0-9]+\.[0-9]+\.[0-9]+ release\b"),
+    re.compile(r"\brelease, surface was\b"),
+    re.compile(r"\bv[0-9]+ added\b"),
+    re.compile(r"\bwas [0-9]+ at v[0-9]"),
+    re.compile(r"\bShip state at v[0-9]+\.[0-9]+"),
+    re.compile(r"\bFrozen v[0-9]+\.[0-9]+[^ ]* baseline\b"),
 ]
-_release = '''$CANONICAL_RELEASE_VERSION'''
-def _is_historical(line):
-    m = _PARA_LEAD.match(line)
-    if m and m.group(1) != _release:
+
+# HTML HISTORICAL GUARD (#2977). Two things differ on the rendered .html
+# surface and BOTH are load-bearing:
+#   1. MARKUP SPLITS THE SENTENCE. `schema <strong>vNN</strong> added ...`
+#      never matches the bare `vNN added` ladder guard, so a TRUE
+#      historical ladder mention would be reported as drift. The guard is
+#      therefore evaluated over a TAG-STRIPPED, entity-decoded,
+#      WHITESPACE-COLLAPSED view (collapsing matters: a tag replaced by a
+#      space leaves two spaces, which the single-space guard still misses
+#      — a guard that looks present and does nothing).
+#   2. THE RELEASE ATTRIBUTION LIVES IN A SIBLING ELEMENT. A markdown
+#      release-narrative paragraph opens with its own
+#      `**vX.Y.Z ... prior release.**` lead; an html release CARD puts
+#      `PRIOR RELEASE` and `What's New in v0.7.0` in the two divs ABOVE
+#      the card body carrying the numbers. So the two card markers are
+#      evaluated over a SMALL PRECEDING WINDOW — the same shape
+#      scripts/check-doc-symbol-anchors.sh uses for its hard-wrapped
+#      absent-path disclaimers. Three lines: enough for eyebrow + title,
+#      too short to reach into an unrelated block.
+TAG = re.compile(r"<[^>]+>")
+WS = re.compile(r"\s+")
+HTML_WINDOW = 3
+HTML_HIST_PRIOR = re.compile(r"PRIOR RELEASE", re.IGNORECASE)
+HTML_HIST_WHATSNEW = re.compile(
+    r"What.s New in v([0-9]+\.[0-9]+\.[0-9]+)", re.IGNORECASE)
+
+
+def plain(s):
+    return WS.sub(" ", htmlmod.unescape(TAG.sub(" ", s))).strip()
+
+
+def is_historical(line):
+    m = PARA_LEAD.match(line)
+    if m and m.group(1) != release:
         return True
-    return any(p.search(line) for p in _HIST)
-for ln, line in enumerate(open('$f').read().splitlines(), 1):
-    if _is_historical(line):
+    return any(p.search(line) for p in HIST)
+
+
+def html_window_historical(window):
+    joined = " ".join(plain(w) for w in window)
+    if HTML_HIST_PRIOR.search(joined):
+        return True
+    return any(m.group(1) != release
+               for m in HTML_HIST_WHATSNEW.finditer(joined))
+
+
+for f in os.environ["GATE_NC_FILES"].split():
+    if not os.path.isfile(f):
         continue
-    for m in pat.finditer(line):
-        # Alternation groups: take the FIRST non-None capture
-        val = next((g for g in m.groups() if g is not None), '')
-        if not val:
+    is_html = f.endswith(".html")
+    lines = open(f, encoding="utf-8").read().splitlines()
+    for ln, line in enumerate(lines, 1):
+        if is_html:
+            if is_historical(plain(line)):
+                continue
+            if html_window_historical(lines[max(0, ln - 1 - HTML_WINDOW):ln]):
+                continue
+        elif is_historical(line):
             continue
-        ctx = line.strip()[:160]
-        print(f'{ln}\t{val}\t{ctx}')
-"
-        )" || {
-            printf 'FAIL: check-docs-vs-ssot: %s analysis engine errored on %s (python exited non-zero) — refusing to report PASS (#2713 fail-closed)\n' "$rule_name" "$f" >&2
-            exit 2
-        }
-        while IFS=$'\t' read -r ln val context; do
-            [[ -z "$val" ]] && continue
-            if [[ "$val" != "$canonical" ]]; then
-                emit_fail "$rule_name" "$f" "$ln" "$val" "$canonical" "$context"
-            fi
-        done <<< "$narrative_rows"
-    done
+        for m in pat.finditer(line):
+            # Alternation groups: take the FIRST non-None capture
+            val = next((g for g in m.groups() if g is not None), "")
+            if not val:
+                continue
+            ctx = line.strip()[:160].replace("\t", " ")
+            print(f"{f}\t{ln}\t{val}\t{ctx}")
+NCPY
+    )" || {
+        printf 'FAIL: check-docs-vs-ssot: %s analysis engine errored (python exited non-zero) — refusing to report PASS (#2713 fail-closed)\n' "$rule_name" >&2
+        exit 2
+    }
+    local f ln val context
+    while IFS=$'\t' read -r f ln val context; do
+        [[ -z "$val" ]] && continue
+        if [[ "$val" != "$canonical" ]]; then
+            emit_fail "$rule_name" "$f" "$ln" "$val" "$canonical" "$context"
+        fi
+    done <<< "$narrative_rows"
 }
 
 # pgvector certified-patch rule.
@@ -559,6 +698,109 @@ for ln, line in enumerate(open('$f', encoding='utf-8').read().splitlines(), 1):
             fi
         done <<< "$pgv_rows"
     done
+}
+
+# Sitewide HTML CHROME version-stamp rule (#2977).
+#
+# THE DEFECT. The v1.0.0 doc-drift campaign found the published site's
+# chrome carrying `v0.9.0` across 38 pages while every gate stayed green.
+# Chrome is the highest-leverage claim on the whole site — it is the
+# version an operator reads on EVERY page — and it was the one claim
+# nothing checked.
+#
+# THE ANCHOR is CHROME, not prose. Two shapes, both of which are
+# per-page furniture rather than narrative:
+#   * the footer stamp, scoped to the text INSIDE a `<footer>` element:
+#     `ai-memory v1.0.0 · Apache 2.0 · …`, `© 2026 AlphaOne LLC.
+#     Licensed Apache-2.0. ai-memory v1.0.0 — …`
+#   * the hero/nav release badge: `<span class="badge">v1.0.0 · …`
+# Scoping to the chrome is what keeps the rule off legitimate prose. A
+# page may say "v0.9.0 shipped the attestation default" in its body all
+# day; that is history, and the rule never reads it.
+#
+# PUBLISHED-INSTALL REFERENCES ARE SKIPPED, deliberately and by name. The
+# v1.0.0 TAG-CUT IS OPERATOR-GATED (CLAUDE.md §release gate), so the last
+# PUBLISHED artefact is still v0.9.0 and an install/download line that
+# says so is CORRECT — flagging it would push a doc author to publish an
+# install command for a tag that does not exist, which is worse than the
+# drift the rule is here to catch. Footer scoping already excludes almost
+# all of these; the keyword skip below is the belt for the rare footer
+# that carries a download link.
+#
+# Frozen pages never reach this rule: they are filtered out of
+# HTML_DOC_FILES by HTML_FROZEN_EXEMPT at the top of this script, which is
+# exactly why a `whats-new-v0.8.0` page may keep stamping v0.8.0.
+check_html_version_stamp_rule() {
+    local rule_name="HTML_CHROME_VERSION_STAMP"
+    local canonical="$CANONICAL_RELEASE_VERSION"
+    if [[ -z "$canonical" ]]; then
+        printf 'FAIL: %s: could not resolve the release version from Cargo.toml — refusing to validate (#2713 fail-closed)\n' \
+            "$rule_name" >&2
+        fail_count=$((fail_count + 1))
+        return
+    fi
+    # ONE python for the whole scan set (the check_narrative_count_rule
+    # batching rationale): 53 interpreter startups to read 53 footers is
+    # cost with no work in it.
+    local rows
+    rows="$(
+        GATE_STAMP_FILES="${HTML_DOC_FILES[*]:-}" python3 - <<'PY'
+import os
+import re
+
+if os.environ.get("AI_MEMORY_DOCS_GATE_SELFTEST_FAULT"):
+    raise RuntimeError("check-docs-vs-ssot self-test: injected analysis-engine fault (#2713)")
+
+FOOTER_OPEN = re.compile(r"<footer\b", re.IGNORECASE)
+FOOTER_CLOSE = re.compile(r"</footer\s*>", re.IGNORECASE)
+# `ai-memory v1.0.0` / `ai-memory&trade; v1.0.0` / `ai-memory™ v1.0.0`
+FOOTER_STAMP = re.compile(
+    r"ai-memory(?:&trade;|&#8482;|™)?\s+v([0-9]+\.[0-9]+\.[0-9]+)")
+# The hero/nav release badge: `<span class="badge">v1.0.0 &middot; …`
+BADGE_STAMP = re.compile(
+    r'class="badge"[^>]*>\s*v([0-9]+\.[0-9]+\.[0-9]+)')
+# Published-install / download references legitimately trail the last
+# PUBLISHED tag while the tag-cut is operator-gated.
+INSTALL_REF = re.compile(
+    r"install|download|releases/download|/tag/|git\s+checkout|"
+    r"cargo\s+add|crates\.io|homebrew|brew\s|docker\s+pull|"
+    r"npm\s+i(?:nstall)?\b|pip\s+install|ghcr\.io|apt-get",
+    re.IGNORECASE,
+)
+
+for path in os.environ.get("GATE_STAMP_FILES", "").split():
+    if not os.path.isfile(path):
+        continue
+    lines = open(path, encoding="utf-8").read().splitlines()
+    depth = 0
+    for ln, line in enumerate(lines, 1):
+        opens = len(FOOTER_OPEN.findall(line))
+        closes = len(FOOTER_CLOSE.findall(line))
+        in_footer = depth > 0 or opens > 0
+        depth += opens - closes
+        if depth < 0:
+            depth = 0
+        if INSTALL_REF.search(line):
+            continue
+        hits = []
+        if in_footer:
+            hits += [("footer", m) for m in FOOTER_STAMP.finditer(line)]
+        hits += [("badge", m) for m in BADGE_STAMP.finditer(line)]
+        for kind, m in hits:
+            ctx = line.strip()[:160].replace("\t", " ")
+            print(f"{path}\t{ln}\t{m.group(1)}\t{kind}\t{ctx}")
+PY
+    )" || {
+        printf 'FAIL: check-docs-vs-ssot: html chrome version-stamp engine errored (python exited non-zero) — refusing to report PASS (#2713 fail-closed)\n' >&2
+        exit 2
+    }
+    local f ln val kind context
+    while IFS=$'\t' read -r f ln val kind context; do
+        [[ -z "$val" ]] && continue
+        if [[ "$val" != "$canonical" ]]; then
+            emit_fail "$rule_name ($kind)" "$f" "$ln" "v$val" "v$canonical" "$context"
+        fi
+    done <<< "$rows"
 }
 
 # Env-var census rule (#836 3B / 2026-06-09 GA drive). Every
@@ -694,6 +936,7 @@ check_generalised_numeric_claims() {
     local out
     if ! out="$(
         GATE_DOC_FILES="${DOC_FILES[*]}" \
+        GATE_HTML_FILES="${HTML_DOC_FILES[*]:-}" \
         C_ROUTES="$CANONICAL_ROUTES_COUNT" \
         C_PATHS="$CANONICAL_UNIQUE_PATHS_COUNT" \
         C_SCHEMA="$CANONICAL_SCHEMA_VERSION" \
@@ -703,10 +946,16 @@ check_generalised_numeric_claims() {
         C_CLI_DEFAULT="$CANONICAL_CLI_DEFAULT" \
         C_RELEASE="$CANONICAL_RELEASE_VERSION" \
         python3 - <<'PY'
+import html as htmlmod
 import os
 import re
 
 docs = os.environ["GATE_DOC_FILES"].split()
+# #2977 — the operator-facing docs/**/*.html surface, resolved by the
+# enroll-by-default glob + frozen-exemption list at the top of this
+# script. Scanned by the SAME rule table as the .md set (see the markup
+# dialect note below) but under an html-aware historical guard.
+html_docs = os.environ.get("GATE_HTML_FILES", "").split()
 release = os.environ["C_RELEASE"]
 
 # Self-test fault-injection (#2713): when this env var is set the analysis
@@ -726,18 +975,42 @@ canon = {
     "EXPECTED_CLI_SUBCOMMANDS_DEFAULT": os.environ["C_CLI_DEFAULT"],
 }
 
-# `**92**` / `92` / `` `92` `` -- bold, code-span, or bare.
-NUM = r"(?:\*\*|`)?([0-9]+)(?:\*\*|`)?"
+# MARKUP DIALECT (#2977). ONE anchor grammar, two dialects. The rendered
+# .html pages restate the same noun-phrase anchors as the .md sources, but
+# with `<strong>`/`<code>` where markdown writes `**`/`` ` ``, and with
+# `&nbsp;` where markdown writes a space. Writing a SECOND html rule table
+# would give two definitions that can silently disagree (the standing
+# CLAUDE.md objection: "two definitions that can disagree teach reviewers
+# to ignore both"), so the delimiters below simply admit BOTH spellings and
+# the SAME table serves both file types. A .md file never contains
+# `<strong>` and a .html file never contains `**`, so neither dialect
+# widens the other's match set.
+#
+# Each alternative inside MK is NON-EMPTY on purpose: a `*`-quantified
+# alternative nested inside a `+`-quantified group is the classic
+# catastrophic-backtracking shape.
+MK = r"(?:</?(?:strong|b|code|em|i)>|\*\*|`)"
+# SP1 keeps the "at least one separator" requirement the markdown `[ ]+`
+# positions carried; SP0 replaces the `[ ]*(?:\*\*)?[ ]*` runs.
+SP0 = r"(?:[ ]|&nbsp;|" + MK + r")*"
+SP1 = r"(?:[ ]|&nbsp;|" + MK + r")+"
+BOLD_OPEN = r"(?:\*\*|<strong>|<b>)"
+BOLD_CLOSE = r"(?:\*\*|</strong>|</b>)"
+CODE_OPEN = r"(?:`|<code>)"
+CODE_CLOSE = r"(?:`|</code>)"
+# `**92**` / `92` / `` `92` `` / `<strong>92</strong>` / `<code>92</code>`
+NUM = (r"(?:" + BOLD_OPEN + r"|" + CODE_OPEN + r")?([0-9]+)"
+       r"(?:" + BOLD_CLOSE + r"|" + CODE_CLOSE + r")?")
 
 RULES = [
     ("EXPECTED_PRODUCTION_ROUTES_COUNT", [
-        NUM + r"[ ]*(?:\*\*)?[ ]*(?:production[ ]+)?(?:HTTP|REST)[ ]+routes?[ ]+registrations",
-        NUM + r"[ ]*(?:\*\*)?[ ]*(?:production[ ]+)?HTTP[ ]+routes\b",
-        NUM + r"[ ]*production[ ]+`\.route\(\.\.\.\)`[ ]+registrations",
-        NUM + r"[ ]*(?:\*\*)?[ ]*route[ ]+registrations",
+        NUM + SP0 + r"(?:production" + SP1 + r")?(?:HTTP|REST)" + SP1 + r"routes?" + SP1 + r"registrations",
+        NUM + SP0 + r"(?:production" + SP1 + r")?HTTP" + SP1 + r"routes\b",
+        NUM + SP0 + r"production" + SP1 + CODE_OPEN + r"\.route\(\.\.\.\)" + CODE_CLOSE + SP1 + r"registrations",
+        NUM + SP0 + r"route" + SP1 + r"registrations",
     ]),
     ("EXPECTED_PRODUCTION_UNIQUE_PATHS_COUNT", [
-        NUM + r"[ ]*(?:\*\*)?[ ]*unique[ ]+(?:URL[ ]+)?paths",
+        NUM + SP0 + r"unique" + SP1 + r"(?:URL" + SP1 + r")?paths",
     ]),
     # BOLD-ONLY, deliberately. A bare `schema v52` is the ladder-history
     # phrasing the pre-existing CURRENT_SCHEMA_VERSION rule above already
@@ -746,28 +1019,33 @@ RULES = [
     # red-line ~30 lines of legitimate history across ROADMAP, the
     # PORTABILITY spec, and the compliance inventory. `schema **vNN**`
     # is the SURFACE-SUMMARY phrasing — the register's own stale shape.
+    # CODE-span is deliberately NOT admitted here either: the html twin of
+    # a bare `schema v52` is `schema <code>v52</code>`, which is exactly
+    # the pinned-artefact / ladder-history spelling the bold-only rule
+    # exists to spare (docs/reference-architecture/index.html pins the
+    # do-1461 golden fleet at `schema <code>v78</code>`).
     ("CURRENT_SCHEMA_VERSION", [
-        r"schema[ ]+\*\*v([0-9]+)\*\*",
+        r"schema" + SP1 + BOLD_OPEN + r"v([0-9]+)" + BOLD_CLOSE,
     ]),
     ("Memory::FIELD_COUNT", [
-        NUM + r"-field(?:\*\*)?[ ]*(?:`Memory`|struct)",
+        NUM + r"-field" + SP0 + r"(?:" + CODE_OPEN + r"Memory" + CODE_CLOSE + r"|struct)",
     ]),
     # `--profile full`-anchored, deliberately. A bare `N MCP tools`
     # matches the per-release capability ladder ("5 MCP tools", "4 MCP
     # tools") and per-family subset counts, none of which are claims
     # about the full-profile total.
     ("Profile::full().expected_tool_count()", [
-        NUM + r"[ ]*(?:\*\*)?[ ]*MCP[ ]+tools[ ]+at[ ]+`--profile[ ]+full`",
-        NUM + r"-entry(?:\*\*)?[ ]+surface",
-        NUM + r"[ ]*(?:\*\*)?[ ]*advertised[ ]+entries[ ]+at[ ]+`--profile[ ]+full`",
+        NUM + SP0 + r"MCP" + SP1 + r"tools" + SP1 + r"at" + SP1 + CODE_OPEN + r"--profile" + SP1 + r"full" + CODE_CLOSE,
+        NUM + r"-entry" + SP1 + r"surface",
+        NUM + SP0 + r"advertised" + SP1 + r"entries" + SP1 + r"at" + SP1 + CODE_OPEN + r"--profile" + SP1 + r"full" + CODE_CLOSE,
     ]),
     ("EXPECTED_CLI_SUBCOMMANDS_SAL", [
-        NUM + r"[ ]*(?:\*\*)?[ ]*(?:CLI[ ]+|top-level[ ]+)?subcommands[ ]+under[ ]+`--features[ ]+sal",
-        r"yields[ ]+\*\*([0-9]+)\*\*[ ]+by[ ]+unlocking",
+        NUM + SP0 + r"(?:CLI" + SP1 + r"|top-level" + SP1 + r")?subcommands" + SP1 + r"under" + SP1 + CODE_OPEN + r"--features" + SP1 + r"sal",
+        r"yields" + SP1 + BOLD_OPEN + r"([0-9]+)" + BOLD_CLOSE + SP1 + r"by" + SP1 + r"unlocking",
     ]),
     ("EXPECTED_CLI_SUBCOMMANDS_DEFAULT", [
-        NUM + r"[ ]*(?:\*\*)?[ ]*(?:CLI[ ]+|top-level[ ]+)?subcommands[ ]+in[ ]+the[ ]+default[ ]+build",
-        NUM + r"[ ]*(?:\*\*)?[ ]*in[ ]+the[ ]+default[ ]+build",
+        NUM + SP0 + r"(?:CLI" + SP1 + r"|top-level" + SP1 + r")?subcommands" + SP1 + r"in" + SP1 + r"the" + SP1 + r"default" + SP1 + r"build",
+        NUM + SP0 + r"in" + SP1 + r"the" + SP1 + r"default" + SP1 + r"build",
     ]),
 ]
 RULES = [(k, [re.compile(p) for p in ps]) for k, ps in RULES]
@@ -810,27 +1088,92 @@ def is_historical(line):
     return any(p.search(line) for p in HISTORICAL)
 
 
-for f in docs:
+# ---- HTML HISTORICAL GUARD (#2977) ----------------------------------
+# The markdown guards above are line-scoped because a markdown
+# release-narrative paragraph IS one line, opening with its own
+# `**v0.8.0 … prior release.**` lead. The rendered .html surface breaks
+# that assumption in two independent ways, and BOTH would turn TRUE
+# history into reported drift:
+#
+#   1. MARKUP SPLITS THE SENTENCE. `schema <strong>v67</strong> added the
+#      target_agent_id_idx column` never matches the bare `vNN added`
+#      ladder guard, because the tags sit between the two words. The guard
+#      is therefore evaluated over a TAG-STRIPPED, entity-decoded view of
+#      the line. (This is not hypothetical: it is the single hit the
+#      widened scan produced on the tree at 57b7fe35.)
+#
+#   2. THE RELEASE ATTRIBUTION LIVES IN A SIBLING ELEMENT. An HTML release
+#      CARD puts `▸ PRIOR RELEASE` and `What's New in v0.7.0` in the two
+#      divs ABOVE the card body that carries the numbers, so nothing on
+#      the number-bearing line says which release it describes. The two
+#      card markers are therefore evaluated over a SMALL PRECEDING WINDOW
+#      — the same shape scripts/check-doc-symbol-anchors.sh uses for its
+#      hard-wrapped absent-path disclaimers. THREE lines: enough for
+#      eyebrow + title, too short to reach into an unrelated block.
+#
+# `What's New in vX.Y.Z` is historical only when X.Y.Z is NOT the current
+# release, so a card describing the CURRENT release keeps being checked.
+TAG = re.compile(r"<[^>]+>")
+WS = re.compile(r"\s+")
+HTML_WINDOW = 3
+HTML_HIST_PRIOR = re.compile(r"PRIOR RELEASE", re.IGNORECASE)
+HTML_HIST_WHATSNEW = re.compile(
+    r"What.s New in v([0-9]+\.[0-9]+\.[0-9]+)", re.IGNORECASE)
+
+
+def plain(s):
+    # Whitespace is COLLAPSED, not merely substituted: replacing a tag
+    # with a space leaves `v67  added` (two spaces), which the ladder
+    # guard's single-space `\bv[0-9]+ added\b` would still miss — the
+    # guard would look present and do nothing.
+    return WS.sub(" ", htmlmod.unescape(TAG.sub(" ", s))).strip()
+
+
+def html_window_historical(window):
+    joined = " ".join(plain(w) for w in window)
+    if HTML_HIST_PRIOR.search(joined):
+        return True
+    return any(m.group(1) != release
+               for m in HTML_HIST_WHATSNEW.finditer(joined))
+
+
+def scan(f, is_html):
     try:
         text = open(f, encoding="utf-8").read()
     except OSError:
-        continue
-    for ln, line in enumerate(text.splitlines(), 1):
+        return
+    lines = text.splitlines()
+    for ln, line in enumerate(lines, 1):
         ctx = line.strip()[:160].replace("\t", " ")
-        m = CURRENT_RELEASE.search(line)
-        if m and m.group(1) != release:
-            print(
-                "CURRENT_RELEASE_ATTRIBUTION\t"
-                f"{f}\t{ln}\tv{m.group(1)}\tv{release}\t{ctx}"
-            )
-        if is_historical(line):
-            continue
+        if is_html:
+            if is_historical(plain(line)):
+                continue
+            if html_window_historical(lines[max(0, ln - 1 - HTML_WINDOW):ln]):
+                continue
+        else:
+            # RULE N1 is a MARKDOWN paragraph-lead rule; the html surface
+            # has no `**vX — current release.**` shape. Its html analogue
+            # is the footer/nav chrome stamp, policed by its own rule.
+            m = CURRENT_RELEASE.search(line)
+            if m and m.group(1) != release:
+                print(
+                    "CURRENT_RELEASE_ATTRIBUTION\t"
+                    f"{f}\t{ln}\tv{m.group(1)}\tv{release}\t{ctx}"
+                )
+            if is_historical(line):
+                continue
         for key, pats in RULES:
             for pat in pats:
                 for hit in pat.finditer(line):
                     val = hit.group(1)
                     if val != canon[key]:
                         print(f"{key}\t{f}\t{ln}\t{val}\t{canon[key]}\t{ctx}")
+
+
+for f in docs:
+    scan(f, False)
+for f in html_docs:
+    scan(f, True)
 PY
     )"; then
         # FAIL CLOSED (#2713): the numeric-claim analysis engine exited
@@ -907,6 +1250,7 @@ run_all_rules() {
     check_env_var_census_rule
     check_generalised_numeric_claims
     check_pgvector_version_rule
+    check_html_version_stamp_rule
     # MCP tool count at --profile full
     check_narrative_count_rule \
         "Profile::full().expected_tool_count() (registry tools)" \
@@ -1065,6 +1409,14 @@ run_self_test() {
 
     cd "$tmpdir"
     mkdir -p src/storage src/lib src/models src/mcp src/hooks
+    # #2977 — the frozen-page exemption SSOT the html scan set resolves
+    # against. A REAL one (not an empty stub) so the html legs below can
+    # prove BOTH directions of the boundary.
+    mkdir -p scripts/qc-allowlists
+    cat > scripts/qc-allowlists/html-doc-frozen-exempt.txt <<'FROZENEOF'
+# fixture exemption SSOT
+docs/whats-new-v
+FROZENEOF
     # Minimal canonical fixture: CURRENT_SCHEMA_VERSION = 53
     cat > src/storage/migrations.rs <<EOF
 const CURRENT_SCHEMA_VERSION: i64 = 53;
@@ -1541,6 +1893,215 @@ PGVECGOOD
         cd "$REPO_ROOT"; exit 1
     fi
     echo "PASS: self-test — the certified pgvector patch (0.8.6) still PASSES"
+
+    # ================================================================
+    # #2977 — THE GITHUB-PAGES (.html) SURFACE
+    # ================================================================
+    # Before #2977 the html scan set was ONE file, so ~70 hand-authored
+    # Jekyll pages were ungated and drifted invisibly through the whole
+    # v1.0.0 campaign. These legs pin the three properties the widening
+    # rests on: the html dialect is really READ (RED), a corrected page
+    # really PASSES (GREEN), and the two historical guards that make the
+    # widening survivable are load-bearing rather than decorative.
+    #
+    # Fixture canonicals: schema 53 · routes 87 · paths 73 · tools 12 ·
+    #                     cli 78 default / 80 sal · fields 26 · hooks 25 ·
+    #                     release 9.9.9
+    rm -f "$led" "$tmpdir/docs/CONFIG_SCHEMA.md" "$tmpdir/docs/compliance/nsa-csi-mcp.html"
+    cat > CLAUDE.md <<'HTML2977CLAUDE'
+Fixture CLAUDE.md — deliberately carries no narrative counts.
+HTML2977CLAUDE
+    cat > README.md <<'HTML2977README'
+Fixture README — deliberately carries no narrative counts.
+HTML2977README
+
+    # ---- RED: the html markup dialect is really read. Every claim below
+    # is the html twin of a shape the .md scanner already catches, and NOT
+    # ONE of them matches a markdown-only anchor.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLSTALECLAIMS'
+<p>Surface: schema <strong>v78</strong>, <strong>101</strong> MCP tools at <code>--profile full</code>.</p>
+<p><strong>92</strong> HTTP route registrations over <strong>78</strong> unique URL paths.</p>
+<p>The record is a <strong>28-field</strong> <code>Memory</code>.</p>
+<p>The CLI ships <strong>89</strong> subcommands under <code>--features sal</code>.</p>
+HTMLSTALECLAIMS
+    if html_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test #2977 — the widened gate ACCEPTED html-dialect stale SSOT claims" >&2
+        printf '%s\n' "$html_out" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    html_missing=0
+    for shape in \
+        "CURRENT_SCHEMA_VERSION: docs/at-a-glance.html:1 claims \"78\"" \
+        "Profile::full().expected_tool_count(): docs/at-a-glance.html:1 claims \"101\"" \
+        "EXPECTED_PRODUCTION_ROUTES_COUNT: docs/at-a-glance.html:2 claims \"92\"" \
+        "EXPECTED_PRODUCTION_UNIQUE_PATHS_COUNT: docs/at-a-glance.html:2 claims \"78\"" \
+        "Memory::FIELD_COUNT: docs/at-a-glance.html:3 claims \"28\"" \
+        "EXPECTED_CLI_SUBCOMMANDS_SAL: docs/at-a-glance.html:4 claims \"89\"" \
+    ; do
+        if ! grep -qF "$shape" <<<"$html_out"; then
+            echo "FAIL: self-test #2977 — widened gate did not flag: $shape" >&2
+            html_missing=1
+        fi
+    done
+    if [[ "$html_missing" -ne 0 ]]; then
+        printf '%s\n' "$html_out" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 RED — six html-dialect SSOT claims (<strong>/<code> spans) are REJECTED on an enroll-by-default page"
+
+    # ---- GREEN-on-fixed: the SAME page with the fixture canonicals.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLGOODCLAIMS'
+<p>Surface: schema <strong>v53</strong>, <strong>12</strong> MCP tools at <code>--profile full</code>.</p>
+<p><strong>87</strong> HTTP route registrations over <strong>73</strong> unique URL paths.</p>
+<p>The record is a <strong>26-field</strong> <code>Memory</code>.</p>
+<p>The CLI ships <strong>80</strong> subcommands under <code>--features sal</code>.</p>
+HTMLGOODCLAIMS
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 GREEN — the CORRECTED html page was still rejected" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 GREEN — the same html page carrying the canonical values PASSES"
+
+    # ---- HISTORICAL GUARD 1: TAG-STRIPPING. The verbatim
+    # docs/agent-identity.html shape. `schema <strong>v67</strong> added`
+    # is a TRUE ladder statement; without the tag-stripped view the guard
+    # never sees the `vNN added` phrase and the gate reports history as
+    # drift. This is the ONE hit the widened scan produced at 57b7fe35.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLLADDER'
+<p>Backing this, schema <strong>v67</strong> added the <code>target_agent_id_idx</code> column.</p>
+HTMLLADDER
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 — the html guard fired on a LEGITIMATE tag-split ladder mention" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 — a tag-split 'schema <strong>vNN</strong> added' ladder mention still PASSES"
+
+    # ---- HISTORICAL GUARD 2: THE PRECEDING-LINE WINDOW. An html release
+    # CARD puts its attribution in the two divs ABOVE the numbers, so
+    # nothing on the number-bearing line says which release it describes.
+    # BOTH directions are asserted, because a window guard that fired
+    # unconditionally would be indistinguishable from not scanning at all.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLCARD'
+<div class="card-eyebrow">&#9656; PRIOR RELEASE</div>
+<div class="card-title">What's New in v0.7.0 — attested-cortex</div>
+<p class="card-body"><strong>74</strong> MCP tools at <code>--profile full</code>, 27-event hook pipeline.</p>
+HTMLCARD
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 — the window guard did NOT spare an html PRIOR-RELEASE card" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 — an html release CARD (eyebrow + title in the divs above) is spared"
+
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLCARDLESS'
+<p class="card-body"><strong>74</strong> MCP tools at <code>--profile full</code>, 27-event hook pipeline.</p>
+HTMLCARDLESS
+    if card_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test #2977 — the SAME numbers WITHOUT the release-card markers were accepted." >&2
+        echo "       The window guard would then be a blanket exemption, not a guard." >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    grep -qF 'Profile::full().expected_tool_count(): docs/at-a-glance.html:1 claims "74"' <<<"$card_out" || {
+        echo "FAIL: self-test #2977 — card-less stale tool count not flagged" >&2
+        printf '%s\n' "$card_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    grep -qF 'HookEvent variants: docs/at-a-glance.html:1 claims "27"' <<<"$card_out" || {
+        echo "FAIL: self-test #2977 — card-less stale hook count not flagged (the widened HookEvent scan set)" >&2
+        printf '%s\n' "$card_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    echo "PASS: self-test #2977 — the SAME numbers with the card markers REMOVED are REJECTED (the window is a guard, not a blanket)"
+
+    # ---- FROZEN EXEMPTION, both directions. A page named in
+    # scripts/qc-allowlists/html-doc-frozen-exempt.txt carries the very
+    # same stale claims and must PASS: "what's new in vN" is, by
+    # construction, a statement about vN.
+    rm -f "$tmpdir/docs/at-a-glance.html"
+    cat > "$tmpdir/docs/whats-new-v09.html" <<'HTMLFROZEN'
+<p>Surface: schema <strong>v78</strong>, <strong>101</strong> MCP tools at <code>--profile full</code>.</p>
+HTMLFROZEN
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 — a FROZEN page (html-doc-frozen-exempt.txt) was scanned" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 — a page named in html-doc-frozen-exempt.txt is EXEMPT (the same claims pass there)"
+    rm -f "$tmpdir/docs/whats-new-v09.html"
+
+    # ---- THE EXEMPTION SSOT IS REQUIRED. A gate that silently resolves
+    # its scan set without the frozen boundary either reds every frozen
+    # page or drops the widening; refuse instead. Asserted here rather
+    # than waived under --self-test, because a check the self-test cannot
+    # reach is a check nobody has proven.
+    mv "$tmpdir/scripts/qc-allowlists/html-doc-frozen-exempt.txt" "$tmpdir/exempt.bak"
+    if ex_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test #2977 — a MISSING frozen-exemption SSOT did not fail the gate" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    grep -q 'html-doc-frozen-exempt.txt' <<<"$ex_out" || {
+        echo "FAIL: self-test #2977 — the missing-SSOT failure did not name the file" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    mv "$tmpdir/exempt.bak" "$tmpdir/scripts/qc-allowlists/html-doc-frozen-exempt.txt"
+    echo "PASS: self-test #2977 — a missing frozen-exemption SSOT FAILS CLOSED"
+
+    # ---- SITEWIDE CHROME VERSION STAMP. The campaign found v0.9.0 chrome
+    # on 38 pages while every gate stayed green. Fixture release: 9.9.9.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLSTAMPBAD'
+<span class="badge">v0.9.0 &middot; Apache-2.0</span>
+<p>ai-memory v0.7.0 shipped the attested cortex.</p>
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v0.9.0 — source on GitHub</p>
+</footer>
+HTMLSTAMPBAD
+    if stamp_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test #2977 — a stale sitewide chrome version stamp was ACCEPTED" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    grep -qF 'HTML_CHROME_VERSION_STAMP (footer): docs/at-a-glance.html:4 claims "v0.9.0"' <<<"$stamp_out" || {
+        echo "FAIL: self-test #2977 — the stale FOOTER chrome stamp was not flagged" >&2
+        printf '%s\n' "$stamp_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    grep -qF 'HTML_CHROME_VERSION_STAMP (badge): docs/at-a-glance.html:1 claims "v0.9.0"' <<<"$stamp_out" || {
+        echo "FAIL: self-test #2977 — the stale hero/nav BADGE chrome stamp was not flagged" >&2
+        printf '%s\n' "$stamp_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    # ...and the PROSE mention OUTSIDE the footer must NOT be flagged: a
+    # page saying what v0.7.0 shipped is history, not chrome.
+    grep -qF 'docs/at-a-glance.html:2' <<<"$stamp_out" && {
+        echo "FAIL: self-test #2977 — the chrome rule fired on PROSE outside the footer" >&2
+        printf '%s\n' "$stamp_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    echo "PASS: self-test #2977 — stale FOOTER + BADGE chrome stamps are REJECTED, body prose is spared"
+
+    # ---- GREEN-on-fixed + the PUBLISHED-INSTALL carve-out. The v1.0.0
+    # tag-cut is operator-gated, so an install/download line pinned at the
+    # last PUBLISHED tag is CORRECT; flagging it would push a doc author
+    # to publish an install command for a tag that does not exist.
+    cat > "$tmpdir/docs/at-a-glance.html" <<'HTMLSTAMPGOOD'
+<span class="badge">v9.9.9 &middot; Apache-2.0</span>
+<footer>
+  <p>© 2026 AlphaOne LLC. Licensed Apache-2.0. ai-memory v9.9.9 — source on GitHub</p>
+  <p>Install the published build: <code>cargo install ai-memory v0.9.0</code></p>
+</footer>
+HTMLSTAMPGOOD
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 GREEN — a current chrome stamp + a published-install reference were rejected" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 GREEN — a current chrome stamp PASSES and a published-install reference is SKIPPED"
+
+    # ---- and a FROZEN page keeps its own historical chrome stamp.
+    rm -f "$tmpdir/docs/at-a-glance.html"
+    cat > "$tmpdir/docs/whats-new-v09.html" <<'HTMLSTAMPFROZEN'
+<footer><p>ai-memory v0.9.0 — what shipped in v0.9.0</p></footer>
+HTMLSTAMPFROZEN
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test #2977 — the chrome rule fired on a FROZEN per-release page" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test #2977 — a frozen per-release page keeps its own historical chrome stamp"
 
     cd "$REPO_ROOT"
 }

--- a/scripts/qc-allowlists/html-doc-frozen-exempt.txt
+++ b/scripts/qc-allowlists/html-doc-frozen-exempt.txt
@@ -1,0 +1,58 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# FROZEN GitHub-Pages HTML surfaces — the exemption SSOT for the doc-drift
+# gates that walk `docs/**/*.html` (#2977).
+#
+# WHY THIS FILE EXISTS. Before #2977 the two claims gates carried a
+# one-file / three-file HTML allowlist, so ~70 hand-authored Jekyll pages
+# under `docs/` were UNGATED. That is why the HTML surface drifted
+# invisibly through the v1.0.0 campaign (stale schema versions, a sitewide
+# v0.9.0 chrome stamp, a false sub-10ms recall claim, a
+# bench-as-merge-blocker claim, a kind-count 10-vs-16) while every gate
+# stayed green. An enumerated INCLUDE list cannot close that class — the
+# rot IS that a new page lands ungated — so the scan set is
+# ENROLL-BY-DEFAULT and the EXEMPTIONS are the enumerated thing.
+#
+# CONSUMERS (both read this file; it is the single definition, so the two
+# gates cannot drift apart on where the frozen boundary sits):
+#   * scripts/check-docs-vs-ssot.sh      — numeric-claim + CLI-count +
+#                                          HookEvent + chrome-version rules
+#   * scripts/check-ci-job-claims.sh     — named-CI-job existence +
+#                                          enforcement-truthfulness rules
+#
+# FORMAT. One PATH SUBSTRING per line; a doc is exempt when its
+# repo-relative path CONTAINS the substring. `#` starts a comment. Every
+# entry MUST carry a rationale naming WHY the page is frozen, so the
+# boundary can be audited in one read. Keep it minimal and anchored: an
+# entry that stops matching anything is dead weight that hides coverage.
+#
+# THE TEST FOR AN ENTRY: is every number on the page a TRUE STATEMENT
+# ABOUT A PAST RELEASE, by construction? If the page would be WRONG after
+# a version bump, it is frozen. If it would merely be STALE, it is live
+# and belongs under the gate.
+
+# Jekyll layout template — chrome scaffolding, not published content.
+docs/_layouts/
+
+# Frozen per-release evidence + compatibility trees. Every number in them
+# describes the tree AS IT WAS at that release.
+docs/v0.7.0/
+docs/v0.7/
+
+# Per-release narrative pages. "What's new in vN" is, by construction, a
+# statement about vN; re-pointing them at the canonical would destroy the
+# release record the pages exist to keep.
+docs/whats-new-v
+docs/v070-architecture.html
+docs/v070-changelog.html
+docs/release-v0.7.1.html
+
+# Frozen v0.7.0-era AI-NHI assessment. The page IS the artefact of that
+# assessment (its own footer chrome stamps v0.7.0), not a live doc.
+docs/ai-nhi-pm-v9.html
+
+# Dated point-in-time security assessments. An assessment OF vX keeps
+# citing vX forever; that is the artefact being correct, not drift.
+docs/compliance/nsa-control-test-matrix.html
+docs/compliance/v1.0.0-security-assessment.html


### PR DESCRIPTION
Closes the systemic root cause of the HTML drift the v1.0.0 docs campaign kept finding: ~70 hand-authored Jekyll pages under `docs/` were ungated (3-file allowlist + markdown-only regexes).

## What
- **Enroll-by-default scan set**: `docs/**/*.html` minus the frozen pages named in the new **shared exemption SSOT** `scripts/qc-allowlists/html-doc-frozen-exempt.txt` — read by BOTH gates so the frozen boundary cannot drift apart; missing file / empty resolved set fails closed. Deliberately inverts the .md enumerated-include argument (#2839): this defect class IS 'a new page lands ungated'.
- **One rule table, both dialects** (`<strong>`/`<b>` ↔ `**`, `<code>` ↔ backtick, `&nbsp;` ↔ space) — widening the corpus without teaching the regexes HTML would have been a #2444-shape no-op. Historical guards run tag-stripped + whitespace-collapsed, release-card markers use a 3-line preceding window (anchors precedent from check-doc-symbol-anchors).
- **New chrome version-stamp rule**: footer `ai-memory vX.Y.Z` + hero/nav badge must equal Cargo.toml. Body prose never read; frozen pages keep their historical stamp; published-install refs skipped by name (tag-cut is operator-gated, so v0.9.0 install lines are CORRECT).
- `check-ci-job-claims` html corpus widened identically + citation shapes admit `<code>` (campaign C6 finding was invisible for two independent reasons).
- **Residual drift the new rules caught on first run, fixed** (docs → code, never reverse): evidence-hub footer/meta still v0.9.0; at-a-glance bench 'CI guard' → advisory; reproducible-baselines `Bench · bench` phantom job → the real advisory `bench` job.

## Evidence (Fable independently re-verified in the worktree)
- Self-tests: **25/25** legs (docs-vs-ssot, 10 new) + **19/19** (ci-job-claims, 5 new), zero non-PASS lines
- Independent RED injection by reviewer (schema v78 + badge v0.8.1 into a live page): both FAIL lines fired; reverted → green
- Full runs green: docs-vs-ssot, ci-job-claims (18 workflows), doc-symbol-anchors, sdk-route-paths, capacity-claims (#2869 — no allowlist entries added), benchmark-claims; `bash -n` both scripts; `cargo test --test doc_claims_integrity` 4/4
- Perf: gate ~12s vs 19s pre-change baseline while scanning 53 more pages (per-rule python batching, fail-closed preserved)

## Notes for review
- The frozen/live boundary is now load-bearing; every exemption entry carries its rationale. Two deliberate non-fixes left as stale-but-arguably-true: `reference-architecture/index.html` meta (pins the 0.9.0 golden binary) and `spec/v1.html` v0.9.0 conformance claim (should not be silently re-asserted for v1.0.0 without re-verification) — will file a follow-up decision issue.
- `scripts/` edit de-classifies this from docs-only → full heavy CI expected.

Closes #2977 (manual close needed — non-default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)