### PR TITLE
fix(cli): bind recall ledger to the CALLER identity, not the --as-agent namespace (#2988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (CLI-surface parity — bind the recall ledger to the CALLER, not a namespace #2988)
+
+- **#2988 — the recall ledger bound a NAMESPACE into the identity column.**
+  Both CLI recall paths wrote `--as-agent` (a namespace) into
+  `recall_observations.agent_id`: `src/cli/recall.rs` passed
+  `args.as_agent`, and the interactive shell passed `None`. The #1705
+  cross-agent replay guard keys on that column (`agent_id IS NULL OR agent_id
+  = ?`), so it was inert on both paths — a namespace cannot gate an identity,
+  and a WRONG identity in that column is worse than NULL. Both now bind
+  `resolve_read_visibility_caller()`, the same value the MCP/HTTP writer
+  stamps (`mcp::tools::recall::record_recall_observations`). `--as-agent`
+  remains the namespace-scope visibility knob. Precedent-copy — the
+  fail-closed posture was already decided on the MCP/HTTP reference surface,
+  and this does not tighten behaviour beyond that precedent. Pinned by
+  `recall_ledger_binds_caller_identity_not_as_agent_2988` (a CLI-surface
+  replay-guard regression test the original coverage lacked).
+
 ### Fixed (B7 structural gate — pg transcript-write twins allowlisted)
 
 - The #3064 batch D merge added two write-SQL functions in

--- a/src/cli/recall.rs
+++ b/src/cli/recall.rs
@@ -604,11 +604,22 @@ pub(crate) fn run_with_embedder(
                 score: *s,
             })
             .collect();
+        // #2988 — bind the RECALLING agent's identity into the ledger, NOT
+        // `--as-agent` (a NAMESPACE). The MCP/HTTP recall path stamps the
+        // read-visibility caller (`resolve_read_visibility_caller`) here
+        // (see `mcp::tools::recall::record_recall_observations`, which passes
+        // `caller`); reuse the same `vis_caller` so the #1705 cross-agent
+        // replay guard (`mark_consumed_guarded`: `agent_id IS NULL OR
+        // agent_id = ?`) is bound to the true recaller (or `NULL` when no
+        // stable identity is set) instead of a namespace in the identity
+        // column. Pre-fix `args.as_agent.as_deref()` wrote the namespace into
+        // the identity slot, making the guard inert on the CLI surface.
+        // `--as-agent` remains the namespace-scope visibility knob.
         if let Err(e) = crate::observations::record_recall_with_identity(
             conn,
             &recall_id,
             &candidates,
-            args.as_agent.as_deref(),
+            vis_caller.as_deref(),
             effective_namespace.as_deref(),
         ) {
             writeln!(out.stderr, "ai-memory: recall ledger append failed: {e}")?;
@@ -1138,6 +1149,75 @@ mod tests {
             Some(v) => unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", v) },
             None => unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") },
         }
+    }
+
+    /// #2988 — the recall ledger MUST bind the RECALLING agent's identity
+    /// (the `resolve_read_visibility_caller` value the MCP/HTTP surface
+    /// stamps), NEVER the `--as-agent` NAMESPACE. Pre-fix the CLI wrote
+    /// `--as-agent` into the `agent_id` column, making the #1705 cross-agent
+    /// replay guard (`mark_consumed_guarded`: `agent_id IS NULL OR
+    /// agent_id = ?`) inert — a namespace can't gate an identity, and a
+    /// WRONG identity is worse than NULL. This pins the caller-identity bind.
+    #[test]
+    fn recall_ledger_binds_caller_identity_not_as_agent_2988() {
+        // Serialize on the crate-wide agent-id env lock (#1772) since this
+        // test mutates `AI_MEMORY_AGENT_ID` process-wide.
+        let _envg = crate::identity::agent_id_env_test_lock();
+        let prev = std::env::var_os("AI_MEMORY_AGENT_ID");
+
+        let mut env = TestEnv::fresh();
+        let db = env.db_path.clone();
+        // Seed a COLLECTIVE row so the #2990 per-row ownership post-filter does
+        // not hide it from the non-owner caller (else there would be no ledger
+        // row to inspect).
+        seed_scoped(
+            &db,
+            "proj/a",
+            "needle ledger title",
+            "content",
+            "collective",
+            "ai:owner",
+        );
+
+        let mut args = default_args();
+        args.namespace = Some("proj/a".to_string());
+        // A NAMESPACE, deliberately equal-shaped to a slash-scoped id so the
+        // pre-fix "namespace in the identity column" bug would go unnoticed by
+        // a shape check alone.
+        args.as_agent = Some("proj/a".to_string());
+        let cfg = AppConfig::default();
+
+        // SAFETY: process-global env mutation serialized on the crate-wide
+        // agent-id test lock held for this test's body.
+        unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", "ai:cert-fed-proxy") };
+        {
+            let mut out = env.output();
+            let _ = run(&db, &args, true, &cfg, &mut out);
+        }
+        // Restore BEFORE asserting so a failure never leaks the var.
+        // SAFETY: serialized on the crate-wide agent-id test lock.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("AI_MEMORY_AGENT_ID", v) },
+            None => unsafe { std::env::remove_var("AI_MEMORY_AGENT_ID") },
+        }
+
+        let conn = db::open(&db).unwrap();
+        let ids: Vec<Option<String>> = conn
+            .prepare("SELECT DISTINCT agent_id FROM recall_observations")
+            .unwrap()
+            .query_map([], |r| r.get::<_, Option<String>>(0))
+            .unwrap()
+            .map(std::result::Result::unwrap)
+            .collect();
+        assert!(
+            ids.iter()
+                .any(|id| id.as_deref() == Some("ai:cert-fed-proxy")),
+            "recall ledger must bind the caller identity (#2988); got {ids:?}"
+        );
+        assert!(
+            !ids.iter().any(|id| id.as_deref() == Some("proj/a")),
+            "the --as-agent NAMESPACE must NOT land in the agent_id column (#2988); got {ids:?}"
+        );
     }
 
     #[test]

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -100,11 +100,17 @@ pub fn handle_command(parts: &[&str], conn: &Connection, out: &mut CliOutput<'_>
                                 score: *s,
                             })
                             .collect();
+                        // #2988 — bind the recalling agent's identity into the
+                        // ledger (MCP/HTTP precedent), so the #1705 cross-agent
+                        // replay guard is not inert on the shell recall path.
+                        // `None` (unset AI_MEMORY_AGENT_ID) preserves the
+                        // single-tenant trust-all posture.
+                        let vis_caller = crate::identity::resolve_read_visibility_caller();
                         if let Err(e) = crate::observations::record_recall_with_identity(
                             conn,
                             &recall_id,
                             &candidates,
-                            None,
+                            vis_caller.as_deref(),
                             None,
                         ) {
                             let _ =


### PR DESCRIPTION
## Summary

Re-lands the #2988 slice of PR #3051, which was **lost in a rebase**. The bug: both CLI recall funnels wrote the wrong value into `recall_observations.agent_id`, leaving the #1705 cross-agent replay guard (`mark_consumed_guarded`: `agent_id IS NULL OR agent_id = ?`) **inert on the CLI surface**.

- `src/cli/recall.rs` passed `args.as_agent.as_deref()` — but `--as-agent` is a **NAMESPACE** (validated via `validate_namespace`), so a namespace landed in the identity column. A wrong identity there is worse than NULL: every CLI-originated `recall_id` became consumable by any agent, and the ledger carried a false principal.
- `src/cli/shell.rs` hardcoded `None`, so the recaller's identity was never recorded even with `AI_MEMORY_AGENT_ID` set.

Both now bind `resolve_read_visibility_caller()` — the same read-visibility caller the MCP/HTTP writer already stamps (`mcp::tools::recall::record_recall_observations`, `handlers::recall`, `store::sqlite` via `effective_principal()`). `--as-agent` remains the namespace-scope visibility knob. Precedent-copy of the already-decided fail-closed reference posture; nothing tightened beyond it.

## What the rebase lost / how it was re-landed

The original PR bundled #2990/#2992/#3036/#2988. The #2990 per-row visibility post-filter survived on base (`src/cli/recall.rs:579`), but the one-line #2988 ledger bind reverted to the buggy `args.as_agent.as_deref()`. Recovered the intended fix from pre-rebase commit `b9f66a29`, adapted the regression test to the current test infrastructure (`seed_scoped` collective row so the #2990 post-filter doesn't hide the ledgered row), and re-applied on `release/v1.0.0`.

## Audit (all `record_recall_with_identity` funnels)

Confirmed the two CLI funnels were the only buggy ones. Non-CLI production paths already bind a real identity: MCP passes `caller`, `handlers::recall` passes `agent_for_ledger`, `store::sqlite` passes `ctx.effective_principal()`. Identity is bound from the resolved principal ladder, never a self-asserted request field. No `src/identity/*` edit → no cert §7 amendment required.

## Proof

`recall_ledger_binds_caller_identity_not_as_agent_2988`:
- **FAILS pre-fix**: `agent_id = "proj/a"` (the namespace) — `recall ledger must bind the caller identity (#2988); got [Some("proj/a")]`
- **PASSES post-fix**: `agent_id = "ai:cert-fed-proxy"`, and the `proj/a` namespace never lands in the identity column.

## Verification

- Regression test: PASS (fix) / FAIL (reverted) — both proven locally.
- `cli::recall::tests` 40/0, `cli::shell` 42/0.
- Structural suite: `record_stop_structural_b7`, `append_only_spine_guard_g6`, `cli_write_verb_pg_refuse_ceiling_2572`, `db_open_funnel_ceiling_2445`, `qual_6_7_legacy_error_type_ceiling`, `qual_expiry_floor_local_write_funnel_2515`, `mcp_param_names_invariant`, `attest_level_string_invariant`, `qual_12_todo_tracker_discipline`, `qual_10_module_size_ceiling` — all PASS (with `AI_MEMORY_TEST_POSTGRES_URL` real pg).
- Clippy `--features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic`: clean.
- `cargo fmt --check`: clean. `scripts/check-hardcoded-literals.sh`: PASS.

rust-1.98 rules: UNSAFE-04 (unforgeable identity invariant behind the resolved-principal ladder), ERRORS-09 (illegal cross-agent-replay state made unrepresentable), TEST-01/TEST-02/ERRORS-24 (unit-test conventions).

No SSOT-pin changes (no new tools/routes/params/schema versions). CHANGELOG [Unreleased] updated.

Closes #2988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY