### PR TITLE
B17-B2-v2: HTTP/gov authz #3225/#3226/#3227/#3228 (fail-closed + M7 parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#3228` postgres HTTP DELETE: non-`NotFound` pre-get Err is 503;
   governance is not skipped. `NotFound` still 404s at delete.
 
+- Coverage test-drift (#3250): `cid_migration_v74.rs` re-open pin,
+  `recall_purity_p01.rs` tip pin, and `skill_retire_lifecycle.rs`
+  upgrade/re-open pins now expect schema v91 (were still 90 after
+  BRANCH1 advanced the ladder). Migration is correct; the second
+  assertion was missed.
+
 ### Tests (B17 BRANCH 2)
 
 - `tests/http_capture_turn_k9_3225.rs` (live-pg twin, ignored without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closed.
 - QUAL-10 lockstep: `src/store/postgres.rs` 39_500 → 39_650
   (never lower).
+### Fixed (B17 BRANCH 2 — HTTP/gov: #3225 #3226 #3227 #3228)
+
+- `#3225` HTTP `POST /api/v1/capture_turn` now honours K9 + namespace
+  governance (Deny → 403, Ask/Pending → 202) before the durable write,
+  matching MCP `memory_capture_turn`.
+- `#3226` HTTP `POST /api/v1/actions/{id}/transition` binds
+  `claimed_by` to the live lease holder (`authorize_claimed_by`) and
+  rejects control-char / non-holder callers (403/400). Shared with MCP
+  `#3009`.
+- `#3227` namespace-less bulk forget: `resolve_governance_policy` Err
+  is 503, not ungoverned (ERRORS-19). Forget does not run.
+- `#3228` postgres HTTP DELETE: non-`NotFound` pre-get Err is 503;
+  governance is not skipped. `NotFound` still 404s at delete.
+
+### Tests (B17 BRANCH 2)
+
+- `tests/http_capture_turn_k9_3225.rs` (live-pg twin, ignored without
+  URL); lib `http_capture_turn_respects_namespace_deny`.
+- `tests/http_transition_claimed_by_3226.rs`; lib
+  `authorize_claimed_by_binds_live_holder_3009`.
 
 ### Fixed (B15 — remaining six CI tests; Approve-arm pending queue)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1206,6 +1206,17 @@ this cluster does not close — the three an adversary can drive are covered.
   an autonomous mutation the caller never named). No postgres synthesis
   lane exists (`memory_store` is sqlite-native). Source:
   `src/mcp/tools/store/{mod,synthesis}.rs`.
+### Security (HTTP/pg governance skip cluster: #3225 capture_turn K9)
+
+- **#3225 — HTTP `POST /api/v1/capture_turn` skipped the K9 permission gate
+  and namespace governance that MCP `memory_capture_turn` enforces.** The
+  HTTP route ran `prepare_capture_turn` then `capture_turn_idempotent` only
+  (`src/handlers/capture_turn.rs`), so an HTTP client could write a turn into
+  a namespace a Deny rule / `delete`/`write` standard would refuse on MCP.
+  HTTP now mirrors MCP: `Permissions::evaluate` (Deny → 403, Ask → 202) then
+  `enforce_governance` / `enforce_governance_action` (Deny → 403, Pending →
+  202) before the durable write. A dedup-hit is a no-op, so gating first is
+  safe. Pinned by `http_capture_turn_respects_namespace_deny`.
 
 ### Security (CLI-surface parity: sign `link` edges #3036; bind the recall ledger to the CALLER, not a namespace #2988)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `#3225` HTTP `POST /api/v1/capture_turn` now honours K9 + namespace
   governance (Deny → 403, Ask/Pending → 202) before the durable write,
-  matching MCP `memory_capture_turn`.
+  matching MCP `memory_capture_turn`. `#3292` M7 unowned-owner-lock
+  Deny is allow-through on both HTTP helpers (MCP parity; HTTP is
+  not stricter).
 - `#3226` HTTP `POST /api/v1/actions/{id}/transition` binds
   `claimed_by` to the live lease holder (`authorize_claimed_by`) and
   rejects control-char / non-holder callers (403/400). Shared with MCP
@@ -99,6 +101,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   URL); lib `http_capture_turn_respects_namespace_deny`.
 - `tests/http_transition_claimed_by_3226.rs`; lib
   `authorize_claimed_by_binds_live_holder_3009`.
+- Review follow-up (Fable 3712a9bc): lib
+  `forget_policy_probe_fault_is_503_and_does_not_delete_3227`,
+  `postgres_delete_pre_get_fault_is_503_and_does_not_delete_3228`,
+  `http_capture_turn_k9_ask_returns_202`,
+  `http_capture_turn_namespace_governance_pending_returns_202`.
+  `#3227`/`#3228` Err arms now go through `store_err_to_response`
+  (no third `"storage backend unavailable"` site). HTTP capture_turn
+  Deny reproduces MCP `#3292` M7 unowned-owner-lock allow-through.
 
 ### Fixed (B15 — remaining six CI tests; Approve-arm pending queue)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1206,6 +1206,11 @@ this cluster does not close — the three an adversary can drive are covered.
   an autonomous mutation the caller never named). No postgres synthesis
   lane exists (`memory_store` is sqlite-native). Source:
   `src/mcp/tools/store/{mod,synthesis}.rs`.
+### Security (HTTP/pg governance skip cluster: #3225 capture_turn K9; #3227 forget probe; #3228 pg delete pre-get)
+
+- **#3227 — namespace-less bulk forget treated a `resolve_governance_policy` Err as ungoverned.** `#1849` refuses a cross-namespace forget when any matched ns carries a non-`Any` delete level, but the probe used `.ok().flatten()` so a DB fault skipped the gate and the forget proceeded (ERRORS-19). Probe `Err` is now 503; the forget does not run.
+- **#3228 — postgres HTTP DELETE skipped governance when `get()` failed.** `app.store.get(&ctx, &id).await.ok()` collapsed a transport/DB error to `None`, the `if let Some(mem)` consult was skipped, and `delete` still ran. Non-`NotFound` get errors are now 503; the delete does not run. `NotFound` still 404s at delete.
+
 ### Security (HTTP/pg governance skip cluster: #3225 capture_turn K9)
 
 - **#3225 — HTTP `POST /api/v1/capture_turn` skipped the K9 permission gate

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -670,6 +670,37 @@ pub fn lease_get(
         .optional()
 }
 
+/// #3009 / #3226 — shape-validate a caller-supplied `claimed_by` and bind
+/// it to the live lease holder.
+///
+/// A `claimed_by` with embedded control characters is refused (audit
+/// log-injection guard). A live (non-expired) lease whose holder is not
+/// `claimed_by` is refused so two agents cannot each believe they own
+/// the action. `lease = None` (or an expired lease) is the unbound /
+/// lease-free flow — leases are the ownership primitive, so this never
+/// blocks a lease-less transition.
+///
+/// # Errors
+/// Returns a caller-facing string on a shape or holder mismatch.
+pub fn authorize_claimed_by(
+    claimed_by: &str,
+    lease: Option<&crate::models::Lease>,
+    now: i64,
+    action_id: &str,
+) -> Result<(), String> {
+    crate::validate::validate_agent_id(claimed_by).map_err(|e| e.to_string())?;
+    if let Some(lease) = lease
+        && lease.expires_at > now
+        && lease.holder != claimed_by
+    {
+        return Err(format!(
+            "claimed_by '{claimed_by}' is not the live lease holder '{}' on action {action_id}",
+            lease.holder
+        ));
+    }
+    Ok(())
+}
+
 /// `tracing` target for the lease-expiry reclaim/requeue sweep. Hoisted here
 /// (the lowest layer that logs under it) so the background loop
 /// [`crate::background::lease_sweep`] and this module share ONE spelling of
@@ -1486,5 +1517,35 @@ mod tests {
             persisted.holder, winners[0],
             "the persisted holder must be the reported winner"
         );
+    }
+
+    /// #3009 / #3226 — `authorize_claimed_by` shape-validates and binds to
+    /// the live lease holder; an expired or missing lease is unbound.
+    #[test]
+    fn authorize_claimed_by_binds_live_holder_3009() {
+        let live = crate::models::Lease {
+            action_id: "act-1".to_string(),
+            holder: "ai:w1".to_string(),
+            acquired_at: 1,
+            expires_at: 1_000,
+            heartbeat_at: 1,
+        };
+        assert!(authorize_claimed_by("ai:w1", Some(&live), 10, "act-1").is_ok());
+        let err = authorize_claimed_by("ai:w2", Some(&live), 10, "act-1")
+            .expect_err("non-holder must be refused");
+        assert!(
+            err.contains("not the live lease holder"),
+            "holder-mismatch wording, got {err}"
+        );
+        // Expired lease is unbound.
+        let expired = crate::models::Lease {
+            expires_at: 5,
+            ..live.clone()
+        };
+        assert!(authorize_claimed_by("ai:w2", Some(&expired), 10, "act-1").is_ok());
+        // No lease is unbound.
+        assert!(authorize_claimed_by("ai:w2", None, 10, "act-1").is_ok());
+        // Control-char claimed_by is refused even with no lease.
+        assert!(authorize_claimed_by("bad\nid", None, 10, "act-1").is_err());
     }
 }

--- a/src/handlers/capture_turn.rs
+++ b/src/handlers/capture_turn.rs
@@ -66,6 +66,7 @@ fn capture_turn_ok(result: &crate::models::CaptureTurnResult, attest_level: &str
 /// header authenticates the caller (same precedence as every other
 /// HTTP write); a `metadata.agent_id` in the body MUST agree with it
 /// (enforced inside `prepare_capture_turn`, #1413).
+#[allow(clippy::too_many_lines)]
 pub async fn capture_turn(
     State(app): State<AppState>,
     headers: HeaderMap,
@@ -97,11 +98,37 @@ pub async fn capture_turn(
     };
     let attest_level = write.signed_event.attest_level.clone();
 
+    // #3225 — MCP `handle_capture_turn` runs K9 `Permissions::evaluate` +
+    // K3 `enforce_governance` before the idempotent write. HTTP used to
+    // skip both (prepare + `capture_turn_idempotent` only), so a Deny
+    // rule / namespace standard that MCP would refuse was an ungated
+    // HTTP write. Mirror MCP: Deny → 403, Ask/Pending → 202, before
+    // any durable write. A dedup-hit is a no-op, so gating first is
+    // safe (a denied namespace refuses uniformly whether or not the
+    // turn was already captured).
+    if let Some(resp) = http_capture_turn_k9_gate(&write, &agent_id) {
+        return resp;
+    }
+
     #[cfg(feature = "sal")]
     let response = {
+        let capability = match crate::handlers::capability_from_headers(&headers, &agent_id) {
+            Ok(c) => c,
+            Err(resp) => return resp,
+        };
+        if let Some(resp) = http_capture_turn_governance_via_store(
+            &app,
+            &write,
+            &agent_id,
+            capability.as_ref(),
+        )
+        .await
+        {
+            return resp;
+        }
         // Single SAL path: `app.store` wraps the sqlite OR postgres
         // adapter, so this serves both backends through the trait method.
-        let ctx = crate::store::CallerContext::for_agent(agent_id);
+        let ctx = crate::store::CallerContext::for_agent(agent_id).with_capability(capability);
         match app.store.capture_turn_idempotent(&ctx, &write).await {
             Ok(result) => capture_turn_ok(&result, &attest_level),
             Err(e) => store_err_to_response(e),
@@ -114,6 +141,9 @@ pub async fn capture_turn(
         // directly under the shared connection lock.
         let state = app.db.clone();
         let lock = state.lock().await;
+        if let Some(resp) = http_capture_turn_governance_via_db(&lock.0, &write, &agent_id) {
+            return resp;
+        }
         // #2121 — tenant HTTP surface: never substrate-authored (parity with
         // the SAL branch above, whose `for_agent` ctx has
         // `bypass_visibility = false`).
@@ -128,4 +158,182 @@ pub async fn capture_turn(
     };
 
     response
+}
+
+/// Action label for the L4 capture-turn write gate. Matches the MCP
+/// `ACTION_CAPTURE_TURN` spelling so Deny/Ask/Pending envelopes stay
+/// cross-surface identical (#3225).
+const ACTION_CAPTURE_TURN: &str = "capture_turn";
+
+/// #3225 — K9 permission gate (backend-blind). Deny → 403; Ask → 202.
+fn http_capture_turn_k9_gate(
+    write: &crate::models::CaptureTurnWrite,
+    agent_id: &str,
+) -> Option<Response> {
+    use crate::permissions::{Op, PermissionContext, Permissions};
+    let gate_namespace = write.memory.namespace.clone();
+    let payload = json!({
+        "id": write.memory.id,
+        "title": write.memory.title,
+        "namespace": gate_namespace,
+    });
+    let ctx = PermissionContext {
+        op: Op::MemoryStore,
+        namespace: gate_namespace.clone(),
+        agent_id: agent_id.to_string(),
+        payload,
+    };
+    match Permissions::evaluate(&ctx, &[]) {
+        crate::permissions::Decision::Allow | crate::permissions::Decision::Modify(_) => None,
+        crate::permissions::Decision::Deny(reason) => Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": crate::governance::deny_message(
+                        ACTION_CAPTURE_TURN,
+                        crate::governance::DenyGate::PermissionRule,
+                        &reason,
+                    ),
+                })),
+            )
+                .into_response(),
+        ),
+        crate::permissions::Decision::Ask(prompt) => Some(
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "status": "ask",
+                    "reason": prompt,
+                    "action": ACTION_CAPTURE_TURN,
+                    "namespace": gate_namespace,
+                })),
+            )
+                .into_response(),
+        ),
+    }
+}
+
+/// #3225 — namespace-governance gate on the SAL path (sqlite-SAL + postgres).
+/// Deny → 403; Pending → 202. Probe error → the typed store-error envelope.
+#[cfg(feature = "sal")]
+async fn http_capture_turn_governance_via_store(
+    app: &AppState,
+    write: &crate::models::CaptureTurnWrite,
+    agent_id: &str,
+    capability: Option<&crate::governance::capability::CapabilityToken>,
+) -> Option<Response> {
+    use crate::models::GovernanceDecision;
+    let ns = &write.memory.namespace;
+    let payload = json!({
+        "id": write.memory.id,
+        "title": write.memory.title,
+        "namespace": ns,
+    });
+    if let Some(resp) =
+        super::create::http_pre_governance_decision_gate(ns, "store", agent_id, Some(&write.memory.id))
+    {
+        return Some(resp);
+    }
+    match app
+        .store
+        .enforce_governance_action(
+            crate::store::GovernedAction::Store,
+            ns,
+            agent_id,
+            Some(&write.memory.id),
+            Some(agent_id),
+            &payload,
+            capability,
+        )
+        .await
+    {
+        Ok(GovernanceDecision::Allow) => None,
+        Ok(GovernanceDecision::Deny(refusal)) => Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": crate::governance::deny_message(
+                        ACTION_CAPTURE_TURN,
+                        crate::governance::DenyGate::Governance,
+                        &refusal.reason,
+                    ),
+                })),
+            )
+                .into_response(),
+        ),
+        Ok(GovernanceDecision::Pending(pending_id)) => Some(
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "status": "pending",
+                    (field_names::PENDING_ID): pending_id,
+                    "reason": crate::errors::msg::GOVERNANCE_REQUIRES_APPROVAL,
+                    "action": ACTION_CAPTURE_TURN,
+                    "namespace": ns,
+                })),
+            )
+                .into_response(),
+        ),
+        Err(e) => Some(store_err_to_response(e)),
+    }
+}
+
+/// #3225 — namespace-governance gate on the non-SAL sqlite path.
+#[cfg(not(feature = "sal"))]
+fn http_capture_turn_governance_via_db(
+    conn: &rusqlite::Connection,
+    write: &crate::models::CaptureTurnWrite,
+    agent_id: &str,
+) -> Option<Response> {
+    use crate::models::{GovernanceDecision, GovernedAction};
+    let ns = &write.memory.namespace;
+    let payload = json!({
+        "id": write.memory.id,
+        "title": write.memory.title,
+        "namespace": ns,
+    });
+    if let Some(resp) =
+        super::create::http_pre_governance_decision_gate(ns, "store", agent_id, Some(&write.memory.id))
+    {
+        return Some(resp);
+    }
+    match crate::db::enforce_governance(
+        conn,
+        GovernedAction::Store,
+        ns,
+        agent_id,
+        Some(&write.memory.id),
+        Some(agent_id),
+        &payload,
+        None,
+    ) {
+        Ok(GovernanceDecision::Allow) => None,
+        Ok(GovernanceDecision::Deny(refusal)) => Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": crate::governance::deny_message(
+                        ACTION_CAPTURE_TURN,
+                        crate::governance::DenyGate::Governance,
+                        &refusal.reason,
+                    ),
+                })),
+            )
+                .into_response(),
+        ),
+        Ok(GovernanceDecision::Pending(pending_id)) => Some(
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "status": "pending",
+                    (field_names::PENDING_ID): pending_id,
+                    "reason": crate::errors::msg::GOVERNANCE_REQUIRES_APPROVAL,
+                    "action": ACTION_CAPTURE_TURN,
+                    "namespace": ns,
+                })),
+            )
+                .into_response(),
+        ),
+        Err(e) => Some(crate::handlers::errors::governance_error_500(&e)),
+    }
 }

--- a/src/handlers/capture_turn.rs
+++ b/src/handlers/capture_turn.rs
@@ -247,19 +247,28 @@ async fn http_capture_turn_governance_via_store(
         .await
     {
         Ok(GovernanceDecision::Allow) => None,
-        Ok(GovernanceDecision::Deny(refusal)) => Some(
-            (
-                StatusCode::FORBIDDEN,
-                Json(json!({
-                    "error": crate::governance::deny_message(
-                        ACTION_CAPTURE_TURN,
-                        crate::governance::DenyGate::Governance,
-                        &refusal.reason,
-                    ),
-                })),
-            )
-                .into_response(),
-        ),
+        Ok(GovernanceDecision::Deny(refusal)) => {
+            // #3292 M7 — unowned-standard Owner lock must not 403 a
+            // legitimate capture. MCP `memory_capture_turn` allow-through
+            // (`is_unowned_owner_lock`); HTTP was stricter (over-refuse).
+            if refusal.is_unowned_owner_lock() {
+                None
+            } else {
+                Some(
+                    (
+                        StatusCode::FORBIDDEN,
+                        Json(json!({
+                            "error": crate::governance::deny_message(
+                                ACTION_CAPTURE_TURN,
+                                crate::governance::DenyGate::Governance,
+                                &refusal.reason,
+                            ),
+                        })),
+                    )
+                        .into_response(),
+                )
+            }
+        }
         Ok(GovernanceDecision::Pending(pending_id)) => Some(
             (
                 StatusCode::ACCEPTED,
@@ -310,19 +319,26 @@ fn http_capture_turn_governance_via_db(
         None,
     ) {
         Ok(GovernanceDecision::Allow) => None,
-        Ok(GovernanceDecision::Deny(refusal)) => Some(
-            (
-                StatusCode::FORBIDDEN,
-                Json(json!({
-                    "error": crate::governance::deny_message(
-                        ACTION_CAPTURE_TURN,
-                        crate::governance::DenyGate::Governance,
-                        &refusal.reason,
-                    ),
-                })),
-            )
-                .into_response(),
-        ),
+        Ok(GovernanceDecision::Deny(refusal)) => {
+            // #3292 M7 — MCP↔HTTP parity: unowned-owner-lock allow-through.
+            if refusal.is_unowned_owner_lock() {
+                None
+            } else {
+                Some(
+                    (
+                        StatusCode::FORBIDDEN,
+                        Json(json!({
+                            "error": crate::governance::deny_message(
+                                ACTION_CAPTURE_TURN,
+                                crate::governance::DenyGate::Governance,
+                                &refusal.reason,
+                            ),
+                        })),
+                    )
+                        .into_response(),
+                )
+            }
+        }
         Ok(GovernanceDecision::Pending(pending_id)) => Some(
             (
                 StatusCode::ACCEPTED,

--- a/src/handlers/capture_turn.rs
+++ b/src/handlers/capture_turn.rs
@@ -116,13 +116,9 @@ pub async fn capture_turn(
             Ok(c) => c,
             Err(resp) => return resp,
         };
-        if let Some(resp) = http_capture_turn_governance_via_store(
-            &app,
-            &write,
-            &agent_id,
-            capability.as_ref(),
-        )
-        .await
+        if let Some(resp) =
+            http_capture_turn_governance_via_store(&app, &write, &agent_id, capability.as_ref())
+                .await
         {
             return resp;
         }
@@ -229,9 +225,12 @@ async fn http_capture_turn_governance_via_store(
         "title": write.memory.title,
         "namespace": ns,
     });
-    if let Some(resp) =
-        super::create::http_pre_governance_decision_gate(ns, "store", agent_id, Some(&write.memory.id))
-    {
+    if let Some(resp) = super::create::http_pre_governance_decision_gate(
+        ns,
+        "store",
+        agent_id,
+        Some(&write.memory.id),
+    ) {
         return Some(resp);
     }
     match app
@@ -292,9 +291,12 @@ fn http_capture_turn_governance_via_db(
         "title": write.memory.title,
         "namespace": ns,
     });
-    if let Some(resp) =
-        super::create::http_pre_governance_decision_gate(ns, "store", agent_id, Some(&write.memory.id))
-    {
+    if let Some(resp) = super::create::http_pre_governance_decision_gate(
+        ns,
+        "store",
+        agent_id,
+        Some(&write.memory.id),
+    ) {
         return Some(resp);
     }
     match crate::db::enforce_governance(

--- a/src/handlers/coordination.rs
+++ b/src/handlers/coordination.rs
@@ -147,7 +147,10 @@ pub async fn transition_action(
     {
         return (
             StatusCode::BAD_REQUEST,
-            Json(json!({"error": crate::errors::msg::invalid("claimed_by", e)})),
+            Json(json!({"error": crate::errors::msg::invalid(
+                crate::mcp::param_names::CLAIMED_BY,
+                e,
+            )})),
         )
             .into_response();
     }

--- a/src/handlers/coordination.rs
+++ b/src/handlers/coordination.rs
@@ -518,11 +518,7 @@ async fn local_transition_via_db(
             }
         };
         if let Err(msg) = crate::actions::authorize_claimed_by(cb, lease.as_ref(), now, action_id) {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": msg})),
-            )
-                .into_response());
+            return Err((StatusCode::FORBIDDEN, Json(json!({"error": msg}))).into_response());
         }
     }
     let current = match crate::actions::get(&lock.0, action_id) {
@@ -582,11 +578,7 @@ async fn local_transition_via_store(
             Err(e) => return Err(super::store_err_to_response(e)),
         };
         if let Err(msg) = crate::actions::authorize_claimed_by(cb, lease.as_ref(), now, action_id) {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": msg})),
-            )
-                .into_response());
+            return Err((StatusCode::FORBIDDEN, Json(json!({"error": msg}))).into_response());
         }
     }
     let current = match app.store.action_get(&ctx, action_id).await {

--- a/src/handlers/coordination.rs
+++ b/src/handlers/coordination.rs
@@ -142,9 +142,20 @@ pub async fn transition_action(
             .into_response();
     };
     let now = chrono::Utc::now().timestamp();
+    if let Some(cb) = body.claimed_by.as_deref()
+        && let Err(e) = crate::validate::validate_agent_id(cb)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": crate::errors::msg::invalid("claimed_by", e)})),
+        )
+            .into_response();
+    }
 
     // Local write (dual-path): sqlite via app.db + crate::actions (default),
-    // postgres via the SAL trait (under --features sal).
+    // postgres via the SAL trait (under --features sal). The #3009/#3226
+    // lease-holder bind lives inside each local-write helper so sqlite and
+    // postgres cannot drift.
     let local = {
         #[cfg(feature = "sal")]
         {
@@ -241,11 +252,22 @@ pub async fn send_signal(
                 .into_response();
         }
     };
-    let signal_type = body
-        .signal_type
-        .as_deref()
-        .and_then(crate::models::SignalType::from_str)
-        .unwrap_or_default();
+    // #3226 — reject an unknown `signal_type` like MCP `handle_signal_send`
+    // (A6-13 / #3007 sibling). An ABSENT value still defaults; a PRESENT
+    // but unknown token is 400, never silently coerced to `notify`.
+    let signal_type = match body.signal_type.as_deref() {
+        Some(s) => match crate::models::SignalType::from_str(s) {
+            Some(t) => t,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid signal_type: {s}")})),
+                )
+                    .into_response();
+            }
+        },
+        None => crate::models::SignalType::default(),
+    };
     let now = chrono::Utc::now().timestamp();
     // #3011 — wire `signals.expires_at` from an optional `ttl_secs` (validated +
     // overflow-checked), so the gc pruner can reap the caller-declared-ephemeral
@@ -484,6 +506,25 @@ async fn local_transition_via_db(
     now: i64,
 ) -> Result<(crate::models::Action, crate::models::ActionState, String), Response> {
     let lock = app.db.lock().await;
+    if let Some(cb) = claimed_by {
+        let lease = match crate::actions::lease_get(&lock.0, action_id) {
+            Ok(l) => l,
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": format!("lease_get failed: {e}")})),
+                )
+                    .into_response());
+            }
+        };
+        if let Err(msg) = crate::actions::authorize_claimed_by(cb, lease.as_ref(), now, action_id) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": msg})),
+            )
+                .into_response());
+        }
+    }
     let current = match crate::actions::get(&lock.0, action_id) {
         Ok(Some(a)) => a,
         Ok(None) => {
@@ -535,6 +576,19 @@ async fn local_transition_via_store(
     now: i64,
 ) -> Result<(crate::models::Action, crate::models::ActionState, String), Response> {
     let ctx = crate::store::CallerContext::for_agent(node_agent_id.to_string());
+    if let Some(cb) = claimed_by {
+        let lease = match app.store.lease_get(&ctx, action_id).await {
+            Ok(l) => l,
+            Err(e) => return Err(super::store_err_to_response(e)),
+        };
+        if let Err(msg) = crate::actions::authorize_claimed_by(cb, lease.as_ref(), now, action_id) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": msg})),
+            )
+                .into_response());
+        }
+    }
     let current = match app.store.action_get(&ctx, action_id).await {
         Ok(Some(a)) => a,
         Ok(None) => {

--- a/src/handlers/memories.rs
+++ b/src/handlers/memories.rs
@@ -891,7 +891,26 @@ pub async fn delete_memory(
         };
         let ctx =
             crate::store::CallerContext::for_agent(agent_id.clone()).with_capability(capability);
-        let target = app.store.get(&ctx, &id).await.ok();
+        // #3228 — a get() transport/DB fault is 503, never "not found".
+        // `.ok()` collapsed every Err onto None, skipped the governance
+        // consult, and still called delete (ERRORS-19 fail-open).
+        // NotFound stays None so a missing row still 404s at delete.
+        let target = match app.store.get(&ctx, &id).await {
+            Ok(mem) => Some(mem),
+            Err(crate::store::StoreError::NotFound { .. }) => None,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    id = %id,
+                    "postgres delete pre-get failed; refusing (#3228)"
+                );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({"error": "storage backend unavailable"})),
+                )
+                    .into_response();
+            }
+        };
 
         // F-A2A1.2 (#700) — governance enforcement on the postgres delete
         // path. Mirrors the sqlite gate at line ~1913 below: a denied

--- a/src/handlers/memories.rs
+++ b/src/handlers/memories.rs
@@ -904,11 +904,7 @@ pub async fn delete_memory(
                     id = %id,
                     "postgres delete pre-get failed; refusing (#3228)"
                 );
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    Json(json!({"error": "storage backend unavailable"})),
-                )
-                    .into_response();
+                return store_err_to_response(e);
             }
         };
 

--- a/src/handlers/memories_query.rs
+++ b/src/handlers/memories_query.rs
@@ -635,16 +635,15 @@ pub async fn forget_memories(
                 Err(e) => {
                     // #3227 — 503, not "ungoverned". A probe that could not
                     // run is not evidence the namespace is ungoverned.
+                    // Route through `store_err_to_response` (same as #3225
+                    // capture_turn) so the literal is not triplicated and
+                    // the status mapping stays typed (ERRORS-02).
                     tracing::error!(
                         error = %e,
                         namespace = %ns,
                         "forget governance policy probe failed; refusing (#3227)"
                     );
-                    return (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Json(json!({"error": "storage backend unavailable"})),
-                    )
-                        .into_response();
+                    return store_err_to_response(e);
                 }
             };
             if governed {

--- a/src/handlers/memories_query.rs
+++ b/src/handlers/memories_query.rs
@@ -626,13 +626,27 @@ pub async fn forget_memories(
             }
         };
         for ns in &matched {
-            let governed = app
-                .store
-                .resolve_governance_policy(ns)
-                .await
-                .ok()
-                .flatten()
-                .is_some_and(|p| !matches!(p.core.delete, crate::models::GovernanceLevel::Any));
+            // #3227 — a policy-probe Err is 503, never "ungoverned". `.ok()`
+            // mapped a DB fault onto the ungoverned arm and the forget
+            // proceeded (ERRORS-19 fail-open delete).
+            let governed = match app.store.resolve_governance_policy(ns).await {
+                Ok(policy) => policy
+                    .is_some_and(|p| !matches!(p.core.delete, crate::models::GovernanceLevel::Any)),
+                Err(e) => {
+                    // #3227 — 503, not "ungoverned". A probe that could not
+                    // run is not evidence the namespace is ungoverned.
+                    tracing::error!(
+                        error = %e,
+                        namespace = %ns,
+                        "forget governance policy probe failed; refusing (#3227)"
+                    );
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(json!({"error": "storage backend unavailable"})),
+                    )
+                        .into_response();
+                }
+            };
             if governed {
                 return (
                     StatusCode::FORBIDDEN,

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -15875,6 +15875,378 @@ async fn http_capture_turn_respects_namespace_deny() {
     );
 }
 
+/// #3225 — K9 `Ask` on capture_turn is 202, not an ungated write.
+/// The Deny test only exercises `Permissions::evaluate` Deny; Ask is
+/// the other K9 short-circuit before namespace governance.
+#[tokio::test]
+async fn http_capture_turn_k9_ask_returns_202() {
+    use crate::governance::{
+        PermissionRule, RuleDecision, clear_active_permission_rules_for_test,
+        set_active_permission_rules,
+    };
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _g = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _mode = crate::config::lock_permissions_mode_for_test();
+    clear_active_permission_rules_for_test();
+    // Enforce escalates K9 Ask → Deny. Advisory is the mode where
+    // `Permissions::evaluate` actually returns `Decision::Ask`, which
+    // is the HTTP 202 arm Fable asked for (3712a9bc).
+    crate::config::override_active_permissions_mode_for_test(
+        crate::config::PermissionsMode::Advisory,
+    );
+    set_active_permission_rules(vec![PermissionRule {
+        namespace_pattern: "askme/*".to_string(),
+        op: crate::governance::Op::MemoryStore.as_str().to_string(),
+        agent_pattern: "*".to_string(),
+        decision: RuleDecision::Ask,
+        reason: Some("confirm HTTP capture".to_string()),
+    }]);
+
+    let state = test_state();
+    let app = capture_turn_test_router(state);
+    let (status, payload) = post_capture_turn(
+        &app,
+        "alice",
+        &json!({
+            "host_session_id": "sess-3225-ask",
+            "host_turn_index": 0,
+            "role": "user",
+            "content": "please confirm this capture",
+            "namespace": "askme/ops"
+        }),
+    )
+    .await;
+    clear_active_permission_rules_for_test();
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "#3225: K9 Ask on capture_turn must be 202, got {status} {payload}"
+    );
+    assert_eq!(payload["status"].as_str(), Some("ask"));
+    assert_eq!(payload["action"].as_str(), Some("capture_turn"));
+}
+
+/// B17-B2 review (3712a9bc): mock SAL adapter that injects get/probe
+/// faults and counts mutating calls so 503 cannot still delete.
+#[cfg(feature = "sal")]
+struct B17B2FaultStore {
+    get_fault: bool,
+    probe_fault: bool,
+    delete_calls: std::sync::atomic::AtomicUsize,
+    forget_calls: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(feature = "sal")]
+impl B17B2FaultStore {
+    fn get_fault() -> Self {
+        Self {
+            get_fault: true,
+            probe_fault: false,
+            delete_calls: std::sync::atomic::AtomicUsize::new(0),
+            forget_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+    fn probe_fault() -> Self {
+        Self {
+            get_fault: false,
+            probe_fault: true,
+            delete_calls: std::sync::atomic::AtomicUsize::new(0),
+            forget_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[cfg(feature = "sal")]
+#[async_trait::async_trait]
+impl crate::store::MemoryStore for B17B2FaultStore {
+    fn capabilities(&self) -> crate::store::Capabilities {
+        crate::store::Capabilities::empty()
+    }
+    async fn store(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        mem: &crate::models::Memory,
+    ) -> crate::store::StoreResult<String> {
+        Ok(mem.id.clone())
+    }
+    async fn get(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        id: &str,
+    ) -> crate::store::StoreResult<crate::models::Memory> {
+        if self.get_fault {
+            return Err(crate::store::StoreError::BackendUnavailable {
+                backend: "mock".into(),
+                detail: "injected fault".into(),
+            });
+        }
+        Err(crate::store::StoreError::NotFound { id: id.to_string() })
+    }
+    async fn update(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _id: &str,
+        _patch: crate::store::UpdatePatch,
+    ) -> crate::store::StoreResult<()> {
+        Ok(())
+    }
+    async fn delete(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _id: &str,
+    ) -> crate::store::StoreResult<()> {
+        self.delete_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+    async fn list(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _filter: &crate::store::Filter,
+    ) -> crate::store::StoreResult<Vec<crate::models::Memory>> {
+        Ok(vec![])
+    }
+    async fn search(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _query: &str,
+        _filter: &crate::store::Filter,
+    ) -> crate::store::StoreResult<Vec<crate::models::Memory>> {
+        Ok(vec![])
+    }
+    async fn verify(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        id: &str,
+    ) -> crate::store::StoreResult<crate::store::VerifyReport> {
+        Ok(crate::store::VerifyReport {
+            memory_id: id.to_string(),
+            integrity_ok: true,
+            findings: vec![],
+            signature_verified: false,
+            cid_ok: None,
+            cid_mismatch: None,
+        })
+    }
+    async fn link(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _link: &crate::models::MemoryLink,
+    ) -> crate::store::StoreResult<()> {
+        Ok(())
+    }
+    async fn list_links(
+        &self,
+        _namespace: Option<&str>,
+    ) -> crate::store::StoreResult<Vec<crate::models::MemoryLink>> {
+        Ok(vec![])
+    }
+    async fn register_agent(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _agent: &crate::models::AgentRegistration,
+    ) -> crate::store::StoreResult<()> {
+        Ok(())
+    }
+    async fn forget(
+        &self,
+        _ctx: &crate::store::CallerContext,
+        _namespace: Option<&str>,
+        _pattern: Option<&str>,
+        _tier: Option<&crate::models::Tier>,
+        _archive: bool,
+    ) -> crate::store::StoreResult<usize> {
+        self.forget_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(0)
+    }
+    async fn forget_distinct_namespaces(
+        &self,
+        _pattern: Option<&str>,
+        _tier: Option<&crate::models::Tier>,
+    ) -> crate::store::StoreResult<Vec<String>> {
+        if self.probe_fault {
+            Ok(vec!["fault-ns".to_string()])
+        } else {
+            Ok(vec![])
+        }
+    }
+    async fn resolve_governance_policy(
+        &self,
+        _namespace: &str,
+    ) -> crate::store::StoreResult<Option<crate::models::GovernancePolicy>> {
+        if self.probe_fault {
+            Err(crate::store::StoreError::BackendUnavailable {
+                backend: "mock".into(),
+                detail: "injected fault".into(),
+            })
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(feature = "sal")]
+fn b17_b2_state_with_store(
+    store: Arc<dyn crate::store::MemoryStore>,
+    backend: StorageBackend,
+    admins: Vec<String>,
+) -> AppState {
+    let mut state = test_app_state(test_state());
+    state.store = store;
+    state.storage_backend = backend;
+    state.admin_agent_ids = Arc::new(admins);
+    state
+}
+
+/// #3227 — policy-probe Err is 503 and forget does not run.
+#[cfg(feature = "sal")]
+#[tokio::test]
+async fn forget_policy_probe_fault_is_503_and_does_not_delete_3227() {
+    use std::sync::atomic::Ordering;
+    let store = Arc::new(B17B2FaultStore::probe_fault());
+    let app = Router::new()
+        .route("/api/v1/forget", axum_post(forget_memories))
+        .with_state(b17_b2_state_with_store(
+            store.clone(),
+            StorageBackend::Sqlite,
+            vec!["alice".to_string()],
+        ));
+    let resp = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/forget")
+                .method("POST")
+                .header(crate::HEADER_CONTENT_TYPE, crate::MIME_JSON)
+                .header("x-agent-id", "alice")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({ "pattern": "alpha" })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "#3227: probe fault must 503"
+    );
+    assert_eq!(
+        store.forget_calls.load(Ordering::SeqCst),
+        0,
+        "#3227: forget must not run after a probe fault"
+    );
+}
+
+/// #3228 — postgres DELETE pre-get non-NotFound Err is 503 and delete
+/// does not run.
+#[cfg(feature = "sal")]
+#[tokio::test]
+async fn postgres_delete_pre_get_fault_is_503_and_does_not_delete_3228() {
+    use std::sync::atomic::Ordering;
+    let store = Arc::new(B17B2FaultStore::get_fault());
+    let app = Router::new()
+        .route(
+            "/api/v1/memories/{id}",
+            axum::routing::delete(delete_memory),
+        )
+        .with_state(b17_b2_state_with_store(
+            store.clone(),
+            StorageBackend::Postgres,
+            vec!["alice".to_string()],
+        ));
+    let resp = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/memories/mem-3228")
+                .method("DELETE")
+                .header("x-agent-id", "alice")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "#3228: pre-get fault must 503"
+    );
+    assert_eq!(
+        store.delete_calls.load(Ordering::SeqCst),
+        0,
+        "#3228: delete must not run after a pre-get fault"
+    );
+}
+
+/// #3225 — namespace-governance Pending (not K9) returns 202.
+#[cfg(feature = "sal")]
+#[tokio::test]
+async fn http_capture_turn_namespace_governance_pending_returns_202() {
+    let _gate = pin_governance_enforce_for_test();
+    crate::governance::clear_active_permission_rules_for_test();
+    let f = tempfile::NamedTempFile::new().unwrap();
+    let path = f.path().to_path_buf();
+    let conn = crate::db::open(&path).unwrap();
+    let ns = "gov-capture-3225";
+    // seed_governance_policy talks to a Db mutex; seed the same file
+    // the SAL store will open.
+    drop(conn);
+    {
+        let db: Db = Arc::new(Mutex::new((
+            crate::db::open(&path).unwrap(),
+            path.clone(),
+            ResolvedTtl::default(),
+            true,
+        )));
+        seed_governance_policy(
+            &db,
+            ns,
+            serde_json::json!({
+                "write": "approve",
+                "delete": "owner",
+                "promote": "any",
+                "approver": "human",
+            }),
+        )
+        .await;
+    }
+    let store: Arc<dyn crate::store::MemoryStore> =
+        Arc::new(crate::store::sqlite::SqliteStore::open(&path).unwrap());
+    let db: Db = Arc::new(Mutex::new((
+        crate::db::open(&path).unwrap(),
+        path,
+        ResolvedTtl::default(),
+        true,
+    )));
+    let mut state = b17_b2_state_with_store(store, StorageBackend::Sqlite, vec!["alice".into()]);
+    state.db = db;
+    let app = Router::new()
+        .route("/api/v1/capture_turn", axum_post(capture_turn))
+        .with_state(state);
+    let (status, payload) = post_capture_turn(
+        &app,
+        "alice",
+        &json!({
+            "host_session_id": "sess-3225-pending",
+            "host_turn_index": 0,
+            "role": "user",
+            "content": "queued capture, not stored",
+            "namespace": ns
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "#3225: namespace-gov Pending must be 202, got {status} {payload}"
+    );
+    assert_eq!(payload["status"].as_str(), Some("pending"));
+    assert_eq!(payload["action"].as_str(), Some("capture_turn"));
+    assert!(payload["pending_id"].is_string(), "pending_id: {payload}");
+}
+
 // ---------------------------------------------------------------------------
 // #1579 B4 — gzip response compression + TOON format negotiation
 // ---------------------------------------------------------------------------

--- a/src/handlers/tests.rs
+++ b/src/handlers/tests.rs
@@ -15822,6 +15822,59 @@ async fn http_capture_turn_rejects_agent_id_mismatch_1413() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
+/// #3225 — HTTP `POST /capture_turn` must honour a K9 namespace Deny the
+/// same way MCP `memory_capture_turn` does. Pre-fix the HTTP route skipped
+/// `Permissions::evaluate`, so a rule that MCP would refuse was an ungated
+/// write. Deny → 403; the turn is not stored.
+#[tokio::test]
+async fn http_capture_turn_respects_namespace_deny() {
+    use crate::governance::{
+        PermissionRule, RuleDecision, clear_active_permission_rules_for_test,
+        set_active_permission_rules,
+    };
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _g = LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    clear_active_permission_rules_for_test();
+    crate::config::override_active_permissions_mode_for_test(
+        crate::config::PermissionsMode::Enforce,
+    );
+    set_active_permission_rules(vec![PermissionRule {
+        namespace_pattern: "secrets/*".to_string(),
+        op: crate::governance::Op::MemoryStore.as_str().to_string(),
+        agent_pattern: "*".to_string(),
+        decision: RuleDecision::Deny,
+        reason: Some("no HTTP capture into secrets".to_string()),
+    }]);
+
+    let state = test_state();
+    let app = capture_turn_test_router(state);
+    let (status, payload) = post_capture_turn(
+        &app,
+        "alice",
+        &json!({
+            "host_session_id": "sess-3225",
+            "host_turn_index": 0,
+            "role": "user",
+            "content": "secret operator directive",
+            "namespace": "secrets/ops"
+        }),
+    )
+    .await;
+    clear_active_permission_rules_for_test();
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "#3225: K9 Deny on capture_turn namespace must be 403, got {status} {payload}"
+    );
+    let err = payload["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("denied") || err.contains("no HTTP capture into secrets"),
+        "#3225: denial must surface the rule reason, got {payload}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // #1579 B4 — gzip response compression + TOON format negotiation
 // ---------------------------------------------------------------------------

--- a/src/identity/sign.rs
+++ b/src/identity/sign.rs
@@ -635,7 +635,10 @@ pub fn canonical_cbor_transition(t: &SignableTransition<'_>) -> Result<Vec<u8>> 
             ciborium::Value::Text(t.from_state.to_string()),
         ),
         ("to_state", ciborium::Value::Text(t.to_state.to_string())),
-        ("claimed_by", text_or_null(t.claimed_by)),
+        (
+            crate::mcp::param_names::CLAIMED_BY,
+            text_or_null(t.claimed_by),
+        ),
         ("nonce", ciborium::Value::Bytes(t.nonce.to_vec())),
         (
             field_names::CREATED_AT,

--- a/src/mcp/tools/action.rs
+++ b/src/mcp/tools/action.rs
@@ -228,15 +228,8 @@ pub fn handle_action_transition(
     // (leases are the ownership primitive), so this never blocks the
     // lease-free flow.
     if let Some(cb) = claimed_by.as_deref() {
-        crate::validate::validate_agent_id(cb).map_err(|e| e.to_string())?;
-        if let Some(lease) = crate::actions::lease_get(conn, id).map_err(|e| e.to_string())? {
-            if lease.expires_at > now && lease.holder != cb {
-                return Err(format!(
-                    "claimed_by '{cb}' is not the live lease holder '{}' on action {id}",
-                    lease.holder
-                ));
-            }
-        }
+        let lease = crate::actions::lease_get(conn, id).map_err(|e| e.to_string())?;
+        crate::actions::authorize_claimed_by(cb, lease.as_ref(), now, id)?;
     }
 
     match crate::actions::transition(conn, id, to, claimed_by.as_deref(), now)

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -16047,7 +16047,7 @@ fn pg_row_to_action(r: &sqlx::postgres::PgRow) -> StoreResult<crate::models::Act
         payload: serde_json::from_str(&payload).unwrap_or(serde_json::Value::Null),
         priority: r.try_get("priority").map_err(|e| g("action.priority", e))?,
         agent_id: r.try_get("agent_id").ok(),
-        claimed_by: r.try_get("claimed_by").ok(),
+        claimed_by: r.try_get(crate::mcp::param_names::CLAIMED_BY).ok(),
         vector_clock: serde_json::from_str(&vector_clock).unwrap_or(serde_json::Value::Null),
         metadata: serde_json::from_str(&metadata).unwrap_or(serde_json::Value::Null),
         created_at: r

--- a/tests/cid_migration_v74.rs
+++ b/tests/cid_migration_v74.rs
@@ -60,11 +60,9 @@ fn v74_columns_and_version_both_backends() {
         db::migrations::current_schema_version_for_tests(),
         "fresh open reaches the current schema tip"
     );
-    // Tip pin: the ladder head advanced to v90 (#2385 archive genesis-cid
-    // parity — the v74 pair below MIRRORED onto `archived_memories`, so
-    // archive->restore carries the address instead of re-minting it; was v89 =
-    // #2392 postgres FTS `tags` fold) — the v74 cid columns asserted below
-    // still exist, only the tip moved.
+    // Tip pin: the ladder head advanced to v91 (#3250 archived_memory_links
+    // source_cid/target_cid). The v74 cid columns asserted below still
+    // exist; only the tip moved (was v90 = #2385 archive genesis-cid).
     assert_eq!(db::migrations::current_schema_version_for_tests(), 91);
     // The additive columns exist and are queryable.
     assert!(
@@ -78,7 +76,7 @@ fn v74_columns_and_version_both_backends() {
     let conn2 = db::open(&path).unwrap();
     assert_eq!(
         schema_version(&conn2),
-        90,
+        db::migrations::current_schema_version_for_tests(),
         "re-open stays at the current tip idempotently"
     );
     assert!(

--- a/tests/http_capture_turn_k9_3225.rs
+++ b/tests/http_capture_turn_k9_3225.rs
@@ -67,7 +67,9 @@ async fn build_pg_router(url: &str) -> axum::Router {
         llm_call_timeout: std::time::Duration::from_secs(30),
         replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
         verify_require_nonce: false,
-        federation_nonce_cache: Arc::new(ai_memory::identity::replay::FederationNonceCache::default()),
+        federation_nonce_cache: Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
         autonomous_hooks: false,
         auto_tag_queue: None,
         atomise_queue: None,

--- a/tests/http_capture_turn_k9_3225.rs
+++ b/tests/http_capture_turn_k9_3225.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3225 — HTTP `POST /api/v1/capture_turn` must refuse a K9 namespace
+//! Deny the same way MCP `memory_capture_turn` does. The lib-tier pin
+//! lives in `src/handlers/tests.rs::http_capture_turn_respects_namespace_deny`
+//! (sqlite). This binary is the live-postgres twin: same rule, postgres
+//! SAL write path, `--include-ignored`.
+
+#![cfg(feature = "sal-postgres")]
+#![allow(clippy::too_many_lines, clippy::doc_markdown, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::governance::{
+    PermissionRule, RuleDecision, clear_active_permission_rules_for_test,
+    set_active_permission_rules,
+};
+use ai_memory::handlers::{ApiKeyState, AppState, Db, StorageBackend};
+use ai_memory::store::MemoryStore;
+use ai_memory::store::postgres::PostgresStore;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tokio::sync::{Mutex, RwLock};
+use tower::ServiceExt as _;
+
+fn postgres_url() -> Option<String> {
+    std::env::var("AI_MEMORY_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+async fn build_pg_router(url: &str) -> axum::Router {
+    ai_memory::handlers::admin_role::mark_request_authn_configured(true);
+    ai_memory::config::override_active_permissions_mode_for_test(
+        ai_memory::config::PermissionsMode::Enforce,
+    );
+    let conn = ai_memory::db::open(std::path::Path::new(":memory:")).expect("scratch sqlite");
+    let db: Db = Arc::new(Mutex::new((
+        conn,
+        std::path::PathBuf::from(":memory:"),
+        ResolvedTtl::default(),
+        true,
+    )));
+    let store: Arc<dyn MemoryStore> = Arc::new(
+        PostgresStore::connect(url)
+            .await
+            .expect("connect postgres adapter"),
+    );
+    let app_state = AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(RwLock::new(Some(Vec::new()))),
+        storage_backend: StorageBackend::Postgres,
+        store,
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: Arc::new(ai_memory::identity::replay::FederationNonceCache::default()),
+        autonomous_hooks: false,
+        auto_tag_queue: None,
+        atomise_queue: None,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(Vec::new()),
+        rule_cache: Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    ai_memory::build_router(api_key_state, app_state)
+}
+
+/// Live-postgres twin of `http_capture_turn_respects_namespace_deny`.
+#[tokio::test]
+#[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL"]
+async fn http_capture_turn_respects_namespace_deny() {
+    let Some(url) = postgres_url() else {
+        panic!("AI_MEMORY_TEST_POSTGRES_URL unset — cannot run live-pg #3225 pin");
+    };
+    clear_active_permission_rules_for_test();
+    set_active_permission_rules(vec![PermissionRule {
+        namespace_pattern: "secrets/*".to_string(),
+        op: ai_memory::governance::Op::MemoryStore.as_str().to_string(),
+        agent_pattern: "*".to_string(),
+        decision: RuleDecision::Deny,
+        reason: Some("no HTTP capture into secrets".to_string()),
+    }]);
+
+    let router = build_pg_router(&url).await;
+    let ns = format!("secrets/ops-3225-{}", uuid::Uuid::new_v4());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/capture_turn")
+        .header("content-type", "application/json")
+        .header("x-agent-id", "alice")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "host_session_id": "sess-3225-pg",
+                "host_turn_index": 0,
+                "role": "user",
+                "content": "secret operator directive",
+                "namespace": ns
+            }))
+            .expect("body"),
+        ))
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .expect("body");
+    let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(json!({}));
+    clear_active_permission_rules_for_test();
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "#3225 pg: K9 Deny on capture_turn must be 403, got {status} {payload}"
+    );
+}

--- a/tests/http_transition_claimed_by_3226.rs
+++ b/tests/http_transition_claimed_by_3226.rs
@@ -56,7 +56,9 @@ fn build_sqlite_router(db_path: &Path) -> axum::Router {
         llm_call_timeout: std::time::Duration::from_secs(30),
         replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
         verify_require_nonce: false,
-        federation_nonce_cache: Arc::new(ai_memory::identity::replay::FederationNonceCache::default()),
+        federation_nonce_cache: Arc::new(
+            ai_memory::identity::replay::FederationNonceCache::default(),
+        ),
         autonomous_hooks: false,
         auto_tag_queue: None,
         atomise_queue: None,
@@ -209,9 +211,7 @@ mod pg {
             ResolvedTtl::default(),
             true,
         )));
-        let pg = PostgresStore::connect(url)
-            .await
-            .expect("connect postgres");
+        let pg = PostgresStore::connect(url).await.expect("connect postgres");
         let store: Arc<dyn MemoryStore> = Arc::new(pg);
         let app_state = AppState {
             db,

--- a/tests/http_transition_claimed_by_3226.rs
+++ b/tests/http_transition_claimed_by_3226.rs
@@ -1,0 +1,308 @@
+// Copyright 2026 AlphaOne LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//! #3226 — HTTP `POST /api/v1/actions/{id}/transition` must bind
+//! `claimed_by` to the live lease holder (MCP #3009) and reject an
+//! unknown `signal_type` (MCP A6-13). Pre-fix HTTP took `claimed_by`
+//! verbatim and coerced unknown signal types to `notify`.
+
+#![cfg(feature = "sal")]
+#![allow(
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::expect_used,
+    clippy::similar_names
+)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use ai_memory::config::{FeatureTier, ResolvedScoring, ResolvedTtl};
+use ai_memory::handlers::{ApiKeyState, AppState, Db, StorageBackend};
+use ai_memory::models::Action;
+use ai_memory::store::MemoryStore;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tempfile::NamedTempFile;
+use tokio::sync::{Mutex, RwLock};
+use tower::ServiceExt as _;
+
+fn build_sqlite_router(db_path: &Path) -> axum::Router {
+    let conn = ai_memory::db::open(db_path).expect("reopen");
+    let db: Db = Arc::new(Mutex::new((
+        conn,
+        db_path.to_path_buf(),
+        ResolvedTtl::default(),
+        true,
+    )));
+    let store: Arc<dyn MemoryStore> =
+        Arc::new(ai_memory::store::sqlite::SqliteStore::open(db_path).expect("SqliteStore"));
+    let app_state = AppState {
+        db,
+        embedder: Arc::new(None),
+        vector_index: Arc::new(Mutex::new(None)),
+        federation: Arc::new(None),
+        tier_config: Arc::new(FeatureTier::Keyword.config()),
+        scoring: Arc::new(ResolvedScoring::default()),
+        profile: Arc::new(ai_memory::profile::Profile::core()),
+        mcp_config: Arc::new(None),
+        active_keypair: Arc::new(None),
+        family_embeddings: Arc::new(RwLock::new(Some(Vec::new()))),
+        storage_backend: StorageBackend::Sqlite,
+        store,
+        llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+        auto_tag_model: Arc::new(None),
+        llm_call_timeout: std::time::Duration::from_secs(30),
+        replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+        verify_require_nonce: false,
+        federation_nonce_cache: Arc::new(ai_memory::identity::replay::FederationNonceCache::default()),
+        autonomous_hooks: false,
+        auto_tag_queue: None,
+        atomise_queue: None,
+        recall_scope: Arc::new(None),
+        deferred_audit_queue: Arc::new(None),
+        admin_agent_ids: Arc::new(Vec::new()),
+        rule_cache: Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+        resolved_models: Arc::new(ai_memory::reload::Swappable::new(
+            ai_memory::config::ResolvedModels::default(),
+        )),
+        runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+        max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    let api_key_state = ApiKeyState {
+        key: None,
+        mtls_enforced: false,
+        enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+        identity_mode: ai_memory::config::HttpIdentityMode::default(),
+    };
+    ai_memory::build_router(api_key_state, app_state)
+}
+
+fn seed_action_with_lease(db_path: &Path, id: &str, holder: &str) {
+    let conn = ai_memory::db::open(db_path).expect("seed open");
+    let now = chrono::Utc::now().timestamp();
+    let action = Action {
+        id: id.to_string(),
+        namespace: "cov-3226".to_string(),
+        kind: "test".to_string(),
+        state: ai_memory::models::ActionState::Pending,
+        title: "tx".to_string(),
+        payload: json!({}),
+        priority: 5,
+        agent_id: Some("ai:cov".to_string()),
+        claimed_by: None,
+        vector_clock: json!({}),
+        metadata: json!({}),
+        created_at: now,
+        updated_at: now,
+    };
+    ai_memory::actions::create(&conn, &action).expect("create action");
+    match ai_memory::actions::lease_acquire(&conn, id, holder, now, now + 120)
+        .expect("lease_acquire")
+    {
+        ai_memory::actions::LeaseAcquire::Acquired(_) => {}
+        ai_memory::actions::LeaseAcquire::Conflict => panic!("fresh lease must acquire"),
+    }
+}
+
+async fn post_json(router: axum::Router, uri: &str, body: serde_json::Value) -> StatusCode {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-agent-id", "ai:tester")
+        .body(Body::from(serde_json::to_vec(&body).expect("body")))
+        .expect("request");
+    router.oneshot(req).await.expect("oneshot").status()
+}
+
+/// HTTP transition with `claimed_by` that is not the live lease holder is 403.
+#[tokio::test]
+async fn http_transition_claimed_by_not_holder() {
+    let f = NamedTempFile::new().expect("tempfile");
+    let db_path = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&db_path).expect("init schema");
+    seed_action_with_lease(&db_path, "act-3226", "ai:w1");
+
+    let router = build_sqlite_router(&db_path);
+    let status = post_json(
+        router,
+        "/api/v1/actions/act-3226/transition",
+        json!({"to": "claimed", "claimed_by": "ai:w2"}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "#3226: non-holder claimed_by must be 403"
+    );
+
+    // Holder succeeds; control-char claimed_by is 400.
+    let router = build_sqlite_router(&db_path);
+    let ok = post_json(
+        router,
+        "/api/v1/actions/act-3226/transition",
+        json!({"to": "claimed", "claimed_by": "ai:w1"}),
+    )
+    .await;
+    assert_eq!(ok, StatusCode::OK, "#3226: lease holder must transition");
+
+    let router = build_sqlite_router(&db_path);
+    let bad = post_json(
+        router,
+        "/api/v1/actions/act-3226/transition",
+        json!({"to": "in_progress", "claimed_by": "bad\nid"}),
+    )
+    .await;
+    assert_eq!(
+        bad,
+        StatusCode::BAD_REQUEST,
+        "#3226: control-char claimed_by must be 400"
+    );
+}
+
+/// HTTP `POST /signals` rejects an unknown `signal_type` (MCP A6-13 parity).
+#[tokio::test]
+async fn http_send_signal_rejects_unknown_signal_type() {
+    let f = NamedTempFile::new().expect("tempfile");
+    let db_path = f.path().to_path_buf();
+    let _ = ai_memory::db::open(&db_path).expect("init schema");
+    let router = build_sqlite_router(&db_path);
+    let status = post_json(
+        router,
+        "/api/v1/signals",
+        json!({
+            "namespace": "cov-3226",
+            "subject": "s",
+            "signal_type": "bogus"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "#3226: unknown signal_type must be 400, not coerced to notify"
+    );
+}
+
+#[cfg(feature = "sal-postgres")]
+mod pg {
+    use super::*;
+    use ai_memory::store::CallerContext;
+    use ai_memory::store::postgres::PostgresStore;
+
+    fn postgres_url() -> Option<String> {
+        std::env::var("AI_MEMORY_TEST_POSTGRES_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+    }
+
+    async fn build_pg_router(url: &str) -> (axum::Router, Arc<dyn MemoryStore>) {
+        ai_memory::handlers::admin_role::mark_request_authn_configured(true);
+        let conn = ai_memory::db::open(std::path::Path::new(":memory:")).expect("scratch sqlite");
+        let db: Db = Arc::new(Mutex::new((
+            conn,
+            std::path::PathBuf::from(":memory:"),
+            ResolvedTtl::default(),
+            true,
+        )));
+        let pg = PostgresStore::connect(url)
+            .await
+            .expect("connect postgres");
+        let store: Arc<dyn MemoryStore> = Arc::new(pg);
+        let app_state = AppState {
+            db,
+            embedder: Arc::new(None),
+            vector_index: Arc::new(Mutex::new(None)),
+            federation: Arc::new(None),
+            tier_config: Arc::new(FeatureTier::Keyword.config()),
+            scoring: Arc::new(ResolvedScoring::default()),
+            profile: Arc::new(ai_memory::profile::Profile::core()),
+            mcp_config: Arc::new(None),
+            active_keypair: Arc::new(None),
+            family_embeddings: Arc::new(RwLock::new(Some(Vec::new()))),
+            storage_backend: StorageBackend::Postgres,
+            store: Arc::clone(&store),
+            llm: Arc::new(ai_memory::reload::SwappableLlm::new(None)),
+            auto_tag_model: Arc::new(None),
+            llm_call_timeout: std::time::Duration::from_secs(30),
+            replay_cache: Arc::new(ai_memory::identity::replay::ReplayCache::default()),
+            verify_require_nonce: false,
+            federation_nonce_cache: Arc::new(
+                ai_memory::identity::replay::FederationNonceCache::default(),
+            ),
+            autonomous_hooks: false,
+            auto_tag_queue: None,
+            atomise_queue: None,
+            recall_scope: Arc::new(None),
+            deferred_audit_queue: Arc::new(None),
+            admin_agent_ids: Arc::new(Vec::new()),
+            rule_cache: Arc::new(ai_memory::governance::rule_cache::RuleCache::new()),
+            resolved_models: Arc::new(ai_memory::reload::Swappable::new(
+                ai_memory::config::ResolvedModels::default(),
+            )),
+            runtime: ai_memory::runtime_context::RuntimeContext::global_arc(),
+            max_page_size: ai_memory::handlers::MAX_BULK_SIZE,
+            enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+            http_identity_mode: ai_memory::config::HttpIdentityMode::default(),
+        };
+        let api_key_state = ApiKeyState {
+            key: None,
+            mtls_enforced: false,
+            enrolled_agent_keys: Arc::new(std::collections::HashMap::new()),
+            identity_mode: ai_memory::config::HttpIdentityMode::default(),
+        };
+        (ai_memory::build_router(api_key_state, app_state), store)
+    }
+
+    /// Live-postgres twin of `http_transition_claimed_by_not_holder`.
+    #[tokio::test]
+    #[ignore = "requires AI_MEMORY_TEST_POSTGRES_URL"]
+    async fn http_transition_claimed_by_not_holder() {
+        let Some(url) = postgres_url() else {
+            panic!("AI_MEMORY_TEST_POSTGRES_URL unset — cannot run live-pg #3226 pin");
+        };
+        let (router, store) = build_pg_router(&url).await;
+        let ctx = CallerContext::for_agent("ai:cov".to_string());
+        let now = chrono::Utc::now().timestamp();
+        let id = format!("act-3226-{}", uuid::Uuid::new_v4());
+        let action = Action {
+            id: id.clone(),
+            namespace: "cov-3226-pg".to_string(),
+            kind: "test".to_string(),
+            state: ai_memory::models::ActionState::Pending,
+            title: "tx".to_string(),
+            payload: json!({}),
+            priority: 5,
+            agent_id: Some("ai:cov".to_string()),
+            claimed_by: None,
+            vector_clock: json!({}),
+            metadata: json!({}),
+            created_at: now,
+            updated_at: now,
+        };
+        store
+            .action_create(&ctx, &action)
+            .await
+            .expect("action_create");
+        store
+            .lease_acquire(&ctx, &id, "ai:w1", now, now + 120)
+            .await
+            .expect("lease_acquire");
+
+        let status = post_json(
+            router,
+            &format!("/api/v1/actions/{id}/transition"),
+            json!({"to": "claimed", "claimed_by": "ai:w2"}),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "#3226 pg: non-holder claimed_by must be 403"
+        );
+    }
+}

--- a/tests/recall_purity_p01.rs
+++ b/tests/recall_purity_p01.rs
@@ -1217,9 +1217,8 @@ fn v77_migration_backfills_preexisting_rows_folded() {
     let dir = tempfile::tempdir_in(&root).expect("tempdir");
     let path = dir.path().join("v77.db");
 
-    // Fresh open reaches the current tip (v90, #2385 archive genesis-cid
-    // parity: additive `archived_memories.cid` / `cid_genesis`) with the v77
-    // `folded` column present.
+    // Fresh open reaches the current tip (v91, #3250 archive-link cids)
+    // with the v77 `folded` column present.
     let conn = db::open(&path).expect("open");
     assert_eq!(db::migrations::current_schema_version_for_tests(), 91);
     let version: i64 = conn
@@ -1229,7 +1228,7 @@ fn v77_migration_backfills_preexisting_rows_folded() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(version, 90, "fresh open reaches the current tip");
+    assert_eq!(version, 91, "fresh open reaches the current tip");
     assert!(
         conn.prepare("SELECT folded FROM recall_observations LIMIT 0")
             .is_ok(),

--- a/tests/skill_retire_lifecycle.rs
+++ b/tests/skill_retire_lifecycle.rs
@@ -359,9 +359,9 @@ fn migration_v82_applies_and_is_idempotent() {
         )
         .unwrap();
     assert_eq!(
-        version, 90,
+        version, 91,
         "upgrade-from-v81 runs the full ladder to the current tip (v82 re-adds the \
-         retire columns; v83 adds agent_api_keys; v90 adds the archive cid pair)"
+         retire columns; v83 adds agent_api_keys; v91 adds archive-link cids)"
     );
     assert!(
         conn2
@@ -380,7 +380,7 @@ fn migration_v82_applies_and_is_idempotent() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(v3, 90, "re-open stays at the current tip idempotently");
+    assert_eq!(v3, 91, "re-open stays at the current tip idempotently");
     // A retire round-trips end-to-end on the migrated DB.
     let _: Value = handle_skill_register(
         &conn3,


### PR DESCRIPTION
Security: HTTP fail-open authz cluster. #3225 capture_turn K9+ns governance (Deny→403/Pending→202), #3226 lease-holder bind (spoof→403), #3227/#3228 fault→503 fail-closed, M7 MCP↔HTTP parity (is_unowned_owner_lock allow-through). Review round: store_err_to_response reuse (un-ratchet) + fault-injecting fail-closed tests + M7 parity. Branch-CI-before-merge; Fable signed admin-lift merge on green.