### PR TITLE
fix(#3068): identity-less audit reader must not bleed a sibling's forensic watermark

### DIFF
--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -121,15 +121,18 @@ MAP=(
   "consolidate_confidence_floor_2935|subst|min_confidence = min_confidence.min(mem.confidence);>>>min_confidence = min_confidence.min(1.0); // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
   "consolidate_derived_kind_2935|subst|memory_kind: crate::models::MemoryKind::Claim,>>>memory_kind: crate::models::MemoryKind::Observation, // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
   # #2955 — forensic watermark PER-DATABASE scoping. The control is a SINGLE
-  # branch in `scan_file_last_watermark` (not a guard fn), so it uses `subst`:
-  # neutralizing `if line_id != mine {` to `if false {` stops the cross-DB skip,
-  # so a SIBLING database's watermark (a different genesis `db_id`) is honored as
-  # THIS db's high-water — the exact cross-DB watermark bleed #2955 closes. The
-  # lane test asserts a foreign-`db_id` watermark is NOT returned to a scoped
-  # reader; the mutation makes it returned => RED. Both backends read through
-  # this ONE shared reader (`last_audit_watermark`), so the pg twin is
-  # composite-covered by the same proof.
-  "scan_file_last_watermark_db_id_scope_2955|subst|) && line_id != mine>>>) && false // CERT-REMOVAL-PROOF-MUTATION|src/governance/audit.rs|audit_watermark_db_id_scope_2955|foreign_db_watermark_not_honored_as_this_db_high_water"
+  # match arm in `scan_file_last_watermark` (not a guard fn), so it uses `subst`:
+  # neutralizing the `(Some(line_id), Some(mine)) if line_id != mine => continue`
+  # arm's guard to `if false` stops the cross-DB skip, so a SIBLING database's
+  # watermark (a different genesis `db_id`) is honored as THIS db's high-water —
+  # the exact cross-DB watermark bleed #2955 closes. The lane test asserts a
+  # foreign-`db_id` watermark is NOT returned to a scoped reader; the mutation
+  # makes it returned => RED. Both backends read through this ONE shared reader
+  # (`last_audit_watermark`), so the pg twin is composite-covered by the same
+  # proof. (v1.0.0 #3068 rewrote this branch from an `if let` guard to a `match`;
+  # the IDENTITY-LESS-reader arm `(Some(_), None)` added there is a SEPARATE
+  # control proven by `empty_migrated_store_not_convicted_on_sibling_watermark`.)
+  "scan_file_last_watermark_db_id_scope_2955|subst|(Some(row_db_id), Some(mine)) if row_db_id != mine => continue,>>>(Some(row_db_id), Some(mine)) if false => continue, // CERT-REMOVAL-PROOF-MUTATION|src/governance/audit.rs|audit_watermark_db_id_scope_2955|foreign_db_watermark_not_honored_as_this_db_high_water"
 )
 
 # Apply MUTATION to function CTL in TARGET, per SHAPE.

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -1103,24 +1103,62 @@ pub fn last_audit_watermark(db_id: Option<&str>) -> Option<(i64, String)> {
     // (unauthenticated) anchor. The L7 exonerating lanes gate on
     // [`audit_watermark_exoneration_authenticated`] instead.
     //
-    // v1.0.0 #2955 — `db_id` scopes the SHARED on-host forensic sink PER
-    // DATABASE (mirrors [`read_head_anchor_high_water`]): a watermark carrying a
-    // DIFFERENT db_id anchors a sibling DB on this mount and is skipped, so a
-    // restored / rotated / co-located DB's head can never be read as THIS db's
-    // high-water. `db_id = None` (an opener with no genesis / empty chain) reads
-    // every watermark — the conservative pre-#2955 posture.
+    // v1.0.0 #2955 / #3068 — `db_id` scopes the SHARED on-host forensic sink
+    // PER DATABASE: a watermark carrying a DIFFERENT db_id anchors a sibling DB
+    // on this mount and is skipped, so a restored / rotated / co-located DB's
+    // head can never be read as THIS db's high-water. An IDENTITY-LESS reader
+    // (`db_id = None`, no genesis / empty chain) counts only db_id-LESS (legacy)
+    // watermarks and SKIPS every IDENTIFIED one — it cannot own a watermark
+    // stamped for an identified database (see [`scan_file_last_watermark`]).
+    // #3068: the pre-fix "None reads every watermark" posture let a freshly-
+    // migrated empty chain be convicted of truncation on a live sibling's
+    // climbing watermark. Wipe-to-empty of a formerly-identified chain is owned
+    // by the SIGNED head-anchor-log lane ([`read_head_anchor_high_water`] /
+    // `RollbackCheck`), NOT this raw unsigned lane.
+    let mut skipped_identified = false;
     for file in files.iter().rev().take(2) {
-        if let Some((seq, hash, _signed)) = scan_file_last_watermark(file, db_id) {
+        let scan = scan_file_last_watermark(file, db_id);
+        if let Some((seq, hash, _signed)) = scan.last {
             return Some((seq, hash));
         }
+        skipped_identified |= scan.skipped_identified_for_idless;
+    }
+    if skipped_identified {
+        // #3068 — the degrade is OBSERVABLE, never a silent withhold: an
+        // operator relying on the raw forensic-watermark lane (no audit-witness
+        // enrolled) is told WHY it withheld and where the attestable control is.
+        tracing::warn!(
+            target: AUDIT_TRACE_TARGET,
+            "verify-audit-trail: this database has no genesis / empty audit chain \
+             (db_head = 0), and the SHARED on-host forensic watermark sink carries \
+             only watermarks stamped for OTHER (identified) databases — none can \
+             be attributed to this opener, so the forensic-watermark truncation \
+             lane WITHHOLDS (#3068 cross-store bleed fix). Wipe-to-empty detection \
+             for a formerly-identified chain is owned by the SIGNED head-anchor-log \
+             lane; enrol an audit-witness key (AI_MEMORY_WITNESS_KEY_DIR / \
+             AI_MEMORY_WITNESS_PUBKEY) for that attestable control."
+        );
     }
     None
 }
 
-/// The most-recent watermark row in a single forensic file:
-/// `(head_sequence, head_canonical_hash, signed)` where `signed` is `true`
-/// iff that row carried a non-empty Ed25519 `sig`. `None` if the file carries
-/// no watermark. Malformed / wrong-version rows are skipped.
+/// Outcome of one forensic-file watermark scan.
+struct WatermarkScan {
+    /// The most-recent eligible watermark row for the resolving database:
+    /// `(head_sequence, head_canonical_hash, signed)` where `signed` is `true`
+    /// iff that row carried a non-empty Ed25519 `sig`. `None` if the file
+    /// carried no watermark eligible for this opener.
+    last: Option<(i64, String, bool)>,
+    /// v1.0.0 #3068 — set when an IDENTITY-LESS opener (`db_id = None`, an
+    /// empty / no-genesis chain) SKIPPED at least one IDENTIFIED (db_id-bearing)
+    /// watermark on this shared sink. Surfaces the cross-store deferral to the
+    /// caller so the degrade is OBSERVABLE ([`last_audit_watermark`] WARNs)
+    /// rather than a silent withhold.
+    skipped_identified_for_idless: bool,
+}
+
+/// The most-recent watermark row in a single forensic file (see
+/// [`WatermarkScan`]). Malformed / wrong-version rows are skipped.
 ///
 /// The `signed` bit is what the L7
 /// [`audit_watermark_exoneration_authenticated`] gate consumes: `verify_since`
@@ -1128,9 +1166,15 @@ pub fn last_audit_watermark(db_id: Option<&str>) -> Option<(i64, String)> {
 /// lanes must additionally confirm the exact watermark they trust is itself
 /// signed. [`last_audit_watermark`] ignores the bit (the CONVICTING lanes read
 /// the raw unauthenticated anchor).
-fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, String, bool)> {
-    let f = File::open(path).ok()?;
+fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> WatermarkScan {
+    let Ok(f) = File::open(path) else {
+        return WatermarkScan {
+            last: None,
+            skipped_identified_for_idless: false,
+        };
+    };
     let mut found: Option<(i64, String, bool)> = None;
+    let mut skipped_identified_for_idless = false;
     for line in BufReader::new(f).lines() {
         let Ok(line) = line else { continue };
         if line.trim().is_empty() {
@@ -1147,18 +1191,42 @@ fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, St
         {
             continue;
         }
-        // v1.0.0 #2955 — per-database scoping (mirrors `scan_head_anchor_log`'s
-        // #2370 match): a watermark carrying a DIFFERENT db_id anchors a sibling
-        // DB sharing this on-host sink and must NEVER become this opener's
-        // high-water. A db_id-less (legacy) watermark is counted conservatively
-        // for every opener; `db_id = None` (no genesis / empty chain) counts
-        // every watermark. Only the cross-DB (foreign-id) row is skipped.
-        if let (Some(line_id), Some(mine)) = (
+        // v1.0.0 #2955 / #3068 — per-database scoping of the SHARED on-host
+        // forensic sink. A watermark declares the database it anchors via its
+        // payload `db_id` (the genesis-derived [`crate::signed_events::db_id_from_genesis_parts`]).
+        match (
             row.payload.get("db_id").and_then(serde_json::Value::as_str),
             db_id,
-        ) && line_id != mine
-        {
-            continue;
+        ) {
+            // #2955 — a watermark for a DIFFERENT identified DB anchors a
+            // sibling sharing this mount and must NEVER become this (identified)
+            // opener's high-water.
+            (Some(row_db_id), Some(mine)) if row_db_id != mine => continue,
+            // #3068 — an IDENTITY-LESS opener (no genesis / empty chain) cannot
+            // OWN an IDENTIFIED watermark: a row that declares a db_id belongs
+            // to some identified database, and an opener that has neither
+            // genesis nor chain is provably not it. Reading it as this opener's
+            // high-water is the cross-store bleed #3068 reported (a freshly-
+            // migrated DB co-located with a live sibling was convicted of
+            // truncation on the sibling's climbing watermark). Skip it, and
+            // record the skip so the caller can surface the deferral. An empty
+            // chain (`db_head = 0`, no genesis) has NOTHING to truncate FROM, so
+            // withholding here suppresses no legitimate same-db truncation; the
+            // ONLY case deferred is a wipe-to-empty of a FORMERLY-identified
+            // chain, which is owned by the SIGNED, K1-pinned head-anchor-log
+            // lane (`scan_head_anchor_log` / `RollbackCheck`) — that lane
+            // DELIBERATELY still over-counts for a None reader because its pin
+            // gate makes the over-count an ATTESTABLE wipe detector, whereas
+            // THIS lane reads the raw UNSIGNED anchor and must not over-convict.
+            (Some(_), None) => {
+                skipped_identified_for_idless = true;
+                continue;
+            }
+            // (Some, Some) matching own db_id, or (None, _) a db_id-LESS legacy
+            // (pre-#2955) watermark counted CONSERVATIVELY for every opener
+            // (over-detect toward Evidence on the one-release compat window,
+            // never suppression): counted below.
+            _ => {}
         }
         let seq = row
             .payload
@@ -1172,7 +1240,10 @@ fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, St
             found = Some((seq, hash.to_string(), !row.sig.is_empty()));
         }
     }
-    found
+    WatermarkScan {
+        last: found,
+        skipped_identified_for_idless,
+    }
 }
 
 /// L7 (PR-4, forensic-audit-trail wave) — earliest `--since` sentinel the
@@ -1248,7 +1319,7 @@ pub fn audit_watermark_exoneration_authenticated(
         return false;
     };
     for file in files.iter().rev().take(2) {
-        if let Some((_, _, signed)) = scan_file_last_watermark(file, db_id) {
+        if let Some((_, _, signed)) = scan_file_last_watermark(file, db_id).last {
             return signed;
         }
     }

--- a/tests/audit_watermark_db_id_scope_2955.rs
+++ b/tests/audit_watermark_db_id_scope_2955.rs
@@ -20,7 +20,11 @@
 //!   the foreign row honored → this test RED);
 //! - THIS db's own watermark IS still honored (the fix does not over-block);
 //! - a legacy id-less watermark is counted CONSERVATIVELY for every opener;
-//! - `db_id = None` (empty chain) reads every watermark (pre-#2955 posture);
+//! - v1.0.0 #3068 — an IDENTITY-LESS opener (`db_id = None`, no genesis / empty
+//!   chain) counts only db_id-LESS legacy watermarks and SKIPS every IDENTIFIED
+//!   one, so two stores sharing one host never bleed a sibling's head (the
+//!   pre-#3068 "None reads every watermark" posture convicted a freshly-migrated
+//!   empty chain of truncation on a live sibling's climbing watermark);
 //! - END-TO-END: a foreign watermark can no longer forge a `Detected`
 //!   truncation verdict against a chain that was never truncated.
 //!
@@ -114,12 +118,17 @@ fn foreign_db_watermark_not_honored_as_this_db_high_water() {
         "own-db watermark must still be honored"
     );
 
-    // `db_id = None` (an opener with no genesis / empty chain) reads every
-    // watermark — the conservative pre-#2955 posture.
+    // v1.0.0 #3068 — an IDENTITY-LESS opener (`db_id = None`, no genesis /
+    // empty chain) can NOT own an IDENTIFIED (db_id-bearing) watermark: the
+    // `db-alpha` row is skipped, so a freshly-migrated empty chain co-located
+    // with a live sibling is never convicted of truncation on the sibling's
+    // watermark. (Pre-#3068 this returned `Some((100, ...))` — the cross-store
+    // bleed.) Wipe-to-empty of a formerly-identified chain is owned by the
+    // SIGNED head-anchor-log lane, not this raw unsigned lane.
     assert_eq!(
         forensic::last_audit_watermark(None),
-        Some((100, "sibling-head-hash".to_string())),
-        "None (no genesis) must read every watermark (conservative posture)"
+        None,
+        "None (no genesis) must NOT read an identified sibling's watermark (#3068)"
     );
 }
 
@@ -232,5 +241,85 @@ fn own_db_watermark_still_detects_truncation() {
             db_head: 3,
         },
         "own-db watermark must still convict a real tail truncation; report={report:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3068 — TWO STORES, ONE HOST: an IDENTITY-LESS (empty-chain / no-
+// genesis) opener sharing the on-host forensic sink with an IDENTIFIED sibling
+// must NOT read the sibling's watermark as its own high-water, but a LEGACY
+// id-less watermark is still counted (conservative compat window preserved).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn idless_opener_skips_identified_sibling_but_counts_legacy() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("e-forensic");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // A live IDENTIFIED sibling (its own genesis-derived db_id) stamped a high
+    // head=78_000 into the SHARED sink.
+    forensic::record_audit_watermark(78_000, "sibling-head", Some("sibling-db-id"));
+    forensic::flush_blocking();
+
+    // An IDENTITY-LESS opener (None = no genesis / empty chain) must NOT read
+    // the identified sibling's watermark — cross-store bleed closed (#3068).
+    assert_eq!(
+        forensic::last_audit_watermark(None),
+        None,
+        "an identity-less opener must not read an identified sibling's watermark (#3068)"
+    );
+
+    // But a LEGACY id-less watermark on the same sink IS still counted for the
+    // identity-less opener (over-detect toward Evidence, never suppression).
+    forensic::record_audit_watermark(42, "legacy-head", None);
+    forensic::flush_blocking();
+    assert_eq!(
+        forensic::last_audit_watermark(None),
+        Some((42, "legacy-head".to_string())),
+        "a legacy id-less watermark must still be counted for an identity-less opener"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3068 — a freshly-migrated store (memories migrated, but the
+// signed_events audit chain is genuinely EMPTY: 0 rows, no genesis) must NOT be
+// convicted of truncation on a co-located live sibling's climbing watermark.
+// This is the exact shape #3068 reported against the pg-186 hive store.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_migrated_store_not_convicted_on_sibling_watermark() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("f-forensic");
+    let ddir = fresh_dir("f-db");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // Fresh store: no signed_events rows appended → genesis_db_id == None.
+    let conn = open_db(ddir.path());
+    assert_eq!(
+        genesis_db_id(&conn).expect("genesis db_id read"),
+        None,
+        "a fresh store has no signed_events genesis"
+    );
+
+    // A live sibling on the SHARED sink is at head=78_000 and climbing.
+    forensic::record_audit_watermark(78_000, "sibling-head", Some("sibling-db-id"));
+    forensic::flush_blocking();
+
+    // #3068 — pre-fix this forged `Detected { anchored_head: 78_000, db_head: 0 }`.
+    let report = verify_audit_trail(&conn, None, None).expect("verify");
+    assert_eq!(
+        report.head_sequence, 0,
+        "empty chain head is 0; report={report:?}"
+    );
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Unknown,
+        "an empty migrated store must not be convicted on a sibling's watermark (#3068); report={report:?}"
     );
 }


### PR DESCRIPTION
## Root cause (enterprise-federation audit finding #3068)

`ai-memory verify-audit-trail` against a freshly-migrated postgres store whose `signed_events` chain is **genuinely empty** (0 rows, no genesis) reported `truncation: detected, anchored_head=78153 (climbing), db_head=0` — a **false conviction**. The host runs 10+ ai-memory processes sharing one on-host forensic-watermark mount.

Confirmed with 3 live probes against the pg-186 hive daemon:
1. pg `signed_events` = 0 rows, no `sequence=1` genesis → `PostgresStore::verify_audit_trail` (`src/store/postgres.rs:12281`) resolves `watermark_db_id = None`.
2. `last_audit_watermark(None)` (`src/governance/audit.rs`) reads the SHARED sink `/home/.../audit/forensic-2026-08-19.jsonl`; `scan_file_last_watermark` skipped a row only when BOTH the row's db_id and the reader's db_id were `Some` and differed — so a `None` reader NEVER skipped a foreign row.
3. The sink held 491 watermark rows all carrying ONE **foreign** db_id `0e013105…`, max_head climbing (a live sibling). The empty pg store convicted on it.

This is a **real cross-store bleed**, not honest inheritance (the sibling watermark is live/climbing with a foreign db_id, not a static migration source) — it violates the #2955 promise that "a co-located DB's head can never be read as THIS db's high-water" for the identity-less (empty-chain) reader.

## Decision — 5-agent adversarial vote (`4d3ea1c5`)

T3/T4 crossroads (persisted-verdict / security posture). Tally: **4× A-with-amendment / 1× C**.

**Option A (adopted):** an identity-less (`db_id = None`) reader now matches ONLY db_id-**less** (legacy pre-#2955) watermarks and **skips** every **identified** (db_id-bearing) one — it cannot own a watermark stamped for an identified database. An empty chain (`db_head = 0`, no genesis) has nothing to truncate FROM, so this withholds **no** legitimate same-db truncation; the only case deferred is wipe-to-empty of a formerly-identified chain, owned by the **signed, K1-pinned head-anchor-log lane** (`scan_head_anchor_log` / `RollbackCheck`).

- `scan_head_anchor_log` is **deliberately unchanged**: its pin gate makes its None over-count an *attestable* wipe detector; this raw *unsigned* lane must not over-convict. (Lens 5's mirror-the-lanes amendment was rejected with reasoning — it would regress the primary control, per Lens 2's verification.)
- The degrade is **observable**: `last_audit_watermark` WARNs when a None reader skips an identified watermark and finds no eligible one, naming the attestable control.
- One predicate change in backend-agnostic `scan_file_last_watermark` fixes **both** sqlite + postgres and the truncation / head-hash / exoneration lanes in lockstep (K3 parity; the shared reader has exactly 1 caller).

## Tests
- New two-stores-one-host regressions in `tests/audit_watermark_db_id_scope_2955.rs`: `idless_opener_skips_identified_sibling_but_counts_legacy`, `empty_migrated_store_not_convicted_on_sibling_watermark` (asserts `genesis_db_id == None`, `head_sequence == 0`, `truncation == Unknown` — the exact pg shape).
- Updated the existing `None`-reads-everything assertion.
- Removal-proof harness row retargeted to the new match-arm syntax; re-proven load-bearing (broken→RED, restored→GREEN).

## Gates
`cargo fmt --all --check`; clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` on **default / sal / sal-postgres / vectorlite** (all clean); `cargo audit` (clean, 3 pre-existing allowed advisories); `cargo check --examples`; `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` pass (no ceiling bump); target + neighboring audit-lane tests green.

## AI involvement
Root-caused and implemented by Claude (Opus 4.8) under operator authority; design resolved by the deterministic 5-agent adversarial vote (`4d3ea1c5`). Signed commit by AlphaOne.

Closes #3068

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY