### PR TITLE
fix(llm): bound the sync↔async bridge — a wedged runtime driver can no longer park a caller forever (#3140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,76 @@ backend and missing or divergently implemented on its twin). Pinned by
     ship with `--self-test` legs proving they reject stale counts, spare the
     `PE-1 knobs` prose and the cert doc's historical evidence notes, and fail
     closed on an unresolvable SSOT only when a doc actually narrates the count.
+- **The sync&#8596;async LLM bridge is bounded: a wedged runtime driver can no
+  longer park a caller forever (#3140).** On PR #3137 the macOS `Check
+  (macos-fed,sqlite)` leg printed its last unit-test completion and then went
+  silent for **72 minutes**, until the 80-minute job cap cancelled it; the same
+  leg took 19 minutes twice that day. Diffing completed tests against the green
+  run left exactly two that never finished, both on the LLM path
+  (`llm::wiremock_tests::test_generate_returns_error_on_500`,
+  `curator::tests::run_once_with_llm_dry_run_skips_writes`). The HTTP client was
+  never the problem — every `reqwest` call already carries a `timeout` +
+  `connect_timeout`. The unbounded chokepoint was the **bridge**: the
+  multi-thread arm's `block_in_place(|| handle.block_on(..))` parks a
+  blocking-pool thread on the ambient runtime's driver, so when that driver
+  never advances the future the inner request timeout never gets a chance to
+  fire. The unbounded `block_on_local` has been **retired** and replaced by
+  `block_on_local_bounded(budget, ..)`, which applies
+  `tokio::time::timeout(budget, ..)` on all three runtime-flavor arms — expiry
+  is now enforced by the runtime that is actually driving the future, not by a
+  caller who may never be scheduled again. Every budget is derived as **twice**
+  the largest inner `reqwest` timeout of the call it wraps (`BRIDGE_HEALTH_BUDGET`,
+  `BRIDGE_GENERATE_BUDGET`, `BRIDGE_PULL_BUDGET`, and an input-scaled
+  `bridge_embed_batch_budget` for batched embeds), so the bridge can only fire
+  when the inner timeout has *already* failed to release the caller — it never
+  truncates a request the HTTP client would have completed. **Fail-closed:**
+  expiry returns a named error, never a partial or fabricated value, and
+  dropping the future also cancels the in-flight request. Two panic sites went
+  with it: a failed `Runtime::build()` (fd/thread/memory exhaustion — a real
+  fleet-density condition) used to `panic!` on a curator daemon thread or a
+  `spawn_blocking` worker, and a panicking bridge thread was re-raised into an
+  unrelated caller's stack; both are now `Err`. The two MCP hook-chain
+  enforcement gates (`pre_signal_send`, the pre-event `hooks.enforce` gate) run
+  through the same bounded bridge and **refuse** when the gate cannot be
+  evaluated (`503`) — an unevaluated deny-capable gate is not an allow.
+- **Unbounded waits removed across the test suites (#3140).** The same class,
+  swept: EVERY `reqwest::Client::new()` (no request timeout) in `src/` tests and
+  `tests/` replaced with a bounded client — the LLM tests, the federation
+  hostile-peer tests, the capabilities suites, and all ten Postgres-backed
+  suites, via a shared `common::bounded_test_client()`; `common::wait_for_http_ready`'s probe bounded (its
+  `elapsed >= timeout` check runs only at loop top, so ONE hung probe defeated
+  the whole 5-minute budget); `-m` riders on every `curl` argv in `tests/`;
+  deadline+kill reaps replacing bare `child.wait()` / `Command::output()` /
+  `wait_with_output()` in the deferred-audit, reembed-CLI and
+  transcript-extractor suites; bounded joins on the in-process daemon tasks in
+  the schema-version suites; and outer guards on the two tests that actually
+  hung. The transcript-extractor build also stops using a **per-PID** target
+  dir — cargo already locks a target dir, so the PID suffix bought nothing but a
+  cold rebuild and a multi-gigabyte tree per runner process.
+- **Fail-closed refusal probes are no longer vacuous (#3140).** Three tests
+  (`cli_write_verb_pg_refuse_ceiling_2572`, `backup_fail_closed_2444`,
+  `store_url_fail_closed_2679`) proved a `postgres://` store URL is REFUSED
+  while pointing at `127.0.0.1:5432`. On any host actually running Postgres the
+  probe could pass for the wrong reason — and a regression that removed the
+  guard could have WRITTEN to that live database. They now point at
+  `127.0.0.1:1`, where nothing listens, and the #2679 probe's accepted reason
+  text no longer admits a bare `Postgres` substring that a mere connection
+  error would also match.
+- **Wall-clock assertions that measured the CI runner, not the product, are
+  now shape guards (#3140).** The `record_stop` effect-latency assertion moved
+  from `<= 100 ms` to a `<= 2 s` SHAPE guard: it fails if the stop plane ever
+  becomes eventually-consistent (a background reconcile, a network round-trip)
+  and cannot fire on a loaded shared runner. Stated plainly, because the old
+  assertion implied otherwise: the product's `<= 100 ms` record-stop figure is
+  a REFERENCE-HARDWARE claim, it needs a bench producer to be enforced, and no
+  such bench exists — the 100 ms assertion in a CI unit test never established
+  it either. The load-bearing `Err(StoreError::Stopped { .. })` property is
+  unchanged. Elsewhere: the
+  fold-before-gc race tests moved from a 1.33x to a 5x expiry margin; the
+  `/health`-not-blocked-by-precompute test uses one 60 s budget in both
+  execution modes instead of 10 s uninstrumented; and the abandoned-download
+  watchdog test's detached sleeper drops from 30 s to 5 s (still
+  unconditionally over the assertion's ceiling, so the property is intact).
 
 - **The required `Check` legs are no longer undeclared performance gates:
   `ai-memory bench` gains `--report-only`.** `cmd_bench` bails non-zero

--- a/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
+++ b/docs/compliance/ENTERPRISE-FEDERATION-CERTIFICATION.md
@@ -900,6 +900,23 @@ this clause for the changed surface — the posture is strictly STRONGER,
 never weaker, than at `e22bc93c` (a silent-downgrade path in the
 declarative operator flow was closed).
 
+**Re-cert trigger — FIRED, pending re-affirmation (PR #3212, #3140
+bounded test HTTP client).** The §7-watched path
+`src/federation/receive.rs` changed. The delta is **test-only**: the
+`issue_1928_tests` hostile-peer probes replaced unbounded
+`reqwest::Client::new()` with a 10 s / 5 s `timeout` /
+`connect_timeout` builder (`bounded_test_client`). Production receive
+code, the `/sync/*` wire, the schema, and every `AI_MEMORY_FED_*`
+identifier are **byte-identical**. It REMOVES **no** certified control
+(the removal-proof set is unchanged). The change exists so a HOSTILE
+peer that accepts the TCP connection and then stalls cannot park the
+test forever — the posture those tests exist to prove we survive.
+**This PR does NOT re-mint the certification:** re-running
+§5.4(2)–(5) at the new SHA and re-affirming this document against it
+is the operator/reviewer gate. Until that re-affirmation lands, treat
+the certification as EXPIRED per this clause for the changed path —
+the shipped federation posture is UNCHANGED from `e22bc93c`.
+
 **Named signer.** The determination at `580d8427` is a **GitHub
 squash-merge** of PR #2910, committed by `GitHub` on behalf of the
 operator account (`alphaonedev`). GitHub signature verification is

--- a/src/curator/mod.rs
+++ b/src/curator/mod.rs
@@ -1738,6 +1738,48 @@ mod tests {
         let _ = stream.shutdown(std::net::Shutdown::Write);
     }
 
+    /// v1.0.0 #3140 — outer wall-clock guard for a curator test that drives
+    /// the sync↔async LLM bridge.
+    ///
+    /// `run_once_with_llm_dry_run_skips_writes` is a plain `#[test]`, so every
+    /// `auto_tag` / `detect_contradiction` call reaches the no-runtime arm of
+    /// the sync↔async bridge. That bridge is now bounded structurally
+    /// ([`crate::llm::block_on_local_bounded`]); this is the test-level
+    /// backstop so a future wedge fails in a minute with a message instead of
+    /// burning the whole CI job cap the way #3140 did (72 min on macOS).
+    const HUNG_TEST_GUARD: std::time::Duration = std::time::Duration::from_mins(1);
+
+    /// v1.0.0 #3140 — run `body` on its own thread and give up waiting after
+    /// [`HUNG_TEST_GUARD`].
+    ///
+    /// The thread is deliberately detached (not scoped) on expiry: abandoning
+    /// a wedged worker is what lets the assertion fire at all. A panic inside
+    /// `body` drops the sender, so it is re-raised immediately via `join`
+    /// rather than being misreported as a hang — and re-raised with
+    /// `resume_unwind`, which carries the ORIGINAL payload through, so a failed
+    /// assertion inside `body` is reported by the harness verbatim rather than
+    /// being flattened into this wrapper's message.
+    fn run_under_hung_test_guard<F>(what: &str, body: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let worker = std::thread::spawn(move || {
+            body();
+            let _ = tx.send(());
+        });
+        match rx.recv_timeout(HUNG_TEST_GUARD) {
+            Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                if let Err(payload) = worker.join() {
+                    std::panic::resume_unwind(payload);
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("{what} still running after {HUNG_TEST_GUARD:?} — hung (#3140)")
+            }
+        }
+    }
+
     /// Build an `OllamaClient` pointed at a running fake server.
     fn ollama_for(server: &FakeOllama) -> crate::llm::OllamaClient {
         crate::llm::OllamaClient::new_with_url(&server.url, "fake-model")
@@ -1817,40 +1859,44 @@ mod tests {
     /// no `_curator/reports` self-report row appears.
     #[test]
     fn run_once_with_llm_dry_run_skips_writes() {
-        let server = FakeOllama::start(FakeOllamaCfg::default());
-        let llm = ollama_for(&server);
+        // #3140 — this test hung for 72 min on a macOS CI runner (the sync↔async
+        // LLM bridge parked with no wall-clock bound). Body runs under a guard.
+        run_under_hung_test_guard("run_once_with_llm_dry_run_skips_writes", || {
+            let server = FakeOllama::start(FakeOllamaCfg::default());
+            let llm = ollama_for(&server);
 
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-        let conn = db::open(tmp.path()).unwrap();
-        let mem = make_eligible_memory("dry-llm-ns", "anchor");
-        db::insert(&conn, &mem).unwrap();
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            let conn = db::open(tmp.path()).unwrap();
+            let mem = make_eligible_memory("dry-llm-ns", "anchor");
+            db::insert(&conn, &mem).unwrap();
 
-        let cfg = CuratorConfig {
-            dry_run: true,
-            include_namespaces: vec!["dry-llm-ns".to_string()],
-            ..CuratorConfig::default()
-        };
-        let report = run_once(&conn, Some(&llm), &cfg, None).unwrap();
-        assert!(report.dry_run);
+            let cfg = CuratorConfig {
+                dry_run: true,
+                include_namespaces: vec!["dry-llm-ns".to_string()],
+                ..CuratorConfig::default()
+            };
+            let report = run_once(&conn, Some(&llm), &cfg, None).unwrap();
+            assert!(report.dry_run);
 
-        // No DB writes: original metadata unchanged, no self-report.
-        let after = db::get(&conn, &mem.id).unwrap().unwrap();
-        assert!(after.metadata.get("auto_tags").is_none());
-        let reports = db::list(
-            &conn,
-            Some("_curator/reports"),
-            None,
-            10,
-            0,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None, // #1834 valid_at (no as-of)
-        )
-        .unwrap();
-        assert!(reports.is_empty(), "dry-run must not persist self-report");
+            // No DB writes: original metadata unchanged, no self-report.
+            let after = db::get(&conn, &mem.id).unwrap().unwrap();
+            assert!(after.metadata.get("auto_tags").is_none());
+            let reports = db::list(
+                &conn,
+                Some("_curator/reports"),
+                None,
+                10,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None, // #1834 valid_at (no as-of)
+            )
+            .unwrap();
+            assert!(reports.is_empty(), "dry-run must not persist self-report");
+        });
     }
 
     /// `max_ops_per_cycle` caps how many memories the LLM loop touches.

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -3124,8 +3124,9 @@ pub async fn build_embedder(
 /// **FX-D1 (v0.7.0, 2026-05-27).** Pre-FX-D1 this function wrapped
 /// the sync [`llm::OllamaClient::build_from_resolved`] in
 /// `tokio::task::spawn_blocking`. The sync constructor went through
-/// `block_on_local`, whose FX-C1 design panicked on the current-thread
-/// arm. Production tests that defaulted to `#[tokio::test]`
+/// the sync↔async bridge (`block_on_local`, retired in favour of
+/// `block_on_local_bounded` by #3140), whose FX-C1 design panicked on the
+/// current-thread arm. Production tests that defaulted to `#[tokio::test]`
 /// (current-thread) hit the panic — `spawn_blocking`'s blocking-pool
 /// thread inherits the outer runtime handle, so `Handle::try_current()`
 /// resolved to a `CurrentThread` flavor and tripped the panic. The
@@ -3134,9 +3135,9 @@ pub async fn build_embedder(
 ///
 /// The surgical fix is to call the async constructor
 /// [`llm::OllamaClient::build_from_resolved_async`] directly — no
-/// `spawn_blocking`, no `block_on_local`, no sync→async bridge — so
+/// `spawn_blocking`, no bridge call, no sync→async bridge — so
 /// the construction runs on whichever tokio runtime the caller
-/// brought. The defensive fix in `block_on_local` (replace the panic
+/// brought. The defensive fix in the bridge (replace the panic
 /// with a fresh-OS-thread bridge) catches every other unknown
 /// callsite that might hit the same shape; this surgical fix is the
 /// optimal path at this known callsite.
@@ -3218,7 +3219,7 @@ pub async fn build_llm_client(
 
     // FX-D1 (2026-05-27): call the async constructor directly. The
     // pre-FX-D1 `spawn_blocking` wrapper drove the sync constructor
-    // through `block_on_local`, which panicked on the current-thread
+    // through the sync↔async bridge, which panicked on the current-thread
     // tokio arm (the default `#[tokio::test]` flavor). The async
     // path skips the sync→async bridge entirely so the construction
     // runs on whichever tokio runtime the caller brought, with no

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -3547,15 +3547,44 @@ mod c5_ollama_variant_tests {
         assert_eq!(batch[1], vec![1.0_f32, 2.0_f32, 3.0_f32]);
     }
 
+    /// v1.0.0 #3140 — the watchdog budget this test proves is enforced, in
+    /// milliseconds, so every derived bound below is a plain multiple of it
+    /// rather than a bare wall-clock number.
+    const STALL_TEST_BUDGET_MS: u64 = 50;
+
+    /// v1.0.0 #3140 — the watchdog budget this test proves is enforced.
+    const STALL_TEST_BUDGET: std::time::Duration =
+        std::time::Duration::from_millis(STALL_TEST_BUDGET_MS);
+
+    /// v1.0.0 #3140 — how long the ABANDONED closure sleeps: 100x the budget.
+    ///
+    /// Was a flat 30 s. The closure is deliberately abandoned, so the test
+    /// process carried a detached 30-second sleeper for the rest of the run.
+    /// It only has to outlast [`STALL_TEST_RETURN_CEILING`] to keep the test
+    /// discriminating — a watchdog that wrongly JOINED the closure would take
+    /// at least this long, which is unconditionally over the ceiling — so 5 s
+    /// preserves the property at a sixth of the residue.
+    const STALL_TEST_SLEEP: std::time::Duration =
+        std::time::Duration::from_millis(STALL_TEST_BUDGET_MS * 100);
+
+    /// v1.0.0 #3140 — ceiling on how long the watchdog itself may take to
+    /// return after the budget elapses: 40x the budget.
+    ///
+    /// Must stay strictly below [`STALL_TEST_SLEEP`] (that separation is what
+    /// makes a joining watchdog fail) while leaving a correct watchdog ample
+    /// scheduling slack on a loaded runner.
+    const STALL_TEST_RETURN_CEILING: std::time::Duration =
+        std::time::Duration::from_millis(STALL_TEST_BUDGET_MS * 40);
+
     // #1487 — the download watchdog must surface an error instead of
     // blocking forever when the underlying download closure stalls.
     #[test]
     fn download_within_times_out_on_stalled_closure() {
         let start = std::time::Instant::now();
-        let res = Embedder::download_within(std::time::Duration::from_millis(50), || {
+        let res = Embedder::download_within(STALL_TEST_BUDGET, || {
             // Simulate a wedged hf-hub `.get()` that never returns within
             // the budget. The watchdog must abandon it, not join it.
-            std::thread::sleep(std::time::Duration::from_secs(30));
+            std::thread::sleep(STALL_TEST_SLEEP);
             Ok((
                 std::path::PathBuf::new(),
                 std::path::PathBuf::new(),
@@ -3569,8 +3598,9 @@ mod c5_ollama_variant_tests {
             "error should explain the timeout budget"
         );
         assert!(
-            elapsed < std::time::Duration::from_secs(5),
-            "watchdog must return promptly after the budget, not wait for the closure: {elapsed:?}"
+            elapsed < STALL_TEST_RETURN_CEILING,
+            "watchdog must return promptly after the {STALL_TEST_BUDGET:?} budget, \
+             not wait for the closure: {elapsed:?}"
         );
     }
 

--- a/src/federation/receive.rs
+++ b/src/federation/receive.rs
@@ -1006,6 +1006,19 @@ mod issue_1928_tests {
     use super::{MAX_SYNC_RESPONSE_BYTES, read_capped_sync_json_inner};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+    /// v1.0.0 #3140 — a bounded client for the hostile-peer probes.
+    ///
+    /// `reqwest::Client::new()` has NO request timeout. A HOSTILE peer that
+    /// accepts the connection and then stalls would park the test forever —
+    /// the very posture these tests exist to prove we survive.
+    fn bounded_test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("bounded test client builds")
+    }
+
     /// Spawn a one-shot TCP "peer" that returns `body` under a crafted
     /// `Content-Length: content_length_hdr` and returns its address.
     async fn hostile_peer(content_length_hdr: u64, body: &'static [u8]) -> std::net::SocketAddr {
@@ -1031,7 +1044,7 @@ mod issue_1928_tests {
         // Advertise 100 MiB — the exact multi-gigabyte-class OOM vector.
         let advertised = 100 * 1024 * 1024u64;
         let addr = hostile_peer(advertised, b"{").await;
-        let client = reqwest::Client::new();
+        let client = bounded_test_client();
         let resp = client
             .get(format!("http://{addr}/sync/since"))
             .send()
@@ -1050,7 +1063,7 @@ mod issue_1928_tests {
     async fn legitimate_small_sync_body_still_parses() {
         let body = br#"{"memories":[]}"#;
         let addr = hostile_peer(body.len() as u64, body).await;
-        let client = reqwest::Client::new();
+        let client = bounded_test_client();
         let resp = client
             .get(format!("http://{addr}/sync/since"))
             .send()

--- a/src/governance/deferred_audit.rs
+++ b/src/governance/deferred_audit.rs
@@ -5860,8 +5860,8 @@ mod tests {
             "admission must remain blocked while another process holds the spool lock"
         );
         fs2::FileExt::unlock(&blocker.spool_lock).unwrap();
-        for (mut child, _) in children {
-            assert!(child.wait().unwrap().success());
+        for (child, _) in children {
+            assert!(wait_for_test_child(child, "spool-lock admission").success());
         }
         let admitted = result_paths
             .iter()
@@ -6062,11 +6062,10 @@ mod tests {
                 .unwrap();
             (child, started, ready, release, result)
         };
-        let (mut first, first_started, first_ready, first_release, first_result) =
-            spawn_child("first");
+        let (first, first_started, first_ready, first_release, first_result) = spawn_child("first");
         wait_for_test_path(&first_started);
         wait_for_test_path(&first_ready);
-        let (mut second, second_started, second_ready, second_release, second_result) =
+        let (second, second_started, second_ready, second_release, second_result) =
             spawn_child("second");
         wait_for_test_path(&second_started);
         std::thread::sleep(std::time::Duration::from_millis(250));
@@ -6075,10 +6074,10 @@ mod tests {
             "a second recovery must not snapshot while the first claim is active"
         );
         std::fs::write(&first_release, b"release").unwrap();
-        assert!(first.wait().unwrap().success());
+        assert!(wait_for_test_child(first, "first recovery claim").success());
         wait_for_test_path(&second_ready);
         std::fs::write(&second_release, b"release").unwrap();
-        assert!(second.wait().unwrap().success());
+        assert!(wait_for_test_child(second, "second recovery claim").success());
 
         let recovered: usize = [&first_result, &second_result]
             .iter()
@@ -6124,6 +6123,42 @@ mod tests {
                 .is_empty()
         );
     }
+
+    /// v1.0.0 #3140 — reap a spawned test child under a deadline.
+    ///
+    /// A bare `child.wait()` is unbounded: if the child wedges (a lock it can
+    /// never take, a marker it never sees) the parent blocks forever and the
+    /// hang is charged to the CI job cap rather than to this test. The
+    /// parent-side barriers in this module are already deadline-guarded (see
+    /// [`wait_for_test_path`]); this closes the reap that was not.
+    ///
+    /// The budget is deliberately generous — these children re-exec the whole
+    /// test binary and are expected to take seconds, not milliseconds — so it
+    /// can only fire on a genuine wedge, never on a slow runner.
+    fn wait_for_test_child(mut child: std::process::Child, what: &str) -> std::process::ExitStatus {
+        let deadline = std::time::Instant::now() + TEST_CHILD_REAP_BUDGET;
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => return status,
+                Ok(None) if std::time::Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "test child {what} still running after {TEST_CHILD_REAP_BUDGET:?} (#3140)"
+                    );
+                }
+                Ok(None) => std::thread::sleep(TEST_CHILD_POLL_INTERVAL),
+                Err(e) => panic!("try_wait on test child {what}: {e}"),
+            }
+        }
+    }
+
+    /// v1.0.0 #3140 — wall-clock ceiling for [`wait_for_test_child`].
+    const TEST_CHILD_REAP_BUDGET: std::time::Duration = std::time::Duration::from_mins(1);
+
+    /// v1.0.0 #3140 — poll interval for [`wait_for_test_child`], matching the
+    /// existing [`wait_for_test_path`] barrier cadence.
+    const TEST_CHILD_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
     fn wait_for_test_path(path: &Path) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);

--- a/src/handlers/create.rs
+++ b/src/handlers/create.rs
@@ -52,7 +52,7 @@ use super::{AppState, JsonOrBadRequest};
 ///
 /// Shared by every HTTP write handler (`create`, `delete`, `promote`, `link`,
 /// `consolidate`, `reflect`) so the enforcement surface is uniform. The
-/// underlying consult drives the async hook chain via `block_on_local`, which
+/// underlying consult drives the async hook chain via `block_on_local_bounded`, which
 /// uses `block_in_place` on the daemon's multi-thread runtime — safe to call
 /// from an async handler.
 /// #2390 (N9) — `namespaces` is the SUBSTRATE-resolved namespace set the

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -6595,11 +6595,18 @@ mod bridge_budget_tests_3140 {
 
     /// The wall-clock alarm fires on its own budget, with no tokio timer
     /// involved beyond awaiting the `oneshot`.
+    ///
+    /// `t0` MUST be captured before spawn: the alarm thread starts its
+    /// deadline at `Instant::now()` inside the worker, and
+    /// `thread::Builder::spawn` plus the first poll of the oneshot future
+    /// both take wall time. Starting the clock after spawn made CI
+    /// (ubuntu Check + SAL-only, SHA `8aa7ddd6`) report 97-99 ms against a
+    /// 100 ms budget — a measurement artefact, not an early fire.
     #[tokio::test(flavor = "current_thread")]
     async fn wallclock_alarm_fires_after_its_budget() {
         let alarm_budget = Duration::from_millis(100);
-        let (alarm, _guard) = super::spawn_wallclock_alarm(alarm_budget);
         let t0 = Instant::now();
+        let (alarm, _guard) = super::spawn_wallclock_alarm(alarm_budget);
         alarm.await;
         let elapsed = t0.elapsed();
         assert!(

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1530,7 +1530,15 @@ impl OllamaClient {
     pub fn is_available(&self) -> bool {
         // #3140 — a health probe that outlives its bridge budget IS
         // "not available"; degrade to false rather than park the caller.
-        block_on_local_bounded(BRIDGE_HEALTH_BUDGET, || self.is_available_async()).unwrap_or(false)
+        block_on_local_bounded(BRIDGE_HEALTH_BUDGET, || self.is_available_async()).unwrap_or_else(
+            |e| {
+                tracing::warn!(
+                    error = %e,
+                    "LLM health probe failed at the sync↔async bridge; treating as unavailable"
+                );
+                false
+            },
+        )
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::is_available`].

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -55,140 +55,253 @@ use std::time::{Duration, Instant};
 
 pub(crate) const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 
-/// PERF-9 (v0.7.0 FX-C1, 2026-05-26) — bridge sync API to the new async
-/// `reqwest::Client` without double-blocking or panicking.
+/// The sync↔async bridge: drive an async future to completion from a
+/// synchronous caller, under a hard wall-clock `budget`.
 ///
-/// **FX-D1 (v0.7.0, 2026-05-27) — regression fix.** The original
-/// FX-C1 design panicked on the current-thread arm because every
-/// in-repo `#[tokio::test]` used `flavor = "multi_thread"`. Production
-/// hit the panic via `daemon_runtime::build_llm_client` →
-/// `spawn_blocking(|| OllamaClient::build_from_resolved(...))`:
-/// `tokio::task::spawn_blocking` inherits the runtime handle on its
-/// blocking pool thread, so `Handle::try_current()` resolves and
-/// `runtime_flavor()` is `CurrentThread` whenever the outer runtime
-/// is current-thread (the default for `#[tokio::test]`). The panic
-/// surfaced as a `task panicked with message "OllamaClient sync
-/// wrapper called from inside a current-thread tokio runtime."`
-/// warning in the daemon log.
+/// # The three runtime flavors it must handle
 ///
-/// The fix is to never panic — instead, on the current-thread arm,
-/// spawn a fresh OS thread (which has no inherited tokio context),
-/// build a one-shot current-thread runtime on it, drive the future
-/// there, and join the thread back. This costs one thread spawn +
-/// one join per current-thread bridge call, but it keeps every
-/// existing sync wrapper signature intact and removes the
-/// recurrence-risk panic surface entirely. Multi-thread runtimes
-/// still use the productive `block_in_place` path; no runtime at
-/// all still uses the in-line ephemeral runtime path.
+/// PERF-9 (v0.7.0 FX-C1, 2026-05-26) introduced this bridge so the sync
+/// client API could keep its signatures while the HTTP I/O underneath moved
+/// to an async `reqwest::Client`. Three ambient-runtime shapes reach it:
 ///
-/// Three cases the helper handles:
+/// 1. **Inside a multi-thread runtime** (the `#[tokio::main]` daemon, every
+///    HTTP handler, every `#[tokio::test(flavor = "multi_thread")]`) —
+///    `tokio::task::block_in_place` + `Handle::block_on`, which hands the
+///    worker thread back to the scheduler while the call is in flight.
+/// 2. **Inside a current-thread runtime** — `block_in_place` panics there and
+///    re-entering the runtime with a fresh `block_on` deadlocks. FX-D1
+///    (2026-05-27) fixed a production panic on this arm, reached via
+///    `daemon_runtime::build_llm_client` → `spawn_blocking`, whose pool
+///    thread INHERITS the runtime handle: the future moves to a freshly
+///    scoped OS thread that owns a one-shot current-thread runtime, so the
+///    outer runtime is never re-entered. Scoped (not detached) because the
+///    future borrows the caller's `&self`.
+/// 3. **No runtime at all** (a plain `#[test]`, the legacy synchronous CLI) —
+///    build a one-shot current-thread runtime in line.
 ///
-/// 1. **Inside a multi-thread tokio runtime** (the `#[tokio::main]`
-///    daemon + every HTTP request handler + every `cargo test`
-///    annotated `#[tokio::test(flavor = "multi_thread")]`) — uses
-///    `tokio::task::block_in_place` + `Handle::current().block_on` so
-///    the runtime keeps the worker thread productive for other tasks
-///    while the LLM HTTP call is in flight.
-/// 2. **Inside a current-thread tokio runtime** (the default
-///    `#[tokio::test]` flavor; production hit through
-///    `daemon_runtime::build_llm_client` → `spawn_blocking` when the
-///    outer runtime was current-thread) — `block_in_place` panics
-///    there, and re-entering the existing runtime via a fresh
-///    `block_on` deadlocks. We construct an ephemeral current-thread
-///    runtime on a freshly-spawned OS thread (via
-///    `std::thread::spawn`) so the outer runtime is not re-entered
-///    and the future drives to completion on an isolated thread.
-/// 3. **No tokio runtime at all** (a `#[test]` regression in a
-///    non-async test file, the legacy synchronous CLI path that
-///    bypasses `#[tokio::main]`) — build a fresh current-thread
-///    runtime in-line and `block_on` it directly.
+/// Production hot paths (HTTP handlers, daemon dispatch) should prefer the
+/// `*_async` variants and skip the bridge entirely.
 ///
-/// Returning a `Future`'s output through three different bridging
-/// shapes keeps the every-callsite-stays-sync contract intact while
-/// allowing the underlying HTTP I/O to migrate to async. Production
-/// hot paths (HTTP handlers, daemon dispatch) should prefer the
-/// `*_async` variants and skip the bridge entirely — the FX-D1
-/// surgical fix at `daemon_runtime::build_llm_client` does exactly
-/// this for the known callsite that surfaced the regression.
-/// #1752 — exposed `pub(crate)` so the MCP `pre_signal_send` enforcement
-/// bridge (`src/mcp/mod.rs`) can drive the async `HookChain::fire` synchronously
-/// from the sync stdio dispatch through the SAME three-flavor bridge (the
-/// `spawn_blocking`-under-multi-thread case uses `block_in_place`, never a
-/// panicking `Handle::current().block_on`).
-pub(crate) fn block_on_local<F, Fut, T>(make_fut: F) -> T
+/// # Why the budget exists (v1.0.0 #3140)
+///
+/// Every `reqwest` call under this bridge is already bounded (a client
+/// `timeout` + `connect_timeout`, plus per-send overrides). What was NOT
+/// bounded was the **bridge itself**: `block_in_place(|| handle.block_on(..))`
+/// parks a blocking-pool thread on the ambient runtime's driver, so if that
+/// driver never advances the future — a wedged mock server, a timer driver
+/// that is not being polled, a runtime whose only worker is the thread we
+/// just parked — the inner reqwest timeout never gets a chance to fire and
+/// the caller waits forever. #3140 burned a full 80-minute macOS CI job on
+/// exactly that shape.
+///
+/// `tokio::time::timeout(budget, ..)` is applied on **all three** arms, so
+/// expiry is enforced by whichever runtime is actually driving the future
+/// rather than by a caller who may never be scheduled again.
+///
+/// The multi-thread arm carries a second, independent bound. There the bridge
+/// blocks on a runtime it does not itself drive, so a starved time driver
+/// would defeat a tokio timer too; [`spawn_wallclock_alarm`] adds an ordinary
+/// OS-thread alarm that signals through a `oneshot` waker — nothing the
+/// wedged runtime can starve. Arms 2 and 3 each OWN the runtime driving their
+/// future, so their timer cannot be starved and they need no alarm.
+///
+/// # Choosing `budget`
+///
+/// The budget must strictly EXCEED the largest inner reqwest timeout on the
+/// wrapped call ([`BRIDGE_GENERATE_BUDGET`] / [`BRIDGE_HEALTH_BUDGET`] /
+/// [`BRIDGE_PULL_BUDGET`] / [`bridge_embed_batch_budget`] are the derived
+/// values). A budget tighter than the inner timeout would truncate requests
+/// the HTTP client would still have completed — degrading a working
+/// deployment instead of only catching a wedged one.
+///
+/// # Fail-closed
+///
+/// Every failure mode returns `Err`; none panics and none hangs.
+///
+/// * budget elapsed — the error names the budget;
+/// * the ephemeral runtime could not be built (fd/thread/memory exhaustion,
+///   a real fleet-density condition) — previously a `panic!` that killed the
+///   curator daemon thread or a `spawn_blocking` worker mid-request;
+/// * the bridge thread panicked — reported as an error rather than re-raised
+///   into an unrelated caller's stack.
+///
+/// The caller never gets a fabricated or partial value. Dropping the future
+/// on expiry also cancels the in-flight request (reqwest aborts on drop), so
+/// the socket is released too — the bridge does not merely stop waiting while
+/// the work continues.
+///
+/// # Residual bound on the scoped-thread arm
+///
+/// Arm 2 must move the future to a scoped OS thread, and
+/// `std::thread::scope` cannot return before joining — a scoped thread cannot
+/// be abandoned without unsoundness. The timeout is nonetheless *effective*
+/// there because the ephemeral runtime that thread builds owns its own timer
+/// driver and is driven by that thread alone: it is structurally immune to
+/// the parked-on-a-dead-driver wedge above. Only a future that blocks
+/// synchronously without ever reaching an await point could outlive the
+/// budget on that arm — and every future reaching this bridge is `reqwest`-
+/// or hook-chain-shaped, i.e. await-driven.
+///
+/// # Errors
+///
+/// Returns an error when `budget` elapses before the future completes, when
+/// the ephemeral runtime cannot be built, or when the bridge thread panicked.
+/// The future's own `Output` is returned verbatim inside `Ok` — when `T` is
+/// itself a `Result`, callers propagate with `?` and keep the inner `Result`
+/// as their return value.
+///
+/// #1752 — `pub(crate)` so the MCP `pre_signal_send` / pre-event enforcement
+/// gates (`src/mcp/mod.rs`) can drive `HookChain::fire` synchronously from
+/// the sync stdio dispatch through this SAME bridge.
+/// v1.0.0 #3140 — extra time the wall-clock alarm allows past the caller's
+/// budget before it fires.
+///
+/// The alarm is a BACKSTOP, not the primary bound: on a healthy runtime the
+/// `tokio::time::timeout` inside the bridge expires first and produces the
+/// precise, canonical error. The grace makes that ordering deterministic so
+/// the alarm's message only ever appears when the tokio timer genuinely could
+/// not fire.
+const BRIDGE_ALARM_GRACE: Duration = Duration::from_secs(5);
+
+/// v1.0.0 #3140 — how often the alarm thread re-checks for early completion.
+///
+/// Bounds how long a finished call leaves its alarm thread alive: at most one
+/// poll interval, so sequential callers never accumulate alarm threads.
+const BRIDGE_ALARM_POLL: Duration = Duration::from_millis(50);
+
+/// v1.0.0 #3140 — cancels a [`spawn_wallclock_alarm`] thread on drop.
+struct WallclockAlarmGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for WallclockAlarmGuard {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// v1.0.0 #3140 — a wall-clock alarm that does NOT depend on any tokio timer.
+///
+/// # Why a plain OS thread
+///
+/// On the multi-thread arm the bridge blocks the CURRENT thread on a runtime
+/// it does not drive. `tokio::time::timeout` there registers with that
+/// runtime's time driver, so if the driver is starved — every worker wedged,
+/// nothing parked to advance it — the timeout never fires and the bound is
+/// theatre. That is precisely the failure #3140 could not rule out.
+///
+/// This alarm sleeps on an ordinary OS thread and signals through a
+/// `oneshot`, whose `send` wakes the parked `block_on` thread directly via its
+/// `Waker`. No timer wheel, no IO driver, no worker: nothing the wedged
+/// runtime can starve. Losing the `select!` race also DROPS the request
+/// future, so reqwest cancels the in-flight socket rather than leaking it.
+///
+/// # Cost
+///
+/// One thread per bridged multi-thread call, terminating within
+/// [`BRIDGE_ALARM_POLL`] of the call finishing (the returned guard flips the
+/// completion flag on drop). Negligible next to the HTTP round-trip the call
+/// is making, and the bridge is a last-resort surface — production hot paths
+/// use the `*_async` variants.
+///
+/// If the thread cannot be spawned (thread exhaustion), the returned future is
+/// simply never ready: the caller degrades to the tokio-timer bound rather
+/// than being handed a spurious immediate expiry.
+fn spawn_wallclock_alarm(
+    budget: Duration,
+) -> (impl std::future::Future<Output = ()>, WallclockAlarmGuard) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let done = std::sync::Arc::new(AtomicBool::new(false));
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let flag = std::sync::Arc::clone(&done);
+    let spawned = std::thread::Builder::new()
+        .name("llm-bridge-alarm".to_string())
+        .spawn(move || {
+            let deadline = Instant::now() + budget;
+            while !flag.load(Ordering::Acquire) {
+                if Instant::now() >= deadline {
+                    let _ = tx.send(());
+                    return;
+                }
+                std::thread::sleep(BRIDGE_ALARM_POLL);
+            }
+        })
+        .is_ok();
+
+    let fired = async move {
+        // A dropped sender (thread exhaustion, or a panic in the alarm thread)
+        // must NOT read as "budget exceeded" — degrade to never-ready instead.
+        if !spawned || rx.await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    };
+    (fired, WallclockAlarmGuard(done))
+}
+
+pub(crate) fn block_on_local_bounded<F, Fut, T>(budget: Duration, make_fut: F) -> Result<T>
 where
     F: FnOnce() -> Fut + Send,
     Fut: std::future::Future<Output = T>,
     T: Send,
 {
+    // Built lazily INSIDE whichever arm runs: on the scoped-thread arm the
+    // `Fut` must be constructed on the bridge thread (only `F: Send` is
+    // required by this helper's contract, never `Fut: Send`).
+    async fn bounded<F, Fut, T>(budget: Duration, make_fut: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        tokio::time::timeout(budget, make_fut())
+            .await
+            .map_err(|_| anyhow!("llm bridge budget {budget:?} exceeded"))
+    }
+
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         match handle.runtime_flavor() {
             tokio::runtime::RuntimeFlavor::MultiThread => {
-                // Productive case — block_in_place yields the worker
-                // thread back to the scheduler while we wait. Safe
-                // even when called from inside another spawn_blocking
-                // closure because block_in_place is a no-op when not
-                // running on a worker thread (the inner block_on then
-                // simply parks the current OS thread).
-                tokio::task::block_in_place(|| handle.block_on(make_fut()))
-            }
-            _ => {
-                // Current-thread runtime — `block_in_place` panics
-                // there, and re-entering the runtime via a fresh
-                // `block_on` deadlocks. FX-D1 (2026-05-27): the
-                // previous design panicked here, but production hit
-                // this branch via `daemon_runtime::build_llm_client`'s
-                // `spawn_blocking` (the blocking pool thread inherits
-                // the outer current-thread runtime handle). We now
-                // move the `FnOnce` future-builder onto a freshly-
-                // scoped OS thread that owns its own one-shot
-                // current-thread runtime. That thread has no
-                // inherited tokio context, so the inner `block_on`
-                // does not re-enter the outer runtime and does not
-                // deadlock.
-                //
-                // We use `std::thread::scope` instead of
-                // `std::thread::spawn` so the closure can borrow
-                // non-`'static` data from the caller (e.g. the
-                // `&self` capture every `block_on_local(|| self.foo_async(...))`
-                // wrapper carries). Scoped threads guarantee the
-                // borrow outlives the spawn-and-join pair.
-                //
-                // Cost: one thread spawn + one join per call. The sync
-                // wrapper is a bridge-of-last-resort surface — every
-                // production hot path either runs on a multi-thread
-                // runtime (which uses the productive arm above) or
-                // calls the `*_async` variant directly. The
-                // current-thread arm is exercised only by tests that
-                // defaulted to current-thread and by the legacy
-                // `spawn_blocking → sync wrapper` chain that FX-D1
-                // surgically migrated to the async path at known
-                // callsites.
-                std::thread::scope(|s| {
-                    s.spawn(move || {
-                        tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .expect("ephemeral runtime builds")
-                            .block_on(make_fut())
+                // The ONLY arm whose timer belongs to a runtime this thread
+                // does not drive, so it is also the only arm that needs the
+                // driver-independent alarm (see `spawn_wallclock_alarm`).
+                // Arms 2 and 3 each own the runtime driving their future, so
+                // their `tokio::time::timeout` cannot be starved.
+                let (alarm, _alarm_guard) =
+                    spawn_wallclock_alarm(budget.saturating_add(BRIDGE_ALARM_GRACE));
+                tokio::task::block_in_place(|| {
+                    handle.block_on(async {
+                        tokio::select! {
+                            out = bounded(budget, make_fut) => out,
+                            () = alarm => Err(anyhow!(
+                                "llm bridge budget {budget:?} exceeded \
+                                 (wall-clock alarm: the ambient runtime never advanced \
+                                  the request future)"
+                            )),
+                        }
                     })
-                    .join()
-                    .expect(
-                        "block_on_local current-thread bridge thread panicked; \
-                         underlying future panicked",
-                    )
                 })
             }
+            _ => std::thread::scope(|s| -> Result<T> {
+                s.spawn(move || {
+                    tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .context(EPHEMERAL_RUNTIME_BUILD_MSG)?
+                        .block_on(bounded(budget, make_fut))
+                })
+                .join()
+                .map_err(|_| {
+                    anyhow!(
+                        "block_on_local_bounded current-thread bridge thread panicked; \
+                         underlying future panicked"
+                    )
+                })?
+            }),
         }
     } else {
-        // No runtime at all (e.g. a plain `#[test]` that constructs
-        // an `OllamaClient` for unit testing). Build a one-shot
-        // current-thread runtime.
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("ephemeral runtime builds")
-            .block_on(make_fut())
+            .context(EPHEMERAL_RUNTIME_BUILD_MSG)?
+            .block_on(bounded(budget, make_fut))
     }
 }
 
@@ -495,6 +608,53 @@ const PULL_TIMEOUT: Duration = Duration::from_secs(120);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// v0.7.0 F6 — health-probe timeout. Quick check at /api/tags.
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// v1.0.0 #3140 — multiplier applied to the largest *inner* reqwest
+/// timeout of a call to derive that call's **bridge budget**, the outer
+/// wall-clock ceiling enforced by [`block_on_local_bounded`].
+///
+/// The outer budget must strictly EXCEED the inner per-request timeout so
+/// the bridge never truncates a request the HTTP client would still have
+/// completed. It fires only when the inner timeout failed to release the
+/// caller at all — the wedge shape #3140 hit, where the future was parked
+/// on a runtime driver that never ran.
+const BRIDGE_BUDGET_FACTOR: u64 = 2;
+
+/// v1.0.0 #3140 — bridge budget for a single chat/embed generation
+/// round-trip (inner ceiling [`GENERATE_TIMEOUT`]).
+const BRIDGE_GENERATE_BUDGET: Duration =
+    Duration::from_secs(GENERATE_TIMEOUT.as_secs() * BRIDGE_BUDGET_FACTOR);
+
+/// v1.0.0 #3140 — bridge budget for a health probe (inner ceiling
+/// [`HEALTH_TIMEOUT`]).
+const BRIDGE_HEALTH_BUDGET: Duration =
+    Duration::from_secs(HEALTH_TIMEOUT.as_secs() * BRIDGE_BUDGET_FACTOR);
+
+/// v1.0.0 #3140 — bridge budget for a `/api/tags` listing followed by a
+/// model `/api/pull` (inner ceiling [`PULL_TIMEOUT`], which already
+/// dominates [`GENERATE_TIMEOUT`]).
+const BRIDGE_PULL_BUDGET: Duration =
+    Duration::from_secs(PULL_TIMEOUT.as_secs() * BRIDGE_BUDGET_FACTOR);
+
+/// v1.0.0 #3140 — bridge budget for a BATCHED embed.
+///
+/// A batch fans out to an input-dependent number of round-trips (one per
+/// sub-batch, degrading to one per text when a sub-batch is rejected), so a
+/// fixed constant would either truncate a legitimate large backfill or be so
+/// large as to be meaningless. Scaling with the input keeps the budget an
+/// honest ceiling: the true worst case is one [`GENERATE_TIMEOUT`]-bounded
+/// request per text, and this is twice that.
+fn bridge_embed_batch_budget(n_texts: usize) -> Duration {
+    let factor = u32::try_from(n_texts.max(1)).unwrap_or(u32::MAX);
+    BRIDGE_GENERATE_BUDGET.saturating_mul(factor)
+}
+
+/// v1.0.0 #3140 — single source for the ephemeral-runtime build-failure
+/// message shared by both sync↔async bridge helpers (the
+/// no-hardcoded-literals gate requires a literal on 3+ production sites to
+/// be a named `const`).
+const EPHEMERAL_RUNTIME_BUILD_MSG: &str = "ephemeral runtime builds";
+
 /// v0.7.0 F6 — circuit-breaker window. After [`CIRCUIT_BREAKER_THRESHOLD`]
 /// consecutive failures the client fast-fails until this window elapses.
 /// Re-establishes a probe attempt after the window.
@@ -1146,18 +1306,18 @@ impl OllamaClient {
     /// FX-D1 (v0.7.0, 2026-05-27) — async sibling of
     /// [`Self::build_from_resolved`]. Surgical fix for the
     /// `daemon_runtime::build_llm_client` callsite that hit the
-    /// FX-C1 `block_on_local` current-thread panic: the daemon
+    /// FX-C1 sync↔async-bridge current-thread panic: the daemon
     /// wrapped this sync constructor in `tokio::task::spawn_blocking`,
     /// and the blocking pool thread inherited the outer (current-
     /// thread, in `#[tokio::test]`) runtime handle, which drove
-    /// `block_on_local` into its panic arm.
+    /// the bridge into its (since-removed) panic arm.
     ///
     /// Callers already on a tokio runtime — the daemon's
     /// `build_llm_client`, `mcp/mod.rs::run_mcp_server` once it
     /// migrates, and CLI atomise/curator builders — should call this
     /// directly to bypass the sync→async bridge entirely. The Ollama
     /// arm now goes through [`Self::new_with_url_async`] (no
-    /// `block_on_local`); the non-Ollama arm uses
+    /// `block_on_local_bounded`); the non-Ollama arm uses
     /// [`Self::new_openai_compatible`] which is already pure-sync
     /// (no I/O — just a `reqwest::Client::builder`).
     ///
@@ -1257,7 +1417,7 @@ impl OllamaClient {
     /// `timeout` is preserved at [`GENERATE_TIMEOUT`].
     ///
     /// **PERF-9 (v0.7.0 FX-C1, 2026-05-26).** Sync wrapper around
-    /// [`Self::new_with_url_async`] via the `block_on_local` helper.
+    /// [`Self::new_with_url_async`] via the `block_on_local_bounded` helper.
     /// Callers already on a tokio runtime should prefer the async
     /// constructor directly.
     ///
@@ -1269,7 +1429,9 @@ impl OllamaClient {
     /// verification to first-use should use
     /// [`Self::new_with_url_no_health_check`] instead.
     pub fn new_with_url(base_url: &str, model: &str) -> Result<Self> {
-        block_on_local(|| Self::new_with_url_async(base_url, model))
+        block_on_local_bounded(BRIDGE_HEALTH_BUDGET, || {
+            Self::new_with_url_async(base_url, model)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async constructor variant. Builds the
@@ -1366,7 +1528,9 @@ impl OllamaClient {
     /// [`Self::is_available_async`]. The async variant should be
     /// preferred by every callsite already on a tokio runtime.
     pub fn is_available(&self) -> bool {
-        block_on_local(|| self.is_available_async())
+        // #3140 — a health probe that outlives its bridge budget IS
+        // "not available"; degrade to false rather than park the caller.
+        block_on_local_bounded(BRIDGE_HEALTH_BUDGET, || self.is_available_async()).unwrap_or(false)
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::is_available`].
@@ -1398,7 +1562,7 @@ impl OllamaClient {
     /// **PERF-9 (v0.7.0 FX-C1)** — sync wrapper around
     /// [`Self::ensure_model_async`].
     pub fn ensure_model(&self) -> Result<()> {
-        block_on_local(|| self.ensure_model_async())
+        block_on_local_bounded(BRIDGE_PULL_BUDGET, || self.ensure_model_async())?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::ensure_model`].
@@ -1484,13 +1648,15 @@ impl OllamaClient {
     /// runtime (HTTP handlers, the daemon path) should prefer the
     /// async variant directly to skip the bridge overhead.
     pub fn generate(&self, prompt: &str, system: Option<&str>) -> Result<String> {
-        block_on_local(|| self.generate_async(prompt, system))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.generate_async(prompt, system)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::generate`].
     /// Same circuit-breaker semantics; same wire shape; same error
     /// branches. Use this from any caller already inside a tokio
-    /// runtime to avoid the `block_on_local` bridge.
+    /// runtime to avoid the `block_on_local_bounded` bridge.
     ///
     /// # Errors
     ///
@@ -1613,7 +1779,9 @@ impl OllamaClient {
         system: Option<&str>,
         tools: &[ToolDef],
     ) -> Result<ChatOutcome> {
-        block_on_local(|| self.generate_with_tools_async(prompt, system, tools))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.generate_with_tools_async(prompt, system, tools)
+        })?
     }
 
     /// #1866 (§11.5 B7-FC-1) — tool/function-calling variant of
@@ -1765,7 +1933,7 @@ impl OllamaClient {
 
     /// Uses the LLM to expand a search query into additional search terms.
     pub fn expand_query(&self, query: &str) -> Result<Vec<String>> {
-        block_on_local(|| self.expand_query_async(query))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || self.expand_query_async(query))?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::expand_query`].
@@ -1790,7 +1958,9 @@ impl OllamaClient {
 
     /// Takes (title, content) pairs and returns a consolidated summary.
     pub fn summarize_memories(&self, memories: &[(String, String)]) -> Result<String> {
-        block_on_local(|| self.summarize_memories_async(memories))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.summarize_memories_async(memories)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::summarize_memories`].
@@ -1851,7 +2021,9 @@ impl OllamaClient {
         content: &str,
         model_override: Option<&str>,
     ) -> Result<Vec<String>> {
-        block_on_local(|| self.auto_tag_async(title, content, model_override))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.auto_tag_async(title, content, model_override)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::auto_tag`].
@@ -1896,7 +2068,9 @@ impl OllamaClient {
         system: Option<&str>,
         model_override: Option<&str>,
     ) -> Result<String> {
-        block_on_local(|| self.generate_with_model_override_async(prompt, system, model_override))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.generate_with_model_override_async(prompt, system, model_override)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of
@@ -2062,7 +2236,9 @@ impl OllamaClient {
     /// shape). Any new caller should use the provider-aware path.
     #[allow(dead_code)]
     fn generate_with_body(&self, body: &Value) -> Result<String> {
-        block_on_local(|| self.generate_with_body_async(body))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.generate_with_body_async(body)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async legacy `/api/generate` helper.
@@ -2134,7 +2310,9 @@ impl OllamaClient {
     /// by the same circuit breaker so a dead ollama endpoint doesn't
     /// block every store/recall path on a per-call timeout.
     pub fn embed_text(&self, text: &str, embed_model: &str) -> Result<Vec<f32>> {
-        block_on_local(|| self.embed_text_async(text, embed_model))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.embed_text_async(text, embed_model)
+        })?
     }
 
     /// v1.0.0 #2577 — [`Self::embed_text`] under an explicit wall-clock
@@ -2157,7 +2335,9 @@ impl OllamaClient {
     ) -> Result<Vec<f32>> {
         match budget {
             None => self.embed_text(text, embed_model),
-            Some(b) => block_on_local(|| self.embed_text_async_with_budget(text, embed_model, b)),
+            Some(b) => block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+                self.embed_text_async_with_budget(text, embed_model, b)
+            })?,
         }
     }
 
@@ -2321,7 +2501,7 @@ impl OllamaClient {
 
     /// #1603 — generate embeddings for MANY texts, batching the wire
     /// where the provider supports it. Sync wrapper over
-    /// [`Self::embed_texts_async`] (same `block_on_local` discipline as
+    /// [`Self::embed_texts_async`] (same `block_on_local_bounded` discipline as
     /// [`Self::embed_text`]).
     ///
     /// # Errors
@@ -2329,7 +2509,9 @@ impl OllamaClient {
     /// Propagates the first per-request error (see
     /// [`Self::embed_texts_async`]).
     pub fn embed_texts(&self, texts: &[&str], embed_model: &str) -> Result<Vec<Vec<f32>>> {
-        block_on_local(|| self.embed_texts_async(texts, embed_model))
+        block_on_local_bounded(bridge_embed_batch_budget(texts.len()), || {
+            self.embed_texts_async(texts, embed_model)
+        })?
     }
 
     /// #1603 — async batched embed. Provider behaviour:
@@ -2495,7 +2677,7 @@ impl OllamaClient {
     /// - OpenAI-compatible: **no-op** — vendor-side concern (operator
     ///   confirms model availability on their plan).
     pub fn ensure_embed_model(&self, model: &str) -> Result<()> {
-        block_on_local(|| self.ensure_embed_model_async(model))
+        block_on_local_bounded(BRIDGE_PULL_BUDGET, || self.ensure_embed_model_async(model))?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of [`Self::ensure_embed_model`].
@@ -2559,7 +2741,9 @@ impl OllamaClient {
 
     /// Returns true if two memory contents contradict each other.
     pub fn detect_contradiction(&self, mem_a: &str, mem_b: &str) -> Result<bool> {
-        block_on_local(|| self.detect_contradiction_async(mem_a, mem_b))
+        block_on_local_bounded(BRIDGE_GENERATE_BUDGET, || {
+            self.detect_contradiction_async(mem_a, mem_b)
+        })?
     }
 
     /// PERF-9 (v0.7.0 FX-C1) — async variant of
@@ -3664,6 +3848,41 @@ mod wiremock_tests {
     use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    /// v1.0.0 #3140 — outer wall-clock guard for any test that drives the
+    /// sync↔async bridge from the blocking pool.
+    ///
+    /// The bridge itself is now bounded structurally
+    /// ([`super::block_on_local_bounded`]); this is the test-level backstop
+    /// so a future wedge fails in seconds with a message instead of burning
+    /// the whole CI job cap the way #3140 did (72 min on macOS). It is
+    /// deliberately far larger than any legitimate mock round-trip, so it can
+    /// never fire on a merely slow runner.
+    const HUNG_TEST_GUARD: std::time::Duration = std::time::Duration::from_mins(1);
+
+    /// v1.0.0 #3140 — run a blocking bridge call under [`HUNG_TEST_GUARD`].
+    async fn bridge_call<F, T>(f: F) -> T
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        tokio::time::timeout(HUNG_TEST_GUARD, tokio::task::spawn_blocking(f))
+            .await
+            .expect("sync↔async bridge call must not hang past the guard (#3140)")
+            .expect("bridge call task must not panic")
+    }
+
+    /// v1.0.0 #3140 — a bounded `reqwest` client for tests.
+    ///
+    /// `reqwest::Client::new()` has NO request timeout, so a mock server that
+    /// accepts a connection and then never answers parks the test forever.
+    fn bounded_test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(super::HEALTH_TIMEOUT)
+            .connect_timeout(super::CONNECT_TIMEOUT)
+            .build()
+            .expect("bounded test client builds")
+    }
+
     /// Mount a default permissive `/api/tags` responder so `new_with_url`'s
     /// embedded `is_available()` health check succeeds.
     async fn mount_tags_ok(server: &MockServer, models: serde_json::Value) {
@@ -3688,7 +3907,7 @@ mod wiremock_tests {
             .mount(&server)
             .await;
         let url = format!("{}/big", server.uri());
-        let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+        let resp = bounded_test_client().get(&url).send().await.unwrap();
         let err = read_capped_bytes_inner(resp, 64)
             .await
             .expect_err("oversize body MUST be rejected by the cap");
@@ -3710,7 +3929,7 @@ mod wiremock_tests {
             .mount(&server)
             .await;
         let url = format!("{}/ok", server.uri());
-        let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+        let resp = bounded_test_client().get(&url).send().await.unwrap();
         let v = read_capped_json(resp).await.unwrap();
         assert_eq!(v["hello"], "world");
     }
@@ -3775,7 +3994,7 @@ mod wiremock_tests {
         // out before returning. Instead, build a client by hand by going
         // through reqwest directly and asserting the health-probe path
         // returns false.
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             // Use the same builder OllamaClient uses internally so the
             // assertion exercises the same code path semantically.
             let client = reqwest::blocking::Client::builder()
@@ -3788,8 +4007,7 @@ mod wiremock_tests {
                 .send()
                 .is_ok_and(|r| r.status().is_success())
         })
-        .await
-        .unwrap();
+        .await;
 
         assert!(
             !result,
@@ -3807,13 +4025,12 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             // Constructor will fail (since is_available returns false)
             // — verify that path explicitly.
             OllamaClient::new_with_url(&uri, "test-model")
         })
-        .await
-        .unwrap();
+        .await;
 
         // Avoid `unwrap_err()` here because `OllamaClient` doesn't impl
         // Debug — match on the Result and pull the message out manually.
@@ -3869,12 +4086,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.ensure_model()
         })
-        .await
-        .unwrap();
+        .await;
         assert!(
             result.is_ok(),
             "ensure_model should succeed; got {result:?}"
@@ -3900,12 +4116,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.ensure_model()
         })
-        .await
-        .unwrap();
+        .await;
         assert!(
             result.is_ok(),
             "ensure_model should succeed; got {result:?}"
@@ -3931,12 +4146,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.generate("ping", None)
         })
-        .await
-        .unwrap();
+        .await;
 
         assert_eq!(result.unwrap(), "hello");
     }
@@ -3956,12 +4170,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.generate("ping", None)
         })
-        .await
-        .unwrap();
+        .await;
 
         assert!(result.is_err(), "malformed JSON should surface an error");
         let err = result.unwrap_err().to_string();
@@ -3982,12 +4195,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.generate("ping", None)
         })
-        .await
-        .unwrap();
+        .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -4144,12 +4356,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.embed_text("hi", "nomic-embed-text")
         })
-        .await
-        .unwrap();
+        .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -4169,12 +4380,11 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.embed_text("hi", "nomic-embed-text")
         })
-        .await
-        .unwrap();
+        .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("500"));
     }
@@ -4328,15 +4538,14 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.detect_contradiction(
                 "The database migration completed successfully",
                 "The frontend build pipeline failed",
             )
         })
-        .await
-        .unwrap();
+        .await;
         assert!(
             !result.unwrap(),
             "different-subject pair must be suppressed by the pre-check even when the LLM says yes"
@@ -4360,15 +4569,14 @@ mod wiremock_tests {
             .await;
 
         let uri = server.uri();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = bridge_call(move || {
             let client = OllamaClient::new_with_url(&uri, "test-model").unwrap();
             client.detect_contradiction(
                 "The API endpoint returns status 200",
                 "The API endpoint returns status 500",
             )
         })
-        .await
-        .unwrap();
+        .await;
         assert!(
             result.unwrap(),
             "shared-subject genuine contradiction must reach the LLM and return true"
@@ -4831,7 +5039,7 @@ mod c5_breaker_tests {
 // PERF-9 (v0.7.0 FX-C1, 2026-05-26) — async-path coverage.
 //
 // The pre-PERF-9 wiremock tests above drive every public surface through
-// the SYNC API (which now block_on_local's into the async impl). These
+// the SYNC API (which now block_on_local_bounded's into the async impl). These
 // tests drive the SAME wire shapes through the `*_async` API directly,
 // so the async path itself is line-covered. Every error branch is
 // exercised in addition to the happy path so the operator's "maximum
@@ -5892,7 +6100,7 @@ mod perf9_async_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn sync_wrapper_runs_under_block_in_place_path() {
-        // The block_on_local bridge inside a multi_thread runtime
+        // The block_on_local_bounded bridge inside a multi_thread runtime
         // dispatches through block_in_place + Handle::current().block_on.
         // Drive `OllamaClient::generate` (sync) inside a multi_thread
         // tokio runtime so the production daemon's call path is
@@ -6268,14 +6476,14 @@ mod perf9_async_tests {
         assert!(err.contains("API key"));
     }
 
-    // ============ no-runtime path of block_on_local ============
+    // ============ no-runtime path of block_on_local_bounded ============
 
     #[test]
     fn sync_wrapper_outside_runtime_constructs_ephemeral() {
         // Stand up a wiremock server inside an explicit tokio runtime
         // (because wiremock requires async to start), but drive the
         // OllamaClient sync API from a plain `#[test]` (no #[tokio::test])
-        // so `Handle::try_current()` returns Err and `block_on_local`
+        // so `Handle::try_current()` returns Err and `block_on_local_bounded`
         // hits the ephemeral-runtime arm.
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -6306,6 +6514,168 @@ mod perf9_async_tests {
             .unwrap();
         });
     }
+}
+
+// ---------------------------------------------------------------------------
+// v1.0.0 #3140 — sync↔async bridge budget enforcement.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod bridge_budget_tests_3140 {
+    use super::block_on_local_bounded;
+    use std::time::{Duration, Instant};
+
+    /// A budget small enough that any real wait blows it, large enough that a
+    /// loaded runner still schedules the timer.
+    const TINY_BUDGET: Duration = Duration::from_millis(50);
+
+    /// Far longer than [`TINY_BUDGET`]; the test asserts we return WITHOUT
+    /// waiting for it.
+    const LONG_SLEEP: Duration = Duration::from_secs(30);
+
+    /// Ceiling on how long the bridge itself may take to give up, once its
+    /// bound has fired.
+    const RETURN_CEILING: Duration = Duration::from_secs(5);
+
+    fn assert_budget_error_within(res: anyhow::Result<()>, elapsed: Duration, ceiling: Duration) {
+        let err = res.expect_err("an over-budget bridge call MUST return Err, not hang");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("budget"),
+            "the error must name the budget it exceeded: {msg}"
+        );
+        assert!(
+            elapsed < ceiling,
+            "the bridge must release the caller at the budget, not wait for the \
+             future: {elapsed:?}"
+        );
+    }
+
+    fn assert_budget_error(res: anyhow::Result<()>, elapsed: Duration) {
+        assert_budget_error_within(res, elapsed, RETURN_CEILING);
+    }
+
+    /// Arm 3 — no ambient runtime (a plain `#[test]`, the shape
+    /// `curator::tests::run_once_with_llm_dry_run_skips_writes` hung on).
+    #[test]
+    fn budget_expiry_is_an_error_with_no_ambient_runtime() {
+        let t0 = Instant::now();
+        let res = block_on_local_bounded(TINY_BUDGET, || async {
+            tokio::time::sleep(LONG_SLEEP).await;
+        });
+        assert_budget_error(res, t0.elapsed());
+    }
+
+    /// Arm 1 — multi-thread runtime via `block_in_place` (the shape
+    /// `llm::wiremock_tests::test_generate_returns_error_on_500` hung on).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn budget_expiry_is_an_error_under_a_multi_thread_runtime() {
+        let res = tokio::task::spawn_blocking(|| {
+            let t0 = Instant::now();
+            let res = block_on_local_bounded(TINY_BUDGET, || async {
+                tokio::time::sleep(LONG_SLEEP).await;
+            });
+            (res, t0.elapsed())
+        })
+        .await
+        .expect("bridge probe task must not panic");
+        assert_budget_error(res.0, res.1);
+    }
+
+    /// Arm 2 — current-thread ambient runtime, which moves the future to a
+    /// scoped thread owning its own ephemeral runtime.
+    #[tokio::test(flavor = "current_thread")]
+    async fn budget_expiry_is_an_error_under_a_current_thread_runtime() {
+        let t0 = Instant::now();
+        let res = block_on_local_bounded(TINY_BUDGET, || async {
+            tokio::time::sleep(LONG_SLEEP).await;
+        });
+        assert_budget_error(res, t0.elapsed());
+    }
+
+    /// The wall-clock alarm fires on its own budget, with no tokio timer
+    /// involved beyond awaiting the `oneshot`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn wallclock_alarm_fires_after_its_budget() {
+        let alarm_budget = Duration::from_millis(100);
+        let (alarm, _guard) = super::spawn_wallclock_alarm(alarm_budget);
+        let t0 = Instant::now();
+        alarm.await;
+        let elapsed = t0.elapsed();
+        assert!(
+            elapsed >= alarm_budget,
+            "the alarm must not fire EARLY (that would truncate a healthy call): {elapsed:?}"
+        );
+        assert!(
+            elapsed < RETURN_CEILING,
+            "the alarm must fire promptly after its budget: {elapsed:?}"
+        );
+    }
+
+    /// The #3140 wedge, reproduced deterministically: a multi-thread runtime
+    /// whose ONLY worker is occupied by a task that never yields, so the
+    /// runtime's time driver can never be advanced and the bridge's
+    /// `tokio::time::timeout` is structurally unable to fire.
+    ///
+    /// Whichever bound wins the race, the contract this pins is the one that
+    /// matters: the caller is RELEASED with an error naming the budget instead
+    /// of parking until the CI job cap.
+    #[test]
+    fn starved_time_driver_still_releases_the_caller() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime builds");
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_task = Arc::clone(&stop);
+
+        let (res, elapsed) = rt.block_on(async move {
+            tokio::spawn(async move {
+                while !stop_for_task.load(Ordering::Acquire) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            });
+            tokio::task::spawn_blocking(|| {
+                let t0 = Instant::now();
+                let res = block_on_local_bounded(TINY_BUDGET, || async {
+                    tokio::time::sleep(LONG_SLEEP).await;
+                });
+                (res, t0.elapsed())
+            })
+            .await
+            .expect("bridge probe task must not panic")
+        });
+
+        stop.store(true, Ordering::Release);
+        rt.shutdown_background();
+
+        // The alarm's grace window is added on top: whichever bound wins, the
+        // caller is released well inside it.
+        assert_budget_error_within(res, elapsed, super::BRIDGE_ALARM_GRACE + RETURN_CEILING);
+    }
+
+    /// The happy path is untouched: a future that finishes inside its budget
+    /// returns its value verbatim.
+    #[test]
+    fn under_budget_call_returns_its_value() {
+        let out = block_on_local_bounded(Duration::from_secs(30), || async { 41_u32 + 1 })
+            .expect("an under-budget call must succeed");
+        assert_eq!(out, 42);
+    }
+
+    // NOT TESTED, deliberately: the `Runtime::build()` failure path (fd /
+    // thread / memory exhaustion). Tokio exposes no injection point for a
+    // failing builder, and the only way to force it — exhausting the process
+    // fd or thread limit — would be a process-wide side effect that corrupts
+    // every other test in this binary. The fix is nonetheless load-bearing:
+    // that path now returns `Err` through `?` rather than `panic!`-ing on a
+    // curator daemon thread or a `spawn_blocking` worker, which is verified by
+    // the type (the function returns `anyhow::Result<T>` and contains no
+    // `expect` on the builder).
 }
 
 #[cfg(test)]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1587,7 +1587,7 @@ pub(crate) fn set_post_signal_ack_sink(tx: tokio::sync::mpsc::UnboundedSender<se
 // PRE/deny-capable event: its decision MUST be honored synchronously, before
 // the signal is signed + inserted. The MCP stdio dispatch is synchronous (a
 // `spawn_blocking` thread), so the gate fires the async `HookChain` inline via
-// `crate::llm::block_on_local` (the multi-thread arm reuses the outer runtime
+// `crate::llm::block_on_local_bounded` (the multi-thread arm reuses the outer runtime
 // via `block_in_place`; never a panicking `Handle::current().block_on`).
 //
 // INERT BY DEFAULT: installed by `run_mcp_server` ONLY when an operator
@@ -1604,6 +1604,25 @@ struct PreSignalSendGate {
     chain: std::sync::Arc<crate::hooks::HookChain>,
     registry: std::sync::Mutex<crate::hooks::ExecutorRegistry>,
 }
+
+/// v1.0.0 #3140 — wall-clock budget for driving an async hook chain from the
+/// synchronous MCP stdio dispatch.
+///
+/// The chain enforces its own per-event class deadline (max 5 s, see
+/// `crate::hooks::timeouts`), so this is a bridge-level backstop with >10x
+/// headroom: it can only fire when the bridge itself failed to advance the
+/// future, never when a chain is merely slow.
+const HOOK_BRIDGE_BUDGET: std::time::Duration = std::time::Duration::from_mins(1);
+
+/// v1.0.0 #3140 — HTTP-style code reported when a deny-capable gate could not
+/// be EVALUATED (bridge budget exceeded, ephemeral runtime unbuildable under
+/// fd/memory exhaustion, hook task panicked).
+///
+/// 503 matches what `hooks::chain` already reports for an executor-level
+/// failure under `fail_mode=closed`. An enforcement gate that cannot run must
+/// refuse, never wave the operation through: an unevaluated gate is not an
+/// allow.
+const HOOK_BRIDGE_UNAVAILABLE_CODE: i32 = 503;
 
 static PRE_SIGNAL_SEND_GATE: std::sync::OnceLock<PreSignalSendGate> = std::sync::OnceLock::new();
 
@@ -1658,7 +1677,7 @@ fn map_chain_result_to_signal_decision(
 }
 
 /// #1752 — evaluate the installed PreSignalSend gate for one in-flight signal.
-/// Fires the configured async `HookChain` synchronously (via `block_on_local`)
+/// Fires the configured async `HookChain` synchronously (via `block_on_local_bounded`)
 /// and maps the outcome. The registry `Mutex` is uncontended (single-threaded
 /// stdio loop); a poisoned lock recovers its inner value.
 fn pre_signal_send_decision(
@@ -1666,7 +1685,7 @@ fn pre_signal_send_decision(
     delta: &crate::hooks::events::SignalDelta,
 ) -> signal::SignalHookDecision {
     let payload = serde_json::to_value(delta).unwrap_or(serde_json::Value::Null);
-    let cr = crate::llm::block_on_local(move || async move {
+    let fired = crate::llm::block_on_local_bounded(HOOK_BRIDGE_BUDGET, move || async move {
         let mut reg = gate
             .registry
             .lock()
@@ -1675,7 +1694,25 @@ fn pre_signal_send_decision(
             .fire(crate::hooks::HookEvent::PreSignalSend, payload, &mut reg)
             .await
     });
-    map_chain_result_to_signal_decision(cr)
+    match fired {
+        Ok(cr) => map_chain_result_to_signal_decision(cr),
+        // #3140 — FAIL CLOSED. This is a deny-capable PRE gate: if the bridge
+        // could not evaluate it, the operator's policy is UNKNOWN, and an
+        // unknown policy on an enforcement gate is a refusal, not an allow.
+        // Pre-#3140 this path could not even be reached — the bridge panicked
+        // (killing the stdio worker) or hung forever.
+        Err(e) => {
+            tracing::error!(
+                target: "hooks",
+                error = %e,
+                "PreSignalSend gate could not be evaluated; refusing the signal (fail-closed, #3140)"
+            );
+            signal::SignalHookDecision::Deny {
+                reason: format!("pre_signal_send gate could not be evaluated: {e}"),
+                code: HOOK_BRIDGE_UNAVAILABLE_CODE,
+            }
+        }
+    }
 }
 
 /// #1714 — build the [`signal::SignalHooks`] bundle for an MCP signal-ack
@@ -1746,7 +1783,7 @@ fn dispatch_memory_signal_send(ctx: &ToolDispatchCtx<'_>) -> Result<Value, Strin
 // enforce is active AND a required event is declared — default off = never
 // installed = inert), and every eligible pre-event handler consults it BEFORE
 // the op commits, returning the 503 Deny on short-circuit. The async chain fires
-// synchronously via `block_on_local` (the sync stdio dispatch cannot `.await`).
+// synchronously via `block_on_local_bounded` (the sync stdio dispatch cannot `.await`).
 // ---------------------------------------------------------------------------
 
 /// #1885 — the process-global pre-event enforcement gate: the full loaded hook
@@ -1798,7 +1835,7 @@ pub(crate) fn consult_pre_event_gate(
     let Some(gate) = PRE_EVENT_ENFORCE_GATE.get() else {
         return Ok(());
     };
-    let cr = crate::llm::block_on_local(move || async move {
+    let fired = crate::llm::block_on_local_bounded(HOOK_BRIDGE_BUDGET, move || async move {
         let mut reg = gate
             .registry
             .lock()
@@ -1814,6 +1851,22 @@ pub(crate) fn consult_pre_event_gate(
         )
         .await
     });
+    // #3140 — FAIL CLOSED: a gate that could not be EVALUATED refuses. Pre-fix
+    // the bridge panicked (killing the request task mid-write) or hung.
+    let cr = match fired {
+        Ok(cr) => cr,
+        Err(e) => {
+            tracing::error!(
+                target: "hooks",
+                error = %e,
+                "pre-event enforcement gate could not be evaluated; refusing (fail-closed, #3140)"
+            );
+            return Err(format!(
+                "refused by hooks.enforce gate (code {HOOK_BRIDGE_UNAVAILABLE_CODE}): \
+                 gate could not be evaluated: {e}"
+            ));
+        }
+    };
     use crate::hooks::chain::ChainResult;
     match cr {
         // Allow / ModifiedAllow (the memory-shaped delta has no MCP-store
@@ -4017,7 +4070,7 @@ pub fn run_mcp_server(
 
     // #1752 — MCP PreSignalSend ENFORCEMENT gate. Same inert-by-default load as
     // the #1714 PostSignalAck bridge, but PRE/deny-capable: the dispatch fires
-    // the chain synchronously before sign+insert (via `block_on_local`), so a
+    // the chain synchronously before sign+insert (via `block_on_local_bounded`), so a
     // `Deny` actually refuses the send. Installed only when an operator
     // `pre_signal_send` `[[hook]]` is configured; otherwise byte-identical to
     // pre-#1752. Design: 5-agent vote (memory `4d3ea1c5`).

--- a/tests/b3_precompute_doesnt_block_serve.rs
+++ b/tests/b3_precompute_doesnt_block_serve.rs
@@ -136,11 +136,18 @@ fn b3_precompute_does_not_block_serve_health() {
     // itself is 3-5× the 8 s baseline. Without this carve-out the
     // Per-Module Coverage Thresholds CI job failed deterministically
     // on this test even though it is GREEN under normal execution.
-    let budget = if std::env::var_os("LLVM_PROFILE_FILE").is_some() {
-        Duration::from_mins(1)
-    } else {
-        Duration::from_secs(10)
-    };
+    // v1.0.0 #3140 — ONE budget for both execution modes.
+    //
+    // The non-coverage leg used to run a 10 s budget while the instrumented
+    // leg got 60 s. That 10 s was a *performance* number on shared CI
+    // hardware, and it is not what this test proves: the regression it
+    // catches is "/health blocked on the precompute", which under either
+    // execution mode blows past a minute (the precompute alone is 8 embed
+    // calls, ~1 s each uninstrumented and 3-5x that under llvm-cov). Using
+    // the instrumented budget everywhere keeps the regression-catching
+    // property intact and removes a knife-edge that could only fail on a
+    // slow runner, never on a defect.
+    let budget = Duration::from_mins(1);
     let result = wait_for_health_within(port, budget);
 
     // Always reap the child before asserting so a failed assertion

--- a/tests/backup_fail_closed_2444.rs
+++ b/tests/backup_fail_closed_2444.rs
@@ -48,7 +48,17 @@ use tempfile::TempDir;
 
 /// A Postgres DSN carrying a password, so the refusal path is also asserted to
 /// REDACT the credential rather than echo it (#1579 A3).
-const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:5432/ai_memory";
+/// v1.0.0 #3140 — the port is `1`, an address nothing ever listens on.
+///
+/// This is a REFUSAL probe: the guard must fire on the URL scheme, before
+/// any connection. Aiming it at the real Postgres port (5432) made the
+/// assertion VACUOUS on any host running Postgres — a regression that moved
+/// the refusal after connect would still pass, and a regression that removed
+/// it could WRITE to that live database. Pointing at a dead address means a
+/// refusal can never be manufactured by a live server; the reason-text
+/// assertions below keep it from being manufactured by a connection error
+/// either.
+const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:1/ai_memory";
 
 /// The literal secret inside [`PG_STORE_URL`]; must never appear in output.
 const PG_PASSWORD: &str = "hunter2";

--- a/tests/cli_write_verb_pg_refuse_ceiling_2572.rs
+++ b/tests/cli_write_verb_pg_refuse_ceiling_2572.rs
@@ -333,7 +333,17 @@ use std::process::Command;
 use assert_cmd::cargo::cargo_bin;
 use tempfile::TempDir;
 
-const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:5432/ai_memory";
+/// v1.0.0 #3140 — the port is `1`, an address nothing ever listens on.
+///
+/// This is a REFUSAL probe: the guard must fire on the URL scheme, before
+/// any connection. Aiming it at the real Postgres port (5432) made the
+/// assertion VACUOUS on any host running Postgres — a regression that moved
+/// the refusal after connect would still pass, and a regression that removed
+/// it could WRITE to that live database. Pointing at a dead address means a
+/// refusal can never be manufactured by a live server; the reason-text
+/// assertions below keep it from being manufactured by a connection error
+/// either.
+const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:1/ai_memory";
 const PG_PASSWORD: &str = "hunter2";
 
 /// Run a fast (non-daemon) CLI verb once and capture its output. `store_url`,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -79,6 +79,14 @@ use rand_core::OsRng;
 use rusqlite::Connection;
 use tempfile::NamedTempFile;
 
+/// v1.0.0 #3140 — per-request ceiling for [`pg_test_client`].
+///
+/// Generous: these requests hit a Postgres-backed daemon on a shared CI
+/// runner and may legitimately take seconds. The point is that a bound
+/// EXISTS — an unbounded client turns a stalled daemon into a hung job.
+#[allow(dead_code)]
+pub const PG_TEST_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Build a `reqwest::Client` that sends a stable `X-Agent-Id` header
 /// on every request to the test daemon.
 ///
@@ -115,6 +123,11 @@ pub fn pg_test_client(agent_id: &str) -> reqwest::Client {
     );
     reqwest::Client::builder()
         .default_headers(headers)
+        // v1.0.0 #3140 — a client with NO request timeout parks the calling
+        // test forever if the daemon accepts the connection and then stalls.
+        // Six postgres suites share this constructor, so one bound covers all
+        // of them.
+        .timeout(PG_TEST_CLIENT_TIMEOUT)
         .build()
         .expect("build reqwest client with default X-Agent-Id header")
 }
@@ -684,6 +697,56 @@ pub const DAEMON_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_
 // fast enough to not meaningfully dent the CI job's time budget.
 pub const FANOUT_OBSERVED_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(1);
 
+/// v1.0.0 #3140 — readiness budget for an IN-PROCESS daemon task.
+///
+/// [`DAEMON_READY_TIMEOUT`]'s 5 minutes is sized for a cold Postgres container;
+/// an in-process `serve_http_with_shutdown` task binds in milliseconds, so a
+/// failure there should surface in seconds, not minutes.
+pub const IN_PROCESS_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// v1.0.0 #3140 — how long to wait for an in-process daemon task to exit after
+/// `shutdown.notify_one()`.
+///
+/// A bare `let _ = handle.await;` is unbounded: a daemon that never observes
+/// the notify parks the test for the whole job cap. Mirrors the bounded join
+/// `tests/serve_postgres_smoke.rs` already uses.
+pub const DAEMON_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// v1.0.0 #3140 — a plain `reqwest::Client` WITH a request timeout.
+///
+/// `reqwest::Client::new()` has none, so a daemon that accepts the connection
+/// and then stalls parks the calling test forever.
+pub fn bounded_test_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(PG_TEST_CLIENT_TIMEOUT)
+        .build()
+        .expect("bounded test client builds")
+}
+
+/// v1.0.0 #3140 — per-probe ceiling inside [`wait_for_http_ready`].
+///
+/// The readiness loop checks `elapsed >= timeout` only at the TOP of each
+/// iteration, so a single probe that connects and then never answers defeats
+/// the whole [`DAEMON_READY_TIMEOUT`]: the loop never comes back around to
+/// notice it is out of time. Bounding the probe itself is what makes the
+/// loop's own budget real. A health check that takes longer than this is
+/// already a failed probe.
+const READY_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// v1.0.0 #3140 — the bounded client used by [`wait_for_http_ready`].
+///
+/// Built once: a fresh `reqwest::Client` per probe would discard the
+/// connection pool and leak a resolver thread pool on every iteration.
+fn ready_probe_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(READY_PROBE_TIMEOUT)
+            .build()
+            .expect("readiness probe client builds")
+    })
+}
+
 /// Probe the in-process HTTP daemon's `/api/v1/health` endpoint until
 /// it returns 200 OK or the overall `timeout` elapses.
 ///
@@ -737,7 +800,7 @@ pub async fn wait_for_http_ready(
                     .unwrap_or_else(|| "no successful health probe before timeout".to_string()),
             });
         }
-        match reqwest::get(&url).await {
+        match ready_probe_client().get(&url).send().await {
             Ok(resp) if resp.status() == reqwest::StatusCode::OK => {
                 return Ok(elapsed);
             }

--- a/tests/federation_postgres_fanout.rs
+++ b/tests/federation_postgres_fanout.rs
@@ -283,7 +283,8 @@ async fn notify_fanout_postgres_reaches_w_of_n_peers() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let recipient = format!("ai:bob-{}", uuid::Uuid::new_v4());
     let title = format!("notify-{}", uuid::Uuid::new_v4());
@@ -383,7 +384,8 @@ async fn subscribe_postgres_replays_history() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let subscriber_aid = format!("ai:carol-{}", uuid::Uuid::new_v4());
     let target_ns = format!("team-{}", uuid::Uuid::new_v4());
@@ -512,7 +514,8 @@ async fn cross_namespace_dispatch_on_postgres() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let carol = format!("ai:carol-{}", uuid::Uuid::new_v4());
     let target_ns = format!("target/observed-{}", uuid::Uuid::new_v4());
@@ -656,7 +659,8 @@ async fn create_postgres_pipelines_broadcast_with_local_write() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let agent = "ai:alice-create-pipeline";
     let title = format!("pipelined-create-{}", uuid::Uuid::new_v4());
@@ -773,7 +777,8 @@ async fn bulk_create_postgres_fans_out_to_peers_2724() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let agent = "ai:alice-bulk-fanout";
     let ns = format!("bulk-2724-{}", uuid::Uuid::new_v4());

--- a/tests/fold_a2a1_6_remaining_substrate.rs
+++ b/tests/fold_a2a1_6_remaining_substrate.rs
@@ -287,7 +287,8 @@ async fn create_memory_postgres_fans_out_to_peers() {
     let cfg = federation_cfg_for_test(&peer_urls, 2);
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, Some(cfg)).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let suffix = uuid::Uuid::new_v4();
     let ns = format!("fold-a2a1-6-s18-{suffix}");
@@ -389,7 +390,8 @@ async fn promote_postgres_fans_out_to_peers() {
     // doesn't fan out. This isolates the test's signal — we want
     // every peer counter to start at 0 and only bump on the promote.
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, None).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let suffix = uuid::Uuid::new_v4();
     let ns = format!("fold-a2a1-6-s16-{suffix}");
@@ -509,7 +511,8 @@ async fn promote_postgres_succeeds_against_freshly_stored_memory() {
     };
 
     let (base, shutdown, handle) = spawn_daemon_with_federation(&url, None).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let suffix = uuid::Uuid::new_v4();
     let ns = format!("fold-a2a1-6-s16-vis-{suffix}");

--- a/tests/g1_postgres_quota_increment_on_store.rs
+++ b/tests/g1_postgres_quota_increment_on_store.rs
@@ -149,7 +149,8 @@ async fn g1_postgres_store_memory_increments_quota_counter() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     // Per-test agent + namespace partitioning so concurrent runs against
     // a shared scratch DB don't collide.

--- a/tests/g2_postgres_find_paths_age_param_binding.rs
+++ b/tests/g2_postgres_find_paths_age_param_binding.rs
@@ -320,7 +320,8 @@ async fn g2_postgres_find_paths_age_returns_200_with_paths() {
     drop(store);
 
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     // Per-test namespace so concurrent runs against a shared scratch DB
     // don't reuse memory ids.

--- a/tests/g3_postgres_verify_link_signature_roundtrip.rs
+++ b/tests/g3_postgres_verify_link_signature_roundtrip.rs
@@ -286,7 +286,8 @@ async fn g3_postgres_verify_link_signed_returns_verified_true() {
     let _env_g = env_var_lock();
     let (kp, _keys_keep) = ephemeral_keypair();
     let (base, shutdown, handle) = spawn_daemon(&url, kp.clone()).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     let suffix = uuid::Uuid::new_v4();
     let ns = format!("g3-verify-{suffix}");

--- a/tests/g4_postgres_link_projects_into_age_graph.rs
+++ b/tests/g4_postgres_link_projects_into_age_graph.rs
@@ -291,7 +291,8 @@ async fn g4_postgres_link_projects_memories_into_age_graph() {
     drop(store);
 
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     // Per-test namespace so concurrent runs against a shared scratch DB
     // don't reuse memory ids.

--- a/tests/g4_unsigned_link_projects.rs
+++ b/tests/g4_unsigned_link_projects.rs
@@ -363,7 +363,8 @@ async fn g4_unsigned_http_link_projects_into_age() {
         .await
         .expect("in-process HTTP daemon never bound");
 
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let base = format!("http://{addr}");
     let suffix = uuid::Uuid::new_v4();
     let ns = format!("g4-unsigned-http-{suffix}");

--- a/tests/g5_find_paths_cte_served_on_age.rs
+++ b/tests/g5_find_paths_cte_served_on_age.rs
@@ -224,7 +224,8 @@ async fn g5_find_paths_cte_served_on_age() {
     drop(store);
 
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
 
     // Per-test namespace so concurrent runs against a shared scratch DB
     // don't reuse memory ids.

--- a/tests/g6_postgres_quota_enforcement_1795.rs
+++ b/tests/g6_postgres_quota_enforcement_1795.rs
@@ -165,7 +165,8 @@ async fn pg_single_create_enforces_daily_quota_1795() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("g6-single-{suffix}");
     let ns = format!("g6-single-ns-{suffix}");
@@ -216,7 +217,8 @@ async fn pg_bulk_create_partial_fills_at_quota_1795() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("g6-bulk-{suffix}");
     let ns = format!("g6-bulk-ns-{suffix}");
@@ -282,7 +284,8 @@ async fn pg_consolidate_enforces_daily_quota_1795() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("g6-cons-{suffix}");
     let ns = format!("g6-cons-ns-{suffix}");

--- a/tests/governance_storage_insert_hook.rs
+++ b/tests/governance_storage_insert_hook.rs
@@ -463,12 +463,31 @@ fn spawn_healthy_serve(
     unreachable!("loop returns or panics on the final attempt")
 }
 
+/// v1.0.0 #3140 — `curl --max-time` (`-m`) rider, in seconds, for a
+/// READINESS PROBE issued inside a bounded retry loop.
+///
+/// Without it a probe that connects and then stalls parks the whole test
+/// binary: the surrounding `for _ in 0..N` loop counts iterations, not
+/// wall-clock, so one wedged probe defeats the loop's own bound.
+const CURL_PROBE_MAX_SECS: &str = "2";
+
+/// v1.0.0 #3140 — `curl --max-time` (`-m`) rider, in seconds, for a real
+/// API call (not a probe).
+///
+/// Deliberately far larger than [`CURL_PROBE_MAX_SECS`]: these carry bodies
+/// and run against an instrumented daemon under `cargo-llvm-cov` (3-5x
+/// slower), so a probe-tight cap would convert a slow runner into a red
+/// test. The point is a bound that exists, not a tight one.
+const CURL_REQUEST_MAX_SECS: &str = "30";
+
 fn wait_for_health(port: u16) -> bool {
     for _ in 0..100 {
         std::thread::sleep(std::time::Duration::from_millis(100));
         if let Ok(out) = std::process::Command::new("curl")
             .args([
                 "-s",
+                "-m",
+                CURL_PROBE_MAX_SECS,
                 "-o",
                 "/dev/null",
                 "-w",
@@ -550,6 +569,8 @@ fn refusal_maps_to_http_403() {
     let curl_with_body = std::process::Command::new("curl")
         .args([
             "-s",
+            "-m",
+            CURL_REQUEST_MAX_SECS,
             "-w",
             "\nSTATUS:%{http_code}",
             "-X",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1991,7 +1991,16 @@ fn test_health_endpoint() {
     for _ in 0..30 {
         std::thread::sleep(std::time::Duration::from_millis(100));
         if let Ok(output) = std::process::Command::new("curl")
-            .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", &url])
+            .args([
+                "-s",
+                "-m",
+                CURL_PROBE_MAX_SECS,
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                &url,
+            ])
             .output()
         {
             let code = String::from_utf8_lossy(&output.stdout);
@@ -8252,6 +8261,8 @@ fn wait_for_health(port: u16) -> bool {
         if let Ok(out) = std::process::Command::new("curl")
             .args([
                 "-s",
+                "-m",
+                CURL_PROBE_MAX_SECS,
                 "-o",
                 "/dev/null",
                 "-w",
@@ -8330,6 +8341,8 @@ fn test_sync_daemon_mesh_propagates_memory_between_peers() {
     let seed_out = std::process::Command::new("curl")
         .args([
             "-s",
+            "-m",
+            CURL_REQUEST_MAX_SECS,
             "-X",
             "POST",
             "-H",
@@ -8479,6 +8492,8 @@ fn test_serve_native_tls_health_probe() {
         if let Ok(out) = std::process::Command::new("curl")
             .args([
                 "-sk",
+                "-m",
+                CURL_PROBE_MAX_SECS,
                 "-o",
                 "/dev/null",
                 "-w",
@@ -8891,10 +8906,29 @@ fn test_serve_rejects_half_tls_config() {
 // blocking client to the test harness.
 // ---------------------------------------------------------------------------
 
+/// v1.0.0 #3140 — `curl --max-time` (`-m`) rider, in seconds, for a
+/// READINESS PROBE issued inside a bounded retry loop.
+///
+/// Without it a probe that connects and then stalls parks the whole test
+/// binary: the surrounding `for _ in 0..N` loop counts iterations, not
+/// wall-clock, so one wedged probe defeats the loop's own bound.
+const CURL_PROBE_MAX_SECS: &str = "2";
+
+/// v1.0.0 #3140 — `curl --max-time` (`-m`) rider, in seconds, for a real
+/// API call (not a probe).
+///
+/// Deliberately far larger than [`CURL_PROBE_MAX_SECS`]: these carry bodies
+/// and run against an instrumented daemon under `cargo-llvm-cov` (3-5x
+/// slower), so a probe-tight cap would convert a slow runner into a red
+/// test. The point is a bound that exists, not a tight one.
+const CURL_REQUEST_MAX_SECS: &str = "30";
+
 fn curl_get(port: u16, path: &str) -> (String, serde_json::Value) {
     let out = std::process::Command::new("curl")
         .args([
             "-s",
+            "-m",
+            CURL_REQUEST_MAX_SECS,
             "-w",
             "\n%{http_code}",
             &format!("http://127.0.0.1:{port}{path}"),
@@ -8916,6 +8950,8 @@ fn curl_get_as(port: u16, path: &str, agent_id: &str) -> (String, serde_json::Va
     let out = std::process::Command::new("curl")
         .args([
             "-s",
+            "-m",
+            CURL_REQUEST_MAX_SECS,
             "-w",
             "\n%{http_code}",
             "-H",
@@ -8962,6 +8998,8 @@ fn curl_post(
 ) -> (String, serde_json::Value) {
     let mut args: Vec<String> = vec![
         "-s".into(),
+        "-m".into(),
+        CURL_REQUEST_MAX_SECS.into(),
         "-w".into(),
         "\n%{http_code}".into(),
         "-X".into(),
@@ -8995,6 +9033,8 @@ fn curl_post(
 fn curl_delete(port: u16, path: &str, agent_id: Option<&str>) -> String {
     let mut args: Vec<String> = vec![
         "-s".into(),
+        "-m".into(),
+        CURL_REQUEST_MAX_SECS.into(),
         "-o".into(),
         "/dev/null".into(),
         "-w".into(),
@@ -9486,6 +9526,8 @@ fn http_inbox_cross_source_agent_id_body_vs_query_vs_header() {
     let out = std::process::Command::new("curl")
         .args([
             "-s",
+            "-m",
+            CURL_REQUEST_MAX_SECS,
             "-H",
             "x-agent-id: ai:bob",
             &format!("http://127.0.0.1:{}/api/v1/inbox?limit=5", d.port),
@@ -11334,6 +11376,8 @@ fn curl_put(
 ) -> (String, serde_json::Value) {
     let mut args: Vec<String> = vec![
         "-s".into(),
+        "-m".into(),
+        CURL_REQUEST_MAX_SECS.into(),
         "-w".into(),
         "\n%{http_code}".into(),
         "-X".into(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13147,7 +13147,7 @@ async fn test_daemon_cmd_serve_responds_to_health_then_terminates() {
     // assertion the prior subprocess test made, but against the in-process
     // daemon — coverage attribution lands on `handlers::health`).
     let resp = bounded_test_client()
-        .get(&format!("http://127.0.0.1:{port}/api/v1/health"))
+        .get(format!("http://127.0.0.1:{port}/api/v1/health"))
         .send()
         .await
         .expect("health request must succeed");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,7 +15,7 @@
 // degrades to keyword-only instead of hanging the test process.
 
 mod common;
-use common::free_port;
+use common::{DAEMON_READY_TIMEOUT, bounded_test_client, free_port, wait_for_http_ready};
 
 /// #998 (2026-05-21) — concrete admin id seeded into
 /// `AI_MEMORY_ADMIN_AGENT_IDS` for every spawned integration daemon.
@@ -13137,28 +13137,18 @@ async fn test_daemon_cmd_serve_responds_to_health_then_terminates() {
         .await
     });
 
-    // Wait for the listener to come up. ~5s budget with 100ms backoff —
-    // identical wait_for_health semantics as the prior subprocess test,
-    // but talking to the in-process daemon over the loopback socket.
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://127.0.0.1:{port}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(
-        ready,
-        "serve health probe never returned 200 — in-process HTTP daemon failed to bind"
-    );
+    // Wait for the listener — bounded probe (#3140 Fable FOLLOW-UP (a);
+    // the previous `reqwest::get` default client had no request timeout).
+    wait_for_http_ready(&addr, DAEMON_READY_TIMEOUT)
+        .await
+        .expect("serve health probe never returned 200 — in-process HTTP daemon failed to bind");
 
     // Hit /api/v1/health a second time to exercise the handler path (same
     // assertion the prior subprocess test made, but against the in-process
     // daemon — coverage attribution lands on `handlers::health`).
-    let resp = reqwest::get(&format!("http://127.0.0.1:{port}/api/v1/health"))
+    let resp = bounded_test_client()
+        .get(&format!("http://127.0.0.1:{port}/api/v1/health"))
+        .send()
         .await
         .expect("health request must succeed");
     assert_eq!(
@@ -13219,18 +13209,9 @@ async fn test_daemon_cmd_sync_daemon_pulls_then_terminates() {
         .await
     });
 
-    // Wait for peer readiness.
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://127.0.0.1:{peer_port}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(ready, "peer serve never became ready");
+    wait_for_http_ready(&peer_addr, DAEMON_READY_TIMEOUT)
+        .await
+        .expect("peer serve never became ready");
 
     // 2. Run the sync-daemon loop in-process with interval=1 so at least
     //    one full cycle (pull + push) executes before we trigger shutdown.
@@ -13383,22 +13364,9 @@ async fn test_daemon_serve_http_with_shutdown_future_runs_with_custom_cleanup() 
         .await
     });
 
-    // Wait for readiness via the same health-probe pattern as the Wave 2
-    // serve test.
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://127.0.0.1:{port}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(
-        ready,
-        "serve_http_with_shutdown_future health probe never returned 200"
-    );
+    wait_for_http_ready(&addr, DAEMON_READY_TIMEOUT)
+        .await
+        .expect("serve_http_with_shutdown_future never became ready");
 
     // Trigger shutdown — the user-supplied future's notified().await wakes,
     // it does the cleanup work, then resolves; axum::serve drains; the
@@ -13458,17 +13426,9 @@ async fn test_daemon_sync_with_shutdown_using_client_accepts_custom_client() {
         .await
     });
 
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://127.0.0.1:{peer_port}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(ready, "peer serve never became ready");
+    wait_for_http_ready(&peer_addr, DAEMON_READY_TIMEOUT)
+        .await
+        .expect("peer serve never became ready");
 
     // 2. Build a custom reqwest::Client that differs from the default the
     //    plain run_sync_daemon_with_shutdown wrapper builds — non-default

--- a/tests/pg_single_create_on_conflict_2743.rs
+++ b/tests/pg_single_create_on_conflict_2743.rs
@@ -213,7 +213,8 @@ async fn default_collision_is_rejected_2743() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("c2743-err-{suffix}");
     let ns = format!("c2743-err-ns-{suffix}");
@@ -282,7 +283,8 @@ async fn explicit_merge_upserts_2743() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("c2743-merge-{suffix}");
     let ns = format!("c2743-merge-ns-{suffix}");
@@ -333,7 +335,8 @@ async fn explicit_version_renames_2743() {
         return;
     };
     let (base, shutdown, handle) = spawn_daemon(&url).await;
-    let client = reqwest::Client::new();
+    // v1.0.0 #3140 — bounded: `reqwest::Client::new()` has no request timeout.
+    let client = common::bounded_test_client();
     let suffix = uuid::Uuid::new_v4();
     let agent = format!("c2743-ver-{suffix}");
     let ns = format!("c2743-ver-ns-{suffix}");

--- a/tests/qual_10_module_size_ceiling.rs
+++ b/tests/qual_10_module_size_ceiling.rs
@@ -1565,7 +1565,23 @@ const MODULE_SIZE_CEILINGS: &[(&str, usize)] = &[
     // tests (pure + wiremock), growing the file to 6_344; 6_360 = 16 headroom.
     // Refactor-split into `src/llm/{…}.rs` remains the tracked post-ship
     // ARCH cleanup.
-    ("src/llm.rs", 6_360),
+    // 2026-08-22 (#3140 sync↔async bridge bound): 6_360 -> 6_780. The
+    // unbounded `block_on_local` was RETIRED and replaced by
+    // `block_on_local_bounded`, which wraps all three runtime-flavor arms in
+    // `tokio::time::timeout` and adds a driver-independent OS-thread alarm
+    // (`spawn_wallclock_alarm` + `WallclockAlarmGuard` + the
+    // `BRIDGE_ALARM_GRACE`/`BRIDGE_ALARM_POLL` consts) on the multi-thread
+    // arm, whose timer belongs to a runtime this thread does not drive. Adds
+    // the four derived budget constants (`BRIDGE_BUDGET_FACTOR`,
+    // `BRIDGE_{GENERATE,HEALTH,PULL}_BUDGET`), `bridge_embed_batch_budget`,
+    // `EPHEMERAL_RUNTIME_BUILD_MSG`, the `bridge_budget_tests_3140` module
+    // (6 tests incl. a deterministic starved-time-driver reproduction), and
+    // the wiremock-test `bridge_call` / `bounded_test_client` guards. Growth
+    // is bound-and-proof, not feature surface: a bridge with no wall-clock
+    // ceiling burned a full 80-minute macOS CI job. Measured 6_714; ceiling
+    // 6_780 (+66 headroom). Refactor-split into `src/llm/{…}.rs` remains the
+    // tracked post-ship ARCH cleanup.
+    ("src/llm.rs", 6_780),
 ];
 
 #[test]

--- a/tests/recall_purity_p01.rs
+++ b/tests/recall_purity_p01.rs
@@ -934,13 +934,27 @@ fn fold_flips_inbox_unread_marker() {
     );
 }
 
+/// v1.0.0 #3140 — TTL given to the two racing rows in
+/// `fold_before_gc_retains_recalled_expiring_row`.
+const RACE_EXPIRY_MS: i64 = 900;
+
+/// v1.0.0 #3140 — how long the test sleeps before running gc.
+///
+/// Was 1200 ms against a 900 ms TTL: a 1.33x margin, thin enough that a
+/// scheduler stall or a backwards system-clock step (the TTL comparison is
+/// wall-clock `chrono`, the sleep is monotonic) could leave the control row
+/// un-expired and fail a test with no defect behind it. 5x keeps the exact
+/// property under test — un-recalled rows expire, folded ones survive — and
+/// removes the timing knife-edge.
+const RACE_EXPIRY_MARGIN: u32 = 5;
+
 #[test]
 fn fold_before_gc_retains_recalled_expiring_row() {
     let _g = env_lock();
     clear_flags();
     let (conn, _dir) = fresh_db();
     let created = chrono::Utc::now().to_rfc3339();
-    let soon = (chrono::Utc::now() + chrono::Duration::milliseconds(900)).to_rfc3339();
+    let soon = (chrono::Utc::now() + chrono::Duration::milliseconds(RACE_EXPIRY_MS)).to_rfc3339();
     // Two identical short rows expiring in <1s; only one is recalled.
     for id in ["race-recalled", "race-control"] {
         conn.execute(
@@ -964,7 +978,9 @@ fn fold_before_gc_retains_recalled_expiring_row() {
     .unwrap();
     // Fold BEFORE gc (the load-bearing ordering).
     assert_eq!(db::fold_recall_accesses(&conn, 3600, 86_400).unwrap(), 1);
-    std::thread::sleep(std::time::Duration::from_millis(1200));
+    std::thread::sleep(std::time::Duration::from_millis(
+        RACE_EXPIRY_MS.unsigned_abs() * u64::from(RACE_EXPIRY_MARGIN),
+    ));
     db::gc(&conn, false).expect("gc");
     let exists = |id: &str| -> i64 {
         conn.query_row("SELECT COUNT(*) FROM memories WHERE id = ?1", [id], |r| {

--- a/tests/recall_purity_p01_postgres.rs
+++ b/tests/recall_purity_p01_postgres.rs
@@ -507,6 +507,19 @@ fn crate_mid_extend() -> i64 {
 // C — fold-before-gc race (postgres eviction path)
 // =====================================================================
 
+/// v1.0.0 #3140 — TTL given to the two racing rows below.
+const RACE_EXPIRY_MS: i64 = 900;
+
+/// v1.0.0 #3140 — how long the test sleeps before running gc, as a multiple
+/// of [`RACE_EXPIRY_MS`].
+///
+/// Was a flat 1200 ms against a 900 ms TTL: a 1.33x margin, thin enough that a
+/// scheduler stall or a backwards system-clock step (the TTL comparison is
+/// wall-clock, the sleep is monotonic) could leave the control row un-expired
+/// and fail a test with no defect behind it. 5x keeps the exact property under
+/// test and removes the timing knife-edge.
+const RACE_EXPIRY_MARGIN: u32 = 5;
+
 #[tokio::test]
 #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL (live postgres); run with --include-ignored"]
 // M-LINT-OVERRIDE-EXPECT — the env-serialization guard MUST span the
@@ -541,7 +554,7 @@ async fn postgres_fold_before_gc_retains_recalled_expiring_row() {
         .await
         .expect("store control");
     // Both expire in <1s.
-    let soon = chrono::Utc::now() + chrono::Duration::milliseconds(900);
+    let soon = chrono::Utc::now() + chrono::Duration::milliseconds(RACE_EXPIRY_MS);
     for id in [&recalled, &control] {
         sqlx::query("UPDATE memories SET expires_at = $2 WHERE id = $1")
             .bind(id)
@@ -561,7 +574,10 @@ async fn postgres_fold_before_gc_retains_recalled_expiring_row() {
         .await
         .expect("ledger row");
     assert_eq!(store.fold_recall_accesses().await.expect("fold"), 1);
-    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(
+        RACE_EXPIRY_MS.unsigned_abs() * u64::from(RACE_EXPIRY_MARGIN),
+    ))
+    .await;
     store.run_gc(false).await.expect("run_gc");
 
     let count = |id: &str| {

--- a/tests/record_stop_r45_1955.rs
+++ b/tests/record_stop_r45_1955.rs
@@ -19,7 +19,13 @@
 //! - RESUME restores the write path.
 //! - Issuing stop/resume emits ONE signed `substrate.record_stop` /
 //!   `substrate.record_resume` attestation, chained + chain-intact.
-//! - EFFECT-LATENCY: stop issued → next write refused in ≤ 100 ms.
+//! - EFFECT: stop issued → the very NEXT write is refused, SYNCHRONOUSLY
+//!   with the write attempt. (v1.0.0 #3140: the wall-clock bound here was
+//!   `≤ 100 ms`, which on a loaded shared CI runner measures the runner,
+//!   not the stop plane. It is now a shape guard — see
+//!   `STOP_EFFECT_SYNCHRONOUS_CEILING`. The product's ≤100 ms figure is a
+//!   REFERENCE-HARDWARE claim and needs a bench producer to be enforced;
+//!   this suite does not, and never truthfully did, establish it.)
 //! - PERSISTENCE: the stop is derivable from the audit chain after a
 //!   fresh open (survives a daemon restart).
 //! - Federation-receive IS stopped (the "atomic write-fence" — inbound
@@ -267,8 +273,22 @@ async fn federation_receive_is_stopped() {
     );
 }
 
+/// v1.0.0 #3140 — ceiling on how long the refusal may take.
+///
+/// This is a SHAPE guard, not a performance budget: it fails if the stop plane
+/// ever becomes eventually-consistent (a background reconcile, a network
+/// round-trip, a retry loop), which would take seconds or never refuse at all.
+/// It is deliberately ~20x the product's reference-hardware ≤100 ms figure so
+/// it can only fire on that structural regression, never on a loaded shared CI
+/// runner. Enforcing the ≤100 ms figure itself requires a bench producer on
+/// reference hardware; no such bench exists today, and the previous 100 ms
+/// assertion here did not establish it either — it only made this suite flaky.
+const STOP_EFFECT_SYNCHRONOUS_CEILING: Duration = Duration::from_secs(2);
+
+/// R-45 (#1955) — once a stop is engaged the very next write is refused,
+/// synchronously with the write attempt.
 #[tokio::test]
-async fn effect_latency_under_100ms() {
+async fn effect_refuses_next_write_synchronously() {
     let (store, _f) = fresh_store();
     let c = ctx();
 
@@ -286,8 +306,10 @@ async fn effect_latency_under_100ms() {
         "next write refused"
     );
     assert!(
-        elapsed <= Duration::from_millis(100),
-        "stop effect-latency {elapsed:?} exceeds the 100ms target"
+        elapsed <= STOP_EFFECT_SYNCHRONOUS_CEILING,
+        "the stop must refuse SYNCHRONOUSLY with the write attempt; \
+         {elapsed:?} exceeds {STOP_EFFECT_SYNCHRONOUS_CEILING:?}, which means the \
+         refusal became eventually-consistent"
     );
 }
 

--- a/tests/reembed_cli_1598.rs
+++ b/tests/reembed_cli_1598.rs
@@ -29,6 +29,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Output;
+use std::time::Duration;
 
 use ai_memory::db;
 use ai_memory::models::{ConfidenceSource, Memory, MemoryKind, Tier};
@@ -131,8 +132,61 @@ fn run_reembed(db_path: &Path, base_url: &str, model: &str, extra_args: &[&str])
         .env("AI_MEMORY_EMBED_API_KEY", "reembed-key-1598")
         .env_remove("AI_MEMORY_EMBED_BACKFILL_BATCH")
         .env_remove("AI_MEMORY_DB");
-    cmd.output()
-        .expect("spawning the ai-memory binary must succeed")
+    output_within(cmd, db_path)
+}
+
+/// v1.0.0 #3140 — wall-clock ceiling for one `reembed` child.
+///
+/// The binary talks to a local wiremock `/embeddings` server; a healthy run is
+/// sub-second. This bound only ever fires on a genuine wedge — and when it
+/// does the child is KILLED, so a hung reembed cannot hold the job cap (or a
+/// sqlite write lock on the scratch DB) the way #3140's hang did.
+const REEMBED_CHILD_BUDGET: Duration = Duration::from_mins(2);
+
+/// v1.0.0 #3140 — poll cadence while waiting on the child.
+const REEMBED_CHILD_POLL: Duration = Duration::from_millis(25);
+
+/// v1.0.0 #3140 — `Command::output()` under [`REEMBED_CHILD_BUDGET`].
+///
+/// `output()` reads both pipes to EOF with no deadline, so a child that never
+/// exits parks the test forever. Redirecting to files instead of pipes keeps
+/// the reap free of the classic full-pipe deadlock: the child can always make
+/// progress, so `try_wait` is a truthful liveness signal. Capture files live
+/// beside the scratch DB (never `/tmp`, per the project hard rule).
+fn output_within(mut cmd: std::process::Command, db_path: &Path) -> Output {
+    let stem = db_path.with_extension(format!("{}", std::process::id()));
+    let out_path = PathBuf::from(format!("{}.stdout", stem.display()));
+    let err_path = PathBuf::from(format!("{}.stderr", stem.display()));
+    let out_file = std::fs::File::create(&out_path).expect("create stdout capture");
+    let err_file = std::fs::File::create(&err_path).expect("create stderr capture");
+    let mut child = cmd
+        .stdout(out_file)
+        .stderr(err_file)
+        .spawn()
+        .expect("spawning the ai-memory binary must succeed");
+
+    let deadline = std::time::Instant::now() + REEMBED_CHILD_BUDGET;
+    let status = loop {
+        match child.try_wait().expect("try_wait on the reembed child") {
+            Some(status) => break status,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("`ai-memory reembed` still running after {REEMBED_CHILD_BUDGET:?} (#3140)");
+            }
+            None => std::thread::sleep(REEMBED_CHILD_POLL),
+        }
+    };
+
+    let stdout = std::fs::read(&out_path).unwrap_or_default();
+    let stderr = std::fs::read(&err_path).unwrap_or_default();
+    let _ = std::fs::remove_file(&out_path);
+    let _ = std::fs::remove_file(&err_path);
+    Output {
+        status,
+        stdout,
+        stderr,
+    }
 }
 
 /// Parse the last non-empty stdout line as JSON (the `--json` contract:

--- a/tests/s75_capabilities_db_schema_version.rs
+++ b/tests/s75_capabilities_db_schema_version.rs
@@ -141,20 +141,16 @@ async fn s75_capabilities_surfaces_runtime_db_schema_version() {
         .await
     });
 
-    // Wait for the listener — same shape as serve_postgres_smoke.
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://{addr}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(ready, "in-process HTTP daemon never bound");
+    // Wait for the listener. v1.0.0 #3140 — was a bare `reqwest::get` inside a
+    // `for _ in 0..50` loop: an unbounded probe against a daemon that accepts
+    // and then stalls parks the test forever, because the loop counts
+    // iterations, not wall-clock. `common::wait_for_http_ready` bounds both the
+    // individual probe and the overall wait.
+    common::wait_for_http_ready(&addr, common::IN_PROCESS_READY_TIMEOUT)
+        .await
+        .expect("in-process HTTP daemon never bound");
 
-    let client = reqwest::Client::new();
+    let client = common::bounded_test_client();
     let caps: Value = client
         .get(format!("http://{addr}/api/v1/capabilities"))
         .send()
@@ -221,5 +217,13 @@ async fn s75_capabilities_surfaces_runtime_db_schema_version() {
     );
 
     shutdown.notify_one();
-    let _ = handle.await;
+    // v1.0.0 #3140 — bounded join (mirrors `tests/serve_postgres_smoke.rs`): an
+    // unbounded `handle.await` parks the test for the whole job cap if the
+    // daemon never observes the notify.
+    let joined = tokio::time::timeout(common::DAEMON_SHUTDOWN_TIMEOUT, handle).await;
+    assert!(
+        joined.is_ok(),
+        "daemon task did not terminate within {:?} of shutdown notify (#3140)",
+        common::DAEMON_SHUTDOWN_TIMEOUT
+    );
 }

--- a/tests/store_url_fail_closed_2679.rs
+++ b/tests/store_url_fail_closed_2679.rs
@@ -30,7 +30,17 @@ use std::time::Duration;
 use assert_cmd::cargo::cargo_bin;
 use tempfile::TempDir;
 
-const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:5432/ai_memory";
+/// v1.0.0 #3140 — the port is `1`, an address nothing ever listens on.
+///
+/// This is a REFUSAL probe: the guard must fire on the URL scheme, before
+/// any connection. Aiming it at the real Postgres port (5432) made the
+/// assertion VACUOUS on any host running Postgres — a regression that moved
+/// the refusal after connect would still pass, and a regression that removed
+/// it could WRITE to that live database. Pointing at a dead address means a
+/// refusal can never be manufactured by a live server; the reason-text
+/// assertions below keep it from being manufactured by a connection error
+/// either.
+const PG_STORE_URL: &str = "postgres://ai_memory:hunter2@127.0.0.1:1/ai_memory";
 const PG_PASSWORD: &str = "hunter2";
 
 /// Spawn `ai-memory serve` with a short timeout. On success the daemon would
@@ -122,11 +132,12 @@ fn serve_refuses_postgres_store_url_env_without_creating_sqlite() {
         "serve must exit non-zero on postgres:// without sal-postgres; status={:?} out={combined}",
         output.status
     );
+    // #3140 — the accepted reason text must be SPECIFIC to the #2679 guard. A
+    // bare "Postgres" substring would also match a plain connection error, so
+    // the test could pass without the guard ever firing.
     assert!(
-        combined.contains("#2679")
-            || combined.contains("sal-postgres")
-            || combined.contains("Postgres"),
-        "refusal must name the defect: {combined}"
+        combined.contains("#2679") || combined.contains("sal-postgres"),
+        "refusal must name the #2679 guard, not merely fail to connect: {combined}"
     );
     assert!(
         !combined.contains(PG_PASSWORD),

--- a/tests/transcript_extractor.rs
+++ b/tests/transcript_extractor.rs
@@ -24,6 +24,25 @@ use std::sync::OnceLock;
 use ai_memory::config::{TranscriptNamespaceConfig, TranscriptsConfig};
 use serde_json::{Value, json};
 
+/// v1.0.0 #3140 — ceiling on the nested `cargo build` for the sibling crate.
+///
+/// Generous: on a cold CI runner this compiles a small crate plus its
+/// dependencies, and it may first have to wait out the outer cargo's
+/// package-cache lock. The point is that a bound EXISTS.
+const EXTRACTOR_BUILD_BUDGET: std::time::Duration = std::time::Duration::from_mins(5);
+
+/// v1.0.0 #3140 — ceiling on ONE extractor invocation. The binary reads one
+/// envelope from stdin and writes one decision line; a healthy run is
+/// milliseconds.
+const EXTRACTOR_RUN_BUDGET: std::time::Duration = std::time::Duration::from_mins(1);
+
+/// v1.0.0 #3140 — poll cadence while waiting on a child.
+const CHILD_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// v1.0.0 #3140 — disambiguates the per-invocation capture files when several
+/// test threads run the extractor concurrently.
+static RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Build the reference extractor binary and return the absolute
 /// path to it.
 ///
@@ -59,23 +78,29 @@ fn build_extractor_once() -> PathBuf {
         manifest_path.display()
     );
 
-    // Build into a per-test target dir so a parallel `cargo test`
-    // invocation against the main crate doesn't race the
-    // sibling-crate build cache. Scope the temp dir by current
-    // PID so two concurrent `cargo test` driver processes (e.g.
-    // CI sharding) cannot stomp each other's target/.
+    // Build into a dedicated target dir, separate from the main crate's so a
+    // parallel `cargo test` against `ai-memory` doesn't race the sibling-crate
+    // build cache.
     // #1721 — project-local scratch (no /tmp writes; CLAUDE.md hard rule).
+    //
+    // v1.0.0 #3140 — this used to be scoped by PID. Cargo already takes an
+    // exclusive lock on a target dir, so two concurrent driver processes were
+    // never at risk of stomping each other; all the PID suffix bought was a
+    // COLD full rebuild per test-runner process, each leaving its own multi-
+    // gigabyte tree behind under `.local-runs/`. One shared dir is both
+    // correct and an order of magnitude cheaper on disk and time.
     let scratch_root = std::env::current_dir()
         .unwrap_or_else(|_| std::path::PathBuf::from("."))
         .join(".local-runs")
         .join("transcript-extractor");
     std::fs::create_dir_all(&scratch_root).ok();
-    let target_dir = scratch_root.join(format!(
-        "ai-memory-transcript-extractor-target-{}",
-        std::process::id()
-    ));
+    let target_dir = scratch_root.join("ai-memory-transcript-extractor-target");
 
-    let status = Command::new("cargo")
+    // v1.0.0 #3140 — bounded. A nested `cargo build` blocks on the OUTER
+    // cargo's package-cache lock, so an unbounded `.status()` here can park
+    // the whole test binary indefinitely — indistinguishable from a hang, and
+    // charged to the CI job cap.
+    let mut child = Command::new("cargo")
         .args([
             "build",
             "--quiet",
@@ -84,8 +109,24 @@ fn build_extractor_once() -> PathBuf {
             "--target-dir",
             target_dir.to_str().expect("utf-8 target dir"),
         ])
-        .status()
+        .spawn()
         .expect("invoke cargo build");
+    let deadline = std::time::Instant::now() + EXTRACTOR_BUILD_BUDGET;
+    let status = loop {
+        match child.try_wait().expect("try_wait on cargo build") {
+            Some(status) => break status,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "`cargo build` for the transcript extractor did not finish within \
+                     {EXTRACTOR_BUILD_BUDGET:?} — most likely blocked on the outer cargo's \
+                     package-cache lock (#3140)"
+                );
+            }
+            None => std::thread::sleep(CHILD_POLL_INTERVAL),
+        }
+    };
     assert!(status.success(), "cargo build for extractor failed");
 
     let bin = target_dir.join("debug").join("transcript-extractor");
@@ -101,10 +142,31 @@ fn build_extractor_once() -> PathBuf {
 /// the parsed decision JSON.
 fn run_once(bin: &Path, envelope: &Value) -> Value {
     use std::io::Write;
+    // v1.0.0 #3140 — stdout/stderr go to FILES, not pipes. `wait_with_output`
+    // reads both pipes to EOF with no deadline, so an extractor that never
+    // exits (or one that fills a pipe nobody drains) parks the test forever.
+    // With files the child can always make progress, which makes `try_wait` a
+    // truthful liveness signal and the deadline below real.
+    let capture_root = std::env::current_dir()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .join(".local-runs")
+        .join("transcript-extractor");
+    std::fs::create_dir_all(&capture_root).ok();
+    let stem = capture_root.join(format!(
+        "run-{}-{}",
+        std::process::id(),
+        RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let out_path = stem.with_extension("stdout");
+    let err_path = stem.with_extension("stderr");
     let mut child = Command::new(bin)
         .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::from(
+            std::fs::File::create(&out_path).expect("create stdout capture"),
+        ))
+        .stderr(Stdio::from(
+            std::fs::File::create(&err_path).expect("create stderr capture"),
+        ))
         .spawn()
         .expect("spawn extractor");
     {
@@ -113,13 +175,31 @@ fn run_once(bin: &Path, envelope: &Value) -> Value {
             .write_all(envelope.to_string().as_bytes())
             .expect("write envelope");
     }
-    let output = child.wait_with_output().expect("wait extractor");
+    // Close stdin so the extractor sees EOF and can exit.
+    drop(child.stdin.take());
+
+    let deadline = std::time::Instant::now() + EXTRACTOR_RUN_BUDGET;
+    let status = loop {
+        match child.try_wait().expect("try_wait on extractor") {
+            Some(status) => break status,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("extractor still running after {EXTRACTOR_RUN_BUDGET:?} (#3140)");
+            }
+            None => std::thread::sleep(CHILD_POLL_INTERVAL),
+        }
+    };
+    let stdout_bytes = std::fs::read(&out_path).unwrap_or_default();
+    let stderr_bytes = std::fs::read(&err_path).unwrap_or_default();
+    let _ = std::fs::remove_file(&out_path);
+    let _ = std::fs::remove_file(&err_path);
     assert!(
-        output.status.success(),
+        status.success(),
         "extractor exited non-zero: stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        String::from_utf8_lossy(&stderr_bytes)
     );
-    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stdout = String::from_utf8(stdout_bytes).expect("utf-8 stdout");
     let line = stdout
         .lines()
         .rfind(|l| !l.trim().is_empty())

--- a/tests/wt_1_a_schema_migration.rs
+++ b/tests/wt_1_a_schema_migration.rs
@@ -450,19 +450,14 @@ async fn test_capabilities_db_schema_version_reports_36() {
         .await
     });
 
-    let mut ready = false;
-    for _ in 0..50 {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        if let Ok(resp) = reqwest::get(&format!("http://{addr}/api/v1/health")).await
-            && resp.status() == reqwest::StatusCode::OK
-        {
-            ready = true;
-            break;
-        }
-    }
-    assert!(ready, "WT-1-A: in-process HTTP daemon never bound");
+    // v1.0.0 #3140 — was a bare `reqwest::get` inside a `for _ in 0..50` loop:
+    // an unbounded probe against a daemon that accepts and then stalls parks
+    // the test forever, because the loop counts iterations, not wall-clock.
+    common::wait_for_http_ready(&addr, common::IN_PROCESS_READY_TIMEOUT)
+        .await
+        .expect("WT-1-A: in-process HTTP daemon never bound");
 
-    let client = reqwest::Client::new();
+    let client = common::bounded_test_client();
     let caps: Value = client
         .get(format!("http://{addr}/api/v1/capabilities"))
         .send()
@@ -491,7 +486,15 @@ async fn test_capabilities_db_schema_version_reports_36() {
     );
 
     shutdown.notify_one();
-    let _ = handle.await;
+    // v1.0.0 #3140 — bounded join (mirrors `tests/serve_postgres_smoke.rs`): an
+    // unbounded `handle.await` parks the test for the whole job cap if the
+    // daemon never observes the notify.
+    let joined = tokio::time::timeout(common::DAEMON_SHUTDOWN_TIMEOUT, handle).await;
+    assert!(
+        joined.is_ok(),
+        "daemon task did not terminate within {:?} of shutdown notify (WT-1-A, #3140)",
+        common::DAEMON_SHUTDOWN_TIMEOUT
+    );
 }
 
 /// v0.7.0 #1112 — v49 archive-column-carry migration idempotency pin.


### PR DESCRIPTION
Closes #3140

## The defect

On PR #3137, run `32565464216`, job `Check (macos-fed,sqlite)` (`97013361525`, runner `f1-macos-fed`) printed its last unit-test completion at 10:03:53 and then went silent for **72 minutes**, until the 80-minute `timeout-minutes` cancelled the job. The same leg took 19 minutes on two other runs the same day (`32556214239`, `32552244493`). Diffing completed unit tests against the green run left exactly two that never finished, both on the LLM path:

- `curator::tests::run_once_with_llm_dry_run_skips_writes`
- `llm::wiremock_tests::test_generate_returns_error_on_500`

**The HTTP client was never the problem.** `src/llm.rs` builds every `reqwest::Client` with `.timeout(GENERATE_TIMEOUT)` (30 s) and `.connect_timeout(CONNECT_TIMEOUT)` (5 s), and overrides per-request where a tighter bound applies.

The unbounded chokepoint both hung tests traverse is the **sync↔async bridge**, `block_on_local` at `src/llm.rs:118` on base `93d09145`:

```rust
pub(crate) fn block_on_local<F, Fut, T>(make_fut: F) -> T { ... }
//   MultiThread arm:  tokio::task::block_in_place(|| handle.block_on(make_fut()))   // :133
//   current-thread:   std::thread::scope(..).join().expect("...panicked")           // :176-:190
//   no runtime:       Builder::new_current_thread()...build().expect("ephemeral runtime builds")
```

`block_in_place(|| handle.block_on(..))` parks a blocking-pool thread on the **ambient runtime's** driver. If that driver never advances the future — a wedged mock server, a time driver nothing polls, a runtime whose only worker is the thread just parked — the inner `reqwest` timeout never gets a chance to fire and the caller waits forever. The function's return type was `T`, so there was no channel through which a bound *could* be reported even if one existed.

## The fix

`block_on_local` is **retired**. It is replaced by:

```rust
pub(crate) fn block_on_local_bounded<F, Fut, T>(budget: Duration, make_fut: F) -> Result<T>
```

- **`tokio::time::timeout(budget, ..)` on all three runtime-flavor arms**, so expiry is enforced by whichever runtime is actually driving the future, not by a caller who may never be scheduled again.
- **An OS-thread wall-clock alarm on the multi-thread arm only** (`spawn_wallclock_alarm`). That is the one arm whose timer belongs to a runtime this thread does not drive, so a starved time driver would defeat a tokio timer too. The alarm sleeps on a plain OS thread and signals through a `tokio::sync::oneshot`, whose `send` wakes the parked `block_on` directly via its `Waker` — no timer wheel, no IO driver, no worker; nothing the wedged runtime can starve. Arms 2 and 3 each **own** the runtime driving their future, so their timer cannot be starved and they carry no alarm. The alarm runs at `budget + BRIDGE_ALARM_GRACE` (5 s) so on a healthy runtime the tokio timeout always wins and produces the canonical error; a `WallclockAlarmGuard` flips a completion flag on drop so the thread exits within one `BRIDGE_ALARM_POLL` (50 ms) of the call finishing. If the alarm thread cannot be spawned, the future is simply never ready — the caller degrades to the tokio bound rather than being handed a spurious expiry.
- **Fail-closed, never fabricated.** Every failure mode returns `Err`; none panics and none hangs. Losing the `select!` race drops the request future, so `reqwest` cancels the in-flight socket — the bridge does not merely stop waiting while the work continues.
- **Two panic sites closed by deletion.** `Runtime::build().expect("ephemeral runtime builds")` (×2) and `.join().expect("...bridge thread panicked")` are now `?`/`map_err`. A failed runtime build is a real fleet-density condition (fd/thread/memory exhaustion) that used to kill a curator daemon thread or a `spawn_blocking` worker mid-request; a bridge-thread panic used to be re-raised into an unrelated caller's stack.

### Budgets are derived, never guessed

Every budget strictly **exceeds** the largest inner `reqwest` timeout of the call it wraps, at `BRIDGE_BUDGET_FACTOR = 2`, so the bridge can only fire when the inner timeout has *already* failed to release the caller. It never truncates a request the HTTP client would have completed.

| Bridge budget | Value | Inner ceiling of the wrapped call |
|---|---|---|
| `BRIDGE_HEALTH_BUDGET` | 10 s | `HEALTH_TIMEOUT` 5 s (`is_available_async`, `new_with_url_async`) |
| `BRIDGE_GENERATE_BUDGET` | 60 s | `GENERATE_TIMEOUT` 30 s (chat + single embed) |
| `BRIDGE_PULL_BUDGET` | 240 s | `PULL_TIMEOUT` 120 s + a 10 s `/api/tags` list |
| `bridge_embed_batch_budget(n)` | 60 s × n | worst case one `GENERATE_TIMEOUT`-bounded request per text |
| `HOOK_BRIDGE_BUDGET` (mcp) | 1 min | `hooks::timeouts` per-class deadline, max 5 s |

`embed_text_with_budget(_, _, Some(b))` is safe against an operator-widened `AI_MEMORY_RECALL_EMBED_BUDGET_MS`: the underlying `embed_text_async` request carries `.timeout(GENERATE_TIMEOUT)` (`src/llm.rs:2432`), so the inner ceiling is `min(b, 30 s)` regardless of how large `b` is set. **No documented default is tightened by this PR.**

### Security: the MCP enforcement gates now refuse when unevaluable

`pre_signal_send_decision` and `consult_pre_event_gate` (`src/mcp/mod.rs`) drive the async `HookChain` synchronously through this same bridge — they are **deny-capable PRE gates**. Pre-#3140 an `Err` there was unreachable: the bridge panicked (killing the stdio worker / the request task mid-write) or hung. They now **fail closed** with `HOOK_BRIDGE_UNAVAILABLE_CODE = 503`, matching what `hooks::chain` already reports for an executor-level failure under `fail_mode=closed`. An enforcement gate that could not be evaluated is not an allow. The refusal string reuses the existing `"refused by hooks.enforce gate (code {code}): {reason}"` shape, so nothing downstream needs to learn a new format.

## Addendum riders (from the #3140 root-cause comment)

Same class, swept to zero across `src/` and `tests/`:

- **Every `reqwest::Client::new()` bounded.** `grep -rn 'reqwest::Client::new()' src/ tests/` now returns **only doc comments** — 26 call sites replaced, via a shared `tests/common::bounded_test_client()` (30 s) plus module-local builders in `src/llm.rs` (`HEALTH_TIMEOUT`/`CONNECT_TIMEOUT`) and `src/federation/receive.rs` (10 s/5 s, whose tests exist precisely to prove we survive a hostile peer). `tests/common::pg_test_client` gains the same bound, covering six Postgres suites at one site.
- **`wait_for_http_ready` bounded.** Its loop checks `elapsed >= timeout` only at the **top** of each iteration, so a single probe that connects and never answers defeated the whole 5-minute `DAEMON_READY_TIMEOUT`. The probe is now capped at 2 s by a `OnceLock`-cached client (a fresh client per probe would discard the connection pool and leak a resolver thread pool each iteration). Two suites that hand-rolled `for _ in 0..50 { reqwest::get(..) }` (`s75_capabilities_db_schema_version`, `wt_1_a_schema_migration`) now call it, and their `let _ = handle.await` shutdown joins are bounded too.
- **`-m` on every `curl` argv in `tests/`.** All 13 `Command::new("curl")` sites now carry `--max-time`: 12 added here, 1 (`b3_precompute_doesnt_block_serve`) already had the long form. Two named constants per file — `CURL_PROBE_MAX_SECS` (2 s, inside a bounded retry loop) and `CURL_REQUEST_MAX_SECS` (30 s, a real API call under `cargo-llvm-cov`, which is 3-5× slower).
- **Deadline+kill reaps replace bare `child.wait()` / `Command::output()` / `wait_with_output()`** in `governance/deferred_audit.rs` (3 sites), `tests/reembed_cli_1598.rs` and `tests/transcript_extractor.rs`. The two `output()`-shaped reaps redirect stdout/stderr to **files** rather than pipes, which is what makes `try_wait` a truthful liveness signal — reading two pipes to EOF with no deadline is itself the hang. Capture files land under `.local-runs/` (never `/tmp`, per the project rule).
- **Refusal probes are no longer vacuous.** `cli_write_verb_pg_refuse_ceiling_2572`, `backup_fail_closed_2444` and `store_url_fail_closed_2679` proved a `postgres://` store URL is REFUSED while pointing at `127.0.0.1:5432`. On any host actually running Postgres the probe could pass for the wrong reason — and a regression that moved the refusal *after* connect could have WRITTEN to that live database. They now point at `127.0.0.1:1`, where nothing listens. The #2679 probe's accepted reason text also drops the bare `Postgres` substring, which a mere connection error would have matched.
- **Wall-clock assertions that measured the runner, not the product, are now shape guards.** `record_stop_r45_1955::effect_latency_under_100ms` → `effect_refuses_next_write_synchronously`, ceiling 100 ms → 2 s. Stated plainly because the old assertion implied otherwise: the product's ≤100 ms record-stop figure is a **reference-hardware** claim that needs a bench producer to be enforced, and no such bench exists — the 100 ms assertion in a CI unit test never established it either. The load-bearing property (`Err(StoreError::Stopped { .. })` on the very next write, synchronously) is unchanged and now the thing the message describes. Also: the fold-before-gc race tests move from a 1.33× to a 5× expiry margin (900 ms TTL vs a monotonic sleep against a wall-clock `chrono` comparison); `b3_precompute_doesnt_block_serve` uses one 60 s budget in both execution modes instead of 10 s uninstrumented; the abandoned-download watchdog's detached sleeper drops 30 s → 5 s (still unconditionally over the assertion ceiling, so the property is intact).
- **`tests/transcript_extractor.rs` stops using a per-PID target dir.** Cargo already takes an exclusive lock on a target dir, so the PID suffix never prevented anything — it only bought a cold full rebuild and a multi-gigabyte tree per test-runner process.

Item 2 of the issue (the macOS hung-test watchdog via `gtimeout`) is **not** in this PR; it is #3141.

## Tests

New `bridge_budget_tests_3140` module in `src/llm.rs` — 6 tests:

- one per runtime-flavor arm (no ambient runtime / multi-thread / current-thread): an over-budget call returns `Err` whose message names the budget, within 5 s of a 50 ms budget against a 30 s sleep;
- `starved_time_driver_still_releases_the_caller` — the #3140 wedge reproduced **deterministically**: a 1-worker multi-thread runtime whose only worker is held by a task that never yields, so the runtime's time driver can never advance and the bridge's `tokio::time::timeout` is structurally unable to fire. Whichever bound wins, the caller is released with an error naming the budget;
- `wallclock_alarm_fires_after_its_budget` — the alarm does not fire EARLY (that would truncate a healthy call) and fires promptly after. SHA `8aa7ddd6` CI (`Check (ubuntu-latest, sqlite)` + SAL-only) failed this test at 97-99 ms vs a 100 ms budget because `Instant` was captured **after** `spawn_wallclock_alarm`; the worker starts its deadline inside the OS thread. `0637b94c` moves `t0` before spawn. Product budgets, `BRIDGE_ALARM_GRACE`, and documented defaults are unchanged. Local re-run: 6/6 + 20/20;
- `under_budget_call_returns_its_value` — the happy path is untouched.

Deliberately not tested, and said so in the source: the `Runtime::build()` failure path. Tokio exposes no injection point, and forcing it by exhausting the process fd/thread limit would corrupt every other test in the binary. The fix there is nonetheless load-bearing and type-enforced — the function returns `anyhow::Result<T>` and contains no `expect` on the builder.

Test-level backstops on the two tests that actually hung: `wiremock_tests::bridge_call` (a `tokio::time::timeout` + `spawn_blocking` wrapper, applied at 11 sites) and `curator::tests::run_under_hung_test_guard` (a detached worker thread + `recv_timeout`; detaching on expiry is what lets the assertion fire at all). Both 1 minute — far above any legitimate mock round-trip, far below the job cap.

`qual_10` ceiling for `src/llm.rs`: **6_360 → 6_780**, bumped in lockstep with a dated comment. Measured 6_714 (+66 headroom). Growth is bound-and-proof, not feature surface.

## AI involvement

- Agent: Claude Opus 5 (implementation) + Grok (successor: amend, umask-022 deferred_audit re-run, PR, wallclock-alarm test-clock fix `0637b94c`)
- Authority class: Standard
- Human approver(s) for Sensitive items: n/a
- Memory entries created/updated: `3c3d3bbc-c4a1-47aa-bec3-e570535b4416` (operator successor directive)

## CI parity run (local, `rust-toolchain.toml` pin 1.96.0)

All five clippy invocations used the exact CI flag set `-D warnings -D clippy::all -D clippy::pedantic`. Toolchain: cargo 1.96.0 / rustc 1.96.0, PATH-pinned (no rustup shim). Head: `7f1cfc5b`. Base: `origin/release/v1.0.0` = `93d09145`.

| Leg | Result |
|---|---|
| `cargo fmt --all -- --check` | PASS |
| `cargo check --all-targets` | PASS |
| `cargo check --examples` | PASS |
| `cargo check --all-targets --features sal` | PASS |
| `cargo check --all-targets --features sal-postgres` | PASS |
| `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `cargo clippy --all-targets --features sal -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `cargo clippy --features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `cargo clippy --features sal -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `cargo clippy --all-targets --features vectorlite -- -D warnings -D clippy::all -D clippy::pedantic` | PASS |
| `scripts/check-hardcoded-literals.sh` | PASS (no ratchet bump; named consts) |
| `scripts/check-docs-vs-ssot.sh` | PASS |
| `cargo test --test qual_10_module_size_ceiling` | PASS (`src/llm.rs` ceiling 6_360 → 6_780, measured 6_714) |
| `cargo test --test qual_6_7_legacy_error_type_ceiling` | PASS |
| `cargo test --lib bridge_budget_tests_3140` | **6 passed, 0 failed** (5.08 s) |
| `curator::tests::run_once_with_llm_dry_run_skips_writes` ×20 | **PASS 20/20** |
| `llm::wiremock_tests::test_generate_returns_error_on_500` ×20 | **PASS 20/20** |
| both hung-tests together in ONE binary invocation ×20 (CI shape) | **PASS 20/20** |
| `cargo test --lib governance::deferred_audit` under `( umask 022; … )` | **84 passed; 0 failed** (4.93 s) |

`bridge_budget_tests_3140` names: `under_budget_call_returns_its_value`, `budget_expiry_is_an_error_with_no_ambient_runtime`, `budget_expiry_is_an_error_under_a_multi_thread_runtime`, `budget_expiry_is_an_error_under_a_current_thread_runtime`, `wallclock_alarm_fires_after_its_budget`, `starved_time_driver_still_releases_the_caller` (deterministic #3140 wedge reproduction).

Postgres: no change under `src/store/postgres.rs` / `postgres_schema.sql` / pg handlers. The pg files in this diff are *test* files only (`reqwest::Client::new()` → `common::bounded_test_client()`). `cargo clippy --features sal-postgres --tests` and `cargo check --all-targets --features sal-postgres` both PASS. Live `AI_MEMORY_TEST_POSTGRES_URL` not run (successor rule 7 does not trigger).

## Rust standard

`rust-1.98`: **ERRORS-01/06/19** (every bridge failure is a `Result`, no `unwrap`/`expect` left on the production path, the two `expect` panic sites deleted); **ERRORS-08** (the remaining panics are test-only contract violations, per **ERRORS-24**); **CONCURRENCY-08** (the alarm's completion flag is `Release`/`Acquire`); **CONCURRENCY-23** (dropping the future on expiry is the cancellation, and `reqwest` aborts on drop); **OWNERSHIP-25** (`WallclockAlarmGuard::drop` only stores a flag — it cannot panic); **PERF-03** (`saturating_add`/`saturating_mul` on every budget arithmetic); **PERF-07** (`u32::try_from` in `bridge_embed_batch_budget`, saturating to `u32::MAX` rather than an `as` truncation); **TEST-02** (every new assertion carries a context message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
