### PR TITLE
docs: correct stale recall write-coupling claims (recall is PURE) (#3086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,27 @@ audit (epic #3076), fixed in one cohesive change.
   load-bearing. Comment corrected (`src/handlers/postgres_gate.rs`).
 
 Regression coverage: `tests/pg_audit_3070_3074.rs` (live-pg gated).
+### Docs (recall write-coupling drift corrected; #3086)
+
+- **SDK docstrings + operator docs still described `memory_recall` as
+  synchronously write-coupled** (bumping `access_count` and sliding TTLs on
+  every recall) — a claim that has been false since recall became a PURE read
+  at v1.0.0 (#1869 P0-1 + #1953 removed the `AI_MEMORY_RECALL_TOUCH_SYNC`
+  knob). Recall now writes **zero** rows to `memories`; it appends one row per
+  returned memory to the append-only `recall_observations` ledger, and the
+  access ladders (access-count, TTL floor-extend, mid→long promotion at 5
+  accesses, priority every 10, opt-in confidence decay) are applied out of
+  band by the periodic fold job (`db::fold_recall_accesses`), never inline on
+  the recall path. The SQLite 3x7 audit (#3086) flagged the stale sites; this
+  corrects them to the pure-recall / ledger-fold framing already used in
+  `sdk/typescript/README.md` and `docs/architectures-t1.html`. Docs/comments
+  only — zero behavior change. Files: `sdk/python/ai_memory/client.py`,
+  `sdk/typescript/src/client.ts`, `docs/DEVELOPER_GUIDE.md`,
+  `docs/GLOSSARY.md`, `docs/recall.md`, `docs/CLI_REFERENCE.md`,
+  `docs/USER_GUIDE.md`, `docs/ADMIN_GUIDE.md`, `docs/postgres-age-guide.md`,
+  `docs/essays/brass-tacks-2-how.html`, `docs/spec/v1.md`,
+  `docs/spec/TRACT-L1-CLAIM-CONTRACT.md`, `docs/confidence-calibration.md`.
+
 ### Fixed (`ai-memory migrate` dropped rows past 1000 AND never copied embeddings; #1876 #3060)
 
 - **Data-loss: cross-backend `migrate` copied memory TEXT but NOT the

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -1420,7 +1420,7 @@ The HTTP daemon exposes **94 production `.route(...)` registrations / 80 unique 
 | `POST` | `/memories/{id}/promote` | Promote a memory to long-term |
 | `GET` | `/memories` | List memories with filters |
 | `GET` | `/search` | AND search with 6-factor scoring |
-| `GET` | `/recall` | OR recall with touch + auto-promote |
+| `GET` | `/recall` | OR recall — pure read (access ladders folded from the ledger out of band) |
 | `POST` | `/recall` | OR recall (POST body) |
 | `POST` | `/forget` | Bulk delete by pattern/namespace/tier |
 | `POST` | `/consolidate` | Consolidate 2-100 memories |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -92,13 +92,17 @@ ai-memory store --title "Prod incident postmortem" \
 
 ### `recall`
 
-Semantic + keyword hybrid recall. **Mutates the database**: increments
-`access_count`, raises `expires_at` to
+Semantic + keyword hybrid recall. **Pure read** (#1953): writes zero
+rows to `memories` — no `access_count` bump, no TTL extension, no
+promotion on the recall path. It appends one row per returned memory to
+the append-only `recall_observations` ledger. The access ladders are
+applied out of band by the periodic fold job (`db::fold_recall_accesses`)
+from that ledger: increment `access_count`, raise `expires_at` to
 `MAX(current expires_at, now + per-tier-extend_secs)` (extension FLOOR —
 an access can never move an expiry earlier; issue
 [#1596](https://github.com/alphaonedev/ai-memory-mcp/issues/1596),
 superseding the [#830](https://github.com/alphaonedev/ai-memory-mcp/issues/830)
-replacement contract), auto-promotes mid→long at 5 accesses.
+replacement contract), auto-promote mid→long at 5 accesses.
 
 | Flag | Type | Default | Notes |
 |------|------|---------|-------|

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -193,7 +193,7 @@ The sqlite storage layer. The pre-#961 monolithic `src/db.rs` is GONE — split 
 | `forget()` | Bulk delete by namespace + FTS pattern + tier |
 | `list()` | List with filters: namespace, tier, priority, date range, tags, offset |
 | `search()` | FTS5 AND search with 6-factor composite scoring |
-| `recall()` | FTS5 OR search + touch + auto-promote + TTL extension |
+| `recall()` | FTS5 OR search — PURE read; access ladders (touch/auto-promote/TTL extension) folded from the `recall_observations` ledger out of band |
 | `find_contradictions()` | Find memories in same namespace with similar titles |
 | `consolidate()` | Merge multiple memories, delete originals, aggregate tags and max priority. **Uses BEGIN IMMEDIATE/COMMIT transaction** for atomicity. |
 | `sanitize_fts_query()` | Strips special characters and quotes tokens to prevent FTS injection |
@@ -686,7 +686,7 @@ Response: `{"results": [...], "count": 3, "query": "database migration"}`
 
 Uses 6-factor scoring (without tier boost). Queries are sanitized to prevent FTS injection.
 
-### Recall (OR semantics + touch)
+### Recall (OR semantics — pure read)
 
 ```
 GET /recall?context=auth+flow+jwt&namespace=my-app&limit=10&tags=auth&since=2026-01-01T00:00:00Z&until=2026-12-31T23:59:59Z
@@ -703,7 +703,7 @@ Content-Type: application/json
 
 Response: `{"memories": [...], "count": 5}`
 
-Recall automatically: bumps `access_count`, extends TTL, and auto-promotes mid-tier memories with 5+ accesses to long-term. The touch operation is transactional.
+Recall is a PURE read: it writes zero rows to `memories` (no `access_count` bump, no TTL extension, no tier promotion on the recall path; #1953). The only write is one row appended to the append-only `recall_observations` ledger. The access ladders — `access_count` bump, TTL floor-extend, auto-promotion of mid-tier memories with 5+ accesses to long-term — are applied out of band by the periodic fold job (`db::fold_recall_accesses`) from that ledger. This makes recall safe to retry and safe to serve from a read replica.
 
 ### Forget (Bulk Delete)
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -218,8 +218,12 @@ explicitly via `--quorum-writes` (default `0` = federation off); the
 
 Query operation that returns memories matching a natural-language
 context. Semantics: semantic + keyword + priority/confidence/recency
-blend. **Mutates the DB**: increments `access_count`, extends TTL,
-promotes mid→long at 5 accesses, nudges priority every 10 accesses.
+blend. **Pure read** (#1953): writes zero rows to `memories` on the
+recall path — no `access_count` bump, no TTL extension, no promotion.
+It appends one row to the append-only `recall_observations` ledger; the
+access ladders (increment `access_count`, extend TTL, promote mid→long
+at 5 accesses, nudge priority every 10) are applied out of band by the
+periodic fold job (`db::fold_recall_accesses`) from that ledger.
 
 ## SAL — Storage Abstraction Layer (v0.7)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1609,7 +1609,7 @@ Update an existing memory by ID. Only the fields you provide are changed.
 
 ### recall
 
-Recall memories relevant to a context. Fuzzy OR search with ranked results; auto-touches recalled memories.
+Recall memories relevant to a context. Fuzzy OR search with ranked results. Recall is a PURE read (#1953): it writes zero rows to `memories`; the access ladders (access-count, TTL extension, promotion) are folded from the append-only `recall_observations` ledger out of band by the periodic fold job.
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
@@ -1912,7 +1912,9 @@ Show archive statistics (count, size, oldest/newest).
 
 ### Automatic Behaviors
 
-- **TTL extension**: Every time a memory is recalled, its expiry extends (1 hour for short, 1 day for mid)
+Recall itself is a **pure read** — it writes zero rows to `memories` and records each access in the append-only `recall_observations` ledger instead (#1953). The behaviors below are applied out of band by the periodic **fold job** (`db::fold_recall_accesses`) from that ledger, not inline on the recall path:
+
+- **TTL extension**: A recalled memory's expiry is floor-extended (1 hour for short, 1 day for mid; an access never moves an expiry earlier)
 - **Auto-promotion**: A mid-tier memory recalled 5+ times automatically becomes long-term (expiry cleared)
 - **Priority reinforcement**: Every 10 accesses, a memory's priority increases by 1 (max 10)
 - **Garbage collection**: Expired memories are cleaned up every 30 minutes (optionally archived instead of deleted when `archive_on_gc = true` in `config.toml`)

--- a/docs/confidence-calibration.md
+++ b/docs/confidence-calibration.md
@@ -34,7 +34,9 @@ column (schema v39 sqlite / v38 postgres):
   `memory_calibrate_confidence` MCP tool) replaced the live value with
   a per-(namespace, source) baseline computed from shadow-mode samples.
 * `decayed` — the freshness-decay updater applied
-  `exp(-age * ln(2) / half_life)` on a recall touch. Opt-in via
+  `exp(-age * ln(2) / half_life)` when the periodic fold job applies the
+  recall-access ladders from the `recall_observations` ledger (recall
+  itself is a pure read; #1953). Opt-in via
   `AI_MEMORY_CONFIDENCE_DECAY=1` or per-namespace
   `confidence_decay_half_life_days` policy.
 

--- a/docs/essays/brass-tacks-2-how.html
+++ b/docs/essays/brass-tacks-2-how.html
@@ -86,7 +86,7 @@ footer a{color:var(--muted)}
   "last_handoff": "2026-05-17T22:14:03Z" }</code></pre>
 
   <h2><span class="step-num">02</span> Recall &mdash; what do I already know about this</h2>
-  <p>Before doing anything, the agent calls <code>memory_recall</code> against the context "flaky test in pipeline." This is hybrid recall: FTS5 keyword score blended with cosine similarity over MiniLM embeddings, weighted by tier, priority, confidence, and recency. Every recall mutates the database (touches access_count, refreshes expires_at, promotes mid&rarr;long at 5 accesses).</p>
+  <p>Before doing anything, the agent calls <code>memory_recall</code> against the context "flaky test in pipeline." This is hybrid recall: FTS5 keyword score blended with cosine similarity over MiniLM embeddings, weighted by tier, priority, confidence, and recency. Recall is a pure read: it writes zero rows to <code>memories</code> and appends one row to the append-only <code>recall_observations</code> ledger instead (#1953). The access ladders (access_count, expires_at floor-extend, mid&rarr;long promotion at 5 accesses) are folded from that ledger out of band by the periodic fold job, never inline on the recall path.</p>
   <div class="label">Tool call</div>
   <pre><code>memory_recall({ "context": "flaky test pipeline", "limit": 5 })</code></pre>
   <div class="label">Excerpt</div>

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -536,7 +536,7 @@ hybrid recall pipeline, and accept governance write paths.
 |---|---|---|
 | `POST` | `/api/v1/sync/push` | per-row `MemoryStore::apply_remote_memory` / `apply_remote_link` / `apply_remote_deletion`. Heterogeneous federation (sqlite ↔ postgres) round-trips. |
 | `GET` | `/api/v1/sync/since` | `MemoryStore::list_memories_updated_since` |
-| `GET` | `/api/v1/recall` and `POST /api/v1/recall` | `MemoryStore::recall_hybrid` (FTS + pgvector cosine + adaptive blend; mode=hybrid when embedder loaded). Touch ops fire via `MemoryStore::touch_after_recall`. |
+| `GET` | `/api/v1/recall` and `POST /api/v1/recall` | `MemoryStore::recall_hybrid` (FTS + pgvector cosine + adaptive blend; mode=hybrid when embedder loaded). PURE read (#1953) — no touch on the recall path; access ladders folded from the `recall_observations` ledger out of band by `MemoryStore::fold_recall_accesses`. |
 | `POST` | `/api/v1/pending/{id}/approve` | (Continuation 3 / Phase 20) full consensus state machine via `MemoryStore::governance_approve_with_consensus` — Human / Agent(required) / Consensus(N) variations + registered-agent gating + threshold transition. |
 | `POST` | `/api/v1/pending/{id}/reject` | `MemoryStore::pending_decide(approve=false)` + audit emit. |
 | `POST` | `/api/v1/namespaces/{ns}/standard` and `POST /api/v1/namespaces` | auto-seeds placeholder via `MemoryStore::store`, then `MemoryStore::set_namespace_standard` |
@@ -866,7 +866,7 @@ parity test is the gate that prevents it.
 | HTTP KG handlers (kg_query/kg_timeline/kg_invalidate) | ✓ | ✓ (Wave-3 Continuation — Phase 5) |
 | HTTP federation push/pull (sync/push, sync/since) | ✓ | ✓ (Wave-3 Continuation 2 — Phase 8) |
 | HTTP audit chain emit + cross-restart sequence persistence | ✓ | ✓ (Wave-3 Continuation 2 — Phase 9) |
-| HTTP full hybrid recall pipeline (FTS + pgvector + adaptive blend + touch) | ✓ | ✓ (Wave-3 Continuation 2 — Phase 10) |
+| HTTP full hybrid recall pipeline (FTS + pgvector + adaptive blend; pure read + out-of-band ledger fold) | ✓ | ✓ (Wave-3 Continuation 2 — Phase 10) |
 | HTTP governance write paths (pending decide, namespace standard) | ✓ | ✓ (Wave-3 Continuation 2 — Phase 11) |
 | HTTP full governance pipeline (multi-vote consensus + approver_type + inheritance walk on writes) | ✓ | ✓ (Wave-3 Continuation 3 — Phase 20) |
 | HTTP forget / consolidate / contradictions / notify / gc / import / export / archive write paths | ✓ | ✓ (Wave-3 Continuation 3 — Phase 13/14/15/16/17/18/19) |

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -30,12 +30,18 @@ mutates the database (touch, TTL extension, auto-promotion).
    (contains `/`), recall broadens to the ancestor chain and applies a
    small score bonus to memories nearer the queried leaf.
 6. **Token-budget greedy fill** (Phase P6 / R1) — see below.
-7. **Touch** — increment `access_count`, reset the sliding TTL window
-   (`expires_at = now + 1h` short / `now + 1d` mid — a per-access
-   **replacement**, not a max-of-old-and-new extend; long-tier rows
-   are untouched), auto-promote mid → long at 5 accesses, increment
-   priority every 10. Touch runs only on memories that survive every
-   prior stage, including the budget cut.
+7. **Ledger append (recall is PURE)** — recall writes **zero** rows to
+   `memories`; it appends one `recall_observations` row per returned
+   memory that survived every prior stage (including the budget cut) and
+   returns (#1953; the `AI_MEMORY_RECALL_TOUCH_SYNC` opt-back-in was
+   removed at v1.0.0). The access ladders — increment `access_count`,
+   TTL floor-extend (`expires_at = MAX(expires_at, now + 1h)` short /
+   `MAX(expires_at, now + 1d)` mid, an access can never move an expiry
+   earlier per [#1596](https://github.com/alphaonedev/ai-memory-mcp/issues/1596);
+   long-tier rows are untouched), auto-promote mid → long at 5 accesses,
+   increment priority every 10 — are applied out of band by the periodic
+   fold job (`db::fold_recall_accesses`, default every 60 s, plus a fold
+   at the top of every GC tick), never inline on the recall path.
 
 ---
 

--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -359,9 +359,9 @@ eviction; they are unbundled and serve different purposes:
 | # | Surface | What it is | Symbol |
 |---|---|---|---|
 | 1 | **Recall ranking** | recency + capped access-count + tier bonus tilt *ordering* toward fresh/hot rows | the FTS score `+ MIN(access_count,50)*0.1 + … + recency_factor + tier_bonus` (`storage::mod`) |
-| 2 | **TTL floor-extend on access** | an access raises `expires_at` by a per-tier floor — frequently-recalled rows live longer | `SHORT_TTL_EXTEND_SECS` / `MID_TTL_EXTEND_SECS` (`models::mod`), #1596 |
-| 3 | **Confidence decay on touch** | a memory's `confidence` decays with age on recall touch | `crate::confidence::decay`, `ConfidenceSource::Decayed` |
-| 4 | **Access-count promotion** | mid→long auto-promotion at 5 accesses; priority increments every 10 | recall-pipeline touch ops |
+| 2 | **TTL floor-extend on access** | an access raises `expires_at` by a per-tier floor — frequently-recalled rows live longer; recall is pure (#1953), so this is applied by the fold job from the ledger, not inline | `SHORT_TTL_EXTEND_SECS` / `MID_TTL_EXTEND_SECS` (`models::mod`), #1596 |
+| 3 | **Confidence decay on access** | a memory's `confidence` decays with age when the fold job applies the recall-access ladders (recall itself writes nothing) | `crate::confidence::decay`, `ConfidenceSource::Decayed` |
+| 4 | **Access-count promotion** | mid→long auto-promotion at 5 accesses; priority increments every 10 — folded from the `recall_observations` ledger, not on the recall path | fold-job ladders (`fold_recall_accesses`) |
 
 ### 10.2 The true gap (localized)
 

--- a/docs/spec/v1.md
+++ b/docs/spec/v1.md
@@ -209,9 +209,13 @@ be byte-equivalent under JSON encoding (§2) when:
 - `--preserve-archived` is passed when `archived` is non-empty.
 - The intermediate store is **fresh** (no other writers).
 
-Timestamps and access counters that are part of the live recall touch
-loop (`last_accessed_at`, `access_count`) are byte-equivalent only if
-the imported store is not queried between import and re-export.
+Timestamps and access counters that the recall access-signal loop
+updates (`last_accessed_at`, `access_count`) are byte-equivalent only if
+the imported store is not queried between import and re-export. Recall
+itself is pure (#1953) — it appends to the `recall_observations` ledger
+rather than writing these columns inline — but a subsequent fold/GC
+folds those ledger rows into `memories`, so querying the store can still
+change them.
 
 ### 5.1 Identity preservation
 

--- a/sdk/python/ai_memory/client.py
+++ b/sdk/python/ai_memory/client.py
@@ -335,9 +335,13 @@ class AiMemoryClient:
     ) -> RecallResponse:
         """``POST /api/v1/recall`` — hybrid FTS + semantic recall.
 
-        Uses the POST form because ``context`` can be long prose. Every
-        recall is write-coupled: the server bumps ``access_count`` and
-        extends TTLs on returned memories.
+        Uses the POST form because ``context`` can be long prose. Recall is
+        a PURE read: it writes zero rows to ``memories`` and never bumps
+        ``access_count`` or extends TTLs on the recall path (#1953). Each
+        returned memory appends one row to the append-only
+        ``recall_observations`` ledger; the access ladders (access-count,
+        TTL floor-extend, mid->long promotion, priority) are applied out of
+        band by the daemon's periodic fold job from that ledger.
         """
         body = RecallRequest(
             context=context,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -409,7 +409,7 @@ export class AiMemoryClient {
   // Recall / search / forget
   // ========================================================================
 
-  /** `POST /api/v1/recall` — fuzzy hybrid recall (mutates access_count + TTL). */
+  /** `POST /api/v1/recall` — fuzzy hybrid recall; PURE (writes zero rows to `memories`; access ladders folded from the ledger out of band, #1953). */
   async recall(
     body: RecallRequest,
     opts?: RequestOptions,


### PR DESCRIPTION
## Summary

SDK docstrings and operator docs still described `memory_recall` as synchronously write-coupled — bumping `access_count` and sliding TTLs on every recall. That has been false since v1.0.0: **#1869 P0-1 + #1953** made recall a **PURE read** and removed the `AI_MEMORY_RECALL_TOUCH_SYNC` knob. Recall writes **zero** rows to `memories`; it appends one row per returned memory to the append-only `recall_observations` ledger, and the access ladders (access-count, TTL floor-extend, mid→long promotion at 5 accesses, priority every 10, opt-in confidence decay) are applied out of band by the periodic fold job (`db::fold_recall_accesses`), never inline on the recall path.

This corrects the stale sites to the pure-recall / ledger-fold framing already used in `sdk/typescript/README.md` and `docs/architectures-t1.html` (the SQLite 3x7 audit's model wording). **Docs + SDK docstrings only — zero behavior change; no `.rs` source touched.**

## Files changed
- `sdk/python/ai_memory/client.py` — recall docstring
- `sdk/typescript/src/client.ts` — recall docstring
- `docs/DEVELOPER_GUIDE.md` — method table + `### Recall` heading + body
- `docs/GLOSSARY.md` — Recall entry
- `docs/recall.md` — pipeline step 7 (Touch → ledger append)
- `docs/CLI_REFERENCE.md` — `recall` subcommand
- `docs/USER_GUIDE.md` — recall CLI blurb + Automatic Behaviors
- `docs/ADMIN_GUIDE.md` — HTTP route table
- `docs/postgres-age-guide.md` — recall route row + backend-parity row
- `docs/essays/brass-tacks-2-how.html` — recall step
- `docs/spec/v1.md` — round-trip byte-equivalence note
- `docs/spec/TRACT-L1-CLAIM-CONTRACT.md` — §10.1 gradient-surface table
- `docs/confidence-calibration.md` — `decayed` source description
- `CHANGELOG.md` — `[Unreleased]` docs entry

Out of scope per the issue: `README.md` / `ROADMAP.md` / `CLAUDE.md` release-narrative + Recall-Pipeline history paragraphs (true history), the frozen `docs/v0.*/` and `docs/v1.0.0/` trees, and `src/` recall-pipeline code (already pure — this is doc drift).

## Doc gates (all exit 0)
- `bash scripts/check-docs-vs-ssot.sh` → 0
- `bash scripts/check-doc-symbol-anchors.sh` → 0
- `bash scripts/check-ci-job-claims.sh` → 0
- `bash scripts/check-sdk-route-paths.sh` → 0

No `.rs` doc-comments touched, so cargo fmt/clippy parity is unaffected.

Closes #3086
Epic #3076

## AI involvement
Authored by Claude Opus 4.8 (easy-coder tier) under operator authority. Mechanical docs-drift correction; no crossroads-vote trigger (single-correct-answer doc fix matching two already-corrected model sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY