### PR TITLE
fix(curator): run SAL ConsolidationPass under spawn_blocking (#3244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (#3244 — SAL ConsolidationPass skipped under `spawn_blocking`)
+
+- **#3116's nested-runtime guard used `Handle::try_current()` as the panic
+  probe, which skipped the SAL `ConsolidationPass` on every production
+  cycle.** Quoted at `src/curator/mod.rs` (pre-fix):
+  `if tokio::runtime::Handle::try_current().is_ok() { report.errors.push("consolidation pass: skipped — … wrap the call in spawn_blocking …"); return; }`.
+  A tokio 1.52 `spawn_blocking` thread **has** a current Handle
+  (`runtime/blocking/pool.rs` calls `rt.enter()`) but does **not** call
+  `enter_runtime` — the only condition for "Cannot start a runtime from
+  within a runtime". `Runtime::block_on` inside `spawn_blocking` is
+  therefore legal (that is why the pre-#3116 daemon path worked). Both
+  production entrypoints already wrap the curator in `spawn_blocking`
+  (`daemon_runtime.rs` two sites + CLI `--once`) on a **multi-thread**
+  runtime, so with `compaction.enabled = true` every cycle pushed the
+  skip error and the pass never ran. The skip is now only the
+  current-thread Handle (`#[tokio::test]` default, where `block_in_place`
+  panics); production `spawn_blocking` drives via `block_in_place` + a
+  nested current-thread `block_on` (CONCURRENCY-22 / ERRORS-08). A
+  multi-thread `spawn_blocking` positive-control test asserts the pass
+  ran; the existing `#[tokio::test]` panic-avoidance skip is kept.
+
 ### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
 
 Two CLI paths diverged from the guard the MCP/HTTP reference surface already

--- a/src/curator/mod.rs
+++ b/src/curator/mod.rs
@@ -628,12 +628,17 @@ fn run_size_gc_pass(
 /// `clusters_formed`) for parity: autonomy's `clusters_formed` is already
 /// post-reserved-namespace-filter, which is what `eligible_clusters` measures.
 ///
-/// Sync↔async bridge: the curator daemon runs on a `spawn_blocking` OS thread
-/// (no ambient runtime), so a scoped current-thread runtime `block_on` is safe
-/// here — never call this from inside the async `serve` runtime. Best-effort:
-/// store/runtime/sweep errors land in `report.errors`, never aborting the
-/// cycle. In-memory (`:memory:`) connections have no path to re-open and are
-/// skipped. Decision provenance: 5-agent vote `4d3ea1c5` (#1746).
+/// Sync↔async bridge: the curator daemon and CLI `--once` both run
+/// `run_once` on a `spawn_blocking` thread. That thread HAS a tokio
+/// [`Handle`](tokio::runtime::Handle) (1.52 blocking pool `rt.enter()`)
+/// but is NOT driving the runtime (`enter_runtime`), so a nested
+/// current-thread `block_on` is legal — see [`tokio_current_thread_handle_present`]
+/// and #3244. A current-thread worker still degrades to a reported skip
+/// (ERRORS-08) instead of panicking. Best-effort: store/runtime/sweep
+/// errors land in `report.errors`, never aborting the cycle. In-memory
+/// (`:memory:`) connections have no path to re-open and are skipped.
+/// Decision provenance: 5-agent vote `4d3ea1c5` (#1746); skip-probe
+/// correction #3244.
 #[cfg(feature = "sal")]
 fn run_consolidation_pass(
     conn: &Connection,
@@ -645,21 +650,20 @@ fn run_consolidation_pass(
     if !cfg.compaction.enabled {
         return;
     }
-    // ERRORS-08 / CONCURRENCY-22 — the `rt.block_on` below PANICS
-    // ("Cannot start a runtime from within a runtime") when `run_once` is
-    // reached from a thread that already has an ambient tokio runtime. That
-    // contract used to be documentation-only on a `pub fn`, so an async
-    // caller crashed instead of getting a `Result`. Detect the in-runtime
-    // case and DEGRADE (skip this pass, surface the reason) rather than
-    // unwinding the caller: the corpus is untouched either way, but a
-    // reported skip is recoverable and a panic is not.
-    if tokio::runtime::Handle::try_current().is_ok() {
-        report.errors.push(
-            "consolidation pass: skipped — curator::run_once was called from inside an async \
-             runtime; wrap the call in tokio::task::spawn_blocking so the pass can drive its \
-             own runtime"
-                .to_string(),
-        );
+    // ERRORS-08 / CONCURRENCY-22 / #3244 — nested `Runtime::block_on`
+    // panics on a *current-thread* worker (`#[tokio::test]` default).
+    // `Handle::try_current()` is the wrong probe: a `spawn_blocking`
+    // thread also has a Handle (tokio 1.52 `rt.enter()`) and that is
+    // the production shape (daemon + CLI `--once`), so the #3116 guard
+    // skipped every `compaction.enabled` cycle. Skip only the
+    // current-thread Handle (where `block_in_place` itself panics);
+    // multi-thread (production) drives via `block_in_place` so a
+    // worker is parked rather than nested-block_on'd, and a
+    // `spawn_blocking` thread is a no-op then legal `block_on`.
+    if tokio_current_thread_handle_present() {
+        report
+            .errors
+            .push(CONSOLIDATION_PASS_SKIPPED_NESTED_RUNTIME.to_string());
         return;
     }
     let Some(path) = conn.path().map(std::path::PathBuf::from) else {
@@ -681,19 +685,20 @@ fn run_consolidation_pass(
     )
     // #1750 — thread the operator-resolved cosine gate into the clusterer.
     .with_cosine_threshold(cfg.compaction.cosine_threshold);
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => {
-            report
-                .errors
-                .push(format!("consolidation pass: runtime build failed: {e}"));
-            return;
-        }
+    let drive_pass = || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("consolidation pass: runtime build failed: {e}"))?;
+        rt.block_on(pass.run(candidates))
+            .map_err(|e| format!("consolidation pass: {e}"))
     };
-    match rt.block_on(pass.run(candidates)) {
+    // Current-thread Handle already skipped. Remaining cases (multi-thread
+    // worker, spawn_blocking, no runtime): `block_in_place` is a no-op
+    // when not entered and parks a multi-thread worker so nested block_on
+    // is legal. CONCURRENCY-22.
+    let outcome = tokio::task::block_in_place(drive_pass);
+    match outcome {
         Ok(out) => {
             // Fold the SAL consolidator's outcome into the autonomy report so
             // the self-report (keyed on AutonomyPassReport fields) is accurate
@@ -706,7 +711,41 @@ fn run_consolidation_pass(
             report.compaction_pass_rolled_back += out.rolled_back;
             report.errors.extend(out.errors);
         }
-        Err(e) => report.errors.push(format!("consolidation pass: {e}")),
+        Err(e) => report.errors.push(e),
+    }
+}
+
+/// Operator-visible skip when `run_once` is on a thread that is *driving*
+/// a tokio runtime (`enter_runtime`). `spawn_blocking` is NOT this case
+/// (#3244). Kept as one named const so the production skip and the
+/// `#[tokio::test]` assertion share a single spelling.
+#[cfg(feature = "sal")]
+const CONSOLIDATION_PASS_SKIPPED_NESTED_RUNTIME: &str = "consolidation pass: skipped — curator::run_once was called from inside an async \
+     runtime; wrap the call in tokio::task::spawn_blocking so the pass can drive its \
+     own runtime";
+
+/// True iff this thread currently holds a **current-thread** tokio Handle.
+///
+/// Tokio 1.52 `spawn_blocking` threads inherit the outer runtime's Handle
+/// via `rt.enter()` (so [`Handle::try_current`] is `Ok`) but are not
+/// driving (`enter_runtime`). Nested `Runtime::block_on` is legal there
+/// on a **multi-thread** runtime — the production daemon / CLI `--once`
+/// shape (#3244). A current-thread Handle is the `#[tokio::test]` default
+/// worker, where both nested `block_on` and `block_in_place` panic.
+/// Probing `enter_runtime` by building a nested runtime and
+/// `catch_unwind` is not viable: dropping that runtime on a worker
+/// panics a second time ("Cannot drop a runtime in a context where
+/// blocking is not allowed"). Fail closed (ERRORS-08): any non-multi-thread
+/// Handle is treated as would-panic.
+#[cfg(feature = "sal")]
+#[must_use]
+fn tokio_current_thread_handle_present() -> bool {
+    match tokio::runtime::Handle::try_current() {
+        Err(_) => false,
+        Ok(handle) => !matches!(
+            handle.runtime_flavor(),
+            tokio::runtime::RuntimeFlavor::MultiThread
+        ),
     }
 }
 
@@ -3334,5 +3373,83 @@ mod consolidation_pass_tests_1746 {
                 "a skipped pass must leave every source row intact"
             );
         }
+    }
+
+    /// #3244 — `Handle::try_current()` is true on a `spawn_blocking` thread
+    /// (tokio 1.52 blocking pool `rt.enter()`) even though that thread is
+    /// not driving the runtime. Both production entrypoints already wrap
+    /// `run_once` in `spawn_blocking` on a **multi-thread** runtime; this
+    /// positive control asserts the SAL pass RAN rather than skipped.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn consolidation_pass_runs_under_spawn_blocking() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = db::open(tmp.path()).unwrap();
+        let candidates = seed(&conn);
+        let cfg = CuratorConfig {
+            compaction: CompactionConfig {
+                enabled: true,
+                ..CompactionConfig::default()
+            },
+            ..CuratorConfig::default()
+        };
+        let llm = CountingStubLlm {
+            summarize_calls: Mutex::new(0),
+        };
+
+        let (report, llm) = tokio::task::spawn_blocking(move || {
+            let mut report = CuratorReport::new(false);
+            run_consolidation_pass(&conn, &candidates, &cfg, &llm, &mut report);
+            (report, llm)
+        })
+        .await
+        .expect("spawn_blocking join");
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .all(|e| !e.contains("inside an async runtime")),
+            "must not skip under spawn_blocking, got {:?}",
+            report.errors
+        );
+        assert!(
+            report.compaction_pass_clusters_eligible >= 1,
+            "the dup cluster should be eligible, report: {report:?}"
+        );
+        assert_eq!(
+            report.autonomy.memories_consolidated, 2,
+            "both sources folded into report.autonomy"
+        );
+        assert!(
+            *llm.summarize_calls.lock().unwrap() >= 1,
+            "the pass must invoke the LLM, not skip"
+        );
+    }
+
+    #[test]
+    fn tokio_current_thread_handle_absent_without_a_runtime() {
+        assert!(
+            !tokio_current_thread_handle_present(),
+            "a plain #[test] thread has no tokio Handle"
+        );
+    }
+
+    #[tokio::test]
+    async fn tokio_current_thread_handle_present_on_an_async_worker() {
+        assert!(
+            tokio_current_thread_handle_present(),
+            "#[tokio::test] default flavor is current-thread"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tokio_current_thread_handle_absent_under_spawn_blocking() {
+        let current_thread = tokio::task::spawn_blocking(tokio_current_thread_handle_present)
+            .await
+            .expect("spawn_blocking join");
+        assert!(
+            !current_thread,
+            "spawn_blocking on a multi-thread runtime inherits a MultiThread Handle"
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Closes #3244.** Fable QC post-merge of #3116: the SAL `ConsolidationPass` never ran in production because the nested-runtime panic probe treated `spawn_blocking` as the forbidden case.

R-405, quoted live pre-fix at `src/curator/mod.rs:656-663` (ae3e0aec):

```rust
if tokio::runtime::Handle::try_current().is_ok() {
    report.errors.push("consolidation pass: skipped — … wrap the call in spawn_blocking …");
    return;
}
```

Tokio 1.52 source: a `spawn_blocking` thread **has** a current Handle (`runtime/blocking/pool.rs:481` calls `rt.enter()`) but never calls `enter_runtime` (`context/runtime.rs:40-69`), which is the only condition for `"Cannot start a runtime from within a runtime"`. `Runtime::block_on` inside `spawn_blocking` is therefore legal — that is why the pre-#3116 daemon path worked.

Both production entrypoints already wrap the curator in `spawn_blocking` on a **multi-thread** runtime (`daemon_runtime.rs` two sites + CLI `--once`), so with `compaction.enabled = true` every cycle pushed the skip error telling the operator to do what they already did.

## Fix

Do **not** use `Handle::try_current()` as a sufficient panic probe.

- Skip only a **current-thread** Handle (`#[tokio::test]` default), where both nested `block_on` and `block_in_place` panic. Degrade-not-panic: reported skip, corpus untouched (ERRORS-08).
- Production `spawn_blocking` (multi-thread Handle) drives via `block_in_place` + a nested current-thread `block_on` (CONCURRENCY-22). `block_in_place` is a no-op on the blocking pool.
- Catch-unwind of a nested runtime is **not** a viable `enter_runtime` probe: dropping that runtime on a worker panics a second time (`Cannot drop a runtime in a context where blocking is not allowed`).

Residual (documented): `spawn_blocking` under a **current-thread** runtime still skips. Production `main.rs` builds `Builder::new_multi_thread()`; the CLI `--once` and both daemon sites ride that runtime.

## Tests

Kept:

- `consolidation_pass_degrades_instead_of_panicking_inside_a_runtime` (`#[tokio::test]` default current-thread) — still skips, still does not panic.

Added:

- `consolidation_pass_runs_under_spawn_blocking` (`#[tokio::test(flavor = "multi_thread")]`) — **positive control**: pass RAN (eligible ≥ 1, 2 sources folded, LLM invoked, no skip error).
- `tokio_current_thread_handle_absent_without_a_runtime`
- `tokio_current_thread_handle_present_on_an_async_worker`
- `tokio_current_thread_handle_absent_under_spawn_blocking`

8/8 `consolidation_pass_tests_1746` passed.

## CI-parity (local, 1.96.0, umask 022)

All in one `build-gate.sh` admission:

- `cargo fmt --all --check`
- `cargo check --all-targets` / `--features sal` / `--features sal-postgres` / `--examples`
- Five clippy legs, all `-D warnings -D clippy::all -D clippy::pedantic`: default; `--all-targets --features sal`; `--features sal-postgres --tests`; `--features sal`; `--all-targets --features vectorlite`
- `cargo test --features sal --lib consolidation_pass_tests_1746` — 8 passed
- `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling`
- `scripts/check-hardcoded-literals.sh` + `scripts/check-docs-vs-ssot.sh`

Log: `/home/fate_two/v07/v09-dev/.local-runs/wt-3244-consolid-skip-gates2.log`

Pg: no `src/store/postgres.rs` / schema / handler changes. Live pg not run.

## Decision

Hop-always via `std::thread::scope` was considered (issue's first option) but needs `dyn AutonomyLlm + Sync` to send `&llm` across the thread. Flavor-split matches production (multi-thread + `spawn_blocking`) without widening the LLM trait object. Catch-unwind was tried and **falsified** (double-panic on runtime Drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
