### PR TITLE
fix(capabilities): report the CONSTRUCTED embedder, not the config default (#3063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,33 @@ Regression coverage: `tests/pg_audit_3070_3074.rs` (live-pg gated).
   2500 rows). This is a single-correct-answer bug fix restoring the
   documented contract via the pagination the SQL layer already implements
   (crossroads-protocol exempt).
+### Fixed (capabilities advertised the CONFIGURED embedder, not the CONSTRUCTED one; [#3063](https://github.com/alphaonedev/ai-memory-mcp/issues/3063))
+
+- **#3063 — `memory_capabilities` / `GET /api/v1/capabilities` reported the
+  resolved-config embedding model + dim, not the embedder the process actually
+  loaded.** The `models.embedding` / `models.embedding_dim` fields were built
+  from the resolver-derived `ResolvedModels` (the CONFIGURED default), so under
+  the operator-documented "embedding-guard-gap" — config resolves the nomic-768
+  tier preset while boot falls back to the local `all-MiniLM-L6-v2` (384-dim)
+  embedder (e.g. `AI_MEMORY_NO_CONFIG=1`, or a configured model the daemon
+  cannot construct) — capabilities advertised `nomic-embed-text-v1.5` / `768`
+  while recall was actually MiniLM / `384`. An operator reading `/capabilities`
+  believed recall was nomic-768 quality when it was MiniLM-384. Both runtime
+  emit sites (MCP `memory_capabilities` dispatch, HTTP `get_capabilities`) now
+  reconcile the resolved-config `ResolvedModels` against the LIVE `Embedder` at
+  emit time (`embeddings::reconcile_capability_models`), so `models.*` reports
+  the CONSTRUCTED embedder's real model id + dim; when the loaded embedder
+  disagrees with what config resolved a loud one-shot WARN
+  (`target: embeddings.capability_drift`) fires so an operator is not silently
+  misled. New `Embedder::capability_model_id()` reports the loaded model id
+  (local → the `MiniLM` HF id; remote → the operator-picked model verbatim).
+  The capabilities wire SHAPE is unchanged (same fields, corrected values), so
+  no schema / token-budget contract moves. Regression:
+  `tests/capabilities_embedder_truth_3063.rs` (drives the real
+  `build_capability_models` with a constructed embedder that differs from
+  config, including the fallback-mismatch case) +
+  `embeddings::tests::{capability_model_id_reports_constructed_remote_model_3063,
+  reconcile_overrides_config_with_constructed_embedder_3063}`.
 
 ### Fixed (Batman auto-atomisation was structurally inert product-wide; #2983 #2984 #2985 #2986 #2987)
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -873,6 +873,24 @@ pub trait Embed: Send + Sync {
         false
     }
 
+    /// #3063 — canonical model id of the CONSTRUCTED embedder for the
+    /// capabilities surface, or `None` when the impl carries none (test
+    /// doubles / abstract impls). Exposed on `dyn Embed` because the
+    /// `memory_capabilities` dispatch holds the embedder as `&dyn Embed`. The
+    /// production [`Embedder`] overrides this (and [`Embed::embedding_dim`])
+    /// with its real values so `/capabilities` reports what actually loaded,
+    /// not the resolved-config default. Default `None` → capabilities leaves
+    /// the config-resolved value unchanged.
+    fn embedding_model_id(&self) -> Option<String> {
+        None
+    }
+
+    /// #3063 — vector dimensionality of the CONSTRUCTED embedder, or `None`
+    /// for impls that report none. See [`Embed::embedding_model_id`].
+    fn embedding_dim(&self) -> Option<usize> {
+        None
+    }
+
     /// #2167 — the [`embedding_space_fingerprint`] of the vectors this embedder
     /// produces, exposed on the `dyn Embed` interface so the trait-generic
     /// backfill sweep ([`crate::store::run_embedding_backfill_on_store`],
@@ -1212,6 +1230,28 @@ impl Embedder {
             Self::Ollama {
                 model_name, dim, ..
             } => format!("{model_name} ({dim}-dim, remote)"),
+        }
+    }
+
+    /// #3063 — canonical model identifier for the capabilities surface.
+    ///
+    /// Reports the model the process ACTUALLY constructed, NOT the
+    /// resolved-config default. The two diverge under the operator-
+    /// documented "embedding-guard-gap" fallback: config resolves the
+    /// nomic-768 tier preset while boot falls back to the local
+    /// MiniLM-384 embedder (e.g. `AI_MEMORY_NO_CONFIG=1`, or a configured
+    /// model the daemon cannot construct — see
+    /// [`crate::daemon_runtime::resolve_embedder_model`]). The local
+    /// variant is ALWAYS `MiniLM` (the sole in-process model), so it
+    /// reports the [`crate::config::EmbeddingModel::MiniLmL6V2`] HF id;
+    /// the remote variant reports its operator-picked model id verbatim.
+    #[must_use]
+    pub fn capability_model_id(&self) -> String {
+        match self {
+            Self::Local { .. } => crate::config::EmbeddingModel::MiniLmL6V2
+                .hf_model_id()
+                .to_string(),
+            Self::Ollama { model_name, .. } => model_name.clone(),
         }
     }
 
@@ -1838,6 +1878,16 @@ impl Embed for Embedder {
         Self::is_degraded(self)
     }
 
+    fn embedding_model_id(&self) -> Option<String> {
+        // #3063 — the constructed embedder's real model id.
+        Some(Self::capability_model_id(self))
+    }
+
+    fn embedding_dim(&self) -> Option<usize> {
+        // #3063 — the constructed embedder's real vector dim.
+        Some(Self::dim(self))
+    }
+
     fn space_fingerprint(&self) -> String {
         // Delegate to the inherent #2168 method (returns the SSOT fingerprint).
         Embedder::space_fingerprint(self)
@@ -1849,6 +1899,126 @@ impl Embed for Embedder {
         // produce the same vectors. Safe to cache across instances.
         Some(Embedder::space_fingerprint(self))
     }
+}
+
+// ---------------------------------------------------------------------------
+// #3063 — capabilities must report the CONSTRUCTED embedder, not the config
+// default. The `memory_capabilities` / `GET /api/v1/capabilities` `models.*`
+// block is built from the resolver-derived `ResolvedModels`, but under the
+// embedding-guard-gap the embedder the process actually loaded can differ
+// (config resolves nomic-768; boot falls back to MiniLM-384). Left unfixed,
+// an operator reading `/capabilities` believes recall is nomic-768 quality
+// when it is MiniLM-384 — a truthfulness defect, not a data-integrity one,
+// but the capabilities surface is the operator's window into the live wiring.
+// ---------------------------------------------------------------------------
+
+/// #3063 — true when the LOADED embedder's `(model, dim)` disagrees with the
+/// config-resolved embedding identity. Pure (no side effects); drives the
+/// one-shot capabilities WARN in [`reconcile_capability_models`].
+///
+/// The dimension is the load-bearing, unambiguous signal (768 vs 384 → a
+/// different vector space); the model id is compared canonically so a matching
+/// deployment (resolved `nomic-embed-text-v1.5`, loaded remote `nomic-embed-
+/// text-v1.5`, equal dims) does not spuriously warn.
+#[must_use]
+pub fn embedder_capability_mismatch(
+    resolved: &crate::config::ResolvedEmbeddings,
+    loaded_model: &str,
+    loaded_dim: usize,
+) -> bool {
+    let dim_mismatch = resolved
+        .embedding_dim
+        .and_then(|d| usize::try_from(d).ok())
+        .is_some_and(|d| d != loaded_dim);
+    let model_mismatch = !embedding_model_ids_equivalent(&resolved.model, loaded_model);
+    dim_mismatch || model_mismatch
+}
+
+/// Canonical equivalence of two embedding-model id strings. When BOTH resolve
+/// to a known [`crate::config::EmbeddingModel`] they must be the same variant;
+/// otherwise fall back to a trimmed case-insensitive string compare (so an
+/// operator-picked API model id matches itself).
+fn embedding_model_ids_equivalent(a: &str, b: &str) -> bool {
+    use crate::config::EmbeddingModel;
+    match (
+        EmbeddingModel::from_canonical_id(a),
+        EmbeddingModel::from_canonical_id(b),
+    ) {
+        (Some(x), Some(y)) => x == y,
+        _ => a.trim().eq_ignore_ascii_case(b.trim()),
+    }
+}
+
+/// #3063 — return the [`crate::config::ResolvedModels`] the capabilities
+/// surface should report, with `embeddings.{model, embedding_dim}` overridden
+/// to the embedder the process ACTUALLY constructed. When no embedder is loaded
+/// (keyword tier / load failure) the config-resolved value stands unchanged.
+///
+/// When the loaded embedder disagrees with what config resolved, a one-shot
+/// (`Once`-gated) WARN is emitted so an operator is not silently misled about
+/// recall quality. Both runtime emit sites — the MCP `memory_capabilities`
+/// dispatch and the HTTP `GET /api/v1/capabilities` handler — thread their live
+/// `Option<&dyn Embed>` through here.
+#[must_use]
+pub fn reconcile_capability_models(
+    resolved: &crate::config::ResolvedModels,
+    embedder: Option<&dyn Embed>,
+) -> crate::config::ResolvedModels {
+    // Held as `&dyn Embed` because the MCP `memory_capabilities` dispatch
+    // carries the live embedder that way. `embedding_model_id` /
+    // `embedding_dim` default to `None` on impls that don't carry a real
+    // model (test doubles); the production `Embedder` overrides both.
+    let (Some(loaded_model), Some(loaded_dim)) = (
+        embedder.and_then(Embed::embedding_model_id),
+        embedder.and_then(Embed::embedding_dim),
+    ) else {
+        return resolved.clone();
+    };
+    warn_on_embedder_capability_mismatch(resolved, &loaded_model, loaded_dim);
+    override_embedding_identity(resolved, &loaded_model, loaded_dim)
+}
+
+/// #3063 — clone `resolved` with the embedding model id + dim overwritten to
+/// the constructed embedder's real values. Split out from
+/// [`reconcile_capability_models`] so the override is unit-testable via
+/// primitives without constructing a live [`Embedder`].
+#[must_use]
+pub fn override_embedding_identity(
+    resolved: &crate::config::ResolvedModels,
+    loaded_model: &str,
+    loaded_dim: usize,
+) -> crate::config::ResolvedModels {
+    let mut out = resolved.clone();
+    out.embeddings.model = loaded_model.to_string();
+    out.embeddings.embedding_dim = u32::try_from(loaded_dim).ok();
+    out
+}
+
+/// One-shot WARN when the loaded embedder differs from the resolved config
+/// (the #3063 embedding-guard-gap). `Once`-gated so a busy daemon does not
+/// spam the log on every capabilities call.
+fn warn_on_embedder_capability_mismatch(
+    resolved: &crate::config::ResolvedModels,
+    loaded_model: &str,
+    loaded_dim: usize,
+) {
+    if !embedder_capability_mismatch(&resolved.embeddings, loaded_model, loaded_dim) {
+        return;
+    }
+    static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+    WARN_ONCE.call_once(|| {
+        tracing::warn!(
+            target: "embeddings.capability_drift",
+            configured_model = %resolved.embeddings.model,
+            configured_dim = resolved.embeddings.embedding_dim.unwrap_or(0),
+            loaded_model = %loaded_model,
+            loaded_dim,
+            "capabilities: LOADED embedder differs from resolved config \
+             (embedding-guard-gap #3063) — /capabilities now reports the \
+             CONSTRUCTED embedder (model+dim); recall quality is the LOADED \
+             model, NOT the configured default"
+        );
+    });
 }
 
 /// Constant for backward compatibility — dimension of the default (`MiniLM`) embedding.
@@ -2152,6 +2322,41 @@ mod tests {
             "google/gemini-embedding-2 (3072-dim, remote)"
         );
         assert!(!embedder.is_degraded());
+    }
+
+    #[test]
+    fn capability_model_id_reports_constructed_remote_model_3063() {
+        let embedder = Embedder::new_remote(
+            offline_openai_compatible_client(),
+            "google/gemini-embedding-2".to_string(),
+            3072,
+        );
+        assert_eq!(embedder.capability_model_id(), "google/gemini-embedding-2");
+        assert_eq!(embedder.dim(), 3072);
+    }
+
+    #[test]
+    fn reconcile_overrides_config_with_constructed_embedder_3063() {
+        // Resolved config claims the nomic-768 tier preset, but the process
+        // actually constructed a 384-dim embedder (the embedding-guard-gap).
+        // Capabilities must report the CONSTRUCTED 384, not the config 768.
+        let mut resolved = crate::config::ResolvedModels::default();
+        resolved.embeddings.model = "nomic-embed-text-v1.5".to_string();
+        resolved.embeddings.embedding_dim = Some(768);
+
+        let loaded = Embedder::new_remote(
+            offline_openai_compatible_client(),
+            "all-MiniLM-L6-v2".to_string(),
+            384,
+        );
+        let out = reconcile_capability_models(&resolved, Some(&loaded as &dyn Embed));
+        assert_eq!(out.embeddings.model, "all-MiniLM-L6-v2");
+        assert_eq!(out.embeddings.embedding_dim, Some(384));
+
+        // None embedder → config-resolved value stands unchanged.
+        let passthrough = reconcile_capability_models(&resolved, None);
+        assert_eq!(passthrough.embeddings.model, "nomic-embed-text-v1.5");
+        assert_eq!(passthrough.embeddings.embedding_dim, Some(768));
     }
 
     #[test]

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -68,6 +68,18 @@ pub async fn get_capabilities(
         .as_ref()
         .as_ref()
         .is_some_and(|e| !e.is_degraded());
+    // #3063 — the `models.*` block must report the CONSTRUCTED embedder's
+    // model + dim, not the resolved-config default (they diverge under the
+    // embedding-guard-gap: config resolves nomic-768 while boot fell back to
+    // the local MiniLM-384 embedder). Reconcile against the live embedder;
+    // a loud one-shot WARN fires when they disagree.
+    let reconciled_models = crate::embeddings::reconcile_capability_models(
+        app.resolved_models.current().as_ref(),
+        app.embedder
+            .as_ref()
+            .as_ref()
+            .map(|e| e as &dyn crate::embeddings::Embed),
+    );
     let lock = app.db.lock().await;
     let conn = &lock.0;
     let result = match accept {
@@ -76,8 +88,9 @@ pub async fn get_capabilities(
             // v0.7.x (issue #1168) — the operator-resolved models
             // triple drives the `models.*` block so it matches the
             // boot banner + the live LLM client wiring, not the
-            // compiled tier preset.
-            app.resolved_models.current().as_ref(),
+            // compiled tier preset. #3063 — reconciled to the
+            // constructed embedder above.
+            &reconciled_models,
             None,
             embedder_loaded,
             Some(conn),
@@ -92,7 +105,7 @@ pub async fn get_capabilities(
         ),
         _ => crate::mcp::handle_capabilities_with_conn(
             app.tier_config.as_ref(),
-            app.resolved_models.current().as_ref(),
+            &reconciled_models,
             None,
             embedder_loaded,
             Some(conn),

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2403,10 +2403,16 @@ fn dispatch_memory_capabilities(ctx: &ToolDispatchCtx<'_>) -> Result<Value, Stri
     // auth rejection) is degraded and must report `false` so
     // `recall_mode_active` follows truthfully.
     let embedder_live = ctx.embedder.is_some_and(|e| !e.is_degraded());
+    // #3063 — report the CONSTRUCTED embedder's model + dim in
+    // `models.*`, not the resolved-config default (they diverge under
+    // the embedding-guard-gap: config resolves nomic-768 while boot
+    // fell back to MiniLM-384). A loud one-shot WARN fires on mismatch.
+    let reconciled_models =
+        crate::embeddings::reconcile_capability_models(ctx.resolved_models, ctx.embedder);
     let result = match accept {
         CapabilitiesAccept::V3 => handle_capabilities_with_conn_v3(
             ctx.tier_config,
-            ctx.resolved_models,
+            &reconciled_models,
             ctx.reranker,
             embedder_live,
             Some(ctx.conn),
@@ -2417,7 +2423,7 @@ fn dispatch_memory_capabilities(ctx: &ToolDispatchCtx<'_>) -> Result<Value, Stri
         ),
         _ => handle_capabilities_with_conn(
             ctx.tier_config,
-            ctx.resolved_models,
+            &reconciled_models,
             ctx.reranker,
             embedder_live,
             Some(ctx.conn),

--- a/tests/capabilities_embedder_truth_3063.rs
+++ b/tests/capabilities_embedder_truth_3063.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3063 — `memory_capabilities` / `GET /api/v1/capabilities` must report the
+//! CONSTRUCTED embedder's model + dim, NOT the resolved-config default.
+//!
+//! Root cause: the `models.*` block is built by
+//! [`ai_memory::config::build_capability_models`] from the resolver-derived
+//! `ResolvedModels`. Under the operator-documented "embedding-guard-gap" the
+//! embedder the process actually loaded can differ from what config resolved
+//! (e.g. config resolves the nomic-768 tier preset while boot falls back to
+//! the local MiniLM-384 embedder). Pre-fix, `/capabilities` advertised
+//! nomic/768 while recall was actually MiniLM/384.
+//!
+//! These tests drive the pure reconciliation helpers + the REAL capabilities
+//! `models.*` builder (the function that carried the bug), so no live embedder
+//! construction (HF-Hub fetch / candle) is needed.
+
+use ai_memory::config::{FeatureTier, ResolvedModels, build_capability_models};
+use ai_memory::embeddings::{
+    embedder_capability_mismatch, override_embedding_identity, reconcile_capability_models,
+};
+
+/// Resolved config for the nomic-768 tier preset — the value the capabilities
+/// surface reported BEFORE #3063 regardless of what actually loaded.
+fn nomic_768_resolved() -> ResolvedModels {
+    let mut rm = ResolvedModels::default();
+    rm.embeddings.model = "nomic-embed-text-v1.5".to_string();
+    rm.embeddings.embedding_dim = Some(768);
+    rm
+}
+
+#[test]
+fn capabilities_report_constructed_minilm_not_config_nomic_3063() {
+    // The guard-gap fallback: config says nomic-768, loaded embedder is
+    // MiniLM-384. Capabilities MUST report 384.
+    let resolved = nomic_768_resolved();
+    let reconciled = override_embedding_identity(&resolved, "all-MiniLM-L6-v2", 384);
+
+    // Flow it through the REAL capabilities `models.*` builder with an
+    // embedding-enabled tier (autonomous). This is the function #3063 fixes.
+    let tier = FeatureTier::Autonomous.config();
+    let models = build_capability_models(&tier, &reconciled);
+
+    assert_eq!(
+        models.embedding_dim, 384,
+        "capabilities must report the CONSTRUCTED embedder dim (384), not the config default (768)"
+    );
+    assert_eq!(
+        models.embedding, "all-MiniLM-L6-v2",
+        "capabilities must report the CONSTRUCTED embedder model, not the config default"
+    );
+}
+
+#[test]
+fn mismatch_detected_for_guard_gap_fallback_3063() {
+    let resolved = nomic_768_resolved();
+    // nomic-768 configured, MiniLM-384 loaded → mismatch (the case that WARNs).
+    assert!(embedder_capability_mismatch(
+        &resolved.embeddings,
+        "all-MiniLM-L6-v2",
+        384
+    ));
+}
+
+#[test]
+fn no_mismatch_when_loaded_matches_config_3063() {
+    let resolved = nomic_768_resolved();
+    // Same model (canonical id) + same dim → no mismatch, no spurious WARN.
+    assert!(!embedder_capability_mismatch(
+        &resolved.embeddings,
+        "nomic-embed-text-v1.5",
+        768
+    ));
+    // The org-prefixed HF id is the SAME model canonically → still no mismatch.
+    assert!(!embedder_capability_mismatch(
+        &resolved.embeddings,
+        "nomic-ai/nomic-embed-text-v1.5",
+        768
+    ));
+}
+
+#[test]
+fn matching_deployment_capabilities_unchanged_3063() {
+    // When the loaded embedder matches config, the reported model + dim are
+    // byte-identical to the pre-#3063 config-driven values.
+    let resolved = nomic_768_resolved();
+    let reconciled = override_embedding_identity(&resolved, "nomic-embed-text-v1.5", 768);
+    let tier = FeatureTier::Autonomous.config();
+    let models = build_capability_models(&tier, &reconciled);
+    assert_eq!(models.embedding, "nomic-embed-text-v1.5");
+    assert_eq!(models.embedding_dim, 768);
+}
+
+#[test]
+fn no_embedder_leaves_config_values_intact_3063() {
+    // Keyword tier / load failure: no embedder → config-resolved value stands.
+    let resolved = nomic_768_resolved();
+    let out = reconcile_capability_models(&resolved, None);
+    assert_eq!(out.embeddings.model, "nomic-embed-text-v1.5");
+    assert_eq!(out.embeddings.embedding_dim, Some(768));
+}


### PR DESCRIPTION
## Summary (epic #3076)

Closes #3063.

`memory_capabilities` (MCP bootstrap) and `GET /api/v1/capabilities` advertised the **resolver-derived** embedding model + dim (the CONFIGURED default), not the embedder the process actually **constructed**. Under the operator-documented "embedding-guard-gap" the two diverge: config resolves the nomic-768 tier preset while boot falls back to the local `all-MiniLM-L6-v2` (384-dim) embedder (e.g. `AI_MEMORY_NO_CONFIG=1`, or a configured model the daemon cannot construct). Pre-fix, `/capabilities` reported `nomic-embed-text-v1.5` / `768` while recall was actually MiniLM / `384` — an operator was silently misled about recall quality.

## Root cause

`build_capability_models` (`src/config.rs`) builds `models.embedding` / `models.embedding_dim` from `ResolvedModels.embeddings` — the config-resolved values. The two runtime emit sites (`dispatch_memory_capabilities` in `src/mcp/mod.rs`, `get_capabilities` in `src/handlers/system.rs`) passed the config-resolved `ResolvedModels` straight through, even though the live `Embedder` was in scope.

## Fix

- Both emit sites now reconcile `ResolvedModels` against the LIVE embedder at emit time via `embeddings::reconcile_capability_models`, so `models.*` reports the **constructed** embedder's real model id + dim.
- Loud one-shot WARN (`target: embeddings.capability_drift`) when the loaded embedder disagrees with what config resolved.
- New `Embed::embedding_model_id` / `Embed::embedding_dim` trait accessors (default `None`; production `Embedder` overrides with real values) expose the identity across the `&dyn Embed` dispatch boundary. `Embedder::capability_model_id()` reports the loaded model id (local → MiniLM HF id; remote → operator-picked id verbatim).
- Capabilities wire **shape** is unchanged (same fields, corrected values) — no schema / token-budget contract moves.

## Data-integrity note

The memory TEXT (durable truth) is untouched; this is a truthfulness fix on a **reporting** surface. The embedding vectors themselves are unaffected — the change makes capabilities stop misrepresenting which vector space recall is actually running in, which is squarely the "degrade, never mislead" posture.

## Files changed

- `src/embeddings.rs` — `Embedder::capability_model_id()`, `Embed::embedding_model_id`/`embedding_dim` trait defaults + `Embedder` overrides, `reconcile_capability_models` / `override_embedding_identity` / `embedder_capability_mismatch` helpers + one-shot WARN, 2 unit tests.
- `src/mcp/mod.rs` — reconcile at `dispatch_memory_capabilities`.
- `src/handlers/system.rs` — reconcile at `get_capabilities`.
- `tests/capabilities_embedder_truth_3063.rs` — new regression suite.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Tests

- `tests/capabilities_embedder_truth_3063.rs` — drives the real `build_capability_models` with a constructed embedder that differs from config (incl. the fallback-mismatch case), the matching-deployment no-op case, and the no-embedder passthrough.
- `embeddings::tests::{capability_model_id_reports_constructed_remote_model_3063, reconcile_overrides_config_with_constructed_embedder_3063}`.

## Gates (local)

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` — exit 0
- `cargo clippy --all-targets --features sal,sal-postgres -- -D warnings -D clippy::all -D clippy::pedantic` — exit 0 (covers both sal and sal-postgres legs)
- `( umask 022; AI_MEMORY_NO_CONFIG=1 cargo test --test capabilities_embedder_truth_3063 )` — 5 passed
- `cargo test --lib embeddings::tests` — 45 passed (incl. the 2 new #3063 tests)
- capabilities regression suites (`capabilities_v2`, `compliance_capability_truth_2400_2401`, `issue_1168_capabilities_resolver_drift`) compile clean — signatures unchanged
- vectorlite leg skipped: no vectorlite-gated code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY