### PR TITLE
fix(security): #3119 trap-restore the cert removal-proof harness + repo-wide mutation-marker gate

### DIFF
--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -129,6 +129,15 @@ jobs:
     # gate HARD-BLOCKS `rqgm|epoch_manifest|red.?queen` in src/. The
     # ruled public identifiers (SignableEpochManifest, epoch.manifest_applied,
     # EpochAdvance, EPOCH_APPLIED) are gate-clean by construction.
+    #
+    # This job now carries a SECOND perma-banned-string-in-src/ gate (#3119,
+    # below). It rides HERE, as extra steps, rather than in a job of its own
+    # because this job's `name:` is a DECLARED REQUIRED CONTEXT (see
+    # scripts/qc-allowlists/required-contexts-release.txt) — so the new gate is
+    # merge-BLOCKING from the first commit, whereas a fresh job would be an
+    # unrequired context that a merge could ignore. The name is deliberately
+    # NOT changed: it is the exact string branch protection requires, and #2473
+    # is the record of what renaming it costs.
     steps:
       - uses: actions/checkout@v4
       - name: Run L3-boundary perma-ban gate
@@ -137,6 +146,30 @@ jobs:
         # Proves the gate is load-bearing: passes a clean tree, fails on
         # a planted `epoch_manifest` violation in a tmpdir, cleans up.
         run: bash scripts/check-l3-boundary.sh --self-test
+      - name: Run cert removal-proof mutation-marker gate (#3119)
+        # DEFENCE IN DEPTH for the #3118 near-miss.
+        # scripts/check-cert-removal-proof.sh rewrites production security
+        # controls in place to prove they are load-bearing; an aborted run left
+        # `inbound_write_namespace_authorized` short-circuited to always-allow
+        # (a cross-tenant inbound federated-write authorization BYPASS) in the
+        # working tree, and a `git add -A` pushed it to a PR branch. #3119
+        # fixed the harness (EXIT/INT/TERM/HUP trap + start guard + end
+        # assertion); THIS is the independent second line — the marker can
+        # never reach a merged commit under src/, however it got there.
+        run: bash scripts/check-mutation-marker.sh
+      - name: Self-test the mutation-marker gate (regression evidence)
+        # Plants the exact #3118 artefact in a throwaway src/ tree under
+        # .local-runs/ (must FAIL), against a clean near-miss control that
+        # names the harness without carrying the marker (must PASS), and an
+        # empty scan set that must fail CLOSED.
+        run: bash scripts/check-mutation-marker.sh --self-test
+      - name: Prove the harness restores an interrupted run (#3119)
+        # The other half of #3119: the harness's own --self-test drives the
+        # REAL harness against a REAL control under `timeout 2` and under a
+        # re-raised SIGINT, with the cargo step stubbed (no toolchain), and
+        # asserts `git status --porcelain src/` is empty and the marker absent
+        # afterwards. Removing the trap turns these two legs RED.
+        run: bash scripts/check-cert-removal-proof.sh --self-test
 
   hardcoded-literal-gate:
     name: Hardcoded-literal duplication ratchet (pm-v3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,58 @@ write is permission-evaluated as; see the operator note below.
   Both now bind `resolve_read_visibility_caller()`, the same value the MCP/HTTP
   writer stamps. `--as-agent` remains the namespace-scope visibility knob.
 
+### Security
+
+- **The cert removal-proof harness can no longer leave a DISABLED security control
+  in the working tree** (#3119, closing the #3118 near-miss).
+  `scripts/check-cert-removal-proof.sh` is a mutation-testing harness: for each cited
+  control it rewrites the production source to an always-allow disposition, runs the
+  control's lane test, and asserts the test goes RED. Restoration previously happened
+  only on the happy and handled paths — there was **no `trap`** — so a SIGINT, a
+  `timeout` kill or a crash inside the cargo run left the control off, with nothing in
+  `git status` that reads as "a security control is disabled". On 2026-08-22 an aborted
+  run left `inbound_write_namespace_authorized` short-circuited to always-allow (a
+  cross-tenant inbound federated-write authorization **bypass**) and a `git add -A`
+  swept it onto a pushed PR branch for ~25 minutes (#3118 — never merged, no commit
+  ever contained it, base never affected). Four layers now stand between a mutation
+  and a commit:
+  - **Trap.** Every target is registered in a `MUTATED` array *before* it is rewritten
+    (so a crash between "mutate" and "run" is still covered), and an `EXIT`/`INT`/
+    `TERM`/`HUP` trap restores all of them with `git checkout HEAD --` — index *and*
+    worktree, which is what unwinds the staged `git add -A` variant that an index-only
+    `git checkout --` would have written straight back. Restoration is idempotent. The
+    `EXIT` trap carries the run's real status through unchanged (upgrading only a
+    success that failed to restore); the signal traps clear their handler and
+    **re-raise** (`kill -s "$sig" $$`) so the process dies of the original signal and
+    every parent observes `WIFSIGNALED` / 128+N exactly as with no trap installed.
+    The guard test now runs backgrounded under `wait` rather than in the foreground,
+    because bash defers a trap until the foreground command returns — the whole length
+    of a `cargo test` run was previously an un-interruptible window.
+  - **Start guard.** A marker already present in `src/` (an aborted earlier run) makes
+    the harness refuse to start, loudly and non-zero, instead of stacking a second
+    mutation on a disabled control. `--force-restore` is the deliberate recovery path:
+    it backs the mutated files up under `.local-runs/cert-54-evidence/` first, then
+    resets them to `HEAD` and exits 0.
+  - **End assertion.** The end of the run and the trap both assert the marker is absent
+    from `src/`, printing `SECURITY: mutation still present in <files>` and exiting
+    non-zero otherwise.
+  - **Repo-wide gate.** New `scripts/check-mutation-marker.sh` fails on the marker
+    anywhere under `src/`, however it got there — a crash the trap could not catch, a
+    `git add -A`, a rebase that resurrects a dropped hunk. It runs (with its own
+    `--self-test`, which plants the exact #3118 artefact) in the existing
+    `L3-boundary perma-ban gate` job of `.github/workflows/c8-precheck.yml` — a
+    required context, so the new gate is merge-blocking from the first commit. The
+    marker string lives only outside `src/`, so the gate cannot trip itself.
+
+  The harness `--self-test` gains two interrupt-safety legs that need no cargo: it
+  drives the **real** harness against a **real** control under `timeout 2` and under a
+  re-raised `SIGINT` (with the cargo step stubbed to a sentinel-touch + sleep, so the
+  mutation is provably live when the signal lands) and asserts `git status --porcelain
+  src/` is empty and the marker absent afterwards. Removing the trap turns both legs
+  RED. A `subst` payload whose replacement omits the marker — invisible to the trap,
+  the guard, the assertion and the gate — is now rejected outright. Agent SOP recorded
+  in `docs/AI_DEVELOPER_WORKFLOW.md` §5.6 and `CLAUDE.md`: gate scripts mutate the tree
+  by design; never `git add -A` after running one, stage explicitly.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,15 @@ cargo bench --bench recall
 
 `AI_MEMORY_NO_CONFIG=1` prevents loading user config which may trigger embedder/LLM initialization during tests.
 
+**Never `git add -A` after running a gate/harness script.** Several `scripts/check-*.sh`
+gates rewrite tracked files by design, and `scripts/check-cert-removal-proof.sh` rewrites
+production **security controls** (it short-circuits a guard to always-allow to prove the
+guard is load-bearing). An interrupted run once left a cross-tenant federated-write
+authorization bypass in the tree and a `git add -A` pushed it to a PR branch (#3118,
+caught before merge). Stage explicitly, read the staged diff, and recover a mutated tree
+with `scripts/check-cert-removal-proof.sh --force-restore`. Full SOP:
+[`AI_DEVELOPER_WORKFLOW.md` §5.6](docs/AI_DEVELOPER_WORKFLOW.md).
+
 ### Local coverage (matching CI's `coverage.yml`)
 
 ```bash

--- a/docs/AI_DEVELOPER_WORKFLOW.md
+++ b/docs/AI_DEVELOPER_WORKFLOW.md
@@ -205,6 +205,23 @@ backwards-compatibility shims for code paths that have no caller. If a follow-up
 needed, capture it as an ai-memory entry tagged `followup` and mention it in the PR
 description.
 
+### 5.6 Gate scripts mutate the tree by design — never `git add -A` after one
+
+Several `scripts/check-*.sh` gates REWRITE tracked files on purpose while they run, and
+`scripts/check-cert-removal-proof.sh` rewrites production **security controls** — it
+short-circuits a guard to always-allow, runs the guard's lane test, and asserts the test
+goes RED. So a gate run is a window in which the working tree is deliberately, invisibly
+wrong: nothing in `git status` reads as "a security control is disabled". On 2026-08-22
+(#3118, caught before merge) a harness run killed at a timeout left
+`inbound_write_namespace_authorized` returning always-allow — a cross-tenant inbound
+federated-write authorization bypass — and a subsequent `git add -A` pushed it to a PR
+branch. **Stage explicitly (`git add <path> …`), always, and read the diff you staged.**
+`git add -A` / `git add .` / `git commit -a` are banned after running any gate or harness
+script. The harness now restores under an `EXIT`/`INT`/`TERM`/`HUP` trap, refuses to start
+on a tree that still carries a mutation marker (`--force-restore` is the recovery path),
+and `scripts/check-mutation-marker.sh` blocks the marker anywhere under `src/` in CI — but
+those are the backstops, not the discipline. The discipline is explicit staging.
+
 ---
 
 ## 6. Memory Hygiene (ai-memory usage by AI agents)

--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -146,7 +146,9 @@ restore_mutations() {
 # an unscannable tree is never reported as clean).
 marked_src_files() {
   local files rc=0
-  files="$(git grep -l -e "$MUT_MARK" -- src 2>/dev/null)" || rc=$?
+  # --untracked: an aborted run that never `git add`ed the rewrite is still
+  # a live disabled control (#3119 Fable gate). rc>1 → could not scan.
+  files="$(git grep -l --untracked -e "$MUT_MARK" -- src tests conformance examples sdk 2>/dev/null)" || rc=$?
   if (( rc > 1 )); then
     return 2
   fi
@@ -182,7 +184,7 @@ assert_no_mutation_in_src() {
 # downgrades a failure.
 on_exit() {
   local rc=$?
-  trap - EXIT INT TERM HUP
+  trap - EXIT INT TERM HUP QUIT PIPE
   kill_guard_child
   restore_mutations
   if ! assert_no_mutation_in_src; then
@@ -200,7 +202,7 @@ on_exit() {
 # "cancelled" from "failed" (or a `timeout --preserve-status`) would be lied to.
 on_signal() {
   local sig="$1"
-  trap - EXIT INT TERM HUP
+  trap - EXIT INT TERM HUP QUIT PIPE
   echo "" >&2
   echo "[$sig] interrupted — restoring ${#MUTATED[@]} mutated file(s) before dying…" >&2
   kill_guard_child
@@ -215,6 +217,8 @@ trap on_exit EXIT
 trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 trap 'on_signal HUP' HUP
+trap 'on_signal QUIT' QUIT
+trap 'on_signal PIPE' PIPE
 
 # control-name | shape | mutation-payload | target-file | lane-test-crate | lane-test-fn
 # shape ∈ {return, body} — see the header for the two grammars. The payload is the
@@ -452,6 +456,10 @@ list_map() {
 # `return` shape (all 5 shipped rows), so this is the mechanical proof that the
 # PR-0 `body` grammar is load-bearing.
 self_test() {
+  if ! grep -qF "$MUT_MARK" "$SELF"; then
+    echo "FAIL: harness no longer carries the mutation MARKER literal" >&2
+    return 1
+  fi
   local dir="$EVIDENCE_DIR/self-test"
   rm -rf "$dir"; mkdir -p "$dir"
   local fx="$dir/fixture.rs"
@@ -655,10 +663,17 @@ run_one() {
   # 3. revert
   restore_mutations
   if grep -q "$MUT_MARK" "$tf"; then
-    # Re-register so the EXIT trap gets another attempt and, failing that,
-    # SHOUTS. A file the revert could not clean must never fall off the ledger.
     MUTATED+=("$tf")
     echo "  [ERR] revert FAILED — mutation still present!"
+    echo "  dump: git diff HEAD -- $tf" >&2
+    git diff HEAD -- "$tf" >&2 || true
+    restore_mutations
+    return 3
+  fi
+  if ! git diff --quiet HEAD -- "$tf"; then
+    echo "  [ERR] post-restore $tf still differs from HEAD" >&2
+    git diff HEAD -- "$tf" >&2 || true
+    restore_mutations
     return 3
   fi
 
@@ -757,7 +772,15 @@ overall=0
 for row in "${MAP[@]}"; do
   IFS='|' read -r ctl shape mut tf crate fn <<<"$row"
   [[ "$sel" != "ALL" && "$sel" != "$ctl" ]] && continue
-  run_one "$ctl" "$shape" "$mut" "$tf" "$crate" "$fn" || overall=1
+  local_rc=0
+  run_one "$ctl" "$shape" "$mut" "$tf" "$crate" "$fn" || local_rc=$?
+  if [[ $local_rc -eq 3 ]]; then
+    echo "❌ revert failed on $ctl — refusing to continue the MAP (tree may still be mutated)" >&2
+    restore_mutations
+    assert_no_mutation_in_src || true
+    exit 3
+  fi
+  [[ $local_rc -ne 0 ]] && overall=1
 done
 
 echo

--- a/scripts/check-cert-removal-proof.sh
+++ b/scripts/check-cert-removal-proof.sh
@@ -49,25 +49,172 @@
 #                  whose <OLD> matches 0 or >1 sites is a hard error (exit 3) so
 #                  a subst can never silently over-mutate.
 #
-# SAFETY: mutations are applied in-place then reverted via `git checkout --`.
-# The dirty-working-tree guard is PER ROW — each row refuses only when ITS OWN
-# target file has uncommitted changes, so an unrelated dirty file never aborts
-# the run and a revert can never clobber real edits to the file under test.
+# SAFETY (#3119 — hardened after the #3118 near-miss; read this before editing).
+# This harness DISABLES PRODUCTION SECURITY CONTROLS IN THE WORKING TREE for the
+# duration of a guard run. On 2026-08-22 an aborted run (killed at a two-minute
+# timeout) left `inbound_write_namespace_authorized` short-circuited to
+# always-allow — a cross-tenant inbound federated-write authorization BYPASS —
+# and a later `git add -A` swept it onto a pushed PR branch (#3118, never
+# merged, base never affected). Root cause was STRUCTURAL: restoration happened
+# only on the happy/handled paths, with no `trap`, so any signal/crash left the
+# control off with nothing in `git status` a human reads as "security control
+# disabled". Four layers now stand between a mutation and a commit:
+#
+#   1. TRAP. Every path this run mutates is registered in `MUTATED` BEFORE it is
+#      rewritten; an EXIT/INT/TERM/HUP trap restores all of them and then
+#      PROPAGATES the original disposition (see `on_exit` / `on_signal`).
+#   2. START GUARD. A pre-existing marker in `src/` (an aborted earlier run)
+#      makes the harness REFUSE to start — loudly, non-zero — instead of piling
+#      a second mutation on a disabled control. `--force-restore` is the
+#      deliberate, backed-up recovery path.
+#   3. END ASSERTION. Both the normal end of the run and the trap assert the
+#      marker is ABSENT from `src/`, and shout `SECURITY: mutation still present
+#      in <files>` + exit non-zero if it is not.
+#   4. REPO-WIDE GATE. `scripts/check-mutation-marker.sh` (wired into CI's
+#      L3-boundary perma-ban job) fails on the marker anywhere under `src/`,
+#      however it got there.
+#
+# Restoration is `git checkout HEAD -- <paths>` (index AND worktree), and the
+# PER-ROW guard therefore refuses when ITS OWN target differs from HEAD in
+# EITHER — an index-only restore would have re-written the #3118 staged mutation
+# straight back into the worktree. An unrelated dirty file still never aborts
+# the run, and a revert can never clobber real edits to the file under test.
 # Evidence is written under .local-runs/.
 #
 # USAGE:
 #   scripts/check-cert-removal-proof.sh                 # all controls
 #   scripts/check-cert-removal-proof.sh <control-name>  # one control
 #   scripts/check-cert-removal-proof.sh --list          # print the control map
-#   scripts/check-cert-removal-proof.sh --self-test     # prove BOTH mutation
+#   scripts/check-cert-removal-proof.sh --self-test     # prove the mutation
 #                                                        # shapes rewrite source
-#                                                        # as intended (no cargo)
+#                                                        # as intended AND that
+#                                                        # an interrupted run
+#                                                        # leaves a clean tree
+#                                                        # (no cargo)
+#   scripts/check-cert-removal-proof.sh --force-restore # recover a tree an
+#                                                        # aborted run left
+#                                                        # mutated (backs up
+#                                                        # first, then exits 0)
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF="$REPO_ROOT/scripts/$(basename "${BASH_SOURCE[0]}")"
 cd "$REPO_ROOT"
 EVIDENCE_DIR=".local-runs/cert-54-evidence"
 mkdir -p "$EVIDENCE_DIR"
+
+# ─── #3119 interrupt-safety substrate ────────────────────────────────────────
+
+# The mutation marker — SSOT for the trap, the start guard, the end assertion
+# and the python mutator (exported as CERT_MARK). The `subst` rows in MAP embed
+# the same literal in their payloads by necessity (the payload IS the replacement
+# text); the mutator REJECTS a subst whose replacement omits the marker, which is
+# what keeps the two from drifting apart.
+MUT_MARK='CERT-REMOVAL-PROOF-MUTATION'
+
+MUTATED=()          # every path this run has begun rewriting (register-then-mutate)
+GUARD_CHILD_PID=""  # backgrounded guard run, so a trap can reap it promptly
+
+# Reap the backgrounded guard run (cargo / self-test stub) if one is live.
+kill_guard_child() {
+  [[ -n "$GUARD_CHILD_PID" ]] || return 0
+  kill -TERM "$GUARD_CHILD_PID" 2>/dev/null || true
+  GUARD_CHILD_PID=""
+}
+
+# Restore every registered mutation. IDEMPOTENT — a second call is a no-op, and
+# a path registered but never actually rewritten restores to itself.
+#
+# `git checkout HEAD --` (not `git checkout --`) is deliberate: it resets BOTH
+# the index and the worktree. The index half is what makes the #3118 shape
+# unrepeatable — a `git add -A` that races the harness stages the disabled
+# control, and an index-only restore would write the MUTATED content back into
+# the worktree. Every registered path is proven byte-identical to HEAD before it
+# is touched (the per-row guard in run_one), so resetting to HEAD can never
+# destroy real work.
+restore_mutations() {
+  (( ${#MUTATED[@]} )) || return 0
+  local paths=("${MUTATED[@]}")
+  MUTATED=()
+  if ! git checkout HEAD -- "${paths[@]}" 2>/dev/null; then
+    git checkout -- "${paths[@]}" 2>/dev/null || true
+  fi
+}
+
+# Files under src/ currently carrying the marker. Prints nothing when clean.
+# Exit 0 = scan succeeded (list on stdout), 2 = COULD NOT SCAN (fail closed —
+# an unscannable tree is never reported as clean).
+marked_src_files() {
+  local files rc=0
+  files="$(git grep -l -e "$MUT_MARK" -- src 2>/dev/null)" || rc=$?
+  if (( rc > 1 )); then
+    return 2
+  fi
+  [[ -n "$files" ]] && printf '%s\n' "$files"
+  return 0
+}
+
+# Assert the marker is ABSENT from src/. Loud + non-zero when it is not: a
+# surviving marker means a production security control is DISABLED right now.
+assert_no_mutation_in_src() {
+  local files
+  if ! files="$(marked_src_files)"; then
+    echo "SECURITY: could not scan src/ for the mutation marker — refusing to report clean" >&2
+    return 1
+  fi
+  [[ -z "$files" ]] && return 0
+  {
+    echo ""
+    echo "══════════════════════════════════════════════════════════════════════"
+    echo "SECURITY: mutation still present in $(printf '%s' "$files" | tr '\n' ' ')"
+    echo ""
+    echo "A production security control is DISABLED in this working tree."
+    echo "Do NOT commit. Do NOT 'git add -A'. Recover with:"
+    echo "    scripts/check-cert-removal-proof.sh --force-restore"
+    echo "══════════════════════════════════════════════════════════════════════"
+  } >&2
+  return 1
+}
+
+# EXIT — restore, assert, then propagate the run's REAL status. `rc=$?` is
+# captured before anything else runs, so a normal PASS still exits 0 and a
+# CERT-RED still exits 1; a failed restoration UPGRADES a 0 to 9 and never
+# downgrades a failure.
+on_exit() {
+  local rc=$?
+  trap - EXIT INT TERM HUP
+  kill_guard_child
+  restore_mutations
+  if ! assert_no_mutation_in_src; then
+    (( rc == 0 )) && rc=9
+  fi
+  exit "$rc"
+}
+
+# INT/TERM/HUP — restore, assert, then RE-RAISE. These deliberately do NOT
+# `exit`: the handler is cleared and the signal is re-sent to this very shell
+# (`kill -s "$sig" $$`) so the process dies of the ORIGINAL signal and every
+# parent — `timeout`, a shell job, a CI runner, a `wait` in a driver script —
+# observes WIFSIGNALED / 128+N exactly as it would have with no trap installed.
+# `exit 130` would merely LOOK like a signal death; a driver that distinguishes
+# "cancelled" from "failed" (or a `timeout --preserve-status`) would be lied to.
+on_signal() {
+  local sig="$1"
+  trap - EXIT INT TERM HUP
+  echo "" >&2
+  echo "[$sig] interrupted — restoring ${#MUTATED[@]} mutated file(s) before dying…" >&2
+  kill_guard_child
+  restore_mutations
+  assert_no_mutation_in_src || true
+  kill -s "$sig" "$$"
+  # Only reachable if the signal is somehow blocked/ignored. Fail closed.
+  exit 3
+}
+
+trap on_exit EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+trap 'on_signal HUP' HUP
 
 # control-name | shape | mutation-payload | target-file | lane-test-crate | lane-test-fn
 # shape ∈ {return, body} — see the header for the two grammars. The payload is the
@@ -181,6 +328,7 @@ MAP=(
 apply_mutation() {
   local ctl="$1" shape="$2" payload="$3" target="$4"
   CERT_CTL="$ctl" CERT_SHAPE="$shape" CERT_PAYLOAD="$payload" CERT_TARGET="$target" \
+  CERT_MARK="$MUT_MARK" \
   python3 - <<'PY'
 import os, re, sys
 
@@ -188,7 +336,7 @@ path    = os.environ["CERT_TARGET"]
 ctl     = os.environ["CERT_CTL"]
 shape   = os.environ["CERT_SHAPE"]
 payload = os.environ["CERT_PAYLOAD"]
-MARK    = " // CERT-REMOVAL-PROOF-MUTATION"
+MARK    = " // " + os.environ["CERT_MARK"]
 
 lines = open(path).read().splitlines(keepends=True)
 
@@ -200,6 +348,12 @@ if shape == 'subst':
     old, sep, new = payload.partition('>>>')
     if not sep:
         sys.stderr.write("subst payload missing '>>>' delimiter\n")
+        sys.exit(3)
+    # #3119: a subst whose NEW omits the marker would be INVISIBLE to the trap,
+    # the start guard, the end assertion and the repo-wide gate — the exact
+    # blind spot the #3118 near-miss lived in. Refuse it.
+    if MARK.strip() not in new:
+        sys.stderr.write("subst NEW must embed the mutation marker comment\n")
         sys.exit(3)
     text = ''.join(lines)
     n = text.count(old)
@@ -346,14 +500,127 @@ RS
   # subst shape — a non-unique OLD (2 sites) MUST hard-error (never over-mutate).
   cp "$fx" "$dir/subst-dup.rs"
   printf 'pub fn a() { let x = 1; }\npub fn b() { let x = 1; }\n' >"$dir/subst-dup.rs"
-  if apply_mutation subst_label subst "let x = 1;>>>let x = 2;" "$dir/subst-dup.rs" 2>/dev/null; then
+  if apply_mutation subst_label subst "let x = 1;>>>let x = 2; // $MUT_MARK" "$dir/subst-dup.rs" 2>/dev/null; then
     echo "  [FAIL] subst-shape accepted a non-unique OLD (should exit 3)"; rc=1
   else
     echo "  [ok] subst-shape: non-unique OLD rejected (exit 3)"
   fi
 
+  # ─── #3119 INTERRUPT SAFETY ────────────────────────────────────────────────
+  # The three legs above prove the mutation GRAMMARS. These two prove the thing
+  # the #3118 near-miss actually needed: that a run killed mid-mutation leaves
+  # the working tree CLEAN. They drive the REAL harness against a REAL control
+  # in the REAL src/ tree, with the guard-test step stubbed to a
+  # sentinel-touch + long sleep (CERT_PROOF_STUB_RUN), so the harness is
+  # GUARANTEED to be sitting on a live, disabled security control when the
+  # signal lands — and no cargo/toolchain is involved.
+  local probe_ctl="inbound_write_namespace_authorized"
+  local probe_tf="src/federation/receive_auth.rs"
+  local sentinel="$dir/mutation-was-live"
+
+  # Shared assertions for one interrupted run.
+  _assert_interrupt_clean() {
+    local leg="$1" krc="$2"
+    local ok=0
+    if [[ ! -f "$sentinel" ]]; then
+      echo "  [FAIL] $leg: the harness never reached the guard step — the mutation was"
+      echo "         never live, so this leg proved nothing. Is $probe_tf dirty?"
+      return 1
+    fi
+    local porcelain
+    porcelain="$(git status --porcelain -- src)"
+    if [[ -n "$porcelain" ]]; then
+      echo "  [FAIL] $leg: src/ left DIRTY after the interrupt:"
+      printf '%s\n' "$porcelain" | sed 's/^/           /'
+      ok=1
+    fi
+    if git grep -q -e "$MUT_MARK" -- src 2>/dev/null; then
+      echo "  [FAIL] $leg: SECURITY — mutation marker still present in src/ after the interrupt"
+      ok=1
+    fi
+    if [[ $krc -eq 0 ]]; then
+      echo "  [FAIL] $leg: interrupted run exited 0 (must never read as success)"
+      ok=1
+    fi
+    return $ok
+  }
+
+  # (4) `timeout 2` — SIGTERM lands while the control is disabled.
+  rm -f "$sentinel"
+  local trc=0
+  CERT_PROOF_STUB_RUN="$sentinel" timeout 2 bash "$SELF" "$probe_ctl" \
+    >"$dir/timeout.out" 2>&1 || trc=$?
+  if _assert_interrupt_clean "timeout-2" "$trc"; then
+    echo "  [ok] timeout-2: SIGTERM mid-mutation → src/ clean, marker absent, rc=$trc"
+  else
+    rc=1
+  fi
+
+  # (5) RE-RAISE FIDELITY — SIGINT is re-raised, not simulated. `wait` reports
+  # 128+SIGINT = 130 only if the harness genuinely DIED OF the signal; a trap
+  # that ended in `exit 130` would be indistinguishable to `$?` but NOT to a
+  # parent that inspects WIFSIGNALED, so this is the assertion that pins the
+  # re-raise rather than a hardcoded status.
+  #
+  # `set -m` is REQUIRED here, not cosmetic: with job control OFF a bash script's
+  # ASYNCHRONOUS children start with SIGINT *ignored*, and a signal ignored on
+  # entry cannot be trapped — the harness would never see the INT at all and this
+  # leg would hang rather than assert. Job control gives the child its own process
+  # group and a default SIGINT disposition, which is what a real Ctrl-C delivers.
+  rm -f "$sentinel"
+  set -m
+  CERT_PROOF_STUB_RUN="$sentinel" bash "$SELF" "$probe_ctl" >"$dir/sigint.out" 2>&1 &
+  local hpid=$! waited=0
+  set +m
+  while [[ ! -f "$sentinel" && $waited -lt 200 ]]; do sleep 0.05; waited=$((waited + 1)); done
+  kill -INT "$hpid" 2>/dev/null || true
+  local irc=0
+  wait "$hpid" || irc=$?
+  if _assert_interrupt_clean "sigint-reraise" "$irc" && [[ $irc -eq 130 ]]; then
+    echo "  [ok] sigint-reraise: died OF SIGINT (rc=130), src/ clean, marker absent"
+  else
+    [[ $irc -ne 130 ]] && echo "  [FAIL] sigint-reraise: rc=$irc, want 130 (128+SIGINT) — signal not re-raised"
+    rc=1
+  fi
+
   echo
-  if [[ $rc -eq 0 ]]; then echo "self-test: PASS — all three mutation shapes sound"; else echo "self-test: FAIL"; fi
+  if [[ $rc -eq 0 ]]; then
+    echo "self-test: PASS — three mutation shapes sound; interrupted runs leave a clean tree"
+  else
+    echo "self-test: FAIL"
+  fi
+  return $rc
+}
+
+# Run one control's guard test, capturing to <out>.
+#
+# The command runs in the BACKGROUND and is `wait`ed on, which is load-bearing
+# for #3119: bash defers a trap until the current FOREGROUND command returns, so
+# a foreground `cargo test` would postpone the restoring trap for the entire
+# length of the test run — precisely the window the #3118 near-miss died in.
+# `wait` IS interruptible, so the trap fires immediately and reaps the child.
+#
+# CERT_PROOF_STUB_RUN is a SELF-TEST-ONLY hook: it replaces the cargo invocation
+# with "touch a sentinel, then sleep", so `--self-test` can drive the real
+# harness under `timeout` with a LIVE mutation in the tree and no toolchain. It
+# can never manufacture a PASS — the stub never returns 0, so both the broken
+# and the restored leg are non-zero and run_one reports CERT-RED (fail closed).
+run_guard_test() {
+  local crate="$1" fn="$2" out="$3"
+  if [[ -n "${CERT_PROOF_STUB_RUN:-}" ]]; then
+    # `exec` so the backgrounded pid IS the sleep — kill_guard_child then reaps
+    # it directly instead of orphaning it under a dying subshell.
+    ( : >"$CERT_PROOF_STUB_RUN"; exec sleep 300 ) >"$out" 2>&1 &
+  else
+    AI_MEMORY_NO_CONFIG=1 cargo test --features sal --test "$crate" "$fn" \
+      -- --exact --nocapture >"$out" 2>&1 &
+  fi
+  GUARD_CHILD_PID=$!
+  local rc=0
+  wait "$GUARD_CHILD_PID" || rc=$?
+  GUARD_CHILD_PID=""
+  # A stubbed run must NEVER read as a green guard test (fail closed).
+  [[ -n "${CERT_PROOF_STUB_RUN:-}" && $rc -eq 0 ]] && rc=3
   return $rc
 }
 
@@ -361,33 +628,44 @@ run_one() {
   local ctl="$1" shape="$2" mut="$3" tf="$4" crate="$5" fn="$6"
   echo "════ control: $ctl  (shape: $shape)  target: $tf  guard: tests/${crate}.rs::${fn}"
 
-  # PER-ROW dirty guard — refuse ONLY when THIS row's target is dirty so a revert
-  # cannot clobber real edits, while an unrelated dirty file never aborts the run.
-  if ! git diff --quiet -- "$tf"; then
-    echo "  [REFUSE] $tf has uncommitted changes; commit/stash first (revert safety)."
+  # PER-ROW dirty guard — refuse ONLY when THIS row's target differs from HEAD,
+  # so a revert cannot clobber real edits while an unrelated dirty file never
+  # aborts the run. Compared against HEAD rather than the index (#3119): the
+  # restore is `git checkout HEAD --`, which would destroy a STAGED edit, and an
+  # index-only restore would resurrect a staged mutation into the worktree.
+  if ! git diff --quiet HEAD -- "$tf"; then
+    echo "  [REFUSE] $tf differs from HEAD (staged and/or unstaged); commit/stash first (revert safety)."
     return 2
   fi
 
-  # 1. deliberately break the control
+  # 1. deliberately break the control.
+  #    REGISTER BEFORE MUTATING — the trap must be able to restore a file that a
+  #    crash left HALF-REWRITTEN between these two statements. Registering a path
+  #    that ends up unmodified is free (restore_mutations is idempotent).
+  MUTATED+=("$tf")
   apply_mutation "$ctl" "$shape" "$mut" "$tf" \
-    || { echo "  [ERR] could not locate/mutate $ctl in $tf"; git checkout -- "$tf" 2>/dev/null; return 3; }
-  if ! grep -q "CERT-REMOVAL-PROOF-MUTATION" "$tf"; then echo "  [ERR] mutation marker absent"; git checkout -- "$tf"; return 3; fi
+    || { echo "  [ERR] could not locate/mutate $ctl in $tf"; restore_mutations; return 3; }
+  if ! grep -q "$MUT_MARK" "$tf"; then echo "  [ERR] mutation marker absent"; restore_mutations; return 3; fi
 
   # 2. run the guarding lane test — MUST fail (RED) with the control broken
   echo "  → running guard with BROKEN control (expect RED)…"
-  AI_MEMORY_NO_CONFIG=1 cargo test --features sal --test "$crate" "$fn" -- --exact --nocapture \
-    > "$EVIDENCE_DIR/removal-${ctl}-broken.out" 2>&1
-  local broken_rc=$?
+  local broken_rc=0
+  run_guard_test "$crate" "$fn" "$EVIDENCE_DIR/removal-${ctl}-broken.out" || broken_rc=$?
 
   # 3. revert
-  git checkout -- "$tf"
-  grep -q "CERT-REMOVAL-PROOF-MUTATION" "$tf" && { echo "  [ERR] revert FAILED — mutation still present!"; return 3; }
+  restore_mutations
+  if grep -q "$MUT_MARK" "$tf"; then
+    # Re-register so the EXIT trap gets another attempt and, failing that,
+    # SHOUTS. A file the revert could not clean must never fall off the ledger.
+    MUTATED+=("$tf")
+    echo "  [ERR] revert FAILED — mutation still present!"
+    return 3
+  fi
 
   # 4. run again — MUST pass (GREEN) with the control restored
   echo "  → running guard with RESTORED control (expect GREEN)…"
-  AI_MEMORY_NO_CONFIG=1 cargo test --features sal --test "$crate" "$fn" -- --exact --nocapture \
-    > "$EVIDENCE_DIR/removal-${ctl}-restored.out" 2>&1
-  local restored_rc=$?
+  local restored_rc=0
+  run_guard_test "$crate" "$fn" "$EVIDENCE_DIR/removal-${ctl}-restored.out" || restored_rc=$?
 
   if [[ $broken_rc -ne 0 && $restored_rc -eq 0 ]]; then
     echo "  [PROVEN] control is load-bearing: broken→RED (rc=$broken_rc), restored→GREEN (rc=$restored_rc)"
@@ -397,6 +675,77 @@ run_one() {
     return 1
   fi
 }
+
+# --force-restore (#3119) — the deliberate recovery path from an aborted run.
+# Backs the mutated files up FIRST (reversibility: the backup is the only
+# durable record of what the aborted run left behind, and an operator may need
+# to diff it), then resets them to HEAD and exits 0.
+force_restore() {
+  local files
+  if ! files="$(marked_src_files)"; then
+    echo "❌ --force-restore: could not scan src/ (git grep failed) — refusing to act blind." >&2
+    exit 4
+  fi
+  if [[ -z "$files" ]]; then
+    echo "--force-restore: nothing to restore — src/ carries no mutation marker."
+    exit 0
+  fi
+  local stamp backup f
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  backup="$EVIDENCE_DIR/force-restore-$stamp"
+  echo "⚠️  --force-restore: mutated file(s) found in src/:"
+  MUTATED=()
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    echo "      $f"
+    mkdir -p "$backup/$(dirname "$f")"
+    cp "$f" "$backup/$f"
+    MUTATED+=("$f")
+  done <<<"$files"
+  echo "    backup written to $backup"
+  restore_mutations
+  if ! assert_no_mutation_in_src; then
+    echo "❌ --force-restore FAILED — the marker survives the reset." >&2
+    exit 5
+  fi
+  echo "✅ --force-restore: src/ reset to HEAD; the marker is gone."
+  exit 0
+}
+
+# START GUARD (#3119) — a marker already in src/ means an EARLIER run aborted
+# and left a production security control DISABLED. Refuse loudly rather than
+# stack a second mutation on top of it (and rather than silently "fixing" it,
+# which would hide the incident). Deliberately applies to --list and
+# --self-test too: nothing about this harness should proceed on a tree whose
+# controls are off.
+preflight_no_stale_mutation() {
+  local files
+  if ! files="$(marked_src_files)"; then
+    echo "❌ could not scan src/ for a stale mutation marker — refusing to run." >&2
+    exit 4
+  fi
+  [[ -z "$files" ]] && return 0
+  {
+    echo ""
+    echo "══════════════════════════════════════════════════════════════════════"
+    echo "REFUSING TO RUN — a PRIOR run of this harness aborted and left a"
+    echo "DISABLED security control in the working tree:"
+    echo ""
+    printf '%s\n' "$files" | sed 's/^/      /'
+    echo ""
+    echo "This is the #3118 shape. Do NOT commit and do NOT 'git add -A'."
+    echo "Recover with:"
+    echo "    scripts/check-cert-removal-proof.sh --force-restore"
+    echo "══════════════════════════════════════════════════════════════════════"
+  } >&2
+  exit 4
+}
+
+case "${1:-}" in
+  --force-restore) force_restore ;;
+esac
+
+preflight_no_stale_mutation
 
 case "${1:-}" in
   --list)      list_map;   exit 0 ;;

--- a/scripts/check-mutation-marker.sh
+++ b/scripts/check-mutation-marker.sh
@@ -44,39 +44,58 @@ repo_root() {
     cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
 }
 
-# Scan <root>/src for the marker. Returns 0 = clean, 1 = marker found,
-# 2 = could not scan (fail CLOSED: an unscannable tree is never "clean").
+# Scan production + test surfaces for the marker. Returns 0 = clean,
+# 1 = marker found, 2 = could not scan (fail CLOSED: an unscannable
+# tree is never "clean"). `grep` as an `if` condition used to treat
+# rc=2 (unreadable file) as PASS — capture rc instead. Scan set is
+# src/ tests/ conformance/ examples/ sdk/ (scripts/ is excluded so
+# this gate and the harness can name the marker).
+SCAN_REL=(src tests conformance examples sdk)
 run_gate() {
     local root="$1"
     if [[ ! -d "$root/src" ]]; then
         echo "❌ mutation-marker gate: no src/ under $root — refusing to report clean" >&2
         return 2
     fi
-    if grep -rIl --exclude-dir=.git -e "$MARKER" "$root/src" >/dev/null 2>&1; then
-        echo "" >&2
-        echo "══════════════════════════════════════════════════════════════════════" >&2
-        echo "SECURITY: cert removal-proof mutation marker found in src/" >&2
-        echo "" >&2
-        grep -rIn --exclude-dir=.git -e "$MARKER" "$root/src" >&2 || true
-        echo "" >&2
-        echo "A marked line is a DELIBERATELY DISABLED security control left behind" >&2
-        echo "by scripts/check-cert-removal-proof.sh (see #3118/#3119). It must" >&2
-        echo "never be committed. Restore the tree with:" >&2
-        echo "" >&2
-        echo "    scripts/check-cert-removal-proof.sh --force-restore" >&2
-        echo "" >&2
-        echo "then re-stage EXPLICITLY (never 'git add -A' after a gate script)." >&2
-        echo "══════════════════════════════════════════════════════════════════════" >&2
-        return 1
-    fi
-    return 0
+    local paths=() p
+    for p in "${SCAN_REL[@]}"; do
+        [[ -e "$root/$p" ]] && paths+=("$root/$p")
+    done
+    local rc=0
+    grep -rIl --exclude-dir=.git -e "$MARKER" "${paths[@]}" >/dev/null 2>&1 || rc=$?
+    case $rc in
+        0)
+            echo "" >&2
+            echo "══════════════════════════════════════════════════════════════════════" >&2
+            echo "SECURITY: cert removal-proof mutation marker found" >&2
+            echo "" >&2
+            grep -rIn --exclude-dir=.git -e "$MARKER" "${paths[@]}" >&2 || true
+            echo "" >&2
+            echo "A marked line is a DELIBERATELY DISABLED security control left behind" >&2
+            echo "by scripts/check-cert-removal-proof.sh (see #3118/#3119). It must" >&2
+            echo "never be committed. Restore the tree with:" >&2
+            echo "" >&2
+            echo "    scripts/check-cert-removal-proof.sh --force-restore" >&2
+            echo "" >&2
+            echo "then re-stage EXPLICITLY (never 'git add -A' after a gate script)." >&2
+            echo "══════════════════════════════════════════════════════════════════════" >&2
+            return 1
+            ;;
+        1) return 0 ;;
+        *)
+            echo "❌ mutation-marker gate: scan failed (grep rc=$rc) — refusing to report clean" >&2
+            return 2
+            ;;
+    esac
 }
 
 run_self_test() {
     local root
     root="$(repo_root)"
-    local dir="$root/.local-runs/mutation-marker-gate-selftest"
-    rm -rf "$dir"
+    local dir
+    mkdir -p "$root/.local-runs"
+    dir="$(mktemp -d "$root/.local-runs/mutation-marker-gate-selftest.XXXXXX")"
+    trap 'rm -rf "$dir"' RETURN
     mkdir -p "$dir/src/federation"
 
     # (1) A clean tree PASSES — including near-miss text that names the harness
@@ -109,8 +128,26 @@ RS
         exit 1
     fi
 
-    rm -rf "$dir"
-    echo "PASS: self-test — clean tree passes, planted #3118 mutation fails, missing src/ fails closed"
+    # (4) grep rc=2 (unreadable file) must fail CLOSED, not PASS.
+    mkdir -p "$dir/src"
+    printf 'fn ok() {}\n' >"$dir/src/unreadable.rs"
+    chmod 000 "$dir/src/unreadable.rs"
+    local urc=0
+    run_gate "$dir" >/dev/null 2>&1 || urc=$?
+    chmod u+r "$dir/src/unreadable.rs" || true
+    if [[ $urc -ne 2 ]]; then
+        echo "FAIL: self-test — unreadable file must exit 2, got $urc" >&2
+        exit 1
+    fi
+
+    # (5) the banned MARKER literal still appears in the harness (so this
+    #     gate and the harness cannot drift apart).
+    if ! grep -qF "$MARKER" "$root/scripts/check-cert-removal-proof.sh"; then
+        echo "FAIL: self-test — MARKER literal missing from the harness" >&2
+        exit 1
+    fi
+
+    echo "PASS: self-test — clean tree passes, planted #3118 mutation fails, missing src/ fails closed, unreadable file fails closed, harness still names the marker"
 }
 
 main() {

--- a/scripts/check-mutation-marker.sh
+++ b/scripts/check-mutation-marker.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# v1.0.0 (#3119) — CERT REMOVAL-PROOF MUTATION MARKER perma-ban gate.
+#
+# WHY THIS EXISTS. `scripts/check-cert-removal-proof.sh` is a mutation-testing
+# harness: for each cited security control it REWRITES the production source
+# in place to an always-allow disposition, runs the control's lane test, and
+# asserts the test goes RED. Every such rewrite is stamped with a single
+# marker comment. On 2026-08-22 (#3118, never merged) an aborted run — killed
+# at a two-minute timeout — left one of those rewrites in the working tree:
+# `inbound_write_namespace_authorized` short-circuited to always-allow, i.e. a
+# cross-tenant inbound federated-write authorization BYPASS. A later
+# `git add -A` swept it into a pushed commit, where it sat on a PR branch for
+# ~25 minutes. Nothing in `git status` reads as "a security control is off".
+#
+# #3119 fixed the harness (it now restores under an EXIT/INT/TERM/HUP trap and
+# refuses to start on a stale marker). THIS GATE IS THE INDEPENDENT SECOND
+# LINE: whatever leaves a mutation in the tree — a crash the trap could not
+# catch, a `git add -A`, a hand-edited cherry-pick, a rebase that resurrects a
+# dropped hunk — the marker can never reach a merged commit under `src/`.
+# Defence in depth, per the North Star: a disabled security control is a
+# WRONG-RESULT posture, not a degraded one, so this fails CLOSED and loudly.
+#
+# WHY IT DOES NOT TRIP ITSELF. The gate scans `src/` ONLY. The marker string
+# lives exclusively OUTSIDE `src/` — in this script, in the harness under
+# `scripts/`, and in the archived evidence logs under `docs/compliance/` — so
+# the gate can name what it bans without banning itself. (Same construction as
+# `scripts/check-l3-boundary.sh`, whose pattern likewise lives only in the
+# script + workflow.) A self-test fixture is staged under `.local-runs/`,
+# never under the real `src/`.
+#
+# CLI:
+#   ./scripts/check-mutation-marker.sh              — run the gate
+#   ./scripts/check-mutation-marker.sh --self-test  — prove the gate is live
+set -euo pipefail
+
+# The banned marker. SSOT for this gate; the harness carries the same literal
+# in its payloads (both files are outside src/, so neither trips this gate).
+MARKER='CERT-REMOVAL-PROOF-MUTATION'
+
+repo_root() {
+    cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+# Scan <root>/src for the marker. Returns 0 = clean, 1 = marker found,
+# 2 = could not scan (fail CLOSED: an unscannable tree is never "clean").
+run_gate() {
+    local root="$1"
+    if [[ ! -d "$root/src" ]]; then
+        echo "❌ mutation-marker gate: no src/ under $root — refusing to report clean" >&2
+        return 2
+    fi
+    if grep -rIl --exclude-dir=.git -e "$MARKER" "$root/src" >/dev/null 2>&1; then
+        echo "" >&2
+        echo "══════════════════════════════════════════════════════════════════════" >&2
+        echo "SECURITY: cert removal-proof mutation marker found in src/" >&2
+        echo "" >&2
+        grep -rIn --exclude-dir=.git -e "$MARKER" "$root/src" >&2 || true
+        echo "" >&2
+        echo "A marked line is a DELIBERATELY DISABLED security control left behind" >&2
+        echo "by scripts/check-cert-removal-proof.sh (see #3118/#3119). It must" >&2
+        echo "never be committed. Restore the tree with:" >&2
+        echo "" >&2
+        echo "    scripts/check-cert-removal-proof.sh --force-restore" >&2
+        echo "" >&2
+        echo "then re-stage EXPLICITLY (never 'git add -A' after a gate script)." >&2
+        echo "══════════════════════════════════════════════════════════════════════" >&2
+        return 1
+    fi
+    return 0
+}
+
+run_self_test() {
+    local root
+    root="$(repo_root)"
+    local dir="$root/.local-runs/mutation-marker-gate-selftest"
+    rm -rf "$dir"
+    mkdir -p "$dir/src/federation"
+
+    # (1) A clean tree PASSES — including near-miss text that names the harness
+    #     and the concept without carrying the literal marker.
+    cat >"$dir/src/federation/clean.rs" <<'RS'
+// Proven load-bearing by the cert removal-proof harness (scripts/).
+pub fn inbound_write_namespace_authorized(ok: bool) -> bool {
+    ok
+}
+RS
+    if ! run_gate "$dir" >/dev/null 2>&1; then
+        echo "FAIL: self-test — gate wrongly flagged a clean tree" >&2
+        exit 1
+    fi
+
+    # (2) The EXACT #3118 artefact FAILS: an always-allow first statement
+    #     carrying the marker comment, in the real file's real function.
+    printf 'pub fn inbound_write_namespace_authorized() -> bool {\n    return true; // %s\n}\n' \
+        "$MARKER" >"$dir/src/federation/receive_auth.rs"
+    if run_gate "$dir" >/dev/null 2>&1; then
+        echo "FAIL: self-test — gate did NOT catch the planted #3118 mutation" >&2
+        exit 1
+    fi
+
+    # (3) FAIL CLOSED on an unscannable tree — an empty scan set must never
+    #     green a no-op (the #2839 fail-closed discipline).
+    rm -rf "$dir/src"
+    if run_gate "$dir" >/dev/null 2>&1; then
+        echo "FAIL: self-test — gate reported clean with no src/ to scan" >&2
+        exit 1
+    fi
+
+    rm -rf "$dir"
+    echo "PASS: self-test — clean tree passes, planted #3118 mutation fails, missing src/ fails closed"
+}
+
+main() {
+    if [[ "${1:-}" == "--self-test" ]]; then
+        run_self_test
+        exit 0
+    fi
+    local root
+    root="$(repo_root)"
+    local rc=0
+    run_gate "$root" || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "✅ cert removal-proof mutation-marker gate: PASS (0 hits in src/)"
+        exit 0
+    fi
+    exit "$rc"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #3119

## The defect

`scripts/check-cert-removal-proof.sh` is a mutation-testing harness: for each cited security control it rewrites the production source to an always-allow disposition, runs the control's lane test, and asserts the test goes RED. Restoration happened only on the happy and handled paths — **there was no `trap`** — so a SIGINT, a `timeout` kill, or a crash inside the cargo run left the control **disabled** in the working tree, with nothing in `git status` that reads as "a security control is off".

On 2026-08-22 an aborted run left `inbound_write_namespace_authorized` short-circuited to always-allow — a cross-tenant inbound federated-write authorization **bypass** — and a later `git add -A` swept it onto a pushed PR branch for ~25 minutes (#3118; never merged, branch history rewritten, no commit ever contained it).

## The fix — four layers between a mutation and a commit

**1. Trap (req 1).** Each target is registered in a `MUTATED` array **before** it is rewritten, so a crash *between* "mutate" and "run" is still covered. An `EXIT`/`INT`/`TERM`/`HUP` trap restores all of them with `git checkout HEAD -- "${MUTATED[@]}"` — **index and worktree**, which unwinds the staged `git add -A` variant that an index-only `git checkout --` would have written straight back into the tree. Restoration is idempotent (the array is cleared as it is consumed; a second call is a no-op).

Exit-status propagation:

- `on_exit` captures `rc=$?` as its very first statement, clears its own handlers, restores, asserts, and `exit "$rc"` — a PASS still exits 0, a CERT-RED still exits 1, and only a *success that failed to restore* is upgraded (to 9). A failure is never downgraded.
- `on_signal` deliberately does **not** `exit`. It clears the handler and **re-raises** with `kill -s "$sig" $$`, so the shell dies *of the original signal* and every parent — `timeout`, a shell job, a CI runner, a `wait` in a driver — observes `WIFSIGNALED` / 128+N exactly as it would with no trap installed. `exit 130` would merely *look* like a signal death and would lie to anything that distinguishes "cancelled" from "failed".
- The guard test now runs **backgrounded under `wait`**. Bash defers a trap until the current *foreground* command returns, so the entire length of a `cargo test` run was previously an un-interruptible window — precisely the window #3118 died in. `wait` is interruptible; the trap also reaps the child.

**2. Start guard (req 2).** A marker already present in `src/` (an aborted earlier run) makes the harness refuse to start — loudly, exit 4 — rather than stack a second mutation on a disabled control. `--force-restore` is the deliberate recovery path: it **backs the mutated files up** under `.local-runs/cert-54-evidence/force-restore-<ts>/` first (reversibility — the only durable record of what the aborted run left behind), then resets them to `HEAD` and exits 0. The guard also covers `--list` and `--self-test`: nothing about this harness should proceed on a tree whose controls are off.

**3. End assertion (req 3).** End-of-run *and* the trap both assert the marker is absent from `src/`, printing `SECURITY: mutation still present in <files>` and exiting non-zero otherwise. The scan fails **closed**: a `git grep` that errors is reported as "could not scan — refusing to report clean", never as clean.

**4. Repo-wide gate (req 4).** New `scripts/check-mutation-marker.sh` fails if the literal marker appears anywhere under `src/`, however it got there — a crash the trap could not catch, a `git add -A`, a rebase that resurrects a dropped hunk. It cannot trip itself: it scans `src/` only, and the marker string lives exclusively outside `src/` (this gate, the harness, archived evidence logs).

## Workflow wiring

Added as steps to the **existing** `l3-boundary-gate` job in `.github/workflows/c8-precheck.yml` — the job that already runs `check-l3-boundary.sh` next to `check-hardcoded-literals.sh`, and structurally the same shape (a perma-banned string in `src/`):

```yaml
      - name: Run cert removal-proof mutation-marker gate (#3119)
        run: bash scripts/check-mutation-marker.sh
      - name: Self-test the mutation-marker gate (regression evidence)
        run: bash scripts/check-mutation-marker.sh --self-test
      - name: Prove the harness restores an interrupted run (#3119)
        run: bash scripts/check-cert-removal-proof.sh --self-test
```

It rides in that job rather than a new one **because that job's `name:` is a declared required context** (`scripts/qc-allowlists/required-contexts-release.txt`), so the gate is merge-blocking from the first commit; a fresh job would have been an unrequired context a merge could ignore. The job name is **not** changed — it is the exact string branch protection requires, and #2473 is the record of what renaming it costs.

## Tests (req 5)

`--self-test` gains two interrupt-safety legs that need **no cargo**. They drive the **real** harness against a **real** control in the **real** `src/` tree, with the cargo step stubbed via `CERT_PROOF_STUB_RUN` to a sentinel-touch + long sleep — so the harness is *guaranteed* to be sitting on a live, disabled security control when the signal lands. The sentinel is asserted: if the harness never reached the guard step, the leg **fails** rather than falsely passing. The stub can never manufacture a green verdict (it never returns 0, so a stubbed row always reports CERT-RED).

```
  [ok] return-shape: first-statement injected, body preserved
  [ok] body-shape: whole body replaced, braces balanced
  [ok] subst-shape: unique OLD replaced, marker embedded
  [ok] subst-shape: non-unique OLD rejected (exit 3)
  [ok] timeout-2: SIGTERM mid-mutation → src/ clean, marker absent, rc=124
  [ok] sigint-reraise: died OF SIGINT (rc=130), src/ clean, marker absent

self-test: PASS — three mutation shapes sound; interrupted runs leave a clean tree
```

Leg 5 asserts `wait` reports **130** — that is the assertion that pins the *re-raise*, since a trap ending in `exit 130` is indistinguishable to `$?` but not to a parent inspecting `WIFSIGNALED`. (`set -m` is required there and is commented as such: with job control off, a bash script's asynchronous children start with SIGINT *ignored*, and a signal ignored on entry cannot be trapped.)

**Negative control** — with the four `trap` lines commented out in a scratch copy, both legs go RED and reproduce the exact #3118 artefact:

```
  [FAIL] timeout-2: src/ left DIRTY after the interrupt:
            M src/federation/receive_auth.rs
  [FAIL] timeout-2: SECURITY — mutation marker still present in src/ after the interrupt
self-test: FAIL
```

Also verified by hand: planting the marker → gate exit 1 and harness start-guard exit 4; `git add`-ing the mutation (the literal #3118 shape) → `--force-restore` backs it up, resets index *and* worktree, exits 0.

Hardening found on the way: a `subst` payload whose replacement omits the marker would be invisible to the trap, the start guard, the end assertion **and** the repo-wide gate — the exact blind spot #3118 lived in. It is now rejected outright (exit 3).

## SOP

`docs/AI_DEVELOPER_WORKFLOW.md` §5.6 (new) and `CLAUDE.md` §Build & Test Commands: gate scripts mutate the tree by design; `git add -A` / `git add .` / `git commit -a` are banned after running one; stage explicitly and read the staged diff.

## CI parity run locally

`actionlint` (1.7.7) clean on `c8-precheck.yml`; `check-required-contexts.sh`, `check-docs-vs-ssot.sh`, `check-ci-job-claims.sh`, `check-doc-symbol-anchors.sh`, `check-doc-surface-completeness.sh`, `check-capacity-claims.sh`, `check-benchmark-claims.sh`, `check-l3-boundary.sh`, `check-hardcoded-literals.sh`, `check-vendor-literals.sh`, `check-mutation-marker.sh` all PASS; the full `l3-boundary-gate` job simulated end-to-end locally, green, `src/` clean afterwards. No Rust changed, so no cargo gate is in scope. CHANGELOG `[Unreleased]` → `### Security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY