### PR TITLE
fix(ci): bench --report-only — CLI smoke must not be a perf gate on non-reference hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The required `Check` legs are no longer undeclared performance gates:
+  `ai-memory bench` gains `--report-only`.** `cmd_bench` bails non-zero
+  whenever any operation's measured p95 exceeds its target by more than 10%, so
+  the TWO integration tests that ran `bench` and asserted `status.success()`
+  were in effect asserting the performance contract from inside the required
+  `Check` matrix. On GitHub-hosted VMs they ran isolated and passed; on the
+  self-hosted `Check (linux-fed,sqlite)` leg
+  `tests/integration.rs::test_cli_smoke_canonical_paths` step 19 ran while the
+  rest of the suite had the box at load 36 and went red (CI run 32556214239).
+  `PERFORMANCE.md` §"Measurement methodology" calibrates the budgets to
+  GitHub-hosted `ubuntu-latest` (hardware multiplier 1.0) and exactly one gate
+  measures them there — `.github/workflows/bench.yml`, which runs on that
+  runner class and builds `--release`. A debug binary on a contended
+  self-hosted box compared against an `ubuntu-latest`-calibrated target is a
+  measurement read off the wrong machine. The new `--report-only` flag
+  still measures every operation, still prints each `pass`/`fail` status and
+  every regression row, and adds `"report_only": true` to the `--json` envelope
+  plus a one-line stderr notice in table mode — it only stops the
+  budget/regression verdict from failing the process. Both tests now pass
+  `--report-only` and assert envelope SHAPE instead: step 19 gains non-empty
+  `results` plus per-row `operation`, `measured_p95_ms`, `target_p95_ms` and
+  `status` in `{pass, fail}`; `test_cli_bench_emits_json_with_seven_results_and_passes_budget`
+  keeps all eight-operation and per-field assertions, gains `report_only ==
+  true`, and is renamed
+  `test_cli_bench_emits_json_with_eight_results_report_only` (the old name
+  claimed seven results while asserting eight, and claimed a budget pass it no
+  longer makes). Fatal semantics are unchanged when the flag is absent.
 - **Record-stop enforcement no longer silently degrades at the SAL layer when
   the sqlite DB path resolves through a symlink** (e.g. the macOS
   `/var -> /private/var` temp dir). The `SqliteStore` write-funnel gate keyed

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -599,13 +599,31 @@ operation's measured p95 exceeds its target by more than 10%.
 | `--regression-threshold <PCT>` | f64 | `bench::DEFAULT_REGRESSION_THRESHOLD_PCT` | Growth threshold for regression flagging (clamped `[0.0, 1000.0]`). |
 | `--history <PATH>` | path | — | Append the run as one JSONL row to a history file (rolling p95 trend). |
 | `--scale <ROWS>` | usize | — | #1579 B8: seed a scratch corpus of `<ROWS>` rows first and gate against the `PERFORMANCE.md` §"Corpus-scale budgets" table (clamped `[1, 1_000_000]`). |
+| `--report-only` | bool | `false` | Measure and report, but never exit non-zero on a budget or regression verdict. Adds `"report_only": true` to the `--json` envelope and a one-line notice on stderr in table mode. |
 
 ```bash
 ai-memory bench
 ai-memory bench --json --history ./bench/history.jsonl
 ai-memory bench --baseline ./bench/baseline-v0.6.3.json
 ai-memory bench --scale 10000
+ai-memory bench --json --iterations 2 --warmup 0 --report-only
 ```
+
+**`--report-only` (diagnostic / smoke use).** Every operation is still
+timed and its `pass`/`fail` status still printed — only the exit code
+changes. The absolute p95 budgets are calibrated to specific reference
+hardware: `PERFORMANCE.md` §"Measurement methodology" defines them against
+GitHub-hosted `ubuntu-latest`, the runner class its hardware multiplier
+table gives 1.0. Exactly one gate measures them there —
+`.github/workflows/bench.yml`, which runs on `ubuntu-latest` and builds
+`--release`. Anywhere else — a self-hosted runner sharing the box with
+another test suite, a developer laptop, an unoptimized debug build — you
+are comparing a different machine against `ubuntu-latest`-calibrated
+targets, so the measured latencies say nothing about the performance
+contract and failing on them turns machine load into a red build. Use
+`--report-only` when the caller only needs to prove the subcommand runs
+and emits well-formed output; leave it off wherever the budget verdict is
+the point.
 
 Operations covered by `src/bench.rs`: `memory_store` (no embedding),
 `memory_search` (FTS5), `memory_recall` (hot, depth=1),

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -80,11 +80,15 @@ pub const P95_TOLERANCE: f64 = 1.10;
 ///
 /// Apple's `macos-latest` GHA runner pool has substantially higher
 /// I/O scheduling variance and cold-start latency than `ubuntu-latest`.
-/// `tests/integration.rs::test_cli_bench_emits_json_with_seven_results_and_passes_budget`
-/// drives `ai-memory bench --iterations 5` end-to-end and asserts the
-/// process exits 0 — at the small iteration count the macOS tail can
-/// blow the absolute `target_p95_ms` budgets even when the underlying
-/// code is healthy. Per #1193 "Proposed fix" option 1 (preferred):
+/// At a small iteration count the macOS tail can blow the absolute
+/// `target_p95_ms` budgets even when the underlying code is healthy.
+/// (The test that originally surfaced this,
+/// `tests/integration.rs::test_cli_bench_emits_json_with_eight_results_report_only`,
+/// no longer asserts the budget verdict — it runs `--report-only`, because a
+/// required `Check` leg is the wrong place for a perf assertion. The
+/// multiplier stays load-bearing regardless: it still decides the
+/// `Status::Pass`/`Fail` every result reports, on every platform and in every
+/// caller.) Per #1193 "Proposed fix" option 1 (preferred):
 /// apply a centralized multiplier inside the runner-effective budget
 /// path so the pass/fail verdict is platform-aware while the canonical
 /// `target_p95_ms` reported in the JSON envelope still reflects the
@@ -1148,6 +1152,67 @@ pub fn compare_against_baseline(
     out
 }
 
+/// Process-level verdict for a completed latency bench run.
+///
+/// `results` and `regressions` have already been rendered by the caller
+/// (table or JSON), so this decides only whether the process exits zero.
+///
+/// # `report_only`
+///
+/// When `report_only` is `true` BOTH gates are downgraded to advisory: every
+/// per-operation `status` and every regression row is still measured and
+/// printed, but neither can fail the process.
+///
+/// This exists because the absolute p95 budgets are pinned to specific
+/// reference hardware — `PERFORMANCE.md` §"Measurement methodology" defines
+/// them against GitHub-hosted `ubuntu-latest`, the runner class its hardware
+/// multiplier table gives 1.0 — and exactly ONE gate measures them there:
+/// `.github/workflows/bench.yml`, which runs on `ubuntu-latest` and builds
+/// `--release`. A diagnostic or smoke caller anywhere else — a self-hosted
+/// runner sharing the box with the rest of a test suite, a developer laptop, an
+/// unoptimized debug build — is measuring a different machine against
+/// `ubuntu-latest`-calibrated targets, so its latencies say nothing about the
+/// performance contract and letting them fail the process turns machine load
+/// into a red build. `--report-only` lets such a caller prove the subcommand
+/// runs and emits well-formed output while leaving budget enforcement to the
+/// one gate that runs on the calibrated hardware.
+///
+/// # Errors
+///
+/// Without `report_only`, returns an error when any operation's measured p95
+/// exceeded its budget by more than the documented 10% tolerance
+/// ([`Status::Fail`]), and/or when any baseline comparison row is flagged as
+/// regressed. The three message shapes (budget, regression, both) are part of
+/// the CLI contract.
+pub fn verdict(
+    results: &[OperationResult],
+    regressions: Option<&[Regression]>,
+    regression_threshold: f64,
+    report_only: bool,
+) -> Result<()> {
+    let budget_failed = results.iter().any(|r| matches!(r.status, Status::Fail));
+    let regression_failed = regressions.is_some_and(|rows| rows.iter().any(|r| r.regressed));
+
+    if report_only {
+        return Ok(());
+    }
+
+    if budget_failed && regression_failed {
+        anyhow::bail!(
+            "bench: at least one operation exceeded its p95 budget by >10% AND regressed >{regression_threshold:.1}% vs baseline"
+        );
+    }
+    if budget_failed {
+        anyhow::bail!("bench: at least one operation exceeded its p95 budget by >10%");
+    }
+    if regression_failed {
+        anyhow::bail!(
+            "bench: at least one operation regressed >{regression_threshold:.1}% vs baseline"
+        );
+    }
+    Ok(())
+}
+
 /// Render a regression table to a string, mirroring the layout of
 /// [`render_table`].
 #[must_use]
@@ -1735,5 +1800,72 @@ mod tests {
         assert!(table.contains("memory_search (FTS5)"));
         assert!(table.contains("REGRESSION"));
         assert!(table.contains("OK"));
+    }
+
+    /// One synthetic over-budget row, reused by the `verdict` tests below.
+    #[allow(dead_code)]
+    fn failing_result() -> OperationResult {
+        OperationResult {
+            operation: Operation::StoreNoEmbedding,
+            label: Operation::StoreNoEmbedding.label(),
+            target_p95_ms: 10.0,
+            measured_p50_ms: 40.0,
+            measured_p95_ms: 50.0,
+            measured_p99_ms: 60.0,
+            samples: 5,
+            status: Status::Fail,
+        }
+    }
+
+    #[test]
+    fn verdict_fails_on_budget_without_report_only() {
+        // Fatal semantics when the flag is absent stay byte-identical: an
+        // over-budget row is an error carrying the documented message.
+        let err = verdict(&[failing_result()], None, 10.0, false)
+            .expect_err("an over-budget row must fail the run");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("exceeded its p95 budget"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn verdict_report_only_downgrades_budget_failure() {
+        // `--report-only` measures and reports the same `Fail` status but
+        // never fails the process, so a CLI smoke on non-reference hardware
+        // is not an undeclared perf gate (CI run 32556214239).
+        verdict(&[failing_result()], None, 10.0, true)
+            .expect("report-only must not fail on an over-budget row");
+    }
+
+    #[test]
+    fn verdict_report_only_downgrades_regression_failure() {
+        let rows = vec![Regression {
+            operation: Operation::StoreNoEmbedding,
+            label: Operation::StoreNoEmbedding.label(),
+            baseline_p95_ms: 10.0,
+            measured_p95_ms: 30.0,
+            delta_pct: 200.0,
+            threshold_pct: 10.0,
+            regressed: true,
+        }];
+        let err = verdict(&[], Some(&rows), 10.0, false)
+            .expect_err("a regressed row must fail the run without report-only");
+        assert!(
+            format!("{err:#}").contains("regressed"),
+            "unexpected message: {err:#}"
+        );
+        verdict(&[], Some(&rows), 10.0, true)
+            .expect("report-only must not fail on a regressed row");
+    }
+
+    #[test]
+    fn verdict_passes_when_nothing_failed() {
+        let ok = OperationResult {
+            status: Status::Pass,
+            ..failing_result()
+        };
+        verdict(&[ok], None, 10.0, false).expect("a passing run exits zero");
     }
 }

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -735,6 +735,11 @@ pub struct DoctorCliArgs {
 }
 
 #[derive(Args)]
+// Four independent on/off switches (`--json`, `--verified`, `--relevance`,
+// `--report-only`) that clap maps 1:1 onto CLI flags; collapsing them into an
+// enum/struct would change the published CLI surface, so the pedantic
+// three-bool ceiling is waived here.
+#[allow(clippy::struct_excessive_bools)]
 pub struct BenchArgs {
     /// Measured iterations per operation. Clamped to `[1, 100_000]`.
     #[arg(long, default_value_t = bench::DEFAULT_ITERATIONS)]
@@ -797,6 +802,27 @@ pub struct BenchArgs {
     /// (only consulted under `--relevance`). Clamped to `>= 1`.
     #[arg(long, value_name = "K", default_value_t = bench_relevance::DEFAULT_RELEVANCE_K)]
     pub k: usize,
+    /// Measure and report, but never fail the process on a budget or
+    /// regression verdict. Every operation is still timed and its
+    /// `pass`/`fail` status still printed (and `report_only: true` is added to
+    /// the `--json` envelope), so nothing is hidden — only the exit code
+    /// changes.
+    ///
+    /// WHY: the absolute p95 budgets are pinned to specific reference
+    /// hardware — `PERFORMANCE.md` §"Measurement methodology" defines them
+    /// against GitHub-hosted `ubuntu-latest`, the runner class its hardware
+    /// multiplier table gives 1.0 — and exactly ONE gate measures them there:
+    /// `.github/workflows/bench.yml`, which runs on `ubuntu-latest` and builds
+    /// `--release`. A smoke or diagnostic invocation anywhere else — a
+    /// self-hosted runner sharing the box with the rest of a test suite, a
+    /// developer laptop, an unoptimized debug build — is measuring a different
+    /// machine against `ubuntu-latest`-calibrated targets, so its latencies say
+    /// nothing about the performance contract and failing on them turns machine
+    /// load into a red build. Use this flag whenever the caller only needs to
+    /// prove the subcommand runs and emits well-formed output; leave it off
+    /// wherever the budget verdict is the point.
+    #[arg(long)]
+    pub report_only: bool,
 }
 
 /// Default `--batch` page-size hint for `ai-memory migrate`. Currently
@@ -7344,6 +7370,7 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
                 "warmup": warmup,
                 "scale": scale,
                 "verified": args.verified,
+                "report_only": args.report_only,
                 "results": results,
                 "regressions": regressions,
             }))?
@@ -7353,6 +7380,15 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
         if let Some(rows) = &regressions {
             println!();
             print!("{}", bench::render_regression_table(rows));
+        }
+        if args.report_only {
+            // stderr, mirroring the `--history` notice below, so the rendered
+            // table on stdout stays byte-identical for downstream consumers.
+            let mut stderr = std::io::stderr().lock();
+            let _ = writeln!(
+                stderr,
+                "bench: --report-only — measured and reported, budgets NOT enforced (they are calibrated to ubuntu-latest per PERFORMANCE.md and gated only by .github/workflows/bench.yml, which runs there)"
+            );
         }
     }
 
@@ -7374,27 +7410,16 @@ fn cmd_bench(args: &BenchArgs) -> Result<()> {
         );
     }
 
-    let budget_failed = results
-        .iter()
-        .any(|r| matches!(r.status, bench::Status::Fail));
-    let regression_failed = regressions
-        .as_ref()
-        .is_some_and(|rows| rows.iter().any(|r| r.regressed));
-
-    if budget_failed && regression_failed {
-        anyhow::bail!(
-            "bench: at least one operation exceeded its p95 budget by >10% AND regressed >{regression_threshold:.1}% vs baseline"
-        );
-    }
-    if budget_failed {
-        anyhow::bail!("bench: at least one operation exceeded its p95 budget by >10%");
-    }
-    if regression_failed {
-        anyhow::bail!(
-            "bench: at least one operation regressed >{regression_threshold:.1}% vs baseline"
-        );
-    }
-    Ok(())
+    // The verdict lives in `bench::verdict` so the fatal-vs-advisory decision
+    // is unit-testable without spawning the binary. `--report-only` downgrades
+    // both gates to advisory; every status/regression row above is printed
+    // either way.
+    bench::verdict(
+        &results,
+        regressions.as_deref(),
+        regression_threshold,
+        args.report_only,
+    )
 }
 
 /// L10 (Wave-2) — the relevance-at-scale sub-mode of `ai-memory bench`.
@@ -12397,6 +12422,7 @@ decision = "allow"
             verified: false,
             relevance: true,
             k: 5,
+            report_only: false,
         };
         // Table render arm.
         cmd_bench(&base).expect("cmd_bench relevance (table) must return Ok");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8017,28 +8017,53 @@ fn test_hier_recall_touches_only_ancestor_matches() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_cli_bench_emits_json_with_seven_results_and_passes_budget() {
+fn test_cli_bench_emits_json_with_eight_results_report_only() {
     // End-to-end CLI integration test for the `ai-memory bench`
     // subcommand (Pillar 3 / Stream E). Verifies that:
-    //   1. The binary exits 0 (no operation exceeded its p95 budget).
+    //   1. The binary exits 0.
     //   2. --json output is parseable and well-shaped.
     //   3. All 8 hot-path operations are reported (incl. the #1871
     //      handler-layer rerank-stage recall op).
     //   4. Each result carries the fields documented in PERFORMANCE.md.
+    //   5. The `--report-only` mode is surfaced in the envelope.
     //
     // The bench subcommand seeds a disposable :memory: SQLite DB
     // internally, so no fixture is required. Iterations are kept tiny
-    // to keep CI time bounded — the fact that the budgets are met
-    // even at 5 iterations is itself a smoke test of the budget math.
+    // to keep CI time bounded.
+    //
+    // WHERE THE BUDGET VERDICT LIVES: `.github/workflows/bench.yml` — one job,
+    // on GitHub-hosted `ubuntu-latest`, building `--release`. That runner class
+    // is not incidental: `PERFORMANCE.md` §"Measurement methodology" defines
+    // every p95 target against it and its hardware multiplier table gives it
+    // 1.0. The verdict is deliberately NOT asserted here. This test runs inside
+    // the required `Check` matrix on SELF-HOSTED runners that execute the rest
+    // of the suite concurrently on the same box, against an unoptimized debug
+    // build — a p95 measured there compared against an `ubuntu-latest`-
+    // calibrated target is a measurement read off the wrong machine, so
+    // asserting it turns machine load into a red build (that is exactly how the
+    // `test_cli_smoke_canonical_paths` bench step went red on CI run
+    // 32556214239, job `Check (linux-fed,sqlite)`, at load 36). `--report-only`
+    // keeps every measurement and every per-operation `pass`/`fail` status in
+    // the payload — the assertions below still pin the full envelope SHAPE —
+    // while leaving budget ENFORCEMENT to the gate on the calibrated hardware.
     let bin = env!("CARGO_BIN_EXE_ai-memory");
     let out = cmd(bin)
-        .args(["bench", "--json", "--iterations", "5", "--warmup", "0"])
+        .args([
+            "bench",
+            "--json",
+            "--iterations",
+            "5",
+            "--warmup",
+            "0",
+            "--report-only",
+        ])
         .output()
         .expect("failed to spawn ai-memory bench");
 
     assert!(
         out.status.success(),
-        "bench exited non-zero (a budget regression?): stderr={}",
+        "bench --report-only exited non-zero (it must never fail on a budget \
+         or regression verdict): stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
 
@@ -8049,6 +8074,11 @@ fn test_cli_bench_emits_json_with_seven_results_and_passes_budget() {
     // Envelope shape.
     assert_eq!(parsed["iterations"], serde_json::json!(5));
     assert_eq!(parsed["warmup"], serde_json::json!(0));
+    assert_eq!(
+        parsed["report_only"],
+        serde_json::json!(true),
+        "bench --report-only must surface the mode in the JSON envelope"
+    );
     let results = parsed["results"]
         .as_array()
         .expect("results must be a JSON array");
@@ -12430,7 +12460,18 @@ fn test_cli_smoke_canonical_paths() {
     );
     assert!(backup_output.status.success(), "backup failed");
 
-    // 19. bench: run microbench (with minimal iterations to stay fast)
+    // 19. bench: run microbench (with minimal iterations to stay fast).
+    //
+    // `--report-only` is REQUIRED here: this is a CLI smoke, not a perf gate.
+    // Without it `cmd_bench` bails whenever any measured p95 exceeds its
+    // budget by >10%, which made this step an undeclared performance
+    // assertion — and it duly went red on a self-hosted runner that was at
+    // load 36 running the rest of this suite (CI run 32556214239, job
+    // `Check (linux-fed,sqlite)`). The budgets are calibrated to GitHub-hosted
+    // `ubuntu-latest` (`PERFORMANCE.md` §"Measurement methodology", hardware
+    // multiplier 1.0) and are enforced by the one gate that runs there,
+    // `.github/workflows/bench.yml`. What this step must prove is that the
+    // subcommand runs and emits a well-formed JSON envelope.
     let bench_output = cmd_output_or_panic(
         binary,
         &[
@@ -12442,12 +12483,44 @@ fn test_cli_smoke_canonical_paths() {
             "2",
             "--warmup",
             "0",
+            "--report-only",
         ],
     );
     assert!(bench_output.status.success(), "bench failed");
     let bench_result: serde_json::Value =
         serde_json::from_slice(&bench_output.stdout).expect("bench --json must be valid JSON");
     assert!(bench_result["results"].is_array());
+    assert_eq!(
+        bench_result["report_only"],
+        serde_json::json!(true),
+        "bench --report-only must surface the mode in the JSON envelope"
+    );
+    let bench_rows = bench_result["results"]
+        .as_array()
+        .expect("bench results must be a JSON array");
+    assert!(
+        !bench_rows.is_empty(),
+        "bench must report at least one operation"
+    );
+    for r in bench_rows {
+        assert!(
+            r["operation"].is_string(),
+            "each bench result needs an `operation`: {r}"
+        );
+        assert!(
+            r["measured_p95_ms"].is_number(),
+            "each bench result needs a numeric `measured_p95_ms`: {r}"
+        );
+        assert!(
+            r["target_p95_ms"].is_number(),
+            "each bench result needs a numeric `target_p95_ms`: {r}"
+        );
+        let verdict = r["status"].as_str().unwrap_or_default();
+        assert!(
+            verdict == "pass" || verdict == "fail",
+            "each bench result needs a `status` of pass|fail, got {verdict:?}: {r}"
+        );
+    }
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&backup_dir);


### PR DESCRIPTION
## Defect

`cmd_bench` (`src/daemon_runtime.rs`) `anyhow::bail!`s whenever ANY operation's measured p95 exceeds its `target_p95_ms` by more than 10% (`budget_failed`). **Two** integration tests ran `bench` and asserted `status.success()`, so both were **undeclared performance gates living inside the required `Check` matrix**.

The one that fired: `tests/integration.rs::test_cli_smoke_canonical_paths` step 19. Measured by Fable on CI run [32556214239](https://github.com/alphaonedev/ai-memory-mcp/actions/runs/32556214239), job **`Check (linux-fed,sqlite)`** on runner **f2-linux-fed-2** — it ran while the rest of the suite had the box at **load 36** and panicked at `tests/integration.rs:12447` ("bench failed"). On GitHub-hosted VMs the same step ran isolated and passed.

`PERFORMANCE.md` pins the budgets to reference hardware (`ubuntu-latest`, hardware multiplier 1.0), and the performance gate is **one dedicated job** — `.github/workflows/bench.yml`, which builds `--release` and runs the workload as that job's only work. A debug binary on a contended shared runner measures nothing about the performance contract.

## Change

1. **`BenchArgs` gains `--report-only`.** Every operation is still measured and its `pass`/`fail` status still printed, and regression rows still render. `"report_only": true` is added to the `--json` envelope and a one-line notice goes to **stderr** in table mode (mirroring the existing `--history` notice, so the rendered table on stdout stays byte-identical). Only the process verdict changes. The doc comment states why.
2. **The verdict moves into the pure `bench::verdict`** (`src/bench.rs`) so the fatal-vs-advisory decision is unit-testable without spawning the binary. Fatal semantics are **byte-identical when the flag is absent** — the same three message shapes (budget / regression / both). `--report-only` downgrades BOTH `budget_failed` and `regression_failed` to advisory.
3. **Step 19** passes `--report-only`, keeps the existing JSON assertions, and adds: `report_only == true`; `results` is a **non-empty array**; each result has `operation`, `measured_p95_ms`, `target_p95_ms`, and `status` in {`pass`, `fail`}.
4. **`test_cli_bench_emits_json_with_seven_results_and_passes_budget`** (the latent flake flagged in review) likewise passes `--report-only`. **Every shape assertion is kept** — exactly 8 results, all eight documented per-result fields, `status` in {`pass`, `fail`} — plus the new `report_only == true`. Renamed **`test_cli_bench_emits_json_with_eight_results_report_only`**: the old name claimed *seven* results while asserting *eight*, and claimed a budget pass it no longer makes. Its doc comment now states where the budget verdict lives and why it is not asserted there.
5. **Unit tests** (`src/bench.rs` `mod tests`) pin both directions — a synthetic `Status::Fail` row is `Err` containing `"exceeded its p95 budget"` without the flag and `Ok` with it; the same for a regressed baseline row; plus a passing-run control.
6. **`MACOS_BUDGET_MULT` doc comment** cited the renamed test *and justified itself by that test asserting exit 0* — a rationale that no longer holds. Rewritten to state what still makes the multiplier load-bearing (it decides the `Status::Pass`/`Fail` every result reports, in every caller). **The constant's value and behavior are unchanged.**
7. **Docs/SSOT/CHANGELOG**: `docs/CLI_REFERENCE.md` bench section gains the flag row, an example, and a paragraph on why; `CHANGELOG.md` `[Unreleased]` -> **Fixed**, covering both tests (base entries untouched).

`BenchArgs` carries `#[allow(clippy::struct_excessive_bools)]` with a comment: the fourth bool is a 1:1 CLI flag, and collapsing them into an enum would change the published CLI surface.

## Audit of every `bench` invocation in `tests/`

| Site | Asserted exit 0? | `--baseline`? | Disposition |
|---|---|---|---|
| `tests/integration.rs` step 19 (`test_cli_smoke_canonical_paths`) | yes | no | **fixed** — `--report-only` + shape assertions |
| `tests/integration.rs:8020` `..._seven_results_and_passes_budget` | yes | no | **fixed** — `--report-only`, all shape assertions kept, renamed `..._eight_results_report_only` |
| `tests/bench_verified_dispatch_1961.rs:17` (2 tests) | **no** — already documents the exact failure mode | no | already immune, no change |
| `tests/cov_ga2_misc.rs:465` `daemon_cmd_bench_scale_path_runs` | **no** — accepts `Ok` or a `bench:` error | no | already immune, no change |
| `tests/cli_integration.rs:106`, `tests/integration.rs:12229` | `bench --help` only | n/a | no change |
| `tests/integration.rs` `FAILURE_CASES` | asserts **failure** on invalid args | n/a | no change |

No `bench` invocation in `tests/` asserts a budget verdict any more.

## Rebase onto 48e52192 (post-#3129)

#3129 moved `bench.yml` **back to GitHub-hosted `ubuntu-latest`** and codified
the runner-placement rule at the head of `ci.yml`. That **resolves** the
doc-vs-reality drift an earlier revision of this branch had to hedge around:
the enforcing gate now demonstrably runs on the hardware the budgets are
calibrated to, so every comment in this PR states that directly instead of
hedging. The required `Check (…)` legs remain `[self-hosted, linux-fed]`
(warm-cache), so the defect this PR fixes is unchanged.

Rebase was clean — no CHANGELOG conflict; base entries intact, this PR's entry
is a pure addition.

## Verification (local, CI-parity)

- `cargo check --all-targets` — pass
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` on **default**, **sal**, **sal-postgres**, **vectorlite** — all four pass
- `cargo fmt --all`
- `cargo test --test integration` -> `test_cli_smoke_canonical_paths` + `test_cli_bench_emits_json_with_eight_results_report_only` — both pass
- `cargo test --lib bench::tests` — 28 pass
- `cargo test --test qual_10_module_size_ceiling --test qual_6_7_legacy_error_type_ceiling` — 4 pass, no ceiling bump needed
- `scripts/check-docs-vs-ssot.sh` — PASS (no pin change required)
- `scripts/check-vendor-literals.sh` — PASS

## North Star

No data path touched. `bench` seeds a disposable `:memory:` DB and never reads or writes the operator's DB. The change is exit-code-only and **fails open in the direction of reporting, never of hiding**: the `fail` status of every over-budget operation is still measured, still printed, and still machine-readable in the JSON envelope. `--report-only` is opt-in and never the default, so the enforcing `bench.yml` gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
