### PR TITLE
fix(postgres): atomic namespace_meta sever inside PostgresStore::delete tx (#3245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ probe (citing #2445) but kept it for the corpus probe.
   hook evaluation. Both process-global registries are now `tokio::sync::Mutex`;
   the guard is acquired with `.lock().await` inside the already-bridged future.
   Fail-closed bridge-budget behaviour is unchanged.
+### Fixed (pg delete atomicity — `namespace_meta` sever inside the delete tx; #3245)
+
+- **`PostgresStore::delete` severs `namespace_meta` inside the same
+  transaction as the tombstone leaf + row DELETE.** The sqlite twin
+  (`storage::delete` / `delete_inner`, #3115) already ran SEVER + TOMBSTONE +
+  DELETE under one `BEGIN IMMEDIATE`. Postgres ran
+  `SQL_SEVER_NAMESPACE_META_BY_STANDARD_ID` pool-direct on `&self.pool`
+  *before* `begin()`, so a failing (or rolled-back) delete left the
+  governance binding severed with the memory still live — an unrecoverable
+  policy downgrade from a delete that never happened. Flag-OFF was two
+  autocommit statements with the same window. One tx now covers all three
+  writes on both flag states. Regression:
+  `pg_delete_failure_leaves_namespace_meta_intact_3245`.
+- **NotFound is decided before `tx.commit()`.** A 0-row DELETE used to
+  commit the sever (and flag-ON tombstone leaf) then return `NotFound`.
+  Dropping the tx rolls back. Regression:
+  `pg_delete_unknown_id_does_not_commit_sever_or_tombstone_3245`.
 
 ### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -19523,80 +19523,73 @@ impl MemoryStore for PostgresStore {
         self.assert_caller_owns_for_mutation(ctx, id, "delete", REASON_UNSTAMPED_TENANT_DELETE)
             .await?;
 
-        // #1642 / #2503 — parity with sqlite `storage::delete`: if this memory
-        // is registered as a namespace standard, SEVER the `namespace_meta`
-        // binding(s) pointing at it BEFORE deleting the memory, mirroring the
-        // sqlite ordering. Pre-#1642 the postgres delete left a dangling
-        // `standard_id`; pre-#2503 both backends DELETED the binding rows,
-        // destroying the governance configuration (and `parent_namespace`
-        // inheritance link) of every namespace that pointed here — including
-        // namespaces the deleting principal has no authority over.
+        // #1642 / #2503 / #3245 — SEVER `namespace_meta` bindings pointing
+        // here BEFORE the row DELETE, matching sqlite `storage::delete`
+        // (`delete_inner`: sever, optional TOMBSTONE leaf, DELETE). Pre-#1642
+        // postgres left a dangling `standard_id`; pre-#2503 both backends
+        // DELETED the binding rows (destroying `parent_namespace` inheritance
+        // of namespaces the deleting principal has no authority over).
+        // Pre-#3245 the sever ran pool-direct on `&self.pool` BEFORE
+        // `begin()`, so a failing delete committed an unrecoverable policy
+        // downgrade while the memory stayed live; flag-OFF was two autocommit
+        // statements with the same window. One tx now covers sever + leaf +
+        // delete: either the memory is gone WITH its sever (and leaf), or
+        // nothing changed.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| to_store_err("delete begin tx", e))?;
         sqlx::query(SQL_SEVER_NAMESPACE_META_BY_STANDARD_ID)
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| to_store_err("delete: namespace_meta sever", e))?;
 
-        // APPEND-ONLY-SANCTIONED (#1823 G6) — capture-then-compact TOMBSTONE:
-        // under the flag, run the leaf + the memory delete in ONE tx so they
-        // commit atomically. Flag-OFF falls through to the byte-identical
-        // pool-direct delete below.
-        if crate::config::append_only_enabled() {
-            let mut tx = self
-                .pool
-                .begin()
-                .await
-                .map_err(|e| to_store_err("delete begin tx", e))?;
-            if let Some((ns, ver)) = sqlx::query_as::<_, (String, i64)>(SQL_SELECT_NS_VERSION_BY_ID)
+        // APPEND-ONLY-SANCTIONED (#1823 G6) — capture-then-compact TOMBSTONE
+        // leaf in THIS tx, before the delete. Flag-OFF skips the leaf and
+        // still runs the delete in the same tx (not a second autocommit).
+        if crate::config::append_only_enabled()
+            && let Some((ns, ver)) = sqlx::query_as::<_, (String, i64)>(SQL_SELECT_NS_VERSION_BY_ID)
                 .bind(id)
                 .fetch_optional(&mut *tx)
                 .await
                 .map_err(|e| to_store_err("delete read row for tombstone leaf", e))?
-            {
-                pg_emit_revision_leaf_if_enabled(
-                    &mut tx,
-                    id,
-                    crate::revisions::RecordKind::Tombstone,
-                    Some(ver),
-                    &ns,
-                    None,
-                    &chrono::Utc::now().to_rfc3339(),
-                )
-                .await
-                .map_err(|e| to_store_err("append tombstone revision leaf", e))?;
-            }
-            let rows = sqlx::query(SQL_DELETE_MEMORY_BY_ID)
-                .bind(id)
-                .execute(&mut *tx)
-                .await
-                .map_err(|e| to_store_err("delete", e))?
-                .rows_affected();
-            tx.commit()
-                .await
-                .map_err(|e| to_store_err("delete commit tx", e))?;
-            if rows == 0 {
-                return Err(StoreError::NotFound { id: id.to_string() });
-            }
-            self.unproject_memory_ids_best_effort(&[id]).await;
-            return Ok(());
+        {
+            pg_emit_revision_leaf_if_enabled(
+                &mut tx,
+                id,
+                crate::revisions::RecordKind::Tombstone,
+                Some(ver),
+                &ns,
+                None,
+                &chrono::Utc::now().to_rfc3339(),
+            )
+            .await
+            .map_err(|e| to_store_err("append tombstone revision leaf", e))?;
         }
-
-        let rows_affected = sqlx::query(SQL_DELETE_MEMORY_BY_ID)
+        let rows = sqlx::query(SQL_DELETE_MEMORY_BY_ID)
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| to_store_err("delete", e))?
             .rows_affected();
-        if rows_affected == 0 {
-            Err(StoreError::NotFound { id: id.to_string() })
-        } else {
-            // #1783 — the relational row + its cascade-deleted memory_links
-            // are gone; remove the now-orphaned AGE :Memory node + edges so
-            // kg_query/find_paths don't return ghost edges. Best-effort,
-            // own-tx (this path is pool-direct, no surrounding tx).
-            self.unproject_memory_ids_best_effort(&[id]).await;
-            Ok(())
+        // #3245 Fable gate — a 0-row DELETE is NotFound. Commit-then-NotFound
+        // would land the namespace_meta sever (and any flag-ON tombstone leaf)
+        // for a row that was never deleted. Dropping `tx` rolls back. Mirrors
+        // sqlite `delete_inner`. ERRORS-09 / fail-closed.
+        if rows == 0 {
+            return Err(StoreError::NotFound { id: id.to_string() });
         }
+        tx.commit()
+            .await
+            .map_err(|e| to_store_err("delete commit tx", e))?;
+        // #1783 — the relational row + its cascade-deleted memory_links
+        // are gone; remove the now-orphaned AGE :Memory node + edges so
+        // kg_query/find_paths don't return ghost edges. Best-effort,
+        // own-tx (after the delete tx commits).
+        self.unproject_memory_ids_best_effort(&[id]).await;
+        Ok(())
     }
 
     async fn list(&self, ctx: &CallerContext, filter: &Filter) -> StoreResult<Vec<Memory>> {

--- a/tests/pg_delete_namespace_meta_atomicity_3245.rs
+++ b/tests/pg_delete_namespace_meta_atomicity_3245.rs
@@ -1,0 +1,258 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3245 — `PostgresStore::delete` must roll the `namespace_meta` SEVER
+//! back with a failed row DELETE (sqlite twin:
+//! `delete_rolls_the_namespace_standard_sever_back_with_the_row` in
+//! `tests/parity_write_funnels.rs`).
+//!
+//! Pre-fix the sever ran pool-direct on `&self.pool` BEFORE `begin()`, so a
+//! failing delete left the governance binding severed with the memory still
+//! live. A `BEFORE DELETE` trigger injects the failure after the sever
+//! (same shape as the sqlite test).
+//!
+//! `#[ignore]` + `sal-postgres`. Run against the scratch PG:
+//! ```text
+//! AI_MEMORY_TEST_POSTGRES_URL=postgres://… \
+//!   cargo test --features sal,sal-postgres \
+//!     --test pg_delete_namespace_meta_atomicity_3245 \
+//!     -- --include-ignored --nocapture
+//! ```
+
+#![cfg(feature = "sal-postgres")]
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::too_many_lines,
+    clippy::doc_markdown
+)]
+
+use ai_memory::models::{Memory, Tier};
+use ai_memory::store::postgres::PostgresStore;
+use ai_memory::store::{CallerContext, MemoryStore};
+
+async fn live_pg() -> Option<PostgresStore> {
+    let url = std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()?;
+    match PostgresStore::connect(&url).await {
+        Ok(s) => Some(s),
+        Err(e) => {
+            eprintln!("skip: PostgresStore::connect failed: {e}");
+            None
+        }
+    }
+}
+
+fn sample_memory(id: &str, namespace: &str, owner: &str) -> Memory {
+    Memory {
+        id: id.to_string(),
+        tier: Tier::Long,
+        namespace: namespace.to_string(),
+        title: format!("title-{id}"),
+        content: "3245 pg delete atomicity".to_string(),
+        tags: vec![],
+        priority: 5,
+        confidence: 1.0,
+        source: "test".to_string(),
+        access_count: 0,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        last_accessed_at: None,
+        expires_at: None,
+        metadata: serde_json::json!({ "agent_id": owner }),
+        version: 1,
+        ..Memory::default()
+    }
+}
+
+/// Identifier-safe suffix (hex only) for a per-run trigger / function name
+/// so this test cannot collide with a sibling on the shared scratch PG.
+fn ident_suffix(unique: uuid::Uuid) -> String {
+    unique.simple().to_string()
+}
+
+#[tokio::test]
+#[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL (live postgres); run with --include-ignored"]
+async fn pg_delete_failure_leaves_namespace_meta_intact_3245() {
+    let Some(store) = live_pg().await else {
+        eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+        return;
+    };
+    let unique = uuid::Uuid::new_v4();
+    let suffix = ident_suffix(unique);
+    let owner = format!("ai:3245-{suffix}");
+    let ctx = CallerContext::for_agent(owner.clone());
+    let ns = format!("fix-3245-{suffix}");
+    let fn_name = format!("ai_memory_3245_block_del_{suffix}");
+    let trig_name = format!("ai_memory_3245_trig_{suffix}");
+    let pool = store.pool();
+
+    let std_mem = sample_memory(&format!("mem-3245-{suffix}"), &ns, &owner);
+    let std_id = store.store(&ctx, &std_mem).await.expect("store standard");
+    store
+        .set_namespace_standard(&ctx, &ns, &std_id, None)
+        .await
+        .expect("set namespace standard");
+    let pre = store
+        .get_namespace_standard(&ctx, &ns)
+        .await
+        .expect("get standard pre-delete");
+    assert_eq!(
+        pre.as_ref().map(|(sid, _)| sid.as_str()),
+        Some(std_id.as_str()),
+        "standard must resolve before the injected failure"
+    );
+
+    // Drop any leftover from a previous killed run of this unique name,
+    // then install a BEFORE DELETE trigger that aborts only this id.
+    let drop_trig = format!("DROP TRIGGER IF EXISTS {trig_name} ON memories");
+    let drop_fn = format!("DROP FUNCTION IF EXISTS {fn_name}()");
+    sqlx::query(&drop_trig)
+        .execute(pool)
+        .await
+        .expect("drop leftover trigger");
+    sqlx::query(&drop_fn)
+        .execute(pool)
+        .await
+        .expect("drop leftover function");
+
+    let create_fn = format!(
+        "CREATE FUNCTION {fn_name}() RETURNS trigger \
+         LANGUAGE plpgsql AS $fn$ \
+         BEGIN \
+           RAISE EXCEPTION 'parity-injected delete failure'; \
+         END; \
+         $fn$;"
+    );
+    sqlx::query(&create_fn)
+        .execute(pool)
+        .await
+        .expect("create abort function");
+    let create_trig = format!(
+        "CREATE TRIGGER {trig_name} \
+         BEFORE DELETE ON memories \
+         FOR EACH ROW \
+         WHEN (OLD.id = '{std_id}') \
+         EXECUTE FUNCTION {fn_name}()"
+    );
+    sqlx::query(&create_trig)
+        .execute(pool)
+        .await
+        .expect("create abort trigger");
+
+    let err = store
+        .delete(&ctx, &std_id)
+        .await
+        .expect_err("the delete must fail");
+    assert!(
+        err.to_string().contains("parity-injected"),
+        "expected the injected abort, got: {err}"
+    );
+
+    let bound: Option<String> =
+        sqlx::query_scalar("SELECT standard_id FROM namespace_meta WHERE namespace = $1")
+            .bind(&ns)
+            .fetch_one(pool)
+            .await
+            .expect("read binding");
+    assert_eq!(
+        bound.as_deref(),
+        Some(std_id.as_str()),
+        "#3245: the namespace-standard SEVER must roll back with the failed \
+         DELETE. Pre-fix the sever ran as its OWN autocommit statement, so \
+         it COMMITTED and the namespace lost its governance binding while \
+         the memory stayed live — an unrecoverable policy downgrade from a \
+         delete that never happened"
+    );
+    let still_live = store.get(&ctx, &std_id).await;
+    assert!(
+        still_live.is_ok(),
+        "the memory row must still be live after the rolled-back delete; \
+         got {still_live:?}"
+    );
+
+    // Best-effort cleanup: drop the injector first so a later delete can
+    // succeed, then remove the test rows.
+    let _ = sqlx::query(&drop_trig).execute(pool).await;
+    let _ = sqlx::query(&drop_fn).execute(pool).await;
+    let _ = store.delete(&ctx, &std_id).await;
+    let _ = sqlx::query("DELETE FROM namespace_meta WHERE namespace = $1")
+        .bind(&ns)
+        .execute(pool)
+        .await;
+}
+
+/// Fable gate #3255 item 1 — deleting an unknown id must return `NotFound`
+/// WITHOUT committing the namespace_meta sever (or any tombstone leaf).
+/// Admin `bypass_visibility` is required so the caller-owns pre-check does
+/// not NotFound before `begin()`; that is the arm that used to commit.
+#[tokio::test]
+#[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL (live postgres); run with --include-ignored"]
+async fn pg_delete_unknown_id_does_not_commit_sever_or_tombstone_3245() {
+    let Some(store) = live_pg().await else {
+        eprintln!("skip: AI_MEMORY_TEST_POSTGRES_URL not set");
+        return;
+    };
+    let unique = uuid::Uuid::new_v4();
+    let suffix = ident_suffix(unique);
+    let ns = format!("fix-3245-nf-{suffix}");
+    let ghost_id = format!("ghost-3245-{suffix}");
+    let pool = store.pool();
+    let admin = CallerContext::for_admin("operator:3245-notfound");
+
+    sqlx::query(
+        "INSERT INTO namespace_meta (namespace, standard_id, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (namespace) DO UPDATE SET standard_id = EXCLUDED.standard_id",
+    )
+    .bind(&ns)
+    .bind(&ghost_id)
+    .execute(pool)
+    .await
+    .expect("seed namespace_meta bound to a never-stored id");
+
+    let tombs_before: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM forget_tombstones WHERE memory_id = $1")
+            .bind(&ghost_id)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+
+    let err = store
+        .delete(&admin, &ghost_id)
+        .await
+        .expect_err("unknown id must be NotFound");
+    match err {
+        ai_memory::store::StoreError::NotFound { id } => {
+            assert_eq!(id, ghost_id);
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+
+    let bound: Option<String> =
+        sqlx::query_scalar("SELECT standard_id FROM namespace_meta WHERE namespace = $1")
+            .bind(&ns)
+            .fetch_one(pool)
+            .await
+            .expect("read binding");
+    assert_eq!(
+        bound.as_deref(),
+        Some(ghost_id.as_str()),
+        "NotFound must roll back the namespace_meta sever; a delete that \
+         never happened must not downgrade governance"
+    );
+
+    let tombs_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM forget_tombstones WHERE memory_id = $1")
+            .bind(&ghost_id)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
+    assert_eq!(
+        tombs_after, tombs_before,
+        "NotFound must not insert a forget_tombstones row for a missing id"
+    );
+
+    let _ = sqlx::query("DELETE FROM namespace_meta WHERE namespace = $1")
+        .bind(&ns)
+        .execute(pool)
+        .await;
+}


### PR DESCRIPTION
Closes #3245.

Fable QC post-merge of #3115 (R-405 at `ae3e0aec`): `PostgresStore::delete` severs `namespace_meta` pool-direct **outside** the delete tx. Sqlite was already atomic (`storage::delete` / `delete_inner`, `BEGIN IMMEDIATE` + sever + tombstone + delete). Postgres was not.

## Confirmed defect (quoted live code)

Pre-fix `src/store/postgres.rs` (tip of `release/v1.0.0` at `85b4d0e4`):

```
sqlx::query(SQL_SEVER_NAMESPACE_META_BY_STANDARD_ID)
    .bind(id)
    .execute(&self.pool)   // BEFORE begin()
```

The tx covered only the TOMBSTONE leaf + row DELETE. A failing delete left the governance binding severed with the memory **still live** — an unrecoverable policy downgrade from a delete that never happened. Flag-OFF was two autocommit statements with the same window.

## Fix

One transaction now covers **sever + optional TOMBSTONE leaf + DELETE** on both flag states, matching sqlite `delete_inner` order:

1. `begin()`
2. `SQL_SEVER_NAMESPACE_META_BY_STANDARD_ID` on `&mut *tx`
3. flag-ON: identity-only TOMBSTONE leaf in the same tx
4. `SQL_DELETE_MEMORY_BY_ID` on `&mut *tx`
5. `commit()` — AGE unproject remains best-effort **after** commit (#1783)

Flag-OFF skips the leaf and still runs the delete in the same tx (not a second autocommit). A `?` after `begin()` drops the `Transaction` and sqlx rolls it back (CONCURRENCY-23).

Hunks are confined to `PostgresStore::delete` so a later rebase onto #3252 (`fix/3185-3127-pg-search-ssot`) is mechanical.

**Residual (out of scope, not this PR):** `apply_remote_deletion` still severs pool-direct before its own `begin()`. Same class, different funnel; not touched so this diff stays disjoint from #3252.

## Tests

- `pg_delete_failure_leaves_namespace_meta_intact_3245` — live-PG, `#[ignore]`. Installs a per-id `BEFORE DELETE` trigger (`RAISE EXCEPTION 'parity-injected delete failure'`), calls `PostgresStore::delete`, asserts the error contains `parity-injected`, `namespace_meta.standard_id` is still the original id, and `get` still returns the row. Sqlite twin: `delete_rolls_the_namespace_standard_sever_back_with_the_row` (still green).
- Ran on scratch PG `:5445` (`AI_MEMORY_TEST_POSTGRES_URL` from `SCRATCH-PG-3133-URL.txt`). **Never** `AI_MEMORY_ALLOW_SCHEMA_AHEAD`. Never production DATABASE.

```
test pg_delete_failure_leaves_namespace_meta_intact_3245 ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
```

## QUAL-10

`src/store/postgres.rs` measured **35180**, ceiling **35200** (no bump). Do **not** copy 35150 from #3252 — that commit is not on this tree. Headroom 20. `qual_10_module_size_ceiling` + `qual_6_7_legacy_error_type_ceiling` green.

## rust-1.98

- **ERRORS-01 / ERRORS-02 / ERRORS-19** — `Result` + `?`; no silently dropped `Result`; tx errors surface via `to_store_err`.
- **CONCURRENCY-04** — sever + leaf + delete acquire/commit in one global order; no stranded intermediate write.
- **CONCURRENCY-23** — dropping the uncommitted `Transaction` on `?` rolls back (cancellation / error safety).
- **OWNERSHIP-05** — borrow `&mut *tx` for the three writes; do not clone the pool handle.

## CI-parity (local, one build-gate admission)

- `cargo fmt --all --check`
- `cargo check --all-targets` (default / `sal` / `sal-postgres`) + `cargo check --examples`
- clippy `-D warnings -D clippy::all -D clippy::pedantic`: `--all-targets` default / `sal` / `sal-postgres` / `vectorlite`; plus CI-exact `clippy`, `clippy --features sal`, `clippy --features sal-postgres --tests`
- `qual_10_module_size_ceiling`, `qual_6_7_legacy_error_type_ceiling`
- sqlite twin + live-pg #3245 test
- `scripts/check-hardcoded-literals.sh`, `scripts/check-docs-vs-ssot.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
