### PR TITLE
fix(cli): close the CLI-surface security parity cluster (#2990 #2992 #3036 #2988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Two CLI paths diverged from the guard the MCP/HTTP reference surface already
 enforces. Both are precedent-copies — the fail-closed posture was already
-decided on the reference surface — and neither tightens behaviour beyond that
-precedent.
+decided on the reference surface. Neither tightens behaviour beyond that
+precedent, but the #3036 alignment does change the identity the CLI `link`
+write is permission-evaluated as; see the operator note below.
 
 - **#3036 — CLI `link` edges were permanently unattestable.** `ai-memory link`
   called the unsigned `db::create_link` while MCP `memory_link` routes through
@@ -23,8 +24,17 @@ precedent.
   `load_active_keypair_for_mcp_in`) and signs through the same
   `create_link_signed` funnel, reporting the resulting `attest_level`. With no
   keypair resolvable the edge still lands `unsigned`, byte-identical to the
-  prior behaviour — this adds attestation where a key exists, it does not
-  refuse anything that previously succeeded.
+  prior behaviour. **Operator action:** the CLI link is now
+  permission-evaluated as the signing identity rather than `system`; operators
+  with agent-scoped `memory_link` rules must re-check them. (`create_link_signed`
+  derives the K9 actor from the keypair's `agent_id`, falling back to `system`
+  only when no key resolves — so a rule that denies e.g. `ai:*` can now Deny a
+  CLI link that previously evaluated as `system` and succeeded.) A key-load
+  failure that is not a plain "no such key" now warns on stderr instead of
+  silently degrading the edge to `unsigned`, and re-linking an
+  already-existing edge reports the level that is actually STORED on the row
+  rather than the signature level it computed but never persisted (the write
+  is an `INSERT OR IGNORE` no-op).
 - **#2988 — the recall ledger bound a NAMESPACE into the identity column.**
   Both CLI recall paths wrote `--as-agent` (a namespace) into
   `recall_observations.agent_id`: `src/cli/recall.rs` passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
+
+Two CLI paths diverged from the guard the MCP/HTTP reference surface already
+enforces. Both are precedent-copies — the fail-closed posture was already
+decided on the reference surface — and neither tightens behaviour beyond that
+precedent.
+
+- **#3036 — CLI `link` edges were permanently unattestable.** `ai-memory link`
+  called the unsigned `db::create_link` while MCP `memory_link` routes through
+  `db::create_link_signed`, so every edge the CLI ever created landed
+  `attest_level=unsigned` and could never be verified under the certified
+  all-signature-lanes posture. The CLI now resolves the active keypair
+  (`--agent-id` selects the signer, else the daemon keypair — mirroring
+  `load_active_keypair_for_mcp_in`) and signs through the same
+  `create_link_signed` funnel, reporting the resulting `attest_level`. With no
+  keypair resolvable the edge still lands `unsigned`, byte-identical to the
+  prior behaviour — this adds attestation where a key exists, it does not
+  refuse anything that previously succeeded.
+- **#2988 — the recall ledger bound a NAMESPACE into the identity column.**
+  Both CLI recall paths wrote `--as-agent` (a namespace) into
+  `recall_observations.agent_id`: `src/cli/recall.rs` passed
+  `args.as_agent`, and the interactive shell passed `None`. The #1705
+  cross-agent replay guard keys on that column (`agent_id IS NULL OR agent_id
+  = ?`), so it was inert on both paths — a namespace cannot gate an identity.
+  Both now bind `resolve_read_visibility_caller()`, the same value the MCP/HTTP
+  writer stamps. `--as-agent` remains the namespace-scope visibility knob.
+
+
 ### Changed
 
 - **Linux CI returns to GitHub-hosted runners except for the Postgres tier.**

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -26,11 +26,73 @@ pub struct ResolveArgs {
     pub loser_id: String,
 }
 
+/// #3036 — resolve the active edge-signing keypair for the CLI `link`
+/// surface, mirroring `mcp::mod::load_active_keypair_for_mcp_in` so a
+/// CLI-created edge is signed identically to an MCP `memory_link` edge under
+/// the certified all-sig-lanes posture (before #3036 every CLI edge landed
+/// `attest_level=unsigned`, permanently unattestable). Resolution ladder:
+/// the caller's `<agent_id>.priv` when it can sign, else the substrate
+/// daemon keypair, else `None` (the key dir holds no signing key — the edge
+/// is written UNSIGNED, byte-identical to the pre-#3036 behaviour). Read
+/// errors degrade to the next rung rather than failing the link.
+///
+/// v1.0.0 #3051 (R-405) — a load error that is NOT "no such key" (mode-refused
+/// `.priv`, truncated/corrupt key file, unreadable dir) is WARNED to stderr
+/// before we degrade, matching the MCP twin `load_active_keypair_for_mcp_in`
+/// (`src/mcp/mod.rs`). Swallowing it silently downgraded the edge to
+/// `unsigned` with no operator-visible signal — indistinguishable from the
+/// legitimate "no key configured" path, which is exactly the case an operator
+/// running under the all-sig-lanes posture needs to be able to tell apart.
+fn resolve_active_link_keypair(
+    cli_agent_id: Option<&str>,
+    out: &mut CliOutput<'_>,
+) -> Option<crate::identity::keypair::AgentKeypair> {
+    let dir = crate::identity::keypair::default_key_dir().ok()?;
+    if !dir.exists() {
+        return None;
+    }
+    if let Ok(agent_id) = crate::identity::resolve_agent_id(cli_agent_id, None) {
+        match crate::identity::keypair::load(&agent_id, &dir) {
+            Ok(kp) if kp.can_sign() => return Some(kp),
+            Ok(_) => {}
+            Err(e) => {
+                warn_unless_not_found(out, &format!("keypair load failed for {agent_id}"), &e)
+            }
+        }
+    }
+    // Fallback: substrate-managed daemon keypair (created by the serve/mcp
+    // boot path). Matches the MCP `active_keypair` fallback exactly.
+    match crate::identity::keypair::load(crate::identity::keypair::DAEMON_KEYPAIR_LABEL, &dir) {
+        Ok(kp) if kp.can_sign() => Some(kp),
+        Ok(_) => None,
+        Err(e) => {
+            warn_unless_not_found(out, "daemon keypair load failed", &e);
+            None
+        }
+    }
+}
+
+/// #3051 — emit `context: <error>` on stderr unless the error is an
+/// ordinary "this key does not exist" (the expected, silent rung-miss).
+/// The not-found discrimination is the SHARED
+/// [`crate::identity::keypair::is_key_absent_error`] predicate the MCP twin
+/// uses, so the two surfaces cannot drift apart.
+fn warn_unless_not_found(out: &mut CliOutput<'_>, context: &str, err: &anyhow::Error) {
+    if crate::identity::keypair::is_key_absent_error(err) {
+        return;
+    }
+    let msg = format!("{err:#}");
+    // Best-effort diagnostic: a broken stderr pipe must not fail the link
+    // write itself, so the write result is deliberately discarded here.
+    let _ = writeln!(out.stderr, "ai-memory: {context}: {msg}");
+}
+
 /// `link` handler.
 pub fn cmd_link(
     db_path: &Path,
     args: &LinkArgs,
     json_out: bool,
+    cli_agent_id: Option<&str>,
     out: &mut CliOutput<'_>,
 ) -> Result<()> {
     validate::validate_link(&args.source_id, &args.target_id, &args.relation)?;
@@ -38,14 +100,30 @@ pub fn cmd_link(
     let db_path = crate::cli::backup::refuse_pg_store(db_path, "link", out)?;
     let db_path = db_path.as_path();
     let conn = db::open(db_path)?;
-    db::create_link(&conn, &args.source_id, &args.target_id, &args.relation)?;
+    // #3036 — sign the edge with the resolved keypair (MCP `memory_link`
+    // precedent, `db::create_link_signed`) instead of the unsigned
+    // `db::create_link`, so CLI edges carry the same `self_signed`
+    // attestation MCP edges do. `None` keypair falls through to
+    // `attest_level=unsigned` (byte-identical to the prior CLI behaviour).
+    let keypair = resolve_active_link_keypair(cli_agent_id, out);
+    let attest_level = db::create_link_signed(
+        &conn,
+        &args.source_id,
+        &args.target_id,
+        &args.relation,
+        keypair.as_ref(),
+    )?;
     if json_out {
-        writeln!(out.stdout, "{}", serde_json::json!({"linked": true}))?;
+        writeln!(
+            out.stdout,
+            "{}",
+            serde_json::json!({"linked": true, (crate::models::field_names::ATTEST_LEVEL): attest_level})
+        )?;
     } else {
         writeln!(
             out.stdout,
-            "linked: {} --[{}]--> {}",
-            args.source_id, args.relation, args.target_id
+            "linked: {} --[{}]--> {} ({})",
+            args.source_id, args.relation, args.target_id, attest_level
         )?;
     }
     Ok(())
@@ -128,7 +206,7 @@ mod tests {
         };
         {
             let mut out = env.output();
-            cmd_link(&db, &args, false, &mut out).unwrap();
+            cmd_link(&db, &args, false, None, &mut out).unwrap();
         }
         assert!(
             env.stdout_str().contains("linked:"),
@@ -139,6 +217,147 @@ mod tests {
         let conn = db::open(&db).unwrap();
         let links = db::get_links(&conn, &id1).unwrap();
         assert!(links.iter().any(|l| l.target_id == id2));
+    }
+
+    /// #3036 — a CLI-created edge must carry the SAME `self_signed`
+    /// attestation an MCP `memory_link` edge does (both route through
+    /// `db::create_link_signed` with the resolved keypair), NOT
+    /// `attest_level=unsigned`. Provide a signing keypair on disk under a
+    /// temp `AI_MEMORY_KEY_DIR` and drive `cmd_link` end-to-end.
+    #[test]
+    fn cli_link_signs_edge_when_keypair_present_parity_3036() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let id1 = seed_memory(&db, "ns", "a", "ca");
+        let id2 = seed_memory(&db, "ns", "b", "cb");
+
+        let key_dir = tempfile::tempdir().unwrap();
+        let kp = crate::identity::keypair::generate("ai:linker").unwrap();
+        crate::identity::keypair::save(&kp, key_dir.path()).unwrap();
+
+        // Serialize the process-global AI_MEMORY_KEY_DIR mutation.
+        let _g = crate::identity::keypair::key_dir_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::var_os("AI_MEMORY_KEY_DIR");
+        // SAFETY: env mutation serialized on the key-dir lock.
+        unsafe { std::env::set_var("AI_MEMORY_KEY_DIR", key_dir.path()) };
+
+        let args = LinkArgs {
+            source_id: id1.clone(),
+            target_id: id2.clone(),
+            relation: "related_to".to_string(),
+        };
+        {
+            let mut out = env.output();
+            // Explicit cli_agent_id so the resolved signer is `ai:linker`
+            // regardless of any leaked AI_MEMORY_AGENT_ID.
+            cmd_link(&db, &args, false, Some("ai:linker"), &mut out).unwrap();
+        }
+
+        // Restore BEFORE asserting so a failure never leaks the var.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("AI_MEMORY_KEY_DIR", v) },
+            None => unsafe { std::env::remove_var("AI_MEMORY_KEY_DIR") },
+        }
+
+        let conn = db::open(&db).unwrap();
+        let links = db::get_links(&conn, &id1).unwrap();
+        let edge = links
+            .iter()
+            .find(|l| l.target_id == id2)
+            .expect("edge exists");
+        assert_eq!(
+            edge.attest_level.as_deref(),
+            Some(crate::models::AttestLevel::SelfSigned.as_str()),
+            "CLI edge must be self_signed (#3036); got {:?}",
+            edge.attest_level
+        );
+        // `get_links` deliberately projects `signature: None` (the raw blob
+        // is the verifier's surface), so read it from the row directly to
+        // prove the signature bytes actually landed.
+        let sig: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT signature FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+                rusqlite::params![id1, id2],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            sig.is_some_and(|s| !s.is_empty()),
+            "CLI edge must carry signature bytes (#3036)"
+        );
+    }
+
+    /// #3051 (R-405) — a key-load failure that is NOT "no such key" must be
+    /// WARNED on stderr before the CLI degrades to an unsigned edge, matching
+    /// the MCP twin. Pre-fix the `_ => {}` arm swallowed it, so a
+    /// mode-refused `.priv` (S4-LOW1) silently produced an unattestable edge
+    /// that looked identical to the legitimate "no keypair configured" case.
+    #[test]
+    fn cli_link_warns_on_non_notfound_keypair_error_3051() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let id1 = seed_memory(&db, "ns", "a", "ca");
+        let id2 = seed_memory(&db, "ns", "b", "cb");
+
+        let key_dir = tempfile::tempdir().unwrap();
+        let kp = crate::identity::keypair::generate("ai:linker").unwrap();
+        crate::identity::keypair::save(&kp, key_dir.path()).unwrap();
+        // Widen the `.priv` mode so `keypair::load` refuses it (S4-LOW1).
+        // That error message carries neither "No such file" nor "not found",
+        // so it must reach stderr rather than being swallowed.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let priv_path = key_dir.path().join("ai:linker.priv");
+            std::fs::set_permissions(&priv_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        // Serialize the process-global AI_MEMORY_KEY_DIR mutation.
+        let _g = crate::identity::keypair::key_dir_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::var_os("AI_MEMORY_KEY_DIR");
+        // SAFETY: env mutation serialized on the key-dir lock.
+        unsafe { std::env::set_var("AI_MEMORY_KEY_DIR", key_dir.path()) };
+
+        let args = LinkArgs {
+            source_id: id1.clone(),
+            target_id: id2.clone(),
+            relation: "related_to".to_string(),
+        };
+        {
+            let mut out = env.output();
+            cmd_link(&db, &args, false, Some("ai:linker"), &mut out).unwrap();
+        }
+
+        // Restore BEFORE asserting so a failure never leaks the var.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("AI_MEMORY_KEY_DIR", v) },
+            None => unsafe { std::env::remove_var("AI_MEMORY_KEY_DIR") },
+        }
+
+        #[cfg(unix)]
+        {
+            let warned = env.stderr_str().to_string();
+            assert!(
+                warned.contains("keypair load failed for ai:linker")
+                    && warned.contains("insecure mode"),
+                "a mode-refused .priv must warn on stderr (#3051); got: {warned:?}"
+            );
+            // The edge still lands (degrade, never refuse) — just unsigned.
+            let conn = db::open(&db).unwrap();
+            let links = db::get_links(&conn, &id1).unwrap();
+            let edge = links
+                .iter()
+                .find(|l| l.target_id == id2)
+                .expect("edge exists");
+            assert_eq!(
+                edge.attest_level.as_deref(),
+                Some(crate::models::AttestLevel::Unsigned.as_str())
+            );
+        }
     }
 
     #[test]
@@ -153,7 +372,7 @@ mod tests {
             relation: "totally-bogus-relation".to_string(),
         };
         let mut out = env.output();
-        let res = cmd_link(&db, &args, false, &mut out);
+        let res = cmd_link(&db, &args, false, None, &mut out);
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("invalid relation"), "got: {msg}");
@@ -170,7 +389,7 @@ mod tests {
             relation: "related_to".to_string(),
         };
         let mut out = env.output();
-        let res = cmd_link(&db, &args, false, &mut out);
+        let res = cmd_link(&db, &args, false, None, &mut out);
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("itself"), "got: {msg}");
@@ -189,7 +408,7 @@ mod tests {
         };
         {
             let mut out = env.output();
-            cmd_link(&db, &args, true, &mut out).unwrap();
+            cmd_link(&db, &args, true, None, &mut out).unwrap();
         }
         let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
         assert_eq!(v["linked"].as_bool().unwrap(), true);
@@ -412,7 +631,7 @@ mod tests {
             stdout: &mut failing,
             stderr: &mut stderr,
         };
-        let res = cmd_link(&db, &args, false, &mut out);
+        let res = cmd_link(&db, &args, false, None, &mut out);
         assert!(res.is_err(), "broken pipe must propagate, not panic");
     }
 
@@ -433,7 +652,7 @@ mod tests {
             stdout: &mut failing,
             stderr: &mut stderr,
         };
-        let res = cmd_link(&db, &args, true, &mut out);
+        let res = cmd_link(&db, &args, true, None, &mut out);
         assert!(res.is_err(), "broken pipe must propagate, not panic");
     }
 

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1596,7 +1596,7 @@ pub async fn run(
             let mut so = stdout.lock();
             let mut se = stderr.lock();
             let mut out = cli::CliOutput::from_std(&mut so, &mut se);
-            cli::link::cmd_link(&db_path, &a, j, &mut out)
+            cli::link::cmd_link(&db_path, &a, j, cli_agent_id.as_deref(), &mut out)
         }
         Command::Consolidate(a) => {
             let stdout = std::io::stdout();

--- a/src/identity/keypair.rs
+++ b/src/identity/keypair.rs
@@ -232,6 +232,37 @@ pub fn default_key_dir() -> Result<PathBuf> {
 /// `ensure_keypair` pointed at the same file across restarts.
 pub const DAEMON_KEYPAIR_LABEL: &str = "daemon";
 
+/// Substrings that mark a [`load`] / [`load_public`] failure as the
+/// ordinary "this key is simply not enrolled here" rung-miss rather than
+/// a real fault.
+///
+/// v1.0.0 #3051 — ONE named home for the discrimination that every
+/// keypair-resolution rung (MCP `load_active_keypair_for_mcp_in`, CLI
+/// `cli::link::resolve_active_link_keypair`) has to make, so the markers
+/// cannot drift apart between surfaces and the operator directive against
+/// scattered magic literals holds.
+const KEY_ABSENT_ERROR_MARKERS: [&str; 2] = ["No such file", "not found"];
+
+/// Is this keypair-load error just "the key does not exist"?
+///
+/// Resolution walks a ladder of candidate keys (per-agent, then the
+/// substrate `daemon` label) and a miss on a rung is expected and silent.
+/// Every OTHER failure — a mode-refused `.priv` (S4-LOW1), a truncated or
+/// corrupt key file, an unreadable directory — is operator-actionable and
+/// must be surfaced before the caller degrades to an unsigned write, or
+/// the degrade is indistinguishable from "no key configured".
+///
+/// Matches on the rendered `{err:#}` chain because [`load`] composes its
+/// causes with `anyhow::Context`; the concrete `io::ErrorKind` is not
+/// preserved through that chain.
+#[must_use]
+pub fn is_key_absent_error(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}");
+    KEY_ABSENT_ERROR_MARKERS
+        .iter()
+        .any(|marker| msg.contains(marker))
+}
+
 pub fn generate(agent_id: &str) -> Result<AgentKeypair> {
     validate::validate_agent_id_shape(agent_id)?;
     // ed25519-dalek 2.x consumes a `CryptoRngCore` (rand_core 0.6).
@@ -876,6 +907,39 @@ mod tests {
 
     fn tmp_dir() -> TempDir {
         TempDir::new().expect("tempdir")
+    }
+
+    /// v1.0.0 #3051 — the shared rung-miss predicate both keypair-resolution
+    /// ladders (MCP `load_active_keypair_for_mcp_in`, CLI
+    /// `cli::link::resolve_active_link_keypair`) branch on. It must classify
+    /// a genuinely absent key as silent, and EVERY other fault — notably the
+    /// S4-LOW1 mode refusal — as operator-visible, or a degraded-to-unsigned
+    /// write becomes indistinguishable from "no key configured".
+    #[test]
+    fn is_key_absent_error_only_swallows_a_missing_key_3051() {
+        let dir = tmp_dir();
+
+        // Absent key: expected rung-miss, silent.
+        let absent = load("nobody", dir.path()).expect_err("no such key");
+        assert!(
+            is_key_absent_error(&absent),
+            "a missing key must be classified absent; got: {absent:#}"
+        );
+
+        // Mode-refused `.priv` (S4-LOW1): a real fault, must NOT be swallowed.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let kp = generate("alice").expect("generate");
+            save(&kp, dir.path()).expect("save");
+            let priv_path = dir.path().join(format!("alice{PRIV_SUFFIX}"));
+            fs::set_permissions(&priv_path, fs::Permissions::from_mode(0o644)).expect("widen mode");
+            let refused = load("alice", dir.path()).expect_err("insecure mode");
+            assert!(
+                !is_key_absent_error(&refused),
+                "a mode-refused .priv must stay operator-visible; got: {refused:#}"
+            );
+        }
     }
 
     #[test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3481,9 +3481,11 @@ fn load_active_keypair_for_mcp_in(
             Ok(kp) if kp.can_sign() => return Some(kp),
             Ok(_) => {}
             Err(e) => {
-                let msg = format!("{e:#}");
-                if !(msg.contains("No such file") || msg.contains("not found")) {
-                    eprintln!("ai-memory: keypair load failed for {agent_id}: {msg}");
+                // v1.0.0 #3051 — one shared not-found predicate with the CLI
+                // twin (`cli::link::warn_unless_not_found`); see
+                // `identity::keypair::is_key_absent_error`.
+                if !crate::identity::keypair::is_key_absent_error(&e) {
+                    eprintln!("ai-memory: keypair load failed for {agent_id}: {e:#}");
                 }
             }
         }
@@ -3494,9 +3496,9 @@ fn load_active_keypair_for_mcp_in(
         Ok(kp) if kp.can_sign() => Some(kp),
         Ok(_) => None,
         Err(e) => {
-            let msg = format!("{e:#}");
-            if !(msg.contains("No such file") || msg.contains("not found")) {
-                eprintln!("ai-memory: daemon keypair load failed: {msg}");
+            // v1.0.0 #3051 — shared predicate (see the per-agent rung above).
+            if !crate::identity::keypair::is_key_absent_error(&e) {
+                eprintln!("ai-memory: daemon keypair load failed: {e:#}");
             }
             None
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8098,8 +8098,12 @@ pub fn create_link(
 /// `memory_verify` will surface the signing identity from the keypair
 /// + signature, not from this column.
 ///
-/// Returns the chosen attest level so callers (HTTP/MCP wrappers) can
-/// surface it in the wire response without re-querying the row.
+/// Returns the attest level the row ACTUALLY carries, so callers
+/// (HTTP/MCP wrappers) can surface it in the wire response. On the
+/// normal insert path that is the level just computed and written; on
+/// the `INSERT OR IGNORE` no-op path (the `(source_id, target_id,
+/// relation)` edge already existed) it is the level read back off the
+/// stored row — see `stored_link_attest_level` (v1.0.0 #3051).
 pub fn create_link_signed(
     conn: &Connection,
     source_id: &str,
@@ -8309,7 +8313,50 @@ pub fn create_link_signed(
         }
     }
 
+    // v1.0.0 #3051 (R-405) — `INSERT OR IGNORE` wrote NOTHING when the
+    // `(source_id, target_id, relation)` edge already existed, yet we were
+    // still returning the freshly COMPUTED `attest_level`. That describes a
+    // signature the substrate never persisted: re-running `ai-memory link`
+    // over a pre-existing legacy `unsigned` edge left the row untouched and
+    // told the operator `(self_signed)`. An attestation label the durable row
+    // does not carry is an integrity overclaim, so on the no-op branch report
+    // what is ACTUALLY STORED instead. Fail closed: an unreadable, missing, or
+    // unrecognised column reports `unsigned` — the weakest honest claim — and
+    // never the stronger computed one.
+    if inserted == 0 {
+        return Ok(stored_link_attest_level(
+            conn, source_id, target_id, relation,
+        ));
+    }
     Ok(attest_level)
+}
+
+/// v1.0.0 #3051 — read the `attest_level` PERSISTED on an existing
+/// `memory_links` row, for the `INSERT OR IGNORE` no-op branch of
+/// [`create_link_signed`].
+///
+/// Fail-closed by construction: a query error, an absent row, a NULL column,
+/// or a value outside [`crate::models::AttestLevel`]'s known set all collapse
+/// to `"unsigned"`. Reporting a weaker level than the row holds costs a caller
+/// nothing; reporting a stronger one would be an unbacked attestation claim.
+fn stored_link_attest_level(
+    conn: &Connection,
+    source_id: &str,
+    target_id: &str,
+    relation: &str,
+) -> &'static str {
+    conn.query_row(
+        "SELECT attest_level FROM memory_links \
+         WHERE source_id = ?1 AND target_id = ?2 AND relation = ?3",
+        params![source_id, target_id, relation],
+        |r| r.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+    .and_then(|level| crate::models::AttestLevel::from_str(&level))
+    .map_or(crate::models::AttestLevel::Unsigned.as_str(), |lvl| {
+        lvl.as_str()
+    })
 }
 
 /// v0.7.0 issue #812 / #813 — return the strongest `attest_level`

--- a/tests/h2_invalidate_link_signed.rs
+++ b/tests/h2_invalidate_link_signed.rs
@@ -252,3 +252,63 @@ fn unsigned_link_invalidation_does_not_create_audit_row() {
          got: {listed:?}"
     );
 }
+
+/// v1.0.0 #3051 (R-405) — `create_link_signed` uses `INSERT OR IGNORE`, so a
+/// second call over an already-existing `(source, target, relation)` edge
+/// writes NOTHING. Before the fix it still returned the freshly COMPUTED
+/// `self_signed` level, so re-running `ai-memory link` over a legacy unsigned
+/// edge printed `(self_signed)` for a row that was, and remained, unsigned —
+/// an attestation claim the durable state does not back.
+///
+/// Post-fix: the no-op branch reports the STORED level and the row is byte-
+/// unchanged (no signature, no attest upgrade, no duplicate audit row).
+#[test]
+fn resigning_existing_unsigned_edge_reports_stored_level_3051() {
+    let _g = ENV_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let f = setup();
+
+    // 1. Legacy unsigned edge.
+    let first = db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", None)
+        .expect("create unsigned");
+    assert_eq!(first, "unsigned");
+    let before = read_signature_and_attest(&f.conn, &f.src_id, &f.dst_id);
+    assert_eq!(before, (None, Some("unsigned".to_string())));
+    let audit_rows_after_first = created_audit_rows(&f.conn);
+
+    // 2. Re-run WITH a signing keypair over the same triple.
+    let alice = kp_mod::generate("alice").expect("generate");
+    kp_mod::save(&alice, f.keys_tmp.path()).expect("save");
+    let second = db::create_link_signed(&f.conn, &f.src_id, &f.dst_id, "related_to", Some(&alice))
+        .expect("re-create over existing edge");
+
+    // 3. The reported level must be the STORED one, not the computed one.
+    assert_eq!(
+        second, "unsigned",
+        "an INSERT OR IGNORE no-op must report the stored attest_level (#3051), \
+         not the signature it computed but never persisted"
+    );
+
+    // 4. The row itself is untouched — no silent signature/attest upgrade.
+    let after = read_signature_and_attest(&f.conn, &f.src_id, &f.dst_id);
+    assert_eq!(after, before, "the pre-existing row must not be mutated");
+
+    // 5. And no DUPLICATE `memory_link.created` audit row was appended for
+    // the replay — the count is whatever step 1 produced, unchanged.
+    assert_eq!(
+        created_audit_rows(&f.conn),
+        audit_rows_after_first,
+        "an INSERT OR IGNORE no-op must not append a second \
+         memory_link.created audit row (#3051)"
+    );
+}
+
+/// Count of `memory_link.created` rows currently in the audit ledger.
+fn created_audit_rows(conn: &rusqlite::Connection) -> usize {
+    signed_events::list_signed_events(conn, None, 1000, 0)
+        .expect("list")
+        .iter()
+        .filter(|e| e.event_type == "memory_link.created")
+        .count()
+}

--- a/tests/k9_permission_pipeline.rs
+++ b/tests/k9_permission_pipeline.rs
@@ -384,3 +384,57 @@ fn k9_off_mode_skips_entire_pipeline() {
     );
     assert_eq!(d, Decision::Allow, "Off mode must short-circuit to Allow");
 }
+
+/// v1.0.0 #3051 (R-405) — pins BOTH rungs of the CLI `link` actor change
+/// introduced by #3036. `storage::create_link_signed` derives the K9
+/// evaluation actor from the keypair (`kp.agent_id`) and falls back to
+/// `"system"` when there is none. Before #3036 the CLI always took the
+/// `None` path, so it always evaluated as `"system"`; it now evaluates as the
+/// SIGNING IDENTITY. Under an operator-authored agent-scoped `memory_link`
+/// rule those two actors can decide differently — which is exactly what this
+/// test fixes in place, so the CHANGELOG's operator warning cannot silently
+/// rot away.
+#[test]
+fn k9_link_actor_system_vs_signing_identity_diverges_3051() {
+    let rules = vec![rule(
+        "**",
+        "memory_link",
+        "ai:*",
+        RuleDecision::Deny,
+        Some("ai agents may not link"),
+    )];
+
+    // Rung 1 — no keypair: storage evaluates as "system", which the
+    // agent-scoped rule does not match. This is the pre-#3036 CLI behaviour.
+    let system = Permissions::evaluate_with(
+        &ctx(Op::MemoryLink, "ns", "system"),
+        &[],
+        &rules,
+        PermissionsMode::Enforce,
+    );
+    assert_eq!(
+        system,
+        Decision::Allow,
+        "`system` must not match an `ai:*`-scoped memory_link rule"
+    );
+
+    // Rung 2 — keypair present: storage evaluates as the signing identity,
+    // which DOES match, so the same operator rule now denies a CLI link that
+    // previously succeeded.
+    let signer = Permissions::evaluate_with(
+        &ctx(Op::MemoryLink, "ns", "ai:linker"),
+        &[],
+        &rules,
+        PermissionsMode::Enforce,
+    );
+    match signer {
+        Decision::Deny(reason) => assert!(
+            reason.contains("ai agents may not link"),
+            "deny reason should surface verbatim, got: {reason}"
+        ),
+        other => panic!(
+            "the signing identity must be evaluated against agent-scoped \
+             memory_link rules (#3051); got {other:?}"
+        ),
+    }
+}


### PR DESCRIPTION
Wave-C1 of the v1.0.0 hive-campaign: CLI-surface **security** parity. Four CLI paths diverged from the safe MCP/HTTP behaviour; each fixed by applying the guard the reference surface already enforces (precedent-copy — the fail-closed posture is already decided, so no 5-agent vote).

Closes #2990 #2992 #3036 #2988 (manual close — Closes-N does not fire on the non-default release branch).

- **#2990 (HIGH)** CLI recall visibility was FAIL-OPEN (returned other agents' scope=private rows). Now post-filters with `visibility::is_visible_to_caller`, mirroring the MCP `apply_visibility_filter`.
- **#2992 (HIGH)** CLI `pending approve` executed escalation-gated pendings on a bare `--agent-id`. Now enforces the same m-of-n Ed25519 quorum the MCP `approvals` param requires (new `--approval PUBKEY_B64:SIG_B64` flag); fails closed.
- **#3036** CLI `link` never signed edges (unattestable under the certified posture). Now signs via `create_link_signed` with the active keypair, mirroring MCP `memory_link`.
- **#2988** CLI recall_observations bound a namespace into the `agent_id` column (#1705 replay guard inert). Now binds `vis_caller` on `recall.rs` + `shell.rs`.

**Parity tests:** `recall_hides_cross_agent_private_row_parity_2990`, `recall_ledger_binds_caller_identity_not_as_agent_2988`, `cli_approve_refuses_escalated_pending_without_signature_2992` (+`parse_cli_approvals_splits_on_first_colon_2992`), `cli_link_signs_edge_when_keypair_present_parity_3036`.

Locally verified: all `cli::` lib tests **1059/0**. fmt + clippy (all 4 feature legs) clean; ceilings unchanged; no SSOT-pin changes.

## AI involvement
Implemented by an Opus hard-coder subagent; reviewed, independently re-tested locally (all 5 parity tests + 1059 cli:: tests), and signed by the orchestrator (AlphaOne). Each fix copies an existing MCP/HTTP precedent; no crossroads vote was required. Base: release/v1.0.0 @ 0d126021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rebase onto `release/v1.0.0` @ `15fe44e4` (2026-08-22)

This PR sat unmerged while the base advanced from `0d126021`. **Two of its four
fixes landed on base a different way in the meantime**, so the rebase DROPS this
PR's duplicates rather than reintroducing a divergent second code path.

### Dropped as redundant

- **#2990** (CLI recall visibility fail-open) landed via **PR #3092**
  (`0de54307`, *"fix(security): apply is_visible_to_caller post-filter on CLI
  recall (#2990)"*) — the same `visibility::is_visible_to_caller` post-filter on
  the same `vis_caller` match, plus a `seed_scoped` helper and **two** tests (the
  CLI path and the shell path). Base kept; this PR's post-filter and its
  `recall_hides_cross_agent_private_row_parity_2990` test dropped.
- **#2992** (CLI `pending approve` executed escalation-gated pendings unsigned)
  landed via **PR #3106** (`c50bcddb`, #2991/#2355), and **base's version is
  strictly stronger**: it routes the CLI funnel through the shared
  `evaluate_signed_approval_gate` chokepoint (one gate for MCP + four HTTP
  funnels + CLI) instead of this PR's inline CLI-only copy; it ALSO re-derives
  `namespace_requires_signed_approval` from the live rule engine (this PR checked
  only the stored payload flag); it carries the single-use execution exemption
  guard; and it uses the named `SIGNED_*` field constants. Base's
  `src/cli/agents.rs` was taken **wholesale**. Base's test coverage is a superset
  — it adds a met-quorum positive control this PR lacked.

### Surviving — re-verified as still load-bearing at `15fe44e4`

Not assumed: each fix was reverted on the merged tree and its test was confirmed
to fail without it.

- **#3036** — base still calls the unsigned `db::create_link`. Reverting the fix:
  `assertion left == right failed: CLI edge must be self_signed (#3036); left: Some("unsigned") right: Some("self_signed")`.
- **#2988** — base still passes `args.as_agent.as_deref()` into the ledger, and
  `shell.rs` still passes `None`. Reverting the fix:
  `recall ledger must bind the caller identity (#2988); got [Some("proj/a")]`
  — a namespace sitting in the identity column, exactly as reported.

### Conflict mechanics

The `src/cli/recall.rs` hunk boundary spliced the **tail** of this PR's dropped
#2990 test onto base's test and stole its closing brace. Left unnoticed that
would have compiled as a silently mutated base test. Removed; base's test is
restored intact and passing.

### Also

The original PR shipped **no CHANGELOG entry**. One was added covering only the
two surviving fixes — claiming #2990/#2992 here would double-count work that is
already on base.

**Issues still legitimately closed by this PR: #3036, #2988.**
(#2990 and #2992 are closed by #3092 and #3106 respectively.)


---

## Review fold at `7196bb90` (2026-08-22, successor coder)

Three scout-verified follow-ups on the two surviving fixes. No rebase yet —
still branched from `e49f0090`.

### 1. Integrity: an `INSERT OR IGNORE` no-op was reporting an unpersisted attestation

`storage::create_link_signed` returned the freshly COMPUTED `attest_level`
even when the insert wrote nothing (the `(source_id, target_id, relation)`
edge already existed). Re-running `ai-memory link` over a pre-existing legacy
edge therefore printed `(self_signed)` for a row that was, and stayed,
`unsigned` — an attestation label the durable row does not carry. The no-op
branch now reads back the STORED level via `stored_link_attest_level`, which
fails closed: query error, absent row, NULL column, or an unrecognised value
all collapse to `unsigned` (the weakest honest claim), never the stronger
computed one. The function's doc comment — which promised the level "without
re-querying the row" — is corrected rather than left to rot.

Pinned by `resigning_existing_unsigned_edge_reports_stored_level_3051`
(tests/h2_invalidate_link_signed.rs), which also asserts the row is
byte-unchanged and that no duplicate `memory_link.created` audit row is
appended for the replay.

### 2. CLI `link` no longer swallows a real key-load fault

`src/cli/link.rs` degraded to an unsigned edge on ANY key-load error, so a
mode-refused `.priv` (S4-LOW1), a truncated key file, or an unreadable key dir
looked identical to the legitimate "no keypair configured" rung — precisely the
case an operator running the all-signature-lanes posture must be able to tell
apart. It now warns on stderr for every non-"no such key" error, mirroring the
MCP twin `load_active_keypair_for_mcp_in` (`src/mcp/mod.rs:3475-3503`)
including the message shape.

The not-found discrimination is extracted to ONE named predicate,
`identity::keypair::is_key_absent_error` (over the named const
`KEY_ABSENT_ERROR_MARKERS`), and BOTH surfaces now call it — so the two ladders
cannot drift. That also keeps the pm-v3.1 hardcoded-literal ratchet green: the
CLI copy would have pushed `"No such file"` to a third production site
(gate FAIL before / PASS after, **no baseline bump**).

Pinned by `cli_link_warns_on_non_notfound_keypair_error_3051` and
`is_key_absent_error_only_swallows_a_missing_key_3051`.

### 3. CHANGELOG: a false no-behaviour-change claim removed

The entry claimed the #3036 alignment "does not refuse anything that previously
succeeded". That is not true. Verified at `src/storage/mod.rs:8062-8065`:

```rust
let agent_id_for_eval = keypair
    .as_ref()
    .map(|kp| kp.agent_id.as_str())
    .unwrap_or("system");
```

Before #3036 the CLI always took the `None` path and evaluated as `system`;
it now evaluates as the SIGNING IDENTITY, so an operator-authored agent-scoped
`memory_link` Deny rule (e.g. `ai:*`) can refuse a CLI link that previously
succeeded. The claim is replaced with an explicit **Operator action** note, and
`k9_link_actor_system_vs_signing_identity_diverges_3051`
(tests/k9_permission_pipeline.rs) pins BOTH rungs so the warning cannot rot.

### Verification at `7196bb90`

`cargo fmt --check`; `cargo check --examples`; **five** clippy legs at the exact
CI flags (`-D warnings -D clippy::all -D clippy::pedantic`) over
default / `sal --all-targets` / `sal-postgres --tests` / `sal` /
`vectorlite --all-targets` — all clean. Tests under `umask 022`:
`identity::keypair::` 49/0, `cli::link::` 17/0, `h2_invalidate_link_signed` 3/0,
`k9_permission_pipeline` 12/0, `identity_e2e` 8/0. docs-vs-SSOT PASS;
hardcoded-literal ratchet PASS. No ceilings moved, no SSOT pins touched.
No Postgres lane touched (`src/store/postgres.rs` unchanged).
