### PR TITLE
fix(security): apply is_visible_to_caller post-filter on CLI recall (#2990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,23 @@ federation requests while advertising that no security knob can be loosened.
   in `src/security_profile.rs`, the `17`→`21` narrative in
   `src/enterprise_federation_posture.rs`, and the certification doc
   (`docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md`).
+### Security (cross-agent private-row confidentiality; #2990)
+
+- **#2990 (GA Wave-1 blocker, #3089) — the shell-to-CLI recall path leaked
+  other agents' `scope=private` rows.** The MCP and HTTP recall paths apply a
+  per-row ownership post-filter (`crate::visibility::is_visible_to_caller`)
+  after the `db::recall*` SQL scan, but the CLI path (`cli::recall::
+  run_with_embedder`) did not. The SQL `visibility_clause` only gates private
+  rows by owner when `--as-agent` is supplied (it binds the private prefix
+  placeholder from the namespace); with `--as-agent` absent — the common CLI
+  invocation — that placeholder is NULL and the whole gate short-circuits to
+  "all visible", so a CLI recall could surface another agent's `scope=private`
+  rows even with `AI_MEMORY_AGENT_ID` set. The CLI path now applies the SAME
+  `is_visible_to_caller` post-filter the MCP/HTTP paths use, keyed on the
+  read-visibility caller (`identity::resolve_read_visibility_caller`,
+  `AI_MEMORY_AGENT_ID`). Fail-closed: the filter can only HIDE rows, never
+  widen the returned set; `None` caller (no stable env identity) preserves the
+  single-tenant trust-all read posture. Collective and caller-owned rows pass.
 
 ### Fixed (enterprise-federation Postgres-adapter audit; #3070 #3073 #3074)
 

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -541,6 +541,29 @@ pub(crate) fn run_with_embedder(
             .collect(),
     };
 
+    // v0.7.0 #1468 / v1.0.0 #2990 — per-row ownership visibility post-filter,
+    // mirroring the MCP/HTTP recall paths (`crate::mcp::tools::recall::
+    // handle_recall_dto`'s `apply_visibility_filter`). The `db::recall*` SQL
+    // gate applies the #151 namespace-scope (`--as-agent`) gate but NOT the
+    // per-row `scope=private` ownership predicate UNLESS `--as-agent` was
+    // passed: with `as_agent=None` (the common CLI case) the
+    // `visibility_clause` private prefix (`?8`) binds NULL, short-circuiting
+    // the whole gate to "all visible" so a cross-agent `scope=private` row
+    // would otherwise reach the CLI wire. When `vis_caller` is `Some`, drop
+    // every row the caller does not own via the canonical
+    // `crate::visibility::is_visible_to_caller` predicate (owner OR
+    // inbox-target for private; collective + subtree-matched team/unit/org
+    // pass). `None` (no stable `AI_MEMORY_AGENT_ID`) keeps the single-tenant
+    // trust-all read posture. Fail-closed: this can only HIDE rows, never
+    // widen the returned set.
+    let results: Vec<(crate::models::Memory, f64)> = match vis_caller.as_deref() {
+        None => results,
+        Some(c) => results
+            .into_iter()
+            .filter(|(m, _)| crate::visibility::is_visible_to_caller(m, c))
+            .collect(),
+    };
+
     // v0.9.0 P0-1 (#1869, T8) — CLI ledger append: with recall pure by
     // default, a recall that writes no `recall_observations` row
     // vanishes from the access signal (its counts freeze). Record the
@@ -856,6 +879,145 @@ mod tests {
         // No assertion error; JSON shape comes through.
         let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
         assert!(v["memories"].is_array());
+    }
+
+    /// v1.0.0 #2990 — seed a memory with an explicit `scope` + owner
+    /// `agent_id` (the two `metadata` keys the visibility predicate reads),
+    /// so the cross-agent private-visibility regression can assert on real
+    /// scoped rows. Mirrors `seed_memory` field-for-field except for the two
+    /// injected keys.
+    fn seed_scoped(
+        db_path: &Path,
+        namespace: &str,
+        title: &str,
+        content: &str,
+        scope: &str,
+        owner: &str,
+    ) -> String {
+        use crate::models::{self, ConfidenceSource};
+        let conn = db::open(db_path).expect("db::open");
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut metadata = models::default_metadata();
+        if let Some(obj) = metadata.as_object_mut() {
+            obj.insert(
+                crate::META_KEY_AGENT_ID.to_string(),
+                serde_json::Value::String(owner.to_string()),
+            );
+            obj.insert(
+                crate::META_KEY_SCOPE.to_string(),
+                serde_json::Value::String(scope.to_string()),
+            );
+        }
+        let mem = models::Memory {
+            id: uuid::Uuid::new_v4().to_string(),
+            tier: models::Tier::Mid,
+            namespace: namespace.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            priority: 5,
+            confidence: 1.0,
+            source: "import".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            metadata,
+            memory_kind: models::MemoryKind::Observation,
+            confidence_source: ConfidenceSource::CallerProvided,
+            version: 1,
+            lifecycle_state: models::LifecycleState::Open,
+            ..Default::default()
+        };
+        db::insert(&conn, &mem).expect("db::insert")
+    }
+
+    #[test]
+    fn recall_cli_drops_cross_agent_private_row_2990() {
+        // v1.0.0 #2990 (GA Wave-1) — the shell-to-CLI recall path MUST apply
+        // the same per-row ownership post-filter the MCP/HTTP recall paths
+        // apply. Without `--as-agent`, the `db::recall*` SQL visibility gate
+        // short-circuits to "all visible" (`?8`/private-prefix binds NULL),
+        // so a cross-agent `scope=private` row would reach the CLI wire. The
+        // `is_visible_to_caller` post-filter keyed on `AI_MEMORY_AGENT_ID`
+        // closes the leak: agent A must NOT see agent B's private row, owner
+        // B must, and a `collective` row is visible to both.
+        //
+        // Serialize on the crate-wide agent-id env lock (#1772) since this
+        // test mutates `AI_MEMORY_AGENT_ID` process-wide.
+        let _envg = crate::identity::agent_id_env_test_lock();
+        let prev = std::env::var_os("AI_MEMORY_AGENT_ID");
+
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        // Agent B's private row and a world-readable collective row, both
+        // keyword-matching "needle". No `--as-agent` on the recall (the
+        // common CLI shape that leaves the SQL gate inert).
+        seed_scoped(
+            &db,
+            "test",
+            "needle private",
+            "bob secret",
+            "private",
+            "ai:bob",
+        );
+        seed_scoped(
+            &db,
+            "test",
+            "needle collective",
+            "shared body",
+            "collective",
+            "ai:bob",
+        );
+
+        let titles_for = |agent: &str, env: &mut TestEnv, db: &Path| -> Vec<String> {
+            // SAFETY: process-global env mutation serialized on the
+            // crate-wide agent-id test lock held for this test's body.
+            unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", agent) };
+            let args = default_args();
+            let cfg = AppConfig::default();
+            {
+                let mut out = env.output();
+                run(db, &args, true, &cfg, &mut out).unwrap();
+            }
+            let v: serde_json::Value = serde_json::from_str(env.stdout_str().trim()).unwrap();
+            let titles = v["memories"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|m| m["title"].as_str().unwrap().to_string())
+                .collect::<Vec<_>>();
+            env.stdout.clear();
+            env.stderr.clear();
+            titles
+        };
+
+        // Agent A (ai:alice) — private row owned by ai:bob is HIDDEN; the
+        // collective row is visible.
+        let alice = titles_for("ai:alice", &mut env, &db);
+        assert!(
+            !alice.iter().any(|t| t == "needle private"),
+            "CONFIDENTIALITY LEAK: agent A saw agent B's private row: {alice:?}"
+        );
+        assert!(
+            alice.iter().any(|t| t == "needle collective"),
+            "collective row must be visible to agent A: {alice:?}"
+        );
+
+        // Owner B (ai:bob) — sees its own private row AND the collective row.
+        let bob = titles_for("ai:bob", &mut env, &db);
+        assert!(
+            bob.iter().any(|t| t == "needle private"),
+            "owner B must see its own private row: {bob:?}"
+        );
+        assert!(
+            bob.iter().any(|t| t == "needle collective"),
+            "collective row must be visible to owner B: {bob:?}"
+        );
+
+        // Restore the pre-test env (still holding the lock).
+        // SAFETY: serialized on the crate-wide agent-id test lock.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", v) },
+            None => unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") },
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a cross-agent private-row **confidentiality leak** on the shell-to-CLI recall path (GA Wave-1 blocker, per GA triage #3089 Wave 1).

`cli::recall::run_with_embedder` did not apply the per-row ownership post-filter that the **MCP** (`mcp::tools::recall::handle_recall_dto`) and **HTTP** recall paths apply after the `db::recall*` SQL scan. As a result a CLI recall could surface another agent's `scope=private` rows.

### Root cause

The SQL `visibility_clause` gates private rows by owner **only when `--as-agent` is supplied**. `compute_visibility_prefixes(None)` returns an all-`None` tuple, binding the clause's private-prefix placeholder (`?8`) to `NULL`, which short-circuits the whole gate:

```
AND ( ?8 IS NULL  OR  scope='collective'  OR  (scope='private' AND ?12 ... )  OR ... )
```

With `--as-agent` absent — the common CLI invocation — `?8 IS NULL` makes the gate a no-op, so the `caller` bind (`?12`, from `AI_MEMORY_AGENT_ID`) is never consulted and **every** row is returned, including other agents' private rows.

### Fix

Mirror the MCP `apply_visibility_filter` **exactly** on the CLI path: after the Form-4 / Form-6 post-filters and before the observations-ledger append, drop rows the read-visibility caller does not own via the canonical `crate::visibility::is_visible_to_caller` predicate. The caller resolves via `crate::identity::resolve_read_visibility_caller` (`AI_MEMORY_AGENT_ID`).

- **Fail-closed / data-integrity**: the filter can only **HIDE** rows, never widen the returned set. A `None` caller (no stable env identity) preserves the single-tenant trust-all read posture — no behavior change for the single-operator default.
- Collective and caller-owned rows pass; a misspelled/unknown scope degrades to private (existing `#2633` semantics in the shared predicate).
- No new predicate invented — reuses the same `is_visible_to_caller` the other four read surfaces already call.

### Test

`recall_cli_drops_cross_agent_private_row_2990` (in `src/cli/recall.rs`): agent B stores a `scope=private` row; a CLI recall as agent **A** must NOT return it, as owner **B** it does, and a `collective` row is visible to both. Proven load-bearing via a **negative control** — with the filter disabled the test FAILs with `CONFIDENTIALITY LEAK: agent A saw agent B's private row`.

### Gates (all green)

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` on **default / sal / sal-postgres / vectorlite**
- `cargo check --examples`
- `AI_MEMORY_NO_CONFIG=1 cargo test --lib recall_cli_drops_cross_agent_private_row_2990` (umask 022) — pass
- `cargo audit` — exit 0

## Files

- `src/cli/recall.rs` — post-filter + regression test
- `CHANGELOG.md` — `[Unreleased]` Security entry

Closes #2990

## AI involvement

Authored by Claude (Opus 4.8) as the hard-coder in the autonomous v1.0.0 loop. Human operator gates merge/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
