### PR TITLE
fix(recall): HTTP postgres must not double-write the access ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (HTTP postgres double-counted the access ledger)
+
+- **HTTP postgres recall no longer writes the `recall_observations` ledger twice.**
+  `#3180` (landed via the `#3240` SAL-parity cluster) made
+  `PostgresStore::recall_hybrid` append one observation per returned row —
+  the sqlite SAL twin, required so a pg-backed fleet's lifecycle is not
+  frozen. The HTTP handler still recorded the POST-form4 / kinds / rerank
+  set under a *second* `recall_id`. Every HTTP pg recall therefore folded
+  2× (the `#3266` access-fold echo amplifier); the Certified pg+AGE
+  purity pin `postgres_recall_purity_sal_and_http_entry_paths` saw 300
+  ledger rows against an expected 100 (10 SAL + 10 HTTP×2). HTTP now sets
+  `Filter.skip_access_ledger` and remains the single writer for the
+  filtered set / response `recall_id`. Direct SAL callers still append
+  once. Pin: `recall_hybrid_skip_access_ledger_writes_nothing`.
+
 ### Documentation (2026-08-26)
 
 - **Learn ai-memory** section on the docs site (`docs/learn/`): a hub plus three

--- a/src/handlers/hook_subscribers.rs
+++ b/src/handlers/hook_subscribers.rs
@@ -1359,6 +1359,8 @@ pub async fn session_start(
             metadata_eq: None,
             // #3185/#3127 — keyword-search-only axis; list ignores it.
             source_uri: None,
+            // Recall-hybrid only; list ignores it (default false).
+            skip_access_ledger: false,
         };
         let ctx = crate::store::CallerContext::for_agent(&caller);
         return match app.store.list(&ctx, &filter).await {

--- a/src/handlers/memories_query.rs
+++ b/src/handlers/memories_query.rs
@@ -168,6 +168,8 @@ pub async fn list_memories(
             metadata_eq: None,
             // #3185/#3127 — keyword-search-only axis; list ignores it.
             source_uri: None,
+            // Recall-hybrid only; list ignores it (default false).
+            skip_access_ledger: false,
         };
         let ctx = crate::store::CallerContext::for_agent(&caller);
         return match app.store.list(&ctx, &filter).await {
@@ -394,6 +396,8 @@ pub async fn search_memories(
             // #3185/#3127 — compose `q + source_uri + since` lands on
             // the keyword-search SSOT. None = no URI narrowing.
             source_uri: source_uri.map(str::to_string),
+            // Recall-hybrid only; search ignores it (default false).
+            skip_access_ledger: false,
         };
         // #942 SECURITY-high (Track A QC sweep, 2026-05-20) — replace
         // the hardcoded `"ai:http"` principal with the header-resolved

--- a/src/handlers/power_consolidation.rs
+++ b/src/handlers/power_consolidation.rs
@@ -1119,6 +1119,8 @@ pub async fn load_family_handler(
             metadata_eq: Some(family_eq.clone()),
             // #3185/#3127 — keyword-search-only axis; list ignores it.
             source_uri: None,
+            // Recall-hybrid only; list ignores it (default false).
+            skip_access_ledger: false,
         };
         // QC P1 fix (2026-05-20): load_family lists every memory in
         // the namespace tagged with a `family` metadata field. With

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -505,6 +505,13 @@ async fn recall_response(
         // (RFC3339 shape validated at the entry handlers). Stored as the raw
         // RFC3339 string; the SAL recall/list SQL binds it directly.
         filter.valid_at = valid_at.map(str::to_string);
+        // This handler records the POST-form4 / kinds / rerank set under
+        // the `recall_id` echoed in the response (touch ops fire on the
+        // FILTERED set — comment at apply_form4 below). Without the skip,
+        // `PostgresStore::recall_hybrid` (#3180) also appended the
+        // PRE-filter set under a different recall_id, so every HTTP pg
+        // recall folded 2× — the #3266 access-fold echo amplifier.
+        filter.skip_access_ledger = true;
         return match app
             .store
             .recall_hybrid(&ctx_caller, context, query_emb.as_deref(), &filter)
@@ -792,11 +799,12 @@ async fn recall_response(
     };
 
     // #1710 — populate the recall_observations ledger on the sqlite
-    // HTTP recall branch too (the postgres branch already does via the
-    // SAL trait, #1705; the MCP path does via the free-fn). Closes the
-    // §2.5 audit-parity gap: a sqlite-backed daemon answering recall
-    // over HTTP never logged the recall. The recall_id is echoed in the
-    // response so a caller can cite it on a later memory_store / link.
+    // HTTP recall branch too (the postgres branch records in the
+    // handler after skip_access_ledger, #1705/#3180; the MCP path
+    // does via the free-fn). Closes the §2.5 audit-parity gap: a
+    // sqlite-backed daemon answering recall over HTTP never logged
+    // the recall. The recall_id is echoed in the response so a
+    // caller can cite it on a later memory_store / link.
     //
     // DEADLOCK GUARD: routing this through `app.store.record_recall_observation`
     // would re-acquire `self.state.lock()` WHILE the recall DB lock below

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -949,6 +949,22 @@ pub struct Filter {
     /// filter. Empty string is treated as `None` by the HTTP parser
     /// before it reaches this field.
     pub source_uri: Option<String>,
+    /// v1.0.0 — skip the `recall_hybrid` access-ledger append.
+    ///
+    /// Default `false` (`#[derive(Default)]`): SAL / MCP / CLI callers
+    /// that invoke `recall_hybrid` directly still get one observation
+    /// per returned row (#3180 postgres twin of the sqlite SAL append).
+    /// Set `true` ONLY when the caller will record the POST-filter set
+    /// itself — the HTTP postgres handler applies form-4 / kinds /
+    /// rerank / session-recency AFTER `recall_hybrid` returns, then
+    /// writes the ledger under the `recall_id` echoed in the response.
+    /// Without this flag, HTTP postgres double-counted every hit
+    /// (SAL append + handler append, two `recall_id`s) and the access
+    /// fold amplified recall 2× — the #3266 echo-amplifier class.
+    /// Honoured by `recall_hybrid` on both adapters. Ignored by `list`
+    /// / `search`. Existing `..Default::default()` call sites are
+    /// byte-identical.
+    pub skip_access_ledger: bool,
 }
 
 /// The core trait. Every backend implements this; ai-memory's HTTP /

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -23336,37 +23336,45 @@ impl MemoryStore for PostgresStore {
         // downstream signal could not be recorded would trade a working read
         // for a bookkeeping row. The discard is explicit, never a dropped
         // `Result` (ERRORS-19).
-        let candidates: Vec<(String, String, i64, f64)> = results
-            .iter()
-            .enumerate()
-            .map(|(i, (m, score))| {
-                (
-                    m.id.clone(),
-                    if query_embedding.is_some() {
-                        "hybrid"
-                    } else {
-                        "keyword"
-                    }
-                    .to_string(),
-                    i64::try_from(i + 1).unwrap_or(i64::MAX),
-                    *score,
-                )
-            })
-            .collect();
-        if !candidates.is_empty() {
-            let recall_id = uuid::Uuid::new_v4().to_string();
-            if let Err(e) = self
-                .recall_observation_insert(
-                    &recall_id,
-                    &candidates,
-                    Some(ctx.effective_principal()),
-                    filter.namespace.as_deref(),
-                )
-                .await
-            {
-                tracing::warn!(
-                    "recall_hybrid (SAL-postgres): ledger append failed (non-fatal): {e}"
-                );
+        //
+        // `skip_access_ledger`: HTTP postgres sets this so the handler, not
+        // this method, is the single writer — it records the POST-form4 /
+        // kinds / rerank set under the `recall_id` the response echoes.
+        // Recording here AND in the handler double-counted every HTTP hit
+        // (two recall_ids) and the access fold amplified recall 2×.
+        if !filter.skip_access_ledger {
+            let candidates: Vec<(String, String, i64, f64)> = results
+                .iter()
+                .enumerate()
+                .map(|(i, (m, score))| {
+                    (
+                        m.id.clone(),
+                        if query_embedding.is_some() {
+                            "hybrid"
+                        } else {
+                            "keyword"
+                        }
+                        .to_string(),
+                        i64::try_from(i + 1).unwrap_or(i64::MAX),
+                        *score,
+                    )
+                })
+                .collect();
+            if !candidates.is_empty() {
+                let recall_id = uuid::Uuid::new_v4().to_string();
+                if let Err(e) = self
+                    .recall_observation_insert(
+                        &recall_id,
+                        &candidates,
+                        Some(ctx.effective_principal()),
+                        filter.namespace.as_deref(),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        "recall_hybrid (SAL-postgres): ledger append failed (non-fatal): {e}"
+                    );
+                }
             }
         }
         Ok(results)

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1339,7 +1339,10 @@ impl MemoryStore for SqliteStore {
         // RETURNED set, mirroring the MCP/HTTP/CLI writers; rows are
         // stamped pre-folded under the sync legacy flag via the shared
         // insert-layer stamp. A ledger error never blocks the recall.
-        if crate::observations::table_exists(&conn) {
+        // `skip_access_ledger`: caller will record the post-filter set
+        // itself (HTTP postgres is the production user; sqlite HTTP
+        // still goes through `db::` and records in the handler).
+        if !filter.skip_access_ledger && crate::observations::table_exists(&conn) {
             let recall_id = uuid::Uuid::new_v4().to_string();
             let mode = if query_embedding.is_some() {
                 "hybrid"
@@ -4384,6 +4387,61 @@ mod tests {
             "recall_hybrid keyword fallback returned nothing"
         );
         assert!(hits[0].1 > 0.0, "score must be positive");
+    }
+
+    #[tokio::test]
+    async fn recall_hybrid_skip_access_ledger_writes_nothing() {
+        let store = fresh_store();
+        let ctx = CallerContext::for_agent("alice");
+        let mem = test_memory(
+            "skip-ledger-target",
+            "indigo elephant chess fts5 token skip ledger",
+        );
+        store.store(&ctx, &mem).await.expect("store");
+        let recorded = store
+            .recall_hybrid(
+                &ctx,
+                "elephant",
+                None,
+                &Filter {
+                    limit: 10,
+                    ..Filter::default()
+                },
+            )
+            .await
+            .expect("default recall records the ledger");
+        assert!(!recorded.is_empty(), "default recall must hit the row");
+        let after_default = store
+            .list_recall_observations(None, None, None, None, 100)
+            .await
+            .expect("list after default");
+        assert_eq!(
+            after_default.len(),
+            recorded.len(),
+            "default recall_hybrid writes one observation per returned row"
+        );
+        store
+            .recall_hybrid(
+                &ctx,
+                "elephant",
+                None,
+                &Filter {
+                    limit: 10,
+                    skip_access_ledger: true,
+                    ..Filter::default()
+                },
+            )
+            .await
+            .expect("skipped recall");
+        let after_skip = store
+            .list_recall_observations(None, None, None, None, 100)
+            .await
+            .expect("list after skip");
+        assert_eq!(
+            after_skip.len(),
+            after_default.len(),
+            "skip_access_ledger must not append a second observation set"
+        );
     }
 
     #[tokio::test]

--- a/tests/recall_purity_p01_postgres.rs
+++ b/tests/recall_purity_p01_postgres.rs
@@ -191,6 +191,8 @@ async fn postgres_recall_purity_sal_and_http_entry_paths() {
     let mut expected_growth: i64 = 0;
 
     // ---- SAL entry path (recall_hybrid) — pure read on postgres. ----
+    // #3180: SAL postgres now appends the access ledger (sqlite parity);
+    // count those rows so the growth pin below is exact.
     let ctx = CallerContext::for_agent("ai:test:p01");
     let filter = Filter {
         namespace: Some(ns.to_string()),
@@ -205,6 +207,7 @@ async fn postgres_recall_purity_sal_and_http_entry_paths() {
             .expect("sal recall_hybrid");
         assert!(!rows.is_empty(), "SAL recall must return the corpus");
         let got: Vec<String> = rows.iter().map(|(m, _)| m.id.clone()).collect();
+        expected_growth += i64::try_from(got.len()).expect("SAL row count fits i64");
         match &first_ids {
             None => first_ids = Some(got),
             Some(prev) => assert_eq!(prev, &got, "SAL result set drifted"),
@@ -309,9 +312,11 @@ async fn postgres_recall_purity_sal_and_http_entry_paths() {
         pre_dump, post_dump,
         "PURITY VIOLATION (postgres): recall mutated a table other than recall_observations"
     );
-    // (c) Ledger grew by exactly the HTTP returned-row total (the SAL
-    // trait recall itself does not append on postgres — the handler
-    // does), every row unfolded in the pure default.
+    // (c) Ledger grew by exactly the SAL returned-row total (#3180
+    // append) plus the HTTP returned-row total (handler records the
+    // post-filter set once; skip_access_ledger stops the SAL append
+    // on that path so HTTP is not double-counted). Every row unfolded
+    // in the pure default.
     let (post_total, unfolded) = ledger_counts(&pool).await;
     assert_eq!(post_total - pre_total, expected_growth);
     assert_eq!(unfolded, expected_growth);


### PR DESCRIPTION
## Summary

Certified pg+AGE has been deterministically red since `#3240` (`c3344757`) on `postgres_recall_purity_sal_and_http_entry_paths` — ledger growth **300 vs 100**. Fable's 08-27 note flagged it as a `#3240` fold/gc suspect. It is not: `#3267` does not touch recall, and the fold job is not in this test.

**Cause:** `#3180` (inside the `#3240` SAL-parity cluster) made `PostgresStore::recall_hybrid` append `recall_observations` (sqlite SAL parity — without it a pg-backed fleet's lifecycle is frozen). The HTTP postgres handler **still** records the POST-form4 / kinds / rerank set under a **second** `recall_id`. Every HTTP pg recall therefore writes the ledger twice; the access fold applies both rows → **2× echo amplifier** (the `#3266` class). The purity test also drives 10 SAL recalls (another 100 rows) and only counted HTTP, so 100 + 200 = 300.

Production HTTP postgres is 2× per recall, not 3×. Still a product bug, swarm-relevant.

## Fix

- New `Filter.skip_access_ledger` (default `false`; existing `..Default::default()` call sites unchanged).
- HTTP postgres sets it `true` before `recall_hybrid`. The handler remains the single writer for the **filtered** set under the `recall_id` echoed in the response (touch ops fire on the FILTERED set — existing contract).
- Direct SAL callers still append once (`#3180` stays).
- Sqlite SAL honors the same flag (HTTP sqlite still goes through `db::` and records in the handler; defensive parity).
- Purity test now counts SAL rows too; pin `recall_hybrid_skip_access_ledger_writes_nothing`.
- Ledger-append `Err` is still WARN + continue (ERRORS-19).

## Test plan

- [x] `cargo test --features sal --lib recall_hybrid_skip_access_ledger` — pass
- [x] `cargo test --test qual_10_module_size_ceiling` — pass (`postgres.rs` 38_662 / 38_800)
- [ ] Certified pg+AGE cell on this PR: `postgres_recall_purity_sal_and_http_entry_paths` green (the live pin)

## `#3267` ACK

Merged semantics received. Only open release PR besides this one is `#3257` (docs). No open branch asserts the old rolsuper-refusal / doctor-CRITICAL contract. `#3266` vote R1–R6 folded into `docs/ROADMAP-v110.md` on `#3257` (`d4bcb0de`).