### PR TITLE
docs(truthfulness): correct SDK search docstrings + t2 recall-p95 overclaim (#3066, #3057)

### DIFF
--- a/docs/architectures-t2.html
+++ b/docs/architectures-t2.html
@@ -532,7 +532,7 @@ ai-memory namespace set-standard --namespace agents/secops --id &lt;standard-mem
         <tr><td>Concurrent writers</td><td>~10–20 before mutex contention shows up</td><td>Bulk imports starve real-time agents</td></tr>
         <tr><td>Total memories</td><td>~10⁶ before HNSW RAM cost is noticeable</td><td>Vector index lives in-process</td></tr>
         <tr><td>Write throughput</td><td>~500-2000 writes/sec (single SQLite writer)</td><td>Bulk operations should chunk</td></tr>
-        <tr><td>Recall p95</td><td>sub-10ms at 10⁵ memories with HNSW</td><td>Scales to 10⁶ with care</td></tr>
+        <tr><td>Recall p95</td><td>~361 ms measured at 10⁵ rows (SQLite, #1579 P1 audit — see <a href="performance.html" style="color:var(--p1)">performance.html</a>); the ≤50 ms budget holds only at small-corpus/default scale</td><td>Default ≤50 ms budget stops holding past ~100k rows</td></tr>
         <tr><td>Network exposure</td><td>loopback by default, mTLS available</td><td>Set up TLS before binding non-loopback</td></tr>
         <tr><td>Cross-machine sharing</td><td>none</td><td>Walk to <a href="architectures-t3.html" style="color:var(--p1)">Tier 3</a></td></tr>
       </tbody>

--- a/sdk/python/ai_memory/client.py
+++ b/sdk/python/ai_memory/client.py
@@ -301,7 +301,7 @@ class AiMemoryClient:
         agent_id: str | None = None,
         as_agent: str | None = None,
     ) -> list[Memory]:
-        """``GET /api/v1/search`` — FTS keyword AND search."""
+        """``GET /api/v1/search`` — FTS keyword OR search (matches any token)."""
         raw = self._request(
             "GET",
             "/api/v1/search",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -422,7 +422,7 @@ export class AiMemoryClient {
     });
   }
 
-  /** `GET /api/v1/search` — AND keyword search (read-only). */
+  /** `GET /api/v1/search` — keyword OR search (matches any token, read-only). */
   async search(
     query: SearchQuery,
     opts?: RequestOptions,


### PR DESCRIPTION
Fixes two truthfulness/overclaim findings under epic #3076. Non-Rust (SDK docstrings + one GitHub-Pages HTML claim). Docstrings only for the SDK — no code behavior changed.

## #3066 (MED) — SDK `search` docstrings said "AND", implementation is OR
Both SDK clients docstringed `search` as an "AND keyword search", but the implementation (pg + sqlite) is OR-joined — it matches **any** token (live-confirmed: `q=bittensor semiconductors` returns rows matching either token). The OR code is the intended FTS5-parity behavior; the docs were the overclaim.

- `sdk/python/ai_memory/client.py:304` — `FTS keyword AND search` → `FTS keyword OR search (matches any token)`
- `sdk/typescript/src/client.ts:425` — `AND keyword search (read-only)` → `keyword OR search (matches any token, read-only)`
- `sdk/python/ai_memory/async_client.py` — its `search` method carries **no** docstring line, so no change.

## #3057 (MED) — false sub-10ms recall p95 claim on a live Pages page
`docs/architectures-t2.html` (Limits table) claimed **"Recall p95: sub-10ms at 10⁵ memories with HNSW"**, contradicting the **measured** `memory_recall` p95 of **361 ms at 100k rows** (#1579 P1 audit, cited on `docs/performance.html`). Corrected to the measured figure, citing `performance.html`, and noting the ≤50 ms budget holds only at small-corpus/default scale. Verified `architectures-t2.html` is **not** in `scripts/qc-allowlists/html-doc-frozen-exempt.txt` (it is a live page).

## Gates (shell only)
- `bash scripts/check-docs-vs-ssot.sh` — exit 0
- `bash scripts/check-ci-job-claims.sh` — exit 0
- `bash scripts/check-sdk-route-paths.sh` — exit 0 (docstring edit does not trip the SDK-path gate; the printed NOTICEs are pre-existing stale-ledger entries, loud notices not failures)

Closes #3066
Closes #3057

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY