### PR TITLE
fix(#3049,#3173): federation-receive coord secret screen + synthesis ownership gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,47 @@ Known residual, deliberately out of scope and filed as #3207: the pg
 `sweep_pending_action_timeouts` still emits no `pending_action.timed_out` row
 (the sqlite sweeper does). It is the one governance transition of the four that
 this cluster does not close — the three an adversary can drive are covered.
+### Security
+
+- **#3049 — federation-receive secret screen for inbound coordination rows.**
+  Follow-up from #2994: the CALLER-origin screen on signal/checkpoint create
+  was live, but `POST /api/v1/sync/push` `signals[]` / `checkpoints[]` had
+  ZERO screening — a peer running `AI_MEMORY_SECRET_SCREEN_MODE=off` (or a
+  hostile peer) could land a credential in this node's `signals` /
+  `checkpoints` tables, where it is queryable, forensic-exported, and
+  re-egressed. The receive arm now runs `secret_screen::redact_signal_for_storage`
+  / `redact_checkpoint_for_storage` AFTER the lane's authorization gates
+  (so forged-signature / authorship / namespace-scope still see the bytes
+  the peer signed) and BEFORE persist. Disposition is REDACT-only, never
+  refuse — a refused inbound row would diverge replicas (the #1821 lesson);
+  this restores the documented federation-receive contract, it does not
+  tighten it. When the redaction touches the SIGNED surface (`Signal.subject`
+  / `sha256(body)`; checkpoint `resolution`) the presented attestation is
+  dropped with a loud WARN so the row lands honestly unsigned rather than
+  carrying a signature that cannot cover its own stored bytes (#2340).
+  Source: `src/secret_screen.rs`, `src/handlers/federation_receive.rs`
+  (signals apply loop + checkpoint Accept arm only).
+- **#3173 — synthesis merge plane ownership gate.**
+  `db::find_synthesis_candidates` is namespace-scoped only, and the
+  Form-1 `db::update` / `db::delete` sites plus the exact-dup merge
+  detour ran on a bare `rusqlite::Connection` with none of the #1786
+  `visibility::caller_owns_for_mutation` gates the explicit MCP mutation
+  handlers apply. Under `AI_MEMORY_AGENT_ID` multi-tenancy in a shared
+  namespace, an autonomous synthesis verdict (or an exact-dup
+  `on_conflict=merge`) could overwrite or hard-delete another agent's
+  row. The candidate pool is now filtered to rows the caller may mutate
+  BEFORE the curator sees them; every mutate site re-checks and REFUSES
+  (`caller does not own this memory`) rather than silently skipping; the
+  update+delete queue is vetted BEFORE `BEGIN IMMEDIATE` so a refusal
+  cannot leave a half-applied merge. The exact-dup detour searches the
+  FULL pool so a cross-owner collision refuses loudly instead of
+  falling through to an opaque `(title, namespace)` UNIQUE violation.
+  Keyed on `resolve_read_visibility_caller` (env-only) so the
+  single-operator trust-all default is byte-unchanged. Inbox recipients
+  are NOT owners here (`allow_inbox = false` — a synthesis verdict is
+  an autonomous mutation the caller never named). No postgres synthesis
+  lane exists (`memory_store` is sqlite-native). Source:
+  `src/mcp/tools/store/{mod,synthesis}.rs`.
 
 ### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -5370,6 +5370,48 @@ enabled = true
         );
     }
 
+    /// Text (non-JSON) renderer of `doctor --posture`. The JSON tests
+    /// above never enter the `else` arm that prints `[FAIL]` / `fix:` /
+    /// `overall: FAIL`. After #3267 grew this file, Per-Module Coverage
+    /// on #3239 measured 89.87% < the 90% floor; this pins the operator
+    /// path so the floor holds (TEST-01/02, ERRORS-24).
+    #[test]
+    fn run_posture_enterprise_federation_text_report_names_fail_and_fix() {
+        if crate::config::run_env_isolated_child_or_spawn(
+            "cli::doctor::tests::run_posture_enterprise_federation_text_report_names_fail_and_fix",
+        ) {
+            return;
+        }
+        let _g = posture_env_lock();
+        clear_posture_env();
+        let _cleanup = PostureEnvGuard;
+
+        let mut stdout = Vec::<u8>::new();
+        let mut stderr = Vec::<u8>::new();
+        let mut out = CliOutput::from_std(&mut stdout, &mut stderr);
+        let exit = run_posture(
+            crate::enterprise_federation_posture::POSTURE_ENTERPRISE_FEDERATION,
+            false,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(exit, 2, "a bare env must exit non-zero (§5.4(2))");
+        let stdout_str = String::from_utf8(stdout).unwrap();
+        assert!(
+            stdout_str.contains("[FAIL]"),
+            "text report must name FAIL rows: {stdout_str}"
+        );
+        assert!(
+            stdout_str.contains("fix:"),
+            "text report must carry remediation: {stdout_str}"
+        );
+        assert!(
+            stdout_str.contains("overall: FAIL"),
+            "text report must close with overall FAIL: {stdout_str}"
+        );
+        drop(stderr);
+    }
+
     /// PASSES on a fully-hardened env (asi-hard engaged + every
     /// federation-specific §5.3 addition satisfied). Skips only the
     /// at-rest-encryption row when this test binary was not compiled

--- a/src/handlers/federation_receive.rs
+++ b/src/handlers/federation_receive.rs
@@ -3497,6 +3497,18 @@ pub async fn sync_push(
             noop += 1;
             continue;
         }
+        // #3049 — federation-RECEIVE secret screen for the coordination plane.
+        // The caller-origin arm (#2994) screens `subject` / `body` before a
+        // LOCAL signal is signed + inserted, but the RECEIVE arm had none, so a
+        // credential shipped by an `off`-mode (or hostile) peer landed verbatim
+        // in this node's `signals` table and re-egressed on the next push.
+        // REDACT-only — a refusal here would diverge replicas (#1821) — and it
+        // runs AFTER the forged-signature / authorship / namespace gates above
+        // so those still see exactly the bytes the peer signed. The helper
+        // clears the now-stale `signature`/`sender_pubkey` when it mutates the
+        // signed surface (#2340 discipline).
+        let screened_signal = crate::secret_screen::redact_signal_for_storage(sig);
+        let sig = screened_signal.as_ref().unwrap_or(sig);
         let bytes = i64::try_from(sig.body.to_string().len()).unwrap_or(i64::MAX);
         if let Err(e) = crate::quotas::check_and_record_storage_only(
             &lock.0,
@@ -3752,6 +3764,18 @@ pub async fn sync_push(
                     noop += 1;
                     continue;
                 }
+                // #3049 — federation-RECEIVE secret screen, checkpoint arm.
+                // `apply_inbound_resolution` persists the wire `resolution` /
+                // `resolution_note` onto a locally-pending anchor and the WHOLE
+                // wire row (`title` / `condition` / `metadata` too) on the
+                // first-landing INSERT arm — none of it screened before #3049.
+                // REDACT-only, and applied AFTER
+                // `authorize_remote_checkpoint_resolution` so the resolver-key
+                // attestation is still checked against the bytes the resolver
+                // actually signed. The helper clears the presented attestation
+                // iff it had to redact the SIGNED `resolution` field (#2340).
+                let screened_cp = crate::secret_screen::redact_checkpoint_for_storage(cp);
+                let cp = screened_cp.as_ref().unwrap_or(cp);
                 match crate::checkpoints::apply_inbound_resolution(&lock.0, cp) {
                     Ok(crate::checkpoints::InboundResolutionOutcome::Applied) => {
                         checkpoints_applied += 1;

--- a/src/mcp/tools/store/mod.rs
+++ b/src/mcp/tools/store/mod.rs
@@ -598,6 +598,55 @@ pub(crate) fn handle_store(
     let existing =
         db::find_synthesis_candidates(conn, &mem.title, &mem.namespace).unwrap_or_default();
 
+    // #3173 (authz / data-integrity) — OWNERSHIP GATE on the synthesis merge
+    // plane.
+    //
+    // `db::find_synthesis_candidates` is NAMESPACE-scoped only
+    // (`storage::find_similar_title_candidates(conn, title, namespace, 20)` —
+    // no owner predicate), and every mutate site downstream of it runs on a
+    // bare `rusqlite::Connection` with NONE of the #1786
+    // `visibility::caller_owns_for_mutation` gates the explicit
+    // `memory_update` / `memory_delete` / `memory_promote` MCP handlers apply.
+    // Under `AI_MEMORY_AGENT_ID` multi-tenancy in a shared namespace, an
+    // autonomous LLM synthesis verdict (`update` / `delete`) — or the
+    // exact-dup merge detour below — could therefore overwrite or HARD-DELETE
+    // a row owned by a DIFFERENT agent, silently, with the caller's identity
+    // never checked against the victim row.
+    //
+    // Two layers, mirroring `mcp::tools::delete`:
+    //   1. Filter the candidate pool to rows the caller may mutate BEFORE the
+    //      curator ever sees them. That is also a confidentiality fix — the
+    //      pre-#3173 prompt inlined another agent's title + content.
+    //   2. Re-check ownership at EVERY mutate site (`synthesis::…`) and REFUSE
+    //      — never silently skip — when a verdict names a row the caller does
+    //      not own.
+    //
+    // Keyed on the ENFORCED-read caller (`resolve_read_visibility_caller`,
+    // env-only) so it fires ONLY when `AI_MEMORY_AGENT_ID` is set, leaving the
+    // single-operator trust-all default byte-unchanged (#1468/#1720 B1).
+    let mutation_caller = crate::identity::resolve_read_visibility_caller();
+    let synthesis_candidates: std::borrow::Cow<'_, [crate::models::Memory]> =
+        match mutation_caller.as_deref() {
+            None => std::borrow::Cow::Borrowed(existing.as_slice()),
+            Some(caller) => {
+                let kept: Vec<crate::models::Memory> = existing
+                    .iter()
+                    .filter(|c| synthesis::caller_may_mutate(c, caller))
+                    .cloned()
+                    .collect();
+                if kept.len() != existing.len() {
+                    tracing::warn!(
+                        target: "synthesis",
+                        namespace = %mem.namespace,
+                        caller = %caller,
+                        withheld = existing.len() - kept.len(),
+                        "synthesis.candidates_withheld_not_owned",
+                    );
+                }
+                std::borrow::Cow::Owned(kept)
+            }
+        };
+
     // v0.7.x Form 1 (#754) — the namespace policy was resolved ONCE
     // at the auto-classify hook above (#1579 A1); the synthesis path
     // (Form 1) and the synchronous-atomise mode (Form 2) consume that
@@ -676,7 +725,14 @@ pub(crate) fn handle_store(
             ));
         }
         let llm_client = llm.expect("synthesis_eligible guarantees llm.is_some()");
-        synthesis::run_synthesis_pass(llm_client, &mem, &agent_id, &existing, &ns_policy)?
+        // #3173 — the curator sees ONLY the caller-mutable pool.
+        synthesis::run_synthesis_pass(
+            llm_client,
+            &mem,
+            &agent_id,
+            &synthesis_candidates,
+            &ns_policy,
+        )?
     } else {
         synthesis::SynthesisOutcome::empty()
     };
@@ -714,12 +770,14 @@ pub(crate) fn handle_store(
     if let Some(resp) = synthesis::apply_synthesis_updates_and_deletes(
         conn,
         &mem,
-        &existing,
+        &synthesis_candidates,
         embedder,
         vector_index,
         &synthesis_outcome,
         active_keypair,
-    ) {
+        // #3173 — re-checked at every `db::update` / `db::delete` inside.
+        mutation_caller.as_deref(),
+    )? {
         return Ok(resp);
     }
     // When no update fired, capture the list of to-be-deleted
@@ -730,6 +788,17 @@ pub(crate) fn handle_store(
     // deletes, this is a zero-cost empty list.
     let pending_synthesis_delete_targets =
         synthesis::pending_synthesis_delete_targets(&synthesis_outcome);
+    // #3173 — vet the deferred delete queue BEFORE the standard insert, so an
+    // ownership violation REFUSES the whole store call instead of hard-deleting
+    // another agent's row after the new row has already landed. The queue is
+    // drawn from the already-filtered pool, so this is the structural backstop
+    // (the mutate-site re-check inside
+    // `apply_pending_synthesis_deletes_with_links` is the last one).
+    synthesis::assert_caller_may_mutate_all(
+        &synthesis_candidates,
+        mutation_caller.as_deref(),
+        &pending_synthesis_delete_targets,
+    )?;
 
     let exact_dup = if matches!(on_conflict, OnConflict::Merge) {
         existing
@@ -739,6 +808,21 @@ pub(crate) fn handle_store(
         None
     };
     if let Some(dup) = exact_dup {
+        // #3173 — owner gate on the exact-dup merge detour. This branch applies
+        // the incoming CALLER content over an EXISTING row via `db::update` on a
+        // bare connection; without the gate a second agent storing the same
+        // (title, namespace) in a shared namespace silently overwrote the first
+        // agent's content. The search deliberately runs over the FULL candidate
+        // pool (not the #3173-filtered one) so a cross-owner collision REFUSES
+        // loudly here rather than falling through to the insert tail and
+        // surfacing as an opaque `(title, namespace)` UNIQUE violation.
+        // `allow_inbox = false` mirrors the `memory_update` gate (#1786).
+        if let Some(caller) = mutation_caller.as_deref()
+            && !synthesis::caller_may_mutate(dup, caller)
+        {
+            synthesis::audit_mutation_refusal(crate::audit::AuditAction::Update, dup, caller);
+            return Err(crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY.into());
+        }
         // #2121/#2122 funnel audit — clause-1 gate on the exact-dup merge
         // detour. This tool-layer `(title, namespace)` dedup applies the
         // incoming CALLER content via `db::update` and returns before the
@@ -964,6 +1048,10 @@ pub(crate) fn handle_store(
         &actual_id,
         &pending_synthesis_delete_targets,
         active_keypair,
+        // #3173 — last-resort mutate-site re-check (the refusing gate ran
+        // before the insert above).
+        &synthesis_candidates,
+        mutation_caller.as_deref(),
     );
 
     // PR-5 (issue #487): security audit trail. No-op when disabled.

--- a/src/mcp/tools/store/synthesis.rs
+++ b/src/mcp/tools/store/synthesis.rs
@@ -705,3 +705,92 @@ pub(super) fn synthesis_eligible(
         && !namespace.starts_with('_')
         && !ns_policy.effective_legacy_per_pair_classifier()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn owned_by(owner: &str) -> Memory {
+        Memory {
+            id: "mem-3173-alice".to_string(),
+            namespace: "shared/ns".to_string(),
+            title: "shared title".to_string(),
+            metadata: json!({ crate::META_KEY_AGENT_ID: owner }),
+            ..Memory::default()
+        }
+    }
+
+    fn inbox_for(owner: &str, target: &str) -> Memory {
+        Memory {
+            metadata: json!({
+                crate::META_KEY_AGENT_ID: owner,
+                crate::META_KEY_TARGET_AGENT_ID: target,
+            }),
+            ..owned_by(owner)
+        }
+    }
+
+    #[test]
+    fn caller_may_mutate_owner_yes_cross_owner_no_3173() {
+        let alice = owned_by("ai:alice");
+        assert!(caller_may_mutate(&alice, "ai:alice"));
+        assert!(
+            !caller_may_mutate(&alice, "ai:bob"),
+            "cross-owner MUST fail the synthesis-plane gate"
+        );
+    }
+
+    #[test]
+    fn caller_may_mutate_inbox_recipient_is_not_owner_3173() {
+        // SYNTHESIS_ALLOW_INBOX = false: an inbox recipient never asked
+        // for the row to be merged away, so they must not count as owner.
+        let inbox = inbox_for("ai:alice", "ai:bob");
+        assert!(
+            !caller_may_mutate(&inbox, "ai:bob"),
+            "inbox recipient must NOT own a synthesis mutation"
+        );
+        assert!(caller_may_mutate(&inbox, "ai:alice"));
+    }
+
+    #[test]
+    fn assert_caller_may_mutate_refuses_cross_owner_and_unvetted_3173() {
+        let alice = owned_by("ai:alice");
+        let pool = [alice];
+        assert!(
+            assert_caller_may_mutate(
+                &pool,
+                Some("ai:alice"),
+                crate::audit::AuditAction::Update,
+                "mem-3173-alice",
+            )
+            .is_ok()
+        );
+        let err = assert_caller_may_mutate(
+            &pool,
+            Some("ai:bob"),
+            crate::audit::AuditAction::Update,
+            "mem-3173-alice",
+        )
+        .expect_err("cross-owner MUST refuse, never skip");
+        assert_eq!(err, crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY);
+        let missing = assert_caller_may_mutate(
+            &pool,
+            Some("ai:alice"),
+            crate::audit::AuditAction::Delete,
+            "not-in-pool",
+        )
+        .expect_err("unvetted target MUST refuse");
+        assert_eq!(missing, crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY);
+        assert!(
+            assert_caller_may_mutate(
+                &pool,
+                None,
+                crate::audit::AuditAction::Update,
+                "mem-3173-alice",
+            )
+            .is_ok(),
+            "None caller is the single-operator trust-all default"
+        );
+    }
+}

--- a/src/mcp/tools/store/synthesis.rs
+++ b/src/mcp/tools/store/synthesis.rs
@@ -39,6 +39,114 @@ use crate::{db, hnsw::VectorSearchIndex};
 
 use super::AUTONOMY_MIN_CONTENT_LEN;
 
+/// #3173 — `allow_inbox` for every synthesis-plane ownership check.
+///
+/// STRICTER than the `memory_delete` gate (`allow_inbox = true`) and equal to
+/// the `memory_update` / `memory_promote` gates: a synthesis verdict is an
+/// AUTONOMOUS mutation the caller never named, so an inbox RECIPIENT — who
+/// never asked for that row to be merged away or hard-deleted — must not be
+/// treated as an owner here.
+const SYNTHESIS_ALLOW_INBOX: bool = false;
+
+/// #3173 — the single ownership predicate every synthesis-plane mutate site
+/// applies. Thin, named wrapper over the canonical #1786
+/// [`crate::visibility::caller_owns_for_mutation`] so the pool filter in
+/// `mod.rs` and the per-site re-checks below can never drift apart.
+#[must_use]
+pub(super) fn caller_may_mutate(mem: &Memory, caller: &str) -> bool {
+    crate::visibility::caller_owns_for_mutation(mem, caller, SYNTHESIS_ALLOW_INBOX)
+}
+
+/// #3173 — emit the security audit row for a REFUSED cross-owner synthesis
+/// mutation. `AuditOutcome::Deny`, so a SIEM sees the attempt rather than the
+/// pre-#3173 silent success.
+pub(super) fn audit_mutation_refusal(
+    action: crate::audit::AuditAction,
+    mem: &Memory,
+    caller: &str,
+) {
+    tracing::warn!(
+        target: "synthesis",
+        namespace = %mem.namespace,
+        candidate_id = %mem.id,
+        caller = %caller,
+        "synthesis.refused_cross_owner_mutation",
+    );
+    crate::audit::emit(
+        crate::audit::EventBuilder::new(
+            action,
+            crate::audit::actor(
+                caller.to_string(),
+                crate::audit::synthesis_sources::HOST_FALLBACK,
+                None,
+            ),
+            crate::audit::target_memory(
+                mem.id.clone(),
+                mem.namespace.clone(),
+                Some(mem.title.clone()),
+                Some(mem.tier.to_string()),
+                None,
+            ),
+        )
+        .outcome(crate::audit::AuditOutcome::Deny),
+    );
+}
+
+/// #3173 — REFUSE (never silently skip) when a synthesis verdict names a row
+/// the caller may not mutate.
+///
+/// `candidates` is the already-ownership-filtered pool, so the target must be
+/// present in it AND still pass [`caller_may_mutate`]; a target absent from the
+/// vetted pool is refused too (it can only come from a pool/verdict mismatch,
+/// which is exactly the state a mutate site must not act on). A `None` caller
+/// is the single-operator default — trust-all, byte-unchanged.
+///
+/// # Errors
+/// [`crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY`] when the caller is set
+/// and the target is not caller-mutable.
+pub(super) fn assert_caller_may_mutate(
+    candidates: &[Memory],
+    caller: Option<&str>,
+    action: crate::audit::AuditAction,
+    target_id: &str,
+) -> Result<(), String> {
+    let Some(caller) = caller else {
+        return Ok(());
+    };
+    match candidates.iter().find(|c| c.id == target_id) {
+        Some(row) if caller_may_mutate(row, caller) => Ok(()),
+        Some(row) => {
+            audit_mutation_refusal(action, row, caller);
+            Err(crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY.into())
+        }
+        None => {
+            tracing::warn!(
+                target: "synthesis",
+                candidate_id = %target_id,
+                caller = %caller,
+                "synthesis.refused_unvetted_mutation_target",
+            );
+            Err(crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY.into())
+        }
+    }
+}
+
+/// #3173 — [`assert_caller_may_mutate`] over a whole verdict queue, used to
+/// vet the deferred delete list BEFORE the standard insert commits.
+///
+/// # Errors
+/// Propagates the first [`assert_caller_may_mutate`] refusal.
+pub(super) fn assert_caller_may_mutate_all(
+    candidates: &[Memory],
+    caller: Option<&str>,
+    target_ids: &[String],
+) -> Result<(), String> {
+    for id in target_ids {
+        assert_caller_may_mutate(candidates, caller, crate::audit::AuditAction::Delete, id)?;
+    }
+    Ok(())
+}
+
 /// Outcome of the synthesis pass that the store handler needs to
 /// thread through the rest of the write path.
 pub(super) struct SynthesisOutcome {
@@ -262,6 +370,17 @@ fn k9_allows_synthesis_delete(namespace: &str, agent_id: &str, candidate_id: &st
 /// Queued deletes that target the primary-update id are skipped so
 /// the store handler does not delete the very row it just merged the
 /// incoming fact into.
+///
+/// #3173 — `caller` is the ENFORCED-read caller (`None` = single-operator
+/// trust-all). Every `db::update` / `db::delete` below re-checks ownership
+/// against the vetted `existing` pool and REFUSES the whole store call
+/// (`Err`) rather than silently skipping a cross-owner mutation. The refusal
+/// is raised BEFORE the transaction opens, so no partial merge can land.
+///
+/// # Errors
+/// [`crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY`] when any queued update
+/// or delete targets a row the caller does not own.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn apply_synthesis_updates_and_deletes(
     conn: &rusqlite::Connection,
     mem: &Memory,
@@ -270,9 +389,26 @@ pub(super) fn apply_synthesis_updates_and_deletes(
     vector_index: Option<&dyn VectorSearchIndex>,
     outcome: &SynthesisOutcome,
     active_keypair: Option<&AgentKeypair>,
-) -> Option<Value> {
+    caller: Option<&str>,
+) -> Result<Option<Value>, String> {
     let primary_update = outcome.updates.first().cloned();
-    let (primary_id, _) = primary_update.as_ref()?;
+    let Some((primary_id, _)) = primary_update.as_ref() else {
+        return Ok(None);
+    };
+
+    // #3173 — vet EVERY queued mutation before the BEGIN IMMEDIATE below, so a
+    // cross-owner verdict can never leave a half-applied merge behind. The pool
+    // is already ownership-filtered in `mod.rs`; this is the mutate-site
+    // re-check the issue requires (`delete.rs:231-236` precedent).
+    for (cand_id, _) in &outcome.updates {
+        assert_caller_may_mutate(existing, caller, crate::audit::AuditAction::Update, cand_id)?;
+    }
+    for del_id in &outcome.deletes {
+        if del_id == primary_id {
+            continue;
+        }
+        assert_caller_may_mutate(existing, caller, crate::audit::AuditAction::Delete, del_id)?;
+    }
 
     // #1700 — apply the whole synthesis merge atomically. db::update /
     // db::insert / db::delete / create_link_signed are all transaction-free, so
@@ -281,13 +417,13 @@ pub(super) fn apply_synthesis_updates_and_deletes(
     // the entire merge back instead of leaving a half-synthesised store.
     // Vector-index mutations are in-memory and DEFERRED until after COMMIT so a
     // rollback can never leave the index out of sync with the DB.
-    // #3163 — RAII guard. The early `return None` arms below keep their
+    // #3163 — RAII guard. The early `return Ok(None)` arms below keep their
     // explicit ROLLBACK so the write lock is released at the exact bail-out
     // point; the guard is what covers a PANIC unwind out of any of the
     // update/link/delete calls, and it no-ops once the connection is back in
     // autocommit, so the two are idempotent with each other.
     let Ok(write_txn) = crate::storage::connection::WriteTxn::begin(conn) else {
-        return None;
+        return Ok(None);
     };
     let mut deferred_index_ops: Vec<(String, Vec<f32>)> = Vec::new();
 
@@ -327,7 +463,7 @@ pub(super) fn apply_synthesis_updates_and_deletes(
                     "synthesis update failed for {cand_id}: {e}; rolling back merge",
                 );
                 let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
-                return None;
+                return Ok(None);
             }
         };
         if content_changed && let Some(emb) = embedder {
@@ -431,7 +567,7 @@ pub(super) fn apply_synthesis_updates_and_deletes(
                 "synthesis delete failed for {del_id}: {e}; rolling back merge",
             );
             let _ = conn.execute_batch(crate::storage::connection::SQL_ROLLBACK);
-            return None;
+            return Ok(None);
         }
     }
 
@@ -441,7 +577,7 @@ pub(super) fn apply_synthesis_updates_and_deletes(
     // whole merge back, so the deferred vector-index swaps below are never
     // applied against a store that did not durably change.
     if write_txn.commit().is_err() {
-        return None;
+        return Ok(None);
     }
     if let Some(idx) = vector_index {
         for (id, embedding) in deferred_index_ops {
@@ -451,7 +587,9 @@ pub(super) fn apply_synthesis_updates_and_deletes(
     }
 
     // Construct the response from the PRIMARY update's target.
-    let target = existing.iter().find(|c| c.id == *primary_id).cloned()?;
+    let Some(target) = existing.iter().find(|c| c.id == *primary_id).cloned() else {
+        return Ok(None);
+    };
     let preserved_metadata =
         crate::identity::preserve_provenance_keys(&target.metadata, &mem.metadata);
     let echoed_agent_id = preserved_metadata
@@ -474,7 +612,7 @@ pub(super) fn apply_synthesis_updates_and_deletes(
         resp["synthesis_failed"] = json!(true);
         resp["synthesis_failed_reason"] = json!(reason);
     }
-    Some(resp)
+    Ok(Some(resp))
 }
 
 /// Apply pending delete verdicts when no update fired — the store
@@ -504,13 +642,32 @@ pub(super) fn pending_synthesis_delete_targets(outcome: &SynthesisOutcome) -> Ve
 ///
 /// Best-effort: a per-candidate failure (link emit, delete) is
 /// warn-logged and does not roll back the standard insert.
+///
+/// #3173 — the LAST-RESORT ownership re-check. The queue was already vetted
+/// by [`assert_caller_may_mutate_all`] BEFORE the standard insert committed
+/// (that is where a cross-owner verdict REFUSES the store call); by the time
+/// this runs the new row is durable, so a violation here cannot refuse — it
+/// skips the candidate with a WARN + a `Deny` audit row rather than
+/// hard-deleting a row the caller does not own.
 pub(super) fn apply_pending_synthesis_deletes_with_links(
     conn: &rusqlite::Connection,
     new_id: &str,
     pending_deletes: &[String],
     active_keypair: Option<&AgentKeypair>,
+    candidates: &[Memory],
+    caller: Option<&str>,
 ) {
     for del_id in pending_deletes {
+        if assert_caller_may_mutate(
+            candidates,
+            caller,
+            crate::audit::AuditAction::Delete,
+            del_id,
+        )
+        .is_err()
+        {
+            continue;
+        }
         if let Err(e) = db::create_link_signed(
             conn,
             new_id,

--- a/src/secret_screen.rs
+++ b/src/secret_screen.rs
@@ -456,13 +456,32 @@ pub fn screen_for_caller(content: &str) -> Result<(), SecretRefusal> {
     }
 }
 
-/// STORAGE-funnel screen (the origin-blind backstop wired into
-/// `db::insert` / `db::insert_if_newer` and the postgres store path). When
-/// the mode is not `Off` and a credential is detected, returns the REDACTED
-/// content to persist instead — NEVER refuses, so federation-receive /
-/// recovery / internal re-store paths preserve CRDT convergence + the
-/// capture-first guarantee (the 5-agent vote's killer objection). Returns
-/// `None` when the content is clean or screening is `Off`.
+/// STORAGE-funnel screen for ONE string. When the mode is not `Off` and a
+/// credential is detected, returns the REDACTED content to persist instead —
+/// NEVER refuses, so federation-receive / recovery / internal re-store paths
+/// preserve CRDT convergence + the capture-first guarantee (the 5-agent
+/// vote's killer objection). Returns `None` when the content is clean or
+/// screening is `Off`.
+///
+/// # What is (and is not) wired to this function — #3049 claims-truth fix
+///
+/// This is the per-STRING primitive, NOT the memory-row funnel. The
+/// origin-blind backstop the memory lane runs is the whole-row wrapper
+/// [`redact_memory_for_storage`], which is what is actually wired into
+/// `db::insert` (`storage::insert_inner`), `db::insert_if_newer`,
+/// `storage::merge_inbound`, the postgres store path
+/// (`store::postgres::screen_storage_memory`), and the forensic bundle.
+/// Before #3049 this doc claimed THIS function was "wired into `db::insert` /
+/// `db::insert_if_newer` and the postgres store path", which is false and
+/// invited the reading that any surface reaching a `db::*` insert inherits a
+/// string-level screen. Its own direct non-test callers are the entity-alias
+/// canonicalization (`storage::entity_register` on both backends), the
+/// forensic bundle's decrypted-content arm, the whole-row / metadata
+/// recursions in this module, and the coordination helpers at the bottom of
+/// this file. Everything else screens through one of those wrappers or is
+/// NOT screened at all — the coordination plane (#2994 caller arm, #3049
+/// federation-receive arm) is screened only because it calls the helpers
+/// below explicitly.
 #[must_use]
 pub fn redact_for_storage(content: &str) -> Option<String> {
     if screen_mode() == SecretScreenMode::Off {
@@ -722,6 +741,184 @@ pub fn screen_json_field_for_caller(field: &mut serde_json::Value) -> Result<(),
         *field = redacted;
     }
     Ok(())
+}
+
+// ── #3049 — coordination-plane FEDERATION-RECEIVE screen ─────────────────
+//
+// #2994 (above) closed the CALLER-origin coordination leak. The federation
+// RECEIVE arm — `POST /sync/push` `signals[]` / `checkpoints[]` — had ZERO
+// screening at v1.0.0 base: neither apply loop in
+// `handlers::federation_receive` called any `secret_screen` entry point, so
+// a peer running `AI_MEMORY_SECRET_SCREEN_MODE=off` (or a hostile peer)
+// could land a credential verbatim in this node's `signals` /
+// `checkpoints` tables, where it is queryable, forensic-exported, and
+// re-egressed on the next `/sync/push`.
+//
+// Disposition is REDACT-ONLY, never refuse — a refused inbound row would
+// diverge replicas (the #1821 lesson, and the same rule the memory lane's
+// `redact_memory_for_storage` follows). The screen runs AFTER the lane's
+// authorization gates (signature / authorship / namespace-scope), because
+// those gates answer "did this peer really send these bytes" and must see
+// exactly the bytes the peer signed — screening first would false-accuse a
+// legitimately-signed secret-bearing row of forgery and silently drop it.
+//
+// Because the screen mutates bytes that are INSIDE the signed canonical
+// surface, it carries the #2340 discipline: when the redaction touches a
+// signed field, the presented attestation can no longer cover any bytes
+// this node will persist, so it is DROPPED (loud WARN) and the row lands
+// honestly UNSIGNED rather than carrying a signature that silently fails
+// against its own stored content.
+
+/// Tracing target for a federation-receive coordination redaction that also
+/// had to drop the presented attestation (#3049 / #2340 discipline).
+const COORD_SCREEN_TRACE_TARGET: &str = "secret.redacted";
+
+/// FEDERATION-RECEIVE screen for an inbound `/sync/push` signal (#3049).
+///
+/// Screens the two caller-controlled credential vectors the #2994 caller arm
+/// screens — [`crate::models::Signal::subject`] (plain text) and
+/// [`crate::models::Signal::body`] (JSON string leaves, minus the
+/// [`METADATA_SCREEN_CARVE_OUT_KEYS`] crypto carve-out) — and returns the
+/// row to persist. NEVER refuses. Returns `None` (zero-copy) when the signal
+/// is clean or screening is `Off`.
+///
+/// `subject` and `sha256(body)` are both inside
+/// [`crate::identity::sign::SignableSignal`], so any redaction invalidates
+/// the wire signature: the returned clone therefore has `signature` and
+/// `sender_pubkey` CLEARED (#2340 discipline — an honestly-unsigned row
+/// beats one whose signature cannot cover its own stored bytes).
+#[must_use]
+pub fn redact_signal_for_storage(sig: &crate::models::Signal) -> Option<crate::models::Signal> {
+    if screen_mode() == SecretScreenMode::Off {
+        return None;
+    }
+    fold_screened_signal(
+        sig,
+        redact_for_storage(&sig.subject),
+        redact_metadata_values(&sig.body),
+    )
+}
+
+/// Pure core of [`redact_signal_for_storage`] — split out so the
+/// attestation-drop disposition is unit-testable without touching the
+/// process-global screen-mode `OnceLock` (the `apply_screened_inbound`
+/// precedent).
+fn fold_screened_signal(
+    sig: &crate::models::Signal,
+    subject: Option<String>,
+    body: Option<serde_json::Value>,
+) -> Option<crate::models::Signal> {
+    if subject.is_none() && body.is_none() {
+        return None;
+    }
+    let mut out = sig.clone();
+    if let Some(subject) = subject {
+        out.subject = subject;
+    }
+    if let Some(body) = body {
+        out.body = body;
+    }
+    // Every screened signal field is inside the signed canonical bytes, so a
+    // hit ALWAYS invalidates the presented signature.
+    if !out.signature.is_empty() || !out.sender_pubkey.is_empty() {
+        tracing::warn!(
+            target: COORD_SCREEN_TRACE_TARGET,
+            signal_id = %sig.id,
+            "sync_push: secret screen redacted the SIGNED surface of an inbound \
+             signal; dropping the presented signature (it covers raw bytes this \
+             node will not persist) so the row cannot read as tampered (#3049 / \
+             #2340). Origin should redact-before-sign (#1801)."
+        );
+        out.signature.clear();
+        out.sender_pubkey.clear();
+    }
+    Some(out)
+}
+
+/// FEDERATION-RECEIVE screen for an inbound `/sync/push` resolved checkpoint
+/// (#3049).
+///
+/// Screens every free-text / structured field
+/// [`crate::checkpoints::apply_inbound_resolution`] can persist from the
+/// wire: `title`, `condition`, `resolution`, `resolution_note`, and
+/// `metadata`. That is a SUPERSET of the #2994 caller arm (`title` /
+/// `condition` / `metadata`) because the resolution CAS additionally
+/// persists the wire `resolution` + `resolution_note` onto a locally-pending
+/// anchor. NEVER refuses. Returns `None` (zero-copy) when the checkpoint is
+/// clean or screening is `Off`.
+///
+/// Only `resolution` is inside
+/// [`crate::identity::sign::SignableCheckpointResolution`]; when THAT field
+/// is redacted the presented resolution attestation (`signature` /
+/// `resolver_pubkey`) is CLEARED for the same #2340 reason as
+/// [`redact_signal_for_storage`]. A hit confined to the unsigned fields
+/// keeps the attestation intact — it still covers exactly the bytes it
+/// signed.
+#[must_use]
+pub fn redact_checkpoint_for_storage(
+    cp: &crate::models::Checkpoint,
+) -> Option<crate::models::Checkpoint> {
+    if screen_mode() == SecretScreenMode::Off {
+        return None;
+    }
+    fold_screened_checkpoint(
+        cp,
+        redact_for_storage(&cp.title),
+        redact_metadata_values(&cp.condition),
+        cp.resolution.as_deref().and_then(redact_for_storage),
+        cp.resolution_note.as_deref().and_then(redact_for_storage),
+        redact_metadata_values(&cp.metadata),
+    )
+}
+
+/// Pure core of [`redact_checkpoint_for_storage`] (see
+/// [`fold_screened_signal`] for why the fold is split out).
+fn fold_screened_checkpoint(
+    cp: &crate::models::Checkpoint,
+    title: Option<String>,
+    condition: Option<serde_json::Value>,
+    resolution: Option<String>,
+    resolution_note: Option<String>,
+    metadata: Option<serde_json::Value>,
+) -> Option<crate::models::Checkpoint> {
+    if title.is_none()
+        && condition.is_none()
+        && resolution.is_none()
+        && resolution_note.is_none()
+        && metadata.is_none()
+    {
+        return None;
+    }
+    let signed_surface_mutated = resolution.is_some();
+    let mut out = cp.clone();
+    if let Some(title) = title {
+        out.title = title;
+    }
+    if let Some(condition) = condition {
+        out.condition = condition;
+    }
+    if let Some(resolution) = resolution {
+        out.resolution = Some(resolution);
+    }
+    if let Some(note) = resolution_note {
+        out.resolution_note = Some(note);
+    }
+    if let Some(metadata) = metadata {
+        out.metadata = metadata;
+    }
+    if signed_surface_mutated && (!out.signature.is_empty() || !out.resolver_pubkey.is_empty()) {
+        tracing::warn!(
+            target: COORD_SCREEN_TRACE_TARGET,
+            checkpoint_id = %cp.id,
+            "sync_push: secret screen redacted the SIGNED `resolution` of an inbound \
+             checkpoint; dropping the presented resolution attestation (it covers raw \
+             bytes this node will not persist) so the row cannot read as tampered \
+             (#3049 / #2340). Origin should redact-before-sign (#1801)."
+        );
+        out.signature.clear();
+        out.resolver_pubkey.clear();
+    }
+    Some(out)
 }
 
 #[cfg(test)]

--- a/src/secret_screen.rs
+++ b/src/secret_screen.rs
@@ -1194,4 +1194,118 @@ mod tests {
             );
         }
     }
+
+    // ── #3049 — federation-receive coordination-plane folds ──────────
+    //
+    // These drive the PURE cores (`fold_screened_signal` /
+    // `fold_screened_checkpoint`) so they do not touch the process-global
+    // `SCREEN_MODE` OnceLock. The integration binary
+    // `tests/federation_receive_coord_screen_3049.rs` is the load-bearing
+    // `/sync/push` proof.
+
+    fn sample_signal(subject: &str) -> crate::models::Signal {
+        crate::models::Signal {
+            id: "sig-3049-unit".to_string(),
+            namespace: "coord/screen".to_string(),
+            from_agent: "ai:peer".to_string(),
+            to_agent: None,
+            subject: subject.to_string(),
+            body: serde_json::json!({"hello": "world"}),
+            signal_type: crate::models::SignalType::Notify,
+            in_reply_to: None,
+            correlation_id: None,
+            reference_ids: serde_json::json!([]),
+            created_at: 1_700_000_000,
+            expires_at: None,
+            delivered_at: None,
+            read_at: None,
+            acknowledged_at: None,
+            signature: vec![0xAB; 64],
+            sender_pubkey: vec![0xCD; 32],
+        }
+    }
+
+    fn sample_checkpoint() -> crate::models::Checkpoint {
+        crate::models::Checkpoint {
+            id: "cp-3049-unit".to_string(),
+            namespace: "coord/screen".to_string(),
+            title: "needs approval".to_string(),
+            condition_type: crate::models::ConditionType::Approval,
+            condition: serde_json::json!({}),
+            state: crate::models::CheckpointState::Resolved,
+            created_by: "ai:peer".to_string(),
+            resolved_by: Some("ai:peer".to_string()),
+            resolution: Some("approved".to_string()),
+            resolution_note: None,
+            signature: vec![0xAB; 64],
+            resolver_pubkey: vec![0xCD; 32],
+            created_at: 1_700_000_000,
+            deadline_at: None,
+            resolved_at: Some(1_700_000_900),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn fold_screened_signal_redacted_subject_clears_attestation_3049() {
+        let sig = sample_signal("clean subject");
+        let out = fold_screened_signal(&sig, Some(REDACTION_PLACEHOLDER.to_string()), None)
+            .expect("hit must clone");
+        assert_eq!(out.subject, REDACTION_PLACEHOLDER);
+        assert!(
+            out.signature.is_empty() && out.sender_pubkey.is_empty(),
+            "signed surface mutation MUST drop the presented attestation (#2340)"
+        );
+        assert_eq!(out.body, sig.body, "un-hit body is preserved");
+    }
+
+    #[test]
+    fn fold_screened_signal_clean_is_none_3049() {
+        let sig = sample_signal("clean subject");
+        assert!(
+            fold_screened_signal(&sig, None, None).is_none(),
+            "clean signal is a zero-copy None so the receive loop binds the original"
+        );
+        assert!(!sig.signature.is_empty(), "fixture itself stays signed");
+    }
+
+    #[test]
+    fn fold_screened_checkpoint_resolution_hit_clears_attestation_3049() {
+        let cp = sample_checkpoint();
+        let out = fold_screened_checkpoint(
+            &cp,
+            None,
+            None,
+            Some(REDACTION_PLACEHOLDER.to_string()),
+            None,
+            None,
+        )
+        .expect("hit must clone");
+        assert_eq!(out.resolution.as_deref(), Some(REDACTION_PLACEHOLDER));
+        assert!(
+            out.signature.is_empty() && out.resolver_pubkey.is_empty(),
+            "redacting the SIGNED `resolution` MUST drop the presented attestation"
+        );
+    }
+
+    #[test]
+    fn fold_screened_checkpoint_title_hit_preserves_attestation_3049() {
+        let cp = sample_checkpoint();
+        let out = fold_screened_checkpoint(
+            &cp,
+            Some(REDACTION_PLACEHOLDER.to_string()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("hit must clone");
+        assert_eq!(out.title, REDACTION_PLACEHOLDER);
+        assert_eq!(
+            out.signature, cp.signature,
+            "a hit confined to unsigned fields (title) MUST keep the resolution attestation"
+        );
+        assert_eq!(out.resolver_pubkey, cp.resolver_pubkey);
+        assert_eq!(out.resolution, cp.resolution);
+    }
 }

--- a/tests/federation_receive_coord_screen_3049.rs
+++ b/tests/federation_receive_coord_screen_3049.rs
@@ -1,0 +1,392 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3049 — federation-RECEIVE secret screen for the coordination plane.
+//!
+//! A `/sync/push` `signals[]` / `checkpoints[]` entry carrying a credential
+//! must be REDACTED (never refused — a refusal would diverge replicas, the
+//! #1821 lesson) before it is persisted. The gate is
+//! `secret_screen::redact_signal_for_storage` / `redact_checkpoint_for_storage`
+//! wired in `handlers::federation_receive` AFTER the forged-signature /
+//! authorship / namespace-scope / checkpoint-resolution-authz gates so those
+//! still see the bytes the peer signed, and BEFORE `signals::insert` /
+//! `checkpoints::apply_inbound_resolution`.
+//!
+//! Dedicated binary: `secret_screen::SCREEN_MODE` is a process-wide
+//! `OnceLock` (first writer wins). This file is the only setter in this
+//! process.
+
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::await_holding_lock)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::missing_panics_doc)]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tower::ServiceExt as _;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::federation::receive_auth::{REQUIRE_CHECKPOINT_SIG_ENV, REQUIRE_SIGNAL_SIG_ENV};
+use ai_memory::federation::signing::REQUIRE_SIG_ENV;
+use ai_memory::handlers::{ApiKeyState, AppState, Db, StorageBackend};
+use ai_memory::models::{Checkpoint, CheckpointState, ConditionType, Signal, SignalType};
+use ai_memory::secret_screen::{REDACTION_PLACEHOLDER, SecretScreenMode, set_screen_mode};
+
+/// Canonical AWS access-key fixture the detector is pinned on
+/// (`src/secret_screen.rs::detects_aws_access_key`).
+const AWS_AKIA_FIXTURE: &str = "AKIAIOSFODNN7EXAMPLE";
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn seed_screen_mode_refuse() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| set_screen_mode(SecretScreenMode::Refuse));
+}
+
+fn setup_router() -> (axum::Router, Db) {
+    let db_tmp = tempfile::NamedTempFile::new().expect("db tempfile");
+    let db_path = db_tmp.path().to_path_buf();
+    std::mem::forget(db_tmp);
+    let _ = ai_memory::db::open(&db_path).expect("db::open");
+    let conn = ai_memory::db::open(&db_path).expect("reopen for AppState");
+    let db: Db = Arc::new(Mutex::new((
+        conn,
+        db_path.clone(),
+        ResolvedTtl::default(),
+        true,
+    )));
+    let app_state = AppState {
+        db: db.clone(),
+        embedder: Arc::new(None),
+        vector_index: Arc::new(Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(tokio::sync::RwLock::new(Some(Vec::new()))),
+        storage_backend: StorageBackend::Sqlite,
+        #[cfg(feature = "sal")]
+        store: Arc::new(
+            ai_memory::store::sqlite::SqliteStore::open(&db_path).expect("open SqliteStore"),
+        ),
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
+        autonomous_hooks: false,
+        auto_tag_queue: None,
+        atomise_queue: None,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(Vec::new()),
+        rule_cache: std::sync::Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: std::sync::Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: std::sync::Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    (ai_memory::build_router(api_key_state, app_state), db)
+}
+
+/// Isolate the #3049 screen: disable the orthogonal federation gates so an
+/// unsigned inbound coordination row reaches the screen arm. Zero-config
+/// (no peer allowlist) so Layer-1 authorship / namespace-scope are no-ops.
+fn relax_orthogonal_gates() {
+    unsafe {
+        std::env::set_var(REQUIRE_SIG_ENV, "0");
+        std::env::set_var("AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT", "0");
+        std::env::set_var(REQUIRE_SIGNAL_SIG_ENV, "0");
+        std::env::set_var(REQUIRE_CHECKPOINT_SIG_ENV, "0");
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+}
+
+fn clear_all_env() {
+    unsafe {
+        std::env::remove_var(REQUIRE_SIG_ENV);
+        std::env::remove_var("AI_MEMORY_FED_REQUIRE_PEER_ENROLLMENT");
+        std::env::remove_var(REQUIRE_SIGNAL_SIG_ENV);
+        std::env::remove_var(REQUIRE_CHECKPOINT_SIG_ENV);
+        std::env::remove_var(ai_memory::federation::peer_attestation::PEER_ATTESTATION_ENV);
+    }
+}
+
+fn make_signal(from_agent: &str, namespace: &str, subject: &str, body: Value) -> Signal {
+    Signal {
+        id: uuid::Uuid::new_v4().to_string(),
+        namespace: namespace.to_string(),
+        from_agent: from_agent.to_string(),
+        to_agent: None,
+        subject: subject.to_string(),
+        body,
+        signal_type: SignalType::Notify,
+        in_reply_to: None,
+        correlation_id: None,
+        reference_ids: json!([]),
+        created_at: 1_700_000_000,
+        expires_at: None,
+        delivered_at: None,
+        read_at: None,
+        acknowledged_at: None,
+        signature: Vec::new(),
+        sender_pubkey: Vec::new(),
+    }
+}
+
+fn make_checkpoint(id: &str, namespace: &str, title: &str, resolution: &str) -> Checkpoint {
+    Checkpoint {
+        id: id.to_string(),
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        condition_type: ConditionType::Approval,
+        condition: json!({}),
+        state: CheckpointState::Resolved,
+        created_by: "ai:peer-3049".to_string(),
+        resolved_by: Some("ai:peer-3049".to_string()),
+        resolution: Some(resolution.to_string()),
+        resolution_note: None,
+        signature: Vec::new(),
+        resolver_pubkey: Vec::new(),
+        created_at: 1_700_000_000,
+        deadline_at: None,
+        resolved_at: Some(1_700_000_900),
+        metadata: Value::Null,
+    }
+}
+
+async fn post_sync_push(router: &axum::Router, body: Value, peer_id: &str) -> (StatusCode, Value) {
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/sync/push")
+        .header("content-type", "application/json")
+        .header(
+            ai_memory::federation::peer_attestation::PEER_ID_HEADER,
+            peer_id,
+        )
+        .body(Body::from(body_bytes))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, v)
+}
+
+fn i(v: &Value, key: &str) -> i64 {
+    v[key].as_i64().unwrap_or(-1)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_push_signal_secret_is_redacted_not_skipped_3049() {
+    let _g = env_lock();
+    seed_screen_mode_refuse();
+    clear_all_env();
+    relax_orthogonal_gates();
+    let (router, db) = setup_router();
+
+    let sig = make_signal(
+        "ai:peer-3049",
+        "coord/screen",
+        &format!("rotate key {AWS_AKIA_FIXTURE}"),
+        json!({"note": "clean"}),
+    );
+    let id = sig.id.clone();
+    let body = json!({
+        "sender_agent_id": "ai:peer-3049",
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "signals": [serde_json::to_value(&sig).expect("serialize signal")],
+        "dry_run": false,
+    });
+    let (status, resp) = post_sync_push(&router, body, "ai:peer-3049").await;
+    let stored = {
+        let lock = db.lock().await;
+        ai_memory::signals::get(&lock.0, &id)
+            .expect("signals::get")
+            .expect("signal MUST be persisted, not skipped")
+    };
+    clear_all_env();
+
+    assert_eq!(status, StatusCode::OK, "resp={resp}");
+    assert_eq!(
+        i(&resp, "signals_applied"),
+        1,
+        "secret-bearing signal MUST apply (redact, never skip): resp={resp}"
+    );
+    assert!(
+        !stored.subject.contains(AWS_AKIA_FIXTURE),
+        "persisted subject still carries the secret: {}",
+        stored.subject
+    );
+    assert!(
+        stored.subject.contains(REDACTION_PLACEHOLDER),
+        "persisted subject must carry {REDACTION_PLACEHOLDER}: {}",
+        stored.subject
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_push_signal_body_secret_is_redacted_3049() {
+    let _g = env_lock();
+    seed_screen_mode_refuse();
+    clear_all_env();
+    relax_orthogonal_gates();
+    let (router, db) = setup_router();
+
+    let sig = make_signal(
+        "ai:peer-3049",
+        "coord/screen",
+        "clean subject",
+        json!({"token": AWS_AKIA_FIXTURE}),
+    );
+    let id = sig.id.clone();
+    let body = json!({
+        "sender_agent_id": "ai:peer-3049",
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "signals": [serde_json::to_value(&sig).expect("serialize signal")],
+        "dry_run": false,
+    });
+    let (status, resp) = post_sync_push(&router, body, "ai:peer-3049").await;
+    let stored = {
+        let lock = db.lock().await;
+        ai_memory::signals::get(&lock.0, &id)
+            .expect("signals::get")
+            .expect("signal MUST be persisted")
+    };
+    clear_all_env();
+
+    assert_eq!(status, StatusCode::OK, "resp={resp}");
+    assert_eq!(i(&resp, "signals_applied"), 1, "resp={resp}");
+    let token = stored
+        .body
+        .get("token")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert!(
+        !token.contains(AWS_AKIA_FIXTURE),
+        "persisted body still carries the secret: {}",
+        stored.body
+    );
+    assert!(
+        token.contains(REDACTION_PLACEHOLDER),
+        "persisted body token must carry {REDACTION_PLACEHOLDER}: {}",
+        stored.body
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_push_checkpoint_resolution_secret_is_redacted_3049() {
+    let _g = env_lock();
+    seed_screen_mode_refuse();
+    clear_all_env();
+    relax_orthogonal_gates();
+    let (router, db) = setup_router();
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let cp = make_checkpoint(
+        &id,
+        "coord/screen",
+        "needs approval",
+        &format!("approved with {AWS_AKIA_FIXTURE}"),
+    );
+    let body = json!({
+        "sender_agent_id": "ai:peer-3049",
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "checkpoints": [serde_json::to_value(&cp).expect("serialize checkpoint")],
+        "dry_run": false,
+    });
+    let (status, resp) = post_sync_push(&router, body, "ai:peer-3049").await;
+    let stored = {
+        let lock = db.lock().await;
+        ai_memory::checkpoints::get(&lock.0, &id)
+            .expect("checkpoints::get")
+            .expect("checkpoint MUST be persisted, not skipped")
+    };
+    clear_all_env();
+
+    assert_eq!(status, StatusCode::OK, "resp={resp}");
+    assert_eq!(
+        i(&resp, "checkpoints_applied"),
+        1,
+        "secret-bearing checkpoint MUST apply (redact, never skip): resp={resp}"
+    );
+    let resolution = stored.resolution.as_deref().unwrap_or("");
+    assert!(
+        !resolution.contains(AWS_AKIA_FIXTURE),
+        "persisted resolution still carries the secret: {resolution}"
+    );
+    assert!(
+        resolution.contains(REDACTION_PLACEHOLDER),
+        "persisted resolution must carry {REDACTION_PLACEHOLDER}: {resolution}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_push_clean_signal_is_byte_identical_3049() {
+    let _g = env_lock();
+    seed_screen_mode_refuse();
+    clear_all_env();
+    relax_orthogonal_gates();
+    let (router, db) = setup_router();
+
+    let sig = make_signal(
+        "ai:peer-3049",
+        "coord/screen",
+        "no credentials here",
+        json!({"hello": "world"}),
+    );
+    let id = sig.id.clone();
+    let body = json!({
+        "sender_agent_id": "ai:peer-3049",
+        "sender_clock": {"entries": {}},
+        "memories": [],
+        "signals": [serde_json::to_value(&sig).expect("serialize signal")],
+        "dry_run": false,
+    });
+    let (status, resp) = post_sync_push(&router, body, "ai:peer-3049").await;
+    let stored = {
+        let lock = db.lock().await;
+        ai_memory::signals::get(&lock.0, &id)
+            .expect("signals::get")
+            .expect("clean signal MUST persist")
+    };
+    clear_all_env();
+
+    assert_eq!(status, StatusCode::OK, "resp={resp}");
+    assert_eq!(i(&resp, "signals_applied"), 1, "resp={resp}");
+    assert_eq!(stored.subject, "no credentials here");
+    assert!(
+        !stored.subject.contains(REDACTION_PLACEHOLDER),
+        "clean subject must not be redacted"
+    );
+}

--- a/tests/qual_6_7_legacy_error_type_ceiling.rs
+++ b/tests/qual_6_7_legacy_error_type_ceiling.rs
@@ -248,7 +248,15 @@ const QUAL_6_CEILING: usize = 124;
 // (operator-facing write-time validator, rendered verbatim by `rules add`).
 // Floors never fall: #3204's `gate_gc_sweep` and #3031's matcher validator
 // are independent adds. Measured after rebase.
-const QUAL_7_CEILING: usize = 45;
+// 2026-08-26 (#3239 rebase onto e9bf9dea) — raised 45 → 47 for the two
+// #3173 mutate-site helpers `assert_caller_may_mutate` /
+// `assert_caller_may_mutate_all` in `src/mcp/tools/store/synthesis.rs`.
+// They return `Result<(), String>` so a cross-owner refusal flows verbatim
+// into the MCP `handle_store` `Result<Value, String>` envelope
+// (`CALLER_DOES_NOT_OWN_MEMORY`) — the same String-refusal contract as
+// the rest of the store handler, not a new error type. Independent of
+// #3204/#3223; never lower. Re-measure after this rebase.
+const QUAL_7_CEILING: usize = 47;
 
 #[test]
 fn qual_6_result_value_string_count_below_ceiling() {

--- a/tests/synthesis_ownership_gate_3173.rs
+++ b/tests/synthesis_ownership_gate_3173.rs
@@ -1,0 +1,261 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3173 — synthesis merge plane ownership gate.
+//!
+//! `db::find_synthesis_candidates` is namespace-scoped only. Under
+//! `AI_MEMORY_AGENT_ID` multi-tenancy in a shared namespace, an exact-dup
+//! `on_conflict=merge` (and any LLM synthesis UPDATE/DELETE verdict) must
+//! REFUSE when the existing row is owned by a different agent, never
+//! overwrite or hard-delete it. The single-operator default (env unset)
+//! stays byte-unchanged (trust-all merge).
+//!
+//! Dedicated binary so `AI_MEMORY_AGENT_ID` mutations cannot leak into
+//! other integration suites. Serialized inside this file by `env_lock`.
+
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::similar_names)]
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use ai_memory::config::ResolvedTtl;
+use ai_memory::models::Memory;
+use ai_memory::storage as db;
+use chrono::Utc;
+use rusqlite::Connection;
+use serde_json::{Value, json};
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn permissive_attestation_for_tests() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| unsafe { std::env::set_var("AI_MEMORY_REQUIRE_AGENT_ATTESTATION", "0") });
+}
+
+fn local_runs_root() -> PathBuf {
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".local-runs")
+        .join("tmp")
+}
+
+fn open_db() -> (Connection, PathBuf) {
+    permissive_attestation_for_tests();
+    let root = local_runs_root();
+    std::fs::create_dir_all(&root).ok();
+    let p = root.join(format!("synth-own-3173-{}.db", uuid::Uuid::new_v4()));
+    let conn = db::open(&p).expect("open db");
+    (conn, p)
+}
+
+fn seed_owned(
+    conn: &Connection,
+    title: &str,
+    content: &str,
+    namespace: &str,
+    owner: &str,
+) -> String {
+    let now = Utc::now().to_rfc3339();
+    let mem = Memory {
+        id: uuid::Uuid::new_v4().to_string(),
+        tier: ai_memory::models::Tier::Mid,
+        namespace: namespace.to_string(),
+        title: title.to_string(),
+        content: content.to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: json!({ ai_memory::META_KEY_AGENT_ID: owner }),
+        reflection_depth: 0,
+        memory_kind: ai_memory::models::MemoryKind::Observation,
+        entity_id: None,
+        persona_version: None,
+        citations: Vec::new(),
+        source_uri: None,
+        source_span: None,
+        confidence_source: ai_memory::models::ConfidenceSource::CallerProvided,
+        confidence_signals: None,
+        confidence_decayed_at: None,
+        version: 1,
+        ..Memory::default()
+    };
+    let id = mem.id.clone();
+    db::insert(conn, &mem).expect("seed insert");
+    id
+}
+
+fn run_store(conn: &Connection, db_path: &PathBuf, params: Value) -> Result<Value, String> {
+    let ttl = ResolvedTtl::default();
+    ai_memory::mcp::tools::handle_store_for_tests(
+        conn, db_path, &params, None, None, None, &ttl,
+        false, // autonomous_hooks off — exact-dup path is LLM-independent
+        None, None,
+    )
+}
+
+struct AgentIdGuard {
+    prev: Option<std::ffi::OsString>,
+}
+
+impl AgentIdGuard {
+    fn set(id: &str) -> Self {
+        let prev = std::env::var_os("AI_MEMORY_AGENT_ID");
+        unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", id) };
+        Self { prev }
+    }
+
+    fn unset() -> Self {
+        let prev = std::env::var_os("AI_MEMORY_AGENT_ID");
+        unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") };
+        Self { prev }
+    }
+}
+
+impl Drop for AgentIdGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var("AI_MEMORY_AGENT_ID", v),
+                None => std::env::remove_var("AI_MEMORY_AGENT_ID"),
+            }
+        }
+    }
+}
+
+#[test]
+fn exact_dup_cross_owner_merge_refuses_and_preserves_3173() {
+    let _g = env_lock();
+    let (conn, path) = open_db();
+    let ns = "shared/3173";
+    let title = "shared synthesis title";
+    let alice_content = "alice original content that must survive bob's merge";
+    let alice_id = seed_owned(&conn, title, alice_content, ns, "ai:alice");
+
+    let _agent = AgentIdGuard::set("ai:bob");
+    let err = run_store(
+        &conn,
+        &path,
+        json!({
+            "title": title,
+            "content": "bob overwrite attempt — must never land",
+            "namespace": ns,
+            "on_conflict": "merge",
+            "agent_id": "ai:bob",
+        }),
+    )
+    .expect_err("cross-owner exact-dup merge MUST refuse");
+    assert!(
+        err.contains(ai_memory::errors::msg::CALLER_DOES_NOT_OWN_MEMORY),
+        "expected ownership refusal, got: {err}"
+    );
+
+    let survived = db::get(&conn, &alice_id)
+        .expect("get")
+        .expect("alice row MUST still exist");
+    assert_eq!(
+        survived.content, alice_content,
+        "alice's durable text MUST be byte-unchanged"
+    );
+    assert_eq!(
+        survived
+            .metadata
+            .get(ai_memory::META_KEY_AGENT_ID)
+            .and_then(Value::as_str),
+        Some("ai:alice")
+    );
+}
+
+#[test]
+fn similar_title_does_not_mutate_other_owner_3173() {
+    let _g = env_lock();
+    let (conn, path) = open_db();
+    let ns = "shared/3173";
+    let alice_content = "alice kubernetes deployment notes body";
+    let alice_id = seed_owned(
+        &conn,
+        "kubernetes deployment notes",
+        alice_content,
+        ns,
+        "ai:alice",
+    );
+
+    let _agent = AgentIdGuard::set("ai:bob");
+    let resp = run_store(
+        &conn,
+        &path,
+        json!({
+            "title": "kubernetes rolling deploy strategy",
+            "content": "bob's own similar-title row — must insert, never touch alice",
+            "namespace": ns,
+            "on_conflict": "merge",
+            "agent_id": "ai:bob",
+        }),
+    )
+    .expect("similar-title store must insert a new row, not refuse");
+    let bob_id = resp
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("store echo id");
+    assert_ne!(bob_id, alice_id, "bob must not have reused alice's id");
+
+    let survived = db::get(&conn, &alice_id)
+        .expect("get")
+        .expect("alice row MUST still exist");
+    assert_eq!(survived.content, alice_content);
+    let bob = db::get(&conn, bob_id).expect("get").expect("bob row");
+    assert_eq!(
+        bob.metadata
+            .get(ai_memory::META_KEY_AGENT_ID)
+            .and_then(Value::as_str),
+        Some("ai:bob")
+    );
+}
+
+#[test]
+fn exact_dup_single_operator_default_still_merges_3173() {
+    let _g = env_lock();
+    let (conn, path) = open_db();
+    let ns = "solo/3173";
+    let title = "single operator title";
+    let original = "original content";
+    let id = seed_owned(&conn, title, original, ns, "ai:alice");
+
+    let _agent = AgentIdGuard::unset();
+    let resp = run_store(
+        &conn,
+        &path,
+        json!({
+            "title": title,
+            "content": "merged content from trust-all default",
+            "namespace": ns,
+            "on_conflict": "merge",
+        }),
+    )
+    .expect("env-unset exact-dup MUST still merge (single-operator default)");
+    let echoed = resp.get("id").and_then(Value::as_str).unwrap_or("");
+    assert_eq!(echoed, id, "merge must echo the existing id, not insert");
+
+    let got = db::get(&conn, &id).expect("get").expect("row");
+    assert_eq!(got.content, "merged content from trust-all default");
+    assert_eq!(
+        got.metadata
+            .get(ai_memory::META_KEY_AGENT_ID)
+            .and_then(Value::as_str),
+        Some("ai:alice"),
+        "provenance agent_id is immutable across the merge"
+    );
+}

--- a/tests/synthesis_ownership_gate_3173.rs
+++ b/tests/synthesis_ownership_gate_3173.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::similar_names)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use ai_memory::config::ResolvedTtl;
@@ -98,10 +98,10 @@ fn seed_owned(
     id
 }
 
-fn run_store(conn: &Connection, db_path: &PathBuf, params: Value) -> Result<Value, String> {
+fn run_store(conn: &Connection, db_path: &Path, params: &Value) -> Result<Value, String> {
     let ttl = ResolvedTtl::default();
     ai_memory::mcp::tools::handle_store_for_tests(
-        conn, db_path, &params, None, None, None, &ttl,
+        conn, db_path, params, None, None, None, &ttl,
         false, // autonomous_hooks off — exact-dup path is LLM-independent
         None, None,
     )
@@ -149,7 +149,7 @@ fn exact_dup_cross_owner_merge_refuses_and_preserves_3173() {
     let err = run_store(
         &conn,
         &path,
-        json!({
+        &json!({
             "title": title,
             "content": "bob overwrite attempt — must never land",
             "namespace": ns,
@@ -197,7 +197,7 @@ fn similar_title_does_not_mutate_other_owner_3173() {
     let resp = run_store(
         &conn,
         &path,
-        json!({
+        &json!({
             "title": "kubernetes rolling deploy strategy",
             "content": "bob's own similar-title row — must insert, never touch alice",
             "namespace": ns,
@@ -238,7 +238,7 @@ fn exact_dup_single_operator_default_still_merges_3173() {
     let resp = run_store(
         &conn,
         &path,
-        json!({
+        &json!({
             "title": title,
             "content": "merged content from trust-all default",
             "namespace": ns,


### PR DESCRIPTION
## Summary

- **#3049** — `POST /api/v1/sync/push` `signals[]` / `checkpoints[]` had ZERO secret screening at `ae3e0aec`. A peer on `AI_MEMORY_SECRET_SCREEN_MODE=off` (or a hostile peer) could land a credential in this node's `signals` / `checkpoints` tables, then re-egress it. The receive arm now redacts those fields AFTER the lane's authorization gates and BEFORE persist. REDACT-only, never refuse (a refusal would diverge replicas — the #1821 lesson). Restores the documented federation-receive contract; does not tighten a documented default.
- **#3173** — the Form-1 synthesis merge plane mutated rows with no ownership gate: `find_synthesis_candidates` is namespace-scoped only, and `db::update` / `db::delete` plus the exact-dup merge detour ran on a bare `rusqlite::Connection`. Under `AI_MEMORY_AGENT_ID` multi-tenancy an autonomous verdict (or `on_conflict=merge`) could overwrite or hard-delete another agent's row. The candidate pool is now filtered BEFORE the curator sees it; every mutate site re-checks and REFUSES (`caller does not own this memory`); the exact-dup detour searches the FULL pool so a cross-owner collision refuses loudly. Env-unset single-operator default is byte-unchanged.

## AI involvement

- Agent: Claude Opus 5 (Grok Build / wt-coord-screen-synth-own successor)
- Authority class: Sensitive (authz / credential-handling)
- Human approver(s) for Sensitive items: operator (this dispatch)
- Memory entries created/updated: `e02ebd0b-6b7f-4510-8407-9f97b9896300` (operator directive)

## Test plan

- [x] `cargo check --all-targets` (default)
- [x] `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic` (default)
- [x] `cargo clippy --all-targets --features sal -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo clippy --features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo clippy --features sal -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo clippy --all-targets --features vectorlite -- -D warnings -D clippy::all -D clippy::pedantic`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --examples`
- [x] `cargo test --test federation_receive_coord_screen_3049` (4 passed)
- [x] `cargo test --test synthesis_ownership_gate_3173` (3 passed)
- [x] lib unit tests: `fold_screened_*`, `caller_may_mutate_*`, `assert_caller_may_mutate_*`
- [x] `cargo test --test form_1_synthesis` (19 passed — single-operator default regression)
- [x] `cargo test --test issue_2122_synthesis_provenance_enforce` (3 passed)
- [x] `cargo test --test qual_10_module_size_ceiling`
- [x] `cargo test --test qual_6_7_legacy_error_type_ceiling` (QUAL-7 43 → 45 lockstep for the two #3173 helpers)
- [x] `scripts/check-hardcoded-literals.sh`
- [x] `scripts/check-docs-vs-ssot.sh`
- [ ] `cargo audit` (CI)
- [ ] Manual security checklist (Engineering Standards §3.2) reviewed

## Linked issues

Closes #3049 #3173

## #3049 — federation-receive coord secret screen (R-405)

**Verified defect at `ae3e0aec`:** `grep -c secret_screen src/handlers/federation_receive.rs` was 0. `Signal.subject` / `Signal.body` (`src/models/signal.rs`) federated verbatim through `crate::signals::insert`. Checkpoint `apply_inbound_resolution` persisted wire `title` / `condition` / `resolution` / `resolution_note` / `metadata` unscreened.

**The gate (quoted):**

```3310:3311:src/handlers/federation_receive.rs
        let screened_signal = crate::secret_screen::redact_signal_for_storage(sig);
        let sig = screened_signal.as_ref().unwrap_or(sig);
```

```3570:3571:src/handlers/federation_receive.rs
                let screened_cp = crate::secret_screen::redact_checkpoint_for_storage(cp);
                let cp = screened_cp.as_ref().unwrap_or(cp);
```

Screen sits AFTER forged-signature / authorship / namespace-scope / `authorize_remote_checkpoint_resolution` (those still see the bytes the peer signed) and BEFORE `signals::insert` / `checkpoints::apply_inbound_resolution`. Clean rows are zero-copy (`None`).

**Disposition:** REDACT-only. `redact_for_storage` already never refuses; `SecretScreenMode::Refuse` at the storage funnel still redacts. Documented contract restored, not tightened.

**#2340 discipline:** a hit on the signed surface (`SignableSignal.subject` + `sha256(body)`; `SignableCheckpointResolution.resolution`) CLEARS `signature`/`sender_pubkey` (signals) or `signature`/`resolver_pubkey` (checkpoints, only when `resolution` was redacted) with a loud WARN, so the row lands honestly unsigned rather than carrying a signature that cannot cover its own stored bytes. A title/metadata-only checkpoint hit PRESERVES the resolution attestation.

**Scope:** signals apply loop + checkpoint Accept arm ONLY. `/sync/push` memory-row arms (~1983-2140) untouched (disjoint from sibling PRs).

**Tests:**
- `fold_screened_signal_redacted_subject_clears_attestation_3049`
- `fold_screened_signal_clean_is_none_3049`
- `fold_screened_checkpoint_resolution_hit_clears_attestation_3049`
- `fold_screened_checkpoint_title_hit_preserves_attestation_3049`
- `sync_push_signal_secret_is_redacted_not_skipped_3049`
- `sync_push_signal_body_secret_is_redacted_3049`
- `sync_push_checkpoint_resolution_secret_is_redacted_3049`
- `sync_push_clean_signal_is_byte_identical_3049`

## #3173 — synthesis ownership gate (R-405)

**Verified defect:** `db::find_synthesis_candidates` → `find_similar_title_candidates(conn, title, namespace, 20)` — namespace only. Mutate sites `src/mcp/tools/store/synthesis.rs` `db::update` / `db::delete` and `store/mod.rs` exact-dup `db::update` had no `caller_owns_for_mutation`. Contrast `src/mcp/tools/delete.rs:231-236`. Positive finding kept: `candidate_id` IS membership-validated against the supplied candidate set in `src/synthesis/mod.rs`, so filtering the POOL is the load-bearing fix.

**The exact-dup gate (quoted):**

```805:809:src/mcp/tools/store/mod.rs
        if let Some(caller) = mutation_caller.as_deref()
            && !synthesis::caller_may_mutate(dup, caller)
        {
            synthesis::audit_mutation_refusal(crate::audit::AuditAction::Update, dup, caller);
            return Err(crate::errors::msg::CALLER_DOES_NOT_OWN_MEMORY.into());
```

Keyed on `identity::resolve_read_visibility_caller()` (env-only) so the single-operator trust-all default is byte-unchanged. `SYNTHESIS_ALLOW_INBOX = false` (stricter than MCP delete, equal to update/promote): a synthesis verdict is an autonomous mutation the caller never named.

Layer 2: `apply_synthesis_updates_and_deletes` is now `Result<Option<Value>, String>` and vets the whole update+delete queue BEFORE `BEGIN IMMEDIATE`. The deferred delete queue is vetted before the standard insert.

**pg:** no postgres synthesis lane. `memory_store` takes `ctx.conn: &rusqlite::Connection` unconditionally; `grep synthesis src/store/postgres.rs` is reflection/consolidation only. No `AI_MEMORY_TEST_POSTGRES_URL` run (and none needed).

**Tests:**
- `caller_may_mutate_owner_yes_cross_owner_no_3173`
- `caller_may_mutate_inbox_recipient_is_not_owner_3173`
- `assert_caller_may_mutate_refuses_cross_owner_and_unvetted_3173`
- `exact_dup_cross_owner_merge_refuses_and_preserves_3173`
- `similar_title_does_not_mutate_other_owner_3173`
- `exact_dup_single_operator_default_still_merges_3173`

## Decisions (flag for reviewer)

1. **#3049 screening = REDACT-only, never refuse.** Matches the issue body, `SecretScreenMode::Redact`'s own doc, and the memory lane. Documented contract restored.
2. **Screen AFTER authorization, not before.** Screening first would make a legitimately-signed secret-bearing signal fail `signals::verify` and be dropped as *forged* — silent divergence.
3. **#2340: drop stale attestation rather than persist a signature that cannot cover stored bytes.** Open question: dropping a checkpoint's resolution attestation downgrades the audit record of that resolution. Alternative ("reads as tampered") is worse; honest unsigned wins, and it only fires on a credential-bearing signed `resolution`.
4. **#3173 `allow_inbox = false`.** Stricter than `memory_delete`. An inbox recipient never asked for the row to be merged away.
5. **QUAL-7 ceiling 43 → 45** for the two `Result<(), String>` helpers. They match the existing MCP `handle_store` String-refusal envelope; a `MemoryError` migration of the whole family is a separate follow-up.

## rust-1.98 IDs applied

ERRORS-01/02/09/19 (refuse as `Result`, never silently drop), OWNERSHIP-03/13 (`&Path`/`&Value` not owned copies — Clippy `ptr_arg` / `needless_pass_by_value`), API-04 (named `caller_may_mutate` wrapper), TEST-01/02 (load-bearing asserts, not vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
