### PR TITLE
fix(cli): close the CLI/MCP correctness parity cluster (#3025 #3040 #3037 #2989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1534,6 +1534,43 @@ Regression coverage: `tests/pg_audit_3070_3074.rs` (live-pg gated).
   config, including the fallback-mismatch case) +
   `embeddings::tests::{capability_model_id_reports_constructed_remote_model_3063,
   reconcile_overrides_config_with_constructed_embedder_3063}`.
+### Fixed (Wave-C2 — CLI/MCP correctness parity; #3025 #3040 #3037 #2989)
+
+- **#3025 — CLI `store --json` reported the REQUESTED tier/expiry/version on an
+  upsert, not the persisted row.** On a `(title, namespace)` upsert `db::insert`
+  merges onto the existing row (tier stays monotonic-max, `version` bumps,
+  `expires_at` follows the persisted tier), but the response serialized the
+  in-memory request — so a `--tier short` upsert over a `long` row reported
+  `tier=short`/`version=1`/`exp=+6h` while the DB stayed `long`/`v2`/no-expiry
+  (the #2444 reports-success-doing-nothing / honesty class). The CLI now
+  re-reads the persisted row after the write and echoes it (both `--json` and
+  the text line), matching the MCP `echo_tier` precedent
+  (`src/mcp/tools/store/mod.rs`). Source: `src/cli/store.rs`.
+- **#3040 — MCP `memory_list` ignored `AI_MEMORY_MAX_PAGE_SIZE` while HTTP
+  honored it (asymmetric OOM guard).** The MCP stdio loop carries no `AppState`,
+  so the resolved `[limits].max_page_size` cap is now mirrored into a
+  process-global (`crate::set_max_page_size` / `max_page_size`, the
+  `set_max_inflight_requests` precedent), seeded at boot from
+  `AppConfig::resolve_limits()`, and consulted by the list handler — which caps
+  at the SMALLER of its historical 200-row ceiling and the operator cap, so MCP
+  never exceeds the guard HTTP applies. Source: `src/lib.rs`,
+  `src/daemon_runtime.rs`, `src/mcp/tools/list.rs`.
+- **#3037 — `dependents-of-invalidated --transitive` was unreachable from the
+  CLI (hardcoded non-transitive).** The R55/#1959 transitive taint walk shipped
+  on HTTP + MCP but the CLI subcommand hardcoded `json!({memory_id})`. A
+  `--transitive` flag is added and threaded through to the shared handler, with
+  the downstream suspect set rendered in text output. Source:
+  `src/cli/commands/dependents_of_invalidated.rs`.
+- **#2989 — the `recall_observations` read surface hid `agent_id`/`namespace`/
+  `folded`; the doc claimed a false 1:1 column mirror.** The ledger STORES the
+  v58/#1705 identity binding (`agent_id`, `namespace`) + the v77/#1869 `folded`
+  fold-state, but the `Observation` read struct omitted them, so "who recalled
+  what, in which namespace, folded or not" was unanswerable through the
+  sanctioned MCP/HTTP read surface and the #1705 identity binding was
+  read-invisible. The three columns are now surfaced on the read struct + both
+  backends' `list_recall_observations` SELECT (sqlite + postgres), and the doc
+  now truthfully mirrors the columns. Output-only (no input-schema / tool-count
+  change). Source: `src/observations/mod.rs`, `src/store/postgres.rs`.
 
 ### Fixed (Batman auto-atomisation was structurally inert product-wide; #2983 #2984 #2985 #2986 #2987)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,48 @@ write is permission-evaluated as; see the operator note below.
   in `docs/AI_DEVELOPER_WORKFLOW.md` §5.6 and `CLAUDE.md`: gate scripts mutate the tree
   by design; never `git add -A` after running one, stage explicitly.
 
+- **#3025 — CLI `store --json` reported the REQUESTED tier/expiry/version on an
+  upsert, not the persisted row.** On a `(title, namespace)` upsert `db::insert`
+  merges onto the existing row (tier stays monotonic-max, `version` bumps,
+  `expires_at` follows the persisted tier), but the response serialized the
+  in-memory request — so a `--tier short` upsert over a `long` row reported
+  `tier=short`/`version=1`/`exp=+6h` while the DB stayed `long`/`v2`/no-expiry
+  (the #2444 reports-success-doing-nothing / honesty class). The CLI now
+  re-reads the persisted row after the write and echoes it (both `--json` and
+  the text line), matching the MCP `echo_tier` precedent
+  (`src/mcp/tools/store/mod.rs`). The read-back FAILS CLOSED: if the
+  verification read errors, or finds no row (an invariant violation — the id
+  came from `db::insert`), the command errors instead of quietly falling back
+  to echoing the requested values, which would have broken this fix's own
+  guarantee on the error path and left the caller unable to tell a verified
+  echo from an unverified one. Both messages state that the WRITE ALREADY
+  HAPPENED and name the id, so a non-zero exit is not misread as "nothing was
+  stored". Source: `src/cli/store.rs`.
+- **#3040 — MCP `memory_list` ignored `AI_MEMORY_MAX_PAGE_SIZE` while HTTP
+  honored it (asymmetric OOM guard).** The MCP stdio loop carries no `AppState`,
+  so the resolved `[limits].max_page_size` cap is now mirrored into a
+  process-global (`crate::set_max_page_size` / `max_page_size`, the
+  `set_max_inflight_requests` precedent), seeded at boot from
+  `AppConfig::resolve_limits()`, and consulted by the list handler — which caps
+  at the SMALLER of its historical 200-row ceiling and the operator cap, so MCP
+  never exceeds the guard HTTP applies. Source: `src/lib.rs`,
+  `src/daemon_runtime.rs`, `src/mcp/tools/list.rs`.
+- **#3037 — `dependents-of-invalidated --transitive` was unreachable from the
+  CLI (hardcoded non-transitive).** The R55/#1959 transitive taint walk shipped
+  on HTTP + MCP but the CLI subcommand hardcoded `json!({memory_id})`. A
+  `--transitive` flag is added and threaded through to the shared handler, with
+  the downstream suspect set rendered in text output. Source:
+  `src/cli/commands/dependents_of_invalidated.rs`.
+- **#2989 — the `recall_observations` read surface hid `agent_id`/`namespace`/
+  `folded`; the doc claimed a false 1:1 column mirror.** The ledger STORES the
+  v58/#1705 identity binding (`agent_id`, `namespace`) + the v77/#1869 `folded`
+  fold-state, but the `Observation` read struct omitted them, so "who recalled
+  what, in which namespace, folded or not" was unanswerable through the
+  sanctioned MCP/HTTP read surface and the #1705 identity binding was
+  read-invisible. The three columns are now surfaced on the read struct + both
+  backends' `list_recall_observations` SELECT (sqlite + postgres), and the doc
+  now truthfully mirrors the columns. Output-only (no input-schema / tool-count
+  change). Source: `src/observations/mod.rs`, `src/store/postgres.rs`.
 ### Changed
 
 - **Linux CI returns to GitHub-hosted runners except for the Postgres tier.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,11 @@ write is permission-evaluated as; see the operator note below.
   guarantee on the error path and left the caller unable to tell a verified
   echo from an unverified one. Both messages state that the WRITE ALREADY
   HAPPENED and name the id, so a non-zero exit is not misread as "nothing was
-  stored". Source: `src/cli/store.rs`.
+  stored". The PR-5/#487 Store audit now emits AFTER the read-back using the
+  persisted title/namespace/tier (never the requested ones), and also emits
+  on the fail-closed path as `outcome=error` / `error=verification_failed: …`
+  so a committed row is never silent on the trail (ERRORS-19). Source:
+  `src/cli/store.rs`.
 - **#3040 — MCP `memory_list` ignored `AI_MEMORY_MAX_PAGE_SIZE` while HTTP
   honored it (asymmetric OOM guard).** The MCP stdio loop carries no `AppState`,
   so the resolved `[limits].max_page_size` cap is now mirrored into a

--- a/src/cli/commands/dependents_of_invalidated.rs
+++ b/src/cli/commands/dependents_of_invalidated.rs
@@ -26,6 +26,14 @@ pub struct DependentsOfInvalidatedArgs {
     #[arg(long = "memory-id", value_name = "ID")]
     pub memory_id: String,
 
+    /// v1.0.0 R55 (#1959 / #3037) — additionally walk the FULL provenance
+    /// DAG (P = derived_from/reflects_on/derives_from) DOWNSTREAM so a
+    /// suspect source taints every record derived from it, transitively.
+    /// Parity with the HTTP + MCP `transitive` flag; the direct default
+    /// (single inbound `reflects_on` hop) stays byte-identical when unset.
+    #[arg(long)]
+    pub transitive: bool,
+
     /// Emit the raw JSON envelope.
     #[arg(long)]
     pub json: bool,
@@ -44,7 +52,10 @@ pub fn cmd_dependents_of_invalidated(
     out: &mut CliOutput<'_>,
 ) -> Result<()> {
     let conn = db::open(db_path)?;
-    let params = json!({"memory_id": args.memory_id});
+    // #3037 — thread the CLI `--transitive` flag through to the shared MCP
+    // handler so the R55/#1959 transitive taint walk is reachable from the
+    // terminal (parity with HTTP `transitive:true` + the MCP tool param).
+    let params = json!({"memory_id": args.memory_id, "transitive": args.transitive});
 
     let envelope = crate::mcp::handle_dependents_of_invalidated(&conn, &params)
         .map_err(|e| anyhow::anyhow!("dependents-of-invalidated: {e}"))?;
@@ -64,6 +75,25 @@ pub fn cmd_dependents_of_invalidated(
             let id = d.get("id").and_then(Value::as_str).unwrap_or("?");
             let ns = d.get("namespace").and_then(Value::as_str).unwrap_or("?");
             writeln!(out.stdout, "  {id}  ns={ns}")?;
+        }
+    }
+    // #3037 — when transitive was requested, render the downstream suspect set.
+    if args.transitive {
+        let t_count = envelope
+            .get("transitive_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        writeln!(out.stdout, "transitive suspects: {t_count}")?;
+        if let Some(arr) = envelope
+            .get("transitive_suspects")
+            .and_then(Value::as_array)
+        {
+            for s in arr {
+                let id = s.get("id").and_then(Value::as_str).unwrap_or("?");
+                let depth = s.get("depth").and_then(Value::as_u64).unwrap_or(0);
+                let relation = s.get("relation").and_then(Value::as_str).unwrap_or("?");
+                writeln!(out.stdout, "  {id}  depth={depth}  via={relation}")?;
+            }
         }
     }
     Ok(())
@@ -92,6 +122,7 @@ mod tests {
         }
         let args = DependentsOfInvalidatedArgs {
             memory_id: target,
+            transitive: false,
             json: false,
         };
         {
@@ -110,6 +141,7 @@ mod tests {
         let db = env.db_path.clone();
         let args = DependentsOfInvalidatedArgs {
             memory_id: "nonexistent".into(),
+            transitive: false,
             json: true,
         };
         {
@@ -121,12 +153,74 @@ mod tests {
         assert_eq!(envelope["count"].as_u64(), Some(0));
     }
 
+    /// #3037 — the CLI `--transitive` flag threads through to the shared MCP
+    /// handler so the R55/#1959 downstream taint walk is reachable from the
+    /// terminal (previously hardcoded non-transitive; only HTTP + MCP had it).
+    #[test]
+    fn dependents_of_invalidated_cli_transitive_surfaces_downstream_suspects_3037() {
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let target = seed_memory(&db, "ns", "invalidated-reflection", "content");
+        let m1 = seed_memory(&db, "ns", "direct-dependent", "content");
+        let m2 = seed_memory(&db, "ns", "transitive-derivative", "content");
+        {
+            let conn = db::open(&db).unwrap();
+            // m1 reflects_on target — a DIRECT dependent + depth-1 descendant.
+            db::create_link(&conn, &m1, &target, "reflects_on").unwrap();
+            // m2 derived_from m1 — a depth-2 TRANSITIVE descendant of target.
+            db::create_link(&conn, &m2, &m1, "derived_from").unwrap();
+        }
+
+        // Without --transitive: only the direct inbound reflects_on hop.
+        let base = DependentsOfInvalidatedArgs {
+            memory_id: target.clone(),
+            transitive: false,
+            json: true,
+        };
+        {
+            let mut out = env.output();
+            cmd_dependents_of_invalidated(&db, &base, &mut out).expect("ok");
+        }
+        let base_env: Value = serde_json::from_str(env.stdout_str().trim()).expect("parse");
+        assert_eq!(base_env["count"].as_u64(), Some(1));
+        assert!(
+            base_env.get("transitive_count").is_none(),
+            "no transitive set without the flag: {base_env}"
+        );
+
+        // With --transitive: the full downstream P-DAG (m1 depth-1 + m2 depth-2).
+        env.stdout.clear();
+        let t = DependentsOfInvalidatedArgs {
+            memory_id: target,
+            transitive: true,
+            json: true,
+        };
+        {
+            let mut out = env.output();
+            cmd_dependents_of_invalidated(&db, &t, &mut out).expect("ok");
+        }
+        let t_env: Value = serde_json::from_str(env.stdout_str().trim()).expect("parse");
+        let ids: Vec<&str> = t_env["transitive_suspects"]
+            .as_array()
+            .expect("suspects array")
+            .iter()
+            .filter_map(|s| s["id"].as_str())
+            .collect();
+        assert!(ids.contains(&m1.as_str()), "m1 must be a suspect: {t_env}");
+        assert!(ids.contains(&m2.as_str()), "m2 must be a suspect: {t_env}");
+        assert!(
+            t_env["transitive_count"].as_u64().unwrap() >= 2,
+            "transitive_count must cover the downstream DAG: {t_env}"
+        );
+    }
+
     #[test]
     fn dependents_of_invalidated_cli_empty_id_returns_err() {
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         let args = DependentsOfInvalidatedArgs {
             memory_id: String::new(),
+            transitive: false,
             json: true,
         };
         let mut out = env.output();

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -146,6 +146,38 @@ fn read_stdin_to_string() -> Result<String> {
 /// every emit routes through `out.stdout` / `out.stderr` instead of
 /// `println!` / `eprintln!`.
 #[allow(clippy::too_many_lines)]
+/// #3025 — read back the row `db::insert` just committed, so the response can
+/// report what the DB ACTUALLY stored rather than what the caller requested.
+///
+/// **Fails closed (ERRORS-19).** The guarantee this fix exists to make is
+/// "the response reports the STORED values, not the requested ones". A
+/// verification read that fails and then falls back to echoing the REQUESTED
+/// values breaks exactly that guarantee on the error path, and does it
+/// invisibly: the caller cannot tell a verified echo from an unverified one,
+/// which is the same reports-success-doing-nothing class (#2444) the fix was
+/// written to close. So both failure modes are errors:
+///
+/// * `Err` — the read itself failed (transient / IO).
+/// * `Ok(None)` — an INVARIANT VIOLATION: `db::insert` returned this id, so the
+///   row must be readable. Never a silent fallback.
+///
+/// Both messages state that the WRITE ALREADY HAPPENED and name the id, so an
+/// operator reading the failure knows the row exists and only its verification
+/// failed — the exit code must not be read as "nothing was stored".
+fn read_back_persisted(conn: &rusqlite::Connection, actual_id: &str) -> Result<models::Memory> {
+    match db::get(conn, actual_id) {
+        Ok(Some(persisted)) => Ok(persisted),
+        Ok(None) => anyhow::bail!(
+            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
+             found no such row; refusing to report the requested values as if they were stored"
+        ),
+        Err(e) => anyhow::bail!(
+            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
+             failed: {e}; refusing to report the requested values as if they were stored"
+        ),
+    }
+}
+
 pub fn run(
     db_path: &Path,
     args: StoreArgs,
@@ -434,10 +466,9 @@ pub fn run(
     // stays `long`), `version` bumps, and `expires_at` follows the persisted
     // tier — so echoing `mem` would report a downgrade / expiry / version that
     // never happened (the #2444 reports-success-doing-nothing / honesty class).
-    // An echo-read failure must not turn the already-committed write into an
-    // error; fall back to `mem`. MCP precedent: `src/mcp/tools/store/mod.rs`
-    // `echo_tier`.
-    let persisted = db::get(&conn, &actual_id).ok().flatten();
+    // FAIL CLOSED on a failed read-back — see `read_back_persisted`.
+    // MCP precedent: `src/mcp/tools/store/mod.rs` `echo_tier`.
+    let persisted = read_back_persisted(&conn, &actual_id)?;
 
     // PR-5 (issue #487): security audit trail. No-op when disabled.
     crate::audit::emit(crate::audit::EventBuilder::new(
@@ -463,12 +494,9 @@ pub fn run(
         .map(|c| &c.id)
         .collect();
     if json_out {
-        // #3025 — serialize the PERSISTED row (falling back to `mem` only if
-        // the echo-read failed) so tier/version/expiry are the DB's truth.
-        let mut j = match persisted.as_ref() {
-            Some(p) => serde_json::to_value(p)?,
-            None => serde_json::to_value(&mem)?,
-        };
+        // #3025 — serialize the PERSISTED row so tier/version/expiry are the
+        // DB's truth. Unconditional: an unverified write never reaches here.
+        let mut j = serde_json::to_value(&persisted)?;
         j["id"] = serde_json::json!(actual_id);
         let filtered: Vec<&String> = contradictions
             .iter()
@@ -481,12 +509,8 @@ pub fn run(
         writeln!(out.stdout, "{}", serde_json::to_string(&j)?)?;
     } else {
         // #3025 — echo the PERSISTED tier/namespace, not the requested ones.
-        let tier = persisted
-            .as_ref()
-            .map_or_else(|| mem.tier.clone(), |p| p.tier.clone());
-        let namespace = persisted
-            .as_ref()
-            .map_or(mem.namespace.as_str(), |p| p.namespace.as_str());
+        let tier = &persisted.tier;
+        let namespace = persisted.namespace.as_str();
         writeln!(out.stdout, "stored: {actual_id} [{tier}] (ns={namespace})")?;
         if !filtered.is_empty() {
             writeln!(
@@ -1103,5 +1127,57 @@ mod tests {
             Some(prior.path().as_os_str())
         );
         unsafe { std::env::remove_var("AI_MEMORY_KEY_DIR") };
+    }
+
+    /// #3025 (fail-closed half) — the read-back that verifies what was
+    /// persisted must ERROR when the row cannot be read, never fall back to
+    /// echoing the REQUESTED values. The fallback was the original shape and
+    /// it broke the fix's own contract on the error path: the caller could not
+    /// distinguish a verified echo from an unverified one, which is the very
+    /// reports-success-doing-nothing class (#2444) #3025 exists to close.
+    ///
+    /// `Ok(None)` is the invariant-violation arm: `db::insert` returned the id,
+    /// so the row must be readable. The happy path (this helper returning the
+    /// PERSISTED row) is the positive control in
+    /// `test_store_upsert_json_reports_persisted_not_requested_3025`, which
+    /// drives `run()` end-to-end through this gate — so the two tests below
+    /// cannot pass by rejecting everything.
+    #[test]
+    fn read_back_persisted_errors_when_row_is_missing_3025() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = db::open(tmp.path()).unwrap();
+
+        let err = read_back_persisted(&conn, "no-such-id-3025")
+            .expect_err("a missing row must be an error, never a silent fallback");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no-such-id-3025"),
+            "the error must name the id so the operator can find the row: {msg}"
+        );
+        assert!(
+            msg.contains("WAS STORED"),
+            "the error must say the write already happened, so a non-zero exit \
+             is not misread as 'nothing was stored': {msg}"
+        );
+    }
+
+    /// The `Err` arm of the same gate: a read-back that FAILS (here: the
+    /// `memories` table dropped out from under the reader, standing in for a
+    /// transient/IO failure) is an error too, carrying the same
+    /// write-already-happened wording and the id.
+    #[test]
+    fn read_back_persisted_errors_when_read_fails_3025() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = db::open(tmp.path()).unwrap();
+        conn.execute_batch("DROP TABLE memories;")
+            .expect("drop table to force a read failure");
+
+        let err = read_back_persisted(&conn, "id-read-fails-3025")
+            .expect_err("a failed read-back must be an error, never a silent fallback");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("id-read-fails-3025") && msg.contains("WAS STORED"),
+            "the error must name the id and say the write already happened: {msg}"
+        );
     }
 }

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -146,38 +146,6 @@ fn read_stdin_to_string() -> Result<String> {
 /// every emit routes through `out.stdout` / `out.stderr` instead of
 /// `println!` / `eprintln!`.
 #[allow(clippy::too_many_lines)]
-/// #3025 — read back the row `db::insert` just committed, so the response can
-/// report what the DB ACTUALLY stored rather than what the caller requested.
-///
-/// **Fails closed (ERRORS-19).** The guarantee this fix exists to make is
-/// "the response reports the STORED values, not the requested ones". A
-/// verification read that fails and then falls back to echoing the REQUESTED
-/// values breaks exactly that guarantee on the error path, and does it
-/// invisibly: the caller cannot tell a verified echo from an unverified one,
-/// which is the same reports-success-doing-nothing class (#2444) the fix was
-/// written to close. So both failure modes are errors:
-///
-/// * `Err` — the read itself failed (transient / IO).
-/// * `Ok(None)` — an INVARIANT VIOLATION: `db::insert` returned this id, so the
-///   row must be readable. Never a silent fallback.
-///
-/// Both messages state that the WRITE ALREADY HAPPENED and name the id, so an
-/// operator reading the failure knows the row exists and only its verification
-/// failed — the exit code must not be read as "nothing was stored".
-fn read_back_persisted(conn: &rusqlite::Connection, actual_id: &str) -> Result<models::Memory> {
-    match db::get(conn, actual_id) {
-        Ok(Some(persisted)) => Ok(persisted),
-        Ok(None) => anyhow::bail!(
-            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
-             found no such row; refusing to report the requested values as if they were stored"
-        ),
-        Err(e) => anyhow::bail!(
-            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
-             failed: {e}; refusing to report the requested values as if they were stored"
-        ),
-    }
-}
-
 pub fn run(
     db_path: &Path,
     args: StoreArgs,
@@ -459,35 +427,66 @@ pub fn run(
         db::find_contradictions(&conn, &mem.title, &mem.namespace).unwrap_or_default();
     let actual_id = db::insert(&conn, &mem)?;
 
-    // #3025 — re-read the persisted row so the response reflects what the DB
-    // ACTUALLY stored, never the requested-but-not-persisted values. On a
-    // `(title, namespace)` upsert `db::insert` merges onto the existing row:
-    // tier stays monotonic-max (a `--tier short` upsert over a `long` row
-    // stays `long`), `version` bumps, and `expires_at` follows the persisted
-    // tier — so echoing `mem` would report a downgrade / expiry / version that
-    // never happened (the #2444 reports-success-doing-nothing / honesty class).
-    // FAIL CLOSED on a failed read-back — see `read_back_persisted`.
-    // MCP precedent: `src/mcp/tools/store/mod.rs` `echo_tier`.
-    let persisted = read_back_persisted(&conn, &actual_id)?;
-
     // PR-5 (issue #487): security audit trail. No-op when disabled.
-    crate::audit::emit(crate::audit::EventBuilder::new(
-        crate::audit::AuditAction::Store,
-        crate::audit::actor(
-            agent_id.clone(),
-            cli_agent_id.map_or(crate::audit::synthesis_sources::DEFAULT_FALLBACK, |_| {
-                crate::audit::synthesis_sources::EXPLICIT
-            }),
-            args.scope.clone(),
-        ),
-        crate::audit::target_memory(
-            actual_id.clone(),
-            mem.namespace.clone(),
-            Some(mem.title.clone()),
-            Some(mem.tier.to_string()),
-            args.scope.clone(),
-        ),
-    ));
+    // Built once so both arms share the same actor (the write already
+    // happened; the trail must not go silent on a failed read-back).
+    let store_actor = crate::audit::actor(
+        agent_id.clone(),
+        cli_agent_id.map_or(crate::audit::synthesis_sources::DEFAULT_FALLBACK, |_| {
+            crate::audit::synthesis_sources::EXPLICIT
+        }),
+        args.scope.clone(),
+    );
+
+    // #3025 — re-read the persisted row so the response (AND the audit
+    // target) reflects what the DB ACTUALLY stored, never the
+    // requested-but-not-persisted values. On a `(title, namespace)`
+    // upsert `db::insert` merges onto the existing row: tier stays
+    // monotonic-max (a `--tier short` upsert over a `long` row stays
+    // `long`), `version` bumps, and `expires_at` follows the persisted
+    // tier — so echoing `mem` would report a downgrade / expiry /
+    // version that never happened (the #2444 reports-success-doing-
+    // nothing / honesty class). FAIL CLOSED on a failed read-back —
+    // see `read_back_persisted`. MCP precedent:
+    // `src/mcp/tools/store/mod.rs` `echo_tier`.
+    //
+    // Audit is emitted in BOTH arms: Allow + persisted target on
+    // success; Error + `verification_failed` + requested target on
+    // the fail-closed path (the row is already committed; PR-5
+    // forbids a silent write).
+    let persisted = match read_back_persisted(&conn, &actual_id) {
+        Ok(p) => {
+            crate::audit::emit(crate::audit::EventBuilder::new(
+                crate::audit::AuditAction::Store,
+                store_actor,
+                crate::audit::target_memory(
+                    actual_id.clone(),
+                    p.namespace.clone(),
+                    Some(p.title.clone()),
+                    Some(p.tier.to_string()),
+                    args.scope.clone(),
+                ),
+            ));
+            p
+        }
+        Err(e) => {
+            crate::audit::emit(
+                crate::audit::EventBuilder::new(
+                    crate::audit::AuditAction::Store,
+                    store_actor,
+                    crate::audit::target_memory(
+                        actual_id.clone(),
+                        mem.namespace.clone(),
+                        Some(mem.title.clone()),
+                        Some(mem.tier.to_string()),
+                        args.scope.clone(),
+                    ),
+                )
+                .error(format!("verification_failed: {e}")),
+            );
+            return Err(e);
+        }
+    };
     let filtered: Vec<&String> = contradictions
         .iter()
         .filter(|c| c.id != mem.id && c.id != actual_id)
@@ -521,6 +520,41 @@ pub fn run(
         }
     }
     Ok(())
+}
+
+/// #3025 — read back the row `db::insert` just committed, so the response can
+/// report what the DB ACTUALLY stored rather than what the caller requested.
+///
+/// Lives BELOW `run` so `#[allow(clippy::too_many_lines)]` and `run`'s
+/// doc-comment attach to `run` (not this helper).
+///
+/// **Fails closed (ERRORS-19).** The guarantee this fix exists to make is
+/// "the response reports the STORED values, not the requested ones". A
+/// verification read that fails and then falls back to echoing the REQUESTED
+/// values breaks exactly that guarantee on the error path, and does it
+/// invisibly: the caller cannot tell a verified echo from an unverified one,
+/// which is the same reports-success-doing-nothing class (#2444) the fix was
+/// written to close. So both failure modes are errors:
+///
+/// * `Err` — the read itself failed (transient / IO).
+/// * `Ok(None)` — an INVARIANT VIOLATION: `db::insert` returned this id, so the
+///   row must be readable. Never a silent fallback.
+///
+/// Both messages state that the WRITE ALREADY HAPPENED and name the id, so an
+/// operator reading the failure knows the row exists and only its verification
+/// failed — the exit code must not be read as "nothing was stored".
+fn read_back_persisted(conn: &rusqlite::Connection, actual_id: &str) -> Result<models::Memory> {
+    match db::get(conn, actual_id) {
+        Ok(Some(persisted)) => Ok(persisted),
+        Ok(None) => anyhow::bail!(
+            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
+             found no such row; refusing to report the requested values as if they were stored"
+        ),
+        Err(e) => anyhow::bail!(
+            "memory {actual_id} WAS STORED, but the read-back that verifies what was persisted \
+             failed: {e}; refusing to report the requested values as if they were stored"
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -427,6 +427,18 @@ pub fn run(
         db::find_contradictions(&conn, &mem.title, &mem.namespace).unwrap_or_default();
     let actual_id = db::insert(&conn, &mem)?;
 
+    // #3025 — re-read the persisted row so the response reflects what the DB
+    // ACTUALLY stored, never the requested-but-not-persisted values. On a
+    // `(title, namespace)` upsert `db::insert` merges onto the existing row:
+    // tier stays monotonic-max (a `--tier short` upsert over a `long` row
+    // stays `long`), `version` bumps, and `expires_at` follows the persisted
+    // tier — so echoing `mem` would report a downgrade / expiry / version that
+    // never happened (the #2444 reports-success-doing-nothing / honesty class).
+    // An echo-read failure must not turn the already-committed write into an
+    // error; fall back to `mem`. MCP precedent: `src/mcp/tools/store/mod.rs`
+    // `echo_tier`.
+    let persisted = db::get(&conn, &actual_id).ok().flatten();
+
     // PR-5 (issue #487): security audit trail. No-op when disabled.
     crate::audit::emit(crate::audit::EventBuilder::new(
         crate::audit::AuditAction::Store,
@@ -451,7 +463,12 @@ pub fn run(
         .map(|c| &c.id)
         .collect();
     if json_out {
-        let mut j = serde_json::to_value(&mem)?;
+        // #3025 — serialize the PERSISTED row (falling back to `mem` only if
+        // the echo-read failed) so tier/version/expiry are the DB's truth.
+        let mut j = match persisted.as_ref() {
+            Some(p) => serde_json::to_value(p)?,
+            None => serde_json::to_value(&mem)?,
+        };
         j["id"] = serde_json::json!(actual_id);
         let filtered: Vec<&String> = contradictions
             .iter()
@@ -463,11 +480,14 @@ pub fn run(
         }
         writeln!(out.stdout, "{}", serde_json::to_string(&j)?)?;
     } else {
-        writeln!(
-            out.stdout,
-            "stored: {} [{}] (ns={})",
-            actual_id, mem.tier, mem.namespace
-        )?;
+        // #3025 — echo the PERSISTED tier/namespace, not the requested ones.
+        let tier = persisted
+            .as_ref()
+            .map_or_else(|| mem.tier.clone(), |p| p.tier.clone());
+        let namespace = persisted
+            .as_ref()
+            .map_or(mem.namespace.as_str(), |p| p.namespace.as_str());
+        writeln!(out.stdout, "stored: {actual_id} [{tier}] (ns={namespace})")?;
         if !filtered.is_empty() {
             writeln!(
                 out.stderr,
@@ -575,6 +595,61 @@ mod tests {
         assert_eq!(v["title"].as_str().unwrap(), "test title");
         assert_eq!(v["tier"].as_str().unwrap(), Tier::Mid.as_str());
         assert_eq!(v["namespace"].as_str().unwrap(), "test-ns");
+    }
+
+    /// #3025 — on a `(title, namespace)` upsert the CLI `store --json`
+    /// response MUST report the PERSISTED row (tier/version/expiry), never the
+    /// requested-but-not-persisted values. A `--tier short` upsert over a
+    /// `long` row stays `long` and bumps `version`; pre-fix the response
+    /// echoed the requested `short`/`version:1`, lying about a downgrade that
+    /// never happened.
+    #[test]
+    fn test_store_upsert_json_reports_persisted_not_requested_3025() {
+        let _lock = locked_env();
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        let cfg = config::AppConfig::default();
+
+        // First store: a long-tier row.
+        let mut first = default_args();
+        first.title = "upsert-3025".to_string();
+        first.tier = Tier::Long.as_str().to_string();
+        {
+            let mut out = env.output();
+            run(&db, first, true, &cfg, Some("test-agent"), &mut out).unwrap();
+        }
+        let first_json: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+        assert_eq!(first_json["tier"].as_str().unwrap(), Tier::Long.as_str());
+
+        // Upsert the SAME (title, namespace) requesting `short`. The DB keeps
+        // `long` (tier monotonicity) and bumps `version`.
+        env.stdout.clear();
+        let mut second = default_args();
+        second.title = "upsert-3025".to_string();
+        second.tier = Tier::Short.as_str().to_string();
+        second.content = "updated content".to_string();
+        {
+            let mut out = env.output();
+            run(&db, second, true, &cfg, Some("test-agent"), &mut out).unwrap();
+        }
+        let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+        // Response reflects the PERSISTED row, not the requested `short`.
+        assert_eq!(
+            v["tier"].as_str().unwrap(),
+            Tier::Long.as_str(),
+            "response must echo the persisted tier, got: {v}"
+        );
+        assert_ne!(v["tier"].as_str().unwrap(), Tier::Short.as_str());
+        // The persisted upsert bumped `version` past the create-time 1.
+        assert!(
+            v["version"].as_u64().unwrap() >= 2,
+            "persisted version must have bumped on upsert, got: {v}"
+        );
+        // Both stores addressed the same row.
+        assert_eq!(
+            v["id"].as_str().unwrap(),
+            first_json["id"].as_str().unwrap()
+        );
     }
 
     #[test]

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -1232,6 +1232,14 @@ pub async fn run(
         // at router-build time. Idempotent; harmless on the mcp/CLI paths
         // that never build the HTTP router.
         crate::set_max_inflight_requests(limits.max_inflight_requests);
+        // #3040 — seed the process-wide list/bulk page-size cap from the same
+        // resolved `[limits]` config (env `AI_MEMORY_MAX_PAGE_SIZE` >
+        // `[limits].max_page_size` > compiled `MAX_BULK_SIZE`). The HTTP surface
+        // reads `AppState.max_page_size`; the MCP stdio list handler has no
+        // `AppState`, so it consults this seeded global — closing the asymmetry
+        // where MCP `memory_list` ignored the OOM guard HTTP honors. Idempotent;
+        // harmless on every subcommand path.
+        crate::set_max_page_size(limits.max_page_size);
     }
     // #1579 B7 — seed the process-wide sqlite `PRAGMA mmap_size` from
     // the resolved `[storage]` config (env `AI_MEMORY_DB_MMAP_SIZE` >

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -971,6 +971,33 @@ pub fn max_inflight_requests() -> usize {
     MAX_INFLIGHT_REQUESTS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// #3040 — process-wide list/bulk page-size cap (`AI_MEMORY_MAX_PAGE_SIZE`,
+/// env #52), the OOM guard that bounds per-request in-memory materialization.
+/// The HTTP surface reads it via `AppState.max_page_size`; the MCP stdio loop
+/// carries no `AppState`, so the same resolved cap is mirrored into this atomic
+/// (the `MAX_INFLIGHT_REQUESTS` precedent) and consulted by the MCP list
+/// handler, closing the asymmetry where MCP `memory_list` honored no cap while
+/// HTTP did. Seeded once at daemon/mcp/CLI boot from
+/// `AppConfig::resolve_limits().max_page_size` (env > `[limits].max_page_size`
+/// > compiled `MAX_BULK_SIZE`). The pre-boot / raw-library default is the
+/// compiled `MAX_BULK_SIZE` so the unseeded lib-test read is byte-identical to
+/// the historical behavior.
+static MAX_PAGE_SIZE: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(crate::handlers::MAX_BULK_SIZE);
+
+/// Seed the process-wide list/bulk page-size cap (#3040). Called once at boot
+/// from the resolved `[limits]` config, alongside `set_max_inflight_requests`.
+pub fn set_max_page_size(cap: usize) {
+    MAX_PAGE_SIZE.store(cap, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Current process-wide list/bulk page-size cap (#3040). Consumed by the MCP
+/// `memory_list` handler so it honors the same OOM guard HTTP applies.
+#[must_use]
+pub fn max_page_size() -> usize {
+    MAX_PAGE_SIZE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// #1733 (Pillar-4 4.A) — sample rate for the admission-shed `WARN` log.
 /// The Prometheus `ai_memory_admission_shed_total` counter records every
 /// shed; the log line is sampled (1st, then every Nth) so sustained

--- a/src/mcp/tools/list.rs
+++ b/src/mcp/tools/list.rs
@@ -74,6 +74,25 @@ pub(super) fn handle_list(
     params: &Value,
     caller: Option<&str>,
 ) -> Result<Value, String> {
+    // #3040 — honor the same list/bulk page-size cap (`AI_MEMORY_MAX_PAGE_SIZE`,
+    // env #52) the HTTP surface applies via `AppState.max_page_size`. The MCP
+    // stdio loop carries no `AppState`, so the resolved cap is mirrored into a
+    // process-global seeded at boot; consult it here so `memory_list` can never
+    // return more rows than the operator's OOM guard permits. Unseeded
+    // raw-library reads yield the compiled `MAX_BULK_SIZE`, so the historical
+    // 200-row default is unchanged.
+    handle_list_capped(conn, params, caller, crate::max_page_size())
+}
+
+/// #3040 — inner list handler with the operator's page-size cap threaded in
+/// explicitly, so the cap plumbing is unit-testable without mutating the
+/// process-global `MAX_PAGE_SIZE` (which concurrent list tests read).
+fn handle_list_capped(
+    conn: &rusqlite::Connection,
+    params: &Value,
+    caller: Option<&str>,
+    page_cap: usize,
+) -> Result<Value, String> {
     let namespace = params["namespace"].as_str();
     // v0.8.0 PE-2 (#1730) — read-action governance gate (zero-config
     // fast-path when no read_action rules exist).
@@ -105,11 +124,16 @@ pub(super) fn handle_list(
         validate::validate_valid_at(v).map_err(|e| e.to_string())?;
     }
 
+    // #3040 — cap the page size at the SMALLER of the historical MCP 200-row
+    // ceiling and the operator-resolved `max_page_size`, so MCP never exceeds
+    // the OOM guard (and never loosens its own tighter default when the cap is
+    // larger than 200).
+    let effective_limit = limit.min(200).min(page_cap);
     let results = db::list(
         conn,
         namespace,
         tier.as_ref(),
-        limit.min(200),
+        effective_limit,
         0,
         None,
         None,
@@ -249,6 +273,27 @@ mod tests {
         db::insert(&conn, &make_mem("a", "ns", MTier::Mid, "ai:a")).expect("ins");
         let out = handle_list(&conn, &json!({"limit": u64::MAX}), None).expect("ok");
         assert_eq!(out["count"].as_u64(), Some(1));
+    }
+
+    // #3040 — the operator's `max_page_size` cap bounds the MCP list page, so
+    // `memory_list` never returns more rows than the OOM guard HTTP applies.
+    #[test]
+    fn page_size_cap_bounds_mcp_list_3040() {
+        let conn = fresh_conn();
+        for i in 0..3 {
+            db::insert(&conn, &make_mem(&format!("m{i}"), "ns", MTier::Mid, "ai:a")).expect("ins");
+        }
+        // Large caller limit + a small operator cap (2) → the page is bounded.
+        let capped = handle_list_capped(&conn, &json!({"limit": 1000}), None, 2).expect("ok");
+        assert_eq!(
+            capped["count"].as_u64(),
+            Some(2),
+            "max_page_size=2 must cap the MCP list page: {capped}"
+        );
+        // A cap larger than the historical MCP 200-row ceiling never LOOSENS it
+        // (all 3 rows are under both bounds, so all 3 return).
+        let generous = handle_list_capped(&conn, &json!({"limit": 1000}), None, 5000).expect("ok");
+        assert_eq!(generous["count"].as_u64(), Some(3));
     }
 
     // E. idempotency

--- a/src/observations/mod.rs
+++ b/src/observations/mod.rs
@@ -227,9 +227,16 @@ pub fn mark_consumed_guarded(
 }
 
 /// One row of `recall_observations` as it travels over the read-side
-/// MCP `memory_recall_observations` tool. Mirrors the SQL columns 1:1
-/// plus a derived `consumed` boolean (the SQL column is an INTEGER
-/// 0/1).
+/// MCP `memory_recall_observations` tool + the HTTP mirror. Mirrors the
+/// SQL columns 1:1, with the `consumed` / `folded` INTEGER-0/1 columns
+/// surfaced as booleans.
+///
+/// #2989 — `agent_id` (v58 / #1705 identity binding), `namespace` (v58),
+/// and `folded` (v77 / #1869 recall purity) were STORED by the ledger but
+/// omitted from this read struct, so "who recalled what, in which namespace,
+/// folded or not" was unanswerable through the sanctioned read surface and
+/// the "1:1" doc claim was false. They are now surfaced (both backends), so
+/// the #1705 identity binding is no longer write-only.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Observation {
     pub recall_id: String,
@@ -243,6 +250,18 @@ pub struct Observation {
     pub consumed_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consumed_by_memory_id: Option<String>,
+    /// #1705 (schema v58) — the agent that performed the recall this row
+    /// records. Nullable: legacy pre-v58 rows carry `NULL`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// #1705 (schema v58) — the namespace the recall was scoped to.
+    /// Nullable: legacy pre-v58 rows carry `NULL`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    /// #1869 (schema v77) — recall-purity fold state: `true` once the
+    /// periodic FOLD job has applied this row's access signal to the
+    /// `memories` row.
+    pub folded: bool,
 }
 
 /// Read-side query for the `memory_recall_observations` MCP tool.
@@ -263,7 +282,8 @@ pub fn list_observations(
 ) -> Result<Vec<Observation>> {
     let mut sql = String::from(
         "SELECT recall_id, memory_id, retriever, rank, score, consumed, \
-                observed_at, consumed_at, consumed_by_memory_id \
+                observed_at, consumed_at, consumed_by_memory_id, \
+                agent_id, namespace, folded \
            FROM recall_observations \
           WHERE 1=1",
     );
@@ -314,6 +334,10 @@ pub fn list_observations(
                 observed_at: row.get(6)?,
                 consumed_at: row.get(7).ok(),
                 consumed_by_memory_id: row.get(8).ok(),
+                // #2989 — surface the v58 identity binding + v77 fold state.
+                agent_id: row.get(9).ok(),
+                namespace: row.get(10).ok(),
+                folded: row.get::<_, i64>(11).unwrap_or(0) != 0,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -479,6 +503,43 @@ mod tests {
         // INSERT OR IGNORE on the composite PK collapses the replay
         // to zero inserts. (Caller's perspective: idempotent.)
         assert_eq!(n, 0);
+    }
+
+    /// #2989 — the read struct + `list_observations` surface the v58 identity
+    /// binding (`agent_id`, `namespace`) + the v77 `folded` fold-state that the
+    /// ledger stores, so "who recalled what, in which namespace, folded or not"
+    /// is answerable through the sanctioned read surface (they were hidden, and
+    /// the "1:1 column mirror" doc claim was false).
+    #[test]
+    fn list_observations_surfaces_identity_and_fold_state_2989() {
+        let conn = fresh();
+        seed_memory(&conn, "m1");
+        record_recall_with_identity(
+            &conn,
+            "r1",
+            &[Candidate {
+                memory_id: "m1",
+                retriever: "hybrid",
+                rank: 1,
+                score: 0.9,
+            }],
+            Some("ai:cert-fed-proxy"),
+            Some("team/eng"),
+        )
+        .expect("record");
+
+        let obs = list_observations(&conn, Some("r1"), None, None, None, 10).expect("list");
+        assert_eq!(obs.len(), 1);
+        let o = &obs[0];
+        assert_eq!(o.agent_id.as_deref(), Some("ai:cert-fed-proxy"));
+        assert_eq!(o.namespace.as_deref(), Some("team/eng"));
+        assert!(!o.folded, "a fresh recall row lands unfolded (folded=0)");
+
+        // And they travel onto the wire (the MCP tool / HTTP output envelope).
+        let j = serde_json::to_value(o).expect("serialize");
+        assert_eq!(j["agent_id"].as_str(), Some("ai:cert-fed-proxy"));
+        assert_eq!(j["namespace"].as_str(), Some("team/eng"));
+        assert_eq!(j["folded"].as_bool(), Some(false));
     }
 
     #[test]

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -23089,7 +23089,8 @@ impl MemoryStore for PostgresStore {
         // parameter (no string interpolation of caller input).
         let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
             "SELECT recall_id, memory_id, retriever, rank, score, consumed, \
-                    observed_at, consumed_at, consumed_by_memory_id \
+                    observed_at, consumed_at, consumed_by_memory_id, \
+                    agent_id, namespace, folded \
                FROM recall_observations WHERE TRUE",
         );
         if let Some(rid) = recall_id {
@@ -23151,6 +23152,13 @@ impl MemoryStore for PostgresStore {
                 observed_at: observed_at.to_rfc3339(),
                 consumed_at: consumed_at.map(|t| t.to_rfc3339()),
                 consumed_by_memory_id: r.try_get("consumed_by_memory_id").ok(),
+                // #2989 — surface the v58 identity binding + v77 fold state
+                // (postgres twin of the sqlite `list_observations` mapping).
+                agent_id: r.try_get("agent_id").ok(),
+                namespace: r.try_get("namespace").ok(),
+                folded: r
+                    .try_get("folded")
+                    .map_err(|e| to_store_err("obs.folded", e))?,
             });
         }
         Ok(out)

--- a/tests/qual_6_7_legacy_error_type_ceiling.rs
+++ b/tests/qual_6_7_legacy_error_type_ceiling.rs
@@ -139,7 +139,15 @@ fn count_matches(root: &Path, needle: &str) -> usize {
 // atomisation-specific behaviour is asserted with an INJECTED curator by
 // `tests/batman_atomise_wiring_2983.rs` and the hook's own unit suite.
 // Net acknowledged: +1 (test-only).
-const QUAL_6_CEILING: usize = 120;
+// 2026-08-18 (#3040) — raised 120 -> 121 for the `handle_list_capped` inner
+// helper split out of `handle_list` in `src/mcp/tools/list.rs`. The MCP list
+// path now honors the operator `AI_MEMORY_MAX_PAGE_SIZE` page-size cap (parity
+// with the HTTP `AppState.max_page_size` OOM guard); the cap is threaded as an
+// explicit `page_cap` param to the inner helper so it is unit-testable without
+// mutating the process-global. The helper MUST mirror the existing
+// `Result<Value, String>` MCP-dispatch envelope of `handle_list`, so it is that
+// type by construction — no new error contract. Net acknowledged: +1.
+const QUAL_6_CEILING: usize = 121;
 
 /// QUAL-7 ceiling: 6+ sites at v2-review time + slack. Raised
 /// 25 → 26 for the #1455 fail-CLOSED governance pair in


### PR DESCRIPTION
Wave-C2 of the v1.0.0 hive-campaign: CLI/MCP **correctness** parity. Four surface-divergence / honesty defects; each fix makes the divergent surface match the already-correct one (precedent-copy / bug-fix / doc-fix — no vote).

Closes #3025 #3040 #3037 #2989 (manual close — non-default release branch).

- **#3025** CLI `store --json` reported the REQUESTED tier/expiry/version on an upsert, not the PERSISTED row (#2444 honesty class). Now re-reads and echoes the persisted row, mirroring MCP `echo_tier`. DEGRADE-never-lie.
- **#3040** MCP `memory_list` ignored `AI_MEMORY_MAX_PAGE_SIZE` (asymmetric OOM guard). Now mirrors the resolved cap to a boot-seeded process-global (`set_max_page_size`, the `set_max_inflight_requests` precedent) and caps the MCP list page.
- **#3037** dependents-of-invalidated `--transitive` was unreachable from the CLI. Added the flag, threaded through the shared handler.
- **#2989** recall_observations read surface hid `agent_id`/`namespace`/`folded` (#1705 binding write-only; false 1:1-mirror doc). Surfaced the 3 columns on the struct + both backends' SELECT + fixed the doc. Output-only — no schema/snapshot change.

**SSOT:** qual_6_7 legacy-error ceiling 120→121 (the `handle_list_capped` helper split, same `Result<Value,String>` envelope). No new subcommand/route/tool/schema.

Locally verified: 4 new tests + affected modules **60/0**; fmt + clippy (all 4 feature legs) clean; qual_10 + `cli_subcommand_count_invariant` unchanged.

## AI involvement
Implemented by an Opus coder subagent; reviewed, independently re-tested locally (all 4 parity tests + 60 affected-module tests), and signed by the orchestrator (AlphaOne). Precedent-copying / honesty fixes; no crossroads vote required. Base: release/v1.0.0 @ 0d126021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rebase onto `release/v1.0.0` @ `15fe44e4` (2026-08-22)

Merged **clean — zero conflicts** (GitHub's CONFLICTING flag was stale
mergeability computed against an older base). **Nothing here is redundant:**
none of #3025 / #3040 / #3037 / #2989 appears anywhere in `src/` on base, and
git found nothing to reconcile in any of the nine files.

Re-checked against the new base:
- `qual_6_7` legacy-error ceiling: base is still **120**, so this PR's
  documented +1 → **121** still lands exactly.
- SSOT drift gate PASS with values **identical to base** — `full_tools=103`,
  `routes=94`, `cli_default=90`, `cli_sal=92` all unmoved (`--transitive` is a
  flag, not a subcommand, so the CLI counts correctly do not move).

### #3025 completed: the verification read now FAILS CLOSED

Review follow-up. As originally written the fix read back the persisted row with
`db::get(&conn, &actual_id).ok().flatten()` and, on `None`, fell back to
reporting the **requested** values — which is precisely the pre-fix behaviour
this fix exists to remove. The guarantee is *"the response reports the STORED
values, not the requested ones"*, so a verification read that fails and then
reports the requested values breaks the fix's own contract on the error path,
and does it invisibly: the caller cannot distinguish a verified echo from an
unverified one. That is the same reports-success-doing-nothing class (#2444)
#3025 was written to close, and an `ERRORS-19` silent discard.

The read-back is now the extracted helper `read_back_persisted`, and **both**
failure modes are errors:

- `Err` — the read itself failed (transient / IO);
- `Ok(None)` — an **invariant violation**: `db::insert` returned this id, so the
  row must be readable. Never a silent fallback.

Both messages lead with **`WAS STORED`** and name the id, so an operator reading
the failure knows the row exists and only its *verification* failed — a non-zero
exit must not be misread as "nothing was stored". Both call sites (`--json` and
the text line) now consume the persisted row unconditionally; the `Option` and
its two `map_or` fallbacks to the requested `mem` are gone, so no code path can
report requested values any more.

Tests: `read_back_persisted_errors_when_row_is_missing_3025` (the `Ok(None)`
arm) and `read_back_persisted_errors_when_read_fails_3025` (the `Err` arm,
forced by dropping the `memories` table under the reader). The pre-existing
`test_store_upsert_json_reports_persisted_not_requested_3025` drives `run()`
end-to-end through this gate and is the positive control, so the pair cannot
pass by rejecting everything. CHANGELOG updated.

**Issues still legitimately closed by this PR: #3025, #3040, #3037, #2989.**
