### PR TITLE
fix(storage): fail-closed on unreadable memories COUNT in core-relation gate (#3246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-thread `spawn_blocking` positive-control test asserts the pass
   ran; the existing `#[tokio::test]` panic-avoidance skip is kept.
 
+### Security (migration core-relation gate: an unreadable `memories` COUNT is not "no corpus"; #3246)
+
+Closes a remaining fail-OPEN in the #3113 sqlite ladder gate. The populated-corpus
+discriminator refused only on `Some(n > 0)`; `corpus_row_count` used `.ok()` so
+any `COUNT(*) FROM memories` fault became `None`, and `None` was treated as the
+same no-brick path as `Some(0)`. `memories` ships in the bootstrap `SCHEMA` and
+is replayed by `db::open` before `migrate`, so `None` never means "fixture
+without a corpus" — it means the count FAILED (corruption / I/O / `BUSY`).
+Under `AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES=1` (pinned ON by `asi-hard`) a
+database with missing core relations AND an unreadable corpus stamped the tip
+with only a WARN. The same PR already removed `.ok()` on the `sqlite_master`
+probe (citing #2445) but kept it for the corpus probe.
+
+- **`Some(0)` stays the documented no-brick path.** An empty fixture / archive-less
+  deployment still opens under enforcement; `asi-hard` does not become more
+  fragile than `standard`.
+- **`None` / a failed COUNT refuses under enforcement** and, under the
+  DEFAULT (non-enforced) posture, **fails the migration** (`Err`) instead of
+  warning-and-stamping — the named change, not a silent tightening of the
+  documented `Some(0)` no-brick path. Either way the tail cannot stamp
+  integrity as intact on the strength of a failed read. The check is still
+  inside the migrate transaction BEFORE the stamp: a refusal rolls the
+  ladder back and leaves the database UNCHANGED.
+- **Truthy grammar SSOT.** `config::migration_require_core_tables` now delegates
+  to `governance::audit::env_flag_enabled` (`1` / `true` / `yes` / `on`); the
+  documented tokens are unchanged.
+
 ### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
 
 Two CLI paths diverged from the guard the MCP/HTTP reference surface already

--- a/src/config.rs
+++ b/src/config.rs
@@ -4627,19 +4627,16 @@ pub fn cid_enforce_enabled() -> bool {
 pub const ENV_MIGRATION_REQUIRE_CORE_TABLES: &str = "AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES";
 
 /// v1.0.0 (#3113) — whether a missing core relation REFUSES the schema stamp
-/// (see [`ENV_MIGRATION_REQUIRE_CORE_TABLES`]). Reads the env var directly,
-/// mirroring [`cid_enforce_enabled`]: the migration ladder runs before the
-/// boot-seeded config globals exist, so a boot-seeded atomic would always
-/// read its compile-time default here.
+/// (see [`ENV_MIGRATION_REQUIRE_CORE_TABLES`]). Reads the env var directly
+/// through the shared [`crate::governance::audit::env_flag_enabled`] truthy
+/// grammar (`1` / `true` / `yes` / `on`, case-insensitive for the words):
+/// the migration ladder runs before the boot-seeded config globals exist, so
+/// a boot-seeded atomic would always read its compile-time default here.
+/// Issue #3246: this used to re-implement the same grammar inline; the SSOT
+/// does not change the documented tokens.
 #[must_use]
 pub fn migration_require_core_tables() -> bool {
-    std::env::var(ENV_MIGRATION_REQUIRE_CORE_TABLES)
-        .ok()
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            matches!(v.as_str(), "1" | "true" | "yes" | "on")
-        })
-        .unwrap_or(false)
+    crate::governance::audit::env_flag_enabled(ENV_MIGRATION_REQUIRE_CORE_TABLES)
 }
 
 /// v0.8.1 W1 (#1821 / gap G29) — the `[security]` config block.

--- a/src/security_profile.rs
+++ b/src/security_profile.rs
@@ -381,11 +381,11 @@ const KNOBS: &[KnobSpec] = &[
     // CERTIFIED deployment REFUSE the stamp rather than warn — the #3033
     // "asi-hard no-disable" contract applied to schema integrity.
     //
-    // Safe to pin ON: refusal additionally requires a POSITIVELY OBSERVED
-    // populated corpus (`storage::schema_integrity::refusal_required`), so a
-    // fresh or archive-less hardened deployment with an empty corpus is never
-    // bricked, and the refusal itself mutates nothing — it rolls the ladder
-    // back and leaves the database readable at its old version.
+    // Safe to pin ON: refusal treats `Some(0)` (empty corpus) as no-brick, so
+    // a fresh or archive-less hardened deployment is never refused, and the
+    // refusal itself mutates nothing — it rolls the ladder back and leaves
+    // the database readable at its old version. An *unreadable* corpus
+    // (`None` / failed COUNT) does refuse under this pin (#3246).
     KnobSpec {
         env: crate::config::ENV_MIGRATION_REQUIRE_CORE_TABLES,
         hard_value: "1",

--- a/src/storage/migrations.rs
+++ b/src/storage/migrations.rs
@@ -4003,13 +4003,15 @@ pub(crate) fn migrate(conn: &Connection) -> Result<()> {
         // itself reads `sqlite_master` + `COUNT(*)` and issues no DDL/DML, so
         // this gate can neither lose nor corrupt data.
         let missing_core = super::schema_integrity::report(conn, CURRENT_SCHEMA_VERSION)?;
-        // Refusal additionally requires a POSITIVELY OBSERVED populated corpus
-        // (`refusal_required`): an empty database with a high stamp is the
-        // ordinary fixture / archive-less shape and holds no lost data, so
-        // refusing it would brick a fresh deployment for nothing — and since
-        // `asi-hard` PINS enforcement on, that would make the hardened posture
-        // strictly more fragile than the standard one with no integrity gain.
-        if super::schema_integrity::refusal_required(conn, &missing_core) {
+        // Refusal requires a missing relation AND (a populated corpus OR an
+        // unreadable COUNT). `Some(0)` is the documented no-brick empty
+        // fixture / archive-less shape — no lost data, because no data — so
+        // refusing it would brick a fresh `asi-hard` deployment (which PINS
+        // enforcement on) for nothing. `None` is a failed COUNT
+        // (corruption / I/O / BUSY), not "no corpus"; #3246 refuses that
+        // under enforcement and propagates it otherwise so the tail cannot
+        // stamp integrity as intact on the strength of a failed read.
+        if super::schema_integrity::refusal_required(conn, &missing_core)? {
             return Err(anyhow::anyhow!(super::schema_integrity::refusal_message(
                 &missing_core,
                 CURRENT_SCHEMA_VERSION

--- a/src/storage/schema_integrity.rs
+++ b/src/storage/schema_integrity.rs
@@ -51,11 +51,14 @@
 //!   against the stored stamp and raises the Storage section to `Critical`.
 //! * OPT-IN: [`crate::config::migration_require_core_tables`]
 //!   (`AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES=1`) turns the report into a
-//!   REFUSAL. The check runs inside the migrate transaction and BEFORE the
-//!   `schema_version` stamp, so a refusal rolls the whole ladder back and
-//!   leaves the database exactly as found, still stamped at its old version
-//!   and still fully readable — the stamp is never written over a database
-//!   whose integrity controls could not be applied.
+//!   REFUSAL when a core relation is missing AND the corpus is not the
+//!   documented empty fixture (`COUNT(*) = 0`). An unreadable corpus
+//!   (failed `COUNT(*)`) also refuses under enforcement — unreadability is
+//!   not emptiness (#3246). The check runs inside the migrate transaction
+//!   and BEFORE the `schema_version` stamp, so a refusal rolls the whole
+//!   ladder back and leaves the database exactly as found, still stamped at
+//!   its old version and still fully readable — the stamp is never written
+//!   over a database whose integrity controls could not be applied.
 //!
 //! The refusal is opt-in rather than the default deliberately. Defaulting to
 //! refuse would convert every pre-existing high-stamp fixture and every
@@ -77,8 +80,9 @@ pub const TRACE_TARGET: &str = "ai_memory::storage::schema_integrity";
 const SQL_TABLE_PRESENT: &str =
     "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)";
 
-/// Live-corpus size, used ONLY to colour the diagnostic (populated database
-/// vs empty fixture). Never a gate.
+/// Live-corpus size. `Ok(0)` is the documented no-brick empty-fixture path;
+/// `Err` is unreadability (corruption / I/O / BUSY / missing relation) and
+/// is an input to the refusal predicate — never coerced to "no corpus".
 const SQL_MEMORIES_COUNT: &str = "SELECT COUNT(*) FROM memories";
 
 /// Storage-layer SSOT for the ladder-created core relation NAMES.
@@ -207,16 +211,23 @@ pub fn missing_core_tables(conn: &Connection, effective_version: i64) -> Result<
     Ok(missing)
 }
 
-/// Live-corpus row count, for colouring the diagnostic only.
+/// Live-corpus row count.
 ///
-/// Returns `None` when the count cannot be read — a bare fixture connection
-/// with no `memories` relation is the ordinary case. DELIBERATE discard: this
-/// value never gates anything, and a diagnostic that fails to render must not
-/// convert a warning into an error.
-#[must_use]
-pub fn corpus_row_count(conn: &Connection) -> Option<i64> {
+/// `Ok(0)` is the documented no-brick empty-fixture path (no lost data,
+/// because there is no data). `Err` is a failed `COUNT(*)` — corruption,
+/// I/O, `BUSY`, or a missing `memories` relation. `memories` ships in the
+/// bootstrap `SCHEMA` and is replayed by `db::open` before `migrate`, so a
+/// failed count is never "a fixture without a corpus"; collapsing `Err` to
+/// "no corpus" is the same unknown-as-a-value mistake #2445 fixed on the
+/// `sqlite_master` probe and #3246 closes here (ERRORS-19).
+///
+/// # Errors
+///
+/// Propagates the `COUNT(*)` failure. Callers that only colour a diagnostic
+/// (see [`report`]) may discard with `.ok()`; the refusal predicate must not.
+pub fn corpus_row_count(conn: &Connection) -> Result<i64> {
     conn.query_row(SQL_MEMORIES_COUNT, [], |r| r.get::<_, i64>(0))
-        .ok()
+        .context("count memories rows for the core-relation integrity gate")
 }
 
 /// Render the missing-relation list into the one-line operator diagnostic.
@@ -244,7 +255,10 @@ pub fn describe(missing: &[CoreTable]) -> String {
 pub fn report(conn: &Connection, effective_version: i64) -> Result<Vec<CoreTable>> {
     let missing = missing_core_tables(conn, effective_version)?;
     if !missing.is_empty() {
-        let rows = corpus_row_count(conn);
+        // Diagnostic only: a failed count must not promote this WARN into an
+        // error. The refusal predicate ([`refusal_required`]) is what fails
+        // closed on unreadability (#3246).
+        let rows = corpus_row_count(conn).ok();
         tracing::warn!(
             target: TRACE_TARGET,
             effective_version,
@@ -279,34 +293,41 @@ pub fn report(conn: &Connection, effective_version: i64) -> Result<Vec<CoreTable
 /// 1. at least one core relation is missing;
 /// 2. enforcement is engaged (`AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES=1`, or
 ///    the `asi-hard` pin); and
-/// 3. the corpus is POSITIVELY OBSERVED to hold rows.
+/// 3. the corpus is NOT the documented no-brick empty fixture (`Some(0)`).
 ///
-/// Condition 3 is the load-bearing one. The whole reason the ladder's
-/// existence probes skip rather than fail is that an EMPTY database with a
-/// high stamp is the ordinary fixture / archive-less shape — there is no lost
-/// data there, because there is no data. Refusing it would brick a fresh
-/// deployment for nothing, and since `asi-hard` PINS enforcement on, that
-/// would make the hardened posture strictly more fragile than the standard one
-/// with no integrity gain. Loss is only DEMONSTRABLE when rows exist alongside
-/// a relation that should have been created before them.
+/// Condition 3 is the load-bearing anti-brick invariant. An EMPTY database
+/// with a high stamp is the ordinary fixture / archive-less shape — there is
+/// no lost data there, because there is no data. Refusing it would brick a
+/// fresh deployment for nothing, and since `asi-hard` PINS enforcement on,
+/// that would make the hardened posture strictly more fragile than the
+/// standard one with no integrity gain.
 ///
-/// `corpus_rows == None` (the count could not be read) also does NOT refuse:
-/// the check refuses only on a fact it positively established, never on an
-/// absence of information. An unreadable corpus surfaces through the WARN and
-/// the `doctor` signal instead.
+/// `corpus_rows == None` (the count could not be read) DOES refuse under
+/// enforcement. `memories` ships in the bootstrap `SCHEMA`, so `None` is
+/// never "a fixture without a corpus" — it is a failed `COUNT(*)`
+/// (corruption / I/O / `BUSY`). Coercing that to "no refusal" was the #3246
+/// fail-open: a database with missing core relations AND an unreadable
+/// corpus stamped the tip with only a WARN. Unreadable is not empty.
 #[must_use]
 pub fn refusal_required_with(
     missing: &[CoreTable],
     enforced: bool,
     corpus_rows: Option<i64>,
 ) -> bool {
-    enforced && !missing.is_empty() && matches!(corpus_rows, Some(n) if n > 0)
+    // `Some(0)` is the sole no-brick observation. `None` (unreadability) and
+    // `Some(n > 0)` (demonstrable loss) both refuse under enforcement.
+    enforced && !missing.is_empty() && corpus_rows != Some(0)
 }
 
 /// [`refusal_required_with`] resolved against this process's enforcement flag
 /// and this database's corpus size.
-#[must_use]
-pub fn refusal_required(conn: &Connection, missing: &[CoreTable]) -> bool {
+///
+/// # Errors
+///
+/// Propagates a failed `COUNT(*)` (see [`corpus_row_count`]). A failed count
+/// is unreadability, not emptiness: `migrate` must not stamp integrity as
+/// intact on the strength of a failed read (#2445 / #3246 / ERRORS-19).
+pub fn refusal_required(conn: &Connection, missing: &[CoreTable]) -> Result<bool> {
     // Short-circuit BEFORE the corpus count. `refusal_required_with` would
     // return false for an empty `missing` anyway, but Rust evaluates call
     // arguments EAGERLY — so without this guard every migration pays a full
@@ -317,13 +338,35 @@ pub fn refusal_required(conn: &Connection, missing: &[CoreTable]) -> bool {
     // exactly where it is least affordable. Mirrors `report`'s own emptiness
     // guard; semantics are identical.
     if missing.is_empty() {
-        return false;
+        return Ok(false);
     }
-    refusal_required_with(
+    let corpus_rows = match corpus_row_count(conn) {
+        Ok(n) => Some(n),
+        Err(e) => {
+            // Fail closed always: unreadability is not "no corpus". Under
+            // enforcement this is a refusal (`Ok(true)` → `refusal_message`);
+            // without enforcement it still aborts the stamp (`Err`) rather
+            // than letting the tail write a version whose integrity we could
+            // not even measure. `Some(0)` is the only no-brick path.
+            if crate::config::migration_require_core_tables() {
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    error = %e,
+                    "memories COUNT(*) failed — unreadable is not empty; refusing the stamp under enforcement"
+                );
+                return Ok(true);
+            }
+            return Err(e).context(
+                "memories COUNT(*) unreadable — refusing to stamp schema integrity as intact. \
+                 The database is UNCHANGED (the migration rolled back)",
+            );
+        }
+    };
+    Ok(refusal_required_with(
         missing,
         crate::config::migration_require_core_tables(),
-        corpus_row_count(conn),
-    )
+        corpus_rows,
+    ))
 }
 
 /// The typed refusal raised when enforcement is enabled and relations are
@@ -449,11 +492,15 @@ mod tests {
     }
 
     #[test]
-    fn corpus_row_count_is_none_without_a_memories_relation() {
-        // Diagnostic-only: a bare fixture connection must not turn the WARN
-        // path into an error.
+    fn corpus_row_count_errors_without_a_memories_relation() {
+        // #3246: a missing `memories` relation is a failed COUNT, not "no
+        // corpus". `report` may still discard this for the WARN colouring;
+        // the refusal predicate must not.
         let conn = conn_with(&[]);
-        assert_eq!(corpus_row_count(&conn), None);
+        assert!(
+            corpus_row_count(&conn).is_err(),
+            "COUNT(*) against a missing memories relation must be Err, not Ok(0)/None"
+        );
     }
 
     #[test]
@@ -461,7 +508,17 @@ mod tests {
         let conn = conn_with(&["memories"]);
         conn.execute("INSERT INTO memories (id) VALUES ('m1')", [])
             .expect("seed");
-        assert_eq!(corpus_row_count(&conn), Some(1));
+        assert_eq!(corpus_row_count(&conn).expect("count"), 1);
+    }
+
+    #[test]
+    fn corpus_row_count_reads_an_empty_corpus() {
+        let conn = conn_with(&["memories"]);
+        assert_eq!(
+            corpus_row_count(&conn).expect("count"),
+            0,
+            "an empty memories table is Ok(0), the documented no-brick path"
+        );
     }
 
     #[test]
@@ -506,10 +563,19 @@ mod tests {
     }
 
     #[test]
-    fn an_unreadable_corpus_never_refuses_even_when_enforced() {
-        // Refuse only on a positively established fact, never on an absence of
-        // information. An unreadable corpus surfaces via the WARN + doctor.
-        assert!(!refusal_required_with(&one_missing(), true, None));
+    fn an_unreadable_corpus_refuses_when_enforced() {
+        // #3246: `None` is a failed COUNT, not "no corpus". Under enforcement
+        // (asi-hard pins this ON) an unreadable corpus MUST refuse — the same
+        // fail-closed the sqlite_master probe already has (#2445).
+        assert!(refusal_required_with(&one_missing(), true, None));
+    }
+
+    #[test]
+    fn an_unreadable_corpus_does_not_refuse_when_enforcement_is_off() {
+        // Default posture stays report-only at the predicate: the live
+        // `refusal_required` still propagates the COUNT error so migrate
+        // does not stamp, but the pure predicate itself does not refuse.
+        assert!(!refusal_required_with(&one_missing(), false, None));
     }
 
     #[test]
@@ -530,6 +596,30 @@ mod tests {
     #[test]
     fn a_complete_schema_never_refuses() {
         assert!(!refusal_required_with(&[], true, Some(1_000_000)));
+    }
+
+    #[test]
+    fn refusal_required_propagates_a_failed_count_when_unenforced() {
+        // Default posture: a failed COUNT must not be coerced to "no corpus"
+        // and then stamped. Propagating the error rolls the ladder back.
+        let conn = conn_with(&[]);
+        let missing = one_missing();
+        let err = refusal_required(&conn, &missing).expect_err("failed COUNT must propagate");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("UNCHANGED"),
+            "the operator-facing guarantee must survive a failed COUNT: {msg}"
+        );
+    }
+
+    #[test]
+    fn refusal_required_is_false_on_an_empty_readable_corpus() {
+        let conn = conn_with(&["memories"]);
+        let missing = one_missing();
+        assert!(
+            !refusal_required(&conn, &missing).expect("readable empty corpus"),
+            "Ok(0) stays the documented no-brick path even with relations missing"
+        );
     }
 
     #[test]

--- a/tests/migration_core_relation_integrity_3113.rs
+++ b/tests/migration_core_relation_integrity_3113.rs
@@ -112,7 +112,7 @@ fn a_lost_relation_on_a_populated_database_is_detected() {
         schema_integrity::describe(&missing),
     );
     // And the populated-vs-fixture discriminator must be readable.
-    assert_eq!(schema_integrity::corpus_row_count(&conn), Some(1));
+    assert_eq!(schema_integrity::corpus_row_count(&conn).unwrap(), 1);
 }
 
 #[test]
@@ -140,8 +140,9 @@ fn report_only_posture_preserves_legacy_behaviour_exactly() {
 /// once per hand-written copy. Table-driven so a relation added later is
 /// covered the moment it lands in `CORE_TABLES`, with no test to remember to
 /// write: drop it, restamp the tip, and the loss must be detected, must
-/// warrant refusal under enforcement on a POPULATED corpus, must NOT refuse
-/// under the default posture, and must NEVER refuse on an empty corpus.
+/// warrant refusal under enforcement on a POPULATED or UNREADABLE corpus,
+/// must NOT refuse under the default posture, and must NEVER refuse on an
+/// empty (`Some(0)`) corpus.
 #[test]
 fn every_core_relation_when_lost_is_detected_and_obeys_the_refusal_contract() {
     for entry in schema_integrity::CORE_TABLES {
@@ -156,7 +157,7 @@ fn every_core_relation_when_lost_is_detected_and_obeys_the_refusal_contract() {
             entry.name,
         );
 
-        let rows = schema_integrity::corpus_row_count(&conn);
+        let rows = schema_integrity::corpus_row_count(&conn).ok();
         assert_eq!(
             rows,
             Some(1),
@@ -177,6 +178,12 @@ fn every_core_relation_when_lost_is_detected_and_obeys_the_refusal_contract() {
             !schema_integrity::refusal_required_with(&missing, true, Some(0)),
             "an EMPTY corpus missing {} must never be refused (asi-hard pins \
              enforcement ON, so this is the anti-brick invariant)",
+            entry.name,
+        );
+        assert!(
+            schema_integrity::refusal_required_with(&missing, true, None),
+            "an UNREADABLE corpus missing {} must refuse under enforcement \
+             (#3246: None is a failed COUNT, not no-corpus)",
             entry.name,
         );
     }

--- a/tests/migration_core_relation_unreadable_corpus_3246.rs
+++ b/tests/migration_core_relation_unreadable_corpus_3246.rs
@@ -1,0 +1,150 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1.0.0 (#3246) — an unreadable `memories` COUNT is not "no corpus".
+//!
+//! #3113's refusal predicate treated `corpus_row_count`'s `None` (the
+//! `.ok()`-coerced `COUNT(*)` failure) as the same no-brick path as
+//! `Some(0)`. `memories` ships in the bootstrap `SCHEMA` and is replayed
+//! by `db::open` before `migrate`, so `None` never means "fixture without
+//! a corpus" — it means the count FAILED (corruption / I/O / BUSY). Under
+//! `AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES=1` (pinned ON by `asi-hard`)
+//! that stamped the tip with only a WARN.
+//!
+//! This binary forces the count to fail under enforcement and asserts the
+//! data-integrity contract of the gate as `migrate` sites it: INSIDE a
+//! transaction, BEFORE the stamp. A refusal rolls back; the database is
+//! left EXACTLY as found. Alone in its own test binary: it mutates
+//! process-global env (`2905-posture-test-env-leak`).
+//!
+//! The full ladder is not driven here. Several arms between v74 and the
+//! tip still gate on `version < CURRENT_SCHEMA_VERSION` and query
+//! `memories` (`backfill_memory_cids` among them); dropping the table to
+//! fail COUNT(*) would error in those arms before the gate. The contract
+//! under test is the gate itself, not those arms.
+
+use ai_memory::db;
+use ai_memory::storage::schema_integrity;
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+fn schema_version(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+        [],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+/// The migrate tail: report → refuse-or-stamp, inside BEGIN EXCLUSIVE.
+/// Byte-equivalent control flow to `migrations::migrate`'s pre-stamp gate.
+fn run_gate_and_stamp(conn: &Connection, target: i64) -> anyhow::Result<()> {
+    conn.execute_batch("BEGIN EXCLUSIVE")?;
+    let result = (|| -> anyhow::Result<()> {
+        let missing_core = schema_integrity::report(conn, target)?;
+        if schema_integrity::refusal_required(conn, &missing_core)? {
+            anyhow::bail!(schema_integrity::refusal_message(&missing_core, target));
+        }
+        conn.execute("DELETE FROM schema_version", [])?;
+        conn.execute(
+            "INSERT INTO schema_version (version) VALUES (?1)",
+            rusqlite::params![target],
+        )?;
+        Ok(())
+    })();
+    match result {
+        Ok(()) => {
+            conn.execute_batch("COMMIT")?;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(e)
+        }
+    }
+}
+
+#[test]
+fn enforced_posture_refuses_an_unreadable_corpus_and_leaves_the_stamp_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("ai-memory.db");
+
+    // A real, fully-migrated database holding one durable row.
+    {
+        let conn = db::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO memories (id, tier, namespace, title, content, created_at, updated_at) \
+             VALUES ('m-3246', 'long', 'ns', 't', 'durable source of truth', \
+                     '2026-08-23T00:00:00Z', '2026-08-23T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Lost core relation under a high-but-not-tip stamp, then DROP memories
+    // so COUNT(*) fails. `db::open` cannot be used for the refusal: SCHEMA
+    // would recreate `memories` via CREATE TABLE IF NOT EXISTS and turn
+    // the failed COUNT into Ok(0).
+    let raw = Connection::open(&path).unwrap();
+    raw.execute_batch(
+        "DROP TABLE IF EXISTS governance_rules;\n\
+         DROP TABLE IF EXISTS memories;\n\
+         DELETE FROM schema_version;\n\
+         INSERT INTO schema_version (version) VALUES (87);",
+    )
+    .unwrap();
+    assert_eq!(schema_version(&raw), 87, "precondition: stamp is 87");
+    assert!(
+        schema_integrity::corpus_row_count(&raw).is_err(),
+        "precondition: COUNT(*) must fail after DROP TABLE memories"
+    );
+    let missing = schema_integrity::missing_core_tables(&raw, 89).unwrap();
+    assert!(
+        missing
+            .iter()
+            .any(|t| t.name == schema_integrity::TABLE_GOVERNANCE_RULES),
+        "precondition: governance_rules must be missing"
+    );
+    drop(raw);
+
+    // SAFETY: this test binary contains exactly one test, so no concurrent
+    // test in this process can observe the mutation.
+    unsafe {
+        std::env::set_var(ai_memory::config::ENV_MIGRATION_REQUIRE_CORE_TABLES, "1");
+    }
+
+    let conn = Connection::open(&path).unwrap();
+    let target = db::migrations::current_schema_version_for_tests();
+    let err = run_gate_and_stamp(&conn, target)
+        .expect_err("enforced posture must refuse an unreadable corpus");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(schema_integrity::TABLE_GOVERNANCE_RULES),
+        "the refusal must name the missing relation: {msg}"
+    );
+    assert!(
+        msg.contains("UNCHANGED"),
+        "the refusal must state that the database was not mutated: {msg}"
+    );
+    drop(conn);
+
+    // THE load-bearing assertion. A refusal must not be a mutation:
+    let raw = Connection::open(&path).unwrap();
+    assert_eq!(
+        schema_version(&raw),
+        87,
+        "the stamp must NOT have advanced — that is the entire point of siting \
+         the gate before the stamp, inside the transaction"
+    );
+    assert!(
+        schema_integrity::corpus_row_count(&raw).is_err(),
+        "the gate must not recreate memories — it issues no DDL"
+    );
+    drop(raw);
+
+    // SAFETY: single-test binary, as above.
+    unsafe {
+        std::env::remove_var(ai_memory::config::ENV_MIGRATION_REQUIRE_CORE_TABLES);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3246.

Fable QC post-merge of #3114 (R-405 at `ae3e0aec`): `schema_integrity::corpus_row_count` coerced a failed `COUNT(*) FROM memories` to `None` via `.ok()`, and `refusal_required_with` refused only on `Some(n > 0)`. Under `AI_MEMORY_MIGRATION_REQUIRE_CORE_TABLES=1` (asi-hard pinned) a database with missing core relations AND an unreadable `memories` table stamped the tip with only a WARN.

`memories` ships in the bootstrap `SCHEMA` and is replayed by `db::open` before `migrate`, so `None` never means "fixture without a corpus" — it means the count FAILED (corruption / I/O / BUSY). `Some(0)` stays the documented no-brick empty-fixture path.

## Approach

- `corpus_row_count` returns `Result<i64>` (ERRORS-19 / #2445 sqlite_master precedent). `Ok(0)` is empty; `Err` is unreadability.
- `refusal_required` returns `Result<bool>`. Under enforcement a failed COUNT is a refusal (`Ok(true)` → `refusal_message`). Without enforcement it still propagates so the tail cannot stamp integrity as intact on a failed read.
- `refusal_required_with`: `Some(0)` is the sole no-brick observation; `None` and `Some(n > 0)` refuse under enforcement.
- `report()` still discards a failed COUNT for diagnostic colouring only (a WARN must not become an error).
- LOW rider: `config::migration_require_core_tables` now uses `governance::audit::env_flag_enabled`. Documented tokens (`1` / `true` / `yes` / `on`) are unchanged.

## Tests

- Unit: `corpus_row_count` is `Err` without `memories`; `Ok(0)` on an empty table; `None` refuses when enforced and does not at the pure predicate when unenforced; unenforced `refusal_required` propagates a failed COUNT with `UNCHANGED`.
- `tests/migration_core_relation_unreadable_corpus_3246.rs` (own binary, env isolation): force COUNT to fail under enforcement → refusal names the missing relation + `UNCHANGED`, stamp stays 87.
- Existing empty-corpus anti-brick (`migration_core_relation_empty_corpus_3113`) and populated-corpus refusal (`migration_core_relation_refusal_3113`) stay green.
- Table-driven 3113 contract now pins `None` as refuse-under-enforcement per relation.

## Rules

ERRORS-19 (never silently drop a `Result`), ERRORS-01/02 (`Result` + `?`), ERRORS-09 (unreadable ≠ empty), TEST-01/02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
