### PR TITLE
docs(claims): claims-audit batch 2 — knob count, NSA 9/10, test counts, federation lane confinement, runbook 202/STORE_URL, /tmp backup

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,17 +47,21 @@ jobs:
     # (the rule is stated at the head of ci.yml).
     #
     # `ubuntu-latest` is not a convenience here, it is the REFERENCE HARDWARE
-    # the published budgets are defined against: `PERFORMANCE.md` §"Measurement
-    # methodology" pins CI to "GitHub-hosted Linux x86_64 runners
-    # (`ubuntu-latest`)" and its hardware multiplier table gives that class the
-    # 1.0 multiplier every p95 target in the budget table is expressed in.
-    # `performance/baseline.json` likewise documents itself as a
-    # `regenerate-baseline`-on-`ubuntu-latest` median-of-3 artefact. #3109 moved
-    # the job to `[self-hosted, linux-fed]` WITHOUT moving the budgets, so a
-    # p95 measured on the f2 node was being compared against an
-    # `ubuntu-latest`-calibrated target while the job name, PERFORMANCE.md §7
-    # and the baseline file all still said `ubuntu-latest` — a measurement read
-    # off the wrong machine and a doc-vs-reality drift in the same move.
+    # the published budgets are defined against: `PERFORMANCE.md`
+    # §"Hardware Baseline" pins CI to "GitHub-hosted Linux x86_64 runners
+    # (`ubuntu-latest`)" and its platform multiplier (`MACOS_BUDGET_MULT`)
+    # gives that class the 1.0 multiplier every p95 target in the budget
+    # table is expressed in. `performance/baseline.json` documents the
+    # runner class it must be CAPTURED on (`ubuntu-latest`, via the
+    # `regenerate-baseline` median-of-3 job) — the committed file is still a
+    # dev bootstrap placeholder (`runner_class: local-dev-bootstrap`,
+    # `bootstrap: true`), which is exactly why the compare step skips.
+    # #3109 moved the job to `[self-hosted, linux-fed]` WITHOUT moving the
+    # budgets, so a p95 measured on the f2 node was being compared against an
+    # `ubuntu-latest`-calibrated target while the job name,
+    # PERFORMANCE.md §"Hardware Baseline" and the baseline file all still
+    # said `ubuntu-latest` — a measurement read off the wrong machine and a
+    # doc-vs-reality drift in the same move.
     #
     # Moving it back both makes the job name TRUE again (no rename, so no
     # required-context churn — this job is advisory, see the `paths-ignore`
@@ -115,7 +119,7 @@ jobs:
           {
             echo '## ai-memory bench --scale 10000'
             echo ''
-            echo 'Corpus-scale gate (#1579 B8): same 7 operations over a '
+            echo 'Corpus-scale gate (#1579 B8): same 8 operations over a '
             echo '10k-row seeded corpus, gated against the `[scale]` '
             echo 'budget table in PERFORMANCE.md §"Corpus-scale budgets".'
             echo ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,119 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Claims-audit batch 2: eleven operator-facing claims corrected against their
+  in-tree SSOTs, and two of them pinned so they cannot drift again.** Every item
+  was re-verified against `release/v1.0.0` before editing. Documentation only —
+  no runtime behaviour changes.
+  - **asi-hard pinned-knob count `17` -> `21`** on all five surfaces that
+    narrate it (`SECURITY.md` x2, `README.md`, `docs/deploy/README.md`,
+    `docs/deploy/enterprise-federation.env`, `docs/enterprise-deployment.md`).
+    `src/security_profile.rs::KNOBS` has held 21 entries since
+    [#3033](https://github.com/alphaonedev/ai-memory-mcp/issues/3033) added the
+    four outer federation-transport gates (`AI_MEMORY_FED_REQUIRE_SIG`,
+    `_NONCE`, `_PEER_ENROLLMENT`, `_PUSH_NAMESPACE_SCOPE`); every doc still said
+    17, understating the hardened posture to a procurement reader.
+    `docs/deploy/README.md` gains the four missing bullets.
+  - **NSA CSI MCP badge `10/10` -> `9/10`** (`README.md`, `docs/index.html`,
+    `docs/at-a-glance.html`), matching the project's own
+    `docs/compliance/nsa-csi-mcp-security-mapping.md` and
+    `docs/compliance/honest-limitations.md`: concern (a), access control, is
+    posture-conditional (finding H1) and the mapping deliberately publishes no
+    flat 10/10. `README.md` also gains the "self-assessed, not independently
+    audited" framing and the **NSA non-endorsement** disclaimer that
+    `docs/index.html` already carried.
+  - **Test-attribute count `11,900` -> `12,549`** (badge + body + the four
+    inline `#` comments in `README.md`'s own re-derivation block), re-derived by
+    running those four commands at this tree: `src/` 6,660 + 1,222; `tests/`
+    2,793 + 1,874.
+  - **`15,951 / 0` regression figure now carries its provenance inline**
+    (`docs/index.html`): 2026-05-31 final baseline, v0.7.0 tree. The number is
+    real and provenanced in `docs/evidence.html`; it was being read as current.
+  - **HTTP body-limit anchor** (`README.md`) cites the symbol
+    (`.layer(DefaultBodyLimit::max(HTTP_BODY_LIMIT_BYTES))`) instead of the
+    stale `src/lib.rs:1333` line number (the layer is at 1338 today).
+  - **TOON compression claims** (`README.md` x2) drop the unqualified
+    "40-60%" / "79% smaller" guarantees in favour of what is mechanically
+    enforced: on the pinned 5-memory fixture in `src/toon.rs` the compact form
+    is held below 65% of JSON bytes
+    (`test_toon_size_invariant_5_memories_under_threshold`). The
+    1,600/626/336-byte figures are labelled as one illustrative 3-memory
+    example, not a ratio.
+  - **Federation "three unscoped inbound write lanes" was stale and
+    UNDER-claimed shipped controls.** `docs/federation.md`,
+    `docs/federation-identity.md` and `docs/enterprise-deployment.md` still
+    warned that `links[]`, `signals[]` and the pull-accept path never consult
+    `allowed_namespaces`. Under an enrolled posture they all do:
+    `federation_receive.rs` gates `memories[]`, `links[]` (source AND target
+    stored namespace), `signals[]`, `deletions[]`, `archives[]`, `restores[]`,
+    `action_transitions[]`, `checkpoints[]` and `namespace_meta` through
+    `federation::receive_auth`
+    ([#2489](https://github.com/alphaonedev/ai-memory-mcp/issues/2489)), and
+    `federation::receive::catchup_memory_namespace_authorized` gates the
+    pull-accept path
+    ([#2480](https://github.com/alphaonedev/ai-memory-mcp/issues/2480)). The
+    residual limit is restated honestly: federation replicates plaintext
+    ([#1968](https://github.com/alphaonedev/ai-memory-mcp/issues/1968)), and
+    `CallerContext::for_admin(FEDERATION_CATCHUP)` still bypasses SAL
+    *visibility* — the scope gate runs before it.
+  - **DO runbook quorum semantics `503` -> `202`**
+    (`docs/RUNBOOK-digitalocean-testing.md`). `under_replicated_response`
+    (`src/handlers/parity.rs`) returns **202 Accepted** with `quorum_met:false`
+    for a write whose local commit landed but whose acks missed the deadline
+    (v0.8.1 G12). A tester following the old text would have recorded a durable
+    write as a failure; the pass criteria now count 202 as under-replicated,
+    not failed.
+  - **Chaos runbook set the wrong env var**
+    (`docs/RUNBOOK-chaos-campaign.md`): `AI_MEMORY_DB` is the SQLite `--db`
+    file path, so `export AI_MEMORY_DB=postgres://...` creates a file with that
+    name and silently runs the whole campaign on SQLite. Corrected to
+    `AI_MEMORY_STORE_URL`, with the trap stated inline.
+  - **`scripts/dogfood-rebuild.sh` backed the LIVE MCP database up to `/tmp`**,
+    contradicting the project's own scratch rule; the one artifact that makes
+    the script recoverable was on a reaped filesystem. It now writes to the
+    repo-local, gitignored `.local-runs/`. `CLAUDE.md` is updated to match, and
+    its stale absolute scratch path (`/Users/fate/v07/v07-fixes/.local-runs/`)
+    becomes `<repo-root>/.local-runs/`.
+  - **`90 CLI subcommands`** on `docs/index.html` is qualified as the default
+    build (92 with `sal` features).
+  - **`PERFORMANCE.md`: the budget contract is stated as what it is.** The
+    advisory-Bench note now records that since
+    [#3137](https://github.com/alphaonedev/ai-memory-mcp/issues/3137) the two
+    `ai-memory bench` calls inside the required `Check` legs both run
+    `--report-only`, so NO test in any required status check asserts a budget
+    — a p95 breach is red-in-Bench and nothing else. Both "exits non-zero"
+    sentences now name the `--report-only` carve-out (`src/bench.rs::verdict`
+    measures, prints the same FAIL status, and exits 0). The
+    "mechanically-pinned budget" claim is corrected to discipline-not-mechanism:
+    `operation_targets_match_performance_md` asserts the Rust consts against
+    hardcoded literals and never parses `PERFORMANCE.md`, so a one-sided table
+    edit is caught by nothing. "8 `Operation` variants" is qualified as 8 of
+    10 (`VerifiedStore`/`VerifiedRecall` are `--verified`-only). The
+    `paths-ignore` anchor `bench.yml:20-28` is corrected to `:21-23`, `:26-28`.
+    And the single-sourced 10% regression default now discloses that the
+    advisory CI step overrides it to **50%** (`--regression-threshold 50`,
+    mirrored by `regression_threshold_pct_default: 50` in
+    `performance/baseline.json`).
+  - **`.github/workflows/bench.yml` (comment-only + one word).** The
+    `RUNNER PLACEMENT` comment cited `PERFORMANCE.md §"Measurement
+    methodology"`, "its hardware multiplier table" and `PERFORMANCE.md §7` —
+    none of which exist; the section is `## Hardware Baseline` and the
+    document has no numbered sections. It also claimed
+    `performance/baseline.json` "documents itself as a
+    regenerate-baseline-on-ubuntu-latest median-of-3 artefact", where the
+    committed file is `runner_class: local-dev-bootstrap`, `bootstrap: true`
+    — a placeholder, which is why the compare step skips. Both corrected. The
+    scale-gate summary line said "same 7 operations"; `baseline.json` carries
+    8 results and `PERFORMANCE.md` §"Corpus-scale budgets" says 8.
+  - **`scripts/check-docs-vs-ssot.sh` gains two rules** so two of the above
+    cannot drift again: the asi-hard knob narration is pinned to the
+    `KnobSpec` entry count in `src/security_profile.rs::KNOBS`, and the cert
+    doc's normative exit contract is pinned to
+    `enterprise_federation_posture::ENTERPRISE_FEDERATION_CHECK_COUNT`. Both
+    ship with `--self-test` legs proving they reject stale counts, spare the
+    `PE-1 knobs` prose and the cert doc's historical evidence notes, and fail
+    closed on an unresolvable SSOT only when a doc actually narrates the count.
+
 - **The required `Check` legs are no longer undeclared performance gates:
   `ai-memory bench` gains `--report-only`.** `cmd_bench` bails non-zero
   whenever any operation's measured p95 exceeds its target by more than 10%, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ scripts/dogfood-rebuild.sh
 
 What it does (idempotent — safe to re-run after every commit):
 1. `cargo build --release`
-2. Backs up the live MCP DB to `/tmp/ai-memory-dogfood-test-<ts>.db`
+2. Backs up the live MCP DB to `.local-runs/ai-memory-dogfood-test-<ts>.db`
 3. Dry-runs migrations against the backup (proves v17→v18→v19 etc. round-trip cleanly on real data)
 4. Re-points `/opt/homebrew/bin/ai-memory` → `target/release/ai-memory` (via `brew unlink` + symlink)
 5. Lists running MCP processes that need a Claude Code restart to pick up the new binary
@@ -2621,7 +2621,7 @@ harness's own session cache).
 **Allowed scratch location.** All agent-created scratch lives under:
 
 ```
-/Users/fate/v07/v07-fixes/.local-runs/
+<repo-root>/.local-runs/
 ```
 
 This directory is gitignored (see `.gitignore`). It is the canonical

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -11,7 +11,9 @@ subcommand (Stream E) and the Bench workflow (`.github/workflows/bench.yml`,
 Stream F) both read from these targets. `ai-memory bench` exits non-zero
 when any measured p95 exceeds its target by more than the published 10%
 tolerance (`P95_TOLERANCE = 1.10`, `src/bench.rs`), and the workflow
-propagates that exit code.
+propagates that exit code (`--report-only` suppresses the non-zero exit:
+it measures and prints the same FAIL status but always exits 0 —
+`src/bench.rs::verdict`).
 
 > **The Bench workflow is ADVISORY — it does not block a merge.** Its own
 > header says so verbatim ("Bench is advisory (not in required-status-checks)",
@@ -21,6 +23,12 @@ propagates that exit code.
 > Bench run red and lands the failing table in the run summary; it does not
 > stop the pull request. Treat these budgets as a published contract plus a
 > loud, unmissable signal — not as a merge gate.
+>
+> As of [#3137](https://github.com/alphaonedev/ai-memory-mcp/issues/3137)
+> this is total: the two `ai-memory bench` invocations inside the required
+> `Check` legs (`tests/integration.rs`, the CLI smoke and the eight-result
+> test) both run `--report-only`, so no test in any required status check
+> asserts a budget either. A p95 breach is red-in-Bench and nothing else.
 
 ## Budget Table
 
@@ -28,8 +36,11 @@ Every row below sits in **exactly one** of four buckets, marked inline:
 
 - **(no marker)** — exercised by `ai-memory bench` in the advisory Bench
   workflow on every non-docs PR + trunk push. These rows have a real
-  `Operation` variant in `src/bench.rs` and a mechanically-pinned budget
-  (`operation_targets_match_performance_md`).
+  `Operation` variant in `src/bench.rs` and a budget mirrored in
+  `src/bench.rs::Operation::target_p95_ms`. The mirror is **discipline,
+  not mechanism**: `operation_targets_match_performance_md` asserts the
+  Rust consts against hardcoded literals and never parses this file, so a
+  one-sided edit to the table is not detected by any gate.
 - **\*[advisory]\*** — a published target with **no** bench in `src/bench.rs`.
   Nothing measures it and nothing enforces it; it is an operator-facing
   contract pending the Stream E embedder fixture and related follow-ups
@@ -41,9 +52,12 @@ Every row below sits in **exactly one** of four buckets, marked inline:
   it publishes no target.
 
 Counted at HEAD, the table holds **17 rows: 7 exercised by `ai-memory bench`
-(8 `Operation` variants — the "depth ≤ 3" row covers both `KgQueryDepth1`
-and `KgQueryDepth3`), 8 advisory with no producer, 1 measured by the
-separate `hnsw_rebuild_async` bench, and 1 that is not a budget at all.**
+(8 of the 10 `Operation` variants in `src/bench.rs` — the "depth ≤ 3" row
+covers both `KgQueryDepth1` and `KgQueryDepth3`; the other two,
+`VerifiedStore` / `VerifiedRecall`, are `--verified`-only and covered in
+§"Verified-path benchmarks", not this table), 8 advisory with no producer,
+1 measured by the separate `hnsw_rebuild_async` bench, and 1 that is not a
+budget at all.**
 
 | Operation | Target (p95) | Target (p99) | Notes |
 |---|---|---|---|
@@ -187,7 +201,7 @@ Two limits on that coverage, both load-bearing:
 
 1. **It does not run on every PR.** Both the `pull_request` and `push`
    triggers carry `paths-ignore: ['docs/**', '**/*.md']`
-   (`.github/workflows/bench.yml:20-28`), so a PR touching only docs or
+   (`.github/workflows/bench.yml:21-23`, `:26-28`), so a PR touching only docs or
    Markdown never runs the bench at all.
 2. **A failure blocks nothing.** The Bench workflow is advisory and is not
    in the required-status-check set (see the note at the top of this
@@ -585,7 +599,10 @@ mechanism.
 
 The 10% figure is real and single-sourced: `P95_TOLERANCE = 1.10` in
 `src/bench.rs`, and the independent relative-regression default is
-`DEFAULT_REGRESSION_THRESHOLD_PCT = 10.0`.
+`DEFAULT_REGRESSION_THRESHOLD_PCT = 10.0` — though the advisory CI step
+overrides it to **50%** (`bench.yml` `--regression-threshold 50`, mirrored
+by `regression_threshold_pct_default: 50` in `performance/baseline.json`),
+because a shared-runner p95 at 10% is a flake generator.
 
 p99 targets in the table above are **informational** until the v0.6.3
 soak window closes. They are recorded here to make the long-tail goal
@@ -670,7 +687,9 @@ SQLite database (the operator's main DB is untouched) and reports
 per-operation p50/p95/p99 against the budgets above. Exit code is
 non-zero when any p95 exceeds its budget by more than the published
 10% tolerance — the same subcommand the advisory `bench.yml` workflow
-runs.
+runs (`--report-only` suppresses the non-zero exit: it measures and
+prints the same FAIL status but always exits 0 —
+`src/bench.rs::verdict`).
 
 Two caveats before you compare your run to the published table:
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,30 @@
 [![Rust](https://img.shields.io/badge/rust-1.96%2B-orange?logo=rust)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![SQLite](https://img.shields.io/badge/sqlite-FTS5-003B57?logo=sqlite)](https://www.sqlite.org/)
-[![Tests](https://img.shields.io/badge/tests-11%2C900_%E2%80%A2_%E2%89%A590%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
+[![Tests](https://img.shields.io/badge/tests-12%2C549_%E2%80%A2_%E2%89%A590%25_cov-brightgreen)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Evidence Hub](https://img.shields.io/badge/evidence--hub-campaigns-6ee7ff?logo=githubpages)](https://alphaonedev.github.io/ai-memory-mcp/evidence/)
 [![v0.6.4 Cert](https://img.shields.io/badge/v0.6.4_cert-CERT_GREEN-2ea043?logo=github)](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md)
 [![MCP](https://img.shields.io/badge/MCP-7_default_%2B_1_bootstrap_%E2%80%A2_103_full-blueviolet)]()
-[![NSA CSI](https://img.shields.io/badge/NSA_CSI_MCP-10%2F10_concerns_%E2%80%A2_7%2F7_recs-2ea043)](https://alphaonedev.github.io/ai-memory-mcp/compliance/nsa-csi-mcp.html)
+[![NSA CSI](https://img.shields.io/badge/NSA_CSI_MCP-9%2F10_concerns_%E2%80%A2_7%2F7_recs-2ea043)](https://alphaonedev.github.io/ai-memory-mcp/compliance/nsa-csi-mcp.html)
 [![Evidence v0.6.4](https://img.shields.io/badge/claims-frozen_v0.6.4-c8a2ff)](https://alphaonedev.github.io/ai-memory-mcp/evidence.html)
 [![Evidence v0.7.0](https://img.shields.io/badge/claims-frozen_v0.7.0-7e57c2)](docs/v0.7.0/release-notes.md)
 [![Crates.io Version](https://img.shields.io/crates/v/ai-memory)](https://crates.io/crates/ai-memory)
 [![npm](https://img.shields.io/npm/v/@alphaone/ai-memory?label=npm&logo=npm)](https://www.npmjs.com/package/@alphaone/ai-memory)
 [![PyPI](https://img.shields.io/pypi/v/ai-memory-mcp?label=pypi&logo=pypi&logoColor=white)](https://pypi.org/project/ai-memory-mcp/)
+
+> **On the NSA CSI badge.** ai-memory is **self-assessed** against the NSA
+> Cybersecurity Information document on MCP security (U/OO/6030316-26 |
+> PP-26-1834, May 2026 v1.0): **9 of 10** concerns structurally addressed
+> (concern (a), access control, is posture-conditional — see H1), 7/7
+> recommendations — **not independently audited**. Full mapping:
+> [`docs/compliance/nsa-csi-mcp-security-mapping.md`](docs/compliance/nsa-csi-mcp-security-mapping.md).
+>
+> **NSA non-endorsement.** References to the National Security Agency
+> Cybersecurity Information document on MCP security (U/OO/6030316-26 |
+> PP-26-1834, May 2026 v1.0) describe ai-memory's substrate-level posture
+> relative to NSA-issued guidance. The NSA, the Department of Defense, and
+> the United States Government do not endorse, certify, or recommend
+> ai-memory, AgenticMem, AlphaOne LLC, or any commercial product.
 
 **ai-memory is a persistent memory system for AI assistants.** It works with **any AI that supports MCP** -- Claude, ChatGPT, Grok, Llama, and more. It stores what your AI learns in a local SQLite database, ranks memories by relevance when recalling, and auto-promotes important knowledge to permanent storage. Install it once, and every AI assistant you use remembers your architecture, your preferences, your corrections -- forever.
 
@@ -166,7 +180,7 @@ The MCP, HTTP, and CLI surfaces are reactive. The curator is the part that makes
 
 **Substrate for multi-agent AI.** ai-memory is not an agent runtime and not "autonomous AI" on its own. It is the memory layer that *multi-agent* autonomous deployments need underneath them. Federation (`broadcast_store_quorum` + `spawn_catchup_loop`) handles W-of-N consistency across peers when many agents write in parallel; the curator daemon keeps the shared corpus from degrading into noise as a swarm scribbles into it; webhook subscriptions (HMAC-signed, namespace/agent-filtered, SSRF-hardened) turn the store into a message bus that triggers downstream agents on memory events; namespace hierarchy with N-level inheritance and per-namespace governance policies (write/promote/delete authority, approver type, optional N-of-M consensus) bound the swarm. Stack this under a 24/7 multi-machine agent runner with auto-generated skills, and the combined system clears the *behavioral* bar for autonomous AI. The remaining gaps (no weight-level learning, stateless reasoning kernel, human-seeded root goals) are real and not what ai-memory addresses; ai-memory provides the multi-agent memory substrate that any serious attempt at closing those gaps will need.
 
-**Zero token cost until recall.** Unlike built-in memory systems (Claude Code auto-memory, ChatGPT memory) that load your entire memory into every conversation -- burning tokens and money on every message -- ai-memory uses zero context tokens until the AI explicitly calls `memory_recall`. Only relevant memories come back, ranked by a 6-factor scoring algorithm. **TOON format** (Token-Oriented Object Notation) cuts response tokens by another 40-60% by eliminating repeated field names -- 3 memories in JSON = 1,600 bytes; in TOON = 626 bytes (61% smaller); in TOON compact = 336 bytes (79% smaller). For Claude Code users: **disable auto-memory** (`"autoMemoryEnabled": false` in settings.json) and replace it with ai-memory to stop paying for 200+ lines of memory context on every single message.
+**Zero token cost until recall.** Unlike built-in memory systems (Claude Code auto-memory, ChatGPT memory) that load your entire memory into every conversation -- burning tokens and money on every message -- ai-memory uses zero context tokens until the AI explicitly calls `memory_recall`. Only relevant memories come back, ranked by a 6-factor scoring algorithm. **TOON format** (Token-Oriented Object Notation) eliminates repeated field names; on the pinned 5-memory fixture in `src/toon.rs` the compact form is mechanically held **below 65% of JSON bytes** (`test_toon_size_invariant_5_memories_under_threshold`). The 1,600/626/336-byte figures are a single illustrative 3-memory example, not a guaranteed ratio. For Claude Code users: **disable auto-memory** (`"autoMemoryEnabled": false` in settings.json) and replace it with ai-memory to stop paying for 200+ lines of memory context on every single message.
 
 ---
 
@@ -768,20 +782,20 @@ Beyond MCP, ai-memory also exposes a full HTTP REST API (94 route registrations 
 - **Color CLI output** -- ANSI tier labels (red/yellow/green), priority bars, bold titles, cyan namespaces
 
 ### Quality
-- **11,900 test attributes across the workspace** — **7,634** under `src/` (6,438 `#[test]` + 1,196 `#[tokio::test]`) and **4,266** under `tests/` (2,577 `#[test]` + 1,689 `#[tokio::test]`), grown from the v0.6.4-era ~2,400-test baseline. Measured at this commit, re-derivable in four commands:
+- **12,549 test attributes across the workspace** — **7,882** under `src/` (6,660 `#[test]` + 1,222 `#[tokio::test]`) and **4,667** under `tests/` (2,793 `#[test]` + 1,874 `#[tokio::test]`), grown from the v0.6.4-era ~2,400-test baseline. Measured at this commit, re-derivable in four commands:
 
   ```bash
-  rg -c --no-filename '^\s*#\[test\]'      src/   | awk '{s+=$1} END {print s}'   # 6438
-  rg -c --no-filename '^\s*#\[tokio::test' src/   | awk '{s+=$1} END {print s}'   # 1196
-  rg -c --no-filename '^\s*#\[test\]'      tests/ | awk '{s+=$1} END {print s}'   # 2577
-  rg -c --no-filename '^\s*#\[tokio::test' tests/ | awk '{s+=$1} END {print s}'   # 1689
+  rg -c --no-filename '^\s*#\[test\]'      src/   | awk '{s+=$1} END {print s}'   # 6660
+  rg -c --no-filename '^\s*#\[tokio::test' src/   | awk '{s+=$1} END {print s}'   # 1222
+  rg -c --no-filename '^\s*#\[test\]'      tests/ | awk '{s+=$1} END {print s}'   # 2793
+  rg -c --no-filename '^\s*#\[tokio::test' tests/ | awk '{s+=$1} END {print s}'   # 1874
   ```
 
   The `#[tokio::test` prefix (no closing bracket) is deliberate — it also counts `#[tokio::test(flavor = "multi_thread")]`, which is a test. This is a count of test *attributes*, not of test cases executed by any one `cargo test` invocation. Re-derive before citing; the numbers move every release.
 - **Line coverage is held above the 90% workspace floor** enforced by `coverage/thresholds.toml` `[global].min_line_coverage`, plus a per-module floor for every module (see [Coverage Floor](#coverage-floor-hard-ci-gate)). Net-new v0.6.4 modules measured 100% (`sizes.rs`), 99.50% (`profile.rs`), 97.58% (`cli/audit.rs`), 97.05% (`cli/doctor.rs`), 92.56% (`handlers.rs`), 92.26% (`cli/install.rs`). v0.6.3.x baselines (1,809 / 93.08% and 1,886 / 93.84%) remain frozen on the [evidence page](https://alphaonedev.github.io/ai-memory-mcp/evidence.html); v0.6.4 metrics in the release notes and on the [test-hub campaign](https://github.com/alphaonedev/ai-memory-test-hub/blob/main/campaigns/v0.6.4.md). Empirical NHI discovery acceptance proven separately by the Discovery Gate (T1–T4 matrix vs. live xAI Grok 4.3, 6/6 PASS, **GATE GREEN**) — see the [Evidence Hub](https://alphaonedev.github.io/ai-memory-mcp/evidence/) (the `ai-memory-discovery-gate` Pages site is retired per #2034).
 - **LongMemEval benchmark** -- on ICLR 2025 LongMemEval-S (500 questions, 6 categories), the **shipped binary** measures **96.4% R@5** on the pure FTS5 keyword tier — LLM-independent, fully local, zero API cost — and **96.8% R@5** on the semantic tier. Those come from `harness.py`, which drives one real `ai-memory recall` subprocess per question; it is the binary-faithful path. LLM query expansion with the current-generation Gemma 4 model measures **97.2% R@5 / 99.6% R@10 / 99.8% R@20** on the *shadow* harness (`harness_99.py`, which re-implements scoring outside the binary; cloud-API venue; the historical `gemma3:4b` 97.8% figure is retired as headline per [#1975](https://github.com/alphaonedev/ai-memory-mcp/issues/1975)). Binary-faithful and shadow numbers are comparable **within** a harness, never across. Full per-tier and per-category disclosure: [`benchmarks/longmemeval/results.md`](benchmarks/longmemeval/results.md).
 - **MCP Prompts** -- `recall-first` and `memory-workflow` prompts teach AI clients to use memory proactively
-- **TOON-default** -- recall/list/search responses use TOON compact by default (79% smaller than JSON)
+- **TOON-default** -- recall/list/search responses use TOON compact by default. TOON eliminates repeated field names; on the pinned 5-memory fixture in `src/toon.rs` the compact form is mechanically held **below 65% of JSON bytes** (`test_toon_size_invariant_5_memories_under_threshold`). The 1,600/626/336-byte figures quoted elsewhere are a single illustrative 3-memory example, not a guaranteed ratio.
 - **Criterion benchmarks** -- insert, recall, search at 1K scale
 - **GitHub Actions CI/CD** -- fmt, clippy, test, build on Ubuntu + macOS, release on tag
 
@@ -1291,7 +1305,7 @@ ai-memory includes hardening across all input paths:
 - **Transaction safety** -- all multi-step database operations use transactions; no partial writes on failure
 - **FTS injection prevention** -- user input is sanitized before reaching FTS5 queries; special characters are escaped
 - **Error sanitization** -- internal database paths and system details are stripped from error responses; clients see structured error types (NOT_FOUND, VALIDATION_FAILED, DATABASE_ERROR, CONFLICT)
-- **Body size limits** -- HTTP request bodies are capped at **2 MiB** (`HTTP_BODY_LIMIT_BYTES`, `src/lib.rs:87`) via Axum's `DefaultBodyLimit`, applied as a **root-level router layer** (`src/lib.rs:1333`) — so it covers every route, including `POST /api/v1/memories/bulk`, `POST /api/v1/import` and `POST /api/v1/sync/push`. Size your bulk ingest and federation batches against 2 MiB, not against a per-route exception; there is none. The MCP stdio line cap is separately 16 MiB (`-32700` on overrun)
+- **Body size limits** -- HTTP request bodies are capped at **2 MiB** (`HTTP_BODY_LIMIT_BYTES`, `src/lib.rs:87`) via Axum's `DefaultBodyLimit`, applied as a **root-level router layer** (the `.layer(DefaultBodyLimit::max(HTTP_BODY_LIMIT_BYTES))` on the root router in `src/lib.rs`) — so it covers every route, including `POST /api/v1/memories/bulk`, `POST /api/v1/import` and `POST /api/v1/sync/push`. Size your bulk ingest and federation batches against 2 MiB, not against a per-route exception; there is none. The MCP stdio line cap is separately 16 MiB (`-32700` on overrun)
 - **Bulk operation limits** -- bulk create endpoints enforce maximum batch sizes to prevent resource exhaustion
 - **CORS** -- permissive CORS layer enabled for localhost development workflows
 - **Input validation** -- every write path validates title length, content length, namespace format, source values, priority range (1-10), confidence range (0.0-1.0), tag format, tier values, relation types, and ID format

--- a/docs/RUNBOOK-chaos-campaign.md
+++ b/docs/RUNBOOK-chaos-campaign.md
@@ -48,7 +48,7 @@ On each peer host:
 docker compose -f packaging/docker-compose.postgres.yml up -d
 
 # ai-memory daemon with federation
-export AI_MEMORY_DB=postgres://ai_memory:ai_memory_test@localhost:5433/ai_memory_test
+export AI_MEMORY_STORE_URL=postgres://ai_memory:ai_memory_test@localhost:5433/ai_memory_test
 ai-memory serve \
     --host 0.0.0.0 --port 9077 \
     --tls-cert /etc/ai-memory/cert.pem \
@@ -63,6 +63,11 @@ ai-memory serve \
 
 Each peer points `--quorum-peers` at the **other two**.
 `--quorum-writes 2` = majority quorum on N=3.
+
+`AI_MEMORY_STORE_URL` is the postgres connection string.
+`AI_MEMORY_DB` is the **SQLite file path** (`--db`); setting it to a
+`postgres://` URL creates a file with that name and silently runs the
+campaign on SQLite.
 
 ## Running the campaign
 

--- a/docs/RUNBOOK-digitalocean-testing.md
+++ b/docs/RUNBOOK-digitalocean-testing.md
@@ -214,15 +214,18 @@ done
 ### Quorum-not-met probe
 
 Explicit kill of node-b, write 10 memories to node-a with
-`--quorum-writes 2` against peers b+c. Expected: each write returns
-503 `{"error":"quorum_not_met","got":2,"needed":2,"reason":"timeout"}`
-because only c is reachable (1 ack vs needed 1). Actually with N=3
+`--quorum-writes 2` against peers b+c. Expected: each write whose
+local commit lands but whose acks miss the deadline returns
+**202 Accepted** with `quorum_met:false` (v0.8.1 G12 — the row IS
+durable locally), body
+`{"quorum_met":false,"acks":<n>,"needed":<w>,"reason":"timeout","durability":"local"}`
+(`under_replicated_response`, `src/handlers/parity.rs`). With N=3
 and W=2, local + c should meet quorum. Revise:
 
 With **node-b AND node-c down** (both peers killed), node-a writes
-should **always** return 503. With **node-b down only**, writes
-should succeed via node-c. Both branches must be observed in the
-report.
+should **always** return **202 with `quorum_met:false`**. With
+**node-b down only**, writes should succeed via node-c. Both branches
+must be observed in the report.
 
 ## Phase 3 — Cross-backend migration
 
@@ -271,7 +274,10 @@ Repeat with `--fault partition_minority`, `--fault drop_random_acks`,
 **Pass criteria** per fault class (from ADR-0001):
 
 - `convergence_bound >= 0.995`.
-- `total_fail == 0` (no non-201/non-503 responses).
+- `total_fail == 0` (no responses outside {201, **202**}). Count a
+  202-with-`quorum_met:false` as under-replicated, not as failure: the
+  local commit is durable and the sync daemon drives it to
+  convergence.
 - Post-campaign node counts agree within 1 memory across all three
   peers.
 

--- a/docs/at-a-glance.html
+++ b/docs/at-a-glance.html
@@ -922,7 +922,7 @@ footer.site-foot a { color: var(--text-muted); }
     <div class="stat-item"><span class="stat-num">5</span><span class="stat-label">Platforms (macOS·Linux·Windows·iOS·Android)</span></div>
     <div class="stat-item"><span class="stat-num">15+</span><span class="stat-label">LLM vendors (Ollama + cloud)</span></div>
     <div class="stat-item"><span class="stat-num">v89</span><span class="stat-label">Schema version (v1.0.0)</span></div>
-    <div class="stat-item"><span class="stat-num">10/10</span><span class="stat-label"><a href="compliance/nsa-csi-mcp.html">NSA CSI MCP concerns</a> structurally addressed</span></div>
+    <div class="stat-item"><span class="stat-num">9/10</span><span class="stat-label"><a href="compliance/nsa-csi-mcp.html">NSA CSI MCP concerns</a> structurally addressed (concern (a) is posture-conditional &mdash; H1)</span></div>
   </div>
 </div>
 

--- a/docs/enterprise-deployment.md
+++ b/docs/enterprise-deployment.md
@@ -1079,29 +1079,21 @@ ai-memory does not provide a turnkey GDPR layer; it provides the
 The operator's data-residency policy is encoded in the **namespace
 allowlist** + the **federation peer attestation** + the **`forget`
 operation** + the **archive-purge cadence**. The operator owns the
-policy; the substrate enforces it **in one direction**.
+policy; the substrate enforces it **in both directions** under an
+enrolled posture (#2489/#2480).
 
-> ⚠️ **Residency has two directions and only the outbound one is
-> gated.** On the **SERVE** direction (`/sync/since`, a peer pulling
-> from you) `namespace_allowed_test_glob` is applied default-deny
-> before any row crosses the wire — that half is real. On the
-> **ACCEPT** direction the pull-accept path
-> (`src/federation/receive.rs`) runs as
-> `CallerContext::for_admin(FEDERATION_CATCHUP)` with
-> `bypass_visibility = true` and never consults `PeerAttestationConfig`
-> at all, so a peer you pull from can place rows into any namespace on
-> your node — including `(title, namespace)` dedup-overwrites of rows
-> already there
-> ([#2480](https://github.com/alphaonedev/ai-memory-mcp/issues/2480)).
-> The `links[]` and `signals[]` push lanes are likewise unscoped
+> ✅ **Residency is gated in both directions.** On **SERVE**
+> (`/sync/since`) `namespace_allowed_test_glob` is applied default-deny
+> before any row crosses the wire. On **ACCEPT** the catchup path now
+> applies the SAME operator-authored `allowed_namespaces` list before
+> insert (`catchup_memory_namespace_authorized`,
+> [#2480](https://github.com/alphaonedev/ai-memory-mcp/issues/2480)),
+> as do the `links[]` / `signals[]` push lanes
 > ([#2489](https://github.com/alphaonedev/ai-memory-mcp/issues/2489)).
->
-> For a residency control, that means: **what leaves your region is
-> gated; what arrives is not.** If your obligation is only "our data
-> must not leave region X", the serve-direction gate meets it. If it is
-> also "no foreign-origin data may land in region X's namespaces", the
-> substrate does not yet enforce that — pull only from peers you
-> administer.
+> `CallerContext::for_admin(FEDERATION_CATCHUP)` still bypasses SAL
+> visibility so the peer snapshot round-trips — it no longer bypasses
+> scope. Enforcement requires an ENROLLED posture; zero-config
+> federation is unchanged.
 
 ### 7.5 DNS + routing strategy
 
@@ -1352,10 +1344,11 @@ For an operator piloting a hive in v0.7.0, the responsible shape is:
    same document: *"if subsets of peers should NOT see each other's
    data, the swarm shape is wrong."* Cross-cluster federation replicates
    **plaintext** memory content ([#1968](https://github.com/alphaonedev/ai-memory-mcp/issues/1968))
-   and `PeerScope.allowed_namespaces` is not consulted on three inbound
-   write lanes ([`federation.md`](federation.html) §"Layer 3 — Peer
-   attestation"), so a per-tenant mesh is a topology this substrate
-   disclaims elsewhere. For mutually distrusting tenants use **separate
+   — every inbound write lane now consults
+   `PeerScope.allowed_namespaces` under an enrolled posture
+   (#2489/#2480, see [`federation.md`](federation.html) §"Layer 3 — Peer
+   attestation"), but plaintext replication alone makes a per-tenant
+   mesh a topology this substrate disclaims elsewhere. For mutually distrusting tenants use **separate
    deployments**, not one federated hive with scopes.
 2. **Mesh federation between the three** via the T6 wire shape (signed + nonce + attestation).
 3. **Strict trust gates** — every cross-cluster `PeerScope` row narrows to specific allowed namespaces. No `**` globs cross-cluster.

--- a/docs/federation-identity.md
+++ b/docs/federation-identity.md
@@ -127,10 +127,13 @@ control.
 `src/handlers/`, or in the storage layer. Inside one trust domain it
 enforces nothing at all between the parties that hold valid credentials
 for it. The in-domain confinement primitive is
-`PeerScope.allowed_namespaces` — and three inbound write lanes do not
-consult that either (`links[]`, `signals[]`, and the pull-accept path;
-see [`docs/federation.md`](federation.html) §"Layer 3 — Peer
-attestation" for the table and the tracking issues).
+`PeerScope.allowed_namespaces`, which every inbound write lane —
+`links[]`, `signals[]` and the pull-accept path included — now
+consults under an enrolled posture (#2489/#2480); what still makes
+this not a mutually-distrusting-tenant boundary is that federation
+replicates plaintext (#1968), not an unscoped lane (see
+[`docs/federation.md`](federation.html) §"Layer 3 — Peer
+attestation").
 
 **Therefore:**
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -189,30 +189,22 @@ the `x-peer-id` HTTP header) to a `PeerScope`
   (`AI_MEMORY_FED_REQUIRE_PUSH_NAMESPACE_SCOPE`) for the disposition of
   an enrolled peer that declares no namespaces at all.
 
-> ⚠️ **Three inbound write lanes are NOT namespace-scoped today.**
-> A previous revision of this sentence read "every lane that can
-> reach a write". That universal quantifier was false, and it is the
-> sentence an operator builds tenant isolation on, so it is stated
-> plainly here instead:
->
-> | Unscoped lane | Code | Tracking |
-> |---|---|---|
-> | `/sync/push` `links[]` | `src/handlers/federation_receive.rs` — the `links` loop reaches `db::create_link_inbound` with no scope check | [#2489](https://github.com/alphaonedev/ai-memory-mcp/issues/2489) |
-> | `/sync/push` `signals[]` | same file — `sig.namespace` is read only at the quota call, never compared to `allowed_namespaces` | [#2489](https://github.com/alphaonedev/ai-memory-mcp/issues/2489) |
-> | the entire **pull-accept** path | `src/federation/receive.rs` builds `CallerContext::for_admin(sentinels::FEDERATION_CATCHUP)` (`bypass_visibility = true`) and inserts; `PeerAttestationConfig` is never consulted in that file | [#2480](https://github.com/alphaonedev/ai-memory-mcp/issues/2480) |
->
-> **What that means concretely.** A peer scoped `["public/*"]` can
-> still write graph edges into a namespace it is denied, deliver
-> signals into a denied inbox, and — on any node that *pulls* from
-> it — insert rows into any namespace. Because `contradicts` /
-> `supersedes` edges feed the recall down-weight, the `links[]` gap
-> is a **read-path influence primitive against data the peer cannot
-> read**. The accepted threat model for #2480 is "a configured peer
-> turns hostile / is compromised" — exactly this case.
->
-> Until #2489 and #2480 land, do **not** rely on `allowed_namespaces`
-> as a boundary between mutually distrusting tenants. See
-> §"Multi-peer scaling guidance" for the delivered boundary.
+> ✅ **Inbound write lanes are namespace-confined.**
+> Under an ENROLLED posture (`AI_MEMORY_FED_PEER_ATTESTATION`
+> configured), every inbound write lane routes through the shared
+> by-id / by-namespace choke in `federation::receive_auth`:
+> `/sync/push` `memories[]`, `links[]` (source AND target stored
+> namespace, [#2489](https://github.com/alphaonedev/ai-memory-mcp/issues/2489)),
+> `signals[]` (claimed namespace, #2489), `deletions[]`, `archives[]`,
+> `restores[]`, `action_transitions[]`, `checkpoints[]`,
+> `namespace_meta`, and the catchup pull-accept path
+> (`src/federation/receive.rs::catchup_memory_namespace_authorized`,
+> [#2480](https://github.com/alphaonedev/ai-memory-mcp/issues/2480)).
+> An endpoint whose namespace cannot be resolved is REFUSED, not
+> admitted. Zero-config (no allowlist) is unchanged, byte-identical
+> faith replication. `CallerContext::for_admin(FEDERATION_CATCHUP)`
+> still bypasses SAL *visibility* so a peer snapshot can round-trip —
+> the scope gate runs before it.
 
 The attestation core is
 [`peer_attestation::attest_sender`](../src/federation/peer_attestation.rs)
@@ -766,13 +758,10 @@ PROVISIONAL — believe that marking.
 **Blast radius of a single compromised peer.** Default-deny on both
 `allowed_namespaces` and `allowed_sender_agent_ids` keeps a compromised
 peer from **authoring as other agents** and from **pulling unrelated
-namespaces**. Those two verbs are genuinely contained. What is **not**
-contained today: per the unscoped-lane table in §"Peer attestation"
-above, a compromised peer can still write graph edges into a denied
-namespace (#2489), deliver signals into a denied inbox (#2489), and
-inject rows into any namespace on a node that pulls from it (#2480).
-It can also read the plaintext of everything replicated to it —
-federation is **not** end-to-end encrypted
+namespaces**. Those verbs are contained, and since #2489/#2480 so are the
+link, signal and pull-accept lanes (enrolled posture). What remains
+uncontained: the peer can read the plaintext of everything replicated
+to it — federation is **not** end-to-end encrypted
 ([#1968](https://github.com/alphaonedev/ai-memory-mcp/issues/1968); see
 §"At-rest encryption and federation" below).
 
@@ -801,7 +790,11 @@ credential minted for another fleet and enforces nothing between
 tenants *inside* one domain — it is consulted only under
 `src/federation/identity/`, never on the receive path), and the stated
 in-domain confinement primitive is `PeerScope.allowed_namespaces`,
-which the three lanes above never consult. For heterogeneous trust,
+**which every inbound write lane now consults under an enrolled
+posture (#2489/#2480)**. The residual reason this is not a
+mutually-distrusting-tenant boundary is that federation replicates
+plaintext (#1968) and `trust_domain` is credential-replay scope only.
+For heterogeneous trust,
 §8.8 of `docs/enterprise-deployment.md` gives the correct answer:
 **use multiple disjoint swarms**, not one mesh with scopes.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -374,11 +374,11 @@ footer .legal{margin-top:.5rem;font-size:.78rem;color:var(--text-dim)}
       <span>Model-neutral (MCP)</span>
       <span>103 MCP tools</span>
       <span>94 HTTP routes (80 unique paths)</span>
-      <span>90 CLI subcommands</span>
+      <span>90 CLI subcommands (default build; 92 with <code>sal</code> features)</span>
       <span>Ed25519 attested audit chain</span>
       <span>SQLite&nbsp;+&nbsp;Postgres&#x202F;/&#x202F;AGE</span>
-      <span><a href="compliance/nsa-csi-mcp.html" style="color:#6ee7ff">NSA CSI MCP 10/10 · 7/7</a></span>
-      <span><a href="evidence.html" style="color:#6ee7ff">15,951 / 0 regression suite</a></span>
+      <span><a href="compliance/nsa-csi-mcp.html" style="color:#6ee7ff">NSA CSI MCP 9/10 · 7/7</a></span>
+      <span><a href="evidence.html" style="color:#6ee7ff">15,951 / 0 regression suite (2026-05-31 final baseline, v0.7.0 tree)</a></span>
     </div>
     <div class="cta-row">
       <a class="cta primary" href="#install">Install in 60 seconds</a>
@@ -942,7 +942,7 @@ api_key_env = "XAI_API_KEY"            # env-var name (inline keys rejected at p
     <p class="lede">The full docs surface &mdash; concept pages, API, guides, ADRs &mdash; lives alongside the source.</p>
     <div class="links-grid">
       <a class="lk" href="compliance/index.html"><strong>Compliance &amp; Procurement</strong><span class="desc">NSA CSI MCP mapping · honest limitations · Memory Portability Spec v1</span></a>
-      <a class="lk" href="evidence.html"><strong>Evidence &mdash; frozen claims</strong><span class="desc">Every public number, pinned to a commit + test artifact. 15,951/0 final baseline.</span></a>
+      <a class="lk" href="evidence.html"><strong>Evidence &mdash; frozen claims</strong><span class="desc">Every public number, pinned to a commit + test artifact. 15,951/0 (2026-05-31 final baseline, v0.7.0 tree &mdash; see evidence.html).</span></a>
       <a class="lk" href="USER_GUIDE.html"><strong>User guide</strong><span class="desc">End-to-end MCP tool reference</span></a>
       <a class="lk" href="DEVELOPER_GUIDE.html"><strong>Developer guide</strong><span class="desc">Build from source, extend, add tools</span></a>
       <a class="lk" href="API_REFERENCE.html"><strong>HTTP API</strong><span class="desc">94 routes (80 unique paths)</span></a>

--- a/scripts/check-docs-vs-ssot.sh
+++ b/scripts/check-docs-vs-ssot.sh
@@ -59,6 +59,16 @@
 #  - MemoryLinkRelation::COUNT (=6) → docs claims of "<N> variants" /
 #    "<N> typed link relations".
 #  - MemoryScope::COUNT (=5) → docs claims of "<N> visibility scopes".
+#  - `src/security_profile.rs::KNOBS` entry count -> the asi-hard
+#    pinned-knob narration in SECURITY.md / README.md / docs/deploy/*
+#    / docs/enterprise-deployment.md ("is **N** knobs", "N-knob",
+#    "N-entry pin-and-refuse", "PINS **N** security env knobs", "all
+#    **N** `KNOBS` entries"). CHANGELOG + the cert doc's evidence notes
+#    are EXCLUDED: their 17-knob text is a true pre-#3033 record.
+#  - `enterprise_federation_posture::ENTERPRISE_FEDERATION_CHECK_COUNT`
+#    -> the cert doc's normative exit contract ("returns **0 iff all N
+#    checks pass, else 2**"). The same doc's 18/19-check EVIDENCE notes
+#    are deliberately NOT anchored - they record a past capture.
 #  - pgvector certified PATCH (deploy/docker-1461/provision/lib.sh
 #    DOCKER_1461_PGVECTOR_APT_VERSION, reduced x.y.z — the SAME SSOT
 #    tests/provisioning_pgvector_pin_parity.rs reads) → current-cert doc
@@ -122,6 +132,37 @@ CANONICAL_CLI_SAL=$(extract_const_value src/lib.rs EXPECTED_CLI_SUBCOMMANDS_SAL 
 CANONICAL_MEMORY_FIELDS=$(extract_const_value src/models/memory.rs FIELD_COUNT 'usize')
 CANONICAL_LINK_COUNT=$(extract_const_value src/models/link.rs COUNT 'usize')
 CANONICAL_SCOPE_COUNT=$(extract_const_value src/models/namespace.rs COUNT 'usize')
+
+# asi-hard pinned-knob count — the `KnobSpec` entries in
+# `src/security_profile.rs::KNOBS`, which IS the no-disable contract:
+# every knob in that table is pinned ON at boot and a value below its
+# hard floor REFUSES boot. Five operator-facing surfaces narrate the
+# count (SECURITY.md twice, README.md, docs/deploy/README.md,
+# docs/deploy/enterprise-federation.env, docs/enterprise-deployment.md)
+# and ALL FIVE shipped `17` after #3033 raised the table to 21 by adding
+# the four outer federation-transport gates — a procurement-read
+# understatement of the hardened posture that no gate saw. Counted from
+# the table BODY (`^const KNOBS: &[KnobSpec] = &[` .. `^];`) so the
+# `struct KnobSpec {` definition above it is never counted.
+#
+# `|| true` + the empty-normalisation below keep a genuinely-absent SSOT
+# (the --self-test fixture tree) from aborting the gate under
+# `set -euo pipefail`; an unresolved canonical then FAILS CLOSED inside
+# the rule, but ONLY if a scan-set doc actually narrates a count (no
+# claim to validate = nothing to fail).
+# enterprise-federation posture check count — the SSOT the doctor
+# posture asserts against (`evaluate()` must return exactly this many
+# checks). The cert doc states it as the normative exit contract
+# ("returns **0 iff all N checks pass, else 2**"), and that one sentence
+# is what a procurement reader treats as the gate. It has moved four
+# times (16 -> 18 -> 19 -> 20) and each move had to be caught by hand.
+CANONICAL_EF_CHECK_COUNT="$(
+    extract_const_value src/enterprise_federation_posture.rs \
+        ENTERPRISE_FEDERATION_CHECK_COUNT 'usize' || true
+)"
+if [[ -z "$CANONICAL_EF_CHECK_COUNT" ]]; then
+    CANONICAL_EF_CHECK_COUNT="<unresolved>"
+fi
 
 # Certified pgvector PATCH — the single fleet-wide provisioning pin. It
 # lives ONCE, in the docker-1461 lane's `DOCKER_1461_PGVECTOR_APT_VERSION`
@@ -364,6 +405,35 @@ PGVECTOR_DOC_FILES=(
     docs/CONFIG_SCHEMA.md
     docs/enterprise-deployment.md
     docs/postgres-age-guide.md
+    docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
+)
+
+# Doc surfaces the asi-hard KNOBS-count rule walks. Its OWN scan set
+# ("one rule, one scan set"): the surfaces that narrate the pinned-knob
+# count as a PRESENT fact. Three of them (SECURITY.md, docs/deploy/*)
+# are in no other scan set at all, which is exactly why the post-#3033
+# 17-vs-21 drift was invisible.
+#
+# DELIBERATELY EXCLUDES:
+#   * CHANGELOG.md — every entry is a landing-time snapshot; "the
+#     existing 17-knob asi-hard hardened set" was TRUE when written.
+#   * docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md — it
+#     already says 21 in its current-state row AND carries a signed
+#     `17`-knob EVIDENCE note recording what the captured `.out`
+#     artifacts rendered PRE-#3033. Re-pointing an evidence note at the
+#     canonical would falsify the record the cert rests on.
+#   * infra/federation-lab/README.md — a campaign log, same class.
+KNOB_DOC_FILES=(
+    SECURITY.md
+    README.md
+    docs/deploy/README.md
+    docs/deploy/asi-hard.env
+    docs/deploy/enterprise-federation.env
+    docs/enterprise-deployment.md
+)
+
+# Doc surface the enterprise-federation posture check-count rule walks.
+CERT_CHECK_DOC_FILES=(
     docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
 )
 
@@ -1425,6 +1495,30 @@ run_all_rules() {
         "$CANONICAL_CLI_SAL" \
         'default build / ([0-9]+) under' \
         "${HTML_DOC_FILES[@]}"
+    # asi-hard pinned-knob count (src/security_profile.rs::KNOBS).
+    # FIVE anchors, all BOLD- or hyphen-delimited so a bare integer next
+    # to the word "knobs" can never match. The bold delimiter on the
+    # `is **N** knobs` form is load-bearing: docs/deploy/README.md says
+    # "the config-backed PE-1 knobs and", and a bare `([0-9]+) knobs`
+    # anchor captures the `1` out of `PE-1` and reports phantom drift.
+    check_narrative_count_rule \
+        "asi-hard KNOBS count (src/security_profile.rs::KNOBS)" \
+        "$CANONICAL_ASI_HARD_KNOBS" \
+        'is \*\*([0-9]+) knobs\*\*|PINS \*\*([0-9]+)\*\* security env knobs|([0-9]+)-knob\b|([0-9]+)-entry pin-and-refuse|all \*\*([0-9]+)\*\* `KNOBS` entries' \
+        "${KNOB_DOC_FILES[@]}"
+    # enterprise-federation posture check count
+    # (enterprise_federation_posture::ENTERPRISE_FEDERATION_CHECK_COUNT).
+    # ONE anchor: the cert doc's NORMATIVE exit contract. Scoped that
+    # tightly on purpose — the same document carries `18`/`19`-check
+    # EVIDENCE NOTES describing what the committed `cert-54/*.out`
+    # captures actually rendered at the tree they were taken on. Those
+    # are TRUE statements about a past capture; a broader anchor would
+    # "fix" them into a lie about the evidence bundle.
+    check_narrative_count_rule \
+        "ENTERPRISE_FEDERATION_CHECK_COUNT" \
+        "$CANONICAL_EF_CHECK_COUNT" \
+        'returns \*\*0 iff all ([0-9]+) checks pass' \
+        "${CERT_CHECK_DOC_FILES[@]}"
 
     if [[ "$fail_count" -gt 0 ]]; then
         printf '\n❌ docs-vs-SSOT drift gate: %d violation(s)\n' "$fail_count" >&2
@@ -1442,10 +1536,12 @@ run_all_rules() {
         printf '     HookEvent variants = %s\n' "$CANONICAL_HOOK_EVENTS" >&2
         printf '     pgvector patch = %s (deploy/docker-1461/provision/lib.sh DOCKER_1461_PGVECTOR_APT_VERSION)\n' "$CANONICAL_PGVECTOR_PATCH" >&2
         printf '     Current release version (Cargo.toml) = %s\n' "$CANONICAL_RELEASE_VERSION" >&2
+        printf '     asi-hard KNOBS entries = %s (src/security_profile.rs::KNOBS)\n' "$CANONICAL_ASI_HARD_KNOBS" >&2
+        printf '     ENTERPRISE_FEDERATION_CHECK_COUNT = %s\n' "$CANONICAL_EF_CHECK_COUNT" >&2
         exit 1
     fi
     printf '✅ docs-vs-SSOT drift gate: PASS\n'
-    printf '   Canonical values: schema=%s, full_tools=%s, core_tools=%s, routes=%s, paths=%s, cli_default=%s, cli_sal=%s, mem_fields=%s, link=%s, scope=%s, hooks=%s, pgvector=%s, release=%s\n' \
+    printf '   Canonical values: schema=%s, full_tools=%s, core_tools=%s, routes=%s, paths=%s, cli_default=%s, cli_sal=%s, mem_fields=%s, link=%s, scope=%s, hooks=%s, pgvector=%s, release=%s, asi_hard_knobs=%s, ef_checks=%s\n' \
         "$CANONICAL_SCHEMA_VERSION" \
         "$CANONICAL_FULL_TOOL_COUNT" \
         "$CANONICAL_CORE_TOOL_COUNT" \
@@ -1458,7 +1554,9 @@ run_all_rules() {
         "$CANONICAL_SCOPE_COUNT" \
         "$CANONICAL_HOOK_EVENTS" \
         "$CANONICAL_PGVECTOR_PATCH" \
-        "$CANONICAL_RELEASE_VERSION"
+        "$CANONICAL_RELEASE_VERSION" \
+        "$CANONICAL_ASI_HARD_KNOBS" \
+        "$CANONICAL_EF_CHECK_COUNT"
 }
 
 # --------------------------------------------------------------------
@@ -2040,6 +2138,118 @@ KNOBGOODSH
     fi
     echo "PASS: self-test #3113 — the correct asi-hard knob count still PASSES"
     rm -f "$tmpdir/scripts/check-bootstrap-cert-gate.sh" "$tmpdir/src/security_profile.rs"
+
+    # ================================================================
+    # asi-hard KNOBS count + ENTERPRISE_FEDERATION_CHECK_COUNT
+    # ================================================================
+    # Until this wave neither number had an SSOT rule, and both drifted:
+    # five live surfaces said the asi-hard profile pins 17 knobs after
+    # #3033 raised `KNOBS` to 21. Fixture SSOTs: 3 knobs / 5 checks, so a
+    # planted 4 / 6 must be REJECTED and the true values ACCEPTED.
+    mkdir -p "$tmpdir/docs/deploy" "$tmpdir/docs/compliance"
+    cat > "$tmpdir/src/security_profile.rs" <<'KNOBSSSOT'
+struct KnobSpec {
+    env: &'static str,
+}
+const KNOBS: &[KnobSpec] = &[
+    KnobSpec {
+        env: "A",
+    },
+    KnobSpec {
+        env: "B",
+    },
+    KnobSpec {
+        env: "C",
+    },
+];
+KNOBSSSOT
+    cat > "$tmpdir/src/enterprise_federation_posture.rs" <<'EFSSOT'
+pub const ENTERPRISE_FEDERATION_CHECK_COUNT: usize = 5;
+EFSSOT
+    cat > "$tmpdir/SECURITY.md" <<'KNOBSTALE'
+- The pinned SSOT (`src/security_profile.rs::KNOBS`) is **4 knobs** — see the deploy template.
+Last updated: 2026-08-21 (`asi-hard` 4-knob hardened profile cross-referenced).
+KNOBSTALE
+    cat > "$tmpdir/docs/deploy/README.md" <<'KNOBSTALEDEPLOY'
+This template layers the config-backed PE-1 knobs and the egress posture on top.
+(That list is all **4** `KNOBS` entries.)
+KNOBSTALEDEPLOY
+    cat > "$tmpdir/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md" <<'EFSTALE'
+`run_posture` returns **0 iff all 6 checks pass, else 2**.
+> Evidence note: the captures below PREDATE the last two checks and reflect the 4-check posture.
+EFSTALE
+    if knob_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test — gate did NOT catch the stale asi-hard knob / EF check counts" >&2
+        printf '%s\n' "$knob_out" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    for _want in \
+        'asi-hard KNOBS count (src/security_profile.rs::KNOBS): SECURITY.md:1 claims "4"' \
+        'asi-hard KNOBS count (src/security_profile.rs::KNOBS): SECURITY.md:2 claims "4"' \
+        'asi-hard KNOBS count (src/security_profile.rs::KNOBS): docs/deploy/README.md:2 claims "4"' \
+        'ENTERPRISE_FEDERATION_CHECK_COUNT: docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md:1 claims "6"'
+    do
+        grep -qF "$_want" <<<"$knob_out" || {
+            echo "FAIL: self-test — expected drift not flagged: $_want" >&2
+            printf '%s\n' "$knob_out" >&2
+            cd "$REPO_ROOT"; exit 1; }
+    done
+    # The `PE-1 knobs` prose must NOT match: a bare `([0-9]+) knobs`
+    # anchor would capture the `1` out of `PE-1` and report phantom drift.
+    if grep -qF 'KNOBS): docs/deploy/README.md:1' <<<"$knob_out"; then
+        echo "FAIL: self-test — the knob rule falsely matched 'PE-1 knobs' prose" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    # The cert doc's EVIDENCE NOTE (a true record of a past capture) must
+    # NOT be re-pointed at the canonical.
+    if grep -qF 'ENTERPRISE_FEDERATION_CHECK_COUNT: docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md:2' <<<"$knob_out"; then
+        echo "FAIL: self-test — the EF check rule falsely flagged a historical evidence note" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test — asi-hard KNOBS + EF check-count rules REJECT stale counts, spare 'PE-1 knobs' and the evidence note"
+
+    # ---- CONTROL: the canonical counts (3 knobs / 5 checks) PASS.
+    cat > "$tmpdir/SECURITY.md" <<'KNOBGOOD'
+- The pinned SSOT (`src/security_profile.rs::KNOBS`) is **3 knobs** — see the deploy template.
+Last updated: 2026-08-21 (`asi-hard` 3-knob hardened profile cross-referenced).
+KNOBGOOD
+    cat > "$tmpdir/docs/deploy/README.md" <<'KNOBGOODDEPLOY'
+This template layers the config-backed PE-1 knobs and the egress posture on top.
+(That list is all **3** `KNOBS` entries.)
+KNOBGOODDEPLOY
+    cat > "$tmpdir/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md" <<'EFGOOD'
+`run_posture` returns **0 iff all 5 checks pass, else 2**.
+EFGOOD
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test — the knob / EF check rules fired on the CANONICAL counts" >&2
+        AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1 >/dev/null | sed 's/^/       /' >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    echo "PASS: self-test — the canonical asi-hard knob (3) + EF check (5) counts PASS"
+
+    # ---- FAIL-CLOSED-ONLY-WITH-A-CLAIM: remove both SSOTs. A doc that
+    # narrates NO count has nothing to validate and must stay green;
+    # a doc that DOES narrate one must fail rather than silently pass.
+    rm -f "$tmpdir/src/security_profile.rs" "$tmpdir/src/enterprise_federation_posture.rs"
+    rm -f "$tmpdir/SECURITY.md" "$tmpdir/docs/deploy/README.md"
+    rm -f "$tmpdir/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md"
+    if ! AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" >/dev/null 2>&1; then
+        echo "FAIL: self-test — an ABSENT knob/EF SSOT with no claim to validate did not stay green" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    cat > "$tmpdir/SECURITY.md" <<'KNOBORPHAN'
+- The pinned SSOT (`src/security_profile.rs::KNOBS`) is **3 knobs** — see the deploy template.
+KNOBORPHAN
+    if orphan_out=$(AI_MEMORY_DOCS_GATE_ROOT="$tmpdir" "$REPO_ROOT/scripts/check-docs-vs-ssot.sh" 2>&1); then
+        echo "FAIL: self-test — a knob claim with an UNRESOLVABLE SSOT passed silently (fail-open)" >&2
+        cd "$REPO_ROOT"; exit 1
+    fi
+    grep -qF '<unresolved>' <<<"$orphan_out" || {
+        echo "FAIL: self-test — the unresolved-SSOT failure did not name the unresolved canonical" >&2
+        printf '%s\n' "$orphan_out" >&2
+        cd "$REPO_ROOT"; exit 1; }
+    rm -f "$tmpdir/SECURITY.md"
+    echo "PASS: self-test — an unresolvable knob SSOT FAILS CLOSED only when a doc actually narrates the count"
 
     # ================================================================
     # #2977 — THE GITHUB-PAGES (.html) SURFACE

--- a/scripts/dogfood-rebuild.sh
+++ b/scripts/dogfood-rebuild.sh
@@ -29,7 +29,11 @@ set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIVE_DB="${AI_MEMORY_DB:-$HOME/.claude/ai-memory.db}"
-BACKUP_DB="/tmp/ai-memory-dogfood-test-$(date +%Y%m%dT%H%M%S).db"
+# Scratch lives in the repo-local, gitignored .local-runs/ (CLAUDE.md
+# §"Allowed scratch location"), never /tmp: a /tmp backup of the LIVE MCP
+# database is reaped by tmpfiles/reboot, so the one artifact that makes
+# this script recoverable would silently disappear.
+BACKUP_DB="$REPO/.local-runs/ai-memory-dogfood-test-$(date +%Y%m%dT%H%M%S).db"
 HOMEBREW_BIN="/opt/homebrew/bin/ai-memory"
 
 cd "$REPO"
@@ -45,6 +49,7 @@ echo
 
 echo "==> 2/5  backup live DB → $BACKUP_DB"
 if [[ -f "$LIVE_DB" ]]; then
+  mkdir -p "$REPO/.local-runs"
   cp "$LIVE_DB" "$BACKUP_DB"
   schema_before=$(sqlite3 "$BACKUP_DB" "SELECT MAX(version) FROM schema_version" 2>/dev/null || echo "?")
   echo "    backup OK; schema_version before = $schema_before"


### PR DESCRIPTION
Claims-audit **batch 2**. Every item was scout-verified against `cda57210` and **re-verified line-by-line by me** against this tree before editing (several line anchors had moved). Docs + two shell scripts + one workflow comment block. **No Rust changed.**

No tracking issue exists for this batch, so there is no `Closes`. Related open issues this touches without closing:
- **#3142** — `AI_MEMORY_DB` silently accepts a `postgres://` value and creates a SQLite file with that name. Item 9 below documents the trap in the runbook; the fail-closed refusal is #3142's Rust fix.
- **#3162** — bind the `PERFORMANCE.md` budget table to `src/bench.rs` via a docs-vs-ssot rule. Item 12 below **documents that this binding does not exist today**, which is #3162's premise, not its fix.
- **#3143** — a binary documented as advisory must not be asserted to succeed from inside a required `Check` job. Item 12's `PERFORMANCE.md` note records the post-#3137 state.

---

## What changed

| # | Correction | Files | SSOT it was checked against |
|---|---|---|---|
| 1 | asi-hard pinned-knob count **17 → 21** | `SECURITY.md` ×2, `README.md`, `docs/deploy/README.md` (+ the four missing bullets), `docs/deploy/enterprise-federation.env`, `docs/enterprise-deployment.md` | `src/security_profile.rs::KNOBS` = 21 `KnobSpec` entries since #3033 |
| 2 | NSA CSI MCP **10/10 → 9/10** + self-assessed framing + NSA non-endorsement disclaimer in `README.md` | `README.md`, `docs/index.html`, `docs/at-a-glance.html` | `docs/compliance/nsa-csi-mcp-security-mapping.md:40–42`, `honest-limitations.md:131` |
| 3 | Test attributes **11,900 → 12,549** (badge, body, four inline `#` comments) | `README.md` | re-ran README's own four commands at this tree |
| 4 | `15,951 / 0` gains inline provenance (2026-05-31 final baseline, v0.7.0 tree) | `docs/index.html` ×2 | `docs/evidence.html:209,213` |
| 5 | HTTP body limit cites the symbol, not `src/lib.rs:1333` | `README.md` | layer is at `src/lib.rs:1338` today |
| 6 | TOON: drop unqualified 40-60% / 79% guarantees | `README.md` ×2 | `src/toon.rs:506` `test_toon_size_invariant_5_memories_under_threshold` (< 0.65) |
| 7 | Federation "three unscoped inbound write lanes" — **stale; the docs UNDER-claimed shipped controls** | `docs/federation.md` ×3, `docs/federation-identity.md`, `docs/enterprise-deployment.md` ×3 | `federation_receive.rs:2718–2782` / `:3270–3283`; `federation/receive.rs:47–71` called at `:459/:524/:677` |
| 8 | DO runbook quorum: **503 → 202 + `quorum_met:false`** | `docs/RUNBOOK-digitalocean-testing.md` ×3 | `src/handlers/parity.rs::under_replicated_response` returns `StatusCode::ACCEPTED` |
| 9 | Chaos runbook: `AI_MEMORY_DB` → `AI_MEMORY_STORE_URL` + the trap stated inline | `docs/RUNBOOK-chaos-campaign.md` | `AI_MEMORY_DB` is the SQLite `--db` path (see #3142) |
| 10 | `/tmp` backup of the LIVE MCP DB → `.local-runs/` | `scripts/dogfood-rebuild.sh`, `CLAUDE.md` ×2 | CLAUDE.md §"Allowed scratch location" |
| 11 | "90 CLI subcommands" qualified as default build (92 with `sal`) | `docs/index.html` | `EXPECTED_CLI_SUBCOMMANDS_DEFAULT`/`_SAL` |
| 12 | `PERFORMANCE.md` + `bench.yml` enforcement-truthfulness pass (six + three sub-items) | `PERFORMANCE.md`, `.github/workflows/bench.yml` | `src/bench.rs::verdict`, `Operation` (10 variants), `operation_targets_match_performance_md`, `performance/baseline.json` |
| 13 | **Two new SSOT gate rules** so #1 and the cert check-count cannot drift again | `scripts/check-docs-vs-ssot.sh` | see below |

### Item 7 in detail — this one made the docs *less* trustworthy than the code

`docs/federation.md` carried a ⚠️ table asserting that `links[]`, `signals[]` and the entire pull-accept path never consult `allowed_namespaces`, and told operators not to rely on the scope as a tenant boundary. That was true when written and has not been true since #2489/#2480 landed. Verified at this tree: under an enrolled posture (`AI_MEMORY_FED_PEER_ATTESTATION` configured) **every** inbound write lane routes through `federation::receive_auth` — `memories[]`, `links[]` (source AND target stored namespace), `signals[]`, `deletions[]`, `archives[]`, `restores[]`, `action_transitions[]`, `checkpoints[]`, `namespace_meta` — and the catchup pull-accept path goes through `catchup_memory_namespace_authorized` at all three call sites. An unresolvable endpoint namespace is **refused**, not admitted. Zero-config is unchanged, byte-identical faith replication.

The residual limit is restated rather than dropped: federation replicates **plaintext** (#1968), and `CallerContext::for_admin(FEDERATION_CATCHUP)` still bypasses SAL *visibility* so a peer snapshot round-trips — the scope gate runs before it.

### Item 13 in detail — the two new gate rules

Both follow the file's existing "one rule, one scan set" discipline and ship with `--self-test` legs.

1. **`asi-hard KNOBS count`** — the `KnobSpec` entries in `src/security_profile.rs::KNOBS`, pinned against five anchors (`is **N** knobs`, `PINS **N** security env knobs`, `N-knob`, `N-entry pin-and-refuse`, ``all **N** `KNOBS` entries``) across `SECURITY.md`, `README.md`, `docs/deploy/*`, `docs/enterprise-deployment.md`. Every anchor is bold- or hyphen-delimited on purpose: `docs/deploy/README.md` says "the config-backed PE-1 knobs", and a bare `([0-9]+) knobs` anchor captures the `1` out of `PE-1`. A self-test leg proves that specific false positive stays absent.
2. **`ENTERPRISE_FEDERATION_CHECK_COUNT`** — pinned to `enterprise_federation_posture::ENTERPRISE_FEDERATION_CHECK_COUNT` (20) via the cert doc's **normative exit contract** only (`returns **0 iff all N checks pass, else 2**`). Deliberately narrow: the same document carries 18/19-check **evidence notes** describing what the committed `cert-54/*.out` captures actually rendered at the tree they were taken on. Those are true statements about a past capture; a broader anchor would "fix" them into a lie about the cert's own evidence bundle. A self-test leg proves the evidence-note line is spared.

Both fail closed on an unresolvable SSOT **only when a doc actually narrates the count** — no claim to validate means nothing to fail, so the gate's fixture tree stays green. That path has its own self-test leg too.

**Deliberately NOT added: a test-attribute-count rule.** It needs a generator (the number is produced by four `rg` commands, not a Rust const) — filed as a follow-up below.

## Follow-ups (not in this PR)

- **Test-attribute count needs a generator** before it can be gated; it drifts every release and item 3 will go stale again.
- `infra/federation-lab/README.md:248,305` still say "17-knob". Left alone: `:248` is a campaign-run evidence record, and the file is outside every doc scan set. Worth a scoped decision rather than a silent edit.
- `docs/reviews/`, `docs/audit/` and CHANGELOG retain 10/10 and 17-knob text. Correct as history; left frozen.

## Verification

| Gate | Result |
|---|---|
| `scripts/check-docs-vs-ssot.sh` | ✅ PASS (`asi_hard_knobs=21, ef_checks=20`) |
| `scripts/check-docs-vs-ssot.sh --self-test` | ✅ PASS — incl. 3 new legs |
| `scripts/check-doc-symbol-anchors.sh` | ✅ PASS |
| `scripts/check-doc-surface-completeness.sh` | ✅ PASS |
| `scripts/check-capacity-claims.sh` | ✅ PASS |
| `scripts/check-benchmark-claims.sh` | ✅ PASS |
| `scripts/check-hardcoded-literals.sh` | ✅ PASS |
| `scripts/check-ci-job-claims.sh` | ✅ PASS |
| `scripts/check-vendor-literals.sh` | ✅ PASS |
| `scripts/check-cert-expiry.sh` | ✅ PASS |
| `bash -n` on both touched scripts | ✅ PASS |

Negative-tested both new rules by reverting `SECURITY.md` to 17 and the cert doc to 18 — the gate flagged both with the correct file:line and canonical, then went green again on restore.

`scripts/check-const-name-literals.sh` is **red at the base commit** (`tests/conformance_corpus.rs:676`, `tests/signed_events_dlq_replay_1046.rs:109`) — pre-existing, in files this PR does not touch. Confirmed by stashing.

`cargo check` / clippy / `qual_10` / `qual_6_7` were **not** run: no `.rs` file is modified, so module-size and error-type ceilings cannot have moved. `actionlint` is not installed locally; `bench.yml` parses as YAML and the change is a comment block plus one word inside an `echo` string — CI's actionlint job is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY