### PR TITLE
B17-B1b: clippy doc_markdown + similar_names on BRANCH1 tests (un-red feature gates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (B17-B1b — clippy doc_markdown on BRANCH1 test docs)
+
+- `tests/archive_restore_link_cid_3250.rs` and
+  `tests/b17_integrity_3230_3231.rs`: backtick identifiers in `///`
+  docs (`SignableLink`, `memory_id`, `expires_at`, `capture_turn`,
+  `archive_by_ids`, `archive_restore`) and rename pg `a_cid`/`b_cid`
+  → `src_cid`/`dst_cid` (`clippy::similar_names`). Un-reds Lint,
+  vectorlite feature gate, and Postgres feature gate.
+
 ### Fixed (B17-B1a — hardcoded-literal ratchet after B1 merge)
 
 - `archived_memory_links` is named once as

--- a/tests/archive_restore_link_cid_3250.rs
+++ b/tests/archive_restore_link_cid_3250.rs
@@ -142,7 +142,7 @@ fn pre_v91_null_cids_restore_as_null_3250() {
 }
 
 /// A signed edge still verifies after archive→restore (cids are not in
-/// the SignableLink preimage — COND 2). Pins still round-trip.
+/// the `SignableLink` preimage — COND 2). Pins still round-trip.
 #[test]
 fn signed_edge_still_verifies_after_restore_3250() {
     let conn = open_db();
@@ -260,7 +260,7 @@ mod pg {
         }
     }
 
-    /// Live-pg twin: archive_by_ids + archive_restore round-trips the
+    /// Live-pg twin: `archive_by_ids` + `archive_restore` round-trips the
     /// lineage-DAG pins. Skips when `AI_MEMORY_TEST_POSTGRES_URL` is unset.
     #[tokio::test]
     async fn archive_restore_round_trips_link_cids_pg_3250() {
@@ -283,16 +283,16 @@ mod pg {
             .await
             .expect("store b");
 
-        let a_cid: String = sqlx::query_scalar("SELECT cid FROM memories WHERE id = $1")
+        let src_cid: String = sqlx::query_scalar("SELECT cid FROM memories WHERE id = $1")
             .bind(&a_id)
             .fetch_one(store.pool())
             .await
-            .expect("a cid");
-        let b_cid: String = sqlx::query_scalar("SELECT cid FROM memories WHERE id = $1")
+            .expect("src cid");
+        let dst_cid: String = sqlx::query_scalar("SELECT cid FROM memories WHERE id = $1")
             .bind(&b_id)
             .fetch_one(store.pool())
             .await
-            .expect("b cid");
+            .expect("dst cid");
 
         store
             .link(
@@ -317,8 +317,8 @@ mod pg {
             "UPDATE memory_links SET source_cid = $1, target_cid = $2 \
              WHERE source_id = $3 AND target_id = $4",
         )
-        .bind(&a_cid)
-        .bind(&b_cid)
+        .bind(&src_cid)
+        .bind(&dst_cid)
         .bind(&a_id)
         .bind(&b_id)
         .execute(store.pool())
@@ -342,12 +342,12 @@ mod pg {
         .expect("archived pins");
         assert_eq!(
             arch_src.as_deref(),
-            Some(a_cid.as_str()),
+            Some(src_cid.as_str()),
             "snapshot carries source_cid"
         );
         assert_eq!(
             arch_tgt.as_deref(),
-            Some(b_cid.as_str()),
+            Some(dst_cid.as_str()),
             "snapshot carries target_cid"
         );
 
@@ -364,8 +364,8 @@ mod pg {
         .fetch_one(store.pool())
         .await
         .expect("restored pins");
-        assert_eq!(live_src.as_deref(), Some(a_cid.as_str()));
-        assert_eq!(live_tgt.as_deref(), Some(b_cid.as_str()));
+        assert_eq!(live_src.as_deref(), Some(src_cid.as_str()));
+        assert_eq!(live_tgt.as_deref(), Some(dst_cid.as_str()));
 
         let _ = store.delete(&ctx, &a_id).await;
         let _ = store.delete(&ctx, &b_id).await;

--- a/tests/b17_integrity_3230_3231.rs
+++ b/tests/b17_integrity_3230_3231.rs
@@ -153,7 +153,7 @@ fn sqlite_capture_turn_same_session_turn_is_first_write_wins_3231() {
 /// #3231 — two connections racing the same `(session, turn)` with
 /// different sha256. Both miss the out-of-tx fast-path (neither has
 /// committed yet); `BEGIN IMMEDIATE` serializes; the loser's in-tx
-/// re-probe must return the first writer's memory_id and content.
+/// re-probe must return the first writer's `memory_id` and content.
 ///
 /// Pre-fix this test fails: the waiter takes the insert path, ON CONFLICT
 /// LWW-overwrites content, and both results report `dedup_hit: false`.
@@ -298,7 +298,7 @@ mod pg {
         std::env::var("AI_MEMORY_TEST_POSTGRES_URL").ok()
     }
 
-    /// #3230 — postgres trait `update` (no If-Match) PATCH expires_at on
+    /// #3230 — postgres trait `update` (no If-Match) PATCH `expires_at` on
     /// stored-LONG must keep expiry NULL.
     #[tokio::test]
     async fn pg_patch_expires_at_on_stored_long_stays_null_3230() {
@@ -365,7 +365,7 @@ mod pg {
         let _ = store.delete(&ctx, &id).await;
     }
 
-    /// #3231 — postgres capture_turn same (session, turn) is FWW.
+    /// #3231 — postgres `capture_turn` same (session, turn) is FWW.
     #[tokio::test]
     async fn pg_capture_turn_same_session_turn_is_first_write_wins_3231() {
         let Some(url) = pg_url() else {


### PR DESCRIPTION
Lint-only follow-up to un-red the release tip after B17-B1 (a637db91). Fixes clippy::doc_markdown (missing backticks in test doc-comments) + clippy::similar_names (a_cid/b_cid -> src_cid/dst_cid) in tests/b17_integrity_3230_3231.rs + tests/archive_restore_link_cid_3250.rs. No logic change. Opened to run CI before Fable's signed admin-lift merge (branch-CI-before-merge protocol).