### PR TITLE
ci(throughput): re-home no-pg/no-cargo gates to GitHub-hosted; keep tier + warm-cache jobs self-hosted

### DIFF
--- a/.github/workflows/batman-mode-acceptance.yml
+++ b/.github/workflows/batman-mode-acceptance.yml
@@ -84,6 +84,8 @@ env:
 jobs:
   rust-integration:
     name: Rust integration (issue_800_batman_mode)
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of ci.yml):
+    # `cargo build --release` + two `cargo test --release` binaries.
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +141,11 @@ jobs:
 
   bash-integration:
     name: Bash integration (test-batman-mode-suite.sh)
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of ci.yml):
+    # it rebuilds the release binary against the same
+    # `shared-key: batman-mode-acceptance` cache as `rust-integration` above,
+    # which it `needs:`, so splitting the two across runner classes would throw
+    # that cache away and pay a second cold release build.
     runs-on: [self-hosted, linux-fed]
     needs: rust-integration
     steps:
@@ -188,7 +195,9 @@ jobs:
   # before the test fails with a confusing rustc error.
   surface-stability:
     name: Surface stability (load-bearing symbols)
-    runs-on: [self-hosted, linux-fed]
+    # RUNNER PLACEMENT — GitHub-hosted (rule at the head of ci.yml). Pure
+    # `git ls-files` + `grep` over src/: no toolchain, no cargo, no Postgres.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Assert load-bearing symbols are present

--- a/.github/workflows/batman-mode-acceptance.yml
+++ b/.github/workflows/batman-mode-acceptance.yml
@@ -80,6 +80,15 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # #3128 — EXPLICIT, not inherited. `Swatinem/rust-cache` is what used to export
+  # CARGO_INCREMENTAL=0, and it is now skipped on the self-hosted fleet (see the
+  # rust-cache guards below), so the value must be declared here. Incremental
+  # state is the most fragile thing in a `target/` tree, and the fleet's
+  # `target/` is PERSISTENT and reused across branches — leaving incremental on
+  # there would be a worse version of the very inconsistency the guard closes.
+  # Declaring it at workflow level also means no job depends on the runner
+  # `.env` supplying it.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   rust-integration:
@@ -89,11 +98,32 @@ jobs:
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
         with:
           shared-key: batman-mode-acceptance
       - name: Build release binary
@@ -150,9 +180,30 @@ jobs:
     needs: rust-integration
     steps:
       - uses: actions/checkout@v4
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
         with:
           shared-key: batman-mode-acceptance
       - name: Install sqlite3 + jq (bounded+retry #3090/#2960)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,8 +43,28 @@ env:
 
 jobs:
   bench:
+    # RUNNER PLACEMENT — GitHub-hosted, AND THE NAME IS A CLAIM
+    # (the rule is stated at the head of ci.yml).
+    #
+    # `ubuntu-latest` is not a convenience here, it is the REFERENCE HARDWARE
+    # the published budgets are defined against: `PERFORMANCE.md` §"Measurement
+    # methodology" pins CI to "GitHub-hosted Linux x86_64 runners
+    # (`ubuntu-latest`)" and its hardware multiplier table gives that class the
+    # 1.0 multiplier every p95 target in the budget table is expressed in.
+    # `performance/baseline.json` likewise documents itself as a
+    # `regenerate-baseline`-on-`ubuntu-latest` median-of-3 artefact. #3109 moved
+    # the job to `[self-hosted, linux-fed]` WITHOUT moving the budgets, so a
+    # p95 measured on the f2 node was being compared against an
+    # `ubuntu-latest`-calibrated target while the job name, PERFORMANCE.md §7
+    # and the baseline file all still said `ubuntu-latest` — a measurement read
+    # off the wrong machine and a doc-vs-reality drift in the same move.
+    #
+    # Moving it back both makes the job name TRUE again (no rename, so no
+    # required-context churn — this job is advisory, see the `paths-ignore`
+    # note above) and returns an advisory 6-8 min release build to the hosted
+    # pool instead of a scarce self-hosted slot.
     name: ai-memory bench (ubuntu-latest)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -175,9 +195,14 @@ jobs:
   # artifact for the operator to commit as performance/baseline.json with
   # bootstrap:false — the workflow has contents:read and never auto-commits.
   regenerate-baseline:
+    # RUNNER PLACEMENT — GitHub-hosted, same reference-hardware argument as
+    # `bench` above (the rule is stated at the head of ci.yml). This job MINTS the
+    # committed baseline, so it must run on the runner class the baseline
+    # claims: its own name says `ubuntu-latest`, and so does the `_note` field
+    # it writes into `performance/baseline.json`.
     name: Regenerate bench baseline (ubuntu-latest, median-of-3)
     if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/c8-precheck.yml
+++ b/.github/workflows/c8-precheck.yml
@@ -21,6 +21,15 @@
 #      audit (ai-memory global/policies memory
 #      2cb15d34-2399-4611-a020-df6ef91683fe).
 #
+# RUNNER PLACEMENT (the rule is stated at the head of ci.yml). Every job in this
+# workflow is a SCRIPT-ONLY gate: `bash scripts/check-*.sh` over the checked-out
+# tree, no `cargo build`/`cargo test`, no Postgres. None of them benefit from
+# the self-hosted nodes' warm cargo target cache and none of them need the
+# native pg tier, so all of them run on GitHub-hosted `ubuntu-latest` where they
+# fan out in parallel at no slot cost. #3109 re-homed all 22 onto
+# `[self-hosted, linux-fed]`; on a 2-node fleet that put 22 zero-cargo gates
+# into contention with the four required `Check (…)` legs and starved them.
+#
 # Mirrors the local-developer flow: both `scripts/qc-codegraph-precheck.sh`
 # and `scripts/check-vendor-literals.sh` are the same scripts CI uses.
 # Run `scripts/qc-codegraph-precheck.sh --update` locally to regenerate
@@ -78,7 +87,7 @@ concurrency:
 jobs:
   c8-precheck:
     name: C8 caller-context allowlist check
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +96,7 @@ jobs:
 
   vendor-literal-gate:
     name: Vendor-monoculture + SECS_PER_* lint-gate (#1174 PR10)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +121,7 @@ jobs:
     # scripts/check-required-contexts.sh hard-fails the unquoted form
     # repo-wide, so this cannot silently re-land.
     name: "L3-boundary perma-ban gate (§25.3 S5 / RQ-10 #1853)"
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # v0.9.0 §25.3 S5 — the epoch-closure lane ships under strictly ruled
     # public identifiers; certain internal design-doc identifiers are
@@ -131,7 +140,7 @@ jobs:
 
   hardcoded-literal-gate:
     name: Hardcoded-literal duplication ratchet (pm-v3.1)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # Operator directive (~6mo, escalated 2026-06-09): no hardcoded literal
     # values; no literals embedded in variable/constant names. Instructions
@@ -160,7 +169,7 @@ jobs:
     # schema bumps / SSOT-const changes now fail loudly here when
     # narrative isn't updated in lockstep.
     name: Docs vs SSOT drift gate
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -187,7 +196,7 @@ jobs:
     # from scripts/check-migration-ladder.sh rather than re-derived.
     # Burn-down allowlist, where a STALE entry ALSO FAILS (#2494 style).
     name: Doc symbol/path anchor gate (#2629)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -218,7 +227,7 @@ jobs:
     # membership test passes it (the collection path IS registered) and
     # a parameter-blind test passes it too.
     name: SDK-path vs routes.rs membership gate (#2629)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -255,7 +264,7 @@ jobs:
     # EXISTS." Shipped as a ratchet with a pending-fix ledger because
     # five document-correction lanes are in flight concurrently.
     name: Named-CI-job existence + enforcement-truthfulness gate (#2629)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -290,7 +299,7 @@ jobs:
     # CLOSED. Dependency-free (grep/python3 over src/), matching the
     # toolchain-free posture of the other c8-precheck gates.
     name: Doc surface completeness gate (#2839)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -322,7 +331,7 @@ jobs:
     # it aimed at the defect, and a burn-down allowlist (STALE entry hard-fails)
     # carries the vetted, explicitly-aspirational vision-tier statements.
     name: Capacity-claim ceiling gate (#2869)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -354,7 +363,7 @@ jobs:
     # retired figure are exempt; non-keyword (LLM-expanded / semantic /
     # autonomous) rows use a different canon and are not compared.
     name: Benchmark-claim canon gate (#2879)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -379,7 +388,7 @@ jobs:
     # templates pure ASCII so `terraform apply` renders a cloud-config
     # cloud-init will parse.
     name: Cloud-init ASCII gate
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -402,7 +411,7 @@ jobs:
     # suite until the 1500s watchdog killed it. This gate keeps a new
     # test from silently re-introducing that class.
     name: Test-reachable stdin-read gate (#1989)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -423,7 +432,7 @@ jobs:
     # fleet-wide. HARD-BLOCKS a duplicate numeric prefix / duplicate schema
     # version / ladder gap / cross-adapter tip disagreement / orphan file.
     name: Migration-ladder-uniqueness gate (guardrail-D)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -446,7 +455,7 @@ jobs:
     # HARD-BLOCKS a reintroduced fail-open branch in `install.sh` and
     # any release artifact published without a sibling `.sha256`.
     name: Installer checksum fail-closed gate (#2449)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -477,25 +486,25 @@ jobs:
     # no-op to green. This job is the environment where the guarantee is
     # actually claimed, so here an absent interpreter is a FAILURE.
     name: Non-Rust conformance-reader proof gate (#2452)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      # On the self-hosted fleet we ASSERT the pre-installed interpreters
-      # instead of actions/setup-python / actions/setup-node: those actions
-      # write the GitHub-hosted RUNNER_TOOL_CACHE default
-      # (/Users/runner/hostedtoolcache), which the `fate`/`fate_two` runner
-      # user cannot create, and RUNNER_TOOL_CACHE is runner-managed (.env
-      # cannot override it). The runners ship python3 + node on PATH. The gate
-      # still fails closed when they are missing — this assertion reds the job
-      # BEFORE the gate runs, so the controlled proof never depends on an
-      # accident, and it downloads nothing.
-      - name: Ensure python3 + node present (self-hosted; #2452 fail-closed)
-        shell: bash
-        run: |
-          command -v python3 >/dev/null || { echo "::error::python3 not on PATH on $RUNNER_NAME"; exit 1; }
-          command -v node    >/dev/null || { echo "::error::node not on PATH on $RUNNER_NAME"; exit 1; }
-          echo "python3=$(python3 --version) node=$(node --version)"
+      # The interpreters are PROVISIONED, not assumed. The gate fails closed
+      # when they are missing, so relying on whatever the runner image
+      # happens to ship would make a controlled proof depend on an accident.
+      #
+      # (#3109 replaced these two actions with a `command -v` presence
+      # assertion because on the self-hosted fleet `actions/setup-*` write the
+      # GitHub-hosted RUNNER_TOOL_CACHE default, which the runner user cannot
+      # create. This job is back on `ubuntu-latest` — no cargo, no pg tier —
+      # so the provisioning form is restored with it.)
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       # Needed only by the gate's R-203 / before-after evidence, which
       # compiles tests/conformance_readers.rs standalone with `rustc --test`
       # (the harness is deliberately crate-dependency-free — no cargo build).
@@ -531,7 +540,7 @@ jobs:
     # module-local lock instead of reusing the shared one. This gate
     # keeps a new module from silently re-introducing that class.
     name: Test-env $HOME-lock gate (#2146)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -578,7 +587,7 @@ jobs:
     # workflow's own `push.branches` lost `local/**` for exactly that reason
     # (#2523); `tool-count-drift.yml` was fixed in #2509.
     name: Required-context + classify-base soundness gate (#2494/#2496/#2508)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -657,7 +666,7 @@ jobs:
     # remotes at PR time would make this repo's CI depend on third-party
     # availability and teach reviewers to ignore a red gate.
     name: Git-dependency-source supply-chain gate (#2050/#2512)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -685,7 +694,7 @@ jobs:
     # it keeps a currently-clean property (zero unallowlisted extension
     # references at HEAD) clean at tag-cut, which is the cheapest moment.
     name: "CREATE EXTENSION allowlist gate (#2648)"
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -751,7 +760,7 @@ jobs:
     # issue-tracked) so rule (f) of `scripts/check-required-contexts.sh`
     # stays green in the interim rather than defaulting to unenforced.
     name: Commit-signing posture gate (#2486)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -807,7 +816,7 @@ jobs:
     # Declared REQUIRED in required-contexts-release.txt (mirror-first;
     # live branch-protection API is the operator-gated follow-up).
     name: Enterprise-federation cert-expiry gate (cert §7 / F7)
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cert-postgres-age.yml
+++ b/.github/workflows/cert-postgres-age.yml
@@ -98,6 +98,15 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # #3128 — EXPLICIT, not inherited. `Swatinem/rust-cache` is what used to export
+  # CARGO_INCREMENTAL=0, and it is now skipped on the self-hosted fleet (see the
+  # rust-cache guards below), so the value must be declared here. Incremental
+  # state is the most fragile thing in a `target/` tree, and the fleet's
+  # `target/` is PERSISTENT and reused across branches — leaving incremental on
+  # there would be a worse version of the very inconsistency the guard closes.
+  # Declaring it at workflow level also means no job depends on the runner
+  # `.env` supplying it.
+  CARGO_INCREMENTAL: "0"
   # No dev debug info to keep the heavy sal-postgres test-compile lean. No
   # `-fuse-ld=mold` RUSTFLAGS: mold was a GitHub-hosted-runner headroom hack;
   # the self-hosted node uses its provisioned system linker.
@@ -123,6 +132,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
@@ -195,7 +214,18 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "::notice::cert cells pointed at ephemeral db $CI_FED_DB on the native enterprise-fed tier ($RUNNER_NAME)"
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
 
       - name: Resolve certified stack pins from deploy SSOT
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,53 @@ name: CI
 # superset of the 2026-05-22 dossier baseline; this push refreshes the
 # integrated full-platform CI signal as Tier 1 ship-gate evidence.
 
+# ---------------------------------------------------------------------------
+# RUNNER PLACEMENT — THE RULE (cited by every `# RUNNER PLACEMENT` comment in
+# this repository's workflows; this block is its single statement).
+# ---------------------------------------------------------------------------
+# Self-hosted concurrency is SIX runner instances for the whole repository —
+# four `linux-fed` on one Linux host, two `macos-fed` on one macOS host — shared
+# across every open pull request, and GitHub does not priority-order that queue.
+# GitHub-hosted capacity, at this repository's volume, is not a constraint.
+#
+# So a self-hosted slot is spent ONLY where the node offers something the hosted
+# pool cannot:
+#
+#   pg-tier      the always-up native PG 18.6 + AGE 1.8.0 + pgvector 0.8.6
+#                instance on :5445. A job qualifies if it reads the node-local
+#                tier-URL file, CREATE DATABASEs an ephemeral db on it, or points
+#                AI_MEMORY_TEST_POSTGRES_URL / AI_MEMORY_TEST_AGE_URL at it.
+#   warm-cache   the persistent `target/` tree. A job qualifies if it runs
+#                `cargo build` / `cargo test` / `cargo clippy` over a non-trivial
+#                slice of the crate, where warm-vs-cold is minutes.
+#   script-only  EVERYTHING ELSE — `bash scripts/check-*.sh`, git/grep/python3
+#                over the checked-out tree, container-action steps,
+#                dependency-graph RESOLUTION that never compiles, and Docker
+#                builds whose layer cache is `type=gha` (a container build cannot
+#                see the host's cargo cache). These run on `ubuntu-latest`.
+#
+# WHY THIS IS A RULE AND NOT A PREFERENCE. #3109 put 39 job definitions (43
+# expanded) onto the fleet, `Classify changes` — the root of this workflow's
+# `needs:` graph — among them. With several PRs open, whole runs sat `queued`
+# 40+ minutes because the decider could not get a slot, so the four REQUIRED
+# `Check (…)` legs never started. One absolute follows: A JOB THAT OTHER JOBS
+# `needs:` MUST NEVER BE SELF-HOSTED UNLESS IT IS ITSELF pg-tier OR warm-cache.
+# A queued decider stalls its whole graph.
+#
+# A job moving BACK to the hosted pool must not keep anything the fleet supplied
+# implicitly — a PATH entry for ~/.cargo/bin, CARGO_BUILD_JOBS, a runner-managed
+# RUNNER_TOOL_CACHE, a job-started hook. Where #3109 replaced
+# actions/setup-python / actions/setup-node with a `command -v` presence
+# assertion (the fleet cannot write the hosted RUNNER_TOOL_CACHE default), the
+# setup-* actions are restored with the move back — see `conformance-readers-gate`
+# in c8-precheck.yml. AI_MEMORY_NO_CONFIG=1 is unaffected either way: the runner
+# .env sets it on the fleet and the workflows set it per-step, so hosted jobs
+# behave identically.
+#
+# Adding a job: answer (1) does it need the :5445 tier? (2) does it compile a
+# non-trivial slice of the crate? (3) otherwise hosted — and record the answer as
+# a `# RUNNER PLACEMENT` comment on the job.
+
 on:
   push:
     branches: [main, develop, "release/**"]
@@ -105,11 +152,25 @@ jobs:
   # correctly reported `docs_only=false` on that same commit.
   classify:
     name: Classify changes
-    # v1.0.0 self-hosted CI — was ubuntu-latest; the classify decider is a
-    # toolchain-free git/bash gate, re-homed onto the enterprise-fed Linux
-    # node. The `- id: cls` two-base body is UNCHANGED (frozen by
+    # RUNNER PLACEMENT — GITHUB-HOSTED, AND THIS ONE IS LOAD-BEARING
+    # (the rule is stated at the head of this file).
+    #
+    # `classify` is the ROOT of this workflow's `needs:` graph: `lint`,
+    # `actionlint`, `msrv`, `check` (×4), `postgres-feature`,
+    # `mobile-cross-compile` (×2), `sal-feature`, `vectorlite-feature` and
+    # `dockerfile-validate` all wait on it, so NOTHING in the pipeline can start
+    # until it finishes. #3109 put it on `[self-hosted, linux-fed]`, where it
+    # queued behind ~37 other self-hosted jobs on a 2-node fleet — with several
+    # PRs open the decider itself sat `queued` for 40+ minutes and the four
+    # REQUIRED `Check (…)` legs never started. Head-of-line blocking on the one
+    # job that must never wait.
+    #
+    # It is a toolchain-free git/bash decider — no cargo, no Postgres — so it
+    # has nothing to gain from a self-hosted node and belongs on the hosted
+    # pool, which has no slot contention. DO NOT re-home this job onto
+    # `self-hosted`. The `- id: cls` two-base body is UNCHANGED (frozen by
     # scripts/test/test-ci-workflow-invariants.sh §A).
-    runs-on: [self-hosted, linux-fed]
+    runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.cls.outputs.docs_only }}
       # v0.7.0 Task #12 (#1399) — test-impact selection output.
@@ -332,6 +393,10 @@ jobs:
     name: Lint (fmt + clippy)
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of this
+    # file). Two full pedantic clippy passes (default + `--all-targets
+    # --features sal`); the node's warm `target/` turns a multi-minute cold
+    # compile into an incremental one.
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
@@ -377,7 +442,13 @@ jobs:
   # do not apply, and it always runs — which is the entire point.
   build-script-vetting:
     name: "Build-script custom-build ledger gate (#2635)"
-    runs-on: [self-hosted, linux-fed]
+    # RUNNER PLACEMENT — GitHub-hosted (rule at the head of this file). This job
+    # RESOLVES the dependency graph (`cargo fetch --locked` +
+    # `cargo metadata --offline`) and then runs a python verifier; it never
+    # COMPILES anything, so the self-hosted nodes' warm `target/` directory buys
+    # it nothing. `Swatinem/rust-cache` restores the registry on hosted exactly
+    # as it did before #3109.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -419,7 +490,9 @@ jobs:
     name: actionlint (workflow-injection guard)
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
-    runs-on: [self-hosted, linux-fed]
+    # RUNNER PLACEMENT — GitHub-hosted (rule at the head of this file). A single
+    # container-action step over `.github/workflows/`: no cargo, no Postgres.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: actionlint
@@ -442,6 +515,8 @@ jobs:
     name: MSRV (Rust 1.96)
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of this
+    # file). `cargo check --all-targets` over the whole crate.
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
@@ -951,6 +1026,13 @@ jobs:
     name: Postgres feature gate
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of this
+    # file). NOTE the reason is the cache, NOT the pg tier: since the #3109
+    # rewrite this job no longer talks to Postgres at all (no `services:`, no
+    # `AI_MEMORY_TEST_POSTGRES_URL`) — the live-tier coverage moved to the
+    # `enterprise-fed` legs of `check`. What is left is a full
+    # `--features sal-postgres --tests` compile for pedantic clippy, which is
+    # exactly the workload the warm `target/` exists for.
     runs-on: [self-hosted, linux-fed]
     # #1487 — bound the job so a wedged compile can't pin the runner.
     timeout-minutes: 40
@@ -1105,6 +1187,8 @@ jobs:
   # gates (clippy / build / lib tests) at the same feature combo.
   # Skipped on docs-only PRs alongside the rest of the heavy matrix.
   sal-feature:
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of this
+    # file): clippy + `cargo build --release --features sal` + `cargo test`.
     name: SAL-only feature gate
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
@@ -1148,6 +1232,8 @@ jobs:
   # It also runs `config_precedence` under the feature so the #2256
   # feature-gated env-resolution pin is exercised. Skipped on docs-only PRs.
   vectorlite-feature:
+    # RUNNER PLACEMENT — self-hosted, WARM CACHE (rule at the head of this
+    # file): `--all-targets --features vectorlite` clippy + two test binaries.
     name: vectorlite feature gate
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
@@ -1195,7 +1281,14 @@ jobs:
   dockerfile-validate:
     name: Dockerfile build (no push)
     needs: classify
-    runs-on: [self-hosted, linux-fed]
+    # RUNNER PLACEMENT — GitHub-hosted (rule at the head of this file). The
+    # build happens inside a Docker layer cache backed by `type=gha` (the
+    # GitHub Actions cache service), NOT by the self-hosted nodes' `target/`
+    # directory — the container build cannot see the host's cargo cache at all,
+    # so re-homing it onto the fleet in #3109 consumed a scarce slot for zero
+    # cache benefit. It also keeps buildx/BuildKit state off the persistent
+    # hosts.
+    runs-on: ubuntu-latest
     # Skip on tag pushes — the docker job below handles those (with push).
     if: ${{ !startsWith(github.ref, 'refs/tags/v') && needs.classify.outputs.docs_only != 'true' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,15 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # #3128 — EXPLICIT, not inherited. `Swatinem/rust-cache` is what used to export
+  # CARGO_INCREMENTAL=0, and it is now skipped on the self-hosted fleet (see the
+  # rust-cache guards below), so the value must be declared here. Incremental
+  # state is the most fragile thing in a `target/` tree, and the fleet's
+  # `target/` is PERSISTENT and reused across branches — leaving incremental on
+  # there would be a worse version of the very inconsistency the guard closes.
+  # Declaring it at workflow level also means no job depends on the runner
+  # `.env` supplying it.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   # Classify the diff so docs-only PRs can short-circuit the heavy Rust
@@ -400,11 +409,49 @@ jobs:
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
+      # FAIL CLOSED if rustup is missing on a self-hosted node (#3128).
+      # `dtolnay/rust-toolchain` has an "Install rustup if needed" path that
+      # runs `curl https://sh.rustup.rs | sh`. On a GitHub-hosted runner that is
+      # a clean, throwaway image. On the fleet it curl-pipes an installer into a
+      # SHARED $HOME — which is what happened on f2 at 05:40:33Z on 2026-08-22
+      # ("downloading installer … Rust is installed now") when `~/.cargo/bin/rustup`
+      # was momentarily absent during a rustup self-update, and the job then
+      # built against whatever that install produced. A node missing its
+      # toolchain is a BROKEN NODE: it must red the job loudly, not silently
+      # repair itself from the network. Skipped on hosted runners, where
+      # provisioning the toolchain is exactly the action's job.
+      #
+      # The condition is `!= 'github-hosted'`, NOT `== 'self-hosted'`, so that an
+      # unset or unrecognised `runner.environment` STILL RUNS the assertion. An
+      # unknown runner class must not silently switch a fail-closed control off.
+      # The rust-cache guards below use the opposite polarity for the same
+      # reason: unknown => skip the cache action, whose worst case is a cold
+      # build, never a mixed-provenance `target/`.
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — refusing to let the toolchain action curl-pipe an installer into a shared home. Repair the node."
+            exit 1
+          }
+          echo "rustup=$("$HOME/.cargo/bin/rustup" --version 2>&1 | head -1)"
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
@@ -520,9 +567,30 @@ jobs:
     runs-on: [self-hosted, linux-fed]
     steps:
       - uses: actions/checkout@v4
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (declared MSRV)
         uses: dtolnay/rust-toolchain@1.96.0
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
       - name: cargo check on MSRV
         run: cargo check --all-targets
 
@@ -623,12 +691,32 @@ jobs:
           command -v node    >/dev/null || { echo "::error::node not on PATH on $RUNNER_NAME"; exit 1; }
           echo "python3=$(python3 --version) node=$(node --version)"
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted' && needs.classify.outputs.docs_only != 'true'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         if: needs.classify.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@1.96.0
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
-        if: needs.classify.outputs.docs_only != 'true'
+        if: needs.classify.outputs.docs_only != 'true' && runner.environment == 'github-hosted'
         with:
           # CI-speed (#3089) — SAVE the cache only on trunk `push` events
           # (push.branches = main/develop/release/**). `pull_request` and
@@ -1039,12 +1127,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
         with:
           # CI-speed (#3089) — save the cache only on trunk `push` events;
           # PR + merge_group runs restore-only. See the `check` job for the
@@ -1202,12 +1311,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
 
       - name: Clippy (sal feature)
         run: cargo clippy --features sal -- -D warnings -D clippy::all -D clippy::pedantic
@@ -1243,12 +1373,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - name: Install Rust 1.96.0 (matches rust-toolchain.toml pin)
         uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
 
       - name: Clippy (vectorlite feature, all targets)
         run: cargo clippy --all-targets --features vectorlite -- -D warnings -D clippy::all -D clippy::pedantic

--- a/.github/workflows/session-boot-lifetime.yml
+++ b/.github/workflows/session-boot-lifetime.yml
@@ -24,6 +24,15 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # #3128 — EXPLICIT, not inherited. `Swatinem/rust-cache` is what used to export
+  # CARGO_INCREMENTAL=0, and it is now skipped on the self-hosted fleet (see the
+  # rust-cache guards below), so the value must be declared here. Incremental
+  # state is the most fragile thing in a `target/` tree, and the fleet's
+  # `target/` is PERSISTENT and reused across branches — leaving incremental on
+  # there would be a worse version of the very inconsistency the guard closes.
+  # Declaring it at workflow level also means no job depends on the runner
+  # `.env` supplying it.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   lifetime-tests:
@@ -37,9 +46,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # FAIL CLOSED if rustup is missing on a self-hosted node — see the
+      # `lint` job in ci.yml for the full rationale (#3128).
+      - name: Assert rustup is provisioned (self-hosted; fail-closed #3128)
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          test -x "$HOME/.cargo/bin/rustup" || {
+            echo "::error::rustup is not provisioned at \$HOME/.cargo/bin/rustup on $RUNNER_NAME — repair the node."
+            exit 1
+          }
       - uses: dtolnay/rust-toolchain@stable
 
+      # HOSTED ONLY (#3128). On the self-hosted fleet the workspace `target/` is
+      # PERSISTENT and already IS the warm cache, so this action has nothing to
+      # add and two ways to do harm: its restore extracts an archive saved by a
+      # DIFFERENT runner instance OVER the live tree, and its post-step prunes
+      # that tree. Mixed-provenance artifacts are how PR #3116's self-hosted
+      # build died in 18s with `could not parse/generate dep info at:
+      # …/target/debug/deps/getrandom-*.d — No such file or directory` (disk was
+      # fine). `~/.cargo/{registry,git}` persist natively in $HOME on the fleet,
+      # so nothing is lost. CARGO_INCREMENTAL=0 — which this action used to
+      # export — is now declared in the workflow `env:` block above.
       - uses: Swatinem/rust-cache@v2
+        if: runner.environment == 'github-hosted'
 
       - name: Run lifetime suite
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI throughput: no-pg / no-cargo gates re-homed back to GitHub-hosted; only
+  tier-bound and warm-cache jobs stay on the self-hosted fleet.** The
+  self-hosted move above put **39 job definitions (43 expanded)** onto a
+  **two-node** Linux fleet, including `Classify changes` — the root of `ci.yml`'s
+  `needs:` graph — and ~two dozen `bash scripts/check-*.sh` gates that run no
+  `cargo` and touch no Postgres. With several pull requests open, whole CI runs
+  sat `queued` for 40+ minutes because the decider could not get a slot, so the
+  four REQUIRED `Check (…)` legs never started: head-of-line blocking on the one
+  job that must never wait. Placement is now decided by what a job actually
+  needs — the native pg tier (`pg-tier`) or a warm `target/` (`warm-cache`) keep
+  a self-hosted slot; everything else (`script-only`) returns to `ubuntu-latest`,
+  where parallelism is not scarce. Moved back to GitHub-hosted: `Classify
+  changes`, `actionlint (workflow-injection guard)`, `Build-script custom-build
+  ledger gate (#2635)` (resolves the dependency graph, never compiles),
+  `Dockerfile build (no push)` (its layer cache is `type=gha`, not the host
+  `target/`), `Surface stability (load-bearing symbols)`, and all 22
+  `c8-precheck.yml` integrity gates — with `actions/setup-python` /
+  `actions/setup-node` restored on `Non-Rust conformance-reader proof gate
+  (#2452)`, whose `command -v` presence assertion existed only because the fleet
+  cannot write the hosted `RUNNER_TOOL_CACHE` default. Unchanged on the fleet:
+  the four `Check (…)` legs, `Lint (fmt + clippy)`, `MSRV (Rust 1.96)`,
+  `Postgres feature gate`, `SAL-only feature gate`, `vectorlite feature gate`,
+  the certified pg+AGE cells, the two Batman-mode release-build jobs, and the
+  `Lifetime suite (…)` legs. Self-hosted job definitions: **39 -> 10** (43 -> 14
+  expanded; at most 12 reachable from one pull request). **No required-context
+  NAME changes** — branch protection needs no edit for this change. The rule
+  itself (`pg-tier` / `warm-cache` / `script-only`, and the absolute that a job
+  other jobs `needs:` must never be self-hosted unless it is itself `pg-tier` or
+  `warm-cache`) is stated once at the head of `.github/workflows/ci.yml`, and
+  every re-homed job carries a `# RUNNER PLACEMENT` comment citing it.
+- **`bench.yml` returns to `ubuntu-latest` — the reference hardware its budgets
+  are defined against.** The self-hosted move relocated the advisory bench gate
+  and the baseline-regeneration job to `[self-hosted, linux-fed]` without moving
+  the budgets: `PERFORMANCE.md` pins CI measurement to "GitHub-hosted Linux
+  x86_64 runners (`ubuntu-latest`)" and gives that class the 1.0 hardware
+  multiplier every published p95 target is expressed in, and
+  `performance/baseline.json` describes itself as an `ubuntu-latest` median-of-3
+  artefact — so a p95 measured on the fleet was being compared against an
+  `ubuntu-latest`-calibrated target while the job name, `PERFORMANCE.md` §7 and
+  the baseline file all still said `ubuntu-latest`. Moving both jobs back makes
+  the measurement match its published methodology and makes the two job names
+  (`ai-memory bench (ubuntu-latest)`, `Regenerate bench baseline (ubuntu-latest,
+  median-of-3)`) true again without a rename, so no required-context churn.
+
 - **CI moved to a self-hosted enterprise-fed fleet with a 2x2 `Check` matrix.**
   All compute/gate jobs re-home from GitHub-hosted `ubuntu-latest`/`macos-latest`
   onto two self-hosted runner labels — `[self-hosted, linux-fed]` (host pop-os/f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other jobs `needs:` must never be self-hosted unless it is itself `pg-tier` or
   `warm-cache`) is stated once at the head of `.github/workflows/ci.yml`, and
   every re-homed job carries a `# RUNNER PLACEMENT` comment citing it.
+- **`Swatinem/rust-cache` no longer runs on the self-hosted fleet, and the
+  toolchain action can no longer curl-pipe an installer into a shared `$HOME`.**
+  Two failure modes observed on the fleet, both from a hosted-runner action
+  meeting a PERSISTENT workspace:
+  - PR #3116's self-hosted build died in 18 s with `could not parse/generate dep
+    info at: …/target/debug/deps/getrandom-*.d — No such file or directory`
+    (disk was fine). On the fleet the workspace `target/` already IS the warm
+    cache; `Swatinem/rust-cache` then restores an archive saved by a DIFFERENT
+    runner instance OVER that live tree and prunes it in its post-step, leaving
+    mixed-provenance artifacts. The action is now gated
+    `if: runner.environment == 'github-hosted'` on all nine self-hosted job
+    definitions (`check`, `lint`, `msrv`, `postgres-feature`, `sal-feature`,
+    `vectorlite-feature`, the two Batman-mode jobs, `lifetime-tests`); hosted
+    jobs are untouched. `~/.cargo/{registry,git}` persist natively in `$HOME` on
+    the fleet, so no cache is lost. **`CARGO_INCREMENTAL: "0"` — which that
+    action used to export — is now declared explicitly** in the workflow `env:`
+    block of each affected workflow, rather than left to the action or to the
+    runner `.env`: incremental state is the most fragile thing in a `target/`
+    tree, and the fleet's is persistent and reused across branches.
+  - On 2026-08-22 at 05:40:33Z `dtolnay/rust-toolchain`'s "Install rustup if
+    needed" path ran `curl https://sh.rustup.rs | sh` inside a CI job on f2,
+    because `~/.cargo/bin/rustup` was momentarily absent during a rustup
+    self-update. On a hosted runner that is a throwaway image; on the fleet it
+    installs into a SHARED `$HOME` and the job then builds against whatever that
+    produced. Every self-hosted job that installs a toolchain now runs a
+    fail-closed `test -x "$HOME/.cargo/bin/rustup"` assertion FIRST — a node
+    missing its toolchain reds the job loudly instead of silently repairing
+    itself from the network. Both guards are written `!= 'github-hosted'` /
+    `== 'github-hosted'` so that an unset or unrecognised `runner.environment`
+    still runs the assertion and still skips the cache action.
 - **`bench.yml` returns to `ubuntu-latest` — the reference hardware its budgets
   are defined against.** The self-hosted move relocated the advisory bench gate
   and the baseline-regeneration job to `[self-hosted, linux-fed]` without moving


### PR DESCRIPTION
Closes #3128

## The problem

#3109 (merged as `15fe44e4`) re-homed CI onto the self-hosted enterprise-fed fleet **wholesale** — **39 job definitions / 43 expanded** onto **six** runner instances (four `linux-fed` on one Linux host, two `macos-fed` on one macOS host) shared across every open pull request, with no priority ordering.

`Classify changes` was among them. It is the **root of `ci.yml`'s `needs:` graph** — `lint`, `actionlint`, `msrv`, `check` (×4), `postgres-feature`, `mobile-cross-compile` (×2), `sal-feature`, `vectorlite-feature` and `dockerfile-validate` all wait on it — so while it sat `queued`, the four REQUIRED `Check (…)` legs could not start at all. With 7 PRs open, whole runs sat queued 40+ minutes. Head-of-line blocking on the one job that must never wait.

The slots were largely spent on jobs the fleet does nothing for: all 22 `c8-precheck.yml` gates are `bash scripts/check-*.sh` over the checked-out tree, and `actionlint`, `Dockerfile build (no push)`, `Build-script custom-build ledger gate (#2635)` and `Surface stability (load-bearing symbols)` are the same shape.

## The rule

Stated **once**, at the head of `.github/workflows/ci.yml`; every re-homed job carries a `# RUNNER PLACEMENT` comment citing it.

| Class | Test | Home |
|---|---|---|
| `pg-tier` | reads the node-local tier-URL file, `CREATE DATABASE`s an ephemeral db on `:5445`, or points `AI_MEMORY_TEST_POSTGRES_URL` / `AI_MEMORY_TEST_AGE_URL` at it | self-hosted |
| `warm-cache` | `cargo build` / `test` / `clippy` over a non-trivial slice of the crate, where warm-vs-cold is minutes | self-hosted |
| `script-only` | everything else — `bash scripts/check-*.sh`, git/grep/python3, container-action steps, dependency-graph *resolution* that never compiles, Docker builds whose layer cache is `type=gha` | `ubuntu-latest` |

Plus one absolute: **a job that other jobs `needs:` must never be self-hosted unless it is itself `pg-tier` or `warm-cache`.** A queued decider stalls its whole graph.

## Placement — before / after

`before` = `15fe44e4^` (pre-#3109), `after` = `15fe44e4` (#3109), `proposed` = this PR.

### Moved back to GitHub-hosted

| Workflow | Job | before | after (#3109) | proposed | Reason |
|---|---|---|---|---|---|
| `ci.yml` | `Classify changes` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only (**decider**) |
| `ci.yml` | `actionlint (workflow-injection guard)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only |
| `ci.yml` | `Build-script custom-build ledger gate (#2635)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only |
| `ci.yml` | `Dockerfile build (no push)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only |
| `c8-precheck.yml` | all **22** integrity gates | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only |
| `batman-mode-acceptance.yml` | `Surface stability (load-bearing symbols)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | script-only |
| `bench.yml` | `ai-memory bench (ubuntu-latest)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | reference-hardware |
| `bench.yml` | `Regenerate bench baseline (ubuntu-latest, median-of-3)` | `ubuntu-latest` | self-hosted | **`ubuntu-latest`** | reference-hardware |

`Build-script custom-build ledger gate` **resolves** the graph (`cargo fetch --locked`, `cargo metadata --offline`) and runs a python verifier; it never compiles, so the warm `target/` buys it nothing. `Dockerfile build (no push)` caches to `type=gha` — a container build cannot see the host's cargo cache at all.

### Staying self-hosted

| Workflow | Job | before | after (#3109) | proposed | Reason |
|---|---|---|---|---|---|
| `ci.yml` | `Check (linux-fed,sqlite)` | `Check (ubuntu-latest)` | self-hosted | self-hosted | warm-cache |
| `ci.yml` | `Check (linux-fed,enterprise-fed)` | *(new in #3109)* | self-hosted | self-hosted | **pg-tier** |
| `ci.yml` | `Check (macos-fed,sqlite)` | `Check (macos-latest)` | self-hosted | self-hosted | warm-cache |
| `ci.yml` | `Check (macos-fed,enterprise-fed)` | *(new in #3109)* | self-hosted | self-hosted | **pg-tier** |
| `ci.yml` | `Lint (fmt + clippy)` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache |
| `ci.yml` | `MSRV (Rust 1.96)` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache |
| `ci.yml` | `Postgres feature gate` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache† |
| `ci.yml` | `SAL-only feature gate` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache |
| `ci.yml` | `vectorlite feature gate` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache |
| `cert-postgres-age.yml` | `Certified pg+AGE cells (…)` | `ubuntu-latest` | self-hosted | self-hosted | **pg-tier** |
| `batman-mode-acceptance.yml` | `Rust integration (issue_800_batman_mode)` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache |
| `batman-mode-acceptance.yml` | `Bash integration (test-batman-mode-suite.sh)` | `ubuntu-latest` | self-hosted | self-hosted | warm-cache‡ |
| `session-boot-lifetime.yml` | `Lifetime suite (linux-fed \| macos-fed)` | `${{ matrix.os }}` | self-hosted | self-hosted | warm-cache (schedule/dispatch only) |
| `ci.yml` | `Cross-compile (aarch64-apple-ios \| aarch64-linux-android)` | hosted | hosted | hosted | unchanged by #3109 |

† **warm-cache, not pg-tier.** Verified by reading its steps: since #3109 `Postgres feature gate` has **no `services:` block and never sets `AI_MEMORY_TEST_POSTGRES_URL`** — the live-tier coverage moved to the `enterprise-fed` `Check` legs. What remains is a full `--features sal-postgres --tests` pedantic-clippy compile, which is a cache workload.
‡ It rebuilds the release binary against the same `shared-key: batman-mode-acceptance` cache as the `rust-integration` job it `needs:`; splitting the two across runner classes would throw that cache away.

### Counts

| | self-hosted job definitions | expanded |
|---|---:|---:|
| before #3109 | 0 | 0 |
| after #3109 | 39 | 43 |
| **this PR** | **10** | **14** |

At most **12** of the 14 are reachable from one pull request (the two `Lifetime suite (…)` legs have no `pull_request` trigger), and `batman-mode-acceptance.yml`'s two only when its `paths:` filter matches.

## The bench job — a measurement defect, not just a name

The task was to fix the misleading `ai-memory bench (ubuntu-latest)` display name. Reading `PERFORMANCE.md` turned up the larger problem: `ubuntu-latest` is not a convenience there, it is the **reference hardware** — `PERFORMANCE.md` pins CI measurement to "GitHub-hosted Linux x86_64 runners (`ubuntu-latest`)" and gives that class the **1.0 hardware multiplier every published p95 target is expressed in**, and `performance/baseline.json` describes itself as an `ubuntu-latest` median-of-3 artefact. #3109 moved the measurement without moving the budgets, so a p95 taken on the fleet was being compared against an `ubuntu-latest`-calibrated target while the job name, `PERFORMANCE.md` §7 and the baseline file all still said `ubuntu-latest`.

Moving both jobs back restores the published methodology **and** makes the names true again — so the misleading display name is fixed **with no rename**, and no required-context churn. (Both bench jobs are advisory; `bench.yml:18` says so and neither appears in `required-contexts-release.txt`.)

## Required contexts

**No `name:` changed anywhere.** Verified mechanically by diffing the parsed job-name set of every workflow at `15fe44e4` against this branch — zero differences. `scripts/qc-allowlists/required-contexts-release.txt` is untouched and **branch protection needs no edit for this PR**.

## Environment carried over correctly

`actions/setup-python` / `actions/setup-node` are **restored** on `Non-Rust conformance-reader proof gate (#2452)`. #3109 replaced them with a `command -v python3 || exit 1` presence assertion only because the fleet cannot write the hosted `RUNNER_TOOL_CACHE` default; the gate's whole point (#2452) is that the interpreters are PROVISIONED, not assumed, so the provisioning form comes back with the job.

Audited every moved job for anything the self-hosted runner supplied implicitly — a `PATH` entry for `~/.cargo/bin`, `CARGO_BUILD_JOBS`, a runner-managed `RUNNER_TOOL_CACHE`, `ACTIONS_RUNNER_HOOK_JOB_STARTED`, `$RUNNER_NAME` in a `run:` block. The only `$RUNNER_NAME` uses in moved code were in the presence assertion just removed; every remaining one is in a job that stays on the fleet (`check`, `cert-postgres-age`). `AI_MEMORY_NO_CONFIG=1` is set **per-step by the workflows**, never inherited from the runner `.env`, so it behaves identically on both classes.

## Gates (all run locally, all green)

- `actionlint` 1.7.1 (`-shellcheck=`) over every workflow — exit 0
- YAML parse of every workflow
- `scripts/check-required-contexts.sh` + `--self-test` (the "Required-context + classify-base soundness gate")
- `scripts/check-branch-protection.sh`
- `scripts/test/test-ci-workflow-invariants.sh` (§A freezes the `classify` `- id: cls` body — unchanged)
- `scripts/check-ci-job-claims.sh` + `--self-test` (the "Named-CI-job existence + enforcement-truthfulness gate (#2629)")
- `scripts/check-docs-vs-ssot.sh`
- `check-doc-symbol-anchors.sh`, `check-doc-surface-completeness.sh`, `check-capacity-claims.sh`, `check-benchmark-claims.sh`, `check-hardcoded-literals.sh`, `check-vendor-literals.sh`, `check-l3-boundary.sh`, `check-cloud-init-ascii.sh`, `check-migration-ladder.sh`, `qc-codegraph-precheck.sh`

No `cargo` was run (workflow/YAML-only change; box under a build governor).

`CHANGELOG.md` `[Unreleased]` carries two entries (the re-homing and the bench reference-hardware restoration); the base `[Unreleased]` entries are kept intact.

## Note for the merge

A companion `docs/DEV-CI-ENVIRONMENT.md` §4 placement table (plus the four-instance Linux / two-instance macOS fleet facts and the `svc.sh`-from-runner-root runbook fix) is staged **out of this PR** at `.local-runs/DEV-CI-ENV-followup.md`, because PR #3120 already adds that file and adding it here would conflict at merge. It lands as a follow-on once #3120 has merged.

## AI involvement

Authored by Claude Opus 5 under the Fable 5 orchestration loop; every placement decision was made by reading the job's steps (`services:`, `AI_MEMORY_TEST_POSTGRES_URL`/`CI_FED_DB` usage, `cargo` invocations, cache backend) rather than from the job's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY