### PR TITLE
fix(curator): fail-closed on rollback failure (#3190) + panic-contain consolidation pass (#3283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (curator data-integrity + availability — #3190, #3283)
+
+- **#3190 (data-integrity, GA-blocker) — curator consolidation now FAILS CLOSED
+  when a Stage-6 auto-rollback itself fails.** `ConsolidationPass::run`
+  (`src/curator/compaction.rs`) previously treated a failed rollback as a
+  per-cluster hiccup: it set `restored = 0`, pushed a note into
+  `report.errors`, and `continue`d — even though `persist` had already removed
+  the pre-merge sources and the unverifiable summary was still live. That is a
+  fail-OPEN continuation over a data-loss-shaped state (an unverifiable summary
+  served as truth while sources are silently lost). The pass now HALTS the
+  sweep with a typed, greppable error (`ROLLBACK_FAILED_FAILCLOSED_SLUG`) and
+  DELIBERATELY retains the unverifiable summary — because a partially-failed
+  rollback can leave that summary as the only surviving copy of a source that
+  did not restore, and `db::delete` is a hard row delete. North Star: fail
+  closed; never cause unintentional data loss. New regression test
+  (`rollback_failure_halts_sweep_fail_closed_and_retains_summary_3190`).
+- **#3283 (curator availability, GA-blocker) — the SAL `ConsolidationPass` is
+  now panic-contained.** `run_consolidation_pass` (`src/curator/mod.rs`) had no
+  `catch_unwind`; an LLM-clustering or nested-runtime panic escaped the pass,
+  unwound out of `run_once` and `run_daemon`'s loop, and out of the
+  `spawn_blocking` closure both daemon drivers await — where the `JoinError`
+  was converted into a hard error that TERMINATED the curator daemon. The pass
+  drive is now wrapped in `std::panic::catch_unwind`, so one bad cycle degrades
+  to a logged, reported failure (`CONSOLIDATION_PASS_PANIC_CONTAINED`) with the
+  corpus untouched, and the daemon proceeds to its next cycle. North Star:
+  degrade, never die. New regression test
+  (`consolidation_pass_contains_panic_and_survives_3283`). No product/API/SSOT
+  surface change (no new MCP tools, routes, CLI verbs, or schema versions).
+
 ### Fixed (B7 structural gate — pg transcript-write twins allowlisted)
 
 - The #3064 batch D merge added two write-SQL functions in

--- a/src/curator/compaction.rs
+++ b/src/curator/compaction.rs
@@ -87,6 +87,22 @@ const CONSOLIDATOR_AGENT_ID: &str = crate::identity::sentinels::AI_CURATOR;
 #[cfg(feature = "sal")]
 pub(crate) const COMPACTION_TRACE_TARGET: &str = "curator::compaction";
 
+/// #3190 (data-integrity, GA-blocker) — stable, greppable prefix for the
+/// FAIL-CLOSED sweep halt raised when a Stage-6 auto-rollback ITSELF fails.
+///
+/// Pre-fix the sweep treated a failed rollback as a per-cluster hiccup: it set
+/// `restored = 0`, pushed a note into `report.errors`, and `continue`d — even
+/// though the pre-merge sources had already been removed by `persist` and the
+/// unverifiable summary was still live. That is a fail-OPEN continuation over a
+/// data-loss-shaped state (an unverifiable summary served as truth while
+/// sources are silently lost). Now a failed rollback returns this typed error
+/// from [`ConsolidationPass::run`], HALTING the sweep loudly (North Star: fail
+/// closed; never cause unintentional data loss). One named const so the
+/// production halt and the regression assertion share a single spelling
+/// (pm-v3.1 lint-gate).
+#[cfg(feature = "sal")]
+pub(crate) const ROLLBACK_FAILED_FAILCLOSED_SLUG: &str = "consolidation rollback FAILED — sweep halted fail-closed (sources may be un-restored; unverifiable summary retained for recovery)";
+
 /// #2637 — injection seam for the `PreCompaction` decision gate.
 ///
 /// A `pre_compaction` hook gates the curator's autonomous, hard-DELETE
@@ -460,8 +476,10 @@ impl<'a> ConsolidationPass<'a> {
 
     /// Drive the full six-step compaction lifecycle over `candidates`:
     /// `cluster` → resolve members → `eligible` → `summarize` → `persist`
-    /// → `verify`. Returns a [`ConsolidationRunReport`]; per-cluster
-    /// failures are recorded in `report.errors` and never abort the sweep.
+    /// → `verify`. Returns a [`ConsolidationRunReport`]; ordinary per-cluster
+    /// failures (summarise / persist / a verify that rolls back cleanly) are
+    /// recorded in `report.errors` and never abort the sweep. The ONE
+    /// exception is a Stage-6 rollback that itself fails — see below.
     ///
     /// **Dry-run (`self.dry_run`, a `--dry-run` curator cycle):** the sweep
     /// stops after `eligible` — it counts what it *would* consolidate
@@ -473,7 +491,17 @@ impl<'a> ConsolidationPass<'a> {
     /// the unverifiable summary, and the sweep continues (no rollback entry
     /// is left for that cluster). Note the notify-only
     /// `OnCompactionRollback` hook event is NOT fired — it has no fire site
-    /// at v1.0.0; the failure is reported via the WARN line only.
+    /// at v1.0.0; the clean-rollback failure is reported via the WARN line only.
+    ///
+    /// **FAIL-CLOSED on a failed rollback (#3190, data-integrity GA-blocker):**
+    /// if the Stage-6 auto-rollback ITSELF returns `Err`, the sources are not
+    /// known to be restored and the unverifiable summary is still live.
+    /// [`Self::run`] does NOT continue past that data-loss-shaped state: it
+    /// returns `Err` prefixed with [`ROLLBACK_FAILED_FAILCLOSED_SLUG`],
+    /// halting the sweep, and deliberately RETAINS the unverifiable summary
+    /// (it may be the only surviving copy of a source that failed to restore;
+    /// see the inline rationale). North Star: fail closed, never cause
+    /// unintentional data loss.
     pub(crate) async fn run(&self, candidates: &[Memory]) -> Result<ConsolidationRunReport> {
         let mut report = ConsolidationRunReport::default();
 
@@ -557,31 +585,66 @@ impl<'a> ConsolidationPass<'a> {
                 // v1.0.0 (claims audit 2026-08-22). The operator-visible
                 // signals are the WARN below AND `report.errors` (the
                 // verify-failed string is pushed onto the pass report).
-                let restored = match self.rollback_consolidation(&members, &new_id).await {
-                    Ok(n) => n,
-                    Err(re) => {
-                        report
-                            .errors
-                            .push(format!("{}: rollback failed: {re}", self.name()));
-                        0
+                match self.rollback_consolidation(&members, &new_id).await {
+                    Ok(restored) => {
+                        if restored > 0 {
+                            report.rolled_back += 1;
+                        }
+                        tracing::warn!(
+                            target: COMPACTION_TRACE_TARGET,
+                            pass = self.name(),
+                            summary_id = %new_id,
+                            restored,
+                            error = %e,
+                            "consolidation verify failed — rolled back (Stage-6, #664)"
+                        );
+                        report.errors.push(format!(
+                            "{}: verify failed (rolled back {restored}): {e}",
+                            self.name()
+                        ));
+                        continue;
                     }
-                };
-                if restored > 0 {
-                    report.rolled_back += 1;
+                    Err(re) => {
+                        // #3190 FAIL-CLOSED (data-integrity, GA-blocker). The
+                        // Stage-6 auto-rollback itself failed, so the pre-merge
+                        // sources are NOT known to be restored (some may already
+                        // have been hard-DELETEd by `persist`) and the
+                        // unverifiable summary is still live. The pre-fix code
+                        // `continue`d here — a fail-OPEN continuation that serves
+                        // an unverifiable summary as truth while sources are
+                        // silently lost. Two invariants now hold (North Star:
+                        // fail closed; never cause unintentional data loss):
+                        //
+                        //   1. HALT the sweep loudly — return a typed, greppable
+                        //      error instead of proceeding to the next cluster.
+                        //      The caller (`curator::run_consolidation_pass`)
+                        //      surfaces it as a hard cycle error, not a buried
+                        //      WARN.
+                        //   2. DELIBERATELY do NOT delete the unverifiable
+                        //      summary. `rollback_consolidation` restores sources
+                        //      FIRST and only then deletes the summary, so a
+                        //      failure leaves the summary as potentially the ONLY
+                        //      surviving representation of any source that did not
+                        //      restore. `db::delete` is a HARD row delete;
+                        //      removing it here could destroy that last copy.
+                        //      Retaining it keeps the merged content recoverable
+                        //      (operator `curator --rollback` / manual repair).
+                        tracing::error!(
+                            target: COMPACTION_TRACE_TARGET,
+                            pass = self.name(),
+                            summary_id = %new_id,
+                            verify_error = %e,
+                            rollback_error = %re,
+                            slug = ROLLBACK_FAILED_FAILCLOSED_SLUG,
+                            "consolidation rollback FAILED — sweep halted fail-closed; unverifiable summary RETAINED for recovery"
+                        );
+                        return Err(anyhow::anyhow!(
+                            "{slug}: pass={pass}: summary_id={new_id}: verify_error={e}: rollback_error={re}",
+                            slug = ROLLBACK_FAILED_FAILCLOSED_SLUG,
+                            pass = self.name(),
+                        ));
+                    }
                 }
-                tracing::warn!(
-                    target: COMPACTION_TRACE_TARGET,
-                    pass = self.name(),
-                    summary_id = %new_id,
-                    restored,
-                    error = %e,
-                    "consolidation verify failed — rolled back (Stage-6, #664)"
-                );
-                report.errors.push(format!(
-                    "{}: verify failed (rolled back {restored}): {e}",
-                    self.name()
-                ));
-                continue;
             }
 
             // Happy path — the consolidation verified and sticks. Persist an
@@ -1692,6 +1755,204 @@ mod tests {
                 "squatter not clobbered"
             );
             assert!(crate::db::get(&conn, &result_id).unwrap().is_none());
+        }
+
+        // ---- #3190 fail-closed on a failed rollback -------------------------
+
+        /// #3190 test double — wraps a real `SqliteStore`, delegating every op
+        /// EXCEPT the two failure injections the fail-closed halt needs:
+        ///   * `fail_verify` → `get` returns `NotFound`, so
+        ///     [`ConsolidationPass::verify`] fails and `run` enters the Stage-6
+        ///     auto-rollback branch;
+        ///   * `fail_restore` → `restore_or_conflict` returns a non-`Conflict`
+        ///     backend error, so `rollback_consolidation` itself returns `Err`
+        ///     (the data-loss-shaped state #3190 must fail closed on).
+        ///
+        /// Clustering (`get_embedding_with_space`) and the destructive merge
+        /// (`consolidate`) delegate to the inner store so the pass reaches the
+        /// rollback branch against real data.
+        struct RollbackFailStore {
+            inner: SqliteStore,
+            fail_verify: std::sync::atomic::AtomicBool,
+            fail_restore: std::sync::atomic::AtomicBool,
+        }
+
+        #[async_trait::async_trait]
+        impl MemoryStore for RollbackFailStore {
+            fn capabilities(&self) -> crate::store::Capabilities {
+                self.inner.capabilities()
+            }
+            async fn store(
+                &self,
+                ctx: &CallerContext,
+                memory: &Memory,
+            ) -> crate::store::StoreResult<String> {
+                self.inner.store(ctx, memory).await
+            }
+            async fn get(
+                &self,
+                ctx: &CallerContext,
+                id: &str,
+            ) -> crate::store::StoreResult<Memory> {
+                if self.fail_verify.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Err(StoreError::NotFound { id: id.to_string() });
+                }
+                self.inner.get(ctx, id).await
+            }
+            async fn update(
+                &self,
+                ctx: &CallerContext,
+                id: &str,
+                patch: crate::store::UpdatePatch,
+            ) -> crate::store::StoreResult<()> {
+                self.inner.update(ctx, id, patch).await
+            }
+            async fn delete(&self, ctx: &CallerContext, id: &str) -> crate::store::StoreResult<()> {
+                self.inner.delete(ctx, id).await
+            }
+            async fn list(
+                &self,
+                ctx: &CallerContext,
+                filter: &crate::store::Filter,
+            ) -> crate::store::StoreResult<Vec<Memory>> {
+                self.inner.list(ctx, filter).await
+            }
+            async fn search(
+                &self,
+                ctx: &CallerContext,
+                query: &str,
+                filter: &crate::store::Filter,
+            ) -> crate::store::StoreResult<Vec<Memory>> {
+                self.inner.search(ctx, query, filter).await
+            }
+            async fn verify(
+                &self,
+                ctx: &CallerContext,
+                id: &str,
+            ) -> crate::store::StoreResult<crate::store::VerifyReport> {
+                self.inner.verify(ctx, id).await
+            }
+            async fn link(
+                &self,
+                ctx: &CallerContext,
+                link: &crate::models::MemoryLink,
+            ) -> crate::store::StoreResult<()> {
+                self.inner.link(ctx, link).await
+            }
+            async fn list_links(
+                &self,
+                namespace: Option<&str>,
+            ) -> crate::store::StoreResult<Vec<crate::models::MemoryLink>> {
+                self.inner.list_links(namespace).await
+            }
+            async fn register_agent(
+                &self,
+                ctx: &CallerContext,
+                agent: &crate::models::AgentRegistration,
+            ) -> crate::store::StoreResult<()> {
+                self.inner.register_agent(ctx, agent).await
+            }
+            async fn get_embedding_with_space(
+                &self,
+                ctx: &CallerContext,
+                id: &str,
+            ) -> crate::store::StoreResult<Option<(Vec<f32>, Option<String>)>> {
+                self.inner.get_embedding_with_space(ctx, id).await
+            }
+            async fn consolidate(
+                &self,
+                ctx: &CallerContext,
+                ids: &[String],
+                title: &str,
+                summary: &str,
+                namespace: &str,
+                tier: &Tier,
+                source: &str,
+                consolidator_agent_id: &str,
+            ) -> crate::store::StoreResult<String> {
+                self.inner
+                    .consolidate(
+                        ctx,
+                        ids,
+                        title,
+                        summary,
+                        namespace,
+                        tier,
+                        source,
+                        consolidator_agent_id,
+                    )
+                    .await
+            }
+            async fn restore_or_conflict(
+                &self,
+                ctx: &CallerContext,
+                memory: &Memory,
+            ) -> crate::store::StoreResult<String> {
+                if self.fail_restore.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Err(StoreError::Backend(crate::store::BoxBackendError::new(
+                        "injected rollback restore failure (#3190 fail-closed test)",
+                    )));
+                }
+                self.inner.restore_or_conflict(ctx, memory).await
+            }
+        }
+
+        #[tokio::test]
+        async fn rollback_failure_halts_sweep_fail_closed_and_retains_summary_3190() {
+            // #3190 (data-integrity, GA-blocker): when a Stage-6 auto-rollback
+            // ITSELF fails, the sweep must FAIL CLOSED — halt loudly rather than
+            // `continue` past an unverifiable-summary-served-as-truth /
+            // sources-silently-lost state, and RETAIN the summary (it may be the
+            // only surviving copy of a source that did not restore).
+            //
+            // At the parent commit this FAILS: `run` swallowed the rollback
+            // error and returned `Ok`, continuing the sweep.
+            let (store, _dir) = open_db();
+            let conn = conn_of(&store);
+            let candidates = seed_two_dupes(&conn);
+            let llm = StubLlm::new("synth");
+
+            let fail_store = RollbackFailStore {
+                inner: store,
+                fail_verify: std::sync::atomic::AtomicBool::new(true),
+                fail_restore: std::sync::atomic::AtomicBool::new(true),
+            };
+            let pass = ConsolidationPass::new(&fail_store, &llm, false /* real */);
+
+            let result = pass.run(&candidates).await;
+
+            // FAIL-CLOSED: the sweep HALTS with a typed, greppable error rather
+            // than continuing past the data-loss-shaped state.
+            let err = result.expect_err("a failed rollback must abort the sweep fail-closed");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains(super::super::ROLLBACK_FAILED_FAILCLOSED_SLUG),
+                "halt error must carry the fail-closed slug, got: {msg}"
+            );
+
+            // NO DATA LOSS: the unverifiable summary is RETAINED. A naive
+            // delete-the-summary fail-closed would have destroyed the only
+            // surviving copy of any source that did not restore; the
+            // [consolidated] row must still be present in the backing DB.
+            let rows = crate::db::list(
+                &conn,
+                Some("ns"),
+                None,
+                16,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+            assert!(
+                rows.iter().any(|m| m.title.starts_with("[consolidated]")),
+                "the unverifiable summary must be retained for recovery, titles: {:?}",
+                rows.iter().map(|m| m.title.clone()).collect::<Vec<_>>()
+            );
         }
     } // mod sal_pass_tests
 }

--- a/src/curator/mod.rs
+++ b/src/curator/mod.rs
@@ -697,7 +697,43 @@ fn run_consolidation_pass(
     // worker, spawn_blocking, no runtime): `block_in_place` is a no-op
     // when not entered and parks a multi-thread worker so nested block_on
     // is legal. CONCURRENCY-22.
-    let outcome = tokio::task::block_in_place(drive_pass);
+    //
+    // #3283 — PANIC CONTAINMENT (North Star: degrade, never die). The pass
+    // drives an LLM clusterer plus a nested current-thread runtime; a panic in
+    // either (or any callee) would otherwise unwind out of `run_once`, out of
+    // `run_daemon`'s cycle loop, and out of the `spawn_blocking` closure both
+    // daemon drivers await (`daemon_runtime::run_curator_daemon_with_shutdown`
+    // / `_with_primitives`) — where the resulting `JoinError` is converted into
+    // a hard error that TERMINATES the curator daemon. `catch_unwind` contains
+    // the pass so one bad cycle degrades to a logged, reported failure, not a
+    // dead daemon (`panic = "unwind"` is deliberately retained in Cargo.toml
+    // precisely so this boundary works; `catch_unwind` is inert under
+    // `panic = "abort"`). `AssertUnwindSafe` is sound here: on a caught panic we
+    // observe NONE of the state reachable through the closure — we only record
+    // an error string and return; `report` is mutated only AFTER the boundary,
+    // never inside it. The `catch_unwind` `Result` is handled explicitly,
+    // never dropped (ERRORS-19). Dropping the pass's inner current-thread
+    // runtime while unwinding is safe on every remaining case (no-runtime test
+    // thread, spawn_blocking pool thread — both permit blocking); the
+    // would-double-panic current-thread-worker case is already skipped above.
+    let driven = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tokio::task::block_in_place(drive_pass)
+    }));
+    let outcome = match driven {
+        Ok(result) => result,
+        Err(panic) => {
+            let detail = panic_payload_message(panic.as_ref());
+            tracing::error!(
+                slug = CONSOLIDATION_PASS_PANIC_CONTAINED,
+                detail = %detail,
+                "consolidation pass PANIC contained — cycle degraded, curator daemon preserved (#3283)"
+            );
+            report
+                .errors
+                .push(format!("{CONSOLIDATION_PASS_PANIC_CONTAINED}: {detail}"));
+            return;
+        }
+    };
     match outcome {
         Ok(out) => {
             // Fold the SAL consolidator's outcome into the autonomy report so
@@ -747,6 +783,35 @@ fn tokio_current_thread_handle_present() -> bool {
             tokio::runtime::RuntimeFlavor::MultiThread
         ),
     }
+}
+
+/// #3283 — stable, greppable marker for a CONTAINED `ConsolidationPass` panic.
+///
+/// A panic in the SAL consolidation pass (LLM clustering, nested runtime, or
+/// any callee) is caught at the `run_consolidation_pass` boundary and recorded
+/// under this prefix instead of unwinding out of the `spawn_blocking` closure
+/// the daemon drivers await — where the `JoinError` would TERMINATE the curator
+/// daemon. One bad cycle degrades to this reported failure, not a dead daemon.
+/// One named const so the production log and the regression assertion share a
+/// single spelling (pm-v3.1 lint-gate).
+#[cfg(feature = "sal")]
+pub(crate) const CONSOLIDATION_PASS_PANIC_CONTAINED: &str =
+    "consolidation pass: PANIC contained (cycle degraded, curator daemon preserved)";
+
+/// Extract a human-readable message from a `catch_unwind` panic payload.
+///
+/// Rust panic payloads are `&str` (from `panic!("literal")`) or `String` (from
+/// `panic!("{}", x)`); anything else is opaque and reported as such. Kept as a
+/// named helper so the `#3283` containment site stays readable and the
+/// downcast logic is unit-reachable.
+#[cfg(feature = "sal")]
+#[must_use]
+fn panic_payload_message(panic: &(dyn std::any::Any + Send)) -> String {
+    panic
+        .downcast_ref::<&'static str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| panic.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "non-string panic payload".to_string())
 }
 
 /// Non-`sal` builds carry no SAL `ConsolidationPass`; the consolidation pass is
@@ -3444,6 +3509,84 @@ mod consolidation_pass_tests_1746 {
         assert!(
             !tokio_current_thread_handle_present(),
             "a plain #[test] thread has no tokio Handle"
+        );
+    }
+
+    /// #3283 REGRESSION — a panic inside the SAL `ConsolidationPass` must be
+    /// CONTAINED at the `run_consolidation_pass` boundary, not unwind out and
+    /// (via the daemon drivers' `spawn_blocking` → `JoinError` → hard error)
+    /// kill the curator daemon. Pre-fix `run_consolidation_pass` had no
+    /// `catch_unwind`, so a panicking clusterer/summariser took the caller's
+    /// thread with it. Now the call returns normally, the panic is reported
+    /// under [`CONSOLIDATION_PASS_PANIC_CONTAINED`], the corpus is untouched
+    /// (summarise panics BEFORE any destructive persist), and a subsequent
+    /// pass still consolidates — the stand-in for `run_daemon` proceeding to
+    /// its next cycle rather than dying on the bad one.
+    #[test]
+    fn consolidation_pass_contains_panic_and_survives_3283() {
+        struct PanicSummarizeLlm;
+        impl AutonomyLlm for PanicSummarizeLlm {
+            fn auto_tag(&self, _t: &str, _c: &str) -> anyhow::Result<Vec<String>> {
+                Ok(vec![])
+            }
+            fn detect_contradiction(&self, _a: &str, _b: &str) -> anyhow::Result<bool> {
+                Ok(false)
+            }
+            fn summarize_memories(&self, _m: &[(String, String)]) -> anyhow::Result<String> {
+                panic!("injected clustering/summarise panic (#3283 regression)")
+            }
+        }
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let conn = db::open(tmp.path()).unwrap();
+        let candidates = seed(&conn);
+        let cfg = CuratorConfig {
+            compaction: CompactionConfig {
+                enabled: true,
+                ..CompactionConfig::default()
+            },
+            ..CuratorConfig::default()
+        };
+
+        // The pass panics in `summarize_memories`. Pre-fix this unwound and
+        // took the test thread down; reaching the asserts below AT ALL proves
+        // the panic was contained (the process survived).
+        let panic_llm = PanicSummarizeLlm;
+        let mut report = CuratorReport::new(false);
+        run_consolidation_pass(&conn, &candidates, &cfg, &panic_llm, &mut report);
+
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|e| e.contains(CONSOLIDATION_PASS_PANIC_CONTAINED)),
+            "the contained panic must be surfaced to the operator, got {:?}",
+            report.errors
+        );
+        // Data integrity: summarise panics BEFORE persist, so both sources
+        // survive untouched — a contained panic never corrupts the corpus.
+        assert_eq!(report.autonomy.memories_consolidated, 0);
+        for m in &candidates {
+            assert!(
+                db::get(&conn, &m.id).unwrap().is_some(),
+                "a contained-panic cycle must leave every source row intact"
+            );
+        }
+
+        // Daemon survival: a SUBSEQUENT healthy pass still runs to completion
+        // on the same process + db.
+        let good_llm = CountingStubLlm {
+            summarize_calls: Mutex::new(0),
+        };
+        let mut report2 = CuratorReport::new(false);
+        run_consolidation_pass(&conn, &candidates, &cfg, &good_llm, &mut report2);
+        assert_eq!(
+            report2.autonomy.memories_consolidated, 2,
+            "the daemon survives: the next pass consolidates normally"
+        );
+        assert!(
+            *good_llm.summarize_calls.lock().unwrap() >= 1,
+            "the recovery pass invoked the LLM"
         );
     }
 


### PR DESCRIPTION
## Summary

Two related curator data-integrity / availability GA-blockers in the SAL consolidation subsystem, fixed serial on one branch.

### #3190 — fail-closed when a Stage-6 auto-rollback itself fails (data-integrity)
`ConsolidationPass::run` (`src/curator/compaction.rs`) previously treated a failed rollback as a per-cluster hiccup: it set `restored = 0`, pushed a note into `report.errors`, and `continue`d — even though `persist` had already removed the pre-merge sources and the unverifiable summary was still live. That is a **fail-OPEN continuation over a data-loss-shaped state** (an unverifiable summary served as truth while sources are silently lost).

Fix — the pass now **HALTS the sweep** with a typed, greppable error (`ROLLBACK_FAILED_FAILCLOSED_SLUG`) instead of continuing, and **deliberately RETAINS** the unverifiable summary. Rationale (North Star: never cause unintentional data loss): `rollback_consolidation` restores sources FIRST and only then deletes the summary, so a failure can leave that summary as the **only surviving copy** of a source that did not restore; `db::delete` is a hard row delete, so removing it here could destroy that last copy. Retaining it keeps the merged content recoverable (operator `curator --rollback` / manual repair). The halt surfaces via `run_consolidation_pass`'s existing `Err` arm as a hard cycle error, not a buried WARN.

### #3283 — panic-contain the consolidation pass (availability)
`run_consolidation_pass` (`src/curator/mod.rs`) had no `catch_unwind`; an LLM-clustering or nested-runtime panic escaped the pass, unwound out of `run_once` and `run_daemon`'s cycle loop, and out of the `spawn_blocking` closure both daemon drivers await (`daemon_runtime::run_curator_daemon_with_shutdown` / `_with_primitives`) — where the `JoinError` was converted into a hard error that **terminated the curator daemon**.

Fix — the pass drive is wrapped in `std::panic::catch_unwind(AssertUnwindSafe(..))`, so one bad cycle degrades to a logged, reported failure (`CONSOLIDATION_PASS_PANIC_CONTAINED`) with the corpus untouched, and the daemon proceeds to its next cycle. `panic = "unwind"` is deliberately retained in Cargo.toml precisely so this boundary works. `AssertUnwindSafe` is sound: on a caught panic no state reachable through the closure is observed — only an error string is recorded and the fn returns; `report` is mutated only after the boundary.

## rust-1.98 rules applied
- **ERRORS-19** — both the `catch_unwind` `Result` and the `rollback_consolidation` `Result` are handled explicitly, never dropped.
- **ERRORS-08** — a contained panic is a bug surfaced as a reported failure, not a process death.
- **ERRORS-01** — the fail-closed halt returns a typed `Result` (loud refusal) rather than proceeding into corrupt/ambiguous state.

## Tests (run locally, green)
- `rollback_failure_halts_sweep_fail_closed_and_retains_summary_3190` — a failure-injecting `MemoryStore` decorator forces verify-fail (→ Stage-6 rollback) AND rollback-fail; asserts the sweep returns `Err` carrying the fail-closed slug and the `[consolidated]` summary row is **retained** in the backing DB (no data loss).
- `consolidation_pass_contains_panic_and_survives_3283` — a panicking summariser; asserts `run_consolidation_pass` returns (no unwind), the containment slug is reported, the corpus is intact, and a subsequent healthy pass still consolidates (daemon survives).

## CI parity verified locally
- `cargo fmt --all --check` clean; `bash scripts/check-hardcoded-literals.sh` PASS (new strings are named consts).
- **Clippy** `-D warnings -D clippy::all -D clippy::pedantic --all-targets` clean on all four legs: default, `sal`, `sal-postgres`, `vectorlite`.
- Ceiling tests: `qual_10_module_size_ceiling`, `qual_6_7_legacy_error_type_ceiling` pass (no bump needed).
- Structural suite: `record_stop_structural_b7`, `append_only_spine_guard_g6`, `cli_write_verb_pg_refuse_ceiling_2572`, `db_open_funnel_ceiling_2445`, `qual_expiry_floor_local_write_funnel_2515`, `mcp_param_names_invariant`, `attest_level_string_invariant`, `qual_12_todo_tracker_discipline` — all pass.
- Real-Postgres: `parity_write_funnels`, `qual_pg_write_funnel_parity_2393_2397` pass. No SSOT surface change (no new MCP tools / routes / CLI verbs / schema versions), so no SSOT pin reconciliation required.

Coverage floors NOT lowered (coverage added, not removed). CHANGELOG `[Unreleased]` updated.

Closes #3190
Closes #3283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY