### PR TITLE
docs: standardize data tier on PostgreSQL 18.6 (resolves #3056)

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -174,8 +174,8 @@ to certify a stack whose probed versions drift from the pins below).
 
 | Component | Canonical version | SSOT pin (`deploy/docker-1461/provision/lib.sh`) |
 |---|---|---|
-| PostgreSQL | **18.4** | `PG_APT_VERSION=18.4-1.pgdg13+1`, `EXPECTED_PG_VERSION=18.4` |
-| Apache AGE | **1.7.0** | `AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`, `EXPECTED_AGE_VERSION=1.7.0` |
+| PostgreSQL | **18.6** | `PG_APT_VERSION=18.6-1.pgdg13+2`, `EXPECTED_PG_VERSION=18.6` |
+| Apache AGE | **1.8.0** | `AGE_APT_VERSION=1.8.0~rc0-2.pgdg13+1` (overlaid via pgdg apt on base `AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`; `CREATE EXTENSION age` reports extversion 1.8.0), `EXPECTED_AGE_VERSION=1.8.0` |
 | pgvector (server extension) | **0.8.6** | `PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1` |
 | pgvector (Rust binding crate) | **0.4** | `Cargo.toml` → `pgvector = "0.4"` |
 | ai-memory postgres schema | **v89** | postgres ladder pinned in lockstep with SQLite `CURRENT_SCHEMA_VERSION = 89` (`src/storage/migrations.rs`). NOTE: the `deploy/docker-1461` / `deploy/do-1461` provisioning configs are reproducibility anchors **pinned to the v0.7.0 release** (`EXPECTED_VERSION=0.7.0`, `EXPECTED_SCHEMA=57`, golden SHA), so their `57` is correct *for that pinned release* — it is not a stale copy of the current tip (`CURRENT_SCHEMA_VERSION = 89`). A deployment-validation anchor at the current schema would be a separate config. |
@@ -192,7 +192,7 @@ install recipe and the Docker layering rationale (#1065).
 > lan-parity compose harness legitimately run **PG 16 + AGE 1.6.0 +
 > pgvector 0.8.2** as a second tested combination. Those references are
 > factual (not drift); the *recommended* Enterprise Federated install
-> targets the PG 18.4 / AGE 1.7.0 matrix above.
+> targets the PG 18.6 / AGE 1.8.0 matrix above.
 
 ## Enterprise & operational sections
 

--- a/docs/architectures-t3.html
+++ b/docs/architectures-t3.html
@@ -545,14 +545,14 @@ ai-memory --db /var/lib/ai-memory/store.db serve \
         <tr><th>Component</th><th>Canonical version</th><th>SSOT pin</th></tr>
       </thead>
       <tbody>
-        <tr><td>PostgreSQL</td><td><strong>18.4</strong></td><td><code>PG_APT_VERSION=18.4-1.pgdg13+1</code> · <code>EXPECTED_PG_VERSION=18.4</code></td></tr>
-        <tr><td>Apache AGE</td><td><strong>1.7.0</strong></td><td><code>AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0</code> · <code>EXPECTED_AGE_VERSION=1.7.0</code></td></tr>
-        <tr><td>pgvector (server extension)</td><td><strong>0.8.2</strong></td><td><code>PGVECTOR_APT_VERSION=0.8.2-1.pgdg13+1</code></td></tr>
+        <tr><td>PostgreSQL</td><td><strong>18.6</strong></td><td><code>PG_APT_VERSION=18.6-1.pgdg13+2</code> · <code>EXPECTED_PG_VERSION=18.6</code></td></tr>
+        <tr><td>Apache AGE</td><td><strong>1.8.0</strong></td><td><code>AGE_APT_VERSION=1.8.0~rc0-2.pgdg13+1</code> · <code>EXPECTED_AGE_VERSION=1.8.0</code> (extversion 1.8.0, overlaid via pinned pgdg apt on the <code>release_PG18_1.7.0</code> base image)</td></tr>
+        <tr><td>pgvector (server extension)</td><td><strong>0.8.6</strong></td><td><code>PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1</code></td></tr>
         <tr><td>pgvector (Rust binding crate)</td><td><strong>0.4</strong></td><td><code>Cargo.toml</code> → <code>pgvector = "0.4"</code></td></tr>
         <tr><td>ai-memory postgres schema</td><td><strong>v89</strong></td><td>schema parity with SQLite at v89 (<code>CURRENT_SCHEMA_VERSION = 89</code> in both adapters; the v58–v70 arms are the v0.8.0 coordination + visibility + encryption-prep + archive-edge additive DDL, v71 adds the signed <code>forget_tombstones</code> table per #1821 / G30, the v72–v78 arms are the v0.9.0 append-only revision spine, audit cause-binding, BLAKE3 content-id, lineage-DAG, identity-lineage succession, recall-purity fold state, and model-attestation additive DDL, and the v79–v89 arms are the v1.0.0 crypto-core / claim-bitemporal valid-time / lineage-custody + M-of-N key-recovery / per-agent-api-key / embedding-space provenance / archive-column-parity additive DDL)</td></tr>
       </tbody>
     </table>
-    <p>The bundled stacked image at <code>deploy/docker-1461/Dockerfile.pg-age-vector</code> (<code>ARG AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0</code>, <code>ARG PG_MAJOR=18</code>) layers pgvector 0.8.2 onto the AGE base so K8s / ECS / Cloud Run operators don't build AGE from source. <strong>Alternate tested matrix:</strong> <code>infra/lan-parity-test/</code> legitimately runs PG 16 + AGE 1.6.0 + pgvector 0.8.2 as a second tested combination; the <em>recommended</em> install targets the PG 18.4 / AGE 1.7.0 matrix above.</p>
+    <p>The bundled stacked image at <code>deploy/docker-1461/Dockerfile.pg-age-vector</code> (<code>ARG AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0</code>, <code>ARG PG_MAJOR=18</code>) overlays Apache AGE 1.8.0 and pgvector 0.8.6 via pinned pgdg apt onto the AGE base so K8s / ECS / Cloud Run operators don't build AGE from source. <strong>Alternate tested matrix:</strong> <code>infra/lan-parity-test/</code> legitimately runs PG 16 + AGE 1.6.0 + pgvector 0.8.2 as a second tested combination; the <em>recommended</em> install targets the PG 18.6 / AGE 1.8.0 matrix above.</p>
   </div>
 </section>
 

--- a/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
+++ b/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
@@ -267,7 +267,10 @@ and run `31601912912` (head `90c2a265`). The same certified-stack job
 is also SUCCESS on PR #2910 (the squash that produced `580d8427`).
 This answers the ruling's "executed, at certified versions, not
 CI-on-16-while-certifying-18" — the workflow refuses to certify a mismatched
-stack.
+stack. (Those specific dated runs executed the historical **18.4 / 1.7.0 /
+0.8.5** round; the CURRENT standard tier — **PG 18.6 / AGE 1.8.0 / pgvector
+0.8.6** — is the tier this same workflow asserts in-PR on `release/**` from
+the SSOT pins, per the STANDARD data-tier note below.)
 
 > **pgvector pin advance from 0.8.5 to 0.8.6 (2026-08-14, honest evidence
 > status).** The certified pgvector pin was advanced from `0.8.5-1.pgdg13+1`
@@ -281,25 +284,34 @@ stack.
 > `PGVECTOR_APT_VERSION` and hard-fails on drift, so a GREEN merge of that
 > change IS the `0.8.6` build+assert evidence (fail-closed — a `0.8.6`
 > resolution failure reds the job and blocks the merge). On-host
-> corroboration exists ahead of that run: the permanent container
-> `ai-memory-cert-pg` builds and serves **PostgreSQL 18.4 + Apache AGE 1.7.0
-> + pgvector 0.8.6** with `create_graph`, a pgvector cosine op, and a
-> `sslmode=verify-full` daemon `schema-init` all functional. Until the
-> in-PR `cert-postgres-age.yml` job is GREEN at `0.8.6`, treat the pgvector
-> row above as *pin-current, formal-CI-re-green-pending*.
+> corroboration exists ahead of that run: on 2026-08-14 the permanent
+> container `ai-memory-cert-pg` built and served **PostgreSQL 18.4 + Apache
+> AGE 1.7.0 + pgvector 0.8.6** with `create_graph`, a pgvector cosine op, and a
+> `sslmode=verify-full` daemon `schema-init` all functional. pgvector **0.8.6
+> is now the standard, CI-asserted pin** (`PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`,
+> read by the `Assert certified stack versions` step; see the STANDARD
+> data-tier note below); this dated note records the historical 0.8.5→0.8.6
+> pin advance.
 
-> **Data-tier refresh: PG 18.6 (current stable) + AGE 1.8.0 (newest released
-> AGE for PG18) + pgvector 0.8.6 (current stable) (2026-08-15, honest evidence
-> status).** The certified data tier was refreshed from the ratified **PG 18.4
-> / AGE 1.7.0 / pgvector 0.8.6** triple to **PG 18.6 / AGE 1.8.0 / pgvector
-> 0.8.6** (operator-directed; pgvector unchanged). PG 18.6 and pgvector 0.8.6
-> are current-stable without qualification. **Apache AGE 1.8.0 is the newest
-> RELEASED AGE for PostgreSQL 18** per
+> **STANDARD data tier: PG 18.6 (current stable) + AGE 1.8.0 (newest released
+> AGE for PG18) + pgvector 0.8.6 (current stable) — STANDARDIZED 2026-08-18
+> (operator directive).** **PostgreSQL 18.6 + Apache AGE 1.8.0 + pgvector
+> 0.8.6 is the CURRENT certified/standard enterprise-federation data tier.**
+> It is the SSOT pin in `deploy/docker-1461/provision/lib.sh`
+> (`EXPECTED_PG_VERSION=18.6`, `EXPECTED_AGE_VERSION=1.8.0`,
+> `PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`) and is ASSERTED IN-PR on
+> `release/**` by the `Assert certified stack versions` step of
+> `.github/workflows/cert-postgres-age.yml`, which reads those pins and
+> hard-fails on any drift from exactly those minors — so a GREEN merge to the
+> release branch IS the 18.6 / 1.8.0 / 0.8.6 build+assert evidence
+> (fail-closed: a mismatched resolution reds the job and blocks the merge).
+> PG 18.6 and pgvector 0.8.6 are current-stable without qualification.
+> **Apache AGE 1.8.0 is the newest RELEASED AGE for PostgreSQL 18** per
 > [github.com/apache/age/releases](https://github.com/apache/age/releases)
 > (`PG18/v1.8.0-rc0`, 2026-07-09) — NOTE: the project download page
 > (age.apache.org/download) still lists 1.7.0 as "current stable" and lags the
-> releases page; this cert tracks the newest released AGE for PG18. Both bumps
-> are pinned pgdg apt `.deb`s — `postgresql-18` → `18.6-1.pgdg13+2` and
+> releases page; this cert tracks the newest released AGE for PG18. Both PG and
+> AGE are pinned pgdg apt `.deb`s — `postgresql-18` → `18.6-1.pgdg13+2` and
 > `postgresql-18-age` → `1.8.0~rc0-2.pgdg13+1`. **AGE 1.8.0 is installed VIA
 > pgdg APT, not source-built**: the apache/age Docker Hub image is only at
 > `release_PG18_1.7.0`, but the canonical PostgreSQL apt repo already publishes
@@ -307,25 +319,26 @@ stack.
 > the same `postgresql-18-age` pin the do-1461 NATIVE lane uses. Apache AGE
 > tags every release `X.Y.Z-rc0` on GitHub (its release-vote convention),
 > which is why the pgdg package version reads `1.8.0~rc0-…`; `CREATE EXTENSION
-> age` reports `extversion = 1.8.0`. **The GREEN `cert-postgres-age.yml` runs cited above certified the
-> PRIOR PG 18.4 / AGE 1.7.0 stack; they do NOT prove PG 18.6 / AGE 1.8.0.**
-> The formal in-PR re-green is produced by the `cert-postgres-age.yml` run of
-> the change carrying this refresh (its `Assert certified stack versions` step
-> reads the advanced `EXPECTED_PG_VERSION` / `EXPECTED_AGE_VERSION` from
-> `deploy/docker-1461/provision/lib.sh` and hard-fails on drift, so a GREEN
-> merge IS the 18.6 / 1.8.0 build+assert evidence). On-host corroboration
-> exists ahead of that run: an `ai-memory-cert-pg` image rebuilt on this
-> refresh serves **PostgreSQL 18.6 + Apache AGE 1.8.0 + pgvector 0.8.6** with
-> `postgres --version` = 18.6, AGE `extversion` = 1.8.0, `create_graph`, a
-> pgvector cosine op, the Leg-3 verify-full TLS POS/NEG suite, and a
-> `sslmode=verify-full` daemon `schema-init` all functional; the AGE-1.8.0
-> compatibility gate (the `sal,sal-postgres` AGE / kg tests against the live
-> 18.6 / 1.8.0 container) passed. **A data-tier version refresh MAY warrant
-> cert re-validation** — the ratified determination (2026-08-12) was against
-> the 18.4 / 1.7.0 triple; until the in-PR `cert-postgres-age.yml` job is
-> GREEN at 18.6 / 1.8.0 AND the ratification is re-affirmed against the new
-> triple, treat the PG/AGE rows above as *as-built, formal-CI-re-green +
-> re-validation-pending*.
+> age` reports `extversion = 1.8.0`. **On-host corroboration:** an
+> `ai-memory-cert-pg` image rebuilt on this tier serves **PostgreSQL 18.6 +
+> Apache AGE 1.8.0 + pgvector 0.8.6** with `postgres --version` = 18.6, AGE
+> `extversion` = 1.8.0, `create_graph`, a pgvector cosine op, the Leg-3
+> verify-full TLS POS/NEG suite, and a `sslmode=verify-full` daemon
+> `schema-init` all functional; the AGE-1.8.0 compatibility gate (the
+> `sal,sal-postgres` AGE / kg tests against the live 18.6 / 1.8.0 container)
+> passed.
+>
+> **History (2026-08-12 ratification round — superseded prior minor).** The
+> 5-agent adversarial ratification determination of 2026-08-12 was conducted
+> against the then-current **PG 18.4 / AGE 1.7.0 / pgvector 0.8.6** minor;
+> 18.6 / 1.8.0 is the current-stable successor of the SAME tier (a minor-version
+> advance, not a substrate change). The GREEN `cert-postgres-age.yml` runs
+> cited above (`31601974424`, `31601912912`, PR #2910) executed that historical
+> **18.4 / 1.7.0 / 0.8.5** build — they are the dated record of that round, NOT
+> the current tier's assertion (which is the in-PR `release/**` run of the SSOT
+> pins above). A future federation-wire change still trips the §7 re-cert
+> trigger and requires re-running §5.4(2)–(5) at the new SHA regardless of the
+> data-tier minor.
 
 > **Stack-evidence note (two disjoint corpora).** The certified triple
 > above is **single-node CI evidence**. The only real multi-node mesh
@@ -520,15 +533,14 @@ is observed:**
 4. **`cert-postgres-age.yml` certifying a stack that is NOT the pins the
    `Assert certified stack versions` step reads from
    `deploy/docker-1461/provision/lib.sh`** (a drift that step should have
-   caught) voids it. As of the 2026-08-15 data-tier refresh those pins are
+   caught) voids it. The current standard pins are
    **PG 18.6 / AGE 1.8.0 / pgvector 0.8.6** (`EXPECTED_PG_VERSION=18.6`,
-   `EXPECTED_AGE_VERSION=1.8.0`, `PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`);
-   the ratified 2026-08-12 determination was against the prior
-   **PG 18.4 / AGE 1.7.0 / pgvector 0.8.6** triple, and the §3 refresh note
-   holds the PG/AGE rows as *formal-CI-re-green + re-validation-pending*
-   until the in-PR job is GREEN at 18.6 / 1.8.0 and the ratification is
-   re-affirmed. The disconfirmation trigger tracks the pins the step
-   actually asserts, whichever of those two triples is current.
+   `EXPECTED_AGE_VERSION=1.8.0`, `PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`),
+   standardized 2026-08-18 and asserted in-PR on `release/**` by that step;
+   the 2026-08-12 ratification round was against the prior, now-superseded
+   **PG 18.4 / AGE 1.7.0 / pgvector 0.8.6** minor (recorded as history in the
+   §3 STANDARD data-tier note). The disconfirmation trigger tracks the pins
+   the step actually asserts — currently 18.6 / 1.8.0 / 0.8.6.
    *Observable:* that step (the `Assert certified stack versions` step in
    `.github/workflows/cert-postgres-age.yml`) hard-fails the job on any
    mismatch against those pins.

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -48,13 +48,13 @@ works on postgres.
 
 | Component | Version | Notes |
 |---|---|---|
-| PostgreSQL | **18.4** (canonical) | The recommended Enterprise Federated substrate. SSOT: `deploy/docker-1461/provision/lib.sh` (`EXPECTED_PG_VERSION=18.4`). PG 16.x + AGE 1.6.0 remains a tested alternate matrix (`infra/lan-parity-test/`). |
-| Apache AGE | **1.7.0** (canonical) | Targets PG 18. Use the bundled `deploy/docker-1461/Dockerfile.pg-age-vector` (`apache/age:release_PG18_1.7.0`) or build from source (see below). |
+| PostgreSQL | **18.6** (canonical) | The recommended Enterprise Federated substrate. SSOT: `deploy/docker-1461/provision/lib.sh` (`EXPECTED_PG_VERSION=18.6`). PG 16.x + AGE 1.6.0 remains a tested alternate matrix (`infra/lan-parity-test/`). |
+| Apache AGE | **1.8.0** (canonical extversion) | Targets PG 18. Installed via the pinned pgdg apt package (`postgresql-18-age=1.8.0~rc0-2.pgdg13+1`, SSOT `EXPECTED_AGE_VERSION=1.8.0`) overlaid on the `apache/age:release_PG18_1.7.0` base — `CREATE EXTENSION age` reports extversion 1.8.0. Use the bundled `deploy/docker-1461/Dockerfile.pg-age-vector` or the pgdg apt package (see below). |
 | pgvector | **0.8.6** (canonical) | Faster HNSW; 0.8.3 fixed HNSW-vacuuming index corruption. SSOT: `PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`. **Required**: the `sal-postgres` Cargo feature pulls `dep:pgvector` (Rust binding crate `pgvector = "0.4"`) which maps Rust vectors to the Postgres `vector` column type. |
 | ai-memory | v0.9.0 with `--features sal-postgres` | The `sal-postgres` feature is **off by default** to keep the no-postgres build hermetic. |
 
 > **CI evidence (#2548 / #2512).** The **one true certified triple** —
-> PostgreSQL **18.4** + Apache AGE **1.7.0** + pgvector **0.8.6** — is
+> PostgreSQL **18.6** + Apache AGE **1.8.0** + pgvector **0.8.6** — is
 > exercised **in-PR on `release/**`** by
 > `.github/workflows/cert-postgres-age.yml`, which BUILDS the bundled
 > [`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector)
@@ -62,10 +62,11 @@ works on postgres.
 > declaration source — no literal is re-typed in the workflow), runs the
 > `#[ignore]`-gated postgres cells AND the AGE-backed cells against that built
 > image, and **hard-fails on ANY drift from the exact pinned minors** —
-> PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.6, not merely "PG 18" or
-> "AGE 1.7.x" — so the certified tier is proven by execution, never merely
+> PostgreSQL 18.6, Apache AGE 1.8.0, pgvector 0.8.6, not merely "PG 18" or
+> "AGE 1.8.x" — so the certified tier is proven by execution, never merely
 > claimed (2026-08-01 cutline ruling §5.4(3): "you cannot certify a tier CI
-> does not run"). The `infra/lan-parity-test/` alternate matrix (PG 16 + AGE
+> does not run"; standardized to PG 18.6 / AGE 1.8.0 by operator directive
+> 2026-08-18). The `infra/lan-parity-test/` alternate matrix (PG 16 + AGE
 > 1.6.0) is what the `coverage.yml` line-coverage measurement runs; that is a
 > coverage measurement, not cert evidence.
 
@@ -78,7 +79,8 @@ maps Rust vectors to Postgres `vector` columns), the repo ships a
 ready-made stacked image at
 [`deploy/docker-1461/Dockerfile.pg-age-vector`](../deploy/docker-1461/Dockerfile.pg-age-vector)
 (#1065). It layers pgvector `0.8.6` (precompiled .deb from the pgdg apt
-repo) onto the `apache/age:release_PG18_1.7.0` base — no source build
+repo) onto the `apache/age:release_PG18_1.7.0` base AND upgrades AGE to
+`1.8.0` via the pinned pgdg `postgresql-18-age` package — no source build
 needed. Use this image for any deployment that backs ai-memory onto
 Postgres+AGE. (The `infra/lan-parity-test/` image — PG 16 + AGE 1.6.0 +
 pgvector 0.8.2 — remains as a tested alternate matrix.)
@@ -89,7 +91,7 @@ pgvector 0.8.2 — remains as a tested alternate matrix.)
 > if you write your own SQL probes, prefer the SQL-function form. (A
 > historical AGE 1.5.0 + PG 16 quirk could emit "could not find
 > parameter $N" for some bind shapes against the raw `prepare`-path;
-> the SQL-function form sidesteps it entirely and AGE 1.7.0 on PG 18 is
+> the SQL-function form sidesteps it entirely and AGE 1.8.0 on PG 18 is
 > unaffected. Wave 1 Stream C fixed our equivalence test harness to use
 > the safe form; production code never needed the fix.)
 
@@ -114,11 +116,12 @@ cd pgvector
 sudo make USE_PGXS=1 PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config install
 cd ..
 
-# 3. Apache AGE 1.7.0 from source against PG 18.
-git clone --depth 1 --branch PG18/v1.7.0 https://github.com/apache/age.git
-cd age
-sudo make PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config install
-cd ..
+# 3. Apache AGE 1.8.0 from the PGDG apt repo (the certified install path —
+#    1.8.0 is the newest RELEASED AGE for PG18 and is published as a pinned
+#    pgdg .deb; `CREATE EXTENSION age` reports extversion 1.8.0). The pgdg
+#    package is the same mechanism the do-1461 native lane + bundled
+#    Dockerfile use; there is no stable 1.8.0 source tag (only v1.8.0-rc0).
+sudo apt install -y postgresql-18-age=1.8.0~rc0-2.pgdg13+1
 
 # 4. Restart postgres to pick up the shared libraries.
 sudo systemctl restart postgresql@18-main
@@ -163,7 +166,7 @@ services:
 ```
 
 Plan C operators running on K8s / ECS / Cloud Run build this image
-once, tag it (`pg-age-vector:PG18.4-1.7.0-pgvector0.8.6`), and reference
+once, tag it (`pg-age-vector:PG18.6-1.8.0-pgvector0.8.6`), and reference
 the tag from their workload manifests instead of the bare upstream
 image.
 
@@ -742,7 +745,7 @@ recommendation; the v0.7.0 release does not yet expose these as
 The four KG operations dispatch on the `KgBackend` tag the postgres
 adapter probes at connect time:
 
-| Op | AGE 1.7.0 (Cypher) | CTE fallback | Speedup at depth=5 |
+| Op | AGE 1.8.0 (Cypher) | CTE fallback | Speedup at depth=5 |
 |---|---|---|---|
 | `kg_query` | `MATCH (a)-[*1..d]->(b) WHERE a.id = $1` | recursive `WITH` join | ≥30% (S76 gate) |
 | `kg_timeline` | `MATCH ... WHERE valid_from < $1 AND (valid_until IS NULL OR valid_until > $1)` | recursive temporal join | ≥30% |
@@ -821,7 +824,7 @@ migration guide.)
 ### "could not find parameter $N" against a Cypher query
 
 This is the historical AGE 1.5.0 + PG 16 binding quirk mentioned above
-(AGE 1.7.0 on PG 18 is unaffected). ai-memory's production code never
+(AGE 1.8.0 on PG 18 is unaffected). ai-memory's production code never
 hits it — if you see it, you're running a custom psql probe. Use the
 AGE-recommended SQL-function shape:
 
@@ -878,7 +881,7 @@ parity test is the gate that prevents it.
 
 ## References
 
-- Apache AGE 1.7.0 docs: https://age.apache.org/
+- Apache AGE 1.8.0 docs: https://age.apache.org/
 - pgvector 0.8.6 docs: https://github.com/pgvector/pgvector
 - ai-memory v0.7.0 release notes: [`v0.7.0/release-notes.md`](v0.7.0/release-notes.html)
 - A2A campaign Pages: https://alphaonedev.github.io/ai-memory-a2a-v0.7.0/

--- a/docs/reproducible-baselines.html
+++ b/docs/reproducible-baselines.html
@@ -155,7 +155,7 @@ make down                              <span class="cm"># tear it all down</span
         </tr>
         <tr>
           <td class="col-name">Substrate stack</td>
-          <td>Pinned pgdg <code>.deb</code>s (PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.2) + pinned Ollama release — named constants in <code>provision/lib.sh</code></td>
+          <td>Pinned pgdg <code>.deb</code>s (PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.2) + pinned Ollama release — the pgdg pins as set for this v0.9.0 round (current <code>release/v1.0.0</code> <code>provision/lib.sh</code> pins PostgreSQL 18.6 / Apache AGE 1.8.0 / pgvector 0.8.6)</td>
           <td><code>store.pg_version</code> / <code>store.age_version</code> / <code>store.pgvector_version</code> / <code>store.age_graph</code> verify rows per pg node</td>
         </tr>
         <tr>

--- a/docs/v1.0.0/release-notes.md
+++ b/docs/v1.0.0/release-notes.md
@@ -72,12 +72,12 @@ AGE + pgvector storage backend.
 > `tests/pg_supported_route_inventory_gate_2799.rs`), and **MCP-stdio is
 > structurally SQLite-only** ([#1675](https://github.com/alphaonedev/ai-memory-mcp/issues/1675)):
 > a Postgres-backed deployment serves MCP clients through the HTTP daemon,
-> not `ai-memory mcp`. The certified **PG 18.4 / AGE 1.7.0 / pgvector
-> 0.8.5** stack is now exercised in-PR on every `release/**` PR by
+> not `ai-memory mcp`. The certified **PG 18.6 / AGE 1.8.0 / pgvector
+> 0.8.6** stack is now exercised in-PR on every `release/**` PR by
 > `.github/workflows/cert-postgres-age.yml`, which runs the pg-parity and
 > AGE cells `--include-ignored` against the certified image CI builds from
-> `deploy/docker-1461/Dockerfile.pg-age-vector` (SSOT-pinned PG 18.4 / AGE
-> 1.7.0 / pgvector 0.8.5) and hard-fails on any drift from the exact pinned
+> `deploy/docker-1461/Dockerfile.pg-age-vector` (SSOT-pinned PG 18.6 / AGE
+> 1.8.0 / pgvector 0.8.6) and hard-fails on any drift from the exact pinned
 > minors;
 > the PG 16 / AGE 1.6.0 combination in `coverage.yml` is the documented
 > **alternate** matrix (a line-coverage measurement). See §"Certified
@@ -221,18 +221,21 @@ green under `--features sal,sal-postgres --include-ignored` against the
 pgvector layered in at service start via the `postgresql-16-pgvector` apt
 package. This PG 16 / AGE 1.6.0 combination is the documented **alternate**
 matrix — the stack `coverage.yml` measures line coverage against; the
-certified PG 18.4 / AGE 1.7.0 / pgvector 0.8.5 stack is exercised in-PR
+certified PG 18.6 / AGE 1.8.0 / pgvector 0.8.6 stack is exercised in-PR
 separately by `.github/workflows/cert-postgres-age.yml` (next paragraph).
 
-**CI-asserted in-PR on `release/**` (SSOT-pinned): PostgreSQL 18.4 + Apache
-AGE 1.7.0 + pgvector 0.8.5.** These are the pins
+**CI-asserted in-PR on `release/**` (SSOT-pinned): PostgreSQL 18.6 + Apache
+AGE 1.8.0 + pgvector 0.8.6.** These are the pins
 the deployment SSOT carries — `deploy/docker-1461/provision/lib.sh`
-(`EXPECTED_PG_VERSION=18.4`, `EXPECTED_AGE_VERSION=1.7.0`,
-`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
-`AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0`; the pgvector Rust binding
-is the `pgvector` crate `0.4`, `features = ["sqlx"]`) — and they are the
-current-stable upstream line (Apache AGE 1.8.0 exists only as `rc0` and is
-deliberately not shipped). As of
+(`EXPECTED_PG_VERSION=18.6`, `EXPECTED_AGE_VERSION=1.8.0`,
+`PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`,
+`AGE_BASE_IMAGE=apache/age:release_PG18_1.7.0` with AGE upgraded to 1.8.0
+via a pinned pgdg apt install; the pgvector Rust binding
+is the `pgvector` crate `0.4`, `features = ["sqlx"]`) — standardized to the
+current-stable line by operator directive 2026-08-18. **Apache AGE 1.8.0 is
+the newest RELEASED AGE for PG18** (tagged `PG18/v1.8.0-rc0` per Apache
+AGE's release-vote convention; `CREATE EXTENSION age` reports extversion
+1.8.0), installed via the pinned pgdg `postgresql-18-age` `.deb`. As of
 [#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548) /
 [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) the
 AGE/KG + recall-purity suites run against this exact stack in-PR:
@@ -241,19 +244,19 @@ AGE/KG + recall-purity suites run against this exact stack in-PR:
 docker-1461 mesh ships — with build-args resolved straight from this SSOT
 (`deploy/docker-1461/provision/lib.sh`), runs the resulting image as the
 postgres under test, runs the pg-parity and AGE cells `--include-ignored`,
-and version-asserts the EXACT pinned minors (PostgreSQL 18.4, Apache AGE
-1.7.0, pgvector 0.8.5 — not merely "PG 18" or "pgvector >= 0.8.5") — so the
+and version-asserts the EXACT pinned minors (PostgreSQL 18.6, Apache AGE
+1.8.0, pgvector 0.8.6 — not merely "PG 18" or "pgvector >= 0.8.6") — so the
 certified tier is proven by execution on the cert branch, not merely
 claimed, and CI's build artifact is the SAME artifact the deploy SSOT
 ships (zero drift by construction). The PG 16 / AGE 1.6.0 combination in
 `coverage.yml` remains as the documented alternate matrix.
 
 > **Cross-lane pgvector pin — reconciled ([#2872](https://github.com/alphaonedev/ai-memory-mcp/issues/2872)).**
-> Both certified provisioning SSOTs now pin pgvector **0.8.5**:
-> `deploy/docker-1461/provision/lib.sh` (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg13+1`,
+> Both certified provisioning SSOTs now pin pgvector **0.8.6**:
+> `deploy/docker-1461/provision/lib.sh` (`PGVECTOR_APT_VERSION=0.8.6-1.pgdg13+1`,
 > the container lane on Debian 13) and `deploy/do-1461/provision/lib.sh`
-> (`PGVECTOR_APT_VERSION=0.8.5-1.pgdg24.04+1`,
-> `EXPECTED_PGVECTOR_VERSION=0.8.5`, the NATIVE lane on Ubuntu 24.04). Only
+> (`PGVECTOR_APT_VERSION=0.8.6-1.pgdg24.04+1`,
+> `EXPECTED_PGVECTOR_VERSION=0.8.6`, the NATIVE lane on Ubuntu 24.04). Only
 > the pgdg distro suffix differs by lane (`pgdg13` vs `pgdg24.04`); the
 > patch version is identical and both distro builds exist in the live pgdg
 > apt repo. The earlier `do-1461` pin of `0.8.2` was accidental drift and
@@ -264,7 +267,7 @@ ships (zero drift by construction). The PG 16 / AGE 1.6.0 combination in
 > AGE drift (CI 1.6.0 vs SSOT 1.7.0) is **resolved** by
 > [#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) /
 > [#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548): the
-> certified AGE 1.7.0 / PG 18 canonical stack is now exercised in-PR by
+> certified AGE 1.8.0 / PG 18 canonical stack is now exercised in-PR by
 > `.github/workflows/cert-postgres-age.yml`, while `coverage.yml`'s
 > PG 16 / AGE 1.6.0 run is the documented alternate matrix.
 
@@ -303,9 +306,9 @@ per-call fallback WARN that removal left silent). `find_paths` results
 were and remain correct (the CTE reads the durable `memory_links`);
 `kg_query` / `kg_timeline` / `lineage` still use AGE Cypher.
 
-### CI posture for the SSOT-pinned (18.4) stack — exercised in-PR on `release/**`
+### CI posture for the SSOT-pinned (18.6) stack — exercised in-PR on `release/**`
 
-**The certified PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack is now
+**The certified PG 18.6 + AGE 1.8.0 + pgvector 0.8.6 stack is now
 exercised in-PR.** `.github/workflows/cert-postgres-age.yml`
 ([#2548](https://github.com/alphaonedev/ai-memory-mcp/issues/2548))
 triggers on `pull_request` + `push` to `release/**`, resolves every
@@ -318,8 +321,8 @@ under test, runs the `#[ignore]`-gated pg-parity binaries AND the
 AGE-backed cells (`AI_MEMORY_TEST_AGE_URL` set, so they stop
 self-skipping) under `--features sal-postgres --include-ignored`, and a
 version-assert step hard-fails on ANY drift from the exact pinned minors
-— PostgreSQL 18.4, Apache AGE 1.7.0, pgvector 0.8.5, not a looser "PG 18"
-/ "pgvector >= 0.8.5" match. This is what makes the 2026-08-01 cutline
+— PostgreSQL 18.6, Apache AGE 1.8.0, pgvector 0.8.6, not a looser "PG 18"
+/ "pgvector >= 0.8.6" match. This is what makes the 2026-08-01 cutline
 ruling §5.4(3) executable — the certified tier is proven by execution on
 the cert branch, at the exact certified minors the docs cite.
 
@@ -336,7 +339,7 @@ against an `apache/age:release_PG16_1.6.0` service container — **PG 16 +
 AGE 1.6.0**, retained as the documented alternate matrix (a line-coverage
 measurement, not the certified tier). The former CI-vs-SSOT AGE drift
 ([#2512](https://github.com/alphaonedev/ai-memory-mcp/issues/2512) defect
-2) is **resolved**: CI now exercises the certified AGE 1.7.0 canonical
+2) is **resolved**: CI now exercises the certified AGE 1.8.0 canonical
 tier via `cert-postgres-age.yml` and honestly labels the PG 16 alternate.
 
 ## Additive surfaces
@@ -497,13 +500,14 @@ supersedes ROADMAP §11.6's "public security audit by named third-party
 firm" line for this epic). ROADMAP §27 sequences it as a five-step
 program:
 
-1. **DigitalOcean full-spectrum testing + attestation.** The SSOT-pinned
+1. **DigitalOcean full-spectrum testing + attestation.** The then-SSOT-pinned
    PG 18.4 + AGE 1.7.0 + pgvector 0.8.5 stack was exercised full-spectrum
    on DigitalOcean (the off-CI validation host — at the time this campaign
    ran, DO was the only place that exact triple had been exercised end to
-   end; CI has since begun exercising the same certified triple in-PR on
-   `release/**`, runs `deploy/docker-1461/Dockerfile.pg-age-vector` built
-   to the SSOT-pinned minors, and version-asserts the exact result — see
+   end; CI has since begun exercising the certified triple in-PR on
+   `release/**` — now standardized to PG 18.6 / AGE 1.8.0 / pgvector 0.8.6
+   (operator directive 2026-08-18) — runs `deploy/docker-1461/Dockerfile.pg-age-vector`
+   built to the SSOT-pinned minors, and version-asserts the exact result — see
    §"Certified backend versions" for the current in-PR posture)
    and attested (this also covers the v0.9.0 4-phase
    ship-gate boundary per ROADMAP §17's recorded exception, ruling


### PR DESCRIPTION
## What / Why
Operator decision (2026-08-18): standardize on **PostgreSQL 18.6** (current stable). Reconciles ALL operator-facing docs + GitHub Pages to the certified tier **PostgreSQL 18.6 + Apache AGE 1.8.0 + pgvector 0.8.6**, matching `deploy/*/provision/lib.sh` `EXPECTED_PG_VERSION=18.6` + `cert-postgres-age.yml`.

- cert doc §3/§7: 18.6 promoted from "pending re-affirmation" to the CURRENT standard; 18.4/AGE 1.7.0 re-labeled as 2026-08-12 ratification history (not deleted).
- `CONFIG_SCHEMA.md`, `postgres-age-guide.md`, `v1.0.0/release-notes.md`: present-tense SSOT/CI claims → 18.6/1.8.0/0.8.6.
- `architectures-t3.html` pinned-versions table + `reproducible-baselines.html` attribution → 18.6; measured-run history preserved verbatim.

Resolves #3056. Gates green: docs-vs-ssot, doc-symbol-anchors, ci-job-claims.

## AI involvement
Reconciled by parallel general-purpose subagents against the code SSOT; merge-gated by Fable (Opus 4.8). Signed (AlphaOne, ssh).