### PR TITLE
fix(storage,availability): RAII WriteTxn + typed db_op panics (#3163 #3164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,57 @@ backend and missing or divergently implemented on its twin). Pinned by
   from a POOL rather than sharing one behind a mutex, so an unwind cannot hand a
   dirty connection to the next caller.
 
+### Fixed (availability: production-reachable panics — JoinError re-panic, boot-time thread spawn, silent dead audit drainer, checkpoint authz; #3164)
+
+- **`db_op` / `db_read_op` return `Result` instead of re-panicking the request
+  task.** Both helpers ended in `.expect("… spawn_blocking worker panicked or
+  runtime shut down")`, so a panic in any handler closure — or a
+  `spawn_blocking` cancelled during graceful shutdown — propagated into the
+  connection task instead of producing a 500. Panics are now contained, logged
+  with their payload, and surfaced as a typed `DbOpError`. The PERF-1 (#982)
+  and #1580 dispatch fast paths are unchanged: the same `spawn_blocking` hop,
+  the same pooled read-only connection, and `catch_unwind` costs nothing when
+  nothing panics.
+- **The forensic-audit writer thread spawn no longer aborts boot.**
+  `governance::audit::writer()` `.expect()`ed the `thread::Builder::spawn`
+  result on the MAIN thread during `init_forensic_audit`, so a `clone(2)`
+  refusal (`EAGAIN` from a pids-cgroup cap or `RLIMIT_NPROC` on a dense host) —
+  a resource condition, not a programmer bug — killed the process with exit
+  101 before it served a request. It now returns `Result` (ERRORS-01/02) and
+  every caller degrades: the boot path applies its existing "continuing
+  unsigned" policy, `flush_blocking` logs and returns, and emission surfaces a
+  typed error. A failure does not poison the `OnceLock`, so a later call
+  retries the spawn.
+- **A dead deferred-audit drainer is now visible while the daemon is still
+  running.** The supervisor `panic!`ed when a sink exhausted `max_restarts`.
+  That was deliberately fail-loud, but a panic in a `tokio::spawn`ed task kills
+  only THAT task: the daemon kept serving with the audit drainer permanently
+  dead, and nothing observed it until shutdown finally awaited the
+  `JoinHandle`. `spawn_supervised_drainer` now returns
+  `JoinHandle<Result<(), DrainError>>` with a typed `DrainTerminalState`
+  (`sink_unresolved` / `sink_panicked`) published on the shared
+  `DeferredAuditMetrics` and on a new Prometheus gauge
+  `ai_memory_deferred_audit_drainer_terminal_state` (0 = running/graceful,
+  1 = unresolved, 2 = panicked) that a fleet can alert on. Fail-loud semantics
+  are unchanged — the supervisor still refuses to advance past an unresolved
+  occurrence, and `close_and_flush` still refuses to report a clean drain,
+  now with a machine-readable cause (`DrainFlushError`) instead of a panic
+  payload.
+- **`CheckpointResolutionAuthz::Accept` now CARRIES the verifying key
+  (ERRORS-09).** `authorize_remote_checkpoint_resolution` returned a bare
+  `Accept` from three branches, only one of which had authenticated anything:
+  the two permissive (`require_sig == false`) branches returned `Accept` with
+  `enrolled_key == None`. `mcp::tools::checkpoint` turned that into
+  `enrolled.expect("Accept implies an enrolled verifying key")`, sound ONLY
+  because that one call site hardcodes `require_sig = true` — while its HTTP
+  sibling in `handlers::federation_receive` already passes the RUNTIME flag.
+  Wiring the same flag into the MCP tool would have made a remote peer's
+  unsigned resolution panic an MCP tool. The unsound pairing is now
+  unrepresentable: `Accept(VerifyingKey)` for the authenticated verdict, a
+  distinct `AcceptUnverified` for the permissive rollout window. Behaviour at
+  both call sites is byte-identical; the split exists so no caller can mistake
+  a permissive accept for an authenticated one.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,62 @@ backend and missing or divergently implemented on its twin). Pinned by
   - This file: the #3129 "unchanged on the fleet" list and the nine-job
     `rust-cache` enumeration are marked SUPERSEDED by #3141 — the current total
     is **5 self-hosted legs**.
+### Security (data integrity: RAII write transactions — an unwind can no longer strand the shared sqlite writer mid-transaction; #3163)
+
+- **Every explicit `BEGIN IMMEDIATE` in the substrate is now closed by a
+  destructor, not by discipline.** `Cargo.toml` keeps `panic = "unwind"` and
+  there is no `CatchPanicLayer`, so a panic inside a write path unwound past
+  the hand-written `match result { Err(_) => ROLLBACK }` arm at all **34**
+  manual `BEGIN … COMMIT` sites (`rg -n 'WriteTxn::begin' src/` outside
+  `#[cfg(test)]`). Because the daemon's writer is a SINGLE
+  `rusqlite::Connection` behind a `tokio::sync::Mutex` — which, unlike
+  `std::sync::Mutex`, does **not** poison — the unwind released the mutex with
+  the connection still inside an open write transaction and the next caller
+  inherited it. The nested-`BEGIN` outcome is loud and recoverable; the
+  dangerous one is silent: the three `owns_tx = … && conn.is_autocommit()`
+  write funnels (`insert_inner`, `update_with_expected_version`,
+  `insert_if_newer`) see `is_autocommit() == false`, conclude "the caller owns
+  the transaction", skip their own BEGIN/COMMIT, and let their writes JOIN the
+  orphaned transaction — whose durability is then decided by whoever eventually
+  errors or restarts. That is mixed state and unintentional data loss, which
+  the project ranks above every other concern. New
+  `storage::connection::WriteTxn` issues `ROLLBACK` from `Drop`, which runs on
+  an unwind exactly as it runs on an early `?` return, so the worst case after
+  a panic is a ROLLED-BACK transaction on a usable connection. Converted at all
+  34 sites across `storage/mod.rs` (23), `storage/reflect.rs`,
+  `storage/migrations.rs` (`BEGIN EXCLUSIVE`), `storage/connection.rs`,
+  `store/sqlite.rs` (the SAL store's separate shared writer), `quotas.rs` (2),
+  `atomisation/mod.rs`, `federation/push_dlq.rs`,
+  `mcp/tools/store/synthesis.rs`, and `cli/io.rs` (2 — the `mine` importer's
+  chunked `BEGIN`/`COMMIT` loop, via `WriteTxn::begin_deferred`).
+  `mcp/tools/skill_register.rs` and `mcp/tools/skill_retire.rs` already used
+  RAII `rusqlite::Transaction` and are unchanged.
+- **A failed `COMMIT` no longer strands the connection either.** The house
+  pattern propagated a COMMIT failure with `?` and never rolled back, so the
+  writer was left mid-transaction for the next caller to silently join.
+  `WriteTxn::commit` stays ARMED on failure: the drop that follows the `?`
+  rolls the transaction back and the commit error is still returned. Pinned by
+  a deterministic regression test that forces a real COMMIT failure through a
+  DEFERRED foreign-key violation (SQLite reports it at COMMIT time and
+  deliberately leaves the transaction OPEN).
+- **Defense in depth at the mutex boundary.** `handlers::transport::db_op` now
+  runs a `storage::connection::ensure_autocommit` sweep on BOTH sides of the
+  closure and contains the unwind with `catch_unwind`. A connection that is
+  inside a transaction on acquisition, or left inside one on release, is rolled
+  back; if it cannot be rolled back the request is REFUSED rather than writing
+  into an unknown transaction, and the next acquisition retries the sweep — so
+  a transient failure self-heals with no poison flag, no reopen, and no extra
+  state on the `Db` tuple. A closure that returns `Ok` while leaving a
+  transaction open now fails CLOSED (`DbOpError::OrphanedTransaction`) instead
+  of reporting a write that the sweep just erased.
+- **Postgres lane audited, no change required.** Every Postgres transaction goes
+  through `pool.begin()` → `sqlx::Transaction`, whose `Drop` calls
+  `start_rollback` (sqlx-core 0.8.6); the only `BEGIN` literals in
+  `store/postgres.rs` are inside PL/pgSQL `DO $$ BEGIN … END $$` migration
+  blocks, which are not transaction control. Postgres also takes a connection
+  from a POOL rather than sharing one behind a mutex, so an unwind cannot hand a
+  dirty connection to the next caller.
+
 
 ### Changed
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -430,6 +430,7 @@ Series an operator should wire alerts to (canonical registration:
 | `ai_memory_fed_quarantined_unattributed_total` | counter | Inbound relayed memories quarantined by the route-IN provenance gate (`AI_MEMORY_FED_QUARANTINE_UNATTRIBUTED`, #2966). Always zero when the quarantine knob is off (the default); a non-zero rate means a peer is relaying provenance-less content this node is black-holing until dequarantine. Pairs with the `federation.quarantine.unattributed` WARN. |
 | `ai_memory_hnsw_evictions_total`, `ai_memory_hnsw_size` | counter, gauge | Vector-index pressure; see `AI_MEMORY_VECTOR_INDEX_CAPACITY`. |
 | `ai_memory_federation_push_dlq_depth`, `..._quarantined_by_cause_total{cause}` | gauge, counter | Federation push-DLQ backlog and its cause breakdown. |
+| `ai_memory_deferred_audit_drainer_terminal_state` | gauge | Terminal state of the deferred-audit drainer supervisor: `0` = running/graceful, `1` = sink unresolved past `max_restarts`, `2` = sink panicked past `max_restarts` (#3164). **Page on any non-zero value** — the daemon keeps serving requests, but governance refusals are no longer reaching `signed_events` on that node, so it is audit-degraded until restarted. |
 
 This table is the operationally load-bearing subset, not the full
 registry — scrape the endpoint for the complete list.

--- a/src/atomisation/mod.rs
+++ b/src/atomisation/mod.rs
@@ -882,7 +882,7 @@ fn archive_source(
     atom_count: i64,
     archived_at: &str,
 ) -> anyhow::Result<()> {
-    conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = crate::storage::connection::WriteTxn::begin(conn)?;
     let result = (|| -> anyhow::Result<()> {
         // Merge the existing metadata with the new
         // `atomisation_archived_at` key — never clobber other keys.
@@ -912,11 +912,11 @@ fn archive_source(
     })();
     match result {
         Ok(()) => {
-            conn.execute_batch(crate::storage::connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(())
         }
         Err(e) => {
-            let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }

--- a/src/cli/io.rs
+++ b/src/cli/io.rs
@@ -1023,7 +1023,10 @@ pub fn mine(
     let mut skipped = 0usize;
     let mut errors = 0usize;
 
-    conn.execute_batch("BEGIN")?;
+    // #3163 — RAII: an early `?` return (or a panic) inside the import loop
+    // below now rolls the in-flight chunk back instead of leaving an open
+    // transaction on the connection.
+    let mut write_txn = crate::storage::connection::WriteTxn::begin_deferred(&conn)?;
 
     for conv in &filtered {
         let Some(mined) = mine::conversation_to_memory(conv, format) else {
@@ -1104,12 +1107,14 @@ pub fn mine(
         }
 
         if imported.is_multiple_of(100) && imported > 0 {
-            conn.execute_batch(crate::storage::connection::SQL_COMMIT)?;
-            conn.execute_batch("BEGIN")?;
+            // Close the chunk and open the next one. `commit` consumes the
+            // guard, so the reassignment is what keeps the loop guarded.
+            write_txn.commit()?;
+            write_txn = crate::storage::connection::WriteTxn::begin_deferred(&conn)?;
         }
     }
 
-    conn.execute_batch(crate::storage::connection::SQL_COMMIT)?;
+    write_txn.commit()?;
 
     if json_out {
         writeln!(

--- a/src/federation/push_dlq.rs
+++ b/src/federation/push_dlq.rs
@@ -1343,7 +1343,7 @@ impl FederationDlqSink for SqliteDlqSink {
         // BEGIN IMMEDIATE (not DEFERRED): the body both reads and writes,
         // and a deferred read-then-upgrade is the classic SQLITE_BUSY
         // deadlock shape against the HTTP writer on the same file.
-        conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
+        let write_txn = crate::storage::connection::WriteTxn::begin(&conn)
             .map_err(|e| format!("sqlite expand_erasure_sentinel begin: {e}"))?;
         let outcome = (|| -> rusqlite::Result<SentinelExpansion> {
             // Optimistic-concurrency guard, same token as
@@ -1425,12 +1425,13 @@ impl FederationDlqSink for SqliteDlqSink {
         })();
         match outcome {
             Ok(v) => {
-                conn.execute_batch("COMMIT")
+                write_txn
+                    .commit()
                     .map_err(|e| format!("sqlite expand_erasure_sentinel commit: {e}"))?;
                 Ok(v)
             }
             Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
+                write_txn.rollback();
                 Err(format!("sqlite expand_erasure_sentinel: {e}"))
             }
         }

--- a/src/federation/receive_auth.rs
+++ b/src/federation/receive_auth.rs
@@ -106,8 +106,28 @@ pub fn authorize_remote_transition(
 /// a hard error that drops the rest of the push.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckpointResolutionAuthz {
-    /// Authenticated (or permissively accepted) — apply the resolution.
-    Accept,
+    /// **Authenticated** — the resolution's Ed25519 signature verified against
+    /// the resolver's locally-ENROLLED key, which is carried here.
+    ///
+    /// v1.0.0 #3164 (ERRORS-09, make illegal states unrepresentable): the key
+    /// is a payload of the variant rather than something the caller re-derives
+    /// from a separate `Option<&VerifyingKey>`. Before this, `Accept` was also
+    /// returned by the two PERMISSIVE branches below with `enrolled_key ==
+    /// None`, so "Accept implies an enrolled key" was true only for callers
+    /// that hardcoded `require_sig = true` — and one such caller
+    /// (`mcp::tools::checkpoint`) turned that assumption into an
+    /// `.expect(…)`. Wiring the runtime flag into that call site would have
+    /// made a REMOTE peer able to panic an MCP tool. Splitting the variant
+    /// makes the unsound pairing impossible to construct.
+    Accept(VerifyingKey),
+    /// **Permissively accepted with NO verified signature** — `require_sig`
+    /// is off (an operator opt-in for a heterogeneous-rollout window) and the
+    /// resolution was either unsigned or attributed to a resolver with no
+    /// locally-enrolled key. The resolution is applied, but NOTHING about the
+    /// resolver's identity has been authenticated, so a caller that needs a
+    /// verified attestation (rather than merely "may apply") MUST treat this
+    /// as a non-attested outcome.
+    AcceptUnverified,
     /// Unsigned resolution while signatures are required (fail-closed default).
     RejectUnsigned,
     /// Signed, but the attested resolver has no enrolled public key locally.
@@ -131,10 +151,13 @@ pub enum CheckpointResolutionAuthz {
 /// verdict:
 ///
 /// 1. **Unsigned →** fail-closed ([`CheckpointResolutionAuthz::RejectUnsigned`])
-///    under `require_sig`, else [`CheckpointResolutionAuthz::Accept`] (operator
-///    opt-out for a heterogeneous-rollout window).
+///    under `require_sig`, else [`CheckpointResolutionAuthz::AcceptUnverified`]
+///    (operator opt-out for a heterogeneous-rollout window — applied, but NOT
+///    authenticated).
 /// 2. **Signed →** the resolver MUST have an enrolled key and the signature MUST
-///    verify against *that* key. A present-but-invalid signature is
+///    verify against *that* key. Only that path yields
+///    [`CheckpointResolutionAuthz::Accept`], which carries the verifying key.
+///    A present-but-invalid signature is
 ///    [`CheckpointResolutionAuthz::RejectForged`] **unconditionally** (even under
 ///    permissive `require_sig == false`).
 #[must_use]
@@ -148,18 +171,20 @@ pub fn authorize_remote_checkpoint_resolution(
         return if require_sig {
             CheckpointResolutionAuthz::RejectUnsigned
         } else {
-            CheckpointResolutionAuthz::Accept
+            CheckpointResolutionAuthz::AcceptUnverified
         };
     }
     let Some(key) = enrolled_key else {
         return if require_sig {
             CheckpointResolutionAuthz::RejectNotEnrolled
         } else {
-            CheckpointResolutionAuthz::Accept
+            CheckpointResolutionAuthz::AcceptUnverified
         };
     };
     if verify_checkpoint_resolution(signable, signature, key.as_bytes()) {
-        CheckpointResolutionAuthz::Accept
+        // #3164 — the verifying key travels WITH the verdict, so no call site
+        // can pair an `Accept` with a missing key.
+        CheckpointResolutionAuthz::Accept(*key)
     } else {
         CheckpointResolutionAuthz::RejectForged
     }
@@ -2198,7 +2223,7 @@ mod tests {
         let sig = sign::sign_checkpoint_resolution(&kp, &r).unwrap();
         assert_eq!(
             authorize_remote_checkpoint_resolution(&r, &sig, Some(&kp.public), true),
-            CheckpointResolutionAuthz::Accept
+            CheckpointResolutionAuthz::Accept(kp.public)
         );
     }
 
@@ -2211,7 +2236,7 @@ mod tests {
         );
         assert_eq!(
             authorize_remote_checkpoint_resolution(&r, &[], None, false),
-            CheckpointResolutionAuthz::Accept
+            CheckpointResolutionAuthz::AcceptUnverified
         );
     }
 
@@ -2226,8 +2251,43 @@ mod tests {
         );
         assert_eq!(
             authorize_remote_checkpoint_resolution(&r, &sig, None, false),
-            CheckpointResolutionAuthz::Accept
+            CheckpointResolutionAuthz::AcceptUnverified
         );
+    }
+
+    /// v1.0.0 #3164 (ERRORS-09) — `Accept` CARRIES the key that verified the
+    /// resolution, and the permissive branches can no longer produce it. The
+    /// old shape returned a bare `Accept` from three different branches, only
+    /// one of which had actually authenticated anything — which is what made
+    /// `mcp::tools::checkpoint`'s `.expect("Accept implies an enrolled
+    /// verifying key")` one config flag away from a remote-triggerable panic.
+    #[test]
+    fn checkpoint_accept_carries_the_verifying_key_and_permissive_cannot_produce_it_3164() {
+        let kp = kp_mod::generate("alice").unwrap();
+        let r = cp_fixture("approved");
+        let sig = sign::sign_checkpoint_resolution(&kp, &r).unwrap();
+
+        match authorize_remote_checkpoint_resolution(&r, &sig, Some(&kp.public), true) {
+            CheckpointResolutionAuthz::Accept(verified) => assert_eq!(
+                verified, kp.public,
+                "Accept must carry the ENROLLED key the signature verified against"
+            ),
+            other => panic!("expected an authenticated Accept, got {other:?}"),
+        }
+
+        // Both permissive branches: applied, but NOT authenticated. Neither can
+        // be pattern-matched as `Accept(_)`, so no caller can extract a key
+        // that was never verified.
+        for verdict in [
+            authorize_remote_checkpoint_resolution(&r, &[], None, false),
+            authorize_remote_checkpoint_resolution(&r, &sig, None, false),
+        ] {
+            assert_eq!(verdict, CheckpointResolutionAuthz::AcceptUnverified);
+            assert!(
+                !matches!(verdict, CheckpointResolutionAuthz::Accept(_)),
+                "#3164: an unauthenticated permissive accept must be unrepresentable as Accept"
+            );
+        }
     }
 
     #[test]

--- a/src/governance/audit.rs
+++ b/src/governance/audit.rs
@@ -155,15 +155,34 @@ static WRITER: OnceLock<Sender<WriteOp>> = OnceLock::new();
 /// Lazily spawn (once per process) the background writer and return its
 /// FIFO sender. Subsequent `init`/`shutdown` cycles reuse the same
 /// thread, so repeated test setup never leaks threads.
-fn writer() -> &'static Sender<WriteOp> {
-    WRITER.get_or_init(|| {
-        let (tx, rx) = std::sync::mpsc::channel::<WriteOp>();
-        std::thread::Builder::new()
-            .name(WRITER_THREAD_NAME.to_string())
-            .spawn(move || run_writer(rx))
-            .expect("spawning the forensic audit writer thread");
-        tx
-    })
+///
+/// v1.0.0 #3164 — this used to `.expect()` on the spawn. It runs on the MAIN
+/// thread during boot (`main::init_forensic_audit` → [`init`]), so a
+/// `clone(2)` refusal — `EAGAIN` from a pids-cgroup cap or `RLIMIT_NPROC` on
+/// a dense host, which is a RESOURCE condition and not a programmer bug —
+/// aborted the whole process with exit 101 before it ever served a request.
+/// Returning `Result` (ERRORS-01/ERRORS-02) lets the boot path apply its
+/// existing degraded-audit policy instead of dying, and lets every emission
+/// site surface a typed error rather than inherit a panic.
+///
+/// # Errors
+///
+/// Returns the OS error when the writer thread cannot be spawned. The
+/// `OnceLock` is NOT poisoned by a failure: a later call retries the spawn,
+/// so a transient resource exhaustion self-heals.
+fn writer() -> anyhow::Result<&'static Sender<WriteOp>> {
+    if let Some(tx) = WRITER.get() {
+        return Ok(tx);
+    }
+    let (tx, rx) = std::sync::mpsc::channel::<WriteOp>();
+    std::thread::Builder::new()
+        .name(WRITER_THREAD_NAME.to_string())
+        .spawn(move || run_writer(rx))
+        .with_context(|| format!("spawning the {WRITER_THREAD_NAME} thread"))?;
+    // A concurrent first-caller may have won the race. `get_or_init` then
+    // drops OUR sender, whose receiver-side loop ends on the next `recv()`
+    // and the freshly-spawned thread exits — no leak, no double writer.
+    Ok(WRITER.get_or_init(|| tx))
 }
 
 /// Drain loop for the background writer. Keeps the destination file open
@@ -237,8 +256,19 @@ fn run_writer(rx: Receiver<WriteOp>) {
 /// been spawned (it will be spawned, drain nothing, and return).
 pub fn flush_blocking() {
     let (ack, done) = std::sync::mpsc::channel();
-    if writer().send(WriteOp::Barrier(ack)).is_ok() {
-        let _ = done.recv();
+    // #3164 — a writer that could not be spawned has nothing to drain, so a
+    // failure here is equivalent to an empty queue: log it and return rather
+    // than block forever or abort the caller.
+    match writer() {
+        Ok(w) => {
+            if w.send(WriteOp::Barrier(ack)).is_ok() {
+                let _ = done.recv();
+            }
+        }
+        Err(e) => tracing::error!(
+            target: AUDIT_TRACE_TARGET,
+            "forensic: flush skipped, writer unavailable: {e:#}"
+        ),
     }
 }
 
@@ -247,7 +277,9 @@ pub fn flush_blocking() {
 /// open/append branches (including the error arm) with arbitrary paths.
 #[cfg(test)]
 pub(crate) fn enqueue_append_for_test(path: PathBuf, line: String) {
-    let _ = writer().send(WriteOp::Append { path, line });
+    if let Ok(w) = writer() {
+        let _ = w.send(WriteOp::Append { path, line });
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -367,7 +399,10 @@ pub fn init(dir: &Path, signing_key: Option<SigningKey>) -> Result<()> {
     // before any row for the freshly-initialised sink is enqueued —
     // without this, a re-init over a removed/rotated same-named file
     // would keep writing to the unlinked inode.
-    let _ = writer().send(WriteOp::Reset);
+    // #3164 — a spawn failure surfaces as an `init` error (the boot path
+    // already downgrades to "continuing unsigned" rather than aborting);
+    // it no longer kills the process from the main thread.
+    let _ = writer()?.send(WriteOp::Reset);
     *guard = Some(new_sink);
     Ok(())
 }
@@ -442,7 +477,7 @@ pub fn try_record_decision(
     // request thread, removing per-write file I/O from this serialized
     // critical section (#1472).
     s.last_hash = self_hash;
-    writer()
+    writer()?
         .send(WriteOp::Append {
             path: file_path,
             line,
@@ -3284,6 +3319,45 @@ pub fn apply_rollback_disposition_at_open(
 pub(crate) fn forensic_sink_test_lock() -> &'static std::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
+mod writer_spawn_tests_3164 {
+    use super::*;
+
+    /// v1.0.0 #3164 — the forensic-audit writer spawn is FALLIBLE, not a
+    /// boot-time `.expect()`.
+    ///
+    /// The panic this replaced ran on the MAIN thread during
+    /// `main::init_forensic_audit`, so a `clone(2)` refusal (`EAGAIN` from a
+    /// pids-cgroup cap or `RLIMIT_NPROC` on a dense host) aborted the whole
+    /// process with exit 101 before it served a request. A resource condition
+    /// must be a `Result` (ERRORS-01), and the boot path's existing
+    /// "continuing unsigned" policy then decides.
+    ///
+    /// LIMITATION, stated honestly: forcing a real `clone(2)` EAGAIN inside a
+    /// test process is not portable, so this pins the CONTRACT — the fallible
+    /// signature, the idempotent spawn, and the fact that every caller now
+    /// degrades instead of unwinding — rather than the exhausted-host branch
+    /// itself.
+    #[test]
+    fn writer_is_fallible_and_idempotent() {
+        let first: Result<&'static Sender<WriteOp>> = writer();
+        let first = first.expect("writer spawn must succeed on a healthy host");
+        let second = writer().expect("second call must reuse the same writer");
+        assert!(
+            std::ptr::eq(first, second),
+            "#3164: the OnceLock must hand back ONE sender, never re-spawn"
+        );
+    }
+
+    /// Every `writer()` caller must degrade rather than unwind. `flush_blocking`
+    /// is the one that used to inherit the panic on a spawn failure; it is now
+    /// a no-op-on-failure path and is safe to call before any `init`.
+    #[test]
+    fn flush_blocking_never_panics_without_an_initialised_sink() {
+        flush_blocking();
+    }
 }
 
 #[cfg(test)]

--- a/src/governance/deferred_audit.rs
+++ b/src/governance/deferred_audit.rs
@@ -77,7 +77,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 
@@ -300,6 +300,169 @@ impl DeferredAuditEvent {
     }
 }
 
+/// v1.0.0 #3164 — the TERMINAL state of a deferred-audit drainer supervisor.
+///
+/// The supervisor used to `panic!` when a sink exhausted `max_restarts`. That
+/// was deliberately fail-loud, but a panic in a `tokio::spawn`ed task kills
+/// only THAT task: the daemon kept serving with the audit drainer permanently
+/// dead, and nothing observed it until shutdown awaited the `JoinHandle`. The
+/// state is now typed, returned from the supervisor, published on the shared
+/// metrics the instant it is entered, and reported by `ai-memory doctor` —
+/// so a fleet can SEE a dead drainer while the process is still running.
+///
+/// Fail-loud semantics are unchanged: the supervisor still stops rather than
+/// advancing past an unresolved occurrence, and [`close_and_flush`] still
+/// refuses to report a clean drain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DrainTerminalState {
+    /// The sink kept returning `Err` and exhausted the restart budget.
+    SinkUnresolved,
+    /// The sink kept PANICKING and exhausted the restart budget.
+    SinkPanicked,
+}
+
+impl DrainTerminalState {
+    /// Numeric code published on the shared metrics. `0` is reserved for
+    /// "running / never terminally failed".
+    const CODE_RUNNING: u8 = 0;
+    const CODE_SINK_UNRESOLVED: u8 = 1;
+    const CODE_SINK_PANICKED: u8 = 2;
+
+    /// The metric code for this state.
+    #[must_use]
+    pub fn code(self) -> u8 {
+        match self {
+            Self::SinkUnresolved => Self::CODE_SINK_UNRESOLVED,
+            Self::SinkPanicked => Self::CODE_SINK_PANICKED,
+        }
+    }
+
+    /// Decode a metric code. `None` means the drainer has not terminally
+    /// failed.
+    #[must_use]
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            Self::CODE_SINK_UNRESOLVED => Some(Self::SinkUnresolved),
+            Self::CODE_SINK_PANICKED => Some(Self::SinkPanicked),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase tag for logs, metrics labels, and the `doctor` fact.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SinkUnresolved => "sink_unresolved",
+            Self::SinkPanicked => "sink_panicked",
+        }
+    }
+}
+
+/// v1.0.0 #3164 — the typed terminal failure of a deferred-audit drainer.
+///
+/// Replaces the two `panic!` sites in the supervisor. Carrying the cause as a
+/// value (rather than a panic payload that only `JoinError::is_panic` could
+/// observe) is what lets the shutdown path distinguish "the drainer stopped
+/// because the sink is unresolvable" from "the supervisor task itself was
+/// cancelled or aborted".
+#[derive(Debug)]
+pub enum DrainError {
+    /// The sink remained unresolved across the whole restart budget. The
+    /// in-flight occurrence was NOT advanced past.
+    SinkUnresolved {
+        /// The exhausted restart budget.
+        max_restarts: u32,
+        /// Rendered cause of the final failed append.
+        detail: String,
+    },
+    /// The sink panicked on every attempt across the whole restart budget.
+    /// The in-flight event is unflushed; journal recovery is available only
+    /// when journaling was successfully enabled.
+    SinkPanicked {
+        /// The exhausted restart budget.
+        max_restarts: u32,
+    },
+}
+
+impl DrainError {
+    /// The terminal state this error represents.
+    #[must_use]
+    pub fn terminal_state(&self) -> DrainTerminalState {
+        match self {
+            Self::SinkUnresolved { .. } => DrainTerminalState::SinkUnresolved,
+            Self::SinkPanicked { .. } => DrainTerminalState::SinkPanicked,
+        }
+    }
+}
+
+impl std::fmt::Display for DrainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SinkUnresolved {
+                max_restarts,
+                detail,
+            } => write!(
+                f,
+                "deferred_audit supervisor: sink remained unresolved and exhausted \
+                 max_restarts={max_restarts}; refusing to advance beyond the in-flight \
+                 occurrence: {detail}"
+            ),
+            Self::SinkPanicked { max_restarts } => write!(
+                f,
+                "deferred_audit supervisor: sink panicked and exhausted \
+                 max_restarts={max_restarts}; drain is incomplete and the in-flight event \
+                 is unflushed (journal recovery is available only when journaling was \
+                 successfully enabled)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DrainError {}
+
+/// v1.0.0 #3164 — the outcome of awaiting a deferred-audit supervisor.
+///
+/// `close_and_flush` used to return only `tokio::task::JoinError`, which
+/// conflated "the supervisor panicked" with "the drainer gave up for a stated
+/// reason". Both are still hard failures; they are now distinguishable.
+#[derive(Debug)]
+pub enum DrainFlushError {
+    /// The supervisor task itself failed to join (panicked or was aborted).
+    Join(tokio::task::JoinError),
+    /// The supervisor exited with a typed terminal state.
+    Drain(DrainError),
+}
+
+impl std::fmt::Display for DrainFlushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Join(e) => write!(f, "deferred-audit supervisor join failed: {e}"),
+            Self::Drain(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DrainFlushError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Join(e) => Some(e),
+            Self::Drain(e) => Some(e),
+        }
+    }
+}
+
+impl From<tokio::task::JoinError> for DrainFlushError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        Self::Join(e)
+    }
+}
+
+impl From<DrainError> for DrainFlushError {
+    fn from(e: DrainError) -> Self {
+        Self::Drain(e)
+    }
+}
+
 /// Shared counters surfaced for observability. Cloning is cheap
 /// (just `Arc` bumps); the public read path is on the queue handle.
 #[derive(Debug, Clone, Default)]
@@ -341,9 +504,52 @@ pub struct DeferredAuditMetrics {
     /// burst of refusals while the substrate writer is also churning
     /// out `memory_link.created` rows).
     pub unique_race_retries: Arc<AtomicU64>,
+    /// v1.0.0 #3164 — the drainer supervisor's TERMINAL state, as a
+    /// [`DrainTerminalState::code`] (`0` = running / never terminally failed).
+    ///
+    /// Published the instant the supervisor gives up, so the condition is
+    /// observable while the daemon is still serving instead of only when the
+    /// shutdown path finally awaits the `JoinHandle`. Read it through
+    /// [`DeferredAuditMetrics::terminal_state`].
+    pub terminal_state: Arc<AtomicU8>,
 }
 
 impl DeferredAuditMetrics {
+    /// v1.0.0 #3164 — the drainer supervisor's terminal state, or `None` while
+    /// it is running (or exited gracefully on a closed, fully-drained queue).
+    ///
+    /// A `Some(_)` here means audit delivery is DEAD for this process: the
+    /// daemon may still be serving, but no further refusal will reach
+    /// `signed_events`. Fleet operators alert on this.
+    #[must_use]
+    pub fn terminal_state(&self) -> Option<DrainTerminalState> {
+        DrainTerminalState::from_code(self.terminal_state.load(Ordering::Relaxed))
+    }
+
+    /// Record the supervisor's terminal state. First writer wins, so the
+    /// ORIGINAL cause survives a later observation.
+    ///
+    /// Also publishes the state on the Prometheus registry
+    /// (`ai_memory_deferred_audit_drainer_terminal_state`), which is the
+    /// surface a fleet alerts on: a daemon whose audit drainer is dead keeps
+    /// serving requests, so the condition is invisible without it.
+    fn record_terminal_state(&self, state: DrainTerminalState) {
+        if self
+            .terminal_state
+            .compare_exchange(
+                DrainTerminalState::CODE_RUNNING,
+                state.code(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            crate::metrics::registry()
+                .deferred_audit_drainer_terminal_state
+                .set(i64::from(state.code()));
+        }
+    }
+
     /// Number of events submitted since process boot.
     #[must_use]
     pub fn submitted_count(&self) -> u64 {
@@ -2511,21 +2717,29 @@ pub fn spawn_drainer_task<S: DeferredAuditSink + 'static>(
 ///   - The channel sender is dropped and the channel is fully
 ///     drained (graceful shutdown).
 ///   - A sink exhausts `max_restarts` while retrying one in-flight event, in
-///     which case the supervisor panics so [`close_and_flush`] returns a
-///     `JoinError` instead of falsely reporting a complete drain.
+///     which case the supervisor returns a typed [`DrainError`] so
+///     [`close_and_flush`] fails instead of falsely reporting a complete
+///     drain — and, unlike the `panic!` this replaced (v1.0.0 #3164), the
+///     terminal state is published on [`DeferredAuditMetrics::terminal_state`]
+///     and the `ai_memory_deferred_audit_drainer_terminal_state` gauge the
+///     INSTANT it happens, so a dead drainer is visible while the daemon is
+///     still serving.
 ///
 /// Panic retries use capped exponential backoff. This gives Tokio a
 /// suspension point even under a persistently panicking sink and prevents a
 /// tight panic-hook/log-amplification loop from monopolizing a runtime worker.
 ///
-/// The returned `JoinHandle` resolves when the supervisor exits.
+/// The returned `JoinHandle` resolves when the supervisor exits, carrying
+/// `Ok(())` for a graceful drain and a typed [`DrainError`] for a terminal
+/// give-up (v1.0.0 #3164 — this used to be a `panic!`, which killed only the
+/// supervisor task and left the daemon serving with a silently dead drainer).
 #[must_use]
 pub fn spawn_supervised_drainer<F, S>(
     receiver: UnboundedReceiver<DeferredAuditEvent>,
     make_sink: F,
     metrics: DeferredAuditMetrics,
     max_restarts: u32,
-) -> JoinHandle<()>
+) -> JoinHandle<std::result::Result<(), DrainError>>
 where
     F: Fn() -> S + Send + 'static,
     S: DeferredAuditSink + 'static,
@@ -2539,7 +2753,7 @@ fn spawn_supervised_drainer_inner<F, S>(
     metrics: DeferredAuditMetrics,
     max_restarts: u32,
     mut shutdown: Option<oneshot::Receiver<()>>,
-) -> JoinHandle<()>
+) -> JoinHandle<std::result::Result<(), DrainError>>
 where
     F: Fn() -> S + Send + 'static,
     S: DeferredAuditSink + 'static,
@@ -2594,11 +2808,19 @@ where
                     Ok(Err(e)) => {
                         metrics.append_failures.fetch_add(1, Ordering::Relaxed);
                         if consecutive_restarts == max_restarts {
-                            panic!(
-                                "deferred_audit supervisor: sink remained unresolved and \
-                                 exhausted max_restarts={max_restarts}; refusing to advance \
-                                 beyond the in-flight occurrence: {e:#}"
+                            // #3164 — fail-loud, but as a TYPED terminal state
+                            // instead of a panic that only this task observes.
+                            let err = DrainError::SinkUnresolved {
+                                max_restarts,
+                                detail: format!("{e:#}"),
+                            };
+                            metrics.record_terminal_state(err.terminal_state());
+                            tracing::error!(
+                                terminal_state = err.terminal_state().as_str(),
+                                max_restarts,
+                                "{err}"
                             );
+                            return Err(err);
                         }
                         consecutive_restarts += 1;
                         is_retry = true;
@@ -2615,12 +2837,14 @@ where
                         metrics.drainer_panics.fetch_add(1, Ordering::Relaxed);
                         if consecutive_restarts == max_restarts {
                             metrics.append_failures.fetch_add(1, Ordering::Relaxed);
-                            panic!(
-                                "deferred_audit supervisor: sink panicked and exhausted \
-                                 max_restarts={max_restarts}; drain is incomplete and the \
-                                 in-flight event is unflushed (journal recovery is available \
-                                 only when journaling was successfully enabled)"
+                            let err = DrainError::SinkPanicked { max_restarts };
+                            metrics.record_terminal_state(err.terminal_state());
+                            tracing::error!(
+                                terminal_state = err.terminal_state().as_str(),
+                                max_restarts,
+                                "{err}"
                             );
+                            return Err(err);
                         }
 
                         consecutive_restarts += 1;
@@ -2637,6 +2861,8 @@ where
                 }
             }
         }
+        // Sender dropped + channel drained → graceful shutdown.
+        Ok(())
     })
 }
 
@@ -2645,7 +2871,7 @@ where
 /// not prevent the already-admitted channel prefix from draining to `None`.
 pub(crate) struct DeferredAuditShutdown {
     close: Option<oneshot::Sender<()>>,
-    supervisor: JoinHandle<()>,
+    supervisor: JoinHandle<std::result::Result<(), DrainError>>,
 }
 
 impl DeferredAuditShutdown {
@@ -2655,12 +2881,16 @@ impl DeferredAuditShutdown {
     pub(crate) async fn close_and_flush(
         mut self,
         timeout: std::time::Duration,
-    ) -> std::result::Result<bool, tokio::task::JoinError> {
+    ) -> std::result::Result<bool, DrainFlushError> {
         if let Some(close) = self.close.take() {
             let _ = close.send(());
         }
         match tokio::time::timeout(timeout, &mut self.supervisor).await {
-            Ok(result) => result.map(|()| true),
+            // #3164 — a typed terminal give-up is now distinguishable from a
+            // supervisor join failure; both remain hard, fail-loud errors.
+            Ok(Ok(Ok(()))) => Ok(true),
+            Ok(Ok(Err(drain))) => Err(DrainFlushError::Drain(drain)),
+            Ok(Err(join)) => Err(DrainFlushError::Join(join)),
             Err(_) => {
                 self.supervisor.abort();
                 // Do not await after abort: a synchronous SQLite/fsync/lock
@@ -2687,18 +2917,21 @@ fn panic_retry_backoff(restart: u32) -> std::time::Duration {
 ///
 /// # Errors
 ///
-/// Returns the `tokio::task::JoinError` if the supervisor itself panics or if
-/// the sink exhausts its configured panic-restart budget. An `Ok(())` result
-/// therefore continues to mean that the queue drained completely.
+/// Returns [`DrainFlushError::Join`] if the supervisor task itself fails to
+/// join, and [`DrainFlushError::Drain`] if the sink exhausted its configured
+/// restart budget (v1.0.0 #3164 — previously this arrived as a `JoinError`
+/// wrapping a panic, which carried no machine-readable cause). An `Ok(())`
+/// result therefore continues to mean that the queue drained completely.
 pub async fn close_and_flush(
     queue: DeferredAuditQueue,
-    supervisor: JoinHandle<()>,
-) -> std::result::Result<(), tokio::task::JoinError> {
+    supervisor: JoinHandle<std::result::Result<(), DrainError>>,
+) -> std::result::Result<(), DrainFlushError> {
     // Drop the producer-side sender — once every clone is dropped,
     // the receiver's `recv().await` returns None and the drainer
     // exits gracefully.
     drop(queue);
-    supervisor.await
+    supervisor.await??;
+    Ok(())
 }
 
 /// Default daemon shutdown deadline for background-writer quiescence and
@@ -2782,7 +3015,12 @@ fn drain_accounted(metrics: &DeferredAuditMetrics) -> u64 {
 /// the sink is rebuilt verbatim. No connection is shared with the
 /// substrate writer.
 #[must_use]
-pub fn install_deferred_audit_drainer(db_path: &Path) -> (DeferredAuditQueue, JoinHandle<()>) {
+pub fn install_deferred_audit_drainer(
+    db_path: &Path,
+) -> (
+    DeferredAuditQueue,
+    JoinHandle<std::result::Result<(), DrainError>>,
+) {
     let (queue, receiver) = DeferredAuditQueue::new();
     let metrics = queue.metrics();
     let db_path_buf = db_path.to_path_buf();
@@ -2826,7 +3064,10 @@ pub fn deferred_audit_journal_path(db_path: &Path) -> PathBuf {
 #[must_use]
 pub fn install_deferred_audit_drainer_with_journal(
     db_path: &Path,
-) -> (DeferredAuditQueue, JoinHandle<()>) {
+) -> (
+    DeferredAuditQueue,
+    JoinHandle<std::result::Result<(), DrainError>>,
+) {
     let journal_path = deferred_audit_journal_path(db_path);
     // Boot recovery FIRST (replay-all-then-go-live): chain any pre-crash
     // refusals into signed_events before the live queue/hooks exist.
@@ -2837,7 +3078,7 @@ pub fn install_deferred_audit_drainer_with_journal(
         );
         let (queue, receiver) = DeferredAuditQueue::new();
         drop(receiver);
-        return (queue, tokio::spawn(async {}));
+        return (queue, tokio::spawn(async { Ok(()) }));
     }
     let journal = match DeferredAuditJournal::open(&journal_path) {
         Ok(j) => Arc::new(j),
@@ -2848,7 +3089,7 @@ pub fn install_deferred_audit_drainer_with_journal(
             );
             let (queue, receiver) = DeferredAuditQueue::new();
             drop(receiver);
-            return (queue, tokio::spawn(async {}));
+            return (queue, tokio::spawn(async { Ok(()) }));
         }
     };
     let (queue, receiver) = DeferredAuditQueue::new_with_journal(Some(journal));
@@ -2890,7 +3131,7 @@ pub(crate) fn install_deferred_audit_drainer_with_shutdown(
             queue,
             DeferredAuditShutdown {
                 close: None,
-                supervisor: tokio::spawn(async {}),
+                supervisor: tokio::spawn(async { Ok(()) }),
             },
         );
     }
@@ -2907,7 +3148,7 @@ pub(crate) fn install_deferred_audit_drainer_with_shutdown(
                 queue,
                 DeferredAuditShutdown {
                     close: None,
-                    supervisor: tokio::spawn(async {}),
+                    supervisor: tokio::spawn(async { Ok(()) }),
                 },
             );
         }
@@ -3328,7 +3569,10 @@ mod tests {
             );
         }
         drop(queue);
-        supervisor.await.unwrap();
+        supervisor
+            .await
+            .expect("supervisor join")
+            .expect("#3164: a drained queue must exit with Ok, not a terminal state");
 
         let agents: Vec<_> = recorded
             .lock()
@@ -3365,8 +3609,18 @@ mod tests {
         drop(queue);
         let error = supervisor
             .await
+            .expect("supervisor join")
             .expect_err("retry exhaustion must terminate visibly");
-        assert!(error.is_panic());
+        // #3164 — visible as a TYPED terminal state rather than a panic that
+        // only this task could observe.
+        assert!(
+            matches!(error, DrainError::SinkUnresolved { .. }),
+            "{error:?}"
+        );
+        assert_eq!(
+            metrics.terminal_state(),
+            Some(DrainTerminalState::SinkUnresolved)
+        );
         assert_eq!(attempts.lock().unwrap().as_slice(), ["agent:blocked"; 4]);
         assert_eq!(metrics.append_failure_count(), 4);
         assert_eq!(metrics.appended_count(), 0);
@@ -3474,7 +3728,18 @@ mod tests {
         let err = close_and_flush(queue, supervisor)
             .await
             .expect_err("restart exhaustion must not report a complete drain");
-        assert!(err.is_panic());
+        // #3164 — a TYPED terminal state, not an opaque panic payload.
+        match err {
+            DrainFlushError::Drain(DrainError::SinkPanicked { max_restarts }) => {
+                assert_eq!(max_restarts, 0);
+            }
+            other => panic!("expected a typed SinkPanicked terminal state, got {other:?}"),
+        }
+        assert_eq!(
+            metrics.terminal_state(),
+            Some(DrainTerminalState::SinkPanicked),
+            "#3164: the terminal state must be observable on the shared metrics"
+        );
         assert_eq!(metrics.panic_count(), 1);
         assert_eq!(metrics.append_failure_count(), 1);
         assert_eq!(metrics.appended_count(), 0);
@@ -3770,7 +4035,17 @@ mod tests {
         assert_eq!(metrics.append_failure_count(), 1);
         drop(hook_held);
         drop(queue);
-        assert!(supervisor.await.unwrap_err().is_panic());
+        // #3164 — exhaustion is a TYPED terminal state now, not a panic; the
+        // fail-loud property (the supervisor stops, visibly) is unchanged.
+        let terminal = supervisor
+            .await
+            .expect("supervisor join")
+            .expect_err("an unresolved occurrence must terminate the supervisor");
+        assert!(matches!(terminal, DrainError::SinkUnresolved { .. }));
+        assert_eq!(
+            metrics.terminal_state(),
+            Some(DrainTerminalState::SinkUnresolved)
+        );
     }
 
     #[tokio::test]
@@ -4383,7 +4658,10 @@ mod tests {
             install_deferred_audit_drainer_with_journal(&blocker.join("db.sqlite"));
         assert!(!queue.is_open());
         assert!(!queue.submit_refusal("agent:closed", &refusal_action(), &refusal_decision()));
-        supervisor.await.unwrap();
+        supervisor
+            .await
+            .expect("supervisor join")
+            .expect("#3164: the fail-closed stub supervisor must exit with Ok");
     }
 
     // -----------------------------------------------------------------

--- a/src/handlers/archive.rs
+++ b/src/handlers/archive.rs
@@ -110,10 +110,12 @@ pub async fn list_archive(
     // the LIMIT/OFFSET scan can take 50ms+ at the tail and would
     // otherwise pin a tokio worker.
     let namespace = q.namespace.clone();
-    let result = super::db_op(app.db.clone(), move |guard| {
-        db::list_archived(&guard.0, namespace.as_deref(), limit, offset)
-    })
-    .await;
+    let result = super::transport::flatten_db_op(
+        super::db_op(app.db.clone(), move |guard| {
+            db::list_archived(&guard.0, namespace.as_deref(), limit, offset)
+        })
+        .await,
+    );
     match result {
         Ok(items) => Json(json!({"archived": items, "count": items.len()})).into_response(),
         Err(e) => crate::handlers::errors::handler_error_500(&e),
@@ -229,11 +231,12 @@ pub async fn restore_archive(
     // on the calling thread pre-fix.
     let id_for_restore = id.clone();
     let caller_for_restore = caller.clone();
-    let restored = match super::db_op(app.db.clone(), move |guard| {
-        db::restore_archived_for_caller(&guard.0, &id_for_restore, &caller_for_restore)
-    })
-    .await
-    {
+    let restored = match super::transport::flatten_db_op(
+        super::db_op(app.db.clone(), move |guard| {
+            db::restore_archived_for_caller(&guard.0, &id_for_restore, &caller_for_restore)
+        })
+        .await,
+    ) {
         Ok(v) => v,
         Err(e) => {
             return crate::handlers::errors::handler_error_500(&e);
@@ -373,14 +376,16 @@ pub async fn purge_archive(
     // tokio worker pinned the runtime for the whole DELETE.
     let caller_for_purge = caller.clone();
     let older_than_days = q.older_than_days;
-    let purge_result = super::db_op(app.db.clone(), move |guard| {
-        if is_admin {
-            db::purge_archive(&guard.0, older_than_days)
-        } else {
-            db::purge_archive_for_caller(&guard.0, &caller_for_purge, older_than_days)
-        }
-    })
-    .await;
+    let purge_result = super::transport::flatten_db_op(
+        super::db_op(app.db.clone(), move |guard| {
+            if is_admin {
+                db::purge_archive(&guard.0, older_than_days)
+            } else {
+                db::purge_archive_for_caller(&guard.0, &caller_for_purge, older_than_days)
+            }
+        })
+        .await,
+    );
     match purge_result {
         Ok(n) => Json(json!({
             "purged": n,
@@ -416,7 +421,9 @@ pub async fn archive_stats(
     // archive_stats reads multiple GROUP BY queries off
     // archived_memories and is admin-only — low rate but high tail
     // latency on a saturated archive table.
-    let result = super::db_op(app.db.clone(), move |guard| db::archive_stats(&guard.0)).await;
+    let result = super::transport::flatten_db_op(
+        super::db_op(app.db.clone(), move |guard| db::archive_stats(&guard.0)).await,
+    );
     match result {
         Ok(archive_stats) => Json(archive_stats).into_response(),
         Err(e) => crate::handlers::errors::handler_error_500(&e),

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -3702,7 +3702,14 @@ pub async fn sync_push(
             enrolled.as_ref(),
             require_checkpoint_sig,
         ) {
-            crate::federation::receive_auth::CheckpointResolutionAuthz::Accept => {
+            // #3164 — `Accept(key)` is the authenticated verdict (the key that
+            // verified the resolution); `AcceptUnverified` is the permissive
+            // `require_checkpoint_sig = false` rollout window. Both apply the
+            // resolution, which is byte-identical to the pre-split behaviour of
+            // the single `Accept` arm — the split exists so no caller can
+            // mistake the permissive outcome for an authenticated one.
+            crate::federation::receive_auth::CheckpointResolutionAuthz::Accept(_)
+            | crate::federation::receive_auth::CheckpointResolutionAuthz::AcceptUnverified => {
                 if body.dry_run {
                     noop += 1;
                     continue;

--- a/src/handlers/memories.rs
+++ b/src/handlers/memories.rs
@@ -123,22 +123,24 @@ pub async fn get_memory(
     let lookup: Result<
         Option<(crate::models::Memory, Vec<crate::models::MemoryLink>)>,
         anyhow::Error,
-    > = super::read_pool::db_read_op(app.db.clone(), move |conn| {
-        match db::resolve_id(conn, &id_clone) {
-            Ok(Some(mem)) => {
-                // #869 audit (Category B — safe default): a substrate
-                // failure on `get_links` is non-fatal — the memory
-                // body itself was retrieved cleanly. Empty `links`
-                // array degrades graph navigation rather than
-                // failing the GET.
-                let links = db::get_links(conn, &mem.id).unwrap_or_default();
-                Ok(Some((mem, links)))
+    > = super::transport::flatten_db_op(
+        super::read_pool::db_read_op(app.db.clone(), move |conn| {
+            match db::resolve_id(conn, &id_clone) {
+                Ok(Some(mem)) => {
+                    // #869 audit (Category B — safe default): a substrate
+                    // failure on `get_links` is non-fatal — the memory
+                    // body itself was retrieved cleanly. Empty `links`
+                    // array degrades graph navigation rather than
+                    // failing the GET.
+                    let links = db::get_links(conn, &mem.id).unwrap_or_default();
+                    Ok(Some((mem, links)))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
             }
-            Ok(None) => Ok(None),
-            Err(e) => Err(e),
-        }
-    })
-    .await;
+        })
+        .await,
+    );
     match lookup {
         Ok(Some((mem, links))) => {
             // #927 — 404 (not 403) on a private-row read by a non-owner

--- a/src/handlers/memories_query.rs
+++ b/src/handlers/memories_query.rs
@@ -200,23 +200,25 @@ pub async fn list_memories(
     // the closure (its fields are only read by `db::list`); the
     // visibility post-filter is pure CPU on the owned rows and stays
     // outside the pool connection.
-    let listed = super::read_pool::db_read_op(app.db.clone(), move |conn| {
-        db::list(
-            conn,
-            p.namespace.as_deref(),
-            p.tier.as_ref(),
-            limit,
-            p.offset.unwrap_or(0),
-            p.min_priority,
-            p.since.as_deref(),
-            p.until.as_deref(),
-            p.tags.as_deref(),
-            p.agent_id.as_deref(),
-            // v1.0.0 #1834 — claim-bitemporal AS-OF (validated at entry).
-            p.valid_at.as_deref(),
-        )
-    })
-    .await;
+    let listed = super::transport::flatten_db_op(
+        super::read_pool::db_read_op(app.db.clone(), move |conn| {
+            db::list(
+                conn,
+                p.namespace.as_deref(),
+                p.tier.as_ref(),
+                limit,
+                p.offset.unwrap_or(0),
+                p.min_priority,
+                p.since.as_deref(),
+                p.until.as_deref(),
+                p.tags.as_deref(),
+                p.agent_id.as_deref(),
+                // v1.0.0 #1834 — claim-bitemporal AS-OF (validated at entry).
+                p.valid_at.as_deref(),
+            )
+        })
+        .await,
+    );
     match listed {
         Ok(mems) => {
             // #910 — see postgres branch comment above. `db::list` does
@@ -464,17 +466,19 @@ pub async fn search_memories(
             let ns = p.namespace.clone();
             let eaa = effective_as_agent.clone();
             let vc = visibility_caller.clone();
-            let listed = super::read_pool::db_read_op(app.db.clone(), move |conn| {
-                db::list_by_source_uri(
-                    conn,
-                    &uri_owned,
-                    ns.as_deref(),
-                    Some(limit),
-                    eaa.as_deref(),
-                    vc.as_deref(),
-                )
-            })
-            .await;
+            let listed = super::transport::flatten_db_op(
+                super::read_pool::db_read_op(app.db.clone(), move |conn| {
+                    db::list_by_source_uri(
+                        conn,
+                        &uri_owned,
+                        ns.as_deref(),
+                        Some(limit),
+                        eaa.as_deref(),
+                        vc.as_deref(),
+                    )
+                })
+                .await,
+            );
             return match listed {
                 // #1579 B4 — serialize per the negotiated format.
                 Ok(r) => crate::handlers::wire_format::search_response(
@@ -496,25 +500,27 @@ pub async fn search_memories(
     let eaa = effective_as_agent.clone();
     let su_owned: Option<String> = source_uri.map(str::to_string);
     let vc = visibility_caller.clone();
-    let searched = super::read_pool::db_read_op(app.db.clone(), move |conn| {
-        db::search_with_source_uri(
-            conn,
-            &q,
-            ns.as_deref(),
-            tier.as_ref(),
-            limit,
-            min_priority,
-            since.as_deref(),
-            until.as_deref(),
-            tags.as_deref(),
-            agent_id.as_deref(),
-            eaa.as_deref(),
-            false,
-            su_owned.as_deref(),
-            vc.as_deref(),
-        )
-    })
-    .await;
+    let searched = super::transport::flatten_db_op(
+        super::read_pool::db_read_op(app.db.clone(), move |conn| {
+            db::search_with_source_uri(
+                conn,
+                &q,
+                ns.as_deref(),
+                tier.as_ref(),
+                limit,
+                min_priority,
+                since.as_deref(),
+                until.as_deref(),
+                tags.as_deref(),
+                agent_id.as_deref(),
+                eaa.as_deref(),
+                false,
+                su_owned.as_deref(),
+                vc.as_deref(),
+            )
+        })
+        .await,
+    );
     match searched {
         // #1579 B4 — serialize per the negotiated format.
         Ok(r) => crate::handlers::wire_format::search_response(

--- a/src/handlers/read_pool.rs
+++ b/src/handlers/read_pool.rs
@@ -63,7 +63,7 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use crate::config::ResolvedTtl;
 
-use super::transport::Db;
+use super::transport::{Db, DbOpError};
 
 /// The inner type behind the [`Db`] `Arc<tokio::sync::Mutex<…>>`.
 /// Declared here so the registry can hold a [`Weak`] to exactly that
@@ -227,36 +227,69 @@ fn pool_for(db: &Db) -> anyhow::Result<Arc<ReadPool>> {
 /// resolved TTL or DB path read them from `AppState`, not the writer
 /// tuple).
 ///
-/// **Infallible + graceful**: if the pool cannot be built (e.g. a
+/// **Graceful on pool failure**: if the pool cannot be built (e.g. a
 /// read-only open failure), the call logs a WARN and falls back to the
 /// existing writer connection so the request still succeeds — never a
 /// hard failure introduced by the optimization. The return type matches
-/// `db_op` (`T`, not `Result<T>`) so migrating a handler from `db_op` to
-/// `db_read_op` is a drop-in change.
+/// `db_op` (`Result<T, DbOpError>`) so migrating a handler from `db_op` to
+/// `db_read_op` is still a drop-in change.
 ///
-/// # Panics
+/// v1.0.0 #3164 — this used to return `T` and `.expect()` the `JoinError`, so
+/// a panic in a read closure (or a `spawn_blocking` cancelled during graceful
+/// shutdown) re-panicked the request task. The unwind is now contained and
+/// reported as a logged 500. The #1580 fast path is unchanged: the pooled
+/// read-only connection is still acquired the same way, and `catch_unwind`
+/// costs nothing when nothing panics.
 ///
-/// Panics only if the `spawn_blocking` worker itself panics or the
-/// runtime is shutting down (same contract as `db_op`).
-pub async fn db_read_op<T, F>(db: Db, op: F) -> T
+/// The writer-connection FALLBACK arm additionally runs the #3163 sweep,
+/// because that arm — and only that arm — touches the shared writer.
+pub async fn db_read_op<T, F>(db: Db, op: F) -> Result<T, DbOpError>
 where
     T: Send + 'static,
     F: FnOnce(&rusqlite::Connection) -> T + Send + 'static,
 {
-    tokio::task::spawn_blocking(move || match pool_for(&db) {
-        Ok(pool) => pool.with_conn(op),
-        Err(e) => {
-            tracing::warn!(
-                target: "ai_memory::read_pool",
-                error = %e,
-                "read-pool unavailable; falling back to the writer connection"
-            );
-            let guard = db.blocking_lock();
-            op(&guard.0)
+    tokio::task::spawn_blocking(move || {
+        let outcome =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Result<T, DbOpError> {
+                match pool_for(&db) {
+                    Ok(pool) => Ok(pool.with_conn(op)),
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "ai_memory::read_pool",
+                            error = %e,
+                            "read-pool unavailable; falling back to the writer connection"
+                        );
+                        let guard = db.blocking_lock();
+                        // #3163 — this arm borrows the SHARED writer. A read
+                        // issued inside a foreign, unowned transaction would
+                        // observe that transaction's uncommitted rows, so sweep
+                        // first and fail the read closed if it cannot be
+                        // cleared. Wrong results are never an acceptable
+                        // degradation; fewer results are.
+                        if let Err(sweep) = crate::storage::connection::ensure_autocommit(&guard.0)
+                        {
+                            return Err(DbOpError::WriterTransactionUnclearable(sweep.to_string()));
+                        }
+                        Ok(op(&guard.0))
+                    }
+                }
+            }));
+        match outcome {
+            Ok(value) => value,
+            Err(payload) => {
+                let detail = super::transport::panic_payload_detail(payload.as_ref());
+                tracing::error!(
+                    target: "ai_memory::read_pool",
+                    detail = %detail,
+                    "#3164: db_read_op closure panicked; the request fails with 500 instead of \
+                     re-panicking the connection task"
+                );
+                Err(DbOpError::ClosurePanicked(detail))
+            }
         }
     })
     .await
-    .expect("#1580: db_read_op spawn_blocking worker panicked or runtime shut down")
+    .map_err(|e| DbOpError::WorkerJoin(e.to_string()))?
 }
 
 #[cfg(test)]
@@ -328,7 +361,10 @@ mod tests {
         }));
 
         let joined = tokio::time::timeout(Duration::from_secs(10), async {
-            (h1.await.unwrap(), h2.await.unwrap())
+            (
+                h1.await.unwrap().expect("reader 1 dispatch"),
+                h2.await.unwrap().expect("reader 2 dispatch"),
+            )
         })
         .await
         .expect("both readers must be in flight concurrently (barrier would hang if serialized)");
@@ -348,7 +384,8 @@ mod tests {
             })
             .unwrap_or(-1)
         })
-        .await;
+        .await
+        .expect("dispatch");
         assert_eq!(got, 1, "pooled read must see the just-committed row");
     }
 
@@ -370,9 +407,36 @@ mod tests {
         let read =
             tokio::time::timeout(Duration::from_secs(10), db_read_op(db.clone(), count_rows))
                 .await
-                .expect("pooled read must complete while the writer mutex is held");
+                .expect("pooled read must complete while the writer mutex is held")
+                .expect("dispatch");
         assert_eq!(read, 1);
         drop(writer_guard);
+    }
+
+    /// v1.0.0 #3164 — a panic inside a READ closure must be contained and
+    /// reported, not re-panicked into the request task by an `.expect()` on
+    /// the `JoinError`. The pooled connection is read-only and holds no
+    /// transaction, so the only casualty is the one request.
+    #[tokio::test]
+    async fn db_read_op_contains_a_closure_panic_3164() {
+        let (_tmp, db) = file_db();
+        seed_row(&db, "panic1").await;
+
+        let err = db_read_op(db.clone(), |_conn| -> i64 {
+            panic!("#3164: injected panic in a read closure");
+        })
+        .await
+        .expect_err("the panic must surface as a typed dispatch error");
+        assert!(
+            matches!(err, DbOpError::ClosurePanicked(_)),
+            "expected a contained closure panic, got {err:?}"
+        );
+
+        // The pool survives: the next read still works.
+        let got = db_read_op(db.clone(), count_rows)
+            .await
+            .expect("the read pool must still serve after a contained panic");
+        assert_eq!(got, 1);
     }
 
     /// The pool is disabled for `:memory:` (per-connection databases) and
@@ -390,7 +454,7 @@ mod tests {
         seed_row(&db, "mem1").await;
         // pool_for returns Err for :memory:; db_read_op falls back to the
         // writer guard, which DOES hold the row.
-        let got = db_read_op(db.clone(), count_rows).await;
+        let got = db_read_op(db.clone(), count_rows).await.expect("dispatch");
         assert_eq!(got, 1, "in-memory fallback reads the writer connection");
     }
 }

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -749,11 +749,12 @@ async fn recall_response(
     let ns_allowlist: Option<Vec<String>> = match namespace {
         Some(ns) if query_emb.is_some() && crate::hnsw::vector_ns_allowlist_enabled() => {
             let ns_owned = ns.to_string();
-            match super::read_pool::db_read_op(app.db.clone(), move |conn| {
-                db::vector_recall_allowlist_ids(conn, &ns_owned)
-            })
-            .await
-            {
+            match super::transport::flatten_db_op(
+                super::read_pool::db_read_op(app.db.clone(), move |conn| {
+                    db::vector_recall_allowlist_ids(conn, &ns_owned)
+                })
+                .await,
+            ) {
                 Ok(ids) => Some(ids),
                 Err(e) => {
                     tracing::warn!(
@@ -847,7 +848,11 @@ async fn recall_response(
             .as_ref()
             .map(|e| e.space_fingerprint())
     });
-    let (result, mode) = super::read_pool::db_read_op(app.db.clone(), move |conn| {
+    // #3164 — a dispatch failure (a panicking read closure, or a shutting-down
+    // runtime) surfaces as an `Err` recall result on the SAME path the
+    // substrate's own errors take, so the handler renders one 500 rather than
+    // re-panicking the connection task.
+    let (result, mode) = match super::read_pool::db_read_op(app.db.clone(), move |conn| {
         if let Some(qe) = qe_owned.as_deref() {
             // SAFETY: `precomputed_hits` is Some when `query_emb` is
             // Some, by construction of the if-let above. The empty
@@ -916,7 +921,13 @@ async fn recall_response(
             (r, crate::models::RECALL_MODE_KEYWORD)
         }
     })
-    .await;
+    .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            return crate::handlers::errors::handler_error_500(&e);
+        }
+    };
 
     // PHASE 2 (writer) — authoritative touch + recall_observations
     // ledger, batched under one brief writer lock. Mirrors the postgres
@@ -935,7 +946,7 @@ async fn recall_response(
         // + `namespace` stamping.
         let agent_for_ledger = as_agent.or(caller_principal).map(str::to_string);
         let ns_for_ledger = namespace.map(str::to_string);
-        super::db_op(app.db.clone(), move |guard| {
+        if let Err(e) = super::db_op(app.db.clone(), move |guard| {
             // #1710 — record the recalled set into the ledger on the
             // writer connection (no second lock; mirrors the MCP free-fn).
             if crate::observations::table_exists(&guard.0) {
@@ -959,7 +970,18 @@ async fn recall_response(
                 }
             }
         })
-        .await;
+        .await
+        {
+            // #3164 — the ledger write is best-effort telemetry (its own
+            // internal failure already only WARNs), so a dispatch failure is
+            // logged and the recall response still returns the rows the read
+            // phase truthfully produced.
+            tracing::warn!(
+                target: crate::handlers::transport::DB_OP_TRACE_TARGET,
+                error = %e,
+                "recall (sqlite-http): observation-ledger write could not be dispatched"
+            );
+        }
     }
 
     match result {

--- a/src/handlers/transport.rs
+++ b/src/handlers/transport.rs
@@ -45,12 +45,11 @@ pub type Db = Arc<Mutex<(rusqlite::Connection, std::path::PathBuf, ResolvedTtl, 
 ///   `tokio::sync::Mutex` API explicitly supports this from a
 ///   spawn_blocking worker; the worker is OFF the tokio runtime threads
 ///   so no await-deadlock risk.
-/// - Returns `T` directly. Join errors from `spawn_blocking` (panic
-///   propagation, runtime shutdown) surface via `expect`; a panic
-///   inside the closure unwinds the blocking worker and the join error
-///   is logged before the handler aborts with a 500 — the caller's
-///   `Result<T, _>` is the right shape to surface domain errors. Join
-///   failures are runtime bugs, not request-shape failures.
+/// - Returns `Result<T, DbOpError>`. v1.0.0 #3164: this used to return `T`
+///   and `.expect()` the `JoinError`, so a panic anywhere in the closure —
+///   or a `spawn_blocking` cancelled during graceful shutdown — RE-PANICKED
+///   the request task instead of producing a 500. Join and panic failures
+///   are now typed and logged; domain errors still ride inside `T`.
 ///
 /// The helper deliberately does NOT take `headers: HeaderMap` /
 /// `caller: &str` etc. — every closure already captures whatever extra
@@ -71,7 +70,16 @@ pub type Db = Arc<Mutex<(rusqlite::Connection, std::path::PathBuf, ResolvedTtl, 
 /// Type parameter `T` requires `Send + 'static` because the closure's
 /// return value crosses the spawn_blocking boundary back to the tokio
 /// runtime.
-pub async fn db_op<T, F>(db: Db, op: F) -> T
+///
+/// # Errors
+///
+/// Returns [`DbOpError`] only for DISPATCH failures — the closure
+/// panicked, the blocking worker could not be joined, or the shared
+/// writer connection was left in (or found in) a transaction that had to
+/// be swept. Domain errors still ride inside `T`, so a handler that
+/// already renders `Result<T, E>` can fold the two with
+/// [`flatten_db_op`].
+pub async fn db_op<T, F>(db: Db, op: F) -> Result<T, DbOpError>
 where
     T: Send + 'static,
     F: FnOnce(&mut (rusqlite::Connection, std::path::PathBuf, ResolvedTtl, bool)) -> T
@@ -80,10 +88,148 @@ where
 {
     tokio::task::spawn_blocking(move || {
         let mut guard = db.blocking_lock();
-        op(&mut guard)
+
+        // v1.0.0 #3163 PRE-SWEEP — the writer is a SINGLE connection behind a
+        // NON-poisoning `tokio::sync::Mutex`, so acquiring the guard proves
+        // nothing about the connection's transaction state. Before running any
+        // statement, prove the connection is in autocommit. If it is not and
+        // it cannot be cleared, REFUSE: running new writes inside a foreign,
+        // unowned transaction is exactly the mixed-state outcome the prime
+        // directive forbids. Because the check is on ACQUISITION, a transient
+        // failure self-heals on the next request without any poison flag,
+        // reopen, or extra state on the `Db` tuple.
+        if let Err(e) = crate::storage::connection::ensure_autocommit(&guard.0) {
+            return Err(DbOpError::WriterTransactionUnclearable(e.to_string()));
+        }
+
+        // Contain an unwind out of `op` so the guard below always runs and the
+        // mutex is never released with a half-finished transaction on it.
+        // `AssertUnwindSafe` is required because `&mut guard` is not
+        // `UnwindSafe`; it is justified precisely because the ONE shared
+        // invariant that an unwind could break — the connection's transaction
+        // state — is re-established immediately afterwards rather than
+        // assumed.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| op(&mut guard)));
+
+        // v1.0.0 #3163 POST-SWEEP — runs on EVERY exit: a clean return, a
+        // closure that returned an `Err`-shaped `T` with the transaction still
+        // open, and a panic unwind. `WriteTxn` already makes the substrate's
+        // own BEGIN sites unwind-safe; this is the defense-in-depth layer that
+        // holds even for a transaction this crate did not open.
+        let swept = crate::storage::connection::ensure_autocommit(&guard.0);
+        drop(guard);
+
+        match (outcome, swept) {
+            (Err(payload), _) => {
+                let detail = panic_payload_detail(payload.as_ref());
+                tracing::error!(
+                    target: DB_OP_TRACE_TARGET,
+                    detail = %detail,
+                    "#3164: db_op closure panicked; the writer transaction was swept and the \
+                     request fails with 500 instead of re-panicking the connection task"
+                );
+                Err(DbOpError::ClosurePanicked(detail))
+            }
+            (Ok(_), Err(e)) => Err(DbOpError::WriterTransactionUnclearable(e.to_string())),
+            (Ok(_), Ok(true)) => {
+                // The closure returned normally but left a transaction open,
+                // which the sweep has just ROLLED BACK. Its writes are gone, so
+                // reporting success would be a wrong result — fail closed.
+                tracing::error!(
+                    target: DB_OP_TRACE_TARGET,
+                    "#3163: db_op closure returned with an OPEN write transaction; it has been \
+                     rolled back and the request fails closed rather than reporting a write \
+                     that no longer exists"
+                );
+                Err(DbOpError::OrphanedTransaction)
+            }
+            (Ok(value), Ok(false)) => Ok(value),
+        }
     })
     .await
-    .expect("PERF-1: db_op spawn_blocking worker panicked or runtime shut down")
+    .map_err(|e| DbOpError::WorkerJoin(e.to_string()))?
+}
+
+/// Tracing target for the #3163/#3164 writer-lane integrity events.
+pub(crate) const DB_OP_TRACE_TARGET: &str = "ai_memory::handlers::db_op";
+
+/// Render a caught panic payload as a log-safe string. `panic!` payloads are
+/// `&'static str` or `String` in practice; anything else is reported by shape.
+pub(crate) fn panic_payload_detail(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+/// v1.0.0 #3163/#3164 — why a `db_op` / `db_read_op` dispatch did not deliver
+/// a result.
+///
+/// Every variant is an INFRASTRUCTURE failure, never a request-shape failure:
+/// domain errors continue to ride inside the closure's own return type. All
+/// of them map to a 5xx. Keeping them typed (rather than a re-panic or a
+/// stringly-typed `anyhow`) is what lets a handler log the exact cause and
+/// lets the fleet distinguish "a handler has a bug" from "this daemon's writer
+/// connection is wedged".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbOpError {
+    /// The closure panicked. The unwind was contained; the writer connection
+    /// was swept back to autocommit before the mutex was released.
+    ClosurePanicked(String),
+    /// The `spawn_blocking` worker could not be joined — in practice a runtime
+    /// shutdown or a cancelled task, not a closure fault.
+    WorkerJoin(String),
+    /// The closure returned normally but left an open write transaction, which
+    /// was rolled back. Its writes did NOT persist, so the request fails
+    /// closed rather than reporting a phantom success.
+    OrphanedTransaction,
+    /// The shared writer connection is inside a transaction that could not be
+    /// rolled back. The daemon refuses to write through it; the next
+    /// acquisition retries the sweep.
+    WriterTransactionUnclearable(String),
+}
+
+impl std::fmt::Display for DbOpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClosurePanicked(detail) => write!(f, "database worker panicked: {detail}"),
+            Self::WorkerJoin(detail) => write!(f, "database worker did not complete: {detail}"),
+            Self::OrphanedTransaction => {
+                f.write_str("database worker left an open write transaction; it was rolled back")
+            }
+            Self::WriterTransactionUnclearable(detail) => write!(
+                f,
+                "writer connection is stuck inside a transaction that could not be rolled back: \
+                 {detail}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DbOpError {}
+
+/// v1.0.0 #3164 — fold a `db_op` / `db_read_op` DISPATCH failure into the
+/// closure's own error type, so a handler that already renders `Result<T, E>`
+/// keeps exactly one error path instead of a nested `Result<Result<..>, ..>`.
+///
+/// `anyhow::Error` satisfies the `From<DbOpError>` bound for free (`DbOpError`
+/// is `Error + Send + Sync + 'static`), which covers every substrate closure.
+///
+/// # Errors
+///
+/// Returns the closure's own `E` when the closure ran and failed, and
+/// `E::from(DbOpError)` when the dispatch itself failed.
+pub fn flatten_db_op<T, E>(outcome: Result<Result<T, E>, DbOpError>) -> Result<T, E>
+where
+    E: From<DbOpError>,
+{
+    match outcome {
+        Ok(inner) => inner,
+        Err(dispatch) => Err(E::from(dispatch)),
+    }
 }
 
 /// v0.7.0 Wave-3 — declared storage backend for the daemon.
@@ -1129,6 +1275,9 @@ pub async fn health(State(app): State<AppState>) -> impl IntoResponse {
 /// The sqlite half of [`health`]: one blocking-pool hop, two fixed
 /// statements, no write lock.
 async fn sqlite_liveness(app: &AppState) -> (bool, &'static str) {
+    // #3164 — a dispatch failure IS a liveness failure: the writer connection
+    // could not be reached (or is wedged inside a transaction it will not
+    // leave), which is exactly what `/health` exists to report.
     db_op(app.db.clone(), |guard| {
         if db::ping(&guard.0).is_err() {
             return (false, PROBE_ERROR);
@@ -1139,6 +1288,14 @@ async fn sqlite_liveness(app: &AppState) -> (bool, &'static str) {
         (true, PROBE_REACHABLE)
     })
     .await
+    .unwrap_or_else(|e| {
+        tracing::error!(
+            target: DB_OP_TRACE_TARGET,
+            error = %e,
+            "health: sqlite liveness probe could not be dispatched"
+        );
+        (false, PROBE_ERROR)
+    })
 }
 
 /// v0.6.0.0 — Prometheus scrape endpoint.
@@ -1205,15 +1362,191 @@ async fn cold_prime_memories_gauge(app: &AppState) {
         return;
     }
     let db = app.db.clone();
-    db_op(db, move |guard| {
+    // #3164 — the gauge is an observability convenience; a dispatch failure is
+    // logged and the stale value is served rather than failing the scrape.
+    if let Err(e) = db_op(db, move |guard| {
         crate::background::memories_gauge::refresh_once(&guard.0, now);
     })
-    .await;
+    .await
+    {
+        tracing::error!(
+            target: DB_OP_TRACE_TARGET,
+            error = %e,
+            "metrics: cold-prime of the corpus gauge could not be dispatched"
+        );
+    }
 }
 
 #[cfg(test)]
 mod transport_helpers_tests {
     use super::*;
+
+    // ---------------------------------------------------------------
+    // v1.0.0 #3163 / #3164 — db_op writer-lane integrity
+    // ---------------------------------------------------------------
+
+    /// A minimal shared writer `Db`: one table, the real
+    /// `Arc<tokio::sync::Mutex<..>>` shape every handler uses.
+    fn txn_test_db() -> Db {
+        let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .expect("create t");
+        Arc::new(Mutex::new((
+            conn,
+            std::path::PathBuf::new(),
+            ResolvedTtl::default(),
+            false,
+        )))
+    }
+
+    async fn db_row_count(db: &Db) -> i64 {
+        let guard = db.lock().await;
+        guard
+            .0
+            .query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0))
+            .expect("count")
+    }
+
+    async fn db_is_autocommit(db: &Db) -> bool {
+        db.lock().await.0.is_autocommit()
+    }
+
+    /// THE #3163 regression, end to end on the real shared writer: a panic
+    /// between BEGIN and COMMIT must leave (a) no partial write visible,
+    /// (b) a writer the next request can still use, and (c) a connection back
+    /// in autocommit. Pre-fix the `tokio::sync::Mutex` (which does not poison)
+    /// released a connection still inside `BEGIN IMMEDIATE`, and #3164's
+    /// `.expect()` on the `JoinError` re-panicked the request task on top.
+    #[tokio::test]
+    async fn db_op_panic_between_begin_and_commit_leaves_a_usable_writer_3163() {
+        let db = txn_test_db();
+
+        // `::<(), _>` pins the closure's return type, which panic-only bodies
+        // cannot infer (and `|guard| -> ()` would trip `clippy::unused_unit`).
+        let err = db_op::<(), _>(db.clone(), |guard| {
+            let _write_txn = crate::storage::connection::WriteTxn::begin(&guard.0).expect("begin");
+            guard
+                .0
+                .execute("INSERT INTO t (id) VALUES (1)", [])
+                .expect("partial write");
+            panic!("#3163: injected panic between BEGIN and COMMIT");
+        })
+        .await
+        .expect_err("#3164: db_op must REPORT the panic, not re-panic the caller");
+        assert!(
+            matches!(err, DbOpError::ClosurePanicked(_)),
+            "expected a contained closure panic, got {err:?}"
+        );
+
+        // (c) the writer is back in autocommit …
+        assert!(
+            db_is_autocommit(&db).await,
+            "#3163: the shared writer must not stay inside a transaction"
+        );
+        // (a) … the partial write is NOT visible …
+        assert_eq!(
+            db_row_count(&db).await,
+            0,
+            "#3163: partial write must be rolled back"
+        );
+        // (b) … and the NEXT write on the same `Db` succeeds.
+        db_op(db.clone(), |guard| {
+            let write_txn = crate::storage::connection::WriteTxn::begin(&guard.0)?;
+            guard.0.execute("INSERT INTO t (id) VALUES (2)", [])?;
+            write_txn.commit()
+        })
+        .await
+        .expect("#3163: the next db_op must dispatch")
+        .expect("#3163: the next write on the same Db must succeed");
+        assert_eq!(
+            db_row_count(&db).await,
+            1,
+            "the post-unwind write must persist"
+        );
+    }
+
+    /// The defense-in-depth half of #3163: even a transaction opened WITHOUT
+    /// the `WriteTxn` guard — a future call site, or code this crate does not
+    /// own — cannot be handed to the next writer. The post-closure sweep rolls
+    /// it back at the mutex boundary.
+    #[tokio::test]
+    async fn db_op_sweeps_an_unguarded_open_transaction_3163() {
+        let db = txn_test_db();
+
+        let err = db_op::<(), _>(db.clone(), |guard| {
+            guard
+                .0
+                .execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
+                .expect("raw BEGIN, deliberately unguarded");
+            guard
+                .0
+                .execute("INSERT INTO t (id) VALUES (1)", [])
+                .expect("partial write");
+            panic!("#3163: unguarded transaction abandoned by an unwind");
+        })
+        .await
+        .expect_err("the panic must be contained");
+        assert!(matches!(err, DbOpError::ClosurePanicked(_)), "got {err:?}");
+
+        assert!(
+            db_is_autocommit(&db).await,
+            "#3163: the mutex-boundary sweep must clear an unguarded transaction"
+        );
+        assert_eq!(
+            db_row_count(&db).await,
+            0,
+            "the unguarded write must be rolled back"
+        );
+    }
+
+    /// A closure that returns NORMALLY while leaving a transaction open used
+    /// to report success for writes that the next caller's rollback would
+    /// erase. The sweep rolls them back and the request fails CLOSED, because
+    /// a wrong result is never an acceptable degradation.
+    #[tokio::test]
+    async fn db_op_fails_closed_when_a_closure_returns_with_an_open_transaction_3163() {
+        let db = txn_test_db();
+
+        let err = db_op(db.clone(), |guard| {
+            guard
+                .0
+                .execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
+                .expect("raw BEGIN");
+            guard
+                .0
+                .execute("INSERT INTO t (id) VALUES (1)", [])
+                .expect("write");
+            // Returns Ok WITHOUT committing.
+        })
+        .await
+        .expect_err("#3163: an orphaned transaction must fail the request closed");
+        assert_eq!(err, DbOpError::OrphanedTransaction);
+        assert!(db_is_autocommit(&db).await);
+        assert_eq!(
+            db_row_count(&db).await,
+            0,
+            "the uncommitted write must be gone"
+        );
+    }
+
+    /// The happy path must be untouched: `Ok(value)` through, connection
+    /// clean, PERF-1 dispatch shape unchanged.
+    #[tokio::test]
+    async fn db_op_happy_path_returns_the_closure_value() {
+        let db = txn_test_db();
+        let got = db_op(db.clone(), |guard| {
+            guard
+                .0
+                .execute("INSERT INTO t (id) VALUES (7)", [])
+                .expect("write");
+            42_u32
+        })
+        .await
+        .expect("dispatch");
+        assert_eq!(got, 42);
+        assert_eq!(db_row_count(&db).await, 1);
+        assert!(db_is_autocommit(&db).await);
+    }
 
     #[test]
     fn constant_time_eq_handles_equal_and_diff_inputs() {

--- a/src/mcp/tools/checkpoint.rs
+++ b/src/mcp/tools/checkpoint.rs
@@ -290,16 +290,23 @@ pub fn handle_checkpoint_resolve(
             enrolled.as_ref(),
             true,
         ) {
-            crate::federation::receive_auth::CheckpointResolutionAuthz::Accept => {
-                // Accept ⇒ `enrolled` verified the signature, so it is Some.
-                let pubkey = enrolled
-                    .expect("Accept implies an enrolled verifying key")
-                    .to_bytes()
-                    .to_vec();
-                (None, signed_at, Some((presented_sig, pubkey)))
-            }
-            // RejectUnsigned / RejectNotEnrolled / RejectForged: withhold the
-            // daemon key so the anchor resolves Unsigned (verify:false).
+            // v1.0.0 #3164 (ERRORS-09) — the verdict CARRIES the verifying key
+            // that authenticated the resolution, so the attestation is built
+            // from the value the gate actually verified against. The prior
+            // `enrolled.expect("Accept implies an enrolled verifying key")`
+            // was sound only because `require_sig` is hardcoded `true` two
+            // lines up; the sibling HTTP caller already passes the RUNTIME
+            // flag, so wiring the same flag here would have turned a remote
+            // peer's unsigned resolution into a panic on an MCP tool.
+            crate::federation::receive_auth::CheckpointResolutionAuthz::Accept(verified_key) => (
+                None,
+                signed_at,
+                Some((presented_sig, verified_key.to_bytes().to_vec())),
+            ),
+            // AcceptUnverified (unreachable while `require_sig = true`, but no
+            // longer a panic if that ever changes) / RejectUnsigned /
+            // RejectNotEnrolled / RejectForged: withhold the daemon key so the
+            // anchor resolves Unsigned (verify:false).
             _ => (None, now, None),
         }
     } else {

--- a/src/mcp/tools/store/synthesis.rs
+++ b/src/mcp/tools/store/synthesis.rs
@@ -281,12 +281,14 @@ pub(super) fn apply_synthesis_updates_and_deletes(
     // the entire merge back instead of leaving a half-synthesised store.
     // Vector-index mutations are in-memory and DEFERRED until after COMMIT so a
     // rollback can never leave the index out of sync with the DB.
-    if conn
-        .execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
-        .is_err()
-    {
+    // #3163 — RAII guard. The early `return None` arms below keep their
+    // explicit ROLLBACK so the write lock is released at the exact bail-out
+    // point; the guard is what covers a PANIC unwind out of any of the
+    // update/link/delete calls, and it no-ops once the connection is back in
+    // autocommit, so the two are idempotent with each other.
+    let Ok(write_txn) = crate::storage::connection::WriteTxn::begin(conn) else {
         return None;
-    }
+    };
     let mut deferred_index_ops: Vec<(String, Vec<f32>)> = Vec::new();
 
     // Issue #1239 — counter into `outcome.updates` so subsequent
@@ -435,11 +437,10 @@ pub(super) fn apply_synthesis_updates_and_deletes(
 
     // #1700 — all core writes succeeded; commit the merge as one unit, then
     // apply the deferred in-memory vector-index swaps (the DB is now durable).
-    if conn
-        .execute_batch(crate::storage::connection::SQL_COMMIT)
-        .is_err()
-    {
-        let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+    // A failed COMMIT leaves the guard armed: dropping it here rolls the
+    // whole merge back, so the deferred vector-index swaps below are never
+    // applied against a store that did not durably change.
+    if write_txn.commit().is_err() {
         return None;
     }
     if let Some(idx) = vector_index {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -176,6 +176,21 @@ pub struct Metrics {
     /// to 0 within one replay interval after the peer recovers.
     pub federation_push_dlq_depth: IntGauge,
 
+    /// v1.0.0 #3164 — the deferred-audit drainer supervisor's TERMINAL state:
+    /// `0` = running (or exited gracefully on a fully-drained queue), `1` =
+    /// the sink stayed unresolved and exhausted its restart budget, `2` = the
+    /// sink panicked and exhausted its restart budget.
+    ///
+    /// Pre-#3164 the supervisor `panic!`ed on exhaustion. A panic in a
+    /// `tokio::spawn`ed task kills only THAT task, so the daemon kept serving
+    /// while the audit drainer was permanently dead — and nothing observed it
+    /// until the shutdown path awaited the `JoinHandle`, possibly days later.
+    /// A NON-ZERO value here means governance refusals are no longer reaching
+    /// `signed_events` on this node: alert on it, and treat the node as
+    /// audit-degraded. It is monotonic-by-first-writer, so the ORIGINAL cause
+    /// survives.
+    pub deferred_audit_drainer_terminal_state: IntGauge,
+
     /// #1032 (HIGH, 2026-05-21) — monotonic counter for DLQ rows the
     /// replay worker has marked as quarantined (`attempt_count >=
     /// MAX_REPLAY_ATTEMPTS`). Pre-#1032 the replay loop retried
@@ -665,6 +680,17 @@ impl Metrics {
         )?;
         registry.register(Box::new(federation_push_dlq_depth.clone()))?;
 
+        // v1.0.0 #3164 — deferred-audit drainer terminal-state gauge.
+        let deferred_audit_drainer_terminal_state = IntGauge::new(
+            "ai_memory_deferred_audit_drainer_terminal_state",
+            "Terminal state of the deferred-audit drainer supervisor: 0 = \
+             running/graceful, 1 = sink unresolved past max_restarts, 2 = \
+             sink panicked past max_restarts. Non-zero means governance \
+             refusals are NO LONGER reaching signed_events on this node; the \
+             daemon keeps serving but is audit-degraded until restarted.",
+        )?;
+        registry.register(Box::new(deferred_audit_drainer_terminal_state.clone()))?;
+
         // #1032 (HIGH, 2026-05-21) — federation push DLQ quarantine counter.
         let federation_push_dlq_quarantined = IntCounter::new(
             "ai_memory_federation_push_dlq_quarantined_total",
@@ -1016,6 +1042,7 @@ impl Metrics {
             corrupt_provenance_rows_total,
             auto_export_spawn_failed_total,
             federation_push_dlq_depth,
+            deferred_audit_drainer_terminal_state,
             federation_push_dlq_quarantined,
             federation_push_dlq_quarantined_by_cause,
             federation_push_dlq_legacy_positional,

--- a/src/quotas.rs
+++ b/src/quotas.rs
@@ -493,7 +493,7 @@ pub fn check_and_record(
     // can begin a write transaction until we COMMIT or ROLLBACK. The
     // window between SELECT and UPDATE inside the transaction is
     // therefore safe from another writer's UPDATE racing past us.
-    conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
+    let write_txn = crate::storage::connection::WriteTxn::begin(conn)
         .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("BEGIN IMMEDIATE failed: {e}")))?;
 
     let result: std::result::Result<(), QuotaCheckError> = (|| {
@@ -606,14 +606,15 @@ pub fn check_and_record(
 
     match result {
         Ok(()) => {
-            conn.execute_batch(crate::storage::connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("quota commit failed: {e}")))?;
             Ok(())
         }
         Err(e) => {
-            // Rollback is best-effort — even if it fails, the
-            // transaction is implicitly aborted on connection drop.
-            let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+            // #3163 — the guard rolls back here and, unlike the old
+            // hand-written arm, on an unwind too.
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -692,7 +693,7 @@ pub fn check_and_record_storage_only(
     bytes: i64,
 ) -> std::result::Result<(), QuotaCheckError> {
     let _ = ensure_row(conn, agent_id, namespace).map_err(QuotaCheckError::Sql)?;
-    conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
+    let write_txn = crate::storage::connection::WriteTxn::begin(conn)
         .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("BEGIN IMMEDIATE failed: {e}")))?;
     let result: std::result::Result<(), QuotaCheckError> = (|| {
         let row = load_row(conn, agent_id, namespace)
@@ -726,12 +727,13 @@ pub fn check_and_record_storage_only(
     })();
     match result {
         Ok(()) => {
-            conn.execute_batch(crate::storage::connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .map_err(|e| QuotaCheckError::Sql(anyhow::anyhow!("quota commit failed: {e}")))?;
             Ok(())
         }
         Err(e) => {
-            let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }

--- a/src/storage/connection.rs
+++ b/src/storage/connection.rs
@@ -139,6 +139,7 @@ pub const SQL_BEGIN_EXCLUSIVE: &str = "BEGIN EXCLUSIVE";
 /// aborts the process). The connection is left for the next
 /// [`ensure_autocommit`] sweep, which fails the request closed rather than
 /// writing into a foreign transaction.
+#[must_use = "dropping the guard rolls the transaction back immediately"]
 pub struct WriteTxn<'c> {
     conn: &'c Connection,
     /// `true` once the transaction has been terminated (committed or
@@ -1200,6 +1201,68 @@ mod tests {
             row_count(&conn),
             0,
             "the unguarded write must be rolled back"
+        );
+    }
+
+    /// Structural pin (#3211 Fable gate): after #3115 landed `delete` /
+    /// `archive_by_ids` with raw `execute_batch(SQL_BEGIN_IMMEDIATE)`, the
+    /// "zero raw BEGINs outside connection.rs" claim was already false at
+    /// the tip. Allow-list `connection.rs` (the primitive), `cli/backup.rs`
+    /// (self-terminating exclusive-lock probe), and `handlers/transport.rs`
+    /// (`db_op` sweep tests that *must* open an unguarded BEGIN).
+    #[test]
+    fn no_raw_sql_begin_immediate_outside_allowlisted_sites_3163() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let allow = [
+            "storage/connection.rs",
+            "cli/backup.rs",
+            "handlers/transport.rs",
+        ];
+        let mut hits = Vec::new();
+        fn walk(
+            dir: &std::path::Path,
+            hits: &mut Vec<String>,
+            allow: &[&str],
+            root: &std::path::Path,
+        ) {
+            let Ok(rd) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for ent in rd.flatten() {
+                let path = ent.path();
+                if path.is_dir() {
+                    walk(&path, hits, allow, root);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let rel = path
+                    .strip_prefix(root)
+                    .map(|p| p.to_string_lossy().replace('\\', "/"))
+                    .unwrap_or_default();
+                if allow.iter().any(|a| rel == *a) {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                for (i, line) in text.lines().enumerate() {
+                    if line.contains("execute_batch")
+                        && (line.contains("SQL_BEGIN_IMMEDIATE")
+                            || line.contains("SQL_BEGIN_DEFERRED")
+                            || line.contains("SQL_BEGIN_EXCLUSIVE"))
+                    {
+                        hits.push(format!("{rel}:{}:{line}", i + 1));
+                    }
+                }
+            }
+        }
+        walk(&root, &mut hits, &allow, &root);
+        assert!(
+            hits.is_empty(),
+            "raw execute_batch(SQL_BEGIN_*) outside allow-listed sites (#3163):\n{}",
+            hits.join("\n")
         );
     }
 

--- a/src/storage/connection.rs
+++ b/src/storage/connection.rs
@@ -76,6 +76,215 @@ pub const SQL_BEGIN_IMMEDIATE: &str = "BEGIN IMMEDIATE";
 pub const SQL_COMMIT: &str = "COMMIT";
 pub const SQL_ROLLBACK: &str = "ROLLBACK";
 
+/// v1.0.0 #3163 — the plain (DEFERRED) BEGIN, used by the CLI `mine` import's
+/// chunked transaction. Hoisted out of `cli/io.rs` as an inline literal so
+/// every transaction verb in the substrate is spelled once, here
+/// (pm-v3.1 no-hardcoded-literals). DEFERRED is correct there because the
+/// importer owns its own process-private connection and takes no lock until
+/// its first write.
+pub const SQL_BEGIN_DEFERRED: &str = "BEGIN";
+
+/// v1.0.0 #3163 — the migration ladder's exclusive-lock BEGIN, hoisted out
+/// of `migrations.rs` as an inline literal so every transaction verb in the
+/// substrate is spelled once, here (pm-v3.1 no-hardcoded-literals).
+/// `BEGIN EXCLUSIVE` additionally blocks READERS for the whole ladder, which
+/// is what keeps a concurrent process from observing a half-migrated schema.
+pub const SQL_BEGIN_EXCLUSIVE: &str = "BEGIN EXCLUSIVE";
+
+/// v1.0.0 #3163 — the RAII drop-guard for the explicit-`BEGIN IMMEDIATE`
+/// write-transaction pattern.
+///
+/// # Why this type exists
+///
+/// The substrate drives write transactions manually — `execute_batch(`
+/// [`SQL_BEGIN_IMMEDIATE`]`)` … `execute_batch(`[`SQL_COMMIT`]`)`, with a
+/// hand-written `execute_batch(`[`SQL_ROLLBACK`]`)` on each `Err` arm.
+/// That shape is correct on the happy path and on the arms someone
+/// remembered to write, but it is NOT unwind-safe: `Cargo.toml` keeps
+/// `panic = "unwind"`, and a panic between the BEGIN and the COMMIT skips
+/// every hand-written ROLLBACK.
+///
+/// That matters because the daemon's writer is a SINGLE
+/// `rusqlite::Connection` shared behind a `tokio::sync::Mutex`, and a
+/// `tokio` mutex does **not** poison. An unwind therefore releases the
+/// mutex with the connection still inside an open write transaction, and
+/// the next writer inherits it: its own `BEGIN IMMEDIATE` fails with
+/// "cannot start a transaction within a transaction", or its statements
+/// silently join the orphaned transaction and become visible on someone
+/// else's COMMIT. Both outcomes are mixed state, which the project's prime
+/// directive forbids outright.
+///
+/// `WriteTxn` closes that hole structurally rather than by discipline: the
+/// transaction is ended by [`Drop`], which runs on an unwind exactly as it
+/// runs on an early `?` return. The worst case after a panic is a
+/// ROLLED-BACK transaction on a usable connection — degrade, never corrupt.
+///
+/// # Contract
+///
+/// - [`WriteTxn::begin`] issues `BEGIN IMMEDIATE` (write lock taken up
+///   front, so contention surfaces at BEGIN and is retryable).
+/// - [`WriteTxn::commit`] is the ONLY way to keep the work. A failed
+///   COMMIT still leaves the guard armed, so the drop rolls back.
+/// - Every other exit — an early `?`, an explicit [`WriteTxn::rollback`],
+///   or a panic unwind — rolls back.
+/// - The guard borrows the connection SHAREDLY (`&'c Connection`), so the
+///   surrounding code keeps using `conn` verbatim; adopting the guard is a
+///   line-for-line swap at the BEGIN/COMMIT/ROLLBACK statements, not a
+///   restructure of the transaction body.
+///
+/// # Panics in `Drop`
+///
+/// Never. A failing ROLLBACK is logged at ERROR and swallowed
+/// (rust-1.98 OWNERSHIP-25: a panic in a destructor during an unwind
+/// aborts the process). The connection is left for the next
+/// [`ensure_autocommit`] sweep, which fails the request closed rather than
+/// writing into a foreign transaction.
+pub struct WriteTxn<'c> {
+    conn: &'c Connection,
+    /// `true` once the transaction has been terminated (committed or
+    /// rolled back), which makes [`Drop`] a no-op.
+    finished: bool,
+}
+
+impl<'c> WriteTxn<'c> {
+    /// Open an immediate write transaction on `conn`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `rusqlite` error from `BEGIN IMMEDIATE` — most
+    /// commonly `SQLITE_BUSY` when another connection holds the write
+    /// lock (retryable), or a nested-transaction error when the caller is
+    /// already inside one. No guard is constructed on failure, so nothing
+    /// is left to roll back.
+    pub fn begin(conn: &'c Connection) -> rusqlite::Result<Self> {
+        conn.execute_batch(SQL_BEGIN_IMMEDIATE)?;
+        Ok(Self {
+            conn,
+            finished: false,
+        })
+    }
+
+    /// Open a DEFERRED transaction on `conn` — the chunked-import boundary,
+    /// which takes no write lock until its first write.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `rusqlite` error from `BEGIN`. As with
+    /// [`WriteTxn::begin`], no guard is constructed on failure.
+    pub fn begin_deferred(conn: &'c Connection) -> rusqlite::Result<Self> {
+        conn.execute_batch(SQL_BEGIN_DEFERRED)?;
+        Ok(Self {
+            conn,
+            finished: false,
+        })
+    }
+
+    /// Open an EXCLUSIVE write transaction on `conn` — the schema-migration
+    /// ladder's boundary, which must also exclude readers.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `rusqlite` error from `BEGIN EXCLUSIVE`. As with
+    /// [`WriteTxn::begin`], no guard is constructed on failure.
+    pub fn begin_exclusive(conn: &'c Connection) -> rusqlite::Result<Self> {
+        conn.execute_batch(SQL_BEGIN_EXCLUSIVE)?;
+        Ok(Self {
+            conn,
+            finished: false,
+        })
+    }
+
+    /// Commit the transaction, consuming the guard.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `rusqlite` error from `COMMIT`. The guard stays
+    /// ARMED on failure, so the drop that follows this call rolls the
+    /// transaction back — a half-committed connection is never handed on.
+    pub fn commit(mut self) -> rusqlite::Result<()> {
+        self.conn.execute_batch(SQL_COMMIT)?;
+        // Only a SUCCESSFUL commit disarms the guard. On the error path we
+        // fall through with `finished == false` so `Drop` rolls back.
+        self.finished = true;
+        Ok(())
+    }
+
+    /// Roll the transaction back explicitly, consuming the guard.
+    ///
+    /// Equivalent to dropping the guard; provided so call sites that used
+    /// to write `let _ = conn.execute_batch(SQL_ROLLBACK);` keep saying
+    /// what they mean instead of relying on an invisible drop.
+    pub fn rollback(mut self) {
+        self.finish();
+    }
+
+    /// Terminate the transaction with a ROLLBACK unless it is already
+    /// terminated. Infallible by construction — see the type-level
+    /// "Panics in `Drop`" note.
+    fn finish(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        // A connection already back in autocommit has nothing open: the
+        // COMMIT landed, or SQLite auto-rolled the transaction back after
+        // a fatal statement error. Issuing ROLLBACK there would only log a
+        // spurious "cannot rollback - no transaction is active".
+        if self.conn.is_autocommit() {
+            return;
+        }
+        if let Err(e) = self.conn.execute_batch(SQL_ROLLBACK) {
+            tracing::error!(
+                target: TXN_GUARD_TRACE_TARGET,
+                error = %e,
+                "#3163 WriteTxn: ROLLBACK failed while unwinding a write \
+                 transaction; the shared writer connection is still inside a \
+                 transaction and the next ensure_autocommit sweep will fail \
+                 the request closed rather than write into it"
+            );
+        }
+    }
+}
+
+impl Drop for WriteTxn<'_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Tracing target for the #3163 transaction-integrity guards.
+const TXN_GUARD_TRACE_TARGET: &str = "ai_memory::storage::txn_guard";
+
+/// v1.0.0 #3163 — the mutex-boundary integrity sweep for a SHARED writer
+/// connection.
+///
+/// [`WriteTxn`] makes it structurally impossible for an unwind to leave one
+/// of the substrate's OWN write transactions open. This is the
+/// defense-in-depth layer behind it: called on both sides of every closure
+/// that borrows the daemon's shared writer connection
+/// (`crate::handlers::transport::db_op`), it guarantees the connection is in
+/// autocommit before another caller is allowed to touch it — no matter which
+/// code opened the transaction or how it was abandoned.
+///
+/// Returns `Ok(true)` when an orphaned transaction was found and rolled
+/// back (the caller should log that as a defect), `Ok(false)` when the
+/// connection was already clean.
+///
+/// # Errors
+///
+/// Returns the `rusqlite` error when the connection is inside a transaction
+/// that could NOT be rolled back. That is the fail-closed case: the caller
+/// must refuse the operation rather than run new statements inside an
+/// unknown transaction. The check is retried on the next acquisition, so a
+/// transient failure self-heals without any poison flag or reopen.
+pub fn ensure_autocommit(conn: &Connection) -> rusqlite::Result<bool> {
+    if conn.is_autocommit() {
+        return Ok(false);
+    }
+    conn.execute_batch(SQL_ROLLBACK)?;
+    Ok(true)
+}
+
 /// #1579 B7 — default `PRAGMA mmap_size` in bytes (256 MiB).
 ///
 /// The P1 perf-audit PRAGMA A/B on the 100k-row corpus found
@@ -444,7 +653,7 @@ fn apply_check_constraint_triggers(conn: &Connection) -> Result<()> {
         );
     }
 
-    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let write_txn = WriteTxn::begin(conn)?;
     let result = (|| -> Result<()> {
         conn.execute_batch(CHECK_CONSTRAINT_TRIGGERS_SQLITE)
             .context("apply CHECK-constraint triggers")?;
@@ -452,11 +661,11 @@ fn apply_check_constraint_triggers(conn: &Connection) -> Result<()> {
     })();
     match result {
         Ok(()) => {
-            conn.execute_batch("COMMIT")?;
+            write_txn.commit()?;
             Ok(())
         }
         Err(e) => {
-            let _ = conn.execute_batch("ROLLBACK");
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -811,6 +1020,186 @@ mod tests {
         assert!(
             index_present(&conn, "idx_shadow_obs_namespace_source_observed"),
             "v41 compound shadow index must be re-attached"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // v1.0.0 #3163 — `WriteTxn` unwind/commit-failure contract
+    // -----------------------------------------------------------------
+
+    /// A bare connection with one table, deliberately NOT the full schema —
+    /// these tests pin the transaction guard, not the substrate.
+    fn txn_test_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .expect("create t");
+        conn
+    }
+
+    fn row_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0))
+            .expect("count")
+    }
+
+    #[test]
+    fn write_txn_commit_persists_and_returns_to_autocommit() {
+        let conn = txn_test_conn();
+        let write_txn = WriteTxn::begin(&conn).expect("begin");
+        assert!(
+            !conn.is_autocommit(),
+            "BEGIN IMMEDIATE must leave the connection inside a transaction"
+        );
+        conn.execute("INSERT INTO t (id) VALUES (1)", [])
+            .expect("insert");
+        write_txn.commit().expect("commit");
+        assert!(conn.is_autocommit(), "COMMIT must restore autocommit");
+        assert_eq!(row_count(&conn), 1, "committed row must survive");
+    }
+
+    #[test]
+    fn write_txn_explicit_rollback_discards_the_partial_write() {
+        let conn = txn_test_conn();
+        let write_txn = WriteTxn::begin(&conn).expect("begin");
+        conn.execute("INSERT INTO t (id) VALUES (1)", [])
+            .expect("insert");
+        write_txn.rollback();
+        assert!(conn.is_autocommit(), "ROLLBACK must restore autocommit");
+        assert_eq!(row_count(&conn), 0, "rolled-back row must not be visible");
+    }
+
+    #[test]
+    fn write_txn_drop_without_commit_rolls_back() {
+        let conn = txn_test_conn();
+        {
+            let _write_txn = WriteTxn::begin(&conn).expect("begin");
+            conn.execute("INSERT INTO t (id) VALUES (1)", [])
+                .expect("insert");
+            // No commit — the guard falls out of scope here.
+        }
+        assert!(conn.is_autocommit(), "drop must end the transaction");
+        assert_eq!(row_count(&conn), 0, "uncommitted row must not be visible");
+    }
+
+    /// THE #3163 regression: a PANIC between BEGIN and COMMIT must leave the
+    /// connection usable and the partial write invisible. Pre-fix the
+    /// hand-written `match result { Err(_) => ROLLBACK }` arms were skipped by
+    /// the unwind and the transaction stayed open forever.
+    #[test]
+    fn write_txn_rolls_back_on_panic_unwind_and_connection_stays_usable() {
+        let conn = txn_test_conn();
+
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _write_txn = WriteTxn::begin(&conn).expect("begin");
+            conn.execute("INSERT INTO t (id) VALUES (1)", [])
+                .expect("partial write");
+            panic!("#3163: injected panic between BEGIN and COMMIT");
+        }));
+        assert!(unwound.is_err(), "the injected panic must have unwound");
+
+        // (c) the connection is back in autocommit …
+        assert!(
+            conn.is_autocommit(),
+            "#3163: an unwind must not leave the shared writer inside a transaction"
+        );
+        // (a) … the partial write is NOT visible …
+        assert_eq!(
+            row_count(&conn),
+            0,
+            "#3163: the partial write must have been rolled back by the guard"
+        );
+        // (b) … and the next write on the SAME connection succeeds.
+        let write_txn = WriteTxn::begin(&conn).expect("#3163: next BEGIN must succeed");
+        conn.execute("INSERT INTO t (id) VALUES (2)", [])
+            .expect("post-unwind write");
+        write_txn.commit().expect("post-unwind commit");
+        assert_eq!(row_count(&conn), 1, "the post-unwind write must persist");
+    }
+
+    /// The #3163 addendum: the house pattern propagated a COMMIT failure with
+    /// `?` and NEVER rolled back, stranding the shared writer mid-transaction
+    /// so the next caller saw `is_autocommit() == false`, skipped its own
+    /// BEGIN, and silently joined the orphaned transaction.
+    ///
+    /// A DEFERRED foreign-key violation is the deterministic injection: SQLite
+    /// reports the violation at COMMIT time with `SQLITE_CONSTRAINT` and
+    /// deliberately leaves the transaction OPEN, which is exactly the shape
+    /// the guard has to survive.
+    #[test]
+    fn write_txn_rolls_back_when_commit_itself_fails() {
+        let conn = Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch(
+            "CREATE TABLE parent (id INTEGER PRIMARY KEY);\n\
+             CREATE TABLE t (\n\
+                 id INTEGER PRIMARY KEY,\n\
+                 parent_id INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED\n\
+             );",
+        )
+        .expect("create schema");
+        conn.execute_batch("PRAGMA foreign_keys = ON")
+            .expect("enable FK enforcement");
+
+        let write_txn = WriteTxn::begin(&conn).expect("begin");
+        conn.execute("INSERT INTO t (id, parent_id) VALUES (1, 999)", [])
+            .expect("deferred FK violation is accepted until COMMIT");
+        let err = write_txn
+            .commit()
+            .expect_err("COMMIT must fail on the deferred FK violation");
+        assert!(
+            format!("{err}")
+                .to_ascii_lowercase()
+                .contains("foreign key"),
+            "expected a foreign-key COMMIT failure, got: {err}"
+        );
+
+        // The guard's drop ran on the `?`-return out of `commit()`.
+        assert!(
+            conn.is_autocommit(),
+            "#3163 addendum: a FAILED COMMIT must not strand the writer inside \
+             a transaction"
+        );
+        assert_eq!(row_count(&conn), 0, "the violating row must not survive");
+
+        // And the next write on the same connection succeeds — the exact
+        // property the addendum says was broken.
+        conn.execute("INSERT INTO parent (id) VALUES (999)", [])
+            .expect("next write must succeed");
+        let write_txn = WriteTxn::begin(&conn).expect("next BEGIN must succeed");
+        conn.execute("INSERT INTO t (id, parent_id) VALUES (2, 999)", [])
+            .expect("insert");
+        write_txn.commit().expect("second commit must succeed");
+        assert_eq!(row_count(&conn), 1, "the post-failure write must persist");
+    }
+
+    #[test]
+    fn ensure_autocommit_is_a_no_op_on_a_clean_connection() {
+        let conn = txn_test_conn();
+        assert!(
+            !ensure_autocommit(&conn).expect("clean sweep"),
+            "a connection already in autocommit must report nothing to do"
+        );
+        assert!(conn.is_autocommit());
+    }
+
+    /// The mutex-boundary sweep must clear a transaction the substrate did NOT
+    /// open through [`WriteTxn`] — a future call site, or code this crate does
+    /// not own. This is the defense-in-depth half of #3163.
+    #[test]
+    fn ensure_autocommit_rolls_back_an_unguarded_transaction() {
+        let conn = txn_test_conn();
+        conn.execute_batch(SQL_BEGIN_IMMEDIATE)
+            .expect("raw BEGIN, deliberately unguarded");
+        conn.execute("INSERT INTO t (id) VALUES (1)", [])
+            .expect("partial write");
+
+        assert!(
+            ensure_autocommit(&conn).expect("sweep must succeed"),
+            "the sweep must REPORT that it found and rolled back a transaction"
+        );
+        assert!(conn.is_autocommit(), "the connection must be usable again");
+        assert_eq!(
+            row_count(&conn),
+            0,
+            "the unguarded write must be rolled back"
         );
     }
 

--- a/src/storage/migrations.rs
+++ b/src/storage/migrations.rs
@@ -1570,7 +1570,7 @@ pub(crate) fn migrate(conn: &Connection) -> Result<()> {
         }
     }
 
-    conn.execute_batch("BEGIN EXCLUSIVE")?;
+    let write_txn = super::connection::WriteTxn::begin_exclusive(conn)?;
     let result = (|| -> Result<()> {
         if version < 2 {
             let mut has_confidence = false;
@@ -3883,11 +3883,11 @@ pub(crate) fn migrate(conn: &Connection) -> Result<()> {
 
     match result {
         Ok(()) => {
-            conn.execute_batch(super::connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(())
         }
         Err(e) => {
-            let _ = conn.execute_batch(super::connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1887,9 +1887,11 @@ fn insert_inner(
     let owns_tx = (crate::encryption::encryption_enabled(None)
         || crate::config::append_only_enabled())
         && conn.is_autocommit();
-    if owns_tx {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
-    }
+    let write_txn = if owns_tx {
+        Some(connection::WriteTxn::begin(conn)?)
+    } else {
+        None
+    };
     let sealed_insert = (|| -> Result<String> {
         // #2948 — armed-only version pre-probe. `None` when the spine is OFF
         // (default → no extra read → byte-identical) or when no row currently
@@ -2196,12 +2198,12 @@ fn insert_inner(
         emit_upsert_supersede_leaf_if_enabled(conn, prior_version_on_conflict, &actual_id, mem)?;
         Ok(actual_id)
     })();
-    if owns_tx {
+    if let Some(write_txn) = write_txn {
         match &sealed_insert {
-            Ok(_) => conn.execute_batch(connection::SQL_COMMIT)?,
-            Err(_) => {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
-            }
+            Ok(_) => write_txn.commit()?,
+            // #3163 — the guard would roll back on drop anyway; saying it
+            // explicitly keeps the intent readable at the call site.
+            Err(_) => write_txn.rollback(),
         }
     }
     sealed_insert
@@ -2342,8 +2344,8 @@ pub fn capture_turn_idempotent(
         });
     }
 
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)
-        .map_err(|e| format!("TX_BEGIN_FAILED: {e}"))?;
+    let write_txn =
+        connection::WriteTxn::begin(conn).map_err(|e| format!("TX_BEGIN_FAILED: {e}"))?;
 
     let tx_result = (|| -> std::result::Result<String, String> {
         // #2121 (supersedes the #2110/#2113 unconditional stamp) — the
@@ -2386,7 +2388,8 @@ pub fn capture_turn_idempotent(
 
     match tx_result {
         Ok(memory_id) => {
-            conn.execute_batch(connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .map_err(|e| format!("TX_COMMIT_FAILED: {e}"))?;
             Ok(crate::models::CaptureTurnResult {
                 memory_id,
@@ -2394,7 +2397,7 @@ pub fn capture_turn_idempotent(
             })
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -2473,8 +2476,8 @@ pub fn recover_turn_idempotent(
         });
     }
 
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)
-        .map_err(|e| format!("TX_BEGIN_FAILED: {e}"))?;
+    let write_txn =
+        connection::WriteTxn::begin(conn).map_err(|e| format!("TX_BEGIN_FAILED: {e}"))?;
 
     let tx_result = (|| -> std::result::Result<String, String> {
         // #2121 (supersedes the #2110/#2113 unconditional stamp) — stamp the
@@ -2509,7 +2512,8 @@ pub fn recover_turn_idempotent(
 
     match tx_result {
         Ok(memory_id) => {
-            conn.execute_batch(connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .map_err(|e| format!("TX_COMMIT_FAILED: {e}"))?;
             Ok(crate::models::RecoverTurnResult {
                 memory_id,
@@ -2517,7 +2521,7 @@ pub fn recover_turn_idempotent(
             })
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -2816,7 +2820,7 @@ pub fn touch(conn: &Connection, id: &str, short_extend: i64, mid_extend: i64) ->
     let mid_expires =
         crate::validate::render_canonical_utc(now + chrono::Duration::seconds(mid_extend));
 
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
 
     let result = (|| -> Result<()> {
         // #1596 — the per-access TTL window is an extension FLOOR, not a
@@ -2860,13 +2864,11 @@ pub fn touch(conn: &Connection, id: &str, short_extend: i64, mid_extend: i64) ->
 
     match result {
         Ok(()) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(())
         }
         Err(e) => {
-            if let Err(rb) = conn.execute_batch(connection::SQL_ROLLBACK) {
-                tracing::error!("ROLLBACK failed in touch: {}", rb);
-            }
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -2930,7 +2932,7 @@ pub fn touch_many(
     let mid_expires =
         crate::validate::render_canonical_utc(now + chrono::Duration::seconds(mid_extend));
 
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
 
     let result = (|| -> Result<()> {
         // Cache the three prepared statements once for the whole
@@ -2972,13 +2974,11 @@ pub fn touch_many(
 
     match result {
         Ok(()) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(ids.len())
         }
         Err(e) => {
-            if let Err(rb) = conn.execute_batch(connection::SQL_ROLLBACK) {
-                tracing::error!("ROLLBACK failed in touch_many: {}", rb);
-            }
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -3059,7 +3059,7 @@ pub fn fold_recall_accesses(
     let decay = crate::confidence::decay::decay_enabled();
     let mut total = 0_usize;
     loop {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+        let write_txn = connection::WriteTxn::begin(conn)?;
         let chunk = (|| -> Result<usize> {
             // ≤ FOLD_CHUNK_MEMORIES distinct memories per transaction.
             let agg: Vec<(String, i64, String)> = conn
@@ -3149,20 +3149,18 @@ pub fn fold_recall_accesses(
         })();
         match chunk {
             Ok(0) => {
-                conn.execute_batch(connection::SQL_COMMIT)?;
+                write_txn.commit()?;
                 break;
             }
             Ok(n) => {
-                conn.execute_batch(connection::SQL_COMMIT)?;
+                write_txn.commit()?;
                 total += n;
                 if n < FOLD_CHUNK_MEMORIES {
                     break; // drained
                 }
             }
             Err(e) => {
-                if let Err(rb) = conn.execute_batch(connection::SQL_ROLLBACK) {
-                    tracing::error!("ROLLBACK failed in fold_recall_accesses: {rb}");
-                }
+                write_txn.rollback();
                 return Err(e);
             }
         }
@@ -3566,9 +3564,11 @@ pub fn update_with_expected_version(
     // caller owns the tx, the archive + UPDATE run inside it and the
     // caller's commit/rollback covers atomicity.
     let owns_tx = conn.is_autocommit();
-    if owns_tx {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
-    }
+    let write_txn = if owns_tx {
+        Some(connection::WriteTxn::begin(conn)?)
+    } else {
+        None
+    };
     let txn_result = (|| -> Result<(bool, bool)> {
         if content_changed {
             archive_memory_insert_only(
@@ -3678,16 +3678,16 @@ pub fn update_with_expected_version(
     })();
     match txn_result {
         Ok(r) => {
-            if owns_tx {
-                conn.execute_batch(connection::SQL_COMMIT)?;
+            if let Some(write_txn) = write_txn {
+                write_txn.commit()?;
             }
             Ok(r)
         }
         Err(e) => {
             // Only roll back a tx we opened. When the caller owns the tx,
             // propagating the Err lets THEIR rollback revert the archive.
-            if owns_tx {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            if let Some(write_txn) = write_txn {
+                write_txn.rollback();
             }
             Err(e)
         }
@@ -3910,7 +3910,7 @@ pub fn update_with_archive_on_supersede(
     consult_governance_pre_write(&new_mem)?;
 
     // Steps 1+2 (#1638): one transaction around archive + insert.
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let tx_result = (|| -> Result<()> {
         // Step 1: archive the OLD row with reason='superseded'.
         let moved = archive_memory_no_tx(conn, &archived_id, Some("superseded"))?;
@@ -3927,9 +3927,9 @@ pub fn update_with_archive_on_supersede(
         Ok(())
     })();
     match tx_result {
-        Ok(()) => conn.execute_batch(connection::SQL_COMMIT)?,
+        Ok(()) => write_txn.commit()?,
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             return Err(e);
         }
     }
@@ -4204,7 +4204,7 @@ pub fn conserve_contradiction(
     winner_id: &str,
     curator_keypair: Option<&crate::identity::keypair::AgentKeypair>,
 ) -> Result<()> {
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let tx_result = (|| -> Result<()> {
         // (1) Resurrection-race guard: re-read under the write lock.
         let Some(current) = get(conn, &loser.id)? else {
@@ -4268,9 +4268,9 @@ pub fn conserve_contradiction(
         Ok(())
     })();
     match tx_result {
-        Ok(()) => conn.execute_batch(connection::SQL_COMMIT)?,
+        Ok(()) => write_txn.commit()?,
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             return Err(e);
         }
     }
@@ -4299,7 +4299,7 @@ pub fn reverse_conserve_contradiction(
     canonical_src: &str,
     canonical_tgt: &str,
 ) -> Result<()> {
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let tx_result = (|| -> Result<()> {
         // Remove ONLY the canonical `contradicts` edge for this pair
         // (relation-scoped so we never disturb another relation the pair
@@ -4331,9 +4331,9 @@ pub fn reverse_conserve_contradiction(
         Ok(())
     })();
     match tx_result {
-        Ok(()) => conn.execute_batch(connection::SQL_COMMIT)?,
+        Ok(()) => write_txn.commit()?,
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             return Err(e);
         }
     }
@@ -4356,15 +4356,15 @@ pub fn reverse_conserve_contradiction(
 ///
 /// Returns an error if the INSERT-SELECT or DELETE fails.
 pub fn archive_memory(conn: &Connection, id: &str, reason: Option<&str>) -> Result<bool> {
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = archive_memory_no_tx(conn, id, reason);
     match result {
         Ok(moved) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(moved)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -4884,7 +4884,7 @@ pub fn archive_memory_for_caller(
 ) -> Result<bool> {
     let now = Utc::now().to_rfc3339();
     let reason = reason.unwrap_or(crate::models::field_names::ARCHIVE_REASON_DEFAULT);
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = (|| -> Result<bool> {
         // Owner gate: row must exist AND match the caller (or be an
         // inbox-target row whose recipient is the caller).
@@ -4958,11 +4958,11 @@ pub fn archive_memory_for_caller(
     })();
     match result {
         Ok(moved) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(moved)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -5747,7 +5747,7 @@ pub fn forget(
     // atomic AND pins them to the identical row set: the write lock is held for
     // the whole transaction, so no concurrent writer can change the match set
     // between the archive and the delete.
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = (|| -> Result<usize> {
         if archive {
             // Archive matching memories before deletion.
@@ -5923,11 +5923,11 @@ pub fn forget(
 
     match result {
         Ok(deleted) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(deleted)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -6213,7 +6213,7 @@ pub fn forget_for_caller(
     // for the full rationale). The owner clause (#1772) is pinned to the
     // identical row set across the archive SELECT and the DELETE because the
     // `BEGIN IMMEDIATE` write lock is held for the whole transaction.
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = (|| -> Result<usize> {
         if archive {
             // Archive matching memories before deletion.
@@ -6399,11 +6399,11 @@ pub fn forget_for_caller(
 
     match result {
         Ok(deleted) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(deleted)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -8783,7 +8783,7 @@ pub fn consolidate(
     let now = Utc::now().to_rfc3339();
     let new_id = uuid::Uuid::new_v4().to_string();
 
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
 
     let result = (|| -> Result<String> {
         // Verify all IDs exist and collect metadata in one pass
@@ -9123,13 +9123,11 @@ pub fn consolidate(
 
     match result {
         Ok(id) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(id)
         }
         Err(e) => {
-            if let Err(rb) = conn.execute_batch(connection::SQL_ROLLBACK) {
-                tracing::error!("ROLLBACK failed in consolidate: {}", rb);
-            }
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -10775,8 +10773,14 @@ pub fn invalidate_link(
     // signature) and the audit INSERT leaves H5's silent-supersession
     // state — the exact thing H5 was added to prevent. RESERVED-lock
     // semantics also serialise concurrent writers across processes.
-    conn.execute(connection::SQL_BEGIN_IMMEDIATE, [])?;
-    // From here on, every early return MUST `ROLLBACK` first.
+    let write_txn = connection::WriteTxn::begin(conn)?;
+    // #3163 — `write_txn` now rolls back on EVERY non-commit exit, unwind
+    // included, so correctness no longer depends on remembering this call.
+    // The explicit `rollback()` is kept because it ends the write transaction
+    // at the exact early-return point instead of at end-of-scope, which keeps
+    // the RESERVED lock hold as short as it was before; it is idempotent
+    // against the guard (the guard no-ops once the connection is back in
+    // autocommit).
     let rollback = || {
         let _ = conn.execute(connection::SQL_ROLLBACK, []);
     };
@@ -10911,7 +10915,7 @@ pub fn invalidate_link(
         }
     }
 
-    conn.execute(connection::SQL_COMMIT, [])?;
+    write_txn.commit()?;
     Ok(Some(InvalidateResult {
         valid_until: stamp,
         previous_valid_until: prior,
@@ -12186,8 +12190,7 @@ pub fn append_lineage_record(
 
     // C4 — one IMMEDIATE transaction for body + pubkey sync + witness
     // (clone of the capture_turn_idempotent single-tx contract).
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)
-        .context("append_lineage_record: begin tx")?;
+    let write_txn = connection::WriteTxn::begin(conn).context("append_lineage_record: begin tx")?;
     let tx_result = (|| -> Result<()> {
         conn.execute(
             "INSERT INTO agent_lineage \
@@ -12245,12 +12248,13 @@ pub fn append_lineage_record(
 
     match tx_result {
         Ok(()) => {
-            conn.execute_batch(connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .context("append_lineage_record: commit")?;
             Ok(())
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -13020,7 +13024,7 @@ pub fn gc(conn: &Connection, archive: bool) -> Result<usize> {
     // smaller gc calls).
     let mut total = 0usize;
     loop {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+        let write_txn = connection::WriteTxn::begin(conn)?;
         let result = (|| -> Result<usize> {
             if archive {
                 // v0.6.3.1 P2 (G5) — preserve embedding + tier + expiry on GC archive.
@@ -13102,14 +13106,14 @@ pub fn gc(conn: &Connection, archive: bool) -> Result<usize> {
         })();
         match result {
             Ok(n) => {
-                conn.execute_batch(connection::SQL_COMMIT)?;
+                write_txn.commit()?;
                 total += n;
                 if n < GC_CHUNK_ROWS {
                     break;
                 }
             }
             Err(e) => {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+                write_txn.rollback();
                 return Err(e);
             }
         }
@@ -13221,7 +13225,7 @@ pub fn size_gc(
         // autocommit statements → a crash between them left that victim both
         // archived AND live (duplicate). Per-victim tx bounds the lock-hold
         // (mirrors `gc`'s chunked sweep) while making each eviction atomic.
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+        let write_txn = connection::WriteTxn::begin(conn)?;
         let victim_result = (|| -> Result<()> {
             if archive {
                 // Restorable eviction: archive-before-delete in one step,
@@ -13280,9 +13284,9 @@ pub fn size_gc(
             Ok(())
         })();
         match victim_result {
-            Ok(()) => conn.execute_batch(connection::SQL_COMMIT)?,
+            Ok(()) => write_txn.commit()?,
             Err(e) => {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+                write_txn.rollback();
                 return Err(e);
             }
         }
@@ -13503,7 +13507,7 @@ fn canonical_archived_expiry(conn: &Connection, id: &str) -> Result<Option<Strin
 pub fn restore_archived(conn: &Connection, id: &str) -> Result<bool> {
     let now = Utc::now().to_rfc3339();
     let _erasure_guard = crate::erasure::archive_sync::coordination_lock_if_enabled(conn)?;
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = (|| -> Result<bool> {
         let exists: bool = conn
             .query_row(
@@ -13681,7 +13685,7 @@ pub fn restore_archived(conn: &Connection, id: &str) -> Result<bool> {
     })();
     match result {
         Ok(v) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             // #2064 F1 — the archived row is now live; its cold-tier bundle is
             // a STALE snapshot. Remove it in the same flow so a later
             // non-archiving delete of the live row cannot resurrect the old
@@ -13696,7 +13700,7 @@ pub fn restore_archived(conn: &Connection, id: &str) -> Result<bool> {
             Ok(v)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -13721,7 +13725,7 @@ pub fn restore_archived(conn: &Connection, id: &str) -> Result<bool> {
 pub fn restore_archived_for_caller(conn: &Connection, id: &str, caller: &str) -> Result<bool> {
     let now = Utc::now().to_rfc3339();
     let _erasure_guard = crate::erasure::archive_sync::coordination_lock_if_enabled(conn)?;
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let result = (|| -> Result<bool> {
         // Owner gate: row must exist AND match the caller (or be an
         // inbox-target row whose recipient is the caller, or be a
@@ -13906,7 +13910,7 @@ pub fn restore_archived_for_caller(conn: &Connection, id: &str, caller: &str) ->
     })();
     match result {
         Ok(v) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             // #2064 F1 — remove the now-stale bundle after a successful
             // restore (see [`restore_archived`] for the rationale).
             if v {
@@ -13918,7 +13922,7 @@ pub fn restore_archived_for_caller(conn: &Connection, id: &str, caller: &str) ->
             Ok(v)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }
@@ -14389,9 +14393,11 @@ pub fn insert_if_newer(conn: &Connection, mem: &Memory) -> Result<String> {
     let owns_tx = (crate::encryption::encryption_enabled(None)
         || crate::config::append_only_enabled())
         && conn.is_autocommit();
-    if owns_tx {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
-    }
+    let write_txn = if owns_tx {
+        Some(connection::WriteTxn::begin(conn)?)
+    } else {
+        None
+    };
     let sealed_merge = (|| -> Result<String> {
         // #2954 — armed-only pre-image of the `(title, namespace)` row this
         // upsert may overwrite. `None` when the spine is OFF (byte-identical) or
@@ -14633,12 +14639,12 @@ pub fn insert_if_newer(conn: &Connection, mem: &Memory) -> Result<String> {
         )?;
         Ok(actual_id)
     })();
-    if owns_tx {
+    if let Some(write_txn) = write_txn {
         match &sealed_merge {
-            Ok(_) => conn.execute_batch(connection::SQL_COMMIT)?,
-            Err(_) => {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
-            }
+            Ok(_) => write_txn.commit()?,
+            // #3163 — the guard would roll back on drop anyway; saying it
+            // explicitly keeps the intent readable at the call site.
+            Err(_) => write_txn.rollback(),
         }
     }
     sealed_merge
@@ -14733,7 +14739,7 @@ pub fn merge_inbound(
     // Take the write lock up front so the read-merge-write is atomic
     // against a concurrent peer push (BEGIN IMMEDIATE — same idiom as
     // `consolidate` / `size_gc`).
-    conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
+    let write_txn = connection::WriteTxn::begin(conn)?;
     let tx_result = (|| -> Result<Option<String>> {
         match get(conn, &inbound.id)? {
             Some(existing) => {
@@ -14799,18 +14805,18 @@ pub fn merge_inbound(
 
     match tx_result {
         Ok(Some(id)) => {
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             Ok(id)
         }
         Ok(None) => {
             // Nothing was written in the merge transaction; close it
             // cleanly and fall through to the unchanged LWW path
             // (handles fresh insert + (title, namespace) dedup-upsert).
-            conn.execute_batch(connection::SQL_COMMIT)?;
+            write_txn.commit()?;
             insert_if_newer(conn, inbound)
         }
         Err(e) => {
-            let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            write_txn.rollback();
             Err(e)
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4103,20 +4103,22 @@ pub fn delete(conn: &Connection, id: &str) -> Result<bool> {
     // commit/rollback covers atomicity (which is exactly the guarantee the
     // caller already wanted).
     let owns_tx = conn.is_autocommit();
-    if owns_tx {
-        conn.execute_batch(connection::SQL_BEGIN_IMMEDIATE)?;
-    }
+    let write_txn = if owns_tx {
+        Some(connection::WriteTxn::begin(conn)?)
+    } else {
+        None
+    };
     let txn_result = delete_inner(conn, id);
     match txn_result {
         Ok(changed) => {
-            if owns_tx {
-                conn.execute_batch(connection::SQL_COMMIT)?;
+            if let Some(txn) = write_txn {
+                txn.commit()?;
             }
             Ok(changed)
         }
         Err(e) => {
-            if owns_tx {
-                let _ = conn.execute_batch(connection::SQL_ROLLBACK);
+            if let Some(txn) = write_txn {
+                txn.rollback();
             }
             Err(e)
         }

--- a/src/storage/reflect.rs
+++ b/src/storage/reflect.rs
@@ -586,7 +586,7 @@ pub fn reflect_with_hooks(
     // links inside a single BEGIN IMMEDIATE ... COMMIT block. If any
     // link insert fails, ROLLBACK undoes the reflection row too.
     // Matches the `consolidate` pattern earlier in this file.
-    conn.execute_batch(super::connection::SQL_BEGIN_IMMEDIATE)
+    let write_txn = super::connection::WriteTxn::begin(conn)
         .map_err(|e| ReflectError::Database(e.to_string()))?;
 
     let txn_result = (|| -> std::result::Result<String, ReflectError> {
@@ -646,7 +646,8 @@ pub fn reflect_with_hooks(
 
     match txn_result {
         Ok(actual_id) => {
-            conn.execute_batch(super::connection::SQL_COMMIT)
+            write_txn
+                .commit()
                 .map_err(|e| ReflectError::Database(e.to_string()))?;
             let outcome = ReflectOutcome {
                 id: actual_id,
@@ -668,9 +669,7 @@ pub fn reflect_with_hooks(
             Ok(outcome)
         }
         Err(e) => {
-            if let Err(rb) = conn.execute_batch(super::connection::SQL_ROLLBACK) {
-                tracing::error!("ROLLBACK failed in reflect: {}", rb);
-            }
+            write_txn.rollback();
             Err(e)
         }
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1211,17 +1211,26 @@ impl MemoryStore for SqliteStore {
         // v0.7.0 #1079 — wrap the per-id decay-touch loop in a single
         // BEGIN/COMMIT pair so each id pays only the UPDATE cost.
         if crate::confidence::decay::decay_enabled() {
-            if let Err(e) = conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE) {
-                tracing::warn!("decay-touch BEGIN failed: {e}");
-            } else {
-                for id in ids {
-                    if let Err(e) = crate::confidence::decay::apply_decay_touch(&conn, id) {
-                        tracing::warn!("confidence decay touch failed for memory {id}: {e}");
+            // #3163 — the RAII guard ends this transaction on EVERY exit,
+            // including a panic unwind out of `apply_decay_touch`. Pre-fix an
+            // unwind here stranded an open write transaction on the SAL
+            // store's own long-lived shared writer connection
+            // (`SqliteStore::state`), which is a second non-poisoning
+            // `tokio::sync::Mutex` with exactly the `Db` hazard.
+            match crate::storage::connection::WriteTxn::begin(&conn) {
+                Err(e) => tracing::warn!("decay-touch BEGIN failed: {e}"),
+                Ok(write_txn) => {
+                    for id in ids {
+                        if let Err(e) = crate::confidence::decay::apply_decay_touch(&conn, id) {
+                            tracing::warn!("confidence decay touch failed for memory {id}: {e}");
+                        }
                     }
-                }
-                if let Err(e) = conn.execute_batch(crate::storage::connection::SQL_COMMIT) {
-                    tracing::warn!("decay-touch COMMIT failed: {e}");
-                    let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+                    // A failed COMMIT leaves the guard armed, so the drop that
+                    // follows rolls the partial decay-touch back rather than
+                    // handing the next SAL caller a mid-transaction connection.
+                    if let Err(e) = write_txn.commit() {
+                        tracing::warn!("decay-touch COMMIT failed: {e}");
+                    }
                 }
             }
         }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1982,10 +1982,11 @@ impl MemoryStore for SqliteStore {
         // a transaction"): open our own tx ONLY when the caller does not
         // already hold one.
         let owns_tx = conn.is_autocommit();
-        if owns_tx {
-            conn.execute_batch(crate::storage::connection::SQL_BEGIN_IMMEDIATE)
-                .map_err(box_err)?;
-        }
+        let write_txn = if owns_tx {
+            Some(crate::storage::connection::WriteTxn::begin(&conn).map_err(box_err)?)
+        } else {
+            None
+        };
         let batch = (|| -> anyhow::Result<usize> {
             let mut moved = 0usize;
             for id in ids {
@@ -1997,15 +1998,14 @@ impl MemoryStore for SqliteStore {
         })();
         match batch {
             Ok(moved) => {
-                if owns_tx {
-                    conn.execute_batch(crate::storage::connection::SQL_COMMIT)
-                        .map_err(box_err)?;
+                if let Some(txn) = write_txn {
+                    txn.commit().map_err(box_err)?;
                 }
                 Ok(moved)
             }
             Err(e) => {
-                if owns_tx {
-                    let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
+                if let Some(txn) = write_txn {
+                    txn.rollback();
                 }
                 Err(box_err(e))
             }

--- a/tests/f53_claimed_vs_attested_e2e.rs
+++ b/tests/f53_claimed_vs_attested_e2e.rs
@@ -338,14 +338,14 @@ async fn checkpoint_attestation_claimed_vs_attested() {
     // Attested: signed by the resolver's enrolled key → Accept (both modes).
     assert_eq!(
         authorize_remote_checkpoint_resolution(&r, &sig, Some(&resolver.public), true),
-        CheckpointResolutionAuthz::Accept,
+        CheckpointResolutionAuthz::Accept(resolver.public),
         "signed + enrolled → attested Accept (fail-closed mode)"
     );
 
     // Claimed lane: unsigned → permissive Accept, fail-closed RejectUnsigned.
     assert_eq!(
         authorize_remote_checkpoint_resolution(&r, &[], None, false),
-        CheckpointResolutionAuthz::Accept,
+        CheckpointResolutionAuthz::AcceptUnverified,
         "unsigned → permissive Accept (claimed data lane)"
     );
     assert_eq!(

--- a/tests/governance_deferred_log_audit.rs
+++ b/tests/governance_deferred_log_audit.rs
@@ -35,9 +35,9 @@ use std::time::{Duration, Instant};
 use ai_memory::db;
 use ai_memory::governance::agent_action::{AgentAction, Decision, check_agent_action_deferred};
 use ai_memory::governance::deferred_audit::{
-    AppendOutcome, DeferredAuditEvent, DeferredAuditQueue, DeferredAuditSink,
-    GOVERNANCE_REFUSAL_EVENT_TYPE, SqliteSignedEventsSink, close_and_flush,
-    install_deferred_audit_drainer, spawn_drainer_task, spawn_supervised_drainer,
+    AppendOutcome, DeferredAuditEvent, DeferredAuditQueue, DeferredAuditSink, DrainError,
+    DrainFlushError, DrainTerminalState, GOVERNANCE_REFUSAL_EVENT_TYPE, SqliteSignedEventsSink,
+    close_and_flush, install_deferred_audit_drainer, spawn_drainer_task, spawn_supervised_drainer,
 };
 use ai_memory::governance::rules_store::{self, Rule};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier};
@@ -236,6 +236,110 @@ impl DeferredAuditSink for PanicOnceSink {
         );
         Ok(AppendOutcome::Appended)
     }
+}
+
+/// v1.0.0 #3164 — a sink that panics on EVERY call, so the supervisor's
+/// restart budget is exhausted rather than recovered from.
+struct AlwaysPanicSink;
+
+impl DeferredAuditSink for AlwaysPanicSink {
+    fn append(&mut self, _event: &DeferredAuditEvent) -> anyhow::Result<AppendOutcome> {
+        panic!("AlwaysPanicSink: unrecoverable sink");
+    }
+}
+
+/// v1.0.0 #3164 — a sink that always returns `Err`, exhausting the budget
+/// through the UNRESOLVED arm rather than the panic arm.
+struct AlwaysErrSink;
+
+impl DeferredAuditSink for AlwaysErrSink {
+    fn append(&mut self, _event: &DeferredAuditEvent) -> anyhow::Result<AppendOutcome> {
+        Err(anyhow::anyhow!("AlwaysErrSink: chain write refused"))
+    }
+}
+
+/// v1.0.0 #3164 — exhausting the restart budget on a PANICKING sink must
+/// produce a TYPED terminal state that is observable while the process is
+/// still running, not a `panic!` that silently kills only the supervisor task
+/// and leaves the daemon serving with a dead audit drainer.
+#[tokio::test]
+async fn supervisor_exhaustion_returns_typed_terminal_state_sink_panicked_3164() {
+    let (queue, rx) = DeferredAuditQueue::new();
+    let metrics = queue.metrics();
+    assert_eq!(
+        metrics.terminal_state(),
+        None,
+        "a fresh drainer has no terminal state"
+    );
+
+    let supervisor = spawn_supervised_drainer(rx, || AlwaysPanicSink, metrics.clone(), 0);
+    let event = DeferredAuditEvent::from_refusal(
+        "agent:terminal",
+        &refusal_action(),
+        &refusal_decision("R-terminal", "terminal panic test"),
+    )
+    .unwrap();
+    assert!(queue.submit(event));
+
+    let err = close_and_flush(queue, supervisor)
+        .await
+        .expect_err("#3164: an exhausted budget must NOT report a clean drain");
+    match err {
+        DrainFlushError::Drain(DrainError::SinkPanicked { max_restarts }) => {
+            assert_eq!(max_restarts, 0);
+        }
+        other => panic!("expected a typed SinkPanicked terminal state, got {other:?}"),
+    }
+
+    // The state is published on the SHARED metrics, so a fleet can see a dead
+    // drainer without awaiting the supervisor.
+    assert_eq!(
+        metrics.terminal_state(),
+        Some(DrainTerminalState::SinkPanicked),
+        "#3164: the terminal state must be observable on the metrics handle"
+    );
+    assert_eq!(
+        metrics.terminal_state().map(DrainTerminalState::as_str),
+        Some("sink_panicked")
+    );
+}
+
+/// Sibling of the above for the UNRESOLVED (`Err`-returning sink) arm, whose
+/// `panic!` had the same invisibility problem.
+#[tokio::test]
+async fn supervisor_exhaustion_returns_typed_terminal_state_sink_unresolved_3164() {
+    let (queue, rx) = DeferredAuditQueue::new();
+    let metrics = queue.metrics();
+
+    let supervisor = spawn_supervised_drainer(rx, || AlwaysErrSink, metrics.clone(), 0);
+    let event = DeferredAuditEvent::from_refusal(
+        "agent:unresolved",
+        &refusal_action(),
+        &refusal_decision("R-unresolved", "terminal unresolved test"),
+    )
+    .unwrap();
+    assert!(queue.submit(event));
+
+    let err = close_and_flush(queue, supervisor)
+        .await
+        .expect_err("#3164: an exhausted budget must NOT report a clean drain");
+    match err {
+        DrainFlushError::Drain(DrainError::SinkUnresolved {
+            max_restarts,
+            ref detail,
+        }) => {
+            assert_eq!(max_restarts, 0);
+            assert!(
+                detail.contains("chain write refused"),
+                "the typed error must carry the underlying cause, got {detail:?}"
+            );
+        }
+        ref other => panic!("expected a typed SinkUnresolved terminal state, got {other:?}"),
+    }
+    assert_eq!(
+        metrics.terminal_state(),
+        Some(DrainTerminalState::SinkUnresolved)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Two GA-blocking defects in the same failure family: a panic unwind (or a failed
`COMMIT`) could leave the daemon's **single shared sqlite writer connection inside an
open write transaction**, and the helper that dispatches every sqlite operation
**re-panicked the request task** instead of reporting the failure.

## #3163 — RAII `WriteTxn`: an unwind or a failed COMMIT can no longer strand the writer

`Cargo.toml` keeps `panic = "unwind"` and there is no `CatchPanicLayer`, so a panic in a
write path unwound straight past the hand-written `match result { Err(_) => ROLLBACK }`
arm at all **34** manual `BEGIN … COMMIT` sites. The writer is a SINGLE
`rusqlite::Connection` behind a `tokio::sync::Mutex`, which — unlike `std::sync::Mutex` —
does **not** poison, so the unwind released the mutex with the connection still inside an
open transaction and the next caller inherited it.

The nested-`BEGIN` outcome is loud and recoverable. The dangerous one is **silent**: the
three `owns_tx = … && conn.is_autocommit()` funnels —

- `src/storage/mod.rs:1882` `insert_inner`
- `src/storage/mod.rs:3556` `update_with_expected_version`
- `src/storage/mod.rs:14259` `insert_if_newer`

— see `is_autocommit() == false`, conclude *"the caller owns the transaction"*, skip their
own BEGIN/COMMIT, and let their writes **JOIN the orphaned transaction**, whose durability
is then decided by whoever eventually errors or restarts. That is mixed state and
unintentional data loss, which the prime directive ranks above every other concern.

**Fix — structural, not by discipline.** `storage::connection::WriteTxn` issues `ROLLBACK`
from `Drop`, which runs on an unwind exactly as it runs on an early `?` return. The worst
case after a panic is a **rolled-back transaction on a usable connection** — degrade,
never corrupt.

`commit()` disarms the guard **only on success**, which closes the issue's scout addendum:

> the house pattern `conn.execute_batch(SQL_COMMIT)?` propagates a COMMIT failure WITHOUT
> attempting ROLLBACK … a failed COMMIT leaves the shared writer mid-transaction → next
> caller sees `is_autocommit()==false`, skips BEGIN, joins the stranded txn, never commits.

The same destructor covers the panic path, the failed-COMMIT path, and the non-panic `Err`
path. `ROLLBACK`-from-`Drop` is infallible by construction (no-op when already in
autocommit, ERROR log otherwise) because a panicking destructor during an unwind aborts
the process — rust-1.98 **OWNERSHIP-25**.

Converted at all 34 sites — `storage/mod.rs` (23), `storage/reflect.rs`,
`storage/migrations.rs` (`BEGIN EXCLUSIVE`), `storage/connection.rs`, `store/sqlite.rs`
(the SAL store's *separate* shared writer, a second non-poisoning mutex with the identical
hazard), `quotas.rs` (2), `atomisation/mod.rs`, `federation/push_dlq.rs`,
`mcp/tools/store/synthesis.rs`, `cli/io.rs` (2, via `begin_deferred`).
`mcp/tools/skill_register.rs` and `skill_retire.rs` already used RAII
`rusqlite::Transaction` and are unchanged. Zero raw `execute_batch(…BEGIN…)` remain in
`src/` outside `connection.rs` itself and two deliberately-unguarded transport tests.

**Defense in depth at the mutex boundary.** `db_op` runs
`storage::connection::ensure_autocommit` on **both** sides of the closure and contains the
unwind. A connection found inside a transaction on acquisition, or left inside one on
release, is rolled back; if it cannot be rolled back the request is **refused** rather than
run inside an unknown transaction, and the next acquisition retries the sweep — so a
transient failure self-heals with no poison flag, no reopen, and no extra state on the `Db`
tuple. A closure that returns `Ok` while leaving a transaction open now **fails closed**
(`OrphanedTransaction`) instead of reporting a write the sweep just erased: a wrong result
is never an acceptable degradation, fewer results are. `db_read_op`'s writer-connection
FALLBACK arm sweeps too, because a read issued inside a foreign transaction would observe
that transaction's uncommitted rows.

**Postgres lane audited, no change required.** Every transaction goes through
`pool.begin()` → `sqlx::Transaction`, whose `Drop` calls `start_rollback` (sqlx-core
0.8.6); the only `BEGIN` literals in `store/postgres.rs` are PL/pgSQL
`DO $$ BEGIN … END $$` migration blocks, which are not transaction control. Postgres also
takes a connection from a **pool** rather than sharing one behind a mutex, so an unwind
cannot hand a dirty connection to the next caller.

## #3164 — production-reachable panics

1. **`db_op` / `db_read_op` return `Result` instead of re-panicking the request task.**
   Both ended in `.expect("… spawn_blocking worker panicked or runtime shut down")`
   (`handlers/transport.rs:86`, `handlers/read_pool.rs:259` at `cda57210`), so a panic in
   any handler closure — or a `spawn_blocking` cancelled during graceful shutdown —
   propagated into the connection task instead of producing a 500. Panics are now
   contained, logged with their payload, and surfaced as a typed `DbOpError`; `flatten_db_op`
   folds dispatch failures into the closure's own error type so handlers keep exactly one
   error path. **The PERF-1 (#982) and #1580 fast paths are unchanged** — same
   `spawn_blocking` hop, same pooled read-only connection, and `catch_unwind` costs nothing
   when nothing panics. Degradation is chosen per call site: `/health`'s sqlite probe
   reports a dispatch failure *as* a liveness failure; the corpus-gauge cold prime and
   recall's observation-ledger write log and continue (best-effort telemetry); substrate
   read/write handlers 500.
2. **The forensic-audit writer thread spawn no longer aborts boot.**
   `governance/audit.rs:164` `.expect()`ed `thread::Builder::spawn` on the **main thread**
   during `init_forensic_audit`, so a `clone(2)` refusal (`EAGAIN` from a pids-cgroup cap or
   `RLIMIT_NPROC` on a dense host — a resource condition, not a programmer bug) killed the
   process with exit 101 before it served a request. Now `Result` (ERRORS-01/02); every
   caller degrades; a failure does not poison the `OnceLock`, so a later call retries.
3. **A dead deferred-audit drainer is visible while the daemon still serves.** The
   supervisor `panic!`ed on `max_restarts` exhaustion (`deferred_audit.rs:2597`/`:2618`) —
   deliberately fail-loud, but a panic in a `tokio::spawn`ed task kills only *that* task:
   the daemon kept serving with the audit drainer permanently dead and nothing observed it
   until shutdown finally awaited the `JoinHandle`. Now
   `JoinHandle<Result<(), DrainError>>` with a typed `DrainTerminalState`
   (`sink_unresolved` / `sink_panicked`) published first-writer-wins on the shared
   `DeferredAuditMetrics` **and** on a new gauge
   `ai_memory_deferred_audit_drainer_terminal_state` (0 running/graceful, 1 unresolved,
   2 panicked). Fail-loud semantics unchanged — the supervisor still refuses to advance past
   an unresolved occurrence and `close_and_flush` still refuses to report a clean drain, now
   with a machine-readable cause.
4. **`CheckpointResolutionAuthz::Accept` carries the verifying key (ERRORS-09).** The
   verdict was returned bare from three branches, only one of which had authenticated
   anything: the two permissive (`require_sig == false`) branches returned `Accept` with
   `enrolled_key == None`. `mcp/tools/checkpoint.rs:296` turned that into
   `enrolled.expect("Accept implies an enrolled verifying key")`, sound **only** because
   that call site hardcodes `require_sig = true` two lines up — while its HTTP sibling
   (`handlers/federation_receive.rs:3541`) already passes the **runtime** flag. Wiring the
   same flag into the MCP tool would have made a remote peer's unsigned resolution panic an
   MCP tool. The unsound pairing is now unrepresentable: `Accept(VerifyingKey)` for the
   authenticated verdict, `AcceptUnverified` for the permissive rollout window. Behaviour at
   both call sites is byte-identical.

`src/llm.rs:172/176/190` is **not** touched here — it is routed to the #3140 bridge PR.

## Not in scope: a `doctor` fact for (3)

The drainer's terminal state is process-local to the daemon. `doctor`'s local lane sees
only the DB; its `--remote` lane carries no credential (`DoctorArgs` has no api-key field)
and `/metrics` sits behind `handlers::api_key_auth`; and persisting the state to the DB
would write through the very sink that just failed. The Prometheus gauge is the correct
fleet surface, documented in `docs/API_REFERENCE.md` with a page-on-any-non-zero note.
#3164 marks this bullet DEFERRABLE.

## Tests

- `write_txn_rolls_back_on_panic_unwind_and_connection_stays_usable` — injects a **real
  panic between BEGIN and COMMIT** and asserts the partial write is invisible, the
  connection is back in autocommit, and the **next write on the same connection succeeds**.
- `write_txn_rolls_back_when_commit_itself_fails` — forces a **genuine COMMIT failure** via
  a DEFERRED foreign-key violation (SQLite reports it at COMMIT time and deliberately leaves
  the transaction OPEN) and asserts the same three properties.
- `db_op_panic_between_begin_and_commit_leaves_a_usable_writer_3163` — the same regression
  end-to-end on the real shared `Db`.
- `db_op_sweeps_an_unguarded_open_transaction_3163`,
  `db_op_fails_closed_when_a_closure_returns_with_an_open_transaction_3163`,
  `db_op_happy_path_returns_the_closure_value`, `db_read_op_contains_a_closure_panic_3164`.
- `writer_is_fallible_and_idempotent`, `flush_blocking_never_panics_without_an_initialised_sink`.
- `supervisor_exhaustion_returns_typed_terminal_state_sink_{panicked,unresolved}_3164`.
- `checkpoint_accept_carries_the_verifying_key_and_permissive_cannot_produce_it_3164`.
- Plus the guard's commit / explicit-rollback / drop-without-commit and the two
  `ensure_autocommit` sweep cases.

Local (all under `( umask 022; … )`, toolchain 1.96.0): `storage::connection` 19/19 ·
`transport_helpers_tests` 16/16 · `handlers::read_pool` 5/5 · `governance::deferred_audit`
85/85 · `governance::audit` 46/46 · `federation::receive_auth` 27/27 ·
`governance_deferred_log_audit` 17/17 · `f53_claimed_vs_attested_e2e` 4/4 ·
`signed_events_chain_v34` 10/10 · `deferred_audit_soak` 1/1 · `qual_10` 2/2 · `qual_6_7` 2/2
(neither ceiling needed a bump) · archive owner-gate + `http_source_uri_query` +
`claim_bitemporal_recall_1834` + `http_if_match_concurrency` all green.

CI parity run locally and green: `fmt --check`, **all five** clippy invocations
(`-D warnings -D clippy::all -D clippy::pedantic` on default / `--all-targets --features sal`
/ `--features sal-postgres --tests` / `--features sal` / `--all-targets --features vectorlite`),
`check --examples`, `check-hardcoded-literals.sh` (no ratchet bump — named consts),
`check-docs-vs-ssot.sh`.

## SSOT

No new MCP tool, HTTP route, CLI verb, or schema version, so no tool-count badge,
`EXPECTED_PRODUCTION_ROUTES_COUNT`, param-names census, token-budget, or schema-version pin
moves. One new Prometheus gauge, documented in `docs/API_REFERENCE.md`. CHANGELOG
`[Unreleased]` updated with both sections.

Closes #3163
Addresses #3164 (resumption residual — stays OPEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
