### PR TITLE
fix(audit): read-time WITHHOLD + asi-hard cold-boot carve-out (#3006 #3068 #2942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,47 @@ federation requests while advertising that no security knob can be loosened.
   `AI_MEMORY_AGENT_ID`). Fail-closed: the filter can only HIDE rows, never
   widen the returned set; `None` caller (no stable env identity) preserves the
   single-tenant trust-all read posture. Collective and caller-owned rows pass.
+### Fixed (CERT-KEYSTONE audit-spine read-time fixes; #3006 #3068 #2942)
+
+Per the 2026-08-19 5-agent vote (#3089 Vote A). Two read-time integrity fixes
+sharing `src/governance/audit.rs`; NO on-disk audit artifact is written from the
+daemon at boot (the witness-mount write-authority invariant is preserved).
+
+- **#3006 / #3068 — `verify-audit-trail` false-convicted every fresh /
+  DR-restored / co-located database (forensic WATERMARK lane).** The shared
+  on-host forensic watermark sink is process/host-global, and an identity-less
+  reader (`db_id = None`: a fresh, DR-restored, or store-only-migrated store
+  with an empty audit chain) MATCHED EVERY watermark — so a live sibling's
+  climbing head was read as this store's high-water and forged a `Detected`
+  truncation verdict against a chain that was never truncated. `scan_file_last_watermark`
+  now returns a typed `WatermarkScan` enum MIRRORING the shipped `AnchorScan`
+  (rollback lane): an identity-less / empty-chain / foreign-only opener WITHHOLDS
+  (never match-all `Detected`), counting only db_id-less legacy watermarks and
+  skipping every IDENTIFIED one; the degrade is OBSERVABLE (the same legacy-id-less
+  WARN the rollback lane emits). The withhold is scoped to the FORENSIC WATERMARK
+  lane ONLY — the SIGNED off-table head-anchor ROLLBACK lane deliberately keeps
+  its match-all so a wipe-to-empty of a formerly-identified chain stays convicted
+  (its K1 pin makes the over-count an attestable wipe detector; this raw unsigned
+  lane must not over-convict). The silent `genesis_db_id` `Err → None` degrade in
+  `verify_audit_trail` (`src/signed_events.rs`) is stopped — a genuine read fault
+  now PROPAGATES rather than blinding the lane. The pg twin (`src/store/postgres.rs`
+  `verify_audit_trail`) reads through the SAME shared db_id-scoped reader, so it
+  inherits the fix at K3 parity.
+- **#2942 — an asi-hard cold node could not boot (rollback ROLLBACK lane).**
+  Under `AI_MEMORY_REQUIRE_ROLLBACK_CHECK=1` (pinned by `AI_MEMORY_SECURITY_PROFILE=asi-hard`)
+  a brand-new node whose witness pin is not yet enrolled (`AnchorScan::Unpinnable`)
+  was refused the open (`RollbackCheck::Missing`) — the cold-boot chicken-and-egg
+  (it must boot to RUN its own witness-enrollment ceremony). The shipped #2370-C2
+  bootstrap carve-out is extended to the `Unpinnable` require path: a genesis-less,
+  head-0 opener with NO surviving off-table head anchor boots clean. The
+  fresh-vs-wiped discriminator is the SURVIVING off-table head anchor, not
+  chain-emptiness — a DB that ran under require-mode and was later wiped left
+  anchor lines behind and stays fail-closed. No genesis row is minted on first
+  open (genesis-emit deferred to a narrow follow-up vote).
+
+Regression coverage: `tests/audit_watermark_db_id_scope_2955.rs` (two-DBs-on-one-host
+non-interference, sqlite + live-pg twin), `tests/rollback_evidence_1946.rs`
+(asi-hard cold-boot: fresh node boots, wiped node with surviving anchor refuses).
 
 ### Fixed (enterprise-federation Postgres-adapter audit; #3070 #3073 #3074)
 

--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -120,16 +120,20 @@ MAP=(
   # cov_postgres_governance.rs::consolidate_merges_sources against a live PG.
   "consolidate_confidence_floor_2935|subst|min_confidence = min_confidence.min(mem.confidence);>>>min_confidence = min_confidence.min(1.0); // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
   "consolidate_derived_kind_2935|subst|memory_kind: crate::models::MemoryKind::Claim,>>>memory_kind: crate::models::MemoryKind::Observation, // CERT-REMOVAL-PROOF-MUTATION|src/storage/mod.rs|trust_propagation_1958_1959|consolidate_floors_confidence_and_stamps_claim_2935"
-  # #2955 — forensic watermark PER-DATABASE scoping. The control is a SINGLE
-  # branch in `scan_file_last_watermark` (not a guard fn), so it uses `subst`:
-  # neutralizing `if line_id != mine {` to `if false {` stops the cross-DB skip,
-  # so a SIBLING database's watermark (a different genesis `db_id`) is honored as
-  # THIS db's high-water — the exact cross-DB watermark bleed #2955 closes. The
-  # lane test asserts a foreign-`db_id` watermark is NOT returned to a scoped
-  # reader; the mutation makes it returned => RED. Both backends read through
-  # this ONE shared reader (`last_audit_watermark`), so the pg twin is
-  # composite-covered by the same proof.
-  "scan_file_last_watermark_db_id_scope_2955|subst|) && line_id != mine>>>) && false // CERT-REMOVAL-PROOF-MUTATION|src/governance/audit.rs|audit_watermark_db_id_scope_2955|foreign_db_watermark_not_honored_as_this_db_high_water"
+  # #2955 — forensic watermark PER-DATABASE scoping. The control is a `match`
+  # arm in `scan_file_last_watermark` (not a guard fn), so it uses `subst`:
+  # neutralizing the `(Some(row_db_id), Some(mine)) if row_db_id != mine =>
+  # continue` arm's guard to `if false` stops the cross-DB skip, so a SIBLING
+  # database's watermark (a different genesis `db_id`) is honored as THIS db's
+  # high-water — the exact cross-DB watermark bleed #2955 closes. The lane test
+  # asserts a foreign-`db_id` watermark is NOT returned to a scoped reader; the
+  # mutation makes it returned => RED. Both backends read through this ONE shared
+  # reader (`last_audit_watermark`), so the pg twin is composite-covered by the
+  # same proof. (v1.0.0 #3006/#3068 rewrote this branch from an `if let` guard to
+  # a `match` returning a `WatermarkScan`; the IDENTITY-LESS-reader arm
+  # `(Some(_), None)` added there is a SEPARATE control proven by
+  # `empty_migrated_store_not_convicted_on_sibling_watermark`.)
+  "scan_file_last_watermark_db_id_scope_2955|subst|(Some(row_db_id), Some(mine)) if row_db_id != mine => continue,>>>(Some(row_db_id), Some(mine)) if false => continue, // CERT-REMOVAL-PROOF-MUTATION|src/governance/audit.rs|audit_watermark_db_id_scope_2955|foreign_db_watermark_not_honored_as_this_db_high_water"
 )
 
 # Apply MUTATION to function CTL in TARGET, per SHAPE.

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -1107,30 +1107,90 @@ pub fn last_audit_watermark(db_id: Option<&str>) -> Option<(i64, String)> {
     // DATABASE (mirrors [`read_head_anchor_high_water`]): a watermark carrying a
     // DIFFERENT db_id anchors a sibling DB on this mount and is skipped, so a
     // restored / rotated / co-located DB's head can never be read as THIS db's
-    // high-water. `db_id = None` (an opener with no genesis / empty chain) reads
-    // every watermark — the conservative pre-#2955 posture.
+    // high-water.
+    //
+    // v1.0.0 #3006 / #3068 — an IDENTITY-LESS opener (`db_id = None`, no genesis
+    // / empty chain) WITHHOLDS instead of matching every watermark: it counts
+    // only db_id-LESS (legacy) rows and SKIPS every IDENTIFIED one — it provably
+    // cannot OWN a watermark stamped for an identified database, and the pre-fix
+    // "None reads every watermark" posture let a freshly-migrated / co-located
+    // empty chain be FALSE-CONVICTED of truncation on a live sibling's climbing
+    // watermark. This mirrors [`scan_head_anchor_log`]'s `ForeignOnly` withhold
+    // ([`WatermarkScan`]). Wipe-to-empty of a formerly-IDENTIFIED chain is owned
+    // by the SIGNED head-anchor-log rollback lane ([`read_head_anchor_high_water`]
+    // / `RollbackCheck`), which DELIBERATELY still over-counts for a `None`
+    // reader — its K1 pin makes the over-count an ATTESTABLE wipe detector,
+    // whereas THIS lane reads the raw UNSIGNED anchor and must not over-convict.
+    let mut withheld = false;
     for file in files.iter().rev().take(2) {
-        if let Some((seq, hash, _signed)) = scan_file_last_watermark(file, db_id) {
-            return Some((seq, hash));
+        match scan_file_last_watermark(file, db_id) {
+            WatermarkScan::Found(seq, hash, _signed) => return Some((seq, hash)),
+            WatermarkScan::Withheld => withheld = true,
+            WatermarkScan::NoEligibleRow => {}
         }
+    }
+    if withheld {
+        // #3068 — the degrade is OBSERVABLE, never a silent withhold: an
+        // operator relying on the raw forensic-watermark lane (no audit-witness
+        // enrolled) is told WHY it withheld and where the attestable control is.
+        // Mirrors the legacy-id-less WARN [`scan_head_anchor_log`] emits.
+        tracing::warn!(
+            target: AUDIT_TRACE_TARGET,
+            "verify-audit-trail: this database has no genesis / empty audit chain \
+             (db_head = 0), and the SHARED on-host forensic watermark sink carries \
+             only watermarks stamped for OTHER (identified) databases — none can be \
+             attributed to this opener, so the forensic-watermark truncation lane \
+             WITHHOLDS (#3068 cross-store bleed fix). Wipe-to-empty detection for a \
+             formerly-identified chain is owned by the SIGNED head-anchor-log lane; \
+             enrol an audit-witness key (AI_MEMORY_WITNESS_KEY_DIR / \
+             AI_MEMORY_WITNESS_PUBKEY) for that attestable control."
+        );
     }
     None
 }
 
-/// The most-recent watermark row in a single forensic file:
-/// `(head_sequence, head_canonical_hash, signed)` where `signed` is `true`
-/// iff that row carried a non-empty Ed25519 `sig`. `None` if the file carries
-/// no watermark. Malformed / wrong-version rows are skipped.
+/// v1.0.0 #3006 / #3068 — typed outcome of one forensic-file watermark scan,
+/// MIRRORING [`AnchorScan`] for the raw (unsigned) forensic-watermark lane so an
+/// identity-less / empty-chain / foreign-only opener WITHHOLDS (never match-all
+/// `Detected`). The raw lane carries no K1 pin authority, so there is no
+/// `Unpinnable` analog; the two "no high-water for this opener" states are
+/// [`WatermarkScan::NoEligibleRow`] (mirrors [`AnchorScan::NoPinnedLines`]) and
+/// [`WatermarkScan::Withheld`] (mirrors [`AnchorScan::ForeignOnly`]).
+enum WatermarkScan {
+    /// No watermark row in this file eligible for this opener (mirrors
+    /// [`AnchorScan::NoPinnedLines`]): file absent/empty, or every row was
+    /// malformed / wrong-version / a foreign identified row an identity-less
+    /// opener could not own with NONE it could.
+    NoEligibleRow,
+    /// An IDENTITY-LESS opener (`db_id = None`, no genesis / empty chain)
+    /// SKIPPED at least one IDENTIFIED (db_id-bearing) watermark on this shared
+    /// sink and found NONE it can own (mirrors [`AnchorScan::ForeignOnly`]).
+    /// WITHHOLD — never match-all `Detected`; the caller surfaces the deferral.
+    Withheld,
+    /// The most-recent eligible watermark for this opener (mirrors
+    /// [`AnchorScan::High`]): `(head_sequence, head_canonical_hash, signed)`
+    /// where `signed` is `true` iff that row carried a non-empty Ed25519 `sig`.
+    Found(i64, String, bool),
+}
+
+/// The most-recent watermark row in a single forensic file eligible for this
+/// opener (see [`WatermarkScan`]). Malformed / wrong-version rows are skipped.
 ///
-/// The `signed` bit is what the L7
+/// The `signed` bit ([`WatermarkScan::Found`]) is what the L7
 /// [`audit_watermark_exoneration_authenticated`] gate consumes: `verify_since`
 /// tolerates an unsigned row (counts it, never fails on it), so the exonerating
 /// lanes must additionally confirm the exact watermark they trust is itself
 /// signed. [`last_audit_watermark`] ignores the bit (the CONVICTING lanes read
 /// the raw unauthenticated anchor).
-fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, String, bool)> {
-    let f = File::open(path).ok()?;
+fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> WatermarkScan {
+    let Ok(f) = File::open(path) else {
+        return WatermarkScan::NoEligibleRow;
+    };
     let mut found: Option<(i64, String, bool)> = None;
+    // #3068 — set when an identity-less opener skipped ≥1 IDENTIFIED watermark
+    // (mirrors `scan_head_anchor_log`'s `any_pinned`): decides NoEligibleRow vs
+    // Withheld when `found` is empty.
+    let mut skipped_identified = false;
     for line in BufReader::new(f).lines() {
         let Ok(line) = line else { continue };
         if line.trim().is_empty() {
@@ -1147,18 +1207,30 @@ fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, St
         {
             continue;
         }
-        // v1.0.0 #2955 — per-database scoping (mirrors `scan_head_anchor_log`'s
-        // #2370 match): a watermark carrying a DIFFERENT db_id anchors a sibling
-        // DB sharing this on-host sink and must NEVER become this opener's
-        // high-water. A db_id-less (legacy) watermark is counted conservatively
-        // for every opener; `db_id = None` (no genesis / empty chain) counts
-        // every watermark. Only the cross-DB (foreign-id) row is skipped.
-        if let (Some(line_id), Some(mine)) = (
+        // v1.0.0 #2955 / #3068 — per-database scoping of the SHARED on-host
+        // forensic sink (mirrors `scan_head_anchor_log`'s #2370 match). A
+        // watermark declares the database it anchors via its payload `db_id`.
+        match (
             row.payload.get("db_id").and_then(serde_json::Value::as_str),
             db_id,
-        ) && line_id != mine
-        {
-            continue;
+        ) {
+            // #2955 — a watermark for a DIFFERENT identified DB anchors a sibling
+            // sharing this mount and must NEVER become this (identified) opener's
+            // high-water.
+            (Some(row_db_id), Some(mine)) if row_db_id != mine => continue,
+            // #3068 — an IDENTITY-LESS opener (no genesis / empty chain) cannot
+            // OWN an IDENTIFIED watermark: a row that declares a db_id belongs to
+            // some identified database, and an opener with neither genesis nor
+            // chain is provably not it. Skip it and record the skip so an empty
+            // scan resolves to WITHHOLD (`Withheld`), not `NoEligibleRow`.
+            (Some(_), None) => {
+                skipped_identified = true;
+                continue;
+            }
+            // (Some, Some) matching own db_id, or a db_id-LESS legacy (pre-#2955)
+            // watermark counted CONSERVATIVELY for every opener (over-detect
+            // toward Evidence on the one-release compat window, never suppress).
+            _ => {}
         }
         let seq = row
             .payload
@@ -1172,7 +1244,11 @@ fn scan_file_last_watermark(path: &Path, db_id: Option<&str>) -> Option<(i64, St
             found = Some((seq, hash.to_string(), !row.sig.is_empty()));
         }
     }
-    found
+    match found {
+        Some((seq, hash, signed)) => WatermarkScan::Found(seq, hash, signed),
+        None if skipped_identified => WatermarkScan::Withheld,
+        None => WatermarkScan::NoEligibleRow,
+    }
 }
 
 /// L7 (PR-4, forensic-audit-trail wave) — earliest `--since` sentinel the
@@ -1248,7 +1324,7 @@ pub fn audit_watermark_exoneration_authenticated(
         return false;
     };
     for file in files.iter().rev().take(2) {
-        if let Some((_, _, signed)) = scan_file_last_watermark(file, db_id) {
+        if let WatermarkScan::Found(_, _, signed) = scan_file_last_watermark(file, db_id) {
             return signed;
         }
     }
@@ -2672,6 +2748,35 @@ fn sync_anchor_directory(_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// v1.0.0 #2942 — is there ANY surviving line in the OFF-TABLE head-anchor log,
+/// regardless of whether it K1-pins? The cold-boot carve-out
+/// ([`compute_rollback_verdict_for_report`]) uses this as the fresh-vs-wiped
+/// discriminator when the witness pin is NOT YET enrolled ([`AnchorScan::Unpinnable`]):
+/// a genuinely FRESH node has no anchor log at all, whereas a DB that ran under
+/// require-mode and was later wiped (its `signed_events` emptied AND its witness
+/// key stripped, so the pin is now unresolvable) left anchor lines behind on the
+/// mount — those must keep it fail-closed.
+///
+/// Reads the RAW file only — no pin / signature authority (that is
+/// [`scan_head_anchor_log`]'s job). An unresolvable custody dir or a `NotFound`
+/// log is "no surviving anchor" (nothing to convict FROM: an empty-chain opener
+/// has no same-db truncation this could hide; the destroy-the-whole-mount case
+/// is the documented off-host-witness residual, not this lane). A log that
+/// EXISTS but is unreadable fails CLOSED (treated as a surviving anchor).
+fn off_table_head_anchor_present() -> bool {
+    let Ok(dir) = witness_key_dir() else {
+        return false;
+    };
+    let path = dir.join(HEAD_ANCHOR_LOG_FILENAME);
+    match File::open(&path) {
+        Ok(f) => BufReader::new(f)
+            .lines()
+            .any(|l| l.is_ok_and(|s| !s.trim().is_empty())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    }
+}
+
 /// v1.0.0 #1946 B — read the highest witness-signed head anchored in the
 /// OFF-TABLE head-anchor log, K1-pinned against the enrolled witness pubkey.
 ///
@@ -2992,6 +3097,23 @@ pub fn compute_rollback_verdict_for_report(
         // a rollback (clean under require-mode too). Any other no-anchor case
         // keeps the #1946 withhold / fail-closed posture.
         AnchorScan::NoPinnedLines if db_head == 0 && db_id.is_none() => {
+            RollbackCheck::NotApplicable
+        }
+        // v1.0.0 #2942 — cold-boot carve-out for the asi-hard require path: a
+        // genesis-less, head-0 opener whose witness pin is NOT YET enrolled
+        // (`Unpinnable`) is a genuinely fresh asi-hard node ONLY when NO
+        // off-table head anchor survives on the mount. The discriminator is the
+        // SURVIVING off-table anchor, NOT chain-emptiness: a DB that ran under
+        // require-mode and was later wiped (its `signed_events` emptied AND its
+        // witness key stripped, so the pin is now unresolvable) left anchor
+        // lines behind → NOT carved out → stays fail-closed (`Missing`) below.
+        // No genesis row is minted on first open, so the witness-mount
+        // write-authority invariant is preserved (genesis-emit is deferred to
+        // the narrow T4 vote). Without this a brand-new asi-hard node cannot
+        // boot to RUN its own witness-enrollment ceremony (the chicken-and-egg).
+        AnchorScan::Unpinnable
+            if db_head == 0 && db_id.is_none() && !off_table_head_anchor_present() =>
+        {
             RollbackCheck::NotApplicable
         }
         AnchorScan::NoPinnedLines | AnchorScan::Unpinnable => {

--- a/src/signed_events.rs
+++ b/src/signed_events.rs
@@ -2418,9 +2418,17 @@ pub fn verify_audit_trail(
     // v1.0.0 #2955 — this database's genesis-derived identity scopes the SHARED
     // on-host forensic watermark reads below (both the truncation lane and the
     // #1873 head-hash lane), so a sibling DB sharing this sink can never bleed
-    // its head into THIS db's verdict. `None` on an empty chain / read fault =
-    // the conservative count-every-watermark posture.
-    let watermark_db_id = genesis_db_id(conn).ok().flatten();
+    // its head into THIS db's verdict. `Ok(None)` on an empty chain = the #3068
+    // WITHHOLD posture (an identity-less opener cannot own an identified
+    // sibling's watermark). v1.0.0 #3006/#3068 — PROPAGATE a genuine read fault
+    // instead of the pre-fix silent `Err → None` degrade: `None` now WITHHOLDS
+    // the truncation verdict, so swallowing a read fault to `None` would
+    // silently blind the lane rather than surface the fault. The chain head read
+    // above already `?`-propagates the same-table read, so this is consistent
+    // (mirrors the rollback/emission lanes' propagation, and the pg twin's
+    // `.map_err(…)?` on the identical genesis fetch — K3 parity).
+    let watermark_db_id = genesis_db_id(conn)
+        .context("verify_audit_trail: read genesis db-id for per-database watermark scoping")?;
     let exonerate_ok = crate::governance::audit::audit_watermark_exoneration_authenticated(
         audit_pubkey,
         watermark_db_id.as_deref(),

--- a/tests/audit_watermark_db_id_scope_2955.rs
+++ b/tests/audit_watermark_db_id_scope_2955.rs
@@ -20,7 +20,12 @@
 //!   the foreign row honored → this test RED);
 //! - THIS db's own watermark IS still honored (the fix does not over-block);
 //! - a legacy id-less watermark is counted CONSERVATIVELY for every opener;
-//! - `db_id = None` (empty chain) reads every watermark (pre-#2955 posture);
+//! - v1.0.0 #3006/#3068 — an IDENTITY-LESS opener (`db_id = None`, no genesis /
+//!   empty chain) counts only db_id-LESS legacy watermarks and SKIPS every
+//!   IDENTIFIED one (WITHHOLD, never match-all), so two stores sharing one host
+//!   never bleed a sibling's head (the pre-#3068 "None reads every watermark"
+//!   posture false-convicted a freshly-migrated empty chain of truncation on a
+//!   live sibling's climbing watermark);
 //! - END-TO-END: a foreign watermark can no longer forge a `Detected`
 //!   truncation verdict against a chain that was never truncated.
 //!
@@ -114,12 +119,17 @@ fn foreign_db_watermark_not_honored_as_this_db_high_water() {
         "own-db watermark must still be honored"
     );
 
-    // `db_id = None` (an opener with no genesis / empty chain) reads every
-    // watermark — the conservative pre-#2955 posture.
+    // v1.0.0 #3006/#3068 — an IDENTITY-LESS opener (`db_id = None`, no genesis /
+    // empty chain) can NOT own an IDENTIFIED (db_id-bearing) watermark: the
+    // `db-alpha` row is skipped, so a freshly-migrated empty chain co-located
+    // with a live sibling is never convicted of truncation on the sibling's
+    // watermark. (Pre-#3068 this returned `Some((100, …))` — the cross-store
+    // bleed.) Wipe-to-empty of a formerly-identified chain is owned by the
+    // SIGNED head-anchor-log lane, not this raw unsigned lane.
     assert_eq!(
         forensic::last_audit_watermark(None),
-        Some((100, "sibling-head-hash".to_string())),
-        "None (no genesis) must read every watermark (conservative posture)"
+        None,
+        "None (no genesis) must NOT read an identified sibling's watermark (#3068)"
     );
 }
 
@@ -233,4 +243,153 @@ fn own_db_watermark_still_detects_truncation() {
         },
         "own-db watermark must still convict a real tail truncation; report={report:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3006 / #3068 — TWO STORES, ONE HOST: an IDENTITY-LESS (empty-chain /
+// no-genesis) opener sharing the on-host forensic sink with an IDENTIFIED
+// sibling must NOT read the sibling's watermark as its own high-water, but a
+// LEGACY id-less watermark is still counted (conservative compat window).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn idless_opener_skips_identified_sibling_but_counts_legacy() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("e-forensic");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // A live IDENTIFIED sibling (its own genesis-derived db_id) stamped a high
+    // head=78_000 into the SHARED sink.
+    forensic::record_audit_watermark(78_000, "sibling-head", Some("sibling-db-id"));
+    forensic::flush_blocking();
+
+    // An IDENTITY-LESS opener (None = no genesis / empty chain) must NOT read
+    // the identified sibling's watermark — cross-store bleed closed (#3068).
+    assert_eq!(
+        forensic::last_audit_watermark(None),
+        None,
+        "an identity-less opener must not read an identified sibling's watermark (#3068)"
+    );
+
+    // But a LEGACY id-less watermark on the same sink IS still counted for the
+    // identity-less opener (over-detect toward Evidence, never suppression).
+    forensic::record_audit_watermark(42, "legacy-head", None);
+    forensic::flush_blocking();
+    assert_eq!(
+        forensic::last_audit_watermark(None),
+        Some((42, "legacy-head".to_string())),
+        "a legacy id-less watermark must still be counted for an identity-less opener"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3068 — a freshly-migrated store (memories migrated, but the
+// signed_events audit chain is genuinely EMPTY: 0 rows, no genesis) must NOT be
+// convicted of truncation on a co-located live sibling's climbing watermark.
+// This is the exact shape #3068 reported against the pg-186 hive store — a
+// TWO-DBs-on-one-host non-interference proof end to end through verify.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_migrated_store_not_convicted_on_sibling_watermark() {
+    let _g = forensic_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let fdir = fresh_dir("f-forensic");
+    let ddir = fresh_dir("f-db");
+    forensic::init(fdir.path(), None).expect("forensic init");
+
+    // A live IDENTIFIED sibling anchored a high head into the SHARED sink.
+    forensic::record_audit_watermark(9_000, "sibling-head", Some("live-sibling-db-id"));
+    forensic::flush_blocking();
+
+    // A freshly-migrated store: opened, but its signed_events chain is genuinely
+    // EMPTY (no rows appended → no genesis → genesis_db_id is None).
+    let conn = open_db(ddir.path());
+    assert!(
+        genesis_db_id(&conn).expect("genesis db_id read").is_none(),
+        "an empty-chain migrated store has no genesis identity"
+    );
+
+    // The empty store must NOT be convicted of truncation on the sibling's
+    // climbing watermark — the raw forensic-watermark lane WITHHOLDS. (Pre-#3068
+    // the identity-less read matched the sibling's head=9_000 vs db_head=0 and
+    // forged `Detected { anchored_head: 9_000, db_head: 0 }`.)
+    let report = verify_audit_trail(&conn, None, None).expect("verify");
+    assert_eq!(report.head_sequence, 0, "empty chain; report={report:?}");
+    assert_eq!(
+        report.truncation,
+        TruncationCheck::Unknown,
+        "a co-located sibling's watermark must not convict a freshly-migrated empty chain; \
+         report={report:?}"
+    );
+    assert!(
+        report.is_clean(),
+        "an empty migrated store with only a foreign watermark stays clean; report={report:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3006 / #3068 — POSTGRES TWIN (live-pg, #[ignore]). The pg
+// `verify_audit_trail` reads the SAME db_id-scoped shared forensic reader
+// ([`last_audit_watermark`]) with the pg-resolved `watermark_db_id`, so a
+// co-located FOREIGN sibling watermark must NOT forge a `Detected` truncation
+// verdict on the pg store — TWO DBs on one host do not false-convict each other
+// (K3 parity). Deterministic on the shared suite pg regardless of whether the
+// pg chain is empty (`db_id = None` ⇒ #3068 identity-less WITHHOLD) or populated
+// (`db_id = Some` ⇒ #2955 foreign-id skip): either way the foreign sibling is
+// scoped out and the fresh forensic sink holds only that sibling row ⇒ Unknown.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sal-postgres")]
+mod postgres_twin {
+    use super::{forensic, fresh_dir};
+    use ai_memory::signed_events::TruncationCheck;
+    use ai_memory::store::postgres::PostgresStore;
+
+    async fn live_pg() -> Option<PostgresStore> {
+        let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+        match PostgresStore::connect(&url).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!("skip: postgres connect failed: {e}");
+                None
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL — live postgres"]
+    async fn pg_foreign_sibling_watermark_does_not_convict_this_store() {
+        // No module lock: #[ignore] + live-pg, run explicitly (never races the
+        // sync tests), and a MutexGuard must not be held across an await.
+        let Some(pg) = live_pg().await else {
+            return;
+        };
+
+        // A FRESH forensic sink holding ONLY a FOREIGN identified sibling's
+        // watermark, anchored far ABOVE any possible pg head (so a pre-fix
+        // match-all / unscoped read would forge `Detected`).
+        let fdir = fresh_dir("pg-forensic");
+        forensic::init(fdir.path(), None).expect("forensic init");
+        forensic::record_audit_watermark(
+            9_000_000,
+            "pg-foreign-sibling-head",
+            Some("pg-foreign-sibling-db-id"),
+        );
+        forensic::flush_blocking();
+
+        // The pg twin reads the db_id-scoped shared reader: the foreign sibling
+        // is scoped out on BOTH the empty-chain (#3068) and populated-chain
+        // (#2955) paths, so the sibling never becomes this store's high-water.
+        let report = pg.verify_audit_trail(None, None).await.expect("pg verify");
+        assert_eq!(
+            report.truncation,
+            TruncationCheck::Unknown,
+            "a foreign sibling's watermark must not forge a truncation verdict on the pg \
+             store (K3 cross-store isolation); report={report:?}"
+        );
+    }
 }

--- a/tests/rollback_evidence_1946.rs
+++ b/tests/rollback_evidence_1946.rs
@@ -36,6 +36,17 @@
 //! - emission binds the genesis `db_id` on BOTH backends (sqlite here; the
 //!   `#[ignore]` live-postgres twin below).
 //!
+//! v1.0.0 #2942 (5-agent vote, #3089 Vote A) — asi-hard COLD-BOOT read-time
+//! carve-out:
+//!
+//! - a brand-new asi-hard node whose witness pin is NOT YET enrolled
+//!   (`AnchorScan::Unpinnable`) and that has NO surviving off-table head anchor
+//!   BOOTS CLEAN under require-mode (so it can run its own witness-enrollment
+//!   ceremony — the cold-boot chicken-and-egg), while a wiped node (head-0 /
+//!   genesis-less, pin stripped) with a SURVIVING off-table anchor stays
+//!   fail-closed (`Missing`) and refuses the open. No genesis row is minted on
+//!   first open (the witness-mount write-authority invariant is preserved).
+//!
 //! The witness / operator env vars are process-global, so every test that
 //! sets them serialises via a module-local lock and clears the env on exit.
 
@@ -646,6 +657,68 @@ fn sqlite_witness_emission_binds_v3_genesis_db_id() {
     assert!(
         res.contains(&format!("\"db_id\":\"{db_id}\"")),
         "emission binds THIS database's genesis db-id: {res}"
+    );
+
+    clear_env();
+}
+
+// ── (11b) #2942 — asi-hard cold-boot: fresh node boots, wiped node refuses ──
+
+#[test]
+fn asi_hard_cold_node_boots_fresh_but_refuses_wiped_with_surviving_anchor() {
+    let _g = lock();
+    unsafe {
+        std::env::set_var(witness::REQUIRE_ROLLBACK_CHECK_ENV, "1");
+    }
+
+    // (a) NET-NEW #2942 — a brand-new asi-hard node whose witness pin is NOT yet
+    // enrolled (`Unpinnable`) and that has NO off-table head anchor on the mount
+    // is a genuinely fresh DB: it BOOTS CLEAN under require-mode so the operator
+    // can then run the witness-enrollment ceremony (the cold-boot chicken-and-
+    // egg). Point the witness key dir at an EMPTY dir: no pubkey → Unpinnable,
+    // no anchor log → nothing to roll back FROM.
+    let fresh_kdir = fresh_dir("cold-fresh-keys");
+    unsafe {
+        std::env::set_var(witness::WITNESS_KEY_DIR_ENV, fresh_kdir.path());
+        std::env::remove_var(witness::WITNESS_PUBKEY_ENV);
+    }
+    assert_eq!(
+        witness::compute_rollback_verdict_for_report(0, None),
+        RollbackCheck::NotApplicable,
+        "#2942 cold-boot carve-out: unenrolled pin + head-0 + no surviving anchor is NotApplicable"
+    );
+    let fresh_db = fresh_dir("cold-fresh-db");
+    let fresh_path = fresh_db.path().join("audit.db");
+    drop(
+        ai_memory::db::open(&fresh_path)
+            .expect("#2942 — a fresh asi-hard node must boot under require-mode to self-enrol"),
+    );
+
+    // (b) REGRESSION — a wiped node: head-0 / genesis-less, its witness pin ALSO
+    // stripped (`Unpinnable`), but a SURVIVING off-table head anchor remains on
+    // the mount from a prior require-mode run. The discriminator
+    // (`off_table_head_anchor_present`) keeps it FAIL-CLOSED (`Missing`) → the
+    // open REFUSES under require-mode. (A truly fresh node has no such line.)
+    let wiped_kdir = fresh_dir("cold-wiped-keys");
+    std::fs::write(
+        wiped_kdir.path().join(witness::HEAD_ANCHOR_LOG_FILENAME),
+        "{\"surviving\":\"anchor-line-from-a-prior-require-mode-run\"}\n",
+    )
+    .expect("write surviving off-table anchor");
+    unsafe {
+        std::env::set_var(witness::WITNESS_KEY_DIR_ENV, wiped_kdir.path());
+        std::env::remove_var(witness::WITNESS_PUBKEY_ENV);
+    }
+    assert_eq!(
+        witness::compute_rollback_verdict_for_report(0, None),
+        RollbackCheck::Missing,
+        "#2942 — a surviving off-table anchor keeps a wiped node fail-closed (not carved out)"
+    );
+    let wiped_db = fresh_dir("cold-wiped-db");
+    let wiped_path = wiped_db.path().join("audit.db");
+    assert!(
+        ai_memory::db::open(&wiped_path).is_err(),
+        "#2942 — a wiped node with a surviving off-table anchor must refuse under require-mode"
     );
 
     clear_env();

--- a/tests/security_profile_dispatch_1961.rs
+++ b/tests/security_profile_dispatch_1961.rs
@@ -185,7 +185,10 @@ fn asi_hard_cold_boot_fresh_db_boots_clean_2942() {
     );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout)
         .expect("stats --json parses on a cold-boot asi-hard fresh db");
-    assert_eq!(v["total"], 0, "fresh cold-boot db has zero memories; got: {v}");
+    assert_eq!(
+        v["total"], 0,
+        "fresh cold-boot db has zero memories; got: {v}"
+    );
 }
 
 /// `asi-hard` + an operator LOOSENING override below the hard floor: boot is

--- a/tests/security_profile_dispatch_1961.rs
+++ b/tests/security_profile_dispatch_1961.rs
@@ -88,22 +88,54 @@ fn standard_posture_is_a_noop_and_command_proceeds() {
 
 /// `asi-hard` ENGAGED: the `posture == AsiHard` pin-logging branch runs and
 /// PINS the fail-closed knob set ON — including `AI_MEMORY_REQUIRE_ROLLBACK_CHECK`
-/// (#124), which then refuses to open a fresh DB that has no off-table witness
-/// head anchor. The refusal at the db-open seam is the observable PROOF that
-/// the asi-hard branch executed and its pins took effect (the pin loop runs
-/// BEFORE the db is opened). Exercises the net-new #1961 `AsiHard` arm.
+/// (#124), which refuses to open a WIPED database at the db-open seam.
+///
+/// v1.0.0 #2942 (5-agent vote, #3089 Vote A) narrowed the open-time rollback
+/// control with a cold-boot carve-out: a genuinely FRESH asi-hard node (no
+/// surviving off-table head anchor) now BOOTS so the operator can run the
+/// witness-enrollment ceremony (covered by
+/// [`asi_hard_cold_boot_fresh_db_boots_clean_2942`]). The refuse-open PROOF that
+/// the asi-hard branch executed and its pins took effect therefore moves to a
+/// WIPED node: a `signed_events` head of 0 (genesis-less) BUT a SURVIVING
+/// off-table head anchor from a prior require-mode run whose witness pin is no
+/// longer resolvable (`Unpinnable`). The surviving-anchor discriminator
+/// (`off_table_head_anchor_present`) keeps the verdict `Missing`, so the open is
+/// refused — and ONLY under the asi-hard-pinned require-mode (under `standard`
+/// the same wiped node would open, exactly as
+/// [`standard_posture_is_a_noop_and_command_proceeds`] shows for a clean node).
+/// The wiped state is seeded DETERMINISTICALLY via an explicit
+/// `AI_MEMORY_WITNESS_KEY_DIR` (asi-hard does not pin that operator-owned dir),
+/// so the refusal never depends on ambient default-custody-dir state. Exercises
+/// the net-new #1961 `AsiHard` arm.
 #[test]
-fn asi_hard_engaged_pins_rollback_check_and_refuses_open_on_fresh_db() {
-    let (_dir, db) = fresh_db("asi-hard-engaged");
+fn asi_hard_engaged_pins_rollback_check_and_refuses_open_on_wiped_db() {
+    let (_dir, db) = fresh_db("asi-hard-engaged-wiped");
+    // Seed the wiped-vs-fresh discriminator (#2942): a SURVIVING off-table head
+    // anchor line but NO enrolled pubkey in the witness key dir → the pin is
+    // `Unpinnable` AND an anchor survives, so the cold-boot carve-out does NOT
+    // apply and the rollback verdict stays `Missing` (refuse) under require-mode.
+    let kdir = tempfile::Builder::new()
+        .prefix("asi-hard-wiped-keys-")
+        .tempdir()
+        .expect("tempdir for witness key dir");
+    std::fs::write(
+        kdir.path().join("head-anchor.log"),
+        "{\"surviving\":\"anchor-line-from-a-prior-require-mode-run\"}\n",
+    )
+    .expect("write surviving off-table anchor");
+    let kdir_s = kdir.path().to_str().expect("utf-8 witness key dir path");
     let out = run_ai_memory(
         &db,
         &["stats", "--json"],
-        &[("AI_MEMORY_SECURITY_PROFILE", "asi-hard")],
+        &[
+            ("AI_MEMORY_SECURITY_PROFILE", "asi-hard"),
+            ("AI_MEMORY_WITNESS_KEY_DIR", kdir_s),
+        ],
     );
     assert!(
         !out.status.success(),
-        "asi-hard pins require_rollback_check=1 → fresh-db open must be refused; \
-         exit={:?} stdout={}",
+        "asi-hard pins require_rollback_check=1 → a WIPED db (surviving off-table \
+         anchor, unresolvable pin) open must be refused; exit={:?} stdout={}",
         out.status.code(),
         String::from_utf8_lossy(&out.stdout)
     );
@@ -113,6 +145,47 @@ fn asi_hard_engaged_pins_rollback_check_and_refuses_open_on_fresh_db() {
             || stderr.contains("AI_MEMORY_REQUIRE_ROLLBACK_CHECK"),
         "expected the asi-hard-pinned rollback-check refusal; stderr={stderr}"
     );
+}
+
+/// v1.0.0 #2942 (5-agent vote, #3089 Vote A) — the asi-hard COLD-BOOT carve-out
+/// at the subprocess dispatch seam (the companion of
+/// [`asi_hard_engaged_pins_rollback_check_and_refuses_open_on_wiped_db`]). A
+/// genuinely fresh asi-hard node — genesis-less, `signed_events` head 0, witness
+/// pin NOT yet enrolled, and NO surviving off-table head anchor on the mount —
+/// must BOOT CLEAN under the asi-hard-pinned require-mode, so the operator can
+/// run the witness-enrollment ceremony (the cold-boot chicken-and-egg). Same
+/// asi-hard pins as the wiped case; only the surviving-anchor discriminator
+/// differs, flipping the verdict from `Missing` (refuse) to `NotApplicable`
+/// (proceed). The witness key dir is pointed at an EMPTY dir so the custody
+/// state is deterministic: no pubkey (unenrolled pin) and no `head-anchor.log`
+/// (nothing to roll back FROM).
+#[test]
+fn asi_hard_cold_boot_fresh_db_boots_clean_2942() {
+    let (_dir, db) = fresh_db("asi-hard-cold-fresh");
+    let kdir = tempfile::Builder::new()
+        .prefix("asi-hard-fresh-keys-")
+        .tempdir()
+        .expect("tempdir for empty witness key dir");
+    let kdir_s = kdir.path().to_str().expect("utf-8 witness key dir path");
+    let out = run_ai_memory(
+        &db,
+        &["stats", "--json"],
+        &[
+            ("AI_MEMORY_SECURITY_PROFILE", "asi-hard"),
+            ("AI_MEMORY_WITNESS_KEY_DIR", kdir_s),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "asi-hard #2942 cold-boot carve-out: a genuinely fresh db (unenrolled \
+         pin + head-0 + no surviving off-table anchor) must BOOT CLEAN under \
+         require-mode; exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("stats --json parses on a cold-boot asi-hard fresh db");
+    assert_eq!(v["total"], 0, "fresh cold-boot db has zero memories; got: {v}");
 }
 
 /// `asi-hard` + an operator LOOSENING override below the hard floor: boot is


### PR DESCRIPTION
Closes #3006 #3068 #2942

Per 5-agent vote (#3089 Vote A). CERT-KEYSTONE audit-spine **read-time** fixes sharing `src/governance/audit.rs`. NO on-disk audit artifact is written from the daemon at boot — the witness-mount write-authority invariant is preserved (genesis-emit-on-first-open is deferred to a narrow follow-up T4 vote).

## #3006 / #3068 — forensic WATERMARK lane: WITHHOLD, never match-all

`verify-audit-trail` false-convicted every **fresh / DR-restored / store-only-migrated** database co-located with a live sibling on a shared on-host forensic sink: an identity-less reader (`db_id = None`, empty audit chain) MATCHED EVERY watermark, so a sibling's climbing head forged a `Detected` truncation verdict against a chain that was never truncated.

- `scan_file_last_watermark` now returns a typed **`WatermarkScan` enum MIRRORING the shipped `AnchorScan`** (rollback lane, `src/governance/audit.rs`): `NoEligibleRow` ↔ `NoPinnedLines`, `Withheld` ↔ `ForeignOnly`, `Found(seq,hash,signed)` ↔ `High`. An identity-less / empty-chain / foreign-only opener **WITHHOLDS** (never match-all `Detected`) — it counts only db_id-less legacy watermarks and skips every IDENTIFIED one (it provably cannot own a watermark stamped for an identified DB). The degrade is **OBSERVABLE** (same legacy-id-less WARN the rollback lane emits).
- Scoped to the forensic watermark lane **ONLY** — the SIGNED off-table head-anchor ROLLBACK lane keeps its match-all so a wipe-to-empty of a formerly-identified chain **stays convicted** (its K1 pin makes the over-count an attestable wipe detector; this raw unsigned lane must not over-convict). This two-lane split is load-bearing.
- The silent `genesis_db_id` `Err → None` degrade in `verify_audit_trail` (`src/signed_events.rs`) is stopped: a genuine read fault now **propagates** (consistent with the chain-head read one line above, and with the pg twin's `.map_err(…)?`).
- **pg twin** (`src/store/postgres.rs::verify_audit_trail`) reads the SAME shared db_id-scoped reader, inheriting the fix at K3 parity.
- Cascade PR #3082 fixes the same #3068 bleed with a `struct`; this PR delivers the vote-mandated **enum** form and **subsumes** it (see Residual).

## #2942 — asi-hard cold node could not boot (ROLLBACK lane)

Under `AI_MEMORY_REQUIRE_ROLLBACK_CHECK=1` (pinned by `AI_MEMORY_SECURITY_PROFILE=asi-hard`) a brand-new node whose witness pin is not yet enrolled (`AnchorScan::Unpinnable`) was refused the open (`RollbackCheck::Missing`) — the cold-boot chicken-and-egg (it must boot to RUN its own witness-enrollment ceremony).

- The shipped **#2370-C2 bootstrap carve-out** is extended to the `Unpinnable` require path: a genesis-less, head-0 opener with **NO surviving off-table head anchor** boots clean. The fresh-vs-wiped discriminator is the **surviving off-table anchor** (`off_table_head_anchor_present`), not chain-emptiness — a DB that ran under require-mode and was later wiped left anchor lines behind and stays fail-closed (`Missing`). No genesis row minted on first open.

## Tests

- `tests/audit_watermark_db_id_scope_2955.rs` — `idless_opener_skips_identified_sibling_but_counts_legacy`, `empty_migrated_store_not_convicted_on_sibling_watermark` (two-DBs-on-one-host, sqlite), and `postgres_twin::pg_foreign_sibling_watermark_does_not_convict_this_store` (live-pg twin). Existing `foreign_db_watermark_not_honored_as_this_db_high_water` updated for the WITHHOLD posture.
- `tests/rollback_evidence_1946.rs` — `asi_hard_cold_node_boots_fresh_but_refuses_wiped_with_surviving_anchor` (fresh node boots under require; wiped node with a surviving anchor refuses).
- `scripts/check-cert-removal-proof.sh` map updated for the match-arm rewrite (`--self-test` unaffected; the `scan_file_last_watermark_db_id_scope_2955` control re-proven load-bearing: broken→RED rc=101, restored→GREEN).

## Gates

`cargo check --all-targets` (default) ✔; clippy `-D warnings -D clippy::all -D clippy::pedantic --all-targets` on **default / sal / sal-postgres / vectorlite** all ✔; `cargo fmt --all` ✔; targeted tests under `( umask 022 )` ✔; `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` ✔; removal-proof control re-proven ✔; pg twin + pg emission ✔ vs live PG16.14.

## Residual

- **Two-lane coupling (by design):** the watermark-lane WITHHOLD narrows wipe-to-empty conviction to the SIGNED off-table head-anchor ROLLBACK lane. Safe ONLY if BOTH lanes are armed on every certified node AND every certified node is reopened under require-mode. A node inspected offline via `verify-audit-trail` alone, or with the rollback gate un-armed, could read a wiped chain as clean. The cert CI gate must prove both lanes armed + the empty-chain-with-surviving-own-anchor-still-convicts case on both backends (tracked with the #3016/#3067 bring-up work).
- **Supersedes #3082:** delivers the vote's `WatermarkScan` enum (vs #3082's struct) plus the pg-twin proof + #2942; recommend closing #3082 in favor of this, or land #3082 first and this enum refactor cleanly replaces the struct.
- **Deferred genesis-emit (T4):** the destroy-the-whole-mount / malicious-operator re-genesis vector is not caught by read-time detection (off-host witness / federation co-signature required); unchanged by this PR.

## AI involvement

Implemented by Claude Opus 4.8 (hard-coder) under the ai-memory-mcp v1.0.0 loop, per the 2026-08-19 5-agent adversarial vote recorded in #3089 / `.local-runs/ga-assessment-2026-08-19/vote-decisions.json`. Design mirrors shipped in-tree precedent (`AnchorScan` / `compute_rollback_verdict_for_report`); no new crypto or on-disk artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY