### PR TITLE
fix(skills): fail closed on a postgres-backed daemon — handler 501, honest /capabilities, missing DELETE router-mirror arm (#3183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,44 @@ backend and missing or divergently implemented on its twin). Pinned by
   names the wrong version sends an operator debugging a stuck ladder to the
   wrong arm.
 
+- **Skills on a Postgres-backed daemon now fail closed with the documented 501
+  instead of silently persisting to the node-local scratch SQLite file
+  (#3183).** The skills substrate (`crate::mcp::handle_skill_*`) is typed on a
+  `rusqlite::Connection`, so all nine handlers in `src/handlers/skills.rs` took
+  `app.db.lock()` unconditionally — and on a postgres daemon `app.db` is not the
+  operator's database but the scratch file `bootstrap_serve` opens against
+  `--db` (postgres ships no `skills` table; `migrate_v82` is a version stamp
+  with no DDL). A skill registered against a postgres deployment therefore
+  landed in an empty local file: invisible to every peer, discarded on the next
+  container restart, while `/api/v1/capabilities` reported
+  `skills.implemented: true`. Split-brain plus a false claim, and an
+  unannounced data-loss path for an executable artefact. The router-layer gate
+  already refused these 8 paths (they are absent from
+  `postgres_endpoint_supported` and pinned as fully-501 by
+  `tests/pg_supported_route_inventory_gate_2799.rs`); what was missing was a
+  refusal at the handler itself and an honest capability report. Each handler
+  now re-checks `StorageBackend::Postgres` **first** — ahead of the #949 admin
+  gate, mirroring the middleware's ordering — and returns the same documented
+  envelope via the existing `postgres_not_implemented` helper, so a middleware
+  reorder, a custom router, or an in-process caller can no longer re-open the
+  local-write path. `/api/v1/capabilities` on postgres now reports
+  `skills.implemented: false` plus an additive `unsupported_on_postgres: true`
+  and an `unsupported_reason` naming the hard 501 and the tracking issue;
+  `skills.tools` is unchanged, so clients reading it for the canonical tool
+  names are unaffected. **Sqlite behaviour is untouched.** The postgres 501
+  route inventory is unchanged at 59 supported / 21 fully-501 / 80 unique paths
+  — this release makes the runtime match the partition that was already
+  declared, it does not move it. Consistent with the skills-501 disclosure
+  pending in #3134; documented in `ADMIN_GUIDE`, `agent-skills.md`,
+  `postgres-age-guide.md`, and `docs/deploy/README.md`. Postgres skills storage
+  remains post-GA (#2804). New pin:
+  `tests/skills_fail_closed_on_postgres_3183.rs`, including a removal proof that
+  calls `skill_register_route` directly with no router in the pipeline.
+  Also closes a router-mirror omission found while verifying the above:
+  `path_is_registered_route` matched only `GET` on `/api/v1/skill/{id}`, so
+  `DELETE /api/v1/skill/{id}` — a registered route, and an IRREVERSIBLE
+  lineage purge — was reported UNREGISTERED and fell through the gate to the
+  handler rather than 501-ing. Both controls now agree.
 - **The required `Check` legs are no longer undeclared performance gates:
   `ai-memory bench` gains `--report-only`.** `cmd_bench` bails non-zero
   whenever any operation's measured p95 exceeds its target by more than 10%, so

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -741,6 +741,16 @@ ai-memory schema-init --store-url postgres://…
 
 **Acceptance gate:** AGE p95 must beat CTE p95 by ≥30% at depth=5 to ship in a given build — the bench gate (`feat/v0.7-j-8-age-bench-gate`) enforces it. If AGE isn't faster on your Postgres + hardware combination, stay on the CTE path; the substrate is happy with either. See [MIGRATION § Apache AGE acceleration](MIGRATION_v0.7.html#apache-age-acceleration-opt-in) and the [`attested-cortex` RFC § Decision 3](v0.7/rfc-attested-cortex.html#decision-3--why-age-behind-a-feature-flag-vs-hard-dependency) for why AGE ships behind a feature flag instead of as a hard dependency.
 
+### No skills plane on Postgres (#3183)
+
+The Agent Skills surface is **SQLite-only in v1.0**. Postgres ships no `skills` table (the `migrate_v82` step is a version stamp with no DDL), and the skills substrate is typed on a SQLite connection. On a postgres-backed daemon, therefore:
+
+- all 8 `/api/v1/skill/*` paths return **`501 NOT IMPLEMENTED`** with the standard postgres envelope (`error` / `endpoint` / `storage_backend` / `remediation`) — a hard refusal, not a degraded mode;
+- the `memory_skill_*` MCP tools are unavailable for the same reason;
+- `GET /api/v1/capabilities` reports `skills.implemented: false` together with `skills.unsupported_on_postgres: true` and a human-readable `skills.unsupported_reason`.
+
+This is deliberate fail-closed behaviour. The refusal fires both at the route gate and inside each handler, so a skill registered against a postgres deployment can never be silently written to the node-local scratch SQLite file the daemon opens against `--db` — that file is empty, invisible to every peer, and discarded when the container restarts, which would have been an unannounced data-loss path. If you need skills, run a sqlite-backed daemon; postgres skills storage is tracked by [#2804](https://github.com/alphaonedev/ai-memory-mcp/issues/2804). The full postgres 501 inventory lives in [`postgres-age-guide.md` § What still returns 501 on postgres](postgres-age-guide.html).
+
 ## Permissions & Approvals (A2A) (v0.7+)
 
 The v0.6.x `governance` subsystem is refactored into three composable inputs that resolve to a single `Decision`:

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -45,6 +45,28 @@ makes a skill portable, audit-trail-attested, content-addressed,
 and round-trip-stable across registration, export, and
 re-registration on a different node.
 
+## Storage-backend support: SQLite only (#3183)
+
+> **The skills plane requires a SQLite-backed daemon.** Postgres ships
+> no `skills` table (`migrate_v82` is a version stamp with no DDL) and the
+> substrate below is typed on a `rusqlite::Connection`, so on a daemon
+> started with `--store-url postgres://…` every one of the 8
+> `/api/v1/skill/*` paths returns `501 NOT IMPLEMENTED` and the
+> `memory_skill_*` MCP tools are unavailable. `/api/v1/capabilities`
+> reports `skills.implemented: false` there, with an explicit
+> `unsupported_on_postgres` / `unsupported_reason` disclosure.
+>
+> This is a hard, fail-closed refusal rather than a degraded mode, and
+> deliberately so: the handlers would otherwise have written the skill row
+> to the node-local scratch SQLite file the daemon opens against `--db` —
+> empty, invisible to every peer, and discarded on container restart.
+> Refusing loudly is the data-integrity posture; silently persisting an
+> executable artefact somewhere it will vanish is not. Postgres skills
+> storage is tracked by
+> [#2804](https://github.com/alphaonedev/ai-memory-mcp/issues/2804); see
+> [`postgres-age-guide.md` § What still returns 501 on postgres](postgres-age-guide.html)
+> for the whole postgres 501 inventory.
+
 ## Substrate vs runtime relationship
 
 | Layer | What ai-memory does | What the host agent does |

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -155,3 +155,23 @@ ai-memory serve
 A boot under `asi-hard` prints the pin report (which knobs were pinned from
 unset vs already-compliant) and refuses to start if any pinned knob was set
 below its hard floor.
+
+## Storage-backend caveat: no skills plane on Postgres (#3183)
+
+Neither template selects a storage backend — that is `--store-url` (or
+`--db`) at launch. If you point a templated node at Postgres, note that
+the **Agent Skills plane is SQLite-only in v1.0**: all 8
+`/api/v1/skill/*` paths return `501 NOT IMPLEMENTED` and the
+`memory_skill_*` MCP tools are unavailable, because postgres ships no
+`skills` table. `GET /api/v1/capabilities` discloses this as
+`skills.implemented: false` plus `skills.unsupported_on_postgres: true`.
+
+The refusal is deliberate and fail-closed — it is the same posture the
+templates above take everywhere else. Without it the handlers would have
+written the skill row into the node-local scratch SQLite file the daemon
+opens against `--db`, which on a postgres deployment is empty, invisible
+to every peer, and discarded on container restart. Plan skills onto a
+sqlite-backed node; postgres skills storage is tracked by
+[#2804](https://github.com/alphaonedev/ai-memory-mcp/issues/2804). Full
+inventory: [`../postgres-age-guide.md` § What still returns 501 on
+postgres](../postgres-age-guide.md).

--- a/docs/postgres-age-guide.md
+++ b/docs/postgres-age-guide.md
@@ -670,6 +670,30 @@ in-memory scratch SQLite database that `bootstrap_serve` opens
 against `--db`. On sqlite-backed daemons the gate is a pure
 pass-through.
 
+#### Defence in depth: the skills plane refuses at the handler too (#3183)
+
+The route gate is the *first* line, not the only one. The 8
+`/api/v1/skill/*` paths are the sharpest case: their substrate
+(`crate::mcp::handle_skill_*`) is typed on a `rusqlite::Connection`, so
+`handlers/skills.rs` takes `app.db.lock()` — which on a postgres daemon is
+the node-local scratch SQLite file, not the operator's store. Before
+#3183 a caller who reached those handlers with the middleware absent,
+reordered, or bypassed (a custom router, an in-process call) would have
+written an executable artefact into a file that is invisible to every peer
+and discarded on container restart. Each of the 9 skill handlers now
+re-checks `StorageBackend::Postgres` **first** — ahead of the #949 admin
+gate, mirroring the middleware's own ordering — and returns the same
+documented 501 envelope. Pinned by
+`tests/skills_fail_closed_on_postgres_3183.rs`, which includes a removal
+proof that calls `skill_register_route` directly with no router at all.
+
+`/api/v1/capabilities` discloses the gap in the same release: on a
+postgres-backed daemon `skills.implemented` is `false` and the block
+carries an additive `unsupported_on_postgres: true` plus an
+`unsupported_reason` naming the hard 501 and the tracking issue. The
+`skills.tools` list is unchanged, so a client reading it for the canonical
+tool names is unaffected. On sqlite nothing changes.
+
 ### What still returns 501 on postgres
 
 Of the **80 unique production URL paths** (over **94 `.route(...)`

--- a/src/handlers/postgres_gate.rs
+++ b/src/handlers/postgres_gate.rs
@@ -545,8 +545,18 @@ pub fn path_is_registered_route(method: &axum::http::Method, path: &str) -> bool
         ("POST", p) if checkpoints_resolve_path(p) => true,
         // /api/v1/approvals/{pending_id}
         ("POST", p) if approvals_decide_path(p) => true,
-        // /api/v1/skill/{id} (GET)
-        ("GET", p) if skill_id_path(p) => true,
+        // /api/v1/skill/{id} (GET + DELETE).
+        //
+        // #3183 — DELETE was missing from this router mirror even though
+        // `skill_delete_route` IS registered in `build_router_with_timeout`.
+        // Same omission class as the #1718 finding above, but with teeth: a
+        // pg-unsupported path that this mirror reports as UNREGISTERED falls
+        // through `postgres_route_gate` to Axum instead of 501-ing, so on a
+        // postgres daemon `DELETE /api/v1/skill/{id}` reached the handler and
+        // hard-purged a skill lineage out of the node-local scratch sqlite
+        // file. (`handlers::skills` now also refuses independently, so the
+        // two controls agree instead of relying on either alone.)
+        ("GET" | "DELETE", p) if skill_id_path(p) => true,
         // /api/v1/skill/{id}/resource (GET)
         ("GET", p) if skill_id_sub_path(p, "resource") => true,
         // /api/v1/skill/{id}/export | /promote | /compose | /retire (POST)
@@ -1630,6 +1640,16 @@ mod transport_postgres_gate_tests {
             &Method::GET,
             "/api/v1/skill/skill-1"
         ));
+        // #3183 — DELETE rides the SAME `.route(...)` registration as GET
+        // (`src/lib.rs`: `get(skill_get_route).delete(skill_delete_route)`)
+        // but was absent from this mirror, so `postgres_route_gate` reported
+        // the path UNREGISTERED and passed an IRREVERSIBLE lineage purge
+        // through to the handler instead of emitting the 501 envelope.
+        // Pinned per this function's maintenance contract.
+        assert!(path_is_registered_route(
+            &Method::DELETE,
+            "/api/v1/skill/skill-1"
+        ));
         // /api/v1/skill/{id}/<sub>
         assert!(path_is_registered_route(
             &Method::GET,
@@ -1646,6 +1666,12 @@ mod transport_postgres_gate_tests {
         assert!(path_is_registered_route(
             &Method::POST,
             "/api/v1/skill/skill-1/compose"
+        ));
+        // #3183 — `/retire` is matched by the same arm as the four above
+        // but was the one sub-path with no pin; cover the whole arm.
+        assert!(path_is_registered_route(
+            &Method::POST,
+            "/api/v1/skill/skill-1/retire"
         ));
 
         // `/api/v1/skill/list` IS a real registered route (fixed

--- a/src/handlers/skills.rs
+++ b/src/handlers/skills.rs
@@ -59,12 +59,73 @@ use super::AppState;
 /// Tracing target for the skills HTTP handlers (#1558 tracing-target SSOT).
 const SKILLS_TRACE_TARGET: &str = "ai_memory::handlers::skills";
 
+/// #3183 — fail-closed guard for the **SQLite-only** skills plane.
+///
+/// Every handler below reaches the skills substrate through
+/// `crate::mcp::handle_skill_*`, which is typed on a
+/// `rusqlite::Connection`, so each one takes `app.db.lock()`. On a
+/// postgres-backed daemon `app.db` is NOT the operator's database — it is
+/// the node-local scratch SQLite file `bootstrap_serve` opens against
+/// `--db`: empty, invisible to every peer, and discarded when the
+/// container restarts (`src/store/postgres.rs` `migrate_v82`: "postgres
+/// ships no skills table"). Persisting an executable artefact there while
+/// the daemon advertises a skills plane is a split-brain + claims-truth
+/// defect, so the handlers REFUSE instead of writing to the wrong
+/// database (North Star: degrade, never corrupt — the worst case on
+/// postgres is a loud 501, never a silent local write).
+///
+/// Returns `Some(501)` carrying the documented postgres envelope from
+/// [`crate::handlers::postgres_not_implemented`] — byte-identical in shape
+/// to every other un-migrated surface — when the daemon is
+/// postgres-backed, and `None` on sqlite.
+///
+/// This is the defence-in-depth twin of the router-layer gate, not a
+/// replacement for it: the 8 `/api/v1/skill/*` paths are absent from
+/// [`crate::handlers::postgres_endpoint_supported`], so
+/// `postgres_route_gate` already 501s them on the wire, and that
+/// partition is frozen by `tests/pg_supported_route_inventory_gate_2799.rs`
+/// (`expected_fully_501_paths`). Duplicating the refusal at the handler
+/// means a future middleware reorder, a direct in-process call, or a
+/// custom router assembled without the gate can never re-open the
+/// silent-local-write path. The postgres port is tracked by #2804.
+#[cfg(feature = "sal")]
+fn refuse_skills_on_postgres(
+    app: &AppState,
+    endpoint: &'static str,
+) -> Option<axum::response::Response> {
+    if matches!(app.storage_backend, super::StorageBackend::Postgres) {
+        return Some(crate::handlers::postgres_not_implemented(endpoint));
+    }
+    None
+}
+
+/// Non-`sal` builds compile no postgres adapter at all, so
+/// `AppState::storage_backend` is structurally
+/// [`super::StorageBackend::Sqlite`] and `app.db` IS the operator's
+/// database. The guard is a compile-time no-op there (the `sal`-gated
+/// [`crate::handlers::postgres_not_implemented`] helper does not exist in
+/// this build).
+#[cfg(not(feature = "sal"))]
+fn refuse_skills_on_postgres(
+    _app: &AppState,
+    _endpoint: &'static str,
+) -> Option<axum::response::Response> {
+    None
+}
+
 /// `POST /api/v1/skill` — register a new skill from an inline body.
 pub async fn skill_register_route(
     State(app): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_REGISTER) {
+        return resp;
+    }
     // #949 — admin-only. Skill registration mints an executable
     // artefact; non-admin callers MUST NOT be able to plant a row
     // other agents will subsequently activate.
@@ -96,6 +157,13 @@ pub async fn skill_list_route(
     headers: HeaderMap,
     Query(q): Query<SkillListQuery>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_LIST) {
+        return resp;
+    }
     // #949 — admin-only. The list payload enumerates every skill in
     // the requested namespace including bodies that may be tagged
     // with another tenant's `signing_agent`. Cross-tenant
@@ -142,6 +210,13 @@ pub async fn skill_get_route(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID) {
+        return resp;
+    }
     // #949 — admin-only. The GET response includes the full
     // (decompressed) skill body — the executable capability bundle.
     if let Err(resp) = crate::handlers::admin_role::require_admin(&app, &headers, "skill_get") {
@@ -188,6 +263,13 @@ pub async fn skill_resource_route(
     Path(id): Path<String>,
     Query(q): Query<SkillResourceQuery>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID_RESOURCE) {
+        return resp;
+    }
     // #949 — admin-only. Skill resource blobs are part of the
     // executable bundle (scripts, prompts, fixtures) and inherit
     // the same supply-chain threat surface as the skill body.
@@ -228,6 +310,13 @@ pub async fn skill_export_route(
     Path(id): Path<String>,
     Json(body): Json<SkillExportBody>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID_EXPORT) {
+        return resp;
+    }
     // #949 — admin-only. Export writes `target_folder` on the daemon
     // host (resolved by the daemon, written under the daemon user);
     // any non-admin caller would gain an arbitrary-path write
@@ -273,6 +362,13 @@ pub async fn skill_promote_route(
     Path(id): Path<String>,
     Json(body): Json<SkillPromoteBody>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID_PROMOTE) {
+        return resp;
+    }
     // #949 — admin-only. Promote consumes a reflection memory and
     // mints a new skill row carrying the promoting agent's signing
     // surface. Cross-tenant promote = laundering an executable
@@ -317,6 +413,13 @@ pub async fn skill_compose_route(
     Path(id): Path<String>,
     body: Option<Json<SkillComposeBody>>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID_COMPOSE) {
+        return resp;
+    }
     // #949 — admin-only. Compose reads the skill body PLUS the
     // reflections declared in `composes_with_reflections` — a
     // multi-row read across the caller and other agents' reflection
@@ -376,6 +479,13 @@ pub async fn skill_retire_route(
     Path(id): Path<String>,
     body: Option<Json<SkillRetireBody>>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID_RETIRE) {
+        return resp;
+    }
     // #2024 — admin-only, like every other skill HTTP surface (#949).
     // Retire toggles the discovery + re-register lifecycle of an
     // executable artefact; cross-tenant retire is a supply-chain lever.
@@ -425,6 +535,13 @@ pub async fn skill_delete_route(
     Path(id): Path<String>,
     body: Option<Json<SkillDeleteBody>>,
 ) -> impl IntoResponse {
+    // #3183 — the skills substrate is sqlite-only; on a postgres-backed
+    // daemon `app.db` below is the node-local scratch file, not the
+    // operator's store. Refuse BEFORE the admin gate, mirroring the
+    // ordering `postgres_route_gate` already enforces on the wire.
+    if let Some(resp) = refuse_skills_on_postgres(&app, super::routes::SKILL_ID) {
+        return resp;
+    }
     // #2024 — admin-only (#949). Purge is irreversible; the substrate's
     // retire-first safety gate (or explicit force) still applies underneath.
     if let Err(resp) = crate::handlers::admin_role::require_admin(&app, &headers, "skill_delete") {

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -19,6 +19,21 @@ use super::transport::AppState;
 
 // --- /api/v1/capabilities (GET) -------------------------------------------
 
+/// #3183 — `capabilities.skills` key overlaid on a postgres-backed daemon.
+const CAP_SKILLS: &str = "skills";
+/// #3183 — `capabilities.skills.implemented` key (forced `false` on postgres).
+const CAP_SKILLS_IMPLEMENTED: &str = "implemented";
+/// #3183 — additive postgres-disclosure flag on `capabilities.skills`.
+const CAP_SKILLS_UNSUPPORTED_ON_POSTGRES: &str = "unsupported_on_postgres";
+/// #3183 — additive human-readable reason on `capabilities.skills`.
+const CAP_SKILLS_UNSUPPORTED_REASON: &str = "unsupported_reason";
+/// #3183 — the reason text. Names the tracking issue so an operator reading
+/// the wire can find the port, and states the failure mode (hard 501, not a
+/// degraded mode) rather than implying a partial plane.
+const CAP_SKILLS_POSTGRES_REASON: &str = "the skills plane is sqlite-only: postgres ships no skills table, so every \
+     /api/v1/skill/* path returns 501 NOT IMPLEMENTED and the memory_skill_* MCP \
+     tools are unavailable on a postgres-backed daemon (port tracked by #2804)";
+
 pub async fn get_capabilities(
     State(app): State<AppState>,
     headers: HeaderMap,
@@ -208,6 +223,37 @@ pub async fn get_capabilities(
                     "db_schema_version".to_string(),
                     serde_json::Value::Number(serde_json::Number::from(db_schema_version)),
                 );
+                // #3183 — claims-truth on the skills plane. `CapabilitySkills`
+                // is a compile-time constant (`implemented: true`) because the
+                // skills SUBSTRATE is always built in; but that substrate is
+                // typed on a `rusqlite::Connection`, so on a postgres-backed
+                // daemon it can only ever reach the node-local scratch SQLite
+                // file — the 8 `/api/v1/skill/*` paths are fully fail-closed
+                // 501s (absent from `postgres_endpoint_supported`, pinned by
+                // `tests/pg_supported_route_inventory_gate_2799.rs`, refused a
+                // second time inside `handlers::skills`). Advertising
+                // `implemented: true` there told an operator to plan on a plane
+                // that cannot durably hold a single row. Overlay the honest
+                // posture — additively, so a client reading `skills.tools` for
+                // the canonical tool list is unaffected. sqlite is untouched.
+                if matches!(app.storage_backend, super::StorageBackend::Postgres)
+                    && let Some(skills) = obj
+                        .get_mut(CAP_SKILLS)
+                        .and_then(serde_json::Value::as_object_mut)
+                {
+                    skills.insert(
+                        CAP_SKILLS_IMPLEMENTED.to_string(),
+                        serde_json::Value::Bool(false),
+                    );
+                    skills.insert(
+                        CAP_SKILLS_UNSUPPORTED_ON_POSTGRES.to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+                    skills.insert(
+                        CAP_SKILLS_UNSUPPORTED_REASON.to_string(),
+                        serde_json::Value::String(CAP_SKILLS_POSTGRES_REASON.to_string()),
+                    );
+                }
             }
             (StatusCode::OK, Json(v)).into_response()
         }

--- a/tests/skills_fail_closed_on_postgres_3183.rs
+++ b/tests/skills_fail_closed_on_postgres_3183.rs
@@ -1,0 +1,390 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3183 — the skills plane FAILS CLOSED on a postgres-backed daemon.
+//!
+//! # The defect
+//!
+//! `src/handlers/skills.rs` reaches the skills substrate through
+//! `crate::mcp::handle_skill_*`, which is typed on a
+//! `rusqlite::Connection`; every handler therefore took
+//! `app.db.lock().await` unconditionally. On a postgres-backed daemon
+//! `app.db` is NOT the operator's database — it is the node-local scratch
+//! SQLite file `bootstrap_serve` opens against `--db`
+//! (`src/store/postgres.rs`, `migrate_v82`: "postgres ships no skills
+//! table"). A skill registered against a postgres deployment therefore
+//! landed in an empty local file: invisible to every peer, discarded on
+//! container restart, while `/api/v1/capabilities` reported
+//! `skills.implemented: true`. Split-brain plus a false claim.
+//!
+//! # What this pins
+//!
+//! * **Wire contract.** Every one of the 8 `/api/v1/skill/*` paths returns
+//!   `501 NOT IMPLEMENTED` with the documented postgres envelope
+//!   (`error` / `endpoint` / `storage_backend` / `remediation`) on a
+//!   postgres-backed daemon. Fail closed: the worst case is a loud 501,
+//!   never a silent write to the wrong database (North Star — degrade,
+//!   never corrupt).
+//! * **Removal proof for the middleware.** `skill_register_route` is
+//!   invoked DIRECTLY, with no router and therefore no
+//!   `postgres_route_gate` in the pipeline, and still refuses. Deleting or
+//!   reordering the middleware cannot re-open the silent-local-write path.
+//! * **Claims-truth.** `/api/v1/capabilities` reports
+//!   `skills.implemented: false` plus the additive
+//!   `unsupported_on_postgres` / `unsupported_reason` disclosure on
+//!   postgres.
+//! * **No sqlite regression.** The same assertions inverted on a
+//!   sqlite-backed router: registration succeeds and the capability stays
+//!   `implemented: true`.
+//!
+//! The harness is the `build_fake_pg_router` pattern already used by
+//! `tests/r40_approval_chokepoint.rs`: `storage_backend = Postgres` with a
+//! DISJOINT `SqliteStore` behind the SAL handle. That exercises the real
+//! postgres-branch handler code deterministically in CI with no live
+//! postgres — and it is the STRICTER fixture here, because the backing
+//! store is fully functional, so a handler that failed to refuse would
+//! genuinely persist the row rather than error out for an unrelated
+//! reason.
+//!
+//! The 8-path fully-501 partition itself is frozen by
+//! `tests/pg_supported_route_inventory_gate_2799.rs`
+//! (`expected_fully_501_paths`); this file pins the runtime behaviour that
+//! partition promises. Postgres skills storage is tracked by #2804.
+
+// The module docs above ARE the reviewable rationale for this gate; relax
+// the doc-style pedantic lints rather than mangle the prose. The two
+// `too_many_lines` allows cover the `AppState` fixture (one field per
+// line) and the 9-case route table.
+#![allow(clippy::doc_markdown, clippy::too_many_lines)]
+#![cfg(feature = "sal")]
+
+use std::sync::Arc;
+
+use ai_memory::handlers::{ApiKeyState, AppState, Db, StorageBackend};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt as _;
+
+/// Admin id used for every request — the skills surface is admin-only
+/// (#949), so a non-admin caller would 403 before reaching the postgres
+/// guard and prove nothing.
+const ADMIN: &str = "ai:skills-3183";
+
+/// #1751 — this suite's fixtures are unsigned; pin the permissive
+/// attestation posture for the test process.
+fn permissive_attestation_for_tests() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    // SAFETY: `Once`-gated process-global env write, one stable value for
+    // the process lifetime, set before any gated write is issued.
+    ONCE.call_once(|| unsafe { std::env::set_var("AI_MEMORY_REQUIRE_AGENT_ATTESTATION", "0") });
+}
+
+/// Build an `AppState` for `backend`. `app.db` is an in-memory sqlite
+/// connection (exactly what `bootstrap_serve` opens on a postgres daemon)
+/// and the SAL handle is a real on-disk `SqliteStore`.
+fn app_state(backend: StorageBackend) -> AppState {
+    permissive_attestation_for_tests();
+    // #1570 — model an AUTHENTICATED deployment so the #949 admin
+    // header-role claim is honoured; otherwise the sqlite control below
+    // would 403 before ever reaching the substrate and would "pass" for
+    // the wrong reason.
+    ai_memory::handlers::admin_role::mark_request_authn_configured(true);
+    let scratch = ai_memory::db::open(std::path::Path::new(":memory:")).expect("scratch sqlite");
+    let db: Db = Arc::new(tokio::sync::Mutex::new((
+        scratch,
+        std::path::PathBuf::from(":memory:"),
+        ai_memory::config::ResolvedTtl::default(),
+        true,
+    )));
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile for SqliteStore");
+    let store_path = tmp.path().to_path_buf();
+    std::mem::forget(tmp);
+    let store: Arc<dyn ai_memory::store::MemoryStore> = Arc::new(
+        ai_memory::store::sqlite::SqliteStore::open(&store_path).expect("open SqliteStore"),
+    );
+    AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(tokio::sync::Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(ai_memory::config::FeatureTier::Keyword.config()),
+        scoring: Arc::new(ai_memory::config::ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: backend,
+        store,
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        auto_tag_queue: None,
+        atomise_queue: None,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(vec![ADMIN.to_string()]),
+        rule_cache: Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    }
+}
+
+fn router(backend: StorageBackend) -> axum::Router {
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    ai_memory::build_router(api_key_state, app_state(backend))
+}
+
+async fn call(
+    router: &axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("x-agent-id", ADMIN);
+    let payload = match body {
+        Some(v) => {
+            b = b.header("content-type", "application/json");
+            Body::from(serde_json::to_vec(&v).expect("serialize body"))
+        }
+        None => Body::empty(),
+    };
+    let resp = router
+        .clone()
+        .oneshot(b.body(payload).expect("build request"))
+        .await
+        .expect("router call");
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("read body");
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+/// A minimal but VALID `SKILL.md` registration body (same shape as
+/// `tests/skills_owner_gate_949.rs`) — so a handler that failed to refuse
+/// would actually persist a row rather than bounce on a 400 and pass this
+/// suite for the wrong reason.
+fn valid_register_body() -> Value {
+    json!({
+        "inline_skill": "---\nnamespace: skills-3183\nname: pg-fail-closed-probe\n\
+                         description: A probe skill for the #3183 fail-closed gate.\n---\n\
+                         \nBody for the #3183 probe.\n",
+    })
+}
+
+/// The documented postgres 501 envelope (`postgres_not_implemented` /
+/// `postgres_route_gate`): a machine-parseable shape operator scripts key
+/// off, so assert every field, not just the status code.
+fn assert_documented_501_envelope(status: StatusCode, body: &Value, path: &str) {
+    assert_eq!(
+        status,
+        StatusCode::NOT_IMPLEMENTED,
+        "{path} must fail closed on a postgres-backed daemon, got {status}: {body}"
+    );
+    assert_eq!(
+        body["error"], "endpoint not yet implemented for postgres-backed daemon",
+        "{path}: stable error string: {body}"
+    );
+    assert_eq!(
+        body["storage_backend"], "postgres",
+        "{path}: envelope names the backend: {body}"
+    );
+    assert_eq!(
+        body["endpoint"], path,
+        "{path}: envelope names the endpoint: {body}"
+    );
+    assert!(
+        body["remediation"].as_str().is_some_and(|r| !r.is_empty()),
+        "{path}: envelope carries an actionable remediation: {body}"
+    );
+}
+
+/// The headline case from the issue: registering a skill against a
+/// postgres deployment must NOT land in the node-local scratch sqlite file.
+#[tokio::test]
+async fn skill_register_returns_the_documented_501_envelope_on_postgres() {
+    let router = router(StorageBackend::Postgres);
+    let (status, body) = call(
+        &router,
+        "POST",
+        "/api/v1/skill/register",
+        Some(valid_register_body()),
+    )
+    .await;
+    assert_documented_501_envelope(status, &body, "/api/v1/skill/register");
+}
+
+/// All 8 fully-501 skill paths, every registered method — the partition
+/// `expected_fully_501_paths()` promises, proven at runtime.
+#[tokio::test]
+async fn every_skill_path_fails_closed_on_postgres() {
+    let router = router(StorageBackend::Postgres);
+    let id = "sk-3183";
+    let cases: &[(&str, String, Option<Value>)] = &[
+        (
+            "POST",
+            "/api/v1/skill/register".to_string(),
+            Some(valid_register_body()),
+        ),
+        ("GET", "/api/v1/skill/list".to_string(), None),
+        ("GET", format!("/api/v1/skill/{id}"), None),
+        (
+            "DELETE",
+            format!("/api/v1/skill/{id}"),
+            Some(json!({ "force": true })),
+        ),
+        (
+            "GET",
+            format!("/api/v1/skill/{id}/resource?path=README.md"),
+            None,
+        ),
+        (
+            "POST",
+            format!("/api/v1/skill/{id}/export"),
+            // Deliberately a path that does not exist and is never
+            // written: the refusal fires before the handler resolves it.
+            // (Project rule: no agent-created files under /tmp.)
+            Some(json!({ "target_folder": "./.never-written-3183" })),
+        ),
+        (
+            "POST",
+            format!("/api/v1/skill/{id}/promote"),
+            Some(json!({ "name": "n", "description": "d" })),
+        ),
+        (
+            "POST",
+            format!("/api/v1/skill/{id}/compose"),
+            Some(json!({})),
+        ),
+        (
+            "POST",
+            format!("/api/v1/skill/{id}/retire"),
+            Some(json!({ "unretire": false })),
+        ),
+    ];
+    for (method, uri, body) in cases {
+        let (status, resp) = call(&router, method, uri, body.clone()).await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_IMPLEMENTED,
+            "{method} {uri} must fail closed on postgres, got {status}: {resp}"
+        );
+        assert_eq!(
+            resp["storage_backend"], "postgres",
+            "{method} {uri}: documented envelope: {resp}"
+        );
+    }
+}
+
+/// Removal proof for the router-layer gate: call the handler DIRECTLY, so
+/// `postgres_route_gate` is not in the pipeline at all. The handler must
+/// still refuse — otherwise a middleware reorder, a custom router, or an
+/// in-process caller silently re-opens the local-write path.
+#[tokio::test]
+async fn skill_register_handler_refuses_without_the_route_gate() {
+    use axum::response::IntoResponse as _;
+
+    let app = app_state(StorageBackend::Postgres);
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert("x-agent-id", ADMIN.parse().expect("header value"));
+    let resp = ai_memory::handlers::skill_register_route(
+        axum::extract::State(app),
+        headers,
+        axum::Json(valid_register_body()),
+    )
+    .await
+    .into_response();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("read body");
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    assert_documented_501_envelope(status, &body, "/api/v1/skill/register");
+}
+
+/// Claims-truth: `/capabilities` must not advertise a plane that cannot
+/// durably hold a row on this backend.
+#[tokio::test]
+async fn capabilities_discloses_the_skills_plane_as_unsupported_on_postgres() {
+    let router = router(StorageBackend::Postgres);
+    let (status, body) = call(&router, "GET", "/api/v1/capabilities", None).await;
+    assert_eq!(status, StatusCode::OK, "capabilities: {body}");
+    assert_eq!(
+        body["storage_backend"], "postgres",
+        "fixture really is postgres-backed: {body}"
+    );
+    assert_eq!(
+        body["skills"]["implemented"], false,
+        "postgres must not claim an implemented skills plane: {body}"
+    );
+    assert_eq!(
+        body["skills"]["unsupported_on_postgres"], true,
+        "postgres carries the explicit disclosure flag: {body}"
+    );
+    assert!(
+        body["skills"]["unsupported_reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("501")),
+        "the reason states the failure mode is a hard 501: {body}"
+    );
+    assert!(
+        body["skills"]["tools"].is_array(),
+        "the canonical tool list stays present (additive disclosure): {body}"
+    );
+}
+
+/// Control: sqlite is the supported backend and must be untouched by the
+/// guard — a refusal that fired everywhere would be a regression, not a fix.
+#[tokio::test]
+async fn sqlite_daemon_still_serves_the_skills_plane() {
+    let router = router(StorageBackend::Sqlite);
+
+    let (status, body) = call(
+        &router,
+        "POST",
+        "/api/v1/skill/register",
+        Some(valid_register_body()),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "sqlite skill register must still succeed: {body}"
+    );
+
+    let (status, body) = call(&router, "GET", "/api/v1/skill/list", None).await;
+    assert_eq!(status, StatusCode::OK, "sqlite skill list: {body}");
+
+    let (status, body) = call(&router, "GET", "/api/v1/capabilities", None).await;
+    assert_eq!(status, StatusCode::OK, "capabilities: {body}");
+    assert_eq!(body["storage_backend"], "sqlite", "control backend: {body}");
+    assert_eq!(
+        body["skills"]["implemented"], true,
+        "sqlite keeps the implemented skills plane: {body}"
+    );
+    assert!(
+        body["skills"].get("unsupported_on_postgres").is_none(),
+        "the postgres disclosure must not leak onto sqlite: {body}"
+    );
+}


### PR DESCRIPTION
fix(skills): fail closed on a postgres-backed daemon — handler-level 501, honest /capabilities, and the missing DELETE arm in the router mirror (#3183)

The Agent Skills substrate (`crate::mcp::handle_skill_*`) is typed on a
`rusqlite::Connection`, so all nine handlers in `src/handlers/skills.rs`
took `app.db.lock()` unconditionally. On a postgres-backed daemon
`app.db` is NOT the operator's database — it is the node-local scratch
SQLite file `bootstrap_serve` opens against `--db` (postgres ships no
`skills` table; `migrate_v82` is a version stamp with no DDL). A skill
registered against a postgres deployment therefore landed in an empty
local file: invisible to every peer, discarded on the next container
restart, while `/api/v1/capabilities` reported `skills.implemented:
true`. Split-brain plus a false claim, and an unannounced data-loss path
for an executable artefact.

R-405 correction to the issue's cited lines (verified at `cda57210`):
`postgres_gate.rs:498-499` and `:548-557` are inside
`path_is_registered_route` (lines 406-566) — the 404-vs-501 ROUTER
MIRROR — not inside `postgres_endpoint_supported` (the pg allow-list,
lines 105-254), whose body contains zero `skill` matches. All 8 skills
paths were already in `expected_fully_501_paths()`, so the postgres
route inventory is UNCHANGED at 59 supported / 21 fully-501 / 80 unique
and needs no lockstep bump. The wire-level 501 the issue asks for was
already in place; three real gaps were not.

1. No handler-level refusal. Each of the 9 skill handlers now re-checks
   `StorageBackend::Postgres` FIRST — ahead of the #949 admin gate,
   mirroring `postgres_route_gate`'s own ordering — and returns the same
   documented envelope through the existing `postgres_not_implemented`
   helper. Defence in depth: a middleware reorder, a custom router, or an
   in-process caller can no longer re-open the local-write path.

2. `/api/v1/capabilities` claimed a plane that cannot durably hold a row.
   On postgres it now reports `skills.implemented: false` plus an
   ADDITIVE `unsupported_on_postgres: true` and an `unsupported_reason`
   naming the hard 501 and the tracking issue. `skills.tools` is
   untouched, so clients reading it for the canonical tool names are
   unaffected.

3. A genuine router-mirror omission with teeth. `path_is_registered_route`
   matched only `GET` on `/api/v1/skill/{id}`, yet `src/lib.rs` registers
   `get(skill_get_route).delete(skill_delete_route)` on that same path.
   `postgres_route_gate` returns `next.run(req)` for any path the mirror
   reports UNREGISTERED (postgres_gate.rs:654-661), so on a postgres
   daemon `DELETE /api/v1/skill/{id}` — an IRREVERSIBLE lineage purge —
   reached the handler instead of 501-ing. Added `("GET" | "DELETE", p)`
   plus the unit-test pin this function's maintenance contract requires,
   and a pin for `/retire`, the one sub-path arm that had none.

Sqlite behaviour is untouched throughout; the control test asserts
register + list still succeed and that the postgres disclosure does not
leak onto sqlite.

North Star: degrade, never corrupt. The worst case on postgres is now a
loud, documented 501 — never a silent write to, or purge from, the wrong
database. Postgres skills storage remains post-GA (#2804).

Tests: `tests/skills_fail_closed_on_postgres_3183.rs` (5 tests) —
including a REMOVAL PROOF that invokes `skill_register_route` directly
with no router and therefore no middleware in the pipeline, over a
fixture whose backing store is fully functional so a handler that failed
to refuse would genuinely persist the row.

Docs: `ADMIN_GUIDE`, `agent-skills.md`, `postgres-age-guide.md`,
`docs/deploy/README.md`, CHANGELOG `[Unreleased]`.

Closes #3183

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
