### PR TITLE
fix(migrate): paginate — stop silently truncating at 1000 rows (closes #3054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (`ai-memory migrate` silently dropped every row past the first 1000; #1876)
+
+- **Data-loss: cross-backend `migrate` truncated to the first `LIST_MAX_LIMIT`
+  (1000) memories and reported `errors: 0`.** `migrate::migrate` issued a
+  SINGLE `from.list()` call with `filter.limit = MAX_ROWS` (1_000_000), but
+  both SAL adapters clamp `list` to `LIST_MAX_LIMIT` (1000) and — until this
+  fix — ignored any offset (`SqliteStore::list` passed a hardcoded `0`;
+  `PostgresStore::list` bound no `OFFSET`), so a `migrate` of a corpus larger
+  than 1000 rows persisted only the first 1000 and the `>= MAX_ROWS`
+  saturation guard never fired (1000 < 1_000_000). A 7,888-row hive migrated
+  as `memories_read: 1000, batches: 1` with a clean report. `migrate` now
+  PAGES over the stable total order both adapters already emit
+  (`priority DESC, updated_at DESC, id ASC` — a UNIQUE `id` tiebreak makes
+  OFFSET paging over a static source skip/dup-free), honoring `--batch` as the
+  documented page-size hint, keeping the `MAX_ROWS` total-rows refusal, and
+  adding a completeness guard that pushes a LOUD error rather than reporting
+  success on an incomplete read. Restores the module's own documented
+  "streams in pages" contract. Mechanism: a new `Filter.offset` field
+  (`Default` 0, so every existing call site is byte-identical) threaded into
+  each adapter's `LIMIT ... OFFSET`. `list_links` is unbounded on both
+  adapters and needs no pagination. Pinned by
+  `migrate::tests::migrate_paginates_past_list_max_limit` (sqlite→sqlite,
+  2500 rows). This is a single-correct-answer bug fix restoring the
+  documented contract via the pagination the SQL layer already implements
+  (crossroads-protocol exempt).
+
 ### Fixed (Batman auto-atomisation was structurally inert product-wide; #2983 #2984 #2985 #2986 #2987)
 
 Implements the ratified 5-agent adversarial verdict (protocol `4d3ea1c5`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (`ai-memory migrate` dropped rows past 1000 AND never copied embeddings; #1876 #3060)
+
+- **Data-loss: cross-backend `migrate` copied memory TEXT but NOT the
+  embedding VECTORS (#3060 / F4).** `store()` carries the durable `Memory`
+  struct, but a memory's embedding lives in a separate column (sqlite
+  side-table / postgres pgvector) that the struct does not carry, so a
+  migrated corpus landed with `embedding IS NOT NULL = 0`. Under a certified
+  `AI_MEMORY_INFERENCE_EGRESS=loopback-only`/`deny` posture the destination's
+  external embedder cannot re-derive them, and re-embedding under a different
+  model would change the #2167 `embedding_space` fingerprint. `migrate` now
+  has a Phase 3 that copies each migrated row's stored `(vector, space)`
+  verbatim via `get_embedding_with_space` → `set_embeddings_batch` (bucketed
+  by space, paged) — NEVER re-embedding, NEVER synthesizing a space — records
+  `embeddings_copied` in the `MigrationReport`, and pushes a LOUD error if the
+  copied count falls short of the source's embedded-row count. Reuses existing
+  SAL methods only (no new trait surface). Pinned by
+  `migrate::tests::migrate_copies_embeddings_and_preserves_space`.
+
 ### Fixed (`ai-memory migrate` silently dropped every row past the first 1000; #1876)
 
 - **Data-loss: cross-backend `migrate` truncated to the first `LIST_MAX_LIMIT`

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -7286,6 +7286,7 @@ async fn cmd_migrate(args: &MigrateArgs) -> Result<()> {
             "to_url": to_display,
             "memories_read": report.memories_read,
             "memories_written": report.memories_written,
+            "embeddings_copied": report.embeddings_copied,
             "batches": report.batches,
             "errors": report.errors,
             "dry_run": report.dry_run,
@@ -7297,6 +7298,7 @@ async fn cmd_migrate(args: &MigrateArgs) -> Result<()> {
         println!("  to:                {to_display}");
         println!("  memories_read:     {}", report.memories_read);
         println!("  memories_written:  {}", report.memories_written);
+        println!("  embeddings_copied: {}", report.embeddings_copied);
         println!("  batches:           {}", report.batches);
         println!("  dry_run:           {}", report.dry_run);
         println!("  errors:            {}", report.errors.len());

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -1285,6 +1285,8 @@ pub async fn session_start(
             until: None,
             valid_at: None,
             limit,
+            // #1876 — subscription-mirror listing serves the first window.
+            offset: 0,
             active_embedding_space: None,
             // #2580 — metadata-equality pushdown axis unused on this path.
             metadata_eq: None,

--- a/src/handlers/memories_query.rs
+++ b/src/handlers/memories_query.rs
@@ -158,6 +158,10 @@ pub async fn list_memories(
             // validated at the entry guard above).
             valid_at: p.valid_at.clone(),
             limit,
+            // #1876 — list DTO paging: this surface serves the first window
+            // (no offset param wired yet); the migrate paginator is the
+            // OFFSET consumer.
+            offset: 0,
             // #2167 — list/search never runs the recall space gate.
             active_embedding_space: None,
             // #2580 — metadata-equality pushdown axis unused on this path.
@@ -357,6 +361,8 @@ pub async fn search_memories(
             // surface does not expose it, so no as-of filter applies here.
             valid_at: None,
             limit,
+            // #1876 — keyword-search surface serves the first window only.
+            offset: 0,
             // #2167 — list/search never runs the recall space gate.
             active_embedding_space: None,
             // #2580 — metadata-equality pushdown axis unused on this path.

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -1111,6 +1111,8 @@ pub async fn load_family_handler(
             until: None,
             valid_at: None,
             limit,
+            // #1876 — load_family listing serves the first window.
+            offset: 0,
             // #2167 — load_family listing never runs the recall space gate.
             active_embedding_space: None,
             // #2580 — GIN-served pushdown of the family predicate.

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -155,68 +155,100 @@ pub async fn migrate(
         ..MigrationReport::default()
     };
 
-    // Migration strategy (blocker #298 fix).
+    // Migration strategy — real OFFSET pagination (#1876 fix; restores the
+    // documented "streams in pages" contract).
     //
-    // The earlier pagination used `created_at` as the cursor, but
-    // adapter `list` returns rows ordered by `priority DESC, updated_at
-    // DESC`. Low-priority memories newer than page-1's `min(created_at)`
-    // were permanently skipped — the priority-ordered page didn't
-    // include them, and the created_at cursor then filtered them out on
-    // the next call. That's data loss, silently.
+    // History (blocker #298): an earlier attempt paged on a `created_at`
+    // cursor, but `list` orders by `priority DESC, updated_at DESC`, so
+    // low-priority rows newer than page-1's `min(created_at)` were skipped
+    // — silent data loss. The interim "fix" was a SINGLE `list` call with
+    // `limit = MAX_ROWS`; but both adapters clamp `list` to
+    // `LIST_MAX_LIMIT` (= 1000) and, until #1876, ignored any offset, so the
+    // single call structurally returned only the first <=1000 rows AND the
+    // `>= MAX_ROWS` saturation guard never fired (1000 < 1_000_000) — every
+    // corpus past 1000 memories was silently truncated while the report
+    // said `errors: 0`. That is exactly the loss the #298 comment swore to
+    // prevent.
     //
-    // For v0.6.0 we migrate in a single `list` call capped at MAX_ROWS.
-    // The caller's `batch_size` parameter is kept for API compatibility
-    // but is NOT used to cap total rows — it's a hint for the future
-    // streaming migrate tool (tracked in v0.7 as
-    // `MemoryStore::list_all`).
-    //
-    // Correctness > throughput: a correct single-call migrate is
-    // strictly preferable to a paginated migrate that silently drops
-    // rows. If the source exceeds MAX_ROWS the migration refuses
-    // loudly rather than truncating.
+    // The correct design: page over the SAME stable total order both
+    // adapters already emit — `ORDER BY priority DESC, updated_at DESC,
+    // id ASC` — whose UNIQUE `id` final tiebreak makes OFFSET paging over a
+    // static source skip/dup-free. `batch_size` is the documented page-size
+    // hint; a single page is <= `LIST_MAX_LIMIT` by design, so clamp the
+    // hint into `1..=LIST_MAX_LIMIT` (the default 1000 == the clamp cap).
+    // A TOTAL cap of `MAX_ROWS` still refuses loudly rather than migrating
+    // an unbounded corpus.
     const MAX_ROWS: usize = 1_000_000;
-    let _ = batch_size; // Retained for API compatibility; see comment above.
-
-    let filter = Filter {
-        namespace: namespace_filter.clone(),
-        until: None,
-        limit: MAX_ROWS,
-        ..Filter::default()
-    };
-    let page = match from.list(&ctx, &filter).await {
-        Ok(p) => p,
-        Err(e) => {
-            report.errors.push(format!("source list failed: {e}"));
-            return report;
-        }
-    };
-
-    // Detect cap saturation. If the source returned exactly MAX_ROWS
-    // memories, refuse rather than risk silent truncation. Operators
-    // with >1M memories need the streaming migrate (v0.7).
-    if page.len() >= MAX_ROWS {
-        report.errors.push(format!(
-            "source has >= {} memories; single-call migrate cap reached. \
-             Use the streaming migrate tool (v0.7+) instead of \
-             silently dropping rows.",
-            MAX_ROWS
-        ));
-        return report;
-    }
+    let page_size = batch_size.clamp(1, crate::storage::LIST_MAX_LIMIT);
 
     let mut seen: HashSet<String> = HashSet::new();
-    report.batches = 1;
-    for mem in &page {
-        if !seen.insert(mem.id.clone()) {
-            continue;
-        }
-        report.memories_read += 1;
-        if !dry_run {
-            match to.store(&ctx, mem).await {
-                Ok(_) => report.memories_written += 1,
-                Err(e) => report.errors.push(format!("write {} failed: {e}", mem.id)),
+    let mut offset: usize = 0;
+    loop {
+        let filter = Filter {
+            namespace: namespace_filter.clone(),
+            limit: page_size,
+            offset,
+            ..Filter::default()
+        };
+        let page = match from.list(&ctx, &filter).await {
+            Ok(p) => p,
+            Err(e) => {
+                report
+                    .errors
+                    .push(format!("source list failed at offset {offset}: {e}"));
+                return report;
+            }
+        };
+        let page_len = page.len();
+        report.batches += 1;
+        for mem in &page {
+            // `seen` is belt-and-suspenders over the stable-ordered offset
+            // walk (a static source yields no duplicates); it also guards a
+            // source mutated mid-migrate from double-writing a row.
+            if !seen.insert(mem.id.clone()) {
+                continue;
+            }
+            // Total-rows cap: refuse LOUDLY before crossing MAX_ROWS rather
+            // than silently truncating (the documented streaming contract).
+            if report.memories_read >= MAX_ROWS {
+                report.errors.push(format!(
+                    "source exceeds the {MAX_ROWS}-memory migrate cap; \
+                     refusing to continue rather than risk silent truncation"
+                ));
+                return report;
+            }
+            report.memories_read += 1;
+            if !dry_run {
+                match to.store(&ctx, mem).await {
+                    Ok(_) => report.memories_written += 1,
+                    Err(e) => report.errors.push(format!("write {} failed: {e}", mem.id)),
+                }
             }
         }
+        // A short page means the stable-ordered offset walk has reached the
+        // end of the source. `page_size >= 1`, so this always terminates.
+        if page_len < page_size {
+            break;
+        }
+        offset += page_len;
+    }
+
+    // Completeness safety — never let an INCOMPLETE migrate report success.
+    // The paginator reads the source to exhaustion, so `memories_read` is
+    // the authoritative count of migratable rows (the SAME expiry +
+    // lifecycle filter `list` applies on both backends; a separate raw
+    // COUNT(*) would over-count legitimately-excluded expired/tombstoned
+    // rows, which is why no independent count is taken here). Every read
+    // either writes-ok or records an error, so `written < read` with an
+    // empty error set is structurally impossible today — assert it so any
+    // future regression that silently drops a write FAILS LOUDLY instead of
+    // minting a false success.
+    if !dry_run && report.errors.is_empty() && report.memories_written != report.memories_read {
+        report.errors.push(format!(
+            "incomplete migrate: read {} memories but wrote {} with no \
+             recorded error — refusing to report success",
+            report.memories_read, report.memories_written
+        ));
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -248,6 +280,13 @@ pub async fn migrate(
     //
     // Dry-run mode skips every write but still tallies `links_read`
     // so operators can size the migration before committing.
+    // #1876 — unlike `list`, `list_links` is NOT subject to the
+    // `LIST_MAX_LIMIT` clamp on EITHER adapter: both `SqliteStore::list_links`
+    // and `PostgresStore::list_links` issue a single unbounded
+    // `SELECT ... ORDER BY (source_id, target_id, relation)` with no `LIMIT`,
+    // so this call returns the full edge set in one pass. There is no second
+    // silent-truncation path here to paginate; the deterministic key ordering
+    // is documented on both impls as resume-safe should that ever change.
     let link_filter = namespace_filter.as_deref();
     let links = match from.list_links(link_filter).await {
         Ok(rows) => rows,
@@ -414,9 +453,10 @@ mod tests {
         let report = migrate(&src, &dst, 2, None, false).await;
         assert_eq!(report.memories_read, 5);
         assert_eq!(report.memories_written, 5);
-        // v0.6.0 migrate is single-call (blocker #298 fix); batch_size
-        // parameter retained for API compat but doesn't force pagination.
-        assert_eq!(report.batches, 1);
+        // #1876 — migrate genuinely PAGES again: 5 rows at page_size 2 =
+        // pages of 2, 2, 1 (the last short page terminates the walk).
+        assert_eq!(report.batches, 3);
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
         // Verify destination has them all.
         for i in 0..5 {
             let got = dst.get(&ctx, &format!("m{i}")).await.expect("get dst");
@@ -481,6 +521,71 @@ mod tests {
         assert!(dst.get(&ctx, "ns-m1").await.is_ok());
         assert!(dst.get(&ctx, "ns-m2").await.is_ok());
         assert!(dst.get(&ctx, "ns-m3").await.is_err());
+    }
+
+    /// Count every row in `ns` via the SAME stable-ordered OFFSET paging the
+    /// migrator uses — the only way to tally a corpus larger than
+    /// `LIST_MAX_LIMIT` (a single `list` clamps to <=1000).
+    async fn count_ns(store: &dyn MemoryStore, ctx: &CallerContext, ns: &str) -> usize {
+        let mut offset = 0usize;
+        let mut total = 0usize;
+        loop {
+            let f = Filter {
+                namespace: Some(ns.to_string()),
+                limit: crate::storage::LIST_MAX_LIMIT,
+                offset,
+                ..Filter::default()
+            };
+            let page = store.list(ctx, &f).await.expect("list page");
+            let n = page.len();
+            total += n;
+            if n < crate::storage::LIST_MAX_LIMIT {
+                break;
+            }
+            offset += n;
+        }
+        total
+    }
+
+    /// #1876 regression — a corpus LARGER than `LIST_MAX_LIMIT` (1000) must
+    /// migrate COMPLETELY. Before the fix `migrate` did a single clamped
+    /// `list` call (offset hardcoded to 0), so it read exactly the first
+    /// 1000 rows and reported `errors: 0` — silent data loss on every
+    /// corpus past 1000 memories. This pins the OFFSET paginator: all 2500
+    /// rows land, across multiple batches, with zero errors.
+    #[tokio::test]
+    async fn migrate_paginates_past_list_max_limit() {
+        const N: usize = 2500;
+        assert!(
+            N > crate::storage::LIST_MAX_LIMIT,
+            "test must exceed the per-page clamp to be meaningful"
+        );
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_admin(crate::identity::sentinels::AI_MIGRATE);
+
+        for i in 0..N {
+            let mem = sample_memory(
+                &format!("mem-{i:05}"),
+                "pagination-test",
+                &format!("row {i}"),
+            );
+            src.store(&ctx, &mem).await.unwrap();
+        }
+
+        let report = migrate(&src, &dst, 1000, Some("pagination-test".to_string()), false).await;
+
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+        assert_eq!(report.memories_read, N, "must READ every source row");
+        assert_eq!(report.memories_written, N, "must WRITE every source row");
+        // 2500 rows at page_size 1000 = pages of 1000, 1000, 500.
+        assert_eq!(report.batches, 3, "must page, not single-call truncate");
+
+        // Independent completeness proof: the destination holds all N rows.
+        let dst_count = count_ns(&dst, &ctx, "pagination-test").await;
+        assert_eq!(dst_count, N, "destination must hold every migrated row");
     }
 
     // ----------------------------------------------------------------

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -79,6 +79,12 @@ pub struct MigrationReport {
     /// `INSERT OR IGNORE` on SQLite).
     #[serde(default)]
     pub links_skipped: usize,
+    /// #3060 F4 — count of stored embedding VECTORS copied verbatim from
+    /// the source to the destination (their `embedding_space` fingerprint
+    /// preserved unchanged; NEVER re-embedded). On success this equals the
+    /// number of source memories that carried a stored embedding.
+    #[serde(default)]
+    pub embeddings_copied: usize,
     pub batches: usize,
     pub errors: Vec<String>,
     pub dry_run: bool,
@@ -182,6 +188,9 @@ pub async fn migrate(
     let page_size = batch_size.clamp(1, crate::storage::LIST_MAX_LIMIT);
 
     let mut seen: HashSet<String> = HashSet::new();
+    // #3060 F4 — ids that actually landed on the destination (or, under
+    // `dry_run`, every unique source id). Phase 3 copies their embeddings.
+    let mut migrated_ids: Vec<String> = Vec::new();
     let mut offset: usize = 0;
     loop {
         let filter = Filter {
@@ -218,9 +227,18 @@ pub async fn migrate(
                 return report;
             }
             report.memories_read += 1;
-            if !dry_run {
+            if dry_run {
+                // Tally the id so Phase 3 can size the embedding copy.
+                migrated_ids.push(mem.id.clone());
+            } else {
                 match to.store(&ctx, mem).await {
-                    Ok(_) => report.memories_written += 1,
+                    Ok(_) => {
+                        report.memories_written += 1;
+                        // Only a row that actually landed can receive its
+                        // embedding in Phase 3 (a failed write leaves no
+                        // destination row to stamp).
+                        migrated_ids.push(mem.id.clone());
+                    }
                     Err(e) => report.errors.push(format!("write {} failed: {e}", mem.id)),
                 }
             }
@@ -249,6 +267,96 @@ pub async fn migrate(
              recorded error — refusing to report success",
             report.memories_read, report.memories_written
         ));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Phase 3 — embedding VECTORS (#3060 F4).
+    //
+    // `store()` copies the DURABLE memory TEXT, but a memory's embedding
+    // is a SEPARATE column (sqlite side-table / postgres pgvector) NOT
+    // carried on the `Memory` struct, so Phases 1-2 land a corpus with
+    // ZERO embeddings. That is not merely a perf regression: under a
+    // certified `AI_MEMORY_INFERENCE_EGRESS=loopback-only`/`deny` posture
+    // the destination's external embedder cannot re-derive them, and
+    // re-embedding under a DIFFERENT model would change the #2167
+    // `embedding_space` fingerprint (recall would then refuse to score the
+    // re-derived vectors against the originals). So the ORIGINAL vectors —
+    // and their space stamp — MUST be copied VERBATIM. We NEVER re-embed
+    // and NEVER synthesize a space.
+    //
+    // Read each migrated id's stored `(vector, space)` via
+    // `get_embedding_with_space` (a source row with no stored embedding —
+    // keyword-tier / never-embedded — returns `None` and is skipped:
+    // nothing to copy). Bucket by the VERBATIM space fingerprint because
+    // `set_embeddings_batch` stamps ONE space per call (#2167
+    // M-PARAMETER-CONSISTENCY: every vector in a batch shares one space),
+    // then write each bucket to the destination in pages of `page_size`.
+    // A legacy row whose space is SQL NULL (unverified provenance) buckets
+    // under the empty string — the trait's `&str` space param cannot
+    // express NULL, so its vector is still copied while its NULL→"" space
+    // is the closest the SAL surface allows (does not arise on a
+    // space-stamped corpus; skipping the row would be a silent embedding
+    // LOSS, which the North Star ranks worse).
+    let mut source_embedded: usize = 0;
+    let mut by_space: std::collections::BTreeMap<String, Vec<(String, Vec<f32>)>> =
+        std::collections::BTreeMap::new();
+    // A source store that does not expose stored embeddings at all (an
+    // in-memory / test adapter whose `get_embedding_with_space` returns the
+    // trait-default `UnsupportedCapability`) has nothing to copy — skip the
+    // whole phase gracefully rather than failing an otherwise-clean migrate.
+    let mut embeddings_unsupported = false;
+    for id in &migrated_ids {
+        match from.get_embedding_with_space(&ctx, id).await {
+            Ok(Some((vector, space))) => {
+                source_embedded += 1;
+                by_space
+                    .entry(space.unwrap_or_default())
+                    .or_default()
+                    .push((id.clone(), vector));
+            }
+            Ok(None) => {} // no stored source embedding — nothing to copy
+            Err(crate::store::StoreError::UnsupportedCapability { .. }) => {
+                embeddings_unsupported = true;
+                break;
+            }
+            Err(e) => {
+                report
+                    .errors
+                    .push(format!("read source embedding for {id} failed: {e}"));
+                return report;
+            }
+        }
+    }
+    // When embeddings are unsupported we fall through to the links phase
+    // with nothing copied (byte-identical to pre-#3060 on such a store).
+    if !embeddings_unsupported {
+        if dry_run {
+            // Size the copy without writing (mirrors the memories/links
+            // dry-run tally): every embedded source row WOULD be copied.
+            report.embeddings_copied = source_embedded;
+        } else {
+            for (space, entries) in &by_space {
+                for chunk in entries.chunks(page_size) {
+                    match to.set_embeddings_batch(&ctx, chunk, space).await {
+                        Ok(written) => report.embeddings_copied += written,
+                        Err(e) => report
+                            .errors
+                            .push(format!("write embedding batch (space={space}) failed: {e}")),
+                    }
+                }
+            }
+            // Completeness safety — an embedded source row that was not
+            // copied is silent semantic-recall data loss on the destination,
+            // so refuse to report success on a short copy (the memories-phase
+            // posture).
+            if report.errors.is_empty() && report.embeddings_copied != source_embedded {
+                report.errors.push(format!(
+                    "incomplete embedding copy: source has {source_embedded} embedded \
+                     memories but only {} vectors were copied — refusing to report success",
+                    report.embeddings_copied
+                ));
+            }
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -586,6 +694,90 @@ mod tests {
         // Independent completeness proof: the destination holds all N rows.
         let dst_count = count_ns(&dst, &ctx, "pagination-test").await;
         assert_eq!(dst_count, N, "destination must hold every migrated row");
+    }
+
+    /// #3060 F4 regression — migrate must COPY stored embedding vectors
+    /// verbatim (Phase 3), preserving the #2167 `embedding_space` stamp and
+    /// NEVER re-embedding. Before the fix `migrate` copied only the memory
+    /// TEXT, so the destination landed with zero embeddings — unrecoverable
+    /// under a loopback-only/deny inference-egress posture. Seeds a source
+    /// where a subset of rows carry embeddings (across >1 copy page), then
+    /// asserts the destination embedded-count equals the source's AND a
+    /// sampled row's vector bytes + space match exactly.
+    #[tokio::test]
+    async fn migrate_copies_embeddings_and_preserves_space() {
+        let src_tmp = tempfile::NamedTempFile::new().unwrap();
+        let dst_tmp = tempfile::NamedTempFile::new().unwrap();
+        let src = SqliteStore::open(src_tmp.path()).unwrap();
+        let dst = SqliteStore::open(dst_tmp.path()).unwrap();
+        let ctx = CallerContext::for_admin(crate::identity::sentinels::AI_MIGRATE);
+
+        const SPACE: &str = "test-model#raw";
+        // 5 memories; embed 4 of them (leave "emb-2" un-embedded so the
+        // None-skip path is exercised) with distinct vectors so the sample
+        // assertion is meaningful.
+        for i in 0..5 {
+            let mem = sample_memory(&format!("emb-{i}"), "emb-test", &format!("emb row {i}"));
+            src.store(&ctx, &mem).await.unwrap();
+            if i != 2 {
+                #[allow(clippy::cast_precision_loss)]
+                let vec = vec![i as f32 * 0.5, 1.0 - i as f32 * 0.1, 0.25];
+                src.update_embedding(&ctx, &format!("emb-{i}"), Some(&vec), SPACE)
+                    .await
+                    .unwrap();
+            }
+        }
+        // Sanity: the source really carries 4 embeddings under SPACE.
+        let src_sample = src
+            .get_embedding_with_space(&ctx, "emb-3")
+            .await
+            .unwrap()
+            .expect("source emb-3 embedded");
+        assert_eq!(src_sample.1.as_deref(), Some(SPACE));
+
+        // page_size 2 forces the embedding copy across multiple batches.
+        let report = migrate(&src, &dst, 2, Some("emb-test".to_string()), false).await;
+
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+        assert_eq!(report.memories_written, 5, "all 5 memories migrate");
+        assert_eq!(report.embeddings_copied, 4, "all 4 embeddings copied");
+
+        // Destination embedded-count matches the source's (4).
+        let mut dst_embedded = 0usize;
+        for i in 0..5 {
+            let got = dst
+                .get_embedding_with_space(&ctx, &format!("emb-{i}"))
+                .await
+                .unwrap();
+            if got.is_some() {
+                dst_embedded += 1;
+            }
+        }
+        assert_eq!(
+            dst_embedded, 4,
+            "destination embedded-count must match source"
+        );
+
+        // Sampled id: dest vector bytes + space equal the source verbatim.
+        let dst_sample = dst
+            .get_embedding_with_space(&ctx, "emb-3")
+            .await
+            .unwrap()
+            .expect("dest emb-3 embedded");
+        assert_eq!(dst_sample.0, src_sample.0, "vector must be copied verbatim");
+        assert_eq!(
+            dst_sample.1.as_deref(),
+            Some(SPACE),
+            "embedding_space must be preserved verbatim (never re-derived)"
+        );
+        // The un-embedded source row stays un-embedded on the destination.
+        assert!(
+            dst.get_embedding_with_space(&ctx, "emb-2")
+                .await
+                .unwrap()
+                .is_none(),
+            "un-embedded source row must not gain a synthesized embedding"
+        );
     }
 
     // ----------------------------------------------------------------

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -750,6 +750,17 @@ pub struct Filter {
     /// valid-time filter.
     pub valid_at: Option<String>,
     pub limit: usize,
+    /// v1.0.0 #1876 — OFFSET for paged listing over a STABLE-ordered source.
+    /// Both adapters order by `priority DESC, updated_at DESC, id ASC` (a
+    /// UNIQUE `id` final tiebreak — `build_list_query` on sqlite, the
+    /// `COLLATE "C"` clause on postgres), so a static source paged by
+    /// incrementing `offset` by the prior page length walks the full result
+    /// set with NO skips or duplicates. Threaded into each backend's
+    /// `LIMIT ... OFFSET` bind. Defaults to `0` (`#[derive(Default)]`), so
+    /// every existing `..Filter::default()` / `..Default::default()` call
+    /// site is byte-identical. Set by the migrate paginator
+    /// (`crate::migrate`); the recall path leaves it at 0.
+    pub offset: usize,
     /// v1.0.0 #2167 §3 — the live embedder's space fingerprint for a
     /// semantic `recall_hybrid`. `Some(fp)` gates every stored vector
     /// against `fp` so recall never scores a vector from a different

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -18137,11 +18137,21 @@ impl MemoryStore for PostgresStore {
         // so `{"family": 123}` / `null` / `["core"]` / a NESTED
         // `{"a":{"family":"core"}}` all correctly fail to match, identically
         // to `metadata.get(k).and_then(Value::as_str) == Some(v)`.
+        // #1876 — `$9` is the always-present OFFSET bind (below), so the
+        // conditional metadata-equality axis shifts to `$10`/`$11`.
         let metadata_eq_predicate = if filter.metadata_eq.is_some() {
-            "AND metadata @> jsonb_build_object($9::text, $10::text)"
+            "AND metadata @> jsonb_build_object($10::text, $11::text)"
         } else {
             ""
         };
+        // #1876 — thread the `Filter` OFFSET so the postgres adapter pages
+        // identically to sqlite (SAL parity — both clamp LIMIT to
+        // LIST_MAX_LIMIT and page PAST the first window via OFFSET). The
+        // `ORDER BY ... id COLLATE "C" ASC` tiebreak (#2602) makes offset
+        // paging skip/dup-free over a static source. Always bound as `$9`
+        // (never conditional) so the placeholder number is stable regardless
+        // of the metadata-equality axis.
+        let offset: i64 = i64::try_from(filter.offset).unwrap_or(i64::MAX);
         // v1.0.0 #2602 — `id ASC` is the FINAL total-order tiebreak, IDENTICAL
         // to the sqlite twin (`storage::build_list_query`) + the
         // `memory_load_family` loader: `(priority, updated_at)` ties are common,
@@ -18178,7 +18188,7 @@ impl MemoryStore for PostgresStore {
                {metadata_eq_predicate}
                {lifecycle_vis}
              ORDER BY priority DESC, updated_at DESC, id COLLATE \"C\" ASC
-             LIMIT $5",
+             LIMIT $5 OFFSET $9",
             // v1.0.0 R19/A3 (#1948) — fail-closed lifecycle allow-list. Also
             // covers the export egress: `export_memories` delegates to `list`.
             // v1.0.0 #2585 — explicit projection (see MEMORY_READ_COLUMNS).
@@ -18205,7 +18215,10 @@ impl MemoryStore for PostgresStore {
             // comparison is exactly instant comparison.
             .bind(crate::validate::canonical_valid_time_opt(
                 filter.valid_at.as_deref(),
-            ));
+            ))
+            // #1876 — OFFSET ($9), always bound so the placeholder number is
+            // fixed; the conditional metadata-equality binds follow as $10/$11.
+            .bind(offset);
         let rows = match metadata_eq_binds {
             Some((k, v)) => rows.bind(k).bind(v),
             None => rows,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -401,13 +401,19 @@ impl MemoryStore for SqliteStore {
             // #1877 — clamp to `LIST_MAX_LIMIT` for SAL parity with
             // `PostgresStore::list` (which clamps to the same cap). Without this
             // a caller with `limit > 1000` read a different window per backend.
-            // Paging past the first window rides #1876 (a `Filter` offset).
+            // A single page is <= LIST_MAX_LIMIT by design; #1876 (below) pages
+            // PAST the first window via `filter.offset`.
             if filter.limit == 0 {
                 100
             } else {
                 filter.limit.min(crate::storage::LIST_MAX_LIMIT)
             },
-            0,
+            // #1876 — thread the `Filter` OFFSET (was a hardcoded `0`, which
+            // structurally capped `list` at the first <=1000-row window and
+            // silently truncated every paged consumer — the migrate data-loss
+            // class). `build_list_query`'s stable `id ASC` tiebreak makes
+            // offset paging skip/dup-free over a static source.
+            filter.offset,
             None,
             since.as_deref(),
             until.as_deref(),

--- a/tests/claim_bitemporal_1834_pg.rs
+++ b/tests/claim_bitemporal_1834_pg.rs
@@ -88,6 +88,7 @@ fn filter(ns: &str, valid_at: Option<&str>) -> Filter {
         until: None,
         valid_at: valid_at.map(str::to_string),
         limit: 50,
+        offset: 0,
         active_embedding_space: None,
         // #2580 — metadata-equality pushdown axis unused on this path.
         metadata_eq: None,

--- a/tests/embedding_space_provenance_2167_pg.rs
+++ b/tests/embedding_space_provenance_2167_pg.rs
@@ -131,6 +131,7 @@ async fn pg_recall_never_scores_foreign_space_2167() {
         since: None,
         until: None,
         limit: 50,
+        offset: 0,
         active_embedding_space: Some(active.clone()),
         valid_at: None,
         // #2580 — metadata-equality pushdown axis unused on this path.

--- a/tests/perf_1579_postgres_backfill_tsv.rs
+++ b/tests/perf_1579_postgres_backfill_tsv.rs
@@ -419,6 +419,7 @@ async fn b2_search_still_returns_matches_through_sal() {
         until: None,
         valid_at: None,
         limit: 10,
+        offset: 0,
         active_embedding_space: None,
         // #2580 — metadata-equality pushdown axis unused on this path.
         metadata_eq: None,

--- a/tests/sqlite_list_limit_clamp_1877.rs
+++ b/tests/sqlite_list_limit_clamp_1877.rs
@@ -43,6 +43,7 @@ async fn sqlite_list_clamps_limit_to_list_max_limit_1877() {
         until: None,
         valid_at: None,
         limit: 5000, // > LIST_MAX_LIMIT
+        offset: 0,   // #1876 — clamp behavior is unchanged at offset 0
         active_embedding_space: None,
         // #2580 — metadata-equality pushdown axis unused on this path.
         metadata_eq: None,


### PR DESCRIPTION
## What / Why
Closes #3054. `ai-memory migrate` silently dropped every source row past `LIST_MAX_LIMIT` (1000) and reported success — both SAL adapters clamp `list` to 1000 and ignored offset, `Filter` had no `offset`, and `migrate` did a single `list` call whose `>=MAX_ROWS(1M)` guard never fired. GA data-loss (North Star: silent loss + reports success).

## Fix
- `Filter.offset` (Default 0); threaded in `SqliteStore::list` + `PostgresStore::list` (`OFFSET $9`, metadata-eq → `$10/$11`).
- `migrate` paginates over the stable `ORDER BY priority DESC, updated_at DESC, id ASC` (unique `id` tiebreak → skip/dup-free) with a completeness guard that errors loudly on a partial migrate.

## Verification
- Regression test `migrate_paginates_past_list_max_limit` (2500 rows, 3 batches, read==written==dest==2500).
- Live: 7,888-row sqlite→pg TLS migration = 8 batches, errors:0; dry-run pg→read validates the pg `OFFSET` bind (7,888 read, 8 batches, no skip/dup).
- Four gates green (fmt/clippy-pedantic/test/audit). Fable review + audit APPROVE.

## AI involvement
Implemented by an Opus 5 hard-coder subagent; reviewed + audited + merge-gated by Fable (Opus 4.8). Signed commits (AlphaOne, ssh).