### PR TITLE
ci: CI cycle speedup — apt hardening + build-cache scoping + Merge Queue prereq

### DIFF
--- a/.github/workflows/batman-mode-acceptance.yml
+++ b/.github/workflows/batman-mode-acceptance.yml
@@ -150,8 +150,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: batman-mode-acceptance
-      - name: Install sqlite3 + jq
-        run: sudo apt-get update && sudo apt-get install -y sqlite3 jq
+      - name: Install sqlite3 + jq (bounded+retry #3090/#2960)
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          # #3090/#2960 — bounded, retried, fail-LOUD apt install (mirrors the
+          # postgresql-client hardening #3091). The old bare
+          # `apt-get update && apt-get install` could hang on a stalled apt
+          # mirror until the job timeout fired. No external Action added.
+          apt_ok=0
+          for attempt in 1 2; do
+            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y sqlite3 jq; then
+              apt_ok=1; break
+            fi
+            echo "apt sqlite3+jq attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${apt_ok}" = 1 ] || { echo "::error::sqlite3 + jq install failed"; exit 1; }
+          sqlite3 --version
+          jq --version
       - name: Build release binary + install to PATH
         run: |
           cargo build --release --bin ai-memory

--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -59,6 +59,14 @@ on:
     branches: [main, develop, "release/**"]
   pull_request:
     branches: [main, develop, "release/**"]
+  # Merge Queue (#3089) — this workflow carries several REQUIRED gate contexts,
+  # so it MUST report on the `merge_group` ref or the queue wedges. Its jobs
+  # have no docs-only/event `if:` gating (the two event-scoped gates —
+  # cert-expiry and commit-signing-posture — N/A-skip to exit 0 on a non-PR
+  # event, staying green), so every context reports on merge_group unchanged.
+  # No `name:` changed. See ci.yml for the full merge-queue rationale.
+  merge_group:
+    types: [checks_requested]
 
 # Fork-PR-safe concurrency key: coalesces push + same-branch internal
 # PR events; isolates fork PRs by PR number. See ci.yml for full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main, develop, "release/**"]
+  # Merge Queue (#3089) — GitHub runs a queued PR's REQUIRED checks against the
+  # ephemeral `merge_group` ref, NOT the PR ref. A required workflow that does
+  # not trigger on `merge_group` never reports on that ref, so its context stays
+  # pending forever and the queue wedges the branch. Adding the trigger keeps
+  # the SAME required-context names (no `name:` changed). The `classify` decider
+  # defaults to `docs_only=false` on `merge_group` (explicit arm below): a merge
+  # group must exercise the FULL gate, never short-circuit to a docs-only skip.
+  merge_group:
+    types: [checks_requested]
 
 # Concurrency: coalesces `push` + same-branch internal `pull_request`
 # events while keeping fork PRs isolated.
@@ -155,6 +164,22 @@ jobs:
           #     do not gate merges — required contexts are matched on
           #     the PR head commit.
           ZERO=0000000000000000000000000000000000000000
+          # Merge Queue (#3089) — a `merge_group` event has no PR diff to
+          # classify, and a merge group MUST run the whole pipeline (never a
+          # docs-only short-circuit). Pin it here to `docs_only=false` +
+          # `__ALL__`. The generic fail-closed `else` arm below would also
+          # yield this (empty base → run everything), but the merge queue's
+          # correctness depends on it, so it is explicit and not left implicit
+          # to a future refactor of the base-resolution block.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "test_impact=__ALL__" >> "$GITHUB_OUTPUT"
+            echo "test_impact_count=ALL" >> "$GITHUB_OUTPUT"
+            echo "test_impact_total=ALL" >> "$GITHUB_OUTPUT"
+            echo "test_impact_reason=merge_group-full-pipeline" >> "$GITHUB_OUTPUT"
+            echo "::notice::merge_group event — running the full pipeline (not docs-only)"
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             cls_base="$PR_BASE_SHA"
             if [ -n "$PR_BEFORE" ] && [ "$PR_BEFORE" != "$ZERO" ] && [ "$PR_ACTION" = "synchronize" ]; then
@@ -616,6 +641,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         if: needs.classify.outputs.docs_only != 'true'
+        with:
+          # CI-speed (#3089) — SAVE the cache only on trunk `push` events
+          # (push.branches = main/develop/release/**). `pull_request` and
+          # `merge_group` runs RESTORE the warm trunk cache but never SAVE, so
+          # (a) a failed/partial PR compile cannot poison the shared cache
+          # (the "save-always: false" property) and (b) per-PR caches do not
+          # evict the trunk cache under GitHub's 10 GB/repo LRU limit, keeping
+          # the hit-rate high across PRs. Worst case degrades to a colder
+          # cache (slower, never wrong). rust-cache@v2 is the repo's existing
+          # house action — no new/unpinned Action is introduced.
+          save-if: ${{ github.event_name == 'push' }}
 
       # v0.9.0 pre-GA (#1853) — e1 macOS anti-flake. The
       # tests/e1_orchestration_dry_run.rs harness historically ran a NESTED
@@ -976,6 +1012,12 @@ jobs:
           mold --version
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # CI-speed (#3089) — save the cache only on trunk `push` events;
+          # PR + merge_group runs restore-only. See the `check` job above for
+          # the full rationale (no cache poison from a failed PR compile; no
+          # LRU eviction of the warm trunk cache). No new Action introduced.
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Wait for postgres readiness
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,13 @@ on:
     branches: [main, develop, "release/**", "feat/v0.7.0-grand-slam"]
   push:
     branches: [main, develop, "feat/v0.7.0-grand-slam", "release/**"]
+  # Merge Queue (#3089) — `Per-Module Coverage Thresholds` (+ the sibling
+  # doc/claims gates) are REQUIRED contexts, so this workflow MUST report on
+  # the `merge_group` ref or the queue wedges. The `Coverage classify` decider
+  # defaults to `docs_only=false` on `merge_group` (explicit arm below): the
+  # full llvm-cov sweep runs, never a docs-only short-circuit. See ci.yml.
+  merge_group:
+    types: [checks_requested]
 
 # v0.7.x (#1148) — cancel stale runs on a PR when a new push lands.
 # Fork-PR-safe concurrency key: coalesces push + same-branch internal
@@ -93,6 +100,15 @@ jobs:
           # said docs_only=false (12-file backend change) while ci.yml's
           # incremental one said true (CLAUDE.md-only last commit) — the
           # in-repo A/B that proved the defect. ci.yml now matches this.
+          # Merge Queue (#3089) — a merge_group event has no PR diff; a merge
+          # group MUST run the full llvm-cov sweep (never a docs-only skip).
+          # Pin docs_only=false explicitly (the fail-closed `else`/empty-base
+          # arm below would also yield it, but the queue depends on it).
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::merge_group event — running the full coverage sweep (not docs-only)"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
           elif [ "${{ github.event_name }}" = "push" ]; then
@@ -300,6 +316,12 @@ jobs:
           mold --version
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # CI-speed (#3089) — save the cache only on trunk `push` events;
+          # PR + merge_group runs restore-only. See ci.yml's `check` job for
+          # the full rationale (no poison from a failed compile; no LRU
+          # eviction of the warm trunk cache). No new Action introduced.
+          save-if: ${{ github.event_name == 'push' }}
 
       # #2019 — the reranker (cross-encoder/ms-marco-MiniLM-L-6-v2) + embedder
       # (sentence-transformers/all-MiniLM-L6-v2) tests download their weights via
@@ -383,12 +405,29 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Install jq + postgresql-client
+      - name: Install jq + postgresql-client (bounded+retry #3090/#2960)
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq postgresql-client
+          set -euo pipefail
+          # #3090/#2960 — bounded, retried, fail-LOUD apt install, mirroring the
+          # postgresql-client hardening #3091 landed in cert-postgres-age.yml.
+          # The old bare `apt-get update && apt-get install` had NO step timeout,
+          # NO retry: a stalled apt mirror blocked until the JOB timeout fired.
+          # Now: step-level timeout-minutes + per-command GNU `timeout`, one
+          # retry, `::error::` + exit 1 on failure. No external Action added.
+          apt_ok=0
+          for attempt in 1 2; do
+            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y jq postgresql-client; then
+              apt_ok=1; break
+            fi
+            echo "apt jq+postgresql-client attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${apt_ok}" = 1 ] || { echo "::error::jq + postgresql-client install failed"; exit 1; }
+          jq --version
+          psql --version
 
       - name: Install pgvector + provision AGE/vector extensions
+        timeout-minutes: 6
         env:
           PGPASSWORD: ai_memory_test
         run: |
@@ -398,8 +437,20 @@ jobs:
           # (apache/age inherits debian-bookworm via postgres:16).
           PG_CONTAINER=$(docker ps --filter "ancestor=apache/age:release_PG16_1.6.0" --format '{{.ID}}' | head -1)
           echo "pg container: $PG_CONTAINER"
-          docker exec "$PG_CONTAINER" apt-get update
-          docker exec "$PG_CONTAINER" apt-get install -y postgresql-16-pgvector
+          # #3090/#2960 — bounded, retried, fail-LOUD apt install INSIDE the pg
+          # container (the pgdg/debian mirror is the flaky bit). GNU `timeout`
+          # bounds each docker exec; one retry; `::error::` + exit 1 on failure
+          # so a stalled mirror fails loud instead of hanging to the step/job
+          # timeout. No external Action added.
+          pgv_ok=0
+          for attempt in 1 2; do
+            if timeout 180 docker exec "$PG_CONTAINER" apt-get update \
+               && timeout 180 docker exec "$PG_CONTAINER" apt-get install -y postgresql-16-pgvector; then
+              pgv_ok=1; break
+            fi
+            echo "pgvector apt install attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${pgv_ok}" = 1 ] || { echo "::error::postgresql-16-pgvector install failed"; exit 1; }
           # Provision extensions + the memory_graph AGE graph the SAL
           # postgres adapter expects. Mirrors infra/lan-parity-test/init-age.sql.
           psql -h 127.0.0.1 -p 5432 -U ai_memory -d ai_memory_test -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1085,9 +1085,21 @@ jobs:
           TAG: ${{ needs.preflight.outputs.tag }}
 
       - name: Install copr-cli
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pipx
+          set -euo pipefail
+          # #3090/#2960 — bounded, retried, fail-LOUD apt install (mirrors the
+          # postgresql-client hardening #3091). The old bare
+          # `apt-get update && apt-get install -y pipx` could hang on a stalled
+          # apt mirror until the job timeout fired. No external Action added.
+          apt_ok=0
+          for attempt in 1 2; do
+            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y pipx; then
+              apt_ok=1; break
+            fi
+            echo "apt pipx attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${apt_ok}" = 1 ] || { echo "::error::pipx install failed"; exit 1; }
           pipx ensurepath
           pipx install copr-cli
           pipx inject copr-cli rich
@@ -1099,7 +1111,20 @@ jobs:
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
 
       - name: Install RPM build tools
-        run: sudo apt-get update && sudo apt-get install -y rpm
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          # #3090/#2960 — bounded, retried, fail-LOUD apt install (mirrors the
+          # postgresql-client hardening #3091). No external Action added.
+          apt_ok=0
+          for attempt in 1 2; do
+            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y rpm; then
+              apt_ok=1; break
+            fi
+            echo "apt rpm attempt ${attempt} failed; retrying" >&2; sleep 5
+          done
+          [ "${apt_ok}" = 1 ] || { echo "::error::rpm install failed"; exit 1; }
+          rpm --version
 
       - name: Build source RPM
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (CI cycle speedup: apt hardening + build-cache scoping + Merge Queue prereq; #3089 #2960 #3090)
+
+Follow-on to #3091 (which hardened only the `mold` install). CI-only change; no
+product code, no job `name:` changed, no required-context set changed, still
+`runs-on: ubuntu-latest`.
+
+- **Hardened every remaining flaky `apt-get install` (the #2960/#3090 class).**
+  #3091 fixed `mold` + one `postgresql-client`, but other bare
+  `apt-get update && install` steps could still hang on a stalled apt mirror
+  until the job timeout fired (it cost #3094 a full rerun). Swept all workflows
+  and applied #3091's exact shape — step-level `timeout-minutes`, per-command
+  GNU `timeout`, one bounded retry, `::error::` + `exit 1` fail-loud — to:
+  `coverage.yml` **Install jq + postgresql-client** and the in-container
+  **pgvector** install (`docker exec … apt-get`), `batman-mode-acceptance.yml`
+  **sqlite3 + jq**, and `release.yml` **pipx** (copr-cli) + **rpm**. No external
+  Action added (the apt mirror stays the source; only the hang is bounded).
+- **Scoped the Rust build cache save to trunk pushes on the three heavy compile
+  jobs** (`check` matrix, `Postgres feature gate`, `Per-Module Coverage
+  Thresholds`). Those jobs already use the repo's house action
+  `Swatinem/rust-cache@v2`; adding a second `actions/cache` target-dir layer
+  would only bloat/stale it. Instead each now sets
+  `save-if: ${{ github.event_name == 'push' }}` so `pull_request` + `merge_group`
+  runs **restore** the warm trunk cache but never **save** — a failed/partial PR
+  compile can no longer poison the shared cache, and per-PR caches no longer
+  evict the trunk cache under GitHub's 10 GB/repo LRU limit. Worst case degrades
+  to a colder cache (slower, never wrong).
+- **Added the `merge_group` trigger to every workflow carrying a REQUIRED status
+  check** (`ci.yml`, `c8-precheck.yml`, `coverage.yml`) — the prerequisite for
+  enabling GitHub Merge Queue. Without it a queued PR's required checks never run
+  on the merge-group ref and the queue wedges the branch. Both docs-only
+  classifiers (`Classify changes`, `Coverage classify`) now pin
+  `docs_only=false` on `merge_group` so a merge group exercises the FULL gate
+  (never a docs-only short-circuit); the two event-scoped `c8-precheck` gates
+  (cert-expiry, commit-signing-posture) N/A-skip to exit 0 on the non-PR event.
+  No job `name:` changed — the same required contexts report on `merge_group` as
+  on `pull_request`. `cert-postgres-age.yml` was intentionally left off: it
+  carries no required context (verified against live branch protection), and it
+  is a heavy Postgres+AGE job that would slow the queue for no gating benefit.
+  New `test-ci-workflow-invariants.sh` scenario s9 pins the merge_group
+  full-pipeline invariant.
+
 ### Fixed (CI reliability — mold-install hang + runner-disk reclaim; #3090 #2960)
 
 Two GitHub-Actions infra flakes were throttling the `release/v1.0.0` merge

--- a/scripts/test/test-ci-workflow-invariants.sh
+++ b/scripts/test/test-ci-workflow-invariants.sh
@@ -266,6 +266,19 @@ OUT="$(run_cls "$F" "$BLOCK" EVENT_NAME=schedule PR_ACTION="" PR_BASE_SHA="" PR_
     && ok "s8 unknown event fails closed" \
     || bad "s8 unknown event" "got docs_only=$(getout "$OUT" docs_only)"
 
+# --- Scenario 9 (#3089, Merge Queue): a `merge_group` event MUST run the full
+# pipeline — docs_only=false + __ALL__ — regardless of what the diff would be,
+# so a queued PR's required contexts all report on the merge_group ref. Even a
+# docs-shaped fixture must NOT short-circuit here.
+F="$SCRATCH/s9"; build_fixture "$F" docs docs
+OUT="$(run_cls "$F" "$BLOCK" EVENT_NAME=merge_group PR_ACTION="" PR_BASE_SHA="" PR_BEFORE="")"
+[ "$(getout "$OUT" docs_only)" = "false" ] \
+    && [ "$(getout "$OUT" test_impact)" = "__ALL__" ] \
+    && [ "$(getout "$OUT" test_impact_reason)" = "merge_group-full-pipeline" ] \
+    && ok "s9 merge_group runs the full pipeline (docs_only=false, __ALL__) — no docs-only short-circuit" \
+    || bad "s9 merge_group must run everything" \
+           "docs_only=$(getout "$OUT" docs_only) impact=$(getout "$OUT" test_impact) reason=$(getout "$OUT" test_impact_reason)"
+
 # --- Regression leg: the PRE-FIX block MUST mis-classify scenario 1. --------
 # Fail-closed: a missing or repaired fixture is a FAILURE, never a SKIP. A
 # regression leg that can quietly opt out is not evidence of anything.


### PR DESCRIPTION
Follow-on to #3091 (which hardened only the `mold` install). **CI-only change**: no product code, no job `name:` changed, no required-context set changed, still `runs-on: ubuntu-latest`. Refs #2960 #3090. Tracker #3089.

## 1. Harden every remaining flaky `apt-get install` (#2960/#3090 class)

#3091 fixed `mold` + one `postgresql-client`, but other bare `apt-get update && install` steps could still hang on a stalled apt mirror until the *job* timeout fired — it cost #3094 a full rerun. Swept all workflows and applied #3091's **exact shape** (step-level `timeout-minutes`, per-command GNU `timeout`, one bounded retry, `::error::` + `exit 1` fail-loud):

| Workflow | Step | Package(s) |
|---|---|---|
| `coverage.yml` | Install jq + postgresql-client | `jq postgresql-client` |
| `coverage.yml` | Install pgvector (in-container `docker exec … apt-get`) | `postgresql-16-pgvector` |
| `batman-mode-acceptance.yml` | Install sqlite3 + jq | `sqlite3 jq` |
| `release.yml` | Install copr-cli | `pipx` |
| `release.yml` | Install RPM build tools | `rpm` |

No external Action added — the apt mirror stays the source; only the **hang** is bounded (fail loud, never hang).

## 2. Scope the Rust build cache save to trunk pushes (heavy compile jobs)

The three named heavy jobs — `check` matrix, `Postgres feature gate`, `Per-Module Coverage Thresholds` — **already** use the repo's house action `Swatinem/rust-cache@v2`. Adding a second `actions/cache` target-dir layer would only bloat/stale it (the exact risk to avoid). Instead each now sets:

```yaml
save-if: ${{ github.event_name == 'push' }}
```

So `pull_request` + `merge_group` runs **restore** the warm trunk cache but never **save** — a failed/partial PR compile can no longer poison the shared cache (the "save-always: false" property), and per-PR caches no longer evict the trunk cache under GitHub's 10 GB/repo LRU limit. Worst case degrades to a colder cache (slower, never wrong). **No new/unpinned Action** — `rust-cache@v2` is already the house pattern repo-wide.

## 3. Merge Queue prerequisite — `merge_group` trigger on required workflows

Added `merge_group: {types: [checks_requested]}` to **every workflow carrying a REQUIRED status check**: `ci.yml`, `c8-precheck.yml`, `coverage.yml`. Verified against live branch protection — all 33 required contexts are carried by exactly these three. Without this trigger a queued PR's required checks never run on the merge-group ref and the queue wedges the branch.

### Per-job merge_group-run audit (every required context)
- **Both docs-only classifiers** (`Classify changes`, `Coverage classify`) get an explicit `merge_group` arm pinning `docs_only=false` → the FULL gate runs, never a docs-only short-circuit. (The pre-existing fail-closed `else` arm already yielded this; pinned explicitly because the queue's correctness depends on it.)
- **All docs_only-gated jobs** (Lint, MSRV, actionlint, feature gates, Check matrix, Cross-compile, Dockerfile, Per-Module Coverage) → run, since `docs_only=false` on merge_group. `Dockerfile build`'s `!startsWith(github.ref,'refs/tags/v')` guard passes on the `gh-readonly-queue/…` ref.
- **All static c8-precheck integrity gates** (no event/`if:` dependency) → run against the merge-group checkout unchanged.
- **The two event-scoped gates** (`cert-expiry-gate`, `commit-signing-posture`) → N/A-skip to `exit 0` on the non-PR event (their scripts' `*)` / `!= pull_request` arms) → report green.
- **Coverage PR-comment steps** (`github.event_name == 'pull_request'`) → skip on merge_group (no PR to comment); the gate step itself still runs.

No job `name:` changed — the same required contexts report on `merge_group` as on `pull_request`. **No job was found that cannot run cleanly on merge_group.**

`cert-postgres-age.yml` was **intentionally excluded**: it carries **no** required context (confirmed against live `required_status_checks`), and it is a heavy Postgres+AGE cert job that would slow the queue for no gating benefit — the coordinator's authoritative filter is "jobs that appear in `required-contexts-release.txt`", and it does not.

New `test-ci-workflow-invariants.sh` scenario **s9** pins the merge_group full-pipeline invariant.

## Gates (all exit 0)
- `bash scripts/check-required-contexts.sh` → OK
- `bash scripts/check-required-contexts.sh --self-test` → PASS
- `bash scripts/check-ci-job-claims.sh` → PASS (18 workflows parsed)
- `bash scripts/test/test-ci-workflow-invariants.sh` → **32/32 PASS** (incl. new s9; Section C confirms triggers still parse — push branches protected-branch-only, no #2508 twin)
- `python3 yaml.safe_load` on all 5 edited workflows → OK
- `bash -n` on every new `run:` block → OK

## Risk (one line per change)
- **apt hardening**: bounds a hang into a loud fail; strictly safer than the bare install — worst case a genuinely-down mirror fails the step loudly (as intended) instead of hanging to the job timeout.
- **cache save-if**: cannot affect build/test correctness (only cache save timing); worst case a colder cache = slower, never wrong; one-line reversible.
- **merge_group trigger**: additive `on:` key invisible to the dual-trigger gate's awk parser (keys only on push/pull_request); classifiers fail-closed to full-pipeline; no required context can go missing.

## AI involvement
Authored by Claude (Opus 4.8) as the hard-coder agent under an Opus 5 orchestrator, per the ai-memory v1.0.0 loop. All gate/test exit codes above were run locally in the PR worktree before push. Human operator gates tag-cut and branch-protection changes; this PR changes neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY