### PR TITLE
ci: harden mold install (pin+bound, fail-loud) + pg-parity disk reclaim (#3090 #2960)

### DIFF
--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -120,11 +120,65 @@ jobs:
         with:
           components: clippy
 
-      - name: Install mold linker + postgresql-client
+      - name: Install mold linker + postgresql-client (#1148, pinned+bounded #3090)
+        timeout-minutes: 8
+        env:
+          MOLD_VERSION: "2.4.1"
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold postgresql-client
+          set -euo pipefail
+          # ------------------------------------------------------------------
+          # #3090 — bounded, pinned, fail-loud install (see ci.yml for the full
+          # rationale). The old bare `apt-get install -y mold postgresql-client`
+          # could hang on a stalled apt mirror until the job timeout fired. mold
+          # comes from a pinned first-party release tarball (apt bounded
+          # fallback); postgresql-client stays on bounded apt. No external
+          # Action added.
+          # ------------------------------------------------------------------
+          install_from_tarball() {
+            local arch tgz url dir ok attempt
+            arch="$(uname -m)"
+            tgz="mold-${MOLD_VERSION}-${arch}-linux.tar.gz"
+            url="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${tgz}"
+            dir="$(mktemp -d)"; ok=0
+            for attempt in 1 2; do
+              if timeout 120 curl -fsSL --retry 2 --retry-delay 3 -o "${dir}/${tgz}" "${url}"; then
+                ok=1; break
+              fi
+              echo "mold tarball fetch attempt ${attempt} failed; retrying" >&2; sleep 3
+            done
+            [ "${ok}" = 1 ] || return 1
+            tar -xzf "${dir}/${tgz}" -C "${dir}"
+            sudo install -m0755 "${dir}/mold-${MOLD_VERSION}-${arch}-linux/bin/mold" /usr/local/bin/mold
+            sudo ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          }
+          install_from_apt() {
+            local ok attempt; ok=0
+            for attempt in 1 2; do
+              if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y mold; then
+                ok=1; break
+              fi
+              echo "apt mold install attempt ${attempt} failed; retrying" >&2; sleep 5
+            done
+            [ "${ok}" = 1 ]
+          }
+          if ! { command -v mold >/dev/null 2>&1 && mold --version | grep -q "${MOLD_VERSION}"; }; then
+            if ! install_from_tarball; then
+              echo "::warning::pinned mold tarball unavailable — falling back to apt"
+              install_from_apt || { echo "::error::mold install failed (tarball + apt both failed)"; exit 1; }
+            fi
+          fi
+          command -v mold >/dev/null 2>&1 || { echo "::error::mold not on PATH after install"; exit 1; }
           mold --version
+          # postgresql-client — bounded apt, one retry, fail loud.
+          pg_ok=0
+          for attempt in 1 2; do
+            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y postgresql-client; then
+              pg_ok=1; break
+            fi
+            echo "apt postgresql-client attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${pg_ok}" = 1 ] || { echo "::error::postgresql-client install failed"; exit 1; }
+          psql --version
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,10 +919,60 @@ jobs:
         with:
           components: clippy
 
-      - name: Install mold linker (#1148)
+      - name: Install mold linker (#1148, pinned+bounded #3090)
+        timeout-minutes: 6
+        env:
+          MOLD_VERSION: "2.4.1"
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
+          set -euo pipefail
+          # ------------------------------------------------------------------
+          # #3090 — the old body was a bare `apt-get update && apt-get install
+          # -y mold` with NO step timeout, NO retry, NO pin. When the Azure apt
+          # mirror stalled, the step blocked until the JOB `timeout-minutes`
+          # fired (75 on coverage) — a ~1h15m flake per PR. This step is now
+          # idempotent, PINNED, time-bounded (step `timeout-minutes` above +
+          # per-command GNU `timeout`), retried once, and FAILS LOUD (exit 1)
+          # rather than hanging if mold cannot be fetched. Primary path pulls a
+          # pinned first-party mold release tarball from github.com (the infra
+          # the runner already trusts) into /usr/local/bin, removing the flaky
+          # apt mirror from the happy path; apt is the bounded fallback only. No
+          # external Action is added (repo no-external-code-injection rule).
+          # ------------------------------------------------------------------
+          if command -v mold >/dev/null 2>&1 && mold --version | grep -q "${MOLD_VERSION}"; then
+            echo "mold ${MOLD_VERSION} already present: $(mold --version)"; exit 0
+          fi
+          install_from_tarball() {
+            local arch tgz url dir ok attempt
+            arch="$(uname -m)"
+            tgz="mold-${MOLD_VERSION}-${arch}-linux.tar.gz"
+            url="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${tgz}"
+            dir="$(mktemp -d)"; ok=0
+            for attempt in 1 2; do
+              if timeout 120 curl -fsSL --retry 2 --retry-delay 3 -o "${dir}/${tgz}" "${url}"; then
+                ok=1; break
+              fi
+              echo "mold tarball fetch attempt ${attempt} failed; retrying" >&2; sleep 3
+            done
+            [ "${ok}" = 1 ] || return 1
+            tar -xzf "${dir}/${tgz}" -C "${dir}"
+            sudo install -m0755 "${dir}/mold-${MOLD_VERSION}-${arch}-linux/bin/mold" /usr/local/bin/mold
+            sudo ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          }
+          install_from_apt() {
+            local ok attempt; ok=0
+            for attempt in 1 2; do
+              if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y mold; then
+                ok=1; break
+              fi
+              echo "apt mold install attempt ${attempt} failed; retrying" >&2; sleep 5
+            done
+            [ "${ok}" = 1 ]
+          }
+          if ! install_from_tarball; then
+            echo "::warning::pinned mold tarball unavailable — falling back to apt"
+            install_from_apt || { echo "::error::mold install failed (tarball + apt both failed)"; exit 1; }
+          fi
+          command -v mold >/dev/null 2>&1 || { echo "::error::mold not on PATH after install"; exit 1; }
           mold --version
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -243,10 +243,60 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Install mold linker (#1148)
+      - name: Install mold linker (#1148, pinned+bounded #3090)
+        timeout-minutes: 6
+        env:
+          MOLD_VERSION: "2.4.1"
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
+          set -euo pipefail
+          # ------------------------------------------------------------------
+          # #3090 — the old body was a bare `apt-get update && apt-get install
+          # -y mold` with NO step timeout, NO retry, NO pin. When the Azure apt
+          # mirror stalled, the step blocked until the JOB `timeout-minutes`
+          # fired (75 here) — a ~1h15m flake per PR. This step is now
+          # idempotent, PINNED, time-bounded (step `timeout-minutes` above +
+          # per-command GNU `timeout`), retried once, and FAILS LOUD (exit 1)
+          # rather than hanging if mold cannot be fetched. Primary path pulls a
+          # pinned first-party mold release tarball from github.com (the infra
+          # the runner already trusts) into /usr/local/bin, removing the flaky
+          # apt mirror from the happy path; apt is the bounded fallback only. No
+          # external Action is added (repo no-external-code-injection rule).
+          # ------------------------------------------------------------------
+          if command -v mold >/dev/null 2>&1 && mold --version | grep -q "${MOLD_VERSION}"; then
+            echo "mold ${MOLD_VERSION} already present: $(mold --version)"; exit 0
+          fi
+          install_from_tarball() {
+            local arch tgz url dir ok attempt
+            arch="$(uname -m)"
+            tgz="mold-${MOLD_VERSION}-${arch}-linux.tar.gz"
+            url="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${tgz}"
+            dir="$(mktemp -d)"; ok=0
+            for attempt in 1 2; do
+              if timeout 120 curl -fsSL --retry 2 --retry-delay 3 -o "${dir}/${tgz}" "${url}"; then
+                ok=1; break
+              fi
+              echo "mold tarball fetch attempt ${attempt} failed; retrying" >&2; sleep 3
+            done
+            [ "${ok}" = 1 ] || return 1
+            tar -xzf "${dir}/${tgz}" -C "${dir}"
+            sudo install -m0755 "${dir}/mold-${MOLD_VERSION}-${arch}-linux/bin/mold" /usr/local/bin/mold
+            sudo ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          }
+          install_from_apt() {
+            local ok attempt; ok=0
+            for attempt in 1 2; do
+              if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y mold; then
+                ok=1; break
+              fi
+              echo "apt mold install attempt ${attempt} failed; retrying" >&2; sleep 5
+            done
+            [ "${ok}" = 1 ]
+          }
+          if ! install_from_tarball; then
+            echo "::warning::pinned mold tarball unavailable — falling back to apt"
+            install_from_apt || { echo "::error::mold install failed (tarball + apt both failed)"; exit 1; }
+          fi
+          command -v mold >/dev/null 2>&1 || { echo "::error::mold not on PATH after install"; exit 1; }
           mold --version
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/postgres-parity-nightly.yml
+++ b/.github/workflows/postgres-parity-nightly.yml
@@ -72,15 +72,78 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Reclaim runner disk (#2960, first-party, no external action)
+        if: runner.os == 'Linux'
+        run: |
+          # #2960 — this heavy pg+AGE parity job builds sal-postgres and runs
+          # #[ignore]-gated live-PG tests on a stock ubuntu-latest runner
+          # (~14 GiB free). Prune the large preinstalled toolchains this build
+          # never touches BEFORE the compile, guarded so a shifting runner
+          # image can never fail the job. Pure first-party shell — no external
+          # 'free-disk-space' action (repo no-external-code-injection rule).
+          # NOTE: `docker image prune` (not `system prune --volumes`) so the
+          # running `services:` postgres container + its volume are untouched.
+          echo "::group::disk before reclaim"; df -h /; echo "::endgroup::"
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup \
+                      /usr/share/swift /usr/lib/jvm || true
+          sudo docker image prune -af || true
+          sudo apt-get clean || true
+          echo "::group::disk after reclaim"; df -h /; echo "::endgroup::"
+
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
-      - name: Install mold linker (#1148)
+      - name: Install mold linker (#1148, pinned+bounded #3090)
+        timeout-minutes: 6
+        env:
+          MOLD_VERSION: "2.4.1"
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
+          set -euo pipefail
+          # ------------------------------------------------------------------
+          # #3090 — bounded, pinned, fail-loud mold install (see ci.yml for the
+          # full rationale). The old bare `apt-get install -y mold` could hang
+          # on a stalled apt mirror until the job timeout fired. Primary path is
+          # a pinned first-party mold release tarball; apt is the bounded
+          # fallback. No external Action added.
+          # ------------------------------------------------------------------
+          if command -v mold >/dev/null 2>&1 && mold --version | grep -q "${MOLD_VERSION}"; then
+            echo "mold ${MOLD_VERSION} already present: $(mold --version)"; exit 0
+          fi
+          install_from_tarball() {
+            local arch tgz url dir ok attempt
+            arch="$(uname -m)"
+            tgz="mold-${MOLD_VERSION}-${arch}-linux.tar.gz"
+            url="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${tgz}"
+            dir="$(mktemp -d)"; ok=0
+            for attempt in 1 2; do
+              if timeout 120 curl -fsSL --retry 2 --retry-delay 3 -o "${dir}/${tgz}" "${url}"; then
+                ok=1; break
+              fi
+              echo "mold tarball fetch attempt ${attempt} failed; retrying" >&2; sleep 3
+            done
+            [ "${ok}" = 1 ] || return 1
+            tar -xzf "${dir}/${tgz}" -C "${dir}"
+            sudo install -m0755 "${dir}/mold-${MOLD_VERSION}-${arch}-linux/bin/mold" /usr/local/bin/mold
+            sudo ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          }
+          install_from_apt() {
+            local ok attempt; ok=0
+            for attempt in 1 2; do
+              if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y mold; then
+                ok=1; break
+              fi
+              echo "apt mold install attempt ${attempt} failed; retrying" >&2; sleep 5
+            done
+            [ "${ok}" = 1 ]
+          }
+          if ! install_from_tarball; then
+            echo "::warning::pinned mold tarball unavailable — falling back to apt"
+            install_from_apt || { echo "::error::mold install failed (tarball + apt both failed)"; exit 1; }
+          fi
+          command -v mold >/dev/null 2>&1 || { echo "::error::mold not on PATH after install"; exit 1; }
           mold --version
 
       - uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (CI reliability — mold-install hang + runner-disk reclaim; #3090 #2960)
+
+Two GitHub-Actions infra flakes were throttling the `release/v1.0.0` merge
+cascade (each remediation PR lost ~1h15m to reruns). CI-only change; no product
+code, no job renames, no required-context set change.
+
+- **#3090 — the `Install mold linker` step could hang for the full job timeout.**
+  All four mold-install steps (`ci.yml` Postgres feature gate, `coverage.yml`
+  Per-Module Coverage Thresholds, `postgres-parity-nightly.yml`,
+  `cert-postgres-age.yml`) were a bare `apt-get update && apt-get install -y
+  mold` with no step timeout, no retry, and no pin. A stalled Azure apt mirror
+  blocked the step until the *job* `timeout-minutes` fired (75 min on coverage).
+  Each step is now idempotent, installs a **pinned** first-party mold release
+  tarball (`rui314/mold` v2.4.1) into `/usr/local/bin` off the happy path,
+  falls back to a bounded `apt` install, is time-bounded (step `timeout-minutes`
+  + per-command GNU `timeout`), retried once, and **fails loud** (exit 1)
+  instead of hanging. No external Action added.
+
+- **#2960 — added a first-party disk-reclaim step to `postgres-parity-nightly`,**
+  the one heavy mold-using job still lacking one (the required Check matrix,
+  coverage, and Postgres feature gate jobs already carry `#2960` reclaim). Prunes
+  the large unused preinstalled toolchains before the sal-postgres build, guarded
+  with `|| true`; uses `docker image prune` (not `system prune --volumes`) so the
+  running `services:` postgres container is untouched. Pure shell — no external
+  `free-disk-space` action.
+
 ### Fixed (enterprise-federation Postgres-adapter audit; #3070 #3073 #3074)
 
 Three LOW-severity Postgres-adapter findings from the enterprise-federation


### PR DESCRIPTION
## What

Fixes the two GitHub-Actions infra flakes that were throttling the
`release/v1.0.0` GA merge cascade (each remediation PR lost ~1h15m to reruns).
CI-only change — no product code, no job renames, no required-context set change.

### 1. Mold-install hang → burns the full job timeout (#3090)

All four mold-install steps were a bare, unbounded `apt-get update && apt-get
install -y mold` with **no step `timeout-minutes`, no retry, no pin**. When the
Azure apt mirror stalls, the step blocks on the socket until the **job**-level
`timeout-minutes` fires — 75 min on `Per-Module Coverage Thresholds` — so a
transient mirror hiccup costs a full 1h15m and a forced rerun.

Each step (`ci.yml` Postgres feature gate, `coverage.yml` Per-Module Coverage
Thresholds, `postgres-parity-nightly.yml`, `cert-postgres-age.yml`) is now:
- **idempotent** — skips if the pinned mold is already present;
- **pinned + off the flaky path** — installs the pinned first-party
  `rui314/mold` **v2.4.1** release tarball into `/usr/local/bin` (github.com, the
  infra the runner already trusts), removing the apt mirror from the happy path;
- **bounded fallback** — a `timeout`-wrapped `apt` install if the tarball is
  unavailable;
- **time-bounded** — step `timeout-minutes` (6, or 8 on the cert job that also
  installs `postgresql-client`) **and** per-command GNU `timeout`;
- **retried once**, and **fails loud** (`exit 1` + `::error::`) instead of
  hanging.

No external Action is added (repo no-external-code-injection rule) — the pin is a
concrete versioned release URL and the logic is self-contained shell.

### 2. Runner-disk reclaim on the last uncovered heavy job (#2960)

The required Check matrix, coverage, and Postgres feature gate jobs already carry
`#2960` disk-reclaim steps. This PR adds the same **first-party** reclaim to
`postgres-parity-nightly` — the one heavy mold-using job still lacking one — so
its sal-postgres + live-PG build has headroom on a stock ~14 GiB runner. Prunes
the large unused preinstalled toolchains, guarded with `|| true`; uses
`docker image prune` (**not** `system prune --volumes`) so the running
`services:` postgres container and its volume are untouched. Pure shell — no
external `free-disk-space` action.

## Constraints honored

- **No job `name:` renamed**, no required job added/removed — only step names
  changed and steps hardened. `runs-on: ubuntu-latest` preserved on every job.
- Gates green locally:
  - `scripts/check-required-contexts.sh` → exit 0
  - `scripts/check-required-contexts.sh --self-test` → exit 0
  - `scripts/check-ci-job-claims.sh` → exit 0
  - `python3 -c yaml.safe_load` on all four workflows → OK
  - `bash -n` on every new/edited `run:` block → OK

## Risk

Low. Worst case for the mold change is a fast **loud** failure (bounded minutes)
if both the pinned tarball and apt are unreachable — strictly better than the
current silent 75-min hang. The reclaim step is fully guarded (`|| true`) and
cannot fail its job.

Closes #3090. Refs #2960 (disk family), tracker #3089. Family: #2500 #2414 #2415 #2937.

## AI involvement

Authored by Claude (Opus 4.8) under operator direction. All four mold-install
sites and the reclaim gap were located via codegraph/grep; the pinned mold
asset URL was verified against the live `rui314/mold` v2.4.1 release manifest.
Human operator gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
