### PR TITLE
docs(enterprise-federation): TLS-transport subsection + deploy knob-count fix

### DIFF
--- a/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
+++ b/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
@@ -351,6 +351,33 @@ the SSOT pins, per the STANDARD data-tier note below.)
 > reconciliation is tracked in
 > [#2913](https://github.com/alphaonedev/ai-memory-mcp/issues/2913).
 
+> **Data-tier transport — TLS 1.3 / mTLS, encrypted-in-transit
+> (localhost-verified).** The certified data tier above (whatever the
+> current PG/AGE/pgvector triple) is reached over a
+> **mutually-authenticated, encrypted** connection between the ai-memory
+> daemon and its PostgreSQL + AGE backing store — this is the
+> ai-memory↔store DATA-TIER link, DISTINCT from the federation
+> peer↔peer transport (§1 point 2, §6), and it carries no
+> end-to-end-content-encryption claim (that boundary stays open per §6).
+> Live-proven this session with real `psql` / OpenSSL output:
+>
+> - **The daemon connects `sslmode=verify-full`.** ai-memory attaches to
+>   the store via `--store-url postgres://…?sslmode=verify-full` and
+>   presents a client certificate (`CN=ai_memory`), so the session is
+>   mutually authenticated (mTLS-capable) and the server hostname is
+>   verified against the cert.
+> - **The server refuses cleartext.** `ssl=on` with a **hostssl-only**
+>   `pg_hba.conf`: a cleartext TCP connection is REFUSED (`no
+>   pg_hba.conf entry … no encryption`), never silently downgraded.
+>   `ssl_min_protocol_version=TLSv1.2` is the floor.
+> - **Encrypted sessions negotiate TLS 1.3.** The cipher observed is
+>   **`TLS_AES_256_GCM_SHA384`** (TLS 1.3). The server cert SAN covers
+>   `IP:127.0.0.1` + `DNS:localhost`.
+>
+> This is a data-tier transport-confidentiality property, not a capacity
+> or a federation-confidentiality property; read it alongside §6's
+> explicit NOT-COVERED boundaries.
+
 ---
 
 ## 4. §5.4(4)/(5) — negative tests + removal proof

--- a/docs/deploy/enterprise-federation.env
+++ b/docs/deploy/enterprise-federation.env
@@ -77,7 +77,7 @@ AI_MEMORY_REQUIRE_ENTERPRISE_FEDERATION_POSTURE=1
 AI_MEMORY_ENCRYPT_AT_REST=1
 
 # ── Federation-specific additions §5.3 names beyond the asi-hard set. ────
-# All five already default to the certified value (documented per-knob in
+# All six already default to the certified value (documented per-knob in
 # CLAUDE.md's env table) — uncommented here ONLY so the effective posture
 # is explicit in the boot banner (`security.posture.enterprise_federation`
 # target, `daemon_runtime::run`, gated on


### PR DESCRIPTION
## What / Why
Enterprise-federation documentation audit (2026-08-18) against the code SSOT (`src/enterprise_federation_posture.rs`, the 18-control posture) + the live pg-tier proof.

- `ENTERPRISE-FEDERATION-CERTIFICATION.md`: add a data-tier **TLS 1.3 / mTLS** transport subsection (`sslmode=verify-full`, hostssl-only cleartext refusal, `TLS_AES_256_GCM_SHA384`), scoped to the ai-memory↔store link.
- `deploy/enterprise-federation.env`: fix "five"→"six" default-strict knob-count comment.

Verified: the 18-control count, boot-gate env, `doctor --posture` verifier, asi-hard=17 knobs, and 500–1000-agent/≤50-peer scope all correct. Data-tier **version reconciliation (18.4 vs 18.6)** is tracked separately in #3056 (pending version-authority).

Gates green: `check-docs-vs-ssot.sh`, `check-doc-symbol-anchors.sh`, `check-ci-job-claims.sh`, `deploy_templates` 5/5.

## AI involvement
Audited by parallel general-purpose subagents; reconciled + merge-gated by Fable (Opus 4.8). Signed (AlphaOne, ssh).