### PR TITLE
test(atomise): deterministic worker drain — fix #2986 coverage-instrumentation flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests (deterministic atomise-worker drain; fix #2986 coverage-instrumentation flake)
+
+Test-support only; production behaviour byte-identical. The deferred auto-atomise
+test (`deferred_mode_lands_atoms_through_the_bounded_worker_2986`) waited on the
+bounded worker with a fixed 15s wall-clock poll (reopening + `COUNT`-ing every
+50ms), which flaked under `llvm-cov` instrumentation — the instrumented worker
+always lands the atoms but can exceed a fixed timer, and the poll contended with
+the worker's writes. Added `atomise_worker::spawn_joinable`, which returns the
+consumer thread's `JoinHandle`; the test now `drop`s the queue (closing the
+channel) and `join`s the worker, so `rx.recv()` drains every buffered job before
+the assertion — a deterministic await with no timer. `spawn` delegates to it and
+drops the handle, so the daemon-lifetime production path is unchanged.
+
 ### Tests (serialize `AI_MEMORY_AGENT_ID`-dependent recall tests; fix #3092 isolation flake)
 
 Test-only. No product code changed — the #3092 `is_visible_to_caller` recall

--- a/src/background/atomise_worker.rs
+++ b/src/background/atomise_worker.rs
@@ -212,6 +212,22 @@ pub fn resolve_queue_capacity() -> usize {
 /// queue-full honestly) rather than aborting boot.
 #[must_use]
 pub fn spawn(provider: AtomiserProvider) -> Option<AtomiseQueue> {
+    spawn_joinable(provider).map(|(queue, _handle)| queue)
+}
+
+/// Like [`spawn`] but also hands back the consumer thread's [`JoinHandle`].
+///
+/// The consumer exits when every [`AtomiseQueue`] sender is dropped: closing
+/// the channel makes `rx.recv()` return `Err` only AFTER every buffered job has
+/// been drained, so `handle.join()` is a DETERMINISTIC "await full drain" —
+/// no wall-clock deadline. Production uses the handle-less [`spawn`] (the
+/// daemon-lifetime thread is never joined); tests use this to observe that the
+/// deferred atoms have landed without racing a timer (#2986: the old 15s poll
+/// flaked under llvm-cov instrumentation, which slows the worker past the
+/// deadline even though it always completes).
+pub fn spawn_joinable(
+    provider: AtomiserProvider,
+) -> Option<(AtomiseQueue, std::thread::JoinHandle<()>)> {
     let capacity = resolve_queue_capacity();
     let (tx, rx) = std::sync::mpsc::sync_channel::<AtomiseJob>(capacity);
     let spawned = std::thread::Builder::new()
@@ -227,7 +243,7 @@ pub fn spawn(provider: AtomiserProvider) -> Option<AtomiseQueue> {
             tracing::info!(target: TRACE_TARGET, "atomise worker stopped");
         });
     match spawned {
-        Ok(_handle) => Some(AtomiseQueue { tx }),
+        Ok(handle) => Some((AtomiseQueue { tx }, handle)),
         Err(e) => {
             tracing::error!(
                 target: TRACE_TARGET,

--- a/tests/batman_atomise_wiring_2983.rs
+++ b/tests/batman_atomise_wiring_2983.rs
@@ -328,10 +328,11 @@ fn deferred_mode_lands_atoms_through_the_bounded_worker_2986() {
     let calls = Arc::new(Mutex::new(0usize));
     let atomiser = mock_atomiser(&calls);
     let provider_atomiser = Arc::clone(&atomiser);
-    let queue: AtomiseQueue = ai_memory::background::atomise_worker::spawn(Arc::new(move || {
-        Some(Arc::clone(&provider_atomiser))
-    }))
-    .expect("worker spawns");
+    let (queue, worker): (AtomiseQueue, std::thread::JoinHandle<()>) =
+        ai_memory::background::atomise_worker::spawn_joinable(Arc::new(move || {
+            Some(Arc::clone(&provider_atomiser))
+        }))
+        .expect("worker spawns");
 
     let resp = store_through_mcp(
         &conn,
@@ -356,25 +357,28 @@ fn deferred_mode_lands_atoms_through_the_bounded_worker_2986() {
         "deferred mode must not archive the parent inline"
     );
 
-    // …and the single consumer drains it out-of-band.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
-    let mut atoms = 0i64;
-    while std::time::Instant::now() < deadline {
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        let c = db::open(&path).expect("reopen");
-        atoms = c
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE atom_of = ?1",
-                [&source_id],
-                |r| r.get(0),
-            )
-            .unwrap_or(0);
-        if atoms >= 2 {
-            break;
-        }
-    }
-    assert_eq!(atoms, 2, "the bounded worker must land the two mock atoms");
+    // …and the single consumer drains it out-of-band. Close the queue (the
+    // sole sender) and DETERMINISTICALLY await the worker draining the buffered
+    // job by joining its thread — no wall-clock deadline. The prior 15s poll
+    // flaked under llvm-cov instrumentation (#2986): the worker always lands the
+    // atoms but the instrumented build can exceed a fixed timer, and the 50ms
+    // reopen-and-COUNT poll contended with the worker's writes. join() returns
+    // only after `rx.recv()` has drained every buffered job and the consumer
+    // has exited, so the atoms are guaranteed committed here.
     drop(queue);
+    worker
+        .join()
+        .expect("atomise worker thread joins after draining");
+
+    let verify = db::open(&path).expect("reopen");
+    let atoms: i64 = verify
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE atom_of = ?1",
+            [&source_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    assert_eq!(atoms, 2, "the bounded worker must land the two mock atoms");
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Problem
The deferred auto-atomise test `deferred_mode_lands_atoms_through_the_bounded_worker_2986` (tests/batman_atomise_wiring_2983.rs) polled a bounded background worker with a fixed **15s wall-clock deadline** (reopen DB + `COUNT` every 50ms). Under `llvm-cov` instrumentation the worker always lands the atoms but can exceed the timer, and the 50ms poll contended with the worker's own writes → the **Per-Module Coverage** job flaked, intermittently blocking unrelated PRs (surfaced on #3100).

## Fix (deterministic, not a bigger timeout)
- Add `atomise_worker::spawn_joinable(provider) -> Option<(AtomiseQueue, JoinHandle<()>)>`. Closing the channel (dropping every sender) makes `rx.recv()` return `Err` only after every buffered job is drained, so `handle.join()` is a deterministic await.
- The test now `drop(queue)` + `worker.join()` then reads the atom count **once** — no timer, no poll contention.
- `spawn()` delegates to `spawn_joinable` and drops the handle → the daemon-lifetime production path is **byte-identical**.

## Evidence
- Reproduced: 12/12 pass locally even at `--test-threads=16` (confirming it's coverage-instrumentation-only, not a real bug).
- After fix: 5×5 local pass in ~0.75s (was a 15s race); full `batman_atomise_wiring_2983` file 5/5; `cargo fmt --check` + `clippy` clean.

Test-support only; no behavioral change. Permanently unblocks the coverage gate for every PR.