### PR TITLE
test(recall): serialize AI_MEMORY_AGENT_ID-dependent recall tests (fix #3092 isolation flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests (serialize `AI_MEMORY_AGENT_ID`-dependent recall tests; fix #3092 isolation flake)
+
+Test-only. No product code changed — the #3092 `is_visible_to_caller` recall
+post-filter is correct and untouched.
+
+- **Root cause.** #3092 added an owner-keyed visibility post-filter to the CLI
+  recall path (`run_with_embedder`), keyed on the process-global
+  `AI_MEMORY_AGENT_ID` env var: when set + shape-valid, recall drops every row
+  the caller does not own. One sibling test
+  (`recall_cli_drops_cross_agent_private_row_2990`) SETS that var process-wide;
+  Rust runs the module's tests on parallel threads, so any recall test that
+  seeds owner-keyed rows and asserts they are PRESENT could intermittently see
+  an empty result set when it overlapped the set-var window (observed CI failure:
+  `recall_session_default_off_does_not_splice_scope`).
+- **Fix.** Each of the 9 presence-asserting recall tests now takes
+  `crate::identity::agent_id_env_unset_guard()` as its first statement — the
+  panic-safe RAII fixture that acquires the crate-wide agent-id test lock,
+  removes `AI_MEMORY_AGENT_ID` for the test's lifetime, and restores it on drop.
+  This both serializes each reader against the #2990 mutator and pins the
+  trust-all read posture, making the outcome deterministic. Absence-asserting /
+  vacuous-on-empty tests and the pure `apply_form4_recall_filters` unit tests are
+  unaffected and left untouched. Proven with 70 stress iterations
+  (50× `--test-threads=8`, 20× `--test-threads=16`), all green.
+
 ### Changed (CI cycle speedup: apt hardening + build-cache scoping + Merge Queue prereq; #3089 #2960 #3090)
 
 Follow-on to #3091 (which hardened only the `mold` install). CI-only change; no

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -743,6 +743,10 @@ mod tests {
     fn test_recall_keyword_tier_no_embedder() {
         // Keyword tier => no embedder; the keyword branch must run
         // happily and find the seeded title.
+        // #3092 isolation — pin AI_MEMORY_AGENT_ID UNSET (trust-all read)
+        // so a concurrent `recall_cli_drops_cross_agent_private_row_2990`
+        // set-var window can't hide the owner-keyed seeded row.
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "haystack content");
@@ -1041,6 +1045,10 @@ mod tests {
 
     #[test]
     fn test_recall_json_output_includes_score_mode_tokens() {
+        // #3092 isolation — see note on `test_recall_keyword_tier_no_embedder`:
+        // this test asserts the seeded row is PRESENT, so it must run with
+        // AI_MEMORY_AGENT_ID unset (serialized against the #2990 mutator).
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "haystack content");
@@ -1062,6 +1070,9 @@ mod tests {
 
     #[test]
     fn test_recall_text_output_formats_correctly() {
+        // #3092 isolation — asserts the seeded row is PRESENT in stdout;
+        // pin AI_MEMORY_AGENT_ID unset (serialized against the #2990 mutator).
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test-ns", "needle title", "haystack content");
@@ -1144,6 +1155,10 @@ mod tests {
     /// confidence row directly via `db::insert`.
     #[test]
     fn test_recall_text_output_shows_confidence_below_full() {
+        // #3092 isolation — asserts the inserted row renders `conf=50%`, i.e.
+        // it must be PRESENT; pin AI_MEMORY_AGENT_ID unset (serialized against
+        // the #2990 mutator). The row's owner ("") never equals a leaked agent.
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         {
@@ -1205,6 +1220,10 @@ mod tests {
     /// build a no-op so the test stays model-free and offline.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_recall_inside_runtime_uses_block_in_place_bridge() {
+        // #3092 isolation — asserts `count >= 1` (seeded row PRESENT); pin
+        // AI_MEMORY_AGENT_ID unset (serialized against the #2990 mutator).
+        // The guard is !Send but is held across no await in this body.
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "haystack content");
@@ -1424,6 +1443,9 @@ limit = 25
         // Below CLI_HNSW_BUILD_MIN_ENTRIES the vector_index is None and
         // the recall pipeline's linear-scan fallback serves the
         // semantic phase — results must still come back in hybrid mode.
+        // #3092 isolation — asserts the seeded row is PRESENT; pin
+        // AI_MEMORY_AGENT_ID unset (serialized against the #2990 mutator).
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "needle content body");
@@ -1600,6 +1622,10 @@ limit = 25
         // Drives the `confidence < 1.0` branch in the text output loop
         // (line 350) which formats " conf=XX%". Use a custom inserted
         // memory with confidence below 1.0.
+        // #3092 isolation — asserts the inserted row renders `conf=42%`
+        // (PRESENT); pin AI_MEMORY_AGENT_ID unset (serialized against the
+        // #2990 mutator). The row's owner "t" never equals a leaked agent.
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         // Insert a low-confidence memory directly.
@@ -1692,6 +1718,11 @@ limit = 25
     fn recall_session_default_off_does_not_splice_scope() {
         // session_default=false short-circuits the scope branch to None
         // (line 92), so the configured scope is invisible.
+        // #3092 isolation — asserts both seeded namespaces are PRESENT
+        // (`nses.len() >= 2 || contains("other-ns")`); pin AI_MEMORY_AGENT_ID
+        // unset (serialized against the #2990 mutator). This is the exact
+        // assertion observed flaking in CI.
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "scope-ns", "needle title", "content");
@@ -1846,6 +1877,9 @@ limit = 25
     #[test]
     fn recall_with_kind_filter_all_keyword_is_noop() {
         // --kind=all parses to None → no filter applied.
+        // #3092 isolation — asserts `count >= 1` (seeded row PRESENT); pin
+        // AI_MEMORY_AGENT_ID unset (serialized against the #2990 mutator).
+        let _agent_env = crate::identity::agent_id_env_unset_guard();
         let mut env = TestEnv::fresh();
         let db = env.db_path.clone();
         seed_memory(&db, "test", "needle title", "haystack content");


### PR DESCRIPTION
## Summary

Test-only isolation fix for a CI-blocking flake introduced by #3092. **No product code changes** — the #3092 `is_visible_to_caller` recall post-filter is correct and untouched.

## Root cause

#3092 added an owner-keyed visibility post-filter to the CLI recall path (`run_with_embedder`), keyed on the **process-global** `AI_MEMORY_AGENT_ID` env var:

- var **set** + shape-valid → `vis_caller = Some(agent)` → drops every row the caller does not own (owner-keyed `scope=private` default).
- var **unset** → `vis_caller = None` → trust-all → all rows returned.

One sibling test — `recall_cli_drops_cross_agent_private_row_2990` — **sets** `AI_MEMORY_AGENT_ID` process-wide (holding the crate-wide agent-id lock). Rust runs the module's tests on parallel threads, so any recall test that (a) seeds owner-keyed rows (`seed_memory` owner = `test-agent`, or direct `db::insert` with owner `""`/`"t"`), and (b) asserts those rows are **present**, could intermittently observe an **empty** result set when it overlapped the #2990 set-var window.

Observed CI failure: `cli::recall::tests::recall_session_default_off_does_not_splice_scope`, assertion `nses.len() >= 2 || nses.contains("other-ns")`.

## Fix

Each of the **9** presence-asserting recall tests now takes `crate::identity::agent_id_env_unset_guard()` as its first statement — the purpose-built, panic-safe RAII fixture that acquires the crate-wide agent-id test lock, removes `AI_MEMORY_AGENT_ID` for the test's lifetime, and restores the prior value on drop. This both **serializes** each reader against the #2990 mutator (they can never overlap) and pins the **trust-all** read posture, making the outcome deterministic.

Guarded tests (line numbers pre-edit):

| Line | Test | Presence assertion |
|------|------|--------------------|
| 742  | `test_recall_keyword_tier_no_embedder` | `stdout.contains("needle title")` |
| 1042 | `test_recall_json_output_includes_score_mode_tokens` | `!mems.is_empty()` |
| 1063 | `test_recall_text_output_formats_correctly` | `contains("needle title" / "ns=" / "score=" / "memory(ies) recalled")` |
| 1145 | `test_recall_text_output_shows_confidence_below_full` | `contains("conf=50%")` |
| 1206 | `test_recall_inside_runtime_uses_block_in_place_bridge` | `count >= 1` |
| 1422 | `b3_1579_small_corpus_recall_skips_hnsw_and_still_answers_semantically` | `!r.is_empty()` |
| 1598 | `recall_text_output_no_embedder_with_low_confidence_emits_conf_pct` | `contains("conf=42%" / "memory(ies) recalled")` |
| 1691 | `recall_session_default_off_does_not_splice_scope` | `nses.len() >= 2 \|\| contains("other-ns")` (the observed CI flake) |
| 1846 | `recall_with_kind_filter_all_keyword_is_noop` | `count >= 1` |

**Not guarded** (correct to leave): `recall_cli_drops_cross_agent_private_row_2990` (intentionally sets the var and manages its own lock — the non-reentrant `std::sync::Mutex` would deadlock); absence-asserting / vacuous-on-empty tests (`count == 0`, `for m in mems { assert_eq!(ns,…) }`, `len() <= 2`, `is_array()`, `mode == …`, `budget_tokens == …`, stderr-banner-only); and the pure `apply_form4_recall_filters` unit tests (no db/run).

Per-test guard chosen over a blanket `TestEnv::fresh()` acquire — the blanket approach would require refactoring #2990's manual lock management to avoid a double-acquire deadlock, and the per-test guard is the narrower, clearer change.

## Determinism evidence

70 stress iterations, **all green**:

```
=== STRESS 8-thread: PASS=50 FAIL=0 ===   # 50x cargo test --lib cli::recall::tests -- --test-threads=8
=== STRESS 16-thread: PASS=20 FAIL=0 ===  # 20x --test-threads=16
```

Each iteration reported `test result: ok. 37 passed; 0 failed`.

`cargo fmt --check` clean; `cargo clippy --lib --tests -- -D warnings -D clippy::all -D clippy::pedantic` clean (exit 0).

Follow-up to #3092 / #2990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY